### PR TITLE
fix: rewrite stale AGENTS.md + add cold-start + bridge smoketest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,55 +1,239 @@
-# Repository Guidelines
+# AGENTS.md — Rules for AI Coding Agents
 
-## Agent Orientation (first call on a cold start)
+> This file is read by Codex, Jules, and other AI coding agents working on this repository.
+> For Claude-specific instructions see `CLAUDE.md`. For Gemini-specific, see `.claude/rules/gemini-workflow.md`.
 
-**Do not start with `git log` or a grep sweep.** Hit the local API first:
+---
+
+## Cold start (first call on a fresh session)
+
+**Do not start with `git log` or a grep sweep.** Run:
 
 ```bash
-curl -s http://127.0.0.1:8768/api/briefing/session?compact=1   # ~0.7K tokens
-curl -s http://127.0.0.1:8768/api/schema                       # endpoint index
+bash scripts/cold-start.sh          # services-up + compact briefing in one call
 ```
 
 The briefing returns `actions.{active, blocked, next}` + `top_modules[]` — answers "what should I touch" in the same call as "what is the global state". Responses carry a weak ETag; send `If-None-Match` for 304 on repeat polls.
 
 Before claiming work: `GET /api/pipeline/leases`. Before fixing a module: `GET /api/module/{key}/state` (structured `diagnostics[]`). Before re-reviewing: `GET /api/reviews?module={key}`. Situational awareness: `GET /api/tracks/readiness` + `GET /api/activity`.
 
-Full recipe: [`scripts/agent_onboarding.md`](scripts/agent_onboarding.md). If the API is down, fall back to `STATUS.md` + `CLAUDE.md`.
+If the API is down, fall back to `STATUS.md` + `CLAUDE.md`.
 
-Everything below this block is historical MkDocs-era guidance; for current site structure see the Curriculum Structure section in `CLAUDE.md`.
+---
 
-## Project Structure & Module Organization
-- Course content lives under `docs/` and is grouped by track: `docs/prerequisites/`, `docs/linux/`, `docs/k8s/`, and `docs/platform/`. Each track contains numbered `module-X.Y-name.md` files plus local `README.md` overviews.
-- Navigation is defined in `mkdocs.yml`; add new pages there to surface them in the site.
-- Built output is written to `site/` by MkDocs—do not edit it manually. `exercises/` is reserved for future hands-on labs.
+## MANDATORY PRE-SUBMIT CHECKLIST
 
-## Build, Test, and Development Commands
-- Install tooling: `pip install -r requirements.txt`.
-- Live preview with reload: `mkdocs serve -a 0.0.0.0:8000` (serves the docs locally).
-- Static build check: `mkdocs build` (writes the generated site to `site/` and fails on syntax errors).
-- Optional publish: `mkdocs gh-deploy` if you have repo permissions.
+**Before opening a PR, verify EVERY item. If ANY check fails, fix it BEFORE submitting.**
 
-## Coding Style & Naming Conventions
-- Markdown-first; keep headings concise (`## Topic`) and prefer unordered lists for checklists or summaries.
-- File naming: lowercase, hyphen-separated, and numbered (`module-2.3-storage.md`) to match the learning path.
-- Keep sections short (2–6 bullets or paragraphs). Use fenced code blocks with language tags for commands and YAML.
-- Avoid external images when possible; inline examples and text explanations are preferred for portability.
+- [ ] `~/.local/bin/ruff check` clean on every Python file you changed
+- [ ] `.venv/bin/python scripts/test_pipeline.py` — 0 new failures (2 pre-existing `check_failures` tests + 1 `TestStatusFourStage` order flake are acceptable until their dedicated cleanup lands)
+- [ ] `npm run build` passes if you touched content under `src/content/docs/` or Astro config (skip for pure-Python-script changes)
+- [ ] No `sys.executable` anywhere — always `.venv/bin/python` explicitly
+- [ ] No `@pytest.mark.skip` with empty `pass` bodies, no double-skip decorators
+- [ ] Assertions not weakened (no `is True` → `isinstance(..., bool)`)
+- [ ] Every changed file is directly related to the task
+- [ ] Total files changed < 20 (if more, you likely included artifacts)
+- [ ] Diff budget respected (tasks specify a LOC ceiling; if you can't fit, split)
+- [ ] Primary repo is NOT on detached HEAD after your work
 
-## Testing Guidelines
-- Run `mkdocs build` before submitting to catch broken links, malformed Markdown, or navigation errors.
-- For new commands or YAML snippets, validate them locally (e.g., `kubectl explain`, `kind create cluster`) and note assumptions inline.
-- When adding exercises, include expected outcomes and cleanup steps so readers can reset their environment.
+**If you cannot check every box, your PR will be rejected.**
 
-## Exercises & Practice Environments
-- Align with Issue #15: prefer lightweight clusters (kind/minikube) by default; only introduce multi-node or topic-specific clusters when required and state why.
-- Exercise layout lives under `exercises/cka/partN-*/N.N-topic/` with `README.md`, optional `setup.sh`, and `verify.sh` that reports granular checks (✓/✗ plus hints). Include complexity tags `[QUICK]`, `[MEDIUM]`, or `[COMPLEX]`.
-- For verification scripts, aim for helpful feedback (what passed, what failed, and a short hint) rather than simple pass/fail.
+---
 
-## Curriculum Monitoring
-- Follow Issue #14 for certification source tracking. Before adding/updating CKA/CKAD/CKS/KCNA/KCSA modules, confirm the CNCF/LF curriculum version and note the check date in the PR description.
-- If a curriculum change impacts navigation, update `mkdocs.yml` and summarize the delta (what changed and where) in the PR body.
+## Non-Negotiable Rules
 
-## Commit & Pull Request Guidelines
-- Commit messages: short, imperative, and scoped (e.g., `Add kcna scheduling module outline`).
-- Pull requests should state the goal, summarize notable changes, and link any related issue. If altering navigation or moving files, call that out explicitly.
-- Include screenshots only when they meaningfully demonstrate rendered formatting; otherwise rely on `mkdocs build` output.
-- Ensure contributions keep the text authoritative and vendor-neutral; avoid promotional links or tool bias unless clearly marked as opinionated.
+These rules are ABSOLUTE. Violating any one of them results in immediate PR rejection.
+
+### 1. NEVER push or work directly on `main`
+
+Use git worktrees under `.worktrees/<short-name>` on a new branch. Create with:
+```bash
+git worktree add .worktrees/<name> -b <branch-name> main
+```
+
+The primary checkout (`/Users/krisztiankoos/projects/kubedojo`) must always stay on `main`, never detached, never dirty with uncommitted work-in-progress.
+
+### 2. ALWAYS build from the primary main checkout — NOT a worktree
+
+`npm run build` fails inside `.worktrees/*` because Astro's `node_modules` symlink resolution walks `../../node_modules` one level too shallow. When you need to verify the build:
+1. Commit your worktree changes
+2. Fetch the branch from the primary checkout
+3. Run `npm run build` there
+
+This regression bit PR #282. Don't repeat it.
+
+### 3. ALWAYS use `.venv/bin/python`, not `sys.executable` or `python3`
+
+```bash
+# CORRECT
+.venv/bin/python scripts/test_pipeline.py
+subprocess.run(['.venv/bin/python', 'scripts/uk_sync.py', 'status'])
+
+# WRONG — misses venv deps
+python3 scripts/test_pipeline.py
+subprocess.run([sys.executable, ...])
+```
+
+### 4. NEVER weaken linters or tests to make CI pass
+
+- Fix the source files, not the linter config
+- Do not disable rules (`ruff: disable`, `eslint-disable-next-line`, etc.) without an incident-level reason
+- Do not comment out assertions
+- Do not stub imports with `try/except` that silently return empty results
+- Do not skip tests with `@pytest.mark.skip` + `pass`
+
+If a test fails, fix the code or rewrite the test properly.
+
+### 5. NEVER use container or hard-coded absolute paths
+
+This project runs **locally**, not in Docker. Do not use:
+- `/app/src/...` — use relative paths from repo root
+- `localhost:4321`, `localhost:3000` — Astro dev port; prefer `127.0.0.1:4321`
+- Hard-coded machine paths — derive from `Path(__file__).resolve().parent`
+
+Production API binds to `127.0.0.1:8768` per `scripts/services-up`.
+
+### 6. NEVER delete files without explicit instructions
+
+Scripts, docs, and worktrees exist for reasons that aren't always in the current task's scope. If you think something is dead code, flag it in the PR description and leave it alone.
+
+### 7. Scope your PRs — one concern per PR
+
+Do NOT:
+- Change `.python-version` in a "fix tests" PR
+- Regenerate `.pipeline/state.yaml` or review audit files in a "code change" PR
+- Modify `.claude/settings.json` in a "new endpoint" PR
+- Touch content under `src/content/docs/` unrelated to the task
+
+If you find something unrelated that needs fixing, create a separate GitHub issue.
+
+### 8. NEVER include auto-generated artifacts in code PRs
+
+These are auto-written by runtime services — they MUST NOT appear in a code PR:
+
+- `.pipeline/state.yaml` (pipeline state machine)
+- `.pipeline/reviews/**/*.md` (per-module review logs)
+- `.pipeline/logs/**` (timestamped run logs)
+- `.bridge/messages.db` (agent bridge DB)
+- `.cache/**` (endpoint caches)
+- `.pids/**` (service PIDs)
+- `dist/**` (Astro build output)
+- `node_modules/**`
+- Any file matching `*.staging.md`, `*.bak`
+
+If your diff includes these, you staged too aggressively. Re-stage with explicit file names.
+
+### 9. ALWAYS use `scripts/ab` for Codex-from-bridge invocations
+
+The wrapper at `scripts/ab` defaults `CODEX_BRIDGE_MODE=workspace-write` (guarded by `scripts/ops/smoketest_ab_workspace_write.sh`). Override only when you know you need it:
+
+- `CODEX_BRIDGE_MODE=safe scripts/ab ...` — read-only
+- `CODEX_BRIDGE_MODE=danger scripts/ab ...` — full network + FS (for `gh`, pip installs, opening PRs)
+
+For a task that requires opening a PR, **you need `danger` mode** — `workspace-write` blocks network.
+
+### 10. NEVER merge a PR without an independent-family review
+
+Hard rule from session 2026-04-11: 4 PRs landed on tests-passing alone and broke pipeline logic. The reviewer must be from a DIFFERENT model family than the writer (Codex writes → Claude or Gemini reviews; Claude writes → Gemini or Codex reviews; etc.). A tests-passing CI run is NOT a review.
+
+Post the review as a PR comment (not `gh pr review --approve` — fails when the same GH identity owns both author and reviewer).
+
+---
+
+## Project Architecture
+
+KubeDojo is a cloud-native curriculum site built with **Astro/Starlight**. It is NOT an MkDocs project (the migration happened weeks ago — any AGENTS.md/CLAUDE.md guidance mentioning MkDocs is historical).
+
+```
+src/content/docs/              # All content (this is the source of truth)
+├── prerequisites/             # Fundamentals tab
+├── linux/                     # Linux Deep Dive + Everyday Use
+├── cloud/                     # Cloud tab (85 modules)
+├── k8s/                       # Certifications tab (CKA/CKAD/CKS/KCNA/KCSA + specialty)
+├── platform/                  # Platform Engineering tab (199 modules)
+└── uk/                        # Ukrainian translations (~40% coverage)
+
+scripts/
+├── cold-start.sh              # Session entry point
+├── services-up                # Idempotent bring-up for API + pipeline workers
+├── ab                         # Agent bridge CLI (defaults CODEX_BRIDGE_MODE=workspace-write)
+├── ai_agent_bridge/           # Bridge internals (_cli.py, _codex.py, _gemini.py, ...)
+├── agent_runtime/             # Model adapters (codex.py, claude.py, gemini.py)
+├── dispatch.py                # Direct Gemini/Claude CLI dispatch
+├── local_api.py               # :8768 briefing + module state API
+├── v1_pipeline.py             # Quality pipeline v1 (serial)
+├── pipeline_v2/               # Quality pipeline v2 (queue + workers)
+├── uk_sync.py                 # Ukrainian translation pipeline
+├── check_site_health.py       # Health gate
+├── check_links.py             # Link gate
+├── check_citations.py         # Citation gate (2026-04-18)
+├── ops/                       # Smoketests (executable, exit-coded)
+└── prompts/module-writer.md   # Standard prompt for content writing
+
+.pipeline/
+├── state.yaml                 # Pipeline state (auto-generated — never in PRs)
+├── reviews/**/*.md            # Per-module review logs (auto-generated — never in PRs)
+└── logs/**                    # Timestamped run logs (auto-generated)
+
+.bridge/messages.db            # Agent bridge message store (auto-generated)
+
+docs/                          # Internal project docs (pedagogy, rubrics, sessions)
+├── quality-rubric.md          # 8-dim rubric (reviewer's source of truth)
+├── quality-audit-results.md   # STALE as of 2026-04-03 — live scores via /api/quality/scores
+├── pedagogical-framework.md
+├── rubric-profiles/*.yaml     # Per-track rubric overrides
+└── sessions/**                # Session handoffs
+
+.claude/
+├── rules/*.md                 # Scoped rules (auto-loaded by Claude Code)
+├── settings.json              # Shared permissions (committed)
+└── settings.local.json        # Personal overrides (gitignored)
+```
+
+**Key facts:**
+- Python: `.venv/` at repo root, Python 3.12+, use `.venv/bin/python` explicitly
+- Build: `npm run build` → `dist/` (~56s for 1,297 pages)
+- Dev: `npx astro dev` (default port 4321)
+- Local API: `http://127.0.0.1:8768` (started by `scripts/services-up`)
+- K8s version target for content: **1.35**
+- Agent bridge DB: `.bridge/messages.db`
+- Pipeline v2 is the current default; v1 is maintained for backward compatibility
+- Frontmatter requires `title:` and `sidebar.order:` — see `.claude/rules/new-content-checklist.md`
+- Ukrainian content lives under `src/content/docs/uk/` mirroring the EN tree
+
+---
+
+## Common Anti-Patterns
+
+| Anti-Pattern | What to Do Instead |
+|---|---|
+| Running `python3` or `python` without venv prefix | `.venv/bin/python` every time |
+| Building from a `.worktrees/` directory | Switch to primary main, run build there |
+| Skipping `scripts/ab` and calling `codex exec` directly | Always use `scripts/ab` — it sets the default sandbox mode we rely on |
+| Using `workspace-write` (default) for PR-opening tasks | `CODEX_BRIDGE_MODE=danger` when task needs `gh` or network |
+| Parsing `docs/quality-audit-results.md` for current scores | Use `/api/quality/scores` (once #303 lands) — static audit is frozen at 2026-04-03 |
+| Committing `.pipeline/state.yaml` or `.bridge/messages.db` | These are runtime state; add-by-glob will pull them in — stage explicit files only |
+| Editing `mkdocs.yml` (file doesn't exist) | Navigation is handled by Starlight; edit `astro.config.mjs` and frontmatter `sidebar.order` |
+| Running `mkdocs build` or `mkdocs serve` | `npm run build` / `npx astro dev` |
+| Closing issues without adversarial review | Dispatch review to a cross-family model first, post review as comment, THEN close |
+| Parallelizing multiple Gemini calls from pipeline code | Gemini workloads must stay sequential — user runs concurrent workloads elsewhere |
+| Leaving the primary on detached HEAD | After worktree ops or merges, confirm primary is on `main` |
+| Creating a PR without an issue reference | Tag the issue in commit title `feat(foo): bar (#N)` and PR body |
+
+---
+
+## When delegated a GitHub issue via the agent bridge
+
+The expected workflow is:
+
+1. Read the issue: `gh issue view <N> --repo kube-dojo/kube-dojo.github.io`
+2. Create a worktree: `git worktree add .worktrees/<short-name> -b <branch-name> main`
+3. Implement inside the worktree (never on primary `main`)
+4. Run the quality gates listed in the pre-submit checklist
+5. Open a PR: `gh pr create --title "<type>(scope): <summary> (#N)" --body "<summary + test results + LOC diff>"`
+6. Do NOT merge — Claude (or another cross-family reviewer) reviews first per rule 10
+7. Post back via the bridge with the PR URL and a one-line summary of the design choice
+
+If the task exceeds the stated LOC budget (usually ≤200 LOC), **stop and post a split plan as a comment on the issue** instead of shipping a mega-PR. Splitting is a first-class outcome, not a failure.
+
+Don't decline full PR workflows as "too large for bridge" — the bridge handles this exact pattern 20+ times per session. If you genuinely cannot proceed (env constraints, missing context), post a bridge response explaining WHY, with the specific command that failed. Don't improvise around rules.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ If the API is down, fall back to `STATUS.md` + `CLAUDE.md`.
 
 **Before opening a PR, verify EVERY item. If ANY check fails, fix it BEFORE submitting.**
 
-- [ ] `~/.local/bin/ruff check` clean on every Python file you changed
+- [ ] `.venv/bin/ruff check` clean on every Python file you changed
 - [ ] `.venv/bin/python scripts/test_pipeline.py` — 0 new failures (2 pre-existing `check_failures` tests + 1 `TestStatusFourStage` order flake are acceptable until their dedicated cleanup lands)
 - [ ] `npm run build` passes if you touched content under `src/content/docs/` or Astro config (skip for pure-Python-script changes)
 - [ ] No `sys.executable` anywhere — always `.venv/bin/python` explicitly
@@ -150,7 +150,7 @@ src/content/docs/              # All content (this is the source of truth)
 ├── linux/                     # Linux Deep Dive + Everyday Use
 ├── cloud/                     # Cloud tab (85 modules)
 ├── k8s/                       # Certifications tab (CKA/CKAD/CKS/KCNA/KCSA + specialty)
-├── platform/                  # Platform Engineering tab (199 modules)
+├── platform/                  # Platform Engineering tab (220 modules)
 └── uk/                        # Ukrainian translations (~40% coverage)
 
 scripts/
@@ -192,7 +192,7 @@ docs/                          # Internal project docs (pedagogy, rubrics, sessi
 
 **Key facts:**
 - Python: `.venv/` at repo root, Python 3.12+, use `.venv/bin/python` explicitly
-- Build: `npm run build` → `dist/` (~56s for 1,297 pages)
+- Build: `npm run build` → `dist/` (~56s for ~1,800 pages)
 - Dev: `npx astro dev` (default port 4321)
 - Local API: `http://127.0.0.1:8768` (started by `scripts/services-up`)
 - K8s version target for content: **1.35**

--- a/docs/sessions/2026-04-18-session-3-memory-cleanup-and-quality-scores.md
+++ b/docs/sessions/2026-04-18-session-3-memory-cleanup-and-quality-scores.md
@@ -1,0 +1,47 @@
+# Session Handoff — 2026-04-18 Session 3 — Memory Cleanup + Live Quality Scores
+
+## Cold start (next session, read first)
+
+```bash
+bash scripts/cold-start.sh                                   # services-up + compact briefing
+gh pr list --repo kube-dojo/kube-dojo.github.io --author @me # in-flight PRs
+bash scripts/ops/smoketest_ab_workspace_write.sh             # guards CODEX_BRIDGE_MODE default
+```
+
+If the briefing surfaces `critical_quality` alerts for CKA 2.8 / KCNA 3.6 / 3.7 / 4.3: **the API needs a restart** — it's serving cached scores from before #304 merged. Run:
+
+```bash
+kill $(cat .pids/api.pid) && scripts/services-up
+```
+
+## Decisions waiting on you
+
+1. **Review + merge PR #305** (this session's own output: AGENTS.md rewrite + cold-start + bridge smoketest). Claude wrote it — needs cross-family review per the new rule 10. Dispatch to Gemini or Codex before merging.
+2. **Split + re-delegate #279** into #279a (WRITE-time seed injection, ≤150 LOC) / #279b (citation gate step, ≤150 LOC) / #279c (rubric dimension + e2e test, ≤100 LOC). Split plan is on #279 as a comment. Use `CODEX_BRIDGE_MODE=danger scripts/ab ask-codex ...` with a directive prompt — see "Novel info" point 4.
+3. **Restart the local_api process** (above) so the briefing stops showing phantom `critical_quality` alerts. Required for accurate triage signal next session.
+
+## Novel info (not derivable from briefing / git / PR list)
+
+1. **Memory index went 52 → 23 files.** Aggressive consolidation; see `~/.claude/projects/-Users-krisztiankoos-projects-kubedojo/memory/MEMORY.md`. Eight Gemini-related feedback stubs merged into `reference_gemini_collab.md`. Three translation refs merged into `reference_ukrainian_translation.md`. Dead/superseded entries deleted. Future memory adds should stay aggressive — the goal is ≤20 durable entries.
+2. **The "4 critical-quality rewrites" from the session 2 handoff were phantom.** `docs/quality-audit-results.md` is a frozen snapshot from 2026-04-03; CKA 2.8 is 1014 lines now, the KCNA modules are 311-368 lines. All four score 4.2-5.0 under the new live scorer. Don't queue them for rewrite.
+3. **PR #304 replaces the stale scorer.** `GET /api/quality/scores` now walks `src/content/docs/**/module-*.md` directly. Signals: line count (base), frontmatter title, `## Quiz`/`## Knowledge Check`, `## Exercise`/`## Hands-On`/`## Lab`, `\`\`\`mermaid` or `<details>` (conflated — future cleanup). Response fields `source` and `generated_at` added; `audit_path` and `mtime` removed. Cache keyed on sha1 of (relpath + mtime_ns + size) per module. **Nit to clean up later:** `_QUALITY_AUDIT_CACHE` variable name is now misleading.
+4. **"Codex declined full-PR tasks via bridge" was prompt-brittleness, not only stale AGENTS.md.** With directive phrasing — *"either do it or post a split plan; don't write a meta-reply declining"* — the bridge accepted on the second retry. The AGENTS.md rewrite in #305 prevents this from being prompt-craft-dependent, but the decisive unblock in this session was re-prompting. Remember for #279 dispatch.
+5. **Local main diverged from origin during the PR merge sweep.** I committed the agent-comms fix to local main (violating the very rule 1 it introduces), then the 23-PR merge sweep landed origin commits that local didn't have. Resolved by moving the local commit to `feat-fix-agent-comms` branch and hard-resetting local main to origin/main — see PR #305. If you find the same situation again: prefer branch-first, don't commit straight to local main just because the PR rule hasn't been enforced yet.
+6. **bridge task-id idempotency is missing.** The `infra-303` task ran twice (bgknox50f before and bu443928l after I rewrote AGENTS.md); the second run correctly reported the PR was already open, but it still spent a Codex slot. Worth a future fix: broker should detect in-flight task-ids and short-circuit.
+
+## PR state
+
+- **#305 — fix: rewrite stale AGENTS.md + add cold-start + bridge smoketest** — OPEN, awaits cross-family review before merge (rule 10 applies to the author of the rule).
+- All of session 2's 23 PRs merged: 17 cleanly in the initial sweep, 6 (#294, #297, #298, #300, #301, #302) rebased manually on updated main and merged. See session 2 handoff for the original dep stack.
+- **#304 — live quality scores (#303)** — MERGED.
+
+## Incomplete / for next session
+
+- **Split + re-delegate #279** per point 2 above.
+- **Pre-existing test failures on main**, flagged in multiple PR reviews this session, still need a dedicated cleanup PR:
+  - `test_check_failures_tracks_consecutive_failures_only` (from #290/#296 interaction)
+  - `test_check_retries_in_function_without_returning_false` (same)
+  - `test_cmd_status_prints_four_stage_completion_table` (the `TestStatusFourStage` order-dependent flake called out in session 2 handoff)
+- **local_api stale-PID heuristic** at `scripts/local_api.py` L2167-2180 — still over-eager, still masked by `scripts/services-up` touching `.pids/*.pid` mtimes. Replace with `os.kill(pid, 0)` liveness check.
+- **Worktree cleanup** — 27 attached worktrees, several from session 2 branches that are now merged. `git worktree list` shows them; prune after confirming no uncommitted work.
+- **`docs/quality-audit-results.md`** — kept in-repo for historical diff value, but no longer read by any endpoint. Add a header note at the top saying "superseded by live `/api/quality/scores`" so future contributors don't trust it.

--- a/scripts/cold-start.sh
+++ b/scripts/cold-start.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Cold-start ritual for a fresh KubeDojo agent session.
+# Brings up services (idempotent) and prints the compact briefing.
+# Handoffs reference this script instead of duplicating the curl ritual.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+scripts/services-up >&2
+
+API="${KUBEDOJO_API:-http://127.0.0.1:8768}"
+BRIEFING_URL="${API}/api/briefing/session?compact=1"
+
+for _ in 1 2 3 4 5; do
+  if curl -sf "$BRIEFING_URL" >/tmp/kubedojo_briefing.$$; then
+    cat /tmp/kubedojo_briefing.$$
+    rm -f /tmp/kubedojo_briefing.$$
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "ERROR: briefing API did not respond at $BRIEFING_URL — falling back to STATUS.md" >&2
+exit 1

--- a/scripts/cold-start.sh
+++ b/scripts/cold-start.sh
@@ -12,10 +12,12 @@ scripts/services-up >&2
 API="${KUBEDOJO_API:-http://127.0.0.1:8768}"
 BRIEFING_URL="${API}/api/briefing/session?compact=1"
 
+TMP="/tmp/kubedojo_briefing.$$"
+trap 'rm -f "$TMP"' EXIT
+
 for _ in 1 2 3 4 5; do
-  if curl -sf "$BRIEFING_URL" >/tmp/kubedojo_briefing.$$; then
-    cat /tmp/kubedojo_briefing.$$
-    rm -f /tmp/kubedojo_briefing.$$
+  if curl -sf "$BRIEFING_URL" >"$TMP"; then
+    cat "$TMP"
     exit 0
   fi
   sleep 1

--- a/scripts/ops/smoketest_ab_workspace_write.sh
+++ b/scripts/ops/smoketest_ab_workspace_write.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Smoketest: scripts/ab must default CODEX_BRIDGE_MODE=workspace-write,
+# and must respect user overrides.
+#
+# Regression guard for the session-2 2026-04-18 finding: upstream "safe"
+# default silently blocks worktree + gh CLI writes. Loss of this default
+# would burn another debugging session before anyone notices.
+#
+# Exit 0 on pass, non-zero with diagnostic on fail.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+AB="$REPO_ROOT/scripts/ab"
+[ -x "$AB" ] || { echo "FAIL: $AB not executable"; exit 1; }
+
+# Extract the env-setup preamble (everything before the final exec) so we can
+# source it in isolation and inspect the resulting environment without
+# actually invoking the Python bridge.
+exec_line="$(grep -n '^exec ' "$AB" | head -1 | cut -d: -f1)"
+[ -n "$exec_line" ] || { echo "FAIL: no 'exec' line found in $AB"; exit 1; }
+
+preamble="$(mktemp)"
+trap 'rm -f "$preamble"' EXIT
+head -n "$((exec_line - 1))" "$AB" > "$preamble"
+
+# Test 1: default is workspace-write when caller has not set the var.
+actual_default="$(bash -c "unset CODEX_BRIDGE_MODE; source '$preamble'; printf '%s' \"\$CODEX_BRIDGE_MODE\"")"
+if [ "$actual_default" != "workspace-write" ]; then
+  echo "FAIL: default CODEX_BRIDGE_MODE is '$actual_default', expected 'workspace-write'"
+  echo "HINT: upstream default is 'safe' which silently blocks writes, worktrees, and gh CLI."
+  exit 1
+fi
+
+# Test 2: caller-supplied value is respected (not clobbered by the default).
+actual_override="$(bash -c "export CODEX_BRIDGE_MODE=danger; source '$preamble'; printf '%s' \"\$CODEX_BRIDGE_MODE\"")"
+if [ "$actual_override" != "danger" ]; then
+  echo "FAIL: override CODEX_BRIDGE_MODE=danger clobbered to '$actual_override'"
+  echo "HINT: use ':= default' syntax, not '= default', so callers can override."
+  exit 1
+fi
+
+echo "PASS: scripts/ab defaults CODEX_BRIDGE_MODE=workspace-write and respects overrides"


### PR DESCRIPTION
## Summary

- AGENTS.md was severely stale (MkDocs era — the project moved to Astro/Starlight months ago). Rewritten to match the adversarial-rulebook pattern used in learn-ukrainian: mandatory pre-submit checklist, 10 non-negotiable rules, current project architecture, anti-patterns table, and an explicit *"when delegated a GitHub issue via the agent bridge"* workflow.
- \`scripts/cold-start.sh\` — shell wrapper around \`services-up\` + compact briefing, so handoffs can say \`bash scripts/cold-start.sh\` instead of pasting curl commands. Referenced by the new AGENTS.md.
- \`scripts/ops/smoketest_ab_workspace_write.sh\` — exit-coded test that guards \`scripts/ab\`'s \`CODEX_BRIDGE_MODE=workspace-write\` default. Upstream default is \`safe\`, which silently blocks worktrees/writes/gh — don't let it resurface.

## Why

During the 2026-04-18 session, two Codex bridge delegations declined full-PR tasks as \"too large for the bridge path.\" Investigation showed the AGENTS.md file Codex auto-reads on every session still referenced MkDocs, had no mandatory checklist, and no explicit permission for the full-PR workflow. The rewrite closes that gap and prevents the failure mode from being prompt-craft-dependent.

## Test plan

- [x] \`scripts/ops/smoketest_ab_workspace_write.sh\` — passes (verifies default = workspace-write AND override is respected)
- [x] \`bash scripts/cold-start.sh\` — runs \`services-up\` idempotently, retries briefing API 5x, falls back cleanly if API down
- [x] \`npm run build\` — 0 errors (not required for docs-only change, verified anyway: 1797 pages)
- [ ] **Cross-family review required before merge** per rule 10 of the new AGENTS.md (Claude wrote this — Gemini or Codex must review)