### PR TITLE
fix(#354): stop enqueueing orphan check_pre jobs after APPROVE

### DIFF
--- a/scripts/pipeline_v2/review_worker.py
+++ b/scripts/pipeline_v2/review_worker.py
@@ -16,7 +16,6 @@ from .preflight import PreflightFinding, run_preflight
 REVIEW_MODEL = "gpt-5.3-codex-spark"
 REVIEW_FALLBACK_MODEL = "gpt-5.4"
 PATCH_MODEL = "gpt-5.4"
-CHECK_PRE_MODEL = "deterministic"
 SIMPLE_CHECK_IDS = ("PRES", "NO_EMOJI", "K8S_API")
 DEEP_CHECK_IDS = ("COV", "DEPTH", "WHY", "FACT_CHECK")
 REVIEW_MODEL_ESTIMATED_USD = 0.0050
@@ -170,12 +169,15 @@ class ReviewWorker:
                     lease_id=lease.lease_id,
                     payload=event_payload,
                 )
-                self.control_plane.enqueue(
-                    lease.module_key,
-                    phase="check_pre",
-                    model=CHECK_PRE_MODEL,
-                    priority=lease.job_id,
-                )
+                # Historically this enqueued a separate `check_pre` phase
+                # job, but no worker processed them — every APPROVE left an
+                # orphan job that kept the module in `pending_review`
+                # forever (GH #354). Preflight already ran for this module
+                # at the top of this function (line 73); since the review
+                # phase doesn't mutate the file, re-running preflight after
+                # APPROVE would just reconfirm what the top-of-function
+                # preflight already verified. The `check_passed` event
+                # above is the terminal signal; no further phase needed.
                 status = "approved"
             audit_feedback = review_result["feedback"]
             if unverified_fact_claims:

--- a/tests/test_pipeline_v2_review.py
+++ b/tests/test_pipeline_v2_review.py
@@ -15,7 +15,6 @@ import local_api
 from pipeline_common.review_audit import append_review_audit
 from pipeline_v2.control_plane import ControlPlane
 from pipeline_v2.review_worker import (
-    CHECK_PRE_MODEL,
     DEEP_CHECK_IDS,
     REVIEW_FALLBACK_MODEL,
     REVIEW_MODEL,
@@ -290,8 +289,12 @@ def test_review_usage_limit_falls_back_to_gpt_5_4(tmp_path):
 
 
 def test_review_worker_enforces_review_outcomes(tmp_path):
+    # (status, responses, enqueued_phase_or_None, verdict, failed_check)
+    # GH #354: APPROVE no longer enqueues a `check_pre` job — that job
+    # had no worker, leaving every APPROVE stuck in `pending_review`.
+    # `check_passed` is now the terminal event; no follow-up phase.
     cases = [
-        ("approved", [_simple_response("PRES"), _simple_response("NO_EMOJI"), _simple_response("K8S_API"), _deep_response()], "check_pre", "APPROVE", None),
+        ("approved", [_simple_response("PRES"), _simple_response("NO_EMOJI"), _simple_response("K8S_API"), _deep_response()], None, "APPROVE", None),
         ("rejected", [_simple_response("PRES", passed=False), _simple_response("NO_EMOJI"), _simple_response("K8S_API"), _deep_response()], "patch", "REJECT", "PRES"),
         ("rejected", [_simple_response("PRES"), _simple_response("NO_EMOJI"), _simple_response("K8S_API"), _deep_response(fact_evidence="unverified: could not confirm Kubernetes 1.99 claim")], "patch", "REJECT", "FACT_CHECK"),
     ]
@@ -307,17 +310,21 @@ def test_review_worker_enforces_review_outcomes(tmp_path):
         ):
             outcome = worker.run_once()
         assert outcome.status == status
-        payload = json.loads(control_plane.iter_events("check_passed" if phase == "check_pre" else "check_failed")[-1]["payload_json"])
+        event_type = "check_passed" if status == "approved" else "check_failed"
+        payload = json.loads(control_plane.iter_events(event_type)[-1]["payload_json"])
         assert payload["verdict"] == verdict
         if failed_check:
             assert payload["failed_checks"][0]["id"] == failed_check
         if failed_check == "FACT_CHECK":
             assert json.loads(control_plane.iter_events("fact_check_unverified")[-1]["payload_json"])["unverified_claims"][0]["id"] == "FACT_CHECK"
-        queued = _fetch_rows(control_plane.db_path, "SELECT phase, model, queue_state FROM jobs WHERE phase = ?", (phase,))
-        assert len(queued) == 1
-        assert queued[0]["queue_state"] == "pending"
-        if phase == "check_pre":
-            assert queued[0]["model"] == CHECK_PRE_MODEL
+        if phase is None:
+            # GH #354: APPROVE enqueues no follow-up phase job.
+            check_pre_rows = _fetch_rows(control_plane.db_path, "SELECT phase FROM jobs WHERE phase = 'check_pre'")
+            assert check_pre_rows == []
+        else:
+            queued = _fetch_rows(control_plane.db_path, "SELECT phase, model, queue_state FROM jobs WHERE phase = ?", (phase,))
+            assert len(queued) == 1
+            assert queued[0]["queue_state"] == "pending"
         review = local_api.build_module_reviews(case_root, str(module_path.relative_to(case_root)).removesuffix(".md"))
         assert review is not None
         assert review["fact_check_status"] == ("unverified" if failed_check == "FACT_CHECK" else "verified")

--- a/tests/test_pipeline_v2_review.py
+++ b/tests/test_pipeline_v2_review.py
@@ -14,6 +14,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 import local_api
 from pipeline_common.review_audit import append_review_audit
 from pipeline_v2.control_plane import ControlPlane
+from pipeline_v2.cli import _build_status_report
 from pipeline_v2.review_worker import (
     DEEP_CHECK_IDS,
     REVIEW_FALLBACK_MODEL,
@@ -321,6 +322,13 @@ def test_review_worker_enforces_review_outcomes(tmp_path):
             # GH #354: APPROVE enqueues no follow-up phase job.
             check_pre_rows = _fetch_rows(control_plane.db_path, "SELECT phase FROM jobs WHERE phase = 'check_pre'")
             assert check_pre_rows == []
+            # And the user-visible symptom is fixed: the reducer resolves
+            # the approved module to `done`, not `pending_review` (Codex
+            # review nit — assert the actual regression, not just the
+            # missing row).
+            report = _build_status_report(control_plane.db_path)
+            assert report["counts"]["done"] == 1
+            assert report["counts"]["pending_review"] == 0
         else:
             queued = _fetch_rows(control_plane.db_path, "SELECT phase, model, queue_state FROM jobs WHERE phase = ?", (phase,))
             assert len(queued) == 1


### PR DESCRIPTION
Closes #354.

## Summary

\`review_worker\` emitted \`check_passed\` *and* enqueued a \`check_pre\` phase job for every APPROVE verdict. No worker in the codebase processes \`check_pre\` jobs — the \`manual-check-pre\` worker_id in historical events was a one-off manual completion, not code. So every APPROVE left a dangling \`pending\` job that pinned the module to \`pending_review\` in \`cli.py:552-553\` forever.

## Evidence

- 8 \`check_pre\` jobs have ever existed in \`.pipeline/v2.db\`.
- 7 were completed in a single burst 2026-04-17 — all by \`worker_id="manual-check-pre"\` with \`source: "manual_preflight_pass"\`. Neither string exists anywhere in the repo.
- The 8th sat \`pending\` for 5 days (LFCS \`module-1.4-storage-services-and-users-practice\`) and pinned the module to \`pending_review\`, blocking 100% convergence. I manually unstuck it 2026-04-23 via \`ControlPlane.lease_next_job\`.

The bug has been latent because APPROVE is rare (521 reviews, only 7 \`check_passed\`).

## Fix

Option B from the issue: remove the post-APPROVE \`check_pre\` enqueue entirely. Preflight already runs at \`review_worker.py:73\` on every review job — the review phase doesn't mutate the file, so re-running preflight after APPROVE would trivially reconfirm what the top-of-function preflight already verified. The \`check_passed\` event remains the terminal signal; reducer sees no pending phases + completed review → \`done\`.

Also drops the now-unused \`CHECK_PRE_MODEL\` constant and its test import.

## Test plan

- [x] \`test_review_worker_enforces_review_outcomes\`: "approved" case now asserts \`check_pre_rows == []\` (regression guard).
- [x] Full suite: 374 pass, 1 skipped.
- [x] \`ruff check\` clean.

## Review ask

Claude-authored. Codex adversary review per \`docs/review-protocol.md\`. Specific questions:

1. Is it correct that preflight at the top of \`review_worker.run_once\` is sufficient to replace the post-APPROVE \`check_pre\`? Any path where the file could change between those two points that I'm missing?
2. Any downstream consumer of the \`check_passed\` event that depended on a subsequent \`attempt_succeeded\` event for \`phase=check_pre\` (I searched for references and found none, but double-check)?
3. Does the \`CHECK_PRE_MODEL\` removal break anything outside this PR?

🤖 Generated with [Claude Code](https://claude.com/claude-code)