### PR TITLE
feat(dispatch): weekend peak exemption + Claude call budget

### DIFF
--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -75,31 +75,64 @@ def _is_rate_limited(text: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# Claude peak-hours pricing guard
+# Claude peak-hours pricing guard + per-run budget
 # ---------------------------------------------------------------------------
 #
-# Anthropic charges 2x for Claude API calls during peak hours (14:00-20:00
-# local time). To avoid accidental spend, the pipeline refuses to invoke
-# Claude during those hours and leaves any pending work for the next run.
-# Override with KUBEDOJO_IGNORE_PEAK_HOURS=1 if you need to force through.
+# Anthropic charges 2x for Claude API calls during weekday peak hours
+# (14:00-20:00 local). To avoid accidental spend, the pipeline refuses to
+# invoke Claude during those hours. Weekends are exempt — no peak pricing
+# applies Sat/Sun regardless of clock time.
+#
+# Separately, we cap the number of Claude calls per process to prevent a
+# stuck module or runaway retry loop from draining the user's Max-plan quota.
+# Default is 30, override via KUBEDOJO_MAX_CLAUDE_CALLS.
+#
+# Overrides:
+#   KUBEDOJO_IGNORE_PEAK_HOURS=1  → bypass peak-hours refusal
+#   KUBEDOJO_MAX_CLAUDE_CALLS=N   → change per-process call budget
 
 _CLAUDE_PEAK_START_HOUR = 14  # 14:00 local time
 _CLAUDE_PEAK_END_HOUR = 20    # 20:00 local time
+_CLAUDE_CALL_BUDGET_DEFAULT = 30
+_claude_call_count = 0
 
 
 class ClaudeUnavailableError(Exception):
-    """Raised when a Claude call is blocked (peak hours) or fails terminally
-    (rate limit / quota). The pipeline catches this and pauses the affected
-    module so it can resume on the next run without losing state."""
+    """Raised when a Claude call is blocked (peak hours / budget) or fails
+    terminally (rate limit / quota). The pipeline catches this and pauses the
+    affected module so it can resume on the next run without losing state."""
 
 
 def _is_claude_peak_hours() -> bool:
-    """Return True if current local time falls inside the 14:00-20:00 peak
-    window. KUBEDOJO_IGNORE_PEAK_HOURS=1 disables the check."""
+    """Return True if current local time is inside weekday peak hours
+    (14:00-20:00 Mon-Fri). Weekends are always off-peak.
+    KUBEDOJO_IGNORE_PEAK_HOURS=1 disables the check entirely."""
     if os.environ.get("KUBEDOJO_IGNORE_PEAK_HOURS", "") == "1":
         return False
-    hour = datetime.now().hour
-    return _CLAUDE_PEAK_START_HOUR <= hour < _CLAUDE_PEAK_END_HOUR
+    now = datetime.now()
+    if now.weekday() >= 5:  # Sat=5, Sun=6
+        return False
+    return _CLAUDE_PEAK_START_HOUR <= now.hour < _CLAUDE_PEAK_END_HOUR
+
+
+def _claude_call_budget() -> int:
+    """Max Claude calls allowed per process. Read from env var on each call
+    so the user can tune mid-session without restarting."""
+    raw = os.environ.get("KUBEDOJO_MAX_CLAUDE_CALLS", "")
+    if raw.isdigit():
+        return int(raw)
+    return _CLAUDE_CALL_BUDGET_DEFAULT
+
+
+def _check_claude_budget() -> None:
+    """Raise ClaudeUnavailableError if we've already hit the per-process
+    Claude call budget. Counter is incremented on each successful dispatch."""
+    budget = _claude_call_budget()
+    if _claude_call_count >= budget:
+        raise ClaudeUnavailableError(
+            f"Claude call budget exhausted: {_claude_call_count}/{budget} "
+            f"calls this run. Override: KUBEDOJO_MAX_CLAUDE_CALLS=<N>."
+        )
 
 
 def _pace_gemini_calls() -> None:
@@ -288,20 +321,25 @@ def dispatch_claude(prompt: str, model: str = CLAUDE_DEFAULT_MODEL,
     """Call Claude CLI directly. Returns (success, output).
 
     Raises:
-        ClaudeUnavailableError: during 14:00-20:00 local peak-hours (2x pricing)
-            or on terminal rate-limit / quota errors. The pipeline catches this
+        ClaudeUnavailableError: during weekday 14:00-20:00 local peak-hours
+            (2x pricing), when the per-process call budget is exhausted, or
+            on terminal rate-limit / quota errors. The pipeline catches this
             and pauses the affected module so it can resume on the next run.
     """
+    global _claude_call_count
+
     if _is_claude_peak_hours():
         hour = datetime.now().hour
         msg = (
             f"Claude peak hours in effect ({_CLAUDE_PEAK_START_HOUR}:00-"
-            f"{_CLAUDE_PEAK_END_HOUR}:00 local, currently {hour:02d}:xx). "
+            f"{_CLAUDE_PEAK_END_HOUR}:00 local Mon-Fri, currently {hour:02d}:xx). "
             f"Refusing to dispatch to avoid 2x pricing. "
             f"Set KUBEDOJO_IGNORE_PEAK_HOURS=1 to override."
         )
         print(f"⏸ {msg}", file=sys.stderr)
         raise ClaudeUnavailableError(msg)
+
+    _check_claude_budget()
 
     cmd = [
         "npx", "@anthropic-ai/claude-code@latest", "-p",
@@ -333,7 +371,10 @@ def dispatch_claude(prompt: str, model: str = CLAUDE_DEFAULT_MODEL,
                 )
             return False, result.stderr
         output = result.stdout.strip()
+        _claude_call_count += 1
         _log("claude", model, prompt, output, True, elapsed)
+        budget = _claude_call_budget()
+        print(f"  Claude call {_claude_call_count}/{budget} used", file=sys.stderr)
         return True, output
 
     except FileNotFoundError:


### PR DESCRIPTION
## Summary

Two guardrails on top of PR #212 to protect Claude Max-plan quota.

### Weekend exemption

Anthropic's 2x peak-hours pricing only applies Mon–Fri. \`_is_claude_peak_hours()\` now returns \`False\` for Sat/Sun even when the hour is in the 14:00–20:00 window.

Verified on Saturday 19:25 → \`is_peak=False\`.

### Per-run Claude call budget

Stuck modules or runaway retry loops could drain the Max-plan message quota. New per-process counter:

- \`_claude_call_count\` increments on each successful \`dispatch_claude\`
- \`_check_claude_budget()\` raises \`ClaudeUnavailableError\` at \`count >= budget\`
- **Default: 30 calls per run**
- Override: \`KUBEDOJO_MAX_CLAUDE_CALLS=<N>\`
- Reuses the existing pause-and-resume path (PR #212)
- Logs \`Claude call N/budget used\` after each successful call

Rationale for 30: phase 2 = 21 modules × ~0–2 targeted-fix calls typical = ~30 with headroom. Stuck modules exhaust budget quickly, triggering a pause rather than chewing through the whole quota.

## Test plan

- [x] \`python -m unittest scripts.test_pipeline\` — 43/43 pass
- [x] Smoke: Saturday 19:25 → \`is_peak: False\` ✓
- [x] Smoke: budget 29/30 → ok, 30/30 → raises ✓
- [x] Smoke: \`KUBEDOJO_MAX_CLAUDE_CALLS=5\` → budget=5 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)