### PR TITLE
fix(pipeline): bridge v2 review audit writes (#308)

### DIFF
--- a/scripts/pipeline_common/review_audit.py
+++ b/scripts/pipeline_common/review_audit.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import fcntl
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+def _render_audit_entry(event: str, timestamp: str, fields: dict) -> str:
+    checks = fields.get("checks") if isinstance(fields.get("checks"), list) else []
+    passed = [str(check.get("id", "?")) for check in checks if isinstance(check, dict) and check.get("passed")]
+    failed = [str(check.get("id", "?")) for check in checks if isinstance(check, dict) and not check.get("passed")]
+    lines = [
+        f"## {timestamp} — `{event}` — `{fields.get('verdict', '')}`",
+        "",
+        f"**Reviewer**: {fields.get('reviewer', 'unknown')}",
+        f"**Attempt**: {fields.get('attempt', '?')}",
+        f"**Severity**: {fields.get('severity', 'unknown')}",
+        f"**Checks**: {len(passed)}/{len(checks)} passed" + (f" ({' '.join(passed)})" if passed else "") + (f" | **Failed**: {' '.join(failed)}" if failed else ""),
+        f"**Job Id**: {fields['job_id']}",
+        f"**Lease Id**: {fields['lease_id']}",
+    ]
+    failed_evidence = [
+        f"- **{check.get('id', '?')}**: {str(check.get('evidence', '')).strip()}"
+        for check in checks
+        if isinstance(check, dict) and not check.get("passed") and str(check.get("evidence", "")).strip()
+    ]
+    if failed_evidence:
+        lines.extend(["", "**Failed check evidence**:", *failed_evidence])
+    feedback = str(fields.get("feedback", "")).strip()
+    if feedback:
+        lines.extend(["", "**Feedback**:", *[f"> {line}" if line else ">" for line in feedback.splitlines() or [feedback]]])
+    return "\n".join(lines)
+def append_review_audit(module_path: Path, event: str, **fields) -> Path:
+    repo_root = next((parent for parent in (module_path.parent, *module_path.parents) if (parent / ".pipeline").exists()), Path.cwd())
+    module_key = str(fields.pop("module_key", module_path.stem)).removesuffix(".md")
+    target = repo_root / ".pipeline" / "reviews" / f"{module_key.replace('/', '__')}.md"
+    timestamp = fields.pop("timestamp", None)
+    if not isinstance(timestamp, str):
+        current = timestamp or datetime.now(UTC)
+        timestamp = (current.replace(tzinfo=UTC) if current.tzinfo is None else current.astimezone(UTC)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with open(target.with_suffix(".lock"), "w", encoding="utf-8") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        try:
+            existing = target.read_text(encoding="utf-8") if target.exists() else ""
+            if any(fields.get(key) and f"**{key.replace('_', ' ').title()}**: {fields[key]}" in existing for key in ("job_id", "lease_id")):
+                return target
+            body = re.split(r"\n---\n+", existing, maxsplit=1)[1].lstrip() if "\n---\n" in existing else ""
+            entry = _render_audit_entry(event, timestamp, fields)
+            display_path = str(module_path.resolve()) if repo_root not in module_path.resolve().parents else str(module_path.resolve().relative_to(repo_root))
+            target.write_text(
+                "\n".join([
+                    f"# Review Audit: {module_key}",
+                    "",
+                    f"**Path**: `{display_path}`",
+                    f"**First pass**: {(re.findall(r'^## ([0-9TZ:\\-]+) — ', existing, re.MULTILINE) or [timestamp])[-1] if existing else timestamp}",
+                    f"**Last pass**: {timestamp}",
+                    f"**Total passes**: {len(re.findall(r'^## ([0-9TZ:\\-]+) — ', existing, re.MULTILINE)) + 1}",
+                    "**Current phase**: pending",
+                    "**Current reviewer**: -",
+                    "**Current severity**: -",
+                    "",
+                    "---",
+                    "",
+                    entry if not body.strip() else f"{entry}\n\n---\n\n{body.strip()}",
+                    "",
+                ]),
+                encoding="utf-8",
+            )
+        finally:
+            fcntl.flock(lock_file, fcntl.LOCK_UN)
+    return target

--- a/scripts/pipeline_common/review_audit.py
+++ b/scripts/pipeline_common/review_audit.py
@@ -1,71 +1,147 @@
 from __future__ import annotations
 
 import fcntl
+import os
 import re
 from datetime import UTC, datetime
 from pathlib import Path
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    """Stage to a unique tempfile in the same dir, then os.replace — survives SIGKILL mid-write."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    unique = f".{os.getpid()}.{datetime.now(UTC).strftime('%H%M%S%f')}.tmp"
+    tmp = path.with_suffix(path.suffix + unique)
+    try:
+        tmp.write_text(content, encoding="utf-8")
+        os.replace(tmp, path)
+    except Exception:
+        if tmp.exists():
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+        raise
+
+
+def _format_duration(seconds) -> str:
+    if seconds is None:
+        return "unknown"
+    try:
+        total = max(0.0, float(seconds))
+    except (TypeError, ValueError):
+        return str(seconds)
+    if total >= 60:
+        minutes = int(total // 60)
+        remainder = int(round(total - minutes * 60))
+        if remainder == 60:
+            minutes, remainder = minutes + 1, 0
+        return f"{minutes}m {remainder}s"
+    if total >= 10:
+        return f"{int(round(total))}s"
+    if total >= 1:
+        return f"{total:.1f}s"
+    return f"{int(round(total * 1000))}ms"
+
+
+_HEADER_FIELD_RE = re.compile(r"^\*\*(?P<key>[^*]+?)\*\*:\s*(?P<val>.*)$", re.MULTILINE)
+
+
+def _parse_existing_header(existing: str) -> dict[str, str]:
+    """Extract **Key**: Value pairs from an existing audit header (before the first '---')."""
+    header = existing.split("\n---\n", 1)[0] if "\n---\n" in existing else existing
+    return {m.group("key").strip(): m.group("val").strip() for m in _HEADER_FIELD_RE.finditer(header)}
+
+
 def _render_audit_entry(event: str, timestamp: str, fields: dict) -> str:
-    checks = fields.get("checks") if isinstance(fields.get("checks"), list) else []
-    passed = [str(check.get("id", "?")) for check in checks if isinstance(check, dict) and check.get("passed")]
-    failed = [str(check.get("id", "?")) for check in checks if isinstance(check, dict) and not check.get("passed")]
+    raw_checks = fields.get("checks")
+    checks: list = raw_checks if isinstance(raw_checks, list) else []
+    passed = [str(c.get("id", "?")) for c in checks if isinstance(c, dict) and c.get("passed")]
+    failed = [str(c.get("id", "?")) for c in checks if isinstance(c, dict) and not c.get("passed")]
     lines = [
         f"## {timestamp} — `{event}` — `{fields.get('verdict', '')}`",
         "",
         f"**Reviewer**: {fields.get('reviewer', 'unknown')}",
         f"**Attempt**: {fields.get('attempt', '?')}",
         f"**Severity**: {fields.get('severity', 'unknown')}",
-        f"**Checks**: {len(passed)}/{len(checks)} passed" + (f" ({' '.join(passed)})" if passed else "") + (f" | **Failed**: {' '.join(failed)}" if failed else ""),
+        f"**Duration**: {_format_duration(fields.get('duration'))}",
+        (f"**Checks**: {len(passed)}/{len(checks)} passed"
+         + (f" ({' '.join(passed)})" if passed else "")
+         + (f" | **Failed**: {' '.join(failed)}" if failed else "")),
         f"**Job Id**: {fields['job_id']}",
         f"**Lease Id**: {fields['lease_id']}",
     ]
     failed_evidence = [
-        f"- **{check.get('id', '?')}**: {str(check.get('evidence', '')).strip()}"
-        for check in checks
-        if isinstance(check, dict) and not check.get("passed") and str(check.get("evidence", "")).strip()
+        f"- **{c.get('id', '?')}**: {str(c.get('evidence', '')).strip()}"
+        for c in checks
+        if isinstance(c, dict) and not c.get("passed") and str(c.get("evidence", "")).strip()
     ]
     if failed_evidence:
         lines.extend(["", "**Failed check evidence**:", *failed_evidence])
     feedback = str(fields.get("feedback", "")).strip()
     if feedback:
-        lines.extend(["", "**Feedback**:", *[f"> {line}" if line else ">" for line in feedback.splitlines() or [feedback]]])
+        quoted = [f"> {ln}" if ln else ">" for ln in (feedback.splitlines() or [feedback])]
+        lines.extend(["", "**Feedback**:", *quoted])
     return "\n".join(lines)
+
+
 def append_review_audit(module_path: Path, event: str, **fields) -> Path:
-    repo_root = next((parent for parent in (module_path.parent, *module_path.parents) if (parent / ".pipeline").exists()), Path.cwd())
-    module_key = str(fields.pop("module_key", module_path.stem)).removesuffix(".md")
+    """Prepend a v1-compatible audit entry; de-dupes on (job_id, lease_id) and preserves
+    header metadata written by v1 so v1 and v2 can coexist without silent drift.
+    """
+    if "module_key" not in fields:
+        raise ValueError("append_review_audit requires an explicit module_key")
+    module_key = str(fields.pop("module_key")).removesuffix(".md")
+    repo_root = next(
+        (p for p in (module_path.parent, *module_path.parents) if (p / ".pipeline").exists()),
+        Path.cwd(),
+    )
     target = repo_root / ".pipeline" / "reviews" / f"{module_key.replace('/', '__')}.md"
     timestamp = fields.pop("timestamp", None)
     if not isinstance(timestamp, str):
         current = timestamp or datetime.now(UTC)
-        timestamp = (current.replace(tzinfo=UTC) if current.tzinfo is None else current.astimezone(UTC)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        if current.tzinfo is None:
+            current = current.replace(tzinfo=UTC)
+        timestamp = current.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
     target.parent.mkdir(parents=True, exist_ok=True)
     with open(target.with_suffix(".lock"), "w", encoding="utf-8") as lock_file:
         fcntl.flock(lock_file, fcntl.LOCK_EX)
         try:
             existing = target.read_text(encoding="utf-8") if target.exists() else ""
-            if any(fields.get(key) and f"**{key.replace('_', ' ').title()}**: {fields[key]}" in existing for key in ("job_id", "lease_id")):
+            # De-dup by (job_id, lease_id) — same attempt must not write twice.
+            job_id, lease_id = fields.get("job_id"), fields.get("lease_id")
+            if job_id and lease_id and f"**Job Id**: {job_id}\n**Lease Id**: {lease_id}" in existing:
                 return target
             body = re.split(r"\n---\n+", existing, maxsplit=1)[1].lstrip() if "\n---\n" in existing else ""
             entry = _render_audit_entry(event, timestamp, fields)
-            display_path = str(module_path.resolve()) if repo_root not in module_path.resolve().parents else str(module_path.resolve().relative_to(repo_root))
-            target.write_text(
-                "\n".join([
-                    f"# Review Audit: {module_key}",
-                    "",
-                    f"**Path**: `{display_path}`",
-                    f"**First pass**: {(re.findall(r'^## ([0-9TZ:\\-]+) — ', existing, re.MULTILINE) or [timestamp])[-1] if existing else timestamp}",
-                    f"**Last pass**: {timestamp}",
-                    f"**Total passes**: {len(re.findall(r'^## ([0-9TZ:\\-]+) — ', existing, re.MULTILINE)) + 1}",
-                    "**Current phase**: pending",
-                    "**Current reviewer**: -",
-                    "**Current severity**: -",
-                    "",
-                    "---",
-                    "",
-                    entry if not body.strip() else f"{entry}\n\n---\n\n{body.strip()}",
-                    "",
-                ]),
-                encoding="utf-8",
-            )
+            try:
+                display_path = str(module_path.resolve().relative_to(repo_root))
+            except ValueError:
+                display_path = str(module_path.resolve())
+            prior_ts = re.findall(r"^## ([0-9TZ:\-]+) — ", existing, re.MULTILINE)
+            all_ts = prior_ts + [timestamp]
+            existing_header = _parse_existing_header(existing)
+            # Preserve v1-written phase/reviewer/severity when present; fall back to v2's knowledge.
+            phase = existing_header.get("Current phase", "pending")
+            reviewer = existing_header.get("Current reviewer", str(fields.get("reviewer", "-")))
+            severity = existing_header.get("Current severity", str(fields.get("severity", "-")))
+            header = "\n".join([
+                f"# Review Audit: {module_key}",
+                "",
+                f"**Path**: `{display_path}`",
+                f"**First pass**: {min(all_ts)}",
+                f"**Last pass**: {max(all_ts)}",
+                f"**Total passes**: {len(prior_ts) + 1}",
+                f"**Current phase**: {phase}",
+                f"**Current reviewer**: {reviewer}",
+                f"**Current severity**: {severity}",
+            ])
+            content = f"{header}\n\n---\n\n{entry}"
+            if body.strip():
+                content += f"\n\n---\n\n{body.strip()}"
+            content += "\n"
+            _atomic_write_text(target, content)
         finally:
             fcntl.flock(lock_file, fcntl.LOCK_UN)
     return target

--- a/scripts/pipeline_v2/review_worker.py
+++ b/scripts/pipeline_v2/review_worker.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from dispatch import dispatch_codex_review
+from pipeline_common.review_audit import append_review_audit
 
 from .control_plane import ControlPlane, Lease
 from .preflight import PreflightFinding, run_preflight
@@ -104,7 +105,7 @@ class ReviewWorker:
                     details=payload,
                 )
 
-            review_result, actual_calls, actual_usd = self._run_llm_review(
+            review_result, actual_calls, actual_usd, review_model = self._run_llm_review(
                 module_path,
                 lease=lease,
             )
@@ -163,6 +164,24 @@ class ReviewWorker:
                     priority=lease.job_id,
                 )
                 status = "approved"
+            audit_feedback = review_result["feedback"]
+            if unverified_fact_claims:
+                audit_feedback = "\n".join(
+                    [audit_feedback, *[str(check.get("evidence", "")).strip() for check in unverified_fact_claims if str(check.get("evidence", "")).strip()]]
+                ).strip()
+            append_review_audit(
+                module_path,
+                "REVIEW",
+                module_key=lease.module_key,
+                reviewer=review_model,
+                attempt=1,
+                severity="high" if failed_checks else "none",
+                checks=review_result["checks"],
+                feedback=audit_feedback,
+                verdict=verdict,
+                job_id=lease.job_id,
+                lease_id=lease.lease_id,
+            )
 
             self.control_plane.complete_lease(
                 lease.lease_id,
@@ -212,7 +231,7 @@ class ReviewWorker:
         module_path: Path,
         *,
         lease: Lease,
-    ) -> tuple[dict[str, Any], int, float]:
+    ) -> tuple[dict[str, Any], int, float, str]:
         module_text = module_path.read_text(encoding="utf-8")
         aggregated_checks: list[dict[str, Any]] = []
         feedback_parts: list[str] = []
@@ -258,7 +277,7 @@ class ReviewWorker:
             "verdict": verdict,
             "checks": ordered_checks,
             "feedback": feedback,
-        }, actual_calls, round(actual_usd, 4)
+        }, actual_calls, round(actual_usd, 4), active_review_model
 
     def _dispatch_with_retry(
         self,

--- a/scripts/pipeline_v2/review_worker.py
+++ b/scripts/pipeline_v2/review_worker.py
@@ -91,6 +91,19 @@ class ReviewWorker:
                     model=PATCH_MODEL,
                     priority=lease.job_id,
                 )
+                append_review_audit(
+                    module_path,
+                    "CHECK_FAIL",
+                    module_key=lease.module_key,
+                    reviewer="preflight",
+                    attempt=1,
+                    severity="high",
+                    checks=payload["checks"],
+                    feedback=payload["feedback"],
+                    verdict="REJECT",
+                    job_id=lease.job_id,
+                    lease_id=lease.lease_id,
+                )
                 self.control_plane.complete_lease(
                     lease.lease_id,
                     actual_calls=0,

--- a/tests/test_pipeline_v2_review.py
+++ b/tests/test_pipeline_v2_review.py
@@ -11,6 +11,8 @@ import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
+import local_api
+from pipeline_common.review_audit import append_review_audit
 from pipeline_v2.control_plane import ControlPlane
 from pipeline_v2.review_worker import (
     CHECK_PRE_MODEL,
@@ -316,6 +318,29 @@ def test_review_worker_enforces_review_outcomes(tmp_path):
         assert queued[0]["queue_state"] == "pending"
         if phase == "check_pre":
             assert queued[0]["model"] == CHECK_PRE_MODEL
+        review = local_api.build_module_reviews(case_root, str(module_path.relative_to(case_root)).removesuffix(".md"))
+        assert review is not None
+        assert review["fact_check_status"] == ("unverified" if failed_check == "FACT_CHECK" else "verified")
+
+
+def test_review_worker_audit_dedupes_same_job(tmp_path):
+    control_plane = _make_control_plane(tmp_path)
+    module_path = _write_module(tmp_path)
+    job = control_plane.enqueue(str(module_path.relative_to(tmp_path)), phase="review", model=REVIEW_MODEL)
+    worker = ReviewWorker(
+        control_plane,
+        dispatch_fn=Mock(side_effect=[(True, _simple_response("PRES")), (True, _simple_response("NO_EMOJI")), (True, _simple_response("K8S_API")), (True, _deep_response())]),
+    )
+    with patch("pipeline_v2.preflight.subprocess.run", side_effect=_preflight_side_effect), patch(
+        "pipeline_v2.preflight._resolve_link_statuses",
+        return_value={},
+    ):
+        assert worker.run_once().status == "approved"
+    lease_id = control_plane.iter_events("check_passed")[-1]["lease_id"]
+    append_review = Path(tmp_path / ".pipeline" / "reviews" / "docs__module-1.1-review-worker.md")
+    before = append_review.read_text(encoding="utf-8")
+    append_review_audit(module_path, "REVIEW", module_key=str(module_path.relative_to(tmp_path)).removesuffix(".md"), reviewer=REVIEW_MODEL, attempt=1, severity="none", checks=json.loads(_deep_response())["checks"], feedback="deep checks passed", verdict="APPROVE", job_id=job.job_id, lease_id=lease_id)
+    assert append_review.read_text(encoding="utf-8") == before
 
 
 def test_three_simple_dispatches_then_one_deep(tmp_path):

--- a/tests/test_pipeline_v2_review.py
+++ b/tests/test_pipeline_v2_review.py
@@ -343,6 +343,47 @@ def test_review_worker_audit_dedupes_same_job(tmp_path):
     assert append_review.read_text(encoding="utf-8") == before
 
 
+def test_audit_preserves_v1_written_header_metadata(tmp_path):
+    """v2 appending must not overwrite v1's phase/reviewer/severity header fields."""
+    module_path = _write_module(tmp_path)
+    review_path = tmp_path / ".pipeline" / "reviews" / "docs__module-1.1-review-worker.md"
+    review_path.parent.mkdir(parents=True, exist_ok=True)
+    review_path.write_text(
+        "# Review Audit: docs/module-1.1-review-worker\n\n"
+        "**Path**: `docs/module-1.1-review-worker.md`\n"
+        "**First pass**: 2026-04-18T09:00:00Z\n"
+        "**Last pass**: 2026-04-18T09:00:00Z\n"
+        "**Total passes**: 1\n"
+        "**Current phase**: review\n"
+        "**Current reviewer**: codex-gpt-5.4\n"
+        "**Current severity**: medium\n\n"
+        "---\n\n"
+        "## 2026-04-18T09:00:00Z — `REVIEW` — `APPROVE`\n\n"
+        "**Reviewer**: codex-gpt-5.4\n**Attempt**: 1\n**Severity**: medium\n"
+        "**Checks**: 7/7 passed\n**Job Id**: v1-job-1\n**Lease Id**: v1-lease-1\n",
+        encoding="utf-8",
+    )
+    append_review_audit(
+        module_path, "REVIEW",
+        module_key="docs/module-1.1-review-worker",
+        reviewer="gpt-5.3-codex-spark", attempt=2, severity="none",
+        checks=json.loads(_deep_response())["checks"],
+        feedback="v2 added", verdict="APPROVE",
+        job_id="v2-job-1", lease_id="v2-lease-1",
+    )
+    after = review_path.read_text(encoding="utf-8")
+    # v1's header metadata must survive — NOT be replaced with "pending" / "-" / "-"
+    assert "**Current phase**: review" in after
+    assert "**Current reviewer**: codex-gpt-5.4" in after
+    assert "**Current severity**: medium" in after
+    # v2's new entry is prepended
+    assert after.index("v2-job-1") < after.index("v1-job-1")
+    # Duration field present in v2 entry
+    assert "**Duration**:" in after
+    # Both entries present
+    assert "v1-job-1" in after and "v2-job-1" in after
+
+
 def test_three_simple_dispatches_then_one_deep(tmp_path):
     control_plane = _make_control_plane(tmp_path)
     module_path = _write_module(tmp_path)


### PR DESCRIPTION
## Summary
- bridge v2 review outcomes into `.pipeline/reviews/*.md` via a small shared audit helper
- write v1-compatible `REVIEW` entries after v2 `check_passed`/`check_failed`, including job/lease ids for de-dup
- cover verified, unverified, and duplicate-write behavior in the v2 review-worker tests

## Tests
- `ruff check scripts/pipeline_common/review_audit.py scripts/pipeline_v2/review_worker.py tests/test_pipeline_v2_review.py`
- `pytest tests/test_pipeline_v2_review.py tests/test_local_api.py tests/test_v1_pipeline_retry_policy.py`

Refs: #308, #307
LOC: 118 insertions / 3 files
