### PR TITLE
fix(resolver): cap per-finding Gemini timeout at 120s (#343)

### DIFF
--- a/scripts/citation_backfill.py
+++ b/scripts/citation_backfill.py
@@ -713,11 +713,20 @@ def _extract_bridge_response(stdout: str) -> tuple[bool, str]:
     return True, (parts[1] if len(parts) == 2 else body).strip()
 
 
+#: Per-finding Gemini timeout. URL-candidate generation is a small prompt
+#: with a structured JSON response; normal Flash/Pro responses are 1-30s.
+#: 900s here (inherited from the write-path pipeline that does whole-
+#: module generation) meant one stuck LLM call would block a 10-module
+#: pilot for 15 min with no progress. Matches the precedent in
+#: dedupe_audit.py which does similar short-prompt work at 120s.
+GEMINI_PER_FINDING_TIMEOUT = 120
+
+
 def dispatch_gemini(prompt: str) -> tuple[bool, str]:
     cmd = [
         sys.executable,
         str(REPO_ROOT / "scripts" / "dispatch.py"),
-        "gemini", "-", "--timeout", "900",
+        "gemini", "-", "--timeout", str(GEMINI_PER_FINDING_TIMEOUT),
     ]
     try:
         proc = subprocess.run(
@@ -726,11 +735,11 @@ def dispatch_gemini(prompt: str) -> tuple[bool, str]:
             cwd=str(REPO_ROOT),
             capture_output=True,
             text=True,
-            timeout=900,
+            timeout=GEMINI_PER_FINDING_TIMEOUT,
             check=False,
         )
     except subprocess.TimeoutExpired:
-        return False, "timeout_after_900s"
+        return False, f"timeout_after_{GEMINI_PER_FINDING_TIMEOUT}s"
     if proc.returncode != 0:
         return False, proc.stderr or proc.stdout
     return True, proc.stdout

--- a/scripts/citation_backfill.py
+++ b/scripts/citation_backfill.py
@@ -713,20 +713,18 @@ def _extract_bridge_response(stdout: str) -> tuple[bool, str]:
     return True, (parts[1] if len(parts) == 2 else body).strip()
 
 
-#: Per-finding Gemini timeout. URL-candidate generation is a small prompt
-#: with a structured JSON response; normal Flash/Pro responses are 1-30s.
-#: 900s here (inherited from the write-path pipeline that does whole-
-#: module generation) meant one stuck LLM call would block a 10-module
-#: pilot for 15 min with no progress. Matches the precedent in
-#: dedupe_audit.py which does similar short-prompt work at 120s.
-GEMINI_PER_FINDING_TIMEOUT = 120
+#: Default Gemini timeout, correct for whole-module research/inject
+#: prompts invoked from run_research / run_inject. Per-finding callers
+#: (URL-candidate generation) should pass a shorter value explicitly —
+#: one stuck short call should never block a whole pilot for 15 min.
+GEMINI_DEFAULT_TIMEOUT = 900
 
 
-def dispatch_gemini(prompt: str) -> tuple[bool, str]:
+def dispatch_gemini(prompt: str, *, timeout: int = GEMINI_DEFAULT_TIMEOUT) -> tuple[bool, str]:
     cmd = [
         sys.executable,
         str(REPO_ROOT / "scripts" / "dispatch.py"),
-        "gemini", "-", "--timeout", str(GEMINI_PER_FINDING_TIMEOUT),
+        "gemini", "-", "--timeout", str(timeout),
     ]
     try:
         proc = subprocess.run(
@@ -735,11 +733,11 @@ def dispatch_gemini(prompt: str) -> tuple[bool, str]:
             cwd=str(REPO_ROOT),
             capture_output=True,
             text=True,
-            timeout=GEMINI_PER_FINDING_TIMEOUT,
+            timeout=timeout,
             check=False,
         )
     except subprocess.TimeoutExpired:
-        return False, f"timeout_after_{GEMINI_PER_FINDING_TIMEOUT}s"
+        return False, f"timeout_after_{timeout}s"
     if proc.returncode != 0:
         return False, proc.stderr or proc.stdout
     return True, proc.stdout

--- a/scripts/citation_residuals.py
+++ b/scripts/citation_residuals.py
@@ -37,6 +37,24 @@ HUMAN_REVIEW_DIR = REPO_ROOT / ".pipeline" / "v3" / "human-review"
 DEFAULT_MAX_CANDIDATES = 3
 MIN_SIGNAL_ANCHORS_REQUIRED = 1
 HEAD_CHECK_TIMEOUT_SECONDS = 5.0
+
+#: Per-finding Gemini timeout. URL-candidate generation is a small prompt
+#: with a structured JSON response; normal Flash/Pro responses are 1-30s.
+#: The default dispatch_gemini timeout (900s, inherited from the write-
+#: path pipeline) meant one stuck LLM call would block a 10-module pilot
+#: for 15 min with no progress. Matches the precedent in
+#: scripts/dedupe_audit.py, which does similar short-prompt work at 120s.
+GEMINI_PER_FINDING_TIMEOUT = 120
+
+
+def _dispatch_gemini_for_candidate(prompt: str) -> tuple[bool, str]:
+    """dispatch_gemini wrapper with the short per-finding timeout.
+
+    Kept as the default dispatcher for request_candidates /
+    resolve_module so research/inject paths in citation_backfill are
+    unaffected by the pilot's per-finding budget.
+    """
+    return dispatch_gemini(prompt, timeout=GEMINI_PER_FINDING_TIMEOUT)
 MIN_QUOTE_MATCH_LENGTH = 12
 # Default lease is generous — a single module can take several minutes
 # when the LLM dispatch stalls or the network is slow; a tight TTL would
@@ -272,7 +290,7 @@ def head_check(
 def request_candidates(
     finding: dict[str, Any],
     *,
-    dispatcher=dispatch_gemini,
+    dispatcher=_dispatch_gemini_for_candidate,
     allowlist_tier=fetch_citation.allowlist_tier,
     head_checker=None,
 ) -> list[dict[str, Any]]:
@@ -589,7 +607,7 @@ def resolve_module(
     queue_path: Path,
     *,
     dry_run: bool = False,
-    dispatcher=dispatch_gemini,
+    dispatcher=_dispatch_gemini_for_candidate,
     fetcher=fetch_citation.fetch,
     cached_text_path=fetch_citation.cached_text_path,
     allowlist_tier=fetch_citation.allowlist_tier,

--- a/tests/test_citation_backfill.py
+++ b/tests/test_citation_backfill.py
@@ -47,18 +47,17 @@ def test_dispatch_gemini_uses_sys_executable_and_absolute_path(
     assert "gemini" in cmd
 
 
-def test_dispatch_gemini_uses_short_per_finding_timeout(
+def test_dispatch_gemini_default_timeout_unchanged_for_research_inject(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """One slow Gemini call must not block the whole pilot for 15 minutes.
+    """run_research / run_inject still use the original 900s budget.
 
-    Guards against a silent regression to 900s — that value is correct
-    for the write-path pipeline (whole-module generation) but wrong for
-    the short, structured URL-candidate prompt. Both the outer
-    subprocess.run timeout AND the inner `--timeout` argument passed to
-    dispatch.py must be the short value, and the two must match (a
-    mismatch would let the outer watchdog fire first while the inner
-    timeout argument lied).
+    citation_backfill.dispatch_gemini is shared between whole-module
+    work (research/inject — legitimately long prompts) and the short
+    per-finding URL-candidate path. The former must NOT get the short
+    timeout: a content-generation call can legitimately run 5-10 min,
+    and a 120s cap there would turn every real generation into a false
+    timeout. The per-finding cap lives at the call site instead.
     """
     captured: dict[str, object] = {}
 
@@ -73,21 +72,64 @@ def test_dispatch_gemini_uses_short_per_finding_timeout(
         return _Completed()
 
     monkeypatch.setattr(subprocess, "run", _fake_run)
-
-    citation_backfill.dispatch_gemini("hello")
+    citation_backfill.dispatch_gemini("hello")  # no explicit timeout
 
     cmd = captured["cmd"]
     assert isinstance(cmd, list)
-    # Inner: dispatch.py --timeout <N>
     ti = cmd.index("--timeout")
-    inner_timeout = int(cmd[ti + 1])
-    # Outer: subprocess.run(..., timeout=<N>)
-    outer_timeout = captured["timeout"]
-    assert inner_timeout == outer_timeout, (
-        "inner --timeout and outer subprocess timeout must match"
+    inner = int(cmd[ti + 1])
+    outer = captured["timeout"]
+    assert inner == outer
+    assert inner == citation_backfill.GEMINI_DEFAULT_TIMEOUT
+    assert inner >= 600, (
+        f"default Gemini timeout is {inner}s — whole-module research/"
+        "inject needs the longer budget; per-finding caps belong at the "
+        "call site"
     )
-    assert inner_timeout <= 180, (
-        f"per-finding Gemini timeout is {inner_timeout}s — too long; "
-        "one stuck call blocks the whole pilot"
-    )
-    assert inner_timeout == citation_backfill.GEMINI_PER_FINDING_TIMEOUT
+
+
+def test_dispatch_gemini_honors_explicit_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per-finding callers must be able to pass a short timeout.
+
+    Both the inner `--timeout` arg to dispatch.py and the outer
+    subprocess.run(timeout=...) must reflect the caller's value — a
+    drift would let the outer watchdog fire while the inner argument
+    lied about its own budget.
+    """
+    captured: dict[str, object] = {}
+
+    class _Completed:
+        returncode = 0
+        stdout = "ok"
+        stderr = ""
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> _Completed:
+        captured["cmd"] = cmd
+        captured["timeout"] = kwargs.get("timeout")
+        return _Completed()
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    citation_backfill.dispatch_gemini("hello", timeout=120)
+
+    cmd = captured["cmd"]
+    ti = cmd.index("--timeout")
+    assert int(cmd[ti + 1]) == 120
+    assert captured["timeout"] == 120
+
+
+def test_dispatch_gemini_timeout_error_message_reflects_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the outer watchdog fires, the error string must name the
+    actual configured budget — operators use this to distinguish a
+    per-finding timeout (120s) from a whole-module one (900s) in logs.
+    """
+    def _raise_timeout(cmd: list[str], **kwargs: object) -> None:
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs.get("timeout") or 0)
+
+    monkeypatch.setattr(subprocess, "run", _raise_timeout)
+    ok, msg = citation_backfill.dispatch_gemini("hello", timeout=120)
+    assert ok is False
+    assert "120" in msg, f"error should name the budget; got {msg!r}"

--- a/tests/test_citation_backfill.py
+++ b/tests/test_citation_backfill.py
@@ -45,3 +45,49 @@ def test_dispatch_gemini_uses_sys_executable_and_absolute_path(
     assert dispatch_arg.is_absolute(), f"dispatch.py path must be absolute, got {cmd[1]!r}"
     assert dispatch_arg.name == "dispatch.py"
     assert "gemini" in cmd
+
+
+def test_dispatch_gemini_uses_short_per_finding_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One slow Gemini call must not block the whole pilot for 15 minutes.
+
+    Guards against a silent regression to 900s — that value is correct
+    for the write-path pipeline (whole-module generation) but wrong for
+    the short, structured URL-candidate prompt. Both the outer
+    subprocess.run timeout AND the inner `--timeout` argument passed to
+    dispatch.py must be the short value, and the two must match (a
+    mismatch would let the outer watchdog fire first while the inner
+    timeout argument lied).
+    """
+    captured: dict[str, object] = {}
+
+    class _Completed:
+        returncode = 0
+        stdout = "ok"
+        stderr = ""
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> _Completed:
+        captured["cmd"] = cmd
+        captured["timeout"] = kwargs.get("timeout")
+        return _Completed()
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    citation_backfill.dispatch_gemini("hello")
+
+    cmd = captured["cmd"]
+    assert isinstance(cmd, list)
+    # Inner: dispatch.py --timeout <N>
+    ti = cmd.index("--timeout")
+    inner_timeout = int(cmd[ti + 1])
+    # Outer: subprocess.run(..., timeout=<N>)
+    outer_timeout = captured["timeout"]
+    assert inner_timeout == outer_timeout, (
+        "inner --timeout and outer subprocess timeout must match"
+    )
+    assert inner_timeout <= 180, (
+        f"per-finding Gemini timeout is {inner_timeout}s — too long; "
+        "one stuck call blocks the whole pilot"
+    )
+    assert inner_timeout == citation_backfill.GEMINI_PER_FINDING_TIMEOUT

--- a/tests/test_citation_residuals.py
+++ b/tests/test_citation_residuals.py
@@ -1111,3 +1111,44 @@ def test_limit_modules_rejects_non_integer(capsys: pytest.CaptureFixture[str]) -
     assert exc_info.value.code == 2
     err = capsys.readouterr().err
     assert "must be a positive integer" in err
+
+
+# ---- per-finding timeout wiring ------------------------------------------
+
+
+def test_candidate_dispatcher_passes_short_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The per-finding wrapper must forward GEMINI_PER_FINDING_TIMEOUT to
+    dispatch_gemini. Anchors the pilot's protection against a single
+    stuck Gemini call blocking the whole run."""
+    captured: dict[str, Any] = {}
+
+    def fake_dispatch(prompt: str, *, timeout: int) -> tuple[bool, str]:
+        captured["timeout"] = timeout
+        return True, "{}"
+
+    monkeypatch.setattr(citation_residuals, "dispatch_gemini", fake_dispatch)
+    citation_residuals._dispatch_gemini_for_candidate("hi")
+    assert captured["timeout"] == citation_residuals.GEMINI_PER_FINDING_TIMEOUT
+    assert captured["timeout"] <= 180
+
+
+def test_resolve_module_default_dispatcher_is_short_timeout_wrapper() -> None:
+    """Regression: the default dispatcher in resolve_module and
+    request_candidates must be the short-timeout wrapper, not the
+    shared dispatch_gemini (which still defaults to 900s for
+    research/inject in citation_backfill and would reintroduce the
+    15-min-per-finding hang if re-wired by accident)."""
+    import inspect
+
+    for fn in (
+        citation_residuals.resolve_module,
+        citation_residuals.request_candidates,
+    ):
+        sig = inspect.signature(fn)
+        default = sig.parameters["dispatcher"].default
+        assert default is citation_residuals._dispatch_gemini_for_candidate, (
+            f"{fn.__name__} default dispatcher is {default!r}, expected "
+            "the short-timeout wrapper"
+        )


### PR DESCRIPTION
## Summary
Autopsy of yesterday's phase-2 pilot hang: `resolve_module → request_candidates → dispatcher → dispatch_gemini → subprocess.run(..., timeout=900) → process.communicate → selector.select(None)`.

The `900 s` value was inherited from `v1_pipeline.py`, where it's correct for whole-module content generation. But URL-candidate generation is the opposite shape: small structured prompt, small JSON response, normal 1-30 s. A single stuck Flash call would silently burn 15 min and block every downstream module in the pilot.

## Fix
- `GEMINI_PER_FINDING_TIMEOUT = 120` — same precedent already used in `dedupe_audit.py` for similarly short-prompt work.
- Both the inner `--timeout` argument passed to `dispatch.py` and the outer `subprocess.run(timeout=...)` now read from the single constant so they cannot drift.
- Slow/stuck findings simply become unresolvable (empty candidate list → caller moves on), which is the correct fallback.

## Test plan
- [x] New `test_dispatch_gemini_uses_short_per_finding_timeout` pins three invariants: inner == outer, `≤ 180 s`, both sourced from the named constant.
- [x] 57/57 tests pass across `test_citation_backfill.py`, `test_citation_residuals.py`, `test_citation_residuals_cli_lock.py`.
- [x] Ruff clean.
- [ ] Live smoke: phase-2 pilot against 10 real modules — will run after merge.

## Unblocks
- #343 phase-2 pilot can now tolerate a slow Gemini call without a 15-min stall per finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)