### PR TITLE
fix: revive needs_independent_review for last-resort approvals (#235)

### DIFF
--- a/scripts/test_pipeline.py
+++ b/scripts/test_pipeline.py
@@ -1076,6 +1076,45 @@ class TestPipelineTransitions(unittest.TestCase):
         self.assertEqual(mock_review.call_count, 2)
 
     @patch("v1_pipeline.STATE_FILE")
+    @patch("v1_pipeline.CONTENT_ROOT")
+    @patch("subprocess.run")
+    def test_last_resort_same_family_review_sets_pending_flag(
+        self, mock_subprocess, mock_root, mock_state,
+    ):
+        """Writer-family last-resort approvals must preserve the deferred re-review flag."""
+        import v1_pipeline as p
+
+        mock_state.__class__ = type(self.state_file)
+        mock_root.resolve.return_value = Path(self.tmpdir).resolve()
+
+        state = {"modules": {}}
+        all_pass_checks = [{"id": cid, "passed": True} for cid in p.CHECK_IDS]
+        review_sequence = [
+            {"rate_limited": True},
+            {"rate_limited": True},
+            {"verdict": "APPROVE", "severity": "clean",
+             "checks": all_pass_checks, "edits": [], "feedback": ""},
+        ]
+
+        with patch.object(p, "STATE_FILE", self.state_file), \
+             patch.object(p, "CONTENT_ROOT", Path(self.tmpdir)), \
+             patch.object(p, "save_state"), \
+             patch.object(p, "module_key_from_path", return_value="test/module-0.1-test"), \
+             patch.object(p, "step_write", return_value=GOOD_MODULE), \
+             patch.object(p, "step_review", side_effect=review_sequence) as mock_review, \
+             patch.object(p, "ensure_fact_ledger", return_value=sample_fact_ledger()), \
+             patch.object(p, "step_content_aware_fact_ledger", return_value=None), \
+             patch.object(p, "step_check_integrity", return_value=(True, [])), \
+             patch.object(p, "step_check", return_value=(True, [])):
+            p.run_module(self.module_path, state)
+
+        ms = state["modules"]["test/module-0.1-test"]
+        self.assertEqual(ms.get("phase"), "done")
+        self.assertEqual(ms.get("reviewer"), "gemini")
+        self.assertTrue(ms.get("needs_independent_review"))
+        self.assertEqual(mock_review.call_count, 3)
+
+    @patch("v1_pipeline.STATE_FILE")
     @patch("v1_pipeline.dispatch_auto")
     @patch("v1_pipeline.CONTENT_ROOT")
     @patch("subprocess.run")

--- a/scripts/v1_pipeline.py
+++ b/scripts/v1_pipeline.py
@@ -173,11 +173,10 @@ MODELS = {
     # "translate" removed — uk_sync.CHUNKED_MODEL owns translation model config
 }
 
-# Reviewer families considered "independent" of the writer (currently Gemini).
-# Only these count as production-ready reviewers. Gemini reviewing Gemini is a
-# fallback to keep the pipeline moving but flags the module for re-review.
+# Reviewer families considered "independent" for the deferred re-review path
+# and fact-grounding model validation. Claude remains the preferred cross-family
+# fallback when the primary structural reviewer is unavailable.
 INDEPENDENT_REVIEWER_FAMILIES = {"codex", "claude"}
-STRUCTURAL_REVIEW_INDEPENDENCE_RELAXED = True
 
 # Pipeline phases in order.
 # "needs_targeted_fix" is a pause state entered when Claude is unavailable
@@ -2774,6 +2773,7 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
             review_started = datetime.now(UTC)
             reviewer_model = m["review"]
             used_fallback_reviewer = False
+            needs_independent_review_if_approved = False
             review = step_review(
                 module_path,
                 improved or module_path.read_text(),
@@ -2793,8 +2793,7 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
                 if fallback_family == primary_family:
                     print(f"  ⚠ Primary reviewer rate-limited and fallback is same family — skipping to last resort")
                     fallback_allowed = False
-                elif (not STRUCTURAL_REVIEW_INDEPENDENCE_RELAXED and
-                      fallback_family not in INDEPENDENT_REVIEWER_FAMILIES):
+                elif fallback_family not in INDEPENDENT_REVIEWER_FAMILIES:
                     print(f"  ⚠ Review fallback {fallback_model} is not in approved independent families — skipping to last resort")
                     fallback_allowed = False
 
@@ -2848,6 +2847,7 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
                         return False
                     reviewer_model = last_resort_model
                     used_fallback_reviewer = True
+                    needs_independent_review_if_approved = True
 
             if review is None:
                 ms["errors"].append(f"Review failed attempt {attempt+1}")
@@ -2880,10 +2880,7 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
                 ms.pop("sonnet_anchor_failures", None)
                 reviewer_family = _model_family(reviewer_model)
                 ms["reviewer"] = reviewer_family
-                ms["needs_independent_review"] = (
-                    (not STRUCTURAL_REVIEW_INDEPENDENCE_RELAXED) and
-                    reviewer_family not in INDEPENDENT_REVIEWER_FAMILIES
-                )
+                ms["needs_independent_review"] = needs_independent_review_if_approved
                 ms["phase"] = "check"
                 save_state(state)
                 emit_audit(


### PR DESCRIPTION
## Summary
- remove the dead `STRUCTURAL_REVIEW_INDEPENDENCE_RELAXED` gate from the structural review path
- track when review succeeded only via the writer-family last-resort reviewer and persist `needs_independent_review=True` for that case
- add a regression test covering the primary rate-limit -> fallback rate-limit -> last-resort approve flow

## Verification
- `python -m py_compile scripts/v1_pipeline.py scripts/test_pipeline.py`
- `ruff check scripts/v1_pipeline.py scripts/test_pipeline.py` *(fails on pre-existing E402/F541 in these files; no new lint violations introduced by this patch)*
- `pytest -q scripts/test_pipeline.py`