### PR TITLE
fix(pipeline): rejected drafts do not poison persistent fact ledger (#235)

### DIFF
--- a/scripts/test_pipeline.py
+++ b/scripts/test_pipeline.py
@@ -3893,6 +3893,99 @@ class TestRunModuleSplitReviewer(unittest.TestCase):
 
         self.assertTrue(ok)
 
+    def test_rejected_draft_content_ledger_stays_transient_until_approve(self):
+        import v1_pipeline as p
+
+        def content_ledger(claim_text: str) -> dict:
+            return {
+                "as_of_date": "2026-04-18",
+                "topic": "Test Module",
+                "claims": [
+                    {
+                        "id": "C1",
+                        "claim": claim_text,
+                        "status": "SUPPORTED",
+                        "current_truth": claim_text,
+                        "sources": [{"url": "https://example.com/facts", "source_date": "2026-04-18"}],
+                        "conflict_summary": None,
+                        "unverified_reason": None,
+                    }
+                ],
+            }
+
+        review_ledgers: list[dict | None] = []
+        review_sequence = [
+            {
+                "verdict": "REJECT",
+                "checks": [
+                    {"id": "LAB", "passed": False, "evidence": "minor accuracy issue", "edit_refs": [0]},
+                    {"id": "COV", "passed": True},
+                    {"id": "QUIZ", "passed": True},
+                    {"id": "EXAM", "passed": True},
+                    {"id": "DEPTH", "passed": True},
+                    {"id": "WHY", "passed": True},
+                    {"id": "PRES", "passed": True},
+                ],
+                "edits": [
+                    {
+                        "type": "replace",
+                        "find": "## Learning Outcomes",
+                        "new": "## Learning Outcomes (Revised)",
+                        "reason": "revision tag",
+                    }
+                ],
+                "feedback": "Minor accuracy fix.",
+            },
+            {
+                "verdict": "APPROVE",
+                "checks": [{"id": cid, "passed": True} for cid in p.CHECK_IDS],
+                "edits": [],
+                "feedback": "",
+            },
+        ]
+
+        def fake_review(_module_path, _improved, model=None, fact_ledger=None):
+            review_ledgers.append(fact_ledger)
+            return review_sequence[len(review_ledgers) - 1]
+
+        state = {"modules": {}}
+        with patch.object(p, "STATE_FILE", self.state_file), \
+             patch.object(p, "CONTENT_ROOT", Path(self.tmpdir)), \
+             patch.object(p, "save_state"), \
+             patch.object(p, "module_key_from_path", return_value="test/module-0.1-test"), \
+             patch.object(p, "ensure_fact_ledger", return_value=sample_fact_ledger()), \
+             patch.object(
+                 p,
+                 "step_content_aware_fact_ledger",
+                 side_effect=[
+                     content_ledger("Rejected draft-only claim"),
+                     content_ledger("Approved draft claim"),
+                 ],
+             ) as mock_content_ledger, \
+             patch.object(p, "ensure_knowledge_card", return_value="card"), \
+             patch.object(p, "step_write", return_value=GOOD_MODULE), \
+             patch.object(p, "step_review", side_effect=fake_review), \
+             patch.object(p, "step_check_integrity", return_value=(True, [])), \
+             patch.object(p, "step_check", return_value=(True, [])), \
+             patch("subprocess.run"):
+            ok = p.run_module(self.module_path, state)
+
+        self.assertTrue(ok)
+        self.assertEqual(mock_content_ledger.call_count, 2)
+
+        first_claims = {claim.get("claim") for claim in review_ledgers[0].get("claims", [])}
+        second_claims = {claim.get("claim") for claim in review_ledgers[1].get("claims", [])}
+        self.assertIn("Rejected draft-only claim", first_claims)
+        self.assertNotIn("Rejected draft-only claim", second_claims)
+        self.assertIn("Approved draft claim", second_claims)
+
+        persisted_claims = {
+            claim.get("claim")
+            for claim in state["modules"]["test/module-0.1-test"]["fact_ledger"].get("claims", [])
+        }
+        self.assertNotIn("Rejected draft-only claim", persisted_claims)
+        self.assertIn("Approved draft claim", persisted_claims)
+
     def test_existing_binary_gate_tests_still_pass(self):
         suite = unittest.defaultTestLoader.loadTestsFromTestCase(TestBinaryGateIntegration)
         result = unittest.TestResult()

--- a/scripts/v1_pipeline.py
+++ b/scripts/v1_pipeline.py
@@ -3210,18 +3210,21 @@ def run_module(module_path: Path, state: dict, max_retries: int | None = None,
                     pass  # non-critical
                 return True
 
+        if ms["phase"] == "review":
             # Content-aware fact ledger: verify claims actually made in the
-            # written content. Merges with the pre-write topic-based ledger
-            # so the reviewer has both broad coverage and precise grounding.
-            # data_conflict gating happens here, after the draft exists, so
-            # topic-only hypothetical claims do not block the pipeline.
+            # written content. Regenerated each iteration so rejected-draft
+            # claims stay transient — only the APPROVE branch merges them
+            # back into ms["fact_ledger"] (persistent). Generated here (not
+            # under phase=write) so re-review after a clean deterministic
+            # apply picks up the revised content's claims. See #235.
+            content_ledger = None
+            review_fact_ledger = ms.get("fact_ledger")
             if improved and not dry_run:
                 fact_model = m.get("fact_grounding", MODELS["fact_grounding"])
                 content_ledger = step_content_aware_fact_ledger(
                     module_path, improved, model=fact_model
                 )
                 if content_ledger is None:
-                    # Try fallback model
                     fallback_model = m.get("fact_fallback", MODELS["fact_fallback"])
                     if fallback_model != fact_model:
                         content_ledger = step_content_aware_fact_ledger(
@@ -3244,7 +3247,6 @@ def run_module(module_path: Path, state: dict, max_retries: int | None = None,
                         or ms.get("fact_ledger")
                     )
 
-        if ms["phase"] == "review":
             content_for_integrity = improved or module_path.read_text()
             integrity_passed, integrity_messages = step_check_integrity(
                 content_for_integrity, review_fact_ledger or ms.get("fact_ledger") or {}
@@ -3389,6 +3391,11 @@ def run_module(module_path: Path, state: dict, max_retries: int | None = None,
                 # ignore any `edits` returned alongside an APPROVE — an
                 # approval is an immutable snapshot. If the reviewer wants
                 # changes, it must REJECT with severity=targeted.
+                if content_ledger is not None:
+                    ms["fact_ledger"] = (
+                        _merge_fact_ledgers(ms.get("fact_ledger"), content_ledger)
+                        or ms.get("fact_ledger")
+                    )
                 ms["severity"] = "clean"
                 ms["checks_failed"] = []
                 ms["reviewer_schema_version"] = 3


### PR DESCRIPTION
## Summary
- regenerate the content-aware fact ledger per review attempt instead of carrying a rejected draft's merged ledger into retries
- persist merged content-aware claims to module state only after APPROVE, keeping rejected-draft claims transient
- add a regression test covering REJECT -> deterministic retry -> APPROVE so rejected-only claims never land in persistent state

## Verification
- python -m py_compile scripts/v1_pipeline.py scripts/test_pipeline.py
- python -m unittest scripts.test_pipeline.TestRunModuleSplitReviewer.test_rejected_draft_content_ledger_stays_transient_until_approve
- python scripts/test_pipeline.py (fails on pre-existing TestStatusFourStage.test_cmd_status_prints_four_stage_completion_table)
- ruff check scripts/v1_pipeline.py scripts/test_pipeline.py (fails on pre-existing baseline E402/F541 issues in these files)

Composes with PR #287 (_merge_fact_ledgers purity) and PR #289 (ledger 40k windowing).
