### PR TITLE
feat(pipeline): inject write-time citation seeds (#279)

### DIFF
--- a/scripts/test_pipeline.py
+++ b/scripts/test_pipeline.py
@@ -2579,6 +2579,11 @@ class TestKnowledgeCards(unittest.TestCase):
         - Say VPA recommendations come from Prometheus instead of the VPA recommender path.
         """)
 
+    def _write_seed_file(self, content: str) -> None:
+        docs_dir = self.repo_root / "docs"
+        docs_dir.mkdir(parents=True, exist_ok=True)
+        (docs_dir / "citation-seeds-ai-foundations.md").write_text(content)
+
     def test_knowledge_card_written_with_correct_schema(self):
         """Generator writes a schema-valid knowledge card to the cache."""
         import generate_knowledge_card as g
@@ -2772,6 +2777,82 @@ class TestKnowledgeCards(unittest.TestCase):
         verified_block = seen["prompt"].split("## Verified Facts (from fact-grounding pass)", 1)[1]
         verified_block = verified_block.split("IMPROVEMENT PLAN:", 1)[0]
         self.assertNotIn("This unverified claim should not be surfaced", verified_block)
+
+    def test_seed_injection_extracts_matching_entry(self):
+        """step_write should inject only the current module's citation seeds."""
+        import v1_pipeline as p
+
+        self._write_seed_file(textwrap.dedent("""\
+        # AI Foundations — Citation Seeds
+
+        ## `ai/foundations/module-1.1-what-is-ai`
+
+        - [NIST AI RMF](https://nvlpubs.nist.gov/nistpubs/ai/nist.ai.100-1.pdf) — definitional framing
+        - [IBM Deep Blue](https://www.ibm.com/history/deep-blue) — rule-based milestone
+
+        ## `ai/foundations/module-1.2-what-are-llms`
+
+        - [Attention Is All You Need](https://arxiv.org/abs/1706.03762) — transformer source
+        """))
+        seen = {}
+
+        def fake_dispatch(prompt, model=None, timeout=None):
+            seen["prompt"] = prompt
+            return True, GOOD_MODULE
+
+        with patch.object(p, "REPO_ROOT", self.repo_root), \
+             patch.object(p, "dispatch_auto", side_effect=fake_dispatch), \
+             patch.object(p, "module_key_from_path", return_value="ai/foundations/module-1.1-what-is-ai"):
+            result = p.step_write(self.module_path, "Improve factual accuracy")
+
+        self.assertIsNotNone(result)
+        self.assertIn("## Authoritative Sources — cite these inline", seen["prompt"])
+        self.assertIn("https://nvlpubs.nist.gov/nistpubs/ai/nist.ai.100-1.pdf", seen["prompt"])
+        self.assertIn("https://www.ibm.com/history/deep-blue", seen["prompt"])
+        self.assertNotIn("https://arxiv.org/abs/1706.03762", seen["prompt"])
+
+    def test_seed_injection_no_seeds_file_is_noop(self):
+        """Missing seed file should leave the WRITE prompt unchanged."""
+        import v1_pipeline as p
+
+        seen = {}
+
+        def fake_dispatch(prompt, model=None, timeout=None):
+            seen["prompt"] = prompt
+            return True, GOOD_MODULE
+
+        with patch.object(p, "REPO_ROOT", self.repo_root), \
+             patch.object(p, "dispatch_auto", side_effect=fake_dispatch), \
+             patch.object(p, "module_key_from_path", return_value="ai/foundations/module-1.1-what-is-ai"):
+            result = p.step_write(self.module_path, "Improve factual accuracy")
+
+        self.assertIsNotNone(result)
+        self.assertNotIn("## Authoritative Sources — cite these inline", seen["prompt"])
+
+    def test_seed_injection_no_matching_module_is_noop(self):
+        """Existing seed file without a matching section should be ignored."""
+        import v1_pipeline as p
+
+        self._write_seed_file(textwrap.dedent("""\
+        # AI Foundations — Citation Seeds
+
+        ## `ai/foundations/module-1.2-what-are-llms`
+
+        - [Attention Is All You Need](https://arxiv.org/abs/1706.03762) — transformer source
+        """))
+        seen = {}
+
+        def fake_dispatch(prompt, model=None, timeout=None):
+            seen["prompt"] = prompt
+            return True, GOOD_MODULE
+
+        with patch.object(p, "REPO_ROOT", self.repo_root), \
+             patch.object(p, "dispatch_auto", side_effect=fake_dispatch), \
+             patch.object(p, "module_key_from_path", return_value="ai/foundations/module-1.1-what-is-ai"):
+            result = p.step_write(self.module_path, "Improve factual accuracy")
+
+        self.assertIsNotNone(result)
+        self.assertNotIn("## Authoritative Sources — cite these inline", seen["prompt"])
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/test_pipeline.py
+++ b/scripts/test_pipeline.py
@@ -2788,7 +2788,8 @@ class TestKnowledgeCards(unittest.TestCase):
         ## `ai/foundations/module-1.1-what-is-ai`
 
         - [NIST AI RMF](https://nvlpubs.nist.gov/nistpubs/ai/nist.ai.100-1.pdf) — definitional framing
-        - [IBM Deep Blue](https://www.ibm.com/history/deep-blue) — rule-based milestone
+        1. [IBM Deep Blue](https://www.ibm.com/history/deep-blue) — rule-based milestone
+        https://ai.google/responsibility/principles/ — current AI principles
 
         ## `ai/foundations/module-1.2-what-are-llms`
 
@@ -2809,7 +2810,29 @@ class TestKnowledgeCards(unittest.TestCase):
         self.assertIn("## Authoritative Sources — cite these inline", seen["prompt"])
         self.assertIn("https://nvlpubs.nist.gov/nistpubs/ai/nist.ai.100-1.pdf", seen["prompt"])
         self.assertIn("https://www.ibm.com/history/deep-blue", seen["prompt"])
+        self.assertIn("https://ai.google/responsibility/principles/", seen["prompt"])
         self.assertNotIn("https://arxiv.org/abs/1706.03762", seen["prompt"])
+
+    def test_seed_injection_reaches_rewrite_prompt(self):
+        """Rewrite prompts should include the authoritative sources block."""
+        import v1_pipeline as p
+
+        self._write_seed_file(textwrap.dedent("""\
+        # AI Foundations — Citation Seeds
+
+        ## `ai/foundations/module-1.1-what-is-ai`
+
+        - [NIST AI RMF](https://nvlpubs.nist.gov/nistpubs/ai/nist.ai.100-1.pdf) — definitional framing
+        """))
+        seen = {}
+
+        with patch.object(p, "REPO_ROOT", self.repo_root), \
+             patch.object(p, "dispatch_auto", side_effect=lambda prompt, model=None, timeout=None: (seen.__setitem__("prompt", prompt), (True, GOOD_MODULE))[1]), \
+             patch.object(p, "module_key_from_path", return_value="ai/foundations/module-1.1-what-is-ai"):
+            p.step_write(self.module_path, "Improve factual accuracy", rewrite=True)
+
+        self.assertIn("## Authoritative Sources — cite these inline", seen["prompt"])
+        self.assertIn("https://nvlpubs.nist.gov/nistpubs/ai/nist.ai.100-1.pdf", seen["prompt"])
 
     def test_seed_injection_no_seeds_file_is_noop(self):
         """Missing seed file should leave the WRITE prompt unchanged."""
@@ -2852,6 +2875,20 @@ class TestKnowledgeCards(unittest.TestCase):
             result = p.step_write(self.module_path, "Improve factual accuracy")
 
         self.assertIsNotNone(result)
+        self.assertNotIn("## Authoritative Sources — cite these inline", seen["prompt"])
+
+    def test_seed_injection_noop_for_root_level_module_key(self):
+        """Root-level module keys should skip seed lookup entirely."""
+        import v1_pipeline as p
+
+        seen = {}
+
+        with patch.object(p, "REPO_ROOT", self.repo_root), \
+             patch.object(p, "dispatch_auto", side_effect=lambda prompt, model=None, timeout=None: (seen.__setitem__("prompt", prompt), (True, GOOD_MODULE))[1]), \
+             patch.object(p, "module_key_from_path", return_value="module-0.1-test"), \
+             patch.object(Path, "exists", side_effect=AssertionError("seed lookup should be skipped")):
+            p.step_write(self.module_path, "Improve factual accuracy")
+
         self.assertNotIn("## Authoritative Sources — cite these inline", seen["prompt"])
 
 

--- a/scripts/v1_pipeline.py
+++ b/scripts/v1_pipeline.py
@@ -911,6 +911,16 @@ them accurately in your content. Do not contradict them.
 {claims_block}
 """
 
+AUTHORITATIVE_SOURCES_BLOCK_TEMPLATE = """## Authoritative Sources — cite these inline
+
+Use these sources directly in the draft. Cite them inline where relevant and
+include them in the module's `## Sources` section.
+
+{sources_block}
+"""
+
+SEED_SECTION_RE = re.compile(r"^##\s+`([^`]+)`\s*$")
+
 
 def _format_fact_ledger_for_prompt(fact_ledger: dict | None) -> str:
     """Serialize fact ledger for prompt injection."""
@@ -963,6 +973,40 @@ def _format_verified_claims_for_prompt(fact_ledger: dict | None) -> str:
     return VERIFIED_FACTS_BLOCK_TEMPLATE.format(claims_block="\n".join(lines))
 
 
+def _citation_seed_path(module_key: str) -> Path:
+    """Return the per-track citation seed file path for a module key."""
+    track = "-".join(module_key.split("/")[:-1])
+    return REPO_ROOT / "docs" / f"citation-seeds-{track}.md"
+
+
+def _format_authoritative_sources_for_prompt(module_key: str) -> str:
+    """Build a prompt block from the matching module section in a seed file."""
+    seed_path = _citation_seed_path(module_key)
+    if not seed_path.exists():
+        return ""
+
+    current_key: str | None = None
+    lines: list[str] = []
+    for raw_line in seed_path.read_text(encoding="utf-8").splitlines():
+        heading = SEED_SECTION_RE.match(raw_line.strip())
+        if heading:
+            if current_key == module_key:
+                break
+            current_key = heading.group(1).strip()
+            continue
+        if current_key != module_key:
+            continue
+        line = raw_line.strip()
+        if line.startswith("- ") and "http" in line:
+            lines.append(line)
+
+    if not lines:
+        return ""
+    return AUTHORITATIVE_SOURCES_BLOCK_TEMPLATE.format(
+        sources_block="\n".join(lines)
+    )
+
+
 WRITE_PROMPT_TEMPLATE = """CRITICAL INSTRUCTION: Your response must be ONLY the raw markdown content of the improved module. Start your response with the --- frontmatter delimiter. No preamble, no explanation, no summary, no "I have improved..." — ONLY the markdown file content from first line to last.
 
 You are improving a KubeDojo module. You will receive the current module content and an improvement plan.
@@ -993,6 +1037,8 @@ UNVERIFIED in the ledger, hedge explicitly in the module text and cite the
 authority context.
 
 {verified_facts_block}
+
+{authoritative_sources_block}
 
 IMPROVEMENT PLAN:
 {plan}
@@ -1168,6 +1214,7 @@ def step_write(module_path: Path, plan: str, model: str = MODELS["write"],
     fact_ledger_text = _format_fact_ledger_for_prompt(fact_ledger)
     k8s_lifecycle = K8S_LIFECYCLE_BLOCK.format(as_of_date=datetime.now(UTC).date().isoformat())
     verified_facts_block = _format_verified_claims_for_prompt(fact_ledger)
+    authoritative_sources_block = _format_authoritative_sources_for_prompt(key)
 
     if rewrite:
         packet = extract_knowledge_packet(content)
@@ -1179,7 +1226,8 @@ def step_write(module_path: Path, plan: str, model: str = MODELS["write"],
         prompt = WRITE_PROMPT_TEMPLATE.format(
             plan=plan, content=content, knowledge_card=knowledge_card_text,
             fact_ledger=fact_ledger_text, k8s_lifecycle=k8s_lifecycle,
-            verified_facts_block=verified_facts_block)
+            verified_facts_block=verified_facts_block,
+            authoritative_sources_block=authoritative_sources_block)
 
     # Must use dispatch_auto (not dispatch_gemini_with_retry directly) so that
     # Claude Sonnet is actually called for targeted-fix mode. Previously this

--- a/scripts/v1_pipeline.py
+++ b/scripts/v1_pipeline.py
@@ -973,15 +973,19 @@ def _format_verified_claims_for_prompt(fact_ledger: dict | None) -> str:
     return VERIFIED_FACTS_BLOCK_TEMPLATE.format(claims_block="\n".join(lines))
 
 
-def _citation_seed_path(module_key: str) -> Path:
+def _citation_seed_path(module_key: str) -> Path | None:
     """Return the per-track citation seed file path for a module key."""
-    track = "-".join(module_key.split("/")[:-1])
+    track = "-".join(module_key.split("/")[:-1]).strip("-")
+    if not track:
+        return None
     return REPO_ROOT / "docs" / f"citation-seeds-{track}.md"
 
 
 def _format_authoritative_sources_for_prompt(module_key: str) -> str:
     """Build a prompt block from the matching module section in a seed file."""
     seed_path = _citation_seed_path(module_key)
+    if seed_path is None:
+        return ""
     if not seed_path.exists():
         return ""
 
@@ -997,7 +1001,11 @@ def _format_authoritative_sources_for_prompt(module_key: str) -> str:
         if current_key != module_key:
             continue
         line = raw_line.strip()
-        if line.startswith("- ") and "http" in line:
+        if "http" in line and (
+            line.startswith("- ")
+            or re.match(r"^\d+\.\s+", line)
+            or line.startswith("http")
+        ):
             lines.append(line)
 
     if not lines:
@@ -1070,6 +1078,8 @@ UNVERIFIED in the ledger, hedge explicitly in the module text and cite the
 authority context.
 
 {verified_facts_block}
+
+{authoritative_sources_block}
 
 KNOWLEDGE PACKET — MUST PRESERVE:
 The following technical assets are extracted from the original module. You MUST include ALL of them in your rewrite, placed in the appropriate sections. Do NOT omit, summarize, or simplify any of these.
@@ -1221,7 +1231,8 @@ def step_write(module_path: Path, plan: str, model: str = MODELS["write"],
         prompt = REWRITE_PROMPT_TEMPLATE.format(
             file_path=key, plan=plan, content=content, knowledge_packet=packet,
             knowledge_card=knowledge_card_text, fact_ledger=fact_ledger_text,
-            k8s_lifecycle=k8s_lifecycle, verified_facts_block=verified_facts_block)
+            k8s_lifecycle=k8s_lifecycle, verified_facts_block=verified_facts_block,
+            authoritative_sources_block=authoritative_sources_block)
     else:
         prompt = WRITE_PROMPT_TEMPLATE.format(
             plan=plan, content=content, knowledge_card=knowledge_card_text,


### PR DESCRIPTION
Subset of #279, part 1 of 3: implements #279a.

## Summary
- derive `citation-seeds-{track}.md` from the current `module_key` during WRITE
- extract only the matching module section and inject it into the WRITE prompt as `## Authoritative Sources — cite these inline`
- leave WRITE unchanged when the seeds file is missing or the module has no seeded entry
- add unit coverage for match, missing file, and missing module cases

## Verification
- `../../.venv/bin/python -m unittest scripts.test_pipeline` (passes with the 2 known pre-existing failures allowed by AGENTS: `check_failures` tests)
- `npm run build` from primary checkout: passes
- `ruff check scripts/v1_pipeline.py scripts/test_pipeline.py` could not be validated with the required repo venv because `.venv/bin/ruff` is absent in this environment; the available global `ruff` reports existing repo-level violations in these files unrelated to this PR

Refs: #279, #279a