### PR TITLE
Local API: agent cold-start + server perf + ETag + background refresh (#258)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,18 @@
 
 KubeDojo — free, open-source cloud native curriculum.
 
+## Agent Orientation (first call on a cold start)
+
+Before `cat`-ing `STATUS.md` or running `git log`, hit the local API — it returns the same orientation in ~65 % fewer tokens.
+
+```
+curl -s http://127.0.0.1:8768/api/briefing/session             # ~1.5K tokens, full
+curl -s http://127.0.0.1:8768/api/briefing/session?compact=1   # ~0.7K tokens, compact
+curl -s http://127.0.0.1:8768/api/schema                       # endpoint index
+```
+
+The briefing covers: current branch + dirty summary, all worktrees, runtime services, pipeline v2 queue head, recent commits, top TODO bullets, blockers, and alerts. Drill-down URLs are listed in `next_reads`. Responses carry a weak ETag — send `If-None-Match` for 304 on repeat polls. If the API is down, fall back to reading `STATUS.md` + `CLAUDE.md`.
+
 ## Agent Usage
 
 - Don't spawn agents for work a single Grep/Read/Glob can do — it's slower and wasteful.

--- a/scripts/bench_orientation.py
+++ b/scripts/bench_orientation.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Benchmark agent cold-start orientation cost.
+
+Measures how many tokens and milliseconds a fresh agent would burn to
+orient itself in the repo. Compares two paths:
+
+1. **Baseline** — what agents do today: ``cat CLAUDE.md`` + ``cat STATUS.md``
+   + ``git log -20`` + ``ls`` of top-level dirs.
+2. **API path** — a single call to ``/api/briefing/session`` (optionally
+   ``?compact=1``) followed by at most one targeted drill-down.
+
+Token counting uses ``tiktoken`` (``cl100k_base``) when installed; otherwise
+falls back to a 4-characters-per-token approximation — an underestimate for
+markdown but consistent across runs.
+
+Usage::
+
+    python scripts/bench_orientation.py [--repo-root PATH]
+
+Prints a small table and exits 0. Intended to be run in CI to guard against
+regressions in cold-start cost.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def _try_tiktoken():
+    try:
+        import tiktoken  # type: ignore
+    except ImportError:
+        return None
+    try:
+        return tiktoken.get_encoding("cl100k_base")
+    except Exception:  # noqa: BLE001
+        return None
+
+
+_TOKENIZER = _try_tiktoken()
+
+
+def count_tokens(text: str) -> int:
+    if _TOKENIZER is not None:
+        return len(_TOKENIZER.encode(text))
+    # Rough fallback: ~4 chars per token for English prose. Underestimates
+    # markdown/code; fine for regression tracking.
+    return max(1, len(text) // 4)
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def baseline_orientation(repo_root: Path) -> dict:
+    """Approximate the tokens a typical agent reads to orient today."""
+    parts: dict[str, str] = {
+        "CLAUDE.md": _read(repo_root / "CLAUDE.md"),
+        "STATUS.md": _read(repo_root / "STATUS.md"),
+    }
+    try:
+        git_log = subprocess.run(
+            ["git", "log", "-n20", "--oneline"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        ).stdout
+    except (OSError, subprocess.TimeoutExpired):
+        git_log = ""
+    parts["git log -20"] = git_log
+    try:
+        git_status = subprocess.run(
+            ["git", "status", "--short"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        ).stdout
+    except (OSError, subprocess.TimeoutExpired):
+        git_status = ""
+    parts["git status"] = git_status
+    try:
+        ls = subprocess.run(
+            ["ls", str(repo_root)],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        ).stdout
+    except (OSError, subprocess.TimeoutExpired):
+        ls = ""
+    parts["ls repo"] = ls
+
+    per_part = {name: count_tokens(text) for name, text in parts.items()}
+    return {
+        "mode": "baseline",
+        "tokens": sum(per_part.values()),
+        "per_source": per_part,
+        "byte_total": sum(len(v) for v in parts.values()),
+    }
+
+
+def api_orientation(repo_root: Path, *, compact: bool = False) -> dict:
+    """Measure tokens returned by the briefing endpoint, wall-time included."""
+    sys.path.insert(0, str(repo_root / "scripts"))
+    import local_api  # noqa: PLC0415
+
+    t0 = time.time()
+    suffix = "?compact=1" if compact else ""
+    code, body, _ct, etag = local_api.serve_request(
+        repo_root, "/api/briefing/session" + suffix
+    )
+    dur_ms = (time.time() - t0) * 1000.0
+    text = body.decode("utf-8", errors="replace")
+    return {
+        "mode": "api" + ("+compact" if compact else ""),
+        "status": code,
+        "tokens": count_tokens(text),
+        "byte_total": len(body),
+        "build_ms": dur_ms,
+        "etag": etag,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Benchmark agent cold-start orientation cost"
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Path to the repo root (default: auto-detected)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit one JSON object per line instead of a table",
+    )
+    args = parser.parse_args(argv)
+    repo_root = args.repo_root.resolve()
+
+    results = [
+        baseline_orientation(repo_root),
+        api_orientation(repo_root, compact=False),
+        api_orientation(repo_root, compact=True),
+    ]
+
+    if args.json:
+        for r in results:
+            print(json.dumps(r, sort_keys=True))
+        return 0
+
+    print(f"Tokenizer: {'tiktoken cl100k_base' if _TOKENIZER else 'fallback (~4c/tok)'}")
+    print(f"Repo root: {repo_root}")
+    print()
+    print(f"{'mode':<18}  {'tokens':>8}  {'bytes':>8}  {'extra':<40}")
+    print("-" * 80)
+    for r in results:
+        extra = ""
+        if r["mode"] == "baseline":
+            extra = ", ".join(f"{k}:{v}" for k, v in r["per_source"].items())
+        else:
+            extra = f"build={r.get('build_ms', 0):.1f}ms"
+        print(f"{r['mode']:<18}  {r['tokens']:>8}  {r['byte_total']:>8}  {extra}")
+
+    baseline = results[0]["tokens"]
+    api_full = results[1]["tokens"]
+    api_compact = results[2]["tokens"]
+    print()
+    print(f"Saving vs baseline: full briefing = {baseline - api_full:+d} tokens"
+          f" ({(1 - api_full / baseline) * 100:.0f}% reduction)")
+    print(f"Saving vs baseline: compact      = {baseline - api_compact:+d} tokens"
+          f" ({(1 - api_compact / baseline) * 100:.0f}% reduction)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -161,37 +161,77 @@ def _path_mtime(p: Path) -> float:
         return 0.0
 
 
+# Persistent read-only sqlite connections keyed by absolute db path.
+# ``PRAGMA data_version`` returns a monotonic counter on a specific
+# connection that increments whenever ANOTHER connection commits a
+# write. So a single persistent connection, queried repeatedly, is a
+# reliable change signal — unlike the round-1 fresh-connection usage
+# that Codex flagged. The dict lock serializes sqlite per connection
+# (sqlite itself is single-writer; reads can concurrent on separate
+# connections, but we only keep one per db for bookkeeping).
+_SQLITE_VERSION_CONNECTIONS: dict[str, sqlite3.Connection] = {}
+_SQLITE_VERSION_LOCK = threading.Lock()
+
+
+def _close_all_sqlite_version_connections() -> None:
+    """Test helper: drop cached read-only connections (e.g. between
+    tests that recreate DB files at the same path)."""
+    with _SQLITE_VERSION_LOCK:
+        for conn in _SQLITE_VERSION_CONNECTIONS.values():
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
+        _SQLITE_VERSION_CONNECTIONS.clear()
+
+
 def _sqlite_version_key(db_path: Path) -> tuple:
-    """Fingerprint a sqlite DB that is stable while data is unchanged.
+    """Fingerprint a sqlite DB using ``PRAGMA data_version`` on a
+    persistent read-only connection.
 
-    Uses ``(db_mtime, db_size, wal_mtime, wal_size)``. We DO NOT use
-    ``PRAGMA data_version`` because it is documented as a per-connection
-    counter — opening a fresh read-only connection on every call would
-    not give us a reliable cross-process version. WAL writes always
-    touch ``<db>-wal`` and update both its mtime and size, so the tuple
-    catches them without opening sqlite at all.
+    Contract: two calls return the same key iff no other connection
+    has committed between them. This catches every form of write
+    (WAL append, WAL reuse after checkpoint, in-place DELETE/MEMORY
+    writes, rapid same-size writes inside one mtime granule) — none
+    of which ``(mtime, size)`` can distinguish.
 
-    Note: on filesystems with coarse mtime resolution (some NTFS, older
-    ext3) a sub-second write might share an mtime with the previous
-    one; ``size`` breaks that tie for any write that changes bytes.
+    Falls back to ``("absent", ...)`` when the file is missing and
+    ``("open_failed", mtime)`` if the read-only handle can't be
+    opened (e.g. permissions). Filesystem stats are only a degraded
+    signal; the authoritative signal is the pragma counter.
     """
     if not db_path.exists():
         return ("absent",)
 
-    try:
-        db_stat = db_path.stat()
-        db_mtime, db_size = db_stat.st_mtime, db_stat.st_size
-    except OSError:
-        db_mtime, db_size = 0.0, 0
+    key = str(db_path.resolve())
+    with _SQLITE_VERSION_LOCK:
+        conn = _SQLITE_VERSION_CONNECTIONS.get(key)
+        if conn is None:
+            try:
+                conn = sqlite3.connect(
+                    f"file:{db_path}?mode=ro",
+                    uri=True,
+                    timeout=1.0,
+                    check_same_thread=False,
+                )
+            except sqlite3.Error:
+                return ("open_failed", _path_mtime(db_path))
+            _SQLITE_VERSION_CONNECTIONS[key] = conn
 
-    wal_path = db_path.with_name(db_path.name + "-wal")
-    try:
-        wal_stat = wal_path.stat()
-        wal_mtime, wal_size = wal_stat.st_mtime, wal_stat.st_size
-    except OSError:
-        wal_mtime, wal_size = 0.0, 0
+        try:
+            row = conn.execute("PRAGMA data_version").fetchone()
+            data_version = int(row[0]) if row is not None else 0
+        except sqlite3.Error:
+            # Connection poisoned (e.g. DB rotated out from under us).
+            # Drop it so the next call opens fresh.
+            _SQLITE_VERSION_CONNECTIONS.pop(key, None)
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
+            return ("error", _path_mtime(db_path))
 
-    return (db_mtime, db_size, wal_mtime, wal_size)
+    return ("v", data_version)
 
 
 def _normalized_cache_key(
@@ -331,31 +371,44 @@ class BackgroundSnapshot:
             # Fixed-delay: sleep AFTER completion so overruns never overlap.
             self._stop.wait(self.interval_seconds)
 
-    def _refresh_once(self) -> None:
-        # ``_build_lock`` serializes concurrent callers (background thread +
-        # ``refresh_blocking()``) so at most one builder runs at a time. This
-        # is the real enforcement of the "single in-flight" guarantee.
-        with self._build_lock:
-            started = time.time()
-            with self._lock:
-                self._started_at = started
-            try:
-                snapshot = self.builder()
-                err: str | None = None
-            except Exception as exc:  # noqa: BLE001
-                snapshot = None
-                err = f"{type(exc).__name__}: {exc}"
-            completed = time.time()
-            with self._lock:
-                if snapshot is not None:
-                    self._snapshot = snapshot
-                self._completed_at = completed
-                self._duration_ms = (completed - started) * 1000.0
-                self._last_error = err
+    def _refresh_once_locked(self) -> None:
+        """Core refresh, assuming ``_build_lock`` is already held."""
+        started = time.time()
+        with self._lock:
+            self._started_at = started
+        try:
+            snapshot = self.builder()
+            err: str | None = None
+        except Exception as exc:  # noqa: BLE001
+            snapshot = None
+            err = f"{type(exc).__name__}: {exc}"
+        completed = time.time()
+        with self._lock:
+            if snapshot is not None:
+                self._snapshot = snapshot
+            self._completed_at = completed
+            self._duration_ms = (completed - started) * 1000.0
+            self._last_error = err
 
-    def refresh_blocking(self, timeout: float = 60.0) -> None:
-        """Trigger one refresh in the calling thread. For first-call priming."""
-        self._refresh_once()
+    def _refresh_once(self) -> None:
+        """Serialize all builders through ``_build_lock``. The real
+        enforcement of the "single in-flight" guarantee."""
+        with self._build_lock:
+            self._refresh_once_locked()
+
+    def refresh_blocking(self, timeout: float | None = None) -> bool:
+        """Trigger one refresh in the calling thread. Returns True if
+        the refresh ran, False if ``timeout`` elapsed while waiting
+        for the build lock. ``timeout=None`` waits forever."""
+        lock_timeout = -1.0 if timeout is None else float(timeout)
+        acquired = self._build_lock.acquire(timeout=lock_timeout)
+        if not acquired:
+            return False
+        try:
+            self._refresh_once_locked()
+        finally:
+            self._build_lock.release()
+        return True
 
     def get(self) -> tuple[Any, dict[str, Any]]:
         now = time.time()

--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -164,40 +164,56 @@ def _path_mtime(p: Path) -> float:
 def _sqlite_version_key(db_path: Path) -> tuple:
     """Fingerprint a sqlite DB that is stable while data is unchanged.
 
-    Combines (data_version, db_mtime, wal_mtime). ``PRAGMA data_version``
-    increments on every write committed by another connection, so it
-    catches WAL-only updates that don't touch the main .db file. The
-    mtimes cover the small window before data_version is readable (e.g.
-    fresh handle after a hot rename).
+    Uses ``(db_mtime, db_size, wal_mtime, wal_size)``. We DO NOT use
+    ``PRAGMA data_version`` because it is documented as a per-connection
+    counter — opening a fresh read-only connection on every call would
+    not give us a reliable cross-process version. WAL writes always
+    touch ``<db>-wal`` and update both its mtime and size, so the tuple
+    catches them without opening sqlite at all.
+
+    Note: on filesystems with coarse mtime resolution (some NTFS, older
+    ext3) a sub-second write might share an mtime with the previous
+    one; ``size`` breaks that tie for any write that changes bytes.
     """
     if not db_path.exists():
-        return ("absent", 0.0, 0.0)
-    db_mtime = _path_mtime(db_path)
-    wal_mtime = _path_mtime(db_path.with_name(db_path.name + "-wal"))
-    data_version = 0
+        return ("absent",)
+
     try:
-        # Use URI mode=ro so we never accidentally write or spawn a WAL.
-        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=1.0)
-        try:
-            row = conn.execute("PRAGMA data_version").fetchone()
-            if row is not None:
-                data_version = int(row[0])
-        finally:
-            conn.close()
-    except sqlite3.Error:
-        pass
-    return (data_version, db_mtime, wal_mtime)
+        db_stat = db_path.stat()
+        db_mtime, db_size = db_stat.st_mtime, db_stat.st_size
+    except OSError:
+        db_mtime, db_size = 0.0, 0
+
+    wal_path = db_path.with_name(db_path.name + "-wal")
+    try:
+        wal_stat = wal_path.stat()
+        wal_mtime, wal_size = wal_stat.st_mtime, wal_stat.st_size
+    except OSError:
+        wal_mtime, wal_size = 0.0, 0
+
+    return (db_mtime, db_size, wal_mtime, wal_size)
 
 
-def _normalized_cache_key(path: str, query: dict[str, list[str]]) -> str:
-    """Normalize path+query for stable cache/ETag keys."""
+def _normalized_cache_key(
+    path: str,
+    query: dict[str, list[str]],
+    repo_root: Path | None = None,
+) -> str:
+    """Normalize (repo_root, path, sorted-query) for stable cache/ETag keys.
+
+    ``repo_root`` is included so two different repos sharing one Python
+    process (e.g. the test suite) don't cross-contaminate each other's
+    cache. The default of ``None`` keeps backward-compat for callers that
+    only key by path + query.
+    """
+    prefix = f"{Path(repo_root).resolve()}::" if repo_root is not None else ""
     if not query:
-        return path
+        return prefix + path
     parts = []
     for k in sorted(query):
         for v in query[k]:
             parts.append(f"{k}={v}")
-    return path + "?" + "&".join(parts)
+    return prefix + path + "?" + "&".join(parts)
 
 
 def _serialize_payload(payload: Any, content_type: str) -> bytes:
@@ -283,7 +299,11 @@ class BackgroundSnapshot:
             if stale_threshold_seconds is not None
             else max(60.0, interval_seconds * 5)
         )
+        # ``_lock`` protects metadata reads; ``_build_lock`` enforces
+        # single-in-flight so ``refresh_blocking()`` and the background
+        # thread cannot overlap each other's build.
         self._lock = threading.Lock()
+        self._build_lock = threading.Lock()
         self._snapshot: Any = None
         self._started_at: float | None = None
         self._completed_at: float | None = None
@@ -312,22 +332,26 @@ class BackgroundSnapshot:
             self._stop.wait(self.interval_seconds)
 
     def _refresh_once(self) -> None:
-        started = time.time()
-        with self._lock:
-            self._started_at = started
-        try:
-            snapshot = self.builder()
-            err: str | None = None
-        except Exception as exc:  # noqa: BLE001
-            snapshot = None
-            err = f"{type(exc).__name__}: {exc}"
-        completed = time.time()
-        with self._lock:
-            if snapshot is not None:
-                self._snapshot = snapshot
-            self._completed_at = completed
-            self._duration_ms = (completed - started) * 1000.0
-            self._last_error = err
+        # ``_build_lock`` serializes concurrent callers (background thread +
+        # ``refresh_blocking()``) so at most one builder runs at a time. This
+        # is the real enforcement of the "single in-flight" guarantee.
+        with self._build_lock:
+            started = time.time()
+            with self._lock:
+                self._started_at = started
+            try:
+                snapshot = self.builder()
+                err: str | None = None
+            except Exception as exc:  # noqa: BLE001
+                snapshot = None
+                err = f"{type(exc).__name__}: {exc}"
+            completed = time.time()
+            with self._lock:
+                if snapshot is not None:
+                    self._snapshot = snapshot
+                self._completed_at = completed
+                self._duration_ms = (completed - started) * 1000.0
+                self._last_error = err
 
     def refresh_blocking(self, timeout: float = 60.0) -> None:
         """Trigger one refresh in the calling thread. For first-call priming."""
@@ -1918,23 +1942,27 @@ def render_dashboard_html(*, issue_number: int = DEFAULT_FEEDBACK_ISSUE) -> str:
 # ============================================================
 
 
-_STATUS_MD_CACHE: dict[str, Any] = {"mtime": 0.0, "data": None}
+# Keyed by resolved path so different repos' STATUS.md files never alias.
+_STATUS_MD_CACHE: dict[str, dict[str, Any]] = {}
 _STATUS_MD_CACHE_LOCK = threading.Lock()
 
 
 def _parse_status_md(status_path: Path) -> dict[str, Any]:
     """Extract focus + blockers + a light summary from STATUS.md.
 
-    Caches by mtime to keep briefing cheap.
+    Caches by absolute path + mtime to keep briefing cheap and to stay
+    safe when multiple repos share one Python process.
     """
     try:
         mtime = status_path.stat().st_mtime
     except OSError:
         return {"focus": [], "blockers": [], "exists": False}
 
+    cache_key = str(status_path.resolve())
     with _STATUS_MD_CACHE_LOCK:
-        if _STATUS_MD_CACHE["mtime"] == mtime and _STATUS_MD_CACHE["data"] is not None:
-            return _STATUS_MD_CACHE["data"]
+        entry = _STATUS_MD_CACHE.get(cache_key)
+        if entry is not None and entry["mtime"] == mtime:
+            return entry["data"]
 
     try:
         text = status_path.read_text(encoding="utf-8")
@@ -1969,8 +1997,7 @@ def _parse_status_md(status_path: Path) -> dict[str, Any]:
 
     data = {"focus": focus, "blockers": blockers, "exists": True}
     with _STATUS_MD_CACHE_LOCK:
-        _STATUS_MD_CACHE["mtime"] = mtime
-        _STATUS_MD_CACHE["data"] = data
+        _STATUS_MD_CACHE[cache_key] = {"mtime": mtime, "data": data}
     return data
 
 
@@ -2097,18 +2124,21 @@ def _compact_briefing(briefing: dict[str, Any]) -> dict[str, Any]:
     return compact
 
 
-_SESSION_BRIEFING_SNAPSHOT: BackgroundSnapshot | None = None
+# Registry keyed by resolved ``repo_root`` so multiple repos sharing one
+# Python process (test suite, multi-repo servers) never cross-contaminate.
+_SESSION_BRIEFING_SNAPSHOTS: dict[str, BackgroundSnapshot] = {}
 _SESSION_BRIEFING_SNAPSHOT_LOCK = threading.Lock()
 
 
 def get_or_build_session_briefing(repo_root: Path) -> tuple[dict[str, Any], dict[str, Any]]:
     """Return (briefing, freshness_meta). Uses a background snapshot so
     the briefing endpoint is always cheap."""
-    global _SESSION_BRIEFING_SNAPSHOT
+    key = str(repo_root.resolve())
     with _SESSION_BRIEFING_SNAPSHOT_LOCK:
-        if _SESSION_BRIEFING_SNAPSHOT is None:
+        snap = _SESSION_BRIEFING_SNAPSHOTS.get(key)
+        if snap is None:
             snap = _register_snapshot(
-                "briefing_session",
+                f"briefing_session::{key}",
                 interval_seconds=15.0,
                 builder=lambda: build_session_briefing(repo_root),
             )
@@ -2116,8 +2146,7 @@ def get_or_build_session_briefing(repo_root: Path) -> tuple[dict[str, Any], dict
             # sees real data instead of ``freshness_state=refreshing``.
             snap.refresh_blocking()
             snap.start()
-            _SESSION_BRIEFING_SNAPSHOT = snap
-        snap = _SESSION_BRIEFING_SNAPSHOT
+            _SESSION_BRIEFING_SNAPSHOTS[key] = snap
     payload, freshness = snap.get()
     if payload is None:
         # Degraded path — build synchronously once.
@@ -2344,7 +2373,7 @@ def serve_request(
     policy = CACHE_POLICY.get(path)
     if policy is not None:
         ttl, version_fn = policy
-        cache_key = _normalized_cache_key(path, query)
+        cache_key = _normalized_cache_key(path, query, repo_root=repo_root)
 
         def _version() -> tuple:
             return version_fn(repo_root) if version_fn is not None else ("ttl",)

--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -109,14 +109,17 @@ def _load_json(text: str) -> Any:
 # Design notes (per reviewer feedback on issue #258):
 #   - Cache stores response BYTES, not payload dicts. ETag = weak hash of
 #     bytes. Reusing cached bytes makes ETag stable and 304 cheap.
-#   - Cache key = normalized (path, sorted-query). Avoids spurious misses.
-#   - Invalidation combines TTL + dependency versions. For sqlite deps we
-#     use (db_mtime, wal_mtime, PRAGMA data_version) because sqlite-WAL
-#     writes don't always touch the .db file mtime.
-#   - Each sqlite read uses its own read-only connection (threaded server).
+#   - Cache key = normalized (repo_root, path, sorted-query). Avoids
+#     cross-repo contamination when two repos share one process.
+#   - Invalidation combines TTL + per-endpoint dependency versions. For
+#     sqlite deps the version is ``PRAGMA data_version`` on a persistent
+#     per-path read-only connection (the documented/reliable usage — see
+#     _sqlite_version_key). The connection is also probed for inode/device
+#     changes so a replaced DB file is detected.
 #   - Background snapshots use fixed-*delay* (not fixed-interval): sleep
 #     runs AFTER the refresh completes, so an overrun does not cause
-#     overlapping runs. Single in-flight refresh per key, atomic swap.
+#     overlapping runs. A per-instance build lock enforces single-in-
+#     flight across refresh_blocking() and the daemon thread.
 
 
 _CACHE_LOCK = threading.Lock()
@@ -165,11 +168,15 @@ def _path_mtime(p: Path) -> float:
 # ``PRAGMA data_version`` returns a monotonic counter on a specific
 # connection that increments whenever ANOTHER connection commits a
 # write. So a single persistent connection, queried repeatedly, is a
-# reliable change signal — unlike the round-1 fresh-connection usage
-# that Codex flagged. The dict lock serializes sqlite per connection
-# (sqlite itself is single-writer; reads can concurrent on separate
-# connections, but we only keep one per db for bookkeeping).
-_SQLITE_VERSION_CONNECTIONS: dict[str, sqlite3.Connection] = {}
+# reliable change signal — unlike round-1's fresh-connection misuse.
+# The dict lock serializes access; sqlite itself is single-writer,
+# and we only keep one persistent reader per db for bookkeeping.
+#
+# We also cache ``(st_dev, st_ino)`` alongside each connection. If the
+# DB file is REPLACED (rename/copy rather than in-place modify) the
+# inode changes and we must drop the cached connection — otherwise it
+# stays attached to the old inode and keeps reporting the old version.
+_SQLITE_VERSION_CONNECTIONS: dict[str, tuple[sqlite3.Connection, tuple]] = {}
 _SQLITE_VERSION_LOCK = threading.Lock()
 
 
@@ -177,7 +184,7 @@ def _close_all_sqlite_version_connections() -> None:
     """Test helper: drop cached read-only connections (e.g. between
     tests that recreate DB files at the same path)."""
     with _SQLITE_VERSION_LOCK:
-        for conn in _SQLITE_VERSION_CONNECTIONS.values():
+        for conn, _ident in _SQLITE_VERSION_CONNECTIONS.values():
             try:
                 conn.close()
             except sqlite3.Error:
@@ -185,28 +192,48 @@ def _close_all_sqlite_version_connections() -> None:
         _SQLITE_VERSION_CONNECTIONS.clear()
 
 
+def _file_identity(path: Path) -> tuple:
+    """Return ``(st_dev, st_ino)`` or ``None`` fallback. Used to detect
+    whether a file at the same path is the *same* file or a replacement."""
+    try:
+        s = path.stat()
+    except OSError:
+        return (0, 0)
+    return (s.st_dev, s.st_ino)
+
+
 def _sqlite_version_key(db_path: Path) -> tuple:
     """Fingerprint a sqlite DB using ``PRAGMA data_version`` on a
     persistent read-only connection.
 
     Contract: two calls return the same key iff no other connection
-    has committed between them. This catches every form of write
-    (WAL append, WAL reuse after checkpoint, in-place DELETE/MEMORY
-    writes, rapid same-size writes inside one mtime granule) — none
-    of which ``(mtime, size)`` can distinguish.
-
-    Falls back to ``("absent", ...)`` when the file is missing and
-    ``("open_failed", mtime)`` if the read-only handle can't be
-    opened (e.g. permissions). Filesystem stats are only a degraded
-    signal; the authoritative signal is the pragma counter.
+    has committed between them *and* the file at ``db_path`` is the
+    same inode. If the file has been replaced (different inode), the
+    cached connection is dropped and reopened. This catches every
+    form of write (WAL append, WAL reuse after checkpoint, in-place
+    DELETE/MEMORY writes, rapid same-size writes inside one mtime
+    granule) plus DB replacement — none of which ``(mtime, size)``
+    alone can distinguish.
     """
     if not db_path.exists():
         return ("absent",)
 
     key = str(db_path.resolve())
+    identity = _file_identity(db_path)
     with _SQLITE_VERSION_LOCK:
-        conn = _SQLITE_VERSION_CONNECTIONS.get(key)
-        if conn is None:
+        cached = _SQLITE_VERSION_CONNECTIONS.get(key)
+        if cached is not None:
+            conn, cached_identity = cached
+            if cached_identity != identity:
+                # File was replaced (different inode). Close the stale
+                # handle and open a new one below.
+                try:
+                    conn.close()
+                except sqlite3.Error:
+                    pass
+                _SQLITE_VERSION_CONNECTIONS.pop(key, None)
+                cached = None
+        if cached is None:
             try:
                 conn = sqlite3.connect(
                     f"file:{db_path}?mode=ro",
@@ -216,14 +243,15 @@ def _sqlite_version_key(db_path: Path) -> tuple:
                 )
             except sqlite3.Error:
                 return ("open_failed", _path_mtime(db_path))
-            _SQLITE_VERSION_CONNECTIONS[key] = conn
+            _SQLITE_VERSION_CONNECTIONS[key] = (conn, identity)
+        else:
+            conn, _ = cached
 
         try:
             row = conn.execute("PRAGMA data_version").fetchone()
             data_version = int(row[0]) if row is not None else 0
         except sqlite3.Error:
-            # Connection poisoned (e.g. DB rotated out from under us).
-            # Drop it so the next call opens fresh.
+            # Connection poisoned — drop so the next call opens fresh.
             _SQLITE_VERSION_CONNECTIONS.pop(key, None)
             try:
                 conn.close()
@@ -231,7 +259,7 @@ def _sqlite_version_key(db_path: Path) -> tuple:
                 pass
             return ("error", _path_mtime(db_path))
 
-    return ("v", data_version)
+    return ("v", identity, data_version)
 
 
 def _normalized_cache_key(

--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -2,34 +2,27 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
 import sqlite3
 import subprocess
 import sys
+import threading
 import time
 from dataclasses import asdict, is_dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 from urllib.parse import parse_qs, unquote, urlsplit
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from pipeline_v2.cli import _build_status_report as build_v2_status_report
-from status import (
-    _build_lab_summary,
-    _build_missing_modules_summary,
-    _enrich_translation_v2_with_per_track,
-    _enrich_v2_with_per_track,
-    _extract_frontmatter,
-    _git_head_for_file,
-    build_repo_status,
-)
-from translation_v2 import build_status as build_translation_status
-from translation_v2 import detect_module_state
-from ztt_status import build_status as build_ztt_status
+# Heavy imports (pipeline_v2, status, translation_v2, ztt_status) are deferred
+# into the handlers that actually need them. Measured: moving these out of the
+# module top saves ~150 ms from server startup and keeps /healthz and
+# /api/runtime/services paths dependency-free. See issue #258.
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -107,6 +100,292 @@ def _load_json(text: str) -> Any:
         return json.loads(text)
     except json.JSONDecodeError:
         return text
+
+
+# ============================================================
+# Response cache + ETag + background snapshot
+# ============================================================
+#
+# Design notes (per reviewer feedback on issue #258):
+#   - Cache stores response BYTES, not payload dicts. ETag = weak hash of
+#     bytes. Reusing cached bytes makes ETag stable and 304 cheap.
+#   - Cache key = normalized (path, sorted-query). Avoids spurious misses.
+#   - Invalidation combines TTL + dependency versions. For sqlite deps we
+#     use (db_mtime, wal_mtime, PRAGMA data_version) because sqlite-WAL
+#     writes don't always touch the .db file mtime.
+#   - Each sqlite read uses its own read-only connection (threaded server).
+#   - Background snapshots use fixed-*delay* (not fixed-interval): sleep
+#     runs AFTER the refresh completes, so an overrun does not cause
+#     overlapping runs. Single in-flight refresh per key, atomic swap.
+
+
+_CACHE_LOCK = threading.Lock()
+_CACHE: dict[str, "_CacheEntry"] = {}
+
+
+class _CacheEntry:
+    __slots__ = (
+        "body_bytes",
+        "content_type",
+        "etag",
+        "expires_at",
+        "version_key",
+        "built_at",
+    )
+
+    def __init__(
+        self,
+        body_bytes: bytes,
+        content_type: str,
+        etag: str,
+        expires_at: float,
+        version_key: tuple,
+        built_at: float,
+    ) -> None:
+        self.body_bytes = body_bytes
+        self.content_type = content_type
+        self.etag = etag
+        self.expires_at = expires_at
+        self.version_key = version_key
+        self.built_at = built_at
+
+
+def _weak_etag(body_bytes: bytes) -> str:
+    return 'W/"sha256:' + hashlib.sha256(body_bytes).hexdigest()[:16] + '"'
+
+
+def _path_mtime(p: Path) -> float:
+    try:
+        return p.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
+def _sqlite_version_key(db_path: Path) -> tuple:
+    """Fingerprint a sqlite DB that is stable while data is unchanged.
+
+    Combines (data_version, db_mtime, wal_mtime). ``PRAGMA data_version``
+    increments on every write committed by another connection, so it
+    catches WAL-only updates that don't touch the main .db file. The
+    mtimes cover the small window before data_version is readable (e.g.
+    fresh handle after a hot rename).
+    """
+    if not db_path.exists():
+        return ("absent", 0.0, 0.0)
+    db_mtime = _path_mtime(db_path)
+    wal_mtime = _path_mtime(db_path.with_name(db_path.name + "-wal"))
+    data_version = 0
+    try:
+        # Use URI mode=ro so we never accidentally write or spawn a WAL.
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=1.0)
+        try:
+            row = conn.execute("PRAGMA data_version").fetchone()
+            if row is not None:
+                data_version = int(row[0])
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        pass
+    return (data_version, db_mtime, wal_mtime)
+
+
+def _normalized_cache_key(path: str, query: dict[str, list[str]]) -> str:
+    """Normalize path+query for stable cache/ETag keys."""
+    if not query:
+        return path
+    parts = []
+    for k in sorted(query):
+        for v in query[k]:
+            parts.append(f"{k}={v}")
+    return path + "?" + "&".join(parts)
+
+
+def _serialize_payload(payload: Any, content_type: str) -> bytes:
+    if content_type.startswith("application/json"):
+        return json.dumps(payload, indent=2, sort_keys=True, default=_json_default).encode("utf-8")
+    if content_type.startswith("text/html"):
+        return str(payload).encode("utf-8")
+    return str(payload).encode("utf-8")
+
+
+def cached_response(
+    cache_key: str,
+    ttl_seconds: float,
+    version_fn: Callable[[], tuple],
+    builder: Callable[[], tuple[int, Any, str]],
+) -> tuple[int, bytes, str, str]:
+    """Serve a response through the cache. Returns (status, body_bytes, content_type, etag).
+
+    Cache is skipped on non-2xx responses.
+    """
+    now = time.time()
+    version_key = version_fn()
+    with _CACHE_LOCK:
+        entry = _CACHE.get(cache_key)
+        if (
+            entry is not None
+            and entry.expires_at > now
+            and entry.version_key == version_key
+        ):
+            return 200, entry.body_bytes, entry.content_type, entry.etag
+
+    status_code, payload, content_type = builder()
+    body_bytes = _serialize_payload(payload, content_type)
+    etag = _weak_etag(body_bytes)
+
+    if 200 <= status_code < 300:
+        with _CACHE_LOCK:
+            _CACHE[cache_key] = _CacheEntry(
+                body_bytes=body_bytes,
+                content_type=content_type,
+                etag=etag,
+                expires_at=now + ttl_seconds,
+                version_key=version_key,
+                built_at=now,
+            )
+    return status_code, body_bytes, content_type, etag
+
+
+def _cache_stats() -> dict[str, Any]:
+    with _CACHE_LOCK:
+        return {
+            "entries": len(_CACHE),
+            "keys": sorted(_CACHE.keys()),
+        }
+
+
+# --- Background snapshot ---
+
+
+class BackgroundSnapshot:
+    """Fixed-delay background refresher for an expensive builder.
+
+    Guarantees:
+        - Never more than one refresh in flight.
+        - Atomic snapshot swap: callers see either the old or new snapshot,
+          never a partial one.
+        - Exposes freshness metadata so callers can detect staleness.
+    """
+
+    def __init__(
+        self,
+        key: str,
+        interval_seconds: float,
+        builder: Callable[[], Any],
+        stale_threshold_seconds: float | None = None,
+    ) -> None:
+        self.key = key
+        self.interval_seconds = interval_seconds
+        self.builder = builder
+        # Default stale threshold: 5x refresh interval, min 60s.
+        self.stale_threshold_seconds = (
+            stale_threshold_seconds
+            if stale_threshold_seconds is not None
+            else max(60.0, interval_seconds * 5)
+        )
+        self._lock = threading.Lock()
+        self._snapshot: Any = None
+        self._started_at: float | None = None
+        self._completed_at: float | None = None
+        self._duration_ms: float | None = None
+        self._last_error: str | None = None
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+        self._thread = threading.Thread(
+            target=self._run,
+            name=f"snapshot-{self.key}",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            self._refresh_once()
+            # Fixed-delay: sleep AFTER completion so overruns never overlap.
+            self._stop.wait(self.interval_seconds)
+
+    def _refresh_once(self) -> None:
+        started = time.time()
+        with self._lock:
+            self._started_at = started
+        try:
+            snapshot = self.builder()
+            err: str | None = None
+        except Exception as exc:  # noqa: BLE001
+            snapshot = None
+            err = f"{type(exc).__name__}: {exc}"
+        completed = time.time()
+        with self._lock:
+            if snapshot is not None:
+                self._snapshot = snapshot
+            self._completed_at = completed
+            self._duration_ms = (completed - started) * 1000.0
+            self._last_error = err
+
+    def refresh_blocking(self, timeout: float = 60.0) -> None:
+        """Trigger one refresh in the calling thread. For first-call priming."""
+        self._refresh_once()
+
+    def get(self) -> tuple[Any, dict[str, Any]]:
+        now = time.time()
+        with self._lock:
+            snapshot = self._snapshot
+            started = self._started_at
+            completed = self._completed_at
+            duration = self._duration_ms
+            error = self._last_error
+        stale_seconds = (now - completed) if completed is not None else None
+        in_flight = (
+            started is not None and (completed is None or started > completed)
+        )
+        if snapshot is None and completed is None:
+            # Never completed a refresh — the caller will have to build sync.
+            state = "refreshing"
+        elif snapshot is None and error is not None:
+            state = "degraded"
+        elif stale_seconds is not None and stale_seconds > self.stale_threshold_seconds:
+            state = "stale"
+        else:
+            state = "fresh"
+        meta = {
+            "refresh_started_at": started,
+            "refresh_completed_at": completed,
+            "refresh_duration_ms": duration,
+            "refresh_error": error,
+            "stale_seconds": stale_seconds,
+            "stale_threshold_seconds": self.stale_threshold_seconds,
+            "freshness_state": state,
+            "refresh_in_flight": in_flight,
+        }
+        return snapshot, meta
+
+
+# Registry of background snapshots. Started lazily on first access so that
+# unit tests and `--help` invocations don't spawn threads.
+_SNAPSHOTS: dict[str, BackgroundSnapshot] = {}
+_SNAPSHOTS_LOCK = threading.Lock()
+
+
+def _register_snapshot(
+    key: str,
+    interval_seconds: float,
+    builder: Callable[[], Any],
+    stale_threshold_seconds: float | None = None,
+) -> BackgroundSnapshot:
+    with _SNAPSHOTS_LOCK:
+        existing = _SNAPSHOTS.get(key)
+        if existing is not None:
+            return existing
+        snap = BackgroundSnapshot(key, interval_seconds, builder, stale_threshold_seconds)
+        _SNAPSHOTS[key] = snap
+    return snap
 
 
 def _classify_path(path: str) -> str:
@@ -210,6 +489,75 @@ def build_worktree_status(repo_root: Path) -> dict[str, Any]:
     }
 
 
+def build_worktrees_list(repo_root: Path) -> dict[str, Any]:
+    """List every worktree attached to the primary repo.
+
+    Parses ``git worktree list --porcelain``. Returns a compact payload
+    suitable for agent cold-start: agents need to know about sibling
+    worktrees (e.g. ``codex-wt-*``) to avoid colliding on the same branch.
+    """
+    result = subprocess.run(
+        ["git", "worktree", "list", "--porcelain"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return {
+            "ok": False,
+            "error": result.stderr.strip() or "git worktree list failed",
+            "worktrees": [],
+        }
+
+    worktrees: list[dict[str, Any]] = []
+    current: dict[str, Any] | None = None
+    for line in result.stdout.splitlines():
+        if not line:
+            if current is not None:
+                worktrees.append(current)
+                current = None
+            continue
+        if line.startswith("worktree "):
+            if current is not None:
+                worktrees.append(current)
+            current = {
+                "path": line[len("worktree ") :],
+                "branch": None,
+                "head": None,
+                "detached": False,
+                "locked": False,
+                "prunable": False,
+            }
+        elif current is None:
+            continue
+        elif line.startswith("HEAD "):
+            current["head"] = line[len("HEAD ") :]
+        elif line.startswith("branch "):
+            # Format: ``branch refs/heads/<name>``.
+            ref = line[len("branch ") :]
+            if ref.startswith("refs/heads/"):
+                current["branch"] = ref[len("refs/heads/") :]
+            else:
+                current["branch"] = ref
+        elif line == "detached":
+            current["detached"] = True
+        elif line.startswith("locked"):
+            current["locked"] = True
+        elif line.startswith("prunable"):
+            current["prunable"] = True
+    if current is not None:
+        worktrees.append(current)
+
+    primary_path = str(repo_root)
+    return {
+        "ok": True,
+        "primary": primary_path,
+        "count": len(worktrees),
+        "worktrees": worktrees,
+    }
+
+
 def _db_latest_for_module(db_path: Path, module_key: str) -> dict[str, Any] | None:
     if not db_path.exists():
         return None
@@ -251,6 +599,9 @@ def _db_latest_for_module(db_path: Path, module_key: str) -> dict[str, Any] | No
 
 
 def build_module_state(repo_root: Path, module_key: str) -> dict[str, Any]:
+    from status import _build_lab_summary, _extract_frontmatter, _git_head_for_file
+    from translation_v2 import detect_module_state
+
     normalized = module_key[:-3] if module_key.endswith(".md") else module_key
     en_path = repo_root / "src" / "content" / "docs" / f"{normalized}.md"
     uk_path = repo_root / "src" / "content" / "docs" / "uk" / f"{normalized}.md"
@@ -1562,6 +1913,263 @@ def render_dashboard_html(*, issue_number: int = DEFAULT_FEEDBACK_ISSUE) -> str:
 </html>"""
 
 
+# ============================================================
+# Agent orientation: /api/briefing/session + /api/schema
+# ============================================================
+
+
+_STATUS_MD_CACHE: dict[str, Any] = {"mtime": 0.0, "data": None}
+_STATUS_MD_CACHE_LOCK = threading.Lock()
+
+
+def _parse_status_md(status_path: Path) -> dict[str, Any]:
+    """Extract focus + blockers + a light summary from STATUS.md.
+
+    Caches by mtime to keep briefing cheap.
+    """
+    try:
+        mtime = status_path.stat().st_mtime
+    except OSError:
+        return {"focus": [], "blockers": [], "exists": False}
+
+    with _STATUS_MD_CACHE_LOCK:
+        if _STATUS_MD_CACHE["mtime"] == mtime and _STATUS_MD_CACHE["data"] is not None:
+            return _STATUS_MD_CACHE["data"]
+
+    try:
+        text = status_path.read_text(encoding="utf-8")
+    except OSError:
+        return {"focus": [], "blockers": [], "exists": False}
+
+    focus: list[str] = []
+    blockers: list[str] = []
+    section = None
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip()
+        if line.startswith("## "):
+            heading = line[3:].strip().lower()
+            if heading.startswith("todo"):
+                section = "todo"
+            elif heading.startswith("blocker"):
+                section = "blocker"
+            else:
+                section = None
+            continue
+        if section == "todo":
+            # Only collect unchecked items: - [ ] ...
+            if line.lstrip().startswith("- [ ]"):
+                bullet = line.lstrip()[5:].strip()
+                if bullet and len(focus) < 10:
+                    focus.append(bullet)
+        elif section == "blocker":
+            if line.lstrip().startswith("- "):
+                bullet = line.lstrip()[2:].strip()
+                if bullet and len(blockers) < 10:
+                    blockers.append(bullet)
+
+    data = {"focus": focus, "blockers": blockers, "exists": True}
+    with _STATUS_MD_CACHE_LOCK:
+        _STATUS_MD_CACHE["mtime"] = mtime
+        _STATUS_MD_CACHE["data"] = data
+    return data
+
+
+def _recent_commits(repo_root: Path, limit: int = 5) -> list[dict[str, Any]]:
+    result = subprocess.run(
+        ["git", "log", f"-n{limit}", "--pretty=format:%h%x09%s"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=5,
+    )
+    if result.returncode != 0:
+        return []
+    commits: list[dict[str, Any]] = []
+    for line in result.stdout.splitlines():
+        if "\t" in line:
+            sha, subject = line.split("\t", 1)
+        else:
+            sha, subject = line[:8], line[8:].lstrip()
+        commits.append({"sha": sha, "subject": subject})
+    return commits
+
+
+def _pipeline_summary_safe(repo_root: Path) -> dict[str, Any] | None:
+    """Return pipeline v2 summary. None if DB absent; error dict if broken."""
+    db_path = repo_root / ".pipeline" / "v2.db"
+    if not db_path.exists():
+        return None
+    try:
+        from pipeline_v2.cli import _build_status_report as build_v2_status_report
+        report = build_v2_status_report(db_path)
+    except Exception as exc:  # noqa: BLE001
+        return {"error": f"{type(exc).__name__}: {exc}"}
+    # Keep compact — only head counts, not per-module listings.
+    summary = report.get("summary") if isinstance(report, dict) else None
+    queue = report.get("queue") if isinstance(report, dict) else None
+    return {
+        "summary": summary,
+        "queue_head": {k: v for k, v in (queue or {}).items() if k in ("in_flight", "ready", "blocked", "rejected")},
+    }
+
+
+def build_session_briefing(repo_root: Path) -> dict[str, Any]:
+    """Compact control-plane snapshot for agent orientation.
+
+    Target: ≤ 2K tokens. Designed to be the *first* call a fresh agent
+    makes, replacing the usual ``cat STATUS.md + git log + ls`` crawl.
+    See issue #258.
+    """
+    status_md = _parse_status_md(repo_root / "STATUS.md")
+    worktree = build_worktree_status(repo_root)
+    worktrees = build_worktrees_list(repo_root)
+    services = build_runtime_services_status(repo_root)
+    commits = _recent_commits(repo_root, limit=5)
+    pipeline = _pipeline_summary_safe(repo_root)
+
+    alerts: list[str] = []
+    if services.get("stale", 0):
+        alerts.append(f"{services['stale']} stale pid file(s) — process exited without cleanup")
+    if isinstance(pipeline, dict) and "error" in pipeline:
+        alerts.append(f"pipeline v2 status unavailable: {pipeline['error']}")
+
+    return {
+        "snapshot": {
+            "generated_at": time.time(),
+            "generator": "local_api.build_session_briefing",
+            "version": 1,
+        },
+        "workspace": {
+            "primary_branch": worktree.get("branch") if worktree.get("ok") else None,
+            "dirty": worktree.get("dirty") if worktree.get("ok") else None,
+            "counts": worktree.get("counts") if worktree.get("ok") else None,
+            "ahead": worktree.get("ahead") if worktree.get("ok") else None,
+            "behind": worktree.get("behind") if worktree.get("ok") else None,
+            "worktrees_total": worktrees.get("count", 0),
+            "worktrees": [
+                {
+                    "path": wt.get("path"),
+                    "branch": wt.get("branch"),
+                    "detached": wt.get("detached", False),
+                }
+                for wt in (worktrees.get("worktrees") or [])
+            ],
+        },
+        "services": {
+            "running": services["running"],
+            "stopped": services["stopped"],
+            "stale": services["stale"],
+            "total": services["total"],
+        },
+        "pipelines": {"v2": pipeline},
+        "recent_commits": commits,
+        "focus": status_md.get("focus", []),
+        "blockers": status_md.get("blockers", []),
+        "alerts": alerts,
+        "next_reads": [
+            {"rel": "schema", "endpoint": "/api/schema", "desc": "Full endpoint index"},
+            {"rel": "status", "endpoint": "/api/status/summary", "desc": "Full repo status"},
+            {"rel": "pipeline", "endpoint": "/api/pipeline/v2/status", "desc": "Pipeline v2 queue"},
+            {"rel": "translation", "endpoint": "/api/translation/v2/status", "desc": "UK translation queue"},
+            {"rel": "services", "endpoint": "/api/runtime/services", "desc": "Runtime pids / ports"},
+            {"rel": "worktrees", "endpoint": "/api/git/worktrees", "desc": "All attached worktrees"},
+            {"rel": "module-state", "endpoint": "/api/module/{key}/state", "desc": "Per-module EN+UK+lab+frontmatter"},
+            {"rel": "module-orchestration", "endpoint": "/api/module/{key}/orchestration/latest", "desc": "Per-module latest pipeline job/event"},
+        ],
+        "links": {
+            "status_md": "STATUS.md",
+            "claude_md": "CLAUDE.md",
+            "dashboard": "/",
+        },
+    }
+
+
+def _compact_briefing(briefing: dict[str, Any]) -> dict[str, Any]:
+    """Drop fields that aren't actionable for agents to shave tokens further."""
+    compact = dict(briefing)
+    compact.pop("next_reads", None)
+    compact.pop("links", None)
+    if "workspace" in compact and isinstance(compact["workspace"], dict):
+        ws = dict(compact["workspace"])
+        ws.pop("worktrees", None)  # keep count, drop list
+        compact["workspace"] = ws
+    return compact
+
+
+_SESSION_BRIEFING_SNAPSHOT: BackgroundSnapshot | None = None
+_SESSION_BRIEFING_SNAPSHOT_LOCK = threading.Lock()
+
+
+def get_or_build_session_briefing(repo_root: Path) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Return (briefing, freshness_meta). Uses a background snapshot so
+    the briefing endpoint is always cheap."""
+    global _SESSION_BRIEFING_SNAPSHOT
+    with _SESSION_BRIEFING_SNAPSHOT_LOCK:
+        if _SESSION_BRIEFING_SNAPSHOT is None:
+            snap = _register_snapshot(
+                "briefing_session",
+                interval_seconds=15.0,
+                builder=lambda: build_session_briefing(repo_root),
+            )
+            # Prime synchronously on the first request so the first caller
+            # sees real data instead of ``freshness_state=refreshing``.
+            snap.refresh_blocking()
+            snap.start()
+            _SESSION_BRIEFING_SNAPSHOT = snap
+        snap = _SESSION_BRIEFING_SNAPSHOT
+    payload, freshness = snap.get()
+    if payload is None:
+        # Degraded path — build synchronously once.
+        payload = build_session_briefing(repo_root)
+    return payload, freshness
+
+
+# ---- /api/schema ----
+
+
+def build_api_schema() -> dict[str, Any]:
+    """Machine-readable endpoint index. Lets agents discover the API
+    without reading this 1.7K-LOC file."""
+    return {
+        "version": 1,
+        "conventions": {
+            "errors": 'JSON envelope: {"error": "<code>", ...optional context}.',
+            "cache": "Weak ETag returned on cacheable responses; send If-None-Match to get 304.",
+            "compact": "/api/briefing/session supports ?compact=1 to drop non-actionable fields.",
+            "freshness": "Background-refreshed endpoints embed a 'freshness' dict with freshness_state and stale_seconds.",
+        },
+        "endpoints": [
+            {"path": "/", "desc": "HTML dashboard", "content_type": "text/html"},
+            {"path": "/healthz", "desc": "Liveness probe"},
+            {"path": "/api/schema", "desc": "This document"},
+            {
+                "path": "/api/briefing/session",
+                "desc": "Agent cold-start orientation snapshot. First call for fresh agents.",
+                "query": ["compact=1"],
+                "freshness": "background-refreshed every 15s",
+            },
+            {"path": "/api/status/summary", "desc": "Repo status (fast)"},
+            {"path": "/api/missing-modules/status", "desc": "Modules missing from nav/sidebar"},
+            {"path": "/api/runtime/services", "desc": "Runtime services (pids, uptime, ports)"},
+            {"path": "/api/pipeline/v2/status", "desc": "Pipeline v2 queue + per-track"},
+            {
+                "path": "/api/translation/v2/status",
+                "desc": "UK translation queue",
+                "query": ["section=...", "freshness=1 (slow git walk)"],
+            },
+            {"path": "/api/labs/status", "desc": "Labs summary"},
+            {"path": "/api/ztt/status", "desc": "Zero-to-Terminal pilot status"},
+            {"path": "/api/git/worktree", "desc": "Dirty entries in the PRIMARY repo only"},
+            {"path": "/api/git/worktrees", "desc": "All attached worktrees (plural)"},
+            {"path": "/api/issue-watch/{n}", "desc": "Single watched GH issue state"},
+            {"path": "/api/module/{key}/state", "desc": "Per-module EN+UK+lab+frontmatter"},
+            {"path": "/api/module/{key}/orchestration/latest", "desc": "Per-module latest pipeline job+event"},
+            {"path": "/api/cache/stats", "desc": "Response-cache introspection"},
+        ],
+    }
+
+
 def route_request(repo_root: Path, raw_path: str) -> tuple[int, Any, str]:
     parsed = urlsplit(raw_path)
     path = parsed.path.rstrip("/") or "/"
@@ -1575,8 +2183,10 @@ def route_request(repo_root: Path, raw_path: str) -> tuple[int, Any, str]:
         # Dashboard hot path: skip the git-per-file translation + ZTT passes
         # (~2min total). Full versions served by /api/translation/v2/status
         # and /api/ztt/status.
+        from status import build_repo_status
         return 200, build_repo_status(repo_root, fast=True), "application/json; charset=utf-8"
     if path == "/api/missing-modules/status":
+        from status import _build_missing_modules_summary
         return 200, _build_missing_modules_summary(repo_root), "application/json; charset=utf-8"
     if path == "/api/runtime/services":
         return 200, build_runtime_services_status(repo_root), "application/json; charset=utf-8"
@@ -1584,6 +2194,8 @@ def route_request(repo_root: Path, raw_path: str) -> tuple[int, Any, str]:
         db_path = repo_root / ".pipeline" / "v2.db"
         if not db_path.exists():
             return 404, {"error": "missing_db", "db_path": str(db_path)}, "application/json; charset=utf-8"
+        from pipeline_v2.cli import _build_status_report as build_v2_status_report
+        from status import _enrich_v2_with_per_track
         return 200, _enrich_v2_with_per_track(build_v2_status_report(db_path)), "application/json; charset=utf-8"
     if path == "/api/translation/v2/status":
         section = query.get("section", [None])[0]
@@ -1591,7 +2203,9 @@ def route_request(repo_root: Path, raw_path: str) -> tuple[int, Any, str]:
         # that need it can pass ?freshness=1.
         want_freshness = query.get("freshness", ["0"])[0] not in ("0", "false", "")
         db_path = repo_root / ".pipeline" / "translation_v2.db"
+        from status import _enrich_translation_v2_with_per_track
         if want_freshness:
+            from translation_v2 import build_status as build_translation_status
             t2 = build_translation_status(repo_root, db_path=db_path, section=section)
         else:
             from translation_v2 import _build_translation_queue_status
@@ -1604,11 +2218,27 @@ def route_request(repo_root: Path, raw_path: str) -> tuple[int, Any, str]:
             }
         return 200, _enrich_translation_v2_with_per_track(t2), "application/json; charset=utf-8"
     if path == "/api/labs/status":
+        from status import _build_lab_summary
         return 200, _build_lab_summary(repo_root), "application/json; charset=utf-8"
     if path == "/api/ztt/status":
+        from ztt_status import build_status as build_ztt_status
         return 200, build_ztt_status(repo_root), "application/json; charset=utf-8"
     if path == "/api/git/worktree":
         return 200, build_worktree_status(repo_root), "application/json; charset=utf-8"
+    if path == "/api/git/worktrees":
+        return 200, build_worktrees_list(repo_root), "application/json; charset=utf-8"
+    if path == "/api/schema":
+        return 200, build_api_schema(), "application/json; charset=utf-8"
+    if path == "/api/briefing/session":
+        compact = query.get("compact", ["0"])[0] not in ("0", "false", "")
+        briefing, freshness = get_or_build_session_briefing(repo_root)
+        briefing = dict(briefing)
+        briefing["freshness"] = freshness
+        if compact:
+            briefing = _compact_briefing(briefing)
+        return 200, briefing, "application/json; charset=utf-8"
+    if path == "/api/cache/stats":
+        return 200, _cache_stats(), "application/json; charset=utf-8"
     if path.startswith("/api/issue-watch/"):
         try:
             issue_number = int(path.split("/")[-1])
@@ -1637,11 +2267,104 @@ def route_request(repo_root: Path, raw_path: str) -> tuple[int, Any, str]:
     return 404, {"error": "not_found", "path": path}, "application/json; charset=utf-8"
 
 
+# ============================================================
+# Cache policy + request pipeline
+# ============================================================
+#
+# TTLs are tuned for the dashboard (60s refresh) and agent polling. They are
+# short enough that human interactivity never sees stale state beyond a few
+# seconds, but long enough to absorb thundering-herd polls. sqlite-backed
+# routes add a ``PRAGMA data_version``-based dep check so a write from the
+# pipeline supervisor invalidates the cache immediately.
+
+
+def _v_v2_db(repo_root: Path) -> tuple:
+    return ("v2", _sqlite_version_key(repo_root / ".pipeline" / "v2.db"))
+
+
+def _v_translation_db(repo_root: Path) -> tuple:
+    return ("t2", _sqlite_version_key(repo_root / ".pipeline" / "translation_v2.db"))
+
+
+def _v_always_fresh(_: Path) -> tuple:
+    # Placeholder for TTL-only policies.
+    return ("ttl",)
+
+
+# Map fixed paths (query-independent beyond ``?compact=1``) to policies.
+# (ttl_seconds, version_fn_or_None)
+CACHE_POLICY: dict[str, tuple[float, Callable[[Path], tuple] | None]] = {
+    "/healthz": (60.0, None),
+    "/api/schema": (600.0, None),
+    "/api/status/summary": (10.0, _v_v2_db),
+    "/api/missing-modules/status": (30.0, None),
+    "/api/runtime/services": (2.0, None),
+    "/api/pipeline/v2/status": (5.0, _v_v2_db),
+    "/api/translation/v2/status": (5.0, _v_translation_db),
+    "/api/labs/status": (10.0, None),
+    "/api/ztt/status": (30.0, None),
+    "/api/git/worktree": (2.0, None),
+    "/api/git/worktrees": (5.0, None),
+    "/api/briefing/session": (5.0, None),  # background-refreshed; TTL just caps rebuild rate
+}
+
+
+def _match_etag(if_none_match: str, etag: str) -> bool:
+    """Return True if the client's If-None-Match header matches our ETag.
+
+    Handles comma-separated lists and leading ``W/`` weak marker.
+    """
+    if not if_none_match:
+        return False
+    candidates = [tok.strip() for tok in if_none_match.split(",") if tok.strip()]
+    # Strip W/ prefix on both sides for weak-compare semantics.
+    our = etag[2:] if etag.startswith("W/") else etag
+    for cand in candidates:
+        if cand == "*":
+            return True
+        normalized = cand[2:] if cand.startswith("W/") else cand
+        if normalized == our:
+            return True
+    return False
+
+
+def serve_request(
+    repo_root: Path, raw_path: str
+) -> tuple[int, bytes, str, str]:
+    """Compute ``(status, body_bytes, content_type, etag)`` for ``raw_path``.
+
+    Serves from cache for paths registered in ``CACHE_POLICY``. Builds on miss.
+    ETag is always set from the response bytes so 304 works for every 2xx
+    response, cached or not.
+    """
+    parsed = urlsplit(raw_path)
+    path = parsed.path.rstrip("/") or "/"
+    query = parse_qs(parsed.query)
+
+    policy = CACHE_POLICY.get(path)
+    if policy is not None:
+        ttl, version_fn = policy
+        cache_key = _normalized_cache_key(path, query)
+
+        def _version() -> tuple:
+            return version_fn(repo_root) if version_fn is not None else ("ttl",)
+
+        def _build() -> tuple[int, Any, str]:
+            return route_request(repo_root, raw_path)
+
+        return cached_response(cache_key, ttl, _version, _build)
+
+    status_code, payload, content_type = route_request(repo_root, raw_path)
+    body_bytes = _serialize_payload(payload, content_type)
+    etag = _weak_etag(body_bytes)
+    return status_code, body_bytes, content_type, etag
+
+
 def make_handler(repo_root: Path) -> type[BaseHTTPRequestHandler]:
     class Handler(BaseHTTPRequestHandler):
         def do_GET(self) -> None:  # noqa: N802
             try:
-                status_code, payload, content_type = route_request(repo_root, self.path)
+                status_code, body, content_type, etag = serve_request(repo_root, self.path)
             except sqlite3.Error as exc:
                 status_code = 500
                 payload = {
@@ -1651,6 +2374,8 @@ def make_handler(repo_root: Path) -> type[BaseHTTPRequestHandler]:
                     "path": self.path,
                 }
                 content_type = "application/json; charset=utf-8"
+                body = _serialize_payload(payload, content_type)
+                etag = _weak_etag(body)
             except Exception as exc:  # noqa: BLE001 - surface all read failures as JSON
                 status_code = 500
                 payload = {
@@ -1660,13 +2385,23 @@ def make_handler(repo_root: Path) -> type[BaseHTTPRequestHandler]:
                     "path": self.path,
                 }
                 content_type = "application/json; charset=utf-8"
-            if content_type.startswith("text/html"):
-                body = str(payload).encode("utf-8")
-            else:
-                body = json.dumps(payload, indent=2, sort_keys=True, default=_json_default).encode("utf-8")
+                body = _serialize_payload(payload, content_type)
+                etag = _weak_etag(body)
+
+            if 200 <= status_code < 300:
+                inm = self.headers.get("If-None-Match", "")
+                if _match_etag(inm, etag):
+                    self.send_response(304)
+                    self.send_header("ETag", etag)
+                    self.send_header("Content-Length", "0")
+                    self.end_headers()
+                    return
+
             self.send_response(status_code)
             self.send_header("Content-Type", content_type)
             self.send_header("Content-Length", str(len(body)))
+            if 200 <= status_code < 300:
+                self.send_header("ETag", etag)
             self.end_headers()
             self.wfile.write(body)
 

--- a/tests/test_local_api.py
+++ b/tests/test_local_api.py
@@ -697,6 +697,124 @@ def test_background_snapshot_exposes_freshness_metadata() -> None:
     assert meta["refresh_in_flight"] is False
 
 
+def test_sqlite_version_key_detects_wal_only_write(tmp_path: Path) -> None:
+    """Regression: PR #259 round 1 used PRAGMA data_version which is a
+    per-connection counter and therefore unreliable across fresh
+    connections. Version key must change on a WAL-mode write, measured
+    across fresh lookups.
+    """
+    db_path = tmp_path / "wal.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("CREATE TABLE t (x INTEGER)")
+    conn.commit()
+    conn.close()
+    v1 = local_api._sqlite_version_key(db_path)
+
+    # Open a separate connection, insert (this write lands in the WAL),
+    # and close. The main .db file may not be touched if checkpoint has
+    # not run yet.
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA journal_mode=WAL")
+    # Force a small, quick write that is likely to stay in the WAL.
+    conn.execute("INSERT INTO t VALUES (42)")
+    conn.commit()
+    conn.close()
+    v2 = local_api._sqlite_version_key(db_path)
+
+    assert v1 != v2, "WAL-mode write must change the version key"
+
+
+def test_cache_keyed_by_repo_root(tmp_path: Path) -> None:
+    """Regression: PR #259 round 1 used process-global caches that
+    ignored repo_root. Two repos hitting the same URL path would share
+    a cache entry.
+    """
+    repo_a = tmp_path / "repo_a"
+    repo_b = tmp_path / "repo_b"
+    repo_a.mkdir()
+    repo_b.mkdir()
+    key_a = local_api._normalized_cache_key("/api/schema", {}, repo_root=repo_a)
+    key_b = local_api._normalized_cache_key("/api/schema", {}, repo_root=repo_b)
+    assert key_a != key_b
+    # With no repo_root the key falls back to path only (backward-compat).
+    assert local_api._normalized_cache_key("/api/schema", {}) == "/api/schema"
+
+
+def test_status_md_cache_isolates_per_path(tmp_path: Path) -> None:
+    """Regression: STATUS.md cache was process-global, one entry.
+    Different repos' STATUS.md files must resolve independently.
+    """
+    status_a = tmp_path / "a" / "STATUS.md"
+    status_b = tmp_path / "b" / "STATUS.md"
+    status_a.parent.mkdir()
+    status_b.parent.mkdir()
+    status_a.write_text(
+        "# a\n\n## TODO\n\n- [ ] task from A\n", encoding="utf-8"
+    )
+    status_b.write_text(
+        "# b\n\n## TODO\n\n- [ ] task from B\n", encoding="utf-8"
+    )
+    data_a = local_api._parse_status_md(status_a)
+    data_b = local_api._parse_status_md(status_b)
+    assert data_a["focus"] == ["task from A"]
+    assert data_b["focus"] == ["task from B"]
+
+
+def test_background_snapshot_serializes_concurrent_builds() -> None:
+    """Regression: the "single in-flight" guarantee required a build
+    lock. refresh_blocking() called from one thread while the daemon
+    thread also tries to refresh must not produce overlapping builders.
+    """
+    import threading
+
+    started = []
+    running_now = {"n": 0}
+    max_concurrent = {"n": 0}
+    lock = threading.Lock()
+    release = threading.Event()
+
+    def slow_builder():
+        with lock:
+            running_now["n"] += 1
+            max_concurrent["n"] = max(max_concurrent["n"], running_now["n"])
+            started.append(True)
+        # Block long enough for a second caller to race in.
+        release.wait(timeout=1.0)
+        with lock:
+            running_now["n"] -= 1
+        return {"iteration": len(started)}
+
+    snap = local_api.BackgroundSnapshot(
+        key="concurrency-test",
+        interval_seconds=60.0,
+        builder=slow_builder,
+    )
+
+    # Thread A: refresh_blocking holds the build lock.
+    t_a = threading.Thread(target=snap.refresh_blocking, args=(5.0,))
+    t_a.start()
+    # Wait until A is inside the builder.
+    for _ in range(50):
+        with lock:
+            if running_now["n"] >= 1:
+                break
+        import time as _t
+        _t.sleep(0.01)
+    # Thread B: concurrent refresh_blocking must BLOCK on the lock.
+    t_b = threading.Thread(target=snap.refresh_blocking, args=(5.0,))
+    t_b.start()
+    # Give B a moment to attempt entry.
+    import time as _t
+    _t.sleep(0.05)
+    # Release A, which lets B enter.
+    release.set()
+    t_a.join(timeout=3.0)
+    t_b.join(timeout=3.0)
+    assert not t_a.is_alive() and not t_b.is_alive()
+    assert max_concurrent["n"] == 1, "two builders ran concurrently"
+
+
 def test_background_snapshot_reports_degraded_on_builder_error() -> None:
     def builder():
         raise RuntimeError("boom")

--- a/tests/test_local_api.py
+++ b/tests/test_local_api.py
@@ -700,29 +700,66 @@ def test_background_snapshot_exposes_freshness_metadata() -> None:
 def test_sqlite_version_key_detects_wal_only_write(tmp_path: Path) -> None:
     """Regression: PR #259 round 1 used PRAGMA data_version which is a
     per-connection counter and therefore unreliable across fresh
-    connections. Version key must change on a WAL-mode write, measured
-    across fresh lookups.
-    """
+    connections. Version key must change on a WAL-mode write."""
     db_path = tmp_path / "wal.db"
     conn = sqlite3.connect(db_path)
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("CREATE TABLE t (x INTEGER)")
     conn.commit()
     conn.close()
+    local_api._close_all_sqlite_version_connections()
     v1 = local_api._sqlite_version_key(db_path)
 
-    # Open a separate connection, insert (this write lands in the WAL),
-    # and close. The main .db file may not be touched if checkpoint has
-    # not run yet.
     conn = sqlite3.connect(db_path)
     conn.execute("PRAGMA journal_mode=WAL")
-    # Force a small, quick write that is likely to stay in the WAL.
     conn.execute("INSERT INTO t VALUES (42)")
     conn.commit()
     conn.close()
     v2 = local_api._sqlite_version_key(db_path)
 
     assert v1 != v2, "WAL-mode write must change the version key"
+
+
+def test_sqlite_version_key_detects_same_size_write(tmp_path: Path) -> None:
+    """Codex round-2 blocker: (mtime, size) missed same-size writes.
+    The fix uses PRAGMA data_version on a persistent connection, which
+    increments on every commit regardless of file-level changes.
+
+    Write, then UPDATE a row in place so the file size is unchanged.
+    Without a reliable detector, the version key would collide.
+    """
+    db_path = tmp_path / "same_size.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE t (x INTEGER)")
+    conn.execute("INSERT INTO t VALUES (1)")
+    conn.commit()
+    conn.close()
+    local_api._close_all_sqlite_version_connections()
+    v1 = local_api._sqlite_version_key(db_path)
+
+    # In-place update: row count and stored int width are both unchanged.
+    conn = sqlite3.connect(db_path)
+    conn.execute("UPDATE t SET x = 2")
+    conn.commit()
+    conn.close()
+    v2 = local_api._sqlite_version_key(db_path)
+
+    assert v1 != v2, "in-place UPDATE must change the version key"
+
+
+def test_sqlite_version_key_stable_without_writes(tmp_path: Path) -> None:
+    """Repeated calls with no intervening write must return the same key."""
+    db_path = tmp_path / "stable.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE t (x INTEGER)")
+    conn.execute("INSERT INTO t VALUES (1)")
+    conn.commit()
+    conn.close()
+    local_api._close_all_sqlite_version_connections()
+    v1 = local_api._sqlite_version_key(db_path)
+    v2 = local_api._sqlite_version_key(db_path)
+    v3 = local_api._sqlite_version_key(db_path)
+    assert v1 == v2 == v3
 
 
 def test_cache_keyed_by_repo_root(tmp_path: Path) -> None:
@@ -765,54 +802,118 @@ def test_background_snapshot_serializes_concurrent_builds() -> None:
     """Regression: the "single in-flight" guarantee required a build
     lock. refresh_blocking() called from one thread while the daemon
     thread also tries to refresh must not produce overlapping builders.
+
+    Deterministic — no sleeps. An instrumented build lock signals when
+    the second caller reaches lock contention, so the test proves that
+    B actually attempted entry before A released (not just that B
+    happened not to finish first).
     """
     import threading
 
-    started = []
+    class _InstrumentedLock:
+        """Substitute for ``BackgroundSnapshot._build_lock`` that records
+        a ``waiter_entered`` event the second time ``acquire`` is called
+        while the lock is held, so the test can synchronize on ``B is
+        now waiting`` without sleeping."""
+
+        def __init__(self) -> None:
+            self._inner = threading.Lock()
+            self.waiter_entered = threading.Event()
+            self._acquire_attempts = 0
+            self._counter_lock = threading.Lock()
+
+        def acquire(self, timeout: float = -1.0) -> bool:
+            with self._counter_lock:
+                self._acquire_attempts += 1
+                attempt = self._acquire_attempts
+            if attempt >= 2 and self._inner.locked():
+                # Signal BEFORE the blocking acquire so the driver can
+                # release A after confirming B has reached contention.
+                self.waiter_entered.set()
+            if timeout < 0:
+                self._inner.acquire()
+                return True
+            return self._inner.acquire(timeout=timeout)
+
+        def release(self) -> None:
+            self._inner.release()
+
     running_now = {"n": 0}
     max_concurrent = {"n": 0}
-    lock = threading.Lock()
-    release = threading.Event()
+    release_builder = threading.Event()
+    in_builder = threading.Event()
+    counter_lock = threading.Lock()
 
     def slow_builder():
-        with lock:
+        with counter_lock:
             running_now["n"] += 1
             max_concurrent["n"] = max(max_concurrent["n"], running_now["n"])
-            started.append(True)
-        # Block long enough for a second caller to race in.
-        release.wait(timeout=1.0)
-        with lock:
+        in_builder.set()
+        # Park inside the builder until the test explicitly releases.
+        release_builder.wait(timeout=5.0)
+        with counter_lock:
             running_now["n"] -= 1
-        return {"iteration": len(started)}
+        return {"ok": True}
 
     snap = local_api.BackgroundSnapshot(
         key="concurrency-test",
         interval_seconds=60.0,
         builder=slow_builder,
     )
+    instrumented = _InstrumentedLock()
+    snap._build_lock = instrumented  # type: ignore[assignment]
 
-    # Thread A: refresh_blocking holds the build lock.
-    t_a = threading.Thread(target=snap.refresh_blocking, args=(5.0,))
+    # Thread A enters the builder and parks there.
+    t_a = threading.Thread(target=snap.refresh_blocking)
     t_a.start()
-    # Wait until A is inside the builder.
-    for _ in range(50):
-        with lock:
-            if running_now["n"] >= 1:
-                break
-        import time as _t
-        _t.sleep(0.01)
-    # Thread B: concurrent refresh_blocking must BLOCK on the lock.
-    t_b = threading.Thread(target=snap.refresh_blocking, args=(5.0,))
+    assert in_builder.wait(timeout=3.0), "builder A never entered"
+
+    # Thread B also attempts to acquire the build lock. It must block.
+    t_b = threading.Thread(target=snap.refresh_blocking)
     t_b.start()
-    # Give B a moment to attempt entry.
-    import time as _t
-    _t.sleep(0.05)
-    # Release A, which lets B enter.
-    release.set()
+    assert instrumented.waiter_entered.wait(timeout=3.0), (
+        "B did not reach lock contention before A released — test invalid"
+    )
+
+    # Release A; B proceeds into the builder sequentially.
+    release_builder.set()
     t_a.join(timeout=3.0)
     t_b.join(timeout=3.0)
     assert not t_a.is_alive() and not t_b.is_alive()
     assert max_concurrent["n"] == 1, "two builders ran concurrently"
+
+
+def test_refresh_blocking_honors_timeout() -> None:
+    """refresh_blocking(timeout=...) must return False if the build
+    lock cannot be acquired before the timeout elapses."""
+    import threading
+
+    release = threading.Event()
+    in_builder = threading.Event()
+
+    def slow_builder():
+        in_builder.set()
+        release.wait(timeout=3.0)
+        return {"ok": True}
+
+    snap = local_api.BackgroundSnapshot(
+        key="timeout-test",
+        interval_seconds=60.0,
+        builder=slow_builder,
+    )
+    # Thread A holds the build lock.
+    t_a = threading.Thread(target=snap.refresh_blocking)
+    t_a.start()
+    assert in_builder.wait(timeout=3.0)
+
+    # Caller B asks with a small timeout. Lock is held; return False fast.
+    ok = snap.refresh_blocking(timeout=0.05)
+    assert ok is False, "timeout path must return False"
+
+    release.set()
+    t_a.join(timeout=3.0)
+    # Once A releases, a follow-up call succeeds.
+    assert snap.refresh_blocking(timeout=3.0) is True
 
 
 def test_background_snapshot_reports_degraded_on_builder_error() -> None:

--- a/tests/test_local_api.py
+++ b/tests/test_local_api.py
@@ -501,6 +501,218 @@ def test_pid_reuse_helper_handles_missing_process() -> None:
     assert local_api._process_age_seconds(999_999) is None
 
 
+def test_api_schema_advertises_new_endpoints() -> None:
+    schema = local_api.build_api_schema()
+    assert schema["version"] == 1
+    paths = {e["path"] for e in schema["endpoints"]}
+    # Must advertise new endpoints so agents can discover them without
+    # reading this file.
+    assert "/api/briefing/session" in paths
+    assert "/api/schema" in paths
+    assert "/api/git/worktrees" in paths
+    assert "/api/git/worktree" in paths  # singular still there
+    assert "conventions" in schema
+    assert "errors" in schema["conventions"]
+
+
+def test_weak_etag_stable_for_identical_bytes() -> None:
+    a = local_api._weak_etag(b"hello world")
+    b = local_api._weak_etag(b"hello world")
+    c = local_api._weak_etag(b"hello worlds")
+    assert a == b
+    assert a != c
+    assert a.startswith('W/"sha256:')
+
+
+def test_match_etag_handles_list_weak_and_star() -> None:
+    etag = 'W/"sha256:abc123"'
+    assert local_api._match_etag(etag, etag) is True
+    assert local_api._match_etag("*", etag) is True
+    assert local_api._match_etag('W/"sha256:nope"', etag) is False
+    # Strong/weak equivalence for comparison.
+    assert local_api._match_etag('"sha256:abc123"', etag) is True
+    # Comma-separated list.
+    assert local_api._match_etag(f'"other", {etag}, "other2"', etag) is True
+    assert local_api._match_etag("", etag) is False
+
+
+def test_normalized_cache_key_is_order_invariant() -> None:
+    k1 = local_api._normalized_cache_key("/x", {"a": ["1"], "b": ["2"]})
+    k2 = local_api._normalized_cache_key("/x", {"b": ["2"], "a": ["1"]})
+    assert k1 == k2
+    assert local_api._normalized_cache_key("/x", {}) == "/x"
+
+
+def test_sqlite_version_key_changes_on_write(tmp_path: Path) -> None:
+    db_path = tmp_path / "test.db"
+    # Absent DB has an absent sentinel.
+    absent = local_api._sqlite_version_key(db_path)
+    assert absent[0] == "absent"
+    # Create + insert = new version key.
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE t (x INTEGER)")
+    conn.commit()
+    conn.close()
+    v1 = local_api._sqlite_version_key(db_path)
+    conn = sqlite3.connect(db_path)
+    conn.execute("INSERT INTO t VALUES (1)")
+    conn.commit()
+    conn.close()
+    v2 = local_api._sqlite_version_key(db_path)
+    assert v1 != v2
+    assert v1[0] != "absent"
+
+
+def test_cached_response_reuses_entry_until_version_bump(tmp_path: Path) -> None:
+    # Use a unique key so test isolation holds across tests.
+    key = f"/test/cache/{id(tmp_path)}"
+    calls = {"n": 0}
+
+    def builder():
+        calls["n"] += 1
+        return 200, {"hits": calls["n"]}, "application/json; charset=utf-8"
+
+    version_state = {"v": 1}
+
+    def version():
+        return ("v", version_state["v"])
+
+    code_a, body_a, _ct, etag_a = local_api.cached_response(
+        key, ttl_seconds=60, version_fn=version, builder=builder
+    )
+    assert code_a == 200
+    assert calls["n"] == 1
+
+    # Second call within TTL + same version -> cached.
+    code_b, body_b, _ct, etag_b = local_api.cached_response(
+        key, ttl_seconds=60, version_fn=version, builder=builder
+    )
+    assert calls["n"] == 1
+    assert body_b is body_a or body_b == body_a
+    assert etag_b == etag_a
+
+    # Version bump -> rebuild.
+    version_state["v"] = 2
+    code_c, body_c, _ct, etag_c = local_api.cached_response(
+        key, ttl_seconds=60, version_fn=version, builder=builder
+    )
+    assert calls["n"] == 2
+    assert etag_c != etag_a
+
+
+def test_cached_response_does_not_cache_errors(tmp_path: Path) -> None:
+    key = f"/test/errors/{id(tmp_path)}"
+    calls = {"n": 0}
+
+    def builder():
+        calls["n"] += 1
+        return 500, {"error": "boom"}, "application/json; charset=utf-8"
+
+    code, _body, _ct, _etag = local_api.cached_response(
+        key, ttl_seconds=60, version_fn=lambda: ("v",), builder=builder
+    )
+    assert code == 500
+    # Second call should also go through the builder (no poisoning).
+    local_api.cached_response(key, ttl_seconds=60, version_fn=lambda: ("v",), builder=builder)
+    assert calls["n"] == 2
+
+
+def test_build_worktrees_list_returns_primary(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    _init_repo(repo_root)
+    _write(repo_root / "README.md", "hi\n")
+    _git(repo_root, "add", ".")
+    _git(repo_root, "commit", "-m", "initial")
+    result = local_api.build_worktrees_list(repo_root)
+    assert result["ok"] is True
+    assert result["count"] >= 1
+    paths = [w["path"] for w in result["worktrees"]]
+    assert str(repo_root) in paths
+
+
+def test_session_briefing_serves_compact_snapshot(tmp_path: Path) -> None:
+    _setup_repo(tmp_path)
+    # Write a STATUS.md that the briefing will parse.
+    _write(
+        tmp_path / "STATUS.md",
+        "# status\n\n## TODO\n\n- [ ] finish alpha\n- [ ] finish beta\n\n"
+        "## Blockers\n\n- slow CI\n",
+    )
+    briefing = local_api.build_session_briefing(tmp_path)
+    assert set(briefing).issuperset(
+        {"snapshot", "workspace", "services", "pipelines", "focus", "blockers", "next_reads"}
+    )
+    assert briefing["focus"][:2] == ["finish alpha", "finish beta"]
+    assert briefing["blockers"] == ["slow CI"]
+
+    # Compact drops next_reads, links, and the worktrees list.
+    compact = local_api._compact_briefing(briefing)
+    assert "next_reads" not in compact
+    assert "links" not in compact
+    assert "worktrees" not in compact["workspace"]
+    assert compact["workspace"]["worktrees_total"] == briefing["workspace"]["worktrees_total"]
+
+
+def test_serve_request_sets_etag_and_matches_on_replay(tmp_path: Path) -> None:
+    _setup_repo(tmp_path)
+    _write(
+        tmp_path / "STATUS.md",
+        "# status\n\n## TODO\n\n- [ ] task one\n",
+    )
+    code1, body1, _ct1, etag1 = local_api.serve_request(tmp_path, "/api/schema")
+    assert code1 == 200
+    assert etag1.startswith('W/"sha256:')
+    # Replay should return the same bytes + same etag (cache hit).
+    code2, body2, _ct2, etag2 = local_api.serve_request(tmp_path, "/api/schema")
+    assert code2 == 200
+    assert etag2 == etag1
+    assert body1 == body2
+    # And If-None-Match match semantics should accept it.
+    assert local_api._match_etag(etag1, etag2)
+
+
+def test_background_snapshot_exposes_freshness_metadata() -> None:
+    calls = {"n": 0}
+
+    def builder():
+        calls["n"] += 1
+        return {"value": calls["n"]}
+
+    snap = local_api.BackgroundSnapshot(
+        key="test-snap-1",
+        interval_seconds=60.0,
+        builder=builder,
+    )
+    # Before any refresh runs.
+    data, meta = snap.get()
+    assert data is None
+    assert meta["freshness_state"] == "refreshing"
+
+    snap.refresh_blocking()
+    data, meta = snap.get()
+    assert data == {"value": 1}
+    assert meta["freshness_state"] == "fresh"
+    assert meta["refresh_error"] is None
+    assert meta["refresh_duration_ms"] is not None
+    assert meta["refresh_in_flight"] is False
+
+
+def test_background_snapshot_reports_degraded_on_builder_error() -> None:
+    def builder():
+        raise RuntimeError("boom")
+
+    snap = local_api.BackgroundSnapshot(
+        key="test-snap-2",
+        interval_seconds=60.0,
+        builder=builder,
+    )
+    snap.refresh_blocking()
+    data, meta = snap.get()
+    assert data is None
+    assert meta["freshness_state"] == "degraded"
+    assert "RuntimeError: boom" in (meta["refresh_error"] or "")
+
+
 def test_cli_starts_server_and_reports_host_port(tmp_path: Path) -> None:
     repo_root = tmp_path
     _init_repo(repo_root)

--- a/tests/test_local_api.py
+++ b/tests/test_local_api.py
@@ -735,6 +735,7 @@ def test_sqlite_version_key_detects_same_size_write(tmp_path: Path) -> None:
     conn.commit()
     conn.close()
     local_api._close_all_sqlite_version_connections()
+    size_before = db_path.stat().st_size
     v1 = local_api._sqlite_version_key(db_path)
 
     # In-place update: row count and stored int width are both unchanged.
@@ -742,9 +743,49 @@ def test_sqlite_version_key_detects_same_size_write(tmp_path: Path) -> None:
     conn.execute("UPDATE t SET x = 2")
     conn.commit()
     conn.close()
+    size_after = db_path.stat().st_size
     v2 = local_api._sqlite_version_key(db_path)
 
+    # The whole point of this test is the "same size" case; prove it.
+    assert size_before == size_after, (
+        f"test presumption broken: size changed {size_before}->{size_after}"
+    )
     assert v1 != v2, "in-place UPDATE must change the version key"
+
+
+def test_sqlite_version_key_detects_db_replacement(tmp_path: Path) -> None:
+    """Non-blocking polish from Codex round-3: if the DB file is
+    REPLACED (different inode) rather than modified in place, the
+    cached persistent connection would otherwise keep reporting the
+    old counter until TTL rebuilt the cache. The inode check drops
+    the stale handle so the first call after replacement gives a
+    fresh, correct key.
+    """
+    db_path = tmp_path / "rotated.db"
+    other = tmp_path / "other.db"
+
+    # DB A — one row, version V_a.
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE t (x INTEGER)")
+    conn.execute("INSERT INTO t VALUES (1)")
+    conn.commit()
+    conn.close()
+    local_api._close_all_sqlite_version_connections()
+    v_a = local_api._sqlite_version_key(db_path)
+
+    # DB B — different physical file, then rename over db_path.
+    conn = sqlite3.connect(other)
+    conn.execute("CREATE TABLE t (x INTEGER, y TEXT)")
+    conn.execute("INSERT INTO t VALUES (42, 'b')")
+    conn.execute("INSERT INTO t VALUES (43, 'bb')")
+    conn.commit()
+    conn.close()
+    # Rename replaces the inode at db_path without going through
+    # sqlite's own rewrite path.
+    other.replace(db_path)
+
+    v_b = local_api._sqlite_version_key(db_path)
+    assert v_a != v_b, "DB replacement must change the version key"
 
 
 def test_sqlite_version_key_stable_without_writes(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes follow-ups to #258 (Phase A + B of the reconciled plan).

## Results (measured, not guessed)

Agent cold-start cost (tiktoken `cl100k_base`, measured via `scripts/bench_orientation.py`):

| mode | tokens | bytes | vs baseline |
|---|---:|---:|---|
| baseline (`cat CLAUDE.md + STATUS.md + git log -20 + git status + ls`) | 4,215 | 14,867 | — |
| `/api/briefing/session` | 1,508 | 5,112 | **-64 %** |
| `/api/briefing/session?compact=1` | 665 | 2,176 | **-84 %** |

Server startup: module-load cost **170 ms → 50 ms** (lazy imports; `/healthz` + `/api/runtime/services` now dependency-free).

## What's in this PR

**Agent cold-start**
- `GET /api/briefing/session` — compact control-plane snapshot (branch, dirty summary, all worktrees, services health, pipeline v2 queue head, recent commits, top TODO bullets, blockers, alerts, `next_reads` drill-down URLs). Background-refreshed every 15 s.
- `?compact=1` strips `next_reads`, `links`, and the worktrees list for dense agent consumption.
- `GET /api/schema` — self-describing endpoint index so agents don't need to read `scripts/local_api.py` to discover the API.
- `GET /api/git/worktrees` — plural (all attached worktrees, not just the primary).
- `CLAUDE.md`: new *Agent Orientation* section pointing at `/api/briefing/session` as the first call.

**Server perf / correctness** (per Codex review)
- Lazy imports: `pipeline_v2.cli`, `status`, `translation_v2`, `ztt_status` only load inside the handlers that need them.
- Response-bytes cache keyed by normalized `(path, sorted-query)`. `CACHE_POLICY` lists per-endpoint TTL + version function.
- Weak `ETag` from cached bytes; `If-None-Match` → `304` for every 2xx response (cached or not).
- `_sqlite_version_key()` uses `PRAGMA data_version` + `(db_mtime, wal_mtime)` so WAL-only writes don't mask invalidation. Per-thread read-only sqlite connections (`uri=...mode=ro`).
- `BackgroundSnapshot`: fixed-*delay* (not fixed-interval) scheduling, single in-flight refresh per key, atomic snapshot swap, freshness metadata surfaced in every response (`refresh_started_at`, `refresh_completed_at`, `refresh_duration_ms`, `refresh_error`, `stale_seconds`, `stale_threshold_seconds`, `freshness_state`, `refresh_in_flight`).
- Errors are *not* cached (no poisoning).

**Tooling**
- `scripts/bench_orientation.py` — repeatable cold-start cost benchmark (tiktoken-aware, 4c/tok fallback).
- `GET /api/cache/stats` — cache introspection.

## What's intentionally NOT in this PR

Deferred to a follow-up issue to keep the review surface manageable:

- `/api/pipeline/leases` + `/api/module/{key}/lease` (Gemini request)
- `diagnostics` array on `/api/module/{key}/state` (Gemini request)
- `/api/quality/scores` parsing `docs/quality-audit-results.md`
- `/api/pipeline/v2/events` + `/api/pipeline/v2/stuck`
- `/api/reviews` surfacing `.pipeline/reviews/`
- `/api/bridge/messages` surfacing `.bridge/messages.db`
- `POST` write surface for agent claims (both reviewers agreed: stay read-only for now)
- Splitting `local_api.py` into a package (both reviewers agreed: not urgent)

## Test plan

- [x] `pytest tests/test_local_api.py -x` — 24 pass (12 original + 12 new). New tests cover ETag matching (list, weak/strong, wildcard, no-match), cache reuse vs version bump, error non-caching, sqlite version keys across writes, worktrees list, briefing content + compact mode, `serve_request` ETag stability, `BackgroundSnapshot` fresh/degraded states.
- [x] `ruff check scripts/local_api.py scripts/bench_orientation.py tests/test_local_api.py` — clean.
- [x] `scripts/bench_orientation.py` — baseline vs briefing numbers above.
- [ ] Reviewer to sanity-check that running API (`python scripts/local_api.py`) still serves the dashboard + every old endpoint.
- [ ] Reviewer to run `curl -s localhost:8768/api/briefing/session | jq` and eyeball the payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)