### PR TITLE
fix(pipeline): _merge_fact_ledgers is pure and idempotent (#235)

### DIFF
--- a/scripts/test_pipeline.py
+++ b/scripts/test_pipeline.py
@@ -19,6 +19,7 @@ import tempfile
 import threading
 import textwrap
 import unittest
+import copy
 from argparse import Namespace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -2495,15 +2496,53 @@ class TestContentAwareFactLedger(unittest.TestCase):
         claim_texts = {c["claim"] for c in merged["claims"]}
         self.assertIn("topic claim B", claim_texts)
 
+    def test_merge_is_pure_and_idempotent(self):
+        import v1_pipeline as p
+
+        topic = {
+            "as_of_date": "2026-04-12",
+            "topic": "Test",
+            "claims": [
+                {"id": "C7", "claim": "topic claim A", "status": "SUPPORTED"},
+                {"id": "C8", "claim": "topic claim B", "status": "SUPPORTED"},
+            ],
+        }
+        content = {
+            "as_of_date": "2026-04-12",
+            "topic": "Test",
+            "content_aware": True,
+            "claims": [
+                {"id": "C9", "claim": "topic claim A", "status": "SUPPORTED"},
+                {"id": "C10", "claim": "new content claim", "status": "UNVERIFIED"},
+            ],
+        }
+        topic_before = copy.deepcopy(topic)
+        content_before = copy.deepcopy(content)
+
+        merged_once = p._merge_fact_ledgers(topic, content)
+        merged_twice = p._merge_fact_ledgers(topic, content)
+
+        self.assertEqual(topic, topic_before)
+        self.assertEqual(content, content_before)
+        self.assertEqual(merged_once, merged_twice)
+        self.assertIsNot(merged_once, topic)
+        self.assertIsNot(merged_once, content)
+
     def test_merge_returns_topic_when_content_is_none(self):
         import v1_pipeline as p
         topic = {"claims": [{"id": "C1", "claim": "x"}]}
-        self.assertEqual(p._merge_fact_ledgers(topic, None), topic)
+        merged = p._merge_fact_ledgers(topic, None)
+        self.assertEqual(merged, topic)
+        self.assertIsNot(merged, topic)
+        self.assertIsNot(merged["claims"], topic["claims"])
 
     def test_merge_returns_content_when_topic_is_none(self):
         import v1_pipeline as p
         content = {"claims": [{"id": "C1", "claim": "x"}], "content_aware": True}
-        self.assertEqual(p._merge_fact_ledgers(None, content), content)
+        merged = p._merge_fact_ledgers(None, content)
+        self.assertEqual(merged, content)
+        self.assertIsNot(merged, content)
+        self.assertIsNot(merged["claims"], content["claims"])
 
     def test_content_aware_step_caches_with_suffix(self):
         """Content-aware ledger uses '-content' cache suffix."""

--- a/scripts/v1_pipeline.py
+++ b/scripts/v1_pipeline.py
@@ -630,17 +630,20 @@ def _merge_fact_ledgers(topic_ledger: dict | None, content_ledger: dict | None) 
     that don't overlap are kept for broad coverage. Returns a merged ledger
     or the best available single ledger.
     """
-    if not isinstance(content_ledger, dict) or not content_ledger.get("claims"):
-        return topic_ledger
-    if not isinstance(topic_ledger, dict) or not topic_ledger.get("claims"):
-        return content_ledger
+    topic_copy = copy.deepcopy(topic_ledger) if isinstance(topic_ledger, dict) else None
+    content_copy = copy.deepcopy(content_ledger) if isinstance(content_ledger, dict) else None
+
+    if not content_copy or not content_copy.get("claims"):
+        return topic_copy
+    if not topic_copy or not topic_copy.get("claims"):
+        return content_copy
 
     # Use content-aware claims as the base
-    merged_claims = copy.deepcopy(content_ledger["claims"])
+    merged_claims = copy.deepcopy(content_copy["claims"])
     content_texts = {c.get("claim", "").lower().strip() for c in merged_claims if isinstance(c, dict)}
 
     # Add non-overlapping topic claims
-    for claim in topic_ledger.get("claims", []):
+    for claim in topic_copy.get("claims", []):
         if not isinstance(claim, dict):
             continue
         claim_text = claim.get("claim", "").lower().strip()
@@ -653,8 +656,8 @@ def _merge_fact_ledgers(topic_ledger: dict | None, content_ledger: dict | None) 
             claim["id"] = f"C{i}"
 
     return {
-        "as_of_date": content_ledger.get("as_of_date", topic_ledger.get("as_of_date")),
-        "topic": content_ledger.get("topic", topic_ledger.get("topic")),
+        "as_of_date": content_copy.get("as_of_date", topic_copy.get("as_of_date")),
+        "topic": content_copy.get("topic", topic_copy.get("topic")),
         "content_aware": True,
         "claims": merged_claims,
     }


### PR DESCRIPTION
## Summary
- deep-copy both ledger inputs before merging so source dicts are never mutated in place
- return deep-copied single-ledger results for the one-sided cases to avoid aliasing callers to source state
- add regression coverage for unchanged inputs, repeated-call idempotence, and copy semantics

## Verification
- python -m py_compile scripts/v1_pipeline.py scripts/test_pipeline.py
- python scripts/test_pipeline.py TestContentAwareFactLedger -v
- ruff check scripts/v1_pipeline.py scripts/test_pipeline.py  # existing baseline failures in these files (pre-existing E402/F541)