### PR TITLE
feat(#356 part 2): quote-match verification rescues anchorless findings

### DIFF
--- a/scripts/citation_residuals.py
+++ b/scripts/citation_residuals.py
@@ -328,14 +328,19 @@ def normalize_quote(text: str) -> str:
 
 
 def quote_present_in_text(quote: str, body: str) -> bool:
-    """Check whether ``quote`` (or a long-enough prefix) is a substring
-    of ``body`` after whitespace + case normalization.
+    """Check whether ``quote`` is present in ``body`` after whitespace +
+    case normalization.
 
-    Accepts matches of at least ``MIN_QUOTE_MATCH_LENGTH`` characters
-    so minor LLM transcription drift (trailing phrase, missing word)
-    doesn't reject an otherwise-correct citation. Returns False when
-    the quote is too short to be meaningful — that's the LLM hedging,
-    not evidence.
+    Primary path: the full normalized quote must be a substring of the
+    body. Drift-tolerance fallback: BOTH a start window AND an end
+    window (each ≥ ``MIN_QUOTE_MATCH_LENGTH`` chars, word-boundary-
+    aligned) must appear in the body in order. This rejects generic
+    lead-ins like "According to the article..." where only the prefix
+    matches but the claim-specific tail differs (#360 Codex review,
+    must-fix #2).
+
+    Returns False when the normalized quote is too short to be
+    meaningful — that's the LLM hedging, not evidence.
     """
     norm_quote = normalize_quote(quote)
     if len(norm_quote) < MIN_QUOTE_MATCH_LENGTH:
@@ -343,14 +348,44 @@ def quote_present_in_text(quote: str, body: str) -> bool:
     norm_body = normalize_quote(body)
     if norm_quote in norm_body:
         return True
-    # Tolerate LLM drift on the tail: accept if the first
-    # MIN_QUOTE_MATCH_LENGTH-char prefix matches, rounded up to a word
-    # boundary so we don't mid-word match accidentally.
-    prefix = norm_quote[:max(MIN_QUOTE_MATCH_LENGTH, len(norm_quote) // 2)]
-    prefix = prefix.rsplit(" ", 1)[0] if " " in prefix else prefix
-    if len(prefix) >= MIN_QUOTE_MATCH_LENGTH and prefix in norm_body:
-        return True
-    return False
+    # Drift-tolerance fallback: require the quote's start AND end
+    # windows to both appear in the body, in order. The quote must be
+    # roughly 2× MIN + small gap so the start and end windows don't
+    # overlap.
+    if len(norm_quote) < 2 * MIN_QUOTE_MATCH_LENGTH + 4:
+        return False
+    start_window = _trim_to_trailing_word_boundary(
+        norm_quote[: MIN_QUOTE_MATCH_LENGTH + 4]
+    )
+    end_window = _trim_to_leading_word_boundary(
+        norm_quote[-(MIN_QUOTE_MATCH_LENGTH + 4):]
+    )
+    if (
+        len(start_window) < MIN_QUOTE_MATCH_LENGTH
+        or len(end_window) < MIN_QUOTE_MATCH_LENGTH
+    ):
+        return False
+    start_idx = norm_body.find(start_window)
+    if start_idx < 0:
+        return False
+    return end_window in norm_body[start_idx + len(start_window):]
+
+
+def _trim_to_trailing_word_boundary(text: str) -> str:
+    """Drop a trailing partial word so a window ends on a clean
+    whitespace boundary. Returns the original string when no space
+    exists to trim against."""
+    if " " not in text:
+        return text
+    return text.rsplit(" ", 1)[0]
+
+
+def _trim_to_leading_word_boundary(text: str) -> str:
+    """Mirror of _trim_to_trailing_word_boundary for the start of a
+    window: drop a leading partial word."""
+    if " " not in text:
+        return text
+    return text.split(" ", 1)[1]
 
 
 # ---- validation ----------------------------------------------------------
@@ -423,9 +458,23 @@ def validate_candidate(
     matched_anchors = anchors_present_in_text(anchors, body) if has_anchors else []
     quote_matched = quote_present_in_text(expected_quote, body) if has_quote else False
 
-    # Accept if the finding had anchors AND enough of them matched, OR
-    # the LLM committed to a quote AND that quote is on the page.
+    # When anchors exist, they are authoritative: a claim containing
+    # "2018" must land on a page that says "2018". A matching
+    # expected_quote cannot override an anchor mismatch, because a
+    # generic quote can appear on pages that don't match the
+    # claim-specific value (#360 Codex review, must-fix #1). The
+    # quote-only acceptance path is therefore limited to anchorless
+    # findings.
     anchors_ok = has_anchors and len(matched_anchors) >= MIN_SIGNAL_ANCHORS_REQUIRED
+    if has_anchors and not anchors_ok:
+        return {
+            "ok": False,
+            "url": url,
+            "reason": "no_anchor_match",
+            "anchors_expected": anchors,
+            "anchors_matched": matched_anchors,
+            "quote_matched": quote_matched,
+        }
     if anchors_ok or quote_matched:
         return {
             "ok": True,
@@ -438,20 +487,12 @@ def validate_candidate(
             "page_bytes": meta.get("bytes", 0),
         }
 
-    # Nothing matched: explain why.
-    if has_quote and not quote_matched:
-        return {
-            "ok": False,
-            "url": url,
-            "reason": "quote_not_in_page",
-            "expected_quote": expected_quote,
-        }
+    # Anchorless and quote didn't match.
     return {
         "ok": False,
         "url": url,
-        "reason": "no_anchor_match",
-        "anchors_expected": anchors,
-        "anchors_matched": matched_anchors,
+        "reason": "quote_not_in_page",
+        "expected_quote": expected_quote,
     }
 
 

--- a/scripts/citation_residuals.py
+++ b/scripts/citation_residuals.py
@@ -35,6 +35,7 @@ HUMAN_REVIEW_DIR = REPO_ROOT / ".pipeline" / "v3" / "human-review"
 DEFAULT_MAX_CANDIDATES = 3
 MIN_SIGNAL_ANCHORS_REQUIRED = 1
 HEAD_CHECK_TIMEOUT_SECONDS = 5.0
+MIN_QUOTE_MATCH_LENGTH = 12
 
 
 # ---- IO ------------------------------------------------------------------
@@ -136,10 +137,17 @@ high confidence actually discuss the specific claim — same year, same dollar
 figure, same named incident/company. Do not invent URLs. If no allowlist URL
 plausibly covers the claim, return an empty list.
 
+For every candidate you MUST include an `expected_quote` — a specific
+sentence or phrase (minimum 12 characters, case-insensitive) that the page
+actually contains and that supports the claim. The resolver fetches the page
+and rejects any candidate whose expected_quote is not a substring of the
+page body. Do not paraphrase or invent quotes — copy from the page you are
+citing. If you cannot commit to a specific quote, do not include the URL.
+
 Respond with strict JSON, no prose, no code fences:
 {{
   "candidates": [
-    {{"url": "https://...", "tier": "standards|upstream|vendor|incidents|general", "why": "one sentence"}},
+    {{"url": "https://...", "tier": "standards|upstream|vendor|incidents|general", "why": "one sentence", "expected_quote": "A sentence or phrase from the page that supports the claim."}},
     ...
   ]
 }}
@@ -300,14 +308,49 @@ def request_candidates(
             continue
         if not head_checker(url):
             continue
+        quote = str(c.get("expected_quote") or "").strip()
         valid.append(
             {
                 "url": url,
                 "tier": str(c.get("tier") or "unknown"),
                 "why": str(c.get("why") or "").strip(),
+                "expected_quote": quote,
             }
         )
     return valid
+
+
+def normalize_quote(text: str) -> str:
+    """Collapse whitespace, strip, lowercase — makes substring match
+    tolerant of the LLM's minor transcription drift (line breaks,
+    double spaces, casing)."""
+    return re.sub(r"\s+", " ", text).strip().lower()
+
+
+def quote_present_in_text(quote: str, body: str) -> bool:
+    """Check whether ``quote`` (or a long-enough prefix) is a substring
+    of ``body`` after whitespace + case normalization.
+
+    Accepts matches of at least ``MIN_QUOTE_MATCH_LENGTH`` characters
+    so minor LLM transcription drift (trailing phrase, missing word)
+    doesn't reject an otherwise-correct citation. Returns False when
+    the quote is too short to be meaningful — that's the LLM hedging,
+    not evidence.
+    """
+    norm_quote = normalize_quote(quote)
+    if len(norm_quote) < MIN_QUOTE_MATCH_LENGTH:
+        return False
+    norm_body = normalize_quote(body)
+    if norm_quote in norm_body:
+        return True
+    # Tolerate LLM drift on the tail: accept if the first
+    # MIN_QUOTE_MATCH_LENGTH-char prefix matches, rounded up to a word
+    # boundary so we don't mid-word match accidentally.
+    prefix = norm_quote[:max(MIN_QUOTE_MATCH_LENGTH, len(norm_quote) // 2)]
+    prefix = prefix.rsplit(" ", 1)[0] if " " in prefix else prefix
+    if len(prefix) >= MIN_QUOTE_MATCH_LENGTH and prefix in norm_body:
+        return True
+    return False
 
 
 # ---- validation ----------------------------------------------------------
@@ -331,27 +374,31 @@ def validate_candidate(
     advisory only — this is the real gate (#355 Codex review, must-fix).
     """
     url = candidate["url"]
+    expected_quote = str(candidate.get("expected_quote") or "").strip()
 
     # Phase 1: host allowlist (pre-network, deterministic).
     prechecked_tier = allowlist_tier(url)
     if not prechecked_tier:
         return {"ok": False, "url": url, "reason": "off_allowlist"}
 
-    # Phase 2: enforce that the finding has at least one deterministic
-    # anchor to verify. Signals like ``named_incident`` or
-    # ``attribution`` alone don't yield a value we can substring-match in
-    # the page body, so without anchors we'd be accepting "any 200
-    # allowlisted page" — which the fetcher cannot distinguish from the
-    # intended claim (#355 Codex review, must-fix #2).
+    # Phase 2: require some way to verify the page actually discusses
+    # the claim. Two paths:
+    #   A. The finding has deterministic anchors (year/price/percent).
+    #   B. The LLM committed to a specific expected_quote substring.
+    # At least one must be present, otherwise we'd accept "any 200
+    # allowlisted page" regardless of topical relevance. Phase 3 runs
+    # whichever path was populated (or both).
     anchors = extract_anchors(
         finding.get("excerpt", ""),
         finding.get("signals") or [],
     )
-    if not anchors:
+    has_anchors = bool(anchors)
+    has_quote = bool(expected_quote)
+    if not has_anchors and not has_quote:
         return {
             "ok": False,
             "url": url,
-            "reason": "no_anchors_extractable",
+            "reason": "no_verification_signal",
             "signals": finding.get("signals") or [],
         }
 
@@ -372,22 +419,39 @@ def validate_candidate(
         body = text_path.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return {"ok": False, "url": url, "reason": "cache_read_failed"}
-    matched = anchors_present_in_text(anchors, body)
-    if len(matched) < MIN_SIGNAL_ANCHORS_REQUIRED:
+
+    matched_anchors = anchors_present_in_text(anchors, body) if has_anchors else []
+    quote_matched = quote_present_in_text(expected_quote, body) if has_quote else False
+
+    # Accept if the finding had anchors AND enough of them matched, OR
+    # the LLM committed to a quote AND that quote is on the page.
+    anchors_ok = has_anchors and len(matched_anchors) >= MIN_SIGNAL_ANCHORS_REQUIRED
+    if anchors_ok or quote_matched:
+        return {
+            "ok": True,
+            "url": url,
+            "final_url": meta.get("final_url", url),
+            "tier": post_fetch_tier,
+            "anchors_matched": matched_anchors,
+            "quote_matched": quote_matched,
+            "verified_via": "anchors" if anchors_ok else "expected_quote",
+            "page_bytes": meta.get("bytes", 0),
+        }
+
+    # Nothing matched: explain why.
+    if has_quote and not quote_matched:
         return {
             "ok": False,
             "url": url,
-            "reason": "no_anchor_match",
-            "anchors_expected": anchors,
-            "anchors_matched": matched,
+            "reason": "quote_not_in_page",
+            "expected_quote": expected_quote,
         }
     return {
-        "ok": True,
+        "ok": False,
         "url": url,
-        "final_url": meta.get("final_url", url),
-        "tier": post_fetch_tier,
-        "anchors_matched": matched,
-        "page_bytes": meta.get("bytes", 0),
+        "reason": "no_anchor_match",
+        "anchors_expected": anchors,
+        "anchors_matched": matched_anchors,
     }
 
 

--- a/tests/test_citation_residuals.py
+++ b/tests/test_citation_residuals.py
@@ -464,13 +464,39 @@ def test_quote_present_rejects_too_short_quote() -> None:
     ) is False
 
 
-def test_quote_present_tolerates_missing_tail() -> None:
-    """LLM transcription often drops or alters a trailing phrase.
-    The prefix-match fallback tolerates that."""
+def test_quote_present_tolerates_minor_internal_drift() -> None:
+    """The start-AND-end-window fallback tolerates LLM drift in the
+    middle of the quote as long as both bookends match on the page."""
     assert citation_residuals.quote_present_in_text(
         "Amazon scrapped its AI recruiting tool after discovering bias against women",
-        "Amazon scrapped its AI recruiting tool after finding serious issues.",
+        "Amazon scrapped its AI recruiting tool after engineers saw bias against women in training data.",
     ) is True
+
+
+def test_quote_present_rejects_end_changed() -> None:
+    """#360 Codex review, must-fix #2: the old prefix-only fallback
+    accepted end-changed quotes. Now both ends must match."""
+    assert citation_residuals.quote_present_in_text(
+        "Amazon scrapped its AI recruiting tool after discovering bias against women",
+        "Amazon scrapped its AI recruiting tool after finding serious issues in testing.",
+    ) is False
+
+
+def test_quote_present_rejects_generic_lead_in_with_different_subject() -> None:
+    """#360 Codex review, must-fix #2 (concrete adversarial example):
+    a boilerplate lead-in like 'According to the article...' cannot
+    carry a match when the claim-specific tail differs."""
+    quote = (
+        "According to the article published on the company's website earlier "
+        "this year, Amazon scrapped its AI"
+    )
+    body_with_kubernetes_instead = (
+        "According to the article published on the company's website earlier "
+        "this year, Kubernetes changed its default scheduler."
+    )
+    assert citation_residuals.quote_present_in_text(
+        quote, body_with_kubernetes_instead
+    ) is False
 
 
 def test_quote_present_rejects_unrelated_text() -> None:
@@ -575,6 +601,47 @@ def test_validate_candidate_prefers_anchor_when_both_signals_present(
     assert result["ok"] is True
     assert result["verified_via"] == "anchors"
     assert "2018" in result["anchors_matched"]
+    assert result["quote_matched"] is True
+
+
+def test_validate_candidate_rejects_anchor_mismatch_even_when_quote_matches(
+    tmp_path: Path,
+) -> None:
+    """#360 Codex review, must-fix #1: when a finding has deterministic
+    anchors, those anchors are authoritative. A matching
+    expected_quote cannot override anchor mismatch — that's the exact
+    failure mode Codex identified (claim says 2018, page says 2017,
+    but generic quote 'Amazon scrapped its AI tool' is on the page
+    anyway). Must reject, not accept."""
+    finding = {
+        "excerpt": "In 2018 Amazon scrapped its AI tool.",
+        "signals": ["year_reference", "named_incident"],
+    }
+    candidate = {
+        "url": "https://en.wikipedia.org/wiki/Wrong_year_page",
+        "expected_quote": "Amazon scrapped its AI tool",
+    }
+
+    text_file = tmp_path / "body.txt"
+    # Page supports the quote but uses 2017 — the claim-specific year
+    # mismatches. Must reject.
+    text_file.write_text(
+        "In 2017 Amazon scrapped its AI tool after bias concerns.",
+        encoding="utf-8",
+    )
+
+    result = citation_residuals.validate_candidate(
+        candidate,
+        finding,
+        fetcher=lambda u: {"status": 200, "final_url": u, "allowlist_tier": "general"},
+        cached_text_path=lambda _u: text_file,
+        allowlist_tier=lambda _u: "general",
+    )
+    assert result["ok"] is False
+    assert result["reason"] == "no_anchor_match"
+    assert result["anchors_expected"] == ["2018"]
+    assert result["anchors_matched"] == []
+    # Quote DID match on the page — but anchors are authoritative.
     assert result["quote_matched"] is True
 
 

--- a/tests/test_citation_residuals.py
+++ b/tests/test_citation_residuals.py
@@ -414,18 +414,18 @@ def test_validate_candidate_rejects_when_anchors_missing(tmp_path: Path) -> None
     assert result["reason"] == "no_anchor_match"
 
 
-def test_validate_candidate_rejects_anchorless_finding_before_fetch(
+def test_validate_candidate_rejects_finding_with_no_verification_signal(
     tmp_path: Path,
 ) -> None:
-    """Regression for Codex review of #355: a finding with only
-    named_incident/attribution signals yields no extractable anchors, so
-    the resolver cannot verify the page is about the right topic. Phase
-    1 must mark those unresolvable rather than accept any 200 + on-list
-    page."""
+    """Regression for #355 Codex review, updated for #356 Part 2: a
+    finding with only named_incident/attribution signals AND a
+    candidate that provides no expected_quote has nothing to verify
+    against. Must reject pre-fetch with no_verification_signal."""
     finding = {
         "excerpt": "Amazon scrapped its project after concerns.",
         "signals": ["named_incident", "attribution"],
     }
+    # No expected_quote — and no anchors extractable from named_incident.
     candidate = {"url": "https://en.wikipedia.org/wiki/Random_topic"}
 
     fetch_calls: list[str] = []
@@ -442,8 +442,168 @@ def test_validate_candidate_rejects_anchorless_finding_before_fetch(
         allowlist_tier=lambda _u: "general",
     )
     assert result["ok"] is False
-    assert result["reason"] == "no_anchors_extractable"
-    assert fetch_calls == [], "anchorless finding must not trigger a fetch"
+    assert result["reason"] == "no_verification_signal"
+    assert fetch_calls == [], "anchorless+quoteless finding must not trigger a fetch"
+
+
+# ---- #356 Part 2: quote-match verification -------------------------------
+
+
+def test_quote_present_whitespace_and_case_normalized() -> None:
+    assert citation_residuals.quote_present_in_text(
+        "Amazon scrapped its hiring tool in 2018",
+        "Reports AMAZON\nscrapped  its HIRING tool in 2018 — full story follows.",
+    ) is True
+
+
+def test_quote_present_rejects_too_short_quote() -> None:
+    """The LLM hedging with 'maybe' or 'see there' must not pass."""
+    assert citation_residuals.quote_present_in_text(
+        "see there",
+        "You can see there are some references to Amazon here.",
+    ) is False
+
+
+def test_quote_present_tolerates_missing_tail() -> None:
+    """LLM transcription often drops or alters a trailing phrase.
+    The prefix-match fallback tolerates that."""
+    assert citation_residuals.quote_present_in_text(
+        "Amazon scrapped its AI recruiting tool after discovering bias against women",
+        "Amazon scrapped its AI recruiting tool after finding serious issues.",
+    ) is True
+
+
+def test_quote_present_rejects_unrelated_text() -> None:
+    assert citation_residuals.quote_present_in_text(
+        "Microsoft acquired GitHub for $7.5 billion",
+        "This page is about Kubernetes pod lifecycle and has nothing to do with Microsoft.",
+    ) is False
+
+
+def test_validate_candidate_accepts_via_expected_quote_when_no_anchors(
+    tmp_path: Path,
+) -> None:
+    """#356 Part 2 core: a finding with only named_incident signals now
+    resolves when the LLM provides an expected_quote that's on the page."""
+    finding = {
+        "excerpt": "Amazon scrapped its AI recruiting tool after bias concerns.",
+        "signals": ["named_incident", "attribution"],
+    }
+    candidate = {
+        "url": "https://en.wikipedia.org/wiki/Amazon_recruiting_AI",
+        "expected_quote": "Amazon scrapped its AI recruiting tool",
+    }
+
+    text_file = tmp_path / "body.txt"
+    text_file.write_text(
+        "Reuters reports that Amazon scrapped its AI recruiting tool after engineers "
+        "discovered bias against women in training data.",
+        encoding="utf-8",
+    )
+
+    result = citation_residuals.validate_candidate(
+        candidate,
+        finding,
+        fetcher=lambda u: {"status": 200, "final_url": u, "allowlist_tier": "general"},
+        cached_text_path=lambda _u: text_file,
+        allowlist_tier=lambda _u: "general",
+    )
+    assert result["ok"] is True
+    assert result["verified_via"] == "expected_quote"
+    assert result["quote_matched"] is True
+
+
+def test_validate_candidate_rejects_quote_not_on_page(tmp_path: Path) -> None:
+    """Core #356 Part 2: if LLM invents a quote that's not on the fetched
+    page, reject with quote_not_in_page (catches URL-content
+    hallucination)."""
+    finding = {
+        "excerpt": "Some claim about an incident.",
+        "signals": ["named_incident"],
+    }
+    candidate = {
+        "url": "https://en.wikipedia.org/wiki/Real_page",
+        "expected_quote": "A hallucinated sentence that is not on the page at all",
+    }
+
+    text_file = tmp_path / "body.txt"
+    text_file.write_text(
+        "This is a page about Kubernetes pod lifecycle and networking.",
+        encoding="utf-8",
+    )
+
+    result = citation_residuals.validate_candidate(
+        candidate,
+        finding,
+        fetcher=lambda u: {"status": 200, "final_url": u, "allowlist_tier": "general"},
+        cached_text_path=lambda _u: text_file,
+        allowlist_tier=lambda _u: "general",
+    )
+    assert result["ok"] is False
+    assert result["reason"] == "quote_not_in_page"
+    assert result["expected_quote"] == "A hallucinated sentence that is not on the page at all"
+
+
+def test_validate_candidate_prefers_anchor_when_both_signals_present(
+    tmp_path: Path,
+) -> None:
+    """With both year anchor AND expected_quote present and matching,
+    the happy path still returns ok, reporting verified_via=anchors
+    (the cheaper, more trusted signal) when anchors pass."""
+    finding = {
+        "excerpt": "In 2018 Amazon scrapped its AI tool.",
+        "signals": ["year_reference", "named_incident"],
+    }
+    candidate = {
+        "url": "https://en.wikipedia.org/wiki/Real",
+        "expected_quote": "Amazon scrapped its AI tool",
+    }
+
+    text_file = tmp_path / "body.txt"
+    text_file.write_text(
+        "In 2018 Amazon scrapped its AI tool after bias concerns.",
+        encoding="utf-8",
+    )
+
+    result = citation_residuals.validate_candidate(
+        candidate,
+        finding,
+        fetcher=lambda u: {"status": 200, "final_url": u, "allowlist_tier": "general"},
+        cached_text_path=lambda _u: text_file,
+        allowlist_tier=lambda _u: "general",
+    )
+    assert result["ok"] is True
+    assert result["verified_via"] == "anchors"
+    assert "2018" in result["anchors_matched"]
+    assert result["quote_matched"] is True
+
+
+def test_request_candidates_passes_expected_quote_through() -> None:
+    """Ensure the LLM's expected_quote survives JSON parsing and reaches
+    validate_candidate."""
+    finding = {"excerpt": "claim", "signals": [], "search_hint": []}
+
+    def fake_dispatcher(_prompt: str) -> tuple[bool, str]:
+        return True, json.dumps(
+            {
+                "candidates": [
+                    {
+                        "url": "https://en.wikipedia.org/wiki/X",
+                        "tier": "general",
+                        "expected_quote": "A sentence from the page.",
+                    }
+                ]
+            }
+        )
+
+    out = citation_residuals.request_candidates(
+        finding,
+        dispatcher=fake_dispatcher,
+        allowlist_tier=lambda _u: "general",
+        head_checker=lambda _u: True,
+    )
+    assert len(out) == 1
+    assert out[0]["expected_quote"] == "A sentence from the page."
 
 
 # ---- inject_source -------------------------------------------------------


### PR DESCRIPTION
Closes #356 Part 2 (of 3). Parent: #343. Builds on Part 1 (#357, merged).

## Summary

Extends the LLM candidate prompt to require \`expected_quote\` — a specific sentence or phrase from the page the LLM claims to cite. \`validate_candidate()\` fetches the page and substring-matches the quote (case-insensitive, whitespace-normalized, ≥12-char match, prefix-tolerance for LLM drift) before accepting.

This catches the **second** hallucination class that Part 1 didn't: URL exists on allowlist, page returns 200, but the page doesn't actually discuss the claim. Also rescues the **anchorless findings class** (signals like \`named_incident\` / \`attribution\` alone) that phase-1 had to reject outright.

## Verification precedence

\`\`\`
no anchors AND no quote  → reject pre-fetch (no_verification_signal)
anchors present, matched → ok, verified_via=anchors
quote present, matched   → ok, verified_via=expected_quote
neither matched          → reject (quote_not_in_page or no_anchor_match)
\`\`\`

When both anchors and quote are present and both match, report \`verified_via=anchors\` (cheaper, more trusted signal).

## Drift tolerance

\`quote_present_in_text()\`:
1. Normalize whitespace (\`\\s+\` → single space) and lowercase on both sides.
2. Require ≥12-char minimum (rejects LLM hedging like \"see there\").
3. Full-quote substring match wins.
4. If full miss, accept a word-boundary-aligned prefix match — so \"Amazon scrapped its AI recruiting tool after discovering bias\" still accepts when the page says \"Amazon scrapped its AI recruiting tool after finding issues\" (tail changed).

## Expected impact

Re-pilot on the 2026-04-23 modules should now resolve the \`named_incident\` / \`attribution\` findings that went to \`unresolvable\` under phase-1 (1 in fine-tuning-llms, 1 in cloud-ai-services, 1 in multi-account). Projected resolve rate: 60-75% (vs. 20% on the original pilot).

## Test plan

- [x] 8 new tests:
  - 4 on \`quote_present_in_text\`: happy path, too-short reject, tail tolerance, unrelated reject
  - 3 on \`validate_candidate\`: anchorless+quote accepts, quote-not-on-page rejects, both-present reports anchors
  - 1 on \`request_candidates\`: \`expected_quote\` survives JSON parse
- [x] 34/34 total pass (was 26).
- [x] \`ruff check\` clean.
- [ ] Re-pilot against 2026-04-23 modules (follow-up after merge).

## Review ask

Claude-authored. Cross-family Codex review per \`docs/review-protocol.md\`. Specific questions:

1. \`MIN_QUOTE_MATCH_LENGTH = 12\` — too lenient (false-positives on generic phrases) or too strict (misses short valid quotes)? Any data-driven way to choose this besides hand-waving?
2. The prefix-match fallback (\`prefix = norm_quote[:max(12, len/2)]\`, rounded to word boundary): is there a case where a legitimate prefix match produces a false positive? E.g. the LLM starts with a common phrase like \"According to the article,\" that's on many pages.
3. When both anchors AND quote match, I report \`verified_via=anchors\`. Is that the right precedence, or should the more-specific signal (quote) win?
4. \`request_candidates\` now also accepts candidates with empty \`expected_quote\`. Those will then be rejected at \`validate_candidate\` if no anchors. Should \`request_candidates\` drop them earlier? My call: no, the layered rejection gives better diagnostics in \`attempts[]\`. Confirm.
5. Any other bugs / missed edge cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)