### PR TITLE
docs(agents): exempt AI History book PRs from pipeline gate (#394)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,11 +40,9 @@ If the API is down, fall back to `STATUS.md` + `CLAUDE.md`.
 
 ### Book-only AI History PR exception
 
-For PRs that only touch AI History book/research material and do not affect executable code, generated state, or the published Astro site, do **not** run the expensive curriculum pipeline gate. These PRs include changes limited to:
+For PRs that only touch AI History book/research material and do not affect executable code, generated state, or the published Astro site, do **not** run the expensive curriculum pipeline gate. These PRs include changes strictly limited to:
 
-- `docs/research/ai-history/**`
-- AI History narrative/research markdown drafts
-- AI History workflow or coordination docs
+- `docs/research/ai-history/**` (including all narrative drafts, workflow, and coordination docs within this path)
 
 Required checks for these book-only PRs are:
 
@@ -52,7 +50,6 @@ Required checks for these book-only PRs are:
 - [ ] cross-family review posted as a PR comment
 - [ ] no generated artifacts included
 - [ ] primary repo remains on `main`
-- [ ] `npm run build` only if the PR touches `src/content/docs/` or Astro config
 
 Skip `.venv/bin/python scripts/test_pipeline.py` for this category. That test suite validates the curriculum pipeline and has low signal for unpublished book research while consuming substantial local and model resources. If a book PR also changes Python, scripts, pipeline behavior, `src/content/docs/`, Astro config, or shared tooling, this exception does not apply and the full checklist above is required.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,24 @@ If the API is down, fall back to `STATUS.md` + `CLAUDE.md`.
 
 **If you cannot check every box, your PR will be rejected.**
 
+### Book-only AI History PR exception
+
+For PRs that only touch AI History book/research material and do not affect executable code, generated state, or the published Astro site, do **not** run the expensive curriculum pipeline gate. These PRs include changes limited to:
+
+- `docs/research/ai-history/**`
+- AI History narrative/research markdown drafts
+- AI History workflow or coordination docs
+
+Required checks for these book-only PRs are:
+
+- [ ] `git diff --check` clean on the changed files
+- [ ] cross-family review posted as a PR comment
+- [ ] no generated artifacts included
+- [ ] primary repo remains on `main`
+- [ ] `npm run build` only if the PR touches `src/content/docs/` or Astro config
+
+Skip `.venv/bin/python scripts/test_pipeline.py` for this category. That test suite validates the curriculum pipeline and has low signal for unpublished book research while consuming substantial local and model resources. If a book PR also changes Python, scripts, pipeline behavior, `src/content/docs/`, Astro config, or shared tooling, this exception does not apply and the full checklist above is required.
+
 ---
 
 ## Non-Negotiable Rules


### PR DESCRIPTION
## Summary

Adds a narrow AGENTS.md exception for AI History book-only PRs so agents do not run the expensive curriculum pipeline test suite when the change only touches unpublished book research/writing materials.

The exception applies only to PRs limited to AI History book/research material and explicitly does not apply when a PR touches Python, scripts, pipeline behavior, `src/content/docs/`, Astro config, or shared tooling.

Required checks for book-only PRs become:

- `git diff --check` on changed files
- cross-family PR review comment
- no generated artifacts
- primary checkout remains on `main`
- `npm run build` only if `src/content/docs/` or Astro config changed

## Verification

- `git diff --check -- AGENTS.md` passed.
- Intentionally did not run `scripts/test_pipeline.py`; this PR exists to stop using that low-signal gate for book-only work.
- `npm run build` not run; no Astro or `src/content/docs/` changes.

## Issue

Part of #394.
