### PR TITLE
feat(#343): per-module write lock for citation_residuals resolve (unblocks phase-2 bulk)

### DIFF
--- a/scripts/citation_residuals.py
+++ b/scripts/citation_residuals.py
@@ -901,17 +901,29 @@ def main(argv: list[str] | None = None) -> int:
         use_lock = not (args.dry_run or args.no_lock)
         for qp in useful_targets:
             t0 = time.time()
-            module_key = qp.stem
+            # Lock on the CANONICAL module key (e.g. "ai/foo/module-1.1"),
+            # not the flattened queue filename (e.g. "ai-foo-module-1.1").
+            # Queue filenames are slash-flattened slugs, but other writers
+            # (pipeline_v4, future callers of the shared primitive) will
+            # use the real module_key for their locks. Keying on the stem
+            # would miss those writers and could alias two distinct real
+            # keys whose slugs happen to collide. Falls back to stem only
+            # if the JSON is missing the field (legacy files).
+            try:
+                _queue_data = load_queue_file(qp)
+                canonical_key = _queue_data.get("module_key") or qp.stem
+            except Exception:  # noqa: BLE001
+                canonical_key = qp.stem
             if use_lock:
                 conflict = module_lock.acquire_module_lock(
-                    module_key,
+                    canonical_key,
                     holder=worker_id,
                     lease_seconds=args.lease_seconds,
                 )
                 if conflict is not None:
                     totals["skipped_locked"] += 1
                     print(
-                        f"{module_key}: SKIPPED — locked by "
+                        f"{canonical_key}: SKIPPED — locked by "
                         f"{conflict.holder!r} until epoch "
                         f"{conflict.expires_at}"
                     )
@@ -926,13 +938,13 @@ def main(argv: list[str] | None = None) -> int:
                     # crash. An abandoned lock would auto-expire after
                     # lease_seconds but we can be precise here.
                     module_lock.release_module_lock(
-                        module_key, holder=worker_id
+                        canonical_key, holder=worker_id
                     )
                 raise
             else:
                 if use_lock:
                     module_lock.complete_module_lock(
-                        module_key, holder=worker_id, outcome=outcome
+                        canonical_key, holder=worker_id, outcome=outcome
                     )
             totals["considered"] += stats["considered"]
             totals["resolved"] += stats["resolved"]

--- a/scripts/citation_residuals.py
+++ b/scripts/citation_residuals.py
@@ -30,12 +30,19 @@ sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
 import fetch_citation  # noqa: E402
 from citation_backfill import dispatch_gemini, parse_agent_response  # noqa: E402
+from pipeline_common import module_lock  # noqa: E402
 
 HUMAN_REVIEW_DIR = REPO_ROOT / ".pipeline" / "v3" / "human-review"
 DEFAULT_MAX_CANDIDATES = 3
 MIN_SIGNAL_ANCHORS_REQUIRED = 1
 HEAD_CHECK_TIMEOUT_SECONDS = 5.0
 MIN_QUOTE_MATCH_LENGTH = 12
+# Default lease is generous — a single module can take several minutes
+# when the LLM dispatch stalls or the network is slow; a tight TTL would
+# let another worker steal the lock mid-run and clobber writes. A stuck
+# run can always be released manually via sweep_expired_locks after the
+# operator is sure the holding process is dead.
+DEFAULT_LOCK_LEASE_SECONDS = 1800
 
 
 # ---- IO ------------------------------------------------------------------
@@ -814,6 +821,34 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Propose resolutions but do not write to modules or queue JSON",
     )
+    p_resolve.add_argument(
+        "--worker-id",
+        default=None,
+        help=(
+            "Identifier recorded on the per-module write lock. Defaults "
+            "to '<pid>@<hostname>'. Use a stable value (e.g. 'resolver-01') "
+            "when running parallel batches so operators can see who "
+            "holds what."
+        ),
+    )
+    p_resolve.add_argument(
+        "--lease-seconds",
+        type=int,
+        default=DEFAULT_LOCK_LEASE_SECONDS,
+        help=(
+            "Lock TTL. An abandoned run's lock is considered stealable "
+            f"after this many seconds (default {DEFAULT_LOCK_LEASE_SECONDS})."
+        ),
+    )
+    p_resolve.add_argument(
+        "--no-lock",
+        action="store_true",
+        help=(
+            "Skip per-module write locking. Only use for --dry-run or "
+            "in tests; concurrent runs without the lock can clobber "
+            "each other's writes to the same module."
+        ),
+    )
 
     args = parser.parse_args(argv)
 
@@ -853,10 +888,52 @@ def main(argv: list[str] | None = None) -> int:
             print("No residuals with needs_citation findings.")
             return 0
 
-        totals = {"considered": 0, "resolved": 0, "unresolvable": 0, "modules_edited": 0}
+        totals = {
+            "considered": 0,
+            "resolved": 0,
+            "unresolvable": 0,
+            "modules_edited": 0,
+            "skipped_locked": 0,
+        }
+        worker_id = args.worker_id or module_lock.default_holder()
+        # --dry-run does not mutate files; lock not required. --no-lock is
+        # an explicit operator opt-out (use only in tests).
+        use_lock = not (args.dry_run or args.no_lock)
         for qp in useful_targets:
             t0 = time.time()
-            stats = resolve_module(qp, dry_run=args.dry_run)
+            module_key = qp.stem
+            if use_lock:
+                conflict = module_lock.acquire_module_lock(
+                    module_key,
+                    holder=worker_id,
+                    lease_seconds=args.lease_seconds,
+                )
+                if conflict is not None:
+                    totals["skipped_locked"] += 1
+                    print(
+                        f"{module_key}: SKIPPED — locked by "
+                        f"{conflict.holder!r} until epoch "
+                        f"{conflict.expires_at}"
+                    )
+                    continue
+            outcome = "ok"
+            try:
+                stats = resolve_module(qp, dry_run=args.dry_run)
+            except BaseException:
+                outcome = "error"
+                if use_lock:
+                    # Release so a follow-up run is not blocked on our
+                    # crash. An abandoned lock would auto-expire after
+                    # lease_seconds but we can be precise here.
+                    module_lock.release_module_lock(
+                        module_key, holder=worker_id
+                    )
+                raise
+            else:
+                if use_lock:
+                    module_lock.complete_module_lock(
+                        module_key, holder=worker_id, outcome=outcome
+                    )
             totals["considered"] += stats["considered"]
             totals["resolved"] += stats["resolved"]
             totals["unresolvable"] += stats["unresolvable"]
@@ -875,7 +952,8 @@ def main(argv: list[str] | None = None) -> int:
             f"TOTAL: considered={totals['considered']} "
             f"resolved={totals['resolved']} "
             f"unresolvable={totals['unresolvable']} "
-            f"modules_edited={totals['modules_edited']}"
+            f"modules_edited={totals['modules_edited']} "
+            f"skipped_locked={totals['skipped_locked']}"
         )
         if totals["considered"]:
             rate = totals["resolved"] / totals["considered"] * 100

--- a/scripts/pipeline_common/module_lock.py
+++ b/scripts/pipeline_common/module_lock.py
@@ -1,0 +1,387 @@
+"""Per-module write lock backed by `.pipeline/v2.db`.
+
+Purpose
+-------
+Prevent two processes from concurrently rewriting the same module's
+files. Citation-residuals resolve + pipeline_v4 batch + future workers
+all mutate `src/content/docs/<module_key>.md` plus per-module queue
+state under `.pipeline/v3/human-review/<module_key>.json`. A last-write-
+wins race on either file silently loses work.
+
+The lock is advisory — it only protects writers that choose to acquire
+it. It is not a substitute for fcntl or OS-level file locking; it's a
+coordination primitive between cooperating tools.
+
+Contract
+--------
+Schema (created lazily on first use):
+
+    CREATE TABLE module_write_locks (
+        module_key TEXT PRIMARY KEY,
+        holder TEXT NOT NULL,
+        acquired_at INTEGER NOT NULL,
+        expires_at INTEGER NOT NULL,
+        completed_at INTEGER,
+        outcome TEXT
+    )
+
+One row per `module_key`. A live (non-expired, non-completed) row blocks
+others. Expired or completed rows are evicted inside the same
+transaction as a new acquire, so repeat runs do not accumulate dead
+rows.
+
+State transitions:
+- acquire → row inserted with `expires_at = now + ttl`.
+- complete → `completed_at` set, `outcome` recorded. Row becomes
+  inert and will be deleted the next time anyone tries to acquire.
+- release → row deleted. Use when a writer crashes or aborts without a
+  meaningful outcome.
+- sweep_expired → removes dead rows whose `expires_at` has passed. Not
+  required for correctness (acquire evicts as it goes) but useful for
+  observability / housekeeping.
+
+Stolen leases. An expired lock is considered abandoned; the next
+acquirer evicts and takes it. TTL should therefore be *generously*
+longer than the real work, not a tight deadline. 1800 s (30 min) is
+the default to cover large citation_residuals runs including LLM +
+network stalls without forcing risky steals on a slow-but-alive run.
+
+Why a new table instead of `v4_batch_leases`. `pipeline_v4_batch.py`
+defines `v4_batch_leases` locally; that table name is v4-specific.
+The citation_residuals resolver is a v3 consumer and should not pick
+up a v4-named table. A future refactor can migrate v4 batch onto this
+primitive; for now they coexist.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import sqlite3
+import threading
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_DB_PATH = REPO_ROOT / ".pipeline" / "v2.db"
+DEFAULT_LEASE_SECONDS = 1800
+
+LOCK_SCHEMA = """
+CREATE TABLE IF NOT EXISTS module_write_locks (
+    module_key TEXT PRIMARY KEY,
+    holder TEXT NOT NULL,
+    acquired_at INTEGER NOT NULL,
+    expires_at INTEGER NOT NULL,
+    completed_at INTEGER,
+    outcome TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_module_write_locks_expires
+    ON module_write_locks(expires_at);
+"""
+
+_INIT_LOCK = threading.Lock()
+_INITIALIZED_DBS: set[str] = set()
+
+
+@dataclass(frozen=True)
+class LockConflict:
+    """Details about an existing live lock that blocked an acquire."""
+
+    holder: str
+    acquired_at: int
+    expires_at: int
+
+
+class LockAcquireError(RuntimeError):
+    """Raised when acquire_module_lock cannot take the lock.
+
+    The exception carries the live holder's record so the caller can log
+    a precise reason (who holds it, until when) without re-querying.
+    """
+
+    def __init__(self, module_key: str, conflict: LockConflict):
+        self.module_key = module_key
+        self.conflict = conflict
+        super().__init__(
+            f"module {module_key!r} is already locked by "
+            f"{conflict.holder!r} until epoch {conflict.expires_at}"
+        )
+
+
+def default_holder() -> str:
+    """Stable identifier for the current process: pid@hostname."""
+    return f"{os.getpid()}@{socket.gethostname()}"
+
+
+def _ensure_schema(db_path: Path) -> None:
+    """Idempotent CREATE IF NOT EXISTS, serialized per path."""
+    key = str(db_path)
+    if key in _INITIALIZED_DBS:
+        return
+    with _INIT_LOCK:
+        if key in _INITIALIZED_DBS:
+            return
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        setup = sqlite3.connect(db_path, timeout=30)
+        try:
+            setup.execute("PRAGMA journal_mode=WAL")
+            setup.executescript(LOCK_SCHEMA)
+            setup.commit()
+        finally:
+            setup.close()
+        _INITIALIZED_DBS.add(key)
+
+
+def _connect(db_path: Path) -> sqlite3.Connection:
+    _ensure_schema(db_path)
+    conn = sqlite3.connect(db_path, timeout=30)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _current_live_holder(
+    conn: sqlite3.Connection, module_key: str
+) -> LockConflict | None:
+    """Return the current live holder's record, or None if the slot is
+    free or holds only an expired/completed row.
+
+    Callers run this inside a BEGIN IMMEDIATE block after evicting dead
+    rows, so a non-None result is authoritative for the transaction's
+    snapshot.
+    """
+    row = conn.execute(
+        """
+        SELECT holder, acquired_at, expires_at
+        FROM module_write_locks
+        WHERE module_key = ?
+        """,
+        (module_key,),
+    ).fetchone()
+    if row is None:
+        return None
+    return LockConflict(
+        holder=row["holder"],
+        acquired_at=int(row["acquired_at"]),
+        expires_at=int(row["expires_at"]),
+    )
+
+
+def acquire_module_lock(
+    module_key: str,
+    *,
+    holder: str | None = None,
+    lease_seconds: int = DEFAULT_LEASE_SECONDS,
+    db_path: Path | None = None,
+) -> LockConflict | None:
+    """Try to take a lock on module_key. Returns None on success, or a
+    LockConflict describing the live holder if the slot is taken.
+
+    Raises ValueError on obviously wrong inputs (empty key, non-positive
+    TTL). Does not raise on contention — the caller decides whether to
+    skip, retry, or escalate.
+    """
+    if not module_key:
+        raise ValueError("module_key must be non-empty")
+    if lease_seconds <= 0:
+        raise ValueError("lease_seconds must be positive")
+    holder = holder or default_holder()
+    db_path = db_path or DEFAULT_DB_PATH
+    conn = _connect(db_path)
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        # Evict expired-or-completed rows for this key so a stuck or
+        # crashed predecessor does not block forever.
+        conn.execute(
+            """
+            DELETE FROM module_write_locks
+            WHERE module_key = ?
+              AND (completed_at IS NOT NULL
+                   OR expires_at <= CAST(strftime('%s','now') AS INTEGER))
+            """,
+            (module_key,),
+        )
+        try:
+            conn.execute(
+                """
+                INSERT INTO module_write_locks
+                    (module_key, holder, acquired_at, expires_at)
+                VALUES (
+                    ?, ?,
+                    CAST(strftime('%s','now') AS INTEGER),
+                    CAST(strftime('%s','now') AS INTEGER) + ?
+                )
+                """,
+                (module_key, holder, lease_seconds),
+            )
+            conn.commit()
+            return None
+        except sqlite3.IntegrityError:
+            # PRIMARY KEY collision means a live row survived the
+            # eviction step (another holder has a non-expired,
+            # non-completed lock).
+            conflict = _current_live_holder(conn, module_key)
+            conn.rollback()
+            if conflict is None:
+                # Extremely unlikely race: the blocker was evicted by
+                # another connection between our DELETE and INSERT.
+                # Re-raise as transient so the caller can retry.
+                raise
+            return conflict
+    finally:
+        conn.close()
+
+
+def complete_module_lock(
+    module_key: str,
+    *,
+    holder: str | None = None,
+    outcome: str,
+    db_path: Path | None = None,
+) -> bool:
+    """Mark the lock completed with an outcome. Returns True if the row
+    was updated (caller held the lock), False otherwise (someone else
+    held it or it had already been released/expired).
+
+    A completed row is inert — it does not block future acquires — but
+    is kept around briefly so operators can see recent outcomes via a
+    direct query. It is evicted on the next acquire for this key.
+    """
+    if not module_key:
+        raise ValueError("module_key must be non-empty")
+    holder = holder or default_holder()
+    db_path = db_path or DEFAULT_DB_PATH
+    conn = _connect(db_path)
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        cur = conn.execute(
+            """
+            UPDATE module_write_locks
+            SET completed_at = CAST(strftime('%s','now') AS INTEGER),
+                outcome = ?
+            WHERE module_key = ?
+              AND holder = ?
+              AND completed_at IS NULL
+            """,
+            (outcome, module_key, holder),
+        )
+        conn.commit()
+        return cur.rowcount > 0
+    finally:
+        conn.close()
+
+
+def release_module_lock(
+    module_key: str,
+    *,
+    holder: str | None = None,
+    db_path: Path | None = None,
+) -> bool:
+    """Drop a live lock without recording an outcome. Use for aborted
+    runs (user cancelled, crash recovery) where `complete` would be a
+    lie. Returns True if a row was deleted.
+
+    Guarded by holder so a stale process cannot release someone else's
+    lock.
+    """
+    if not module_key:
+        raise ValueError("module_key must be non-empty")
+    holder = holder or default_holder()
+    db_path = db_path or DEFAULT_DB_PATH
+    conn = _connect(db_path)
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        cur = conn.execute(
+            """
+            DELETE FROM module_write_locks
+            WHERE module_key = ?
+              AND holder = ?
+              AND completed_at IS NULL
+            """,
+            (module_key, holder),
+        )
+        conn.commit()
+        return cur.rowcount > 0
+    finally:
+        conn.close()
+
+
+def sweep_expired_locks(db_path: Path | None = None) -> int:
+    """Delete every expired-or-completed lock row. Returns the count.
+
+    Purely hygienic — `acquire_module_lock` evicts the specific key it
+    wants. Call this from a watchdog if you want rows not to linger.
+    """
+    db_path = db_path or DEFAULT_DB_PATH
+    conn = _connect(db_path)
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        cur = conn.execute(
+            """
+            DELETE FROM module_write_locks
+            WHERE completed_at IS NOT NULL
+               OR expires_at <= CAST(strftime('%s','now') AS INTEGER)
+            """
+        )
+        conn.commit()
+        return cur.rowcount
+    finally:
+        conn.close()
+
+
+@contextmanager
+def module_lock(
+    module_key: str,
+    *,
+    holder: str | None = None,
+    lease_seconds: int = DEFAULT_LEASE_SECONDS,
+    db_path: Path | None = None,
+    outcome_on_success: str = "ok",
+    outcome_on_error: str | None = None,
+) -> Iterator[None]:
+    """Context manager: acquire on enter, complete on clean exit,
+    release on exception.
+
+    Raises LockAcquireError if the lock is held. Callers that want to
+    skip-on-contention should call `acquire_module_lock` directly and
+    branch on its return value — the context manager is for the common
+    "take it or bail" path.
+
+    On clean exit: records `outcome_on_success` via complete.
+    On exception: releases the lock so a follow-up run can retry. If
+    `outcome_on_error` is set, records that outcome instead of
+    releasing (useful when you want an audit trail of the failure).
+    """
+    holder = holder or default_holder()
+    conflict = acquire_module_lock(
+        module_key,
+        holder=holder,
+        lease_seconds=lease_seconds,
+        db_path=db_path,
+    )
+    if conflict is not None:
+        raise LockAcquireError(module_key, conflict)
+    try:
+        yield
+    except Exception:
+        if outcome_on_error is not None:
+            complete_module_lock(
+                module_key,
+                holder=holder,
+                outcome=outcome_on_error,
+                db_path=db_path,
+            )
+        else:
+            release_module_lock(
+                module_key, holder=holder, db_path=db_path
+            )
+        raise
+    else:
+        complete_module_lock(
+            module_key,
+            holder=holder,
+            outcome=outcome_on_success,
+            db_path=db_path,
+        )

--- a/tests/test_citation_residuals_cli_lock.py
+++ b/tests/test_citation_residuals_cli_lock.py
@@ -1,0 +1,197 @@
+"""CLI-level tests for citation_residuals resolve + per-module lock.
+
+These tests shim `resolve_module` so the test does not need network,
+LLMs, or real module files. Focus is on the lock orchestration layer in
+`main()`: acquire before each module, complete on success, release on
+crash, and the --no-lock / --dry-run escape hatches.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import citation_residuals  # noqa: E402
+from pipeline_common import module_lock  # noqa: E402
+
+
+@pytest.fixture
+def tmp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    p = tmp_path / ".pipeline" / "v2.db"
+    monkeypatch.setattr(module_lock, "DEFAULT_DB_PATH", p)
+    monkeypatch.setattr(module_lock, "_INITIALIZED_DBS", set())
+    return p
+
+
+@pytest.fixture
+def tmp_queue(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Two fake queue files with one needs_citation each, pointed at by
+    HUMAN_REVIEW_DIR so main() discovers them naturally."""
+    review_dir = tmp_path / "human-review"
+    review_dir.mkdir(parents=True)
+    for key in ("mod-alpha", "mod-beta"):
+        (review_dir / f"{key}.json").write_text(
+            json.dumps(
+                {
+                    "module_key": key,
+                    "queued_findings": {
+                        "needs_citation": [{"line": 1, "signals": ["year_reference"]}]
+                    },
+                    "resolved_findings": [],
+                    "unresolvable_findings": [],
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+    monkeypatch.setattr(citation_residuals, "HUMAN_REVIEW_DIR", review_dir)
+    return review_dir
+
+
+def _fake_resolve(qp: Path, *, dry_run: bool = False, **_: object) -> dict:
+    """A no-op resolver that only reports considered=1 resolved=1."""
+    return {
+        "module_key": qp.stem,
+        "considered": 1,
+        "resolved": 1,
+        "unresolvable": 0,
+        "skipped_already_resolved": 0,
+        "module_edited": True,
+    }
+
+
+def test_main_acquires_and_completes_per_module(
+    tmp_db: Path,
+    tmp_queue: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    monkeypatch.setattr(citation_residuals, "resolve_module", _fake_resolve)
+    rc = citation_residuals.main(["resolve", "--all"])
+    assert rc == 0
+    # Both modules processed successfully.
+    out = capsys.readouterr().out
+    assert "mod-alpha" in out
+    assert "mod-beta" in out
+    assert "skipped_locked=0" in out
+    # Lock table has both rows completed.
+    import sqlite3
+
+    conn = sqlite3.connect(tmp_db)
+    rows = conn.execute(
+        "SELECT module_key, outcome, completed_at FROM module_write_locks "
+        "ORDER BY module_key"
+    ).fetchall()
+    conn.close()
+    assert len(rows) == 2
+    for key, outcome, completed_at in rows:
+        assert outcome == "ok"
+        assert completed_at is not None
+
+
+def test_main_skips_module_held_by_other_worker(
+    tmp_db: Path,
+    tmp_queue: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    monkeypatch.setattr(citation_residuals, "resolve_module", _fake_resolve)
+    # Pre-hold mod-alpha under a different holder. mod-beta is free.
+    conflict = module_lock.acquire_module_lock("mod-alpha", holder="other-worker")
+    assert conflict is None  # acquire succeeded
+
+    rc = citation_residuals.main(
+        ["resolve", "--all", "--worker-id", "resolver-01"]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    # alpha was skipped with a clear reason; beta ran through.
+    assert "mod-alpha: SKIPPED" in out
+    assert "locked by 'other-worker'" in out
+    assert "mod-beta" in out
+    assert "considered=1" in out  # only beta counted toward totals
+    assert "skipped_locked=1" in out
+
+
+def test_main_no_lock_flag_bypasses_locking(
+    tmp_db: Path,
+    tmp_queue: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    monkeypatch.setattr(citation_residuals, "resolve_module", _fake_resolve)
+    # Pre-hold mod-alpha. Without --no-lock this would be skipped.
+    module_lock.acquire_module_lock("mod-alpha", holder="other")
+
+    rc = citation_residuals.main(["resolve", "--all", "--no-lock"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    # Both ran — lock was bypassed.
+    assert "SKIPPED" not in out
+    assert "considered=2" in out
+
+
+def test_main_dry_run_bypasses_locking(
+    tmp_db: Path,
+    tmp_queue: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    monkeypatch.setattr(citation_residuals, "resolve_module", _fake_resolve)
+    # Pre-hold both. --dry-run doesn't write, so no lock contention.
+    module_lock.acquire_module_lock("mod-alpha", holder="other1")
+    module_lock.acquire_module_lock("mod-beta", holder="other2")
+
+    rc = citation_residuals.main(["resolve", "--all", "--dry-run"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "SKIPPED" not in out
+    assert "considered=2" in out
+
+
+def test_main_releases_lock_on_resolver_exception(
+    tmp_db: Path,
+    tmp_queue: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def boom(qp: Path, **_: object) -> dict:
+        raise RuntimeError("synthetic resolver failure")
+
+    monkeypatch.setattr(citation_residuals, "resolve_module", boom)
+    with pytest.raises(RuntimeError, match="synthetic"):
+        citation_residuals.main(
+            ["resolve", "mod-alpha", "--worker-id", "resolver-01"]
+        )
+    # Crash released the lock so the next run can retry the same module.
+    assert (
+        module_lock.acquire_module_lock("mod-alpha", holder="next-worker")
+        is None
+    )
+
+
+def test_main_uses_worker_id_when_provided(
+    tmp_db: Path,
+    tmp_queue: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(citation_residuals, "resolve_module", _fake_resolve)
+    rc = citation_residuals.main(
+        ["resolve", "mod-alpha", "--worker-id", "named-worker-42"]
+    )
+    assert rc == 0
+    import sqlite3
+
+    conn = sqlite3.connect(tmp_db)
+    row = conn.execute(
+        "SELECT holder FROM module_write_locks WHERE module_key = ?",
+        ("mod-alpha",),
+    ).fetchone()
+    conn.close()
+    assert row is not None
+    # Lock still present (completed, not evicted). Holder was the named id.
+    assert row[0] == "named-worker-42"

--- a/tests/test_citation_residuals_cli_lock.py
+++ b/tests/test_citation_residuals_cli_lock.py
@@ -195,3 +195,109 @@ def test_main_uses_worker_id_when_provided(
     assert row is not None
     # Lock still present (completed, not evicted). Holder was the named id.
     assert row[0] == "named-worker-42"
+
+
+def test_main_locks_on_canonical_module_key_not_filename_stem(
+    tmp_db: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for Codex PR #363 review finding.
+
+    Queue filenames are slash-flattened (e.g.
+    `ai-ml-engineering-advanced-genai-module-1.1-fine-tuning-llms.json`)
+    but the canonical module_key inside the JSON keeps slashes
+    (`ai-ml-engineering/advanced-genai/module-1.1-fine-tuning-llms`).
+    The lock must be keyed on the canonical value so other writers
+    using the canonical key coordinate properly. Locking on the stem
+    would cause false non-coordination.
+    """
+    review_dir = tmp_path / "human-review"
+    review_dir.mkdir(parents=True)
+    flattened_filename = "track-topic-module-1"
+    canonical_key = "track/topic/module-1"
+    (review_dir / f"{flattened_filename}.json").write_text(
+        json.dumps(
+            {
+                "module_key": canonical_key,
+                "queued_findings": {
+                    "needs_citation": [{"line": 1, "signals": ["year_reference"]}]
+                },
+                "resolved_findings": [],
+                "unresolvable_findings": [],
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+    monkeypatch.setattr(citation_residuals, "HUMAN_REVIEW_DIR", review_dir)
+    monkeypatch.setattr(citation_residuals, "resolve_module", _fake_resolve)
+
+    rc = citation_residuals.main(
+        ["resolve", "--all", "--worker-id", "resolver-01"]
+    )
+    assert rc == 0
+    import sqlite3
+
+    conn = sqlite3.connect(tmp_db)
+    # Lock row uses the canonical (slashed) key, NOT the stem.
+    row_canonical = conn.execute(
+        "SELECT holder, outcome FROM module_write_locks WHERE module_key = ?",
+        (canonical_key,),
+    ).fetchone()
+    row_stem = conn.execute(
+        "SELECT holder FROM module_write_locks WHERE module_key = ?",
+        (flattened_filename,),
+    ).fetchone()
+    conn.close()
+    assert row_canonical is not None, (
+        "lock was not recorded under the canonical module_key — "
+        "concurrent writers using the canonical key would not "
+        "coordinate with this resolver"
+    )
+    assert row_canonical[0] == "resolver-01"
+    assert row_canonical[1] == "ok"
+    assert row_stem is None, (
+        "lock was incorrectly recorded under the flattened stem"
+    )
+
+
+def test_main_falls_back_to_stem_when_module_key_missing(
+    tmp_db: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy queue files without a `module_key` field fall back to
+    using the filename stem. Preserves behavior for pre-canonical-key
+    files that might still exist in an operator's local pipeline state.
+    """
+    review_dir = tmp_path / "human-review"
+    review_dir.mkdir(parents=True)
+    (review_dir / "legacy-mod.json").write_text(
+        json.dumps(
+            {
+                # No "module_key" field.
+                "queued_findings": {
+                    "needs_citation": [{"line": 1, "signals": ["year_reference"]}]
+                },
+                "resolved_findings": [],
+                "unresolvable_findings": [],
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+    monkeypatch.setattr(citation_residuals, "HUMAN_REVIEW_DIR", review_dir)
+    monkeypatch.setattr(citation_residuals, "resolve_module", _fake_resolve)
+
+    rc = citation_residuals.main(["resolve", "--all"])
+    assert rc == 0
+    import sqlite3
+
+    conn = sqlite3.connect(tmp_db)
+    row = conn.execute(
+        "SELECT module_key FROM module_write_locks"
+    ).fetchone()
+    conn.close()
+    assert row is not None
+    assert row[0] == "legacy-mod"

--- a/tests/test_module_lock.py
+++ b/tests/test_module_lock.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import sqlite3
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from pipeline_common import module_lock  # noqa: E402
+
+
+@pytest.fixture
+def db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point module_lock at a tmp DB per test + clear the schema cache so
+    each test re-runs CREATE TABLE IF NOT EXISTS against its own file.
+    """
+    p = tmp_path / ".pipeline" / "v2.db"
+    monkeypatch.setattr(module_lock, "DEFAULT_DB_PATH", p)
+    monkeypatch.setattr(module_lock, "_INITIALIZED_DBS", set())
+    return p
+
+
+def _row(db_path: Path, module_key: str) -> sqlite3.Row | None:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        return conn.execute(
+            "SELECT * FROM module_write_locks WHERE module_key = ?",
+            (module_key,),
+        ).fetchone()
+    finally:
+        conn.close()
+
+
+def _expire(db_path: Path, module_key: str) -> None:
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "UPDATE module_write_locks SET expires_at = 0 WHERE module_key = ?",
+            (module_key,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_acquire_on_empty_db_succeeds(db_path: Path) -> None:
+    conflict = module_lock.acquire_module_lock("mod-a", holder="worker-1")
+    assert conflict is None
+    row = _row(db_path, "mod-a")
+    assert row is not None
+    assert row["holder"] == "worker-1"
+    assert row["completed_at"] is None
+
+
+def test_double_acquire_same_key_returns_conflict(db_path: Path) -> None:
+    assert module_lock.acquire_module_lock("mod-a", holder="w1") is None
+    conflict = module_lock.acquire_module_lock("mod-a", holder="w2")
+    assert conflict is not None
+    assert conflict.holder == "w1"
+    assert conflict.expires_at > conflict.acquired_at
+
+
+def test_different_keys_do_not_conflict(db_path: Path) -> None:
+    assert module_lock.acquire_module_lock("mod-a", holder="w1") is None
+    assert module_lock.acquire_module_lock("mod-b", holder="w2") is None
+    # Both rows present.
+    assert _row(db_path, "mod-a") is not None
+    assert _row(db_path, "mod-b") is not None
+
+
+def test_expired_lock_gets_stolen(db_path: Path) -> None:
+    assert module_lock.acquire_module_lock("mod-a", holder="w1") is None
+    _expire(db_path, "mod-a")
+    # Another holder takes over cleanly.
+    assert module_lock.acquire_module_lock("mod-a", holder="w2") is None
+    row = _row(db_path, "mod-a")
+    assert row is not None
+    assert row["holder"] == "w2"
+
+
+def test_completed_lock_gets_stolen(db_path: Path) -> None:
+    assert module_lock.acquire_module_lock("mod-a", holder="w1") is None
+    assert module_lock.complete_module_lock(
+        "mod-a", holder="w1", outcome="done"
+    )
+    # Another holder can now take it.
+    assert module_lock.acquire_module_lock("mod-a", holder="w2") is None
+    row = _row(db_path, "mod-a")
+    assert row is not None
+    assert row["holder"] == "w2"
+    # And the completed row is gone — the new acquire evicted it.
+    assert row["completed_at"] is None
+    assert row["outcome"] is None
+
+
+def test_complete_guards_by_holder(db_path: Path) -> None:
+    assert module_lock.acquire_module_lock("mod-a", holder="w1") is None
+    assert not module_lock.complete_module_lock(
+        "mod-a", holder="imposter", outcome="evil"
+    )
+    # Original holder can still complete.
+    assert module_lock.complete_module_lock(
+        "mod-a", holder="w1", outcome="done"
+    )
+
+
+def test_release_guards_by_holder(db_path: Path) -> None:
+    assert module_lock.acquire_module_lock("mod-a", holder="w1") is None
+    assert not module_lock.release_module_lock("mod-a", holder="imposter")
+    # Row still there.
+    assert _row(db_path, "mod-a") is not None
+    assert module_lock.release_module_lock("mod-a", holder="w1")
+    assert _row(db_path, "mod-a") is None
+
+
+def test_release_does_not_touch_completed_row(db_path: Path) -> None:
+    assert module_lock.acquire_module_lock("mod-a", holder="w1") is None
+    assert module_lock.complete_module_lock(
+        "mod-a", holder="w1", outcome="done"
+    )
+    # Completed rows ignore release — the row survives, owner audit trail
+    # stays intact until next acquire evicts it.
+    assert not module_lock.release_module_lock("mod-a", holder="w1")
+    row = _row(db_path, "mod-a")
+    assert row is not None
+    assert row["outcome"] == "done"
+
+
+def test_sweep_clears_expired_and_completed(db_path: Path) -> None:
+    assert module_lock.acquire_module_lock("mod-a", holder="w1") is None
+    assert module_lock.acquire_module_lock("mod-b", holder="w2") is None
+    assert module_lock.acquire_module_lock("mod-c", holder="w3") is None
+    _expire(db_path, "mod-a")
+    module_lock.complete_module_lock("mod-b", holder="w2", outcome="ok")
+    # mod-c is live and should survive.
+    cleared = module_lock.sweep_expired_locks()
+    assert cleared == 2
+    assert _row(db_path, "mod-a") is None
+    assert _row(db_path, "mod-b") is None
+    assert _row(db_path, "mod-c") is not None
+
+
+def test_context_manager_success_records_completion(db_path: Path) -> None:
+    with module_lock.module_lock(
+        "mod-a", holder="w1", outcome_on_success="clean"
+    ):
+        # Re-entry by another holder is blocked inside the body.
+        conflict = module_lock.acquire_module_lock("mod-a", holder="w2")
+        assert conflict is not None
+        assert conflict.holder == "w1"
+    row = _row(db_path, "mod-a")
+    assert row is not None
+    assert row["completed_at"] is not None
+    assert row["outcome"] == "clean"
+
+
+def test_context_manager_exception_releases_by_default(db_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="boom"):
+        with module_lock.module_lock("mod-a", holder="w1"):
+            raise RuntimeError("boom")
+    # Released — row is gone, next acquire unblocked.
+    assert _row(db_path, "mod-a") is None
+    assert module_lock.acquire_module_lock("mod-a", holder="w2") is None
+
+
+def test_context_manager_exception_with_outcome_records_it(
+    db_path: Path,
+) -> None:
+    with pytest.raises(RuntimeError):
+        with module_lock.module_lock(
+            "mod-a",
+            holder="w1",
+            outcome_on_error="crashed",
+        ):
+            raise RuntimeError("boom")
+    row = _row(db_path, "mod-a")
+    assert row is not None
+    assert row["outcome"] == "crashed"
+    assert row["completed_at"] is not None
+
+
+def test_context_manager_conflict_raises_lock_acquire_error(
+    db_path: Path,
+) -> None:
+    assert module_lock.acquire_module_lock("mod-a", holder="w1") is None
+    with pytest.raises(module_lock.LockAcquireError) as excinfo:
+        with module_lock.module_lock("mod-a", holder="w2"):
+            pytest.fail("should not enter body")
+    assert excinfo.value.module_key == "mod-a"
+    assert excinfo.value.conflict.holder == "w1"
+
+
+def test_default_holder_is_pid_at_hostname() -> None:
+    h = module_lock.default_holder()
+    assert "@" in h
+    pid_part, host_part = h.split("@", 1)
+    assert pid_part.isdigit()
+    assert host_part  # non-empty
+
+
+def test_empty_module_key_rejected(db_path: Path) -> None:
+    with pytest.raises(ValueError, match="module_key"):
+        module_lock.acquire_module_lock("", holder="w1")
+    with pytest.raises(ValueError):
+        module_lock.complete_module_lock("", holder="w1", outcome="x")
+    with pytest.raises(ValueError):
+        module_lock.release_module_lock("", holder="w1")
+
+
+def test_nonpositive_lease_rejected(db_path: Path) -> None:
+    with pytest.raises(ValueError, match="lease_seconds"):
+        module_lock.acquire_module_lock(
+            "mod-a", holder="w1", lease_seconds=0
+        )
+    with pytest.raises(ValueError):
+        module_lock.acquire_module_lock(
+            "mod-a", holder="w1", lease_seconds=-5
+        )
+
+
+def test_concurrent_threads_single_winner(db_path: Path) -> None:
+    """Stress: N threads race to acquire the same key. Exactly one wins.
+
+    This is the real contract the caller cares about: the pilot bug
+    (two resolvers on the same module clobbering each other) cannot
+    recur if and only if at most one acquirer succeeds per snapshot.
+    """
+    # Prime the schema cache from the main thread so the threads are not
+    # all doing CREATE TABLE in parallel — the _ensure_schema lock handles
+    # that too, but priming keeps the race purely on the INSERT.
+    assert module_lock.acquire_module_lock("primer", holder="prime") is None
+    module_lock.release_module_lock("primer", holder="prime")
+
+    winners: list[bool] = []
+    barrier = threading.Barrier(10)
+
+    def attempt() -> None:
+        barrier.wait()
+        # Each thread gets a unique holder so the winner's identity is
+        # visible but all 10 are contending for the SAME key.
+        holder = f"t-{threading.get_ident()}"
+        conflict = module_lock.acquire_module_lock(
+            "hot-key", holder=holder
+        )
+        winners.append(conflict is None)
+
+    threads = [threading.Thread(target=attempt) for _ in range(10)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=15)
+    assert all(not t.is_alive() for t in threads), "thread hung"
+    assert sum(1 for w in winners if w) == 1, winners
+
+
+def test_lease_seconds_affects_expires_at(db_path: Path) -> None:
+    before = int(time.time())
+    module_lock.acquire_module_lock(
+        "mod-a", holder="w1", lease_seconds=60
+    )
+    after = int(time.time())
+    row = _row(db_path, "mod-a")
+    assert row is not None
+    assert before + 60 <= row["expires_at"] <= after + 60


### PR DESCRIPTION
Addresses the concurrency gap flagged in PR #357's Codex review: two `citation_residuals resolve` invocations on the same module clobber each other's writes to `src/content/docs/<module_key>.md` and to the per-module queue JSON. That bug bit during the phase-1 pilot (accidental foreground + background run on the same key). Must ship before phase-2 bulk.

## What's added

**`scripts/pipeline_common/module_lock.py`** — small advisory-lock primitive backed by `.pipeline/v2.db`:

- `acquire_module_lock(module_key, *, holder, lease_seconds, db_path) -> LockConflict | None`
- `complete_module_lock(module_key, *, holder, outcome, db_path) -> bool`
- `release_module_lock(module_key, *, holder, db_path) -> bool`
- `sweep_expired_locks(db_path) -> int`
- `module_lock(...)` context manager — acquire, complete on clean exit, release on exception (or record `outcome_on_error`)

Semantics:
- Holder-guarded — only the acquirer can complete or release.
- Expiry-based stealing — abandoned locks auto-evict on next acquire (TTL default 1800s, ~30 min).
- WAL mode, BEGIN IMMEDIATE atomic acquire, PRIMARY KEY collision → `LockConflict` return (never raise on contention).

## What's wired up

`citation_residuals.py resolve`:
- Flags: `--worker-id`, `--lease-seconds`, `--no-lock`.
- Per-module: acquire → `resolve_module()` → complete. Contention logs `SKIPPED — locked by <holder> until epoch <X>` and moves on. Totals add `skipped_locked=N`.
- `--dry-run` and `--no-lock` bypass locking (no writes to protect).
- Crashes release the lock so a follow-up run can retry.
- `resolve_module()` itself stays lock-agnostic — all orchestration in the CLI `main()`.

## Intentionally NOT touched

`pipeline_v4_batch.py` has its own `v4_batch_leases` table with the same shape. Left as-is for this PR — future cleanup can migrate it onto the shared primitive. No in-flight v4 runs exist to conflict.

## Tests

- `tests/test_module_lock.py` — 18 tests: acquire contention, holder guards, expiry stealing, completed-lock reuse, sweep, context manager happy + exception paths, input validation, **threaded stress test** (10 threads racing for the same key; exactly 1 wins).
- `tests/test_citation_residuals_cli_lock.py` — 6 CLI integration tests: acquire-before-resolve, skip-on-contention, --no-lock bypass, --dry-run bypass, crash-releases-lock, --worker-id propagation.
- All 55 existing citation/lock tests pass. New total: **61 passing**.
- `ruff check` clean.

## Review ask (Codex per cross-family rule)

1. **Holder identity.** `default_holder()` returns `<pid>@<hostname>`. Is this robust enough for the real concurrency model (two bash sessions on the same host)? Any reason to prefer a UUID so distinct pids never collide even on pid reuse?
2. **Lock contention UX.** Currently the CLI logs `SKIPPED — locked by <holder> until epoch <X>` and continues. Worth offering a `--fail-on-locked` flag so CI can detect overlap instead of silently skipping? Or is continue-with-skip the right default for `--all` runs?
3. **TTL default.** 1800s is generous. Too generous? The concern is that a stuck run (network hang in fetch_citation) holds the lock until TTL expires, delaying retries. Alternative: shorter TTL + heartbeat refresh mid-run, but that's more machinery.
4. **Crash path edge case.** If `resolve_module` crashes AFTER partial writes (module .md already updated but queue JSON not), `release_module_lock` drops the lock without recording the partial state. The next run would see the updated module + old queue. Is a partial-write audit trail worth adding, or does the atomic `save_queue_file(tmp + replace)` cover enough?
5. **Anything else** — race conditions, transaction boundaries, schema gotchas.

If APPROVE, I'll merge + start the phase-2 bulk prep (fresh-sample pilot on the 64 batch-c residuals modules, then the actual bulk run with `--workers 3` safely).

🤖 Generated with [Claude Code](https://claude.com/claude-code)