### PR TITLE
fix(dispatch): auto-fallback from API-key to OAuth on Gemini 429

### DIFF
--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -40,12 +40,27 @@ _ENV["GEMINI_SESSION"] = "1"        # Disable hostile aliases (eza, bat, zoxide)
 _ENV["KUBEDOJO_PIPELINE"] = "1"     # Suppress inbox hooks during pipeline runs
 # Gemini auth: CLI prefers GEMINI_API_KEY when set; otherwise falls
 # through to OAuth/subscription creds in ~/.gemini/oauth_creds.json.
-# When the API-key tier is rate-limited, set
-# KUBEDOJO_GEMINI_SUBSCRIPTION=1 to strip the key from child env so
-# dispatches use the subscription path instead.
-if os.environ.get("KUBEDOJO_GEMINI_SUBSCRIPTION") == "1":
-    _ENV.pop("GEMINI_API_KEY", None)
-    _ENV.pop("GOOGLE_API_KEY", None)
+#
+# Runtime behavior (see dispatch_gemini_with_retry):
+#   - Default: start on API-key path. If a 429 / quota hit is detected,
+#     automatically strip the key from the child env and retry on OAuth.
+#   - Force subscription: set KUBEDOJO_GEMINI_SUBSCRIPTION=1 to skip the
+#     API-key attempt entirely (e.g. on known-exhausted API quota).
+#
+# _ENV stays unmodified (API-key path). Subscription env is built on
+# demand via _gemini_env(use_subscription=True).
+_FORCE_GEMINI_SUBSCRIPTION = os.environ.get("KUBEDOJO_GEMINI_SUBSCRIPTION") == "1"
+
+
+def _gemini_env(use_subscription: bool) -> dict:
+    """Return the child env for a Gemini dispatch. When use_subscription=True,
+    strip the API keys so the CLI falls back to OAuth creds."""
+    if not use_subscription:
+        return _ENV
+    env = {**_ENV}
+    env.pop("GEMINI_API_KEY", None)
+    env.pop("GOOGLE_API_KEY", None)
+    return env
 
 # GitHub comment char limit (65,536 minus safety margin)
 GH_CHAR_LIMIT = 64000
@@ -196,15 +211,22 @@ CLAUDE_TRANSLATION_TOOLS = (
 
 def dispatch_gemini(prompt: str, model: str | None = None,
                     review: bool = False, timeout: int = 900,
-                    mcp: bool = False) -> tuple[bool, str]:
+                    mcp: bool = False,
+                    use_subscription: bool | None = None) -> tuple[bool, str]:
     """Call Gemini CLI directly. Returns (success, output).
 
     When ``review=True`` and no ``model`` is specified, uses Pro
     (``GEMINI_REVIEW_MODEL``) — Flash hallucinations on code reviews cost more
     iteration time than the extra Pro latency.
+
+    ``use_subscription`` selects the auth path: ``False`` → API key (default),
+    ``True`` → strip keys and use OAuth. ``None`` defers to
+    ``KUBEDOJO_GEMINI_SUBSCRIPTION`` (True if set, else False).
     """
     if model is None:
         model = GEMINI_REVIEW_MODEL if review else GEMINI_DEFAULT_MODEL
+    if use_subscription is None:
+        use_subscription = _FORCE_GEMINI_SUBSCRIPTION
     full_prompt = build_review_message(prompt) if review else prompt
     cmd = [GEMINI_CLI, "-m", model, "-y"]
     if mcp:
@@ -216,7 +238,8 @@ def dispatch_gemini(prompt: str, model: str | None = None,
     try:
         proc = subprocess.Popen(
             cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE, text=True, cwd=str(REPO_ROOT), env=_ENV,
+            stderr=subprocess.PIPE, text=True, cwd=str(REPO_ROOT),
+            env=_gemini_env(use_subscription),
             start_new_session=True,
         )
 
@@ -280,23 +303,40 @@ def dispatch_gemini(prompt: str, model: str | None = None,
 def dispatch_gemini_with_retry(prompt: str, model: str = GEMINI_DEFAULT_MODEL,
                                review: bool = False, max_retries: int = 3,
                                timeout: int = 900, mcp: bool = False) -> tuple[bool, str]:
-    """Call Gemini with retry on rate limits + fallback model."""
+    """Call Gemini with retry on rate limits + fallback model.
+
+    Auth-path fallback: starts on API key by default. If a 429 / quota error
+    is detected and we haven't already switched, flip to the OAuth/subscription
+    path and retry immediately (no backoff — the two tiers have independent
+    quotas). Only after the subscription path also rate-limits do we apply
+    exponential backoff.
+    """
     base_delay = 30
     output = ""
+    use_subscription = _FORCE_GEMINI_SUBSCRIPTION
     for attempt in range(max_retries):
-        ok, output = dispatch_gemini(prompt, model, review, timeout, mcp)
+        ok, output = dispatch_gemini(prompt, model, review, timeout, mcp,
+                                     use_subscription=use_subscription)
         if ok:
             return True, output
 
         # Check for rate limit
         if _is_rate_limited(output):
+            # If we're still on the API-key path, flip to subscription and retry
+            # immediately — the OAuth tier has a separate quota.
+            if not use_subscription:
+                print("Gemini API-key rate-limited — switching to subscription (OAuth) path",
+                      file=sys.stderr)
+                use_subscription = True
+                continue  # no sleep; retry on the other tier
+            # Already on subscription — apply exponential backoff.
             if attempt < max_retries - 1:
                 delay = base_delay * (2 ** attempt)
-                print(f"Rate limited (attempt {attempt + 1}/{max_retries}). Waiting {delay}s...",
+                print(f"Rate limited on subscription (attempt {attempt + 1}/{max_retries}). Waiting {delay}s...",
                       file=sys.stderr)
                 time.sleep(delay)
                 continue
-            # All retries exhausted on rate limit — don't try fallback (same quota)
+            # All retries exhausted on both paths.
             return False, output
 
         # Timeout — don't retry, just fail (Gemini is slow, not broken)
@@ -306,7 +346,8 @@ def dispatch_gemini_with_retry(prompt: str, model: str = GEMINI_DEFAULT_MODEL,
         # Non-rate-limit, non-timeout failure — try fallback model once
         if model != GEMINI_FALLBACK_MODEL:
             print(f"Retrying with fallback model: {GEMINI_FALLBACK_MODEL}", file=sys.stderr)
-            return dispatch_gemini(prompt, GEMINI_FALLBACK_MODEL, review, timeout, mcp)
+            return dispatch_gemini(prompt, GEMINI_FALLBACK_MODEL, review, timeout, mcp,
+                                   use_subscription=use_subscription)
 
         return False, output
 

--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -322,21 +322,32 @@ def dispatch_gemini_with_retry(prompt: str, model: str = GEMINI_DEFAULT_MODEL,
 
         # Check for rate limit
         if _is_rate_limited(output):
-            # If we're still on the API-key path, flip to subscription and retry
-            # immediately — the OAuth tier has a separate quota.
+            # If we're still on the API-key path, flip to subscription and
+            # retry immediately *without consuming the retry budget*. This
+            # guarantees that even callers with max_retries=1 get one attempt
+            # on the OAuth tier (independent quota).
             if not use_subscription:
                 print("Gemini API-key rate-limited — switching to subscription (OAuth) path",
                       file=sys.stderr)
                 use_subscription = True
-                continue  # no sleep; retry on the other tier
-            # Already on subscription — apply exponential backoff.
+                ok, output = dispatch_gemini(prompt, model, review, timeout, mcp,
+                                             use_subscription=True)
+                if ok:
+                    return True, output
+                # Subscription also failed. If it was a rate-limit, fall through
+                # to the backoff branch below. Otherwise, fall through to the
+                # timeout / fallback-model / failure branches.
+
+        if _is_rate_limited(output):
+            # At this point we're on subscription — either because the caller
+            # forced it, or because we just flipped. Apply exponential backoff.
             if attempt < max_retries - 1:
                 delay = base_delay * (2 ** attempt)
                 print(f"Rate limited on subscription (attempt {attempt + 1}/{max_retries}). Waiting {delay}s...",
                       file=sys.stderr)
                 time.sleep(delay)
                 continue
-            # All retries exhausted on both paths.
+            # All retries exhausted.
             return False, output
 
         # Timeout — don't retry, just fail (Gemini is slow, not broken)

--- a/tests/test_dispatch_gemini_timeout.py
+++ b/tests/test_dispatch_gemini_timeout.py
@@ -62,3 +62,59 @@ def test_gemini_quiet_mode_defaults_off_outside_pipeline(monkeypatch):
     monkeypatch.delenv("KUBEDOJO_PIPELINE", raising=False)
 
     assert dispatch._gemini_quiet_mode_enabled() is False
+
+
+def test_gemini_env_strips_api_keys_on_subscription(monkeypatch):
+    monkeypatch.setitem(dispatch._ENV, "GEMINI_API_KEY", "sk-test")
+    monkeypatch.setitem(dispatch._ENV, "GOOGLE_API_KEY", "gg-test")
+
+    api_env = dispatch._gemini_env(use_subscription=False)
+    sub_env = dispatch._gemini_env(use_subscription=True)
+
+    assert api_env["GEMINI_API_KEY"] == "sk-test"
+    assert api_env["GOOGLE_API_KEY"] == "gg-test"
+    assert "GEMINI_API_KEY" not in sub_env
+    assert "GOOGLE_API_KEY" not in sub_env
+    assert sub_env is not api_env  # independent dict, no mutation
+
+
+def test_gemini_with_retry_flips_to_subscription_on_rate_limit():
+    """On 429 from API-key path, next retry must use the subscription path
+    immediately (no backoff — independent quotas)."""
+    calls: list[dict] = []
+
+    def fake_dispatch(*args, use_subscription=None, **kwargs):
+        calls.append({"args": args, "kwargs": kwargs,
+                      "use_subscription": use_subscription})
+        if len(calls) == 1:
+            return False, "429 Too Many Requests — quota exceeded"
+        return True, "real output"
+
+    with patch("dispatch.dispatch_gemini", side_effect=fake_dispatch), \
+         patch("dispatch.time.sleep") as sleep_mock, \
+         patch.object(dispatch, "_FORCE_GEMINI_SUBSCRIPTION", False):
+        ok, output = dispatch.dispatch_gemini_with_retry("hello", max_retries=3)
+
+    assert ok is True
+    assert output == "real output"
+    assert len(calls) == 2
+    assert calls[0]["use_subscription"] is False  # first try: API key
+    assert calls[1]["use_subscription"] is True   # retry: subscription
+    sleep_mock.assert_not_called()  # no backoff between auth-path flip
+
+
+def test_gemini_with_retry_force_subscription_skips_api_key():
+    """When KUBEDOJO_GEMINI_SUBSCRIPTION=1, first call must use subscription."""
+    calls: list[dict] = []
+
+    def fake_dispatch(*args, use_subscription=None, **kwargs):
+        calls.append({"args": args, "kwargs": kwargs,
+                      "use_subscription": use_subscription})
+        return True, "out"
+
+    with patch("dispatch.dispatch_gemini", side_effect=fake_dispatch), \
+         patch.object(dispatch, "_FORCE_GEMINI_SUBSCRIPTION", True):
+        ok, _ = dispatch.dispatch_gemini_with_retry("hello")
+
+    assert ok is True
+    assert calls[0]["use_subscription"] is True

--- a/tests/test_dispatch_gemini_timeout.py
+++ b/tests/test_dispatch_gemini_timeout.py
@@ -118,3 +118,55 @@ def test_gemini_with_retry_force_subscription_skips_api_key():
 
     assert ok is True
     assert calls[0]["use_subscription"] is True
+
+
+def test_gemini_with_retry_flip_works_with_max_retries_one():
+    """Regression: with max_retries=1 the API-key 429 flip must still produce
+    an attempt on the subscription path. Previously the `continue` consumed
+    the only loop iteration and the subscription path was never tried."""
+    calls: list[dict] = []
+
+    def fake_dispatch(*args, use_subscription=None, **kwargs):
+        calls.append({"args": args, "kwargs": kwargs,
+                      "use_subscription": use_subscription})
+        if len(calls) == 1:
+            return False, "429 Too Many Requests — quota exceeded"
+        return True, "real output"
+
+    with patch("dispatch.dispatch_gemini", side_effect=fake_dispatch), \
+         patch("dispatch.time.sleep") as sleep_mock, \
+         patch.object(dispatch, "_FORCE_GEMINI_SUBSCRIPTION", False):
+        ok, output = dispatch.dispatch_gemini_with_retry("hello", max_retries=1)
+
+    assert ok is True
+    assert output == "real output"
+    assert len(calls) == 2
+    assert calls[0]["use_subscription"] is False  # first try: API key
+    assert calls[1]["use_subscription"] is True   # flip retry: subscription
+    sleep_mock.assert_not_called()
+
+
+def test_gemini_with_retry_double_429_falls_back_to_subscription_backoff():
+    """When both API-key AND subscription return 429, the flip produces one
+    subscription attempt, then on the next loop iteration we apply subscription
+    backoff — not another flip."""
+    calls: list[dict] = []
+
+    def fake_dispatch(*args, use_subscription=None, **kwargs):
+        calls.append({"args": args, "kwargs": kwargs,
+                      "use_subscription": use_subscription})
+        if len(calls) <= 2:
+            return False, "429 rate limit"
+        return True, "finally ok"
+
+    with patch("dispatch.dispatch_gemini", side_effect=fake_dispatch), \
+         patch("dispatch.time.sleep") as sleep_mock, \
+         patch.object(dispatch, "_FORCE_GEMINI_SUBSCRIPTION", False):
+        ok, output = dispatch.dispatch_gemini_with_retry("hello", max_retries=3)
+
+    assert ok is True
+    assert output == "finally ok"
+    # Expected sequence: API-key (429) → flip, subscription (429) →
+    # backoff sleep → subscription (success)
+    assert [c["use_subscription"] for c in calls] == [False, True, True]
+    sleep_mock.assert_called_once()  # exactly one backoff between the two subscription attempts


### PR DESCRIPTION
## Summary

- When the Gemini API-key tier hits a 429 / quota error mid-dispatch, the next retry now automatically strips the key and uses the OAuth/subscription path — independent quota, so retry is immediate (no backoff).
- `KUBEDOJO_GEMINI_SUBSCRIPTION=1` is preserved as an opt-out: skip the API-key attempt entirely when that tier is known-exhausted.
- Only after the subscription path *also* rate-limits do we apply exponential backoff.

## Why

Previously `KUBEDOJO_GEMINI_SUBSCRIPTION=1` was a static, up-front switch. On a long batch, if the API-key tier hit 429 mid-run, there was no runtime fallback — the pipeline just hammered the same exhausted tier until `max_retries` ran out.

## Test plan

- [x] New unit tests in `tests/test_dispatch_gemini_timeout.py`:
  - `_gemini_env` strips keys only on subscription, envs are independent dicts
  - 429 on API-key → next retry uses `use_subscription=True`, no sleep between attempts
  - Force-subscription env var → first call already on subscription
- [x] Live dispatch smoke (`dispatch_gemini_with_retry`) returns `OK` via API-key path, no zombies
- [x] 11/11 existing dispatch tests pass; ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)