### PR TITLE
docs(review-protocol): make cross-family reviewer rule explicit

### DIFF
--- a/docs/review-protocol.md
+++ b/docs/review-protocol.md
@@ -18,7 +18,7 @@ Every PR review must come from a **different model family** than the author.
 
 **Never:** Claude reviewing Claude, Codex reviewing Codex, Gemini reviewing Gemini — including sub-model variants (opus reviewing sonnet still counts as Claude→Claude).
 
-**Enforcement:** `scripts/ab ask-{codex,gemini,claude}` with `--review` takes `--from` to label the author family. The reviewer family is determined by which `ask-*` subcommand you invoke. Pick the subcommand whose family differs from `--from`.
+**Operator workflow (not automated enforcement).** `scripts/ab ask-{codex,gemini,claude}` with `--review` records the author family via `--from` and targets the reviewer family via the subcommand chosen — but the CLI does not currently reject a same-family invocation. `scripts/verify_review.py` is passive quote/line verification only. Family separation today is enforced by **convention and reviewer discipline**, not by a hard CLI check. Pick an `ask-*` subcommand whose family differs from `--from`; if a real guard is added later, this section can be renamed back to "Enforcement."
 
 ## Prompt Context
 

--- a/docs/review-protocol.md
+++ b/docs/review-protocol.md
@@ -1,5 +1,25 @@
 # Review Protocol
 
+## Reviewer Assignment (cross-family rule)
+
+Every PR review must come from a **different model family** than the author.
+
+**Families:**
+- **Claude** (Anthropic) — opus-4-x, sonnet-4-x, haiku-4-x
+- **Codex / GPT** (OpenAI) — gpt-5-codex, gpt-5
+- **Gemini** (Google) — gemini-3.x, gemini-2.x
+
+**Why:** same-family self-review shares failure modes. A Claude reviewer misses the same bugs a Claude author wrote because both models share training corpus, hallucination patterns, and blind spots. Cross-family review catches what single-family review cannot.
+
+**Default pairings:**
+- Claude-authored → Codex reviewer (Codex has been more rigorous on content batches; see STATUS.md 2026-04-23 data point on PR #350)
+- Codex-authored → Claude or Gemini reviewer
+- Gemini-authored → Claude or Codex reviewer
+
+**Never:** Claude reviewing Claude, Codex reviewing Codex, Gemini reviewing Gemini — including sub-model variants (opus reviewing sonnet still counts as Claude→Claude).
+
+**Enforcement:** `scripts/ab ask-{codex,gemini,claude}` with `--review` takes `--from` to label the author family. The reviewer family is determined by which `ask-*` subcommand you invoke. Pick the subcommand whose family differs from `--from`.
+
 ## Prompt Context
 
 PROJECT CONTEXT:


### PR DESCRIPTION
Postmortem follow-up from 2026-04-23 session (STATUS.md line 88: _"Make cross-family reviewer rule explicit in `docs/review-protocol.md`"_).

## What this adds

A new `## Reviewer Assignment (cross-family rule)` section at the top of `docs/review-protocol.md`:

- Names the three model families (Claude, Codex, Gemini).
- States the rule: reviewer family must differ from author family.
- Explains why: same-family review shares training corpus, hallucination patterns, and blind spots.
- Lists default pairings and calls out the Codex-as-rigorous-content-reviewer data point from PR #350.
- Notes the "never" cases, including sub-model variants (opus reviewing sonnet still counts as Claude→Claude).
- Points at the enforcement surface (`scripts/ab ask-{codex,gemini,claude} --review --from ...`).

## Why now

The convention has been in effect for months but wasn't written down. Recent PRs (#350, #358, #359, #360) all followed it implicitly. Writing it down:

1. Makes onboarding agents correct-by-default.
2. Prevents accidental Claude-reviewing-Claude when we spawn a secondary Claude instance for parallel work.
3. Gives a single doc link to cite in PR descriptions.

## Review ask

Per the rule being added: **Codex or Gemini reviewer**, not Claude.

Specifically:
1. Does the family taxonomy miss any model family we should name (e.g., Mistral, DeepSeek if those get added to the dispatch pool)?
2. Is the "sub-model variants still count" clause too strict / not strict enough?
3. Any gap between what's documented here and how the `ab ask-*` CLI actually enforces / labels author family?

Trivial doc-only change — no code, no tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)