### PR TITLE
feat(pipeline): print full review feedback + per-dim breakdown

### DIFF
--- a/scripts/v1_pipeline.py
+++ b/scripts/v1_pipeline.py
@@ -848,9 +848,25 @@ def step_review(module_path: Path, improved: str, model: str = MODELS["review"])
 
     print(f"  Verdict: {verdict}")
     if scores:
-        print(f"  Scores: {scores} (sum: {sum(scores)})")
+        dim_labels = [
+            "Pedagogy", "Accuracy", "Depth", "Practical",
+            "Assessment", "Coverage", "Production", "Practitioner",
+        ]
+        per_dim = "  ".join(
+            f"D{i+1}({dim_labels[i][:4]})={s}" for i, s in enumerate(scores)
+        )
+        print(f"  Scores: {scores} (sum: {sum(scores)}/40)")
+        print(f"          {per_dim}")
     if feedback:
-        print(f"  Feedback: {feedback[:200]}")
+        # Print the full feedback verbatim — operators need to read it to
+        # understand why the reviewer rejected and what the FIX blocks say.
+        # The dispatch log also stores it, but surfacing in the run log keeps
+        # the debugging loop tight.
+        print(f"  Feedback:")
+        print(f"  {'─' * 70}")
+        for line in feedback.splitlines() or [feedback]:
+            print(f"  {line}")
+        print(f"  {'─' * 70}")
 
     return result
 


### PR DESCRIPTION
## Summary

\`step_review\` was truncating reviewer feedback to 200 chars, making it impossible to read the \`[Dn] → FIX:\` blocks Codex returns. Operators need to see the full feedback verbatim to verify Sonnet is applying the fix suggestions correctly.

## Changes

**Per-dim score breakdown:**
\`\`\`
Scores: [4, 3, 5, 3, 5, 4, 4, 5] (sum: 33/40)
        D1(Peda)=4  D2(Accu)=3  D3(Dept)=5  D4(Prac)=3  ...
\`\`\`

**Full feedback printed verbatim with visual brackets:**
\`\`\`
Feedback:
──────────────────────────────────────────────────────
[D2] VPA section claims recs come from Prometheus → FIX: replace with ...
[D4] Lab Task 3 uses naked Pod → FIX: use Deployment YAML ...
──────────────────────────────────────────────────────
\`\`\`

## Test plan

- [x] \`python -m unittest scripts.test_pipeline\` — 43/43 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)