### PR TITLE
feat(translation-v2): per-track health + lab metadata verification (#243)

### DIFF
--- a/scripts/status.py
+++ b/scripts/status.py
@@ -418,22 +418,43 @@ def _enrich_translation_v2_with_per_track(t2: dict[str, Any]) -> dict[str, Any]:
         return enriched
     buckets = _per_track_buckets()
     track_modules: dict[str, dict[str, list[str]]] = {
-        slug: {"pending_write": [], "pending_review": [], "pending_patch": [], "dead_letter": []}
+        slug: {"pending_write": [], "pending_review": [], "pending_patch": [], "done": [], "dead_letter": []}
         for slug in list(buckets)
     }
-    for queue_name in ("pending_write", "pending_review", "pending_patch", "dead_letter"):
+    for queue_name in ("pending_write", "pending_review", "pending_patch", "done", "dead_letter"):
         for module_key in queue.get(queue_name, []) or []:
             track = _track_for_key(module_key)
             buckets[track][queue_name] += 1
             track_modules[track][queue_name].append(module_key)
+    track_freshness: dict[str, dict[str, int] | None] = {slug: None for slug in buckets}
+    freshness = t2.get("freshness") or {}
+    if freshness:
+        for slug in track_freshness:
+            track_freshness[slug] = {
+                "up_to_date_count": 0,
+                "stale_count": 0,
+                "dead_letter_count": buckets[slug]["dead_letter"],
+            }
+        for item in freshness.get("modules", []) or []:
+            status = str(item.get("status", ""))
+            if status == "missing":
+                continue
+            track = _track_for_key(str(item.get("module_key", "")))
+            if track_freshness[track] is None:
+                continue
+            if status == "synced":
+                track_freshness[track]["up_to_date_count"] += 1
+            else:
+                track_freshness[track]["stale_count"] += 1
     enriched_queue = dict(queue)
     enriched_queue["per_track"] = [
         {
             "slug": slug,
             "counts": buckets[slug],
             "modules": track_modules[slug],
+            "freshness": track_freshness[slug],
         }
-        for slug in [s for s, _ in TRACK_ORDER] + (["other"] if buckets["other"]["pending_write"] + buckets["other"]["pending_review"] + buckets["other"]["pending_patch"] + buckets["other"]["dead_letter"] else [])
+        for slug in [s for s, _ in TRACK_ORDER] + (["other"] if any(buckets["other"].values()) else [])
     ]
     enriched["queue"] = enriched_queue
     return enriched

--- a/scripts/status.py
+++ b/scripts/status.py
@@ -417,11 +417,17 @@ def _enrich_translation_v2_with_per_track(t2: dict[str, Any]) -> dict[str, Any]:
     if not queue:
         return enriched
     buckets = _per_track_buckets()
+    queue_names = ("pending_write", "pending_review", "in_progress", "done", "dead_letter")
     track_modules: dict[str, dict[str, list[str]]] = {
-        slug: {"pending_write": [], "pending_review": [], "pending_patch": [], "done": [], "dead_letter": []}
+        slug: {name: [] for name in queue_names}
         for slug in list(buckets)
     }
-    for queue_name in ("pending_write", "pending_review", "pending_patch", "done", "dead_letter"):
+    # Ensure buckets has same keys as track_modules (the default _per_track_buckets
+    # comes from content pipeline schema which includes pending_patch we don't use here).
+    for slug in buckets:
+        for name in queue_names:
+            buckets[slug].setdefault(name, 0)
+    for queue_name in queue_names:
         for module_key in queue.get(queue_name, []) or []:
             track = _track_for_key(module_key)
             buckets[track][queue_name] += 1
@@ -433,16 +439,17 @@ def _enrich_translation_v2_with_per_track(t2: dict[str, Any]) -> dict[str, Any]:
             track_freshness[slug] = {
                 "up_to_date_count": 0,
                 "stale_count": 0,
+                "missing_count": 0,
                 "dead_letter_count": buckets[slug]["dead_letter"],
             }
         for item in freshness.get("modules", []) or []:
             status = str(item.get("status", ""))
-            if status == "missing":
-                continue
             track = _track_for_key(str(item.get("module_key", "")))
             if track_freshness[track] is None:
                 continue
-            if status == "synced":
+            if status == "missing":
+                track_freshness[track]["missing_count"] += 1
+            elif status == "synced":
                 track_freshness[track]["up_to_date_count"] += 1
             else:
                 track_freshness[track]["stale_count"] += 1

--- a/scripts/translation_v2.py
+++ b/scripts/translation_v2.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sqlite3
 import sys
 import time
@@ -34,6 +35,8 @@ VERIFY_MODEL = "deterministic-ukrainian-checks"
 DEFAULT_LEASE_SECONDS = 1200
 DEFAULT_MAX_WRITE_ATTEMPTS = 3
 DEFAULT_MAX_VERIFY_ATTEMPTS = 3
+_MODULE_REF_RE = re.compile(r"(?:module|модуль)\s+([\d.]+)", re.IGNORECASE)
+_MARKDOWN_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
 
 
 def _extract_frontmatter(path: Path) -> dict[str, Any]:
@@ -237,11 +240,14 @@ def _build_translation_queue_status(db_path: Path) -> dict[str, Any]:
             return "pending_write" if phase == "review" else "pending_review"
         return "done"
 
-    for module_key in modules:
-        counts[get_status(module_key)] += 1
+    status_by_module = {module_key: get_status(module_key) for module_key in modules}
+    for status in status_by_module.values():
+        counts[status] += 1
 
-    pending_review_list = sorted([m for m in modules if get_status(m) == "pending_review"])
-    pending_write_list = sorted([m for m in modules if get_status(m) == "pending_write"])
+    pending_review_list = sorted([m for m, status in status_by_module.items() if status == "pending_review"])
+    pending_write_list = sorted([m for m, status in status_by_module.items() if status == "pending_write"])
+    done_list = sorted([m for m, status in status_by_module.items() if status == "done"])
+    dead_letter_list = sorted([m for m, status in status_by_module.items() if status == "dead_letter"])
 
     total_modules = len(modules)
     done_count = counts["done"]
@@ -259,6 +265,8 @@ def _build_translation_queue_status(db_path: Path) -> dict[str, Any]:
         "needs_human_count": needs_human_count,
         "pending_review": pending_review_list,
         "pending_write": pending_write_list,
+        "done": done_list,
+        "dead_letter": dead_letter_list,
     }
 
 
@@ -320,6 +328,52 @@ def _count_attempts(control_plane: ControlPlane, module_key: str, event_type: st
     return attempts
 
 
+def _frontmatter_value(frontmatter: dict[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if key in frontmatter:
+            return frontmatter[key]
+    return None
+
+
+def _normalize_lab_metadata_value(field: str, value: Any) -> Any:
+    if value is None:
+        return None
+    if field == "complexity":
+        return str(value).strip().upper()
+    if field == "time":
+        text = " ".join(str(value).split())
+        numbers = tuple(re.findall(r"\d+", text))
+        return numbers if numbers else text.lower()
+    if field == "prerequisites":
+        if isinstance(value, list):
+            return tuple(_normalize_lab_metadata_value(field, item) for item in value)
+        text = " ".join(str(value).split())
+        links = tuple(link.strip().lower() for link in _MARKDOWN_LINK_RE.findall(text))
+        if links:
+            return links
+        modules = tuple(match.lower() for match in _MODULE_REF_RE.findall(text))
+        return modules if modules else text.lower()
+    return value
+
+
+def _lab_metadata_mismatches(repo_root: Path, module_key: str) -> list[str]:
+    en_frontmatter = _extract_frontmatter(_en_path_for_module_key(repo_root, module_key))
+    uk_frontmatter = _extract_frontmatter(_uk_path_for_module_key(repo_root, module_key))
+    mismatches: list[str] = []
+    for label, keys in (
+        ("complexity", ("complexity",)),
+        ("time", ("time", "time_to_complete")),
+        ("prerequisites", ("prerequisites",)),
+    ):
+        en_value = _frontmatter_value(en_frontmatter, *keys)
+        uk_value = _frontmatter_value(uk_frontmatter, *keys)
+        if en_value is None and uk_value is None:
+            continue
+        if _normalize_lab_metadata_value(label, en_value) != _normalize_lab_metadata_value(label, uk_value):
+            mismatches.append(label)
+    return mismatches
+
+
 def _verify_translation(repo_root: Path, module_key: str) -> tuple[bool, dict[str, Any]]:
     state = detect_module_state(repo_root, module_key)
     uk_path = _uk_path_for_module_key(repo_root, module_key)
@@ -342,6 +396,11 @@ def _verify_translation(repo_root: Path, module_key: str) -> tuple[bool, dict[st
     ]
     if quality_errors:
         details["issues"].extend(quality_errors)
+        return False, details
+    metadata_mismatches = _lab_metadata_mismatches(repo_root, module_key)
+    if metadata_mismatches:
+        details["lab_metadata_mismatches"] = metadata_mismatches
+        details["issues"].extend(f"lab_metadata_mismatch:{field}" for field in metadata_mismatches)
         return False, details
     return True, details
 

--- a/tests/test_translation_v2.py
+++ b/tests/test_translation_v2.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import importlib
 import importlib.util
+import json
 import sqlite3
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
 
 def _load_module():
@@ -18,6 +21,7 @@ def _load_module():
 
 
 translation_v2 = _load_module()
+status_script = importlib.import_module("status")
 
 
 def _git(repo_root: Path, *args: str) -> str:
@@ -60,6 +64,63 @@ def _uk_module(*, en_commit: str, en_file: str, title: str = "Українськ
             "Український текст.",
         ]
     )
+
+
+def _module_with_metadata(*, title: str, body: str, metadata: dict[str, Any] | None = None) -> str:
+    lines = ["---", f'title: "{title}"']
+    for key, value in (metadata or {}).items():
+        if isinstance(value, list):
+            rendered = "[" + ", ".join(json.dumps(item, ensure_ascii=False) for item in value) + "]"
+            lines.append(f"{key}: {rendered}")
+        else:
+            lines.append(f'{key}: {json.dumps(value, ensure_ascii=False)}')
+    lines.extend(["---", "", "## Body", "", body])
+    return "\n".join(lines)
+
+
+def _init_translation_status_db(db_path: Path, *entries: tuple[str, str]) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE jobs (id INTEGER PRIMARY KEY, module_key TEXT NOT NULL, phase TEXT NOT NULL, model TEXT, queue_state TEXT NOT NULL);
+            CREATE TABLE events (id INTEGER PRIMARY KEY, module_key TEXT NOT NULL, type TEXT NOT NULL, payload_json TEXT DEFAULT '{}');
+            """
+        )
+        for module_key, event_type in entries:
+            conn.execute(
+                "INSERT INTO jobs (module_key, phase, model, queue_state) VALUES (?, ?, ?, ?)",
+                (module_key, "review", translation_v2.VERIFY_MODEL, "completed"),
+            )
+            conn.execute(
+                "INSERT INTO events (module_key, type, payload_json) VALUES (?, ?, ?)",
+                (module_key, event_type, "{}"),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _verify_with_metadata(
+    repo_root: Path, module_key: str, *, uk_overrides: dict[str, Any] | None = None
+) -> tuple[bool, dict[str, Any]]:
+    metadata = {"complexity": "MEDIUM", "time_to_complete": "45 min", "prerequisites": ["module-0.1-alpha"]}
+    en_path = repo_root / "src/content/docs" / f"{module_key}.md"
+    _write(en_path, _module_with_metadata(title="English Title", body="English body.", metadata=metadata))
+    _git(repo_root, "add", ".")
+    _git(repo_root, "commit", "-m", "english")
+    uk_metadata = {
+        **metadata,
+        "en_commit": _git(repo_root, "log", "-1", "--format=%H", "--", str(en_path)),
+        "en_file": en_path.relative_to(repo_root).as_posix(),
+        **(uk_overrides or {}),
+    }
+    _write(
+        repo_root / "src/content/docs/uk" / f"{module_key}.md",
+        _module_with_metadata(title="Український заголовок", body="Український текст.", metadata=uk_metadata),
+    )
+    return translation_v2._verify_translation(repo_root, module_key)
 
 
 def test_detect_module_state_marks_commit_drift_stale(tmp_path: Path) -> None:
@@ -275,3 +336,92 @@ def test_build_status_treats_recovered_module_as_done(tmp_path: Path) -> None:
     report = translation_v2.build_status(repo_root, db_path=db_path, section="prerequisites/zero-to-terminal")
     assert report["queue"]["counts"]["done"] == 1
     assert report["queue"]["counts"]["dead_letter"] == 0
+
+
+def test_translation_v2_status_reports_per_track_done_and_dead_letter(tmp_path: Path) -> None:
+    db_path = tmp_path / ".pipeline/translation_v2.db"
+    _init_translation_status_db(
+        db_path,
+        ("prerequisites/zero-to-terminal/module-0.1-alpha", "translation_verified"),
+        ("linux/shell/module-1.1-alpha", "module_dead_lettered"),
+    )
+    report = status_script._enrich_translation_v2_with_per_track({"queue": translation_v2._build_translation_queue_status(db_path)})
+    by_track = {item["slug"]: item for item in report["queue"]["per_track"]}
+    assert by_track["prerequisites"]["modules"]["done"] == ["prerequisites/zero-to-terminal/module-0.1-alpha"]
+    assert by_track["linux"]["modules"]["dead_letter"] == ["linux/shell/module-1.1-alpha"]
+
+
+def test_translation_v2_freshness_rollup_is_per_track_not_global(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    _init_repo(repo_root)
+    prereq_en = repo_root / "src/content/docs/prerequisites/zero-to-terminal/module-0.1-alpha.md"
+    linux_en = repo_root / "src/content/docs/linux/shell/module-1.1-alpha.md"
+    _write(prereq_en, _en_module())
+    _write(linux_en, _en_module(title="Linux Alpha"))
+    _git(repo_root, "add", ".")
+    _git(repo_root, "commit", "-m", "english")
+    prereq_commit = _git(repo_root, "log", "-1", "--format=%H", "--", str(prereq_en))
+    linux_old_commit = _git(repo_root, "log", "-1", "--format=%H", "--", str(linux_en))
+
+    _write(
+        repo_root / "src/content/docs/uk/prerequisites/zero-to-terminal/module-0.1-alpha.md",
+        _uk_module(en_commit=prereq_commit, en_file=prereq_en.relative_to(repo_root).as_posix()),
+    )
+    _write(
+        repo_root / "src/content/docs/uk/linux/shell/module-1.1-alpha.md",
+        _uk_module(en_commit=linux_old_commit, en_file=linux_en.relative_to(repo_root).as_posix()),
+    )
+    _git(repo_root, "add", ".")
+    _git(repo_root, "commit", "-m", "ukrainian")
+
+    _write(linux_en, _en_module(title="Linux Alpha v2"))
+    _git(repo_root, "add", ".")
+    _git(repo_root, "commit", "-m", "linux update")
+
+    db_path = repo_root / ".pipeline/translation_v2.db"
+    _init_translation_status_db(
+        db_path,
+        ("prerequisites/zero-to-terminal/module-0.1-alpha", "translation_verified"),
+        ("linux/shell/module-1.1-alpha", "module_dead_lettered"),
+    )
+
+    report = translation_v2.build_status(repo_root, db_path=db_path)
+    enriched = status_script._enrich_translation_v2_with_per_track(report)
+    by_track = {item["slug"]: item for item in enriched["queue"]["per_track"]}
+
+    assert by_track["prerequisites"]["freshness"] == {
+        "up_to_date_count": 1,
+        "stale_count": 0,
+        "dead_letter_count": 0,
+    }
+    assert by_track["linux"]["freshness"] == {
+        "up_to_date_count": 0,
+        "stale_count": 1,
+        "dead_letter_count": 1,
+    }
+
+
+def test_verify_translation_fails_on_lab_metadata_drift(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    _init_repo(repo_root)
+    verified, details = _verify_with_metadata(
+        repo_root,
+        "prerequisites/zero-to-terminal/module-0.6-zeta",
+        uk_overrides={"complexity": "QUICK"},
+    )
+
+    assert verified is False
+    assert "lab_metadata_mismatch:complexity" in details["issues"]
+    assert details["lab_metadata_mismatches"] == ["complexity"]
+
+
+def test_verify_translation_passes_on_lab_metadata_parity(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    _init_repo(repo_root)
+    verified, details = _verify_with_metadata(
+        repo_root,
+        "prerequisites/zero-to-terminal/module-0.7-eta",
+    )
+
+    assert verified is True
+    assert "lab_metadata_mismatches" not in details

--- a/tests/test_translation_v2.py
+++ b/tests/test_translation_v2.py
@@ -392,11 +392,13 @@ def test_translation_v2_freshness_rollup_is_per_track_not_global(tmp_path: Path)
     assert by_track["prerequisites"]["freshness"] == {
         "up_to_date_count": 1,
         "stale_count": 0,
+        "missing_count": 0,
         "dead_letter_count": 0,
     }
     assert by_track["linux"]["freshness"] == {
         "up_to_date_count": 0,
         "stale_count": 1,
+        "missing_count": 0,
         "dead_letter_count": 1,
     }
 


### PR DESCRIPTION
## Summary
Finishing PR for #243. Per Codex's 2026-04-18 audit, the queue control plane had shipped but three gaps remained — all closed here.

## What changed
- **scripts/translation_v2.py** — `_build_translation_queue_status()` returns `done` and `dead_letter` module lists so per-track enrichment has real data to group. Adds per-track `freshness` rollup (`up_to_date_count`, `stale_count`, `dead_letter_count`). Verify step gains a lab-metadata-parity check (complexity, time, prerequisites frontmatter must match EN→UK or verify fails).
- **scripts/status.py** — same enrichment reflected in the repo-wide status surface.

## Test plan
- [x] 9 tests pass including all 4 required ACs:
  - `test_translation_v2_status_reports_per_track_done_and_dead_letter`
  - `test_translation_v2_freshness_rollup_is_per_track_not_global`
  - `test_verify_translation_fails_on_lab_metadata_drift`
  - `test_verify_translation_passes_on_lab_metadata_parity`
- [x] `ruff check` clean on changed files
- [ ] Cross-family review — needs Gemini adversarial pass per rule 10

## Out of scope (per audit)
- Adding first-class `detect` / `complete` queue phases — cosmetic vs issue text
- Triaging the 2 current dead-letter modules (`distributed-systems/5.1`, `5.3`) — user work

## Drafted by
Codex via agent bridge (task `infra-243-finish`). Codex hit the 900s hard timeout after completing code + tests but before the commit/push/PR step; Claude salvaged from the worktree, ran tests clean, and opened this PR.