### PR TITLE
feat(pipeline): Claude Sonnet for targeted fixes + peak-hours refusal

### DIFF
--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -74,6 +74,34 @@ def _is_rate_limited(text: str) -> bool:
     return any(pat.lower() in text_lower for pat in _RATE_LIMIT_PATTERNS)
 
 
+# ---------------------------------------------------------------------------
+# Claude peak-hours pricing guard
+# ---------------------------------------------------------------------------
+#
+# Anthropic charges 2x for Claude API calls during peak hours (14:00-20:00
+# local time). To avoid accidental spend, the pipeline refuses to invoke
+# Claude during those hours and leaves any pending work for the next run.
+# Override with KUBEDOJO_IGNORE_PEAK_HOURS=1 if you need to force through.
+
+_CLAUDE_PEAK_START_HOUR = 14  # 14:00 local time
+_CLAUDE_PEAK_END_HOUR = 20    # 20:00 local time
+
+
+class ClaudeUnavailableError(Exception):
+    """Raised when a Claude call is blocked (peak hours) or fails terminally
+    (rate limit / quota). The pipeline catches this and pauses the affected
+    module so it can resume on the next run without losing state."""
+
+
+def _is_claude_peak_hours() -> bool:
+    """Return True if current local time falls inside the 14:00-20:00 peak
+    window. KUBEDOJO_IGNORE_PEAK_HOURS=1 disables the check."""
+    if os.environ.get("KUBEDOJO_IGNORE_PEAK_HOURS", "") == "1":
+        return False
+    hour = datetime.now().hour
+    return _CLAUDE_PEAK_START_HOUR <= hour < _CLAUDE_PEAK_END_HOUR
+
+
 def _pace_gemini_calls() -> None:
     """Enforce minimum delay between Gemini CLI calls to avoid bursts."""
     global _last_gemini_call_time
@@ -257,7 +285,24 @@ def dispatch_gemini_with_retry(prompt: str, model: str = GEMINI_DEFAULT_MODEL,
 
 def dispatch_claude(prompt: str, model: str = CLAUDE_DEFAULT_MODEL,
                     timeout: int = 600, mcp: bool = False) -> tuple[bool, str]:
-    """Call Claude CLI directly. Returns (success, output)."""
+    """Call Claude CLI directly. Returns (success, output).
+
+    Raises:
+        ClaudeUnavailableError: during 14:00-20:00 local peak-hours (2x pricing)
+            or on terminal rate-limit / quota errors. The pipeline catches this
+            and pauses the affected module so it can resume on the next run.
+    """
+    if _is_claude_peak_hours():
+        hour = datetime.now().hour
+        msg = (
+            f"Claude peak hours in effect ({_CLAUDE_PEAK_START_HOUR}:00-"
+            f"{_CLAUDE_PEAK_END_HOUR}:00 local, currently {hour:02d}:xx). "
+            f"Refusing to dispatch to avoid 2x pricing. "
+            f"Set KUBEDOJO_IGNORE_PEAK_HOURS=1 to override."
+        )
+        print(f"⏸ {msg}", file=sys.stderr)
+        raise ClaudeUnavailableError(msg)
+
     cmd = [
         "npx", "@anthropic-ai/claude-code@latest", "-p",
         "--model", model,
@@ -280,6 +325,12 @@ def dispatch_claude(prompt: str, model: str = CLAUDE_DEFAULT_MODEL,
         if result.returncode != 0:
             print(f"Claude error (exit {result.returncode}): {result.stderr[:500]}", file=sys.stderr)
             _log("claude", model, prompt, "", False, elapsed, result.stderr)
+            # Escalate rate-limit / quota failures so the pipeline can pause
+            # the module instead of treating it as a generic write failure.
+            if _is_rate_limited(result.stderr) or _is_rate_limited(result.stdout):
+                raise ClaudeUnavailableError(
+                    f"Claude rate-limited or quota exhausted: {result.stderr[:200]}"
+                )
             return False, result.stderr
         output = result.stdout.strip()
         _log("claude", model, prompt, output, True, elapsed)

--- a/scripts/v1_pipeline.py
+++ b/scripts/v1_pipeline.py
@@ -103,6 +103,7 @@ from dispatch import (
     dispatch_claude,
     dispatch_codex,
     _is_rate_limited,
+    ClaudeUnavailableError,
 )
 from uk_sync import (
     translate_new_module as uk_translate,
@@ -130,7 +131,8 @@ def dispatch_auto(prompt: str, model: str, timeout: int = 900) -> tuple[bool, st
 
 MODELS = {
     "audit": "gemini-3.1-pro-preview",     # AUDIT+PLAN: rubric evaluation + plan
-    "write": "gemini-3.1-pro-preview",     # WRITE: draft improvements
+    "write": "gemini-3.1-pro-preview",     # WRITE: initial drafts + full REWRITE mode
+    "write_targeted": "claude-sonnet-4-6", # TARGETED FIX: surgical patches (instruction-following)
     "review": "codex",                     # REVIEW: preferred independent reviewer
     "review_fallback": "gemini-3.1-pro-preview",  # used only when "review" is unavailable
     # "translate" removed — uk_sync.CHUNKED_MODEL owns translation model config
@@ -1017,11 +1019,31 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
     if needs_rewrite:
         print(f"  Score {ms.get('sum')}/40 < 28 — using REWRITE mode")
 
+    # targeted_fix starts False; flips True when the REVIEW branch below
+    # routes a reject through the "TARGETED FIX" path. When True, the writer
+    # switches from Gemini (primary) to Claude Sonnet (precision editor) to
+    # reduce dim regression on surgical patches.
+    targeted_fix = False
+
     for attempt in range(max_retries + 1):
         if ms["phase"] in ("write",):
-            improved = step_write(module_path, plan, model=m["write"],
-                                  rewrite=needs_rewrite,
-                                  previous_output=last_good)
+            writer_model = m["write_targeted"] if targeted_fix else m["write"]
+            try:
+                improved = step_write(module_path, plan, model=writer_model,
+                                      rewrite=needs_rewrite,
+                                      previous_output=last_good)
+            except ClaudeUnavailableError as e:
+                # Peak hours or rate limit on Claude. Pause this module cleanly:
+                # reset to audit so the next run re-derives the targeted-fix plan
+                # from fresh state, and return True so the batch runner moves on
+                # without treating this as a pipeline failure.
+                print(f"\n  ⏸ PAUSED (Claude unavailable): {e}")
+                print(f"  Module state preserved. Will resume on next run outside peak hours.")
+                ms["phase"] = "audit"  # forces full re-derivation on next run
+                ms["paused_reason"] = str(e)
+                ms["last_run"] = datetime.now(UTC).isoformat()
+                save_state(state)
+                return True
             if improved is None:
                 ms["errors"].append(f"Write failed attempt {attempt+1}")
                 save_state(state)
@@ -1131,7 +1153,11 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
                     # went 28 → 29 → 30 with D5 dropping 4→3 on one retry. As
                     # long as the module isn't in full REWRITE mode, we should
                     # be surgically patching weak dims, not regenerating.
+                    # Also flip the writer to Claude Sonnet: precision editing is
+                    # what Claude is built for, and Gemini kept regenerating the
+                    # "preserve verbatim" sections despite explicit instructions.
                     needs_rewrite = False
+                    targeted_fix = True
                     weak = [(i + 1, s) for i, s in enumerate(r_scores) if s < 4]
                     passing = [(i + 1, s) for i, s in enumerate(r_scores) if s >= 4]
                     weak_desc = ", ".join(f"D{i}={s}" for i, s in weak)
@@ -1148,12 +1174,14 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
                         f"points to, using their exact FIX suggestions verbatim where possible.\n\n"
                         f"Reviewer feedback (apply the [Dn] → FIX: blocks literally):\n{r_feedback}"
                     )
-                    print(f"  → Targeted fix mode: fixing {weak_desc}, preserving {passing_desc}, sum={r_sum}/40")
+                    print(f"  → Targeted fix mode (Claude Sonnet): fixing {weak_desc}, preserving {passing_desc}, sum={r_sum}/40")
                 elif r_valid and r_sum >= 36 and not r_has_weak:
                     # All dims ≥ 4 but verdict REJECT — qualitative nitpick.
                     # Numeric ground truth says this passes. Use improve mode
-                    # with the feedback as a focused plan.
+                    # with the feedback as a focused plan. Precision editing →
+                    # Claude Sonnet, same reasoning as targeted fix above.
                     needs_rewrite = False
+                    targeted_fix = True
                     plan = (
                         f"NITPICK FIX. Content scored {r_sum}/40, all dimensions pass "
                         f"(every score ≥ 4), but the reviewer raised a concern. "
@@ -1161,11 +1189,13 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
                         f"verbatim (sections, code, diagrams, tables, quiz questions). "
                         f"Reviewer feedback: {r_feedback}"
                     )
-                    print(f"  → Nitpick fix mode: sum={r_sum}/40, no weak dims")
+                    print(f"  → Nitpick fix mode (Claude Sonnet): sum={r_sum}/40, no weak dims")
                 else:
                     # Real quality issues — recompute needs_rewrite from latest score.
-                    # Do NOT leave it pinned from a previous iteration.
+                    # Do NOT leave it pinned from a previous iteration. Full
+                    # rewrites stay on Gemini (long-form generation strength).
                     needs_rewrite = (r_sum < 28) if r_valid else True
+                    targeted_fix = False
                     plan = f"PREVIOUS REVIEW REJECTED. Feedback: {r_feedback}. Fix these issues."
                     if not r_valid:
                         print(f"  ⚠ Review returned {len(r_scores)} scores (expected 8) — using full rewrite")


### PR DESCRIPTION
## Summary

Fixes the rewrite-whack-a-mole problem on targeted-fix retries and adds cost-protection for Claude peak pricing.

### Problem

module-1.5 has been bouncing between Codex review retries:
\`\`\`
Attempt 0: [4,2,4,3,4,4,3,4] sum=28
Attempt 1: [4,3,4,3,4,4,3,4] sum=29
Attempt 2: [4,3,4,4,3,4,4,4] sum=30  (D5 regressed 4->3)
Attempt 3: [4,3,5,3,5,4,4,5] sum=33  (close but min=3)
\`\`\`

Root cause: Gemini regenerates "preserve verbatim" sections despite explicit "DO NOT TOUCH" instructions. Long-form generation strength, but less disciplined on precision instruction-following.

### Fix 1: Claude Sonnet for surgical patches

Three model families in the loop, each playing to its strength:
- **Gemini** — initial drafts + full REWRITE mode (throughput, long-form quality)
- **Codex** — independent reviewer (catches technical errors Gemini misses)
- **Claude Sonnet** — targeted fixes + nitpick fixes (precision editing, honors preservation)

\`MODELS["write_targeted"] = "claude-sonnet-4-6"\`. A local \`targeted_fix\` flag in \`run_module\` flips True in the reject branch when building TARGETED/NITPICK FIX plans, and the next \`step_write\` call routes through Sonnet. Everything else (initial writes, full rewrites, review) is unchanged.

### Fix 2: Peak-hours refusal (14:00–20:00 local)

Anthropic charges 2x during 14:00–20:00 local time. \`dispatch_claude\` now:
- Raises \`ClaudeUnavailableError\` during peak hours (override: \`KUBEDOJO_IGNORE_PEAK_HOURS=1\`)
- Raises the same exception on terminal rate-limit / quota errors

\`run_module\` catches at the targeted-fix step:
- Prints pause reason
- Resets \`phase=audit\` (simplest resumable state — re-derives targeted plan on next run)
- Stores \`ms["paused_reason"]\`
- Returns \`True\` so batch runner continues cleanly to the next module

**Trade-off**: resumption loses one Gemini audit + one Codex review worth of progress because the targeted plan is rebuilt. Cheap vs persisting local plan/last_good across process boundaries.

## Test plan

- [x] \`python -m unittest scripts.test_pipeline\` — **43/43 pass**
- [x] Peak-hours smoke test: \`_is_claude_peak_hours()\` returns True at 19:xx local, False with override
- [ ] Next run of module-1.5 after merge (outside peak or with override): should log \`→ Targeted fix mode (Claude Sonnet): ...\` and converge

🤖 Generated with [Claude Code](https://claude.com/claude-code)