### PR TITLE
refactor(pipeline): pin Gemini constant across remaining workers (#278 PR 1b)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -160,11 +160,11 @@ python scripts/dispatch.py claude "Expand this draft to full depth..."
 ### Programmatic Usage
 
 ```python
-from scripts.dispatch import dispatch_gemini_with_retry, post_to_github
+from scripts.dispatch import GEMINI_WRITER_MODEL, dispatch_gemini_with_retry, post_to_github
 
 ok, output = dispatch_gemini_with_retry("Review this module...", review=True)
 if ok:
-    post_to_github(66, output, "gemini-3.1-pro-preview")
+    post_to_github(66, output, GEMINI_WRITER_MODEL)
 ```
 
 ### Review Criteria

--- a/scripts/agent_runtime/adapters/gemini.py
+++ b/scripts/agent_runtime/adapters/gemini.py
@@ -35,6 +35,11 @@ import re
 import shutil
 from pathlib import Path
 
+try:
+    from dispatch import GEMINI_WRITER_MODEL
+except ImportError:  # pragma: no cover - package import path variant
+    from scripts.dispatch import GEMINI_WRITER_MODEL  # type: ignore
+
 from ..result import ParseResult
 from .base import InvocationPlan
 
@@ -71,7 +76,7 @@ class GeminiAdapter:
     """Adapter for the ``gemini`` CLI (Google Gemini)."""
 
     name: str = "gemini"
-    default_model: str = "gemini-3.1-pro-preview"
+    default_model: str = GEMINI_WRITER_MODEL
     # Gemini has no sandbox distinction between workspace-write and danger —
     # we accept both names but treat them identically (both mean "CLI may
     # write files in cwd via --approval-mode=yolo").

--- a/scripts/agent_runtime/registry.py
+++ b/scripts/agent_runtime/registry.py
@@ -23,6 +23,11 @@ from __future__ import annotations
 import os
 from typing import TypedDict
 
+try:
+    from dispatch import GEMINI_WRITER_MODEL
+except ImportError:  # pragma: no cover - package import path variant
+    from scripts.dispatch import GEMINI_WRITER_MODEL  # type: ignore
+
 
 class AgentEntry(TypedDict):
     """Registry row shape."""
@@ -64,7 +69,7 @@ AGENTS: dict[str, AgentEntry] = {
     },
     "gemini": {
         "adapter": "scripts.agent_runtime.adapters.gemini:GeminiAdapter",
-        "default_model": "gemini-3.1-pro-preview",
+        "default_model": GEMINI_WRITER_MODEL,
         "cost_tier": "low",
         "capabilities": frozenset({
             "content_writing",

--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -29,6 +29,11 @@ from ._messaging import (
 )
 from ._model import check_model
 
+try:
+    from dispatch import GEMINI_WRITER_MODEL
+except ImportError:  # pragma: no cover - package import path variant
+    from scripts.dispatch import GEMINI_WRITER_MODEL  # type: ignore
+
 
 def interactive_mode():
     """Interactive mode for testing."""
@@ -452,7 +457,7 @@ def _build_parser() -> argparse.ArgumentParser:
     converse_parser = subparsers.add_parser("converse", help="Multi-turn conversation with Gemini (includes history)")
     converse_parser.add_argument("content", help="Message content (use '-' to read from stdin)")
     converse_parser.add_argument("--task-id", required=True, help="Conversation thread ID (e.g., 'a1-1-planning')")
-    converse_parser.add_argument("--model", default="gemini-3.1-pro-preview", help="Gemini model")
+    converse_parser.add_argument("--model", default=GEMINI_WRITER_MODEL, help="Gemini model")
     converse_parser.add_argument("--no-github", dest="no_github", action="store_true",
                                  help="Skip auto-posting to GitHub")
 

--- a/scripts/ai_agent_bridge/_gemini.py
+++ b/scripts/ai_agent_bridge/_gemini.py
@@ -50,8 +50,13 @@ from ._messaging import (
 from ._model import _detect_model_error
 from ._prompts import build_gemini_prompt
 
+try:
+    from dispatch import GEMINI_WRITER_MODEL
+except ImportError:  # pragma: no cover - package import path variant
+    from scripts.dispatch import GEMINI_WRITER_MODEL  # type: ignore
 
-def converse_gemini(content: str, task_id: str, model: str = "gemini-3.1-pro-preview",
+
+def converse_gemini(content: str, task_id: str, model: str = GEMINI_WRITER_MODEL,
                     skip_github: bool = False):
     """Multi-turn conversation with Gemini. Includes conversation history in prompt.
 

--- a/scripts/dedupe_audit.py
+++ b/scripts/dedupe_audit.py
@@ -21,7 +21,7 @@ REPO_ROOT = Path(__file__).parent.parent
 CONTENT_ROOT = REPO_ROOT / "src" / "content" / "docs"
 
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
-from dispatch import dispatch_gemini_with_retry  # noqa: E402
+from dispatch import GEMINI_WRITER_MODEL, dispatch_gemini_with_retry  # noqa: E402
 
 
 def extract_title_and_topics(path: Path) -> tuple[str, list[str]]:
@@ -93,7 +93,7 @@ Output ONLY JSON in this format:
 ]}}
 """
 
-    ok, output = dispatch_gemini_with_retry(prompt, model="gemini-3.1-pro-preview", timeout=120)
+    ok, output = dispatch_gemini_with_retry(prompt, model=GEMINI_WRITER_MODEL, timeout=120)
     if not ok:
         return {"error": "dispatch_failed"}
 

--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -44,6 +44,9 @@ GH_CHAR_LIMIT = 64000
 # Model defaults
 # ---------------------------------------------------------------------------
 
+# 2026-04-18: Google still exposes Gemini 3 Pro as preview-only, so pin the
+# currently tested writer alias here until a GA replacement is available.
+GEMINI_WRITER_MODEL = "gemini-3.1-pro-preview"
 GEMINI_DEFAULT_MODEL = "gemini-3-flash-preview"
 GEMINI_FALLBACK_MODEL = "auto"
 CLAUDE_DEFAULT_MODEL = "claude-sonnet-4-6"

--- a/scripts/lab_pipeline.py
+++ b/scripts/lab_pipeline.py
@@ -23,6 +23,7 @@ REPO_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
 from dispatch import (  # noqa: E402
+    GEMINI_WRITER_MODEL,
     _is_rate_limited,
     dispatch_claude,
     dispatch_codex,
@@ -46,7 +47,7 @@ LAB_CHECK_IDS = [
 ]
 STATIC_CHECK_IDS = LAB_CHECK_IDS[:5]
 MODELS = {
-    "review": "gemini-3.1-pro-preview",
+    "review": GEMINI_WRITER_MODEL,
 }
 
 LAB_REVIEW_PROMPT_TEMPLATE = """You are reviewing a hands-on lab for KubeDojo.

--- a/scripts/on-prem/phase2-write-only.py
+++ b/scripts/on-prem/phase2-write-only.py
@@ -3,7 +3,7 @@
 
 Bypasses the v1 pipeline's review/check/score retry loop. Per module:
 
-  1. WRITE — call the chosen writer model (default: gemini-3.1-pro-preview)
+  1. WRITE — call the chosen writer model (default: scripts/dispatch.py writer pin)
   2. SAVE — write the module markdown to disk
   3. FACT-CHECK — call the calibrated fact-grounder (gpt-5.3-codex-spark) on
      the just-written module, produce a structured ledger (SUPPORTED /
@@ -51,13 +51,13 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
-from dispatch import dispatch_gemini_with_retry  # type: ignore  # noqa: E402
+from dispatch import GEMINI_WRITER_MODEL, dispatch_gemini_with_retry  # type: ignore  # noqa: E402
 
 CONTENT_ROOT = REPO_ROOT / "src" / "content" / "docs" / "on-premises"
 LOG_FILE = REPO_ROOT / ".pipeline" / "on-prem-logs" / "phase2-write-only.log"
 LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
 
-DEFAULT_WRITER = os.environ.get("KUBEDOJO_WRITER_MODEL") or "gemini-3.1-pro-preview"
+DEFAULT_WRITER = os.environ.get("KUBEDOJO_WRITER_MODEL") or GEMINI_WRITER_MODEL
 FACT_CHECKER = "gpt-5.3-codex-spark"  # calibrated winner from fact-grounding test
 MIN_CONTENT_CHARS = 2000  # below this is treated as a stub
 FACT_CHECK_TIMEOUT = 900

--- a/scripts/pipeline_v2/write_worker.py
+++ b/scripts/pipeline_v2/write_worker.py
@@ -6,13 +6,14 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
 
+from dispatch import GEMINI_WRITER_MODEL
 from v1_pipeline import _extract_frontmatter_data, find_module_path, step_write
 
 from .control_plane import ControlPlane, Lease
 from .review_worker import REVIEW_MODEL
 
 
-WRITE_MODEL = "gemini-3.1-pro-preview"
+WRITE_MODEL = GEMINI_WRITER_MODEL
 WRITE_ESTIMATED_USD = 0.0350
 STUB_BODY_CHAR_THRESHOLD = 400
 STUB_MARKERS = ("todo", "tbd", "stub", "placeholder", "coming soon")

--- a/scripts/research/writer-calibration-rigorous.py
+++ b/scripts/research/writer-calibration-rigorous.py
@@ -33,6 +33,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
+from dispatch import GEMINI_WRITER_MODEL  # noqa: E402
 
 OUTPUT_DIR = Path("/tmp/writer-rigorous")
 OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
@@ -42,7 +43,7 @@ RESULTS_FILE = OUTPUT_DIR / "results.json"
 # ---------- Configuration ----------
 
 CANDIDATES = [
-    {"name": "gemini-3.1-pro-preview", "family": "gemini", "tier": "frontier"},
+    {"name": GEMINI_WRITER_MODEL, "family": "gemini", "tier": "frontier"},
     {"name": "gpt-5.4", "family": "codex", "tier": "frontier"},
     {"name": "gpt-5.2", "family": "codex", "tier": "long-running"},
     {"name": "gpt-5.3-codex", "family": "codex", "tier": "codex-tuned"},

--- a/scripts/status.py
+++ b/scripts/status.py
@@ -12,6 +12,7 @@ import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from dispatch import GEMINI_WRITER_MODEL
 from pipeline_v2.cli import _build_status_report as build_v2_status_report
 from translation_v2 import build_status as build_translation_v2_status
 from ztt_status import build_status as build_ztt_status
@@ -239,7 +240,7 @@ def _build_translation_summary(repo_root: Path) -> dict[str, Any]:
         "stale": counts["stale"],
         "unknown": counts["unknown"],
         "sync_clean": counts["missing"] == 0 and counts["stale"] == 0 and counts["unknown"] == 0,
-        "writer": "gemini-3.1-pro-preview via uk_sync.py",
+        "writer": f"{GEMINI_WRITER_MODEL} via uk_sync.py",
         "modules": modules,
     }
 
@@ -482,7 +483,7 @@ def build_repo_status(repo_root: Path, *, fast: bool = False) -> dict[str, Any]:
             "translation": (
                 "translation v2 queue + uk_sync worker"
                 if translation_v2 is not None
-                else "gemini-3.1-pro-preview via uk_sync.py"
+                else f"{GEMINI_WRITER_MODEL} via uk_sync.py"
             ),
         },
     }

--- a/scripts/test_lab_pipeline.py
+++ b/scripts/test_lab_pipeline.py
@@ -19,6 +19,7 @@ import sys
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
 import lab_pipeline as lp
+from dispatch import GEMINI_WRITER_MODEL
 
 
 def _write_module(path: Path, *, lab: str | dict | None = None) -> None:
@@ -155,7 +156,7 @@ class TestLabState(unittest.TestCase):
                     "phase": "done",
                     "last_run": "2026-04-14T08:30:00Z",
                     "severity": "clean",
-                    "reviewer": "gemini-3.1-pro-preview",
+                    "reviewer": GEMINI_WRITER_MODEL,
                     "module": "k8s/cka/part1-cluster-architecture/module-1.1-control-plane",
                     "checks_failed": [],
                     "errors": [],
@@ -256,7 +257,7 @@ class TestLabReviewFlow(unittest.TestCase):
                     "phase": "done",
                     "last_run": "2026-04-14T08:30:00Z",
                     "severity": "clean",
-                    "reviewer": "gemini-3.1-pro-preview",
+                    "reviewer": GEMINI_WRITER_MODEL,
                     "module": "k8s/cka/part1-cluster-architecture/module-1.1-control-plane",
                     "checks_failed": [],
                     "errors": [],
@@ -270,7 +271,7 @@ class TestLabReviewFlow(unittest.TestCase):
                 "cka-1.1-control-plane",
                 "LAB_REVIEW",
                 verdict="APPROVE",
-                reviewer="gemini-3.1-pro-preview",
+                reviewer=GEMINI_WRITER_MODEL,
                 severity="clean",
                 module="k8s/cka/part1-cluster-architecture/module-1.1-control-plane",
                 checks=[{"id": "STRUCTURE", "passed": True}],
@@ -280,7 +281,7 @@ class TestLabReviewFlow(unittest.TestCase):
             lp.append_lab_review_audit(
                 "cka-1.1-control-plane",
                 "LAB_DONE",
-                reviewer="gemini-3.1-pro-preview",
+                reviewer=GEMINI_WRITER_MODEL,
                 module="k8s/cka/part1-cluster-architecture/module-1.1-control-plane",
             )
 

--- a/scripts/test_pipeline.py
+++ b/scripts/test_pipeline.py
@@ -33,6 +33,7 @@ sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
 from checks import structural
 from checks.structural import CheckResult
+from dispatch import GEMINI_WRITER_MODEL
 
 
 def sample_fact_ledger() -> dict:
@@ -639,7 +640,7 @@ class TestReviewAuditLog(unittest.TestCase):
             audit_path = p.append_review_audit(
                 self.module_path,
                 "WRITE",
-                writer="gemini-3.1-pro-preview",
+                writer=GEMINI_WRITER_MODEL,
                 mode="write",
                 duration=2.5,
                 plan="Initial write plan",
@@ -654,7 +655,7 @@ class TestReviewAuditLog(unittest.TestCase):
         self.assertIn("**Current severity**: targeted", content)
         self.assertIn("**Total passes**: 1", content)
         self.assertIn("`WRITE`", content)
-        self.assertIn("**Writer**: gemini-3.1-pro-preview", content)
+        self.assertIn(f"**Writer**: {GEMINI_WRITER_MODEL}", content)
 
     def test_second_append_prepends_and_preserves_existing_entries(self):
         import v1_pipeline as p
@@ -696,7 +697,7 @@ class TestReviewAuditLog(unittest.TestCase):
             p.append_review_audit(
                 self.module_path,
                 "WRITE",
-                writer="gemini-3.1-pro-preview",
+                writer=GEMINI_WRITER_MODEL,
                 mode="write",
                 duration=1,
                 plan="first",

--- a/scripts/translation_v2.py
+++ b/scripts/translation_v2.py
@@ -15,6 +15,7 @@ import yaml
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from checks import ukrainian
+from dispatch import GEMINI_WRITER_MODEL
 from pipeline_v2.control_plane import (
     DEFAULT_BUDGETS_PATH,
     ControlPlane,
@@ -27,7 +28,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 DOCS_ROOT = REPO_ROOT / "src" / "content" / "docs"
 UK_ROOT = DOCS_ROOT / "uk"
 DEFAULT_DB_PATH = REPO_ROOT / ".pipeline" / "translation_v2.db"
-TRANSLATE_MODEL = "gemini-3.1-pro-preview"
+TRANSLATE_MODEL = GEMINI_WRITER_MODEL
 TRANSLATE_ESTIMATED_USD = 0.0350
 VERIFY_MODEL = "deterministic-ukrainian-checks"
 DEFAULT_LEASE_SECONDS = 1200

--- a/scripts/uk_sync.py
+++ b/scripts/uk_sync.py
@@ -38,10 +38,10 @@ REPORT_FILE = REPO_ROOT / ".pipeline" / "uk-sync-report.json"
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
 from checks import ukrainian
-from dispatch import dispatch_gemini_with_retry
+from dispatch import GEMINI_WRITER_MODEL, dispatch_gemini_with_retry
 
 CHUNKED_THRESHOLD = 40_000  # chars — modules above this use section-by-section translation
-CHUNKED_MODEL = "gemini-3.1-pro-preview"  # pro for quality on section-by-section
+CHUNKED_MODEL = GEMINI_WRITER_MODEL  # pro for quality on section-by-section
 BATCH_LIMIT = 15_000  # chars — pack adjacent sections into batches up to this size
 
 

--- a/scripts/v1_pipeline.py
+++ b/scripts/v1_pipeline.py
@@ -132,6 +132,7 @@ sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
 from checks import structural, ukrainian, gaps
 from dispatch import (
+    GEMINI_WRITER_MODEL,
     dispatch_gemini_with_retry,
     dispatch_claude,
     dispatch_codex,
@@ -163,9 +164,9 @@ def dispatch_auto(prompt: str, model: str, timeout: int = 900) -> tuple[bool, st
 # ---------------------------------------------------------------------------
 
 MODELS = {
-    "write": "gemini-3.1-pro-preview",     # Preview model — review in monthly evals, re-pin when GA available. See issue #217.
+    "write": GEMINI_WRITER_MODEL,          # Pinned in dispatch.py; re-evaluate monthly and replace when GA is available. See issue #217/#278.
     "write_targeted": "claude-sonnet-4-6", # TARGETED FIX: surgical patches (instruction-following)
-    "review": "gemini-3.1-pro-preview",    # STRUCTURAL REVIEW: calibration-backed choice for split-reviewer flow
+    "review": GEMINI_WRITER_MODEL,         # STRUCTURAL REVIEW: calibration-backed choice for split-reviewer flow
     "review_fallback": "claude-sonnet-4-6",  # independent REVIEW fallback when Codex is unavailable
     "knowledge_card": "gpt-5.3-codex-spark",  # WRITE grounding aligned with fact-grounding calibration
     "fact_grounding": "gpt-5.3-codex-spark",  # split-reviewer architecture: factual grounding ledger
@@ -4393,14 +4394,14 @@ def main():
   resume                           retry stuck modules only
 
 models:
-  --write-model gemini-3.1-pro-preview     override the main writer
+  --write-model {GEMINI_WRITER_MODEL}     override the main writer
   --review-model claude-sonnet-4-6         override the primary reviewer
 """, formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     # Global model overrides
     parser.add_argument("--audit-model", help=argparse.SUPPRESS)
-    parser.add_argument("--write-model", help="Model for WRITE step (default: gemini-3.1-pro-preview)")
-    parser.add_argument("--review-model", help="Model for REVIEW step (default: gemini-3.1-pro-preview)")
+    parser.add_argument("--write-model", help=f"Model for WRITE step (default: {GEMINI_WRITER_MODEL})")
+    parser.add_argument("--review-model", help=f"Model for REVIEW step (default: {GEMINI_WRITER_MODEL})")
 
     subparsers = parser.add_subparsers(dest="command", help="Pipeline command")
 


### PR DESCRIPTION
Follow-up to #278 PR 1, stacked on top of #283 while that PR remains open.

This completes the remaining Gemini writer-model pin by replacing hardcoded `gemini-3.1-pro-preview` references with `GEMINI_WRITER_MODEL` sourced from `scripts/dispatch.py` across the remaining worker/bridge/runtime paths plus the affected tests and script fixtures.

Post-refactor grep proof:
```text
scripts/dispatch.py:49:24:GEMINI_WRITER_MODEL = "gemini-3.1-pro-preview"
```

Validation:
- `../../.venv/bin/python -m py_compile scripts/lab_pipeline.py scripts/uk_sync.py scripts/pipeline_v2/write_worker.py scripts/translation_v2.py scripts/status.py scripts/dedupe_audit.py scripts/on-prem/phase2-write-only.py scripts/research/writer-calibration-rigorous.py scripts/ai_agent_bridge/_cli.py scripts/ai_agent_bridge/_gemini.py scripts/agent_runtime/adapters/gemini.py scripts/agent_runtime/registry.py scripts/test_pipeline.py scripts/test_lab_pipeline.py` ✅
- `../../.venv/bin/python -m pytest tests/test_bridge_inbox.py tests/test_bridge_inbox_cli.py scripts/test_pipeline.py scripts/test_lab_pipeline.py -q` ✅ (`157 passed, 1 skipped`)
- `~/.local/bin/ruff check ...` ⚠️ still fails on pre-existing violations in touched legacy files (`E402`, `F541`, `F841`, and a few unused imports unrelated to this pinning change)
