### PR TITLE
fix(#365): correct CloudWatch/EC2 launch-date historical error

### DIFF
--- a/src/content/docs/cloud/aws-essentials/module-1.10-cloudwatch.md
+++ b/src/content/docs/cloud/aws-essentials/module-1.10-cloudwatch.md
@@ -38,7 +38,7 @@ Had they installed the CloudWatch Agent to collect memory and disk metrics, conf
 
 ## Did You Know?
 
-- **CloudWatch ingests over 1 trillion metrics per day** across all AWS customers. It is one of the oldest AWS services, launching alongside EC2 in 2009, and has grown from a simple CPU-monitoring tool into a massive, globally distributed observability platform.
+- **CloudWatch ingests over a trillion metrics per day** across all AWS customers. Launched in May 2009 — about three years after EC2 (2006) — it has grown from a simple CPU-monitoring tool into a massive, globally distributed observability platform.
 - **EC2 standard metrics have a 5-minute resolution** by default and are completely free. Enabling "detailed monitoring" bumps this to 1-minute resolution but costs approximately $2.10 per instance per month (7 metrics at $0.30 each). Most production workloads strictly require 1-minute resolution to catch transient spikes.
 - **CloudWatch Logs Insights can query terabytes of logs in seconds** using a purpose-built query language. It was released in November 2018 and has largely eliminated the need for teams to ship logs to complex external search clusters just for ad-hoc querying. You only pay $0.005 per GB of data scanned.
 - **The CloudWatch Agent replaced three older tools**: the CloudWatch Monitoring Scripts (Perl-based `mon-put-instance-data.pl`), the SSM CloudWatch Plugin (on Windows), and the older CloudWatch Logs Agent (`awslogs`). If you encounter legacy tutorials referencing these components, they are outdated.


### PR DESCRIPTION
## Summary

Corrects the single Category C finding from the 2026-04-24 residuals audit. module-1.10-cloudwatch.md:41 claimed CloudWatch was "launching alongside EC2 in 2009" — historically impossible.

## The bug

- Amazon EC2 public beta: **August 2006**
- Amazon CloudWatch: **May 2009**

About three years apart, not simultaneous. EC2 did not launch in 2009.

## Before / After

**Before (line 41):**
> - **CloudWatch ingests over 1 trillion metrics per day** across all AWS customers. It is one of the oldest AWS services, launching alongside EC2 in 2009, and has grown from a simple CPU-monitoring tool into a massive, globally distributed observability platform.

**After:**
> - **CloudWatch ingests over a trillion metrics per day** across all AWS customers. Launched in May 2009 — about three years after EC2 (2006) — it has grown from a simple CPU-monitoring tool into a massive, globally distributed observability platform.

## Secondary softening

"Over 1 trillion metrics per day" → "over a trillion metrics per day". The exact figure comes from AWS conference talks and blog posts rather than a pinned authoritative doc. The qualitative claim holds; the softening leaves room for the citation pipeline to attach a proper source later without the resolver having to match an exact numeric anchor.

## Refs

- Closes #365.
- Audit: \`docs/residuals-audit-2026-04-24.md\` (PR #366, merged).
- Audit correctly flagged this under Category C: historically impossible, not merely anonymous or unsourced.

## Test plan

- [x] Single-line prose change in an existing module — no frontmatter / slug / link impact, no build surface.
- [ ] Cross-family review per \`docs/review-protocol.md\` — Claude-authored → Codex reviewer (gpt-5.5 at effort=high per 2026-04-24 user preference).
- [ ] Optional: \`npm run build\` as a belt-and-braces check, though a bullet-prose tweak can't break Starlight rendering.