### PR TITLE
fix(pipeline-v4): expose public skip-citation mode (#322)

### DIFF
--- a/scripts/pipeline_v4.py
+++ b/scripts/pipeline_v4.py
@@ -545,13 +545,14 @@ def run_pipeline_v4(
     max_rubric_retries: int = 2,
     generated_loc_threshold: float = 0.5,
     dry_run: bool = False,
+    skip_citation: bool = False,
 ) -> PipelineV4Result:
     return _run_pipeline_v4(
         module_key,
         max_rubric_retries=max_rubric_retries,
         generated_loc_threshold=generated_loc_threshold,
         dry_run=dry_run,
-        skip_citation=False,
+        skip_citation=skip_citation,
     )
 
 

--- a/scripts/pipeline_v4_batch.py
+++ b/scripts/pipeline_v4_batch.py
@@ -278,7 +278,7 @@ def _run_one(
     dry_run: bool,
     skip_citation: bool,
     lease_seconds: int,
-    runner: Callable[..., pipeline_v4.PipelineV4Result] = pipeline_v4._run_pipeline_v4,
+    runner: Callable[..., pipeline_v4.PipelineV4Result] = pipeline_v4.run_pipeline_v4,
 ) -> dict[str, Any]:
     base: dict[str, Any] = {
         "module_key": candidate.module_key,

--- a/tests/test_pipeline_v4.py
+++ b/tests/test_pipeline_v4.py
@@ -167,6 +167,42 @@ def test_stage_2_happy_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> 
     assert result.citation_v3_exit == 0
 
 
+def test_public_run_pipeline_v4_accepts_skip_citation(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _patch_roots(monkeypatch, tmp_path)
+    _write_module(tmp_path)
+    monkeypatch.setattr(
+        pipeline_v4.rubric_gaps,
+        "gaps_for_module",
+        lambda module_key: {
+            "score": 2.0,
+            "gaps": ["thin", "no_quiz"],
+            "target_loc": 600,
+        },
+    )
+    monkeypatch.setattr(
+        pipeline_v4.expand_module,
+        "expand_module",
+        lambda module_key, gaps, target_loc=600, dry_run=False: _expand_result(
+            gaps_filled=["thin", "no_quiz"],
+            loc_after=600,
+        ),
+    )
+    _patch_rescore_sequence(monkeypatch, [{"score": 4.4, "gaps": []}])
+
+    def _unexpected_citation(module_key: str) -> dict[str, object]:
+        raise AssertionError("skip_citation=True should not invoke citation_v3")
+
+    monkeypatch.setattr(pipeline_v4, "_invoke_citation_pipeline", _unexpected_citation)
+
+    result = pipeline_v4.run_pipeline_v4(MODULE_KEY, skip_citation=True)
+
+    assert result.outcome == "clean"
+    assert result.stage_reached == "DONE"
+    assert result.citation_v3_exit is None
+
+
 def test_stage_3_retry(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     _patch_roots(monkeypatch, tmp_path)
     _write_module(tmp_path)


### PR DESCRIPTION
## Summary
- expose `skip_citation` on the public `run_pipeline_v4()` entrypoint
- switch `pipeline_v4_batch.py` back to the public API instead of the private `_run_pipeline_v4()` helper
- add regression coverage for score-first runs that intentionally stop after stages 1-3

## Validation
- `.venv/bin/ruff check scripts/pipeline_v4.py scripts/pipeline_v4_batch.py tests/test_pipeline_v4.py`
- `.venv/bin/python -m pytest tests/test_pipeline_v4.py tests/test_pipeline_v4_batch.py`
- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/test_pipeline.py`

## Notes
- This does not change the bounded-worker design in `pipeline_v4_batch.py`; the 8-way concurrency text in #322 is stale versus the shipped rate-limit guardrails.
- It aligns the public API with the already-shipped score-first `--skip-citation` batch path so callers no longer need a private helper.