### PR TITLE
fix(pipeline): check_failures tracks consecutive, not lifetime (#235)

### DIFF
--- a/scripts/test_pipeline.py
+++ b/scripts/test_pipeline.py
@@ -1307,6 +1307,72 @@ class TestPipelineTransitions(unittest.TestCase):
         self.assertFalse(result)
 
 
+    @patch("v1_pipeline.STATE_FILE")
+    @patch("v1_pipeline.CONTENT_ROOT")
+    @patch("subprocess.run")
+    def test_check_failures_tracks_consecutive_failures_only(
+        self, mock_subprocess, mock_root, mock_state,
+    ):
+        import v1_pipeline as p
+
+        mock_state.__class__ = type(self.state_file)
+        mock_root.resolve.return_value = Path(self.tmpdir).resolve()
+
+        key = "test/module-0.1-test"
+        state = {
+            "modules": {
+                key: {
+                    "phase": "check",
+                    "severity": "clean",
+                    "reviewer": "codex",
+                    "needs_independent_review": False,
+                    "passes": False,
+                    "errors": [],
+                }
+            }
+        }
+        failed_results = [CheckResult("QUIZ", False, "Missing scenario-based question")]
+        git_ok = subprocess.CompletedProcess(["git"], 0, "", "")
+
+        def prepare_check_phase():
+            self.module_path.with_suffix(".staging.md").write_text(GOOD_MODULE)
+            state["modules"][key]["phase"] = "check"
+
+        with patch.object(p, "STATE_FILE", self.state_file), \
+             patch.object(p, "CONTENT_ROOT", Path(self.tmpdir)), \
+             patch.object(p, "REVIEW_AUDIT_DIR", Path(self.tmpdir) / ".pipeline" / "reviews"), \
+             patch.object(p, "KNOWLEDGE_CARD_DIR", Path(self.tmpdir) / ".pipeline" / "knowledge-cards"), \
+             patch.object(p, "save_state"), \
+             patch.object(p, "ensure_fact_ledger", return_value=sample_fact_ledger()), \
+             patch.object(p, "_git_stage_and_commit", return_value=(git_ok, git_ok)), \
+             patch.object(p, "module_key_from_path", return_value=key), \
+             patch.object(
+                 p,
+                 "step_check",
+                 side_effect=[
+                     (True, []),
+                     (False, failed_results),
+                     (True, []),
+                     (False, failed_results),
+                 ],
+             ):
+            prepare_check_phase()
+            self.assertTrue(p.run_module(self.module_path, state))
+            self.assertEqual(state["modules"][key].get("check_failures"), 0)
+
+            prepare_check_phase()
+            self.assertFalse(p.run_module(self.module_path, state))
+            self.assertEqual(state["modules"][key].get("check_failures"), 1)
+
+            prepare_check_phase()
+            self.assertTrue(p.run_module(self.module_path, state))
+            self.assertEqual(state["modules"][key].get("check_failures"), 0)
+
+            prepare_check_phase()
+            self.assertFalse(p.run_module(self.module_path, state))
+            self.assertEqual(state["modules"][key].get("check_failures"), 1)
+
+
 # ---------------------------------------------------------------------------
 # Test: Binary quality gate — compute_severity unit tests (issue #223)
 # ---------------------------------------------------------------------------

--- a/scripts/v1_pipeline.py
+++ b/scripts/v1_pipeline.py
@@ -2870,7 +2870,7 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
                 # binary-gate view, not the old [D1..D8] vector.
                 ms.pop("scores", None)
                 ms.pop("sum", None)
-                ms.pop("check_failures", None)
+                ms["check_failures"] = 0
                 # Circuit breaker is a CONSECUTIVE counter — reset it on
                 # any path that re-establishes a good state (APPROVE or
                 # 100% deterministic apply). Without this reset, one past
@@ -3162,7 +3162,7 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
         backup.unlink(missing_ok=True)  # remove backup on success
         print(f"  ✓ File written: {module_path}")
 
-        ms.pop("check_failures", None)
+        ms["check_failures"] = 0
         ms["phase"] = "score"
         save_state(state)
         warnings_count = len([


### PR DESCRIPTION
## Summary
- reset check_failures to 0 on APPROVE and successful CHECK so the counter is explicitly consecutive
- add a regression test for the CHECK sequence success -> failure -> success -> failure

## Verification
- python -m py_compile scripts/v1_pipeline.py scripts/test_pipeline.py
- python -m unittest scripts.test_pipeline.TestPipelineTransitions.test_check_failures_tracks_consecutive_failures_only
- python scripts/test_pipeline.py (fails on existing unrelated test: TestStatusFourStage.test_cmd_status_prints_four_stage_completion_table)
- ruff check scripts/v1_pipeline.py scripts/test_pipeline.py (fails on pre-existing E402/F541 issues in these files)