### PR TITLE
feat(#356 part 1): HEAD-check + allowlist pre-filter for LLM-suggested URLs

### DIFF
--- a/scripts/citation_residuals.py
+++ b/scripts/citation_residuals.py
@@ -34,6 +34,7 @@ from citation_backfill import dispatch_gemini, parse_agent_response  # noqa: E40
 HUMAN_REVIEW_DIR = REPO_ROOT / ".pipeline" / "v3" / "human-review"
 DEFAULT_MAX_CANDIDATES = 3
 MIN_SIGNAL_ANCHORS_REQUIRED = 1
+HEAD_CHECK_TIMEOUT_SECONDS = 5.0
 
 
 # ---- IO ------------------------------------------------------------------
@@ -177,14 +178,82 @@ def build_candidate_prompt(finding: dict[str, Any]) -> str:
     )
 
 
+def head_check(
+    url: str,
+    *,
+    timeout: float = HEAD_CHECK_TIMEOUT_SECONDS,
+) -> bool:
+    """Return True if ``url`` resolves to a live 2xx/3xx response.
+
+    Sends an HTTP HEAD first; on 405 Method Not Allowed, falls back to a
+    zero-byte range GET. Any other failure (404, 5xx, timeout, DNS
+    error, connection reset) returns False so the caller can drop the
+    candidate before doing full fetch + anchor matching.
+
+    This is the deterministic gate for URL-existence hallucinations.
+    See GH #356 Part 1. Never raises — any error = "URL is not live
+    enough to cite."
+    """
+    import urllib.error
+    import urllib.request
+
+    def _try(method: str, extra_headers: dict[str, str] | None = None) -> int | None:
+        req = urllib.request.Request(
+            url,
+            method=method,
+            headers={
+                "User-Agent": fetch_citation.DEFAULT_UA,
+                "Accept": fetch_citation.DEFAULT_ACCEPT,
+                **(extra_headers or {}),
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return int(resp.status)
+        except urllib.error.HTTPError as exc:
+            return int(exc.code)
+        except Exception:  # noqa: BLE001 — any transport failure = dead URL
+            return None
+
+    status = _try("HEAD")
+    if status is None:
+        return False
+    if 200 <= status < 400:
+        return True
+    if status == 405:
+        # Server rejects HEAD but may accept a range-limited GET.
+        retry_status = _try("GET", extra_headers={"Range": "bytes=0-0"})
+        if retry_status is None:
+            return False
+        return 200 <= retry_status < 400
+    return False
+
+
 def request_candidates(
     finding: dict[str, Any],
     *,
     dispatcher=dispatch_gemini,
+    allowlist_tier=fetch_citation.allowlist_tier,
+    head_checker=None,
 ) -> list[dict[str, Any]]:
     """Ask the LLM for candidate URLs. Returns a list of dicts with
     ``url``, ``tier``, ``why``. Empty list on any failure (the caller
-    marks the finding unresolvable)."""
+    marks the finding unresolvable).
+
+    Pre-filters hallucinations deterministically:
+      1. URL must be on ``docs/citation-trusted-domains.yaml`` allowlist.
+         LLMs reliably suggest off-allowlist URLs despite the prompt's
+         hard constraint — this filter is advisory's enforcement.
+      2. URL must respond to HEAD (or range-GET fallback) with a 2xx/3xx.
+         Eliminates the "LLM confidently fabricated a 404 URL" class
+         before downstream fetch + anchor work.
+
+    Both filters are injectable for testing. ``head_checker`` defaults
+    to the module-level ``head_check`` but is resolved at call time so
+    tests can swap it in via parameter.
+    """
+    if head_checker is None:
+        head_checker = head_check
     prompt = build_candidate_prompt(finding)
     ok, raw = dispatcher(prompt)
     if not ok:
@@ -202,6 +271,10 @@ def request_candidates(
             continue
         url = str(c.get("url") or "").strip()
         if not url.startswith(("http://", "https://")):
+            continue
+        if not allowlist_tier(url):
+            continue
+        if not head_checker(url):
             continue
         valid.append(
             {
@@ -379,6 +452,7 @@ def resolve_module(
     fetcher=fetch_citation.fetch,
     cached_text_path=fetch_citation.cached_text_path,
     allowlist_tier=fetch_citation.allowlist_tier,
+    head_checker=None,
 ) -> dict[str, Any]:
     """Resolve all `needs_citation` findings for one module.
 
@@ -427,7 +501,12 @@ def resolve_module(
     }
 
     for finding in needs_citation:
-        candidates = request_candidates(finding, dispatcher=dispatcher)
+        candidates = request_candidates(
+            finding,
+            dispatcher=dispatcher,
+            allowlist_tier=allowlist_tier,
+            head_checker=head_checker,
+        )
         if not candidates:
             finding_record = dict(finding)
             finding_record["unresolvable_reason"] = "no_candidates_returned"

--- a/scripts/citation_residuals.py
+++ b/scripts/citation_residuals.py
@@ -185,17 +185,33 @@ def head_check(
 ) -> bool:
     """Return True if ``url`` resolves to a live 2xx/3xx response.
 
-    Sends an HTTP HEAD first; on 405 Method Not Allowed, falls back to a
-    zero-byte range GET. Any other failure (404, 5xx, timeout, DNS
-    error, connection reset) returns False so the caller can drop the
-    candidate before doing full fetch + anchor matching.
+    Escalation ladder:
+        1. HEAD — cheapest probe.
+        2. On 405 Method Not Allowed, zero-byte range GET.
+        3. On Range-specific rejection (403 / 416 / 501 — WAFs that
+           reject Range but would serve a normal GET), plain GET.
+
+    Expected transport failures (DNS, connection reset, timeout,
+    malformed URL) return False. Unexpected exceptions bubble up so
+    coding regressions don't silently convert into "dead URL" drops
+    (#357 Codex review, nit #2).
 
     This is the deterministic gate for URL-existence hallucinations.
-    See GH #356 Part 1. Never raises — any error = "URL is not live
-    enough to cite."
+    See GH #356 Part 1.
     """
+    import http.client
+    import socket
     import urllib.error
     import urllib.request
+
+    _transport_errors: tuple[type[BaseException], ...] = (
+        urllib.error.URLError,
+        http.client.HTTPException,
+        socket.timeout,
+        socket.gaierror,
+        ConnectionError,
+        TimeoutError,
+    )
 
     def _try(method: str, extra_headers: dict[str, str] | None = None) -> int | None:
         req = urllib.request.Request(
@@ -212,7 +228,7 @@ def head_check(
                 return int(resp.status)
         except urllib.error.HTTPError as exc:
             return int(exc.code)
-        except Exception:  # noqa: BLE001 — any transport failure = dead URL
+        except _transport_errors:
             return None
 
     status = _try("HEAD")
@@ -222,10 +238,18 @@ def head_check(
         return True
     if status == 405:
         # Server rejects HEAD but may accept a range-limited GET.
-        retry_status = _try("GET", extra_headers={"Range": "bytes=0-0"})
-        if retry_status is None:
-            return False
-        return 200 <= retry_status < 400
+        range_status = _try("GET", extra_headers={"Range": "bytes=0-0"})
+        if range_status is not None and 200 <= range_status < 400:
+            return True
+        # WAFs/CDNs sometimes reject Range with 403 / 416 / 501 where
+        # a plain GET would return 200. Fall through to a final GET
+        # as the last escalation step (#357 Codex review, nit #1).
+        if range_status in (403, 416, 501):
+            get_status = _try("GET")
+            if get_status is None:
+                return False
+            return 200 <= get_status < 400
+        return False
     return False
 
 

--- a/tests/test_citation_residuals.py
+++ b/tests/test_citation_residuals.py
@@ -61,7 +61,12 @@ def test_request_candidates_parses_json_response() -> None:
             }
         )
 
-    out = citation_residuals.request_candidates(finding, dispatcher=fake_dispatcher)
+    out = citation_residuals.request_candidates(
+        finding,
+        dispatcher=fake_dispatcher,
+        allowlist_tier=lambda _u: "official",
+        head_checker=lambda _u: True,
+    )
     assert len(out) == 2
     assert out[0]["url"] == "https://example.com/a"
     assert out[0]["tier"] == "official"
@@ -73,7 +78,15 @@ def test_request_candidates_handles_dispatch_failure() -> None:
     def failing(_prompt: str) -> tuple[bool, str]:
         return False, "timeout"
 
-    assert citation_residuals.request_candidates(finding, dispatcher=failing) == []
+    assert (
+        citation_residuals.request_candidates(
+            finding,
+            dispatcher=failing,
+            allowlist_tier=lambda _u: "official",
+            head_checker=lambda _u: True,
+        )
+        == []
+    )
 
 
 def test_request_candidates_rejects_non_http_urls() -> None:
@@ -84,7 +97,155 @@ def test_request_candidates_rejects_non_http_urls() -> None:
             {"candidates": [{"url": "javascript:alert(1)"}, {"url": "ftp://x"}]}
         )
 
-    assert citation_residuals.request_candidates(finding, dispatcher=weird) == []
+    assert (
+        citation_residuals.request_candidates(
+            finding,
+            dispatcher=weird,
+            allowlist_tier=lambda _u: "official",
+            head_checker=lambda _u: True,
+        )
+        == []
+    )
+
+
+def test_request_candidates_filters_off_allowlist(tmp_path: Path) -> None:
+    """#356 Part 1: hallucinated off-allowlist URLs never reach the fetch
+    path. Gemini occasionally suggests press domains despite the
+    prompt's allowlist constraint — this filter drops them."""
+    finding = {"excerpt": "x", "signals": [], "search_hint": []}
+
+    def dispatcher(_prompt: str) -> tuple[bool, str]:
+        return True, json.dumps(
+            {
+                "candidates": [
+                    {"url": "https://reuters.com/article"},
+                    {"url": "https://en.wikipedia.org/wiki/X"},
+                ]
+            }
+        )
+
+    head_calls: list[str] = []
+
+    def fake_head(u: str) -> bool:
+        head_calls.append(u)
+        return True
+
+    def fake_allowlist_tier(url: str) -> str | None:
+        return "general" if "wikipedia" in url else None
+
+    out = citation_residuals.request_candidates(
+        finding,
+        dispatcher=dispatcher,
+        allowlist_tier=fake_allowlist_tier,
+        head_checker=fake_head,
+    )
+    assert len(out) == 1
+    assert out[0]["url"] == "https://en.wikipedia.org/wiki/X"
+    # head_check must not be invoked on off-allowlist URLs (wasteful).
+    assert head_calls == ["https://en.wikipedia.org/wiki/X"]
+
+
+def test_request_candidates_filters_404_urls() -> None:
+    """#356 Part 1: URLs that 404 never make it past the filter, even if
+    on allowlist."""
+    finding = {"excerpt": "x", "signals": [], "search_hint": []}
+
+    def dispatcher(_prompt: str) -> tuple[bool, str]:
+        return True, json.dumps(
+            {
+                "candidates": [
+                    {"url": "https://en.wikipedia.org/wiki/Real"},
+                    {"url": "https://en.wikipedia.org/wiki/Hallucinated_404"},
+                ]
+            }
+        )
+
+    def fake_head(u: str) -> bool:
+        return "Real" in u
+
+    out = citation_residuals.request_candidates(
+        finding,
+        dispatcher=dispatcher,
+        allowlist_tier=lambda _u: "general",
+        head_checker=fake_head,
+    )
+    assert len(out) == 1
+    assert out[0]["url"] == "https://en.wikipedia.org/wiki/Real"
+
+
+def test_head_check_accepts_200(monkeypatch: pytest.MonkeyPatch) -> None:
+    import urllib.request
+
+    class _FakeResponse:
+        status = 200
+
+        def __enter__(self) -> "_FakeResponse":
+            return self
+
+        def __exit__(self, *_args: Any) -> None:
+            pass
+
+    def fake_urlopen(req: Any, timeout: float = 0) -> _FakeResponse:
+        return _FakeResponse()
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    assert citation_residuals.head_check("https://ex.com/a") is True
+
+
+def test_head_check_rejects_404(monkeypatch: pytest.MonkeyPatch) -> None:
+    import urllib.error
+    import urllib.request
+
+    def fake_urlopen(req: Any, timeout: float = 0) -> Any:
+        raise urllib.error.HTTPError("url", 404, "Not Found", {}, None)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    assert citation_residuals.head_check("https://ex.com/gone") is False
+
+
+def test_head_check_falls_back_to_get_range_on_405(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Some well-behaved sites reject HEAD with 405 but accept GET. The
+    fallback is a range-limited GET so we don't pull the whole page."""
+    import urllib.error
+    import urllib.request
+
+    call_log: list[tuple[str, dict[str, str]]] = []
+
+    class _FakeResponse:
+        status = 200
+
+        def __enter__(self) -> "_FakeResponse":
+            return self
+
+        def __exit__(self, *_args: Any) -> None:
+            pass
+
+    def fake_urlopen(req: Any, timeout: float = 0) -> Any:
+        call_log.append((req.get_method(), dict(req.headers)))
+        if req.get_method() == "HEAD":
+            raise urllib.error.HTTPError("url", 405, "Method Not Allowed", {}, None)  # type: ignore[arg-type]
+        return _FakeResponse()
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    assert citation_residuals.head_check("https://ex.com/a") is True
+    methods = [m for m, _ in call_log]
+    assert methods == ["HEAD", "GET"]
+    # The GET retry must carry a Range header so we don't pull the full page.
+    get_headers = call_log[1][1]
+    assert get_headers.get("Range") == "bytes=0-0"
+
+
+def test_head_check_rejects_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    import socket
+    import urllib.request
+
+    def fake_urlopen(req: Any, timeout: float = 0) -> Any:
+        raise socket.timeout("timed out")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    assert citation_residuals.head_check("https://ex.com/slow", timeout=0.01) is False
 
 
 # ---- validate_candidate --------------------------------------------------
@@ -345,6 +506,7 @@ def test_resolve_module_end_to_end(
         fetcher=fake_fetcher,
         cached_text_path=fake_cached_text_path,
         allowlist_tier=lambda _u: "official",
+        head_checker=lambda _u: True,
     )
     assert stats["considered"] == 1
     assert stats["resolved"] == 1

--- a/tests/test_citation_residuals.py
+++ b/tests/test_citation_residuals.py
@@ -248,6 +248,80 @@ def test_head_check_rejects_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     assert citation_residuals.head_check("https://ex.com/slow", timeout=0.01) is False
 
 
+def test_head_check_escalates_to_plain_get_when_range_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#357 Codex review nit #1: WAFs/CDNs that 405 HEAD AND reject
+    range GET with 403/416/501 would serve a plain GET. Must escalate
+    rather than return False."""
+    import urllib.error
+    import urllib.request
+
+    methods_seen: list[tuple[str, str | None]] = []
+
+    class _FakeResponse:
+        status = 200
+
+        def __enter__(self) -> "_FakeResponse":
+            return self
+
+        def __exit__(self, *_args: Any) -> None:
+            pass
+
+    def fake_urlopen(req: Any, timeout: float = 0) -> Any:
+        method = req.get_method()
+        range_header = req.headers.get("Range") or req.headers.get("range")
+        methods_seen.append((method, range_header))
+        if method == "HEAD":
+            raise urllib.error.HTTPError("u", 405, "no HEAD", {}, None)  # type: ignore[arg-type]
+        if method == "GET" and range_header:
+            raise urllib.error.HTTPError("u", 416, "no range", {}, None)  # type: ignore[arg-type]
+        return _FakeResponse()
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    assert citation_residuals.head_check("https://ex.com/a") is True
+    assert [m for m, _ in methods_seen] == ["HEAD", "GET", "GET"]
+    assert methods_seen[1][1] == "bytes=0-0"
+    assert methods_seen[2][1] is None
+
+
+def test_head_check_does_not_escalate_on_unrelated_range_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If range GET fails with a non-Range-specific status (e.g. 404),
+    don't waste another request on a plain GET — the URL is dead."""
+    import urllib.error
+    import urllib.request
+
+    methods_seen: list[str] = []
+
+    def fake_urlopen(req: Any, timeout: float = 0) -> Any:
+        methods_seen.append(req.get_method())
+        if req.get_method() == "HEAD":
+            raise urllib.error.HTTPError("u", 405, "no HEAD", {}, None)  # type: ignore[arg-type]
+        raise urllib.error.HTTPError("u", 404, "gone", {}, None)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    assert citation_residuals.head_check("https://ex.com/gone") is False
+    assert methods_seen == ["HEAD", "GET"]
+
+
+def test_head_check_reraises_unexpected_exceptions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#357 Codex review nit #2: unexpected (non-transport) exceptions
+    must NOT be swallowed — that would silently convert coding
+    regressions into 'dead URL' drops."""
+    import urllib.request
+
+    def fake_urlopen(req: Any, timeout: float = 0) -> Any:
+        raise RuntimeError("simulated coding bug")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    with pytest.raises(RuntimeError, match="simulated coding bug"):
+        citation_residuals.head_check("https://ex.com/a")
+
+
 # ---- validate_candidate --------------------------------------------------
 
 


### PR DESCRIPTION
Closes #356 Part 1 (of 3). Parent: #343.

## Summary

Adds two deterministic filters in \`request_candidates()\` that run after Gemini returns JSON but before any candidate reaches \`validate_candidate()\`:

1. **Allowlist pre-filter** — call \`fetch_citation.allowlist_tier(url)\` and drop anything that returns \`None\`. The LLM still suggests press/news URLs ~30% of the time despite the prompt's hard constraint.
2. **HEAD-check** — new \`head_check(url)\` helper sends HTTP HEAD (5s timeout), falls back to zero-byte range GET on 405. Accepts 2xx/3xx only. Any transport failure = drop.

Both injectable for tests; both threaded through \`resolve_module()\` so the injection surface stays consistent for #356 part 2 (quote-match) and part 3 (Codex fallback).

## Evidence it fixes the pilot problem

Smoke test on the real URLs that caused unresolvable findings in the 2026-04-23 pilot (commit \`55e0e9a2\`):

| URL | Old path | New path |
|---|---|---|
| \`en.wikipedia.org/wiki/Algorithmic_bias\` | pass (real) | pass |
| \`en.wikipedia.org/wiki/Gender_bias_in_machine_learning\` | pass → 404 at fetch → \`http_404\` | **drop at HEAD → never fetched** |
| \`learn.microsoft.com/.../migrate-classic-agents\` | pass → 404 at fetch → \`http_404\` | **drop at HEAD → never fetched** |
| \`reuters.com/article/...\` | pass → \`off_allowlist\` after fetch | **drop at allowlist → never fetched** |

## Test plan

- [x] \`ruff check\` clean
- [x] 23/23 tests pass. 6 new: allowlist filter, 404 filter, 200/404/timeout acceptance, 405→GET-range-0 fallback (asserts Range header).
- [x] Real-world smoke test on 4 pilot URLs (2 live, 2 hallucinated) — all correctly classified.
- [ ] Re-pilot on same 3 modules (follow-up after part 2 lands).

## Review ask

Claude-authored. Routing to Codex for adversary review per \`docs/review-protocol.md\`. Specific questions:

1. Is the HEAD → range-GET fallback on 405 correct? (i.e. are there sites that 405 HEAD and 403 range-GET but 200 a plain GET?) The issue says range-GET is the fallback; I want confirmation this is right.
2. Any missed failure modes in \`head_check\`'s bare-except? I catch everything since "URL is not live enough to cite" is the decision we want in all non-2xx/3xx cases, but I want a second opinion that there's no path where we'd incorrectly drop a live URL.
3. Is there a race condition in the file-write path that my pilot accidentally exercised (two resolvers on the same module clobbering)? If so, should we add a pipeline_v2 lease check here or defer that to a bulk-runner PR? My opinion: defer, since this PR doesn't change the write path.
4. Any regressions in the existing 17 tests that I missed updating?

## Out of scope

- Part 2 (quote-match verification) — separate PR
- Part 3 (Codex fallback) — separate PR
- Concurrency / file locking — separate issue when we implement \`--workers N\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)