### PR TITLE
fix(pipeline): CHECK retries in-function, shields outer circuit breaker from recoverable failures (#235)

### DIFF
--- a/scripts/test_pipeline.py
+++ b/scripts/test_pipeline.py
@@ -792,6 +792,40 @@ class TestReviewAuditLog(unittest.TestCase):
             self.assertIn(str(self.module_path), add_paths)
             self.assertIn(str(audit_path), add_paths)
 
+    def test_check_retries_in_function_without_returning_false(self):
+        import v1_pipeline as p
+
+        state = {
+            "modules": {
+                self.module_key: {
+                    "phase": "check",
+                    "reviewer": "gemini",
+                    "severity": "clean",
+                    "errors": [],
+                }
+            }
+        }
+        self.module_path.with_suffix(".staging.md").write_text(GOOD_MODULE)
+        transient_failure = [CheckResult("LINE_COUNT", False, "temporary check failure")]
+        git_ok = subprocess.CompletedProcess(["git"], 0, "", "")
+
+        with self._patch_paths(p), \
+             patch.object(p, "ensure_fact_ledger", return_value=sample_fact_ledger()), \
+             patch.object(
+                 p,
+                 "step_check",
+                 side_effect=[(False, transient_failure), (True, [])],
+             ) as mock_check, \
+             patch.object(p, "_git_stage_and_commit", return_value=(git_ok, git_ok)):
+            ok = p.run_module(self.module_path, state, max_retries=1)
+
+        ms = state["modules"][self.module_key]
+        self.assertTrue(ok)
+        self.assertEqual(mock_check.call_count, 2)
+        self.assertEqual(ms["phase"], "done")
+        self.assertNotIn("check_failures", ms)
+        self.assertNotIn("Deterministic checks failed after review", ms["errors"])
+
     def test_reset_stuck_writes_reset_audit_and_commits_batch(self):
         import v1_pipeline as p
 

--- a/scripts/v1_pipeline.py
+++ b/scripts/v1_pipeline.py
@@ -3135,18 +3135,26 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
             print(f"  ❌ No improved content available for CHECK")
             return False
 
-        check_started = datetime.now(UTC)
-        passed, results = step_check(improved, module_path)
-        if not passed:
-            ms["errors"].append("Deterministic checks failed after review")
-            ms["check_failures"] = ms.get("check_failures", 0) + 1
-            ms["targeted_fix"] = False
-            save_state(state)
+        results = []
+        for check_attempt in range(max_retries + 1):
+            check_started = datetime.now(UTC)
+            passed, results = step_check(improved, module_path)
+            if passed:
+                break
+
             emit_audit(
                 "CHECK_FAIL",
                 duration=(datetime.now(UTC) - check_started).total_seconds(),
                 failed_checks=_render_check_failures(results),
             )
+            if check_attempt < max_retries:
+                print(f"  ↻ CHECK failed, retrying ({check_attempt+1}/{max_retries})")
+                continue
+
+            ms["errors"].append("Deterministic checks failed after review")
+            ms["check_failures"] = ms.get("check_failures", 0) + 1
+            ms["targeted_fix"] = False
+            save_state(state)
             # Keep staging file so we can resume after fixing thresholds
             print(f"  Staging file kept: {staging}")
             return False


### PR DESCRIPTION
## Summary
- move CHECK retry handling inside `run_module` so transient deterministic-check failures do not bubble out as outer batch failures
- only persist `check_failures` and return `False` after the in-function CHECK retry budget is exhausted
- add a regression test covering fail-then-pass CHECK behavior from `phase=check`

## Verification
- `python -m py_compile scripts/v1_pipeline.py scripts/test_pipeline.py`
- `ruff check --extend-ignore E402,F541 scripts/v1_pipeline.py scripts/test_pipeline.py`
- `python -m unittest scripts.test_pipeline.TestReviewAuditLog.test_check_retries_in_function_without_returning_false`
- `python scripts/test_pipeline.py` *(currently has a pre-existing unrelated failure in `TestStatusFourStage.test_cmd_status_prints_four_stage_completion_table`)*