### PR TITLE
Local API Phase C: leases, diagnostics, quality, events, stuck, reviews, bridge (#260)

### DIFF
--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -1400,11 +1400,68 @@ _TRACK_ALIASES: dict[str, tuple[str, ...]] = {
 }
 
 # Tokens that are too generic to contribute to the name-overlap match
-# (e.g. "module", "basics", "intro").
+# (e.g. "module", "part", "intro"). ``basics`` was removed in round-3:
+# it can be the only distinguishing token in short unnumbered labels.
 _NAME_TOKEN_STOPLIST = frozenset({
     "module", "part", "the", "a", "an", "and", "of", "to", "for", "with",
-    "intro", "introduction", "basics", "overview",
+    "intro", "introduction", "overview",
 })
+
+
+# Labels typically look like ``<Track>[ <number>][:-] <Name>``.
+# Capture the leading track prefix so we can match even when the
+# audit ``Track`` column is a subtrack like "Workloads" or "AWS".
+_LABEL_TRACK_PREFIX_RE = re.compile(
+    r"^\s*(?P<track>[A-Za-z][A-Za-z/\- ]*?)\s*(?:[0-9]+(?:\.[0-9]+)*)?\s*[:\-]"
+)
+
+
+def _audit_row_track_tokens(row: dict[str, Any]) -> set[str]:
+    """Return every track-like string attached to an audit row.
+
+    Combines the ``Track`` column (typically a subtrack like
+    ``Workloads`` or ``AWS``) with the ``Track:`` prefix of the
+    ``Module`` label (``CKA 2.8: ...``, ``Platform: ...``).
+    """
+    out: set[str] = set()
+    track_col = str(row.get("track", "")).strip().lower()
+    if track_col:
+        out.add(track_col)
+    module_label = str(row.get("module", ""))
+    m = _LABEL_TRACK_PREFIX_RE.match(module_label)
+    if m:
+        out.add(m.group("track").strip().lower())
+    return out
+
+
+def _alias_matches(alias: str, candidates: set[str]) -> bool:
+    """Whole-word check so ``cka`` doesn't match ``ckad``."""
+    pattern = re.compile(r"\b" + re.escape(alias) + r"\b")
+    return any(pattern.search(c) for c in candidates)
+
+
+_CERT_TRACKS = frozenset({"cka", "ckad", "cks", "kcna", "kcsa"})
+
+
+def _track_word_set(track_slug: str | None, aliases: tuple[str, ...]) -> set[str]:
+    """Tokens that should NOT count as a non-track overlap signal.
+
+    Used to make the name-overlap match meaningful: an overlap of
+    ``{platform, sre}`` between a module path and a "Platform: SRE…"
+    label is vacuous when both are track tokens for this module.
+    """
+    out: set[str] = set()
+    if track_slug:
+        out |= _normalize_name_tokens(track_slug)
+    for alias in aliases:
+        out |= _normalize_name_tokens(alias)
+    # Cert paths share a ``k8s/`` parent segment that's structural,
+    # not semantic. Without this the label "CKA: k8s.io Navigation"
+    # matches any k8s/cka/* module via the vacuous ``{cka, k8s}``
+    # overlap.
+    if track_slug in _CERT_TRACKS:
+        out.add("k8s")
+    return out
 
 
 def _normalize_name_tokens(text: str) -> set[str]:
@@ -1461,56 +1518,59 @@ def _rubric_severity_for_module(
     aliases = _TRACK_ALIASES.get(track_slug, ()) if track_slug else ()
 
     if not aliases:
-        # Without a recognized track, matching is too risky
-        # (round-2 caught "any row wins" false positives).
+        # Unknown track → no match (round-2 caught "any row wins"
+        # false positives).
         return None
 
-    def _row_track_matches(row_track: str) -> bool:
-        rt = row_track.lower()
-        return any(alias in rt for alias in aliases)
+    # Track tokens for THIS module. Used both to filter audit rows
+    # (whole-word match to avoid cka/ckad collision) and to compute
+    # "non-track overlap" in stage 2.
+    track_word_set = _track_word_set(track_slug, aliases)
+
+    def _row_track_matches(row: dict[str, Any]) -> bool:
+        candidates = _audit_row_track_tokens(row)
+        return any(_alias_matches(alias, candidates) for alias in aliases)
 
     # ----- stage 1: numbered match -----
     if number:
-        # Numbers in audit labels usually appear flanked by space or
-        # punctuation. Match a word boundary on both sides of the
-        # number so "2.8" can't match "12.8" or "2.80".
         number_re = re.compile(
-            r"(?:^|[\s\(])" + re.escape(number) + r"(?=[\s:\-\)—.,])"
+            r"(?:^|[\s(])" + re.escape(number) + r"(?=[\s:\-\)—.,])"
         )
         for entry in audit_modules:
             label = str(entry.get("module", ""))
             if not number_re.search(label):
                 continue
-            if _row_track_matches(str(entry.get("track", ""))):
+            if _row_track_matches(entry):
                 return entry.get("severity")
 
     # ----- stage 2: name-overlap match -----
-    # Build the path slug's tokens by stripping the module-number
-    # prefix and any "partN" container, then splitting on dashes.
     name_slug = _MODULE_NUMBER_PREFIX_RE.sub("", last)
     path_tokens = _normalize_name_tokens(name_slug)
-    # Also fold in the parent segment (excluding "part<N>" wrappers)
-    # so "foundations" from ``platform/foundations/...`` is considered.
     for seg in segments[:-1]:
         if _PART_PREFIX_RE.match(seg):
             continue
         path_tokens |= _normalize_name_tokens(seg)
-    # NOTE: we keep track-name tokens in the path set on purpose. The
-    # audit label often includes the track name too ("Prerequisites:
-    # GitOps", "Platform: Systems Thinking"), so that overlap is a
-    # legitimate signal alongside the ``_row_track_matches`` filter.
     if not path_tokens:
         return None
 
     best: tuple[int, str | None] = (0, None)
     for entry in audit_modules:
-        label = str(entry.get("module", ""))
-        if not _row_track_matches(str(entry.get("track", ""))):
+        if not _row_track_matches(entry):
             continue
-        label_tokens = _normalize_name_tokens(label)
-        overlap = len(path_tokens & label_tokens)
-        if overlap >= 2 and overlap > best[0]:
-            best = (overlap, entry.get("severity"))
+        label_tokens = _normalize_name_tokens(str(entry.get("module", "")))
+        overlap = path_tokens & label_tokens
+        # Require ≥ 2 overlap AND at least one NON-track-alias token
+        # in the overlap; otherwise ``{platform, sre}`` alone would
+        # attach any "Platform: ... SRE ..." row to every platform
+        # module containing "sre".
+        if len(overlap) < 2:
+            continue
+        non_track = overlap - track_word_set
+        if not non_track:
+            continue
+        score = len(overlap) + len(non_track)
+        if score > best[0]:
+            best = (score, entry.get("severity"))
     return best[1]
 
 

--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -726,7 +726,7 @@ def build_module_state(repo_root: Path, module_key: str) -> dict[str, Any]:
     lab_summary = _build_lab_summary(repo_root)
     lab_state = next((item for item in lab_summary["items"] if item["lab_id"] == lab_id), None) if lab_id else None
 
-    return {
+    state = {
         "module_key": normalized,
         "track": normalized.split("/", 1)[0] if "/" in normalized else normalized,
         "english_path": str(en_path),
@@ -745,6 +745,8 @@ def build_module_state(repo_root: Path, module_key: str) -> dict[str, Any]:
             "state": lab_state,
         },
     }
+    state["diagnostics"] = build_module_diagnostics(repo_root, normalized, state)
+    return state
 
 
 def build_module_orchestration_latest(repo_root: Path, module_key: str) -> dict[str, Any]:
@@ -754,6 +756,573 @@ def build_module_orchestration_latest(repo_root: Path, module_key: str) -> dict[
         "v2": _db_latest_for_module(repo_root / ".pipeline" / "v2.db", normalized),
         "translation_v2": _db_latest_for_module(repo_root / ".pipeline" / "translation_v2.db", normalized),
     }
+
+
+# ============================================================
+# Phase C: leases, diagnostics, quality, pipeline events/stuck,
+# reviews, bridge messages
+# ============================================================
+
+
+def _query_sqlite_rows(
+    db_path: Path,
+    sql: str,
+    params: tuple = (),
+    limit: int = 1000,
+) -> list[dict[str, Any]]:
+    """Run a read-only query and return rows as dicts. Empty list if
+    the DB is missing or the referenced table doesn't exist; every
+    other sqlite error propagates so the handler can surface it as a
+    500 (silently swallowing hides schema-drift bugs)."""
+    if not db_path.exists():
+        return []
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=1.0)
+    conn.row_factory = sqlite3.Row
+    try:
+        cursor = conn.execute(sql, params)
+        return [dict(row) for row in cursor.fetchmany(limit)]
+    except sqlite3.OperationalError as exc:
+        # "no such table" is an expected "feature not yet provisioned"
+        # state (e.g. bridge DB absent before first message). Anything
+        # else — "no such column", type mismatch, etc. — is a bug the
+        # caller needs to see.
+        if "no such table" in str(exc):
+            return []
+        raise
+    finally:
+        conn.close()
+
+
+def build_pipeline_leases(repo_root: Path, *, now_ms: int | None = None) -> dict[str, Any]:
+    """Active pipeline leases (from ``jobs`` table).
+
+    A lease is active when ``leased_by`` is set and ``lease_expires_at``
+    is in the future. The payload is ordered by expiry so the most-at-
+    risk leases are first.
+    """
+    db_path = repo_root / ".pipeline" / "v2.db"
+    if not db_path.exists():
+        return {"db_path": str(db_path), "active": [], "count": 0, "exists": False}
+
+    now_ms = now_ms if now_ms is not None else int(time.time() * 1000)
+    rows = _query_sqlite_rows(
+        db_path,
+        """
+        SELECT module_key, phase, queue_state, model, priority,
+               leased_by, lease_id, leased_at, lease_expires_at
+        FROM jobs
+        WHERE leased_by IS NOT NULL
+          AND lease_expires_at IS NOT NULL
+          AND lease_expires_at > ?
+        ORDER BY lease_expires_at ASC
+        """,
+        (now_ms,),
+    )
+    for row in rows:
+        exp = row.get("lease_expires_at")
+        if isinstance(exp, (int, float)):
+            row["seconds_to_expiry"] = max(0, int((int(exp) - now_ms) / 1000))
+    return {
+        "db_path": str(db_path),
+        "exists": True,
+        "count": len(rows),
+        "active": rows,
+        "queried_at_ms": now_ms,
+    }
+
+
+def build_module_lease(
+    repo_root: Path, module_key: str, *, now_ms: int | None = None
+) -> dict[str, Any]:
+    """Lease state for one module. Returns ``{held: False}`` when no
+    active lease exists (vs 404 semantics, which would be ambiguous
+    between 'no lease' and 'no pipeline DB')."""
+    db_path = repo_root / ".pipeline" / "v2.db"
+    if not db_path.exists():
+        return {
+            "module_key": module_key,
+            "held": False,
+            "reason": "missing_db",
+            "db_path": str(db_path),
+        }
+    now_ms = now_ms if now_ms is not None else int(time.time() * 1000)
+    rows = _query_sqlite_rows(
+        db_path,
+        """
+        SELECT module_key, phase, queue_state, model, priority,
+               leased_by, lease_id, leased_at, lease_expires_at
+        FROM jobs
+        WHERE module_key = ?
+          AND leased_by IS NOT NULL
+          AND lease_expires_at IS NOT NULL
+          AND lease_expires_at > ?
+        ORDER BY lease_expires_at DESC
+        LIMIT 1
+        """,
+        (module_key, now_ms),
+    )
+    if not rows:
+        return {"module_key": module_key, "held": False}
+    row = rows[0]
+    exp = row.get("lease_expires_at")
+    if isinstance(exp, (int, float)):
+        row["seconds_to_expiry"] = max(0, int((int(exp) - now_ms) / 1000))
+    return {"module_key": module_key, "held": True, "lease": row}
+
+
+# ---- pipeline events / stuck ----
+
+
+def build_pipeline_events(
+    repo_root: Path,
+    module_key: str | None,
+    since_ms: int | None,
+    limit: int = 200,
+) -> dict[str, Any]:
+    """Timeline view of ``.pipeline/v2.db`` events.
+
+    Filter by ``module_key`` (optional) and ``since_ms`` (optional,
+    inclusive). Newest-first, capped by ``limit`` (default 200, max
+    2000 to keep responses bounded).
+    """
+    db_path = repo_root / ".pipeline" / "v2.db"
+    if not db_path.exists():
+        return {"db_path": str(db_path), "exists": False, "count": 0, "events": []}
+    capped = max(1, min(int(limit), 2000))
+    clauses: list[str] = []
+    params: list[Any] = []
+    if module_key:
+        clauses.append("module_key = ?")
+        params.append(module_key)
+    if since_ms is not None:
+        clauses.append("at >= ?")
+        params.append(int(since_ms))
+    where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+    rows = _query_sqlite_rows(
+        db_path,
+        f"""
+        SELECT id, type, module_key, lease_id, payload_json, at
+        FROM events
+        {where}
+        ORDER BY id DESC
+        LIMIT {capped}
+        """,
+        tuple(params),
+    )
+    for row in rows:
+        payload = row.get("payload_json")
+        if isinstance(payload, str):
+            row["payload_json"] = _load_json(payload)
+    return {
+        "db_path": str(db_path),
+        "exists": True,
+        "module_key": module_key,
+        "since_ms": since_ms,
+        "limit": capped,
+        "count": len(rows),
+        "events": rows,
+    }
+
+
+# Phases considered "in-flight" when computing stuck modules. A job
+# that's been sitting in one of these states longer than the threshold
+# is a candidate for human attention.
+_STUCK_IN_FLIGHT_STATES = ("leased", "running", "in_progress")
+_DEFAULT_STUCK_THRESHOLD_SECONDS = 3600  # 1 hour
+
+
+def build_pipeline_stuck(
+    repo_root: Path,
+    *,
+    threshold_seconds: int = _DEFAULT_STUCK_THRESHOLD_SECONDS,
+    now_ms: int | None = None,
+) -> dict[str, Any]:
+    """Dead-letter view — jobs stuck at a phase longer than ``threshold_seconds``.
+
+    Two signals are surfaced:
+
+    - ``stuck_leased``: jobs whose lease has expired OR whose
+      ``leased_at`` is older than the threshold. Implies a crashed
+      worker or a hung builder.
+    - ``stuck_in_state``: jobs in an in-flight queue_state with no
+      recent event (``MAX(events.at)`` older than threshold).
+    """
+    db_path = repo_root / ".pipeline" / "v2.db"
+    if not db_path.exists():
+        return {"db_path": str(db_path), "exists": False, "stuck_leased": [], "stuck_in_state": []}
+
+    now_ms = now_ms if now_ms is not None else int(time.time() * 1000)
+    threshold_ms = threshold_seconds * 1000
+
+    stuck_leased = _query_sqlite_rows(
+        db_path,
+        """
+        SELECT module_key, phase, queue_state, leased_by, lease_id,
+               leased_at, lease_expires_at
+        FROM jobs
+        WHERE leased_by IS NOT NULL
+          AND (
+              (lease_expires_at IS NOT NULL AND lease_expires_at < ?)
+              OR (leased_at IS NOT NULL AND leased_at < ?)
+          )
+        ORDER BY leased_at ASC
+        LIMIT 500
+        """,
+        (now_ms, now_ms - threshold_ms),
+    )
+
+    stuck_in_state = _query_sqlite_rows(
+        db_path,
+        f"""
+        SELECT j.module_key, j.phase, j.queue_state, j.leased_by,
+               j.leased_at, (
+                   SELECT MAX(at) FROM events e
+                   WHERE e.module_key = j.module_key
+               ) AS last_event_at
+        FROM jobs j
+        WHERE j.queue_state IN ({','.join('?' for _ in _STUCK_IN_FLIGHT_STATES)})
+        ORDER BY j.leased_at ASC
+        LIMIT 500
+        """,
+        tuple(_STUCK_IN_FLIGHT_STATES),
+    )
+    # Keep only those whose last event is older than the threshold.
+    stuck_in_state = [
+        row for row in stuck_in_state
+        if (row.get("last_event_at") or 0) < (now_ms - threshold_ms)
+    ]
+
+    return {
+        "db_path": str(db_path),
+        "exists": True,
+        "threshold_seconds": threshold_seconds,
+        "queried_at_ms": now_ms,
+        "stuck_leased_count": len(stuck_leased),
+        "stuck_leased": stuck_leased,
+        "stuck_in_state_count": len(stuck_in_state),
+        "stuck_in_state": stuck_in_state,
+    }
+
+
+# ---- reviews audit log ----
+
+
+_REVIEW_AUDIT_DIR = Path(".pipeline") / "reviews"
+
+
+def _review_filename_to_module_key(filename: str) -> str:
+    """Filenames use ``__`` as path separators. Strip trailing
+    ``.md`` / ``.lock``."""
+    name = filename
+    for suffix in (".md", ".lock"):
+        if name.endswith(suffix):
+            name = name[: -len(suffix)]
+    return name.replace("__", "/")
+
+
+def _module_key_to_review_filename(module_key: str) -> str:
+    return module_key.replace("/", "__") + ".md"
+
+
+def build_reviews_index(repo_root: Path) -> dict[str, Any]:
+    """List every review artifact with its module key and last-modified
+    timestamp. Callers fetch the body via ``/api/reviews?module=...``."""
+    reviews_dir = repo_root / _REVIEW_AUDIT_DIR
+    if not reviews_dir.is_dir():
+        return {"reviews_dir": str(reviews_dir), "exists": False, "count": 0, "reviews": []}
+    reviews: list[dict[str, Any]] = []
+    for path in sorted(reviews_dir.glob("*.md")):
+        try:
+            mtime = path.stat().st_mtime
+            size = path.stat().st_size
+        except OSError:
+            mtime, size = 0.0, 0
+        reviews.append({
+            "module_key": _review_filename_to_module_key(path.name),
+            "filename": path.name,
+            "size": size,
+            "mtime": mtime,
+        })
+    return {
+        "reviews_dir": str(reviews_dir),
+        "exists": True,
+        "count": len(reviews),
+        "reviews": reviews,
+    }
+
+
+def build_module_reviews(
+    repo_root: Path,
+    module_key: str,
+    *,
+    max_bytes: int = 200_000,
+) -> dict[str, Any] | None:
+    """Return the full review log for a module, capped at ``max_bytes``.
+
+    The log is a markdown file produced by the pipeline with one
+    section per review pass (writer, plan, duration, reviewer,
+    severity, etc.). We return it as a single ``body`` string so
+    agents can parse what they need without the API pretending to
+    understand every variation of the format.
+    """
+    reviews_dir = repo_root / _REVIEW_AUDIT_DIR
+    path = reviews_dir / _module_key_to_review_filename(module_key)
+    if not path.is_file():
+        return None
+    try:
+        raw = path.read_bytes()
+    except OSError:
+        return None
+    truncated = False
+    if len(raw) > max_bytes:
+        raw = raw[:max_bytes]
+        truncated = True
+    try:
+        body = raw.decode("utf-8", errors="replace")
+    except UnicodeDecodeError:
+        body = raw.decode("latin-1", errors="replace")
+    try:
+        mtime = path.stat().st_mtime
+    except OSError:
+        mtime = 0.0
+    return {
+        "module_key": module_key,
+        "path": str(path),
+        "size": len(raw) if not truncated else max_bytes,
+        "truncated": truncated,
+        "mtime": mtime,
+        "body": body,
+    }
+
+
+# ---- bridge messages ----
+
+
+def build_bridge_messages(
+    repo_root: Path,
+    since: str | None = None,
+    limit: int = 100,
+) -> dict[str, Any]:
+    """Recent agent-bridge messages from ``.bridge/messages.db``.
+
+    Filter ``since`` is an ISO-8601 timestamp (string comparison is
+    safe here because ``timestamp`` is stored as ISO-8601 UTC by the
+    bridge). ``limit`` caps at 500 rows to keep the payload bounded
+    for agents that just want a recent window.
+    """
+    db_path = repo_root / ".bridge" / "messages.db"
+    if not db_path.exists():
+        return {"db_path": str(db_path), "exists": False, "count": 0, "messages": []}
+    capped = max(1, min(int(limit), 500))
+    if since:
+        rows = _query_sqlite_rows(
+            db_path,
+            f"""
+            SELECT id, task_id, from_llm, to_llm, message_type,
+                   content, timestamp, acknowledged, status
+            FROM messages
+            WHERE timestamp >= ?
+            ORDER BY id DESC
+            LIMIT {capped}
+            """,
+            (since,),
+            limit=capped,
+        )
+    else:
+        rows = _query_sqlite_rows(
+            db_path,
+            f"""
+            SELECT id, task_id, from_llm, to_llm, message_type,
+                   content, timestamp, acknowledged, status
+            FROM messages
+            ORDER BY id DESC
+            LIMIT {capped}
+            """,
+            limit=capped,
+        )
+    # Truncate message content to a readable preview so a burst of
+    # long messages doesn't blow up the response. Full content stays
+    # accessible via the bridge CLI.
+    for row in rows:
+        content = row.get("content")
+        if isinstance(content, str) and len(content) > 400:
+            row["content_preview"] = content[:400] + "… (truncated)"
+            row["content_full_length"] = len(content)
+            row.pop("content", None)
+    return {
+        "db_path": str(db_path),
+        "exists": True,
+        "since": since,
+        "limit": capped,
+        "count": len(rows),
+        "messages": rows,
+    }
+
+
+# ---- quality scores ----
+
+
+_QUALITY_AUDIT_CACHE: dict[str, dict[str, Any]] = {}
+_QUALITY_AUDIT_CACHE_LOCK = threading.Lock()
+
+
+# Matches rows like:
+#   | CKA 2.8: Scheduler Lifecycle Theory | CKA | 55 | **1.3** | Critical | ... |
+# Score is the first bold-number occurrence.
+_QUALITY_ROW_RE = re.compile(
+    r"^\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|\s*([^|]*?)\s*\|\s*\*?\*?([0-9]+(?:\.[0-9]+)?)\*?\*?\s*\|"
+)
+
+
+def build_quality_scores(repo_root: Path) -> dict[str, Any]:
+    """Parse ``docs/quality-audit-results.md`` and expose per-module
+    rubric scores.
+
+    The file is markdown with multiple tables; we walk it row-by-row
+    extracting ``(module, track, lines, score)``. Cached by mtime.
+    """
+    audit_path = repo_root / "docs" / "quality-audit-results.md"
+    if not audit_path.exists():
+        return {"audit_path": str(audit_path), "exists": False, "modules": [], "count": 0}
+
+    try:
+        mtime = audit_path.stat().st_mtime
+    except OSError:
+        mtime = 0.0
+    key = str(audit_path.resolve())
+    with _QUALITY_AUDIT_CACHE_LOCK:
+        entry = _QUALITY_AUDIT_CACHE.get(key)
+        if entry is not None and entry["mtime"] == mtime:
+            return entry["data"]
+
+    try:
+        text = audit_path.read_text(encoding="utf-8")
+    except OSError:
+        return {"audit_path": str(audit_path), "exists": False, "modules": [], "count": 0}
+
+    modules: list[dict[str, Any]] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line.startswith("|"):
+            continue
+        # Skip table header / separator rows.
+        if "---" in line or line.startswith("| Module") or line.startswith("| Rating"):
+            continue
+        match = _QUALITY_ROW_RE.match(line)
+        if not match:
+            continue
+        module = match.group(1).strip()
+        track = match.group(2).strip()
+        lines_str = match.group(3).strip()
+        score = float(match.group(4))
+        try:
+            lines_count = int(lines_str) if lines_str.isdigit() else None
+        except ValueError:
+            lines_count = None
+        # Skip the score-distribution table (first col is "Excellent"/"Good"/etc).
+        if module in {"Excellent", "Good", "Needs Work", "Poor", "Critical"}:
+            continue
+        severity = "critical" if score < 2.0 else (
+            "poor" if score < 2.5 else (
+                "needs_work" if score < 3.5 else (
+                    "good" if score < 4.5 else "excellent"
+                )
+            )
+        )
+        modules.append({
+            "module": module,
+            "track": track,
+            "lines": lines_count,
+            "score": score,
+            "severity": severity,
+        })
+
+    scores = [m["score"] for m in modules]
+    avg = round(sum(scores) / len(scores), 2) if scores else None
+    critical = [m for m in modules if m["severity"] == "critical"]
+    poor = [m for m in modules if m["severity"] == "poor"]
+    data = {
+        "audit_path": str(audit_path),
+        "exists": True,
+        "mtime": mtime,
+        "count": len(modules),
+        "average": avg,
+        "min_score": min(scores) if scores else None,
+        "max_score": max(scores) if scores else None,
+        "critical": critical,
+        "critical_count": len(critical),
+        "poor_count": len(poor),
+        "modules": modules,
+    }
+    with _QUALITY_AUDIT_CACHE_LOCK:
+        _QUALITY_AUDIT_CACHE[key] = {"mtime": mtime, "data": data}
+    return data
+
+
+# ---- module diagnostics ----
+
+
+def build_module_diagnostics(
+    repo_root: Path,
+    module_key: str,
+    base_state: dict[str, Any],
+) -> list[str]:
+    """Compute a short list of actionable diagnostic tags for a module.
+
+    These are cheap signals that let an agent skip a discovery round:
+    if the module already has ``i18n_parity_fail`` set, there's no
+    need to re-check what's broken.
+    """
+    tags: list[str] = []
+    if not base_state.get("english_exists"):
+        tags.append("english_missing")
+        return tags  # Without EN content the rest is moot.
+
+    frontmatter = base_state.get("frontmatter") or {}
+    if not isinstance(frontmatter, dict) or not frontmatter:
+        tags.append("frontmatter_missing")
+    else:
+        if not frontmatter.get("title"):
+            tags.append("frontmatter_no_title")
+
+    lab = base_state.get("lab") or {}
+    if not lab.get("lab_id"):
+        tags.append("no_lab")
+
+    fact = base_state.get("fact_ledger") or {}
+    if not fact.get("exists"):
+        tags.append("no_fact_ledger")
+
+    if not base_state.get("ukrainian_exists"):
+        tags.append("uk_translation_missing")
+    else:
+        uk_state = base_state.get("ukrainian_state") or {}
+        # ``detect_module_state`` returns dict-like structures; flag any
+        # non-happy state so agents can drill in. ``synced`` is the
+        # happy path in translation_v2.
+        if isinstance(uk_state, dict):
+            status = uk_state.get("status") or uk_state.get("state")
+            happy = {"ok", "current", "fresh", "synced"}
+            if status and status not in happy:
+                tags.append(f"uk_state:{status}")
+
+    # Rubric severity from docs/quality-audit-results.md.
+    try:
+        quality = build_quality_scores(repo_root)
+    except Exception:  # noqa: BLE001
+        quality = {"modules": []}
+    # Match by suffix of module_key against the "module" label (the
+    # audit file uses human-readable names). Best-effort.
+    last_segment = module_key.split("/")[-1].lower()
+    for entry in quality.get("modules", []):
+        name = str(entry.get("module", "")).lower()
+        if last_segment in name or name.endswith(last_segment):
+            sev = entry.get("severity")
+            if sev in ("critical", "poor"):
+                tags.append(f"rubric_{sev}")
+            break
+
+    return tags
 
 
 def build_issue_watch_state(repo_root: Path, issue_number: int) -> dict[str, Any] | None:
@@ -2142,6 +2711,35 @@ def build_session_briefing(repo_root: Path) -> dict[str, Any]:
     if isinstance(pipeline, dict) and "error" in pipeline:
         alerts.append(f"pipeline v2 status unavailable: {pipeline['error']}")
 
+    # Phase C: surface stuck pipeline jobs and critical rubric scores so
+    # agents see high-signal issues without polling additional endpoints.
+    try:
+        stuck = build_pipeline_stuck(repo_root)
+    except Exception:  # noqa: BLE001
+        stuck = None
+    if isinstance(stuck, dict) and stuck.get("exists"):
+        leased = stuck.get("stuck_leased_count", 0)
+        in_state = stuck.get("stuck_in_state_count", 0)
+        if leased:
+            alerts.append(f"{leased} job(s) with expired/stale lease — worker may have crashed")
+        if in_state:
+            alerts.append(f"{in_state} job(s) stuck in-flight with no recent event")
+
+    try:
+        quality = build_quality_scores(repo_root)
+    except Exception:  # noqa: BLE001
+        quality = None
+    critical_quality: list[str] = []
+    if isinstance(quality, dict) and quality.get("exists"):
+        if quality.get("critical_count"):
+            alerts.append(
+                f"{quality['critical_count']} module(s) at critical rubric score (<2.0)"
+            )
+        critical_quality = [
+            f"{m['module']} [{m['track']}] score {m['score']}"
+            for m in (quality.get("critical") or [])[:5]
+        ]
+
     return {
         "snapshot": {
             "generated_at": time.time(),
@@ -2175,6 +2773,7 @@ def build_session_briefing(repo_root: Path) -> dict[str, Any]:
         "focus": status_md.get("focus", []),
         "blockers": status_md.get("blockers", []),
         "alerts": alerts,
+        "critical_quality": critical_quality,
         "next_reads": [
             {"rel": "schema", "endpoint": "/api/schema", "desc": "Full endpoint index"},
             {"rel": "status", "endpoint": "/api/status/summary", "desc": "Full repo status"},
@@ -2273,8 +2872,31 @@ def build_api_schema() -> dict[str, Any]:
             {"path": "/api/git/worktree", "desc": "Dirty entries in the PRIMARY repo only"},
             {"path": "/api/git/worktrees", "desc": "All attached worktrees (plural)"},
             {"path": "/api/issue-watch/{n}", "desc": "Single watched GH issue state"},
-            {"path": "/api/module/{key}/state", "desc": "Per-module EN+UK+lab+frontmatter"},
+            {"path": "/api/module/{key}/state", "desc": "Per-module EN+UK+lab+frontmatter+diagnostics"},
             {"path": "/api/module/{key}/orchestration/latest", "desc": "Per-module latest pipeline job+event"},
+            {"path": "/api/module/{key}/lease", "desc": "Current pipeline lease for one module"},
+            {"path": "/api/pipeline/leases", "desc": "Active pipeline leases (ordered by expiry)"},
+            {
+                "path": "/api/pipeline/v2/events",
+                "desc": "Pipeline v2 event timeline",
+                "query": ["module=...", "since_ms=...", "limit=... (max 2000)"],
+            },
+            {
+                "path": "/api/pipeline/v2/stuck",
+                "desc": "Stuck/stalled jobs (expired leases + in-flight-with-stale-events)",
+                "query": ["threshold_seconds=... (default 3600)"],
+            },
+            {
+                "path": "/api/reviews",
+                "desc": "Review audit index (omit query) or single-module log (?module=...)",
+                "query": ["module=..."],
+            },
+            {
+                "path": "/api/bridge/messages",
+                "desc": ".bridge/messages.db tail",
+                "query": ["since=<ISO-8601>", "limit=... (max 500)"],
+            },
+            {"path": "/api/quality/scores", "desc": "Rubric scores from docs/quality-audit-results.md"},
             {"path": "/api/cache/stats", "desc": "Response-cache introspection"},
         ],
     }
@@ -2349,6 +2971,59 @@ def route_request(repo_root: Path, raw_path: str) -> tuple[int, Any, str]:
         return 200, briefing, "application/json; charset=utf-8"
     if path == "/api/cache/stats":
         return 200, _cache_stats(), "application/json; charset=utf-8"
+    if path == "/api/pipeline/leases":
+        return 200, build_pipeline_leases(repo_root), "application/json; charset=utf-8"
+    if path == "/api/pipeline/v2/stuck":
+        try:
+            threshold = int(query.get("threshold_seconds", [str(_DEFAULT_STUCK_THRESHOLD_SECONDS)])[0])
+        except (TypeError, ValueError):
+            threshold = _DEFAULT_STUCK_THRESHOLD_SECONDS
+        threshold = max(60, min(threshold, 24 * 3600))
+        return 200, build_pipeline_stuck(repo_root, threshold_seconds=threshold), "application/json; charset=utf-8"
+    if path == "/api/pipeline/v2/events":
+        mk = query.get("module", [None])[0]
+        module_key: str | None = None
+        if mk:
+            module_key = _validate_module_key(repo_root, mk)
+            if module_key is None:
+                return 400, {"error": "invalid_module_key"}, "application/json; charset=utf-8"
+        try:
+            since_ms = int(query.get("since_ms", ["0"])[0]) or None
+        except (TypeError, ValueError):
+            since_ms = None
+        try:
+            limit = int(query.get("limit", ["200"])[0])
+        except (TypeError, ValueError):
+            limit = 200
+        return 200, build_pipeline_events(repo_root, module_key, since_ms, limit), "application/json; charset=utf-8"
+    if path == "/api/reviews":
+        mk = query.get("module", [None])[0]
+        if mk:
+            module_key = _validate_module_key(repo_root, mk)
+            if module_key is None:
+                return 400, {"error": "invalid_module_key"}, "application/json; charset=utf-8"
+            payload = build_module_reviews(repo_root, module_key)
+            if payload is None:
+                return 404, {"error": "review_not_found", "module_key": module_key}, "application/json; charset=utf-8"
+            return 200, payload, "application/json; charset=utf-8"
+        return 200, build_reviews_index(repo_root), "application/json; charset=utf-8"
+    if path == "/api/bridge/messages":
+        since = query.get("since", [None])[0]
+        try:
+            limit = int(query.get("limit", ["100"])[0])
+        except (TypeError, ValueError):
+            limit = 100
+        return 200, build_bridge_messages(repo_root, since, limit), "application/json; charset=utf-8"
+    if path == "/api/quality/scores":
+        return 200, build_quality_scores(repo_root), "application/json; charset=utf-8"
+    if path.startswith("/api/module/") and path.endswith("/lease"):
+        raw_key = unquote(path[len("/api/module/") : -len("/lease")]).strip("/")
+        if not raw_key:
+            return 400, {"error": "missing_module_key"}, "application/json; charset=utf-8"
+        module_key = _validate_module_key(repo_root, raw_key)
+        if module_key is None:
+            return 400, {"error": "invalid_module_key"}, "application/json; charset=utf-8"
+        return 200, build_module_lease(repo_root, module_key), "application/json; charset=utf-8"
     if path.startswith("/api/issue-watch/"):
         try:
             issue_number = int(path.split("/")[-1])

--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -1119,17 +1119,22 @@ def build_module_reviews(
 def _resolve_bridge_db_path(repo_root: Path) -> Path:
     """Locate ``messages.db`` the same way the bridge CLI does.
 
-    Precedence: explicit ``$AB_DB_PATH`` → ``.bridge/messages.db``
-    (scripts/ab sets this as the repo convention) → the upstream
-    Python default at ``.mcp/servers/message-broker/messages.db``.
-    First existing file wins. If none exist, the first candidate is
-    returned so the caller can surface ``exists=False``.
+    Precedence:
+      1. ``$AB_DB_PATH`` — unconditional. An explicit override must
+         win even if the file doesn't yet exist; the caller surfaces
+         ``exists=False`` when that happens. (Codex round-2 caught that
+         previously we only honored AB_DB_PATH when the file already
+         existed — quietly reading the wrong DB on a fresh override.)
+      2. ``.bridge/messages.db`` — set by the ``scripts/ab`` wrapper
+         and by the repo setup guide; the repo convention.
+      3. ``.mcp/servers/message-broker/messages.db`` — the upstream
+         Python default when no wrapper is used.
+    Within 2 and 3, the first existing file wins; if neither exists,
+    the convention path (2) is returned.
     """
     explicit = os.environ.get("AB_DB_PATH")
     if explicit:
-        p = Path(explicit)
-        if p.exists():
-            return p
+        return Path(explicit)
     candidates = [
         repo_root / ".bridge" / "messages.db",
         repo_root / ".mcp" / "servers" / "message-broker" / "messages.db",
@@ -1137,7 +1142,6 @@ def _resolve_bridge_db_path(repo_root: Path) -> Path:
     for p in candidates:
         if p.exists():
             return p
-    # None exist. Surface the conventional path for the error message.
     return candidates[0]
 
 
@@ -1366,23 +1370,54 @@ def build_module_diagnostics(
 
 
 _MODULE_NUMBER_RE = re.compile(r"module-([0-9]+(?:\.[0-9]+)*)")
+# Used to strip ``module-X.Y-`` prefix from a slug to get a readable
+# name token set.
+_MODULE_NUMBER_PREFIX_RE = re.compile(r"^module-[0-9]+(?:\.[0-9]+)*-")
+_PART_PREFIX_RE = re.compile(r"^part[0-9]+-?")
 
-# Track slugs → strings likely to appear (case-insensitive) in the audit
-# doc's track column. Kept narrow so we don't false-match (e.g. "cka"
-# matching "kcna" substrings).
+# Track slugs → strings likely to appear (case-insensitive) in the
+# audit doc's track column. Kept narrow so we don't false-match
+# (e.g. "cka" matching "kcna" substrings).
 _TRACK_ALIASES: dict[str, tuple[str, ...]] = {
     "cka": ("cka",),
     "ckad": ("ckad",),
     "cks": ("cks",),
     "kcna": ("kcna",),
     "kcsa": ("kcsa",),
-    "prerequisites": ("prerequisites", "k8s basics", "cloud native 101", "modern devops", "zero to terminal"),
+    "prerequisites": (
+        "prerequisites", "k8s basics", "cloud native 101", "modern devops",
+        "zero to terminal", "philosophy", "design",
+    ),
     "linux": ("linux",),
     "cloud": ("cloud",),
-    "platform": ("platform", "toolkit"),
+    "platform": ("platform", "toolkit", "sre", "gitops", "devsecops", "mlops", "aiops"),
     "on-prem": ("on-prem", "on-premises"),
-    "ai-ml-engineering": ("ai/ml", "ai-ml", "ai/ml engineering"),
+    "on-premises": ("on-prem", "on-premises"),
+    "ai-ml-engineering": (
+        "ai/ml", "ai-ml", "ai/ml engineering", "mlops", "genai",
+        "advanced genai", "multimodal", "deep learning", "classical ml",
+    ),
 }
+
+# Tokens that are too generic to contribute to the name-overlap match
+# (e.g. "module", "basics", "intro").
+_NAME_TOKEN_STOPLIST = frozenset({
+    "module", "part", "the", "a", "an", "and", "of", "to", "for", "with",
+    "intro", "introduction", "basics", "overview",
+})
+
+
+def _normalize_name_tokens(text: str) -> set[str]:
+    """Split a string into a lowercase-alphanumeric token set suitable
+    for overlap comparison. Drops pure numbers and stop-words."""
+    tokens = re.split(r"[^a-z0-9]+", text.lower())
+    return {
+        tok
+        for tok in tokens
+        if tok
+        and not tok.isdigit()
+        and tok not in _NAME_TOKEN_STOPLIST
+    }
 
 
 def _rubric_severity_for_module(
@@ -1390,18 +1425,33 @@ def _rubric_severity_for_module(
 ) -> str | None:
     """Best-effort match from a module path to an audit-doc entry.
 
-    We extract (track, number) from the path — e.g. ``k8s/cka/part2/
-    module-2.8-scheduler-lifecycle-theory`` → ``("cka", "2.8")`` — and
-    look for an audit row whose ``track`` matches one of the aliases
-    and whose ``module`` label contains the number token. Falls back
-    to substring matching on the last segment as a last resort.
+    Matching has three stages, each requiring a STRICT track match
+    when the module path has a recognized track — we never fall back
+    to "any track matches" (that was a round-2 false-positive source).
+
+    1. Numbered match. Extract ``(track, number)`` from the path.
+       Require the audit ``track`` column to match a track alias
+       AND the audit ``module`` label to contain the number with
+       word boundaries (so "2.8" doesn't match "12.8"). Accepts
+       labels like "CKA 2.8: ...", "... 2.8 - ...", "... 2.8) ...".
+
+    2. Name-overlap match. For audit rows that have no module
+       number (e.g. ``Platform: Systems Thinking``), compute the
+       overlap between the module path's name tokens and the
+       label's tokens. Require ≥ 2 shared tokens plus a track-
+       alias match. This covers the non-numbered rubric entries
+       that round-2 flagged.
+
+    3. Return None. Unknown track → no match, to avoid the
+       "any row wins" false positive.
     """
     segments = module_key.split("/")
-    last = segments[-1]
-    match = _MODULE_NUMBER_RE.search(last)
-    number = match.group(1) if match else None
-    # Best guess at track = first segment that has an alias, or the
-    # second-to-last when the path has a ``part<X>`` container.
+    last_raw = segments[-1]
+    last = last_raw.lower()
+    num_match = _MODULE_NUMBER_RE.search(last)
+    number = num_match.group(1) if num_match else None
+
+    # Detect the track from the path.
     track_slug = None
     for seg in segments:
         key = seg.lower()
@@ -1410,33 +1460,58 @@ def _rubric_severity_for_module(
             break
     aliases = _TRACK_ALIASES.get(track_slug, ()) if track_slug else ()
 
+    if not aliases:
+        # Without a recognized track, matching is too risky
+        # (round-2 caught "any row wins" false positives).
+        return None
+
     def _row_track_matches(row_track: str) -> bool:
         rt = row_track.lower()
-        return any(alias in rt for alias in aliases) if aliases else True
+        return any(alias in rt for alias in aliases)
 
+    # ----- stage 1: numbered match -----
     if number:
-        # Accept "2.8:" or " 2.8 " or end-of-string; reject partial
-        # matches like "12.8" when looking for "2.8".
-        needle_patterns = (
-            f" {number}:",
-            f" {number} ",
-            f" {number}.",
+        # Numbers in audit labels usually appear flanked by space or
+        # punctuation. Match a word boundary on both sides of the
+        # number so "2.8" can't match "12.8" or "2.80".
+        number_re = re.compile(
+            r"(?:^|[\s\(])" + re.escape(number) + r"(?=[\s:\-\)—.,])"
         )
         for entry in audit_modules:
             label = str(entry.get("module", ""))
-            # Quick check: number appears flanked by space/colon.
-            if not any(p in label for p in needle_patterns) and not label.endswith(f" {number}"):
+            if not number_re.search(label):
                 continue
             if _row_track_matches(str(entry.get("track", ""))):
                 return entry.get("severity")
 
-    # Last-resort substring on the raw slug.
-    slug = last.lower().replace("module-", "").replace("-", " ")
+    # ----- stage 2: name-overlap match -----
+    # Build the path slug's tokens by stripping the module-number
+    # prefix and any "partN" container, then splitting on dashes.
+    name_slug = _MODULE_NUMBER_PREFIX_RE.sub("", last)
+    path_tokens = _normalize_name_tokens(name_slug)
+    # Also fold in the parent segment (excluding "part<N>" wrappers)
+    # so "foundations" from ``platform/foundations/...`` is considered.
+    for seg in segments[:-1]:
+        if _PART_PREFIX_RE.match(seg):
+            continue
+        path_tokens |= _normalize_name_tokens(seg)
+    # NOTE: we keep track-name tokens in the path set on purpose. The
+    # audit label often includes the track name too ("Prerequisites:
+    # GitOps", "Platform: Systems Thinking"), so that overlap is a
+    # legitimate signal alongside the ``_row_track_matches`` filter.
+    if not path_tokens:
+        return None
+
+    best: tuple[int, str | None] = (0, None)
     for entry in audit_modules:
-        label = str(entry.get("module", "")).lower()
-        if slug and slug in label:
-            return entry.get("severity")
-    return None
+        label = str(entry.get("module", ""))
+        if not _row_track_matches(str(entry.get("track", ""))):
+            continue
+        label_tokens = _normalize_name_tokens(label)
+        overlap = len(path_tokens & label_tokens)
+        if overlap >= 2 and overlap > best[0]:
+            best = (overlap, entry.get("severity"))
+    return best[1]
 
 
 def build_issue_watch_state(repo_root: Path, issue_number: int) -> dict[str, Any] | None:

--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -793,18 +793,23 @@ def _query_sqlite_rows(
         conn.close()
 
 
-def build_pipeline_leases(repo_root: Path, *, now_ms: int | None = None) -> dict[str, Any]:
+# Timestamps in .pipeline/v2.db are Unix epoch SECONDS (SQLite's
+# strftime('%s','now') — see scripts/pipeline_v2/control_plane.py). All
+# comparisons here must use the same unit.
+
+
+def build_pipeline_leases(repo_root: Path, *, now_seconds: int | None = None) -> dict[str, Any]:
     """Active pipeline leases (from ``jobs`` table).
 
     A lease is active when ``leased_by`` is set and ``lease_expires_at``
-    is in the future. The payload is ordered by expiry so the most-at-
-    risk leases are first.
+    is in the future. Payload ordered by expiry so the most-at-risk
+    leases are first.
     """
     db_path = repo_root / ".pipeline" / "v2.db"
     if not db_path.exists():
         return {"db_path": str(db_path), "active": [], "count": 0, "exists": False}
 
-    now_ms = now_ms if now_ms is not None else int(time.time() * 1000)
+    now_seconds = now_seconds if now_seconds is not None else int(time.time())
     rows = _query_sqlite_rows(
         db_path,
         """
@@ -816,23 +821,23 @@ def build_pipeline_leases(repo_root: Path, *, now_ms: int | None = None) -> dict
           AND lease_expires_at > ?
         ORDER BY lease_expires_at ASC
         """,
-        (now_ms,),
+        (now_seconds,),
     )
     for row in rows:
         exp = row.get("lease_expires_at")
         if isinstance(exp, (int, float)):
-            row["seconds_to_expiry"] = max(0, int((int(exp) - now_ms) / 1000))
+            row["seconds_to_expiry"] = max(0, int(exp) - now_seconds)
     return {
         "db_path": str(db_path),
         "exists": True,
         "count": len(rows),
         "active": rows,
-        "queried_at_ms": now_ms,
+        "queried_at_seconds": now_seconds,
     }
 
 
 def build_module_lease(
-    repo_root: Path, module_key: str, *, now_ms: int | None = None
+    repo_root: Path, module_key: str, *, now_seconds: int | None = None
 ) -> dict[str, Any]:
     """Lease state for one module. Returns ``{held: False}`` when no
     active lease exists (vs 404 semantics, which would be ambiguous
@@ -845,7 +850,7 @@ def build_module_lease(
             "reason": "missing_db",
             "db_path": str(db_path),
         }
-    now_ms = now_ms if now_ms is not None else int(time.time() * 1000)
+    now_seconds = now_seconds if now_seconds is not None else int(time.time())
     rows = _query_sqlite_rows(
         db_path,
         """
@@ -859,14 +864,14 @@ def build_module_lease(
         ORDER BY lease_expires_at DESC
         LIMIT 1
         """,
-        (module_key, now_ms),
+        (module_key, now_seconds),
     )
     if not rows:
         return {"module_key": module_key, "held": False}
     row = rows[0]
     exp = row.get("lease_expires_at")
     if isinstance(exp, (int, float)):
-        row["seconds_to_expiry"] = max(0, int((int(exp) - now_ms) / 1000))
+        row["seconds_to_expiry"] = max(0, int(exp) - now_seconds)
     return {"module_key": module_key, "held": True, "lease": row}
 
 
@@ -876,14 +881,14 @@ def build_module_lease(
 def build_pipeline_events(
     repo_root: Path,
     module_key: str | None,
-    since_ms: int | None,
+    since_seconds: int | None,
     limit: int = 200,
 ) -> dict[str, Any]:
     """Timeline view of ``.pipeline/v2.db`` events.
 
-    Filter by ``module_key`` (optional) and ``since_ms`` (optional,
-    inclusive). Newest-first, capped by ``limit`` (default 200, max
-    2000 to keep responses bounded).
+    Filter by ``module_key`` (optional) and ``since_seconds`` (optional,
+    inclusive Unix-epoch seconds to match the control-plane's time
+    unit). Newest-first, capped by ``limit`` (default 200, max 2000).
     """
     db_path = repo_root / ".pipeline" / "v2.db"
     if not db_path.exists():
@@ -894,9 +899,9 @@ def build_pipeline_events(
     if module_key:
         clauses.append("module_key = ?")
         params.append(module_key)
-    if since_ms is not None:
+    if since_seconds is not None:
         clauses.append("at >= ?")
-        params.append(int(since_ms))
+        params.append(int(since_seconds))
     where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
     rows = _query_sqlite_rows(
         db_path,
@@ -917,7 +922,7 @@ def build_pipeline_events(
         "db_path": str(db_path),
         "exists": True,
         "module_key": module_key,
-        "since_ms": since_ms,
+        "since_seconds": since_seconds,
         "limit": capped,
         "count": len(rows),
         "events": rows,
@@ -935,24 +940,26 @@ def build_pipeline_stuck(
     repo_root: Path,
     *,
     threshold_seconds: int = _DEFAULT_STUCK_THRESHOLD_SECONDS,
-    now_ms: int | None = None,
+    now_seconds: int | None = None,
 ) -> dict[str, Any]:
     """Dead-letter view — jobs stuck at a phase longer than ``threshold_seconds``.
 
     Two signals are surfaced:
 
     - ``stuck_leased``: jobs whose lease has expired OR whose
-      ``leased_at`` is older than the threshold. Implies a crashed
-      worker or a hung builder.
-    - ``stuck_in_state``: jobs in an in-flight queue_state with no
-      recent event (``MAX(events.at)`` older than threshold).
+      ``leased_at`` is older than the threshold.
+    - ``stuck_in_state``: jobs in an in-flight ``queue_state`` with no
+      recent event *for the current attempt*. Events are correlated
+      to the job's current ``lease_id`` — a recent event from an
+      earlier lease for the same module must not mask a hung current
+      lease.
     """
     db_path = repo_root / ".pipeline" / "v2.db"
     if not db_path.exists():
         return {"db_path": str(db_path), "exists": False, "stuck_leased": [], "stuck_in_state": []}
 
-    now_ms = now_ms if now_ms is not None else int(time.time() * 1000)
-    threshold_ms = threshold_seconds * 1000
+    now_seconds = now_seconds if now_seconds is not None else int(time.time())
+    cutoff = now_seconds - threshold_seconds
 
     stuck_leased = _query_sqlite_rows(
         db_path,
@@ -968,16 +975,21 @@ def build_pipeline_stuck(
         ORDER BY leased_at ASC
         LIMIT 500
         """,
-        (now_ms, now_ms - threshold_ms),
+        (now_seconds, cutoff),
     )
 
+    # Correlate events by lease_id (and fall back to module_key for
+    # jobs without a lease_id) so a fresh event from a previous
+    # attempt can't mask a hung current attempt.
     stuck_in_state = _query_sqlite_rows(
         db_path,
         f"""
         SELECT j.module_key, j.phase, j.queue_state, j.leased_by,
-               j.leased_at, (
+               j.lease_id, j.leased_at,
+               (
                    SELECT MAX(at) FROM events e
-                   WHERE e.module_key = j.module_key
+                   WHERE (j.lease_id IS NOT NULL AND e.lease_id = j.lease_id)
+                      OR (j.lease_id IS NULL AND e.module_key = j.module_key)
                ) AS last_event_at
         FROM jobs j
         WHERE j.queue_state IN ({','.join('?' for _ in _STUCK_IN_FLIGHT_STATES)})
@@ -986,17 +998,19 @@ def build_pipeline_stuck(
         """,
         tuple(_STUCK_IN_FLIGHT_STATES),
     )
-    # Keep only those whose last event is older than the threshold.
+    # Keep only those whose last event for the current attempt is
+    # older than the threshold (NULL/0 counts as stuck — a running
+    # job that has emitted zero events is stuck by definition).
     stuck_in_state = [
         row for row in stuck_in_state
-        if (row.get("last_event_at") or 0) < (now_ms - threshold_ms)
+        if (row.get("last_event_at") or 0) < cutoff
     ]
 
     return {
         "db_path": str(db_path),
         "exists": True,
         "threshold_seconds": threshold_seconds,
-        "queried_at_ms": now_ms,
+        "queried_at_seconds": now_seconds,
         "stuck_leased_count": len(stuck_leased),
         "stuck_leased": stuck_leased,
         "stuck_in_state_count": len(stuck_in_state),
@@ -1070,6 +1084,12 @@ def build_module_reviews(
     if not path.is_file():
         return None
     try:
+        stat = path.stat()
+        on_disk_size = stat.st_size
+        mtime = stat.st_mtime
+    except OSError:
+        on_disk_size, mtime = 0, 0.0
+    try:
         raw = path.read_bytes()
     except OSError:
         return None
@@ -1081,15 +1101,13 @@ def build_module_reviews(
         body = raw.decode("utf-8", errors="replace")
     except UnicodeDecodeError:
         body = raw.decode("latin-1", errors="replace")
-    try:
-        mtime = path.stat().st_mtime
-    except OSError:
-        mtime = 0.0
     return {
         "module_key": module_key,
         "path": str(path),
-        "size": len(raw) if not truncated else max_bytes,
+        "size": on_disk_size,
+        "body_size": len(body.encode("utf-8")),
         "truncated": truncated,
+        "max_bytes": max_bytes if truncated else None,
         "mtime": mtime,
         "body": body,
     }
@@ -1098,19 +1116,43 @@ def build_module_reviews(
 # ---- bridge messages ----
 
 
+def _resolve_bridge_db_path(repo_root: Path) -> Path:
+    """Locate ``messages.db`` the same way the bridge CLI does.
+
+    Precedence: explicit ``$AB_DB_PATH`` → ``.bridge/messages.db``
+    (scripts/ab sets this as the repo convention) → the upstream
+    Python default at ``.mcp/servers/message-broker/messages.db``.
+    First existing file wins. If none exist, the first candidate is
+    returned so the caller can surface ``exists=False``.
+    """
+    explicit = os.environ.get("AB_DB_PATH")
+    if explicit:
+        p = Path(explicit)
+        if p.exists():
+            return p
+    candidates = [
+        repo_root / ".bridge" / "messages.db",
+        repo_root / ".mcp" / "servers" / "message-broker" / "messages.db",
+    ]
+    for p in candidates:
+        if p.exists():
+            return p
+    # None exist. Surface the conventional path for the error message.
+    return candidates[0]
+
+
 def build_bridge_messages(
     repo_root: Path,
     since: str | None = None,
     limit: int = 100,
 ) -> dict[str, Any]:
-    """Recent agent-bridge messages from ``.bridge/messages.db``.
+    """Recent agent-bridge messages from the bridge DB.
 
     Filter ``since`` is an ISO-8601 timestamp (string comparison is
-    safe here because ``timestamp`` is stored as ISO-8601 UTC by the
-    bridge). ``limit`` caps at 500 rows to keep the payload bounded
-    for agents that just want a recent window.
+    safe — the bridge stores ISO-8601 UTC). ``limit`` caps at 500 rows
+    so a single call can't overwhelm a polling agent.
     """
-    db_path = repo_root / ".bridge" / "messages.db"
+    db_path = _resolve_bridge_db_path(repo_root)
     if not db_path.exists():
         return {"db_path": str(db_path), "exists": False, "count": 0, "messages": []}
     capped = max(1, min(int(limit), 500))
@@ -1311,18 +1353,90 @@ def build_module_diagnostics(
         quality = build_quality_scores(repo_root)
     except Exception:  # noqa: BLE001
         quality = {"modules": []}
-    # Match by suffix of module_key against the "module" label (the
-    # audit file uses human-readable names). Best-effort.
-    last_segment = module_key.split("/")[-1].lower()
-    for entry in quality.get("modules", []):
-        name = str(entry.get("module", "")).lower()
-        if last_segment in name or name.endswith(last_segment):
-            sev = entry.get("severity")
-            if sev in ("critical", "poor"):
-                tags.append(f"rubric_{sev}")
-            break
+    # Map module path (e.g. "k8s/cka/part2-workloads-scheduling/
+    # module-2.8-scheduler-lifecycle-theory") to audit labels like
+    # "CKA 2.8: Scheduler Lifecycle Theory" using (track, number)
+    # extracted from the path. Substring matching alone fails because
+    # the audit uses human-readable names, not slugs.
+    sev = _rubric_severity_for_module(module_key, quality.get("modules", []))
+    if sev in ("critical", "poor"):
+        tags.append(f"rubric_{sev}")
 
     return tags
+
+
+_MODULE_NUMBER_RE = re.compile(r"module-([0-9]+(?:\.[0-9]+)*)")
+
+# Track slugs → strings likely to appear (case-insensitive) in the audit
+# doc's track column. Kept narrow so we don't false-match (e.g. "cka"
+# matching "kcna" substrings).
+_TRACK_ALIASES: dict[str, tuple[str, ...]] = {
+    "cka": ("cka",),
+    "ckad": ("ckad",),
+    "cks": ("cks",),
+    "kcna": ("kcna",),
+    "kcsa": ("kcsa",),
+    "prerequisites": ("prerequisites", "k8s basics", "cloud native 101", "modern devops", "zero to terminal"),
+    "linux": ("linux",),
+    "cloud": ("cloud",),
+    "platform": ("platform", "toolkit"),
+    "on-prem": ("on-prem", "on-premises"),
+    "ai-ml-engineering": ("ai/ml", "ai-ml", "ai/ml engineering"),
+}
+
+
+def _rubric_severity_for_module(
+    module_key: str, audit_modules: list[dict[str, Any]]
+) -> str | None:
+    """Best-effort match from a module path to an audit-doc entry.
+
+    We extract (track, number) from the path — e.g. ``k8s/cka/part2/
+    module-2.8-scheduler-lifecycle-theory`` → ``("cka", "2.8")`` — and
+    look for an audit row whose ``track`` matches one of the aliases
+    and whose ``module`` label contains the number token. Falls back
+    to substring matching on the last segment as a last resort.
+    """
+    segments = module_key.split("/")
+    last = segments[-1]
+    match = _MODULE_NUMBER_RE.search(last)
+    number = match.group(1) if match else None
+    # Best guess at track = first segment that has an alias, or the
+    # second-to-last when the path has a ``part<X>`` container.
+    track_slug = None
+    for seg in segments:
+        key = seg.lower()
+        if key in _TRACK_ALIASES:
+            track_slug = key
+            break
+    aliases = _TRACK_ALIASES.get(track_slug, ()) if track_slug else ()
+
+    def _row_track_matches(row_track: str) -> bool:
+        rt = row_track.lower()
+        return any(alias in rt for alias in aliases) if aliases else True
+
+    if number:
+        # Accept "2.8:" or " 2.8 " or end-of-string; reject partial
+        # matches like "12.8" when looking for "2.8".
+        needle_patterns = (
+            f" {number}:",
+            f" {number} ",
+            f" {number}.",
+        )
+        for entry in audit_modules:
+            label = str(entry.get("module", ""))
+            # Quick check: number appears flanked by space/colon.
+            if not any(p in label for p in needle_patterns) and not label.endswith(f" {number}"):
+                continue
+            if _row_track_matches(str(entry.get("track", ""))):
+                return entry.get("severity")
+
+    # Last-resort substring on the raw slug.
+    slug = last.lower().replace("module-", "").replace("-", " ")
+    for entry in audit_modules:
+        label = str(entry.get("module", "")).lower()
+        if slug and slug in label:
+            return entry.get("severity")
+    return None
 
 
 def build_issue_watch_state(repo_root: Path, issue_number: int) -> dict[str, Any] | None:
@@ -2879,7 +2993,11 @@ def build_api_schema() -> dict[str, Any]:
             {
                 "path": "/api/pipeline/v2/events",
                 "desc": "Pipeline v2 event timeline",
-                "query": ["module=...", "since_ms=...", "limit=... (max 2000)"],
+                "query": [
+                    "module=...",
+                    "since_seconds=... (Unix epoch seconds; matches v2.db unit)",
+                    "limit=... (max 2000)",
+                ],
             },
             {
                 "path": "/api/pipeline/v2/stuck",
@@ -2988,14 +3106,14 @@ def route_request(repo_root: Path, raw_path: str) -> tuple[int, Any, str]:
             if module_key is None:
                 return 400, {"error": "invalid_module_key"}, "application/json; charset=utf-8"
         try:
-            since_ms = int(query.get("since_ms", ["0"])[0]) or None
+            since_seconds = int(query.get("since_seconds", ["0"])[0]) or None
         except (TypeError, ValueError):
-            since_ms = None
+            since_seconds = None
         try:
             limit = int(query.get("limit", ["200"])[0])
         except (TypeError, ValueError):
             limit = 200
-        return 200, build_pipeline_events(repo_root, module_key, since_ms, limit), "application/json; charset=utf-8"
+        return 200, build_pipeline_events(repo_root, module_key, since_seconds, limit), "application/json; charset=utf-8"
     if path == "/api/reviews":
         mk = query.get("module", [None])[0]
         if mk:

--- a/tests/test_local_api.py
+++ b/tests/test_local_api.py
@@ -1370,6 +1370,87 @@ def test_rubric_diagnostics_matches_non_numbered_entry(tmp_path: Path) -> None:
     assert sev2 == "needs_work"
 
 
+def test_rubric_diagnostics_matches_via_label_prefix(tmp_path: Path) -> None:
+    """Codex round-3 bug: the Track column is often a SUBtrack
+    ('Workloads', 'AWS', 'Foundations'). The top-level track is in
+    the Module label prefix ('CKA:', 'Platform:', 'Prerequisites:').
+    The matcher must consult both."""
+    audit = tmp_path / "docs" / "quality-audit-results.md"
+    audit.parent.mkdir()
+    audit.write_text(
+        """## All Scored Modules\n\n"""
+        """| Module | Track | Lines | Score | Action | Issue |\n"""
+        """|---|---|---|---|---|---|\n"""
+        """| CKA: Autoscaling | Workloads | 450 | **2.2** | Poor | dry |\n""",
+        encoding="utf-8",
+    )
+    with local_api._QUALITY_AUDIT_CACHE_LOCK:
+        local_api._QUALITY_AUDIT_CACHE.clear()
+    quality = local_api.build_quality_scores(tmp_path)
+    sev = local_api._rubric_severity_for_module(
+        "k8s/cka/part2-workloads-scheduling/module-6-autoscaling",
+        quality["modules"],
+    )
+    # Track col is "Workloads" (no CKA alias) but the label prefix
+    # carries "CKA:" — the matcher must see it.
+    assert sev == "poor"
+
+
+def test_rubric_diagnostics_cka_does_not_match_ckad(tmp_path: Path) -> None:
+    """Codex round-3 bug: raw substring ``'cka' in 'CKAD'`` is True,
+    letting a CKAD audit row attach to a CKA module path. Matcher
+    must use word boundaries."""
+    audit = tmp_path / "docs" / "quality-audit-results.md"
+    audit.parent.mkdir()
+    audit.write_text(
+        """## All Scored Modules\n\n"""
+        """| Module | Track | Lines | Score | Action | Issue |\n"""
+        """|---|---|---|---|---|---|\n"""
+        """| CKAD 3.5: API Deprecations | CKAD | 433 | **2.4** | Poor | reference |\n""",
+        encoding="utf-8",
+    )
+    with local_api._QUALITY_AUDIT_CACHE_LOCK:
+        local_api._QUALITY_AUDIT_CACHE.clear()
+    quality = local_api.build_quality_scores(tmp_path)
+    sev = local_api._rubric_severity_for_module(
+        "k8s/cka/part3-services-networking/module-3.5-gateway-api",
+        quality["modules"],
+    )
+    assert sev is None  # CKA module must NOT pick up the CKAD row.
+
+    # And the CKAD path DOES match.
+    sev_ckad = local_api._rubric_severity_for_module(
+        "k8s/ckad/module-3.5-api-deprecations",
+        quality["modules"],
+    )
+    assert sev_ckad == "poor"
+
+
+def test_rubric_diagnostics_track_only_overlap_is_not_a_match(tmp_path: Path) -> None:
+    """Codex round-3 bug: overlap of ``{platform, sre}`` — both track
+    tokens — must NOT match. Matcher requires ≥ 1 NON-track token in
+    the overlap."""
+    audit = tmp_path / "docs" / "quality-audit-results.md"
+    audit.parent.mkdir()
+    audit.write_text(
+        """## All Scored Modules\n\n"""
+        """| Module | Track | Lines | Score | Action | Issue |\n"""
+        """|---|---|---|---|---|---|\n"""
+        """| Platform: Site Reliability Engineering (SRE) | Platform | 400 | **2.2** | Poor | generic |\n""",
+        encoding="utf-8",
+    )
+    with local_api._QUALITY_AUDIT_CACHE_LOCK:
+        local_api._QUALITY_AUDIT_CACHE.clear()
+    quality = local_api.build_quality_scores(tmp_path)
+    # A platform module whose name just says "sre basics" shouldn't
+    # inherit the severity from a generic "Platform: ... SRE" row.
+    sev = local_api._rubric_severity_for_module(
+        "platform/foundations/module-1-sre-basics",
+        quality["modules"],
+    )
+    assert sev is None
+
+
 def test_rubric_diagnostics_unrecognized_track_never_matches(tmp_path: Path) -> None:
     """Codex round-2 bug: when the path's track wasn't in the alias
     table, matching silently became permissive and could attach a

--- a/tests/test_local_api.py
+++ b/tests/test_local_api.py
@@ -1164,32 +1164,45 @@ def test_reviews_index_and_single(tmp_path: Path) -> None:
 
 
 def test_resolve_bridge_db_path_precedence(tmp_path: Path, monkeypatch) -> None:
-    """Codex round-4 bug: we hardcoded .bridge/messages.db but the
+    """Codex round-1 bug: we hardcoded .bridge/messages.db but the
     Python bridge default is .mcp/servers/message-broker/messages.db.
     Resolution must honor $AB_DB_PATH first, then fall through."""
     repo = tmp_path
-    # No files, no env → convention path.
     monkeypatch.delenv("AB_DB_PATH", raising=False)
     p = local_api._resolve_bridge_db_path(repo)
     assert p == repo / ".bridge" / "messages.db"
 
-    # .mcp path exists → picked over the convention when .bridge is absent.
     mcp_path = repo / ".mcp" / "servers" / "message-broker" / "messages.db"
     mcp_path.parent.mkdir(parents=True)
     mcp_path.write_bytes(b"")
     assert local_api._resolve_bridge_db_path(repo) == mcp_path
 
-    # .bridge path wins over .mcp when both exist (repo convention).
     bridge_path = repo / ".bridge" / "messages.db"
     bridge_path.parent.mkdir(parents=True)
     bridge_path.write_bytes(b"")
     assert local_api._resolve_bridge_db_path(repo) == bridge_path
 
-    # Explicit env var wins over both.
     override = tmp_path / "custom.db"
     override.write_bytes(b"")
     monkeypatch.setenv("AB_DB_PATH", str(override))
     assert local_api._resolve_bridge_db_path(repo) == override
+
+
+def test_resolve_bridge_db_path_honors_nonexistent_override(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Codex round-2 bug: $AB_DB_PATH must win even when the override
+    file doesn't yet exist. Previously we only used it when present,
+    silently reading the wrong DB on a fresh override."""
+    repo = tmp_path
+    bridge_path = repo / ".bridge" / "messages.db"
+    bridge_path.parent.mkdir(parents=True)
+    bridge_path.write_bytes(b"")
+    not_yet_created = tmp_path / "future.db"
+    monkeypatch.setenv("AB_DB_PATH", str(not_yet_created))
+    resolved = local_api._resolve_bridge_db_path(repo)
+    assert resolved == not_yet_created
+    assert not resolved.exists()
 
 
 def test_bridge_messages_filters_and_previews(tmp_path: Path, monkeypatch) -> None:
@@ -1315,6 +1328,71 @@ def test_rubric_diagnostics_matches_by_track_and_number(tmp_path: Path) -> None:
         tmp_path, "k8s/cka/part2-workloads-scheduling/module-2.8-scheduler-lifecycle-theory"
     )
     assert "rubric_critical" in state["diagnostics"]
+
+
+def test_rubric_diagnostics_matches_non_numbered_entry(tmp_path: Path) -> None:
+    """Codex round-2 bug: audit entries like 'Platform: Systems Thinking'
+    (no module number) were never matched. Now resolved via name-token
+    overlap when ≥2 tokens are shared AND the track alias matches."""
+    audit = tmp_path / "docs" / "quality-audit-results.md"
+    audit.parent.mkdir()
+    audit.write_text(
+        """## All Scored Modules\n\n"""
+        """| Module | Track | Lines | Score | Action | Issue |\n"""
+        """|---|---|---|---|---|---|\n"""
+        """| Platform: Systems Thinking | Platform Foundations | 820 | **4.6** | Excellent | gold |\n"""
+        """| Prerequisites: GitOps | Modern DevOps | 543 | **2.9** | Medium | overloaded |\n""",
+        encoding="utf-8",
+    )
+    with local_api._QUALITY_AUDIT_CACHE_LOCK:
+        local_api._QUALITY_AUDIT_CACHE.clear()
+
+    _init_repo(tmp_path)
+    en = tmp_path / "src/content/docs/platform/foundations/module-1-systems-thinking.md"
+    _write(en, "---\ntitle: Systems Thinking\n---\nbody\n")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-m", "init")
+    # Severity is "excellent" so no rubric_* tag is expected. But the
+    # match must have happened; verify by directly probing the helper.
+    quality = local_api.build_quality_scores(tmp_path)
+    sev = local_api._rubric_severity_for_module(
+        "platform/foundations/module-1-systems-thinking",
+        quality["modules"],
+    )
+    assert sev == "excellent"
+
+    # Prerequisites: GitOps → "needs_work" (3.5 > 2.9 >= 2.5). Not
+    # critical/poor, so no tag in diagnostics either; probe the helper.
+    sev2 = local_api._rubric_severity_for_module(
+        "prerequisites/modern-devops/module-5-gitops",
+        quality["modules"],
+    )
+    assert sev2 == "needs_work"
+
+
+def test_rubric_diagnostics_unrecognized_track_never_matches(tmp_path: Path) -> None:
+    """Codex round-2 bug: when the path's track wasn't in the alias
+    table, matching silently became permissive and could attach a
+    random rubric row. Now unknown tracks always return None."""
+    audit = tmp_path / "docs" / "quality-audit-results.md"
+    audit.parent.mkdir()
+    audit.write_text(
+        """## All Scored Modules\n\n"""
+        """| Module | Track | Lines | Score | Action | Issue |\n"""
+        """|---|---|---|---|---|---|\n"""
+        """| CKA 2.8: Scheduler Lifecycle Theory | CKA | 55 | **1.3** | Critical | stub |\n""",
+        encoding="utf-8",
+    )
+    with local_api._QUALITY_AUDIT_CACHE_LOCK:
+        local_api._QUALITY_AUDIT_CACHE.clear()
+    quality = local_api.build_quality_scores(tmp_path)
+    # Path track "exotic" is not in _TRACK_ALIASES. Must not match
+    # ANY row, regardless of number overlap.
+    sev = local_api._rubric_severity_for_module(
+        "exotic/module-2.8-scheduler",
+        quality["modules"],
+    )
+    assert sev is None
 
 
 def test_rubric_diagnostics_no_false_match_for_different_track(tmp_path: Path) -> None:

--- a/tests/test_local_api.py
+++ b/tests/test_local_api.py
@@ -976,27 +976,27 @@ def test_background_snapshot_reports_degraded_on_builder_error() -> None:
 
 
 def test_pipeline_leases_lists_active_only(tmp_path: Path) -> None:
+    """Codex round-1 bug: we were using ms; the control-plane stores
+    Unix epoch SECONDS. Everything below is in seconds."""
     module_key, _ = _setup_repo(tmp_path)
-    now_ms = 1_000_000_000_000
+    now_s = 1_700_000_000  # Realistic seconds-since-epoch value.
 
     conn = sqlite3.connect(tmp_path / ".pipeline/v2.db")
-    # Active lease (expiry in future)
     conn.execute(
         "INSERT INTO jobs (module_key, phase, queue_state, leased_by, lease_id, "
         "leased_at, lease_expires_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
-        (module_key, "write", "leased", "codex", "lease-a", now_ms - 1000, now_ms + 60_000),
+        (module_key, "write", "leased", "codex", "lease-a", now_s - 1, now_s + 60),
     )
-    # Expired lease (must be filtered out)
     conn.execute(
         "INSERT INTO jobs (module_key, phase, queue_state, leased_by, lease_id, "
         "leased_at, lease_expires_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
         ("other/module-stale", "write", "leased", "claude", "lease-b",
-         now_ms - 10_000_000, now_ms - 1_000),
+         now_s - 10_000, now_s - 1),
     )
     conn.commit()
     conn.close()
 
-    result = local_api.build_pipeline_leases(tmp_path, now_ms=now_ms)
+    result = local_api.build_pipeline_leases(tmp_path, now_seconds=now_s)
     assert result["exists"] is True
     assert result["count"] == 1
     assert result["active"][0]["lease_id"] == "lease-a"
@@ -1012,21 +1012,19 @@ def test_pipeline_leases_returns_empty_when_db_missing(tmp_path: Path) -> None:
 
 def test_module_lease_reports_held_vs_free(tmp_path: Path) -> None:
     module_key, _ = _setup_repo(tmp_path)
-    now_ms = 1_000_000_000_000
-    # Initially no lease -> held=False.
-    r = local_api.build_module_lease(tmp_path, module_key, now_ms=now_ms)
+    now_s = 1_700_000_000
+    r = local_api.build_module_lease(tmp_path, module_key, now_seconds=now_s)
     assert r["held"] is False
 
     conn = sqlite3.connect(tmp_path / ".pipeline/v2.db")
     conn.execute(
         "INSERT INTO jobs (module_key, phase, queue_state, leased_by, lease_id, "
         "leased_at, lease_expires_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
-        (module_key, "review", "leased", "gemini", "lease-x",
-         now_ms - 10, now_ms + 120_000),
+        (module_key, "review", "leased", "gemini", "lease-x", now_s - 1, now_s + 120),
     )
     conn.commit()
     conn.close()
-    r = local_api.build_module_lease(tmp_path, module_key, now_ms=now_ms)
+    r = local_api.build_module_lease(tmp_path, module_key, now_seconds=now_s)
     assert r["held"] is True
     assert r["lease"]["leased_by"] == "gemini"
     assert r["lease"]["seconds_to_expiry"] == 120
@@ -1047,60 +1045,88 @@ def test_pipeline_events_filters_and_limits(tmp_path: Path) -> None:
     conn.commit()
     conn.close()
 
-    scoped = local_api.build_pipeline_events(tmp_path, module_key=module_key, since_ms=None, limit=3)
+    scoped = local_api.build_pipeline_events(tmp_path, module_key=module_key, since_seconds=None, limit=3)
     assert scoped["count"] == 3
     assert all(e["module_key"] == module_key for e in scoped["events"])
-    # Newest-first -> ids descending
     ids = [e["id"] for e in scoped["events"]]
     assert ids == sorted(ids, reverse=True)
-    # payload_json should be decoded
     assert isinstance(scoped["events"][0]["payload_json"], dict)
 
-    windowed = local_api.build_pipeline_events(tmp_path, module_key=module_key, since_ms=1002, limit=10)
+    windowed = local_api.build_pipeline_events(tmp_path, module_key=module_key, since_seconds=1002, limit=10)
     ats = [e["at"] for e in windowed["events"]]
     assert all(a >= 1002 for a in ats)
 
 
-def test_pipeline_stuck_catches_expired_and_silent_jobs(tmp_path: Path) -> None:
+def test_pipeline_stuck_catches_expired_and_silent_jobs_in_seconds(tmp_path: Path) -> None:
+    """Bug-fix regression: Codex caught the ms-vs-seconds mismatch.
+    Threshold is now honored in seconds against seconds-valued
+    timestamps from the real control-plane."""
     module_key, _ = _setup_repo(tmp_path)
-    now_ms = 10_000_000
+    now_s = 10_000
     conn = sqlite3.connect(tmp_path / ".pipeline/v2.db")
     # Expired lease -> stuck_leased
     conn.execute(
         "INSERT INTO jobs (module_key, phase, queue_state, leased_by, lease_id, "
         "leased_at, lease_expires_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
-        ("stuck/one", "write", "leased", "codex", "lex",
-         now_ms - 1_000_000, now_ms - 1000),
+        ("stuck/one", "write", "leased", "codex", "lex-1",
+         now_s - 1_000, now_s - 10),
     )
-    # In-flight with no recent event -> stuck_in_state
+    # In-flight with no recent event for current attempt -> stuck_in_state
     conn.execute(
-        "INSERT INTO jobs (module_key, phase, queue_state, leased_by, leased_at) "
+        "INSERT INTO jobs (module_key, phase, queue_state, leased_by, lease_id, leased_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        ("stuck/silent", "review", "running", "claude", "lex-silent", now_s - 10_000),
+    )
+    conn.execute(
+        "INSERT INTO events (module_key, type, lease_id, payload_json, at) "
         "VALUES (?, ?, ?, ?, ?)",
-        ("stuck/silent", "review", "running", "claude", now_ms - 10_000_000),
+        ("stuck/silent", "attempt_started", "lex-silent", "{}", now_s - 10_000),
+    )
+    # Fresh in-flight -> not stuck (has recent event for its lease)
+    conn.execute(
+        "INSERT INTO jobs (module_key, phase, queue_state, leased_by, lease_id, leased_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        ("fresh/one", "review", "running", "claude", "lex-fresh", now_s),
     )
     conn.execute(
-        "INSERT INTO events (module_key, type, payload_json, at) VALUES (?, ?, ?, ?)",
-        ("stuck/silent", "attempt_started", "{}", now_ms - 10_000_000),
-    )
-    # Fresh in-flight -> not stuck (has recent event)
-    conn.execute(
-        "INSERT INTO jobs (module_key, phase, queue_state, leased_by, leased_at) "
+        "INSERT INTO events (module_key, type, lease_id, payload_json, at) "
         "VALUES (?, ?, ?, ?, ?)",
-        ("fresh/one", "review", "running", "claude", now_ms),
-    )
-    conn.execute(
-        "INSERT INTO events (module_key, type, payload_json, at) VALUES (?, ?, ?, ?)",
-        ("fresh/one", "attempt_started", "{}", now_ms - 10),
+        ("fresh/one", "attempt_started", "lex-fresh", "{}", now_s - 10),
     )
     conn.commit()
     conn.close()
 
-    r = local_api.build_pipeline_stuck(tmp_path, threshold_seconds=60, now_ms=now_ms)
+    r = local_api.build_pipeline_stuck(tmp_path, threshold_seconds=60, now_seconds=now_s)
     stuck_leased_keys = {j["module_key"] for j in r["stuck_leased"]}
     stuck_in_state_keys = {j["module_key"] for j in r["stuck_in_state"]}
     assert "stuck/one" in stuck_leased_keys
     assert "stuck/silent" in stuck_in_state_keys
     assert "fresh/one" not in stuck_in_state_keys
+
+
+def test_pipeline_stuck_correlates_events_by_lease_id(tmp_path: Path) -> None:
+    """Codex round-4 bug: correlating events by module_key alone let
+    a fresh event from an EARLIER lease mask a hung current lease."""
+    _setup_repo(tmp_path)
+    now_s = 10_000
+    conn = sqlite3.connect(tmp_path / ".pipeline/v2.db")
+    # Current (hung) lease: running, no event for THIS lease_id.
+    conn.execute(
+        "INSERT INTO jobs (module_key, phase, queue_state, leased_by, lease_id, leased_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        ("rolled/over", "write", "running", "claude", "current-lease", now_s - 10_000),
+    )
+    # Old event from a PREVIOUS lease for the same module — should NOT
+    # make the current attempt look healthy.
+    conn.execute(
+        "INSERT INTO events (module_key, type, lease_id, payload_json, at) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("rolled/over", "attempt_started", "previous-lease", "{}", now_s - 1),
+    )
+    conn.commit()
+    conn.close()
+    r = local_api.build_pipeline_stuck(tmp_path, threshold_seconds=60, now_seconds=now_s)
+    assert any(j["module_key"] == "rolled/over" for j in r["stuck_in_state"])
 
 
 def test_reviews_index_and_single(tmp_path: Path) -> None:
@@ -1124,16 +1150,50 @@ def test_reviews_index_and_single(tmp_path: Path) -> None:
     assert "**Writer**: gemini" in single["body"]
     assert single["truncated"] is False
 
-    # Truncation path.
+    # Truncation path. ``size`` is the actual on-disk size (per Codex
+    # round-4 polish: truncated responses must not lie about file
+    # size); ``max_bytes`` carries the cap applied.
     big_content = "x" * 50_000
     (reviews_dir / "big__one.md").write_text(big_content, encoding="utf-8")
     trunc = local_api.build_module_reviews(tmp_path, "big/one", max_bytes=1000)
     assert trunc is not None
     assert trunc["truncated"] is True
-    assert trunc["size"] == 1000
+    assert trunc["size"] == 50_000
+    assert trunc["max_bytes"] == 1000
+    assert trunc["body_size"] == 1000
 
 
-def test_bridge_messages_filters_and_previews(tmp_path: Path) -> None:
+def test_resolve_bridge_db_path_precedence(tmp_path: Path, monkeypatch) -> None:
+    """Codex round-4 bug: we hardcoded .bridge/messages.db but the
+    Python bridge default is .mcp/servers/message-broker/messages.db.
+    Resolution must honor $AB_DB_PATH first, then fall through."""
+    repo = tmp_path
+    # No files, no env → convention path.
+    monkeypatch.delenv("AB_DB_PATH", raising=False)
+    p = local_api._resolve_bridge_db_path(repo)
+    assert p == repo / ".bridge" / "messages.db"
+
+    # .mcp path exists → picked over the convention when .bridge is absent.
+    mcp_path = repo / ".mcp" / "servers" / "message-broker" / "messages.db"
+    mcp_path.parent.mkdir(parents=True)
+    mcp_path.write_bytes(b"")
+    assert local_api._resolve_bridge_db_path(repo) == mcp_path
+
+    # .bridge path wins over .mcp when both exist (repo convention).
+    bridge_path = repo / ".bridge" / "messages.db"
+    bridge_path.parent.mkdir(parents=True)
+    bridge_path.write_bytes(b"")
+    assert local_api._resolve_bridge_db_path(repo) == bridge_path
+
+    # Explicit env var wins over both.
+    override = tmp_path / "custom.db"
+    override.write_bytes(b"")
+    monkeypatch.setenv("AB_DB_PATH", str(override))
+    assert local_api._resolve_bridge_db_path(repo) == override
+
+
+def test_bridge_messages_filters_and_previews(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.delenv("AB_DB_PATH", raising=False)
     db_path = tmp_path / ".bridge" / "messages.db"
     db_path.parent.mkdir(parents=True)
     conn = sqlite3.connect(db_path)
@@ -1224,6 +1284,85 @@ def test_module_state_flags_missing_lab_and_ledger(tmp_path: Path) -> None:
     assert "no_lab" in diag
     assert "no_fact_ledger" in diag
     assert "uk_translation_missing" in diag
+
+
+def test_rubric_diagnostics_matches_by_track_and_number(tmp_path: Path) -> None:
+    """Codex round-4 bug: rubric matching compared raw slugs like
+    'module-2.8-scheduler-lifecycle-theory' to audit labels like
+    'CKA 2.8: Scheduler Lifecycle Theory' and never matched."""
+    audit = tmp_path / "docs" / "quality-audit-results.md"
+    audit.parent.mkdir()
+    audit.write_text(
+        """## All Scored Modules\n\n"""
+        """| Module | Track | Lines | Score | Action | Issue |\n"""
+        """|---|---|---|---|---|---|\n"""
+        """| CKA 2.8: Scheduler Lifecycle Theory | CKA | 55 | **1.3** | Critical | stub |\n""",
+        encoding="utf-8",
+    )
+    with local_api._QUALITY_AUDIT_CACHE_LOCK:
+        local_api._QUALITY_AUDIT_CACHE.clear()
+
+    # Build minimal EN file for the module under its real-world path.
+    en = (
+        tmp_path
+        / "src/content/docs/k8s/cka/part2-workloads-scheduling/module-2.8-scheduler-lifecycle-theory.md"
+    )
+    _init_repo(tmp_path)
+    _write(en, "---\ntitle: Scheduler\n---\nbody\n")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-m", "init")
+    state = local_api.build_module_state(
+        tmp_path, "k8s/cka/part2-workloads-scheduling/module-2.8-scheduler-lifecycle-theory"
+    )
+    assert "rubric_critical" in state["diagnostics"]
+
+
+def test_rubric_diagnostics_no_false_match_for_different_track(tmp_path: Path) -> None:
+    """A module path like k8s/kcna/module-2.8-... must not pick up a
+    'CKA 2.8:' rubric entry (track disambiguation)."""
+    audit = tmp_path / "docs" / "quality-audit-results.md"
+    audit.parent.mkdir()
+    audit.write_text(
+        """## All Scored Modules\n\n"""
+        """| Module | Track | Lines | Score | Action | Issue |\n"""
+        """|---|---|---|---|---|---|\n"""
+        """| CKA 2.8: Scheduler Lifecycle Theory | CKA | 55 | **1.3** | Critical | stub |\n""",
+        encoding="utf-8",
+    )
+    with local_api._QUALITY_AUDIT_CACHE_LOCK:
+        local_api._QUALITY_AUDIT_CACHE.clear()
+
+    en = tmp_path / "src/content/docs/k8s/kcna/module-2.8-something-unrelated.md"
+    _init_repo(tmp_path)
+    _write(en, "---\ntitle: KCNA\n---\nbody\n")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-m", "init")
+    state = local_api.build_module_state(tmp_path, "k8s/kcna/module-2.8-something-unrelated")
+    assert "rubric_critical" not in state["diagnostics"]
+
+
+def test_query_sqlite_rows_propagates_schema_drift(tmp_path: Path) -> None:
+    """Bug-fix regression: 'no such column' must NOT silently return
+    empty — that was how the priority-column bug stayed hidden."""
+    db_path = tmp_path / "schema.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE jobs (id INTEGER, module_key TEXT)")
+    conn.commit()
+    conn.close()
+    import pytest as _pytest
+    with _pytest.raises(sqlite3.OperationalError) as exc_info:
+        local_api._query_sqlite_rows(db_path, "SELECT ghost_column FROM jobs")
+    assert "no such column" in str(exc_info.value)
+
+
+def test_query_sqlite_rows_tolerates_missing_table(tmp_path: Path) -> None:
+    db_path = tmp_path / "missing_table.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE other (id INTEGER)")
+    conn.commit()
+    conn.close()
+    result = local_api._query_sqlite_rows(db_path, "SELECT * FROM does_not_exist")
+    assert result == []
 
 
 def test_schema_lists_phase_c_endpoints() -> None:

--- a/tests/test_local_api.py
+++ b/tests/test_local_api.py
@@ -73,6 +73,7 @@ def _init_v2_db(path: Path, *, module_key: str) -> None:
               module_key TEXT NOT NULL,
               phase TEXT NOT NULL,
               model TEXT,
+              priority INTEGER,
               queue_state TEXT NOT NULL,
               leased_by TEXT,
               lease_id TEXT,
@@ -87,6 +88,7 @@ def _init_v2_db(path: Path, *, module_key: str) -> None:
               id INTEGER PRIMARY KEY,
               module_key TEXT NOT NULL,
               type TEXT NOT NULL,
+              lease_id TEXT,
               payload_json TEXT DEFAULT '{}',
               at INTEGER
             );
@@ -971,6 +973,272 @@ def test_background_snapshot_reports_degraded_on_builder_error() -> None:
     assert data is None
     assert meta["freshness_state"] == "degraded"
     assert "RuntimeError: boom" in (meta["refresh_error"] or "")
+
+
+def test_pipeline_leases_lists_active_only(tmp_path: Path) -> None:
+    module_key, _ = _setup_repo(tmp_path)
+    now_ms = 1_000_000_000_000
+
+    conn = sqlite3.connect(tmp_path / ".pipeline/v2.db")
+    # Active lease (expiry in future)
+    conn.execute(
+        "INSERT INTO jobs (module_key, phase, queue_state, leased_by, lease_id, "
+        "leased_at, lease_expires_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (module_key, "write", "leased", "codex", "lease-a", now_ms - 1000, now_ms + 60_000),
+    )
+    # Expired lease (must be filtered out)
+    conn.execute(
+        "INSERT INTO jobs (module_key, phase, queue_state, leased_by, lease_id, "
+        "leased_at, lease_expires_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("other/module-stale", "write", "leased", "claude", "lease-b",
+         now_ms - 10_000_000, now_ms - 1_000),
+    )
+    conn.commit()
+    conn.close()
+
+    result = local_api.build_pipeline_leases(tmp_path, now_ms=now_ms)
+    assert result["exists"] is True
+    assert result["count"] == 1
+    assert result["active"][0]["lease_id"] == "lease-a"
+    assert result["active"][0]["seconds_to_expiry"] == 60
+
+
+def test_pipeline_leases_returns_empty_when_db_missing(tmp_path: Path) -> None:
+    result = local_api.build_pipeline_leases(tmp_path)
+    assert result["exists"] is False
+    assert result["count"] == 0
+    assert result["active"] == []
+
+
+def test_module_lease_reports_held_vs_free(tmp_path: Path) -> None:
+    module_key, _ = _setup_repo(tmp_path)
+    now_ms = 1_000_000_000_000
+    # Initially no lease -> held=False.
+    r = local_api.build_module_lease(tmp_path, module_key, now_ms=now_ms)
+    assert r["held"] is False
+
+    conn = sqlite3.connect(tmp_path / ".pipeline/v2.db")
+    conn.execute(
+        "INSERT INTO jobs (module_key, phase, queue_state, leased_by, lease_id, "
+        "leased_at, lease_expires_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (module_key, "review", "leased", "gemini", "lease-x",
+         now_ms - 10, now_ms + 120_000),
+    )
+    conn.commit()
+    conn.close()
+    r = local_api.build_module_lease(tmp_path, module_key, now_ms=now_ms)
+    assert r["held"] is True
+    assert r["lease"]["leased_by"] == "gemini"
+    assert r["lease"]["seconds_to_expiry"] == 120
+
+
+def test_pipeline_events_filters_and_limits(tmp_path: Path) -> None:
+    module_key, _ = _setup_repo(tmp_path)
+    conn = sqlite3.connect(tmp_path / ".pipeline/v2.db")
+    for i in range(5):
+        conn.execute(
+            "INSERT INTO events (module_key, type, payload_json, at) VALUES (?, ?, ?, ?)",
+            (module_key, f"type_{i}", f'{{"i":{i}}}', 1000 + i),
+        )
+    conn.execute(
+        "INSERT INTO events (module_key, type, payload_json, at) VALUES (?, ?, ?, ?)",
+        ("other/module", "x", "{}", 9999),
+    )
+    conn.commit()
+    conn.close()
+
+    scoped = local_api.build_pipeline_events(tmp_path, module_key=module_key, since_ms=None, limit=3)
+    assert scoped["count"] == 3
+    assert all(e["module_key"] == module_key for e in scoped["events"])
+    # Newest-first -> ids descending
+    ids = [e["id"] for e in scoped["events"]]
+    assert ids == sorted(ids, reverse=True)
+    # payload_json should be decoded
+    assert isinstance(scoped["events"][0]["payload_json"], dict)
+
+    windowed = local_api.build_pipeline_events(tmp_path, module_key=module_key, since_ms=1002, limit=10)
+    ats = [e["at"] for e in windowed["events"]]
+    assert all(a >= 1002 for a in ats)
+
+
+def test_pipeline_stuck_catches_expired_and_silent_jobs(tmp_path: Path) -> None:
+    module_key, _ = _setup_repo(tmp_path)
+    now_ms = 10_000_000
+    conn = sqlite3.connect(tmp_path / ".pipeline/v2.db")
+    # Expired lease -> stuck_leased
+    conn.execute(
+        "INSERT INTO jobs (module_key, phase, queue_state, leased_by, lease_id, "
+        "leased_at, lease_expires_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("stuck/one", "write", "leased", "codex", "lex",
+         now_ms - 1_000_000, now_ms - 1000),
+    )
+    # In-flight with no recent event -> stuck_in_state
+    conn.execute(
+        "INSERT INTO jobs (module_key, phase, queue_state, leased_by, leased_at) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("stuck/silent", "review", "running", "claude", now_ms - 10_000_000),
+    )
+    conn.execute(
+        "INSERT INTO events (module_key, type, payload_json, at) VALUES (?, ?, ?, ?)",
+        ("stuck/silent", "attempt_started", "{}", now_ms - 10_000_000),
+    )
+    # Fresh in-flight -> not stuck (has recent event)
+    conn.execute(
+        "INSERT INTO jobs (module_key, phase, queue_state, leased_by, leased_at) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("fresh/one", "review", "running", "claude", now_ms),
+    )
+    conn.execute(
+        "INSERT INTO events (module_key, type, payload_json, at) VALUES (?, ?, ?, ?)",
+        ("fresh/one", "attempt_started", "{}", now_ms - 10),
+    )
+    conn.commit()
+    conn.close()
+
+    r = local_api.build_pipeline_stuck(tmp_path, threshold_seconds=60, now_ms=now_ms)
+    stuck_leased_keys = {j["module_key"] for j in r["stuck_leased"]}
+    stuck_in_state_keys = {j["module_key"] for j in r["stuck_in_state"]}
+    assert "stuck/one" in stuck_leased_keys
+    assert "stuck/silent" in stuck_in_state_keys
+    assert "fresh/one" not in stuck_in_state_keys
+
+
+def test_reviews_index_and_single(tmp_path: Path) -> None:
+    reviews_dir = tmp_path / ".pipeline" / "reviews"
+    reviews_dir.mkdir(parents=True)
+    (reviews_dir / "cka__module-2.8-scheduler.md").write_text(
+        "# Review\n\n## 2026-01-01 — WRITE\n\n**Writer**: gemini\n",
+        encoding="utf-8",
+    )
+    (reviews_dir / "ztt__module-0.1.md").write_text("short", encoding="utf-8")
+
+    index = local_api.build_reviews_index(tmp_path)
+    assert index["exists"] is True
+    assert index["count"] == 2
+    keys = {r["module_key"] for r in index["reviews"]}
+    assert "cka/module-2.8-scheduler" in keys
+    assert "ztt/module-0.1" in keys
+
+    single = local_api.build_module_reviews(tmp_path, "cka/module-2.8-scheduler")
+    assert single is not None
+    assert "**Writer**: gemini" in single["body"]
+    assert single["truncated"] is False
+
+    # Truncation path.
+    big_content = "x" * 50_000
+    (reviews_dir / "big__one.md").write_text(big_content, encoding="utf-8")
+    trunc = local_api.build_module_reviews(tmp_path, "big/one", max_bytes=1000)
+    assert trunc is not None
+    assert trunc["truncated"] is True
+    assert trunc["size"] == 1000
+
+
+def test_bridge_messages_filters_and_previews(tmp_path: Path) -> None:
+    db_path = tmp_path / ".bridge" / "messages.db"
+    db_path.parent.mkdir(parents=True)
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE messages (
+          id INTEGER PRIMARY KEY,
+          task_id TEXT, from_llm TEXT, to_llm TEXT, message_type TEXT,
+          content TEXT, data TEXT, timestamp TEXT, acknowledged INTEGER,
+          status TEXT
+        )
+        """
+    )
+    long_content = "y" * 800
+    for i, ts in enumerate(["2026-01-01T00:00:00Z", "2026-02-01T00:00:00Z", "2026-03-01T00:00:00Z"]):
+        conn.execute(
+            "INSERT INTO messages (task_id, from_llm, to_llm, message_type, content, timestamp, "
+            "acknowledged, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (f"t{i}", "claude", "codex", "review", long_content, ts, 0, "sent"),
+        )
+    conn.commit()
+    conn.close()
+
+    all_ = local_api.build_bridge_messages(tmp_path, since=None, limit=10)
+    assert all_["count"] == 3
+    # Long content trimmed to preview.
+    first = all_["messages"][0]
+    assert "content" not in first  # replaced by preview
+    assert first["content_full_length"] == 800
+    assert first["content_preview"].endswith("(truncated)")
+
+    since = local_api.build_bridge_messages(tmp_path, since="2026-02-01T00:00:00Z", limit=10)
+    assert since["count"] == 2
+
+
+def test_quality_scores_parses_audit_markdown(tmp_path: Path) -> None:
+    audit = tmp_path / "docs" / "quality-audit-results.md"
+    audit.parent.mkdir()
+    audit.write_text(
+        """# Audit\n\n## All Scored Modules\n\n### Critical & High Priority\n\n"""
+        """| Module | Track | Lines | Score | Action | Issue |\n"""
+        """|---|---|---|---|---|---|\n"""
+        """| Alpha Beta | CKA | 55 | **1.3** | Critical | stub |\n"""
+        """| Gamma Module | CKAD | 500 | **3.7** | Good | ok |\n"""
+        """| Delta | KCNA | 74 | **1.7** | Critical | stub |\n""",
+        encoding="utf-8",
+    )
+    # Reset the cache so this test doesn't see a stale parse from
+    # another test's tmp_path.
+    with local_api._QUALITY_AUDIT_CACHE_LOCK:
+        local_api._QUALITY_AUDIT_CACHE.clear()
+
+    r = local_api.build_quality_scores(tmp_path)
+    assert r["exists"] is True
+    assert r["count"] == 3
+    assert r["critical_count"] == 2
+    scores = {m["module"]: m for m in r["modules"]}
+    assert scores["Alpha Beta"]["severity"] == "critical"
+    assert scores["Gamma Module"]["severity"] == "good"
+
+
+def test_module_state_includes_diagnostics(tmp_path: Path) -> None:
+    module_key, _ = _setup_repo(tmp_path)
+    state = local_api.build_module_state(tmp_path, module_key)
+    diagnostics = state.get("diagnostics")
+    assert isinstance(diagnostics, list)
+    # The fixture module has lab + fact_ledger + UK + frontmatter, so
+    # the only nits come from the UK state if it's not "synced". We
+    # don't assert an exact set — just that the field is present and a
+    # list of short strings.
+    for tag in diagnostics:
+        assert isinstance(tag, str) and tag
+        assert len(tag) < 80
+
+
+def test_module_state_flags_missing_lab_and_ledger(tmp_path: Path) -> None:
+    # Minimal repo: no lab, no fact ledger, no UK.
+    repo = tmp_path
+    _init_repo(repo)
+    _write(
+        repo / "src/content/docs/k8s/cka/module-X-stub.md",
+        "---\ntitle: stub\n---\nbody\n",
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "init")
+    state = local_api.build_module_state(repo, "k8s/cka/module-X-stub")
+    diag = state["diagnostics"]
+    assert "no_lab" in diag
+    assert "no_fact_ledger" in diag
+    assert "uk_translation_missing" in diag
+
+
+def test_schema_lists_phase_c_endpoints() -> None:
+    schema = local_api.build_api_schema()
+    paths = {e["path"] for e in schema["endpoints"]}
+    for expected in (
+        "/api/pipeline/leases",
+        "/api/pipeline/v2/events",
+        "/api/pipeline/v2/stuck",
+        "/api/reviews",
+        "/api/bridge/messages",
+        "/api/quality/scores",
+        "/api/module/{key}/lease",
+    ):
+        assert expected in paths, f"/api/schema missing {expected}"
 
 
 def test_cli_starts_server_and_reports_host_port(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #260.

Ships the endpoints deferred from Phase A+B (#259).

## New endpoints

| Endpoint | Purpose |
|---|---|
| `GET /api/pipeline/leases` | Active non-expired leases; prevents cross-agent collisions |
| `GET /api/module/{key}/lease` | Single-module lease state |
| `GET /api/pipeline/v2/events?module=...&since_ms=...&limit=...` | Per-module event timeline |
| `GET /api/pipeline/v2/stuck?threshold_seconds=...` | Expired-lease + stale-event dead-letter views |
| `GET /api/reviews` | Index of `.pipeline/reviews/` |
| `GET /api/reviews?module=...` | Full review log (capped 200 KB, truncated flag) |
| `GET /api/bridge/messages?since=<ISO>&limit=...` | `.bridge/messages.db` tail with content previews |
| `GET /api/quality/scores` | Parses `docs/quality-audit-results.md` → per-module rubric scores + severity |

## Extensions

- `/api/module/{key}/state` → gains `diagnostics` array (`english_missing`, `frontmatter_missing`, `no_lab`, `no_fact_ledger`, `uk_translation_missing`, `uk_state:<status>`, `rubric_critical`, `rubric_poor`). Agents skip the discovery round.
- `/api/briefing/session` → new `alerts` entries for stuck jobs + critical rubric scores; new `critical_quality` list (top 5).
- `/api/schema` → advertises every new endpoint.

## Server-side correctness

- `_query_sqlite_rows` no longer swallows arbitrary sqlite errors. "No such table" (expected "not yet provisioned" state) still returns `[]`; every other `OperationalError` propagates so schema drift surfaces as a 500 rather than silently returning empty. Caught a real bug in testing (missing `priority` column in fixture).
- Test fixture `_init_v2_db` gains `priority` and `events.lease_id` columns to match production schema.

## Non-goals (per reconciled plan in #258)

- No POST / write surface.
- No package refactor.
- No external crawlers (live GH / CVE / Dependabot).

## Measured

- **43 pytest tests pass** (was 32 in #259; +11 new)
- `ruff check` clean
- Bench `scripts/bench_orientation.py`: **63 % full / 83 % compact** token reduction vs baseline — holds after briefing gained the two new alert signals

## Test plan

- [x] Full test suite green in worktree
- [x] Lint clean
- [x] Bench regression guard
- [x] Smoke-test every new endpoint against the real `kubedojo` repo (responses ≤ 42 KB, p99 < 200 ms even for briefing)
- [ ] Codex adversarial review

🤖 Generated with [Claude Code](https://claude.com/claude-code)