### PR TITLE
feat: universal review protocol + verifier for all three agents

### DIFF
--- a/docs/review-protocol.md
+++ b/docs/review-protocol.md
@@ -1,0 +1,40 @@
+# Review Protocol
+
+## Prompt Context
+
+PROJECT CONTEXT:
+KubeDojo is a free, open-source Kubernetes curriculum with 700+ modules:
+- Certification tracks: CKA, CKAD, CKS, KCNA, KCSA (exam-aligned, K8s 1.35)
+- Platform Engineering: SRE, GitOps, DevSecOps, MLOps
+- On-Premises Kubernetes, Cloud, Linux, and AI tracks
+- Quality standard: learning outcomes, inline prompts, scenario-based quizzes
+
+REVIEW RULES:
+1. DIFF vs FILE: a diff only shows what changed. Lines absent from the diff may still exist in the file.
+   Before claiming something is missing, verify absence in the actual branch file, not just the diff.
+2. Mandatory format for every must-fix finding:
+   FINDING: <one-line summary>
+   FILE:LINE: <path>:<N>
+   CURRENT CODE:
+     <verbatim quote from the branch>
+   WHY: <specific failure mode>
+   FIX: <concrete change>
+3. "Missing" claims require proof of absence. If you cannot quote the file or show a search proving absence, delete the finding or demote it to a question.
+4. Do not invent line numbers. Every cited line must exist on the reviewed branch.
+5. Self-check before submit: if the code might exist outside the diff, read/search the file before reporting.
+
+OUTPUT:
+1. Verdict: APPROVE / NEEDS CHANGES / REJECT
+2. Must-Fix findings in the mandatory format
+3. Nits in the same format when useful
+4. Concise focus on what needs changing
+
+## Universal Review Loop
+
+Any orchestrator can run the review loop the same way:
+
+1. Run the reviewer with this protocol prepended to the task.
+2. Verify the review text with `.venv/bin/python scripts/verify_review.py --pr <N> --branch <ref>` or pass `--from-pr` to fetch the latest PR comment directly.
+3. Treat `quote_missing` as hallucinated evidence. Treat `line_mismatch` as a citation accuracy problem. `verified` means the quoted code exists at the cited location.
+4. Optionally post the verifier summary with `--post-comment`.
+5. Decide manually. The verifier is passive evidence-checking only; it warns, but it does not block merge automatically.

--- a/scripts/ai_agent_bridge/_claude.py
+++ b/scripts/ai_agent_bridge/_claude.py
@@ -13,7 +13,6 @@ fire-and-forget path's logging. They will be deleted in Phase 6 cleanup.
 """
 
 import atexit
-import contextlib
 import subprocess
 import sys
 import uuid

--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -28,6 +28,7 @@ from ._messaging import (
     send_message,
 )
 from ._model import check_model
+from ._prompts import build_review_message
 
 try:
     from dispatch import GEMINI_WRITER_MODEL
@@ -409,6 +410,8 @@ def _build_parser() -> argparse.ArgumentParser:
                                    help="Exact sender model ID")
     ask_claude_parser.add_argument("--to-model", dest="to_model",
                                    help="Target model ID")
+    ask_claude_parser.add_argument("--review", action="store_true",
+                                   help="Prepend canonical review protocol to the message")
 
     # ask-codex
     ask_codex_parser = subparsers.add_parser("ask-codex", help="Send message AND invoke Codex (one-step; use '-' to read from stdin)")
@@ -424,6 +427,8 @@ def _build_parser() -> argparse.ArgumentParser:
                                   help="Exact sender model ID")
     ask_codex_parser.add_argument("--to-model", dest="to_model",
                                   help="Target model ID")
+    ask_codex_parser.add_argument("--review", action="store_true",
+                                  help="Prepend canonical review protocol to the message")
 
     # ask-gemini
     ask_gemini_parser = subparsers.add_parser("ask-gemini", help="Send message AND invoke Gemini (one-step)")
@@ -452,6 +457,8 @@ def _build_parser() -> argparse.ArgumentParser:
                                    help="Comma-separated delimiter names for --allow-write mode.")
     ask_gemini_parser.add_argument("--no-github", dest="no_github", action="store_true",
                                    help="Skip auto-posting review to GitHub issue")
+    ask_gemini_parser.add_argument("--review", action="store_true",
+                                   help="Prepend canonical review protocol to the message")
 
     # converse — multi-turn conversation with Gemini
     converse_parser = subparsers.add_parser("converse", help="Multi-turn conversation with Gemini (includes history)")
@@ -593,7 +600,8 @@ def _handle_ask_claude(args):
     data = None
     if args.data:
         data = Path(args.data).read_text()
-    ask_claude(args.content, args.task_id, args.type, data,
+    content = build_review_message(args.content) if args.review else args.content
+    ask_claude(content, args.task_id, args.type, data,
                args.new_session, args.from_llm, args.from_model, args.to_model)
 
 
@@ -603,6 +611,7 @@ def _handle_ask_codex(args):
     if args.data:
         data = Path(args.data).read_text()
     content = sys.stdin.read() if args.content == "-" else args.content
+    content = build_review_message(content) if args.review else content
     ask_codex(content, args.task_id, args.type, data,
               args.new_session, args.from_llm, args.from_model, args.to_model)
 
@@ -613,6 +622,7 @@ def _handle_ask_gemini(args):
     if args.data:
         data = Path(args.data).read_text()
     content = sys.stdin.read() if args.content == "-" else args.content
+    content = build_review_message(content) if args.review else content
     ask_gemini(content, args.task_id, args.type, data, args.model,
                getattr(args, 'from_model', None),
                getattr(args, 'async_mode', False),

--- a/scripts/ai_agent_bridge/_gemini.py
+++ b/scripts/ai_agent_bridge/_gemini.py
@@ -9,7 +9,6 @@ usage logging uniformly across agents.
 """
 
 import atexit
-import contextlib
 import subprocess
 import sys
 import time
@@ -34,7 +33,6 @@ from ._config import (
     _MODEL_CACHE,
     _MODEL_CACHE_TTL,
     _PARENT_ENV,
-    GEMINI_CLI,
     GEMINI_DEFAULT_MODEL,
     REPO_ROOT,
 )

--- a/scripts/ai_agent_bridge/_prompts.py
+++ b/scripts/ai_agent_bridge/_prompts.py
@@ -3,6 +3,20 @@
 from ._config import REPO_ROOT
 
 
+_REVIEW_PROTOCOL_PATH = REPO_ROOT / "docs" / "review-protocol.md"
+
+
+def load_review_context() -> str:
+    """Load the canonical review protocol section used for prompt injection."""
+    text = _REVIEW_PROTOCOL_PATH.read_text("utf-8").strip()
+    return text.split("\n## Universal Review Loop", 1)[0].strip()
+
+
+def build_review_message(content: str) -> str:
+    """Prepend canonical review context to a task message."""
+    return f"{load_review_context()}\n---\n\nTASK:\n{content}"
+
+
 def _load_gemini_context() -> str:
     """Load .gemini/docs/ context files and return as a single block.
 
@@ -154,14 +168,6 @@ Attached data:
 """
     prompt += """
 ---
-
-REVIEW PROTOCOL (mandatory for all review requests):
-- You MUST read every referenced file COMPLETELY before writing your review. Use read_file or cat — do not skim.
-- For EVERY issue you report, cite the exact content from the file (quote the line, value, or field).
-- If you cannot cite evidence from the actual file, do NOT report the issue — you may be hallucinating.
-- Do NOT invent examples that are not in the files. Only critique what actually exists.
-- Before critiquing a vocabulary list, activity list, or similar: list ALL items you found in the file first, THEN review each one.
-- If a file has 25 vocabulary entries, your review must reference the actual 25 entries, not imagined ones.
 
 Please respond appropriately. If this is a request, fulfill it.
 If Claude asked for feedback, provide your honest assessment.

--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -24,7 +24,7 @@ import time
 from datetime import UTC, datetime
 from pathlib import Path
 
-from ai_agent_bridge._prompts import build_review_message, load_review_context
+from ai_agent_bridge._prompts import build_review_message
 
 REPO_ROOT = Path(__file__).parent.parent
 LOG_DIR = REPO_ROOT / ".dispatch-logs"
@@ -181,15 +181,10 @@ CLAUDE_TRANSLATION_TOOLS = (
 )
 
 # ---------------------------------------------------------------------------
-# Gemini review context
-# ---------------------------------------------------------------------------
-
-REVIEW_CONTEXT = load_review_context()
-
-
-# ---------------------------------------------------------------------------
 # Core dispatch functions
 # ---------------------------------------------------------------------------
+# Review context now lives in docs/review-protocol.md and is loaded via
+# ai_agent_bridge._prompts.build_review_message() on the dispatch path.
 
 def dispatch_gemini(prompt: str, model: str | None = None,
                     review: bool = False, timeout: int = 900,

--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -24,6 +24,8 @@ import time
 from datetime import UTC, datetime
 from pathlib import Path
 
+from ai_agent_bridge._prompts import build_review_message, load_review_context
+
 REPO_ROOT = Path(__file__).parent.parent
 LOG_DIR = REPO_ROOT / ".dispatch-logs"
 MCP_CONFIG = REPO_ROOT / ".mcp.json"
@@ -48,6 +50,7 @@ GH_CHAR_LIMIT = 64000
 # currently tested writer alias here until a GA replacement is available.
 GEMINI_WRITER_MODEL = "gemini-3.1-pro-preview"
 GEMINI_DEFAULT_MODEL = "gemini-3-flash-preview"
+GEMINI_REVIEW_MODEL = "gemini-3.1-pro-preview"  # Pro for reviews — hallucinations on Flash cost real iteration time
 GEMINI_FALLBACK_MODEL = "auto"
 CLAUDE_DEFAULT_MODEL = "claude-sonnet-4-6"
 CODEX_DEFAULT_MODEL = "codex"  # lets codex CLI pick the default model
@@ -181,41 +184,25 @@ CLAUDE_TRANSLATION_TOOLS = (
 # Gemini review context
 # ---------------------------------------------------------------------------
 
-REVIEW_CONTEXT = """PROJECT CONTEXT:
-KubeDojo is a free, open-source Kubernetes curriculum with 568+ modules:
-- Certification tracks: CKA, CKAD, CKS, KCNA, KCSA (exam-aligned, K8s 1.35+)
-- Platform Engineering: SRE, GitOps, DevSecOps, MLOps (209 modules)
-- On-Premises Kubernetes: 30 modules
-- Cloud: AWS/GCP/Azure (84 modules)
-- Quality standard: Every module has learning outcomes, inline prompts, scenario-based quizzes
-
-REVIEW PROTOCOL:
-- Read every referenced file COMPLETELY before reviewing. Do not skim.
-- For EVERY issue, cite exact content (quote the line, value, or field).
-- If you cannot cite evidence from the actual file, do NOT report it.
-
-REVIEW CRITERIA:
-- Technical accuracy: K8s commands correct and runnable? Version numbers accurate?
-- Exam alignment: Matches current CNCF exam curriculum?
-- Completeness: Acceptance criteria thorough? Edge cases covered?
-- Junior-friendly: Beginner-accessible? "Why" explained, not just "what"?
-
-Respond with:
-1. Clear verdict: APPROVE / NEEDS CHANGES / REJECT
-2. Specific, actionable feedback
-3. Concise — focus on what needs changing
-"""
+REVIEW_CONTEXT = load_review_context()
 
 
 # ---------------------------------------------------------------------------
 # Core dispatch functions
 # ---------------------------------------------------------------------------
 
-def dispatch_gemini(prompt: str, model: str = GEMINI_DEFAULT_MODEL,
+def dispatch_gemini(prompt: str, model: str | None = None,
                     review: bool = False, timeout: int = 900,
                     mcp: bool = False) -> tuple[bool, str]:
-    """Call Gemini CLI directly. Returns (success, output)."""
-    full_prompt = f"{REVIEW_CONTEXT}\n---\n\nTASK:\n{prompt}" if review else prompt
+    """Call Gemini CLI directly. Returns (success, output).
+
+    When ``review=True`` and no ``model`` is specified, uses Pro
+    (``GEMINI_REVIEW_MODEL``) — Flash hallucinations on code reviews cost more
+    iteration time than the extra Pro latency.
+    """
+    if model is None:
+        model = GEMINI_REVIEW_MODEL if review else GEMINI_DEFAULT_MODEL
+    full_prompt = build_review_message(prompt) if review else prompt
     cmd = [GEMINI_CLI, "-m", model, "-y"]
     if mcp:
         cmd.extend(["--allowed-mcp-server-names", "rag"])
@@ -689,7 +676,7 @@ def main():
     # gemini
     gp = subparsers.add_parser("gemini", help="Dispatch prompt to Gemini CLI")
     gp.add_argument("prompt", help="Prompt text (use '-' to read from stdin)")
-    gp.add_argument("--model", default=GEMINI_DEFAULT_MODEL, help=f"Gemini model (default: {GEMINI_DEFAULT_MODEL})")
+    gp.add_argument("--model", default=None, help=f"Gemini model (default: {GEMINI_REVIEW_MODEL} when --review else {GEMINI_DEFAULT_MODEL})")
     gp.add_argument("--review", action="store_true", help="Prepend KubeDojo review context")
     gp.add_argument("--mcp", action="store_true", help="Enable RAG MCP tools (for translations)")
     gp.add_argument("--github", type=int, metavar="ISSUE", help="Post output to GitHub issue")
@@ -717,11 +704,12 @@ def main():
 
     if args.agent == "gemini":
         prompt = sys.stdin.read() if args.prompt == "-" else args.prompt
+        chosen_model = args.model or (GEMINI_REVIEW_MODEL if args.review else GEMINI_DEFAULT_MODEL)
         ok, output = dispatch_gemini_with_retry(
-            prompt, args.model, args.review, args.retry, args.timeout, args.mcp,
+            prompt, chosen_model, args.review, args.retry, args.timeout, args.mcp,
         )
         if ok and args.github:
-            post_to_github(args.github, output, args.model)
+            post_to_github(args.github, output, chosen_model)
         sys.exit(0 if ok else 1)
 
     elif args.agent == "claude":

--- a/scripts/verify_review.py
+++ b/scripts/verify_review.py
@@ -55,11 +55,20 @@ def _read_target(path: str, branch: str | None) -> str:
     return Path(path).read_text("utf-8")
 
 
+_SUMMARY_PREFIX = "Review verifier for PR"
+
+
 def _read_review(args: argparse.Namespace) -> str:
     if not args.from_pr:
         return sys.stdin.read()
+    # Skip the verifier's own summary comments so repeat --from-pr --post-comment
+    # runs don't parse their own output as if it were the reviewer's.
+    jq = (
+        f'[.comments[] | select(.body | startswith("{_SUMMARY_PREFIX}") | not)]'
+        ' | last | .body // ""'
+    )
     return subprocess.run(
-        ["gh", "pr", "view", str(args.pr), "--json", "comments", "--jq", ".comments[-1].body"],
+        ["gh", "pr", "view", str(args.pr), "--json", "comments", "--jq", jq],
         check=True, text=True, capture_output=True,
     ).stdout
 

--- a/scripts/verify_review.py
+++ b/scripts/verify_review.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Passive verifier for review findings against branch or worktree files."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _norm(text: str) -> str:
+    text = "\n".join(line.strip() for line in text.replace("`", "").splitlines()).strip()
+    return re.sub(r"\s+", " ", text)
+
+
+def parse_findings(review: str) -> list[dict[str, object]]:
+    starts = [m.start() for m in re.finditer(r"^FINDING:", review, re.M)] + [len(review)]
+    findings = []
+    for start, end in zip(starts, starts[1:]):
+        block = review[start:end].strip()
+        loc = re.search(r"^FILE:LINE:\s*(.+?):(\d+)\s*$", block, re.M)
+        code = re.search(r"^CURRENT CODE(?: .*)?:\s*$", block, re.M)
+        if not (loc and code):
+            continue
+        body = []
+        for line in block[code.end():].splitlines():
+            if re.match(r"^[A-Z][A-Z ]+:", line):
+                break
+            body.append(line.lstrip())
+        findings.append({"path": loc.group(1), "line": int(loc.group(2)), "code": "\n".join(body).strip()})
+    return findings
+
+
+def verify_review(review: str, reader) -> list[dict[str, object]]:
+    results = []
+    for finding in parse_findings(review):
+        text = reader(finding["path"])
+        quote = _norm(str(finding["code"]))
+        lines = text.splitlines()
+        span = max(1, str(finding["code"]).count("\n") + 1)
+        start = max(0, int(finding["line"]) - 1)
+        window = _norm("\n".join(lines[start:start + span]))
+        status = "quote_missing" if quote not in _norm(text) else "verified" if quote in window else "line_mismatch"
+        results.append({**finding, "status": status})
+    return results
+
+
+def _read_target(path: str, branch: str | None) -> str:
+    if branch:
+        return subprocess.run(
+            ["git", "show", f"{branch}:{path}"], check=True, text=True, capture_output=True
+        ).stdout
+    return Path(path).read_text("utf-8")
+
+
+def _read_review(args: argparse.Namespace) -> str:
+    if not args.from_pr:
+        return sys.stdin.read()
+    return subprocess.run(
+        ["gh", "pr", "view", str(args.pr), "--json", "comments", "--jq", ".comments[-1].body"],
+        check=True, text=True, capture_output=True,
+    ).stdout
+
+
+def _summary(pr: int, results: list[dict[str, object]]) -> str:
+    counts = {name: sum(r["status"] == name for r in results) for name in ("verified", "line_mismatch", "quote_missing")}
+    lines = [f"Review verifier for PR #{pr}: {counts['verified']} verified, {counts['line_mismatch']} line_mismatch, {counts['quote_missing']} quote_missing."]
+    lines.extend(f"- `{r['status']}` {r['path']}:{r['line']}" for r in results)
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pr", type=int, required=True)
+    parser.add_argument("--branch")
+    parser.add_argument("--from-pr", action="store_true")
+    parser.add_argument("--post-comment", action="store_true")
+    args = parser.parse_args()
+    results = verify_review(_read_review(args), lambda path: _read_target(path, args.branch))
+    body = _summary(args.pr, results)
+    print(body)
+    if args.post_comment:
+        subprocess.run(["gh", "pr", "comment", str(args.pr), "-F", "-"], input=body, check=True, text=True)
+    return 1 if any(r["status"] == "quote_missing" for r in results) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_verify_review.py
+++ b/tests/test_verify_review.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from verify_review import verify_review
+
+
+def _review(path: str, line: int, code: str) -> str:
+    return f"""FINDING: test
+FILE:LINE: {path}:{line}
+CURRENT CODE:
+  {code}
+WHY: reason
+FIX: fix
+"""
+
+
+def test_verify_review_marks_verified_when_quote_matches_claimed_line():
+    results = verify_review(_review("a.py", 2, "beta = 2"), lambda _path: "alpha = 1\nbeta = 2\ngamma = 3\n")
+    assert results[0]["status"] == "verified"
+
+
+def test_verify_review_marks_line_mismatch_when_quote_exists_elsewhere():
+    results = verify_review(_review("a.py", 1, "beta = 2"), lambda _path: "alpha = 1\nbeta = 2\ngamma = 3\n")
+    assert results[0]["status"] == "line_mismatch"
+
+
+def test_verify_review_marks_quote_missing_for_hallucinated_code():
+    results = verify_review(_review("a.py", 2, "delta = 4"), lambda _path: "alpha = 1\nbeta = 2\ngamma = 3\n")
+    assert results[0]["status"] == "quote_missing"
+
+
+def test_verify_review_handles_mixed_outcomes():
+    review = "\n".join(
+        [
+            _review("a.py", 2, "beta = 2").strip(),
+            _review("a.py", 1, "gamma = 3").strip(),
+            _review("a.py", 4, "delta = 4").strip(),
+        ]
+    )
+    results = verify_review(review, lambda _path: "alpha = 1\nbeta = 2\ngamma = 3\n")
+    assert [result["status"] for result in results] == ["verified", "line_mismatch", "quote_missing"]


### PR DESCRIPTION
## Summary
- extract the canonical anti-hallucination review protocol to docs/review-protocol.md and load it from dispatch/bridge helpers
- add --review support to ab ask-claude, ask-codex, and ask-gemini so all three can prepend the same protocol to review tasks
- add scripts/verify_review.py plus focused tests for verified, line_mismatch, quote_missing, and mixed reviews

## Validation
- ../../.venv/bin/python -m pytest tests/test_verify_review.py -x
- ../../.venv/bin/ruff check scripts/verify_review.py scripts/dispatch.py scripts/ai_agent_bridge/
