### PR TITLE
fix(pipeline): lower targeted-fix threshold + preserve passing dims + bump retries

### DIFF
--- a/scripts/v1_pipeline.py
+++ b/scripts/v1_pipeline.py
@@ -923,7 +923,7 @@ def step_check(content: str, path: Path) -> tuple[bool, list]:
 # Full pipeline: run one module through all steps
 # ---------------------------------------------------------------------------
 
-def run_module(module_path: Path, state: dict, max_retries: int = 2,
+def run_module(module_path: Path, state: dict, max_retries: int = 4,
                models: dict | None = None, dry_run: bool = False) -> bool:
     """Run a single module through the full pipeline."""
     m = models or MODELS
@@ -1123,20 +1123,32 @@ def run_module(module_path: Path, state: dict, max_retries: int = 2,
                 r_sum = sum(r_scores) if r_valid else 0
                 r_has_weak = r_valid and any(s < 4 for s in r_scores)
 
-                if r_valid and r_sum >= 33 and r_has_weak:
-                    # Surgical fix — mostly passing, specific weak dims to target
+                if r_valid and r_sum >= 28 and r_has_weak:
+                    # Surgical fix — enough passing content to preserve; fix only
+                    # the weak dims. Threshold was 33 (passing floor) but lowered
+                    # to 28 (IMPROVE mode boundary) because full rewrites were
+                    # regressing already-passing dims (whack-a-mole): module-1.5
+                    # went 28 → 29 → 30 with D5 dropping 4→3 on one retry. As
+                    # long as the module isn't in full REWRITE mode, we should
+                    # be surgically patching weak dims, not regenerating.
                     needs_rewrite = False
                     weak = [(i + 1, s) for i, s in enumerate(r_scores) if s < 4]
+                    passing = [(i + 1, s) for i, s in enumerate(r_scores) if s >= 4]
                     weak_desc = ", ".join(f"D{i}={s}" for i, s in weak)
+                    passing_desc = ", ".join(f"D{i}={s}" for i, s in passing)
                     plan = (
-                        f"TARGETED FIX. Content already scored {r_sum}/40 — "
-                        f"ONLY weak dimension(s): {weak_desc}. "
-                        f"Edit ONLY what the reviewer feedback points to; "
-                        f"preserve EVERYTHING else verbatim (do not touch other sections, "
-                        f"code blocks, diagrams, tables, or quiz questions that were not flagged). "
-                        f"Reviewer feedback: {r_feedback}"
+                        f"TARGETED FIX. Content currently scores {r_sum}/40.\n\n"
+                        f"WEAK dimensions to fix: {weak_desc}.\n"
+                        f"PASSING dimensions — DO NOT TOUCH, leave content exactly verbatim: {passing_desc}.\n\n"
+                        f"The reviewer has specifically approved the passing dimensions — if your "
+                        f"edit changes sections that support those dims, you WILL regress scores "
+                        f"and the module will be rejected again. Do not regenerate code blocks, "
+                        f"diagrams, tables, quiz questions, or inline prompts that were not flagged "
+                        f"in the reviewer's feedback. Apply only the surgical patches the reviewer "
+                        f"points to, using their exact FIX suggestions verbatim where possible.\n\n"
+                        f"Reviewer feedback (apply the [Dn] → FIX: blocks literally):\n{r_feedback}"
                     )
-                    print(f"  → Targeted fix mode: {weak_desc}, sum={r_sum}/40")
+                    print(f"  → Targeted fix mode: fixing {weak_desc}, preserving {passing_desc}, sum={r_sum}/40")
                 elif r_valid and r_sum >= 36 and not r_has_weak:
                     # All dims ≥ 4 but verdict REJECT — qualitative nitpick.
                     # Numeric ground truth says this passes. Use improve mode


### PR DESCRIPTION
## Summary

module-1.5 Codex review retries were showing a whack-a-mole pattern: Gemini fixes one weak dim, regresses another.

\`\`\`
Attempt 0: [4,2,4,3,4,4,3,4] sum=28  (D2 weak, D4 weak, D7 weak)
Attempt 1: [4,3,4,3,4,4,3,4] sum=29  (D2 up, rest held)
Attempt 2: [4,3,4,4,3,4,4,4] sum=30  (D4,D7 up, D5 dropped 4->3)
FAILED after 2 retries
\`\`\`

Root cause: targeted-fix branch only activates at \`sum >= 33\` (passing floor). Below that, the module falls through to a generic "rewrite with feedback" plan that regenerates whole sections and can regress already-passing dims.

## Fixes

1. **Lower targeted-fix threshold 33 → 28.** The REWRITE-mode boundary is \`sum < 28\`. Any \`sum >= 28\` has enough passing content to preserve. Use surgical patching from 28 upward.

2. **Enhanced targeted-fix plan.** Now explicitly lists:
   - **WEAK** dimensions to fix (with scores)
   - **PASSING** dimensions to preserve verbatim (with scores)
   - Explicit warning: *"if your edit changes sections that support those dims, you WILL regress scores"*
   - Instruction to apply Codex's \`[Dn] → FIX:\` blocks literally where possible

3. **max_retries default 2 → 4.** With surgical patching, each retry preserves progress instead of churning, so more retries is cheap insurance for stubborn modules with deep accuracy fixes.

## Test plan

- [x] \`python -m unittest scripts.test_pipeline\` — **43/43 pass**
- [ ] Re-run module-1.5 after merge: should show \`→ Targeted fix mode:\` log line and converge in ≤4 retries

🤖 Generated with [Claude Code](https://claude.com/claude-code)