### PR TITLE
fix(pipeline): defer data_conflict check until after draft

### DIFF
--- a/scripts/test_pipeline.py
+++ b/scripts/test_pipeline.py
@@ -2981,14 +2981,62 @@ class TestRunModuleSplitReviewer(unittest.TestCase):
 
         self.assertEqual(events[:3], ["ledger", "write", "review"])
 
+    def test_topic_conflicts_not_in_final_draft_do_not_block(self):
+        import v1_pipeline as p
+
+        topic_conflict_ledger = {
+            "as_of_date": "2026-04-12",
+            "topic": "Conflict",
+            "claims": [
+                {
+                    "id": f"C{i}",
+                    "claim": f"Hypothetical claim {i}",
+                    "status": "CONFLICTING",
+                }
+                for i in range(1, 6)
+            ],
+        }
+        review_ok = {
+            "verdict": "APPROVE",
+            "checks": [{"id": cid, "passed": True} for cid in p.CHECK_IDS],
+            "edits": [],
+            "feedback": "",
+        }
+        content_ledger = sample_fact_ledger() | {"content_aware": True}
+        state = {"modules": {}}
+        with patch.object(p, "STATE_FILE", self.state_file), \
+             patch.object(p, "CONTENT_ROOT", Path(self.tmpdir)), \
+             patch.object(p, "save_state"), \
+             patch.object(p, "module_key_from_path", return_value="test/module-0.1-test"), \
+             patch.object(p, "ensure_fact_ledger", return_value=topic_conflict_ledger), \
+             patch.object(p, "step_content_aware_fact_ledger", return_value=content_ledger), \
+             patch.object(p, "ensure_knowledge_card", return_value="card"), \
+             patch.object(p, "step_write", return_value=GOOD_MODULE), \
+             patch.object(p, "step_review", return_value=review_ok), \
+             patch.object(p, "step_check_integrity", return_value=(True, [])), \
+             patch.object(p, "step_check", return_value=(True, [])), \
+             patch("subprocess.run"):
+            ok = p.run_module(self.module_path, state)
+
+        self.assertTrue(ok)
+        ms = state["modules"]["test/module-0.1-test"]
+        self.assertEqual(ms.get("phase"), "done")
+        self.assertFalse(any("DATA_CONFLICT" in e for e in ms.get("errors", [])))
+
     def test_data_conflict_triage_exit(self):
         import v1_pipeline as p
 
         conflict_ledger = {
             "as_of_date": "2026-04-12",
             "topic": "Conflict",
+            "content_aware": True,
             "claims": [
-                {"id": f"C{i}", "status": "CONFLICTING"} for i in range(1, 6)
+                {
+                    "id": f"C{i}",
+                    "claim": f"Conflicting drafted claim {i}",
+                    "status": "CONFLICTING",
+                }
+                for i in range(1, 6)
             ],
         }
         state = {"modules": {}}
@@ -2996,7 +3044,11 @@ class TestRunModuleSplitReviewer(unittest.TestCase):
              patch.object(p, "CONTENT_ROOT", Path(self.tmpdir)), \
              patch.object(p, "save_state"), \
              patch.object(p, "module_key_from_path", return_value="test/module-0.1-test"), \
-             patch.object(p, "ensure_fact_ledger", return_value=conflict_ledger):
+             patch.object(p, "ensure_fact_ledger", return_value=sample_fact_ledger()), \
+             patch.object(p, "step_content_aware_fact_ledger", return_value=conflict_ledger), \
+             patch.object(p, "ensure_knowledge_card", return_value="card"), \
+             patch.object(p, "step_write", return_value=GOOD_MODULE), \
+             patch("subprocess.run"):
             ok = p.run_module(self.module_path, state)
 
         self.assertFalse(ok)

--- a/scripts/v1_pipeline.py
+++ b/scripts/v1_pipeline.py
@@ -660,6 +660,22 @@ def _merge_fact_ledgers(topic_ledger: dict | None, content_ledger: dict | None) 
     }
 
 
+def _count_fact_ledger_issues(ledger: dict | None) -> tuple[int, int]:
+    """Return (conflicting, unverified) claim counts for a fact ledger."""
+    if not isinstance(ledger, dict):
+        return 0, 0
+
+    n_conflict = sum(
+        1 for c in ledger.get("claims", [])
+        if isinstance(c, dict) and c.get("status") == "CONFLICTING"
+    )
+    n_unverified = sum(
+        1 for c in ledger.get("claims", [])
+        if isinstance(c, dict) and c.get("status") == "UNVERIFIED"
+    )
+    return n_conflict, n_unverified
+
+
 # ---------------------------------------------------------------------------
 # WRITE step — Gemini drafts improvements
 # ---------------------------------------------------------------------------
@@ -2537,24 +2553,6 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
         review_fact_ledger = ledger_result
         save_state(state)
 
-        n_conflict = sum(
-            1 for c in ledger_result.get("claims", [])
-            if isinstance(c, dict) and c.get("status") == "CONFLICTING"
-        )
-        n_unverified = sum(
-            1 for c in ledger_result.get("claims", [])
-            if isinstance(c, dict) and c.get("status") == "UNVERIFIED"
-        )
-        if (n_conflict >= DATA_CONFLICT_CONFLICT_THRESHOLD or
-                n_unverified >= DATA_CONFLICT_UNVERIFIED_THRESHOLD):
-            ms["phase"] = "data_conflict"
-            ms["errors"].append(
-                f"DATA_CONFLICT: {n_conflict} conflicting + {n_unverified} "
-                f"unverified claims — manual triage required"
-            )
-            save_state(state)
-            return False
-
     # Initial write plan. Legacy `phase="audit"` states from older runs are
     # treated the same as fresh `pending` modules: start a normal first-pass
     # write with the generic plan and let REVIEW produce the real follow-up
@@ -2714,7 +2712,8 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
             # Content-aware fact ledger: verify claims actually made in the
             # written content. Merges with the pre-write topic-based ledger
             # so the reviewer has both broad coverage and precise grounding.
-            # Non-blocking: falls back to topic-based ledger on any failure.
+            # data_conflict gating happens here, after the draft exists, so
+            # topic-only hypothetical claims do not block the pipeline.
             if improved and not dry_run:
                 fact_model = m.get("fact_grounding", MODELS["fact_grounding"])
                 content_ledger = step_content_aware_fact_ledger(
@@ -2728,6 +2727,17 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
                             module_path, improved, model=fallback_model
                         )
                 if content_ledger is not None:
+                    n_conflict, n_unverified = _count_fact_ledger_issues(content_ledger)
+                    if (n_conflict >= DATA_CONFLICT_CONFLICT_THRESHOLD or
+                            n_unverified >= DATA_CONFLICT_UNVERIFIED_THRESHOLD):
+                        _atomic_write_text(staging_path, improved)
+                        ms["phase"] = "data_conflict"
+                        ms["errors"].append(
+                            f"DATA_CONFLICT: {n_conflict} conflicting + {n_unverified} "
+                            f"unverified claims in drafted content — manual triage required"
+                        )
+                        save_state(state)
+                        return False
                     review_fact_ledger = (
                         _merge_fact_ledgers(ms.get("fact_ledger"), content_ledger)
                         or ms.get("fact_ledger")


### PR DESCRIPTION
## Summary
- stop blocking on topic-level fact-ledger conflicts before WRITE runs
- gate `data_conflict` only after the content-aware ledger inspects the generated draft
- preserve the drafted content in staging when an actual drafted claim still trips the gate
- add tests for both the false-positive case and the real drafted-conflict case

## Verification
- `python -m py_compile scripts/v1_pipeline.py`
- `python -m unittest scripts.test_pipeline.TestRunModuleSplitReviewer.test_topic_conflicts_not_in_final_draft_do_not_block scripts.test_pipeline.TestRunModuleSplitReviewer.test_data_conflict_triage_exit`
- `python -m unittest scripts.test_pipeline` *(fails in existing unrelated test: `TestStatusFourStage.test_cmd_status_prints_four_stage_completion_table`)*

Refs #235