### PR TITLE
feat(aks): add missing 5th deep-dive module — Fleet Manager (#184)

### DIFF
--- a/src/content/docs/cloud/aks-deep-dive/index.md
+++ b/src/content/docs/cloud/aks-deep-dive/index.md
@@ -17,8 +17,9 @@ AKS is the fastest-growing managed Kubernetes service, tightly integrated with t
 | 2 | [AKS Advanced Networking](module-7.2-aks-networking/) | 3.5h | Kubenet vs Azure CNI vs Overlay vs Cilium, network policies, Private Link |
 | 3 | [AKS Workload Identity & Security](module-7.3-aks-identity/) | 1.5h | Entra Workload Identity, Secrets Store CSI, Azure Policy, Defender |
 | 4 | [AKS Storage, Observability & Scaling](module-7.4-aks-production/) | 2.5h | Azure Disks/Files, Container Insights, Managed Prometheus, KEDA |
+| 5 | [AKS Fleet Manager & Multi-Cluster Operations](module-7.5-aks-fleet-manager/) | 2.5h | Azure Kubernetes Fleet Manager, Azure Arc, cross-region, GitOps with Flux |
 
-**Total time**: ~9.5 hours
+**Total time**: ~12 hours
 
 ---
 

--- a/src/content/docs/cloud/aks-deep-dive/module-7.5-aks-fleet-manager.md
+++ b/src/content/docs/cloud/aks-deep-dive/module-7.5-aks-fleet-manager.md
@@ -1,0 +1,14 @@
+---
+title: "Module 7.5: Azure Kubernetes Fleet Manager & Multi-Cluster Operations"
+slug: cloud/aks-deep-dive/module-7.5-aks-fleet-manager
+sidebar:
+  order: 6
+---
+> **AKS Deep Dive** | Complexity: `[ADVANCED]` | Time: 2.5h | NEW — pipeline will expand this stub
+>
+> **Topic**: Azure Kubernetes Fleet Manager for centralized multi-cluster AKS operations. Hub-and-spoke topology, cluster registration, fleet-level workload placement, coordinated multi-cluster upgrades, Azure Policy at scale across fleet members, cross-region deployment patterns for high availability and disaster recovery. Integrates with Azure Arc for hybrid and edge AKS clusters, GitOps with Flux extension, and Azure Monitor workspace federation for multi-cluster observability. Covers when to adopt Fleet Manager vs single-cluster patterns, fleet update orchestration strategies (update runs, stages, groups), and workload propagation via ClusterResourcePlacement CRDs. Closes the multi-cluster gap in the AKS deep dive by matching GKE Fleet Management (module 6.5) and providing AKS-native alternatives to EKS cross-cluster patterns.
+
+## Stub
+
+This module is a placeholder. The v1 quality pipeline will rewrite it from scratch
+in REWRITE mode (audit score < 28 triggers full rewrite) using the topic above.


### PR DESCRIPTION
## Summary

Closes #184. Adds the missing 5th AKS Deep Dive module as a stub for the v1 pipeline to expand.

## Gap analysis

EKS (5 modules) and GKE (5 modules) both had complete hyperscaler deep dives; AKS had only 4. Comparing module-by-module:

| Topic | EKS | GKE | AKS before | AKS after |
|---|---|---|---|---|
| Architecture | 5.1 | 6.1 | 7.1 | 7.1 |
| Networking | 5.2 | 6.2 | 7.2 | 7.2 |
| Identity | 5.3 | 6.3 | 7.3 | 7.3 |
| Storage | 5.4 (standalone) | 6.4 (standalone) | combined in 7.4 | combined in 7.4 |
| Production | 5.5 | — | combined in 7.4 | combined in 7.4 |
| Fleet / Multi-Cluster | — | 6.5 | **MISSING** | **7.5 (NEW)** |

GKE had a dedicated Fleet Management module (6.5); AKS had no multi-cluster coverage at all. Azure Kubernetes Fleet Manager is a first-class Azure service that deserves dedicated treatment and aligns AKS with the rest of the track.

## Why Fleet Manager (and not splitting 7.4)

Alternative considered: split the existing AKS 7.4 ("Storage, Observability & Scaling") into two modules — one Storage, one Production. Rejected because:
1. That's a content rewrite, not an addition. Must go through Gemini + pipeline anyway.
2. Splitting would create two weaker modules; the current 7.4 is a coherent "production operations" story.
3. AKS Fleet Manager is a real content gap with no other module covering it — the "Fleet" topic is completely absent from the AKS track.

Picking "add Fleet Manager" is the cleanest scope increase with the highest information gain per new module.

## Topic (for pipeline REWRITE)

Azure Kubernetes Fleet Manager for centralized multi-cluster AKS operations. Hub-and-spoke topology, cluster registration, fleet-level workload placement via ClusterResourcePlacement CRDs, coordinated multi-cluster upgrades (update runs, stages, groups), Azure Policy at fleet scale, cross-region deployment patterns for HA/DR, Azure Arc integration for hybrid/edge clusters, GitOps with Flux extension, Azure Monitor workspace federation. Decision guide: when to adopt Fleet Manager vs single-cluster patterns.

## Changes

- **NEW** `src/content/docs/cloud/aks-deep-dive/module-7.5-aks-fleet-manager.md` — stub with topic description. The v1 pipeline will expand it in REWRITE mode when run.
- **MOD** `src/content/docs/cloud/aks-deep-dive/index.md` — module table now lists 5 modules; total time updated 9.5h → 12h.

## Verification

- `npm run build`: **1636 pages, 0 errors, 73.7s** (+2 pages: the new module stub + rebuilt section index)
- `sidebar.order: 6` matches the sibling convention (2, 3, 4, 5 + next)
- Slug format matches existing: `cloud/aks-deep-dive/module-7.5-aks-fleet-manager`

## Test plan

- [x] Build clean
- [ ] CI on PR (automatic)
- [ ] After merge, user runs: `.venv/bin/python scripts/v1_pipeline.py run cloud/aks-deep-dive/module-7.5-aks-fleet-manager` to trigger full content generation via Gemini
- [ ] Module passes pipeline at >= 33/40 (8-dimension rubric)

🤖 Generated with [Claude Code](https://claude.com/claude-code)