### PR TITLE
fix(pipeline): reject FACT_CHECK with unverified evidence; surface status (#306)

### DIFF
--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -1272,6 +1272,15 @@ def build_module_state(repo_root: Path, module_key: str) -> dict[str, Any]:
             source="pipeline_v2.jobs",
             next_action="wait for lease to release before claiming work",
         ))
+    review = build_module_reviews(repo_root, normalized, max_bytes=50_000)
+    if review and review.get("fact_check_status") == "unverified":
+        state["diagnostics"].append(_diag(
+            severity="warn",
+            code="fact_check_unverified",
+            summary="Latest review contains unverified fact claims",
+            source="reviews",
+            next_action=f"GET /api/reviews?module={normalized}",
+        ))
 
     return state
 
@@ -1670,6 +1679,10 @@ def build_pipeline_stuck(
 
 
 _REVIEW_AUDIT_DIR = Path(".pipeline") / "reviews"
+_VALID_FACT_CHECK_STATUSES = {"verified", "unverified", "failed", "none"}
+_LATEST_REVIEW_RE = re.compile(r"^## .*?— `REVIEW`.*?(?=^## |\Z)", re.MULTILINE | re.DOTALL)
+_FAILED_FACT_CHECK_RE = re.compile(r"^- \*\*FACT_CHECK\*\*:\s*(.+)$", re.MULTILINE)
+_UNVERIFIED_CLAIM_RE = re.compile(r"unverified:\s*(.+)", re.IGNORECASE)
 
 
 def _review_filename_to_module_key(filename: str) -> str:
@@ -1686,7 +1699,25 @@ def _module_key_to_review_filename(module_key: str) -> str:
     return module_key.replace("/", "__") + ".md"
 
 
-def build_reviews_index(repo_root: Path) -> dict[str, Any]:
+def _fact_check_summary(review_body: str) -> dict[str, Any]:
+    latest = next(iter(_LATEST_REVIEW_RE.findall(review_body)), "")
+    failed = [m.strip() for m in _FAILED_FACT_CHECK_RE.findall(latest)]
+    if failed:
+        return {"fact_check_status": "failed", "unverified_evidence": []}
+    unverified = [f"unverified: {m.strip()}" for m in _UNVERIFIED_CLAIM_RE.findall(latest)]
+    if unverified:
+        return {"fact_check_status": "unverified", "unverified_evidence": unverified[:3]}
+    return {
+        "fact_check_status": "verified" if "FACT_CHECK" in latest else "none",
+        "unverified_evidence": [],
+    }
+
+
+def build_reviews_index(
+    repo_root: Path,
+    *,
+    fact_check_status: str | None = None,
+) -> dict[str, Any]:
     """List every review artifact with its module key and last-modified
     timestamp. Callers fetch the body via ``/api/reviews?module=...``."""
     reviews_dir = repo_root / _REVIEW_AUDIT_DIR
@@ -1697,14 +1728,20 @@ def build_reviews_index(repo_root: Path) -> dict[str, Any]:
         try:
             mtime = path.stat().st_mtime
             size = path.stat().st_size
+            summary = _fact_check_summary(path.read_text(encoding="utf-8"))
         except OSError:
             mtime, size = 0.0, 0
+            summary = {"fact_check_status": "none", "unverified_evidence": []}
+        if fact_check_status and summary["fact_check_status"] != fact_check_status:
+            continue
         reviews.append({
             "module_key": _review_filename_to_module_key(path.name),
             "filename": path.name,
             "size": size,
             "mtime": mtime,
+            **summary,
         })
+    reviews.sort(key=lambda item: item["mtime"], reverse=True)
     return {
         "reviews_dir": str(reviews_dir),
         "exists": True,
@@ -1749,6 +1786,7 @@ def build_module_reviews(
         body = raw.decode("utf-8", errors="replace")
     except UnicodeDecodeError:
         body = raw.decode("latin-1", errors="replace")
+    summary = _fact_check_summary(body)
     return {
         "module_key": module_key,
         "path": str(path),
@@ -1757,6 +1795,7 @@ def build_module_reviews(
         "truncated": truncated,
         "max_bytes": max_bytes if truncated else None,
         "mtime": mtime,
+        **summary,
         "body": body,
     }
 
@@ -3753,6 +3792,17 @@ def render_dashboard_html(*, issue_number: int = DEFAULT_FEEDBACK_ISSUE) -> str:
       font-size: 12px; color: var(--text-secondary); line-height: 1.5;
       max-height: 120px; overflow-y: auto; white-space: pre-wrap; word-break: break-word;
     }}
+    .review-list {{ list-style: none; margin: 0; padding: 0; }}
+    .review-item {{ padding: 10px 0; border-bottom: 1px solid var(--border-subtle); }}
+    .review-item:last-child {{ border-bottom: 0; }}
+    .review-head {{ display: flex; align-items: center; justify-content: space-between; gap: 12px; }}
+    .review-pill {{ padding: 2px 8px; border-radius: 999px; font-size: 10px; font-weight: 700; text-transform: uppercase; }}
+    .review-pill.verified {{ background: var(--green-muted); color: var(--green); }}
+    .review-pill.unverified {{ background: var(--amber-muted); color: var(--amber); }}
+    .review-pill.failed {{ background: var(--red-muted); color: var(--red); }}
+    .review-pill.none {{ background: rgba(255,255,255,0.06); color: var(--text-dim); }}
+    .review-note {{ margin-top: 6px; font-size: 12px; color: var(--text-secondary); }}
+    .review-note mark {{ background: var(--amber-muted); color: var(--amber); padding: 0 3px; border-radius: 4px; }}
 
     .clr-green {{ color: var(--green); }}
     .clr-amber {{ color: var(--amber); }}
@@ -4124,6 +4174,17 @@ def render_dashboard_html(*, issue_number: int = DEFAULT_FEEDBACK_ISSUE) -> str:
           <span class="panel-badge" id="missing-badge"></span>
         </div>
         <div class="panel-body" id="missing"></div>
+      </div>
+
+      <div class="panel">
+        <div class="panel-header">
+          <div class="panel-title">
+            <span class="panel-icon" style="background:var(--amber-muted);color:var(--amber);">R</span>
+            Review Audit
+          </div>
+          <span class="panel-badge" id="reviews-badge"></span>
+        </div>
+        <div class="panel-body" id="reviews"></div>
       </div>
 
       <div class="panel">
@@ -4599,6 +4660,29 @@ def render_dashboard_html(*, issue_number: int = DEFAULT_FEEDBACK_ISSUE) -> str:
       el.innerHTML = html;
     }}
 
+    function renderReviews(data) {{
+      const el = $('#reviews');
+      const badge = $('#reviews-badge');
+      if (!data || data.error) {{
+        badge.textContent = 'Unknown';
+        el.innerHTML = `<div class="empty-state">${{esc(data?.error || 'No data')}}</div>`;
+        return;
+      }}
+      const rows = (data.reviews || []).slice(0, 8);
+      const unverified = rows.filter(r => r.fact_check_status === 'unverified').length;
+      badge.textContent = unverified ? `${{unverified}} unverified` : `${{data.count || 0}} reviews`;
+      badge.style.background = unverified ? 'var(--amber-muted)' : 'var(--green-muted)';
+      badge.style.color = unverified ? 'var(--amber)' : 'var(--green)';
+      el.innerHTML = rows.length ? `<ul class="review-list">${{rows.map(r => `
+        <li class="review-item">
+          <div class="review-head">
+            <span class="mono">${{esc(shortenKey(r.module_key))}}</span>
+            <span class="review-pill ${{esc(r.fact_check_status || 'none')}}">${{esc(r.fact_check_status || 'none')}}</span>
+          </div>
+          ${{r.unverified_evidence?.[0] ? `<div class="review-note"><mark>${{esc(r.unverified_evidence[0])}}</mark></div>` : ''}}
+        </li>`).join('')}}</ul>` : '<div class="empty-state">No review audit files</div>';
+    }}
+
     // ---- Phase D: Operator / Readiness / Activity ----
 
     function renderOperator(briefing) {{
@@ -4793,13 +4877,14 @@ def render_dashboard_html(*, issue_number: int = DEFAULT_FEEDBACK_ISSUE) -> str:
       btn.classList.add('loading');
 
       try {{
-        const [summary, missing, services, worktree, feedback, v2Status, transStatus,
+        const [summary, missing, services, worktree, feedback, reviews, v2Status, transStatus,
                briefing, readiness, activity] = await Promise.all([
           fetchJson('/api/status/summary'),
           fetchJson('/api/missing-modules/status'),
           fetchJson('/api/runtime/services'),
           fetchJson('/api/git/worktree'),
           fetchJson(`/api/issue-watch/${{ISSUE}}`),
+          fetchJson('/api/reviews'),
           fetchJson('/api/pipeline/v2/status'),
           fetchJson('/api/translation/v2/status'),
           fetchJson('/api/briefing/session?compact=1'),
@@ -4821,6 +4906,7 @@ def render_dashboard_html(*, issue_number: int = DEFAULT_FEEDBACK_ISSUE) -> str:
         renderPipelinePanel('#trans-body', '#trans-badge', t2Queue, 'Translation V2');
         renderWorktree(worktree);
         renderMissing(missing);
+        renderReviews(reviews);
         renderFeedback(feedback);
 
         const now = new Date();
@@ -5029,6 +5115,10 @@ def build_session_briefing(repo_root: Path) -> dict[str, Any]:
         quality = build_quality_scores(repo_root)
     except Exception:  # noqa: BLE001
         quality = None
+    try:
+        reviews = build_reviews_index(repo_root, fact_check_status="unverified")
+    except Exception:  # noqa: BLE001
+        reviews = None
     critical_quality: list[str] = []
     if isinstance(quality, dict) and quality.get("exists"):
         if quality.get("critical_count"):
@@ -5039,6 +5129,8 @@ def build_session_briefing(repo_root: Path) -> dict[str, Any]:
             f"{m['module']} [{m['track']}] score {m['score']}"
             for m in (quality.get("critical") or [])[:5]
         ]
+    if isinstance(reviews, dict) and reviews.get("count"):
+        alerts.append(f"{reviews['count']} module(s) with unverified fact claims")
 
     # Action-oriented triage lists. Agents ask "what should I touch"
     # not "what's the global state"; the lists below answer that in
@@ -5139,6 +5231,16 @@ def build_session_briefing(repo_root: Path) -> dict[str, Any]:
                 module_key=m.get("module"),
                 reason="critical_quality",
                 endpoint="/api/quality/scores",
+            )
+    if isinstance(reviews, dict) and reviews.get("exists"):
+        for review in (reviews.get("reviews") or [])[:5]:
+            mk = review.get("module_key")
+            _add_row(
+                "blocked",
+                f"{mk or '?'} has unverified fact claim",
+                module_key=mk,
+                reason="fact_check_unverified",
+                endpoint=f"/api/reviews?module={mk}" if mk else None,
             )
 
     if isinstance(pipeline, dict) and pipeline.get("queue_head"):
@@ -5373,7 +5475,7 @@ def build_api_schema() -> dict[str, Any]:
             {
                 "path": "/api/reviews",
                 "desc": "Review audit index (omit query) or single-module log (?module=...)",
-                "query": ["module=..."],
+                "query": ["module=...", "fact_check_status=verified|unverified|failed|none"],
             },
             {
                 "path": "/api/bridge/messages",
@@ -5551,6 +5653,9 @@ def route_request(repo_root: Path, raw_path: str) -> tuple[int, Any, str]:
             limit = 200
         return 200, build_pipeline_events(repo_root, module_key, since_seconds, limit), "application/json; charset=utf-8"
     if path == "/api/reviews":
+        fact_check_status = query.get("fact_check_status", [None])[0]
+        if fact_check_status and fact_check_status not in _VALID_FACT_CHECK_STATUSES:
+            return 400, {"error": "invalid_fact_check_status"}, "application/json; charset=utf-8"
         mk = query.get("module", [None])[0]
         if mk:
             module_key = _validate_module_key(repo_root, mk)
@@ -5560,7 +5665,7 @@ def route_request(repo_root: Path, raw_path: str) -> tuple[int, Any, str]:
             if payload is None:
                 return 404, {"error": "review_not_found", "module_key": module_key}, "application/json; charset=utf-8"
             return 200, payload, "application/json; charset=utf-8"
-        return 200, build_reviews_index(repo_root), "application/json; charset=utf-8"
+        return 200, build_reviews_index(repo_root, fact_check_status=fact_check_status), "application/json; charset=utf-8"
     if path == "/api/bridge/messages":
         since = query.get("since", [None])[0]
         try:

--- a/scripts/pipeline_v2/review_worker.py
+++ b/scripts/pipeline_v2/review_worker.py
@@ -108,16 +108,20 @@ class ReviewWorker:
                 module_path,
                 lease=lease,
             )
-            failed_checks = [check for check in review_result["checks"] if not check["passed"]]
             unverified_fact_claims = [
                 check for check in review_result["checks"]
                 if check["id"] == "FACT_CHECK"
                 and check.get("passed")
                 and str(check.get("evidence", "")).lstrip().lower().startswith("unverified:")
             ]
+            failed_checks = [
+                check for check in review_result["checks"]
+                if not check["passed"] or check in unverified_fact_claims
+            ]
+            verdict = "REJECT" if failed_checks else review_result["verdict"]
             event_payload = {
                 "job_id": lease.job_id,
-                "verdict": review_result["verdict"],
+                "verdict": verdict,
                 "checks": review_result["checks"],
                 "feedback": review_result["feedback"],
             }
@@ -165,7 +169,7 @@ class ReviewWorker:
                 actual_calls=actual_calls,
                 actual_usd=actual_usd,
                 outcome="attempt_succeeded",
-                event_payload={"phase": "review", "verdict": review_result["verdict"]},
+                event_payload={"phase": "review", "verdict": verdict},
             )
             return ReviewRunOutcome(
                 status=status,

--- a/tests/test_local_api.py
+++ b/tests/test_local_api.py
@@ -1536,22 +1536,40 @@ def test_reviews_index_and_single(tmp_path: Path) -> None:
     reviews_dir = tmp_path / ".pipeline" / "reviews"
     reviews_dir.mkdir(parents=True)
     (reviews_dir / "cka__module-2.8-scheduler.md").write_text(
-        "# Review\n\n## 2026-01-01 — WRITE\n\n**Writer**: gemini\n",
+        "# Review\n\n## 2026-01-02 — `REVIEW` — `APPROVE`\n\n**Checks**: 4/4 passed (PRES NO_EMOJI K8S_API FACT_CHECK)\n",
         encoding="utf-8",
     )
-    (reviews_dir / "ztt__module-0.1.md").write_text("short", encoding="utf-8")
+    (reviews_dir / "ztt__module-0.1.md").write_text(
+        "# Review\n\n## 2026-01-03 — `REVIEW` — `APPROVE`\n\n**Checks**: 4/4 passed (PRES NO_EMOJI K8S_API FACT_CHECK)\n\n**Feedback**:\n> unverified: could not confirm version claim\n",
+        encoding="utf-8",
+    )
+    (reviews_dir / "bad__fact.md").write_text(
+        "# Review\n\n## 2026-01-04 — `REVIEW` — `REJECT`\n\n**Checks**: 3/4 passed (PRES NO_EMOJI K8S_API) | **Failed**: FACT_CHECK\n\n**Failed check evidence**:\n- **FACT_CHECK**: API version claim is wrong\n",
+        encoding="utf-8",
+    )
 
     index = local_api.build_reviews_index(tmp_path)
     assert index["exists"] is True
-    assert index["count"] == 2
-    keys = {r["module_key"] for r in index["reviews"]}
+    assert index["count"] == 3
+    statuses = {r["module_key"]: r["fact_check_status"] for r in index["reviews"]}
+    keys = set(statuses)
     assert "cka/module-2.8-scheduler" in keys
     assert "ztt/module-0.1" in keys
+    assert statuses["cka/module-2.8-scheduler"] == "verified"
+    assert statuses["ztt/module-0.1"] == "unverified"
+    assert statuses["bad/fact"] == "failed"
+    assert local_api.build_reviews_index(tmp_path, fact_check_status="unverified")["reviews"][0]["module_key"] == "ztt/module-0.1"
 
     single = local_api.build_module_reviews(tmp_path, "cka/module-2.8-scheduler")
     assert single is not None
-    assert "**Writer**: gemini" in single["body"]
+    assert "FACT_CHECK" in single["body"]
     assert single["truncated"] is False
+    assert single["fact_check_status"] == "verified"
+
+    unverified = local_api.build_module_reviews(tmp_path, "ztt/module-0.1")
+    assert unverified is not None
+    assert unverified["fact_check_status"] == "unverified"
+    assert unverified["unverified_evidence"][0].startswith("unverified:")
 
     # Truncation path. ``size`` is the actual on-disk size (per Codex
     # round-4 polish: truncated responses must not lie about file
@@ -1564,6 +1582,26 @@ def test_reviews_index_and_single(tmp_path: Path) -> None:
     assert trunc["size"] == 50_000
     assert trunc["max_bytes"] == 1000
     assert trunc["body_size"] == 1000
+
+
+def test_reviews_route_filter_module_state_diag_and_briefing_unverified(tmp_path: Path) -> None:
+    module_key, _ = _setup_repo(tmp_path)
+    _write(
+        tmp_path / ".pipeline/reviews/prerequisites__zero-to-terminal__module-0.1-alpha.md",
+        "# Review\n\n## 2026-01-03 — `REVIEW` — `APPROVE`\n\n**Checks**: 4/4 passed (PRES NO_EMOJI K8S_API FACT_CHECK)\n\n**Feedback**:\n> unverified: could not confirm version claim\n",
+    )
+
+    status_code, payload, _ = local_api.route_request(tmp_path, "/api/reviews?fact_check_status=unverified")
+    assert status_code == 200
+    assert payload["count"] == 1
+    assert payload["reviews"][0]["module_key"] == module_key
+
+    state = local_api.build_module_state(tmp_path, module_key)
+    assert "fact_check_unverified" in _diag_codes(state["diagnostics"])
+
+    briefing = local_api.build_session_briefing(tmp_path)
+    assert any("unverified fact claims" in alert for alert in briefing["alerts"])
+    assert any(row.get("reason") == "fact_check_unverified" for row in briefing["action_rows"])
 
 
 def test_resolve_bridge_db_path_precedence(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_pipeline_v2_review.py
+++ b/tests/test_pipeline_v2_review.py
@@ -123,6 +123,7 @@ def _deep_response(
     depth: bool = True,
     why: bool = True,
     fact_check: bool = True,
+    fact_evidence: str | None = None,
 ) -> str:
     checks = [
         {
@@ -149,7 +150,7 @@ def _deep_response(
         {
             "id": "FACT_CHECK",
             "passed": fact_check,
-            "evidence": "facts verified" if fact_check else "could not verify current facts",
+            "evidence": fact_evidence or ("facts verified" if fact_check else "could not verify current facts"),
             "fix_hint": "" if fact_check else "Verify claims against current live sources",
             "line_range": [11, 12],
         },
@@ -286,70 +287,35 @@ def test_review_usage_limit_falls_back_to_gpt_5_4(tmp_path):
     ]
 
 
-def test_approve_response_emits_check_passed_and_enqueues_check_pre(tmp_path):
-    control_plane = _make_control_plane(tmp_path)
-    module_path = _write_module(tmp_path)
-    control_plane.enqueue(str(module_path.relative_to(tmp_path)), phase="review", model=REVIEW_MODEL)
-    dispatch = Mock(
-        side_effect=[
-            (True, _simple_response("PRES")),
-            (True, _simple_response("NO_EMOJI")),
-            (True, _simple_response("K8S_API")),
-            (True, _deep_response()),
-        ]
-    )
-    worker = ReviewWorker(control_plane, dispatch_fn=dispatch)
-
-    with patch("pipeline_v2.preflight.subprocess.run", side_effect=_preflight_side_effect), patch(
-        "pipeline_v2.preflight._resolve_link_statuses",
-        return_value={},
-    ):
-        outcome = worker.run_once()
-
-    assert outcome.status == "approved"
-    passed_event = control_plane.iter_events("check_passed")[-1]
-    payload = json.loads(passed_event["payload_json"])
-    assert payload["verdict"] == "APPROVE"
-    queued = _fetch_rows(
-        control_plane.db_path,
-        "SELECT phase, model, queue_state FROM jobs WHERE phase = 'check_pre'",
-    )
-    assert len(queued) == 1
-    assert queued[0]["model"] == CHECK_PRE_MODEL
-    assert queued[0]["queue_state"] == "pending"
-
-
-def test_reject_response_emits_check_failed_and_enqueues_patch(tmp_path):
-    control_plane = _make_control_plane(tmp_path)
-    module_path = _write_module(tmp_path)
-    control_plane.enqueue(str(module_path.relative_to(tmp_path)), phase="review", model=REVIEW_MODEL)
-    dispatch = Mock(
-        side_effect=[
-            (True, _simple_response("PRES", passed=False)),
-            (True, _simple_response("NO_EMOJI")),
-            (True, _simple_response("K8S_API")),
-            (True, _deep_response()),
-        ]
-    )
-    worker = ReviewWorker(control_plane, dispatch_fn=dispatch)
-
-    with patch("pipeline_v2.preflight.subprocess.run", side_effect=_preflight_side_effect), patch(
-        "pipeline_v2.preflight._resolve_link_statuses",
-        return_value={},
-    ):
-        outcome = worker.run_once()
-
-    assert outcome.status == "rejected"
-    failed_event = control_plane.iter_events("check_failed")[-1]
-    payload = json.loads(failed_event["payload_json"])
-    assert payload["verdict"] == "REJECT"
-    assert payload["failed_checks"][0]["id"] == "PRES"
-    queued = _fetch_rows(
-        control_plane.db_path,
-        "SELECT phase, queue_state FROM jobs WHERE phase = 'patch'",
-    )
-    assert len(queued) == 1
-    assert queued[0]["queue_state"] == "pending"
+def test_review_worker_enforces_review_outcomes(tmp_path):
+    cases = [
+        ("approved", [_simple_response("PRES"), _simple_response("NO_EMOJI"), _simple_response("K8S_API"), _deep_response()], "check_pre", "APPROVE", None),
+        ("rejected", [_simple_response("PRES", passed=False), _simple_response("NO_EMOJI"), _simple_response("K8S_API"), _deep_response()], "patch", "REJECT", "PRES"),
+        ("rejected", [_simple_response("PRES"), _simple_response("NO_EMOJI"), _simple_response("K8S_API"), _deep_response(fact_evidence="unverified: could not confirm Kubernetes 1.99 claim")], "patch", "REJECT", "FACT_CHECK"),
+    ]
+    for i, (status, responses, phase, verdict, failed_check) in enumerate(cases):
+        case_root = tmp_path / f"case-{i}"
+        control_plane = _make_control_plane(case_root)
+        module_path = _write_module(case_root)
+        control_plane.enqueue(str(module_path.relative_to(case_root)), phase="review", model=REVIEW_MODEL)
+        worker = ReviewWorker(control_plane, dispatch_fn=Mock(side_effect=[(True, r) for r in responses]))
+        with patch("pipeline_v2.preflight.subprocess.run", side_effect=_preflight_side_effect), patch(
+            "pipeline_v2.preflight._resolve_link_statuses",
+            return_value={},
+        ):
+            outcome = worker.run_once()
+        assert outcome.status == status
+        payload = json.loads(control_plane.iter_events("check_passed" if phase == "check_pre" else "check_failed")[-1]["payload_json"])
+        assert payload["verdict"] == verdict
+        if failed_check:
+            assert payload["failed_checks"][0]["id"] == failed_check
+        if failed_check == "FACT_CHECK":
+            assert json.loads(control_plane.iter_events("fact_check_unverified")[-1]["payload_json"])["unverified_claims"][0]["id"] == "FACT_CHECK"
+        queued = _fetch_rows(control_plane.db_path, "SELECT phase, model, queue_state FROM jobs WHERE phase = ?", (phase,))
+        assert len(queued) == 1
+        assert queued[0]["queue_state"] == "pending"
+        if phase == "check_pre":
+            assert queued[0]["model"] == CHECK_PRE_MODEL
 
 
 def test_three_simple_dispatches_then_one_deep(tmp_path):


### PR DESCRIPTION
## Summary
- Closes #306. FACT_CHECK results with \`evidence\` starting \`unverified:\` now route to \`patch\` and land as \`rejected\` instead of being silently approved while only emitting telemetry.
- \`/api/reviews\` gains \`fact_check_status\` + \`unverified_evidence[]\` plus a \`?fact_check_status=\` filter; \`/api/module/{key}/state\` diagnostics surface \`fact_check_unverified\`; \`/api/briefing/session\` alerts and action_rows include unverified modules.
- Dashboard gains a Review Audit panel with colored status pills and a snippet of the unverified claim.

## Test plan
- [x] \`pytest tests/test_pipeline_v2_review.py::test_review_worker_enforces_review_outcomes tests/test_local_api.py::test_reviews_index_and_single tests/test_local_api.py::test_reviews_route_filter_module_state_diag_and_briefing_unverified\` — 3 passed
- [x] \`ruff check\` — clean on changed files
- [ ] Cross-family review: needs Gemini or Claude adversarial pass (Codex drafted; rule 10 in AGENTS.md)

## Notes
- Fact-check status is derived heuristically from the markdown review log (parses \`- **FACT_CHECK**:\` lines and \`unverified:\` prefixes). Deterministic for the current \`.pipeline/reviews/*.md\` schema; will need revisiting if the review audit artifact schema changes to JSON.
- Net +113 LOC, under the 150-LOC target from the issue.

🤖 Drafted by Codex via agent bridge; reviewed and landed by Claude.