### PR TITLE
refactor(pipeline): pin Gemini writer model via single constant (#278)

### DIFF
--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -44,6 +44,9 @@ GH_CHAR_LIMIT = 64000
 # Model defaults
 # ---------------------------------------------------------------------------
 
+# 2026-04-18: Google still exposes Gemini 3 Pro as preview-only, so pin the
+# currently tested writer alias here until a GA replacement is available.
+GEMINI_WRITER_MODEL = "gemini-3.1-pro-preview"
 GEMINI_DEFAULT_MODEL = "gemini-3-flash-preview"
 GEMINI_FALLBACK_MODEL = "auto"
 CLAUDE_DEFAULT_MODEL = "claude-sonnet-4-6"

--- a/scripts/v1_pipeline.py
+++ b/scripts/v1_pipeline.py
@@ -132,6 +132,7 @@ sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
 from checks import structural, ukrainian, gaps
 from dispatch import (
+    GEMINI_WRITER_MODEL,
     dispatch_gemini_with_retry,
     dispatch_claude,
     dispatch_codex,
@@ -163,9 +164,9 @@ def dispatch_auto(prompt: str, model: str, timeout: int = 900) -> tuple[bool, st
 # ---------------------------------------------------------------------------
 
 MODELS = {
-    "write": "gemini-3.1-pro-preview",     # Preview model — review in monthly evals, re-pin when GA available. See issue #217.
+    "write": GEMINI_WRITER_MODEL,          # Pinned in dispatch.py; re-evaluate monthly and replace when GA is available. See issue #217/#278.
     "write_targeted": "claude-sonnet-4-6", # TARGETED FIX: surgical patches (instruction-following)
-    "review": "gemini-3.1-pro-preview",    # STRUCTURAL REVIEW: calibration-backed choice for split-reviewer flow
+    "review": GEMINI_WRITER_MODEL,         # STRUCTURAL REVIEW: calibration-backed choice for split-reviewer flow
     "review_fallback": "claude-sonnet-4-6",  # independent REVIEW fallback when Codex is unavailable
     "knowledge_card": "gpt-5.3-codex-spark",  # WRITE grounding aligned with fact-grounding calibration
     "fact_grounding": "gpt-5.3-codex-spark",  # split-reviewer architecture: factual grounding ledger
@@ -4393,14 +4394,14 @@ def main():
   resume                           retry stuck modules only
 
 models:
-  --write-model gemini-3.1-pro-preview     override the main writer
+  --write-model {GEMINI_WRITER_MODEL}     override the main writer
   --review-model claude-sonnet-4-6         override the primary reviewer
 """, formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     # Global model overrides
     parser.add_argument("--audit-model", help=argparse.SUPPRESS)
-    parser.add_argument("--write-model", help="Model for WRITE step (default: gemini-3.1-pro-preview)")
-    parser.add_argument("--review-model", help="Model for REVIEW step (default: gemini-3.1-pro-preview)")
+    parser.add_argument("--write-model", help=f"Model for WRITE step (default: {GEMINI_WRITER_MODEL})")
+    parser.add_argument("--review-model", help=f"Model for REVIEW step (default: {GEMINI_WRITER_MODEL})")
 
     subparsers = parser.add_subparsers(dest="command", help="Pipeline command")
 


### PR DESCRIPTION
Addresses PR 1 of #278.

This PR scopes the refactor to `scripts/dispatch.py` and `scripts/v1_pipeline.py` as requested:
- defines `GEMINI_WRITER_MODEL` once in `scripts/dispatch.py`
- replaces the duplicated writer/reviewer literals in `scripts/v1_pipeline.py`
- updates CLI help text to read from the same constant

Scoped grep proof (`scripts/dispatch.py` + `scripts/v1_pipeline.py`):
```text
scripts/dispatch.py:49:24:GEMINI_WRITER_MODEL = "gemini-3.1-pro-preview"
```

Requested repo-wide grep on the current tree still finds unrelated pre-existing references outside PR 1 scope (`scripts/lab_pipeline.py`, `scripts/uk_sync.py`, `scripts/pipeline_v2/write_worker.py`, bridge/runtime files, and tests), so `rg -n "gemini-3\\.1-pro-preview" scripts tests` is not reduced to a single line by a 2-file PR.

Validation:
- `python -m py_compile scripts/v1_pipeline.py scripts/dispatch.py` ✅
- `~/.local/bin/ruff check scripts/v1_pipeline.py scripts/dispatch.py` ⚠️ fails on pre-existing `E402` / `F541` violations in `scripts/v1_pipeline.py`
- `python -m unittest scripts.test_pipeline` ⚠️ fails on pre-existing `TestStatusFourStage.test_cmd_status_prints_four_stage_completion_table`
