### PR TITLE
chore(deps): fix 4 vulnerabilities (vite, defu)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3202,9 +3202,9 @@
       "license": "MIT"
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "license": "MIT"
     },
     "node_modules/dequal": {
@@ -7446,9 +7446,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",


### PR DESCRIPTION
## Summary

Resolves the 4 open dependabot alerts (3 high, 1 moderate) against the default branch, all in transitive deps surfaced via `package-lock.json`.

| Package | From | To | Severity | Vulnerability |
|---|---|---|---|---|
| vite | 7.3.1 | 7.3.2 | high | Arbitrary file read via dev server WebSocket |
| vite | 7.3.1 | 7.3.2 | high | Path traversal in optimized deps .map handling |
| vite | 7.3.1 | 7.3.2 | moderate | server.fs.deny bypassed with queries |
| defu | 6.1.4 | 6.1.7 | high | Prototype pollution via __proto__ key (CVSS 7.5, GHSA-737v-mqg7-c878) |

## How

Applied via `npm audit fix --package-lock-only`. Neither package is a direct dependency in `package.json` — both are pulled in transitively (vite via astro, defu via unjs utilities). **No `package.json` change.**

## Test plan

- [x] `npm audit` — 0 vulnerabilities
- [x] `npm ci` — clean install from updated lockfile
- [x] `npm run build` — 1632 pages, 0 errors, 78.8s
- [ ] CI on PR (automatic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)