### PR TITLE
feat(pipeline): force independent review even when audit passes

### DIFF
--- a/scripts/test_pipeline.py
+++ b/scripts/test_pipeline.py
@@ -662,11 +662,22 @@ class TestPipelineTransitions(unittest.TestCase):
     @patch("subprocess.run")
     def test_already_passing_module_goes_to_done(self, mock_subprocess, mock_root,
                                                   mock_dispatch, mock_state):
-        """A module that already passes audit should go straight to done."""
+        """An audit-passing module must still get one forced Codex review before done.
+
+        Enforces the "no Gemini-only modules ship" policy: when AUDIT (Gemini)
+        says the module already passes, run_module MUST still send it through
+        one review with the independent reviewer (Codex by default), then land
+        at phase=done with reviewer=codex and needs_independent_review=False.
+        """
         import v1_pipeline as p
 
         mock_state.__class__ = type(self.state_file)
-        mock_dispatch.side_effect = self._mock_audit_pass
+        # First dispatch call = audit (Gemini, passing). Second = forced review
+        # (Codex, approving). mock.side_effect as a list consumes in order.
+        mock_dispatch.side_effect = [
+            self._mock_audit_pass(),
+            self._mock_review_approve(),
+        ]
 
         # Patch CONTENT_ROOT so module_key_from_path works
         mock_root.resolve.return_value = Path(self.tmpdir).resolve()
@@ -676,13 +687,17 @@ class TestPipelineTransitions(unittest.TestCase):
         with patch.object(p, "STATE_FILE", self.state_file), \
              patch.object(p, "CONTENT_ROOT", Path(self.tmpdir)), \
              patch.object(p, "save_state"):
-            # Override module_key_from_path for our temp path
             with patch.object(p, "module_key_from_path", return_value="test/module-0.1-test"):
-                result = p.run_module(self.module_path, state)
+                p.run_module(self.module_path, state)
 
         ms = state["modules"].get("test/module-0.1-test", {})
         self.assertEqual(ms.get("phase"), "done")
         self.assertTrue(ms.get("passes"))
+        # Must have been reviewed by an independent reviewer
+        self.assertEqual(ms.get("reviewer"), "codex")
+        self.assertFalse(ms.get("needs_independent_review", True))
+        # Both audit and review dispatches should have fired
+        self.assertEqual(mock_dispatch.call_count, 2)
 
     def test_dry_run_does_not_modify_files(self):
         """Dry run should audit but not write any files."""

--- a/scripts/v1_pipeline.py
+++ b/scripts/v1_pipeline.py
@@ -949,39 +949,57 @@ def run_module(module_path: Path, state: dict, max_retries: int = 2,
         ms["passes"] = audit["passes"]
         ms["last_run"] = datetime.now(UTC).isoformat()
 
-        if audit["passes"] and audit["check_errors"] == 0:
-            print(f"\n  ✓ Module already passes! ({audit['sum']}/40)")
-            ms["phase"] = "done"
-            save_state(state)
-            return True
-
         plan = audit.get("plan", "")
         if not plan or plan == "PASS":
             plan = f"Improve weak dimensions. Scores: {audit['scores']}. Notes: {audit.get('notes', {})}"
 
-        if dry_run:
-            print(f"\n  [DRY RUN] Would improve: {[f'D{i+1}={s}' for i, s in enumerate(audit['scores']) if s < 4]}")
-            print(f"  [DRY RUN] Plan: {plan[:300]}")
-            return False
-
-        ms["phase"] = "write"
-        save_state(state)
+        if audit["passes"] and audit["check_errors"] == 0:
+            # Audit says it passes — but we MUST get an independent reviewer
+            # stamp before marking done. Audit uses Gemini, which has self-bias
+            # when reviewing other Gemini-written content (see module-1.5:
+            # Gemini 40/40 vs Codex 24-28/40). Force one review cycle with
+            # the preferred reviewer (Codex by default), skipping write.
+            writer_family = m["write"].split("-")[0]
+            reviewer_family = m["review"].split("-")[0]
+            if reviewer_family == writer_family:
+                # Reviewer and writer same family — no cross-check possible.
+                print(f"\n  ✓ Module already passes ({audit['sum']}/40), reviewer same family — done")
+                ms["phase"] = "done"
+                save_state(state)
+                return True
+            print(f"\n  ✓ Audit says module passes ({audit['sum']}/40) — forcing {m['review']} review before done")
+            ms["phase"] = "review"
+            save_state(state)
+            # Populate `improved` from disk so the review/check/score steps
+            # below operate on the current on-disk content (no rewrite).
+            improved = module_path.read_text()
+            last_good = improved
+        else:
+            if dry_run:
+                print(f"\n  [DRY RUN] Would improve: {[f'D{i+1}={s}' for i, s in enumerate(audit['scores']) if s < 4]}")
+                print(f"  [DRY RUN] Plan: {plan[:300]}")
+                return False
+            ms["phase"] = "write"
+            save_state(state)
+            improved = None
+            last_good = None
     else:
         # Resuming — reconstruct plan from state
         plan = f"Resume improvement. Last scores: {ms.get('scores', 'unknown')}."
+        improved = None
+        last_good = None
 
     # WRITE → REVIEW loop (max retries)
-    # Auto-detect rewrite mode: score < 28 means "improve" won't cut it
+    # Auto-detect rewrite mode: score < 28 means "improve" won't cut it.
+    # `improved` and `last_good` are already initialized above (either to
+    # on-disk content when audit passed, or to None when audit failed or
+    # when resuming). `last_good` holds the most recent successful WRITE
+    # output across retries so a REJECT followed by a rewrite improves the
+    # prior attempt instead of starting from scratch.
     needs_rewrite = (ms.get("sum") or 0) < 28
     if needs_rewrite:
         print(f"  Score {ms.get('sum')}/40 < 28 — using REWRITE mode")
 
-    improved = None
-    # `last_good` holds the most recent successful WRITE output across retries.
-    # step_write uses it as the base to improve on, since the module file on
-    # disk is only updated during CHECK (after the loop). Without this, every
-    # retry would re-read the original stub and lose the previous progress.
-    last_good: str | None = None
     for attempt in range(max_retries + 1):
         if ms["phase"] in ("write",):
             improved = step_write(module_path, plan, model=m["write"],


### PR DESCRIPTION
## Summary

Closes the last gap in the Codex-as-official-reviewer rollout (#208). Previously, `run_module` short-circuited to `phase=done` when `step_audit` (Gemini) said a module already scored 40/40 — bypassing Codex entirely.

That defeats the whole point of an independent reviewer: module-1.5 demonstrated that Gemini audits its own writer's output with ~12-point inflation vs Codex (40/40 vs 28/40). A Gemini audit pass cannot be trusted alone.

## New behavior

- Audit passes + reviewer family != writer family → **skip WRITE**, load on-disk content, enter the REVIEW step of the existing retry loop
- Codex APPROVE → CHECK + SCORE + commit with `reviewer=codex`
- Codex REJECT → existing rejection path kicks in: WRITE with Codex feedback as plan, then re-review
- Codex rate-limited → PR #208's fallback to Gemini kicks in, committed with `reviewer=gemini needs-independent-review`, pipeline never halts
- Reviewer family == writer family (e.g. both gemini) → short-circuit to done preserved (no cross-check possible)

## Test updates

`TestPipelineTransitions.test_already_passing_module_goes_to_done` updated:
- `mock_dispatch.side_effect` now a list `[audit_pass, review_approve]` — both dispatches MUST fire
- Asserts `reviewer == "codex"`, `needs_independent_review == False`, `call_count == 2`

## Test plan

- [x] `python -m unittest scripts.test_pipeline.TestPipelineTransitions` — 2/2 pass
- [x] Full suite — 40/41 pass (1 pre-existing TrackAliases failure unrelated, exists on main)
- [ ] First phase 2 module after merge: should always show REVIEW step in logs even if AUDIT says 40/40

🤖 Generated with [Claude Code](https://claude.com/claude-code)