### PR TITLE
chore(pipeline-v4): ignore runtime logs and lock loc_after accounting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ test_script.sh
 .pipeline/state.lock
 .pipeline/ztt-pilot-*/
 .pipeline/v3/
+.pipeline/v4/
 .pipeline/citation-verdicts/
 .pipeline/audit-ztt-*/
 .cache/

--- a/tests/test_expand_module.py
+++ b/tests/test_expand_module.py
@@ -313,6 +313,7 @@ def test_expand_module_integration_shape_and_file_content(monkeypatch, tmp_path:
     assert result.provenance_blocks_added >= 4
     assert result.loc_after >= 220
     final_text = expand_module._module_path(THIN_MODULE_KEY).read_text(encoding="utf-8")
+    assert result.loc_after == expand_module._count_loc(final_text)
     assert "<!-- v4:generated type=no_quiz model=codex turn=1 -->" in final_text
     assert "<!-- v4:generated type=thin model=gemini turn=1 -->" in final_text
     assert "## Quiz" in final_text


### PR DESCRIPTION
## Summary
- ignore `.pipeline/v4/` runtime artifacts in the repo-level ignore rules so batch logs stop appearing as untracked files
- add a regression assertion that `ExpandResult.loc_after` matches the line count of the final written module text

## Validation
- `.venv/bin/ruff check tests/test_expand_module.py`
- `.venv/bin/python -m pytest tests/test_expand_module.py`
- `git check-ignore -v .pipeline/v4/runs/example.jsonl`

## Notes
- this is a small hygiene follow-up to the shipped pipeline-v4 work; it does not change generation behavior