### PR TITLE
feat(pipeline): knowledge cards for web-grounded writes (#217)

### DIFF
--- a/scripts/generate_knowledge_card.py
+++ b/scripts/generate_knowledge_card.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Generate web-grounded knowledge cards for KubeDojo modules."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+
+import yaml
+
+from dispatch import dispatch_codex, _is_rate_limited
+
+REPO_ROOT = Path(__file__).parent.parent
+KNOWLEDGE_CARD_DIR = REPO_ROOT / ".pipeline" / "knowledge-cards"
+
+REQUIRED_FRONTMATTER_KEYS = {
+    "topic",
+    "module_key",
+    "generated_by",
+    "generated_at",
+    "expires",
+}
+
+
+def sanitize_module_key(module_key: str) -> str:
+    """Convert a module key into a stable knowledge-card filename."""
+    return module_key.replace("/", "__")
+
+
+def knowledge_card_path(module_key: str) -> Path:
+    """Return the cached knowledge-card path for a module key."""
+    return KNOWLEDGE_CARD_DIR / f"{sanitize_module_key(module_key)}.md"
+
+
+def strip_markdown_fences(text: str) -> str:
+    """Strip optional ```markdown fences from Codex output."""
+    text = text.strip()
+    if text.startswith("```markdown"):
+        text = text[len("```markdown"):].strip()
+    elif text.startswith("```md"):
+        text = text[len("```md"):].strip()
+    elif text.startswith("```"):
+        text = text[3:].strip()
+    if text.endswith("```"):
+        text = text[:-3].strip()
+    return text
+
+
+def extract_frontmatter(content: str) -> dict:
+    """Parse YAML frontmatter from markdown content."""
+    if not content.startswith("---\n"):
+        return {}
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return {}
+    try:
+        data = yaml.safe_load(parts[1]) or {}
+    except yaml.YAMLError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def extract_topic_line(content: str) -> str | None:
+    """Extract the scaffolded Topic blockquote, if present."""
+    match = re.search(r"^>\s*\*\*Topic\*\*:\s*(.+)$", content, re.MULTILINE)
+    if not match:
+        return None
+    return match.group(1).strip()
+
+
+def extract_learning_outcomes(content: str) -> str:
+    """Extract the Learning Outcomes section as prompt context."""
+    match = re.search(
+        r"^## Learning Outcomes\s*\n(?P<body>[\s\S]*?)(?=^##\s|\Z)",
+        content,
+        re.MULTILINE,
+    )
+    if not match:
+        return "(No Learning Outcomes section found.)"
+    return match.group("body").strip()
+
+
+def is_expired(card_content: str, today: datetime | None = None) -> bool:
+    """Return True if the card is expired or malformed."""
+    data = extract_frontmatter(card_content)
+    expires = data.get("expires")
+    if isinstance(expires, datetime):
+        expires_at = expires.date()
+    elif isinstance(expires, date):
+        expires_at = expires
+    elif isinstance(expires, str):
+        try:
+            expires_at = datetime.fromisoformat(expires).date()
+        except ValueError:
+            return True
+    else:
+        return True
+    if not isinstance(expires_at, date):
+        return True
+    check_date = (today or datetime.now(UTC)).date()
+    return expires_at < check_date
+
+
+def build_prompt(module_key: str, title: str, topic_hint: str,
+                 learning_outcomes: str, generated_at: str,
+                 expires: str) -> str:
+    """Build the Codex prompt for a knowledge card."""
+    return f"""You are generating a KubeDojo knowledge card that will be injected into a WRITE prompt before another model drafts course content.
+
+Use CURRENT web research before answering. Prefer authoritative primary sources:
+- kubernetes.io docs
+- CNCF project pages / announcements
+- official project docs
+- official GitHub repos / release notes
+- official vendor docs only when the topic is vendor-specific
+
+Goal: produce a concise but opinionated grounding card that helps the writer avoid factual drift and stale-cutoff mistakes. The most valuable section is `## Do not`, which should explicitly forbid common hallucinations, deprecated APIs, and outdated project status claims.
+
+Return ONLY markdown. Do not wrap the answer in fences. Follow this exact shape:
+
+```markdown
+---
+topic: "On-prem FinOps and chargeback with OpenCost, Kubecost, and VPA"
+module_key: "on-premises/planning/module-1.5-onprem-finops-chargeback"
+generated_by: "codex"
+generated_at: "{generated_at}"
+expires: "{expires}"
+---
+
+## Current status (as of generated_at)
+- Bullet points with current, source-grounded facts
+
+## Authoritative sources
+- https://example.com/path — short note on what this source confirms
+
+## Do not
+- Hard blocks against known bad claims or stale examples
+```
+
+Requirements:
+- Keep the card roughly 1-3k tokens
+- Frontmatter values must use:
+  - module_key: "{module_key}"
+  - generated_by: "codex"
+  - generated_at: "{generated_at}"
+  - expires: "{expires}"
+- Include at least 3 bullets in `## Current status`
+- Include at least 3 sources in `## Authoritative sources`
+- Include at least 3 bullets in `## Do not`
+- The `topic` should be specific to this module, not generic Kubernetes
+- If a fact is uncertain or version-sensitive, phrase it conservatively and push verification into `## Do not`
+
+Module context:
+- Module key: {module_key}
+- Title: {title}
+- Topic hint: {topic_hint}
+
+Learning Outcomes:
+{learning_outcomes}
+"""
+
+
+def validate_card(card_content: str, module_key: str) -> None:
+    """Validate the returned card shape."""
+    data = extract_frontmatter(card_content)
+    missing = REQUIRED_FRONTMATTER_KEYS - set(data.keys())
+    if missing:
+        raise ValueError(f"Knowledge card missing frontmatter keys: {sorted(missing)}")
+    if data.get("module_key") != module_key:
+        raise ValueError(
+            f"Knowledge card module_key mismatch: expected {module_key!r}, "
+            f"got {data.get('module_key')!r}"
+        )
+    if data.get("generated_by") != "codex":
+        raise ValueError("Knowledge card generated_by must be 'codex'")
+    do_not = re.search(
+        r"^## Do not\s*\n(?P<body>[\s\S]*?)(?=^##\s|\Z)",
+        card_content,
+        re.MULTILINE,
+    )
+    if not do_not:
+        raise ValueError("Knowledge card missing '## Do not' section")
+    bullets = re.findall(r"^- ", do_not.group("body"), re.MULTILINE)
+    if not bullets:
+        raise ValueError("Knowledge card must include at least one '## Do not' bullet")
+
+
+def generate(module_key: str, *, if_missing: bool = False, force: bool = False,
+             model: str = "codex", timeout: int = 900) -> str | None:
+    """Generate a knowledge card for a single module key."""
+    card_path = knowledge_card_path(module_key)
+    if if_missing and not force and card_path.exists():
+        existing = card_path.read_text()
+        if not is_expired(existing):
+            return existing
+
+    from v1_pipeline import find_module_path
+
+    module_path = find_module_path(module_key)
+    if module_path is None:
+        print(f"  ⚠ Knowledge card skipped — module not found: {module_key}")
+        return None
+
+    module_content = module_path.read_text()
+    frontmatter = extract_frontmatter(module_content)
+    title = str(frontmatter.get("title", module_key)).strip()
+    topic_hint = extract_topic_line(module_content) or title
+    learning_outcomes = extract_learning_outcomes(module_content)
+
+    today = datetime.now(UTC).date()
+    generated_at = today.isoformat()
+    expires = (today + timedelta(days=90)).isoformat()
+    prompt = build_prompt(
+        module_key=module_key,
+        title=title,
+        topic_hint=topic_hint,
+        learning_outcomes=learning_outcomes,
+        generated_at=generated_at,
+        expires=expires,
+    )
+
+    ok, output = dispatch_codex(prompt, model=model, timeout=timeout)
+    if not ok:
+        reason = "rate-limited" if _is_rate_limited(output) else "unavailable"
+        summary = (output or "").strip().splitlines()
+        hint = f": {summary[0][:160]}" if summary else ""
+        print(f"  ⚠ Knowledge card generation {reason}{hint}")
+        return None
+
+    card = strip_markdown_fences(output)
+    try:
+        validate_card(card, module_key)
+    except ValueError as exc:
+        print(f"  ⚠ Knowledge card validation failed: {exc}")
+        return None
+
+    card_path.parent.mkdir(parents=True, exist_ok=True)
+    card_path.write_text(card)
+    print(f"  ✓ Knowledge card written: {card_path}")
+    return card
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate a knowledge card for one module")
+    parser.add_argument("module_key", help="Module key, e.g. on-premises/planning/module-1.5-foo")
+    parser.add_argument("--if-missing", action="store_true",
+                        help="Only generate when the cached card is missing or expired")
+    parser.add_argument("--force", action="store_true",
+                        help="Regenerate even if a fresh cached card already exists")
+    args = parser.parse_args()
+
+    card = generate(
+        args.module_key,
+        if_missing=args.if_missing,
+        force=args.force,
+    )
+    if card is None:
+        return 1
+
+    sys.stdout.write(card)
+    if not card.endswith("\n"):
+        sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_pipeline.py
+++ b/scripts/test_pipeline.py
@@ -17,8 +17,11 @@ import shutil
 import tempfile
 import textwrap
 import unittest
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import patch
+
+import yaml
 
 # Ensure scripts/ is on the path
 import sys
@@ -865,12 +868,14 @@ class TestPipelineTransitions(unittest.TestCase):
             {"verdict": "APPROVE", "scores": [4, 4, 4, 4, 4, 4, 4, 5], "feedback": ""},
         ]
 
-        def fake_step_write(module_path, plan, model=None, rewrite=False, previous_output=None):
+        def fake_step_write(module_path, plan, model=None, rewrite=False,
+                            previous_output=None, knowledge_card=None):
             write_calls.append({
                 "plan": plan,
                 "model": model,
                 "rewrite": rewrite,
                 "previous_output": previous_output,
+                "knowledge_card": knowledge_card,
             })
             return GOOD_MODULE
 
@@ -950,6 +955,199 @@ class TestTrackAliases(unittest.TestCase):
     def test_track_from_key_specialty(self):
         import v1_pipeline as p
         self.assertEqual(p._track_from_key("k8s/pca/module-1"), "specialty")
+
+
+# ---------------------------------------------------------------------------
+# Test: Knowledge cards
+# ---------------------------------------------------------------------------
+
+class TestKnowledgeCards(unittest.TestCase):
+    """Test knowledge-card generation, caching, and prompt injection."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.repo_root = Path(self.tmpdir)
+        self.content_root = self.repo_root / "src" / "content" / "docs"
+        self.content_root.mkdir(parents=True, exist_ok=True)
+        self.card_dir = self.repo_root / ".pipeline" / "knowledge-cards"
+        self.module_key = "on-premises/planning/module-1.5-onprem-finops-chargeback"
+        self.module_path = self.content_root / "on-premises" / "planning" / "module-1.5-onprem-finops-chargeback.md"
+        self.module_path.parent.mkdir(parents=True, exist_ok=True)
+        self.module_path.write_text(textwrap.dedent("""\
+        ---
+        title: "Module 1.5: On-Prem FinOps & Chargeback"
+        slug: on-premises/planning/module-1.5-onprem-finops-chargeback
+        sidebar:
+          order: 105
+        ---
+
+        > **Topic**: On-prem FinOps and chargeback with OpenCost, Kubecost, and VPA
+
+        ## Learning Outcomes
+
+        By the end of this module, you will be able to:
+        - Explain OpenCost pricing inputs on bare metal
+        - Compare showback and chargeback trade-offs
+        - Validate rightsizing and VPA recommendation sources
+        """))
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _card_path(self):
+        import v1_pipeline as p
+        return self.card_dir / f"{p.sanitize_module_key(self.module_key)}.md"
+
+    def _build_card(self, *, generated_at: str | None = None,
+                    expires: str | None = None) -> str:
+        today = datetime.now(UTC).date()
+        generated_at = generated_at or today.isoformat()
+        expires = expires or (today + timedelta(days=30)).isoformat()
+        return textwrap.dedent(f"""\
+        ---
+        topic: "On-prem FinOps and chargeback with OpenCost, Kubecost, and VPA"
+        module_key: "{self.module_key}"
+        generated_by: "codex"
+        generated_at: "{generated_at}"
+        expires: "{expires}"
+        ---
+
+        ## Current status (as of generated_at)
+        - OpenCost is a CNCF Incubating project and not a sandbox project.
+        - Current OpenCost custom pricing uses `costModel` keys like `CPU`, `RAM`, `GPU`, and `storage`.
+        - VPA recommendations are surfaced on VerticalPodAutoscaler status.
+
+        ## Authoritative sources
+        - https://www.opencost.io/docs/configuration — current custom pricing schema and examples.
+        - https://kyverno.io/docs/writing-policies/validate/ — current policy authoring guidance and deprecation path.
+        - https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler — VPA components and recommendation flow.
+
+        ## Do not
+        - Call OpenCost a CNCF sandbox project.
+        - Invent `cpuHourlyCost` or `ramHourlyCost` fields in OpenCost custom pricing examples.
+        - Say VPA recommendations come from Prometheus instead of the VPA recommender path.
+        """)
+
+    def test_knowledge_card_written_with_correct_schema(self):
+        """Generator writes a schema-valid knowledge card to the cache."""
+        import generate_knowledge_card as g
+        import v1_pipeline as p
+
+        with patch.object(p, "CONTENT_ROOT", self.content_root), \
+             patch.object(p, "KNOWLEDGE_CARD_DIR", self.card_dir), \
+             patch.object(g, "KNOWLEDGE_CARD_DIR", self.card_dir), \
+             patch.object(g, "dispatch_codex", return_value=(True, f"```markdown\n{self._build_card()}\n```")):
+            card = g.generate(self.module_key, force=True)
+
+        self.assertIsNotNone(card)
+        card_path = self._card_path()
+        self.assertTrue(card_path.exists(), "Knowledge card should be written to disk")
+        frontmatter = yaml.safe_load(card_path.read_text().split("---", 2)[1])
+        for key in ("topic", "module_key", "generated_by", "generated_at", "expires"):
+            self.assertIn(key, frontmatter)
+        self.assertEqual(frontmatter["module_key"], self.module_key)
+        self.assertIn("## Do not", card_path.read_text())
+
+    def test_knowledge_card_cached_when_fresh(self):
+        """Fresh cached cards should be reused without calling Codex."""
+        import generate_knowledge_card as g
+        import v1_pipeline as p
+
+        self.card_dir.mkdir(parents=True, exist_ok=True)
+        existing = self._build_card()
+        self._card_path().write_text(existing)
+        ms = {}
+
+        with patch.object(p, "CONTENT_ROOT", self.content_root), \
+             patch.object(p, "KNOWLEDGE_CARD_DIR", self.card_dir), \
+             patch.object(g, "KNOWLEDGE_CARD_DIR", self.card_dir), \
+             patch.object(g, "dispatch_codex") as mock_codex:
+            card = p.ensure_knowledge_card(self.module_path, ms)
+
+        self.assertEqual(card, existing)
+        self.assertEqual(mock_codex.call_count, 0, "Fresh cache should skip Codex")
+        self.assertNotIn("stale_knowledge_card", ms)
+
+    def test_knowledge_card_regenerated_when_expired(self):
+        """Expired cached cards should trigger regeneration."""
+        import generate_knowledge_card as g
+        import v1_pipeline as p
+
+        self.card_dir.mkdir(parents=True, exist_ok=True)
+        expired = self._build_card(
+            generated_at=(datetime.now(UTC).date() - timedelta(days=120)).isoformat(),
+            expires=(datetime.now(UTC).date() - timedelta(days=1)).isoformat(),
+        )
+        fresh = self._build_card()
+        self._card_path().write_text(expired)
+        ms = {}
+
+        with patch.object(p, "CONTENT_ROOT", self.content_root), \
+             patch.object(p, "KNOWLEDGE_CARD_DIR", self.card_dir), \
+             patch.object(g, "KNOWLEDGE_CARD_DIR", self.card_dir), \
+             patch.object(g, "dispatch_codex", return_value=(True, fresh)) as mock_codex:
+            card = p.ensure_knowledge_card(self.module_path, ms)
+
+        self.assertEqual(card.strip(), fresh.strip())
+        self.assertEqual(mock_codex.call_count, 1)
+        self.assertEqual(self._card_path().read_text().strip(), fresh.strip())
+        self.assertNotIn("stale_knowledge_card", ms)
+
+    def test_knowledge_card_codex_rate_limited_uses_stale(self):
+        """Expired stale card should be reused when Codex is rate-limited."""
+        import generate_knowledge_card as g
+        import v1_pipeline as p
+
+        self.card_dir.mkdir(parents=True, exist_ok=True)
+        stale = self._build_card(
+            generated_at=(datetime.now(UTC).date() - timedelta(days=120)).isoformat(),
+            expires=(datetime.now(UTC).date() - timedelta(days=1)).isoformat(),
+        )
+        self._card_path().write_text(stale)
+        ms = {}
+
+        with patch.object(p, "CONTENT_ROOT", self.content_root), \
+             patch.object(p, "KNOWLEDGE_CARD_DIR", self.card_dir), \
+             patch.object(g, "KNOWLEDGE_CARD_DIR", self.card_dir), \
+             patch.object(g, "dispatch_codex", return_value=(False, "429 Too Many Requests")):
+            card = p.ensure_knowledge_card(self.module_path, ms)
+
+        self.assertEqual(card, stale)
+        self.assertTrue(ms.get("stale_knowledge_card"))
+
+    def test_knowledge_card_codex_rate_limited_no_stale_returns_none(self):
+        """If Codex is rate-limited and no stale card exists, return None."""
+        import generate_knowledge_card as g
+        import v1_pipeline as p
+
+        ms = {}
+        with patch.object(p, "CONTENT_ROOT", self.content_root), \
+             patch.object(p, "KNOWLEDGE_CARD_DIR", self.card_dir), \
+             patch.object(g, "KNOWLEDGE_CARD_DIR", self.card_dir), \
+             patch.object(g, "dispatch_codex", return_value=(False, "429 Too Many Requests")):
+            card = p.ensure_knowledge_card(self.module_path, ms)
+
+        self.assertIsNone(card)
+        self.assertNotIn("stale_knowledge_card", ms)
+
+    def test_knowledge_card_injected_into_write_prompt(self):
+        """step_write should inject the card content into the writer prompt."""
+        import v1_pipeline as p
+
+        card = self._build_card()
+        seen = {}
+
+        def fake_dispatch(prompt, model=None, timeout=None):
+            seen["prompt"] = prompt
+            return True, GOOD_MODULE
+
+        with patch.object(p, "dispatch_auto", side_effect=fake_dispatch), \
+             patch.object(p, "module_key_from_path", return_value=self.module_key):
+            result = p.step_write(self.module_path, "Improve factual accuracy", knowledge_card=card)
+
+        self.assertIsNotNone(result)
+        self.assertIn(card, seen["prompt"])
+        self.assertIn("KNOWLEDGE CARD:", seen["prompt"])
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/v1_pipeline.py
+++ b/scripts/v1_pipeline.py
@@ -49,7 +49,7 @@ import subprocess
 import sys
 import yaml
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import datetime, UTC
+from datetime import date, datetime, UTC
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent.parent
@@ -57,6 +57,7 @@ CONTENT_ROOT = REPO_ROOT / "src" / "content" / "docs"
 STATE_FILE = REPO_ROOT / ".pipeline" / "state.yaml"
 REPORT_FILE = REPO_ROOT / ".pipeline" / "audit-report.json"
 SCORE_SCRIPT = REPO_ROOT / "scripts" / "score_module.py"
+KNOWLEDGE_CARD_DIR = REPO_ROOT / ".pipeline" / "knowledge-cards"
 
 # ---------------------------------------------------------------------------
 # Timestamped logging — tee all print() to a log file
@@ -134,6 +135,7 @@ MODELS = {
     "write_targeted": "claude-sonnet-4-6", # TARGETED FIX: surgical patches (instruction-following)
     "review": "codex",                     # REVIEW: preferred independent reviewer
     "review_fallback": "claude-sonnet-4-6",  # independent REVIEW fallback when Codex is unavailable
+    "knowledge_card": "codex",             # WRITE grounding: current authoritative facts for the topic
     # "translate" removed — uk_sync.CHUNKED_MODEL owns translation model config
 }
 
@@ -220,9 +222,93 @@ def initial_write_plan(key: str) -> str:
     )
 
 
+def sanitize_module_key(module_key: str) -> str:
+    """Convert a module key into a stable knowledge-card filename."""
+    return module_key.replace("/", "__")
+
+
+def knowledge_card_path_for_key(module_key: str) -> Path:
+    """Return the cached knowledge-card path for a module key."""
+    return KNOWLEDGE_CARD_DIR / f"{sanitize_module_key(module_key)}.md"
+
+
+def _extract_frontmatter_data(content: str) -> dict:
+    """Parse YAML frontmatter from markdown content."""
+    if not content.startswith("---\n"):
+        return {}
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return {}
+    try:
+        data = yaml.safe_load(parts[1]) or {}
+    except yaml.YAMLError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _knowledge_card_is_expired(card_content: str) -> bool:
+    """Return True if a knowledge card is expired or malformed."""
+    data = _extract_frontmatter_data(card_content)
+    expires = data.get("expires")
+    if isinstance(expires, datetime):
+        expires_at = expires.date()
+    elif isinstance(expires, date):
+        expires_at = expires
+    elif isinstance(expires, str):
+        try:
+            expires_at = datetime.fromisoformat(expires).date()
+        except ValueError:
+            return True
+    else:
+        return True
+    if not isinstance(expires_at, date):
+        return True
+    return expires_at < datetime.now(UTC).date()
+
+
+def ensure_knowledge_card(module_path: Path, ms: dict,
+                          model: str = MODELS["knowledge_card"]) -> str | None:
+    """Ensure a fresh knowledge card exists for this module. Returns the card
+    content for injection into WRITE prompts, or None if unavailable.
+
+    Behavior:
+    - If .pipeline/knowledge-cards/<key>.md exists and has not expired → read and return
+    - If missing or expired → call generate_knowledge_card.generate()
+    - On Codex rate limit: return existing stale card if any (with stale flag),
+      else None. Set ms["stale_knowledge_card"] = True when using stale.
+    - On success, clear ms["stale_knowledge_card"] if previously set.
+    """
+    key = module_key_from_path(module_path)
+    card_path = knowledge_card_path_for_key(key)
+    existing = card_path.read_text() if card_path.exists() else None
+
+    if existing and not _knowledge_card_is_expired(existing):
+        ms.pop("stale_knowledge_card", None)
+        return existing
+
+    import generate_knowledge_card
+
+    generated = generate_knowledge_card.generate(key, force=True, model=model)
+    if generated is not None:
+        ms.pop("stale_knowledge_card", None)
+        return generated
+
+    if existing:
+        ms["stale_knowledge_card"] = True
+        return existing
+
+    ms.pop("stale_knowledge_card", None)
+    return None
+
+
 # ---------------------------------------------------------------------------
 # WRITE step — Gemini drafts improvements
 # ---------------------------------------------------------------------------
+
+KNOWLEDGE_CARD_UNAVAILABLE = (
+    "(No knowledge card available — use general K8s 1.30+ knowledge but flag any "
+    "uncertain facts for reviewer verification.)"
+)
 
 WRITE_PROMPT_TEMPLATE = """CRITICAL INSTRUCTION: Your response must be ONLY the raw markdown content of the improved module. Start your response with the --- frontmatter delimiter. No preamble, no explanation, no summary, no "I have improved..." — ONLY the markdown file content from first line to last.
 
@@ -241,6 +327,9 @@ RULES:
 - Keep the module's existing voice and style
 - CONVERT any ASCII art diagrams to Mermaid (```mermaid blocks) — Mermaid renders natively in our site
 
+KNOWLEDGE CARD:
+{knowledge_card}
+
 IMPROVEMENT PLAN:
 {plan}
 
@@ -257,6 +346,9 @@ TASK: Rewrite a KubeDojo educational module. The existing module scored too low 
 
 The file path is: {file_path}
 Keep the EXACT same frontmatter (title, slug, sidebar order).
+
+KNOWLEDGE CARD:
+{knowledge_card}
 
 KNOWLEDGE PACKET — MUST PRESERVE:
 The following technical assets are extracted from the original module. You MUST include ALL of them in your rewrite, placed in the appropriate sections. Do NOT omit, summarize, or simplify any of these.
@@ -382,7 +474,8 @@ def count_assets(content: str) -> dict:
 
 def step_write(module_path: Path, plan: str, model: str = MODELS["write"],
                rewrite: bool = False,
-               previous_output: str | None = None) -> str | None:
+               previous_output: str | None = None,
+               knowledge_card: str | None = None) -> str | None:
     """Gemini drafts improvements or full rewrite based on the plan.
 
     If previous_output is provided (e.g. from an earlier attempt in the
@@ -395,13 +488,16 @@ def step_write(module_path: Path, plan: str, model: str = MODELS["write"],
     key = module_key_from_path(module_path)
     mode = "REWRITE" if rewrite else "WRITE"
     print(f"\n  {mode}: {key} (using {model})")
+    knowledge_card_text = knowledge_card or KNOWLEDGE_CARD_UNAVAILABLE
 
     if rewrite:
         packet = extract_knowledge_packet(content)
         prompt = REWRITE_PROMPT_TEMPLATE.format(
-            file_path=key, plan=plan, content=content, knowledge_packet=packet)
+            file_path=key, plan=plan, content=content, knowledge_packet=packet,
+            knowledge_card=knowledge_card_text)
     else:
-        prompt = WRITE_PROMPT_TEMPLATE.format(plan=plan, content=content)
+        prompt = WRITE_PROMPT_TEMPLATE.format(
+            plan=plan, content=content, knowledge_card=knowledge_card_text)
 
     # Must use dispatch_auto (not dispatch_gemini_with_retry directly) so that
     # Claude Sonnet is actually called for targeted-fix mode. Previously this
@@ -889,6 +985,9 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
             ms.pop("targeted_fix", None)
             save_state(state)
 
+    knowledge_card = None
+    resume_from_staging = False
+
     # Initial write plan. Legacy `phase="audit"` states from older runs are
     # treated the same as fresh `pending` modules: start a normal first-pass
     # write with the generic plan and let REVIEW produce the real follow-up
@@ -922,6 +1021,7 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
             improved = staging_path.read_text()
             last_good = improved
             targeted_fix = ms.get("targeted_fix", False)
+            resume_from_staging = True
             mode = "targeted fix" if targeted_fix else "improve"
             print(f"  Loaded staged content ({len(improved)} chars) and saved {mode} plan")
         elif ms["phase"] == "review":
@@ -935,6 +1035,14 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
             improved = None
             last_good = None
             targeted_fix = False
+
+    if ms["phase"] == "write" and not dry_run and not resume_from_staging:
+        try:
+            knowledge_card = ensure_knowledge_card(module_path, ms, model=m["knowledge_card"])
+        except Exception as e:
+            print(f"  ⚠ Knowledge card unavailable — proceeding without grounding: {e}")
+            knowledge_card = None
+        save_state(state)
 
     # WRITE → REVIEW loop (max retries)
     # Auto-detect rewrite mode: score < 28 means "improve" won't cut it.
@@ -952,7 +1060,8 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
             try:
                 improved = step_write(module_path, plan, model=writer_model,
                                       rewrite=needs_rewrite,
-                                      previous_output=last_good)
+                                      previous_output=last_good,
+                                      knowledge_card=knowledge_card)
             except ClaudeUnavailableError as e:
                 # Peak hours / rate limit / budget exhausted on Claude. Pause
                 # this module cleanly so it resumes at the targeted-fix step
@@ -1239,9 +1348,14 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
             pending = ms.get("needs_independent_review", False)
             pending_tag = " needs-independent-review" if pending else ""
             print(f"\n  ✓ PASS: {total}/40 (min: {minimum}) reviewer={reviewer}{pending_tag}")
-            # Auto-commit
+            # Auto-commit the passed module plus the knowledge card it was
+            # grounded against, when available, for full write-time traceability.
+            add_paths = [str(module_path)]
+            card_path = knowledge_card_path_for_key(key)
+            if card_path.exists():
+                add_paths.append(str(card_path))
             add_result = subprocess.run(
-                ["git", "add", str(module_path)],
+                ["git", "add", *add_paths],
                 cwd=str(REPO_ROOT), capture_output=True, text=True,
             )
             if add_result.returncode != 0:


### PR DESCRIPTION
## Summary

Implements Batch B of #217: web-grounding at WRITE time via cached knowledge cards.

Changes:
- add `scripts/generate_knowledge_card.py` for single-module Codex generation with cache/expiry handling, schema validation, and CLI flags
- add `MODELS["knowledge_card"] = "codex"`
- add `ensure_knowledge_card()` to `scripts/v1_pipeline.py` with fresh-cache reuse, stale fallback on Codex unavailability, and fail-open behavior
- inject knowledge cards into both `WRITE_PROMPT_TEMPLATE` and `REWRITE_PROMPT_TEMPLATE`
- include the module knowledge-card file in the same passing SCORE-phase auto-commit when present
- add unit coverage for schema writing, fresh-cache reuse, expiry regeneration, stale fallback, no-stale fallback, and prompt injection

## Knowledge Card Shape

```md
---
topic: "On-prem FinOps and chargeback with OpenCost, Kubecost, and VPA"
module_key: "on-premises/planning/module-1.5-onprem-finops-chargeback"
generated_by: "codex"
generated_at: "2026-04-11"
expires: "2026-07-10"
---

## Current status (as of generated_at)
- ...

## Authoritative sources
- https://example.com/path — what it confirms

## Do not
- ...
```

## Test Plan

- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python -m py_compile scripts/v1_pipeline.py scripts/generate_knowledge_card.py scripts/test_pipeline.py`
- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python -m unittest scripts.test_pipeline`
- `npm ci`
- `npm run build`

Closes part of #217.
