### PR TITLE
fix(on-prem): dynamic sidebar.order + TRACK_ALIASES gap

### DIFF
--- a/scripts/on-prem/_lib.sh
+++ b/scripts/on-prem/_lib.sh
@@ -26,10 +26,6 @@ log() { printf '\n[%(%H:%M:%S)T] %s\n' -1 "$*"; }
 write_stub() {
   local num="$1" sec="$2" stem="$3" title="$4" topic="$5"
   local target="$TRACK_ROOT/$sec/module-${num}-${stem}.md"
-  # sidebar order: major * 100 + minor (e.g. 3.5 -> 305, 9.1 -> 901)
-  local major="${num%.*}"
-  local minor="${num#*.}"
-  local order=$(( major * 100 + minor ))
   local slug="on-premises/${sec}/module-${num}-${stem}"
 
   if [[ -f "$target" ]]; then
@@ -39,6 +35,19 @@ write_stub() {
 
   log "creating stub: $target"
   mkdir -p "$(dirname "$target")"
+
+  # sidebar.order: sequential per-section to match existing on-prem convention.
+  # Existing sections use index.md=0, module-X.1=2, module-X.2=3, ... (they
+  # skip order 1). Count pre-existing module files and assign count+2.
+  # Normalize-sidebar-order.py can re-flow any section if modules are added
+  # out of numerical order.
+  local count=0
+  shopt -s nullglob
+  for f in "$TRACK_ROOT/$sec"/module-*.md; do
+    (( count++ ))
+  done
+  shopt -u nullglob
+  local order=$(( count + 2 ))
   cat > "$target" <<EOF
 ---
 title: "Module ${num}: ${title}"

--- a/scripts/on-prem/normalize-sidebar-order.py
+++ b/scripts/on-prem/normalize-sidebar-order.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Normalize `sidebar.order` values across on-prem module files.
+
+Re-flows every on-prem section so `sidebar.order` values are a contiguous
+sequence starting at the section convention: `index.md=0`, first module=2,
+next=3, next=4, ... (on-prem skips order 1 historically). Modules are
+sorted by their filename's dotted module number (e.g. `3.1` before `3.10`
+before `3.2` — numeric, not lexicographic).
+
+Why this exists:
+- PR #204's initial `_lib.sh` used a `major*100+minor` formula that
+  diverged from the sibling convention (small sequential integers),
+  leaving modules with orders like 105, 305, 901 alongside existing
+  orders 2-5 in the same section. Functionally it sorted correctly, but
+  was inconsistent.
+- This script is idempotent: run it any number of times; it always lands
+  on the same sequential values.
+- Safe to run after phase2-new-modules.sh: any stubs created with the old
+  formula get normalized on the next invocation.
+
+Usage:
+    python scripts/on-prem/normalize-sidebar-order.py --dry-run
+    python scripts/on-prem/normalize-sidebar-order.py --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TRACK_ROOT = REPO_ROOT / "src" / "content" / "docs" / "on-premises"
+
+MODULE_RE = re.compile(r"^module-(\d+)\.(\d+)-.+\.md$")
+ORDER_LINE_RE = re.compile(r"^(\s*order:\s*)\d+(\s*)$", re.MULTILINE)
+FIRST_MODULE_ORDER = 2  # index.md=0; module-X.1=2 (on-prem convention)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--dry-run", action="store_true", help="Print planned changes, write nothing")
+    mode.add_argument("--apply", action="store_true", help="Apply the normalization")
+    return parser.parse_args()
+
+
+def write_text_atomic(path: Path, content: str) -> None:
+    """Write file via tempfile + replace (atomic on POSIX)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        "w", encoding="utf-8", delete=False, dir=path.parent
+    ) as tmp:
+        tmp.write(content)
+        temp_name = tmp.name
+    Path(temp_name).replace(path)
+
+
+def read_current_order(text: str) -> int | None:
+    match = ORDER_LINE_RE.search(text)
+    if not match:
+        return None
+    # The full line looks like "  order: <n>"; extract <n> from the text.
+    number_match = re.search(r"order:\s*(\d+)", match.group(0))
+    return int(number_match.group(1)) if number_match else None
+
+
+def set_order(text: str, new_order: int) -> str:
+    return ORDER_LINE_RE.sub(rf"\g<1>{new_order}\g<2>", text, count=1)
+
+
+def normalize_section(section_dir: Path, dry_run: bool) -> tuple[int, int]:
+    """Normalize one section. Returns (touched, unchanged)."""
+    modules: list[tuple[int, int, Path]] = []
+    for md in section_dir.glob("module-*.md"):
+        match = MODULE_RE.match(md.name)
+        if not match:
+            continue
+        modules.append((int(match.group(1)), int(match.group(2)), md))
+    # Sort by (major, minor) — numeric, not lexicographic
+    modules.sort(key=lambda item: (item[0], item[1]))
+
+    touched = 0
+    unchanged = 0
+    for index, (_major, _minor, md) in enumerate(modules):
+        expected = FIRST_MODULE_ORDER + index
+        text = md.read_text(encoding="utf-8")
+        current = read_current_order(text)
+        if current is None:
+            print(f"  SKIP (no order line): {md.relative_to(REPO_ROOT)}", file=sys.stderr)
+            continue
+        if current == expected:
+            unchanged += 1
+            continue
+        action = "would set" if dry_run else "set"
+        print(f"  {action} {md.relative_to(REPO_ROOT)}: {current} -> {expected}")
+        if not dry_run:
+            write_text_atomic(md, set_order(text, expected))
+        touched += 1
+    return touched, unchanged
+
+
+def main() -> int:
+    args = parse_args()
+    if not TRACK_ROOT.exists():
+        print(f"Track root not found: {TRACK_ROOT}", file=sys.stderr)
+        return 1
+
+    total_touched = 0
+    total_unchanged = 0
+    sections = sorted(p for p in TRACK_ROOT.iterdir() if p.is_dir())
+    for section in sections:
+        touched, unchanged = normalize_section(section, dry_run=args.dry_run)
+        total_touched += touched
+        total_unchanged += unchanged
+
+    mode = "DRY RUN" if args.dry_run else "APPLIED"
+    print(f"\n[{mode}] touched={total_touched}, unchanged={total_unchanged}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/v1_pipeline.py
+++ b/scripts/v1_pipeline.py
@@ -1522,6 +1522,7 @@ def cmd_e2e(args):
             "on-premises/planning", "on-premises/provisioning", "on-premises/networking",
             "on-premises/storage", "on-premises/multi-cluster", "on-premises/security",
             "on-premises/operations", "on-premises/resilience",
+            "on-premises/ai-ml-infrastructure",
         ],
         "linux": [
             "linux/foundations/container-primitives", "linux/foundations/networking",
@@ -1840,7 +1841,7 @@ models (default: gemini-3.1-pro-preview for all steps):
   specialty  pca, cba, capa, kca, otca, ica, cca, finops
   cloud      aws, gcp, azure, architecture, eks, gke, aks, advanced-ops, managed, enterprise
   platform   foundations, disciplines, toolkits
-  on-prem    planning, provisioning, networking, storage, multi-cluster, security, operations, resilience
+  on-prem    planning, provisioning, networking, storage, multi-cluster, security, operations, resilience, ai-ml-infrastructure
   linux      container-primitives, networking, system-essentials, everyday-use, operations, security
 
 examples:


### PR DESCRIPTION
## Summary

Two tech-debt items flagged in the PR #204 review, plus a normalizer to repair any modules that were already stubbed with the old formula.

## Changes

### 1. `v1_pipeline.py` TRACK_ALIASES: add `on-premises/ai-ml-infrastructure`

`TRACK_ALIASES["on-prem"]` enumerated only 8 sections. The new `ai-ml-infrastructure` section added in PR #204 was missing, so a future `v1_pipeline.py e2e on-prem` run would silently skip its 6 modules. This doesn't block phase2-new-modules.sh (which uses per-module `run` bypassing TRACK_ALIASES), but it breaks the fleet re-audit workflow.

### 2. `scripts/on-prem/_lib.sh`: dynamic per-section ordering

The initial PR #204 `_lib.sh` computed `sidebar.order = major*100 + minor`, producing orders like 105, 305, 901. Every other on-prem section uses small sequential integers (index.md=0, module-X.1=2, module-X.2=3, ...). Sort order worked because Starlight's autogenerate is directory-scoped, but it was inconsistent.

New approach: count pre-existing `module-*.md` files in the section directory and assign `count + 2`. Handles both existing sections (next sequential integer) and the new empty `ai-ml-infrastructure` section (first module gets order 2).

### 3. `scripts/on-prem/normalize-sidebar-order.py`: repair existing modules

Idempotent normalizer that re-flows every on-prem section to contiguous sequential integers. Sorts modules by the filename's dotted number (`3.1, 3.2, ..., 3.10` — numeric, not lexicographic). Atomic writes via `tempfile.NamedTemporaryFile` + `Path.replace()`. Supports `--dry-run` and `--apply`.

**When to run:** after `phase2-new-modules.sh` finishes, to repair any stubs that were created with the old formula (PR #204 was in-flight when phase2 started on module 1.5 with order 105).

```bash
.venv/bin/python scripts/on-prem/normalize-sidebar-order.py --dry-run
.venv/bin/python scripts/on-prem/normalize-sidebar-order.py --apply
```

## Verification

- `bash -n scripts/on-prem/_lib.sh` — OK
- `python3 -c "import ast; ast.parse(open('scripts/on-prem/normalize-sidebar-order.py').read())"` — OK
- Normalize dry-run against baseline on-prem (30 existing modules, orders 2-6): **0 changes** (confirms idempotence on already-correct state)
- Normalize dry-run with a test `module-7.99-*` at `order: 999`: correctly plans `999 → 7` (operations has 5 existing modules at orders 2-6)
- `write_stub` dynamic count logic tested directly:
  - `networking` (4 modules) → next new module gets `order=6` ✓
  - `ai-ml-infrastructure` (empty) → first new module gets `order=2` ✓

## Notes for Phase 2 coordination

- This PR does NOT affect currently-running `phase2-new-modules.sh` (bash already sourced `_lib.sh` at script start).
- Any modules already stubbed with `order: 105/305/...` will have those values preserved through the pipeline rewrite (Gemini's REWRITE prompt keeps frontmatter).
- Run the normalizer **after** phase2 finishes to repair them in one pass.

## Test plan

- [x] Syntax checks pass (bash + python)
- [x] Dry-run against current main state shows 0 changes (idempotence)
- [x] Dry-run with a synthetic out-of-range module shows the expected rewrite
- [x] `write_stub` dynamic count logic verified for existing and empty sections
- [ ] CI on PR (automatic)
- [ ] After phase2 completes, run normalizer and confirm all 51 on-prem modules have sequential orders 2-N

🤖 Generated with [Claude Code](https://claude.com/claude-code)