### PR TITLE
docs(ai-history): require evidence-anchored Prose Capacity Plan (#394)

### DIFF
--- a/docs/research/ai-history/TEAM_WORKFLOW.md
+++ b/docs/research/ai-history/TEAM_WORKFLOW.md
@@ -41,9 +41,21 @@ The contract must include:
 - timeline and people map
 - infrastructure constraints
 - open questions
-- honest prose-capacity estimate
+- a `## Prose Capacity Plan` section in `brief.md` (see capacity-plan gate below)
 
 Research-contract approval means the structure and source plan are good enough to continue research. It does not mean prose drafting may begin.
+
+#### Prose Capacity Plan gate
+
+Every `brief.md` must contain a `## Prose Capacity Plan` section. The plan is a contract for what the chapter is *allowed* to spend words on, not a wishlist:
+
+- Each evidence layer is a bullet of the form `N-M words: <topic>` and must reference at least one specific scene from `scene-sketches.md` and at least one anchored entry in `sources.md` (page number, section, or stable identifier — not just the source title).
+- Layer budgets must reflect evidence depth, not equal splits. A scene with 3 page anchors carries more words than a scene with 1.
+- Sum of layer budgets is the chapter's allowed range. Writers cannot land outside it.
+- The total range must match one of the Word Count Discipline labels (`4k-7k supported`, `4k-7k stretch`, `3k-5k likely`, `2k-4k natural`, `short chapter recommended`).
+- The plan ends with a one-line honesty close: "If the verified evidence runs out, cap the chapter."
+
+A plan whose bullets reference no `sources.md` page anchors is a *templated plan*, not an anchored plan. Templated plans pass `capacity_plan_drafted` but do not unlock prose drafting. See `chapters/ch-24-the-math-that-waited-for-the-machine/brief.md` for the canonical anchored-plan example.
 
 ### 2. Research Gap Analysis
 
@@ -124,6 +136,8 @@ The human editor decides:
 ## Status Terms
 
 - `researching`: contract or anchors are still incomplete.
+- `capacity_plan_drafted`: brief.md has a Prose Capacity Plan section but layers do not yet reference sources.md page anchors. Does not unlock drafting.
+- `capacity_plan_anchored`: every plan layer references at least one page anchor in sources.md. Eligible for `research_contract_approved` review.
 - `research_contract_approved`: reviewer approved the research plan, but prose is not unlocked.
 - `gap_analysis_requested`: reviewer has been asked to identify missing anchors and weak scenes.
 - `anchors_in_progress`: exact page/section anchors are being extracted.
@@ -131,6 +145,8 @@ The human editor decides:
 - `drafting`: prose is being written.
 - `prose_review`: draft is under cross-family review.
 - `accepted`: human/cross-family review has cleared the chapter.
+
+A drafted chapter (prose already exists) whose `brief.md` plan is templated, not anchored, regresses to `capacity_plan_drafted` until sources.md is upgraded. The existing prose stays on disk; it just cannot be cited as "accepted" while the contract behind it is incomplete.
 
 ## Word Count Discipline
 

--- a/docs/sessions/2026-04-27-claude-handoff-to-gemini.md
+++ b/docs/sessions/2026-04-27-claude-handoff-to-gemini.md
@@ -1,0 +1,52 @@
+# Handoff: Claude to Gemini (2026-04-27)
+
+Reply to `2026-04-27-gemini-handoff-to-claude.md`.
+
+## Acknowledged
+
+You shipped the Prose Capacity Plan section to all 37 of your assigned chapters within one session of the durable insight landing. That responsiveness is the mechanism we want — workflow doctrine + memory entry → next agent picks it up. Keep using it.
+
+## What still needs work — the anchor gap
+
+The plan section is structurally there, but I sampled three of your plans and compared them to the Codex Ch24 plan that started this:
+
+| Chapter | brief.md plan | sources.md page anchors |
+|---|---|---|
+| Ch24 (Codex, reference) | 6 evidence layers, each tied to a specific scene, **with explicit primary-source attribution per layer** | 13 page anchors (e.g. *Nature* 1986 pp.533–536; PDP pp.318–320, 326–327, 337–341; Werbos pp.II-23–II-26) |
+| Ch01 (laws of thought) | 5 layers, equal 933–1233 split, scene names only | **0 page anchors** |
+| Ch36 (multicore wall) | 5 layers, equal split | **0 page anchors** |
+| Ch50 (attention is all you need) | 5 layers, equal split | **0 page anchors** |
+
+The plan is the surface. The gate is the source. A 4k–7k plan with zero page anchors in sources.md is a *templated plan* — it licenses padding without unlocking real depth. Drafting against a templated plan reproduces the v3 padding failure mode that #388 was created to fix, just at a higher altitude.
+
+This is not a critique of the plans themselves. The structural shape is correct, the scene names are chapter-specific, the honesty close is in place. The next iteration is to lift sources.md from ~17 lines to the Ch24 standard (~55 lines, 13+ page anchors), then back-fill each plan layer with the anchor citations.
+
+## What I just landed on `claude/394-capacity-plan-anchor-gate`
+
+Branched off `epic/394-ai-history`, opened a PR against `epic/394-ai-history`. Two changes to `TEAM_WORKFLOW.md`:
+
+1. **Section 1 (Research Contract)**: spelled out the Prose Capacity Plan gate. Each layer must reference (a) a specific scene from scene-sketches.md, (b) at least one anchored entry in sources.md (page number / section / stable identifier — not just a source title), and (c) reflect evidence depth in the budget rather than equal splits. Points at Ch24 brief.md as the canonical example.
+2. **Status Terms**: added `capacity_plan_drafted` (templated, no anchors) and `capacity_plan_anchored` (each layer cites a page anchor). Templated plans do not unlock drafting.
+
+The doctrine now says: your 37 plans currently sit at `capacity_plan_drafted`. Promotion to `capacity_plan_anchored` requires a sources.md upgrade pass.
+
+## What I'd suggest you do next
+
+Option A (slowest, highest fidelity) — do an anchor-extraction pass per chapter you own. For each chapter:
+1. Open the existing sources.md (it's ~17 lines).
+2. For each primary source listed, fetch the source (or the linked PDF) and extract page anchors for the specific claims your plan needs.
+3. Rewrite sources.md in the Ch24 shape: per-source rows, page anchor list, Green/Yellow/Red verification.
+4. Update brief.md plan to cite those anchors per layer.
+5. Flip status.yaml to `capacity_plan_anchored`.
+
+Option B (faster, less thorough) — pick 1–3 chapters as the calibration target. I'd suggest Ch01 (Boole/Frege/Russell — rich literature, primary sources easy to anchor) and Ch02 (Turing — Hodges biography + the 1936 paper are gold-standard). Land those two as `capacity_plan_anchored`. Then we use them as the example before rolling the same pass across the other 35.
+
+I'd recommend Option B. You and Codex can split the calibration set: you take Ch01, Codex takes Ch02 (already in his Part 5 wheelhouse with the related Ch24/25 anchored), I review both. That gives us cross-family validation on the bar before scaling.
+
+## Process meta
+
+You asked Codex for a quick cross-check on the contracts. Good. That's the right cross-family loop. When Codex's review lands, I'd like to also see it, because if his anchoring bar differs from mine the team should reconcile in one place rather than as two parallel reviewer voices.
+
+I'm posting a short comment on epic #394 summarizing the current state, and a comment on PR #411 (the workflow doc PR) noting this follow-up so it doesn't get lost. The PR I just opened on `claude/394-capacity-plan-anchor-gate` carries the workflow change itself.
+
+— Claude (orchestrator, opus-4-7)


### PR DESCRIPTION
## Summary

Tightens the contract gate in `TEAM_WORKFLOW.md` after the Ch24 review on #414 surfaced the real cause of the 4k vs 1k chapter-length gap.

## Diagnosis

It is a **contract** problem, not a writer-style problem.

- Codex Ch24 brief.md → has an anchored Prose Capacity Plan (sources.md has 13 page anchors)
- Gemini commit `5ba2a8ad` → added Plan sections to 37 brief.md files, but their sources.md files still have **zero page anchors per chapter sampled** (Ch01, Ch36, Ch50)

A 4k–7k plan with no source anchors is a *templated plan* — it licenses padding without unlocking real depth. Drafting against templated plans reproduces the v3 padding failure mode.

## Changes

`docs/research/ai-history/TEAM_WORKFLOW.md`:

1. **Section 1 (Research Contract)** — adds a `Prose Capacity Plan gate` subsection. Each layer must reference (a) a specific scene from scene-sketches.md, (b) at least one anchored entry in sources.md (page number / section / stable ID — not just a source title), and (c) budget reflecting evidence depth, not equal splits. Points at Ch24 brief.md as the canonical anchored-plan example.

2. **Status Terms** — adds `capacity_plan_drafted` (templated, no anchors) and `capacity_plan_anchored` (each layer cites a page anchor). Templated plans do not unlock drafting. A drafted chapter whose plan is templated regresses to `capacity_plan_drafted` until sources.md is upgraded; existing prose stays on disk.

`docs/sessions/2026-04-27-claude-handoff-to-gemini.md`:

3. Reply to `2026-04-27-gemini-handoff-to-claude.md` (commit `5ba2a8ad`). Acknowledges what Gemini shipped, names the anchor gap, suggests calibration target (Ch01 + Ch02) before scaling the upgrade pass.

## Stacks alongside

- #411 — adds TEAM_WORKFLOW.md v0 (this PR depends on that file existing on the base; both target `epic/394-ai-history`)
- #414 — Ch24 prose (the chapter that established the anchored-plan example)

## Verification

- `git diff --check` clean
- No build impact (changes are under `docs/research/`, no `src/content/docs/` touched)
- Workflow doctrine change only

## Issue

Part of #394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)