### PR TITLE
feat(pipeline): peak-hours pause + resume from staging (Flavor B)

### DIFF
--- a/scripts/test_pipeline.py
+++ b/scripts/test_pipeline.py
@@ -780,6 +780,65 @@ class TestPipelineTransitions(unittest.TestCase):
         # audit + review dispatches both fired
         self.assertEqual(mock_dispatch.call_count, 2)
 
+    @patch("v1_pipeline.STATE_FILE")
+    @patch("v1_pipeline.dispatch_auto")
+    @patch("v1_pipeline.CONTENT_ROOT")
+    @patch("subprocess.run")
+    def test_needs_targeted_fix_resumes_from_staging(
+        self, mock_subprocess, mock_root, mock_dispatch, mock_state,
+    ):
+        """phase=needs_targeted_fix resumes at write step with staged content.
+
+        Verifies the peak-hours pause/resume flow (Flavor B): when a module
+        was paused mid-targeted-fix because Claude was unavailable, the next
+        run should load the staged Gemini draft + saved plan, skip audit +
+        initial write + initial review, and jump straight into the
+        targeted-fix retry loop.
+        """
+        import v1_pipeline as p
+
+        mock_state.__class__ = type(self.state_file)
+        mock_root.resolve.return_value = Path(self.tmpdir).resolve()
+
+        # Only the targeted-fix write + its re-review should fire on resume.
+        # No audit, no initial write, no initial review.
+        mock_dispatch.side_effect = [
+            # Claude Sonnet write (targeted fix applied)
+            (True, GOOD_MODULE),
+            # Codex re-review (approve)
+            self._mock_review_approve(),
+        ]
+
+        # Pre-stage a Gemini draft where the pause happened.
+        staging = self.module_path.with_suffix(".staging.md")
+        staging.write_text(GOOD_MODULE)
+
+        state = {
+            "modules": {
+                "test/module-0.1-test": {
+                    "phase": "needs_targeted_fix",
+                    "plan": "TARGETED FIX. D2=3 weak — fix per reviewer feedback.",
+                    "targeted_fix": True,
+                    "paused_reason": "Claude peak hours",
+                    "scores": [4, 3, 4, 4, 4, 4, 4, 4],
+                    "sum": 31,
+                    "errors": [],
+                },
+            },
+        }
+
+        with patch.object(p, "STATE_FILE", self.state_file), \
+             patch.object(p, "CONTENT_ROOT", Path(self.tmpdir)), \
+             patch.object(p, "save_state"):
+            with patch.object(p, "module_key_from_path", return_value="test/module-0.1-test"):
+                p.run_module(self.module_path, state)
+
+        ms = state["modules"]["test/module-0.1-test"]
+        self.assertEqual(ms.get("phase"), "done", "Should converge after targeted fix + re-review")
+        # Exactly 2 dispatch calls: targeted-fix write + re-review. NO audit, NO initial write.
+        self.assertEqual(mock_dispatch.call_count, 2,
+                         "Should skip audit + initial write + initial review; only write + review fire")
+
     def test_dry_run_does_not_modify_files(self):
         """Dry run should audit but not write any files."""
         import v1_pipeline as p

--- a/scripts/v1_pipeline.py
+++ b/scripts/v1_pipeline.py
@@ -143,8 +143,13 @@ MODELS = {
 # fallback to keep the pipeline moving but flags the module for re-review.
 INDEPENDENT_REVIEWER_FAMILIES = {"codex", "claude"}
 
-# Pipeline phases in order
-PHASES = ["pending", "audit", "write", "review", "check", "score", "done"]
+# Pipeline phases in order.
+# "needs_targeted_fix" is a pause state entered when Claude is unavailable
+# (peak hours / rate limit / budget) mid retry-loop. On resume, it loads the
+# staged content + saved plan and transitions back to "write" to re-enter
+# the targeted-fix retry path without re-running audit or initial write.
+PHASES = ["pending", "audit", "write", "review", "needs_targeted_fix",
+          "check", "score", "done"]
 
 # ---------------------------------------------------------------------------
 # State management
@@ -976,6 +981,24 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
             print(f"  ✓ Already done: {total}/40 reviewer={reviewer} — skipping")
             return True
 
+    # Peak-hours pause resume. A module paused mid-targeted-fix has its
+    # staged Gemini draft on disk and its plan saved in state. Transition
+    # back to phase=write so the resume branch below loads them correctly
+    # and re-enters the write→review loop at the targeted-fix step (no
+    # re-audit, no re-initial-write, no re-review).
+    if ms["phase"] == "needs_targeted_fix":
+        staging_path = module_path.with_suffix(".staging.md")
+        if staging_path.exists() and ms.get("plan"):
+            print(f"  ↻ Resuming targeted fix from peak-hours pause")
+            ms["phase"] = "write"
+            save_state(state)
+        else:
+            print(f"  ⚠ needs_targeted_fix phase but staging/plan missing — restarting from audit")
+            ms["phase"] = "audit"
+            ms.pop("plan", None)
+            ms.pop("targeted_fix", None)
+            save_state(state)
+
     # AUDIT+PLAN
     if ms["phase"] in ("pending", "audit"):
         audit = step_audit(module_path, model=m["audit"])
@@ -1024,28 +1047,39 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
             save_state(state)
             improved = None
             last_good = None
+        # Fresh audit path never starts in targeted_fix mode.
+        targeted_fix = False
     else:
-        # Resuming — reconstruct plan from state
-        plan = f"Resume improvement. Last scores: {ms.get('scores', 'unknown')}."
-        improved = None
-        last_good = None
+        # Resuming. Two flavors:
+        # 1. Peak-hours pause resume: state has `plan` + staging file from
+        #    the previous run's Gemini draft. Load them and jump straight
+        #    back into the retry loop at the targeted-fix step (no re-audit,
+        #    no re-initial-write, no re-review — we already have the plan).
+        # 2. Generic resume (interrupted mid-loop in a non-Claude run):
+        #    fall back to a generic "Resume improvement" plan and re-run
+        #    from disk content.
+        staging_path = module_path.with_suffix(".staging.md")
+        if ms.get("plan") and staging_path.exists():
+            plan = ms["plan"]
+            improved = staging_path.read_text()
+            last_good = improved
+            targeted_fix = ms.get("targeted_fix", False)
+            mode = "targeted fix" if targeted_fix else "improve"
+            print(f"  Loaded staged content ({len(improved)} chars) and saved {mode} plan")
+        else:
+            plan = f"Resume improvement. Last scores: {ms.get('scores', 'unknown')}."
+            improved = None
+            last_good = None
+            targeted_fix = False
 
     # WRITE → REVIEW loop (max retries)
     # Auto-detect rewrite mode: score < 28 means "improve" won't cut it.
-    # `improved` and `last_good` are already initialized above (either to
-    # on-disk content when audit passed, or to None when audit failed or
-    # when resuming). `last_good` holds the most recent successful WRITE
-    # output across retries so a REJECT followed by a rewrite improves the
-    # prior attempt instead of starting from scratch.
+    # `improved`, `last_good`, and `targeted_fix` are initialized above by
+    # the fresh-audit or resume branches; DO NOT re-initialize here or
+    # targeted-fix resume state will be lost.
     needs_rewrite = (ms.get("sum") or 0) < 28
     if needs_rewrite:
         print(f"  Score {ms.get('sum')}/40 < 28 — using REWRITE mode")
-
-    # targeted_fix starts False; flips True when the REVIEW branch below
-    # routes a reject through the "TARGETED FIX" path. When True, the writer
-    # switches from Gemini (primary) to Claude Sonnet (precision editor) to
-    # reduce dim regression on surgical patches.
-    targeted_fix = False
 
     for attempt in range(max_retries + 1):
         if ms["phase"] in ("write",):
@@ -1055,13 +1089,29 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
                                       rewrite=needs_rewrite,
                                       previous_output=last_good)
             except ClaudeUnavailableError as e:
-                # Peak hours or rate limit on Claude. Pause this module cleanly:
-                # reset to audit so the next run re-derives the targeted-fix plan
-                # from fresh state, and return True so the batch runner moves on
-                # without treating this as a pipeline failure.
+                # Peak hours / rate limit / budget exhausted on Claude. Pause
+                # this module cleanly so it resumes at the targeted-fix step
+                # on the next run outside peak hours, WITHOUT re-running
+                # audit, initial write, or initial review:
+                #
+                # - Stage `last_good` (the latest Gemini draft from the
+                #   initial write or prior retry) to <module>.staging.md
+                # - Save the targeted-fix `plan` to ms["plan"]
+                # - Save the `targeted_fix` flag so the resume path routes
+                #   the writer to Claude
+                # - Set phase=needs_targeted_fix as a pause marker
+                # - Return True so the batch runner moves on cleanly
                 print(f"\n  ⏸ PAUSED (Claude unavailable): {e}")
-                print(f"  Module state preserved. Will resume on next run outside peak hours.")
-                ms["phase"] = "audit"  # forces full re-derivation on next run
+                print(f"  Progress preserved — will resume at targeted-fix step on next run.")
+                staging_path = module_path.with_suffix(".staging.md")
+                if last_good:
+                    staging_path.write_text(last_good)
+                    print(f"  Staged {len(last_good)} chars to {staging_path.name}")
+                else:
+                    print(f"  ⚠ No last_good content to stage — resume will restart from audit")
+                ms["phase"] = "needs_targeted_fix"
+                ms["plan"] = plan
+                ms["targeted_fix"] = targeted_fix
                 ms["paused_reason"] = str(e)
                 ms["last_run"] = datetime.now(UTC).isoformat()
                 save_state(state)


### PR DESCRIPTION
## Summary

Makes phase 2 productive during weekday peak hours (14:00–20:00). Previously, a Claude-unavailable pause reset \`phase=audit\` and wasted the next run re-doing audit + initial write + initial review before getting back to the targeted-fix step. **Flavor B preserves all prior work** so the resume is zero-waste.

## How it works

**On pause** (Claude unavailable during targeted-fix retry):
1. Stage \`last_good\` (Gemini's latest draft) to \`<module>.staging.md\`
2. Save \`plan\` + \`targeted_fix\` flag to state
3. Set \`phase=needs_targeted_fix\`
4. Return \`True\` → batch runner continues to next module

**On resume** (next run outside peak):
1. Detect \`phase=needs_targeted_fix\` at entry
2. Transition to \`phase=write\` + load staged content as \`improved\` / \`last_good\`
3. Load saved \`plan\` and \`targeted_fix=True\`
4. Jump straight into the retry loop at the write step
5. Sonnet applies the targeted fix → Codex re-reviews → converges

**Zero wasted API calls**: no re-audit, no re-initial-write, no re-initial-review.

## Test

New \`test_needs_targeted_fix_resumes_from_staging\` asserts exactly 2 dispatch calls fire on resume (write + re-review) — NOT the 4 a fresh cycle would fire.

**44/44 tests pass** (up from 43).

## Operator impact

Weekday 14:00–20:00: phase 2 runs initial Gemini drafts + Codex reviews unimpeded. Modules needing a Claude targeted-fix stage their draft, advance the batch, and get picked up at the targeted-fix step on the next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)