### PR TITLE
feat(#343): --limit-modules N for gradual pilot rollout

### DIFF
--- a/scripts/citation_residuals.py
+++ b/scripts/citation_residuals.py
@@ -817,6 +817,20 @@ def main(argv: list[str] | None = None) -> int:
     )
     p_resolve.add_argument("--all", action="store_true", help="Process every queue file")
     p_resolve.add_argument(
+        "--limit-modules",
+        type=int,
+        default=None,
+        metavar="N",
+        help=(
+            "Cap the number of modules processed in an --all run to N. Useful "
+            "for gradual rollout / pilot runs before a full bulk batch — see "
+            "the 2026-04-23 postmortem. Applied AFTER the empty-queue filter, "
+            "so N=10 means 10 modules with actual needs_citation findings, "
+            "not 10 scanned files. Has no effect when a specific module_key is "
+            "given instead of --all."
+        ),
+    )
+    p_resolve.add_argument(
         "--dry-run",
         action="store_true",
         help="Propose resolutions but do not write to modules or queue JSON",
@@ -887,6 +901,14 @@ def main(argv: list[str] | None = None) -> int:
         if not useful_targets:
             print("No residuals with needs_citation findings.")
             return 0
+
+        if args.all and args.limit_modules is not None and args.limit_modules > 0:
+            total_before = len(useful_targets)
+            useful_targets = useful_targets[: args.limit_modules]
+            print(
+                f"--limit-modules {args.limit_modules}: "
+                f"processing {len(useful_targets)} of {total_before} useful modules"
+            )
 
         totals = {
             "considered": 0,

--- a/scripts/citation_residuals.py
+++ b/scripts/citation_residuals.py
@@ -816,18 +816,36 @@ def main(argv: list[str] | None = None) -> int:
         help="Module key or slug. Use --all instead to process every queued file.",
     )
     p_resolve.add_argument("--all", action="store_true", help="Process every queue file")
+
+    def _positive_int(raw: str) -> int:
+        try:
+            value = int(raw)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError(
+                f"--limit-modules must be a positive integer, got {raw!r}"
+            ) from exc
+        if value <= 0:
+            raise argparse.ArgumentTypeError(
+                f"--limit-modules must be >= 1 (got {value}); "
+                "silently treating 0 or negative as 'no limit' would let a "
+                "typo unleash the full bulk run"
+            )
+        return value
+
     p_resolve.add_argument(
         "--limit-modules",
-        type=int,
+        type=_positive_int,
         default=None,
         metavar="N",
         help=(
-            "Cap the number of modules processed in an --all run to N. Useful "
-            "for gradual rollout / pilot runs before a full bulk batch — see "
-            "the 2026-04-23 postmortem. Applied AFTER the empty-queue filter, "
-            "so N=10 means 10 modules with actual needs_citation findings, "
-            "not 10 scanned files. Has no effect when a specific module_key is "
-            "given instead of --all."
+            "Cap the number of modules processed in an --all run to N (>=1). "
+            "Useful for gradual rollout / pilot runs before a full bulk "
+            "batch — see the 2026-04-23 postmortem. Applied AFTER the "
+            "empty-queue filter, so N=10 means 10 modules with actual "
+            "needs_citation findings, not 10 scanned files. Has no effect "
+            "when a specific module_key is given instead of --all. "
+            "0 or negative is rejected up front — an invalid cap must not "
+            "silently degrade to 'no limit'."
         ),
     )
     p_resolve.add_argument(
@@ -902,7 +920,8 @@ def main(argv: list[str] | None = None) -> int:
             print("No residuals with needs_citation findings.")
             return 0
 
-        if args.all and args.limit_modules is not None and args.limit_modules > 0:
+        if args.all and args.limit_modules is not None:
+            # argparse type=_positive_int already rejected 0/negative.
             total_before = len(useful_targets)
             useful_targets = useful_targets[: args.limit_modules]
             print(

--- a/tests/test_citation_residuals.py
+++ b/tests/test_citation_residuals.py
@@ -977,3 +977,86 @@ def test_limit_modules_ignored_when_module_key_given(
     )
     assert rc == 0
     assert len(called) == 1
+
+
+def test_limit_modules_applied_after_empty_queue_filter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cap must slice the useful (non-empty) modules, not the raw scanned files.
+
+    Mixes empty and non-empty queue files in alphabetical order so that a
+    buggy "slice before filter" would pick up an empty file in the first N
+    slots. After-filter behavior must process N modules with real findings.
+    """
+    queue_dir = tmp_path / ".pipeline" / "v3" / "human-review"
+    queue_dir.mkdir(parents=True)
+    finding = {
+        "line": 3,
+        "signals": ["year_reference"],
+        "excerpt": "In 2023 something happened.",
+        "search_hint": ["2023 event"],
+    }
+    # Filenames chosen so the scan order is: a-empty, b-real, c-empty, d-real.
+    # With --limit-modules 2, slice-before-filter would pick {a, b} (1 real),
+    # slice-after-filter must pick {b, d} (2 real).
+    _write_queue_file(queue_dir / "a-empty.json", "a/empty", [])
+    _write_queue_file(queue_dir / "b-real.json", "b/real", [finding])
+    _write_queue_file(queue_dir / "c-empty.json", "c/empty", [])
+    _write_queue_file(queue_dir / "d-real.json", "d/real", [finding])
+
+    monkeypatch.setattr(citation_residuals, "HUMAN_REVIEW_DIR", queue_dir)
+
+    called: list[str] = []
+
+    def fake_resolve_module(qp: Path, **_: Any) -> dict[str, Any]:
+        called.append(qp.stem)
+        return {
+            "module_key": qp.stem,
+            "considered": 1,
+            "resolved": 0,
+            "unresolvable": 0,
+            "module_edited": False,
+        }
+
+    monkeypatch.setattr(citation_residuals, "resolve_module", fake_resolve_module)
+
+    rc = citation_residuals.main(
+        ["resolve", "--all", "--limit-modules", "2", "--no-lock"]
+    )
+    assert rc == 0
+    assert called == ["b-real", "d-real"], (
+        "cap must filter empty queues first; got "
+        f"{called} — if 'a-empty' appears, the slice ran before the filter"
+    )
+
+
+def test_limit_modules_rejects_zero(capsys: pytest.CaptureFixture[str]) -> None:
+    """0 must not silently degrade to 'no limit'. A typo that would unleash
+    the full bulk run is the exact failure mode to prevent."""
+    with pytest.raises(SystemExit) as exc_info:
+        citation_residuals.main(
+            ["resolve", "--all", "--limit-modules", "0", "--no-lock"]
+        )
+    assert exc_info.value.code == 2
+    err = capsys.readouterr().err
+    assert "--limit-modules must be >= 1" in err
+
+
+def test_limit_modules_rejects_negative(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        citation_residuals.main(
+            ["resolve", "--all", "--limit-modules", "-3", "--no-lock"]
+        )
+    assert exc_info.value.code == 2
+    err = capsys.readouterr().err
+    assert "--limit-modules must be >= 1" in err
+
+
+def test_limit_modules_rejects_non_integer(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        citation_residuals.main(
+            ["resolve", "--all", "--limit-modules", "abc", "--no-lock"]
+        )
+    assert exc_info.value.code == 2
+    err = capsys.readouterr().err
+    assert "must be a positive integer" in err

--- a/tests/test_citation_residuals.py
+++ b/tests/test_citation_residuals.py
@@ -884,3 +884,96 @@ def test_build_source_line_safe_title_and_summary() -> None:
     # Summary uses first sentence only.
     assert "Further details" not in line
     assert "Amazon scrapped its AI recruiting tool in 2018." in line
+
+
+# ---- CLI: --limit-modules ------------------------------------------------
+
+
+def test_limit_modules_caps_all_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    queue_dir = tmp_path / ".pipeline" / "v3" / "human-review"
+    queue_dir.mkdir(parents=True)
+    finding = {
+        "line": 3,
+        "signals": ["year_reference"],
+        "excerpt": "In 2023 something happened.",
+        "search_hint": ["2023 event"],
+    }
+    for i in range(3):
+        _write_queue_file(
+            queue_dir / f"ai-demo-module-1.{i}-test.json",
+            f"ai/demo/module-1.{i}-test",
+            [finding],
+        )
+
+    monkeypatch.setattr(citation_residuals, "HUMAN_REVIEW_DIR", queue_dir)
+
+    called: list[Path] = []
+
+    def fake_resolve_module(qp: Path, **_: Any) -> dict[str, Any]:
+        called.append(qp)
+        return {
+            "module_key": qp.stem,
+            "considered": 1,
+            "resolved": 0,
+            "unresolvable": 0,
+            "module_edited": False,
+        }
+
+    monkeypatch.setattr(citation_residuals, "resolve_module", fake_resolve_module)
+
+    rc = citation_residuals.main(
+        ["resolve", "--all", "--limit-modules", "2", "--no-lock"]
+    )
+    assert rc == 0
+    assert len(called) == 2
+    out = capsys.readouterr().out
+    assert "--limit-modules 2" in out
+    assert "processing 2 of 3 useful modules" in out
+
+
+def test_limit_modules_ignored_when_module_key_given(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    queue_dir = tmp_path / ".pipeline" / "v3" / "human-review"
+    queue_dir.mkdir(parents=True)
+    finding = {
+        "line": 3,
+        "signals": ["year_reference"],
+        "excerpt": "In 2023 something happened.",
+        "search_hint": ["2023 event"],
+    }
+    _write_queue_file(
+        queue_dir / "ai-demo-module-1.0-test.json",
+        "ai/demo/module-1.0-test",
+        [finding],
+    )
+
+    monkeypatch.setattr(citation_residuals, "HUMAN_REVIEW_DIR", queue_dir)
+
+    called: list[Path] = []
+
+    def fake_resolve_module(qp: Path, **_: Any) -> dict[str, Any]:
+        called.append(qp)
+        return {
+            "module_key": qp.stem,
+            "considered": 1,
+            "resolved": 0,
+            "unresolvable": 0,
+            "module_edited": False,
+        }
+
+    monkeypatch.setattr(citation_residuals, "resolve_module", fake_resolve_module)
+
+    rc = citation_residuals.main(
+        [
+            "resolve",
+            "ai/demo/module-1.0-test",
+            "--limit-modules",
+            "5",
+            "--no-lock",
+        ]
+    )
+    assert rc == 0
+    assert len(called) == 1


### PR DESCRIPTION
## Summary

- Adds \`--limit-modules N\` to \`citation_residuals.py resolve --all\` so operators can cap a run at N modules without editing the script — the pilot-N knob the 2026-04-23 postmortem asked for.
- Applies the cap AFTER the empty-queue filter, so \`N=10\` means 10 modules with real findings, not 10 scanned files.
- No interaction with #363's per-module lock: \`--limit-modules\` is an outer filter on the loop; \`module_lock.acquire_module_lock\` still wraps each \`resolve_module\` call.
- Refs #343, #363, \`feedback_batch_worker_cap.md\`.

## Usage

\`\`\`bash
# Pilot-10 on fresh batch-c residuals:
python scripts/citation_residuals.py resolve --all --worker-id pilot-2 --limit-modules 10

# Ignored with a single module_key (the single-target path is already N=1):
python scripts/citation_residuals.py resolve ai/demo/module-1.0-test --limit-modules 5
\`\`\`

Prints the cap in effect:

\`\`\`
--limit-modules 10: processing 10 of 64 useful modules
\`\`\`

## Why

Phase-2 bulk at \`--workers 3\` across 64 batch-c residuals modules is the target after #363 landed. Running bulk blind is risky — the audit (PR #366) shows only ~57% of findings are Category A (sourceable), with the rest being pedagogical fiction or ambiguous. A gradual \`--limit-modules 10\` pilot on a fresh sample sets a calibrated resolve-rate before the full run, and keeps the operator loop tight.

Also surfaces early whatever #364 (Sources-line description bug) would produce at scale, before the bulk commits ship.

## Test plan

- [x] 2 new tests: cap applied with \`--all\`; ignored when \`module_key\` given.
- [x] 39/39 existing \`test_citation_residuals.py\` pass (including the lock / canonical-key tests from #363).
- [x] Ruff clean.
- [ ] Cross-family review per \`docs/review-protocol.md\` — prefer Codex (more rigorous on Claude-authored code batches per #350 data point).
- [ ] Smoke: \`python scripts/citation_residuals.py resolve --all --limit-modules 1 --dry-run\` on a real residuals snapshot processes exactly one useful module.