### PR TITLE
feat(pipeline): fact-ledger split-reviewer architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ test_script.sh
 *.bak
 .pipeline/rewrite-output/
 *.staging.md
+.pipeline/fact-ledgers/
+.pipeline/link-cache.json

--- a/scripts/test_pipeline.py
+++ b/scripts/test_pipeline.py
@@ -32,6 +32,25 @@ from checks import structural
 from checks.structural import CheckResult
 
 
+def sample_fact_ledger() -> dict:
+    """Reusable schema-valid fact ledger fixture."""
+    return {
+        "as_of_date": "2026-04-12",
+        "topic": "Test Module",
+        "claims": [
+            {
+                "id": "C1",
+                "claim": "Kubernetes current stable is v1.32",
+                "status": "SUPPORTED",
+                "current_truth": "Kubernetes current stable is v1.32",
+                "sources": [{"url": "https://kubernetes.io/releases/", "source_date": "2026-04-12"}],
+                "conflict_summary": None,
+                "unverified_reason": None,
+            }
+        ],
+    }
+
+
 # ---------------------------------------------------------------------------
 # Fixtures: known-good and known-bad module content
 # ---------------------------------------------------------------------------
@@ -629,7 +648,7 @@ class TestPipelineTransitions(unittest.TestCase):
 
     def _mock_review_approve(self, *args, **kwargs):
         """Mock review that approves (binary gate #223)."""
-        check_ids = ["FACT", "LAB", "COV", "QUIZ", "EXAM", "DEPTH", "WHY", "PRES"]
+        check_ids = ["LAB", "COV", "QUIZ", "EXAM", "DEPTH", "WHY", "PRES"]
         return True, json.dumps({
             "verdict": "APPROVE",
             "severity": "clean",
@@ -640,9 +659,9 @@ class TestPipelineTransitions(unittest.TestCase):
 
     def _mock_review_reject(self, *args, **kwargs):
         """Mock review that rejects with 1 fixable quiz issue."""
-        check_ids = ["FACT", "LAB", "COV", "QUIZ", "EXAM", "DEPTH", "WHY", "PRES"]
+        check_ids = ["LAB", "COV", "QUIZ", "EXAM", "DEPTH", "WHY", "PRES"]
         checks = [{"id": cid, "passed": True} for cid in check_ids]
-        checks[3] = {"id": "QUIZ", "passed": False,
+        checks[2] = {"id": "QUIZ", "passed": False,
                      "evidence": "Recall-based not scenario-based",
                      "edit_refs": [0]}
         return True, json.dumps({
@@ -675,15 +694,16 @@ class TestPipelineTransitions(unittest.TestCase):
 
         with patch.object(p, "STATE_FILE", self.state_file), \
              patch.object(p, "CONTENT_ROOT", Path(self.tmpdir)), \
-             patch.object(p, "save_state"):
+             patch.object(p, "save_state"), \
+             patch.object(p, "ensure_fact_ledger", return_value=sample_fact_ledger()), \
+             patch.object(p, "step_check_integrity", return_value=(True, [])):
             with patch.object(p, "module_key_from_path", return_value="test/module-0.1-test"):
                 p.run_module(self.module_path, state)
 
         ms = state["modules"].get("test/module-0.1-test", {})
         self.assertEqual(ms.get("phase"), "done")
         self.assertTrue(ms.get("passes"))
-        # Must have been reviewed by an independent reviewer
-        self.assertEqual(ms.get("reviewer"), "codex")
+        self.assertEqual(ms.get("reviewer"), "gemini")
         self.assertFalse(ms.get("needs_independent_review", True))
         # Write + review dispatches should have fired
         self.assertEqual(mock_dispatch.call_count, 2)
@@ -757,13 +777,15 @@ class TestPipelineTransitions(unittest.TestCase):
 
         with patch.object(p, "STATE_FILE", self.state_file), \
              patch.object(p, "CONTENT_ROOT", Path(self.tmpdir)), \
-             patch.object(p, "save_state"):
+             patch.object(p, "save_state"), \
+             patch.object(p, "ensure_fact_ledger", return_value=sample_fact_ledger()), \
+             patch.object(p, "step_check_integrity", return_value=(True, [])):
             with patch.object(p, "module_key_from_path", return_value="test/module-0.1-test"):
                 p.run_module(self.module_path, state)
 
         ms = state["modules"]["test/module-0.1-test"]
         self.assertEqual(ms.get("phase"), "done")
-        self.assertEqual(ms.get("reviewer"), "codex")
+        self.assertEqual(ms.get("reviewer"), "gemini")
         self.assertFalse(ms.get("needs_independent_review", True))
         # Only re-review should fire
         self.assertEqual(mock_dispatch.call_count, 1)
@@ -794,6 +816,8 @@ class TestPipelineTransitions(unittest.TestCase):
              patch.object(p, "module_key_from_path", return_value="test/module-0.1-test"), \
              patch.object(p, "step_write", return_value=GOOD_MODULE), \
              patch.object(p, "step_review", side_effect=review_sequence) as mock_review, \
+             patch.object(p, "ensure_fact_ledger", return_value=sample_fact_ledger()), \
+             patch.object(p, "step_check_integrity", return_value=(True, [])), \
              patch.object(p, "step_check", return_value=(True, [])):
             p.run_module(self.module_path, state)
 
@@ -840,12 +864,12 @@ class TestPipelineTransitions(unittest.TestCase):
             "modules": {
                 "test/module-0.1-test": {
                     "phase": "needs_targeted_fix",
-                    "plan": "TARGETED FIX. FACT check failed — fix per reviewer feedback.",
+                    "plan": "TARGETED FIX. LAB check failed — fix per reviewer feedback.",
                     "targeted_fix": True,
                     "paused_reason": "Claude peak hours",
                     "severity": "targeted",
-                    "checks_failed": [{"id": "FACT", "evidence": "example"}],
-                    "reviewer_schema_version": 2,
+                    "checks_failed": [{"id": "LAB", "evidence": "example"}],
+                    "reviewer_schema_version": 3,
                     "errors": [],
                 },
             },
@@ -853,7 +877,9 @@ class TestPipelineTransitions(unittest.TestCase):
 
         with patch.object(p, "STATE_FILE", self.state_file), \
              patch.object(p, "CONTENT_ROOT", Path(self.tmpdir)), \
-             patch.object(p, "save_state"):
+             patch.object(p, "save_state"), \
+             patch.object(p, "ensure_fact_ledger", return_value=sample_fact_ledger()), \
+             patch.object(p, "step_check_integrity", return_value=(True, [])):
             with patch.object(p, "module_key_from_path", return_value="test/module-0.1-test"):
                 p.run_module(self.module_path, state)
 
@@ -882,14 +908,13 @@ class TestPipelineTransitions(unittest.TestCase):
             {
                 "verdict": "REJECT",
                 "checks": [
-                    {"id": "FACT", "passed": False, "evidence": "https://kubernetes.io/docs/x"},
                     {"id": "LAB", "passed": False, "evidence": "lab broken"},
                     {"id": "COV", "passed": False, "evidence": "outcome 3 missing"},
                     {"id": "QUIZ", "passed": False, "evidence": "recall-only"},
                     {"id": "EXAM", "passed": True},
                     {"id": "DEPTH", "passed": False, "evidence": "no gotchas"},
                     {"id": "WHY", "passed": False, "evidence": "no rationale"},
-                    {"id": "PRES", "passed": True},
+                    {"id": "PRES", "passed": False, "evidence": "missing unique value"},
                 ],
                 "edits": [],
                 "feedback": "Severely broken module.",
@@ -903,13 +928,14 @@ class TestPipelineTransitions(unittest.TestCase):
         ]
 
         def fake_step_write(module_path, plan, model=None, rewrite=False,
-                            previous_output=None, knowledge_card=None):
+                            previous_output=None, knowledge_card=None, fact_ledger=None):
             write_calls.append({
                 "plan": plan,
                 "model": model,
                 "rewrite": rewrite,
                 "previous_output": previous_output,
                 "knowledge_card": knowledge_card,
+                "fact_ledger": fact_ledger,
             })
             return GOOD_MODULE
 
@@ -919,6 +945,8 @@ class TestPipelineTransitions(unittest.TestCase):
              patch.object(p, "module_key_from_path", return_value="test/module-0.1-test"), \
              patch.object(p, "step_write", side_effect=fake_step_write), \
              patch.object(p, "step_review", side_effect=review_sequence), \
+             patch.object(p, "ensure_fact_ledger", return_value=sample_fact_ledger()), \
+             patch.object(p, "step_check_integrity", return_value=(True, [])), \
              patch.object(p, "step_check", return_value=(True, [])):
             p.run_module(self.module_path, state)
 
@@ -955,7 +983,6 @@ class TestPipelineTransitions(unittest.TestCase):
             {
                 "verdict": "REJECT",
                 "checks": [
-                    {"id": "FACT", "passed": True},
                     {"id": "LAB", "passed": False, "evidence": "wrong flag", "edit_refs": [0]},
                     {"id": "COV", "passed": True},
                     {"id": "QUIZ", "passed": False, "evidence": "recall", "edit_refs": [1]},
@@ -979,7 +1006,7 @@ class TestPipelineTransitions(unittest.TestCase):
         ]
 
         def fake_step_write(module_path, plan, model=None, rewrite=False,
-                            previous_output=None, knowledge_card=None):
+                            previous_output=None, knowledge_card=None, fact_ledger=None):
             write_calls.append({
                 "plan": plan,
                 "model": model,
@@ -993,6 +1020,8 @@ class TestPipelineTransitions(unittest.TestCase):
              patch.object(p, "module_key_from_path", return_value="test/module-0.1-test"), \
              patch.object(p, "step_write", side_effect=fake_step_write), \
              patch.object(p, "step_review", side_effect=review_sequence), \
+             patch.object(p, "ensure_fact_ledger", return_value=sample_fact_ledger()), \
+             patch.object(p, "step_check_integrity", return_value=(True, [])), \
              patch.object(p, "step_check", return_value=(True, [])):
             p.run_module(self.module_path, state)
 
@@ -1051,6 +1080,21 @@ class TestComputeSeverity(unittest.TestCase):
         sev = self.p.compute_severity("APPROVE", self.all_pass, [])
         self.assertEqual(sev, "clean")
 
+    def test_routes_correctly_with_seven_checks(self):
+        """Split-reviewer structural rubric has 7 checks (FACT removed)."""
+        self.assertEqual(len(self.p.CHECK_IDS), 7)
+        checks = [
+            {"id": "LAB", "passed": False, "edit_refs": [0]},
+            {"id": "COV", "passed": True},
+            {"id": "QUIZ", "passed": True},
+            {"id": "EXAM", "passed": True},
+            {"id": "DEPTH", "passed": True},
+            {"id": "WHY", "passed": True},
+            {"id": "PRES", "passed": True},
+        ]
+        edits = [{"type": "replace", "find": "x", "new": "y"}]
+        self.assertEqual(self.p.compute_severity("REJECT", checks, edits), "targeted")
+
     def test_reject_no_failed_checks_is_severe(self):
         """REJECT with zero failed checks is a structural contradiction → severe."""
         sev = self.p.compute_severity("REJECT", self.all_pass, [])
@@ -1066,7 +1110,7 @@ class TestComputeSeverity(unittest.TestCase):
 
     def test_reject_with_zero_edits_is_severe(self):
         """REJECT with failed checks but no edits at all → severe (can't patch)."""
-        checks = [{"id": "FACT", "passed": False, "evidence": "bad"}] + \
+        checks = [{"id": "LAB", "passed": False, "evidence": "bad"}] + \
                  [{"id": cid, "passed": True} for cid in self.p.CHECK_IDS[1:]]
         sev = self.p.compute_severity("REJECT", checks, [])
         self.assertEqual(sev, "severe")
@@ -1074,7 +1118,7 @@ class TestComputeSeverity(unittest.TestCase):
     def test_reject_uncovered_failure_is_severe(self):
         """A failed check with no edit_refs is uncovered → severe."""
         checks = [
-            {"id": "FACT", "passed": False, "evidence": "bad", "edit_refs": [0]},
+            {"id": "LAB", "passed": False, "evidence": "bad", "edit_refs": [0]},
             {"id": "LAB", "passed": False, "evidence": "lab broken"},  # no edit_refs
         ] + [{"id": cid, "passed": True} for cid in self.p.CHECK_IDS[2:]]
         edits = [{"type": "replace", "find": "x", "new": "y"}]
@@ -1085,7 +1129,7 @@ class TestComputeSeverity(unittest.TestCase):
     def test_reject_targeted_one_to_four_covered_failures(self):
         """1-4 failures, all with edit_refs, all with edits → targeted."""
         checks = [
-            {"id": "FACT", "passed": False, "evidence": "minor", "edit_refs": [0]},
+            {"id": "LAB", "passed": False, "evidence": "minor", "edit_refs": [0]},
             {"id": "LAB", "passed": False, "evidence": "fix", "edit_refs": [1]},
         ] + [{"id": cid, "passed": True} for cid in self.p.CHECK_IDS[2:]]
         edits = [
@@ -1113,7 +1157,7 @@ class TestComputeSeverity(unittest.TestCase):
         misroute to targeted. Validate the shape strictly.
         """
         checks = [
-            {"id": "FACT", "passed": False, "evidence": "x", "edit_refs": True},
+            {"id": "LAB", "passed": False, "evidence": "x", "edit_refs": True},
         ] + [{"id": cid, "passed": True} for cid in self.p.CHECK_IDS[1:]]
         edits = [{"type": "replace", "find": "a", "new": "b"}]
         self.assertEqual(self.p.compute_severity("REJECT", checks, edits), "severe")
@@ -1121,7 +1165,7 @@ class TestComputeSeverity(unittest.TestCase):
     def test_edit_refs_string_is_uncovered(self):
         """edit_refs="0" (string) is not a list of ints → severe."""
         checks = [
-            {"id": "FACT", "passed": False, "evidence": "x", "edit_refs": "0"},
+            {"id": "LAB", "passed": False, "evidence": "x", "edit_refs": "0"},
         ] + [{"id": cid, "passed": True} for cid in self.p.CHECK_IDS[1:]]
         edits = [{"type": "replace", "find": "a", "new": "b"}]
         self.assertEqual(self.p.compute_severity("REJECT", checks, edits), "severe")
@@ -1129,7 +1173,7 @@ class TestComputeSeverity(unittest.TestCase):
     def test_edit_refs_out_of_bounds_is_uncovered(self):
         """edit_refs=[999] points at no real edit → severe."""
         checks = [
-            {"id": "FACT", "passed": False, "evidence": "x", "edit_refs": [999]},
+            {"id": "LAB", "passed": False, "evidence": "x", "edit_refs": [999]},
         ] + [{"id": cid, "passed": True} for cid in self.p.CHECK_IDS[1:]]
         edits = [{"type": "replace", "find": "a", "new": "b"}]
         self.assertEqual(self.p.compute_severity("REJECT", checks, edits), "severe")
@@ -1137,7 +1181,7 @@ class TestComputeSeverity(unittest.TestCase):
     def test_edit_refs_mixed_valid_invalid_is_uncovered(self):
         """If any ref is invalid, the whole check is uncovered → severe."""
         checks = [
-            {"id": "FACT", "passed": False, "evidence": "x", "edit_refs": [0, 999]},
+            {"id": "LAB", "passed": False, "evidence": "x", "edit_refs": [0, 999]},
         ] + [{"id": cid, "passed": True} for cid in self.p.CHECK_IDS[1:]]
         edits = [{"type": "replace", "find": "a", "new": "b"}]
         self.assertEqual(self.p.compute_severity("REJECT", checks, edits), "severe")
@@ -1145,7 +1189,7 @@ class TestComputeSeverity(unittest.TestCase):
     def test_edits_not_a_list_is_severe(self):
         """edits=None or edits=dict → severe (can't patch)."""
         checks = [
-            {"id": "FACT", "passed": False, "evidence": "x", "edit_refs": [0]},
+            {"id": "LAB", "passed": False, "evidence": "x", "edit_refs": [0]},
         ] + [{"id": cid, "passed": True} for cid in self.p.CHECK_IDS[1:]]
         self.assertEqual(self.p.compute_severity("REJECT", checks, None), "severe")
         self.assertEqual(
@@ -1196,6 +1240,8 @@ class TestBinaryGateIntegration(unittest.TestCase):
              patch.object(p, "module_key_from_path", return_value="test/module-0.1-test"), \
              patch.object(p, "step_write", return_value=GOOD_MODULE), \
              patch.object(p, "step_review", side_effect=review_sequence), \
+             patch.object(p, "ensure_fact_ledger", return_value=sample_fact_ledger()), \
+             patch.object(p, "step_check_integrity", return_value=(True, [])), \
              patch.object(p, "step_check", return_value=(True, [])), \
              patch.object(p, "ensure_knowledge_card", return_value="card"):
             p.run_module(self.module_path, state)
@@ -1204,7 +1250,7 @@ class TestBinaryGateIntegration(unittest.TestCase):
         self.assertEqual(ms.get("phase"), "done")
         self.assertEqual(ms.get("severity"), "clean")
         self.assertEqual(ms.get("checks_failed"), [])
-        self.assertEqual(ms.get("reviewer_schema_version"), 2)
+        self.assertEqual(ms.get("reviewer_schema_version"), 3)
         self.assertTrue(ms.get("passes"))
         # Old schema fields must be absent on new-gate runs
         self.assertNotIn("scores", ms)
@@ -1226,7 +1272,7 @@ class TestBinaryGateIntegration(unittest.TestCase):
         write_calls = []
 
         def fake_step_write(module_path, plan, model=None, rewrite=False,
-                            previous_output=None, knowledge_card=None):
+                            previous_output=None, knowledge_card=None, fact_ledger=None):
             write_calls.append({"model": model, "rewrite": rewrite})
             return GOOD_MODULE
 
@@ -1234,9 +1280,8 @@ class TestBinaryGateIntegration(unittest.TestCase):
             {
                 "verdict": "REJECT",
                 "checks": [
-                    {"id": "FACT", "passed": False, "evidence": "one anchor",
+                    {"id": "LAB", "passed": False, "evidence": "one anchor",
                      "edit_refs": [0]},
-                    {"id": "LAB", "passed": True},
                     {"id": "COV", "passed": True},
                     {"id": "QUIZ", "passed": True},
                     {"id": "EXAM", "passed": True},
@@ -1264,6 +1309,8 @@ class TestBinaryGateIntegration(unittest.TestCase):
              patch.object(p, "module_key_from_path", return_value="test/module-0.1-test"), \
              patch.object(p, "step_write", side_effect=fake_step_write), \
              patch.object(p, "step_review", side_effect=review_sequence), \
+             patch.object(p, "ensure_fact_ledger", return_value=sample_fact_ledger()), \
+             patch.object(p, "step_check_integrity", return_value=(True, [])), \
              patch.object(p, "step_check", return_value=(True, [])), \
              patch.object(p, "ensure_knowledge_card", return_value="card"):
             p.run_module(self.module_path, state)
@@ -1312,13 +1359,13 @@ class TestLegacyStateCompat(unittest.TestCase):
             "phase": "done",
             "severity": "clean",
             "checks_failed": [],
-            "reviewer_schema_version": 2,
+            "reviewer_schema_version": 3,
             "passes": True,
             "last_run": "2026-04-11T12:00:00+00:00",
             "errors": [],
-            "reviewer": "codex",
+            "reviewer": "gemini",
         }
-        self.assertEqual(new_ms.get("reviewer_schema_version"), 2)
+        self.assertEqual(new_ms.get("reviewer_schema_version"), 3)
         self.assertIsNone(new_ms.get("scores"))
         self.assertIn("severity", new_ms)
 
@@ -1559,6 +1606,425 @@ class TestKnowledgeCards(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# Test: Fact ledger + integrity gate + split-reviewer run flow
+# ---------------------------------------------------------------------------
+
+class TestFactLedger(unittest.TestCase):
+    """Test fact-ledger generation, validation, and cache behavior."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.repo_root = Path(self.tmpdir)
+        self.content_root = self.repo_root / "src" / "content" / "docs"
+        self.content_root.mkdir(parents=True, exist_ok=True)
+        self.module_path = self.content_root / "test" / "module-0.1-test.md"
+        self.module_path.parent.mkdir(parents=True, exist_ok=True)
+        self.module_path.write_text("---\ntitle: Test Module\n---\n\nBody")
+        self.ledger_dir = self.repo_root / ".pipeline" / "fact-ledgers"
+        self.module_key = "test/module-0.1-test"
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _ledger_payload(self, marker: str = "A") -> dict:
+        return {
+            "as_of_date": "2026-04-12",
+            "topic": f"Test Module {marker}",
+            "claims": [
+                {
+                    "id": "C1",
+                    "claim": "Supported claim",
+                    "status": "SUPPORTED",
+                    "current_truth": f"Supported truth {marker}",
+                    "sources": [{"url": "https://kubernetes.io/releases/", "source_date": "2026-04-12"}],
+                    "conflict_summary": None,
+                    "unverified_reason": None,
+                },
+                {
+                    "id": "C2",
+                    "claim": "Conflicting claim",
+                    "status": "CONFLICTING",
+                    "current_truth": None,
+                    "sources": [
+                        {"url": "https://example.com/a", "source_date": "2026-04-12"},
+                        {"url": "https://example.com/b", "source_date": "2026-04-12"},
+                    ],
+                    "conflict_summary": "Sources disagree.",
+                    "unverified_reason": None,
+                },
+                {
+                    "id": "C3",
+                    "claim": "Unverified claim",
+                    "status": "UNVERIFIED",
+                    "current_truth": None,
+                    "sources": [],
+                    "conflict_summary": None,
+                    "unverified_reason": "No authoritative source found.",
+                },
+            ],
+        }
+
+    def test_fact_ledger_parses_valid_response(self):
+        import v1_pipeline as p
+
+        payload = self._ledger_payload()
+        with patch.object(p, "FACT_LEDGER_DIR", self.ledger_dir), \
+             patch.object(p, "module_key_from_path", return_value=self.module_key), \
+             patch.object(p, "dispatch_auto", return_value=(True, json.dumps(payload))):
+            result = p.step_fact_ledger(self.module_path, topic_hint="Topic", refresh=True)
+
+        self.assertIsNotNone(result)
+        statuses = {c["status"] for c in result["claims"]}
+        self.assertEqual(statuses, {"SUPPORTED", "CONFLICTING", "UNVERIFIED"})
+
+    def test_fact_ledger_validates_required_fields(self):
+        import v1_pipeline as p
+
+        bad_payload = {"as_of_date": "2026-04-12", "topic": "Missing claims"}
+        with patch.object(p, "FACT_LEDGER_DIR", self.ledger_dir), \
+             patch.object(p, "module_key_from_path", return_value=self.module_key), \
+             patch.object(p, "dispatch_auto", return_value=(True, json.dumps(bad_payload))):
+            result = p.step_fact_ledger(self.module_path, topic_hint="Topic", refresh=True)
+
+        self.assertIsNone(result)
+
+    def test_fact_ledger_caches_to_disk(self):
+        import v1_pipeline as p
+
+        payload = self._ledger_payload(marker="A")
+        cache_path = self.ledger_dir / "test__module-0.1-test.json"
+        with patch.object(p, "FACT_LEDGER_DIR", self.ledger_dir), \
+             patch.object(p, "module_key_from_path", return_value=self.module_key), \
+             patch.object(p, "dispatch_auto", return_value=(True, json.dumps(payload))):
+            first = p.step_fact_ledger(self.module_path, topic_hint="Topic")
+
+        self.assertIsNotNone(first)
+        self.assertTrue(cache_path.exists())
+
+        with patch.object(p, "FACT_LEDGER_DIR", self.ledger_dir), \
+             patch.object(p, "module_key_from_path", return_value=self.module_key), \
+             patch.object(p, "dispatch_auto", side_effect=AssertionError("dispatch should not run on cache hit")):
+            second = p.step_fact_ledger(self.module_path, topic_hint="Topic")
+
+        self.assertEqual(first["topic"], second["topic"])
+
+    def test_fact_ledger_cache_expires_after_7_days(self):
+        import v1_pipeline as p
+
+        first_payload = self._ledger_payload(marker="A")
+        second_payload = self._ledger_payload(marker="B")
+        cache_path = self.ledger_dir / "test__module-0.1-test.json"
+
+        with patch.object(p, "FACT_LEDGER_DIR", self.ledger_dir), \
+             patch.object(p, "module_key_from_path", return_value=self.module_key), \
+             patch.object(p, "dispatch_auto", return_value=(True, json.dumps(first_payload))):
+            p.step_fact_ledger(self.module_path, topic_hint="Topic")
+
+        old_ts = (datetime.now(UTC) - timedelta(days=8)).timestamp()
+        os.utime(cache_path, (old_ts, old_ts))
+
+        with patch.object(p, "FACT_LEDGER_DIR", self.ledger_dir), \
+             patch.object(p, "module_key_from_path", return_value=self.module_key), \
+             patch.object(p, "dispatch_auto", return_value=(True, json.dumps(second_payload))) as mock_dispatch:
+            refreshed = p.step_fact_ledger(self.module_path, topic_hint="Topic")
+
+        self.assertEqual(mock_dispatch.call_count, 1)
+        self.assertEqual(refreshed["topic"], "Test Module B")
+
+    def test_fact_ledger_refresh_busts_cache(self):
+        import v1_pipeline as p
+
+        first_payload = self._ledger_payload(marker="A")
+        second_payload = self._ledger_payload(marker="B")
+
+        with patch.object(p, "FACT_LEDGER_DIR", self.ledger_dir), \
+             patch.object(p, "module_key_from_path", return_value=self.module_key), \
+             patch.object(p, "dispatch_auto", return_value=(True, json.dumps(first_payload))):
+            p.step_fact_ledger(self.module_path, topic_hint="Topic")
+
+        with patch.object(p, "FACT_LEDGER_DIR", self.ledger_dir), \
+             patch.object(p, "module_key_from_path", return_value=self.module_key), \
+             patch.object(p, "dispatch_auto", return_value=(True, json.dumps(second_payload))) as mock_dispatch:
+            refreshed = p.step_fact_ledger(self.module_path, topic_hint="Topic", refresh=True)
+
+        self.assertEqual(mock_dispatch.call_count, 1)
+        self.assertEqual(refreshed["topic"], "Test Module B")
+
+
+class TestStepCheckIntegrity(unittest.TestCase):
+    """Test tier-1 deterministic integrity checks."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.link_cache = Path(self.tmpdir) / "link-cache.json"
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_link_health_all_resolve(self):
+        import v1_pipeline as p
+
+        content = "See https://example.com/a and https://example.com/b"
+        with patch.object(p, "LINK_CACHE_FILE", self.link_cache), \
+             patch.object(p, "_get_url_status", return_value=200):
+            passed, messages = p.step_check_integrity(content, sample_fact_ledger())
+
+        self.assertTrue(passed)
+        self.assertFalse(any(m.startswith("LINK_DEAD") for m in messages))
+
+    def test_link_health_dead_url_fails(self):
+        import v1_pipeline as p
+
+        content = "Good https://example.com/ok bad https://example.com/dead"
+
+        def fake_status(url, _cache):
+            return 404 if "dead" in url else 200
+
+        with patch.object(p, "LINK_CACHE_FILE", self.link_cache), \
+             patch.object(p, "_get_url_status", side_effect=fake_status):
+            passed, messages = p.step_check_integrity(content, sample_fact_ledger())
+
+        self.assertFalse(passed)
+        self.assertTrue(any("LINK_DEAD: https://example.com/dead (404)" in m for m in messages))
+
+    def test_yaml_lint_valid_passes(self):
+        import v1_pipeline as p
+
+        content = "```yaml\napiVersion: v1\nkind: Pod\nmetadata:\n  name: demo\n```"
+        with patch.object(p, "LINK_CACHE_FILE", self.link_cache):
+            passed, messages = p.step_check_integrity(content, sample_fact_ledger())
+
+        self.assertTrue(passed)
+        self.assertFalse(any(m.startswith("INVALID_YAML") for m in messages))
+
+    def test_yaml_lint_invalid_fails(self):
+        import v1_pipeline as p
+
+        content = "```yaml\napiVersion: v1\nkind Pod\nmetadata:\n  name: demo\n```"
+        with patch.object(p, "LINK_CACHE_FILE", self.link_cache):
+            passed, messages = p.step_check_integrity(content, sample_fact_ledger())
+
+        self.assertFalse(passed)
+        self.assertTrue(any(m.startswith("INVALID_YAML") for m in messages))
+
+    def test_version_consistency_warns_only(self):
+        import v1_pipeline as p
+
+        content = "This module compares v1.30 and 1.32 behavior."
+        with patch.object(p, "LINK_CACHE_FILE", self.link_cache):
+            passed, messages = p.step_check_integrity(content, sample_fact_ledger())
+
+        self.assertTrue(passed)
+        self.assertTrue(any(m.startswith("VERSION_MISMATCH_WARNING") for m in messages))
+
+    def test_version_stale_fails(self):
+        import v1_pipeline as p
+
+        content = "Old guidance references v1.20 in production."
+        with patch.object(p, "LINK_CACHE_FILE", self.link_cache):
+            passed, messages = p.step_check_integrity(content, sample_fact_ledger())
+
+        self.assertFalse(passed)
+        self.assertTrue(any("STALE_K8S_VERSION: v1.20" in m for m in messages))
+
+    def test_evidence_mapping_unhedged_conflict_fails(self):
+        import v1_pipeline as p
+
+        ledger = {
+            "claims": [
+                {
+                    "id": "C9",
+                    "claim": "Kubernetes current stable is v1.32",
+                    "status": "CONFLICTING",
+                    "current_truth": "Kubernetes current stable is v1.32",
+                    "sources": [],
+                    "conflict_summary": "Disagreement",
+                    "unverified_reason": None,
+                }
+            ]
+        }
+        content = "Kubernetes current stable is v1.32."
+        with patch.object(p, "LINK_CACHE_FILE", self.link_cache):
+            passed, messages = p.step_check_integrity(content, ledger)
+
+        self.assertFalse(passed)
+        self.assertTrue(any("UNHEDGED_CONFLICT: claim C9" in m for m in messages))
+
+    def test_evidence_mapping_hedged_conflict_passes(self):
+        import v1_pipeline as p
+
+        ledger = {
+            "claims": [
+                {
+                    "id": "C10",
+                    "claim": "Kubernetes current stable is v1.32",
+                    "status": "CONFLICTING",
+                    "current_truth": "Kubernetes current stable is v1.32",
+                    "sources": [],
+                    "conflict_summary": "Disagreement",
+                    "unverified_reason": None,
+                }
+            ]
+        }
+        content = (
+            "According to upstream docs as of 2026-04-12, "
+            "Kubernetes current stable is v1.32."
+        )
+        with patch.object(p, "LINK_CACHE_FILE", self.link_cache):
+            passed, messages = p.step_check_integrity(content, ledger)
+
+        self.assertTrue(passed)
+        self.assertFalse(any(m.startswith("UNHEDGED_CONFLICT") for m in messages))
+
+
+class TestRunModuleSplitReviewer(unittest.TestCase):
+    """Integration tests for split-reviewer routing in run_module."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.state_file = Path(self.tmpdir) / "state.yaml"
+        self.module_path = Path(self.tmpdir) / "module-0.1-test.md"
+        self.module_path.write_text(GOOD_MODULE)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_pending_module_runs_fact_ledger_then_writes(self):
+        import v1_pipeline as p
+
+        events: list[str] = []
+        review_ok = {
+            "verdict": "APPROVE",
+            "checks": [{"id": cid, "passed": True} for cid in p.CHECK_IDS],
+            "edits": [],
+            "feedback": "",
+        }
+
+        def fake_fact(*args, **kwargs):
+            events.append("ledger")
+            return sample_fact_ledger()
+
+        def fake_write(*args, **kwargs):
+            events.append("write")
+            return GOOD_MODULE
+
+        def fake_review(*args, **kwargs):
+            events.append("review")
+            return review_ok
+
+        state = {"modules": {}}
+        with patch.object(p, "STATE_FILE", self.state_file), \
+             patch.object(p, "CONTENT_ROOT", Path(self.tmpdir)), \
+             patch.object(p, "save_state"), \
+             patch.object(p, "module_key_from_path", return_value="test/module-0.1-test"), \
+             patch.object(p, "ensure_fact_ledger", side_effect=fake_fact), \
+             patch.object(p, "ensure_knowledge_card", return_value="card"), \
+             patch.object(p, "step_write", side_effect=fake_write), \
+             patch.object(p, "step_review", side_effect=fake_review), \
+             patch.object(p, "step_check_integrity", return_value=(True, [])), \
+             patch.object(p, "step_check", return_value=(True, [])), \
+             patch("subprocess.run"):
+            p.run_module(self.module_path, state)
+
+        self.assertEqual(events[:3], ["ledger", "write", "review"])
+
+    def test_data_conflict_triage_exit(self):
+        import v1_pipeline as p
+
+        conflict_ledger = {
+            "as_of_date": "2026-04-12",
+            "topic": "Conflict",
+            "claims": [
+                {"id": f"C{i}", "status": "CONFLICTING"} for i in range(1, 6)
+            ],
+        }
+        state = {"modules": {}}
+        with patch.object(p, "STATE_FILE", self.state_file), \
+             patch.object(p, "CONTENT_ROOT", Path(self.tmpdir)), \
+             patch.object(p, "save_state"), \
+             patch.object(p, "module_key_from_path", return_value="test/module-0.1-test"), \
+             patch.object(p, "ensure_fact_ledger", return_value=conflict_ledger):
+            ok = p.run_module(self.module_path, state)
+
+        self.assertFalse(ok)
+        ms = state["modules"]["test/module-0.1-test"]
+        self.assertEqual(ms.get("phase"), "data_conflict")
+        self.assertTrue(any("DATA_CONFLICT" in e for e in ms.get("errors", [])))
+
+    def test_review_uses_gemini_not_codex(self):
+        import v1_pipeline as p
+
+        review_models = []
+        state = {"modules": {}}
+        review_ok = {
+            "verdict": "APPROVE",
+            "checks": [{"id": cid, "passed": True} for cid in p.CHECK_IDS],
+            "edits": [],
+            "feedback": "",
+        }
+
+        def fake_review(_module_path, _improved, model=None, fact_ledger=None):
+            review_models.append(model)
+            return review_ok
+
+        with patch.object(p, "STATE_FILE", self.state_file), \
+             patch.object(p, "CONTENT_ROOT", Path(self.tmpdir)), \
+             patch.object(p, "save_state"), \
+             patch.object(p, "module_key_from_path", return_value="test/module-0.1-test"), \
+             patch.object(p, "ensure_fact_ledger", return_value=sample_fact_ledger()), \
+             patch.object(p, "ensure_knowledge_card", return_value="card"), \
+             patch.object(p, "step_write", return_value=GOOD_MODULE), \
+             patch.object(p, "step_review", side_effect=fake_review), \
+             patch.object(p, "step_check_integrity", return_value=(True, [])), \
+             patch.object(p, "step_check", return_value=(True, [])), \
+             patch("subprocess.run"):
+            p.run_module(self.module_path, state)
+
+        self.assertTrue(review_models)
+        self.assertEqual(review_models[0], p.MODELS["review"])
+        self.assertTrue(review_models[0].startswith("gemini"))
+
+    def test_fact_ledger_cache_hit_skips_dispatch(self):
+        import v1_pipeline as p
+
+        key = "test/module-0.1-test"
+        ledger_dir = Path(self.tmpdir) / ".pipeline" / "fact-ledgers"
+        ledger_dir.mkdir(parents=True, exist_ok=True)
+        cache_path = ledger_dir / "test__module-0.1-test.json"
+        cache_path.write_text(json.dumps(sample_fact_ledger(), indent=2))
+
+        state = {"modules": {}}
+        review_ok = {
+            "verdict": "APPROVE",
+            "checks": [{"id": cid, "passed": True} for cid in p.CHECK_IDS],
+            "edits": [],
+            "feedback": "",
+        }
+        with patch.object(p, "STATE_FILE", self.state_file), \
+             patch.object(p, "CONTENT_ROOT", Path(self.tmpdir)), \
+             patch.object(p, "FACT_LEDGER_DIR", ledger_dir), \
+             patch.object(p, "save_state"), \
+             patch.object(p, "module_key_from_path", return_value=key), \
+             patch.object(p, "dispatch_auto", side_effect=AssertionError("dispatch_auto should not run")), \
+             patch.object(p, "ensure_knowledge_card", return_value="card"), \
+             patch.object(p, "step_write", return_value=GOOD_MODULE), \
+             patch.object(p, "step_review", return_value=review_ok), \
+             patch.object(p, "step_check_integrity", return_value=(True, [])), \
+             patch.object(p, "step_check", return_value=(True, [])), \
+             patch("subprocess.run"):
+            ok = p.run_module(self.module_path, state)
+
+        self.assertTrue(ok)
+
+    def test_existing_binary_gate_tests_still_pass(self):
+        suite = unittest.defaultTestLoader.loadTestsFromTestCase(TestBinaryGateIntegration)
+        result = unittest.TestResult()
+        suite.run(result)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.failures, [])
+
+
+# ---------------------------------------------------------------------------
 # Test: Score calculations
 # ---------------------------------------------------------------------------
 
@@ -1581,7 +2047,7 @@ class TestBinaryGatePassingLogic(unittest.TestCase):
     def test_one_check_fails_routes_via_severity(self):
         """One failing check with a clean edit → targeted, not a numeric threshold."""
         checks = [{"id": cid, "passed": True} for cid in self.p.CHECK_IDS]
-        checks[0] = {"id": "FACT", "passed": False, "evidence": "bad",
+        checks[0] = {"id": "LAB", "passed": False, "evidence": "bad",
                      "edit_refs": [0]}
         edits = [{"type": "replace", "find": "a", "new": "b"}]
         self.assertEqual(self.p.compute_severity("REJECT", checks, edits), "targeted")
@@ -1908,7 +2374,7 @@ class TestDeterministicApplyIntegration(unittest.TestCase):
         step_write_calls = []
 
         def fake_step_write(module_path, plan, model=None, rewrite=False,
-                            previous_output=None, knowledge_card=None):
+                            previous_output=None, knowledge_card=None, fact_ledger=None):
             step_write_calls.append({"model": model, "plan": plan[:100]})
             # Return GOOD_MODULE verbatim; the reviewer's edit will patch it.
             return GOOD_MODULE
@@ -1921,9 +2387,8 @@ class TestDeterministicApplyIntegration(unittest.TestCase):
             {
                 "verdict": "REJECT",
                 "checks": [
-                    {"id": "FACT", "passed": False, "evidence": "minor accuracy",
+                    {"id": "LAB", "passed": False, "evidence": "minor accuracy",
                      "edit_refs": [0]},
-                    {"id": "LAB", "passed": True},
                     {"id": "COV", "passed": True},
                     {"id": "QUIZ", "passed": True},
                     {"id": "EXAM", "passed": True},
@@ -1957,6 +2422,8 @@ class TestDeterministicApplyIntegration(unittest.TestCase):
              patch.object(p, "module_key_from_path", return_value="test/module-0.1-test"), \
              patch.object(p, "step_write", side_effect=fake_step_write), \
              patch.object(p, "step_review", side_effect=review_sequence), \
+             patch.object(p, "ensure_fact_ledger", return_value=sample_fact_ledger()), \
+             patch.object(p, "step_check_integrity", return_value=(True, [])), \
              patch.object(p, "step_check", return_value=(True, [])), \
              patch.object(p, "ensure_knowledge_card", return_value="cached card"):
             p.run_module(self.module_path, state)
@@ -2007,8 +2474,8 @@ class TestDeterministicApplyIntegration(unittest.TestCase):
                 "test/module-0.1-test": {
                     "phase": "review",
                     "severity": "targeted",
-                    "checks_failed": [{"id": "FACT", "evidence": "example"}],
-                    "reviewer_schema_version": 2,
+                    "checks_failed": [{"id": "LAB", "evidence": "example"}],
+                    "reviewer_schema_version": 3,
                     "passes": False,
                     "errors": [],
                 }
@@ -2017,7 +2484,7 @@ class TestDeterministicApplyIntegration(unittest.TestCase):
 
         reviews_seen = []
 
-        def fake_step_review(module_path, improved, model=None):
+        def fake_step_review(module_path, improved, model=None, fact_ledger=None):
             reviews_seen.append(improved)
             return {
                 "verdict": "APPROVE",
@@ -2030,7 +2497,7 @@ class TestDeterministicApplyIntegration(unittest.TestCase):
         step_write_calls = []
 
         def fake_step_write(module_path, plan, model=None, rewrite=False,
-                            previous_output=None, knowledge_card=None):
+                            previous_output=None, knowledge_card=None, fact_ledger=None):
             step_write_calls.append(plan[:80])
             return GOOD_MODULE
 
@@ -2040,6 +2507,8 @@ class TestDeterministicApplyIntegration(unittest.TestCase):
              patch.object(p, "module_key_from_path", return_value="test/module-0.1-test"), \
              patch.object(p, "step_write", side_effect=fake_step_write), \
              patch.object(p, "step_review", side_effect=fake_step_review), \
+             patch.object(p, "ensure_fact_ledger", return_value=sample_fact_ledger()), \
+             patch.object(p, "step_check_integrity", return_value=(True, [])), \
              patch.object(p, "step_check", return_value=(True, [])), \
              patch.object(p, "ensure_knowledge_card", return_value="cached card"):
             p.run_module(self.module_path, state)
@@ -2096,10 +2565,10 @@ class TestDeterministicApplyIntegration(unittest.TestCase):
                     "targeted_fix": True,
                     "severity": "targeted",
                     "checks_failed": [
-                        {"id": "FACT", "evidence": "example1"},
-                        {"id": "LAB", "evidence": "example2"},
+                        {"id": "LAB", "evidence": "example1"},
+                        {"id": "QUIZ", "evidence": "example2"},
                     ],
-                    "reviewer_schema_version": 2,
+                    "reviewer_schema_version": 3,
                     "passes": False,
                     "errors": [],
                 }
@@ -2109,7 +2578,7 @@ class TestDeterministicApplyIntegration(unittest.TestCase):
         write_calls_observed = []
 
         def fake_step_write(module_path, plan, model=None, rewrite=False,
-                            previous_output=None, knowledge_card=None):
+                            previous_output=None, knowledge_card=None, fact_ledger=None):
             write_calls_observed.append({
                 "model": model,
                 "plan": plan,
@@ -2117,7 +2586,7 @@ class TestDeterministicApplyIntegration(unittest.TestCase):
             })
             return GOOD_MODULE.replace("## Learning Outcomes", "## Learning Outcomes (FULLY-FIXED)")
 
-        def fake_step_review(module_path, improved, model=None):
+        def fake_step_review(module_path, improved, model=None, fact_ledger=None):
             return {
                 "verdict": "APPROVE",
                 "severity": "clean",
@@ -2132,6 +2601,8 @@ class TestDeterministicApplyIntegration(unittest.TestCase):
              patch.object(p, "module_key_from_path", return_value="test/module-0.1-test"), \
              patch.object(p, "step_write", side_effect=fake_step_write), \
              patch.object(p, "step_review", side_effect=fake_step_review), \
+             patch.object(p, "ensure_fact_ledger", return_value=sample_fact_ledger()), \
+             patch.object(p, "step_check_integrity", return_value=(True, [])), \
              patch.object(p, "step_check", return_value=(True, [])), \
              patch.object(p, "ensure_knowledge_card", return_value="cached card"):
             p.run_module(self.module_path, state)

--- a/scripts/test_pipeline.py
+++ b/scripts/test_pipeline.py
@@ -2145,7 +2145,7 @@ class TestStepCheckIntegrity(unittest.TestCase):
             "See https://example.com/a and https://example.com/b"
         )
         with patch.object(p, "LINK_CACHE_FILE", self.link_cache), \
-             patch.object(p, "_get_url_status", return_value=200):
+             patch.object(p, "_probe_url", return_value=200):
             passed, messages = p.step_check_integrity(content, sample_fact_ledger())
 
         self.assertTrue(passed)
@@ -2159,11 +2159,11 @@ class TestStepCheckIntegrity(unittest.TestCase):
             "Good https://example.com/ok bad https://example.com/dead"
         )
 
-        def fake_status(url, _cache):
+        def fake_status(url):
             return 404 if "dead" in url else 200
 
         with patch.object(p, "LINK_CACHE_FILE", self.link_cache), \
-             patch.object(p, "_get_url_status", side_effect=fake_status):
+             patch.object(p, "_probe_url", side_effect=fake_status):
             passed, messages = p.step_check_integrity(content, sample_fact_ledger())
 
         self.assertFalse(passed)
@@ -2329,6 +2329,50 @@ class TestStepCheckIntegrity(unittest.TestCase):
 
         self.assertFalse(passed)
         self.assertTrue(any(m.startswith("UNMAPPED_CLAIM: Helm v3.17.0") for m in messages))
+
+    def test_reverse_evidence_mapping_ignores_fenced_yaml_examples(self):
+        """Regression for round-2 gpt-5.4 finding: standard K8s YAML examples
+        inside ```yaml fences contain API tokens like `apps/v1` that are
+        syntax, not claims. They must not be forced to appear in the fact
+        ledger, or every module with a code example fails tier-1.
+        """
+        import v1_pipeline as p
+
+        ledger = self._supported_ledger("C1", "Kubernetes current stable is v1.35.")
+        content = (
+            "Kubernetes current stable is v1.35.\n"
+            "\n"
+            "```yaml\n"
+            "apiVersion: apps/v1\n"
+            "kind: Deployment\n"
+            "metadata:\n"
+            "  name: demo\n"
+            "spec:\n"
+            "  selector:\n"
+            "    matchLabels:\n"
+            "      app: demo\n"
+            "  template:\n"
+            "    metadata:\n"
+            "      labels:\n"
+            "        app: demo\n"
+            "    spec:\n"
+            "      containers:\n"
+            "      - name: app\n"
+            "        image: busybox:1.36\n"
+            "```\n"
+            "\n"
+            "```bash\n"
+            "kubectl apply -f deploy.yaml\n"
+            "```\n"
+        )
+        with patch.object(p, "LINK_CACHE_FILE", self.link_cache):
+            passed, messages = p.step_check_integrity(content, ledger)
+
+        self.assertTrue(passed, f"integrity should pass; got messages: {messages}")
+        self.assertFalse(
+            any(m.startswith("UNMAPPED_CLAIM: apps/v1") for m in messages),
+            "apps/v1 inside a ```yaml fence is syntax, not a claim",
+        )
 
 
 class TestRunModuleSplitReviewer(unittest.TestCase):

--- a/scripts/test_pipeline.py
+++ b/scripts/test_pipeline.py
@@ -17,6 +17,7 @@ import shutil
 import tempfile
 import textwrap
 import unittest
+from argparse import Namespace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import patch
@@ -40,9 +41,9 @@ def sample_fact_ledger() -> dict:
         "claims": [
             {
                 "id": "C1",
-                "claim": "Kubernetes current stable is v1.32",
+                "claim": "Kubernetes current stable is v1.35",
                 "status": "SUPPORTED",
-                "current_truth": "Kubernetes current stable is v1.32",
+                "current_truth": "Kubernetes current stable is v1.35",
                 "sources": [{"url": "https://kubernetes.io/releases/", "source_date": "2026-04-12"}],
                 "conflict_summary": None,
                 "unverified_reason": None,
@@ -1325,20 +1326,19 @@ class TestBinaryGateIntegration(unittest.TestCase):
 
 
 class TestLegacyStateCompat(unittest.TestCase):
-    """Modules approved under the v1 (sum/scores) rubric must still load,
-    display, and commit correctly under the new binary gate.
-
-    Per Gemini pair-review critique C, cmd_status must fall back to a
-    [LEGACY] display rather than trying to map D1-D8 to the new check IDs.
-    """
+    """Legacy state fixtures must continue to load and upgrade cleanly."""
 
     def setUp(self):
-        import v1_pipeline as p
-        self.p = p
+        self.tmpdir = tempfile.mkdtemp()
+        self.state_file = Path(self.tmpdir) / "state.yaml"
+        self.module_path = Path(self.tmpdir) / "module-0.1-test.md"
+        self.module_path.write_text(GOOD_MODULE)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
 
     def test_legacy_state_has_scores_and_no_severity(self):
-        """A legacy state entry has scores + sum but no severity field.
-        The status loader must recognize it and count it under legacy."""
+        """v1 legacy fixture shape is still represented correctly."""
         legacy_ms = {
             "phase": "done",
             "scores": [4, 4, 4, 4, 4, 4, 4, 5],
@@ -1353,21 +1353,119 @@ class TestLegacyStateCompat(unittest.TestCase):
         self.assertIsNone(legacy_ms.get("reviewer_schema_version"))
         self.assertIsNotNone(legacy_ms.get("scores"))
 
-    def test_binary_state_has_severity_and_no_scores(self):
-        """A new-gate state entry has severity + checks_failed, no scores."""
-        new_ms = {
-            "phase": "done",
-            "severity": "clean",
-            "checks_failed": [],
-            "reviewer_schema_version": 3,
-            "passes": True,
-            "last_run": "2026-04-11T12:00:00+00:00",
-            "errors": [],
-            "reviewer": "gemini",
+    @patch("subprocess.run")
+    def test_v2_state_fixture_upgrades_to_v3_shape(self, _mock_subprocess):
+        """A v2 fixture (reviewer_schema_version=2) upgrades after one run."""
+        import v1_pipeline as p
+
+        state = {
+            "modules": {
+                "test/module-0.1-test": {
+                    "phase": "review",
+                    "reviewer_schema_version": 2,
+                    "scores": [4, 4, 4, 4, 4, 4, 4, 5],
+                    "sum": 33,
+                    "passes": False,
+                    "errors": [],
+                }
+            }
         }
-        self.assertEqual(new_ms.get("reviewer_schema_version"), 3)
-        self.assertIsNone(new_ms.get("scores"))
-        self.assertIn("severity", new_ms)
+        review_ok = {
+            "verdict": "APPROVE",
+            "checks": [{"id": cid, "passed": True} for cid in p.CHECK_IDS],
+            "edits": [],
+            "feedback": "",
+        }
+
+        with patch.object(p, "STATE_FILE", self.state_file), \
+             patch.object(p, "CONTENT_ROOT", Path(self.tmpdir)), \
+             patch.object(p, "save_state"), \
+             patch.object(p, "module_key_from_path", return_value="test/module-0.1-test"), \
+             patch.object(p, "ensure_fact_ledger", return_value=sample_fact_ledger()), \
+             patch.object(p, "step_check_integrity", return_value=(True, [])), \
+             patch.object(p, "step_review", return_value=review_ok), \
+             patch.object(p, "step_check", return_value=(True, [])):
+            p.run_module(self.module_path, state, max_retries=0)
+
+        ms = state["modules"]["test/module-0.1-test"]
+        self.assertEqual(ms.get("reviewer_schema_version"), 3)
+        self.assertIn("checks_failed", ms)
+        self.assertNotIn("scores", ms)
+        self.assertNotIn("sum", ms)
+
+    @patch("subprocess.run")
+    def test_v1_state_fixture_upgrades_to_v3_shape(self, _mock_subprocess):
+        """A v1 fixture (no reviewer_schema_version) upgrades after one run."""
+        import v1_pipeline as p
+
+        state = {
+            "modules": {
+                "test/module-0.1-test": {
+                    "phase": "review",
+                    "scores": [4, 4, 4, 4, 4, 4, 4, 5],
+                    "sum": 33,
+                    "passes": False,
+                    "errors": [],
+                }
+            }
+        }
+        review_ok = {
+            "verdict": "APPROVE",
+            "checks": [{"id": cid, "passed": True} for cid in p.CHECK_IDS],
+            "edits": [],
+            "feedback": "",
+        }
+
+        with patch.object(p, "STATE_FILE", self.state_file), \
+             patch.object(p, "CONTENT_ROOT", Path(self.tmpdir)), \
+             patch.object(p, "save_state"), \
+             patch.object(p, "module_key_from_path", return_value="test/module-0.1-test"), \
+             patch.object(p, "ensure_fact_ledger", return_value=sample_fact_ledger()), \
+             patch.object(p, "step_check_integrity", return_value=(True, [])), \
+             patch.object(p, "step_review", return_value=review_ok), \
+             patch.object(p, "step_check", return_value=(True, [])):
+            p.run_module(self.module_path, state, max_retries=0)
+
+        ms = state["modules"]["test/module-0.1-test"]
+        self.assertEqual(ms.get("reviewer_schema_version"), 3)
+        self.assertIn("checks_failed", ms)
+        self.assertNotIn("scores", ms)
+        self.assertNotIn("sum", ms)
+
+
+class TestLegacyReviewerCompat(unittest.TestCase):
+    """Legacy reviewer payloads with `scores` should normalize to v3 checks."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.module_path = Path(self.tmpdir) / "module-0.1-test.md"
+        self.module_path.write_text(GOOD_MODULE)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_legacy_scores_normalized_to_checks(self):
+        import v1_pipeline as p
+
+        payload = {
+            "verdict": "APPROVE",
+            "scores": {
+                "lab": 5,
+                "coverage": 4,
+                "quiz": 2,
+            },
+            "feedback": "Legacy schema output",
+        }
+        with patch.object(p, "module_key_from_path", return_value="test/module-0.1-test"), \
+             patch.object(p, "dispatch_auto", return_value=(True, json.dumps(payload))):
+            review = p.step_review(self.module_path, GOOD_MODULE)
+
+        self.assertIsNotNone(review)
+        checks = review.get("checks", [])
+        self.assertGreaterEqual(len(checks), 3)
+        self.assertTrue(any(c.get("id") == "LAB" and c.get("passed") for c in checks))
+        self.assertTrue(any(c.get("id") == "QUIZ" and not c.get("passed") for c in checks))
+        self.assertTrue(all("evidence" in c for c in checks))
 
 
 # ---------------------------------------------------------------------------
@@ -1751,20 +1849,301 @@ class TestFactLedger(unittest.TestCase):
         self.assertEqual(refreshed["topic"], "Test Module B")
 
 
+class TestEnsureFactLedger(unittest.TestCase):
+    """Test ensure_fact_ledger cache precedence and refresh behavior."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.repo_root = Path(self.tmpdir)
+        self.content_root = self.repo_root / "src" / "content" / "docs"
+        self.content_root.mkdir(parents=True, exist_ok=True)
+        self.module_path = self.content_root / "test" / "module-0.1-test.md"
+        self.module_path.parent.mkdir(parents=True, exist_ok=True)
+        self.module_path.write_text("---\ntitle: Test Module\n---\n\nBody")
+        self.ledger_dir = self.repo_root / ".pipeline" / "fact-ledgers"
+        self.module_key = "test/module-0.1-test"
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _payload(self, marker: str = "5") -> dict:
+        return {
+            "as_of_date": "2026-04-12",
+            "topic": f"Test {marker}",
+            "claims": [
+                {
+                    "id": "C1",
+                    "claim": f"Kubernetes stable is v1.3{marker}",
+                    "status": "SUPPORTED",
+                    "current_truth": f"Kubernetes stable is v1.3{marker}",
+                    "sources": [{"url": "https://kubernetes.io/releases/", "source_date": "2026-04-12"}],
+                    "conflict_summary": None,
+                    "unverified_reason": None,
+                }
+            ],
+        }
+
+    def _cache_path(self) -> Path:
+        return self.ledger_dir / "test__module-0.1-test.json"
+
+    def test_no_file_runs_generator(self):
+        import v1_pipeline as p
+
+        ms = {}
+        payload = self._payload("5")
+        with patch.object(p, "FACT_LEDGER_DIR", self.ledger_dir), \
+             patch.object(p, "module_key_from_path", return_value=self.module_key), \
+             patch.object(p, "step_fact_ledger", return_value=payload) as mock_step:
+            result = p.ensure_fact_ledger(self.module_path, ms)
+
+        self.assertEqual(mock_step.call_count, 1)
+        self.assertEqual(result, payload)
+        self.assertEqual(ms.get("fact_ledger"), payload)
+        self.assertIn("fact_ledger_generated_at", ms)
+
+    def test_fresh_file_returns_cached(self):
+        import v1_pipeline as p
+
+        payload = self._payload("5")
+        self.ledger_dir.mkdir(parents=True, exist_ok=True)
+        self._cache_path().write_text(json.dumps(payload))
+        ms = {}
+        with patch.object(p, "FACT_LEDGER_DIR", self.ledger_dir), \
+             patch.object(p, "module_key_from_path", return_value=self.module_key), \
+             patch.object(p, "step_fact_ledger", side_effect=AssertionError("should not regenerate")):
+            result = p.ensure_fact_ledger(self.module_path, ms)
+
+        self.assertEqual(result, payload)
+        self.assertEqual(ms.get("fact_ledger"), payload)
+        self.assertNotIn("fact_ledger_generated_at", ms)
+
+    def test_stale_file_regenerates(self):
+        import v1_pipeline as p
+
+        stale_payload = self._payload("5")
+        fresh_payload = self._payload("6")
+        self.ledger_dir.mkdir(parents=True, exist_ok=True)
+        self._cache_path().write_text(json.dumps(stale_payload))
+        old_ts = (datetime.now(UTC) - timedelta(days=8)).timestamp()
+        os.utime(self._cache_path(), (old_ts, old_ts))
+
+        ms = {}
+        with patch.object(p, "FACT_LEDGER_DIR", self.ledger_dir), \
+             patch.object(p, "module_key_from_path", return_value=self.module_key), \
+             patch.object(p, "step_fact_ledger", return_value=fresh_payload) as mock_step:
+            result = p.ensure_fact_ledger(self.module_path, ms)
+
+        self.assertEqual(mock_step.call_count, 1)
+        self.assertEqual(result, fresh_payload)
+
+    def test_corrupt_file_regenerates(self):
+        import v1_pipeline as p
+
+        self.ledger_dir.mkdir(parents=True, exist_ok=True)
+        self._cache_path().write_text("{not-json")
+        payload = self._payload("7")
+        ms = {}
+        with patch.object(p, "FACT_LEDGER_DIR", self.ledger_dir), \
+             patch.object(p, "module_key_from_path", return_value=self.module_key), \
+             patch.object(p, "step_fact_ledger", return_value=payload) as mock_step:
+            result = p.ensure_fact_ledger(self.module_path, ms)
+
+        self.assertEqual(mock_step.call_count, 1)
+        self.assertEqual(result, payload)
+
+    def test_file_cache_authoritative(self):
+        import v1_pipeline as p
+
+        ms = {
+            "fact_ledger": self._payload("5"),
+            "fact_ledger_generated_at": datetime.now(UTC).isoformat(),
+        }
+        regenerated = self._payload("8")
+        with patch.object(p, "FACT_LEDGER_DIR", self.ledger_dir), \
+             patch.object(p, "module_key_from_path", return_value=self.module_key), \
+             patch.object(p, "step_fact_ledger", return_value=regenerated) as mock_step:
+            result = p.ensure_fact_ledger(self.module_path, ms)
+
+        self.assertEqual(mock_step.call_count, 1, "Missing file must force regeneration even with fresh state metadata")
+        self.assertEqual(result, regenerated)
+        self.assertEqual(ms.get("fact_ledger"), regenerated)
+
+    def test_refresh_bypasses_cache(self):
+        import v1_pipeline as p
+
+        cached = self._payload("5")
+        refreshed = self._payload("9")
+        self.ledger_dir.mkdir(parents=True, exist_ok=True)
+        self._cache_path().write_text(json.dumps(cached))
+        ms = {}
+        with patch.object(p, "FACT_LEDGER_DIR", self.ledger_dir), \
+             patch.object(p, "module_key_from_path", return_value=self.module_key), \
+             patch.object(p, "step_fact_ledger", return_value=refreshed) as mock_step:
+            result = p.ensure_fact_ledger(self.module_path, ms, refresh=True)
+
+        self.assertEqual(mock_step.call_count, 1)
+        self.assertEqual(result, refreshed)
+
+
+class TestCliRefreshFactLedgerFlag(unittest.TestCase):
+    """CLI commands should propagate --refresh-fact-ledger into run_module."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.content_root = Path(self.tmpdir) / "src" / "content" / "docs"
+        self.section = "prerequisites/zero-to-terminal"
+        self.section_dir = self.content_root / self.section
+        self.section_dir.mkdir(parents=True, exist_ok=True)
+        self.module_path = self.section_dir / "module-0.1-test.md"
+        self.module_path.write_text(GOOD_MODULE)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    @patch("sys.exit", side_effect=SystemExit)
+    def test_cmd_run_propagates_flag(self, _mock_exit):
+        import v1_pipeline as p
+
+        args = Namespace(
+            module=str(self.module_path),
+            write_model=None,
+            review_model=None,
+            dry_run=False,
+            refresh_fact_ledger=True,
+        )
+        with patch.object(p, "load_state", return_value={"modules": {}}), \
+             patch.object(p, "run_module", return_value=True) as mock_run:
+            with self.assertRaises(SystemExit):
+                p.cmd_run(args)
+
+        self.assertTrue(mock_run.call_args.kwargs.get("refresh_fact_ledger"))
+
+    @patch("sys.exit", side_effect=SystemExit)
+    def test_cmd_run_section_propagates_flag(self, _mock_exit):
+        import v1_pipeline as p
+
+        args = Namespace(
+            section=self.section,
+            workers=1,
+            track=None,
+            skip_gaps=False,
+            dry_run=False,
+            write_model=None,
+            review_model=None,
+            refresh_fact_ledger=True,
+        )
+        with patch.object(p, "CONTENT_ROOT", self.content_root), \
+             patch.object(p.gaps, "run_track_gap_analysis", return_value=[]), \
+             patch.object(p, "load_state", return_value={"modules": {}}), \
+             patch.object(p, "run_module", return_value=True) as mock_run:
+            with self.assertRaises(SystemExit):
+                p.cmd_run_section(args)
+
+        self.assertTrue(mock_run.call_args.kwargs.get("refresh_fact_ledger"))
+
+    def test_cmd_resume_propagates_flag(self):
+        import v1_pipeline as p
+
+        args = Namespace(
+            write_model=None,
+            review_model=None,
+            refresh_fact_ledger=True,
+        )
+        state = {
+            "modules": {
+                "test/module-0.1-test": {"phase": "review"}
+            }
+        }
+        with patch.object(p, "load_state", return_value=state), \
+             patch.object(p, "find_module_path", return_value=self.module_path), \
+             patch.object(p, "run_module", return_value=True) as mock_run:
+            p.cmd_resume(args)
+
+        self.assertTrue(mock_run.call_args.kwargs.get("refresh_fact_ledger"))
+
+    def test_cmd_e2e_propagates_flag(self):
+        import v1_pipeline as p
+
+        args = Namespace(
+            sections=[self.section],
+            verbose=True,
+            no_translate=True,
+            write_model=None,
+            review_model=None,
+            refresh_fact_ledger=True,
+        )
+        with patch.object(p, "CONTENT_ROOT", self.content_root), \
+             patch.object(p, "load_state", return_value={"modules": {}}), \
+             patch.object(p, "run_module", return_value=True) as mock_run:
+            p.cmd_e2e(args)
+
+        self.assertTrue(mock_run.call_args.kwargs.get("refresh_fact_ledger"))
+
+
 class TestStepCheckIntegrity(unittest.TestCase):
     """Test tier-1 deterministic integrity checks."""
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
         self.link_cache = Path(self.tmpdir) / "link-cache.json"
+        self.state_file = Path(self.tmpdir) / "state.yaml"
+        self.module_path = Path(self.tmpdir) / "module-0.1-test.md"
+        self.module_path.write_text(GOOD_MODULE)
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
+    def _supported_ledger(self, claim_id: str, statement: str) -> dict:
+        return {
+            "claims": [
+                {
+                    "id": claim_id,
+                    "claim": statement,
+                    "status": "SUPPORTED",
+                    "current_truth": statement,
+                    "sources": [],
+                    "conflict_summary": None,
+                    "unverified_reason": None,
+                }
+            ]
+        }
+
+    def test_runs_before_review_on_fail(self):
+        import v1_pipeline as p
+
+        review_calls = {"count": 0}
+
+        def fake_review(*_args, **_kwargs):
+            review_calls["count"] += 1
+            return {
+                "verdict": "APPROVE",
+                "checks": [{"id": cid, "passed": True} for cid in p.CHECK_IDS],
+                "edits": [],
+                "feedback": "",
+            }
+
+        state = {"modules": {}}
+        with patch.object(p, "STATE_FILE", self.state_file), \
+             patch.object(p, "CONTENT_ROOT", Path(self.tmpdir)), \
+             patch.object(p, "save_state"), \
+             patch.object(p, "module_key_from_path", return_value="test/module-0.1-test"), \
+             patch.object(p, "ensure_fact_ledger", return_value=sample_fact_ledger()), \
+             patch.object(p, "step_write", return_value=GOOD_MODULE), \
+             patch.object(p, "step_check_integrity", return_value=(False, ["LINK_DEAD: https://dead.example (404)"])), \
+             patch.object(p, "step_review", side_effect=fake_review), \
+             patch("subprocess.run"):
+            ok = p.run_module(self.module_path, state, max_retries=0)
+
+        self.assertFalse(ok)
+        self.assertEqual(review_calls["count"], 0, "Integrity failure must short-circuit structural review")
+
     def test_link_health_all_resolve(self):
         import v1_pipeline as p
 
-        content = "See https://example.com/a and https://example.com/b"
+        content = (
+            "Kubernetes current stable is v1.35. "
+            "See https://example.com/a and https://example.com/b"
+        )
         with patch.object(p, "LINK_CACHE_FILE", self.link_cache), \
              patch.object(p, "_get_url_status", return_value=200):
             passed, messages = p.step_check_integrity(content, sample_fact_ledger())
@@ -1775,7 +2154,10 @@ class TestStepCheckIntegrity(unittest.TestCase):
     def test_link_health_dead_url_fails(self):
         import v1_pipeline as p
 
-        content = "Good https://example.com/ok bad https://example.com/dead"
+        content = (
+            "Kubernetes current stable is v1.35. "
+            "Good https://example.com/ok bad https://example.com/dead"
+        )
 
         def fake_status(url, _cache):
             return 404 if "dead" in url else 200
@@ -1790,7 +2172,10 @@ class TestStepCheckIntegrity(unittest.TestCase):
     def test_yaml_lint_valid_passes(self):
         import v1_pipeline as p
 
-        content = "```yaml\napiVersion: v1\nkind: Pod\nmetadata:\n  name: demo\n```"
+        content = (
+            "Kubernetes current stable is v1.35.\n"
+            "```yaml\napiVersion: v1\nkind: Pod\nmetadata:\n  name: demo\n```"
+        )
         with patch.object(p, "LINK_CACHE_FILE", self.link_cache):
             passed, messages = p.step_check_integrity(content, sample_fact_ledger())
 
@@ -1800,7 +2185,10 @@ class TestStepCheckIntegrity(unittest.TestCase):
     def test_yaml_lint_invalid_fails(self):
         import v1_pipeline as p
 
-        content = "```yaml\napiVersion: v1\nkind Pod\nmetadata:\n  name: demo\n```"
+        content = (
+            "Kubernetes current stable is v1.35.\n"
+            "```yaml\napiVersion: v1\nkind Pod\nmetadata:\n  name: demo\n```"
+        )
         with patch.object(p, "LINK_CACHE_FILE", self.link_cache):
             passed, messages = p.step_check_integrity(content, sample_fact_ledger())
 
@@ -1810,22 +2198,56 @@ class TestStepCheckIntegrity(unittest.TestCase):
     def test_version_consistency_warns_only(self):
         import v1_pipeline as p
 
-        content = "This module compares v1.30 and 1.32 behavior."
+        ledger = {
+            "claims": [
+                {
+                    "id": "C1",
+                    "claim": "Controller behavior changed in v1.35.",
+                    "status": "SUPPORTED",
+                    "current_truth": "Controller behavior changed in v1.35.",
+                    "sources": [],
+                    "conflict_summary": None,
+                    "unverified_reason": None,
+                },
+                {
+                    "id": "C2",
+                    "claim": "Scheduler behavior changed in v1.36.",
+                    "status": "SUPPORTED",
+                    "current_truth": "Scheduler behavior changed in v1.36.",
+                    "sources": [],
+                    "conflict_summary": None,
+                    "unverified_reason": None,
+                },
+            ]
+        }
+        content = "Controller behavior changed in v1.35. Scheduler behavior changed in v1.36."
         with patch.object(p, "LINK_CACHE_FILE", self.link_cache):
-            passed, messages = p.step_check_integrity(content, sample_fact_ledger())
+            passed, messages = p.step_check_integrity(content, ledger)
 
         self.assertTrue(passed)
         self.assertTrue(any(m.startswith("VERSION_MISMATCH_WARNING") for m in messages))
 
-    def test_version_stale_fails(self):
+    def test_version_floor_1_35(self):
         import v1_pipeline as p
 
-        content = "Old guidance references v1.20 in production."
         with patch.object(p, "LINK_CACHE_FILE", self.link_cache):
-            passed, messages = p.step_check_integrity(content, sample_fact_ledger())
+            passed_134, messages_134 = p.step_check_integrity(
+                "Kubernetes current stable is v1.34.",
+                self._supported_ledger("C34", "Kubernetes current stable is v1.34."),
+            )
+            passed_135, _ = p.step_check_integrity(
+                "Kubernetes current stable is v1.35.",
+                self._supported_ledger("C35", "Kubernetes current stable is v1.35."),
+            )
+            passed_136, _ = p.step_check_integrity(
+                "Kubernetes current stable is v1.36.",
+                self._supported_ledger("C36", "Kubernetes current stable is v1.36."),
+            )
 
-        self.assertFalse(passed)
-        self.assertTrue(any("STALE_K8S_VERSION: v1.20" in m for m in messages))
+        self.assertFalse(passed_134)
+        self.assertTrue(any("STALE_K8S_VERSION: v1.34" in m for m in messages_134))
+        self.assertTrue(passed_135)
+        self.assertTrue(passed_136)
 
     def test_evidence_mapping_unhedged_conflict_fails(self):
         import v1_pipeline as p
@@ -1833,17 +2255,26 @@ class TestStepCheckIntegrity(unittest.TestCase):
         ledger = {
             "claims": [
                 {
+                    "id": "C8",
+                    "claim": "Kubernetes current stable is v1.35",
+                    "status": "SUPPORTED",
+                    "current_truth": "Kubernetes current stable is v1.35",
+                    "sources": [],
+                    "conflict_summary": None,
+                    "unverified_reason": None,
+                },
+                {
                     "id": "C9",
-                    "claim": "Kubernetes current stable is v1.32",
+                    "claim": "Kubernetes current stable is v1.35",
                     "status": "CONFLICTING",
-                    "current_truth": "Kubernetes current stable is v1.32",
+                    "current_truth": "Kubernetes current stable is v1.35",
                     "sources": [],
                     "conflict_summary": "Disagreement",
                     "unverified_reason": None,
                 }
             ]
         }
-        content = "Kubernetes current stable is v1.32."
+        content = "Kubernetes current stable is v1.35."
         with patch.object(p, "LINK_CACHE_FILE", self.link_cache):
             passed, messages = p.step_check_integrity(content, ledger)
 
@@ -1856,10 +2287,19 @@ class TestStepCheckIntegrity(unittest.TestCase):
         ledger = {
             "claims": [
                 {
+                    "id": "C11",
+                    "claim": "Kubernetes current stable is v1.35",
+                    "status": "SUPPORTED",
+                    "current_truth": "Kubernetes current stable is v1.35",
+                    "sources": [],
+                    "conflict_summary": None,
+                    "unverified_reason": None,
+                },
+                {
                     "id": "C10",
-                    "claim": "Kubernetes current stable is v1.32",
+                    "claim": "Kubernetes current stable is v1.35",
                     "status": "CONFLICTING",
-                    "current_truth": "Kubernetes current stable is v1.32",
+                    "current_truth": "Kubernetes current stable is v1.35",
                     "sources": [],
                     "conflict_summary": "Disagreement",
                     "unverified_reason": None,
@@ -1868,13 +2308,27 @@ class TestStepCheckIntegrity(unittest.TestCase):
         }
         content = (
             "According to upstream docs as of 2026-04-12, "
-            "Kubernetes current stable is v1.32."
+            "Kubernetes current stable is v1.35."
         )
         with patch.object(p, "LINK_CACHE_FILE", self.link_cache):
             passed, messages = p.step_check_integrity(content, ledger)
 
         self.assertTrue(passed)
         self.assertFalse(any(m.startswith("UNHEDGED_CONFLICT") for m in messages))
+
+    def test_reverse_evidence_mapping_catches_unmapped_claim(self):
+        import v1_pipeline as p
+
+        ledger = self._supported_ledger("C1", "Kubernetes current stable is v1.35.")
+        content = (
+            "Kubernetes current stable is v1.35. "
+            "Helm v3.17.0 introduces imaginaryKey.priorityClass."
+        )
+        with patch.object(p, "LINK_CACHE_FILE", self.link_cache):
+            passed, messages = p.step_check_integrity(content, ledger)
+
+        self.assertFalse(passed)
+        self.assertTrue(any(m.startswith("UNMAPPED_CLAIM: Helm v3.17.0") for m in messages))
 
 
 class TestRunModuleSplitReviewer(unittest.TestCase):

--- a/scripts/v1_pipeline.py
+++ b/scripts/v1_pipeline.py
@@ -1522,23 +1522,39 @@ def _save_link_cache(cache: dict) -> None:
     _atomic_write_text(LINK_CACHE_FILE, json.dumps(cache, indent=2, ensure_ascii=False))
 
 
-def _get_url_status(url: str, cache: dict) -> int | None:
-    """Return HTTP status for URL, using 24h cache when available."""
-    cached = cache.get(url) if isinstance(cache, dict) else None
-    if isinstance(cached, dict):
-        checked_at_raw = cached.get("checked_at")
-        status = cached.get("status")
-        if isinstance(checked_at_raw, str):
-            try:
-                checked_at = datetime.fromisoformat(checked_at_raw)
-                if checked_at.tzinfo is None:
-                    checked_at = checked_at.replace(tzinfo=UTC)
-                if datetime.now(UTC) - checked_at < LINK_CACHE_TTL:
-                    return status if isinstance(status, int) else None
-            except ValueError:
-                pass
+def _read_cached_url_status(cache: dict, url: str) -> tuple[bool, int | None]:
+    """Look up a cached URL status. Returns (hit, status): hit is True when the
+    cache entry is present AND within TTL. Pure read, no mutation, no network.
+    """
+    if not isinstance(cache, dict):
+        return False, None
+    cached = cache.get(url)
+    if not isinstance(cached, dict):
+        return False, None
+    checked_at_raw = cached.get("checked_at")
+    status = cached.get("status")
+    if not isinstance(checked_at_raw, str):
+        return False, None
+    try:
+        checked_at = datetime.fromisoformat(checked_at_raw)
+    except ValueError:
+        return False, None
+    if checked_at.tzinfo is None:
+        checked_at = checked_at.replace(tzinfo=UTC)
+    if datetime.now(UTC) - checked_at >= LINK_CACHE_TTL:
+        return False, None
+    return True, status if isinstance(status, int) else None
 
-    def _probe(method: str) -> int | None:
+
+def _probe_url(url: str) -> int | None:
+    """Fetch current HTTP status for a URL. Pure network I/O — no cache access.
+
+    Split out of the old `_get_url_status` so the link-cache lock can wrap
+    ONLY the cache read/write, never this function. Wrapping network calls
+    under the lock was the original concurrency bug: it serialized every
+    HTTP probe across the ThreadPoolExecutor and defeated parallelism.
+    """
+    def _call(method: str) -> int | None:
         headers = {"Range": "bytes=0-1023"} if method == "GET" else {}
         req = urllib.request.Request(url, method=method, headers=headers)
         try:
@@ -1554,20 +1570,45 @@ def _get_url_status(url: str, cache: dict) -> int | None:
         except (urllib.error.URLError, TimeoutError, ValueError):
             return None
 
-    head_status = _probe("HEAD")
+    head_status = _call("HEAD")
     status_code = head_status
     if head_status in (403, 405):
-        get_status = _probe("GET")
-        if get_status is not None and get_status < 400:
+        get_status = _call("GET")
+        if get_status is not None:
             status_code = get_status
-        elif get_status is not None:
-            status_code = get_status
-
-    cache[url] = {
-        "status": status_code,
-        "checked_at": datetime.now(UTC).isoformat(),
-    }
     return status_code
+
+
+def _resolve_url_statuses(urls: list[str]) -> dict[str, int | None]:
+    """Resolve URL statuses via the shared link cache with minimal lock scope.
+
+    Phase A (lock): snapshot cache hits, list the URLs that need probing.
+    Phase B (no lock): probe uncached URLs — the slow network calls run
+                       concurrently across threads.
+    Phase C (lock): re-load the cache, merge probed results, persist.
+    """
+    hits: dict[str, int | None] = {}
+    to_probe: list[str] = []
+    with _LINK_CACHE_LOCK:
+        cache = _load_link_cache()
+        for url in urls:
+            hit, status = _read_cached_url_status(cache, url)
+            if hit:
+                hits[url] = status
+            else:
+                to_probe.append(url)
+
+    probed: dict[str, int | None] = {url: _probe_url(url) for url in to_probe}
+
+    if probed:
+        with _LINK_CACHE_LOCK:
+            cache = _load_link_cache()
+            now_iso = datetime.now(UTC).isoformat()
+            for url, status in probed.items():
+                cache[url] = {"status": status, "checked_at": now_iso}
+            _save_link_cache(cache)
+
+    return {**hits, **probed}
 
 
 def _contains_with_tolerance(haystack: str, needle: str,
@@ -1633,35 +1674,53 @@ HELM_KEY_RE = re.compile(r"`([A-Za-z][A-Za-z0-9_.-]*\.[A-Za-z0-9_.-]+)`")
 DEPRECATION_STATUS_TERMS = ("deprecated", "deprecation", "removed", "stable", "ga", "beta", "alpha")
 
 
+_FENCED_CODE_RE = re.compile(r"```[^\n]*\n[\s\S]*?```", re.MULTILINE)
+
+
+def _strip_fenced_code(content: str) -> str:
+    """Remove fenced code blocks. Factual claim extraction runs on prose only:
+    tokens inside code fences are illustrative syntax, not claims the writer
+    is asserting, and separate YAML/lint passes already validate them.
+    """
+    return _FENCED_CODE_RE.sub("", content)
+
+
 def _extract_factual_claim_candidates(content: str) -> list[str]:
-    """Extract likely factual claim fragments that require ledger mapping."""
+    """Extract likely factual claim fragments that require ledger mapping.
+
+    Scans PROSE only (fenced code blocks are stripped first). API tokens and
+    version strings that appear solely inside ```yaml / ```bash examples are
+    treated as syntax, not as claims, and so they are not required to have a
+    corresponding fact-ledger entry.
+    """
+    prose = _strip_fenced_code(content)
     candidates: set[str] = set()
 
-    for match in K8S_VERSION_RE.finditer(content):
+    for match in K8S_VERSION_RE.finditer(prose):
         minor = match.group(1)
-        snippet = content[max(0, match.start() - 40):min(len(content), match.end() + 40)]
+        snippet = prose[max(0, match.start() - 40):min(len(prose), match.end() + 40)]
         compact = " ".join(snippet.split())
         if compact:
             candidates.add(compact)
         candidates.add(f"v1.{minor}")
 
-    for match in PRODUCT_VERSION_RE.finditer(content):
+    for match in PRODUCT_VERSION_RE.finditer(prose):
         candidates.add(" ".join(match.group(0).split()))
 
-    for match in API_NAME_RE.finditer(content):
+    for match in API_NAME_RE.finditer(prose):
         token = match.group(0)
         if token and not token.startswith("http"):
             candidates.add(token)
 
-    for match in HELM_KEY_RE.finditer(content):
+    for match in HELM_KEY_RE.finditer(prose):
         token = match.group(1).strip()
         if token:
             candidates.add(token)
 
-    for line in content.splitlines():
+    for line in prose.splitlines():
         compact = " ".join(line.split())
         lowered = compact.lower()
-        if not compact or compact.startswith("```"):
+        if not compact:
             continue
         if any(term in lowered for term in DEPRECATION_STATUS_TERMS):
             candidates.add(compact[:160])
@@ -1693,16 +1752,17 @@ def step_check_integrity(content: str, fact_ledger: dict) -> tuple[bool, list[st
     errors: list[str] = []
     warnings: list[str] = []
 
-    # 1) Link health with 24h cache
+    # 1) Link health with 24h cache. Cache dict access is protected by
+    # `_LINK_CACHE_LOCK` inside `_resolve_url_statuses`; the actual HTTP
+    # probes run OUTSIDE the lock so parallel section workers don't
+    # serialize on network I/O.
     urls = sorted(set(re.findall(r"https?://[^\s)>\]\"']+", content)))
-    with _LINK_CACHE_LOCK:
-        cache = _load_link_cache()
-        for url in urls:
-            status = _get_url_status(url, cache)
-            if status is None or status >= 400:
-                label = status if status is not None else "ERROR"
-                errors.append(f"LINK_DEAD: {url} ({label})")
-        _save_link_cache(cache)
+    statuses = _resolve_url_statuses(urls)
+    for url in urls:
+        status = statuses.get(url)
+        if status is None or status >= 400:
+            label = status if status is not None else "ERROR"
+            errors.append(f"LINK_DEAD: {url} ({label})")
 
     # 2) K8s version consistency + minimum supported version hard-fail
     versions = set()

--- a/scripts/v1_pipeline.py
+++ b/scripts/v1_pipeline.py
@@ -47,9 +47,11 @@ import re
 import shutil
 import subprocess
 import sys
+import urllib.error
+import urllib.request
 import yaml
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import date, datetime, UTC
+from datetime import date, datetime, timedelta, UTC
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent.parent
@@ -58,6 +60,13 @@ STATE_FILE = REPO_ROOT / ".pipeline" / "state.yaml"
 REPORT_FILE = REPO_ROOT / ".pipeline" / "audit-report.json"
 SCORE_SCRIPT = REPO_ROOT / "scripts" / "score_module.py"
 KNOWLEDGE_CARD_DIR = REPO_ROOT / ".pipeline" / "knowledge-cards"
+FACT_LEDGER_DIR = REPO_ROOT / ".pipeline" / "fact-ledgers"
+FACT_LEDGER_TTL = timedelta(days=7)
+# DESIGN_AMBIGUITY: Spec acceptance #7 asks to add fact-ledgers to .gitignore,
+# while #3 constrains file changes to scripts/*. To satisfy #3, cache remains
+# under `.pipeline/fact-ledgers` but .gitignore is not modified in this change.
+LINK_CACHE_FILE = REPO_ROOT / ".pipeline" / "link-cache.json"
+LINK_CACHE_TTL = timedelta(hours=24)
 
 # ---------------------------------------------------------------------------
 # Timestamped logging — tee all print() to a log file
@@ -121,7 +130,7 @@ def dispatch_auto(prompt: str, model: str, timeout: int = 900) -> tuple[bool, st
         return dispatch_gemini_with_retry(prompt, model=model, timeout=timeout)
     if model.startswith("claude"):
         return dispatch_claude(prompt, model=model, timeout=timeout)
-    if model.startswith("codex"):
+    if model.startswith("codex") or "codex" in model or model.startswith("gpt-"):
         return dispatch_codex(prompt, model=model, timeout=timeout)
     raise ValueError(f"Unknown model family: {model!r} — must start with 'gemini', 'claude', or 'codex'")
 
@@ -133,9 +142,11 @@ def dispatch_auto(prompt: str, model: str, timeout: int = 900) -> tuple[bool, st
 MODELS = {
     "write": "gemini-3.1-pro-preview",     # Preview model — review in monthly evals, re-pin when GA available. See issue #217.
     "write_targeted": "claude-sonnet-4-6", # TARGETED FIX: surgical patches (instruction-following)
-    "review": "codex",                     # REVIEW: preferred independent reviewer
+    "review": "gemini-3.1-pro-preview",    # STRUCTURAL REVIEW: calibration-backed choice for split-reviewer flow
     "review_fallback": "claude-sonnet-4-6",  # independent REVIEW fallback when Codex is unavailable
-    "knowledge_card": "codex",             # WRITE grounding: current authoritative facts for the topic
+    "knowledge_card": "gpt-5.3-codex-spark",  # WRITE grounding aligned with fact-grounding calibration
+    "fact_grounding": "gpt-5.3-codex-spark",  # split-reviewer architecture: factual grounding ledger
+    "fact_fallback": "claude-sonnet-4-6",     # cross-family backup for facts
     # "translate" removed — uk_sync.CHUNKED_MODEL owns translation model config
 }
 
@@ -143,13 +154,14 @@ MODELS = {
 # Only these count as production-ready reviewers. Gemini reviewing Gemini is a
 # fallback to keep the pipeline moving but flags the module for re-review.
 INDEPENDENT_REVIEWER_FAMILIES = {"codex", "claude"}
+STRUCTURAL_REVIEW_INDEPENDENCE_RELAXED = True
 
 # Pipeline phases in order.
 # "needs_targeted_fix" is a pause state entered when Claude is unavailable
 # (peak hours / rate limit / budget) mid retry-loop. On resume, it loads the
 # staged content + saved plan and transitions back to "write" to re-enter
 # the targeted-fix retry path without re-running the initial write.
-PHASES = ["pending", "write", "review", "needs_targeted_fix",
+PHASES = ["pending", "data_conflict", "write", "review", "needs_targeted_fix",
           "check", "score", "done"]
 
 # ---------------------------------------------------------------------------
@@ -184,6 +196,8 @@ def get_module_state(state: dict, module_key: str) -> dict:
         "passes": False,
         "last_run": None,
         "errors": [],
+        "fact_ledger": None,
+        "fact_ledger_generated_at": None,
     })
 
 
@@ -232,6 +246,11 @@ def knowledge_card_path_for_key(module_key: str) -> Path:
     return KNOWLEDGE_CARD_DIR / f"{sanitize_module_key(module_key)}.md"
 
 
+def fact_ledger_path_for_key(module_key: str) -> Path:
+    """Return the cached fact-ledger path for a module key."""
+    return FACT_LEDGER_DIR / f"{sanitize_module_key(module_key)}.json"
+
+
 def _extract_frontmatter_data(content: str) -> dict:
     """Parse YAML frontmatter from markdown content."""
     if not content.startswith("---\n"):
@@ -264,6 +283,35 @@ def _knowledge_card_is_expired(card_content: str) -> bool:
     if not isinstance(expires_at, date):
         return True
     return expires_at < datetime.now(UTC).date()
+
+
+def _cache_is_fresh(path: Path, ttl: timedelta) -> bool:
+    """Return True if file mtime is within ttl."""
+    if not path.exists():
+        return False
+    modified_at = datetime.fromtimestamp(path.stat().st_mtime, UTC)
+    return datetime.now(UTC) - modified_at < ttl
+
+
+def _extract_topic_from_module(module_path: Path) -> str:
+    """Extract module topic from frontmatter title, falling back to filename."""
+    content = module_path.read_text()
+    fm = _extract_frontmatter_data(content)
+    title = fm.get("title")
+    if isinstance(title, str) and title.strip():
+        return title.strip()
+    return module_path.stem
+
+
+def _model_family(model: str) -> str:
+    """Normalize model name to provider family key."""
+    if model.startswith("gemini"):
+        return "gemini"
+    if model.startswith("claude"):
+        return "claude"
+    if model.startswith("codex") or "codex" in model or model.startswith("gpt-"):
+        return "codex"
+    return model.split("-", 1)[0]
 
 
 def ensure_knowledge_card(module_path: Path, ms: dict,
@@ -301,6 +349,120 @@ def ensure_knowledge_card(module_path: Path, ms: dict,
     return None
 
 
+FACT_LEDGER_PROMPT_TEMPLATE = """You are doing a fact-grounding pass for the KubeDojo curriculum module on the topic: {topic}.
+
+As-of date: {as_of_date}
+
+Identify every externally-versioned factual claim that a module on this topic would need to make. For each claim, determine its current truth from authoritative upstream sources (official vendor docs, project sites, CNCF status pages, GitHub release notes).
+
+Return a structured ledger.
+
+Rules:
+- Do NOT answer from memory. Use current upstream documentation.
+- Prefer official vendor/project docs over blog posts.
+- If two authoritative sources disagree, mark CONFLICTING — never synthesize.
+- If you cannot find an authoritative source, mark UNVERIFIED — never guess.
+- Every SUPPORTED claim needs at least 1 resolvable canonical URL and a source date if available.
+- Every CONFLICTING claim needs at least 2 resolvable URLs and a one-sentence conflict summary.
+- Saying "I don't know" costs nothing. Confident wrong answers cost a lot.
+- Output strict JSON only, no prose preamble.
+
+Required JSON shape:
+{{
+  "as_of_date": "{as_of_date}",
+  "topic": "{topic}",
+  "claims": [
+    {{
+      "id": "C1",
+      "claim": "short factual statement",
+      "status": "SUPPORTED" | "CONFLICTING" | "UNVERIFIED",
+      "current_truth": "what is true now or null",
+      "sources": [
+        {{"url": "...", "source_date": "YYYY-MM-DD or null"}}
+      ],
+      "conflict_summary": "one sentence if status is CONFLICTING, else null",
+      "unverified_reason": "one sentence if status is UNVERIFIED, else null"
+    }}
+  ]
+}}
+"""
+
+
+def step_fact_ledger(module_path: Path, topic_hint: str | None = None,
+                     model: str = MODELS["fact_grounding"],
+                     refresh: bool = False) -> dict | None:
+    """Generate or load a cached fact ledger for a module.
+
+    This is the split-reviewer architecture's factual source of truth. It
+    dispatches exactly one call to the fact-grounding model and stores the
+    result in `.pipeline/fact-ledgers/` for 7 days unless refresh is forced.
+    """
+    key = module_key_from_path(module_path)
+    cache_path = fact_ledger_path_for_key(key)
+    if cache_path.exists() and not refresh and _cache_is_fresh(cache_path, FACT_LEDGER_TTL):
+        try:
+            cached = json.loads(cache_path.read_text())
+            claims = cached.get("claims") if isinstance(cached, dict) else None
+            if isinstance(claims, list) and claims:
+                print(f"  ✓ FACT LEDGER cache hit: {cache_path.name}")
+                return cached
+        except (json.JSONDecodeError, OSError) as e:
+            print(f"  ⚠ FACT LEDGER cache unreadable, regenerating: {e}")
+
+    topic = topic_hint or _extract_topic_from_module(module_path)
+    as_of_date = datetime.now(UTC).date().isoformat()
+    prompt = FACT_LEDGER_PROMPT_TEMPLATE.format(topic=topic, as_of_date=as_of_date)
+    key = module_key_from_path(module_path)
+    print(f"\n  FACT LEDGER: {key} (using {model})")
+    ok, output = dispatch_auto(prompt, model=model, timeout=900)
+    if not ok:
+        if output and _is_rate_limited(output):
+            print("  ⚠ FACT LEDGER rate-limited")
+            return {"rate_limited": True}
+        print("  ❌ FACT LEDGER dispatch failed")
+        return None
+
+    ledger = _extract_review_json(output, required_keys=("claims",))
+    if not isinstance(ledger, dict):
+        print("  ❌ FACT LEDGER parse failed")
+        return None
+    claims = ledger.get("claims")
+    if not isinstance(claims, list) or not claims:
+        print("  ❌ FACT LEDGER invalid: missing non-empty claims[]")
+        return None
+
+    ledger_json = json.dumps(ledger, indent=2, ensure_ascii=False)
+    _atomic_write_text(cache_path, ledger_json)
+    print(f"  ✓ FACT LEDGER cached: {cache_path.name}")
+    return ledger
+
+
+def ensure_fact_ledger(module_path: Path, ms: dict,
+                       model: str = MODELS["fact_grounding"],
+                       topic_hint: str | None = None,
+                       refresh: bool = False) -> dict | None:
+    """Ensure a fresh fact ledger is available in module state."""
+    existing = ms.get("fact_ledger")
+    generated_at_raw = ms.get("fact_ledger_generated_at")
+    if not refresh and isinstance(existing, dict) and isinstance(generated_at_raw, str):
+        try:
+            generated_at = datetime.fromisoformat(generated_at_raw)
+            if generated_at.tzinfo is None:
+                generated_at = generated_at.replace(tzinfo=UTC)
+            if datetime.now(UTC) - generated_at < FACT_LEDGER_TTL:
+                claims = existing.get("claims")
+                if isinstance(claims, list) and claims:
+                    return existing
+        except ValueError:
+            pass
+
+    ledger = step_fact_ledger(module_path, topic_hint=topic_hint, model=model, refresh=refresh)
+    if isinstance(ledger, dict) and not ledger.get("rate_limited"):
+        ms["fact_ledger"] = ledger
+        ms["fact_ledger_generated_at"] = datetime.now(UTC).isoformat()
+    return ledger
+
+
 # ---------------------------------------------------------------------------
 # WRITE step — Gemini drafts improvements
 # ---------------------------------------------------------------------------
@@ -309,6 +471,17 @@ KNOWLEDGE_CARD_UNAVAILABLE = (
     "(No knowledge card available — use general K8s 1.30+ knowledge but flag any "
     "uncertain facts for reviewer verification.)"
 )
+
+
+def _format_fact_ledger_for_prompt(fact_ledger: dict | None) -> str:
+    """Serialize fact ledger for prompt injection."""
+    if not isinstance(fact_ledger, dict):
+        return "(No fact ledger available.)"
+    try:
+        return json.dumps(fact_ledger, indent=2, ensure_ascii=False)
+    except (TypeError, ValueError):
+        return "(Fact ledger serialization failed.)"
+
 
 WRITE_PROMPT_TEMPLATE = """CRITICAL INSTRUCTION: Your response must be ONLY the raw markdown content of the improved module. Start your response with the --- frontmatter delimiter. No preamble, no explanation, no summary, no "I have improved..." — ONLY the markdown file content from first line to last.
 
@@ -330,6 +503,13 @@ RULES:
 KNOWLEDGE CARD:
 {knowledge_card}
 
+FACT LEDGER (authoritative, as-of dated):
+{fact_ledger}
+
+Use the fact ledger as the factual source of truth. If a claim is CONFLICTING or
+UNVERIFIED in the ledger, hedge explicitly in the module text and cite the
+authority context.
+
 IMPROVEMENT PLAN:
 {plan}
 
@@ -349,6 +529,13 @@ Keep the EXACT same frontmatter (title, slug, sidebar order).
 
 KNOWLEDGE CARD:
 {knowledge_card}
+
+FACT LEDGER (authoritative, as-of dated):
+{fact_ledger}
+
+Use the fact ledger as the factual source of truth. If a claim is CONFLICTING or
+UNVERIFIED in the ledger, hedge explicitly in the module text and cite the
+authority context.
 
 KNOWLEDGE PACKET — MUST PRESERVE:
 The following technical assets are extracted from the original module. You MUST include ALL of them in your rewrite, placed in the appropriate sections. Do NOT omit, summarize, or simplify any of these.
@@ -475,7 +662,8 @@ def count_assets(content: str) -> dict:
 def step_write(module_path: Path, plan: str, model: str = MODELS["write"],
                rewrite: bool = False,
                previous_output: str | None = None,
-               knowledge_card: str | None = None) -> str | None:
+               knowledge_card: str | None = None,
+               fact_ledger: dict | None = None) -> str | None:
     """Gemini drafts improvements or full rewrite based on the plan.
 
     If previous_output is provided (e.g. from an earlier attempt in the
@@ -489,15 +677,17 @@ def step_write(module_path: Path, plan: str, model: str = MODELS["write"],
     mode = "REWRITE" if rewrite else "WRITE"
     print(f"\n  {mode}: {key} (using {model})")
     knowledge_card_text = knowledge_card or KNOWLEDGE_CARD_UNAVAILABLE
+    fact_ledger_text = _format_fact_ledger_for_prompt(fact_ledger)
 
     if rewrite:
         packet = extract_knowledge_packet(content)
         prompt = REWRITE_PROMPT_TEMPLATE.format(
             file_path=key, plan=plan, content=content, knowledge_packet=packet,
-            knowledge_card=knowledge_card_text)
+            knowledge_card=knowledge_card_text, fact_ledger=fact_ledger_text)
     else:
         prompt = WRITE_PROMPT_TEMPLATE.format(
-            plan=plan, content=content, knowledge_card=knowledge_card_text)
+            plan=plan, content=content, knowledge_card=knowledge_card_text,
+            fact_ledger=fact_ledger_text)
 
     # Must use dispatch_auto (not dispatch_gemini_with_retry directly) so that
     # Claude Sonnet is actually called for targeted-fix mode. Previously this
@@ -552,67 +742,70 @@ def step_write(module_path: Path, plan: str, model: str = MODELS["write"],
 
 
 # ---------------------------------------------------------------------------
-# REVIEW step — Claude strict review
+# REVIEW step — structural binary review
 # ---------------------------------------------------------------------------
 
 REVIEW_PROMPT_TEMPLATE = """You are the Lead Content Auditor for KubeDojo — an
 independent, strict, BINARY reviewer. You do NOT give partial credit. You do
-NOT use a 1-5 scale. Your job is to verify that a Kubernetes learning module
-is technically flawless, pedagogically sound, and ready for production.
+NOT use a 1-5 scale.
 
-You are independent — assume nothing is correct without verification. Web
-search is MANDATORY for factual claims. Verify against current Kubernetes
-documentation, CNCF project status pages, and official tool docs. Kubernetes
-moves fast — check that commands, API versions, and deprecation status match
-the most recent stable release.
+A separate fact-grounding pass has already verified all factual claims in this
+module against current upstream documentation. The fact ledger is provided
+below as `FACT_LEDGER`. You MUST NOT re-grade factual currency — assume the
+ledger is the source of truth. If the module contradicts the ledger, that is a
+structural failure (the writer ignored the ledger), not a factual failure.
+
+Your job is to grade the module on STRUCTURE only:
+- LAB: can a student execute the lab end-to-end?
+- COV: does it cover every Learning Outcome from the frontmatter?
+- QUIZ: do quiz questions require reasoning, not recall?
+- EXAM: does the depth match the certification target (skip if no cert in frontmatter)?
+- DEPTH: at least one practitioner-grade element (production gotcha, decision framework, war story)?
+- WHY: rationale for every major design decision?
+- PRES: every distinct concept/lab/diagram/quiz from the original is preserved (compression OK, deletion of unique value not OK)?
+
+DO NOT add a FACT check. DO NOT search the web for factual currency. DO NOT
+contradict the fact ledger.
 
 MANDATORY CHECKS — answer PASS or FAIL for each:
 
-1. FACT — Are all technical claims verifiable against authoritative sources?
-   Commands use current (non-deprecated) syntax, API versions match current
-   Kubernetes releases, YAML parses against the stated apiVersion, project
-   status (sandbox/incubating/graduated) is correct, doc URLs resolve.
-   A FAIL for FACT MUST include an http/https URL citation in `evidence`
-   pointing to the authoritative source that contradicts the module. No
-   citation = do not flag this check.
-
-2. LAB — Can a student reach the end state of every lab by following the
+1. LAB — Can a student reach the end state of every lab by following the
    text exactly? Commands must include flags needed for non-interactive
    execution (-y, -o json, --force where safe). Multi-step labs must
    include checkpoint verifications the student can run to confirm state
    before proceeding. If you cannot trace a path from start to end state,
    fail LAB.
 
-3. COV — Does the content cover every Learning Outcome listed in the
+2. COV — Does the content cover every Learning Outcome listed in the
    module's frontmatter? A FAIL must list specific outcomes that have no
    corresponding content section.
 
-4. QUIZ — Does every quiz question require reasoning or scenario
+3. QUIZ — Does every quiz question require reasoning or scenario
    application (not fact recall)? "What port does etcd use?" is recall
    and fails. "Given a CrashLoopBackOff on a pod with a PVC, which of
    these four causes is ruled out by the events log?" is scenario and
    passes. Each question must have exactly one correct answer supported
    by the module's own text.
 
-5. EXAM — If the frontmatter declares a `certification:` target (CKA,
+4. EXAM — If the frontmatter declares a `certification:` target (CKA,
    CKAD, CKS, KCNA, KCSA), does the module depth match the published
    CNCF curriculum for that exam? Skip this check entirely if no
    certification is named in frontmatter. A FAIL must cite the specific
    curriculum domain the module fails to meet.
 
-6. DEPTH — Does the module include at least one practitioner-grade
+5. DEPTH — Does the module include at least one practitioner-grade
    element: a production gotcha, a decision framework, a war story, or a
    non-obvious failure mode? This is the anti-"Hello World" guardrail.
    A FAIL means the module reads like a surface tutorial with no
    operational nuance.
 
-7. WHY — Does every major design decision (architecture choice, resource
+6. WHY — Does every major design decision (architecture choice, resource
    selection, flag usage, tradeoff) have at least one sentence of
    rationale? "Do X then Y" with no motivation is a FAIL. You are NOT
    looking for rationale on every individual line — major design
    decisions only.
 
-8. PRES — Every distinct concept, lab, table, diagram, and quiz question
+7. PRES — Every distinct concept, lab, table, diagram, and quiz question
    from the ORIGINAL is present in the IMPROVED version, unless it
    contained a factual error or was explicit duplication. Compression
    and reorganization are ALLOWED. Deletion of unique value is NOT. A
@@ -664,7 +857,6 @@ OUTPUT JSON ONLY — no preamble, no postamble, no markdown fences:
   "verdict": "APPROVE" or "REJECT",
   "severity": "clean" or "targeted" or "severe",
   "checks": [
-    {{"id": "FACT", "passed": true}},
     {{"id": "LAB", "passed": false, "evidence": "...", "edit_refs": [0, 1]}},
     {{"id": "COV", "passed": true}},
     {{"id": "QUIZ", "passed": true}},
@@ -679,9 +871,14 @@ OUTPUT JSON ONLY — no preamble, no postamble, no markdown fences:
   "feedback": "optional prose summary of qualitative notes that don't map to an edit"
 }}
 
-Every one of the 8 check IDs MUST appear in `checks`. Skipping EXAM when
+Every one of the 7 check IDs MUST appear in `checks`. Skipping EXAM when
 there is no `certification:` target is fine — return it as `passed: true`
 with evidence `"no certification target in frontmatter"`.
+
+---
+
+FACT_LEDGER:
+{fact_ledger}
 
 ---
 
@@ -694,7 +891,7 @@ IMPROVED MODULE:
 {improved}
 """
 
-CHECK_IDS = ["FACT", "LAB", "COV", "QUIZ", "EXAM", "DEPTH", "WHY", "PRES"]
+CHECK_IDS = ["LAB", "COV", "QUIZ", "EXAM", "DEPTH", "WHY", "PRES"]
 
 
 def compute_severity(
@@ -715,6 +912,10 @@ def compute_severity(
     - REJECT with no edits at all → severe (nothing to apply)
 
     Fixes Gemini pair-review critique A from round 2.
+
+    Split-reviewer context: factual model routing is selected from
+    `project_fact_grounding_calibration.md`; this function intentionally
+    stays FACT-agnostic and only routes structural reviewer output.
     """
     if verdict == "APPROVE":
         return "clean"
@@ -882,8 +1083,16 @@ def _translate_index(_en_content: str, uk_path: Path, rel_section: str) -> bool:
         return uk_translate(en_path)
 
 
-def _extract_review_json(output: str) -> dict | None:
-    """Extract the final review JSON from a raw reviewer response.
+def _has_required_json_keys(obj: dict, required_keys: tuple[str, ...]) -> bool:
+    """Return True if obj has the required keys for a JSON payload."""
+    if required_keys == ("verdict", "checks"):
+        return "verdict" in obj and ("checks" in obj or "scores" in obj)
+    return all(k in obj for k in required_keys)
+
+
+def _extract_review_json(output: str,
+                         required_keys: tuple[str, ...] = ("verdict", "checks")) -> dict | None:
+    """Extract the final JSON payload from a raw model response.
 
     Codex exec output contains tool-use breadcrumbs, search logs, and the final
     answer on a 'codex' banner line followed by the JSON, then 'tokens used N'.
@@ -902,13 +1111,17 @@ def _extract_review_json(output: str) -> dict | None:
             if candidate.startswith("json"):
                 candidate = candidate[4:]
             try:
-                return json.loads(candidate.strip())
+                obj = json.loads(candidate.strip())
+                if isinstance(obj, dict) and _has_required_json_keys(obj, required_keys):
+                    return obj
             except json.JSONDecodeError:
                 pass
 
     # Direct parse
     try:
-        return json.loads(text)
+        obj = json.loads(text)
+        if isinstance(obj, dict) and _has_required_json_keys(obj, required_keys):
+            return obj
     except json.JSONDecodeError:
         pass
 
@@ -932,13 +1145,7 @@ def _extract_review_json(output: str) -> dict | None:
     for cand in candidates:
         try:
             obj = json.loads(cand)
-            # Binary gate (#223): a valid review has `verdict` + `checks`.
-            # The old rubric used `scores` — we accept either field for
-            # backwards compat with any in-flight legacy reviewer output
-            # during the migration, but new reviewers MUST return `checks`.
-            if isinstance(obj, dict) and "verdict" in obj and (
-                "checks" in obj or "scores" in obj
-            ):
+            if isinstance(obj, dict) and _has_required_json_keys(obj, required_keys):
                 return obj
         except json.JSONDecodeError:
             continue
@@ -1166,8 +1373,9 @@ def apply_review_edits(content: str, edits: list) -> tuple[str, list, list]:
     return patched, applied, failed
 
 
-def step_review(module_path: Path, improved: str, model: str = MODELS["review"]) -> dict | None:
-    """Reviewer (Codex by default) runs the binary quality gate.
+def step_review(module_path: Path, improved: str, model: str = MODELS["review"],
+                fact_ledger: dict | None = None) -> dict | None:
+    """Structural reviewer runs the binary quality gate.
 
     Returns:
         dict with keys {verdict, severity, checks, edits, feedback} on
@@ -1181,7 +1389,11 @@ def step_review(module_path: Path, improved: str, model: str = MODELS["review"])
     key = module_key_from_path(module_path)
     print(f"\n  REVIEW: {key} (using {model})")
 
-    prompt = REVIEW_PROMPT_TEMPLATE.format(original=original, improved=improved)
+    prompt = REVIEW_PROMPT_TEMPLATE.format(
+        original=original,
+        improved=improved,
+        fact_ledger=_format_fact_ledger_for_prompt(fact_ledger),
+    )
 
     ok, output = dispatch_auto(prompt, model=model, timeout=900)
 
@@ -1259,6 +1471,176 @@ def step_review(module_path: Path, improved: str, model: str = MODELS["review"])
 # CHECK step — deterministic checks on improved content
 # ---------------------------------------------------------------------------
 
+def _load_link_cache() -> dict:
+    """Load URL health cache from disk."""
+    if not LINK_CACHE_FILE.exists():
+        return {}
+    try:
+        data = json.loads(LINK_CACHE_FILE.read_text())
+        return data if isinstance(data, dict) else {}
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_link_cache(cache: dict) -> None:
+    """Persist URL health cache atomically."""
+    _atomic_write_text(LINK_CACHE_FILE, json.dumps(cache, indent=2, ensure_ascii=False))
+
+
+def _get_url_status(url: str, cache: dict) -> int | None:
+    """Return HTTP status for URL, using 24h cache when available."""
+    cached = cache.get(url) if isinstance(cache, dict) else None
+    if isinstance(cached, dict):
+        checked_at_raw = cached.get("checked_at")
+        status = cached.get("status")
+        if isinstance(checked_at_raw, str):
+            try:
+                checked_at = datetime.fromisoformat(checked_at_raw)
+                if checked_at.tzinfo is None:
+                    checked_at = checked_at.replace(tzinfo=UTC)
+                if datetime.now(UTC) - checked_at < LINK_CACHE_TTL:
+                    return status if isinstance(status, int) else None
+            except ValueError:
+                pass
+
+    req = urllib.request.Request(url, method="HEAD")
+    status_code: int | None = None
+    try:
+        with urllib.request.urlopen(req, timeout=5) as response:
+            status_code = int(response.getcode())
+    except urllib.error.HTTPError as e:
+        status_code = int(e.code)
+    except (urllib.error.URLError, TimeoutError, ValueError):
+        status_code = None
+
+    cache[url] = {
+        "status": status_code,
+        "checked_at": datetime.now(UTC).isoformat(),
+    }
+    return status_code
+
+
+def _contains_with_tolerance(haystack: str, needle: str, tolerance: int = 10) -> bool:
+    """Return True when needle is found exactly or with end trimming tolerance."""
+    if not needle:
+        return False
+    h = re.sub(r"\s+", " ", haystack).lower()
+    n = re.sub(r"\s+", " ", needle).lower().strip()
+    if not n:
+        return False
+    if n in h:
+        return True
+    if len(n) <= tolerance:
+        return False
+    for trim in range(1, tolerance + 1):
+        if n[trim:] in h:
+            return True
+        if n[:-trim] in h:
+            return True
+    return False
+
+
+def _is_unhedged_claim_assertion(content: str, claim_text: str) -> bool:
+    """Heuristic check for claim assertions with no hedge language nearby."""
+    if not claim_text:
+        return False
+    haystack = content.lower()
+    needle = claim_text.lower().strip()
+    if not needle:
+        return False
+
+    hedge_terms = (
+        "according to",
+        "as of",
+        "reportedly",
+        "appears to",
+        "may",
+        "might",
+        "could",
+        "conflicting",
+        "unverified",
+    )
+    start = 0
+    while True:
+        idx = haystack.find(needle, start)
+        if idx == -1:
+            return False
+        window_start = max(0, idx - 120)
+        window_end = min(len(haystack), idx + len(needle) + 120)
+        window = haystack[window_start:window_end]
+        if not any(term in window for term in hedge_terms):
+            return True
+        start = idx + len(needle)
+
+
+def step_check_integrity(content: str, fact_ledger: dict) -> tuple[bool, list[str]]:
+    """Tier-1 deterministic integrity gate before structural checks."""
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    # 1) Link health with 24h cache
+    urls = sorted(set(re.findall(r"https?://[^\s)>\]\"']+", content)))
+    cache = _load_link_cache()
+    for url in urls:
+        status = _get_url_status(url, cache)
+        if status is None or status >= 400:
+            label = status if status is not None else "ERROR"
+            errors.append(f"LINK_DEAD: {url} ({label})")
+    _save_link_cache(cache)
+
+    # 2) K8s version consistency + stale version hard-fail
+    versions = set()
+    for match in re.finditer(r"\b(v?1\.(\d{1,2}))\b", content):
+        raw, minor_raw = match.group(1), match.group(2)
+        try:
+            minor = int(minor_raw)
+        except ValueError:
+            continue
+        if not (20 <= minor <= 40):
+            continue
+        canonical = f"v1.{minor}"
+        versions.add(canonical)
+        if minor <= 20:
+            errors.append(f"STALE_K8S_VERSION: {canonical}")
+    if len(versions) > 1:
+        warnings.append(f"VERSION_MISMATCH_WARNING: {', '.join(sorted(versions))}")
+
+    # 3) YAML lint for fenced ```yaml blocks
+    for match in re.finditer(r"```yaml\s*\n([\s\S]*?)```", content, re.IGNORECASE):
+        yaml_block = match.group(1)
+        try:
+            yaml.safe_load(yaml_block)
+        except yaml.YAMLError as e:
+            line_offset = content[:match.start(1)].count("\n")
+            line_no = line_offset + 1
+            if getattr(e, "problem_mark", None) is not None:
+                line_no = line_offset + int(e.problem_mark.line) + 1
+            errors.append(f"INVALID_YAML: line {line_no}: {e}")
+
+    # 4) Evidence mapping against fact ledger
+    claims = fact_ledger.get("claims", []) if isinstance(fact_ledger, dict) else []
+    for claim in claims:
+        if not isinstance(claim, dict):
+            continue
+        claim_id = claim.get("id", "?")
+        status = claim.get("status")
+        current_truth = claim.get("current_truth")
+        statement = claim.get("claim") or current_truth or ""
+
+        if status == "SUPPORTED" and isinstance(current_truth, str) and current_truth.strip():
+            if not _contains_with_tolerance(content, current_truth, tolerance=10):
+                warnings.append(f"MISSING_SUPPORTED_CLAIM: claim {claim_id}")
+
+        if status == "CONFLICTING" and isinstance(statement, str) and statement.strip():
+            if _is_unhedged_claim_assertion(content, statement):
+                errors.append(f"UNHEDGED_CONFLICT: claim {claim_id}")
+        if status == "UNVERIFIED" and isinstance(statement, str) and statement.strip():
+            if _is_unhedged_claim_assertion(content, statement):
+                errors.append(f"UNHEDGED_UNVERIFIED: claim {claim_id}")
+
+    return len(errors) == 0, errors + warnings
+
+
 def step_check(content: str, path: Path) -> tuple[bool, list]:
     """Run all deterministic checks on the improved content."""
     print(f"\n  CHECK: running deterministic checks")
@@ -1332,7 +1714,8 @@ def step_check(content: str, path: Path) -> tuple[bool, list]:
 # ---------------------------------------------------------------------------
 
 def run_module(module_path: Path, state: dict, max_retries: int = 4,
-               models: dict | None = None, dry_run: bool = False) -> bool:
+               models: dict | None = None, dry_run: bool = False,
+               refresh_fact_ledger: bool = False) -> bool:
     """Run a single module through the full pipeline."""
     m = models or MODELS
     key = module_key_from_path(module_path)
@@ -1359,6 +1742,13 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
             print(f"  ✓ Already done: {total}/40 reviewer={reviewer} — skipping")
             return True
 
+    if ms["phase"] == "data_conflict" and not refresh_fact_ledger:
+        print("  ✋ Module blocked in data_conflict phase — rerun with --refresh-fact-ledger after manual triage")
+        return False
+    if ms["phase"] == "data_conflict" and refresh_fact_ledger:
+        ms["phase"] = "pending"
+        save_state(state)
+
     # Peak-hours pause resume. A module paused mid-targeted-fix has its
     # staged draft on disk and its plan saved in state. Transition
     # back to phase=write so the resume branch below loads them correctly
@@ -1377,6 +1767,70 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
             ms.pop("targeted_fix", None)
             save_state(state)
 
+    # Phase 0: split-reviewer fact ledger (issue #225).
+    # Model selection rationale is pinned by calibration data in:
+    # /Users/krisztiankoos/.claude/projects/-Users-krisztiankoos-projects-kubedojo/memory/project_fact_grounding_calibration.md
+    if not dry_run:
+        fact_model = m.get("fact_grounding", MODELS["fact_grounding"])
+        fact_family = _model_family(fact_model)
+        if fact_family not in INDEPENDENT_REVIEWER_FAMILIES:
+            ms["errors"].append(
+                f"Configured fact grounding model is not independent: {fact_model}"
+            )
+            save_state(state)
+            return False
+
+        ledger_result = ensure_fact_ledger(
+            module_path,
+            ms,
+            model=fact_model,
+            refresh=refresh_fact_ledger,
+        )
+        if ledger_result is None or (
+            isinstance(ledger_result, dict) and ledger_result.get("rate_limited")
+        ):
+            fallback_model = m.get("fact_fallback", MODELS["fact_fallback"])
+            fallback_family = _model_family(fallback_model)
+            if fallback_family not in INDEPENDENT_REVIEWER_FAMILIES:
+                ms["errors"].append(
+                    f"Configured fact fallback model is not independent: {fallback_model}"
+                )
+                save_state(state)
+                return False
+            print(f"  ⚠ {fact_model} unavailable for FACT LEDGER — falling back to {fallback_model}")
+            ledger_result = ensure_fact_ledger(
+                module_path,
+                ms,
+                model=fallback_model,
+                refresh=refresh_fact_ledger,
+            )
+
+        if not isinstance(ledger_result, dict) or ledger_result.get("rate_limited"):
+            ms["errors"].append("FACT LEDGER generation failed")
+            save_state(state)
+            return False
+
+        ms["fact_ledger"] = ledger_result
+        ms["fact_ledger_generated_at"] = datetime.now(UTC).isoformat()
+        save_state(state)
+
+        n_conflict = sum(
+            1 for c in ledger_result.get("claims", [])
+            if isinstance(c, dict) and c.get("status") == "CONFLICTING"
+        )
+        n_unverified = sum(
+            1 for c in ledger_result.get("claims", [])
+            if isinstance(c, dict) and c.get("status") == "UNVERIFIED"
+        )
+        if n_conflict >= 3 or n_unverified >= 5:
+            ms["phase"] = "data_conflict"
+            ms["errors"].append(
+                f"DATA_CONFLICT: {n_conflict} conflicting + {n_unverified} "
+                f"unverified claims — manual triage required"
+            )
+            save_state(state)
+            return False
+
     knowledge_card = None
     resume_from_staging = False
 
@@ -1391,7 +1845,7 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
             return False
         ms["severity"] = None
         ms["checks_failed"] = []
-        ms["reviewer_schema_version"] = 2
+        ms["reviewer_schema_version"] = 3
         ms["passes"] = False
         ms["phase"] = "write"
         ms["last_run"] = datetime.now(UTC).isoformat()
@@ -1477,7 +1931,8 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
                 improved = step_write(module_path, plan, model=writer_model,
                                       rewrite=needs_rewrite,
                                       previous_output=last_good,
-                                      knowledge_card=knowledge_card)
+                                      knowledge_card=knowledge_card,
+                                      fact_ledger=ms.get("fact_ledger"))
             except ClaudeUnavailableError as e:
                 # Peak hours / rate limit / budget exhausted on Claude. Pause
                 # this module cleanly so it resumes at the targeted-fix step
@@ -1519,33 +1974,39 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
 
         if ms["phase"] == "review":
             reviewer_model = m["review"]
-            review = step_review(module_path, improved or module_path.read_text(), model=reviewer_model)
+            review = step_review(
+                module_path,
+                improved or module_path.read_text(),
+                model=reviewer_model,
+                fact_ledger=ms.get("fact_ledger"),
+            )
 
-            # Rate-limit degradation:
-            # 1. Try Codex.
-            # 2. If unavailable, try Claude Sonnet (still independent).
-            # 3. If both independent reviewers are unavailable, do a same-
-            #    family last-resort review so the pipeline can still make a
-            #    decision, but mark the module for later independent re-review.
+            # Structural reviewer rate-limit degradation:
+            # 1. Try primary structural reviewer.
+            # 2. If unavailable, try configured fallback.
+            # 3. If both unavailable, use writer model as last resort.
             if isinstance(review, dict) and review.get("rate_limited"):
                 fallback_model = m.get("review_fallback", MODELS["review_fallback"])
-                primary_family = reviewer_model.split("-")[0]
-                fallback_family = fallback_model.split("-")[0]
-                writer_family = m["write"].split("-")[0]
+                primary_family = _model_family(reviewer_model)
+                fallback_family = _model_family(fallback_model)
                 if fallback_family == primary_family:
                     print(f"  ⚠ Primary reviewer rate-limited and fallback is same family — aborting review")
                     ms["errors"].append("Primary reviewer rate-limited, no alternative fallback")
                     save_state(state)
                     return False
-                if fallback_family == writer_family or fallback_family not in INDEPENDENT_REVIEWER_FAMILIES:
-                    print(f"  ⚠ Review fallback {fallback_model} is not independent from writer {m['write']} — aborting review")
-                    ms["errors"].append("Configured review fallback is not independent from writer")
+                if (not STRUCTURAL_REVIEW_INDEPENDENCE_RELAXED and
+                        fallback_family not in INDEPENDENT_REVIEWER_FAMILIES):
+                    print(f"  ⚠ Review fallback {fallback_model} is not in approved independent families — aborting review")
+                    ms["errors"].append("Configured review fallback is not an approved independent family")
                     save_state(state)
                     return False
 
                 print(f"  ⚠ {reviewer_model} rate-limited — falling back to {fallback_model}")
                 review = step_review(
-                    module_path, improved or module_path.read_text(), model=fallback_model,
+                    module_path,
+                    improved or module_path.read_text(),
+                    model=fallback_model,
+                    fact_ledger=ms.get("fact_ledger"),
                 )
                 if review is None:
                     ms["errors"].append("Fallback reviewer failed")
@@ -1559,7 +2020,10 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
                         f"require later independent re-review if approved"
                     )
                     review = step_review(
-                        module_path, improved or module_path.read_text(), model=last_resort_model,
+                        module_path,
+                        improved or module_path.read_text(),
+                        model=last_resort_model,
+                        fact_ledger=ms.get("fact_ledger"),
                     )
                     if review is None:
                         ms["errors"].append("Last-resort reviewer failed")
@@ -1583,6 +2047,38 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
                 return False
 
             if review.get("verdict") == "APPROVE":
+                content_for_integrity = improved or module_path.read_text()
+                integrity_passed, integrity_messages = step_check_integrity(
+                    content_for_integrity, ms.get("fact_ledger") or {}
+                )
+                if not integrity_passed:
+                    needs_rewrite = True
+                    targeted_fix = False
+                    plan = (
+                        "SEVERE REWRITE REQUIRED. Tier-1 integrity gate failed before "
+                        "structural CHECK. Rewrite the module and resolve every "
+                        "integrity error.\n\nIntegrity errors:\n"
+                    )
+                    for msg in integrity_messages:
+                        plan += f"\n- {msg}"
+                    ms["plan"] = plan
+                    ms["targeted_fix"] = False
+                    ms["severity"] = "severe"
+                    ms["checks_failed"] = [{"id": "INTEGRITY", "evidence": msg} for msg in integrity_messages]
+                    ms["reviewer_schema_version"] = 3
+                    ms.pop("scores", None)
+                    ms.pop("sum", None)
+                    if improved is not None:
+                        staging_path = module_path.with_suffix(".staging.md")
+                        _atomic_write_text(staging_path, improved)
+                    ms["phase"] = "write"
+                    save_state(state)
+                    print("  ⚠ Tier-1 integrity gate failed — routing to severe rewrite")
+                    if attempt < max_retries:
+                        continue
+                    ms["errors"].append("Integrity gate failed after max retries")
+                    return False
+
                 # Binary gate: on APPROVE, the module's state records that
                 # every check passed. Per Gemini pair-review critique B, we
                 # ignore any `edits` returned alongside an APPROVE — an
@@ -1590,7 +2086,7 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
                 # changes, it must REJECT with severity=targeted.
                 ms["severity"] = "clean"
                 ms["checks_failed"] = []
-                ms["reviewer_schema_version"] = 2
+                ms["reviewer_schema_version"] = 3
                 # Drop any legacy score fields so cmd_status renders the new
                 # binary-gate view, not the old [D1..D8] vector.
                 ms.pop("scores", None)
@@ -1602,9 +2098,10 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
                 # the module exits the pipeline (Gemini + Codex PR review
                 # both flagged this as a hot-path routing bug).
                 ms.pop("sonnet_anchor_failures", None)
-                reviewer_family = reviewer_model.split("-")[0]
+                reviewer_family = _model_family(reviewer_model)
                 ms["reviewer"] = reviewer_family
                 ms["needs_independent_review"] = (
+                    (not STRUCTURAL_REVIEW_INDEPENDENCE_RELAXED) and
                     reviewer_family not in INDEPENDENT_REVIEWER_FAMILIES
                 )
                 ms["phase"] = "check"
@@ -1654,7 +2151,7 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
                         _atomic_write_text(staging_path, patched)
                         ms["severity"] = "targeted"
                         ms["checks_failed"] = [{"id": c.get("id"), "evidence": c.get("evidence", "")} for c in failed_checks]
-                        ms["reviewer_schema_version"] = 2
+                        ms["reviewer_schema_version"] = 3
                         ms.pop("scores", None)
                         ms.pop("sum", None)
                         # Circuit breaker reset on 100% apply — see comment
@@ -1706,7 +2203,7 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
                         ms["targeted_fix"] = True
                         ms["severity"] = "targeted"
                         ms["checks_failed"] = [{"id": c.get("id"), "evidence": c.get("evidence", "")} for c in failed_checks]
-                        ms["reviewer_schema_version"] = 2
+                        ms["reviewer_schema_version"] = 3
                         ms.pop("scores", None)
                         ms.pop("sum", None)
                         ms["phase"] = "write"
@@ -1784,7 +2281,7 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
                 ms["targeted_fix"] = targeted_fix
                 ms["severity"] = r_severity
                 ms["checks_failed"] = [{"id": c.get("id"), "evidence": c.get("evidence", "")} for c in failed_checks]
-                ms["reviewer_schema_version"] = 2
+                ms["reviewer_schema_version"] = 3
                 ms.pop("scores", None)
                 ms.pop("sum", None)
                 # Stage the current improved content so resume loads it as
@@ -1983,7 +2480,13 @@ def cmd_run(args):
         models["review"] = args.review_model
 
     state = load_state()
-    ok = run_module(path, state, models=models, dry_run=getattr(args, "dry_run", False))
+    ok = run_module(
+        path,
+        state,
+        models=models,
+        dry_run=getattr(args, "dry_run", False),
+        refresh_fact_ledger=getattr(args, "refresh_fact_ledger", False),
+    )
     sys.exit(0 if ok else 1)
 
 
@@ -2054,7 +2557,13 @@ def cmd_run_section(args):
         for i, path in enumerate(modules, 1):
             key = module_key_from_path(path)
             print(f"\n[{i}/{len(modules)}] {key}")
-            ok = run_module(path, state, models=models, dry_run=dry_run)
+            ok = run_module(
+                path,
+                state,
+                models=models,
+                dry_run=dry_run,
+                refresh_fact_ledger=getattr(args, "refresh_fact_ledger", False),
+            )
             if ok:
                 passed += 1
             else:
@@ -2062,7 +2571,15 @@ def cmd_run_section(args):
     else:
         with ThreadPoolExecutor(max_workers=workers) as executor:
             futures = {
-                executor.submit(run_module, path, state, 2, models, dry_run): path
+                executor.submit(
+                    run_module,
+                    path,
+                    state,
+                    2,
+                    models,
+                    dry_run,
+                    getattr(args, "refresh_fact_ledger", False),
+                ): path
                 for path in modules
             }
             for future in as_completed(futures):
@@ -2210,7 +2727,8 @@ def cmd_status(args):
     # Build track data from disk + state
     tracks: dict[str, dict] = {}
     legacy_count = 0
-    new_gate_count = 0
+    binary_gate_count = 0
+    split_reviewer_count = 0
     for key in disk_keys:
         track = _track_from_key(key)
         t = tracks.setdefault(track, {
@@ -2223,8 +2741,10 @@ def cmd_status(args):
         ms = modules.get(key, {})
         phase = ms.get("phase")
         schema_version = ms.get("reviewer_schema_version", 1 if ms.get("scores") else None)
-        if schema_version == 2:
-            new_gate_count += 1
+        if schema_version == 3:
+            split_reviewer_count += 1
+        elif schema_version == 2:
+            binary_gate_count += 1
         elif schema_version == 1:
             legacy_count += 1
             # Keep legacy sums available for a faded column — modules
@@ -2251,7 +2771,10 @@ def cmd_status(args):
 
     print(f"\n  Modules: {g_total} total | {g_pass} pass | {g_fail} fail | {g_wip} in progress | {g_todo} not started")
     print(f"  Translations: {g_uk}/{g_total} UK")
-    print(f"  Gate version: {new_gate_count} binary-gate | {legacy_count} legacy rubric")
+    print(
+        f"  Gate version: {split_reviewer_count} split-reviewer | "
+        f"{binary_gate_count} binary-gate | {legacy_count} legacy rubric"
+    )
     if all_legacy:
         print(f"  Legacy score distribution: avg {sum(all_legacy)/len(all_legacy):.1f} | lo {min(all_legacy)} | hi {max(all_legacy)} ({len(all_legacy)} modules)")
     print()
@@ -2329,7 +2852,12 @@ def cmd_resume(args):
     for key, ms in incomplete.items():
         path = find_module_path(key)
         if path and path.exists():
-            run_module(path, state, models=models)
+            run_module(
+                path,
+                state,
+                models=models,
+                refresh_fact_ledger=getattr(args, "refresh_fact_ledger", False),
+            )
 
 
 def cmd_e2e(args):
@@ -2447,7 +2975,12 @@ def cmd_e2e(args):
         for key, ms in incomplete.items():
             path = find_module_path(key)
             if path and path.exists():
-                ok = run_module(path, state, models=models)
+                ok = run_module(
+                    path,
+                    state,
+                    models=models,
+                    refresh_fact_ledger=getattr(args, "refresh_fact_ledger", False),
+                )
                 if ok:
                     resumed += 1
                     consecutive_failures = 0
@@ -2496,7 +3029,12 @@ def cmd_e2e(args):
                 continue
 
             print(f"\n[{i}/{len(modules)}] {key}")
-            ok = run_module(path, state, models=models)
+            ok = run_module(
+                path,
+                state,
+                models=models,
+                refresh_fact_ledger=getattr(args, "refresh_fact_ledger", False),
+            )
             if ok:
                 passed += 1
                 consecutive_failures = 0
@@ -2657,7 +3195,7 @@ models:
     # Global model overrides
     parser.add_argument("--audit-model", help=argparse.SUPPRESS)
     parser.add_argument("--write-model", help="Model for WRITE step (default: gemini-3.1-pro-preview)")
-    parser.add_argument("--review-model", help="Model for REVIEW step (default: codex)")
+    parser.add_argument("--review-model", help="Model for REVIEW step (default: gemini-3.1-pro-preview)")
 
     subparsers = parser.add_subparsers(dest="command", help="Pipeline command")
 
@@ -2673,6 +3211,8 @@ models:
     rp = subparsers.add_parser("run", help="Run a module through the full pipeline")
     rp.add_argument("module", help="Module path or key")
     rp.add_argument("--dry-run", action="store_true", help="Plan only — show the initial write plan without making changes")
+    rp.add_argument("--refresh-fact-ledger", action="store_true",
+                    help="Bypass fact-ledger cache and regenerate from upstream sources")
 
     # run-section
     rsp = subparsers.add_parser("run-section", help="Run all modules in a section")
@@ -2682,6 +3222,8 @@ models:
                      choices=["prerequisites", "linux", "cloud", "k8s"])
     rsp.add_argument("--skip-gaps", action="store_true", help="Skip gap check even if errors found")
     rsp.add_argument("--dry-run", action="store_true", help="Plan only — show the initial write plan without making changes")
+    rsp.add_argument("--refresh-fact-ledger", action="store_true",
+                     help="Bypass fact-ledger cache and regenerate from upstream sources")
 
     # gap-check
     gcp = subparsers.add_parser("gap-check", help="Detect scaffolding gaps in a track/section")
@@ -2698,7 +3240,9 @@ models:
     sp.add_argument("--verbose", "-v", action="store_true", help="Show error details")
 
     # resume
-    subparsers.add_parser("resume", help="Resume incomplete modules")
+    resume_parser = subparsers.add_parser("resume", help="Resume incomplete modules")
+    resume_parser.add_argument("--refresh-fact-ledger", action="store_true",
+                               help="Bypass fact-ledger cache and regenerate from upstream sources")
 
     # e2e
     e2e_parser = subparsers.add_parser("e2e", help="End-to-end: resume stuck + process all sections",
@@ -2720,6 +3264,8 @@ examples:
     e2e_parser.add_argument("sections", nargs="*", help="track aliases or section paths (default: all)")
     e2e_parser.add_argument("--verbose", "-v", action="store_true", help="print full output to stdout (default: quiet, log only)")
     e2e_parser.add_argument("--no-translate", action="store_true", help="skip UK translation step")
+    e2e_parser.add_argument("--refresh-fact-ledger", action="store_true",
+                            help="Bypass fact-ledger cache and regenerate from upstream sources")
 
     args = parser.parse_args()
 

--- a/scripts/v1_pipeline.py
+++ b/scripts/v1_pipeline.py
@@ -47,6 +47,7 @@ import re
 import shutil
 import subprocess
 import sys
+import threading
 import urllib.error
 import urllib.request
 import yaml
@@ -62,11 +63,16 @@ SCORE_SCRIPT = REPO_ROOT / "scripts" / "score_module.py"
 KNOWLEDGE_CARD_DIR = REPO_ROOT / ".pipeline" / "knowledge-cards"
 FACT_LEDGER_DIR = REPO_ROOT / ".pipeline" / "fact-ledgers"
 FACT_LEDGER_TTL = timedelta(days=7)
-# DESIGN_AMBIGUITY: Spec acceptance #7 asks to add fact-ledgers to .gitignore,
-# while #3 constrains file changes to scripts/*. To satisfy #3, cache remains
-# under `.pipeline/fact-ledgers` but .gitignore is not modified in this change.
 LINK_CACHE_FILE = REPO_ROOT / ".pipeline" / "link-cache.json"
 LINK_CACHE_TTL = timedelta(hours=24)
+LINK_HEALTH_TIMEOUT_SEC = 5
+K8S_MIN_SUPPORTED_MINOR = 35
+K8S_VERSION_RE = re.compile(r"\bv?1\.(\d{1,2})\b")
+CLAIM_MATCH_TOLERANCE_CHARS = 10
+DATA_CONFLICT_CONFLICT_THRESHOLD = 3
+DATA_CONFLICT_UNVERIFIED_THRESHOLD = 5
+LEGACY_SCORE_PASS_THRESHOLD = 4
+_LINK_CACHE_LOCK = threading.Lock()
 
 # ---------------------------------------------------------------------------
 # Timestamped logging — tee all print() to a log file
@@ -441,19 +447,21 @@ def ensure_fact_ledger(module_path: Path, ms: dict,
                        model: str = MODELS["fact_grounding"],
                        topic_hint: str | None = None,
                        refresh: bool = False) -> dict | None:
-    """Ensure a fresh fact ledger is available in module state."""
-    existing = ms.get("fact_ledger")
-    generated_at_raw = ms.get("fact_ledger_generated_at")
-    if not refresh and isinstance(existing, dict) and isinstance(generated_at_raw, str):
+    """Ensure a fresh fact ledger is available in module state.
+
+    The on-disk cache is authoritative; state metadata is only a mirror.
+    """
+    key = module_key_from_path(module_path)
+    cache_path = fact_ledger_path_for_key(key)
+
+    if not refresh and cache_path.exists() and _cache_is_fresh(cache_path, FACT_LEDGER_TTL):
         try:
-            generated_at = datetime.fromisoformat(generated_at_raw)
-            if generated_at.tzinfo is None:
-                generated_at = generated_at.replace(tzinfo=UTC)
-            if datetime.now(UTC) - generated_at < FACT_LEDGER_TTL:
-                claims = existing.get("claims")
-                if isinstance(claims, list) and claims:
-                    return existing
-        except ValueError:
+            cached = json.loads(cache_path.read_text())
+            claims = cached.get("claims") if isinstance(cached, dict) else None
+            if isinstance(claims, list) and claims:
+                ms["fact_ledger"] = cached
+                return cached
+        except (json.JSONDecodeError, OSError):
             pass
 
     ledger = step_fact_ledger(module_path, topic_hint=topic_hint, model=model, refresh=refresh)
@@ -1086,6 +1094,8 @@ def _translate_index(_en_content: str, uk_path: Path, rel_section: str) -> bool:
 def _has_required_json_keys(obj: dict, required_keys: tuple[str, ...]) -> bool:
     """Return True if obj has the required keys for a JSON payload."""
     if required_keys == ("verdict", "checks"):
+        # Keep legacy `scores` acceptance so step_review can normalize v1/v2
+        # reviewer payloads to v3 `checks`.
         return "verdict" in obj and ("checks" in obj or "scores" in obj)
     return all(k in obj for k in required_keys)
 
@@ -1416,7 +1426,32 @@ def step_review(module_path: Path, improved: str, model: str = MODELS["review"],
         return None
 
     verdict = result.get("verdict", "REJECT")
-    checks_raw = result.get("checks") or []
+    checks_raw = result.get("checks")
+    if (not isinstance(checks_raw, list) or not checks_raw) and "scores" in result:
+        legacy_scores = result.get("scores")
+        checks_raw = []
+        if isinstance(legacy_scores, dict):
+            score_items = list(legacy_scores.items())
+        elif isinstance(legacy_scores, list):
+            score_items = [(f"d{i+1}", score) for i, score in enumerate(legacy_scores)]
+        else:
+            score_items = []
+        for i, (dim, score) in enumerate(score_items):
+            check_id = re.sub(r"[^A-Za-z0-9]+", "_", str(dim).strip()).strip("_").upper()
+            if not check_id:
+                check_id = f"D{i+1}"
+            score_value = score if isinstance(score, (int, float)) else None
+            passed = bool(score_value is not None and score_value >= LEGACY_SCORE_PASS_THRESHOLD)
+            checks_raw.append({
+                "id": check_id,
+                "passed": passed,
+                "evidence": (
+                    f"legacy score={score!r} "
+                    f"(pass threshold {LEGACY_SCORE_PASS_THRESHOLD})"
+                ),
+            })
+    if not isinstance(checks_raw, list):
+        checks_raw = []
     checks = [c for c in checks_raw if isinstance(c, dict) and "id" in c]
     edits = result.get("edits") or []
     if not isinstance(edits, list):
@@ -1503,15 +1538,30 @@ def _get_url_status(url: str, cache: dict) -> int | None:
             except ValueError:
                 pass
 
-    req = urllib.request.Request(url, method="HEAD")
-    status_code: int | None = None
-    try:
-        with urllib.request.urlopen(req, timeout=5) as response:
-            status_code = int(response.getcode())
-    except urllib.error.HTTPError as e:
-        status_code = int(e.code)
-    except (urllib.error.URLError, TimeoutError, ValueError):
-        status_code = None
+    def _probe(method: str) -> int | None:
+        headers = {"Range": "bytes=0-1023"} if method == "GET" else {}
+        req = urllib.request.Request(url, method=method, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=LINK_HEALTH_TIMEOUT_SEC) as response:
+                if method == "GET":
+                    try:
+                        response.read(1024)
+                    except Exception:
+                        pass
+                return int(response.getcode())
+        except urllib.error.HTTPError as e:
+            return int(e.code)
+        except (urllib.error.URLError, TimeoutError, ValueError):
+            return None
+
+    head_status = _probe("HEAD")
+    status_code = head_status
+    if head_status in (403, 405):
+        get_status = _probe("GET")
+        if get_status is not None and get_status < 400:
+            status_code = get_status
+        elif get_status is not None:
+            status_code = get_status
 
     cache[url] = {
         "status": status_code,
@@ -1520,7 +1570,8 @@ def _get_url_status(url: str, cache: dict) -> int | None:
     return status_code
 
 
-def _contains_with_tolerance(haystack: str, needle: str, tolerance: int = 10) -> bool:
+def _contains_with_tolerance(haystack: str, needle: str,
+                             tolerance: int = CLAIM_MATCH_TOLERANCE_CHARS) -> bool:
     """Return True when needle is found exactly or with end trimming tolerance."""
     if not needle:
         return False
@@ -1573,6 +1624,70 @@ def _is_unhedged_claim_assertion(content: str, claim_text: str) -> bool:
         start = idx + len(needle)
 
 
+PRODUCT_VERSION_RE = re.compile(
+    r"\b(?:kubernetes|k8s|helm|docker|containerd|etcd|cilium|calico|flannel|coredns|istio|argo(?:\s+cd|cd)?)\s+v?\d+\.\d+(?:\.\d+)?\b",
+    re.IGNORECASE,
+)
+API_NAME_RE = re.compile(r"\b[a-z0-9][a-z0-9.-]*/v\d(?:alpha\d+|beta\d+)?\b", re.IGNORECASE)
+HELM_KEY_RE = re.compile(r"`([A-Za-z][A-Za-z0-9_.-]*\.[A-Za-z0-9_.-]+)`")
+DEPRECATION_STATUS_TERMS = ("deprecated", "deprecation", "removed", "stable", "ga", "beta", "alpha")
+
+
+def _extract_factual_claim_candidates(content: str) -> list[str]:
+    """Extract likely factual claim fragments that require ledger mapping."""
+    candidates: set[str] = set()
+
+    for match in K8S_VERSION_RE.finditer(content):
+        minor = match.group(1)
+        snippet = content[max(0, match.start() - 40):min(len(content), match.end() + 40)]
+        compact = " ".join(snippet.split())
+        if compact:
+            candidates.add(compact)
+        candidates.add(f"v1.{minor}")
+
+    for match in PRODUCT_VERSION_RE.finditer(content):
+        candidates.add(" ".join(match.group(0).split()))
+
+    for match in API_NAME_RE.finditer(content):
+        token = match.group(0)
+        if token and not token.startswith("http"):
+            candidates.add(token)
+
+    for match in HELM_KEY_RE.finditer(content):
+        token = match.group(1).strip()
+        if token:
+            candidates.add(token)
+
+    for line in content.splitlines():
+        compact = " ".join(line.split())
+        lowered = compact.lower()
+        if not compact or compact.startswith("```"):
+            continue
+        if any(term in lowered for term in DEPRECATION_STATUS_TERMS):
+            candidates.add(compact[:160])
+
+    return sorted(candidates)
+
+
+def _claim_maps_to_supported_ledger(claim_text: str, supported_ledger_texts: list[str]) -> bool:
+    """Return True when the extracted content claim maps to a supported ledger claim."""
+    if not claim_text:
+        return False
+    for ledger_text in supported_ledger_texts:
+        if not ledger_text:
+            continue
+        if _contains_with_tolerance(ledger_text, claim_text):
+            return True
+        if _contains_with_tolerance(claim_text, ledger_text):
+            return True
+
+        claim_versions = {f"v1.{m.group(1)}" for m in K8S_VERSION_RE.finditer(claim_text)}
+        ledger_versions = {f"v1.{m.group(1)}" for m in K8S_VERSION_RE.finditer(ledger_text)}
+        if claim_versions and claim_versions.intersection(ledger_versions):
+            return True
+    return False
+
+
 def step_check_integrity(content: str, fact_ledger: dict) -> tuple[bool, list[str]]:
     """Tier-1 deterministic integrity gate before structural checks."""
     errors: list[str] = []
@@ -1580,27 +1695,28 @@ def step_check_integrity(content: str, fact_ledger: dict) -> tuple[bool, list[st
 
     # 1) Link health with 24h cache
     urls = sorted(set(re.findall(r"https?://[^\s)>\]\"']+", content)))
-    cache = _load_link_cache()
-    for url in urls:
-        status = _get_url_status(url, cache)
-        if status is None or status >= 400:
-            label = status if status is not None else "ERROR"
-            errors.append(f"LINK_DEAD: {url} ({label})")
-    _save_link_cache(cache)
+    with _LINK_CACHE_LOCK:
+        cache = _load_link_cache()
+        for url in urls:
+            status = _get_url_status(url, cache)
+            if status is None or status >= 400:
+                label = status if status is not None else "ERROR"
+                errors.append(f"LINK_DEAD: {url} ({label})")
+        _save_link_cache(cache)
 
-    # 2) K8s version consistency + stale version hard-fail
+    # 2) K8s version consistency + minimum supported version hard-fail
     versions = set()
-    for match in re.finditer(r"\b(v?1\.(\d{1,2}))\b", content):
-        raw, minor_raw = match.group(1), match.group(2)
+    for match in K8S_VERSION_RE.finditer(content):
+        minor_raw = match.group(1)
         try:
             minor = int(minor_raw)
         except ValueError:
             continue
-        if not (20 <= minor <= 40):
+        if not (0 <= minor <= 99):
             continue
         canonical = f"v1.{minor}"
         versions.add(canonical)
-        if minor <= 20:
+        if minor < K8S_MIN_SUPPORTED_MINOR:
             errors.append(f"STALE_K8S_VERSION: {canonical}")
     if len(versions) > 1:
         warnings.append(f"VERSION_MISMATCH_WARNING: {', '.join(sorted(versions))}")
@@ -1619,17 +1735,23 @@ def step_check_integrity(content: str, fact_ledger: dict) -> tuple[bool, list[st
 
     # 4) Evidence mapping against fact ledger
     claims = fact_ledger.get("claims", []) if isinstance(fact_ledger, dict) else []
+    supported_ledger_texts: list[str] = []
     for claim in claims:
         if not isinstance(claim, dict):
             continue
         claim_id = claim.get("id", "?")
-        status = claim.get("status")
+        status = str(claim.get("status", "")).upper()
         current_truth = claim.get("current_truth")
         statement = claim.get("claim") or current_truth or ""
 
-        if status == "SUPPORTED" and isinstance(current_truth, str) and current_truth.strip():
-            if not _contains_with_tolerance(content, current_truth, tolerance=10):
-                warnings.append(f"MISSING_SUPPORTED_CLAIM: claim {claim_id}")
+        if status in {"SUPPORTED", "VERIFIED"}:
+            if isinstance(current_truth, str) and current_truth.strip():
+                supported_ledger_texts.append(current_truth.strip())
+            if isinstance(claim.get("claim"), str) and claim.get("claim", "").strip():
+                supported_ledger_texts.append(claim.get("claim", "").strip())
+            if isinstance(statement, str) and statement.strip():
+                if not _contains_with_tolerance(content, statement):
+                    errors.append(f"MISSING_SUPPORTED_CLAIM: claim {claim_id}")
 
         if status == "CONFLICTING" and isinstance(statement, str) and statement.strip():
             if _is_unhedged_claim_assertion(content, statement):
@@ -1637,6 +1759,11 @@ def step_check_integrity(content: str, fact_ledger: dict) -> tuple[bool, list[st
         if status == "UNVERIFIED" and isinstance(statement, str) and statement.strip():
             if _is_unhedged_claim_assertion(content, statement):
                 errors.append(f"UNHEDGED_UNVERIFIED: claim {claim_id}")
+
+    # 5) Reverse evidence mapping: content claims must map to supported ledger facts.
+    for extracted in _extract_factual_claim_candidates(content):
+        if not _claim_maps_to_supported_ledger(extracted, supported_ledger_texts):
+            errors.append(f"UNMAPPED_CLAIM: {extracted}")
 
     return len(errors) == 0, errors + warnings
 
@@ -1769,7 +1896,7 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
 
     # Phase 0: split-reviewer fact ledger (issue #225).
     # Model selection rationale is pinned by calibration data in:
-    # /Users/krisztiankoos/.claude/projects/-Users-krisztiankoos-projects-kubedojo/memory/project_fact_grounding_calibration.md
+    # docs/research/fact-grounding-calibration-2026-04-12.md
     if not dry_run:
         fact_model = m.get("fact_grounding", MODELS["fact_grounding"])
         fact_family = _model_family(fact_model)
@@ -1811,7 +1938,6 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
             return False
 
         ms["fact_ledger"] = ledger_result
-        ms["fact_ledger_generated_at"] = datetime.now(UTC).isoformat()
         save_state(state)
 
         n_conflict = sum(
@@ -1822,7 +1948,8 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
             1 for c in ledger_result.get("claims", [])
             if isinstance(c, dict) and c.get("status") == "UNVERIFIED"
         )
-        if n_conflict >= 3 or n_unverified >= 5:
+        if (n_conflict >= DATA_CONFLICT_CONFLICT_THRESHOLD or
+                n_unverified >= DATA_CONFLICT_UNVERIFIED_THRESHOLD):
             ms["phase"] = "data_conflict"
             ms["errors"].append(
                 f"DATA_CONFLICT: {n_conflict} conflicting + {n_unverified} "
@@ -1830,9 +1957,6 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
             )
             save_state(state)
             return False
-
-    knowledge_card = None
-    resume_from_staging = False
 
     # Initial write plan. Legacy `phase="audit"` states from older runs are
     # treated the same as fresh `pending` modules: start a normal first-pass
@@ -1868,7 +1992,6 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
             improved = staging_path.read_text()
             last_good = improved
             targeted_fix = ms.get("targeted_fix", False)
-            resume_from_staging = True
             mode = "targeted fix" if targeted_fix else "improve"
             print(f"  Loaded staged content ({len(improved)} chars) and saved {mode} plan")
         elif ms["phase"] == "review":
@@ -1894,23 +2017,6 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
             last_good = None
             targeted_fix = False
 
-    # Knowledge card must be loaded unconditionally before entering the
-    # write→review loop, regardless of what phase the module is in on entry.
-    # Previously we gated this on `phase == "write"` and `not resume_from_staging`,
-    # which meant resumed modules (e.g. entering at phase=review after a
-    # deterministic apply or peak-hours pause) got KNOWLEDGE_CARD_UNAVAILABLE
-    # on their NEXT write — losing the grounding entirely for any retry that
-    # regenerates content. The card is a stable per-topic artifact and cheap
-    # to read from disk (only the first-time generation costs a Codex call),
-    # so loading it every run is correct and safe.
-    if not dry_run:
-        try:
-            knowledge_card = ensure_knowledge_card(module_path, ms, model=m["knowledge_card"])
-        except Exception as e:
-            print(f"  ⚠ Knowledge card unavailable — proceeding without grounding: {e}")
-            knowledge_card = None
-        save_state(state)
-
     # WRITE → REVIEW loop (max retries)
     # Auto-detect rewrite mode from the binary gate's severity signal on
     # the previous review. severe → full rewrite; anything else → normal
@@ -1928,10 +2034,12 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
         if ms["phase"] in ("write",):
             writer_model = m["write_targeted"] if targeted_fix else m["write"]
             try:
+                # knowledge_card is intentionally not passed to the writer:
+                # fact_ledger is the sole authoritative grounding source.
                 improved = step_write(module_path, plan, model=writer_model,
                                       rewrite=needs_rewrite,
                                       previous_output=last_good,
-                                      knowledge_card=knowledge_card,
+                                      knowledge_card=None,
                                       fact_ledger=ms.get("fact_ledger"))
             except ClaudeUnavailableError as e:
                 # Peak hours / rate limit / budget exhausted on Claude. Pause
@@ -1973,6 +2081,38 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
             save_state(state)
 
         if ms["phase"] == "review":
+            content_for_integrity = improved or module_path.read_text()
+            integrity_passed, integrity_messages = step_check_integrity(
+                content_for_integrity, ms.get("fact_ledger") or {}
+            )
+            if not integrity_passed:
+                needs_rewrite = True
+                targeted_fix = False
+                plan = (
+                    "SEVERE REWRITE REQUIRED. Tier-1 integrity gate failed before "
+                    "structural review. Rewrite the module and resolve every "
+                    "integrity error.\n\nIntegrity errors:\n"
+                )
+                for msg in integrity_messages:
+                    plan += f"\n- {msg}"
+                ms["plan"] = plan
+                ms["targeted_fix"] = False
+                ms["severity"] = "severe"
+                ms["checks_failed"] = [{"id": "INTEGRITY", "evidence": msg} for msg in integrity_messages]
+                ms["reviewer_schema_version"] = 3
+                ms.pop("scores", None)
+                ms.pop("sum", None)
+                if improved is not None:
+                    staging_path = module_path.with_suffix(".staging.md")
+                    _atomic_write_text(staging_path, improved)
+                ms["phase"] = "write"
+                save_state(state)
+                print("  ⚠ Tier-1 integrity gate failed — routing to severe rewrite")
+                if attempt < max_retries:
+                    continue
+                ms["errors"].append("Integrity gate failed after max retries")
+                return False
+
             reviewer_model = m["review"]
             review = step_review(
                 module_path,
@@ -2047,38 +2187,6 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
                 return False
 
             if review.get("verdict") == "APPROVE":
-                content_for_integrity = improved or module_path.read_text()
-                integrity_passed, integrity_messages = step_check_integrity(
-                    content_for_integrity, ms.get("fact_ledger") or {}
-                )
-                if not integrity_passed:
-                    needs_rewrite = True
-                    targeted_fix = False
-                    plan = (
-                        "SEVERE REWRITE REQUIRED. Tier-1 integrity gate failed before "
-                        "structural CHECK. Rewrite the module and resolve every "
-                        "integrity error.\n\nIntegrity errors:\n"
-                    )
-                    for msg in integrity_messages:
-                        plan += f"\n- {msg}"
-                    ms["plan"] = plan
-                    ms["targeted_fix"] = False
-                    ms["severity"] = "severe"
-                    ms["checks_failed"] = [{"id": "INTEGRITY", "evidence": msg} for msg in integrity_messages]
-                    ms["reviewer_schema_version"] = 3
-                    ms.pop("scores", None)
-                    ms.pop("sum", None)
-                    if improved is not None:
-                        staging_path = module_path.with_suffix(".staging.md")
-                        _atomic_write_text(staging_path, improved)
-                    ms["phase"] = "write"
-                    save_state(state)
-                    print("  ⚠ Tier-1 integrity gate failed — routing to severe rewrite")
-                    if attempt < max_retries:
-                        continue
-                    ms["errors"].append("Integrity gate failed after max retries")
-                    return False
-
                 # Binary gate: on APPROVE, the module's state records that
                 # every check passed. Per Gemini pair-review critique B, we
                 # ignore any `edits` returned alongside an APPROVE — an


### PR DESCRIPTION
## Summary

Splits the v1 pipeline into a phase-0 fact-ledger grounding step + a tier-1 deterministic integrity gate + a structural reviewer. Fixes the module-1.5 flap zone where LLM-as-judge kept flipping between contradictory upstream docs on factual currency.

**Architecture shift**: fact grounding moves from reviewer-time to pre-write. The structural reviewer no longer checks facts at all (7 checks instead of 8 — FACT is removed).

## What changed

- `step_fact_ledger()` — phase-0 grounding via \`gpt-5.3-codex-spark\` (calibration winner 25/25), 7-day file-authoritative cache, \`--refresh-fact-ledger\` CLI flag, DATA_CONFLICT triage exit when sources disagree past threshold
- \`step_check_integrity()\` — tier-1 deterministic gate before structural review: link health (HEAD + GET fallback on 403/405, thread-safe cache), K8s version floor (\`K8S_MIN_SUPPORTED_MINOR = 35\`), YAML lint, and bidirectional evidence mapping against the ledger
- \`MODELS[\"review\"]\` → \`gemini-3.1-pro-preview\` (was \`codex\`)
- \`MODELS[\"fact_grounding\"] = \"gpt-5.3-codex-spark\"\`, \`MODELS[\"fact_fallback\"] = \"claude-sonnet-4-6\"\`
- \`knowledge_card\` dropped from the writer path — fact-ledger is the sole grounding source
- Reviewer schema v3 with proper legacy v1/v2 normalization
- \`.pipeline/fact-ledgers/\` and \`.pipeline/link-cache.json\` added to \`.gitignore\`

## Tests

**118 passing** (was 103). New test classes: \`TestFactLedger\`, \`TestStepCheckIntegrity\`, \`TestRunModuleSplitReviewer\`, \`TestEnsureFactLedger\`, \`TestCliRefreshFactLedgerFlag\`, \`TestLegacyReviewerCompat\`. Plus a regression test for the fenced-YAML extractor false-positive caught in round 2 review.

## Review history

Three adversarial review rounds:

| Round | Gemini 3.1 Pro (cross-family) | gpt-5.4 (same-family different-model) |
|---|---|---|
| 1 on \`66747b6\` | NEEDS_CHANGES (7 critical) | NEEDS_CHANGES (5 critical + 1 regression) |
| 2 on \`6dca884\` | NEEDS_CHANGES (lock scope partial) | NEEDS_CHANGES (extractor regression) |
| 3 on \`51075c2\` | **APPROVE** | **APPROVE** |

Authored across the round 1 + round 2 commits by \`gpt-5.3-codex\` via \`codex exec --sandbox workspace-write\`; round 3 fixes done inline by the main Claude session.

## Test plan

- [x] \`python -m unittest scripts.test_pipeline\` — 118/118 pass
- [x] \`python -m py_compile scripts/v1_pipeline.py\` — clean
- [ ] User review before merge
- [ ] After merge: re-run \`run-section\` on the original flap zone (module-1.5 Kubecost on bare metal) to confirm DATA_CONFLICT triage fires instead of looping