### PR TITLE
fix(pipeline): severe rewrite clears stale targeted_fix, uses full rewrite model (#235)

### DIFF
--- a/scripts/test_pipeline.py
+++ b/scripts/test_pipeline.py
@@ -1209,6 +1209,72 @@ class TestPipelineTransitions(unittest.TestCase):
     @patch("v1_pipeline.STATE_FILE")
     @patch("v1_pipeline.CONTENT_ROOT")
     @patch("subprocess.run")
+    def test_stale_targeted_fix_does_not_route_severe_resume_to_targeted_writer(
+        self, mock_subprocess, mock_root, mock_state,
+    ):
+        """Severe rewrite resumes must clear stale targeted_fix before write routing."""
+        import v1_pipeline as p
+
+        mock_state.__class__ = type(self.state_file)
+        mock_root.resolve.return_value = Path(self.tmpdir).resolve()
+
+        staging = self.module_path.with_suffix(".staging.md")
+        staging.write_text(GOOD_MODULE)
+
+        state = {
+            "modules": {
+                "test/module-0.1-test": {
+                    "phase": "write",
+                    "plan": "STALE TARGETED FIX PLAN",
+                    "targeted_fix": True,
+                    "severity": "severe",
+                    "check_failures": 1,
+                    "checks_failed": [{"id": "LAB", "evidence": "stale targeted fix after CHECK failure"}],
+                    "reviewer_schema_version": 3,
+                    "errors": [],
+                },
+            },
+        }
+        write_calls = []
+
+        def fake_step_write(module_path, plan, model=None, rewrite=False,
+                            previous_output=None, knowledge_card=None, fact_ledger=None):
+            write_calls.append({
+                "plan": plan,
+                "model": model,
+                "rewrite": rewrite,
+                "previous_output": previous_output,
+            })
+            return GOOD_MODULE
+
+        with patch.object(p, "STATE_FILE", self.state_file), \
+             patch.object(p, "CONTENT_ROOT", Path(self.tmpdir)), \
+             patch.object(p, "save_state"), \
+             patch.object(p, "module_key_from_path", return_value="test/module-0.1-test"), \
+             patch.object(p, "step_write", side_effect=fake_step_write), \
+             patch.object(p, "step_review", return_value={
+                 "verdict": "APPROVE",
+                 "severity": "clean",
+                 "checks": [{"id": cid, "passed": True} for cid in p.CHECK_IDS],
+                 "edits": [],
+                 "feedback": "",
+             }), \
+             patch.object(p, "ensure_fact_ledger", return_value=sample_fact_ledger()), \
+             patch.object(p, "step_content_aware_fact_ledger", return_value=None), \
+             patch.object(p, "step_check_integrity", return_value=(True, [])), \
+             patch.object(p, "step_check", return_value=(True, [])):
+            p.run_module(self.module_path, state)
+
+        self.assertEqual(len(write_calls), 1, "Expected a single resumed severe rewrite")
+        self.assertTrue(write_calls[0]["rewrite"], "Severe resume must stay in rewrite mode")
+        self.assertEqual(write_calls[0]["model"], p.MODELS["write"],
+                         "Severe rewrite must use the full writer, not the targeted-fix writer")
+        self.assertFalse(state["modules"]["test/module-0.1-test"]["targeted_fix"],
+                         "Stale targeted_fix must be cleared before rewrite routing")
+
+    @patch("v1_pipeline.STATE_FILE")
+    @patch("v1_pipeline.CONTENT_ROOT")
+    @patch("subprocess.run")
     def test_severity_targeted_routes_to_sonnet(
         self, mock_subprocess, mock_root, mock_state,
     ):

--- a/scripts/v1_pipeline.py
+++ b/scripts/v1_pipeline.py
@@ -2626,6 +2626,12 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
     # will be lost.
     prior_severity = ms.get("severity")
     needs_rewrite = prior_severity == "severe"
+    if needs_rewrite and targeted_fix:
+        # Full rewrites must never inherit a stale targeted-fix route from a
+        # prior iteration or resume snapshot.
+        targeted_fix = False
+        ms["targeted_fix"] = False
+        save_state(state)
     if needs_rewrite:
         failed_ids = [c.get("id", "?") for c in (ms.get("checks_failed") or [])]
         print(f"  Prior severity=severe (failed: {failed_ids}) — using REWRITE mode")


### PR DESCRIPTION
## Summary
- clear stale \'targeted_fix\' state before writer routing when a module resumes in severe rewrite mode
- add a regression test covering a CHECK-failure-style resume snapshot with  and stale 

## Verification
- 
- E402 Module level import not at top of file
  --> scripts/test_pipeline.py:34:1
   |
32 | sys.path.insert(0, str(REPO_ROOT / "scripts"))
33 |
34 | from checks import structural
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
35 | from checks.structural import CheckResult
   |

E402 Module level import not at top of file
  --> scripts/test_pipeline.py:35:1
   |
34 | from checks import structural
35 | from checks.structural import CheckResult
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |

E402 Module level import not at top of file
   --> scripts/v1_pipeline.py:133:1
    |
131 | sys.path.insert(0, str(REPO_ROOT / "scripts"))
132 |
133 | from checks import structural, ukrainian, gaps
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
134 | from dispatch import (
135 |     dispatch_gemini_with_retry,
    |

E402 Module level import not at top of file
   --> scripts/v1_pipeline.py:134:1
    |
133 |   from checks import structural, ukrainian, gaps
134 | / from dispatch import (
135 | |     dispatch_gemini_with_retry,
136 | |     dispatch_claude,
137 | |     dispatch_codex,
138 | |     _is_rate_limited,
139 | |     ClaudeUnavailableError,
140 | | )
    | |_^
141 |   from uk_sync import (
142 |       translate_new_module as uk_translate,
    |

E402 Module level import not at top of file
   --> scripts/v1_pipeline.py:141:1
    |
139 |       ClaudeUnavailableError,
140 |   )
141 | / from uk_sync import (
142 | |     translate_new_module as uk_translate,
143 | |     fix_module as uk_fix,
144 | |     _find_content_files as uk_find_content_files,
145 | |     CONTENT_ROOT as UK_CONTENT_ROOT,
146 | |     UK_ROOT,
147 | | )
    | |_^
    |

F541 [*] f-string without any placeholders
   --> scripts/v1_pipeline.py:974:15
    |
973 |     if not ok or not output.strip():
974 |         print(f"  ❌ WRITE failed")
    |               ^^^^^^^^^^^^^^^^^^^^
975 |         return None
    |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
   --> scripts/v1_pipeline.py:991:15
    |
989 |                         "the prompt says", "standard behavior"]
990 |     if any(marker in output[:500] for marker in thinking_markers):
991 |         print(f"  ❌ WRITE failed — Gemini leaked chain-of-thought into output")
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
992 |         return None
    |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:1002:19
     |
1000 |             print(f"  ⚠ Stripped {fm_start} chars of preamble before frontmatter")
1001 |         else:
1002 |             print(f"  ❌ WRITE failed — output has no frontmatter")
     |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
1003 |             return None
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:1284:15
     |
1283 |     if not ok or not output.strip():
1284 |         print(f"  ❌ INDEX rewrite failed")
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
1285 |         return False
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:1298:15
     |
1297 |     if not output.startswith("---"):
1298 |         print(f"  ❌ INDEX rewrite has no frontmatter")
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
1299 |         return False
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:1304:15
     |
1302 |     parts = output.split("---", 2)
1303 |     if len(parts) < 3:
1304 |         print(f"  ❌ INDEX rewrite has malformed frontmatter")
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
1305 |         return False
1306 |     try:
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:1309:19
     |
1307 |         fm = yaml.safe_load(parts[1])
1308 |         if not isinstance(fm, dict) or "title" not in fm:
1309 |             print(f"  ❌ INDEX rewrite missing title in frontmatter")
     |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
1310 |             return False
1311 |     except yaml.YAMLError as e:
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:1916:19
     |
1914 |         # Rate-limit detection so run_module can degrade gracefully
1915 |         if output and _is_rate_limited(output):
1916 |             print(f"  ⚠ REVIEW rate-limited — module flagged for later re-review")
     |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
1917 |             return {"rate_limited": True}
1918 |         print(f"  ❌ REVIEW failed")
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:1918:15
     |
1916 |             print(f"  ⚠ REVIEW rate-limited — module flagged for later re-review")
1917 |             return {"rate_limited": True}
1918 |         print(f"  ❌ REVIEW failed")
     |               ^^^^^^^^^^^^^^^^^^^^^
1919 |         return None
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:1923:15
     |
1921 |     result = _extract_review_json(output)
1922 |     if result is None:
1923 |         print(f"  ❌ Failed to parse REVIEW output")
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
1924 |         print(f"  Raw: {output[:500]}")
1925 |         return None
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:2011:15
     |
2009 |         print(f"  Structured edits: {len(edits)} ({type_summary})")
2010 |     if feedback:
2011 |         print(f"  Feedback:")
     |               ^^^^^^^^^^^^^^
2012 |         print(f"  {'─' * 70}")
2013 |         for line in feedback.splitlines() or [feedback]:
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:2354:11
     |
2352 | def step_check(content: str, path: Path) -> tuple[bool, list]:
2353 |     """Run all deterministic checks on the improved content."""
2354 |     print(f"\n  CHECK: running deterministic checks")
     |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2355 |
2356 |     # Safety guard: reject truncated content (Gemini output limit)
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:2373:19
     |
2371 |         fm = yaml.safe_load(parts[1])
2372 |         if not isinstance(fm, dict) or "title" not in fm:
2373 |             print(f"  ✗ CHECK: frontmatter missing 'title' field")
     |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2374 |             return False, []
2375 |     except yaml.YAMLError as e:
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:2385:15
     |
2383 |     has_en_commit = "en_commit:" in parts[1]
2384 |     if not is_uk and (has_cyrillic_title or has_uk_slug or has_en_commit):
2385 |         print(f"  ✗ CHECK: Ukrainian content in EN file (title/slug/en_commit detected)")
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2386 |         return False, []
2387 |     if is_uk and not has_cyrillic_title and not has_en_commit:
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:2388:15
     |
2386 |         return False, []
2387 |     if is_uk and not has_cyrillic_title and not has_en_commit:
2388 |         print(f"  ✗ CHECK: English content in UK file (no Cyrillic title or en_commit)")
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2389 |         return False, []
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:2458:19
     |
2456 |     if ms["phase"] == "done":
2457 |         if ms.get("needs_independent_review"):
2458 |             print(f"  ↻ Flagged needs_independent_review — resetting to review for independent re-review")
     |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2459 |             ms["phase"] = "review"
2460 |             save_state(state)
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:2482:19
     |
2480 |     if ms["phase"] == "needs_targeted_fix":
2481 |         if staging_path.exists() and ms.get("plan"):
2482 |             print(f"  ↻ Resuming targeted fix from peak-hours pause")
     |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2483 |             ms["phase"] = "write"
2484 |             save_state(state)
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:2486:19
     |
2484 |             save_state(state)
2485 |         else:
2486 |             print(f"  ⚠ needs_targeted_fix phase but staging/plan missing — restarting from initial write")
     |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2487 |             ms["phase"] = "pending"
2488 |             ms.pop("plan", None)
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:2666:23
     |
2664 |                 # - Return True so the batch runner moves on cleanly
2665 |                 print(f"\n  ⏸ PAUSED (Claude unavailable): {e}")
2666 |                 print(f"  Progress preserved — will resume at targeted-fix step on next run.")
     |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2667 |                 staging_path = module_path.with_suffix(".staging.md")
2668 |                 if last_good:
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:2672:27
     |
2670 |                     print(f"  Staged {len(last_good)} chars to {staging_path.name}")
2671 |                 else:
2672 |                     print(f"  ⚠ No last_good content to stage — resume will restart from the initial write")
     |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2673 |                 ms["phase"] = "needs_targeted_fix"
2674 |                 ms["plan"] = plan
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:2715:27
     |
2713 |                         timeout=30,
2714 |                     )
2715 |                     print(f"  Committed draft")
     |                           ^^^^^^^^^^^^^^^^^^^^
2716 |                 except Exception:
2717 |                     pass  # non-critical
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:2800:27
     |
2798 |                 fallback_allowed = True
2799 |                 if fallback_family == primary_family:
2800 |                     print(f"  ⚠ Primary reviewer rate-limited and fallback is same family — skipping to last resort")
     |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2801 |                     fallback_allowed = False
2802 |                 elif (not STRUCTURAL_REVIEW_INDEPENDENCE_RELAXED and
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:3050:31
     |
3048 |                         # severe rewrite (a fresh reviewer pass should
3049 |                         # produce fresh anchors against the same content).
3050 |                         print(f"  ⚠ Zero edits applied deterministically — escalating to severe rewrite")
     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
3051 |                         r_severity = "severe"
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:3062:27
     |
3060 |                         f"scratch and resolve these issues.\n\nReviewer feedback:\n{r_feedback}"
3061 |                     )
3062 |                     print(f"  ⚠ Review returned no valid checks — using full rewrite")
     |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
3063 |                 elif r_severity == "severe":
3064 |                     needs_rewrite = True
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:3139:19
     |
3137 |         elif staging.exists():
3138 |             improved = staging.read_text()
3139 |             print(f"  Resuming CHECK from staging file")
     |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
3140 |         else:
3141 |             print(f"  ❌ No improved content available for CHECK")
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:3141:19
     |
3139 |             print(f"  Resuming CHECK from staging file")
3140 |         else:
3141 |             print(f"  ❌ No improved content available for CHECK")
     |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
3142 |             return False
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:3243:23
     |
3241 |                 print(f"  ⚠ git commit failed: {commit_result.stderr[:200]}")
3242 |             else:
3243 |                 print(f"  ✓ Committed")
     |                       ^^^^^^^^^^^^^^^^
3244 |             return True
3245 |         else:
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:3386:15
     |
3384 |         }
3385 |         gaps_file.write_text(json.dumps(existing, indent=2, ensure_ascii=False))
3386 |         print(f"  Gaps saved to .pipeline/gaps-report.json")
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
3387 |     else:
3388 |         print("  ✓ No scaffolding gaps detected")
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:3392:15
     |
3390 |     if gap_errors and not args.skip_gaps:
3391 |         print(f"\n  ❌ {len(gap_errors)} gap errors — fix before processing modules")
3392 |         print(f"  Use --skip-gaps to override")
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
3393 |         sys.exit(1)
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:3478:19
     |
3476 |                 "D5:Assessment", "D6:Coverage", "D7:Production", "D8:Practitioner",
3477 |             ]
3478 |             print(f"\n  Weak dimensions across section:")
     |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
3479 |             for name, count in zip(dim_names, weak_counts):
3480 |                 if count > 0:
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:3491:11
     |
3489 | def cmd_learning_path(args):
3490 |     """Detect gaps across the full learning path (cross-track transitions)."""
3491 |     print(f"\nCross-Track Gap Analysis")
     |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
3492 |     print(f"{'='*60}")
3493 |     print(f"  Learning path: {' → '.join(d.split('/')[-1] for d, _ in gaps.LEARNING_PATH)}")
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:3537:11
     |
3535 |     }
3536 |     gaps_file.write_text(json.dumps(existing, indent=2, ensure_ascii=False))
3537 |     print(f"\n  Saved to .pipeline/gaps-report.json")
     |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
3538 |
3539 |     sys.exit(1 if errors else 0)
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:4193:27
     |
4191 |                     consecutive_failures += 1
4192 |                 if consecutive_failures >= 5:
4193 |                     print(f"\n  CIRCUIT BREAKER: 5 consecutive resume failures — halting")
     |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
4194 |                     print(f"  Check logs: {LOG_FILE}")
4195 |                     break
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:4286:27
     |
4284 |                 )
4285 |                 if idx_commit.returncode == 0:
4286 |                     print(f"  ✓ Index updates committed")
     |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
4287 |
4288 |     # UK translations: sync modules for completed sections
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:4326:27
     |
4325 |                 if consecutive_uk_failures >= 3:
4326 |                     print(f"  CIRCUIT BREAKER: 3 consecutive UK translation failures — skipping rest")
     |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
4327 |                     break
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:4384:15
     |
4382 |     # Also run LLM gap analysis for deeper detection
4383 |     if args.track in ("prerequisites", "linux"):
4384 |         print(f"\n  For deeper analysis, consider running:")
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
4385 |         print(f"  python scripts/v1_pipeline.py gap-check {args.path} --track {args.track}")
4386 |         print(f"  and reviewing CONCEPT_JUMP warnings manually")
     |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
    --> scripts/v1_pipeline.py:4386:15
     |
4384 |         print(f"\n  For deeper analysis, consider running:")
4385 |         print(f"  python scripts/v1_pipeline.py gap-check {args.path} --track {args.track}")
4386 |         print(f"  and reviewing CONCEPT_JUMP warnings manually")
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
4387 |
4388 |     sys.exit(1 if errors else 0)
     |
help: Remove extraneous `f` prefix

Found 42 errors.
[*] 37 fixable with the `--fix` option. *(fails on pre-existing repo issues: E402/F541 in these files)*
- ...                                                                      [100%]
3 passed, 131 deselected in 0.08s