### PR TITLE
fix(bridge): use current Gemini review fallback models (#394)

### DIFF
--- a/scripts/ai_agent_bridge/__init__.py
+++ b/scripts/ai_agent_bridge/__init__.py
@@ -11,7 +11,9 @@ Configuration:
 - ``AB_WAKE_DIR``: defaults to ``{REPO_ROOT}/.agent/wake``.
 - ``AB_MONITOR_URL``: defaults to empty string (Monitor API disabled).
 - ``AB_GEMINI_MODEL``: defaults to ``batch_gemini_config.FLASH_MODEL`` when importable,
-  else ``gemini-2.0-flash``.
+  else ``gemini-3-flash-preview``.
+- ``AB_GEMINI_REVIEW_MODEL``: defaults to ``gemini-3.1-pro-preview``.
+- ``AB_GEMINI_FALLBACK_MODEL``: defaults to ``gemini-3-flash-preview``.
 - ``AB_PIPELINE_ENV_KEY``: defaults to ``LEARN_UKRAINIAN_PIPELINE``.
 
 All public functions are re-exported here for backward compatibility.
@@ -39,6 +41,8 @@ from ._config import (
     DB_PATH,
     GEMINI_CLI,
     GEMINI_DEFAULT_MODEL,
+    GEMINI_FALLBACK_MODEL,
+    GEMINI_REVIEW_MODEL,
     GH_CHAR_LIMIT,
     PID_DIR,
     REPO_ROOT,
@@ -73,6 +77,8 @@ __all__ = [
     "DB_PATH",
     "GEMINI_CLI",
     "GEMINI_DEFAULT_MODEL",
+    "GEMINI_FALLBACK_MODEL",
+    "GEMINI_REVIEW_MODEL",
     "GH_CHAR_LIMIT",
     "PID_DIR",
     "REPO_ROOT",

--- a/scripts/ai_agent_bridge/__init__.py
+++ b/scripts/ai_agent_bridge/__init__.py
@@ -14,6 +14,8 @@ Configuration:
   else ``gemini-3-flash-preview``.
 - ``AB_GEMINI_REVIEW_MODEL``: defaults to ``gemini-3.1-pro-preview``.
 - ``AB_GEMINI_FALLBACK_MODEL``: defaults to ``gemini-3-flash-preview``.
+- ``AB_PYTHON``: defaults to ``$VIRTUAL_ENV/bin/python`` when set,
+  else ``.venv/bin/python``.
 - ``AB_PIPELINE_ENV_KEY``: defaults to ``LEARN_UKRAINIAN_PIPELINE``.
 
 All public functions are re-exported here for backward compatibility.
@@ -45,6 +47,7 @@ from ._config import (
     GEMINI_REVIEW_MODEL,
     GH_CHAR_LIMIT,
     PID_DIR,
+    PYTHON_CMD,
     REPO_ROOT,
 )
 from ._db import get_db, get_session, init_db, set_session
@@ -81,6 +84,7 @@ __all__ = [
     "GEMINI_REVIEW_MODEL",
     "GH_CHAR_LIMIT",
     "PID_DIR",
+    "PYTHON_CMD",
     "REPO_ROOT",
     "_MODEL_CACHE",
     "_MODEL_CACHE_TTL",

--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -16,7 +16,7 @@ from ._codex import (
     process_all_codex,
     process_for_codex,
 )
-from ._config import GEMINI_DEFAULT_MODEL
+from ._config import GEMINI_DEFAULT_MODEL, GEMINI_REVIEW_MODEL
 from ._db import get_db
 from ._gemini import ask_gemini, converse_gemini, process_and_respond
 from ._messaging import (
@@ -437,7 +437,12 @@ def _build_parser() -> argparse.ArgumentParser:
     ask_gemini_parser.add_argument("--type", default="query", help="Message type (default: query)")
     ask_gemini_parser.add_argument("--data", help="Path to data file to attach")
     ask_gemini_parser.add_argument(
-        "--model", default=GEMINI_DEFAULT_MODEL, help="Gemini model to use"
+        "--model", default=None,
+        help=(
+            "Gemini model to use "
+            f"(default: {GEMINI_REVIEW_MODEL} for --review, "
+            f"else {GEMINI_DEFAULT_MODEL})"
+        )
     )
     ask_gemini_parser.add_argument("--from-model", dest="from_model",
                                    help="Exact sender model ID")
@@ -623,7 +628,8 @@ def _handle_ask_gemini(args):
         data = Path(args.data).read_text()
     content = sys.stdin.read() if args.content == "-" else args.content
     content = build_review_message(content) if args.review else content
-    ask_gemini(content, args.task_id, args.type, data, args.model,
+    model = args.model or (GEMINI_REVIEW_MODEL if args.review else GEMINI_DEFAULT_MODEL)
+    ask_gemini(content, args.task_id, args.type, data, model,
                getattr(args, 'from_model', None),
                getattr(args, 'async_mode', False),
                getattr(args, 'stdout_only', False),

--- a/scripts/ai_agent_bridge/_config.py
+++ b/scripts/ai_agent_bridge/_config.py
@@ -30,6 +30,12 @@ CLAUDE_CMD = ["npx", "@anthropic-ai/claude-code@latest"]
 GEMINI_CLI = shutil.which("gemini") or "gemini"
 CODEX_CLI = shutil.which("codex") or "codex"
 CLAUDE_DEFAULT_MODEL = os.environ.get("AB_CLAUDE_MODEL", "claude-opus-4-7")
+GEMINI_REVIEW_MODEL = os.environ.get(
+    "AB_GEMINI_REVIEW_MODEL", "gemini-3.1-pro-preview"
+)
+GEMINI_FALLBACK_MODEL = os.environ.get(
+    "AB_GEMINI_FALLBACK_MODEL", "gemini-3-flash-preview"
+)
 GEMINI_DEFAULT_MODEL = os.environ.get("AB_GEMINI_MODEL", "")
 if not GEMINI_DEFAULT_MODEL:
     try:
@@ -37,7 +43,7 @@ if not GEMINI_DEFAULT_MODEL:
 
         GEMINI_DEFAULT_MODEL = FLASH_MODEL
     except ImportError:
-        GEMINI_DEFAULT_MODEL = "gemini-2.0-flash"
+        GEMINI_DEFAULT_MODEL = GEMINI_FALLBACK_MODEL
 
 # Snapshot environment for passing to detached children
 # Set GEMINI_SESSION so .bashrc disables hostile aliases (eza, bat, zoxide)

--- a/scripts/ai_agent_bridge/_config.py
+++ b/scripts/ai_agent_bridge/_config.py
@@ -30,6 +30,12 @@ CLAUDE_CMD = ["npx", "@anthropic-ai/claude-code@latest"]
 GEMINI_CLI = shutil.which("gemini") or "gemini"
 CODEX_CLI = shutil.which("codex") or "codex"
 CLAUDE_DEFAULT_MODEL = os.environ.get("AB_CLAUDE_MODEL", "claude-opus-4-7")
+PYTHON_CMD = os.environ.get("AB_PYTHON", "")
+if not PYTHON_CMD:
+    if virtual_env := os.environ.get("VIRTUAL_ENV"):
+        PYTHON_CMD = str(Path(virtual_env) / "bin" / "python")
+    else:
+        PYTHON_CMD = ".venv/bin/python"
 GEMINI_REVIEW_MODEL = os.environ.get(
     "AB_GEMINI_REVIEW_MODEL", "gemini-3.1-pro-preview"
 )

--- a/scripts/ai_agent_bridge/_gemini.py
+++ b/scripts/ai_agent_bridge/_gemini.py
@@ -34,6 +34,7 @@ from ._config import (
     _MODEL_CACHE_TTL,
     _PARENT_ENV,
     GEMINI_DEFAULT_MODEL,
+    GEMINI_FALLBACK_MODEL,
     REPO_ROOT,
 )
 from ._github import _post_review_to_github
@@ -45,7 +46,7 @@ from ._messaging import (
     send_message,
     send_to_gemini,
 )
-from ._model import _detect_model_error
+from ._model import _detect_model_error, check_model
 from ._prompts import build_gemini_prompt
 
 try:
@@ -95,10 +96,16 @@ def ask_gemini(content: str, task_id: str | None = None, msg_type: str = "query"
         if not available:
             age = time.time() - cached_at
             if age < _MODEL_CACHE_TTL:
-                print(f"❌ Model '{model}' was unavailable {int(age)}s ago (cached). Skipping.")
-                print("💡 To switch accounts: run 'gemini auth login' or ask the user to switch.")
-                print("   To retry: --skip-model-check (clears cache)")
-                return None
+                if model == GEMINI_FALLBACK_MODEL:
+                    print(f"❌ Model '{model}' was unavailable {int(age)}s ago (cached). Skipping.")
+                    print("💡 To switch accounts: run 'gemini auth login' or ask the user to switch.")
+                    print("   To retry: --skip-model-check (clears cache)")
+                    return None
+                print(
+                    f"⚠️  Model '{model}' was unavailable {int(age)}s ago "
+                    f"(cached); falling back to '{GEMINI_FALLBACK_MODEL}'."
+                )
+                model = GEMINI_FALLBACK_MODEL
 
     # Auto-enable async for handoff type
     if msg_type == "handoff":
@@ -107,6 +114,8 @@ def ask_gemini(content: str, task_id: str | None = None, msg_type: str = "query"
 
     # Warn if handoff message is too long
     _warn_long_handoff(content, msg_type, task_id)
+
+    model = _resolve_gemini_model(model, async_mode, skip_model_check)
 
     # Send the message
     msg_id = _send_gemini_message(content, task_id, msg_type, data, from_model, model,
@@ -129,6 +138,19 @@ def ask_gemini(content: str, task_id: str | None = None, msg_type: str = "query"
             _extract_and_print(response, extract_tags)
 
     return msg_id
+
+
+def _resolve_gemini_model(model: str, async_mode: bool, skip_model_check: bool) -> str:
+    """Return an available Gemini model, falling back before sync invocation."""
+    if async_mode or skip_model_check or model == GEMINI_FALLBACK_MODEL:
+        return model
+    if check_model(model):
+        return model
+    print(
+        f"⚠️  Gemini model '{model}' is unavailable; "
+        f"falling back to '{GEMINI_FALLBACK_MODEL}'."
+    )
+    return GEMINI_FALLBACK_MODEL
 
 
 def _warn_long_handoff(content: str, msg_type: str, task_id: str | None):
@@ -220,7 +242,7 @@ def _launch_gemini_background(msg: dict, message_id: int, model: str, prompt: st
 
     try:
         bridge_cmd = [
-            sys.executable, str(Path(__file__).parent / "__main__.py"),
+            ".venv/bin/python", str(Path(__file__).parent / "__main__.py"),
             "process", str(message_id),
             "--model", model,
             "--no-timeout"

--- a/scripts/ai_agent_bridge/_gemini.py
+++ b/scripts/ai_agent_bridge/_gemini.py
@@ -35,6 +35,7 @@ from ._config import (
     _PARENT_ENV,
     GEMINI_DEFAULT_MODEL,
     GEMINI_FALLBACK_MODEL,
+    PYTHON_CMD,
     REPO_ROOT,
 )
 from ._github import _post_review_to_github
@@ -242,7 +243,7 @@ def _launch_gemini_background(msg: dict, message_id: int, model: str, prompt: st
 
     try:
         bridge_cmd = [
-            ".venv/bin/python", str(Path(__file__).parent / "__main__.py"),
+            PYTHON_CMD, str(Path(__file__).parent / "__main__.py"),
             "process", str(message_id),
             "--model", model,
             "--no-timeout"

--- a/tests/test_bridge_gemini_models.py
+++ b/tests/test_bridge_gemini_models.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from ai_agent_bridge import _cli, _gemini
+
+
+def _ask_args(*, model: str | None = None, review: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(
+        content="please review",
+        task_id="task-1",
+        type="query",
+        data=None,
+        model=model,
+        review=review,
+        from_model=None,
+        async_mode=False,
+        stdout_only=False,
+        output_path=None,
+        extract=None,
+        skip_model_check=False,
+        allow_write=False,
+        delimiters=None,
+        no_github=True,
+    )
+
+
+def test_ask_gemini_review_defaults_to_review_model(monkeypatch):
+    calls: list[tuple] = []
+    monkeypatch.setattr(_cli, "ask_gemini", lambda *args: calls.append(args))
+
+    _cli._handle_ask_gemini(_ask_args(review=True))
+
+    assert calls
+    assert calls[0][4] == _cli.GEMINI_REVIEW_MODEL
+
+
+def test_ask_gemini_non_review_defaults_to_default_model(monkeypatch):
+    calls: list[tuple] = []
+    monkeypatch.setattr(_cli, "ask_gemini", lambda *args: calls.append(args))
+
+    _cli._handle_ask_gemini(_ask_args())
+
+    assert calls
+    assert calls[0][4] == _cli.GEMINI_DEFAULT_MODEL
+
+
+def test_resolve_gemini_model_uses_requested_model_when_available(monkeypatch):
+    monkeypatch.setattr(_gemini, "check_model", lambda model: True)
+
+    resolved = _gemini._resolve_gemini_model(
+        _gemini.GEMINI_DEFAULT_MODEL,
+        async_mode=False,
+        skip_model_check=False,
+    )
+
+    assert resolved == _gemini.GEMINI_DEFAULT_MODEL
+
+
+def test_resolve_gemini_model_falls_back_when_requested_model_unavailable(
+    monkeypatch,
+):
+    monkeypatch.setattr(_gemini, "check_model", lambda model: False)
+
+    resolved = _gemini._resolve_gemini_model(
+        _cli.GEMINI_REVIEW_MODEL,
+        async_mode=False,
+        skip_model_check=False,
+    )
+
+    assert resolved == _gemini.GEMINI_FALLBACK_MODEL
+
+
+def test_resolve_gemini_model_does_not_check_async_or_fallback(monkeypatch):
+    def fail_check(_model: str) -> bool:
+        raise AssertionError("check_model should not be called")
+
+    monkeypatch.setattr(_gemini, "check_model", fail_check)
+
+    assert (
+        _gemini._resolve_gemini_model(
+            _cli.GEMINI_REVIEW_MODEL,
+            async_mode=True,
+            skip_model_check=False,
+        )
+        == _cli.GEMINI_REVIEW_MODEL
+    )
+    assert (
+        _gemini._resolve_gemini_model(
+            _gemini.GEMINI_FALLBACK_MODEL,
+            async_mode=False,
+            skip_model_check=False,
+        )
+        == _gemini.GEMINI_FALLBACK_MODEL
+    )
+
+
+def test_ask_gemini_cached_unavailable_model_uses_fallback(monkeypatch):
+    seen_models: list[str] = []
+    _gemini._MODEL_CACHE.clear()
+    _gemini._MODEL_CACHE[_cli.GEMINI_REVIEW_MODEL] = (False, _gemini.time.time())
+
+    def send_message(*args):
+        seen_models.append(args[5])
+        return 123
+
+    monkeypatch.setattr(_gemini, "_send_gemini_message", send_message)
+    monkeypatch.setattr(_gemini, "process_and_respond", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        _gemini,
+        "check_model",
+        lambda _model: (_ for _ in ()).throw(
+            AssertionError("cached unavailable model should not be rechecked")
+        ),
+    )
+
+    try:
+        _gemini.ask_gemini(
+            "please review",
+            task_id="task-1",
+            model=_cli.GEMINI_REVIEW_MODEL,
+        )
+    finally:
+        _gemini._MODEL_CACHE.clear()
+
+    assert seen_models == [_gemini.GEMINI_FALLBACK_MODEL]

--- a/tests/test_bridge_gemini_models.py
+++ b/tests/test_bridge_gemini_models.py
@@ -128,3 +128,29 @@ def test_ask_gemini_cached_unavailable_model_uses_fallback(monkeypatch):
         _gemini._MODEL_CACHE.clear()
 
     assert seen_models == [_gemini.GEMINI_FALLBACK_MODEL]
+
+
+def test_launch_gemini_background_uses_configured_python(monkeypatch, tmp_path):
+    captured: dict[str, list[str]] = {}
+
+    class FakeProcess:
+        pid = 321
+
+    def fake_popen(cmd, **_kwargs):
+        captured["cmd"] = cmd
+        return FakeProcess()
+
+    monkeypatch.setattr(_gemini, "PYTHON_CMD", "custom-python")
+    monkeypatch.setattr(_gemini, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(_gemini, "_is_task_locked", lambda *_args: False)
+    monkeypatch.setattr(_gemini, "_write_pid_file", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_gemini.subprocess, "Popen", fake_popen)
+
+    _gemini._launch_gemini_background(
+        {"task_id": "task-1"},
+        123,
+        "gemini-test",
+        "prompt",
+    )
+
+    assert captured["cmd"][0] == "custom-python"


### PR DESCRIPTION
## Summary
- updates bridge defaults away from stale gemini-2.0-flash to gemini-3-flash-preview
- makes ask-gemini --review default to gemini-3.1-pro-preview
- adds sync preflight fallback to gemini-3-flash-preview, including cached-unavailable model handling
- replaces a changed-file sys.executable bridge invocation with explicit .venv/bin/python
- adds focused tests for Gemini model selection and fallback behavior

## Tests
- ../../.venv/bin/ruff check scripts/ai_agent_bridge/_config.py scripts/ai_agent_bridge/__init__.py scripts/ai_agent_bridge/_cli.py scripts/ai_agent_bridge/_gemini.py tests/test_bridge_gemini_models.py
- ../../.venv/bin/python -m pytest tests/test_bridge_gemini_models.py
- ../../.venv/bin/python scripts/test_pipeline.py (166 tests, OK)

No npm build: Python bridge-only change; no src/content/docs or Astro config touched.