### PR TITLE
feat(local-api): add /api/gh/issues and /api/gh/prs endpoints (#276)

### DIFF
--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -29,6 +29,8 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8768
 DOCS_ROOT = REPO_ROOT / "src" / "content" / "docs"
+GH_REPO = "kube-dojo/kube-dojo.github.io"
+GH_CACHE_TTL_SECONDS = 60.0
 GENERATED_PREFIXES = (
     ".astro/",
     ".dispatch-logs/",
@@ -297,6 +299,7 @@ def cached_response(
     ttl_seconds: float,
     version_fn: Callable[[], tuple],
     builder: Callable[[], tuple[int, Any, str]],
+    etag_builder: Callable[[Any, bytes], str] | None = None,
 ) -> tuple[int, bytes, str, str]:
     """Serve a response through the cache. Returns (status, body_bytes, content_type, etag).
 
@@ -315,7 +318,7 @@ def cached_response(
 
     status_code, payload, content_type = builder()
     body_bytes = _serialize_payload(payload, content_type)
-    etag = _weak_etag(body_bytes)
+    etag = etag_builder(payload, body_bytes) if etag_builder is not None else _weak_etag(body_bytes)
 
     if 200 <= status_code < 300:
         with _CACHE_LOCK:
@@ -336,6 +339,153 @@ def _cache_stats() -> dict[str, Any]:
             "entries": len(_CACHE),
             "keys": sorted(_CACHE.keys()),
         }
+
+
+def _gh_json_fields(*fields: str) -> str:
+    return ",".join(fields)
+
+
+def _gh_repo_cmd(*args: str) -> list[str]:
+    return ["gh", *args, "--repo", GH_REPO]
+
+
+def _run_gh_json(*args: str, timeout: int = 10) -> tuple[int, Any]:
+    try:
+        result = subprocess.run(
+            _gh_repo_cmd(*args),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return 503, {"error": "gh CLI not available"}
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        if "Could not resolve to an issue or pull request" in stderr:
+            return 404, {"error": "not_found"}
+        return 502, {"error": "gh command failed", "message": stderr or "gh command failed"}
+    try:
+        return 200, json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        return 502, {"error": "invalid_gh_json", "message": str(exc)}
+
+
+def _normalize_gh_item(item: dict[str, Any]) -> dict[str, Any]:
+    labels = item.get("labels") or []
+    assignees = item.get("assignees") or []
+    comments = item.get("comments") or []
+    return {
+        "number": item.get("number"),
+        "title": item.get("title", ""),
+        "state": item.get("state", ""),
+        "labels": [
+            label.get("name")
+            for label in labels
+            if isinstance(label, dict) and label.get("name")
+        ],
+        "assignees": [
+            assignee.get("login")
+            for assignee in assignees
+            if isinstance(assignee, dict) and assignee.get("login")
+        ],
+        "comments_count": len(comments) if isinstance(comments, list) else 0,
+        "updated_at": item.get("updatedAt", ""),
+        "url": item.get("url", ""),
+    }
+
+
+def _normalize_gh_comments(comments: Any) -> list[dict[str, Any]]:
+    if not isinstance(comments, list):
+        return []
+    normalized: list[dict[str, Any]] = []
+    for comment in comments[-5:]:
+        if not isinstance(comment, dict):
+            continue
+        author = comment.get("author") or {}
+        normalized.append(
+            {
+                "author": author.get("login", "") if isinstance(author, dict) else "",
+                "body": comment.get("body", ""),
+                "created_at": comment.get("createdAt", ""),
+                "url": comment.get("url", ""),
+            }
+        )
+    return normalized
+
+
+def _build_gh_list(kind: str, state: str, limit: int) -> tuple[int, Any, str]:
+    status_code, payload = _run_gh_json(
+        kind,
+        "list",
+        "--state",
+        state,
+        "--limit",
+        str(limit),
+        "--json",
+        _gh_json_fields("number", "title", "state", "labels", "assignees", "comments", "updatedAt", "url"),
+    )
+    if status_code != 200:
+        return status_code, payload, "application/json; charset=utf-8"
+    items = [
+        _normalize_gh_item(item)
+        for item in payload
+        if isinstance(item, dict)
+    ]
+    return 200, {
+        "repo": GH_REPO,
+        "state": state,
+        "limit": limit,
+        "count": len(items),
+        "items": items,
+    }, "application/json; charset=utf-8"
+
+
+def _build_gh_detail(kind: str, number: int) -> tuple[int, Any, str]:
+    fields = ["number", "title", "state", "labels", "assignees", "comments", "updatedAt", "url"]
+    if kind == "pr":
+        fields.append("mergeable")
+    status_code, payload = _run_gh_json(
+        kind,
+        "view",
+        str(number),
+        "--json",
+        _gh_json_fields(*fields),
+    )
+    if status_code != 200:
+        return status_code, payload, "application/json; charset=utf-8"
+    if not isinstance(payload, dict):
+        return 502, {"error": "invalid_gh_json", "message": "expected object"}, "application/json; charset=utf-8"
+    item = _normalize_gh_item(payload)
+    item["comments"] = _normalize_gh_comments(payload.get("comments"))
+    if kind == "pr":
+        item["mergeable"] = payload.get("mergeable")
+    return 200, item, "application/json; charset=utf-8"
+
+
+def _is_gh_path(path: str) -> bool:
+    return (
+        path in {"/api/gh/issues", "/api/gh/prs"}
+        or path.startswith("/api/gh/issues/")
+        or path.startswith("/api/gh/prs/")
+    )
+
+
+def _gh_payload_etag(path: str, payload: Any) -> str:
+    latest = "empty"
+    if isinstance(payload, dict):
+        items = payload.get("items")
+        if isinstance(items, list):
+            updated_values = [
+                item.get("updated_at", "")
+                for item in items
+                if isinstance(item, dict) and item.get("updated_at")
+            ]
+            if updated_values:
+                latest = max(updated_values)
+        elif payload.get("updated_at"):
+            latest = str(payload["updated_at"])
+    return _weak_etag(f"{path}:{latest}".encode("utf-8"))
 
 
 # --- Background snapshot ---
@@ -4891,6 +5041,24 @@ def build_api_schema() -> dict[str, Any]:
             {"path": "/api/ztt/status", "desc": "Zero-to-Terminal pilot status"},
             {"path": "/api/git/worktree", "desc": "Dirty entries in the PRIMARY repo only"},
             {"path": "/api/git/worktrees", "desc": "All attached worktrees (plural)"},
+            {
+                "path": "/api/gh/issues",
+                "desc": "Cached GitHub issue list for agent orientation",
+                "query": ["state=open|closed|all (default open)", "limit=... (default 50, max 200)"],
+            },
+            {
+                "path": "/api/gh/issues/{n}",
+                "desc": "Single GitHub issue with the last 5 comments",
+            },
+            {
+                "path": "/api/gh/prs",
+                "desc": "Cached GitHub pull request list for agent orientation",
+                "query": ["state=open|closed|merged|all (default open)", "limit=... (default 50, max 200)"],
+            },
+            {
+                "path": "/api/gh/prs/{n}",
+                "desc": "Single GitHub pull request with the last 5 comments and mergeable state",
+            },
             {"path": "/api/issue-watch/{n}", "desc": "Single watched GH issue state"},
             {"path": "/api/module/{key}/state", "desc": "Per-module EN+UK+lab+frontmatter+diagnostics"},
             {"path": "/api/module/{key}/orchestration/latest", "desc": "Per-module latest pipeline job+event"},
@@ -5018,6 +5186,36 @@ def route_request(repo_root: Path, raw_path: str) -> tuple[int, Any, str]:
         return 200, build_worktree_status(repo_root), "application/json; charset=utf-8"
     if path == "/api/git/worktrees":
         return 200, build_worktrees_list(repo_root), "application/json; charset=utf-8"
+    if path == "/api/gh/issues":
+        state = query.get("state", ["open"])[0] or "open"
+        if state not in {"open", "closed", "all"}:
+            state = "open"
+        try:
+            limit = int(query.get("limit", ["50"])[0])
+        except (TypeError, ValueError):
+            limit = 50
+        return _build_gh_list("issue", state, max(1, min(limit, 200)))
+    if path.startswith("/api/gh/issues/"):
+        try:
+            number = int(path.split("/")[-1])
+        except ValueError:
+            return 400, {"error": "invalid_issue_number"}, "application/json; charset=utf-8"
+        return _build_gh_detail("issue", number)
+    if path == "/api/gh/prs":
+        state = query.get("state", ["open"])[0] or "open"
+        if state not in {"open", "closed", "merged", "all"}:
+            state = "open"
+        try:
+            limit = int(query.get("limit", ["50"])[0])
+        except (TypeError, ValueError):
+            limit = 50
+        return _build_gh_list("pr", state, max(1, min(limit, 200)))
+    if path.startswith("/api/gh/prs/"):
+        try:
+            number = int(path.split("/")[-1])
+        except ValueError:
+            return 400, {"error": "invalid_pr_number"}, "application/json; charset=utf-8"
+        return _build_gh_detail("pr", number)
     if path == "/api/schema":
         return 200, build_api_schema(), "application/json; charset=utf-8"
     if path == "/api/briefing/session":
@@ -5199,6 +5397,20 @@ def serve_request(
     parsed = urlsplit(raw_path)
     path = parsed.path.rstrip("/") or "/"
     query = parse_qs(parsed.query)
+
+    if _is_gh_path(path):
+        cache_key = _normalized_cache_key(path, query, repo_root=repo_root)
+
+        def _build() -> tuple[int, Any, str]:
+            return route_request(repo_root, raw_path)
+
+        return cached_response(
+            cache_key,
+            GH_CACHE_TTL_SECONDS,
+            lambda: ("gh",),
+            _build,
+            lambda payload, _body: _gh_payload_etag(path, payload),
+        )
 
     policy = CACHE_POLICY.get(path)
     if policy is not None:

--- a/tests/test_local_api_gh.py
+++ b/tests/test_local_api_gh.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import http.client
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from threading import Thread
+from unittest.mock import patch
+
+
+def _load_module():
+    module_path = Path(__file__).resolve().parent.parent / "scripts" / "local_api.py"
+    spec = importlib.util.spec_from_file_location("local_api", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+local_api = _load_module()
+
+
+def _completed(stdout: str) -> object:
+    return local_api.subprocess.CompletedProcess(args=["gh"], returncode=0, stdout=stdout, stderr="")
+
+
+class LocalApiGitHubTests(unittest.TestCase):
+    def setUp(self) -> None:
+        with local_api._CACHE_LOCK:
+            local_api._CACHE.clear()
+
+    def test_issue_list_normalizes_items_and_supports_304(self) -> None:
+        payload = json.dumps(
+            [
+                {
+                    "number": 276,
+                    "title": "First",
+                    "state": "OPEN",
+                    "labels": [{"name": "api"}],
+                    "assignees": [{"login": "alice"}],
+                    "comments": [{"body": "one"}],
+                    "updatedAt": "2026-04-18T08:09:11Z",
+                    "url": "https://example.test/issues/276",
+                },
+                {
+                    "number": 279,
+                    "title": "Second",
+                    "state": "OPEN",
+                    "labels": [],
+                    "assignees": [],
+                    "comments": [],
+                    "updatedAt": "2026-04-18T09:09:11Z",
+                    "url": "https://example.test/issues/279",
+                },
+            ]
+        )
+        with tempfile.TemporaryDirectory() as tmpdir, patch.object(
+            local_api.subprocess, "run", return_value=_completed(payload)
+        ) as mock_run:
+            repo_root = Path(tmpdir)
+            handler_cls = local_api.make_handler(repo_root)
+            server = local_api.ThreadingHTTPServer(("127.0.0.1", 0), handler_cls)
+            thread = Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            try:
+                conn = http.client.HTTPConnection("127.0.0.1", server.server_address[1], timeout=5)
+                conn.request("GET", "/api/gh/issues?state=open&limit=2")
+                resp = conn.getresponse()
+                body = resp.read().decode("utf-8")
+                etag = resp.getheader("ETag")
+                self.assertEqual(resp.status, 200)
+                data = json.loads(body)
+                self.assertEqual(data["count"], 2)
+                self.assertEqual(data["items"][0]["labels"], ["api"])
+                self.assertEqual(data["items"][0]["assignees"], ["alice"])
+                self.assertEqual(data["items"][0]["comments_count"], 1)
+                self.assertEqual(etag, local_api._gh_payload_etag("/api/gh/issues", data))
+
+                conn.request("GET", "/api/gh/issues?state=open&limit=2", headers={"If-None-Match": etag})
+                resp2 = conn.getresponse()
+                self.assertEqual(resp2.status, 304)
+                self.assertEqual(resp2.read(), b"")
+                self.assertEqual(mock_run.call_count, 1)
+            finally:
+                server.shutdown()
+                server.server_close()
+
+    def test_issue_detail_returns_last_five_comments(self) -> None:
+        comments = [
+            {
+                "author": {"login": f"user{i}"},
+                "body": f"comment {i}",
+                "createdAt": f"2026-04-18T0{i}:00:00Z",
+                "url": f"https://example.test/c/{i}",
+            }
+            for i in range(6)
+        ]
+        payload = json.dumps(
+            {
+                "number": 276,
+                "title": "Issue detail",
+                "state": "OPEN",
+                "labels": [{"name": "infra"}],
+                "assignees": [{"login": "owner"}],
+                "comments": comments,
+                "updatedAt": "2026-04-18T10:00:00Z",
+                "url": "https://example.test/issues/276",
+            }
+        )
+        with tempfile.TemporaryDirectory() as tmpdir, patch.object(
+            local_api.subprocess, "run", return_value=_completed(payload)
+        ):
+            status_code, data, _ = local_api.route_request(Path(tmpdir), "/api/gh/issues/276")
+        self.assertEqual(status_code, 200)
+        self.assertEqual(data["comments_count"], 6)
+        self.assertEqual(len(data["comments"]), 5)
+        self.assertEqual(data["comments"][0]["author"], "user1")
+        self.assertEqual(data["comments"][-1]["author"], "user5")
+
+    def test_pr_detail_includes_mergeable(self) -> None:
+        payload = json.dumps(
+            {
+                "number": 298,
+                "title": "PR detail",
+                "state": "OPEN",
+                "labels": [],
+                "assignees": [],
+                "comments": [],
+                "mergeable": "MERGEABLE",
+                "updatedAt": "2026-04-18T10:00:00Z",
+                "url": "https://example.test/pulls/298",
+            }
+        )
+        with tempfile.TemporaryDirectory() as tmpdir, patch.object(
+            local_api.subprocess, "run", return_value=_completed(payload)
+        ):
+            status_code, data, _ = local_api.route_request(Path(tmpdir), "/api/gh/prs/298")
+        self.assertEqual(status_code, 200)
+        self.assertEqual(data["mergeable"], "MERGEABLE")
+
+    def test_gh_unavailable_returns_503(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir, patch.object(
+            local_api.subprocess, "run", side_effect=FileNotFoundError("gh")
+        ):
+            status_code, data, _ = local_api.route_request(Path(tmpdir), "/api/gh/prs")
+        self.assertEqual(status_code, 503)
+        self.assertEqual(data, {"error": "gh CLI not available"})
+
+    def test_schema_lists_gh_endpoints(self) -> None:
+        paths = {entry["path"] for entry in local_api.build_api_schema()["endpoints"]}
+        self.assertIn("/api/gh/issues", paths)
+        self.assertIn("/api/gh/issues/{n}", paths)
+        self.assertIn("/api/gh/prs", paths)
+        self.assertIn("/api/gh/prs/{n}", paths)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #276.

## Summary
- add `/api/gh/issues`, `/api/gh/issues/{n}`, `/api/gh/prs`, and `/api/gh/prs/{n}` to `scripts/local_api.py`
- normalize list rows to `{number, title, state, labels, assignees, comments_count, updated_at, url}` and include last 5 comments for detail routes plus `mergeable` for PR detail
- add 60s TTL caching with weak ETags derived from the latest `updated_at`, plus a focused `unittest` suite and `/api/schema` documentation

## Build report
- `python -m unittest tests.test_local_api_gh` ✅
- `~/.local/bin/ruff check scripts/local_api.py tests/test_local_api_gh.py` ✅
- `npm run build` from primary `main` checkout ✅
- `python - <<'PY' ... route_request(Path('.'), '/api/gh/issues?limit=1') ... PY` smoke call ✅

## Notes
- Diff size: 376 added / 1 deleted lines across 2 files
- `npm run build` emitted pre-existing chunk-size and route-conflict warnings from `main`; the build still completed successfully
