### PR TITLE
feat(local-api): add /api/build/run and /api/build/status endpoints (#277)

### DIFF
--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 import threading
 import time
+import uuid
 from dataclasses import asdict, is_dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -100,6 +101,252 @@ def _load_json(text: str) -> Any:
         return json.loads(text)
     except json.JSONDecodeError:
         return text
+
+
+# ============================================================
+# Build jobs (/api/build/run + /api/build/status)
+# ============================================================
+
+
+_BUILD_JOBS_LOCK = threading.Lock()
+_BUILD_JOBS_STATE: dict[str, dict[str, Any]] = {}
+_BUILD_JOBS_FILENAME = ".cache/build_jobs.json"
+_BUILD_JOBS_MAX = 10
+_BUILD_TAIL_LINES = 30
+_WARNING_LINE_RE = re.compile(r"\bwarning\b", re.IGNORECASE)
+
+
+def _build_jobs_path(repo_root: Path) -> Path:
+    return repo_root / _BUILD_JOBS_FILENAME
+
+
+def _read_build_jobs(repo_root: Path) -> list[dict[str, Any]]:
+    path = _build_jobs_path(repo_root)
+    if not path.exists():
+        return []
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    if isinstance(payload, dict):
+        payload = payload.get("jobs", [])
+    if not isinstance(payload, list):
+        return []
+    return [job for job in payload if isinstance(job, dict)]
+
+
+def _write_build_jobs(repo_root: Path, jobs: list[dict[str, Any]]) -> None:
+    path = _build_jobs_path(repo_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f"{path.name}.tmp")
+    tmp_path.write_text(
+        json.dumps(jobs[-_BUILD_JOBS_MAX :], indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    tmp_path.replace(path)
+
+
+def _reset_build_jobs_state() -> None:
+    """Test helper: drop in-memory build-job state across repos."""
+    with _BUILD_JOBS_LOCK:
+        _BUILD_JOBS_STATE.clear()
+
+
+def _trim_tail(lines: list[str]) -> list[str]:
+    return lines[-_BUILD_TAIL_LINES :]
+
+
+def _normalize_warning_line(line: str) -> str | None:
+    normalized = " ".join(line.strip().split())
+    if not normalized or not _WARNING_LINE_RE.search(normalized):
+        return None
+    return normalized
+
+
+def _find_build_job_locked(state: dict[str, Any], job_id: str) -> dict[str, Any] | None:
+    for job in reversed(state["jobs"]):
+        if job.get("job_id") == job_id:
+            return job
+    return None
+
+
+def _persist_build_state_locked(repo_root: Path, state: dict[str, Any]) -> None:
+    state["jobs"] = state["jobs"][-_BUILD_JOBS_MAX :]
+    _write_build_jobs(repo_root, state["jobs"])
+
+
+def _load_build_state(repo_root: Path) -> dict[str, Any]:
+    repo_key = str(repo_root.resolve())
+    with _BUILD_JOBS_LOCK:
+        state = _BUILD_JOBS_STATE.get(repo_key)
+        if state is not None:
+            return state
+        jobs = _read_build_jobs(repo_root)[-_BUILD_JOBS_MAX :]
+        repaired = False
+        now = time.time()
+        for job in jobs:
+            if job.get("state") != "running":
+                continue
+            started_at = float(job.get("started_at") or now)
+            tail = list(job.get("last_30_lines") or [])
+            tail.append("local_api: build job marked failed after API restart")
+            job["state"] = "fail"
+            job["finished_at"] = now
+            job["duration_s"] = round(max(0.0, now - started_at), 3)
+            job["last_30_lines"] = _trim_tail(tail)
+            job["new_warnings"] = sorted(set(job.get("new_warnings") or []))
+            repaired = True
+        state = {"jobs": jobs, "active_job_id": None}
+        if repaired:
+            _persist_build_state_locked(repo_root, state)
+        _BUILD_JOBS_STATE[repo_key] = state
+        return state
+
+
+def _spawn_build_process(repo_root: Path) -> subprocess.Popen[str]:
+    return subprocess.Popen(
+        ["npm", "run", "build"],
+        cwd=repo_root,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+
+
+def _build_job_payload(job: dict[str, Any]) -> dict[str, Any]:
+    started_at = float(job["started_at"])
+    if job.get("state") == "running":
+        duration_s = round(max(0.0, time.time() - started_at), 3)
+    else:
+        duration_s = job.get("duration_s")
+    return {
+        "job_id": job["job_id"],
+        "started_at": started_at,
+        "state": job["state"],
+        "duration_s": duration_s,
+        "last_30_lines": list(job.get("last_30_lines") or []),
+        "new_warnings": list(job.get("new_warnings") or []),
+        "finished_at": job.get("finished_at"),
+    }
+
+
+def _monitor_build_job(repo_root: Path, job_id: str, process: subprocess.Popen[str]) -> None:
+    state = _load_build_state(repo_root)
+    if process.stdout is not None:
+        for raw_line in process.stdout:
+            line = raw_line.rstrip("\r\n")
+            warning = _normalize_warning_line(line)
+            with _BUILD_JOBS_LOCK:
+                job = _find_build_job_locked(state, job_id)
+                if job is None:
+                    continue
+                tail = list(job.get("last_30_lines") or [])
+                tail.append(line)
+                job["last_30_lines"] = _trim_tail(tail)
+                warning_set = set(job.get("warning_set") or [])
+                if warning is not None:
+                    warning_set.add(warning)
+                baseline = set(job.get("baseline_warning_set") or [])
+                job["warning_set"] = sorted(warning_set)
+                job["new_warnings"] = sorted(warning_set - baseline)
+                _persist_build_state_locked(repo_root, state)
+        process.stdout.close()
+
+    return_code = process.wait()
+    finished_at = time.time()
+    with _BUILD_JOBS_LOCK:
+        job = _find_build_job_locked(state, job_id)
+        if job is None:
+            return
+        baseline = set(job.get("baseline_warning_set") or [])
+        warning_set = set(job.get("warning_set") or [])
+        job["state"] = "pass" if return_code == 0 else "fail"
+        job["finished_at"] = finished_at
+        job["duration_s"] = round(max(0.0, finished_at - float(job["started_at"])), 3)
+        job["new_warnings"] = sorted(warning_set - baseline)
+        job.pop("baseline_warning_set", None)
+        if state.get("active_job_id") == job_id:
+            state["active_job_id"] = None
+        _persist_build_state_locked(repo_root, state)
+
+
+def start_build_job(repo_root: Path) -> tuple[int, Any, str]:
+    state = _load_build_state(repo_root)
+    with _BUILD_JOBS_LOCK:
+        active_job_id = state.get("active_job_id")
+        if active_job_id:
+            active_job = _find_build_job_locked(state, active_job_id)
+            if active_job is not None and active_job.get("state") == "running":
+                return (
+                    409,
+                    {
+                        "error": "build_in_progress",
+                        "job_id": active_job_id,
+                        "started_at": active_job.get("started_at"),
+                    },
+                    "application/json; charset=utf-8",
+                )
+            state["active_job_id"] = None
+
+        previous_green_warnings: set[str] = set()
+        for previous_job in reversed(state["jobs"]):
+            if previous_job.get("state") == "pass":
+                previous_green_warnings = set(previous_job.get("warning_set") or [])
+                break
+
+        started_at = time.time()
+        job_id = f"build-{uuid.uuid4().hex[:12]}"
+        job = {
+            "job_id": job_id,
+            "started_at": started_at,
+            "state": "running",
+            "duration_s": None,
+            "finished_at": None,
+            "last_30_lines": [],
+            "warning_set": [],
+            "baseline_warning_set": sorted(previous_green_warnings),
+            "new_warnings": [],
+        }
+        state["jobs"].append(job)
+        state["active_job_id"] = job_id
+        _persist_build_state_locked(repo_root, state)
+
+    try:
+        process = _spawn_build_process(repo_root)
+    except OSError as exc:
+        finished_at = time.time()
+        with _BUILD_JOBS_LOCK:
+            failed_job = _find_build_job_locked(state, job_id)
+            if failed_job is not None:
+                failed_job["state"] = "fail"
+                failed_job["finished_at"] = finished_at
+                failed_job["duration_s"] = round(max(0.0, finished_at - started_at), 3)
+                failed_job["last_30_lines"] = [f"local_api: failed to start build: {exc}"]
+                failed_job.pop("baseline_warning_set", None)
+                state["active_job_id"] = None
+                _persist_build_state_locked(repo_root, state)
+        return (
+            500,
+            {"error": "build_spawn_failed", "job_id": job_id, "message": str(exc)},
+            "application/json; charset=utf-8",
+        )
+
+    threading.Thread(
+        target=_monitor_build_job,
+        args=(repo_root, job_id, process),
+        daemon=True,
+    ).start()
+    return 202, {"job_id": job_id, "started_at": started_at}, "application/json; charset=utf-8"
+
+
+def get_build_job_status(repo_root: Path, job_id: str) -> tuple[int, Any, str]:
+    state = _load_build_state(repo_root)
+    with _BUILD_JOBS_LOCK:
+        job = _find_build_job_locked(state, job_id)
+        if job is None:
+            return 404, {"error": "build_job_not_found", "job_id": job_id}, "application/json; charset=utf-8"
+        return 200, _build_job_payload(job), "application/json; charset=utf-8"
 
 
 # ============================================================
@@ -4865,6 +5112,8 @@ def build_api_schema() -> dict[str, Any]:
                 "desc": "Per-track, per-section production-readiness grid (cleared/in_flight/dead_letter/not_yet_enqueued)",
             },
             {"path": "/api/runtime/services", "desc": "Runtime services (pids, uptime, ports)"},
+            {"path": "/api/build/run", "desc": "Spawn `npm run build` in the background", "method": "POST"},
+            {"path": "/api/build/status", "desc": "Build job status + tail + warning diff", "query": ["job_id=..."]},
             {"path": "/api/pipeline/v2/status", "desc": "Pipeline v2 queue + per-track"},
             {
                 "path": "/api/translation/v2/status",
@@ -4965,6 +5214,11 @@ def route_request(repo_root: Path, raw_path: str) -> tuple[int, Any, str]:
         return 200, build_tracks_readiness(repo_root), "application/json; charset=utf-8"
     if path == "/api/runtime/services":
         return 200, build_runtime_services_status(repo_root), "application/json; charset=utf-8"
+    if path == "/api/build/status":
+        job_id = query.get("job_id", [None])[0]
+        if not job_id:
+            return 400, {"error": "missing_job_id"}, "application/json; charset=utf-8"
+        return get_build_job_status(repo_root, job_id)
     if path == "/api/pipeline/v2/status":
         db_path = repo_root / ".pipeline" / "v2.db"
         if not db_path.exists():
@@ -5102,6 +5356,13 @@ def route_request(repo_root: Path, raw_path: str) -> tuple[int, Any, str]:
         if module_key is None:
             return 400, {"error": "invalid_module_key"}, "application/json; charset=utf-8"
         return 200, build_module_orchestration_latest(repo_root, module_key), "application/json; charset=utf-8"
+    return 404, {"error": "not_found", "path": path}, "application/json; charset=utf-8"
+
+
+def route_post_request(repo_root: Path, raw_path: str) -> tuple[int, Any, str]:
+    path = urlsplit(raw_path).path.rstrip("/") or "/"
+    if path == "/api/build/run":
+        return start_build_job(repo_root)
     return 404, {"error": "not_found", "path": path}, "application/json; charset=utf-8"
 
 
@@ -5245,6 +5506,26 @@ def make_handler(repo_root: Path) -> type[BaseHTTPRequestHandler]:
             self.send_header("Content-Length", str(len(body)))
             if 200 <= status_code < 300:
                 self.send_header("ETag", etag)
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_POST(self) -> None:  # noqa: N802
+            try:
+                status_code, payload, content_type = route_post_request(repo_root, self.path)
+            except Exception as exc:  # noqa: BLE001 - surface all write failures as JSON
+                status_code = 500
+                payload = {
+                    "error": "internal_error",
+                    "exception": type(exc).__name__,
+                    "message": str(exc),
+                    "path": self.path,
+                }
+                content_type = "application/json; charset=utf-8"
+
+            body = _serialize_payload(payload, content_type)
+            self.send_response(status_code)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(body)))
             self.end_headers()
             self.wfile.write(body)
 

--- a/tests/test_local_api_build.py
+++ b/tests/test_local_api_build.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import http.client
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from threading import Thread
+from unittest import mock
+
+
+def _load_module():
+    module_path = Path(__file__).resolve().parent.parent / "scripts" / "local_api.py"
+    spec = importlib.util.spec_from_file_location("local_api", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+local_api = _load_module()
+
+class LocalApiBuildTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.repo_root = Path(self._tmpdir.name)
+        local_api._reset_build_jobs_state()
+
+    def tearDown(self) -> None:
+        local_api._reset_build_jobs_state()
+        self._tmpdir.cleanup()
+
+    def _spawn_python_build(self, script: str) -> subprocess.Popen[str]:
+        return subprocess.Popen([sys.executable, "-c", script], cwd=self.repo_root, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1)
+
+    def _wait_for_job(self, job_id: str, timeout: float = 5.0) -> dict[str, object]:
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            status_code, payload, _ = local_api.get_build_job_status(self.repo_root, job_id)
+            self.assertEqual(status_code, 200)
+            if payload["state"] != "running":
+                return payload
+            time.sleep(0.05)
+        self.fail(f"timed out waiting for build job {job_id}")
+
+    def test_build_status_persists_warning_diff_from_previous_green(self) -> None:
+        local_api._write_build_jobs(self.repo_root, [{
+            "job_id": "build-prev",
+            "started_at": 10.0,
+            "state": "pass",
+            "duration_s": 1.2,
+            "finished_at": 11.2,
+            "last_30_lines": ["Legacy warning"],
+            "warning_set": ["Legacy warning"],
+            "new_warnings": [],
+        }])
+        script = "import sys; print('Legacy warning', flush=True); print('Brand new warning', file=sys.stderr, flush=True)"
+        with mock.patch.object(local_api, "_spawn_build_process", side_effect=lambda repo_root: self._spawn_python_build(script)):
+            status_code, payload, content_type = local_api.route_post_request(self.repo_root, "/api/build/run")
+        self.assertEqual((status_code, content_type.startswith("application/json")), (202, True))
+        final_payload = self._wait_for_job(payload["job_id"])
+        self.assertEqual((final_payload["state"], final_payload["new_warnings"]), ("pass", ["Brand new warning"]))
+        self.assertEqual(final_payload["last_30_lines"][-2:], ["Legacy warning", "Brand new warning"])
+        persisted_jobs = json.loads(local_api._build_jobs_path(self.repo_root).read_text(encoding="utf-8"))
+        self.assertEqual((persisted_jobs[-1]["job_id"], persisted_jobs[-1]["new_warnings"]), (payload["job_id"], ["Brand new warning"]))
+        endpoints = {entry["path"]: entry for entry in local_api.build_api_schema()["endpoints"]}
+        self.assertEqual(endpoints["/api/build/run"]["method"], "POST")
+        self.assertEqual(endpoints["/api/build/status"]["query"], ["job_id=..."])
+
+    def test_second_post_returns_409_with_inflight_job_id_over_http(self) -> None:
+        script = "import time; print('step 1', flush=True); time.sleep(0.4); print('step 2', flush=True)"
+        with mock.patch.object(local_api, "_spawn_build_process", side_effect=lambda repo_root: self._spawn_python_build(script)):
+            server = local_api.ThreadingHTTPServer(("127.0.0.1", 0), local_api.make_handler(self.repo_root))
+            thread = Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            port = server.server_address[1]
+            self.addCleanup(server.shutdown)
+            self.addCleanup(server.server_close)
+            conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+            conn.request("POST", "/api/build/run")
+            first = conn.getresponse()
+            first_payload = json.loads(first.read().decode("utf-8"))
+            self.assertEqual(first.status, 202)
+            job_id = first_payload["job_id"]
+            conn.request("POST", "/api/build/run")
+            second = conn.getresponse()
+            second_payload = json.loads(second.read().decode("utf-8"))
+            self.assertEqual((second.status, second_payload["error"], second_payload["job_id"]), (409, "build_in_progress", job_id))
+            conn.request("GET", f"/api/build/status?job_id={job_id}")
+            status_response = conn.getresponse()
+            status_payload = json.loads(status_response.read().decode("utf-8"))
+            self.assertEqual((status_response.status, status_payload["job_id"]), (200, job_id))
+            self.assertIn(status_payload["state"], {"running", "pass"})
+            conn.close()
+            self.assertEqual(self._wait_for_job(job_id)["state"], "pass")
+
+    def test_build_jobs_ring_buffer_keeps_last_ten_entries(self) -> None:
+        local_api._write_build_jobs(self.repo_root, [{
+            "job_id": f"build-{idx}",
+            "started_at": float(idx),
+            "state": "pass",
+            "duration_s": 1.0,
+            "finished_at": float(idx) + 1.0,
+            "last_30_lines": [f"job {idx}"],
+            "warning_set": [],
+            "new_warnings": [],
+        } for idx in range(10)])
+        with mock.patch.object(local_api, "_spawn_build_process", side_effect=lambda repo_root: self._spawn_python_build("print('fresh build', flush=True)")):
+            status_code, payload, _ = local_api.route_post_request(self.repo_root, "/api/build/run")
+        self.assertEqual(status_code, 202)
+        self._wait_for_job(payload["job_id"])
+        persisted_jobs = json.loads(local_api._build_jobs_path(self.repo_root).read_text(encoding="utf-8"))
+        self.assertEqual((len(persisted_jobs), persisted_jobs[0]["job_id"], persisted_jobs[-1]["job_id"]), (10, "build-1", payload["job_id"]))


### PR DESCRIPTION
Implements #277.

## Summary
- add `POST /api/build/run` and `GET /api/build/status` to `scripts/local_api.py`
- persist the last 10 build jobs in `.cache/build_jobs.json` with previous-green warning diffs
- cover concurrent POST rejection, ring-buffer persistence, schema docs, and status behavior in `tests/test_local_api_build.py`

## Validation
- `python -m unittest tests.test_local_api_build`
- `ruff check scripts/local_api.py tests/test_local_api_build.py`
- `.venv/bin/ruff check scripts/local_api.py tests/test_local_api_build.py` failed in this checkout: `/opt/homebrew/bin/bash: line 1: .venv/bin/ruff: No such file or directory`
- `npm run build` failed in this worktree because `src/layouts/Homepage.astro` resolves `../../node_modules/@astrojs/starlight/style/layers.css`, which does not exist from the worktree path

## Build report
```text

> kubedojo@1.0.0 build
> astro build

10:37:12 [content] Syncing content
10:37:19 [WARN] [astro-expressive-code] Error while highlighting code block using language "cloudformation" in document "/Users/krisztiankoos/projects/kubedojo/.worktrees/build-endpoints/src/content/docs/cloud/aws-essentials/module-1.12-cloudformation.md". The language could not be found. Using "txt" instead. Ensure that all required languages are either part of the bundle or custom languages provided in the "langs" config option.
10:37:19 [WARN] [astro-expressive-code] Error while highlighting code block using language "cloudformation" in document "/Users/krisztiankoos/projects/kubedojo/.worktrees/build-endpoints/src/content/docs/cloud/aws-essentials/module-1.12-cloudformation.md". The language could not be found. Using "txt" instead. Ensure that all required languages are either part of the bundle or custom languages provided in the "langs" config option.
10:37:19 [WARN] [astro-expressive-code] Error while highlighting code block using language "cloudformation" in document "/Users/krisztiankoos/projects/kubedojo/.worktrees/build-endpoints/src/content/docs/cloud/aws-essentials/module-1.12-cloudformation.md". The language could not be found. Using "txt" instead. Ensure that all required languages are either part of the bundle or custom languages provided in the "langs" config option.
10:37:19 [WARN] [astro-expressive-code] Error while highlighting code block using language "cloudformation" in document "/Users/krisztiankoos/projects/kubedojo/.worktrees/build-endpoints/src/content/docs/cloud/aws-essentials/module-1.12-cloudformation.md". The language could not be found. Using "txt" instead. Ensure that all required languages are either part of the bundle or custom languages provided in the "langs" config option.
10:37:19 [WARN] [astro-expressive-code] Error while highlighting code block using language "cloudformation" in document "/Users/krisztiankoos/projects/kubedojo/.worktrees/build-endpoints/src/content/docs/cloud/aws-essentials/module-1.12-cloudformation.md". The language could not be found. Using "txt" instead. Ensure that all required languages are either part of the bundle or custom languages provided in the "langs" config option.
10:37:19 [WARN] [astro-expressive-code] Error while highlighting code block using language "cloudformation" in document "/Users/krisztiankoos/projects/kubedojo/.worktrees/build-endpoints/src/content/docs/cloud/aws-essentials/module-1.12-cloudformation.md". The language could not be found. Using "txt" instead. Ensure that all required languages are either part of the bundle or custom languages provided in the "langs" config option.
10:37:19 [WARN] [astro-expressive-code] Error while highlighting code block using language "cloudformation" in document "/Users/krisztiankoos/projects/kubedojo/.worktrees/build-endpoints/src/content/docs/cloud/aws-essentials/module-1.12-cloudformation.md". The language could not be found. Using "txt" instead. Ensure that all required languages are either part of the bundle or custom languages provided in the "langs" config option.
10:37:19 [WARN] [astro-expressive-code] Error while highlighting code block using language "cloudformation" in document "/Users/krisztiankoos/projects/kubedojo/.worktrees/build-endpoints/src/content/docs/cloud/aws-essentials/module-1.12-cloudformation.md". The language could not be found. Using "txt" instead. Ensure that all required languages are either part of the bundle or custom languages provided in the "langs" config option.
10:37:19 [WARN] [astro-expressive-code] Error while highlighting code block using language "cloudformation" in document "/Users/krisztiankoos/projects/kubedojo/.worktrees/build-endpoints/src/content/docs/cloud/aws-essentials/module-1.12-cloudformation.md". The language could not be found. Using "txt" instead. Ensure that all required languages are either part of the bundle or custom languages provided in the "langs" config option.
10:37:19 [WARN] [astro-expressive-code] Error while highlighting code block using language "cloudformation" in document "/Users/krisztiankoos/projects/kubedojo/.worktrees/build-endpoints/src/content/docs/cloud/aws-essentials/module-1.12-cloudformation.md". The language could not be found. Using "txt" instead. Ensure that all required languages are either part of the bundle or custom languages provided in the "langs" config option.
10:37:34 [WARN] [astro-expressive-code] Error while highlighting code block using language "haproxy" in document "/Users/krisztiankoos/projects/kubedojo/.worktrees/build-endpoints/src/content/docs/platform/foundations/advanced-networking/module-1.5-load-balancing.md". The language could not be found. Using "txt" instead. Ensure that all required languages are either part of the bundle or custom languages provided in the "langs" config option.
10:37:54 [content] Synced content
10:37:54 [types] Generated 42.40s
10:37:54 [build] output: "static"
10:37:54 [build] mode: "static"
10:37:54 [build] directory: /Users/krisztiankoos/projects/kubedojo/.worktrees/build-endpoints/dist/
10:37:54 [build] Collecting build info...
10:37:54 [build] ✓ Completed in 43.31s.
10:37:54 [build] Building static entrypoints...
10:37:55 [ERROR] [vite] ✗ Build failed in 373ms
Could not resolve "../../node_modules/@astrojs/starlight/style/layers.css" from "src/layouts/Homepage.astro"
file: /Users/krisztiankoos/projects/kubedojo/.worktrees/build-endpoints/src/layouts/Homepage.astro
  Stack trace:
    at getRollupError (file:///Users/krisztiankoos/projects/kubedojo/node_modules/rollup/dist/es/shared/parseAst.js:406:41)
    at ModuleLoader.handleInvalidResolvedId (file:///Users/krisztiankoos/projects/kubedojo/node_modules/rollup/dist/es/shared/node-entry.js:21765:24)
```
