### PR TITLE
feat(on-prem): phase 2 expansion scaffolding for 21 new modules (#197)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -200,6 +200,7 @@ export default defineConfig({
             { label: 'Security & Compliance', autogenerate: { directory: 'on-premises/security' }, collapsed: true },
             { label: 'Day-2 Operations', autogenerate: { directory: 'on-premises/operations' }, collapsed: true },
             { label: 'Resilience & Migration', autogenerate: { directory: 'on-premises/resilience' }, collapsed: true },
+            { label: 'AI/ML Infrastructure', autogenerate: { directory: 'on-premises/ai-ml-infrastructure' }, collapsed: true },
           ],
         },
 

--- a/scripts/on-prem/_lib.sh
+++ b/scripts/on-prem/_lib.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Shared helpers for On-Premises expansion phase scripts (#197).
+# Source from each phase script: source "$(dirname "$0")/_lib.sh"
+# Modeled on scripts/ai-ml/_lib.sh.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PY="$REPO_ROOT/.venv/bin/python"
+TRACK_ROOT="$REPO_ROOT/src/content/docs/on-premises"
+LOG_DIR="$REPO_ROOT/.pipeline/on-prem-logs"
+
+mkdir -p "$LOG_DIR"
+
+if [[ ! -x "$PY" ]]; then
+  echo "ERROR: $PY not found. Activate or create the venv first." >&2
+  exit 1
+fi
+
+cd "$REPO_ROOT"
+
+log() { printf '\n[%(%H:%M:%S)T] %s\n' -1 "$*"; }
+
+# write_stub <num> <section-dir> <filename-stem> "<title>" "<topic>"
+#   num is the dotted module number (e.g. 3.5, 9.1)
+write_stub() {
+  local num="$1" sec="$2" stem="$3" title="$4" topic="$5"
+  local target="$TRACK_ROOT/$sec/module-${num}-${stem}.md"
+  # sidebar order: major * 100 + minor (e.g. 3.5 -> 305, 9.1 -> 901)
+  local major="${num%.*}"
+  local minor="${num#*.}"
+  local order=$(( major * 100 + minor ))
+  local slug="on-premises/${sec}/module-${num}-${stem}"
+
+  if [[ -f "$target" ]]; then
+    log "stub exists, skipping: $target"
+    return 0
+  fi
+
+  log "creating stub: $target"
+  mkdir -p "$(dirname "$target")"
+  cat > "$target" <<EOF
+---
+title: "Module ${num}: ${title}"
+slug: ${slug}
+sidebar:
+  order: ${order}
+---
+> **On-Premises Track** | NEW 2026 module — pipeline will expand this stub
+>
+> **Topic**: ${topic}
+
+## Stub
+
+This module is a placeholder. The v1 quality pipeline will rewrite it from
+scratch in REWRITE mode (audit score < 28 triggers full rewrite) using the
+topic above.
+EOF
+}
+
+# run_pipeline <module-key> — runs v1 pipeline on a single module, logs to file
+run_pipeline() {
+  local key="$1"
+  local logf="$LOG_DIR/$(echo "$key" | tr '/' '_').log"
+  log "PIPELINE: $key  → log: $logf"
+  if "$PY" scripts/v1_pipeline.py run "$key" 2>&1 | tee "$logf"; then
+    log "✓ pipeline OK: $key"
+    return 0
+  else
+    log "✗ pipeline FAILED: $key — see $logf"
+    return 1
+  fi
+}

--- a/scripts/on-prem/phase2-new-modules.sh
+++ b/scripts/on-prem/phase2-new-modules.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+#
+# On-Premises Phase 2 — write 21 new modules for practitioner-grade expansion (#197)
+#
+# Modeled on scripts/ai-ml/phase4b-new-modules.sh. Creates stubs, then runs
+# the v1 pipeline. Stub scores < 28 trigger REWRITE mode → Gemini writes the
+# full module from scratch.
+#
+# Sequential by design — never parallelize Gemini calls.
+# Resumable: completed modules are skipped by the pipeline state machine.
+#
+# Usage:
+#   bash scripts/on-prem/phase2-new-modules.sh            # all 21
+#   bash scripts/on-prem/phase2-new-modules.sh 1 2 3      # only the first 3
+#
+# Prerequisites:
+#   - Phase 1 complete: `.venv/bin/python scripts/v1_pipeline.py e2e on-premises`
+#     (existing 30 modules re-audited against 8-dimension rubric)
+#   - scripts/on-prem/_lib.sh exists (mirror of scripts/ai-ml/_lib.sh)
+
+source "$(dirname "$0")/_lib.sh"
+
+# Module spec arrays — index aligned across all four arrays.
+# Ordering follows #197 Phase 2 section order: 1 → 3 → 4 → 5 → 6 → 7 → 9.
+SEC=(
+  "planning"
+  "networking"
+  "networking"
+  "storage"
+  "storage"
+  "multi-cluster"
+  "multi-cluster"
+  "security"
+  "security"
+  "security"
+  "security"
+  "operations"
+  "operations"
+  "operations"
+  "operations"
+  "ai-ml-infrastructure"
+  "ai-ml-infrastructure"
+  "ai-ml-infrastructure"
+  "ai-ml-infrastructure"
+  "ai-ml-infrastructure"
+  "ai-ml-infrastructure"
+)
+NUM=(
+  "1.5"
+  "3.5"
+  "3.6"
+  "4.4"
+  "4.5"
+  "5.4"
+  "5.5"
+  "6.5"
+  "6.6"
+  "6.7"
+  "6.8"
+  "7.6"
+  "7.7"
+  "7.8"
+  "7.9"
+  "9.1"
+  "9.2"
+  "9.3"
+  "9.4"
+  "9.5"
+  "9.6"
+)
+STEM=(
+  "onprem-finops-chargeback"
+  "cross-cluster-networking"
+  "service-mesh-bare-metal"
+  "object-storage-bare-metal"
+  "database-operators"
+  "fleet-management"
+  "active-active-multi-site"
+  "workload-identity-spiffe"
+  "secrets-management-vault"
+  "policy-as-code"
+  "zero-trust-architecture"
+  "self-hosted-cicd"
+  "self-hosted-registry"
+  "observability-at-scale"
+  "serverless-bare-metal"
+  "gpu-nodes-accelerated"
+  "private-ai-training"
+  "private-llm-serving"
+  "private-mlops-platform"
+  "private-aiops"
+  "high-performance-storage-ai"
+)
+TITLE=(
+  "On-Prem FinOps & Chargeback"
+  "Cross-Cluster Networking"
+  "Service Mesh on Bare Metal"
+  "Object Storage on Bare Metal"
+  "Database Operators"
+  "Fleet Management"
+  "Active-Active Multi-Site"
+  "Workload Identity with SPIFFE/SPIRE"
+  "Secrets Management on Bare Metal"
+  "Policy as Code & Governance"
+  "Zero Trust Architecture"
+  "Self-Hosted CI/CD"
+  "Self-Hosted Container Registry"
+  "Observability at Scale"
+  "Serverless on Bare Metal"
+  "GPU Nodes & Accelerated Computing"
+  "Private AI Training Infrastructure"
+  "Private LLM Serving"
+  "Private MLOps Platform"
+  "Private AIOps"
+  "High-Performance Storage for AI"
+)
+TOPIC=(
+  "On-Prem FinOps and chargeback models. Kubecost and OpenCost on bare metal, showback/chargeback for internal platform teams, capacity rightsizing lifecycle, depreciation modeling, budget alerting, comparing on-prem TCO to cloud FinOps disciplines."
+  "Cross-cluster networking for bare metal K8s. Submariner, Cilium Cluster Mesh, Liqo. East-west traffic across geographically distributed clusters without cloud load balancers. Service discovery, encrypted tunnels, MTU/MSS considerations, dual-stack support."
+  "Service mesh on bare metal without cloud load balancers. Istio, Cilium service mesh, Linkerd, Consul. mTLS, traffic shaping, observability integration. Performance considerations vs cloud mesh deployments. Data plane choices: envoy vs eBPF. Kernel tuning for high-throughput mesh traffic."
+  "Object storage on bare metal with MinIO. S3-compatible API, distributed deployment modes, tiering policies, erasure coding, encryption at rest, Prometheus metrics. Replication topologies, bucket quotas, multi-tenancy via STS. Lifecycle policies, versioning, legal hold."
+  "Database operators on Kubernetes for bare metal. CloudNativePG for PostgreSQL with streaming replication, PITR, pgBouncer. Vitess for MySQL sharding. Self-hosted Redis, Memcached, and Valkey operators. Backup strategies, failover, connection pooling, monitoring."
+  "Fleet management for multi-cluster bare metal. Rancher Fleet, Open Cluster Management, ArgoCD ApplicationSets at scale. Cluster registration, placement rules, GitOps rollout strategies, policy distribution, centralized audit logs. Comparing with Karmada and ClusterAPI-based approaches."
+  "Active-active multi-site architectures on bare metal. Global load balancing without cloud services, cross-DC data replication, conflict resolution patterns. Eventual consistency vs strong consistency tradeoffs. Split-brain prevention. Database replication (Galera, CockroachDB, YugabyteDB on bare metal)."
+  "Workload identity via SPIFFE/SPIRE. Zero-trust workload identity without cloud IAM. X.509 SVIDs, JWT SVIDs, federation across trust domains, workload attestation (k8s, selectors, plugins). Integration with service mesh and secrets managers. Rotation, key management, audit."
+  "Secrets management on bare metal K8s. HashiCorp Vault on bare metal (Raft storage, HA), External Secrets Operator, sealed-secrets, Kubernetes Secrets encryption at rest. KMS integration without cloud services. Secret rotation, dynamic secrets for databases, PKI engine usage."
+  "Policy as Code and governance on K8s. OPA Gatekeeper and Kyverno for admission control. Runtime policy enforcement with Falco and Tetragon. Policy libraries, violation dashboards, exemption workflows. Comparing OPA vs Kyverno: Rego vs native YAML. Policy CI/CD and testing."
+  "Zero Trust Architecture on bare metal K8s. mTLS everywhere via service mesh, network segmentation with NetworkPolicies and Cilium Network Policies, microsegmentation strategies. Identity-based access with SPIFFE, BeyondCorp-style patterns, continuous verification, assume breach posture."
+  "Self-hosted CI/CD on K8s. Tekton Pipelines, Gitea with Actions runners, Jenkins on K8s (JCasC, Kubernetes plugin), Woodpecker CI, Drone. Build caching, artifact storage, secret injection, multi-arch builds. Comparing self-hosted options on capability, resource footprint, and operational burden."
+  "Self-hosted container registries on bare metal. Harbor (replication, scanning, signing), Quay, Zot, GitLab registry. Distribution architecture, pull-through caches, proxy cache for upstream, vulnerability scanning pipelines (Trivy, Clair). Signing with cosign, policy enforcement, storage backends."
+  "Observability at scale on bare metal. Prometheus federation and sharding, Thanos, Cortex, Mimir for long-term storage. OpenTelemetry Collector pipelines. Grafana LGTM stack (Loki, Grafana, Tempo, Mimir). Cardinality management, exemplars, profiling with Pyroscope, alerting fatigue mitigation."
+  "Serverless on bare metal K8s. Knative Serving and Eventing for FaaS patterns, KEDA event-driven autoscaling (scale-to-zero), OpenFaaS, Fission. Cold start optimization, autoscaling triggers, comparing serverless runtimes. When to use serverless vs long-running workloads on bare metal."
+  "GPU nodes and accelerated computing on K8s. NVIDIA GPU Operator, device plugins, MIG (Multi-Instance GPU), GPU time slicing, node labeling, scheduling strategies. Monitoring GPU utilization (DCGM), driver management, CUDA version compatibility. AMD ROCm and Intel Gaudi alternatives."
+  "Private AI training infrastructure. Distributed training on bare metal with PyTorch DDP, FSDP, JAX on K8s. NCCL over InfiniBand/RoCE, RDMA tuning. Job schedulers (Volcano, Kueue, Slurm bridges). Checkpoint storage, fault-tolerant training, topology-aware scheduling for multi-GPU nodes."
+  "Private LLM serving on bare metal. vLLM, Text Generation Inference (TGI), Ollama at scale. Model caching, quantization (GPTQ, AWQ), autoscaling inference with KServe/Kubeflow. Token throughput tuning, batch scheduling, continuous batching, multi-model serving, GPU memory optimization."
+  "Private MLOps platform on bare metal. Kubeflow, MLflow, model registry, experiment tracking, feature stores (Feast on bare metal). Data versioning (DVC, LakeFS), model deployment pipelines, A/B testing harness, lineage tracking. Self-hosted alternatives to SageMaker and Vertex AI."
+  "Private AIOps on bare metal. Anomaly detection for cluster metrics, predictive scaling with ML, self-healing workflows with AI-augmented incident response. Robusta for Prometheus alerts, Kubecost integration, log anomaly detection. Safely letting AI make operational decisions with guardrails."
+  "High-performance storage for AI workloads on bare metal. NFS-over-RDMA, parallel file systems (Lustre, BeeGFS, WekaFS), data pipeline optimization. Managing training dataset storage at scale, checkpoint I/O, avoiding GPU idle on data bottlenecks. Storage tiering for hot/warm/cold model data."
+)
+
+run_one() {
+  local i="$1"
+  local sec="${SEC[$i]}" num="${NUM[$i]}" st="${STEM[$i]}"
+  local t="${TITLE[$i]}" tp="${TOPIC[$i]}"
+  local key="on-premises/${sec}/module-${num}-${st}"
+
+  log "==== Module $((i+1))/21: ${key} ===="
+  write_stub "$num" "$sec" "$st" "$t" "$tp"
+  run_pipeline "$key"
+}
+
+# Pick which to run
+if (( $# > 0 )); then
+  for n in "$@"; do
+    run_one $((n - 1))
+  done
+else
+  for i in "${!STEM[@]}"; do
+    run_one "$i"
+  done
+fi
+
+log "Phase 2 complete. Run 'npm run build' before committing."

--- a/src/content/docs/on-premises/ai-ml-infrastructure/index.md
+++ b/src/content/docs/on-premises/ai-ml-infrastructure/index.md
@@ -1,0 +1,35 @@
+---
+title: "AI/ML Infrastructure (On-Prem)"
+sidebar:
+  order: 0
+---
+
+> **Complexity**: `[ADVANCED]` | 6 modules | ~6 hours
+>
+> **Prerequisites**: [Planning & Economics](../planning/), [Day-2 Operations](../operations/), practical familiarity with Kubernetes GPU workloads.
+
+Running AI and ML workloads on bare metal is a different sport from running them in the cloud. There is no managed SageMaker, no Vertex AI, no `g5.24xlarge` you can spin up for an afternoon. You pick the GPU vendor, rack the hardware, tune the driver stack, build the networking fabric that keeps NCCL happy, and decide how training datasets move through your storage tier without starving the GPUs. This section covers the entire private-AI-infrastructure stack — from GPU scheduling primitives to a full on-prem MLOps platform — with the tradeoffs that only matter when you can't hand the bill to a hyperscaler.
+
+## Modules
+
+| Module | Focus | Time |
+|--------|-------|------|
+| [9.1 GPU Nodes & Accelerated Computing](module-9.1-gpu-nodes-accelerated/) | NVIDIA GPU Operator, MIG, time slicing, DCGM monitoring, AMD ROCm, Intel Gaudi | 60 min |
+| [9.2 Private AI Training Infrastructure](module-9.2-private-ai-training/) | Distributed training, NCCL over InfiniBand/RoCE, Volcano/Kueue, fault-tolerant jobs | 75 min |
+| [9.3 Private LLM Serving](module-9.3-private-llm-serving/) | vLLM, TGI, Ollama at scale, quantization, KServe, continuous batching | 75 min |
+| [9.4 Private MLOps Platform](module-9.4-private-mlops-platform/) | Kubeflow, MLflow, Feast, model registry, experiment tracking on bare metal | 60 min |
+| [9.5 Private AIOps](module-9.5-private-aiops/) | Anomaly detection, predictive scaling, AI-augmented incident response with guardrails | 60 min |
+| [9.6 High-Performance Storage for AI](module-9.6-high-performance-storage-ai/) | NFS-over-RDMA, Lustre/BeeGFS/WekaFS, avoiding GPU idle from storage bottlenecks | 60 min |
+
+---
+
+## Why a dedicated section?
+
+The rest of the on-prem track covers general Kubernetes operations. Accelerated computing adds a layer of complexity that doesn't exist in CPU-only workloads: driver management, MIG partitioning, RDMA fabrics, and dataset I/O patterns that can cost you 50% of your GPU utilization if the storage tier can't keep up. These modules assume you already know how to run a bare-metal K8s cluster and focus on what's specific to AI workloads.
+
+## Not covered here
+
+- **General Kubernetes cluster operations** — see [Day-2 Operations](../operations/)
+- **Cloud AI services** — see the Cloud track's managed-services section
+- **Platform engineering for AI teams (org design, self-service)** — see [Platform Engineering](../../platform/)
+- **AI/ML curriculum content (LLMs, transformers, RAG, fine-tuning)** — see the [AI/ML Engineering](../../ai-ml-engineering/) track

--- a/src/content/docs/on-premises/index.md
+++ b/src/content/docs/on-premises/index.md
@@ -13,39 +13,43 @@ Not every workload belongs in the cloud. Data sovereignty, latency requirements,
 ## Learning Path
 
 ```
-Planning & Economics (4 modules)
+Planning & Economics (5 modules)
         │
         ▼
 Bare Metal Provisioning (4 modules)
         │
-        ├── Networking (4 modules)
-        ├── Storage (3 modules)
-        └── Multi-Cluster & Platform (3 modules)
+        ├── Networking (6 modules)
+        ├── Storage (5 modules)
+        └── Multi-Cluster & Platform (5 modules)
                 │
                 ▼
-        Security & Compliance (4 modules)
+        Security & Compliance (8 modules)
                 │
                 ▼
-        Day-2 Operations (5 modules)
+        Day-2 Operations (9 modules)
                 │
                 ▼
         Resilience & Migration (3 modules)
+                │
+                ▼
+        AI/ML Infrastructure (6 modules)
 ```
 
 ## Sections
 
 | Section | Modules | Focus |
 |---------|---------|-------|
-| [Planning & Economics](planning/) | 4 | Server sizing, cluster topology, TCO, cloud vs on-prem |
+| [Planning & Economics](planning/) | 5 | Server sizing, cluster topology, TCO, cloud vs on-prem, FinOps & chargeback |
 | [Bare Metal Provisioning](provisioning/) | 4 | PXE, MAAS, Talos, Sidero/Metal3 |
-| [Networking](networking/) | 4 | Spine-leaf, BGP, MetalLB, internal DNS/certs |
-| [Storage](storage/) | 3 | Ceph/Rook, local storage, architecture decisions |
-| [Multi-Cluster & Platform](multi-cluster/) | 3 | vSphere/OpenStack, vCluster/Kamaji, Cluster API |
-| [Security & Compliance](security/) | 4 | Air-gapped, HSM/TPM, AD/LDAP, regulated industries |
-| [Day-2 Operations](operations/) | 5 | Upgrades, firmware, node failure, observability, capacity |
+| [Networking](networking/) | 6 | Spine-leaf, BGP, MetalLB, DNS/certs, cross-cluster, service mesh |
+| [Storage](storage/) | 5 | Ceph/Rook, local storage, object storage (MinIO), database operators |
+| [Multi-Cluster & Platform](multi-cluster/) | 5 | vSphere/OpenStack, vCluster/Kamaji, Cluster API, fleet management, active-active |
+| [Security & Compliance](security/) | 8 | Air-gapped, HSM/TPM, AD/LDAP, SPIFFE, Vault, policy-as-code, zero-trust |
+| [Day-2 Operations](operations/) | 9 | Upgrades, firmware, observability, capacity, self-hosted CI/CD & registry, serverless |
 | [Resilience & Migration](resilience/) | 3 | Multi-site DR, hybrid connectivity, cloud repatriation |
+| [AI/ML Infrastructure](ai-ml-infrastructure/) | 6 | GPU nodes, private training, LLM serving, MLOps, AIOps, HPC storage |
 
-**30 modules total.** From "should we go on-prem?" to "how do we run it at scale across two datacenters."
+**51 modules total** (30 existing + 21 new from [#197](https://github.com/kube-dojo/kube-dojo.github.io/issues/197)). From "should we go on-prem?" to "how do we train LLMs on our own GPUs."
 
 ---
 


### PR DESCRIPTION
## Summary

Sets up everything needed to generate the 21 new on-prem modules from #197's Phase 2. After this lands, you run one command and the v1 pipeline + Gemini Pro handle the rest.

```bash
bash scripts/on-prem/phase2-new-modules.sh            # all 21
# or a subset
bash scripts/on-prem/phase2-new-modules.sh 1 2 3      # first 3
```

The script creates stubs under `src/content/docs/on-premises/<section>/` then calls `v1_pipeline.py run` on each. Stubs score 8/40 and trigger REWRITE mode; Gemini writes the full module; pipeline reviews and commits on pass.

## Changes

### New scripts (mirror of `scripts/ai-ml/`)

- **`scripts/on-prem/_lib.sh`** — shared helpers (`log`, `write_stub`, `run_pipeline`). `sidebar.order` is computed as `major*100+minor`, so `9.1` → `901`, `3.5` → `305`. Stubs include the module's topic as a blockquote so the REWRITE prompt has context.

- **`scripts/on-prem/phase2-new-modules.sh`** — orchestrator with all 21 modules pre-populated (section, number, stem, title, topic). Topics taken verbatim from #197's Phase 2 list. Sequential by design (never parallelizes Gemini calls). Resumable via the pipeline state machine.

### New section: `on-premises/ai-ml-infrastructure/` (modules 9.1–9.6)

- **`src/content/docs/on-premises/ai-ml-infrastructure/index.md`** — section landing with module table, complexity/prerequisites, and a scope note ("not covered here" links out to AI/ML Engineering track, Day-2 Operations, Cloud track).

- **`astro.config.mjs`** — adds `AI/ML Infrastructure` sidebar entry after `Resilience & Migration`.

- **`src/content/docs/on-premises/index.md`** — refresh learning path diagram and Sections table to reflect the planned 30 → 51 module count and the new section. The tables show the **target** counts (including modules this PR does NOT yet generate), so post-merge the table will temporarily overstate actual content until `phase2-new-modules.sh` runs.

## The 21 modules

| # | Section | Module | Topic |
|---|---|---|---|
| 1.5 | Planning | On-Prem FinOps & Chargeback | Kubecost, OpenCost, showback/chargeback, capacity rightsizing |
| 3.5 | Networking | Cross-Cluster Networking | Submariner, Cilium Cluster Mesh, Liqo |
| 3.6 | Networking | Service Mesh on Bare Metal | Istio, Cilium mesh, performance tuning |
| 4.4 | Storage | Object Storage on Bare Metal | MinIO, erasure coding, lifecycle, multi-tenancy |
| 4.5 | Storage | Database Operators | CloudNativePG, Vitess, Redis operators |
| 5.4 | Multi-Cluster | Fleet Management | Rancher Fleet, OCM, ArgoCD ApplicationSets |
| 5.5 | Multi-Cluster | Active-Active Multi-Site | Global LB, data replication, conflict resolution |
| 6.5 | Security | Workload Identity (SPIFFE/SPIRE) | X.509/JWT SVIDs, federation, attestation |
| 6.6 | Security | Secrets Management | Vault on bare metal, External Secrets, sealed-secrets |
| 6.7 | Security | Policy as Code & Governance | OPA Gatekeeper, Kyverno, runtime policy |
| 6.8 | Security | Zero Trust Architecture | mTLS, microsegmentation with Cilium |
| 7.6 | Operations | Self-Hosted CI/CD | Tekton, Gitea Actions, Jenkins, Woodpecker |
| 7.7 | Operations | Self-Hosted Container Registry | Harbor, Quay, Zot, signing with cosign |
| 7.8 | Operations | Observability at Scale | Prometheus/Thanos/Cortex/Mimir, OTel, LGTM stack |
| 7.9 | Operations | Serverless on Bare Metal | Knative, KEDA scale-to-zero, OpenFaaS |
| 9.1 | AI/ML Infra (new) | GPU Nodes & Accelerated Computing | NVIDIA GPU Operator, MIG, DCGM |
| 9.2 | AI/ML Infra (new) | Private AI Training Infrastructure | NCCL/RDMA, Volcano, Kueue, fault-tolerant jobs |
| 9.3 | AI/ML Infra (new) | Private LLM Serving | vLLM, TGI, Ollama, KServe, continuous batching |
| 9.4 | AI/ML Infra (new) | Private MLOps Platform | Kubeflow, MLflow, Feast, DVC |
| 9.5 | AI/ML Infra (new) | Private AIOps | Anomaly detection, predictive scaling, guardrailed AI ops |
| 9.6 | AI/ML Infra (new) | High-Performance Storage for AI | NFS-over-RDMA, Lustre, BeeGFS, WekaFS |

## Verification

- `npm ci`: 0 vulnerabilities (PR #202 fixes already landed on main)
- `npm run build`: **1634 pages, 72.5s, 0 errors** (+2 pages vs main: the new `ai-ml-infrastructure` section landing + the rebuilt `on-premises` landing)
- `scripts/on-prem/phase2-new-modules.sh` NOT executed in this PR. All 21 modules are generated by the user after merge.

## Post-merge plan

1. Merge this PR.
2. `bash scripts/on-prem/phase2-new-modules.sh` — user runs the full 21-module pipeline. Sequential Gemini calls, several hours of wall time. Each module is auto-committed on pipeline pass.
3. After completion: `npm run build` + `python scripts/check_site_health.py`.
4. Phase 1 of #197 (re-audit existing 30 on-prem modules) can run after Phase 2 lands, or in parallel in a separate worktree if you prefer.

## Test plan

- [x] `npm ci` clean
- [x] `npm run build` — 1634 pages, 0 errors
- [ ] CI on PR (automatic)
- [ ] After merge: dry-run the phase 2 script (currently no `--dry-run` flag; the first module run is effectively a verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)