### PR TITLE
docs: align gemini-workflow.md + CLAUDE.md with cross-family reviewer rule (#361 follow-up)

### DIFF
--- a/.claude/rules/gemini-workflow.md
+++ b/.claude/rules/gemini-workflow.md
@@ -49,11 +49,15 @@ ok, output = dispatch_gemini_with_retry("Translate...", mcp=True)
 
 ## Gemini Roles
 
-**1. Adversary Reviewer (primary role)**
-- Send completed work to Gemini for review BEFORE closing any issue
-- Gemini catches: version inaccuracies, missing ACs, scope gaps, technical errors, Russicisms in translations
-- If Gemini says NEEDS CHANGES, address feedback before closing
-- Post Gemini's review as a comment on the issue
+**1. Adversary Reviewer (one of three cross-family options)**
+
+Per `docs/review-protocol.md`, every PR review must come from a different model family than the author. Gemini is the cross-family reviewer for Codex-authored or Claude-authored work **when designated** — not a universal default. (For Claude-authored work, Codex has been the more rigorous reviewer on content batches per the 2026-04-23 PR #350 data point; Gemini is lighter/faster and a valid alternative.)
+
+When Gemini is the designated cross-family reviewer:
+- Send completed work to Gemini for review BEFORE closing the issue.
+- Gemini catches: version inaccuracies, missing ACs, scope gaps, technical errors, Russicisms in translations.
+- If Gemini says NEEDS CHANGES, address feedback before closing.
+- Post Gemini's review as a comment on the issue.
 
 **2. Translator (Ukrainian)**
 - Produces good Ukrainian translations (99-100% of original length)
@@ -74,8 +78,8 @@ ok, output = dispatch_gemini_with_retry("Translate...", mcp=True)
 1. **Plan** with Gemini (gap analysis, module specs, structure)
 2. **Draft** — either Gemini drafts (needs expansion) or Claude writes directly (full quality)
 3. **Expand** — if Gemini drafted, Claude agent reads and expands to full depth
-4. **Review** — Gemini adversary review (score, flag issues)
-5. **Fix** — address Gemini feedback
+4. **Review** — cross-family adversary review (a non-Gemini family per `docs/review-protocol.md` when the draft came from Gemini; score, flag issues)
+5. **Fix** — address reviewer feedback
 6. **Commit** — with nav updates, READMEs, changelog
 
 ## Gemini Limitations

--- a/.claude/rules/gemini-workflow.md
+++ b/.claude/rules/gemini-workflow.md
@@ -78,7 +78,7 @@ When Gemini is the designated cross-family reviewer:
 1. **Plan** with Gemini (gap analysis, module specs, structure)
 2. **Draft** — either Gemini drafts (needs expansion) or Claude writes directly (full quality)
 3. **Expand** — if Gemini drafted, Claude agent reads and expands to full depth
-4. **Review** — cross-family adversary review (a non-Gemini family per `docs/review-protocol.md` when the draft came from Gemini; score, flag issues)
+4. **Review** — cross-family adversary review (if Gemini drafted it, use Claude or Codex per `docs/review-protocol.md`; score, flag issues)
 5. **Fix** — address reviewer feedback
 6. **Commit** — with nav updates, READMEs, changelog
 

--- a/.pipeline/codex-handoff.md
+++ b/.pipeline/codex-handoff.md
@@ -138,7 +138,9 @@ scripts/ab ask-claude --task-id handback-to-claude --from codex "Summary of what
 2. Does NOT write code — you (Codex) write, the reviewer reviews
 3. Gemini is one of three families (Claude / Codex / Gemini) — the actual reviewer is chosen to differ from the author family per `docs/review-protocol.md`
 
-## Workflow for this task
+## Historical execution notes (2026-04-15 v2-pipeline handoff)
+
+> **Dated workflow — preserved for audit, not current policy.** The steps below executed on 2026-04-15 for the v2-pipeline codex delegation. Do not run them again. For current reviewer assignment policy, see `docs/review-protocol.md` and the "Key rules for Gemini coordination" / "Important project rules" sections above.
 
 1. Apply code changes (dispatch.py, review_worker.py, patch_worker.py, budgets.yaml)
 2. Run tests: `PYTHONPATH=scripts .venv/bin/pytest scripts/tests/ -q`

--- a/.pipeline/codex-handoff.md
+++ b/.pipeline/codex-handoff.md
@@ -129,13 +129,14 @@ scripts/ab ask-claude --task-id handback-to-claude --from codex "Summary of what
 **Key rules for Gemini coordination:**
 - NEVER parallelize Gemini calls — user runs other concurrent workloads, one at a time
 - Use `--model auto` as the model (never hardpin flash/pro)
-- Always send Gemini for adversarial review before closing any issue
-- If Gemini says NEEDS CHANGES, fix before merging
-- Post Gemini's review as a comment on the GH issue
+- When Gemini is the designated cross-family reviewer (see `docs/review-protocol.md`), send completed work before closing the issue
+- If the reviewer says NEEDS CHANGES, fix before merging
+- Post the review as a comment on the GH issue
 
-**Gemini's role:**
+**Gemini's role (when designated as cross-family reviewer):**
 1. Adversary reviewer — catches bugs Codex misses, flags technical errors
-2. Does NOT write code — you (Codex) write, Gemini reviews
+2. Does NOT write code — you (Codex) write, the reviewer reviews
+3. Gemini is one of three families (Claude / Codex / Gemini) — the actual reviewer is chosen to differ from the author family per `docs/review-protocol.md`
 
 ## Workflow for this task
 
@@ -148,7 +149,7 @@ scripts/ab ask-claude --task-id handback-to-claude --from codex "Summary of what
 
 ## Important project rules
 
-- **Never merge without adversarial review** — Gemini must review before any PR/commit to main
+- **Never merge without adversarial review** — the designated cross-family reviewer (see `docs/review-protocol.md`) must review before any PR/commit to main
 - **Claude never edits module content** — pipeline workers do, not you directly
 - **Never parallelize Gemini calls** — sequential only
 - **Build before push**: `npm run build` — 0 warnings required

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ Full agent recipe: [`scripts/agent_onboarding.md`](scripts/agent_onboarding.md).
 
 1. **Orient via `/api/briefing/session`** (see *Agent Orientation* above). `STATUS.md` is the fallback when the API is down.
 2. Use `scripts/prompts/module-writer.md` for new modules
-3. Send to Gemini for review before closing issues
+3. Send completed work to the designated cross-family reviewer (see `docs/review-protocol.md`) before closing issues
 4. **UPDATE `STATUS.md`** before ending session (the briefing parses it, so stale entries mislead the next session)
 
 ## Build & Serve

--- a/docs/best-practices/agent-bridge.md
+++ b/docs/best-practices/agent-bridge.md
@@ -79,10 +79,10 @@ agent.** Per channel conventions:
 
 1. Write code → stage with `git add`
 2. `git diff --cached > /tmp/diff.txt`
-3. `ab post reviews "Review request for #NNN" --to gemini` (or ask-gemini with the diff attached)
+3. `ab post reviews "Review request for #NNN" --to <reviewer>` — where `<reviewer>` is the **designated cross-family reviewer** (see `docs/review-protocol.md`). Or use `ab ask-{codex,gemini,claude}` directly with the diff attached; pick the family that differs from the author.
 4. Apply feedback or argue back in writing
 5. Commit only after the review is CLEAN or BLOCKING is resolved
-6. Commit message includes `Reviewed-By: gemini-3.1-pro-preview (task-id)` trailer
+6. Commit message includes `Reviewed-By: <reviewer-model-id> (task-id)` trailer — e.g. `Reviewed-By: gpt-5.4 (pr-360-review)`, `Reviewed-By: gemini-3.1-pro-preview (pr-123-review)`, or `Reviewed-By: claude-opus-4-7 (pr-456-review)`, matching the actual reviewer used.
 
 This rule is non-negotiable. Bypassing it was the #1 reason review
 quality degraded on earlier commits.


### PR DESCRIPTION
Follow-up to PR #361 (merged as `4a3e544b`). Addresses Codex's non-blocking nit from that review:

> After this doc lands, that sentence [\".claude/rules/gemini-workflow.md:53\"] is only valid when Gemini is the designated cross-family reviewer. It reads like a universal rule and can conflict with the new pairing guidance.

Same staleness existed in `CLAUDE.md:49` and two more spots in `gemini-workflow.md` (Content Pipeline steps 4 and 5), all fixed here.

## Changes

### `.claude/rules/gemini-workflow.md`
- Header \"Adversary Reviewer (primary role)\" → \"Adversary Reviewer (one of three cross-family options)\".
- Gemini-specific steps now scoped to \"when Gemini is the designated cross-family reviewer.\"
- Content Pipeline step 4: \"Gemini adversary review\" → \"cross-family adversary review (a non-Gemini family per `docs/review-protocol.md` when the draft came from Gemini)\". Gemini cannot review its own draft under the cross-family rule.
- Content Pipeline step 5: \"address Gemini feedback\" → \"address reviewer feedback\".

### `CLAUDE.md`
- Session Workflow step 3: \"Send to Gemini for review\" → \"Send completed work to the designated cross-family reviewer (see `docs/review-protocol.md`)\".

## Review ask

Codex per cross-family rule (Claude-authored). Specifically:

1. Does the rewording cleanly condition Gemini's reviewer role without losing any of the practical guidance (what Gemini catches, how to post the review, etc.)?
2. Is step 4 in the Content Pipeline worded cleanly? The constraint is: if Gemini drafted, reviewer can be Claude or Codex, not Gemini. Current wording: \"a non-Gemini family per docs/review-protocol.md when the draft came from Gemini\" — clear or awkward?
3. Any remaining spots in the repo where \"Gemini is primary reviewer\" is stated implicitly that I missed? I grepped the repo for \"Gemini for review\" and \"Gemini.*review\" — no other hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)