### PR TITLE
feat(#351): post-batch audit for modules marked clean but missing `## Sources`

### DIFF
--- a/scripts/pipeline_v4_batch.py
+++ b/scripts/pipeline_v4_batch.py
@@ -38,6 +38,7 @@ import argparse
 import datetime as dt
 import json
 import os
+import re
 import sqlite3
 import sys
 import threading
@@ -85,7 +86,10 @@ CREATE INDEX IF NOT EXISTS idx_v4_batch_expires ON v4_batch_leases(expires_at);
 OUTCOME_SKIPPED_LOCKED = "skipped_locked"
 OUTCOME_ERROR = "error"
 OUTCOME_CLEAN = "clean"
-SOURCES_HEADER_PATTERN = "\n## Sources\n"
+# ATX H2 named "Sources", anchored to start-of-line, trailing whitespace OK.
+# Mirrors the convention used in other repo checkers; tolerates
+# `## Sources  \n` and EOF-without-final-newline per Codex #359 review.
+SOURCES_HEADER_RE = re.compile(r"^##\s+Sources\s*$", re.MULTILINE)
 
 _INIT_LOCK = threading.Lock()
 _INITIALIZED_DBS: set[str] = set()
@@ -349,10 +353,12 @@ def audit_missing_sources(
             violations.append(module_key)
             continue
         text = module_path.read_text(encoding="utf-8")
-        # Match a ## Sources header at start-of-line (not inside a code
-        # block or inline prose). Anchoring on a leading newline catches
-        # both mid-file and end-of-file cases.
-        if SOURCES_HEADER_PATTERN not in text and not text.startswith("## Sources\n"):
+        # MULTILINE regex against an ATX H2 named "Sources" with optional
+        # trailing whitespace. Start-of-line anchor avoids false-positives
+        # from the string appearing mid-prose; trailing \s* tolerates the
+        # `## Sources  ` (trailing spaces) and EOF-without-newline cases
+        # Codex flagged on PR #359.
+        if not SOURCES_HEADER_RE.search(text):
             violations.append(module_key)
     return violations
 
@@ -554,7 +560,15 @@ def main(argv: list[str] | None = None) -> int:
     # `outcome=clean` but missing a `## Sources` section is the
     # regression class we hit in PR #350. Surface it loudly so the
     # operator sees it before running another bulk batch.
-    if not args.dry_run:
+    #
+    # Skip the audit for:
+    #   - `--dry-run`: no module edits occurred, violations would be spurious.
+    #   - `--skip-citation`: pipeline_v4 explicitly skips Stage 4
+    #     (citation_v3) and can still return outcome=clean when the
+    #     module lifts from no-quiz / no-exercise work alone. A missing
+    #     Sources section is the operator's choice in that mode, not a
+    #     regression. See Codex #359 review, must-fix #1.
+    if not args.dry_run and not args.skip_citation:
         violations = audit_missing_sources(summary.get("results") or [])
         if violations:
             print(

--- a/scripts/pipeline_v4_batch.py
+++ b/scripts/pipeline_v4_batch.py
@@ -84,6 +84,8 @@ CREATE INDEX IF NOT EXISTS idx_v4_batch_expires ON v4_batch_leases(expires_at);
 
 OUTCOME_SKIPPED_LOCKED = "skipped_locked"
 OUTCOME_ERROR = "error"
+OUTCOME_CLEAN = "clean"
+SOURCES_HEADER_PATTERN = "\n## Sources\n"
 
 _INIT_LOCK = threading.Lock()
 _INITIALIZED_DBS: set[str] = set()
@@ -318,6 +320,43 @@ def _run_one(
         }
 
 
+def audit_missing_sources(
+    results: list[dict[str, Any]],
+    *,
+    repo_root: Path = REPO_ROOT,
+) -> list[str]:
+    """Return module_keys reported `outcome=clean` whose file has no
+    ``## Sources`` section (GH #351).
+
+    Context: during PR #350 (batch-c cloud), citation_v3 silently left
+    two of 78 modules with no Sources section at all while reporting
+    them clean. A post-batch audit makes that class of silent failure
+    loud — and cheap: `(str | PurePath).read_text().__contains__()`
+    per module.
+
+    Leading newline guards against false-positives where "## Sources"
+    appears mid-line in a code block or prose.
+    """
+    violations: list[str] = []
+    for r in results:
+        if r.get("outcome") != OUTCOME_CLEAN:
+            continue
+        module_key = r.get("module_key")
+        if not module_key:
+            continue
+        module_path = repo_root / "src" / "content" / "docs" / f"{module_key}.md"
+        if not module_path.exists():
+            violations.append(module_key)
+            continue
+        text = module_path.read_text(encoding="utf-8")
+        # Match a ## Sources header at start-of-line (not inside a code
+        # block or inline prose). Anchoring on a leading newline catches
+        # both mid-file and end-of-file cases.
+        if SOURCES_HEADER_PATTERN not in text and not text.startswith("## Sources\n"):
+            violations.append(module_key)
+    return violations
+
+
 def _summarize(results: list[dict[str, Any]]) -> dict[str, Any]:
     by_outcome: dict[str, int] = {}
     score_delta_total = 0.0
@@ -436,6 +475,7 @@ def run_batch(
         "started_at": started_at,
         "finished_at": dt.datetime.now(dt.UTC).isoformat(timespec="seconds"),
         **_summarize(results),
+        "results": results,
     }
     _emit({"summary": summary})
     return summary
@@ -509,7 +549,23 @@ def main(argv: list[str] | None = None) -> int:
         skip_citation=args.skip_citation,
         lease_seconds=args.lease_seconds,
     )
-    return 0 if summary["by_outcome"].get(OUTCOME_ERROR, 0) == 0 else 1
+    exit_code = 0 if summary["by_outcome"].get(OUTCOME_ERROR, 0) == 0 else 1
+    # Post-batch silent-failure audit (GH #351): a module reported
+    # `outcome=clean` but missing a `## Sources` section is the
+    # regression class we hit in PR #350. Surface it loudly so the
+    # operator sees it before running another bulk batch.
+    if not args.dry_run:
+        violations = audit_missing_sources(summary.get("results") or [])
+        if violations:
+            print(
+                f"\nPost-batch audit FAILED: {len(violations)} module(s) "
+                "reported outcome=clean but have no `## Sources` section:",
+                file=sys.stderr,
+            )
+            for module_key in violations:
+                print(f"  - {module_key}", file=sys.stderr)
+            exit_code = max(exit_code, 1)
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/tests/test_pipeline_v4_batch.py
+++ b/tests/test_pipeline_v4_batch.py
@@ -404,3 +404,153 @@ def test_cli_exit_code_failure_on_error(
 
     monkeypatch.setattr(pipeline_v4_batch, "run_batch", _fake_run_batch)
     assert pipeline_v4_batch.main(["--limit", "1"]) == 1
+
+
+# ---- GH #351 — post-batch missing-Sources audit ---------------------------
+
+
+def _write_module_351(repo_root: Path, module_key: str, body: str) -> Path:
+    path = repo_root / "src" / "content" / "docs" / f"{module_key}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_audit_missing_sources_clean_module_with_sources_passes(
+    tmp_path: Path,
+) -> None:
+    _write_module_351(
+        tmp_path,
+        "ai/demo/module-1.0-ok",
+        "# Title\n\nBody.\n\n## Sources\n\n- [x](https://ex) — note\n",
+    )
+    results = [
+        {
+            "module_key": "ai/demo/module-1.0-ok",
+            "outcome": pipeline_v4_batch.OUTCOME_CLEAN,
+        }
+    ]
+    assert (
+        pipeline_v4_batch.audit_missing_sources(results, repo_root=tmp_path) == []
+    )
+
+
+def test_audit_missing_sources_clean_module_without_sources_flagged(
+    tmp_path: Path,
+) -> None:
+    _write_module_351(
+        tmp_path,
+        "ai/demo/module-1.0-missing",
+        "# Title\n\nBody with no sources block.\n",
+    )
+    results = [
+        {
+            "module_key": "ai/demo/module-1.0-missing",
+            "outcome": pipeline_v4_batch.OUTCOME_CLEAN,
+        }
+    ]
+    assert pipeline_v4_batch.audit_missing_sources(
+        results, repo_root=tmp_path
+    ) == ["ai/demo/module-1.0-missing"]
+
+
+def test_audit_missing_sources_skips_non_clean_outcomes(tmp_path: Path) -> None:
+    """A module not marked `clean` (needs_human / failed / skipped_locked)
+    is out of audit scope — those are expected to be incomplete."""
+    _write_module_351(
+        tmp_path,
+        "ai/demo/module-1.0-needs-human",
+        "# Title\n\nNo sources.\n",
+    )
+    results = [
+        {"module_key": "ai/demo/module-1.0-needs-human", "outcome": "needs_human"},
+        {"module_key": "ai/demo/module-1.0-needs-human", "outcome": "failed"},
+        {
+            "module_key": "ai/demo/module-1.0-needs-human",
+            "outcome": pipeline_v4_batch.OUTCOME_SKIPPED_LOCKED,
+        },
+    ]
+    assert pipeline_v4_batch.audit_missing_sources(
+        results, repo_root=tmp_path
+    ) == []
+
+
+def test_audit_missing_sources_flags_missing_file(tmp_path: Path) -> None:
+    """A clean result whose module file doesn't exist is also a
+    violation — the pipeline claimed something it can't back."""
+    results = [
+        {
+            "module_key": "ai/demo/module-that-does-not-exist",
+            "outcome": pipeline_v4_batch.OUTCOME_CLEAN,
+        }
+    ]
+    assert pipeline_v4_batch.audit_missing_sources(
+        results, repo_root=tmp_path
+    ) == ["ai/demo/module-that-does-not-exist"]
+
+
+def test_audit_missing_sources_rejects_inline_sources_string(tmp_path: Path) -> None:
+    """'## Sources' as a substring (not at start-of-line) must not
+    count as having a Sources section."""
+    _write_module_351(
+        tmp_path,
+        "ai/demo/module-1.0-tricky",
+        "# Title\n\nSomeone wrote '## Sources' inline in prose here.\n",
+    )
+    results = [
+        {
+            "module_key": "ai/demo/module-1.0-tricky",
+            "outcome": pipeline_v4_batch.OUTCOME_CLEAN,
+        }
+    ]
+    assert pipeline_v4_batch.audit_missing_sources(
+        results, repo_root=tmp_path
+    ) == ["ai/demo/module-1.0-tricky"]
+
+
+def test_cli_exit_code_failure_on_missing_sources(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Integration: clean result whose module has no Sources → CLI exits 1."""
+    _patch_db(monkeypatch, tmp_path)
+    monkeypatch.setattr(pipeline_v4_batch, "REPO_ROOT", tmp_path)
+    _write_module_351(tmp_path, "demo/module-missing", "# Title\n\nNo sources.\n")
+
+    def _fake_run_batch(**kwargs):
+        return {
+            "processed": 1,
+            "by_outcome": {"clean": 1},
+            "results": [
+                {
+                    "module_key": "demo/module-missing",
+                    "outcome": pipeline_v4_batch.OUTCOME_CLEAN,
+                }
+            ],
+        }
+
+    monkeypatch.setattr(pipeline_v4_batch, "run_batch", _fake_run_batch)
+    assert pipeline_v4_batch.main(["--limit", "1"]) == 1
+
+
+def test_cli_dry_run_skips_missing_sources_audit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """--dry-run doesn't write to modules, so the audit would produce
+    spurious violations. Skip it."""
+    _patch_db(monkeypatch, tmp_path)
+    monkeypatch.setattr(pipeline_v4_batch, "REPO_ROOT", tmp_path)
+
+    def _fake_run_batch(**kwargs):
+        return {
+            "processed": 1,
+            "by_outcome": {"clean": 1},
+            "results": [
+                {
+                    "module_key": "demo/module-missing",
+                    "outcome": pipeline_v4_batch.OUTCOME_CLEAN,
+                }
+            ],
+        }
+
+    monkeypatch.setattr(pipeline_v4_batch, "run_batch", _fake_run_batch)
+    assert pipeline_v4_batch.main(["--limit", "1", "--dry-run"]) == 0

--- a/tests/test_pipeline_v4_batch.py
+++ b/tests/test_pipeline_v4_batch.py
@@ -554,3 +554,71 @@ def test_cli_dry_run_skips_missing_sources_audit(
 
     monkeypatch.setattr(pipeline_v4_batch, "run_batch", _fake_run_batch)
     assert pipeline_v4_batch.main(["--limit", "1", "--dry-run"]) == 0
+
+
+def test_cli_skip_citation_skips_missing_sources_audit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Codex #359 review, must-fix #1: pipeline_v4 run with
+    --skip-citation explicitly bypasses Stage 4 and can still return
+    outcome=clean. The audit must not flag those modules — a missing
+    ## Sources is the operator's choice in that mode, not a regression."""
+    _patch_db(monkeypatch, tmp_path)
+    monkeypatch.setattr(pipeline_v4_batch, "REPO_ROOT", tmp_path)
+
+    def _fake_run_batch(**kwargs):
+        return {
+            "processed": 1,
+            "by_outcome": {"clean": 1},
+            "results": [
+                {
+                    "module_key": "demo/module-skipped-citation",
+                    "outcome": pipeline_v4_batch.OUTCOME_CLEAN,
+                }
+            ],
+        }
+
+    monkeypatch.setattr(pipeline_v4_batch, "run_batch", _fake_run_batch)
+    assert pipeline_v4_batch.main(["--limit", "1", "--skip-citation"]) == 0
+
+
+def test_audit_accepts_sources_header_with_trailing_whitespace(
+    tmp_path: Path,
+) -> None:
+    """Codex #359 review, must-fix #2: '## Sources  ' with trailing
+    spaces is a valid ATX H2 and must not be flagged."""
+    _write_module_351(
+        tmp_path,
+        "ai/demo/trailing-ws",
+        "# Title\n\nBody.\n\n## Sources  \n\n- [x](https://ex) — note\n",
+    )
+    results = [
+        {
+            "module_key": "ai/demo/trailing-ws",
+            "outcome": pipeline_v4_batch.OUTCOME_CLEAN,
+        }
+    ]
+    assert (
+        pipeline_v4_batch.audit_missing_sources(results, repo_root=tmp_path) == []
+    )
+
+
+def test_audit_accepts_sources_header_at_eof_without_trailing_newline(
+    tmp_path: Path,
+) -> None:
+    """Codex #359 review, must-fix #2: '## Sources' at EOF without a
+    final newline is a valid ATX H2 and must not be flagged."""
+    _write_module_351(
+        tmp_path,
+        "ai/demo/eof-sources",
+        "# Title\n\nBody.\n\n## Sources",
+    )
+    results = [
+        {
+            "module_key": "ai/demo/eof-sources",
+            "outcome": pipeline_v4_batch.OUTCOME_CLEAN,
+        }
+    ]
+    assert (
+        pipeline_v4_batch.audit_missing_sources(results, repo_root=tmp_path) == []
+    )


### PR DESCRIPTION
Closes #351.

## Summary

Adds \`audit_missing_sources(results, repo_root)\` to \`scripts/pipeline_v4_batch.py\`. Walks the batch result list, and for any entry with \`outcome=clean\` checks that the module file on disk contains \`\\n## Sources\\n\`. Wires it into \`main()\` — violations print to stderr and force exit code 1.

## Why

PR #350 (batch-c cloud) silently shipped **2 of 78 modules with outcome=clean but no Sources section at all** (\`module-2.7-cloud-run\`, \`module-7.5-aks-fleet-manager\`). Codex review caught them after the fact; our own pipeline said they were clean. This audit turns the silent-failure class into a loud one.

## Scope / trade-offs

- Matches \`\\n## Sources\\n\` (anchored on start-of-line) to avoid false-positives from inline substrings.
- Skipped under \`--dry-run\` since dry runs don't write modules.
- Flags \"clean but module file missing\" as a violation — if the pipeline claims clean, the file should exist.
- \`run_batch\` summary now includes \`results\` so the audit has something to walk. Additive — existing callers unaffected.

## Test plan

- [x] 7 new unit tests: clean+with-sources passes, clean+no-sources flagged, non-clean outcomes skipped, missing module file flagged, inline substring rejected, CLI integration exit 1, \`--dry-run\` skips.
- [x] Full suite: 390 passed, 1 skipped.
- [x] \`ruff check\` clean.

## Review ask

Claude-authored. Cross-family Codex review per \`docs/review-protocol.md\`. Specific questions:

1. Is the header-detection pattern (\`\\n## Sources\\n\` + \`text.startswith(\"## Sources\\n\")\`) tight enough? Any Markdown edge case where a legitimate Sources section wouldn't match (e.g. CRLF line endings, trailing whitespace on the header line)?
2. Is wiring into \`main()\` the right integration point? Alternative: expose it as a standalone CLI subcommand / separate script that CI calls. My call: inline, because bulk runs should fail fast and operators already watch \`main()\`'s exit code.
3. Should \`--dry-run\` enabling the audit with a warning-only mode be a follow-up? My call: no, dry-run is genuinely incompatible with the audit (no module edits occur).
4. Any regressions in the existing 16 \`test_pipeline_v4_batch.py\` tests I missed updating?

🤖 Generated with [Claude Code](https://claude.com/claude-code)