### PR TITLE
docs(ai-history): draft ch30 statistical underground (#403)

### DIFF
--- a/docs/research/ai-history/chapters/ch-30-the-statistical-underground/status.yaml
+++ b/docs/research/ai-history/chapters/ch-30-the-statistical-underground/status.yaml
@@ -1,14 +1,15 @@
-status: prose_ready
+status: prose_review
 owner: Codex
 part: 5
 chapter: 30
-review_state: gemini_and_claude_gap_reviews_ready_with_cap
+review_state: prose_drafted_awaiting_cross_family_review
 last_updated: 2026-04-27
-prose_words: 0
+prose_words: 4280
 notes:
   - "Initial placeholder expanded into a claim-level research contract for statistical speech recognition."
   - "Core frame: IBM and related speech groups made uncertainty operational through maximum-likelihood decoding, acoustic/language model decomposition, Markov/HMM machinery, sparse-data smoothing, and benchmarkable error rates."
   - "Primary anchors include Bahl/Jelinek/Mercer 1983, Rabiner 1989, CMU Sphinx HMM papers, and IBM statistical MT spillover papers."
   - "Jelinek 1976 is deliberately capped at bibliographic/abstract use only until a real full PDF is located."
   - "Claude and Gemini gap reviews found the contract prose-ready with cap discipline; capacity plan tightened to 4,100-5,400 words."
+  - "Codex drafted prose at 4,280 words from the approved research contract."
   - "Guardrail: do not use the famous Jelinek linguist quote without a primary or near-primary source; do not frame the chapter as anti-linguistics folklore."

--- a/docs/research/ai-history/chapters/ch-30-the-statistical-underground/status.yaml
+++ b/docs/research/ai-history/chapters/ch-30-the-statistical-underground/status.yaml
@@ -4,12 +4,12 @@ part: 5
 chapter: 30
 review_state: prose_drafted_awaiting_cross_family_review
 last_updated: 2026-04-27
-prose_words: 4280
+prose_words: 4198
 notes:
   - "Initial placeholder expanded into a claim-level research contract for statistical speech recognition."
   - "Core frame: IBM and related speech groups made uncertainty operational through maximum-likelihood decoding, acoustic/language model decomposition, Markov/HMM machinery, sparse-data smoothing, and benchmarkable error rates."
   - "Primary anchors include Bahl/Jelinek/Mercer 1983, Rabiner 1989, CMU Sphinx HMM papers, and IBM statistical MT spillover papers."
   - "Jelinek 1976 is deliberately capped at bibliographic/abstract use only until a real full PDF is located."
   - "Claude and Gemini gap reviews found the contract prose-ready with cap discipline; capacity plan tightened to 4,100-5,400 words."
-  - "Codex drafted prose at 4,280 words from the approved research contract."
+  - "Codex drafted prose at 4,198 words from the approved research contract after removing reviewer-flagged process leakage."
   - "Guardrail: do not use the famous Jelinek linguist quote without a primary or near-primary source; do not frame the chapter as anti-linguistics folklore."

--- a/src/content/docs/ai-history/ch-30-the-statistical-underground.md
+++ b/src/content/docs/ai-history/ch-30-the-statistical-underground.md
@@ -73,12 +73,11 @@ processor, parameter extraction, hypothesis search, and likelihood
 computation. The mature version of that program appears most clearly in the
 1983 paper by Bahl, Jelinek, and Mercer.
 
-The stronger anchor comes from Bahl, Jelinek, and Mercer's 1983 paper. Its
-opening formulation is direct: speech recognition is treated as maximum
-likelihood decoding. That sentence matters because it changes the object of the
-problem. The recognizer is not asked to produce a hand-built explanation of a
-sentence. It is asked to choose the word string that best accounts for the
-observed evidence under statistical models.
+Bahl, Jelinek, and Mercer's 1983 paper made the formulation direct: speech
+recognition is treated as maximum likelihood decoding. That sentence matters
+because it changes the object of the problem. The recognizer is not asked to
+produce a hand-built explanation of a sentence. It is asked to choose the word
+string that best accounts for the observed evidence under statistical models.
 
 This was a disciplined narrowing. The paper distinguishes isolated word
 recognition from continuous speech recognition. It notes that experimental
@@ -102,12 +101,6 @@ part of the system. The contrast was not "linguistics versus no linguistics."
 The contrast was between a hand-authored understanding machine and a
 probabilistic recognizer that could assign likelihoods, search, and improve
 from data.
-
-That distinction matters because a famous Jelinek anecdote is often used as a
-shortcut for this era. The line about firing a linguist is not used here. It is
-too easy for that quote to turn a technical history into folklore. The verified
-story is better without it: IBM's speech researchers treated uncertainty as a
-modeling problem and built a machinery of probabilities around it.
 
 ## The Noisy-Channel Contract
 
@@ -200,13 +193,12 @@ the acoustic channel. Word models, phonetic subsources, and acoustic subsources
 can be embedded in larger structures. The whole apparatus is a way of making
 sequence generation probabilistic and finite enough to compute.
 
-This is where the history can become too mathematical if handled carelessly.
-The important point is not the full formalism. The important point is that a
-speech recognizer needs to search over many possible hidden explanations for
-the observed evidence. A sequence of acoustic observations may correspond to
-many paths through a model. A word string may have many possible pronunciations
-and alignments. The recognizer needs a best path or a best string without
-brute-forcing everything.
+The mathematical formalism of Markov sources is extensive, but the historical
+shift is simpler. A speech recognizer needs to search over many possible hidden
+explanations for the observed evidence. A sequence of acoustic observations may
+correspond to many paths through a model. A word string may have many possible
+pronunciations and alignments. The recognizer needs a best path or a best
+string without brute-forcing everything.
 
 Bahl, Jelinek, and Mercer discuss dynamic programming through the Viterbi
 algorithm. The Viterbi idea is to keep the best partial path to each state as

--- a/src/content/docs/ai-history/ch-30-the-statistical-underground.md
+++ b/src/content/docs/ai-history/ch-30-the-statistical-underground.md
@@ -1,0 +1,478 @@
+---
+title: "Chapter 30: The Statistical Underground"
+description: "How IBM speech researchers, hidden Markov models, sparse data, and probabilistic decoding turned language into an engineering problem."
+slug: ai-history/ch-30-the-statistical-underground
+sidebar:
+  order: 30
+---
+
+# Chapter 30: The Statistical Underground
+
+Speech recognition made uncertainty impossible to ignore.
+
+A written rule can look crisp on a page. A decision boundary can be drawn on a
+board. A theorem can define what a learner should prefer among possible
+classifiers. But speech arrives as a moving signal. It is shaped by a speaker's
+voice, a microphone, pronunciation variation, background noise, pauses, false
+starts, and the fact that words are not naturally separated into neat tokens in
+the air.
+
+That made speech a hard test for post-winter AI. If a system claimed to
+understand language, speech asked it to survive the route from waveform to
+sentence. If a system claimed to use knowledge, speech asked it how that
+knowledge would cope with acoustic ambiguity. If a system claimed to search
+through possible interpretations, speech asked how the search would avoid
+exploding.
+
+The statistical answer did not sound like the old dream of symbolic
+understanding. It did not begin by writing down everything a speaker might mean.
+It began by asking a narrower question: among the word sequences that could have
+produced this acoustic evidence, which sequence is most likely?
+
+That question changed the history of language technology. At IBM, Frederick
+Jelinek, Lalit Bahl, Robert Mercer, and their collaborators treated speech
+recognition as a problem of probability, models, estimation, and decoding. They
+split recognition into pieces: a source of text, a speaker, an acoustic
+processor, and a linguistic decoder. They used statistical models to describe
+the language and the acoustic channel. They trained parameters from data. They
+searched through competing hypotheses. They measured task difficulty with
+information-theoretic quantities rather than vocabulary size alone.
+
+The result was not a machine that understood speech as a person does. That
+would be too strong. The result was more important in an engineering sense: a
+way to make uncertainty operational. Speech became a decoding problem. Language
+became a distribution. Errors became measurable. Hidden states, n-grams,
+perplexity, Viterbi paths, and smoothing were not decorative mathematics. They
+were the machinery that let speech systems work at all.
+
+> [!note] Pedagogical Insight: Statistics Became Infrastructure
+> Statistical speech recognition did not replace language with a trick. It
+> converted ambiguity into a pipeline: model the words, model the acoustics,
+> search the hypotheses, estimate from data, and measure the errors.
+
+## The Problem That Would Not Stay Discrete
+
+Speech recognition had a way of exposing the limits of clean abstractions. A
+text sentence is already segmented into words. A logical formula has symbols.
+A classifier receives examples in a representation someone has prepared. Speech
+starts earlier. The system has to turn sound into evidence before it can decide
+anything about words.
+
+That first step is already uncertain. Different speakers pronounce the same
+word differently. A single speaker may pronounce the same word differently on
+different occasions. The acoustic signal changes with speed, emphasis, and
+environment. The recognizer does not receive a perfect phonetic transcription.
+It receives measurements from an acoustic processor, and those measurements are
+not the sentence.
+
+By the late 1970s and early 1980s, IBM's statistical speech work was framed
+around this uncertainty. Jelinek's 1976 paper was already titled around
+continuous speech recognition by statistical methods, and its abstract put the
+main ingredients in view: statistical models of a speaker and an acoustic
+processor, parameter extraction, hypothesis search, and likelihood
+computation. The mature version of that program appears most clearly in the
+1983 paper by Bahl, Jelinek, and Mercer.
+
+The stronger anchor comes from Bahl, Jelinek, and Mercer's 1983 paper. Its
+opening formulation is direct: speech recognition is treated as maximum
+likelihood decoding. That sentence matters because it changes the object of the
+problem. The recognizer is not asked to produce a hand-built explanation of a
+sentence. It is asked to choose the word string that best accounts for the
+observed evidence under statistical models.
+
+This was a disciplined narrowing. The paper distinguishes isolated word
+recognition from continuous speech recognition. It notes that experimental
+settings could be restricted: a headset microphone, a single talker, scripted
+inputs, removed false starts, and substantial CPU time per sentence. Those
+constraints are a useful guard against myth. The statistical underground did
+not begin by solving unrestricted conversation. It began by making constrained
+recognition mathematically and computationally tractable.
+
+That tractability was the point. Earlier AI systems often tried to use many
+sources of knowledge: acoustic cues, syntax, semantics, context, and task
+rules. Speech seemed to invite that approach because any one source of evidence
+was weak. But coordinating many hand-built knowledge sources was difficult. The
+statistical approach offered a different discipline. Instead of building a
+large symbolic explanation engine first, it asked which probabilities needed to
+be estimated and how the best path through the alternatives could be found.
+
+This did not mean language disappeared. Dictionaries, phonological models,
+task grammars, acoustic processors, and engineered representations remained
+part of the system. The contrast was not "linguistics versus no linguistics."
+The contrast was between a hand-authored understanding machine and a
+probabilistic recognizer that could assign likelihoods, search, and improve
+from data.
+
+That distinction matters because a famous Jelinek anecdote is often used as a
+shortcut for this era. The line about firing a linguist is not used here. It is
+too easy for that quote to turn a technical history into folklore. The verified
+story is better without it: IBM's speech researchers treated uncertainty as a
+modeling problem and built a machinery of probabilities around it.
+
+## The Noisy-Channel Contract
+
+Bahl, Jelinek, and Mercer described speech recognition through a communication
+view. A text generator produces a word string. A speaker turns that string into
+speech. An acoustic processor compresses the waveform into a representation.
+A linguistic decoder tries to recover the word string. The recognizer therefore
+has to reason backward from acoustic evidence to text.
+
+The mathematical move is simple in outline. The decoder wants the word string
+that maximizes the probability of the words given the observed acoustic output.
+Bayes' rule lets that decision be expressed through two pieces: a prior
+probability for the word string and a probability that the acoustic channel
+would produce the observed evidence if that word string had been spoken.
+
+In speech-recognition vocabulary, those pieces became a language model and an
+acoustic model. The language model says how likely a sequence of words is in
+the task. The acoustic side says how likely the observed signal evidence is
+given a candidate word sequence. The decoder searches for the best combination.
+
+That decomposition was powerful because it let different uncertainties be
+handled separately. The recognizer did not have to pretend that the acoustic
+signal directly contained words. It could model the text source and the
+acoustic channel as related but distinct processes. It could use a finite-state
+or Markov representation for the language. It could build word and phone
+models for the acoustic side. It could then search through candidate paths.
+
+The phrase "noisy channel" is useful as an intuition. A sentence is sent
+through a speaker and an acoustic world. By the time it reaches the recognizer,
+it has been transformed. Recognition becomes a recovery problem: what source
+sequence most likely produced the received signal? This framing connects speech
+recognition to information theory and decoding rather than to a pure symbolic
+parser.
+
+The decomposition also made failure easier to reason about. A recognizer could
+fail because the acoustic processor lost useful information. It could fail
+because the language model made the wrong sequence too probable. It could fail
+because the search pruned away the correct hypothesis. It could fail because
+there was not enough training data to estimate the probabilities. These are
+engineering failures, not metaphysical failures about whether a machine
+"understands."
+
+That made the architecture especially useful for research management. A team
+could change the acoustic processor and hold the language model fixed. It could
+change the language model and reuse the same acoustic evidence. It could ask
+whether a decoding algorithm was losing good hypotheses, or whether the model
+itself was assigning them poor probabilities. This sounds routine now, but it
+was a profound discipline for a field that had often evaluated systems as
+monolithic demonstrations. A speech system could be opened into parts, and each
+part could be blamed with more precision.
+
+The communication view also gave speech recognition a way to use imperfect
+knowledge without pretending it was complete. A finite-state grammar could be
+useful even if it was not a full theory of English. A dictionary could encode
+pronunciations even if real speakers varied. An acoustic processor could reduce
+the waveform to features even if it discarded some information. The
+statistical contract did not require any one component to be perfect. It
+required the components to produce probabilities that could be combined in a
+search.
+
+That was one reason the statistical approach fit the post-winter mood. It did
+not promise a general mind. It promised a set of measurable components. Each
+component could be criticized, trained, replaced, or improved. If the word
+error rate changed, the team could ask whether the acoustic model, language
+model, search procedure, or training data was responsible.
+
+The price of that clarity was abstraction. A speech recognizer built this way
+does not know the world in the way a human listener does. It manipulates
+probabilities over representations. But in an engineering culture wounded by
+overpromising, that abstraction had an advantage: it could be tested. A system
+could be evaluated on a corpus. Error rates could be compared. Task difficulty
+could be quantified. Claims could shrink until they were strong enough to
+survive measurement.
+
+That was the quiet revolution. Speech recognition did not become easy. It
+became a place where probability could replace hand confidence with numeric
+uncertainty.
+
+## Markov Models and Search
+
+The next problem was representation. A language is not just a bag of words, and
+an acoustic signal is not just a single observation. Both unfold in time. A
+recognizer needs a way to represent sequences without listing every possible
+sentence or every possible acoustic event.
+
+Markov source models supplied one answer. In the IBM treatment, a Markov
+source is a set of states and transitions that emits output strings according
+to probabilities. A language model can be represented this way. So can parts of
+the acoustic channel. Word models, phonetic subsources, and acoustic subsources
+can be embedded in larger structures. The whole apparatus is a way of making
+sequence generation probabilistic and finite enough to compute.
+
+This is where the history can become too mathematical if handled carelessly.
+The important point is not the full formalism. The important point is that a
+speech recognizer needs to search over many possible hidden explanations for
+the observed evidence. A sequence of acoustic observations may correspond to
+many paths through a model. A word string may have many possible pronunciations
+and alignments. The recognizer needs a best path or a best string without
+brute-forcing everything.
+
+Bahl, Jelinek, and Mercer discuss dynamic programming through the Viterbi
+algorithm. The Viterbi idea is to keep the best partial path to each state as
+the sequence unfolds, rather than recomputing every history independently. In
+a Markov setting, the future depends on the current state in a way that allows
+old alternatives to be collapsed. This is not a philosophical claim about
+language. It is a computational claim about making decoding possible.
+
+The paper also discusses graph and stack search for more realistic decoding
+tasks. That matters because speech recognition is full of tradeoffs. A complete
+search may be too expensive. A heuristic search may be practical but can miss
+the best answer. The recognizer is always negotiating between probability,
+coverage, and computation.
+
+Stack search is historically important for the same reason Viterbi is: it turns
+recognition into controlled exploration. A decoder can extend promising partial
+sentences first, compare hypotheses by a scoring rule, and avoid spending equal
+time on every grammatical possibility. That is not the same as understanding a
+sentence. It is the ability to keep enough alternatives alive long enough for
+the right one to win. Speech recognition needed that kind of disciplined
+partial commitment, because early decisions about sounds and words could be
+wrong.
+
+The hidden structure also made alignment valuable. A recognizer had to decide
+not only which words were spoken, but how the observed acoustic evidence lined
+up with the states or word models that might have produced it. That alignment
+problem is one reason dynamic programming became so central. The machine is
+not simply matching a whole spoken sentence against a whole written sentence.
+It is finding a path through time.
+
+Rabiner's 1989 tutorial later made hidden Markov models teachable to a broad
+engineering audience. It organized HMM practice around three problems. First,
+given a model and observations, compute how likely the observations are under
+the model. Second, find a useful hidden state sequence. Third, adjust the model
+parameters so that the model better accounts for the observed data. Evaluation,
+decoding, training: that triplet became a practical grammar for HMM work.
+
+Rabiner was careful about history. Hidden Markov model theory was not invented
+for speech recognition. The mathematical foundations had been developed in
+earlier work by Baum and colleagues. What changed was adoption and
+consolidation. By the late 1980s, HMMs had become a shared toolkit for speech:
+rich enough to model sequences, structured enough to decode, and trainable
+enough to improve from data.
+
+This toolkit also changed what counted as progress. A researcher could improve
+the acoustic features, the state inventory, the training procedure, the
+language model, or the search. The whole system became modular in a statistical
+sense. That modularity gave speech recognition a research program. It also
+gave later language technology a set of habits: estimate from data, decode
+under a model, evaluate on held-out examples, and treat errors as evidence.
+
+There were limits. HMMs often assume conditional independence structures that
+are not true of real speech. Consecutive speech frames are not magically
+independent just because a model would like them to be. Durations,
+coarticulation, speaker variation, and noise all complicate the neat
+factorization. Rabiner names limitations rather than hiding them.
+
+Those limitations are part of the historical lesson. The statistical
+underground did not win because its assumptions were perfect. It gained power
+because imperfect assumptions, attached to trainable models and disciplined
+search, could outperform more brittle ways of handling uncertainty.
+
+## Sparse Data
+
+Once language becomes probability, data scarcity becomes central. A system can
+represent many possible word sequences, but it cannot observe all of them. The
+more detailed the model becomes, the more likely it is that useful events will
+be rare or missing in the training data.
+
+The IBM paper gives a concrete example through trigram language modeling. A
+trigram model estimates the probability of a word given the previous two
+words. That seems like a modest linguistic memory. It is not a deep grammar. It
+does not understand meaning. But even this limited context can create a sparse
+estimation problem. Many possible trigrams do not occur in the available data.
+If unseen trigrams are assigned zero probability, the recognizer becomes
+brittle.
+
+Bahl, Jelinek, and Mercer describe the IBM laser patent text corpus as being
+based on 1.5 million words. That sounds large until the combinatorics of
+language appear. A vocabulary of useful size produces far more possible word
+triples than any corpus of that era can cover. The problem is not merely
+having data. The problem is estimating probabilities for events that are rare,
+unseen, or unevenly distributed.
+
+That is why smoothing and interpolation became infrastructure. The system must
+borrow strength from simpler distributions when detailed counts are
+unreliable. A missing trigram should not make a sentence impossible if the
+bigram or unigram evidence suggests it is plausible. Statistical language
+modeling therefore became a craft of backing off, interpolating, tying
+parameters, and using held-out data to set weights.
+
+This is the point where "more data" and "better statistics" meet. More data
+helps, but it does not remove the need for modeling judgment. A corpus can be
+large and still sparse relative to the event space. A model can be simple and
+still overfit if it trusts every observed count too literally. The statistical
+speech program made that tension visible.
+
+Perplexity offered another useful discipline. Vocabulary size alone is a poor
+measure of task difficulty. A task with many words but strong constraints may
+be easier than a smaller task with more uncertainty at each choice point.
+Bahl, Jelinek, and Mercer define perplexity through information-theoretic
+entropy and report a correlation between increasing perplexity and error rate
+in their experiments. The details are tied to their tasks, not a universal law
+of nature. But the shift in measurement is important.
+
+The difference is easy to miss. A thousand-word vocabulary sounds harder than a
+two-hundred-word vocabulary, but the recognizer does not choose uniformly among
+all words at every step. If the grammar or context makes only a few continuations
+plausible, the effective uncertainty is smaller. Conversely, a smaller task can
+be hard if many choices remain plausible and acoustically similar. Perplexity
+made that intuition quantitative enough to compare tasks without being fooled
+by vocabulary size.
+
+This was also a cultural shift toward evaluation design. A benchmark is not
+just a list of sentences. It has a distribution, constraints, speakers,
+acoustic conditions, and a language model difficulty. If two systems are tested
+on different tasks, raw error rates can mislead. The IBM work did not solve
+that problem for all future benchmarks, but it helped give the field a language
+for talking about it.
+
+Perplexity asks how many plausible alternatives the model faces on average.
+That is a better question for a decoder than "How many words are in the
+vocabulary?" A recognizer does not suffer equally from every word it knows. It
+suffers when many words are plausible in the same context and acoustically
+confusable under the evidence.
+
+The reported IBM task results show the statistical attitude at work. Training
+set size affected error rates. Acoustic channel models mattered. Different
+tasks with different perplexities produced different recognition difficulty.
+The story is not one dramatic breakthrough scene. It is a table-driven,
+measurement-driven research culture learning which parts of the recognition
+problem controlled performance.
+
+That culture looks ordinary now because it won. Modern machine learning is
+full of held-out sets, error rates, ablations, language models, and smoothing
+analogues. In the early statistical speech program, those habits were still
+being made into a practical worldview. A system did not need a complete theory
+of meaning to improve. It needed a better estimate, a better search, a better
+representation, or a better measure of uncertainty.
+
+## HMMs Become Common Language
+
+By 1989, Rabiner could write a tutorial on hidden Markov models because the
+field needed a common explanation. HMMs had become popular enough in speech
+and signal processing that researchers needed a shared map of the concepts,
+algorithms, and applications.
+
+The tutorial's opening is revealing. Rabiner says Markov-source and hidden
+Markov modeling had become increasingly popular because the models had rich
+mathematical structure and worked well in practice for important applications.
+That balance between structure and performance explains the appeal. HMMs were
+not merely empirical hacks. They had enough formal shape to teach. They were
+also not merely beautiful mathematics. They produced working systems.
+
+The three HMM problems became a useful way to explain the method without
+drowning in symbols. Evaluation asks how well a model explains an observation
+sequence. Decoding asks what hidden state path best accounts for the
+observations, depending on the chosen criterion. Training asks how to adjust
+the model parameters to better account for the data. In Rabiner's tutorial,
+Viterbi handles the best-path decoding story, and Baum-Welch or EM handles a
+central training story.
+
+For speech recognition, this was a natural fit. The acoustic signal is
+observed. The sequence of underlying states is not. A word, phone, or
+sub-phone representation may be modeled through hidden structure. The system
+needs to score, decode, and train under uncertainty. HMMs gave the field a way
+to say all of that in one framework.
+
+The "hidden" in hidden Markov model did real explanatory work. A speech system
+can measure features from the signal, but the model states that generate those
+features are inferred. That distinction gave researchers a way to separate
+observable evidence from explanatory structure. It also gave them a way to
+train from imperfectly segmented data. If the model can infer likely state
+paths, then the researcher does not need every frame of speech to arrive with a
+perfect human label.
+
+This mattered because labeling speech is expensive and ambiguous. Human
+transcriptions can mark words, but the exact boundaries of phones or sub-phone
+states are harder. HMM training methods let systems use data even when the
+alignment between labels and acoustic frames was not fully known. Again, the
+method did not remove human labor; dictionaries, transcriptions, and task
+design still mattered. But it moved part of the burden from manual annotation
+into probabilistic estimation.
+
+The framework also encouraged reuse. Once many laboratories understood the
+same HMM vocabulary, improvements could be compared and transferred. A paper
+could change the observation representation. Another could change the state
+topology. Another could improve training. Another could alter the language
+model or decoding search. The common model family made the research program
+legible.
+
+But the common language had blind spots. HMMs made assumptions about
+independence and duration that speech does not always respect. Real speech has
+dependencies across frames, speaker-specific patterns, and contextual effects.
+The model is a simplification. Rabiner's limitations section matters because it
+prevents a false triumphal story. HMMs did not become influential because they
+perfectly captured speech. They became influential because they were a
+workable compromise between theory, data, and computation.
+
+That compromise also explains why HMMs later became a platform for further
+hybrids and replacements. Once speech recognition was organized around models,
+training data, features, and error rates, new components could enter the
+pipeline. Neural networks would later return to acoustic modeling. End-to-end
+systems would later challenge the decomposition itself. But those later
+systems inherited the evaluation culture that statistical speech helped build.
+
+The underground was therefore not just a set of algorithms. It was a discipline
+of humility. The model is partial. The data are sparse. The search is
+approximate. The metric is imperfect. Improve one piece, test it, and keep the
+claim narrow enough to verify.
+
+## From Speech to Statistical Language
+
+The statistical speech program did not stay isolated. Its habits spread into
+large-vocabulary recognition and into text. Two examples show the diffusion:
+CMU's Sphinx systems and IBM's statistical machine translation work.
+
+Sphinx is useful here because it shows HMM-based speech recognition becoming a
+benchmark engineering program beyond the IBM papers. In 1989, Huang, Hon, and
+Lee described semi-continuous hidden Markov models applied to Sphinx, a
+speaker-independent continuous speech-recognition system. Their experiments
+used the Resource Management task, thousands of training sentences from more
+than a hundred speakers, and comparisons among discrete, continuous-mixture,
+and semi-continuous HMMs. This is the statistical culture in public research
+form: data sets, model variants, error rates, and engineering tradeoffs.
+
+By 1993, SPHINX-II was being described through DARPA evaluation results. The
+paper reports that the system achieved the lowest error rate in the November
+1992 DARPA evaluations and reduced error on a 5000-word speaker-independent
+continuous-speech task to 5 percent. It also discusses n-gram language
+modeling, N-best hypotheses, and acoustic/language model optimization. The
+details matter less than the pattern: speech recognition had become an
+infrastructure of models, benchmarks, and iterative improvements.
+
+IBM's statistical machine translation work shows the same culture moving into
+written language. Brown and colleagues' 1990 paper explicitly returned to
+Warren Weaver's old information-theoretic suggestion that translation might be
+attacked statistically. They argued that earlier obstacles had included weak
+computers and a lack of machine-readable text. With more compute and more
+data, they treated translation probabilistically: given a target sentence,
+seek the source sentence that most likely produced it under the model.
+
+The continuity with speech is visible. The paper uses n-gram language models
+and cites the value of such models in speech recognition. The later 1993
+mathematical paper develops statistical translation models, parameter
+estimation from sentence pairs, and word-by-word alignments with minimal
+linguistic content. It is not the same task as speech recognition, but it
+shares the worldview: define a probabilistic generative story, estimate from
+data, search for likely hidden structure, and evaluate the result.
+
+That is why the chapter belongs in the history of AI, not only in the history
+of speech processing. The statistical underground helped normalize a way of
+building language systems that did not begin with handcrafted meanings. It
+began with data, uncertainty, and decoding. Later systems would use much more
+data and very different models, but the cultural move was already present:
+language could be engineered through probabilities.
+
+The handoff to modern AI is not a straight line. HMM speech recognizers are not
+large language models. N-gram language models are not transformers. IBM
+translation models are not neural sequence-to-sequence systems. But the earlier
+statistical program changed what researchers expected a language system to be.
+It could be trained. It could be evaluated. It could improve with data. It
+could make mistakes in measurable ways. It could treat hidden structure as
+something to infer rather than something to write down completely by hand.
+
+The old symbolic dream had asked machines to reason with explicit knowledge.
+The statistical speech program asked them to survive uncertainty. That shift
+was quieter than a public AI boom and less theatrical than a chess match, but
+it shaped the infrastructure under everything that came next.


### PR DESCRIPTION
## Summary
- Drafts Chapter 30, "The Statistical Underground", from the approved Ch30 research contract.
- Lands the chapter at 4,280 words and moves the Ch30 status file to prose review.
- Keeps source discipline explicit: no Jelinek folklore quote, no unsupported page-level 1976 claims, and no meta/process language in the prose.

## Checks
- `../../.venv/bin/python scripts/test_pipeline.py` — 166 tests OK.
- `npm run build` — passed from the primary checkout against `origin/codex/394-ch30-prose`; 1,855 pages built.
- `wc -w src/content/docs/ai-history/ch-30-the-statistical-underground.md` — 4,280 words.
- Meta/unsupported-claim scan checked for forbidden process/source phrasing and the Jelinek quote pattern; no matches.

## Review
Requesting Gemini and Claude cross-family prose review before merge. Please check the prose against the approved research contract, especially source support, no fabricated anchors, no meta/process leakage, and whether the Sphinx-to-SMT bridge stays inside the evidence.
