### PR TITLE
fix(#364): drop finding-excerpt-as-description in Sources line

### DIFF
--- a/scripts/citation_residuals.py
+++ b/scripts/citation_residuals.py
@@ -514,11 +514,21 @@ def short_id_for(url: str) -> str:
 
 
 def build_source_line(url: str, finding: dict[str, Any], *, title: str | None = None) -> str:
-    """Render one `- [title](url) — note` bullet for the Sources list."""
+    """Render one ``- [title](url)`` bullet for the Sources list.
+
+    ``finding`` is retained in the signature for call-site compatibility
+    but is intentionally unused: earlier versions appended a "description"
+    derived from the finding's excerpt, which was the *claim being cited*
+    rather than a description of what the source actually says (see #364).
+    A URL-derived title is sufficient provenance; richer per-source
+    descriptions — if wanted — should come from the cited page itself
+    (``<title>``, ``<meta description>``) or an LLM summary of the page
+    body, never from the module text.
+    """
+    del finding  # intentionally unused; see docstring
     display_title = title or _derive_title_from_url(url)
-    note = _summarize_finding(finding)
     safe_title = display_title.replace("[", r"\[").replace("]", r"\]")
-    return f"- [{safe_title}]({url}) — {note}"
+    return f"- [{safe_title}]({url})"
 
 
 def _derive_title_from_url(url: str) -> str:
@@ -528,23 +538,17 @@ def _derive_title_from_url(url: str) -> str:
     host = (parsed.hostname or "").removeprefix("www.")
     path_segments = [seg for seg in parsed.path.split("/") if seg]
     tail = path_segments[-1] if path_segments else ""
+    # Strip the document extension (.html/.htm) so the title reads as a
+    # page name rather than a filename. Non-doc extensions (.pdf, .json)
+    # are preserved because they carry meaningful format signal.
+    for ext in (".html", ".htm"):
+        if tail.lower().endswith(ext):
+            tail = tail[: -len(ext)]
+            break
     readable = tail.replace("-", " ").replace("_", " ").strip()
     if host and readable:
         return f"{host}: {readable}"
     return host or url
-
-
-def _summarize_finding(finding: dict[str, Any]) -> str:
-    excerpt = (finding.get("excerpt") or "").strip()
-    # First sentence of excerpt, capped at 160 chars — enough for context
-    # without duplicating the whole paragraph.
-    first_sentence = re.split(r"(?<=[.!?])\s+", excerpt, maxsplit=1)[0]
-    summary = first_sentence[:160].strip()
-    if not summary:
-        return "Supporting citation for the flagged claim."
-    if not summary.endswith((".", "!", "?")):
-        summary += "."
-    return summary
 
 
 def inject_source(module_text: str, source_line: str) -> tuple[str, bool]:

--- a/tests/test_citation_residuals.py
+++ b/tests/test_citation_residuals.py
@@ -871,7 +871,15 @@ def test_resolve_module_marks_unresolvable_when_no_candidates(
 # ---- source_line rendering -----------------------------------------------
 
 
-def test_build_source_line_safe_title_and_summary() -> None:
+def test_build_source_line_omits_finding_excerpt() -> None:
+    """Regression guard for #364. The Sources-line description MUST NOT
+    derive from the finding's excerpt — the excerpt is the claim being
+    cited, not a description of what the source documents. Earlier
+    resolver versions shipped the excerpt verbatim as the description,
+    producing lines that read as though the cited source authored the
+    original claim. The Sources line is now title-only; richer
+    per-source descriptions should come from the page itself, not from
+    the module text."""
     finding = {
         "excerpt": "Amazon scrapped its AI recruiting tool in 2018. Further details here.",
         "signals": ["year_reference"],
@@ -881,9 +889,52 @@ def test_build_source_line_safe_title_and_summary() -> None:
     )
     assert line.startswith("- [")
     assert "https://www.reuters.com/article/idUSKCN1MK08G" in line
-    # Summary uses first sentence only.
+    # No trailing description dash + text: "- [title](url)" only.
+    assert " — " not in line, f"unexpected description separator in: {line!r}"
+    # Absolutely no excerpt text in the output — this is the #364 failure
+    # mode. If this assertion ever regresses, every phase-2 bulk resolve
+    # will ship claim-text-as-description lines again.
+    assert "Amazon scrapped" not in line
     assert "Further details" not in line
-    assert "Amazon scrapped its AI recruiting tool in 2018." in line
+
+
+def test_build_source_line_escapes_brackets_in_derived_title() -> None:
+    line = citation_residuals.build_source_line(
+        "https://example.com/docs/foo-[bar]-baz", {"excerpt": "anything"}
+    )
+    # Bracket chars in the derived title must be escaped so the Markdown
+    # link syntax stays unambiguous.
+    assert r"\[bar\]" in line
+
+
+def test_build_source_line_respects_explicit_title() -> None:
+    line = citation_residuals.build_source_line(
+        "https://example.com/doc",
+        {"excerpt": "anything"},
+        title="AWS Well-Architected: Reliability Pillar",
+    )
+    assert "[AWS Well-Architected: Reliability Pillar]" in line
+    assert "(https://example.com/doc)" in line
+    assert " — " not in line
+
+
+def test_derive_title_strips_html_extension() -> None:
+    # The resolver targets vendor docs that often end in .html; stripping
+    # the document extension makes the title read as a page name rather
+    # than a filename ("foo bar" rather than "foo bar.html").
+    title = citation_residuals._derive_title_from_url(
+        "https://docs.aws.amazon.com/whitepapers/latest/"
+        "organizing-your-aws-environment/benefits-of-using-multiple-aws-accounts.html"
+    )
+    assert title == "docs.aws.amazon.com: benefits of using multiple aws accounts"
+
+
+def test_derive_title_preserves_non_doc_extension() -> None:
+    # .pdf carries format signal the reader cares about — keep it.
+    title = citation_residuals._derive_title_from_url(
+        "https://example.com/whitepapers/reliability.pdf"
+    )
+    assert title.endswith("reliability.pdf")
 
 
 # ---- CLI: --limit-modules ------------------------------------------------


### PR DESCRIPTION
## Summary

Unblocks #343 phase-2 bulk. The resolver's \`_summarize_finding\` took the finding's \`excerpt\` (the module's original claim text) and injected it as the Sources-line description. Readers saw lines like:

\`\`\`
- [docs.aws.amazon.com: benefits...](url) — The root cause of this catastrophic failure was not the load test itself, nor was it the junior developer's actions.
\`\`\`

The URL is valid (AWS whitepaper). The description reads as though the whitepaper authored that claim. Incompatible with the human-curated Sources lines already in the module.

## What this PR does

- Delete \`_summarize_finding\` entirely.
- \`build_source_line\` emits \`- [title](url)\` — no trailing description.
- Strip \`.html\`/\`.htm\` from URL-derived titles so the page reads as a name, not a filename. \`.pdf\` etc. preserved (format signal).
- \`finding\` stays in the signature for call-site compatibility but is documented as intentionally unused.

Before:

\`\`\`
- [docs.aws.amazon.com: benefits of using multiple aws accounts.html](url) — The root cause of this catastrophic failure was not the load test itself.
\`\`\`

After:

\`\`\`
- [docs.aws.amazon.com: benefits of using multiple aws accounts](url)
\`\`\`

## What this PR intentionally does NOT do

- **No LLM one-liner describing the page content.** That is the preferred higher-quality fix but requires either a second dispatch per resolve or a page-body parser. An honest absence beats a misleading description, so ship minimum viable first.
- **Does not re-resolve already-committed garbage descriptions.** A later content sweep or re-resolve will catch those. Out of scope here.

## Tests

- Old \`test_build_source_line_safe_title_and_summary\` (which locked in the bug) replaced by \`test_build_source_line_omits_finding_excerpt\` — a regression guard asserting the output contains neither excerpt text nor a description separator. **If this ever regresses, every phase-2 bulk resolve will re-introduce claim-text-as-description lines.**
- 3 new tests covering escape-bracket safety, explicit-title override, and extension-stripping policy.
- 47/47 tests pass. Ruff clean.

## Refs

- Closes #364.
- Unblocks #343 phase-2 bulk pilot (fresh 10-module sample using the new \`--limit-modules 10\` flag from #367).
- Related: #344 (phase-2 overstated/off-topic scope), #341 (epic).

## Test plan

- [x] 47/47 existing tests pass.
- [x] Smoke: \`build_source_line\` on real vendor URLs (AWS whitepaper, learn.microsoft, cloud.google) matches existing Sources-line convention style, minus description.
- [ ] Cross-family review per \`docs/review-protocol.md\` — Claude-authored, so Codex reviewer preferred.
- [ ] Post-merge: run \`resolve --all --limit-modules 1 --dry-run\` on a real residuals snapshot to confirm a resolved finding produces a clean \`- [title](url)\` line.