### PR TITLE
fix(pipeline): unify retry policy across serial/parallel/reset-stuck modes (#235)

### DIFF
--- a/scripts/v1_pipeline.py
+++ b/scripts/v1_pipeline.py
@@ -79,6 +79,8 @@ DATA_CONFLICT_UNVERIFIED_THRESHOLD = 5
 LEGACY_SCORE_PASS_THRESHOLD = 4
 CONTENT_AWARE_FACT_LEDGER_MAX_CHARS = 40_000
 CONTENT_AWARE_FACT_LEDGER_OVERLAP_CHARS = 4_000
+MAX_RETRIES = 4
+REVIEW_REJECTED_ERROR_RE = re.compile(r"^Review rejected (\d+) times$")
 _LINK_CACHE_LOCK = threading.Lock()
 _PARALLEL_RUN_SECTION_STATE_LOCK = None
 _PARALLEL_RUN_SECTION_GIT_LOCK = None
@@ -303,11 +305,15 @@ def get_module_state(state: dict, module_key: str) -> dict:
     })
 
 
-def _run_module_in_parallel(module_path: Path, shared_state: dict, max_retries: int = 4,
+def _run_module_in_parallel(module_path: Path, shared_state: dict, max_retries: int | None = None,
                             models: dict | None = None, dry_run: bool = False,
                             refresh_fact_ledger: bool = False,
                             write_only: bool = False) -> bool:
-    """Run one module with an isolated worker-local state snapshot."""
+    """Run one module with an isolated worker-local state snapshot.
+
+    Uses the shared retry cap from `_resolve_max_retries` so parallel
+    workers follow the same policy as serial/reset-stuck modes (#235).
+    """
     module_key = module_key_from_path(module_path)
     local_state = _parallel_worker_state(shared_state, module_key)
     _PARALLEL_RUN_SECTION_CONTEXT.value = {
@@ -319,7 +325,7 @@ def _run_module_in_parallel(module_path: Path, shared_state: dict, max_retries: 
         ok = run_module(
             module_path,
             local_state,
-            max_retries=max_retries,
+            max_retries=_resolve_max_retries(max_retries),
             models=models,
             dry_run=dry_run,
             refresh_fact_ledger=refresh_fact_ledger,
@@ -2641,7 +2647,7 @@ def step_check(content: str, path: Path) -> tuple[bool, list]:
 # Full pipeline: run one module through all steps
 # ---------------------------------------------------------------------------
 
-def run_module(module_path: Path, state: dict, max_retries: int = 4,
+def run_module(module_path: Path, state: dict, max_retries: int | None = None,
                models: dict | None = None, dry_run: bool = False,
                refresh_fact_ledger: bool = False,
                write_only: bool = False) -> bool:
@@ -2650,6 +2656,7 @@ def run_module(module_path: Path, state: dict, max_retries: int = 4,
     If write_only=True, skip fact-ledger, review, and checks — just draft
     the content and save. Used for bulk content creation before review pass.
     """
+    max_retries = _resolve_max_retries(max_retries)
     m = models or MODELS
     key = module_key_from_path(module_path)
     ms = get_module_state(state, key)
@@ -3549,7 +3556,7 @@ def cmd_run(args):
         models["review"] = args.review_model
 
     state = load_state()
-    ok = run_module(
+    ok = _run_module_with_retry_policy(
         path,
         state,
         models=models,
@@ -3633,7 +3640,7 @@ def cmd_run_section(args):
         for i, path in enumerate(modules, 1):
             key = module_key_from_path(path)
             print(f"\n[{i}/{len(modules)}] {key}")
-            ok = run_module(
+            ok = _run_module_with_retry_policy(
                 path,
                 state,
                 models=models,
@@ -3658,7 +3665,6 @@ def cmd_run_section(args):
                         _run_module_in_parallel,
                         path,
                         state,
-                        max_retries=2,
                         models=models,
                         dry_run=dry_run,
                         refresh_fact_ledger=getattr(args, "refresh_fact_ledger", False),
@@ -4160,6 +4166,30 @@ def _apply_model_overrides(args) -> dict:
     return models
 
 
+def _resolve_max_retries(max_retries: int | None = None) -> int:
+    """Return the shared retry cap used across execution modes."""
+    return MAX_RETRIES if max_retries is None else max_retries
+
+
+def _run_module_with_retry_policy(module_path: Path, state: dict, **kwargs) -> bool:
+    """Run a module with the repo-wide retry cap."""
+    return run_module(
+        module_path,
+        state,
+        max_retries=_resolve_max_retries(),
+        **kwargs,
+    )
+
+
+def _is_resettable_review_rejection(error: object, max_retries: int | None = None) -> bool:
+    """Match historical rejection counters that should be reset under the current cap."""
+    match = REVIEW_REJECTED_ERROR_RE.match(str(error))
+    if not match:
+        return False
+    rejection_count = int(match.group(1))
+    return 1 <= rejection_count <= (_resolve_max_retries(max_retries) + 1)
+
+
 def cmd_resume(args):
     """Resume pipeline from where it stopped."""
     global _quiet
@@ -4185,7 +4215,7 @@ def cmd_resume(args):
     for key, ms in incomplete.items():
         path = find_module_path(key)
         if path and path.exists():
-            run_module(
+            _run_module_with_retry_policy(
                 path,
                 state,
                 models=models,
@@ -4233,10 +4263,10 @@ def cmd_reset_stuck(args):
         # Review rejected max times — match any count
         errors = ms.get("errors", [])
         rejected_errors = [
-            str(e) for e in errors if re.match(r"Review rejected \d+ times", str(e))
+            str(e) for e in errors if _is_resettable_review_rejection(e)
         ]
         if rejected_errors:
-            ms["errors"] = [e for e in errors if not re.match(r"Review rejected \d+ times", str(e))]
+            ms["errors"] = [e for e in errors if not _is_resettable_review_rejection(e)]
             cleared_errors.extend(rejected_errors)
             ms["phase"] = "pending"
             _clear_resume_metadata(ms, staging_path)
@@ -4406,7 +4436,7 @@ def cmd_e2e(args):
         for key, ms in incomplete.items():
             path = find_module_path(key)
             if path and path.exists():
-                ok = run_module(
+                ok = _run_module_with_retry_policy(
                     path,
                     state,
                     models=models,
@@ -4469,7 +4499,7 @@ def cmd_e2e(args):
                 continue
 
             print(f"\n[{i}/{len(modules)}] {key}")
-            ok = run_module(
+            ok = _run_module_with_retry_policy(
                 path,
                 state,
                 models=models,

--- a/tests/test_v1_pipeline_retry_policy.py
+++ b/tests/test_v1_pipeline_retry_policy.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import argparse
+import builtins
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import v1_pipeline
+
+builtins.print = v1_pipeline._original_print
+
+
+def _write_section(tmp_path: Path) -> tuple[Path, list[Path]]:
+    docs_root = tmp_path / "docs"
+    section_path = docs_root / "test-track" / "part1"
+    section_path.mkdir(parents=True, exist_ok=True)
+    modules = [
+        section_path / "module-1.1-one.md",
+        section_path / "module-1.2-two.md",
+    ]
+    for module_path in modules:
+        module_path.write_text("# Test module\n", encoding="utf-8")
+    return docs_root, modules
+
+
+def _run_section_args(*, workers: int) -> argparse.Namespace:
+    return argparse.Namespace(
+        section="test-track/part1",
+        track="test",
+        skip_gaps=True,
+        write_model=None,
+        review_model=None,
+        workers=workers,
+        dry_run=False,
+        write_only=False,
+        refresh_fact_ledger=False,
+        verbose=True,
+    )
+
+
+def test_run_section_serial_uses_shared_retry_cap(tmp_path, monkeypatch):
+    docs_root, modules = _write_section(tmp_path)
+    observed: list[int | None] = []
+
+    def fake_run_module(module_path: Path, state: dict, max_retries: int | None = None, **kwargs) -> bool:
+        assert module_path in modules
+        observed.append(max_retries)
+        return True
+
+    monkeypatch.setattr(v1_pipeline, "CONTENT_ROOT", docs_root)
+    monkeypatch.setattr(v1_pipeline, "load_state", lambda: {"modules": {}})
+    monkeypatch.setattr(v1_pipeline.gaps, "run_track_gap_analysis", lambda *args, **kwargs: [])
+    monkeypatch.setattr(v1_pipeline, "run_module", fake_run_module)
+
+    with pytest.raises(SystemExit) as exc:
+        v1_pipeline.cmd_run_section(_run_section_args(workers=1))
+
+    assert exc.value.code == 0
+    assert observed == [v1_pipeline.MAX_RETRIES, v1_pipeline.MAX_RETRIES]
+
+
+def test_run_section_parallel_uses_shared_retry_cap(tmp_path, monkeypatch):
+    docs_root, modules = _write_section(tmp_path)
+    observed: list[int | None] = []
+
+    def fake_run_module(module_path: Path, state: dict, max_retries: int | None = None, **kwargs) -> bool:
+        assert module_path in modules
+        observed.append(max_retries)
+        return True
+
+    monkeypatch.setattr(v1_pipeline, "CONTENT_ROOT", docs_root)
+    monkeypatch.setattr(v1_pipeline, "load_state", lambda: {"modules": {}})
+    monkeypatch.setattr(v1_pipeline.gaps, "run_track_gap_analysis", lambda *args, **kwargs: [])
+    monkeypatch.setattr(v1_pipeline, "run_module", fake_run_module)
+
+    with pytest.raises(SystemExit) as exc:
+        v1_pipeline.cmd_run_section(_run_section_args(workers=2))
+
+    assert exc.value.code == 0
+    assert sorted(observed) == [v1_pipeline.MAX_RETRIES, v1_pipeline.MAX_RETRIES]
+
+
+def test_reset_stuck_recovers_rejection_below_shared_retry_cap(tmp_path, monkeypatch):
+    docs_root, modules = _write_section(tmp_path)
+    module_path = modules[0]
+    module_key = "test-track/part1/module-1.1-one"
+    rejection_count = v1_pipeline.MAX_RETRIES - 1
+    state = {
+        "modules": {
+            module_key: {
+                "phase": "write",
+                "errors": [f"Review rejected {rejection_count} times"],
+            }
+        }
+    }
+    save_state = Mock()
+
+    monkeypatch.setattr(v1_pipeline, "CONTENT_ROOT", docs_root)
+    monkeypatch.setattr(v1_pipeline, "load_state", lambda: state)
+    monkeypatch.setattr(v1_pipeline, "save_state", save_state)
+    monkeypatch.setattr(v1_pipeline, "find_module_path", lambda key: module_path if key == module_key else None)
+    monkeypatch.setattr(v1_pipeline, "append_review_audit", lambda *args, **kwargs: tmp_path / "reset-audit.json")
+    monkeypatch.setattr(
+        v1_pipeline,
+        "_git_stage_and_commit",
+        lambda *args, **kwargs: (
+            SimpleNamespace(returncode=0, stderr=""),
+            SimpleNamespace(returncode=0, stderr=""),
+        ),
+    )
+
+    v1_pipeline.cmd_reset_stuck(argparse.Namespace())
+
+    assert state["modules"][module_key]["phase"] == "pending"
+    assert state["modules"][module_key]["errors"] == []
+    save_state.assert_called_once_with(state)


### PR DESCRIPTION
## Summary
- introduce a shared `MAX_RETRIES` policy and route module execution through it in single-module, serial section, parallel section, resume, and e2e paths
- remove the parallel-only hard-coded retry cap of `2`
- make `reset-stuck` clear stranded historical `Review rejected N times` states up to the shared cap, including worker-era counts below the terminal serial count
- add focused regression tests for serial mode, parallel mode, and reset-stuck recovery at `MAX_RETRIES - 1`

## Verification
- `python -m py_compile scripts/v1_pipeline.py tests/test_v1_pipeline_retry_policy.py`
- `ruff check --extend-ignore E402,F541 scripts/v1_pipeline.py tests/test_v1_pipeline_retry_policy.py`
- `pytest -q tests/test_v1_pipeline_retry_policy.py`

## Notes
- plain `ruff check scripts/v1_pipeline.py` still reports pre-existing `E402`/`F541` issues unrelated to this fix, so this PR keeps scope to the retry-policy bug only.