### PR TITLE
fix(pipeline): review fallback chain continues to last-resort instead of hard-failing (#235)

### DIFF
--- a/scripts/test_pipeline.py
+++ b/scripts/test_pipeline.py
@@ -1264,6 +1264,102 @@ class TestPipelineTransitions(unittest.TestCase):
         self.assertEqual(mock_review.call_count, 3)
 
     @patch("v1_pipeline.STATE_FILE")
+    @patch("v1_pipeline.CONTENT_ROOT")
+    @patch("subprocess.run")
+    def test_review_skips_same_writer_family_fallback_to_last_resort(
+        self, mock_subprocess, mock_root, mock_state,
+    ):
+        """Same-writer-family fallback should skip straight to last resort and preserve re-review flag."""
+        import v1_pipeline as p
+
+        mock_state.__class__ = type(self.state_file)
+        mock_root.resolve.return_value = Path(self.tmpdir).resolve()
+
+        state = {"modules": {}}
+        models = {
+            **p.MODELS,
+            "write": "claude-sonnet-4-6",
+            "review": "gemini-3.1-pro-preview",
+            "review_fallback": "claude-sonnet-4-6",
+        }
+        all_pass_checks = [{"id": cid, "passed": True} for cid in p.CHECK_IDS]
+        review_sequence = [
+            {"rate_limited": True},
+            {"verdict": "APPROVE", "severity": "clean",
+             "checks": all_pass_checks, "edits": [], "feedback": ""},
+        ]
+
+        with patch.object(p, "STATE_FILE", self.state_file), \
+             patch.object(p, "CONTENT_ROOT", Path(self.tmpdir)), \
+             patch.object(p, "save_state"), \
+             patch.object(p, "module_key_from_path", return_value="test/module-0.1-test"), \
+             patch.object(p, "step_write", return_value=GOOD_MODULE), \
+             patch.object(p, "step_review", side_effect=review_sequence) as mock_review, \
+             patch.object(p, "ensure_fact_ledger", return_value=sample_fact_ledger()), \
+             patch.object(p, "step_content_aware_fact_ledger", return_value=None), \
+             patch.object(p, "step_check_integrity", return_value=(True, [])), \
+             patch.object(p, "step_check", return_value=(True, [])):
+            p.run_module(self.module_path, state, models=models)
+
+        ms = state["modules"]["test/module-0.1-test"]
+        self.assertEqual(ms.get("phase"), "done")
+        self.assertEqual(ms.get("reviewer"), "claude")
+        self.assertTrue(ms.get("needs_independent_review"))
+        self.assertEqual(mock_review.call_count, 2)
+        self.assertEqual(
+            [call.kwargs["model"] for call in mock_review.call_args_list],
+            [models["review"], models["write"]],
+        )
+
+    @patch("v1_pipeline.STATE_FILE")
+    @patch("v1_pipeline.CONTENT_ROOT")
+    @patch("subprocess.run")
+    def test_review_uses_approved_cross_family_fallback_before_last_resort(
+        self, mock_subprocess, mock_root, mock_state,
+    ):
+        """Approved cross-family fallback should be used instead of the last-resort writer reviewer."""
+        import v1_pipeline as p
+
+        mock_state.__class__ = type(self.state_file)
+        mock_root.resolve.return_value = Path(self.tmpdir).resolve()
+
+        state = {"modules": {}}
+        models = {
+            **p.MODELS,
+            "write": "claude-sonnet-4-6",
+            "review": "gemini-3.1-pro-preview",
+            "review_fallback": "gpt-5.3-codex-spark",
+        }
+        all_pass_checks = [{"id": cid, "passed": True} for cid in p.CHECK_IDS]
+        review_sequence = [
+            {"rate_limited": True},
+            {"verdict": "APPROVE", "severity": "clean",
+             "checks": all_pass_checks, "edits": [], "feedback": ""},
+        ]
+
+        with patch.object(p, "STATE_FILE", self.state_file), \
+             patch.object(p, "CONTENT_ROOT", Path(self.tmpdir)), \
+             patch.object(p, "save_state"), \
+             patch.object(p, "module_key_from_path", return_value="test/module-0.1-test"), \
+             patch.object(p, "step_write", return_value=GOOD_MODULE), \
+             patch.object(p, "step_review", side_effect=review_sequence) as mock_review, \
+             patch.object(p, "ensure_fact_ledger", return_value=sample_fact_ledger()), \
+             patch.object(p, "step_content_aware_fact_ledger", return_value=None), \
+             patch.object(p, "step_check_integrity", return_value=(True, [])), \
+             patch.object(p, "step_check", return_value=(True, [])):
+            p.run_module(self.module_path, state, models=models)
+
+        ms = state["modules"]["test/module-0.1-test"]
+        self.assertEqual(ms.get("phase"), "done")
+        self.assertEqual(ms.get("reviewer"), "codex")
+        self.assertFalse(ms.get("needs_independent_review", True))
+        self.assertEqual(mock_review.call_count, 2)
+        self.assertEqual(
+            [call.kwargs["model"] for call in mock_review.call_args_list],
+            [models["review"], models["review_fallback"]],
+        )
+
+    @patch("v1_pipeline.STATE_FILE")
     @patch("v1_pipeline.dispatch_auto")
     @patch("v1_pipeline.CONTENT_ROOT")
     @patch("subprocess.run")

--- a/scripts/v1_pipeline.py
+++ b/scripts/v1_pipeline.py
@@ -3003,11 +3003,11 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
             # 3. If both unavailable, use writer model as last resort.
             if isinstance(review, dict) and review.get("rate_limited"):
                 fallback_model = m.get("review_fallback", MODELS["review_fallback"])
-                primary_family = _model_family(reviewer_model)
+                writer_family = _model_family(m["write"])
                 fallback_family = _model_family(fallback_model)
                 fallback_allowed = True
-                if fallback_family == primary_family:
-                    print(f"  ⚠ Primary reviewer rate-limited and fallback is same family — skipping to last resort")
+                if fallback_family == writer_family:
+                    print("  ⚠ Primary reviewer rate-limited and fallback matches writer family — skipping to last resort")
                     fallback_allowed = False
                 elif fallback_family not in INDEPENDENT_REVIEWER_FAMILIES:
                     print(f"  ⚠ Review fallback {fallback_model} is not in approved independent families — skipping to last resort")


### PR DESCRIPTION
## Summary
- treat review fallback models from the writer family as invalid and continue to the writer-model last-resort path instead of aborting
- preserve `needs_independent_review=True` when the last-resort reviewer approves so a later independent re-review is still required, matching the #288 interaction
- add regression coverage for both same-writer-family fallback skipping and approved cross-family fallback usage

## Verification
- `python -m py_compile scripts/v1_pipeline.py scripts/test_pipeline.py`
- `pytest -q scripts/test_pipeline.py -k "review_falls_back_to_sonnet_without_pending_flag or review_skips_same_writer_family_fallback_to_last_resort or review_uses_approved_cross_family_fallback_before_last_resort"`
- `pytest -q scripts/test_pipeline.py -k TestPipelineTransitions`
- `ruff check scripts/v1_pipeline.py scripts/test_pipeline.py` *(fails on pre-existing repo-wide E402/F541 lint noise in these files; no new ruff findings from this patch)*