### PR TITLE
fix(pipeline): step_write and step_update_index now use dispatch_auto

### DIFF
--- a/scripts/v1_pipeline.py
+++ b/scripts/v1_pipeline.py
@@ -507,7 +507,13 @@ def step_write(module_path: Path, plan: str, model: str = MODELS["write"],
     else:
         prompt = WRITE_PROMPT_TEMPLATE.format(plan=plan, content=content)
 
-    ok, output = dispatch_gemini_with_retry(prompt, model=model, timeout=900)
+    # Must use dispatch_auto (not dispatch_gemini_with_retry directly) so that
+    # Claude Sonnet is actually called for targeted-fix mode. Previously this
+    # was hardcoded to Gemini, which caused `model="claude-sonnet-4-6"` to be
+    # passed to the Gemini CLI, fail with ModelNotFoundError, and silently
+    # fall back to Gemini's "auto" model — completely defeating the point of
+    # routing precision edits to Claude (PR #212).
+    ok, output = dispatch_auto(prompt, model=model, timeout=900)
 
     if not ok or not output.strip():
         print(f"  ❌ WRITE failed")
@@ -668,7 +674,7 @@ def step_update_index(section_path: Path, model: str = MODELS["write"]) -> bool:
     )
 
     print(f"\n  INDEX: {rel_section} (using {model})")
-    ok, output = dispatch_gemini_with_retry(prompt, model=model, timeout=600)
+    ok, output = dispatch_auto(prompt, model=model, timeout=600)
 
     if not ok or not output.strip():
         print(f"  ❌ INDEX rewrite failed")


### PR DESCRIPTION
## Summary

PR #212 introduced Claude Sonnet as the targeted-fix writer, but \`step_write\` was still hardcoded to call \`dispatch_gemini_with_retry\` directly. When the pipeline passed \`model='claude-sonnet-4-6'\` to \`step_write\`, the Gemini CLI received the name, errored with \`ModelNotFoundError\`, and fell back to Gemini's \`auto\` — **completely defeating the point of routing precision edits to Claude.**

## Evidence (module-1.5 retry log)

\`\`\`
→ Targeted fix mode (Claude Sonnet): fixing D2=3, D4=3, D7=3, ...
WRITE: module-1.5 (using claude-sonnet-4-6)
Gemini error (exit 1): ModelNotFoundError: Requested entity was not found
Retrying with fallback model: auto
✓ WRITE produced 50669 chars    ← still Gemini, NOT Sonnet
\`\`\`

## Fix

\`step_write\` and \`step_update_index\` now route through \`dispatch_auto\`, which dispatches by model prefix (\`gemini\` / \`claude\` / \`codex\`) — the same way \`step_review\` and \`step_audit\` already do.

## Test plan

- [x] \`python -m unittest scripts.test_pipeline\` — 43/43 pass
- [ ] Next module-1.5 retry after merge: log line should show the write produced by Sonnet, and since Sonnet actually honors \`DO NOT TOUCH\` instructions, no passing dims should regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)