### PR TITLE
docs(ai-history): Ch11 (Dartmouth Summer 1956) research contract (#401)

### DIFF
--- a/docs/research/ai-history/chapters/ch-11-the-summer-ai-named-itself/brief.md
+++ b/docs/research/ai-history/chapters/ch-11-the-summer-ai-named-itself/brief.md
@@ -1,1 +1,55 @@
-# Brief: Chapter 11
+# Brief: Chapter 11 — The Summer AI Named Itself
+
+## Thesis
+
+The 1956 Dartmouth Summer Research Project on Artificial Intelligence did not invent the field's ideas — those came from cybernetics, Turing's universal machine, McCulloch-Pitts neurons, Shannon's information theory, and Solomonoff's inductive inference work. What Dartmouth did was give the ideas a name, a credentialed group of organizers, and an eight-week working session that produced almost no shared output but legitimized "Artificial Intelligence" as a fundable research category. The infrastructure story is small: a ~$7,500 Rockefeller grant against a $13,500 request, a New Hampshire college willing to host four organizers and roughly six other attendees, and an institutionalized term — chosen by John McCarthy specifically to escape the disciplinary baggage of cybernetics and automata theory. Whether McCarthy was the very first writer to put the phrase "Artificial Intelligence" on paper is an open question; what is verified is that the August 1955 Proposal *named* the program around it.
+
+## Scope
+
+- IN SCOPE: the August 31, 1955 funding proposal; McCarthy's institutional naming of "Artificial Intelligence" (whether or not he was the first writer to use the phrase); the four organizers (McCarthy, Minsky, Rochester, Shannon); the conference itself (June–August 1956 at Dartmouth College in Hanover, NH); the seven research topics from the proposal; who actually attended for substantial portions; Newell and Simon's pre-existing Logic Theorist demo; the relationship to existing cybernetics work (Wiener, McCulloch); what the conference *did not* settle.
+- OUT OF SCOPE: the Logic Theorist itself (Ch12); LISP (Ch13); the perceptron (Ch14); subsequent ARPA funding (Ch16); the Lighthill report (Ch18); the AI winter (Ch28).
+
+## Boundary Contract
+
+This chapter must not present Dartmouth as the founding moment when AI began. The intellectual foundations existed before — McCulloch-Pitts (1943), Wiener's *Cybernetics* (1948), Shannon's information theory (1948), Turing (1950), and Solomonoff's inductive inference work in progress at the time. It must also not present the conference as a productive working group. Most attendee accounts describe a summer of partial attendance, parallel solo work, and very little common output. The chapter's stance: what made Dartmouth historically decisive was institutional, not intellectual — a name, a credentialed group of organizers, and a small grant that legitimized "AI" as a fundable category. Not a discovery. Not a founding. A naming and credentialing event.
+
+The chapter must also not invent dialogue or internal states for any participant. Every quoted sentence must come from a primary source (proposal text, paper, letter, oral history, contemporaneous note). Reconstructed atmospherics are permitted only where multiple independent sources converge.
+
+## Scenes Outline
+
+1. **The Proposal (August 1955).** McCarthy drafts the funding application with Minsky, Rochester, Shannon. Names the field "Artificial Intelligence." Lists 7 research topics. Asks Rockefeller for $13,500; receives ~$7,500.
+2. **The Naming Decision.** Why "Artificial Intelligence"? McCarthy's later reminiscence on rejecting "automata studies" and "complex information processing." Wiener's cybernetics shadow. Why each rejected name carried baggage McCarthy wanted to escape.
+3. **The Summer of 1956.** Who actually showed up. Newell and Simon arrive partway through with a working program (Logic Theorist) — surprising the organizers, who had a less concrete agenda. Solomonoff stays the longest.
+4. **What Did Not Happen.** No conference proceedings. No shared definition of intelligence agreed on. Most participants leave with their pre-existing research programs unchanged. McCarthy's later assessment.
+5. **What Did Happen — The Naming Aftermath.** The phrase "Artificial Intelligence" begins appearing in funding proposals, paper titles, and curricula within months. The four organizers become the field's gatekeepers. ARPA's later AI funding rolls forward on Dartmouth's vocabulary.
+
+## Prose Capacity Plan
+
+This chapter can support a long narrative only if it is built from verified evidence layers rather than padding:
+
+- 600-900 words: **The 1955 proposal as institutional artifact** — what it asked for, what it got, what its 7 topics implied about the founders' research programs. Anchored to: Dartmouth Proposal opening section (Stanford-hosted PDF, p.1, conjecture on simulation); Proposal pp.2-7 listing of 7 topics; Rockefeller archives for the funding amount. Scene: 1.
+- 700-1,000 words: **The naming decision** — McCarthy's choice of "Artificial Intelligence" over alternatives, and what each rejected name carried as baggage (Wiener's cybernetics; "automata theory"; "complex information processing"). Anchored to: McCarthy 2007 retrospective ("What is Artificial Intelligence?"); McCorduck 1979 Ch.5; Crevier 1993 Ch.2. Scene: 2.
+- 600-900 words: **Who attended and what they did during the summer** — the difference between the proposal's "10-man study" and the actual attendance pattern. Newell-Simon's Logic Theorist demo as the only substantial running program. Anchored to: Solomonoff Papers (world.std.com/~rjs); McCorduck 1979 pp. ~100-115; Crevier 1993 pp. 30-50; Nilsson 2010 pp. 53-72. Scene: 3.
+- 500-800 words: **The unproductive summer** — why the conference produced almost no shared output and how that became part of its mythology. McCarthy's later admissions on what the conference did not accomplish. Anchored to: McCarthy 2007 retrospective; Solomonoff papers; Crevier 1993 Ch.2. Scene: 4.
+- 1,000-1,500 words: **The institutional aftermath and honest close** — how a name and a credentialed group of four organizers turned a disappointing summer into the founding myth, and how ARPA's later funding rolled forward on that myth. The layer ends with a brief reframing of what Dartmouth was *not* — not a founding act of intellectual creation, but a naming and credentialing event. Anchored to: Nilsson 2010 pp. 53-72; McCorduck 1979 pp. 115-130; Edwards *The Closed World* (1996); Moor 2006 *AI Magazine* commemoration; G. Solomonoff *dartray.pdf* pp. 5-10 for naming/attendance synthesis. Scene: 5.
+
+Total: **3,400-5,100 words**. Label: `4k-7k stretch` — feasible if McCarthy's contemporary correspondence with Shannon and Rockefeller is located in the Stanford archives or Dartmouth special collections, and if Solomonoff's contemporaneous notes anchor the "what actually happened" scene at page level. Otherwise `3k-5k likely` from secondary sources only.
+
+If the verified evidence runs out, cap the chapter.
+
+## Citation Bar
+
+- Minimum primary sources before review: Dartmouth Proposal (1955); McCarthy 2007 retrospective; Solomonoff oral history or contemporaneous notes; one of (Newell & Simon 1956 Logic Theorist paper, Minsky's contemporary papers, Shannon-McCarthy correspondence).
+- Minimum secondary sources before review: McCorduck 1979 (*Machines Who Think*); Crevier 1993 (*AI: The Tumultuous History*); Nilsson 2010 (*The Quest for Artificial Intelligence*); Moor 2006 *AI Magazine* commemoration.
+- All Prose Capacity Plan layers must be promoted from Yellow to Green via verified page anchors before prose drafting begins.
+
+## Conflict Notes
+
+- **"Founding of AI"** — strongly disputed. The field has multiple plausible founding moments (Turing 1950, McCulloch-Pitts 1943, Shannon 1948, the 1955 proposal, the 1956 summer, the first ARPA grants ~1962). The chapter's stance is that 1956 was the *naming* moment, not the founding moment.
+- **Attendance counts vary** across secondary sources. McCorduck, Crevier, and Nilsson differ on who came when. Use Solomonoff's contemporaneous notes as the source of truth where they are available.
+- **The "10-man study"** — the proposal's headline number was never realized. Roughly six attendees stayed for substantial portions; others came for days. Sources do not fully reconcile attendance.
+- **Did Wiener decline to attend or was he never seriously invited?** Sources conflict. McCorduck and Crevier offer different readings of McCarthy's stance toward Wiener.
+
+## Honest Prose-Capacity Estimate
+
+Pre-anchor estimate: **3,400-5,100 words** with the source plan above. Confidence the lower bound is achievable from secondary-source anchoring: high. Confidence the upper bound is achievable: depends on archival success (Dartmouth special collections, Stanford McCarthy papers, Solomonoff's contemporaneous diary). Plan to cap at the natural length the verified evidence supports — do not pad to reach 4k+ if the archives do not yield page anchors.

--- a/docs/research/ai-history/chapters/ch-11-the-summer-ai-named-itself/gap-analysis.md
+++ b/docs/research/ai-history/chapters/ch-11-the-summer-ai-named-itself/gap-analysis.md
@@ -1,0 +1,186 @@
+# Gap Analysis: Chapter 11 - The Summer AI Named Itself
+
+Source: dual-reviewer pass on PR #419 / Issue #401, recorded 2026-04-27.
+Claude authored the original contract; Codex (gpt-5.4) provided the
+first cross-family review and anchor extraction (commit `a454a791`);
+Gemini (gemini-3-flash-preview) provided the second cross-family review
+with hallucination filter applied (commit `63d0ba87`). This is the
+first chapter in Part 3 to receive the full Codex+Gemini dual-reviewer
+treatment per the dual-review policy adopted 2026-04-27.
+
+## Current Verdict
+
+Research contract approved with status `capacity_plan_anchored`. Claim
+counts after both reviewers integrated: **13 Green / 12 Yellow / 1 Red**
+(the single Red is the Wiener exclusion claim, archive-blocked at the
+Rockefeller / Norbert Wiener correspondence level). Pending human final
+pass and ideally promotion of 2-3 additional Yellow Scene-2 claims via
+the McCarthy 2007 retrospective before drafting unlocks.
+
+## Codex Review (first cross-family, gpt-5.4)
+
+Verdict: NEEDS_CHANGES with 4 must-fix findings — all addressed in
+commit `a454a791`.
+
+### Must-fix integrations from Codex
+
+1. **Honest-close layer in Prose Capacity Plan had no scene/source
+   anchor** — folded into Scene 5 layer (1,000-1,500 words) with named
+   sources. Plan now passes the #416 capacity-plan gate cleanly.
+2. **Three scene-sketches beats lacked rows in the sources.md
+   Scene-Level Claim Table** — added rows for "four organizers as
+   gatekeepers", "Logic Theorist + LISP as next-gen programs", and
+   "AI as established label by early 1960s".
+3. **Wiener-personality beat treated as near-fact despite
+   open-questions Q1 marking the issue Red** — demoted to "contested
+   interpretation across secondary sources" with explicit do-not-draft
+   note.
+4. **"Coined the term" language inconsistent with Q4 marked
+   non-blocking** — downgraded to "named the program /
+   institutionalized the term" across brief.md, sources.md, and
+   people.md. Q4 stays non-blocking; Q6 (week-level dates) moved out
+   of blocking section per its own "Minor" note.
+
+### Codex anchor extraction (7 claims promoted to Green)
+
+Codex used `curl` + `pdftotext` on the Stanford-hosted Dartmouth
+Proposal PDF (which Claude's WebFetch couldn't read — the PDF was
+CCITT Fax encoded, but Codex's shell tooling handled it). Seven claims
+promoted to Green from primary `DartmouthProposal55` p. 1, 2, 4, 5:
+
+- Aug 31, 1955 submission, four signatories (p. 1).
+- Opening conjecture: "every aspect of learning... can be precisely
+  described that a machine can simulate it" (p. 1).
+- 7 research topics (p. 2).
+- 2-month / 10-man framing (p. 2).
+- Dartmouth College, Hanover NH, summer 1956 (p. 2).
+- $13,500 requested amount (p. 4).
+- Shannon's planned partial attendance (p. 5).
+
+The granted ~$7,500 amount stays Yellow (archive-blocked at the
+Rockefeller Foundation correspondence level).
+
+### Sources added per Codex's anchor-hunt
+
+- G. Solomonoff *dartray.pdf* (secondary synthesis, fetchable).
+- Specific Solomonoff archive items (rayattend, trenattend, mccarthylist
+  — image-only, hand-verification needed).
+- McCarthy-to-Morison 1956 letter, McCarthy December 1956 postmortem,
+  McCarthy 1959 "Programs with Common Sense" (archive-blocked at
+  primary level).
+
+## Gemini Review (second cross-family, gemini-3-flash-preview)
+
+Verdict: NEEDS_CHANGES with 4 substantive findings, integrated with
+hallucination filter applied in commit `63d0ba87`. Per
+`feedback_gemini_hallucinates_anchors.md` (memory adopted 2026-04-27),
+no Gemini-cited claim is promoted to Green without independent
+verification by `curl` + `pdftotext` or Codex equivalent.
+
+### Filtered integration
+
+- **DECLINED — Mauchly/IRE March 1956 claim:** not findable in
+  `dartray.pdf`; Gemini's IRE Transactions citation could not be
+  independently verified.
+- **DECLINED — verbatim McCarthy quote URL:** `jmc.stanford.edu/
+  history/...` returns 404. Substance of McCarthy's naming motive
+  was kept and re-anchored to `dartray.pdf` paraphrasing McCorduck
+  1979 p. 53 (which Claude verified via local `pdftotext` on
+  `dartray.pdf`).
+- **ACCEPTED — Solomonoff precision finding:** verified independently.
+  The workshop ran 8 weeks (June 18 – Aug 17, 1956) per Ray
+  Solomonoff's notes [34]; three people (Ray, Marvin, McCarthy)
+  attended full-time.
+- **ACCEPTED — Moor 2006 "founding a community" framing:**
+  incorporated into Scene 5 phrasing.
+
+### Independent Claude anchor extraction (6 new Green claims)
+
+Claude's own `dartray.pdf` `pdftotext` pass yielded 6 new Green claims
+beyond Codex's 7:
+
+- 8-week duration (June 18 – Aug 17, 1956) corrects the "6 weeks"
+  secondary myth — Ray's notes [34] verified.
+- Three full-time attendees (Ray Solomonoff, Marvin Minsky, John
+  McCarthy).
+- McCarthy naming motive (paraphrase chain dartray → McCorduck p. 53).
+- Alternative names list (cybernetics, automata theory, complex
+  information processing, thinking machines).
+- Trenchard More's 3-week rotation in place of Nathaniel Rochester.
+- Date reconciliation: Aug 31 drafted (Stanford PDF cover) vs Sep 2
+  sent (dartray) — both now Green, reconciled.
+
+## Claims Still Yellow or Red
+
+| Claim Area | Status | Why |
+|---|---|---|
+| Mauchly/IRE March 1956 mention of "AI" | Yellow | Gemini-cited; could not verify via `dartray.pdf` or `curl`+`pdftotext`; still worth pursuing. |
+| Granted Rockefeller Foundation amount (~$7,500) | Yellow | Archive-blocked at the Rockefeller Foundation correspondence level. |
+| Pre-1955 informal use of "AI" by Solomonoff or others | Yellow | Open question per Codex review; would refine "named the program, didn't coin first" framing. |
+| Wiener exclusion from Dartmouth | Red | Archive-blocked at Norbert Wiener correspondence level. Existing secondary speculation is contested; do not draft. |
+| Five Scene-2 attendee biographical claims | Yellow | Claude has Codex's 7 + own 6 anchors for the workshop level; individual attendee depth (especially Solomonoff, More, Selfridge) needs additional primary anchors. |
+| McCarthy 2007 retrospective naming-decision passage | Yellow | Codex followed the index and subpages 1-5 and did NOT find the naming-decision passage. Worth a deeper crawl. |
+
+## Required Anchors Before Prose Readiness
+
+- McCarthy 2007 retrospective: locate the naming-decision passage on
+  alternate hosted versions (Stanford www-formal subpages 6+) or the
+  Hofstra retrospective volume.
+- Mauchly/IRE March 1956 verification or formal removal from the
+  contract.
+- Decide whether the granted Rockefeller amount must be Green for
+  prose readiness or whether Yellow plus the requested-amount Green
+  is sufficient.
+- 2-3 additional Yellow Scene-2 attendee claims to Green via
+  Solomonoff archive image hand-verification or oral history
+  transcripts.
+
+## Scene Strength
+
+| Scene | Strength | Notes |
+|---|---|---|
+| Scene 1 — The 1955 Proposal: McCarthy, Minsky, Rochester, Shannon | Strong | `DartmouthProposal55` pp. 1-5 anchor the four-signatory framing, Aug 31 submission, $13,500 request, 7 topics, 2-month / 10-man framing, Hanover summer 1956. |
+| Scene 2 — Who Actually Showed Up: 8 weeks, 3 full-time + rotators | Strong (post-Gemini integration) | `dartray.pdf` notes [34] anchor 8-week run, 3 full-time attendees, More 3-week rotation; Solomonoff archive image-only items still need hand-verification for individual depth. |
+| Scene 3 — The Naming Question: cybernetics vs. AI | Medium-strong | McCarthy naming motive paraphrased via McCorduck 1979 p. 53; alternative names list anchored. |
+| Scene 4 — The Workshop's Output: LT, IPL, GPS prelude | Medium-strong | Cross-link to Ch12 LT/GPS sources; Logic Theorist + LISP-as-future-program anchors added by Codex. |
+| Scene 5 — Naming, Not Founding: long-tail community formation | Strong | Moor 2006 "founding a community" framing integrated; Honest-close layer now anchored to Scene 5. |
+
+## Word Count Assessment
+
+- Core range now: `4k-7k supported`. Codex's 7 + Claude's 6 + Gemini's
+  filtered framing additions support a 4,500-6,000 word chapter
+  without padding.
+- Stretch range with 2-3 additional Scene-2 attendee Green claims +
+  the McCarthy 2007 naming passage: 6,000-7,000 words.
+
+## Responsible Expansion Path
+
+To reach 4,000-7,000 words without bloat:
+
+- Open in 1955 with the proposal's four-signatory framing and
+  $13,500 request, anchored to `DartmouthProposal55` pp. 1, 4.
+- Move to the actual 8-week workshop with 3 full-time attendees,
+  anchored to Solomonoff's notes [34]; do not assert specific
+  "discussion sessions" without primary records.
+- Use the alternative-names list (cybernetics, automata theory,
+  complex information processing, thinking machines) to anchor the
+  naming-question scene, not modern hindsight.
+- Frame the chapter as "naming the program, institutionalizing the
+  term" — not "founding AI" — per the Boundary Contract's downgrade
+  of "coined the term."
+- Keep Wiener exclusion as a one-paragraph contested-interpretation
+  note; do not draft a Wiener-personality scene.
+
+## Handoff Requests
+
+- Locate the McCarthy 2007 retrospective naming-decision passage on
+  alternate hosted versions or the Moor 2006 *Hofstra Lectures*
+  volume.
+- Decide whether to drop or pursue the Mauchly/IRE March 1956 claim;
+  it currently has no verified anchor.
+- Decide whether the granted Rockefeller amount Yellow is acceptable
+  for prose, or whether Codex's archive-block flag should hold the
+  scene at the requested-amount level only.
+- Hand-verify the Solomonoff archive image-only items (rayattend,
+  trenattend, mccarthylist) for any additional Scene-2 attendee
+  depth.

--- a/docs/research/ai-history/chapters/ch-11-the-summer-ai-named-itself/gap-analysis.md
+++ b/docs/research/ai-history/chapters/ch-11-the-summer-ai-named-itself/gap-analysis.md
@@ -1,7 +1,7 @@
 # Gap Analysis: Chapter 11 - The Summer AI Named Itself
 
 Source: dual-reviewer pass on PR #419 / Issue #401, recorded 2026-04-27.
-Claude authored the original contract; Codex (gpt-5.4) provided the
+Claude authored the original contract; Codex (gpt-5.5) provided the
 first cross-family review and anchor extraction (commit `a454a791`);
 Gemini (gemini-3-flash-preview) provided the second cross-family review
 with hallucination filter applied (commit `63d0ba87`). This is the
@@ -17,7 +17,7 @@ Rockefeller / Norbert Wiener correspondence level). Pending human final
 pass and ideally promotion of 2-3 additional Yellow Scene-2 claims via
 the McCarthy 2007 retrospective before drafting unlocks.
 
-## Codex Review (first cross-family, gpt-5.4)
+## Codex Review (first cross-family, gpt-5.5)
 
 Verdict: NEEDS_CHANGES with 4 must-fix findings — all addressed in
 commit `a454a791`.

--- a/docs/research/ai-history/chapters/ch-11-the-summer-ai-named-itself/infrastructure-log.md
+++ b/docs/research/ai-history/chapters/ch-11-the-summer-ai-named-itself/infrastructure-log.md
@@ -1,1 +1,56 @@
-# Infrastructure Log: Chapter 11
+# Infrastructure Log: Chapter 11 — The Summer AI Named Itself
+
+Technical and institutional metrics relevant to the chapter's infrastructure-history thesis. Each row is what made the Dartmouth event *operationally* possible (or what its operational limits were). Verification colors are tracked because infrastructure claims that look like throwaway facts are often the ones secondary sources copy from each other without primary evidence.
+
+## Funding
+
+| Item | Value | Verification |
+|---|---|---|
+| Funder | Rockefeller Foundation | Yellow — widely documented secondary; primary archival anchor pending. |
+| Amount requested | $13,500 | Yellow — Proposal cover/budget section pending verification on Stanford-hosted PDF. |
+| Amount granted | ~$7,500 | Yellow — secondary sources widely cite this; primary archival anchor (Rockefeller archives) not yet accessed. |
+| Approval date | Spring 1956 (specific date unknown) | Red — needs Rockefeller archive access. |
+| Conditions on the grant | Unknown — conditions presumably standard for the era. | Red — needs primary archival access. |
+
+## Conference
+
+| Item | Value | Verification |
+|---|---|---|
+| Venue | Dartmouth College, Hanover, New Hampshire | Yellow — Proposal cover page should anchor this; pending PDF verification. |
+| Stated duration in Proposal | Two months, summer 1956 | Yellow — pending Proposal opening section anchor. |
+| Actual conference window | Approximately June 18 – August 17, 1956 | Yellow — secondary sources vary in specific weeks; Solomonoff's notes are the primary candidate for exact dating. |
+| Stated participant count | "10-man study" per Proposal headline | Yellow — pending Proposal opening section anchor. |
+| Actual substantial attendance | Approximately 6 attendees stayed for substantial portions; others came for days. | Yellow — multiple secondary sources converge; primary anchor in Solomonoff notes pending. |
+| Computers on-site | None mentioned in Proposal as available at Dartmouth itself. | Yellow — Newell and Simon's Logic Theorist ran on the JOHNNIAC (RAND) and was discussed/demonstrated rather than executed at Dartmouth in real time. Specific anchor pending. |
+| Output documents | Zero published proceedings volume. | Yellow — confirmed by absence in literature; McCarthy 2007 retrospective likely confirms. |
+
+## Pre-existing Programs Discussed
+
+| Program | Status at conference | Verification |
+|---|---|---|
+| Newell-Simon Logic Theorist | Working program; demonstrated and discussed during the summer. | Yellow — multiple secondary sources; primary anchor in Newell-Simon September 1956 IRE paper and Solomonoff notes. |
+| McCarthy's chess-program ideas | Discussed; no working program at conference. | Yellow — secondary sources cite this; primary anchor pending. |
+| Minsky's neural-net learning machine ideas | Discussed; no working program at conference. | Yellow — secondary sources cite this; primary anchor pending. |
+| Solomonoff's inductive inference work | In progress; not formally demonstrated as a program. | Yellow — Solomonoff papers; primary anchor pending. |
+
+## Vocabulary Adopted
+
+| Term | Status before Aug 1955 | Status after Aug 1955 |
+|---|---|---|
+| "Artificial Intelligence" | Not in established academic use as a research-field name. | Adopted by the Proposal. Spreads to funding proposals, paper titles, and curriculum descriptions over 1957-1958. |
+| "Cybernetics" | Established research field after Wiener 1948. | Coexists with AI but increasingly sees the AI label peel off the symbolic/computational research it once contained. |
+| "Automata theory" | Established mathematical research field. | Continues as its own field; AI distances itself from this label per McCarthy 2007 retrospective. |
+| "Complex information processing" | Newell-Simon's term for what they were doing. | Continues to be used by Newell-Simon themselves but loses ground to "AI" in the broader community. |
+
+## Operational Limits Worth Naming in Prose
+
+These are the infrastructure constraints the chapter should foreground when explaining why Dartmouth produced almost no shared output:
+
+- **No shared computer.** No Dartmouth-hosted machine was made available to the conference for real-time experimentation. The closest functioning computational substrate was the JOHNNIAC at RAND — 2,500 miles away. Newell-Simon's Logic Theorist had to be discussed rather than re-executed.
+- **No shared programming language.** The conference predates LISP (McCarthy, 1958-1960). Each researcher used their own conventions on their own machines. There was no medium for collaborative programming.
+- **Partial attendance pattern.** Most attendees came for portions of the eight weeks. The proposal's "10-man" framing implied a fixed cohort; the reality was a rotating partial-attendance pattern that made shared output structurally difficult.
+- **No conference-style proceedings expectation.** The Proposal was written as a *summer research project*, not a conference. There was no commitment to a published volume. This was institutional, not just lazy — the same pattern shaped many Rockefeller-funded summer research projects of the era.
+
+## Notes
+
+- Several "infrastructure facts" frequently repeated in tertiary sources (e.g., "the conference invented AI") collapse into the *naming* claim that the chapter has already moved out of `infrastructure-log.md` and into `brief.md` *Boundary Contract*. Infrastructure-log claims should stay narrowly *operational*: who funded it, when, where, with what equipment, how many people, what got produced.

--- a/docs/research/ai-history/chapters/ch-11-the-summer-ai-named-itself/open-questions.md
+++ b/docs/research/ai-history/chapters/ch-11-the-summer-ai-named-itself/open-questions.md
@@ -1,3 +1,67 @@
-# Open Questions
+# Open Questions: Chapter 11 — The Summer AI Named Itself
 
-- SCRUBBED: All claims downgraded to Yellow. Need REAL, empirical page/section anchors from verified online PDFs or archives. Do not hallucinate.
+Surfaced from `brief.md` *Conflict Notes* and the Yellow/Red entries in `sources.md`. Each question identifies the specific evidence needed to resolve it. Drafting cannot rely on any open-question item until its evidence is in hand.
+
+## Resolution Required Before Drafting
+
+### Q1. The Wiener exclusion
+- **Question:** Did Wiener actively decline to attend the Dartmouth conference, was he politely uninvited, or was he never seriously invited in the first place?
+- **Why it matters:** McCarthy's choice of "Artificial Intelligence" over "cybernetics" implies a deliberate distancing from Wiener's program. If the chapter draws that connection in prose, it needs a defensible reading of why Wiener was absent.
+- **Evidence needed:** McCarthy's contemporary correspondence (Stanford McCarthy Papers); Wiener's own letters from 1955 (MIT Wiener Papers); McCorduck's interview notes; Crevier's interview notes.
+- **Status:** Red. Do not draft a load-bearing scene about Wiener until at least one of the archival items above is in hand.
+
+### Q2. Exact Rockefeller disbursement and conditions
+- **Question:** What was the actual disbursement schedule of the ~$7,500? Were there reporting requirements? Did the Foundation review the conference's outputs (or absence thereof) afterward?
+- **Why it matters:** The infrastructure-thesis works partly because the funding was small and unconditional enough that institutional output was not enforced. Verifying that this is what actually happened (vs. assumed) tightens the claim.
+- **Evidence needed:** Rockefeller Foundation archival records (RAC, North Tarrytown NY).
+- **Status:** Red. Will likely require physical archive access or correspondence with RAC archivists.
+
+### Q3. What did each attendee actually demonstrate?
+- **Question:** Beyond Newell-Simon's Logic Theorist, did any attendee demonstrate a working program during the summer?
+- **Why it matters:** The chapter's "almost no shared output" claim needs to be precise. If McCarthy or Minsky ran any program, the claim has to allow for that exception.
+- **Evidence needed:** Solomonoff's contemporaneous notes; McCarthy 2007 retrospective; surviving conference correspondence.
+- **Status:** Red→Yellow. Solomonoff archive is publicly available; specific notes need locating.
+
+### Q5. Pre-1955 McCarthy-Shannon correspondence pattern
+- **Question:** What was the pre-Proposal correspondence between McCarthy and Shannon that led to the joint application?
+- **Why it matters:** The Proposal's institutional weight came partly from Shannon's name. Understanding *why* Shannon agreed to co-sign tightens the credentialing-mechanism claim in Scene 5.
+- **Evidence needed:** Shannon papers (MIT or Bell Labs archives); Stanford McCarthy Papers.
+- **Status:** Red. Archival access required.
+
+## Lower-Priority Questions (Do Not Block Drafting)
+
+### Q4. Pre-1955 use of "Artificial Intelligence"
+- **Question:** Did the term "Artificial Intelligence" appear in print anywhere before the August 31, 1955 Proposal?
+- **Why it matters:** The chapter no longer claims McCarthy *coined* the phrase — it claims he *named the program* via the Proposal (per Codex review 2026-04-27, the contract was downgraded across brief.md, sources.md, scene-sketches.md). With the language downgraded, Q4 is informational rather than load-bearing.
+- **Evidence needed:** Search of pre-1955 academic literature (mathematics, psychology, computer science, philosophy of mind). Solomonoff's pre-1955 papers as one candidate. Library of Congress newspaper archives as another.
+- **Status:** Yellow. Non-blocking. If discovered, the chapter would add a footnote noting earlier informal usage; the institutional naming claim stands.
+
+### Q6. Conference dates with week-level precision
+- **Question:** When exactly did the conference run? Sources cite slightly different week-of-the-summer ranges.
+- **Why it matters:** Minor — the chapter does not depend on week-level precision. The Proposal anchors "summer 1956" at p.2 (Green). Specific weeks are background detail.
+- **Evidence needed:** Solomonoff contemporaneous notes; Dartmouth special collections.
+- **Status:** Yellow. Non-blocking. Per Codex review 2026-04-27 — this question's own note already said the precision is "Minor", inconsistent with prior blocking classification.
+
+### Q7. Did the Proposal exist in a public form before August 31, 1955?
+- Earlier drafts may have circulated among the four organizers in spring 1955.
+- Status: Yellow. Useful for the naming-decision scene but not load-bearing.
+
+### Q8. What did McCarthy think the conference would produce, and how does that differ from what he later said it produced?
+- Status: Yellow. The McCarthy 2007 retrospective likely answers this directly.
+
+### Q9. Were there other 1955-1956 funding proposals that competed for the same Rockefeller money or used similar terminology?
+- Status: Yellow. Useful context for how distinctive the Dartmouth Proposal was institutionally. Not load-bearing.
+
+## Notes on resolution sequence
+
+The order of attempted resolution:
+1. ✅ **Done (Codex 2026-04-27):** Dartmouth Proposal PDF — promoted Scenes 1, 3 to multiple Green anchors (date, location, 7 topics, $13,500 request, Shannon's planned partial attendance).
+2. Solomonoff Papers (publicly accessible, image-only — needs hand-verification) — would resolve Q3 and partially Q1.
+3. McCarthy 2007 retrospective (publicly accessible — Codex did not find naming passage on indexed pages) — would resolve Q8, partially Q1, and the McCarthy-naming-language Yellow claims in Scene 2.
+4. G. Solomonoff *dartray.pdf* (publicly accessible) — direct fetch, would tighten naming/attendance synthesis.
+5. McCorduck 1979 / Crevier 1993 / Nilsson 2010 page anchors (book-scan or hardcopy) — partially resolves all.
+6. Stanford McCarthy Papers (archival) — resolves Q1, Q5, Q9.
+7. Rockefeller archives (archival) — resolves Q2.
+8. MIT Wiener Papers (archival) — resolves Q1.
+
+Rows 2-5 are tractable without physical archive trips. Rows 6-8 require either archive access or correspondence with archivists. The chapter has now reached `capacity_plan_anchored` status: every Prose Capacity Plan layer cites at least one source identifier, and 7 Scene-Level Claim Table rows are Green via the Stanford PDF anchor extraction. Promotion of additional scenes from Yellow to Green is a stretch upgrade pursued via rows 2-5 next.

--- a/docs/research/ai-history/chapters/ch-11-the-summer-ai-named-itself/people.md
+++ b/docs/research/ai-history/chapters/ch-11-the-summer-ai-named-itself/people.md
@@ -1,1 +1,69 @@
-# People: Chapter 11
+# People: Chapter 11 — The Summer AI Named Itself
+
+Verified protagonist bios. Bios are kept short — material that does not directly bear on the 1955-1956 Dartmouth window stays out. Verification colors track how confident the chapter can be in load-bearing biographical claims when drafting.
+
+## The Four Organizers
+
+### John McCarthy (1927-2011)
+- **Position in 1955-56:** Assistant professor of mathematics at Dartmouth College.
+- **Role in the chapter:** Lead drafter of the Proposal; institutionalized the term "Artificial Intelligence" through it (whether McCarthy was the absolute first to use the phrase in print is open question Q4). Hosted the conference at Dartmouth.
+- **Why he matters here:** McCarthy is the chapter's central protagonist. His later career (Stanford SAIL, LISP, situation calculus) is out of scope; his 2007 retrospective ("What is Artificial Intelligence?") is a primary source for the naming-decision scene.
+- **Verification:** Yellow — biographical facts are well-documented in standard sources; the *specific* claim about why he chose the name needs the McCarthy 2007 anchor.
+
+### Marvin Minsky (1927-2016)
+- **Position in 1955-56:** Junior Fellow at Harvard in Math and Neurology (per dartray.pdf), soon moving to MIT.
+- **Role in the chapter:** Co-organizer; wrote the "neural nets" section of the Proposal. **One of three full-time attendees** during the 8-week workshop (with McCarthy and Solomonoff).
+- **Why he matters here:** Brought the McCulloch-Pitts neural lineage into the Proposal; later co-founded the MIT AI Lab. His 1961 "Steps Toward Artificial Intelligence" *Proceedings of the IRE* paper is a useful follow-up source for what symbolic-AI research actually became.
+- **Verification:** **Green** for full-time attendance — dartray.pdf p.~3 verified by Claude `pdftotext` 2026-04-27. Yellow for specific Proposal-section authorship until Stanford McCarthy Papers anchor lands.
+
+### Nathaniel Rochester (1919-2001)
+- **Position in 1955-56:** Manager of the IBM 701 development team; later chief architect of IBM Research.
+- **Role in the chapter:** Co-organizer; brought industrial computing weight and IBM access. The "automatic computers" section of the Proposal almost certainly reflects his hardware perspective.
+- **Why he matters here:** The conference's only direct industrial-research voice. His role tempers any narrative that frames Dartmouth as purely academic.
+- **Verification:** Yellow — bio well-documented; specific Proposal contributions need primary anchor.
+
+### Claude Shannon (1916-2001)
+- **Position in 1955-56:** Bell Labs; already famous for the 1948 information-theory paper.
+- **Role in the chapter:** Co-organizer; gave the Proposal credibility with the funder. Less active during the conference itself per attendee accounts.
+- **Why he matters here:** The Proposal needed a star name to get past Rockefeller's review. Shannon was that name. His conference attendance was reportedly partial; this is a small but useful infrastructure-of-authority point.
+- **Verification:** Yellow — bio well-documented; partial-attendance claim is widely repeated in secondary sources but needs Solomonoff's notes or Shannon's correspondence as primary.
+
+## The Other Substantial Attendees
+
+### Ray Solomonoff (1926-2009)
+- **Position in 1955-56:** Independent researcher; B.S. from University of Chicago (1944), then Technical Research Group in New York.
+- **Role in the chapter:** **The Contemporaneous Chronicler.** One of three people — alongside organizers McCarthy and Minsky — who attended for the *entire* 8-week workshop (June 18–Aug 17, 1956). Solomonoff was the only non-organizer to do so. His handwritten notes are the chapter's most reliable primary source for what actually happened during the summer.
+- **Why he matters here:** The contemporaneous record. His full-time attendance + detailed notes corrects the often-repeated "6 weeks" myth (Ray's notes say 8 weeks; Marvin's and Trenchard's notes agree). His later work on algorithmic probability/inductive inference is out of scope for Ch11.
+- **Verification:** **Green** for full-time attendance and the 8-week duration — verified via dartray.pdf (Grace Solomonoff's synthesis citing Ray's notes [34]) by Claude `pdftotext` 2026-04-27. Specific archive items (rayattend.pdf, etc.) are image-only and need hand-verification for finer-grained scene anchors.
+
+### Allen Newell (1927-1992)
+- **Position in 1955-56:** RAND Corporation, transitioning toward Carnegie Tech.
+- **Role in the chapter:** Arrived at Dartmouth with Simon, bringing a working Logic Theorist program. The only substantial running demonstration of the summer.
+- **Why he matters here:** The Newell-Simon arrival is the chapter's main "what did happen" beat. Their work was largely independent of the organizers' Proposal; they brought their own research program rather than absorbing one.
+- **Verification:** Yellow — bio well-documented; specific arrival timing and demonstration claim need Solomonoff notes or the September 1956 IRE paper as primary.
+
+### Herbert Simon (1916-2001)
+- **Position in 1955-56:** Carnegie Institute of Technology (later Carnegie Mellon).
+- **Role in the chapter:** Newell's collaborator on Logic Theorist. Simon's later Nobel in Economics is out of scope for Ch11.
+- **Why he matters here:** Half of the Newell-Simon arrival. Simon was a more public voice than Newell in subsequent decades; his 1969 *Sciences of the Artificial* lectures are out of scope here.
+- **Verification:** Yellow — bio well-documented; conference-specific role needs primary anchor.
+
+## The Notable Absence
+
+### Norbert Wiener (1894-1964)
+- **Position in 1955-56:** MIT, established cybernetics figure.
+- **Role in the chapter:** Did not attend. Whether he was actively excluded, declined an invitation, or was never seriously invited is the chapter's largest unresolved factual question.
+- **Why he matters here:** McCarthy's choice of "Artificial Intelligence" over "cybernetics" was a deliberate distancing from Wiener's program. Wiener's absence at Dartmouth is therefore a load-bearing scene element if it can be sourced honestly.
+- **Verification:** **Red** — secondary sources (McCorduck 1979, Crevier 1993) offer different readings. The chapter cannot draft a load-bearing scene about Wiener's absence until either McCarthy's contemporary correspondence or Wiener's own letters resolve the question.
+
+### Trenchard More (rotation attendee)
+- **Position in 1955-56:** Rochester's student at IBM.
+- **Role in the chapter:** Attended three of the eight weeks "in place of" Rochester, who was busy on the IBM 704 (per dartray.pdf p.~14). Took detailed notes that survived; one of the three contemporaneous note-takers (with Solomonoff and Minsky).
+- **Why he matters here:** A second corroborating note-taker for the workshop's actual content; his 3-week rotation also illustrates the partial-attendance pattern the Proposal's "10-man" framing obscured.
+- **Verification:** **Green** for the 3-week rotation and Rochester-replacement role — dartray.pdf p.~14 verified by Claude `pdftotext` 2026-04-27.
+
+## Notes on bios
+
+- All bios are kept narrowly to 1955-1956. Later careers (LISP, MIT AI Lab, Bell Labs information theory work, Carnegie cognitive science) are deliberately out of scope.
+- Bios mention each person's *position* in 1955-56 because institutional location was load-bearing for who got included in the Proposal and who got left out.
+- No invented quotes. Where a bio implies motive (e.g. "Shannon's name gave the Proposal credibility"), the implication must be cited from a secondary source or marked as conjecture.

--- a/docs/research/ai-history/chapters/ch-11-the-summer-ai-named-itself/scene-sketches.md
+++ b/docs/research/ai-history/chapters/ch-11-the-summer-ai-named-itself/scene-sketches.md
@@ -1,1 +1,85 @@
-# Scene Sketches: Chapter 11
+# Scene Sketches: Chapter 11 — The Summer AI Named Itself
+
+Citation-anchored scene beats. Each scene maps to a layer in `brief.md` *Prose Capacity Plan*. Each beat must cite a specific source identifier; beats with no anchor are flagged Red and stay out of prose until upgraded.
+
+## Scene 1 — The Proposal (August 1955)
+
+Anchored layer: *600-900 words: The 1955 proposal as institutional artifact* (brief.md Prose Capacity Plan).
+
+| Beat | Anchor | Status |
+|---|---|---|
+| McCarthy and three co-organizers submit a Rockefeller funding application dated August 31, 1955. | Dartmouth Proposal p.1 (Stanford PDF). | **Green** — verified by Codex `pdftotext` 2026-04-27. |
+| The Proposal opens with the conjecture that every aspect of learning or any feature of intelligence can in principle be so precisely described that a machine can be made to simulate it. | Dartmouth Proposal p.1 (Stanford PDF). | **Green** — verified by Codex `pdftotext` 2026-04-27. |
+| The Proposal lists seven research topics: automatic computers, programming for natural language, neuron nets, theory of the size of a calculation, self-improvement, abstractions, randomness and creativity. | Dartmouth Proposal p.2 (Stanford PDF). | **Green** — verified by Codex `pdftotext` 2026-04-27. |
+| The Proposal asks Rockefeller for $13,500 and proposes a 2-month, 10-man study at Dartmouth College, Hanover NH, summer 1956. | Dartmouth Proposal p.2 (location/duration) + p.4 (request amount), Stanford PDF. | **Green** — verified by Codex `pdftotext` 2026-04-27. |
+| Shannon's portion of the Proposal indicates he plans to attend only partially. | Dartmouth Proposal p.5 (Stanford PDF). | **Green** — verified by Codex `pdftotext` 2026-04-27. NB this anchors *planned* attendance only; actual attendance is a separate Yellow beat. |
+| The four signatories are McCarthy (Dartmouth), Minsky (Harvard), Rochester (IBM), Shannon (Bell Labs). | Dartmouth Proposal p.1 (Stanford PDF). | **Green** — verified by Codex `pdftotext` 2026-04-27. |
+| Rockefeller eventually grants approximately $7,500 — about 55% of the request. | Rockefeller Foundation archival records (not yet accessed). | Yellow — secondary sources widely repeat; primary anchor still archive-blocked. |
+
+**Scene-level note:** The infrastructure beat to foreground is the *gap* between the Proposal's framing (10-man, organized, productive summer) and the reality (~6 substantial attendees, partial attendance, no shared machine). Don't draft the gap until the infrastructure beats land Yellow at minimum.
+
+## Scene 2 — The Naming Decision
+
+Anchored layer: *700-1,000 words: The naming decision* (brief.md Prose Capacity Plan).
+
+| Beat | Anchor | Status |
+|---|---|---|
+| McCarthy chose "Artificial Intelligence" rather than reusing "cybernetics," "automata theory," or "complex information processing." | dartray.pdf p.~6 paraphrasing McCorduck 1979 p.53 (citation [26, p.53]). | **Green** for the dartray paraphrase chain — verified Claude `pdftotext` 2026-04-27. |
+| McCarthy chose the name "partly for its neutrality; avoiding a focus on narrow automata theory, and avoiding cybernetics which was too heavily focused on analog feedback, as well as him potentially having to accept the assertive Norbert Wiener as guru or having to argue with him." | dartray.pdf p.~6 verbatim paraphrase (citation [26, p.53] = McCorduck 1979). | **Green** for the paraphrase as quoted; the dartray text gives the substance of McCarthy's stated reasoning, citing McCorduck. NB this is dartray's paraphrase of McCorduck's interview, not McCarthy verbatim. Frame in prose accordingly. |
+| The other contemporary names for the field circa 1956 were "cybernetics, automata theory, complex information processing," or informally "thinking machines." | dartray.pdf p.~22 (line 552 verbatim list). | **Green** — verified Claude `pdftotext` 2026-04-27. |
+| Whether McCarthy's rejection of "cybernetics" was specifically a Wiener-personality issue (vs. just the disciplinary scope of the term) — the dartray paraphrase says BOTH: cybernetics was wrong because it was "too heavily focused on analog feedback" AND McCarthy did not want to accept Wiener as guru. The distinction the chapter should preserve: this is McCarthy's *stated motive*, not Wiener's personal failings. | dartray.pdf p.~6 (paraphrase chain). | **Green** for the dartray paraphrase reflecting both reasons; Yellow for any sharper Wiener-specific psychological reading. Do not turn this into a Wiener takedown. |
+| The naming choice was ratified institutionally by the Proposal's acceptance and dispersion of the term across funding documents over 1957-1958. | Multiple secondary sources; primary anchors pending. | Yellow |
+
+**Scene-level note:** The chapter argues that the *naming* was the load-bearing institutional move. Be precise about what this means — McCarthy did not invent the *idea* of intelligent machines (Turing, Wiener, McCulloch, Pitts, Solomonoff already had); he chose a new *label* for a research program that needed institutional separation from existing labels.
+
+## Scene 3 — The Summer of 1956
+
+Anchored layer: *600-900 words: Who attended and what they did during the summer* (brief.md Prose Capacity Plan).
+
+| Beat | Anchor | Status |
+|---|---|---|
+| The Proposal's "10-man" framing was never realized in practice. Most attendees came for portions of the 8 weeks. | dartray.pdf p.~14 ("the people had other commitments and so they came for short times and different times" — McCarthy quote); Solomonoff Papers; McCorduck 1979. | **Green** for the partial-attendance pattern (verified Claude `pdftotext` 2026-04-27 against dartray.pdf p.~14). Yellow for the specific count of attendees still pending Solomonoff archive hand-verification. |
+| The workshop ran approximately 8 weeks (June 18–August 17, 1956), not 6 weeks as some secondary sources state. | dartray.pdf p.~7 citing Ray Solomonoff's notes [34] with corroboration from Minsky and Trenchard More notes. | **Green** — verified Claude `pdftotext` 2026-04-27. |
+| Three people — McCarthy (host), Minsky (organizer), and Solomonoff (non-organizer) — attended the entire 8-week workshop. Solomonoff was the only non-organizer to do so. | dartray.pdf p.~3 ("Ray, Marvin, and McCarthy were the only three who spent the whole time at the Workshop"). | **Green** — verified Claude `pdftotext` 2026-04-27. |
+| Newell and Simon arrived partway through the summer with a working version of the Logic Theorist program — the only substantial running demonstration of the conference. | Newell-Simon September 1956 IRE paper; Solomonoff Papers; McCorduck 1979; Crevier 1993; Nilsson 2010. | Yellow |
+| Trenchard More attended three of the eight weeks in place of Rochester, who was busy on the IBM 704. | dartray.pdf p.~14. | **Green** — verified Claude `pdftotext` 2026-04-27. |
+| Shannon's attendance plan was partial per the Proposal text itself; his actual attendance is reported partial across secondary sources. | Dartmouth Proposal p.5 (Stanford PDF) for *planned* partial attendance; Solomonoff notes for *actual* attendance. | **Green** for planned (Codex anchor); Yellow for actual. |
+| McCarthy was the consistent on-site presence throughout the summer as host. | dartray.pdf p.~3 (one of three full-time attendees). | **Green** — verified Claude `pdftotext` 2026-04-27. |
+| Most discussions involved circulating ideas rather than running programs. The Logic Theorist (Newell-Simon) was the substantive exception. | dartray.pdf p.~14; multiple secondary sources. | Yellow — substantive claim widely supported but exact wording from dartray pending fuller reading. |
+
+**Scene-level note:** Avoid invented atmospherics ("the dining hall buzzed with conversation"). Beats must come from contemporaneous notes (Solomonoff) or from interviews secondary sources conducted with attendees. Where multiple secondary sources converge on the same general claim but no primary anchor exists, the prose should phrase this with appropriate hedging ("according to attendee accounts") rather than as direct fact.
+
+## Scene 4 — What Did Not Happen
+
+Anchored layer: *500-800 words: The unproductive summer* (brief.md Prose Capacity Plan).
+
+| Beat | Anchor | Status |
+|---|---|---|
+| No conference proceedings volume was published. | Confirmed by absence in literature; McCarthy 2007 retrospective likely confirms. | Yellow |
+| No shared definition of "intelligence" or "Artificial Intelligence" was agreed during the summer. | McCarthy 2007 retrospective; secondary sources widely. | Yellow |
+| Most participants left with their pre-existing research programs unchanged. | McCorduck 1979; Crevier 1993; McCarthy 2007. | Yellow |
+| McCarthy himself characterized the summer as a disappointment in later interviews and the 2007 retrospective. | McCarthy 2007 retrospective; specific phrasing verification pending. | Yellow — exact quote needed before any direct quotation in prose. |
+| The conference produced no shared paper, no joint program, and no formal research collaboration extending past the summer. | McCarthy 2007 retrospective; secondary sources. | Yellow |
+
+**Scene-level note:** This scene's narrative job is to dismantle the founding-myth framing without becoming a takedown. The point is not that Dartmouth was a failure — it's that the conference's historical importance is *not* in what was produced *during* it. Tone: matter-of-fact historical correction, not contrarian rhetoric.
+
+## Scene 5 — What Did Happen — The Naming Aftermath
+
+Anchored layer: *700-1,000 words: The institutional aftermath* (brief.md Prose Capacity Plan).
+
+| Beat | Anchor | Status |
+|---|---|---|
+| The phrase "Artificial Intelligence" begins appearing in funding proposals, paper titles, and curriculum descriptions over 1957-1958. | Specific examples need primary anchors with dates. | Yellow |
+| The four organizers become the field's gatekeepers — McCarthy at Stanford, Minsky at MIT, Rochester at IBM, Shannon at Bell Labs/MIT. | Standard secondary sources; specific institutional dates need verification. | Yellow |
+| ARPA's later AI funding (~1962+) uses Dartmouth-era vocabulary in its program documents. | Edwards 1996 *The Closed World*; Nilsson 2010. Primary anchor in ARPA program documents pending. | Yellow |
+| The Logic Theorist (Newell-Simon) and McCarthy's later LISP work become the most-cited next-generation symbolic-AI programs — not because Dartmouth produced them, but because Dartmouth credentialed their authors as field organizers. | Secondary sources widely; cross-link to Ch12, Ch13. | Yellow |
+| By the early 1960s, "Artificial Intelligence" is the established label for symbolic and computational learning research separated from cybernetics and from automata theory. | Multiple secondary sources; specific anchor in Edwards 1996 or Nilsson 2010 pending. | Yellow |
+
+**Scene-level note:** This is where the chapter's thesis lands. The narrative move is "Dartmouth's importance was not the summer; it was the credentialing pipeline that the summer set up." Don't overstate — the chapter must not claim that nothing else mattered or that ARPA funding was inevitable. The pattern is *probabilistic*: Dartmouth made the AI label legible to funders, and the legibility compounded.
+
+## Cross-scene notes
+
+- No invented dialogue. Every quoted sentence must come from a primary source.
+- Where secondary sources conflict (e.g., on Wiener's exclusion, on attendance), the chapter should name the disagreement rather than picking a side.
+- "Founding of AI" framing is dismantled across Scenes 4 and 5; do not let any scene accidentally re-introduce it.
+- The chapter should NOT include an explainer of cybernetics, neural networks, or symbolic AI as concepts. Those belong in Ch5, Ch6, Ch12. Ch11's narrow focus is the *naming and credentialing event*.

--- a/docs/research/ai-history/chapters/ch-11-the-summer-ai-named-itself/sources.md
+++ b/docs/research/ai-history/chapters/ch-11-the-summer-ai-named-itself/sources.md
@@ -1,1 +1,128 @@
-# Sources: Chapter 11
+# Sources: Chapter 11 — The Summer AI Named Itself
+
+## Verification Key
+
+- **Green**: claim has primary evidence with verified page/section anchor plus independent confirmation.
+- **Yellow**: claim has one strong source, page anchor pending verification, or unresolved attribution nuance.
+- **Red**: claim should not be drafted yet.
+
+## Primary Sources
+
+| Source | Use | Verification |
+|---|---|---|
+| McCarthy, Minsky, Rochester, Shannon, "A Proposal for the Dartmouth Summer Research Project on Artificial Intelligence," August 31, 1955. URL: http://jmc.stanford.edu/articles/dartmouth/dartmouth.pdf | Anchor for: the term "Artificial Intelligence" institutionalized by McCarthy via the Proposal; the opening conjecture that "every aspect of learning or any other feature of intelligence can in principle be so precisely described that a machine can be made to simulate it" (p.1); the seven research topics (p.2); the four signatories; the request amount $13,500 (p.4); June–August 1956 timing at Dartmouth College, Hanover NH (p.2); Shannon's planned partial attendance (p.5). | **Green** for: opening conjecture (p.1), 7-topic list (p.2), 2-month/10-man framing and Hanover NH location (p.2), $13,500 request (p.4), Shannon's planned partial attendance (p.5). Verified by `curl` + `pdftotext` on the Stanford-hosted PDF (Codex anchor extraction, 2026-04-27). The granted ~$7,500 amount remains unverified from this PDF and must wait for Rockefeller archives. |
+| John McCarthy, "What is Artificial Intelligence?", revised November 12, 2007. URL: http://www-formal.stanford.edu/jmc/whatisai/ | Anchor for: McCarthy's later reflection on the choice of "Artificial Intelligence" over alternatives; his characterization of the term as practically motivated. | Yellow until page-level anchor extraction is performed. Open access. |
+| Ray Solomonoff Papers, Solomonoff Archive. URL: http://world.std.com/~rjs/ | Parent anchor for the contemporaneous archival items below. | Yellow. Specific items pinned individually below per Codex's archive structural confirmation. |
+| Solomonoff Archive item: `rayattend.pdf`. URL: http://world.std.com/~rjs/ (specific path TBC). | Anchor for: Solomonoff's own attendance dates and pattern. | Yellow. Image-only PDF per Codex's anchor-hunt; OCR was too noisy for Green promotion. Needs better-quality scan or hand-verification. |
+| Solomonoff Archive item: `trenattend.pdf`. URL: http://world.std.com/~rjs/ (specific path TBC). | Anchor for: Trenchard More's attendance and report. | Yellow. Same image-only PDF caveat. |
+| Solomonoff Archive item: `mccarthylist.pdf`. URL: http://world.std.com/~rjs/ (specific path TBC). | Anchor for: McCarthy's contemporaneous attendee list. | Yellow. Same image-only PDF caveat. |
+| McCarthy-to-Morison letter (1956), referenced in McCarthy archival materials. | Anchor for: contemporary correspondence about the conference and attendance. | Red. Archival access required; not yet attempted. |
+| McCarthy, "Dartmouth mathematics project" (December 1956 postmortem report). | Anchor for: McCarthy's contemporary assessment of what the conference produced. | Red. Archival access required. |
+| McCarthy 1959, "Programs with Common Sense," in *Mechanisation of Thought Processes* (HMSO 1959), pp. 75-91. | Anchor for: post-Dartmouth research direction (Scene 5 aftermath only — not for the naming scene). | Yellow until specific page anchors are needed. |
+| Allen Newell and Herbert Simon, "The Logic Theory Machine — A Complex Information Processing System," IRE Transactions on Information Theory, vol. IT-2, no. 3 (September 1956), pp. 61-79. | Anchor for: the running Logic Theorist program that Newell and Simon brought to Dartmouth; what it actually proved; how this differed from the conference's other "intentions to study" outputs. | Yellow until page-level anchor extraction. |
+| Marvin Minsky, "Steps Toward Artificial Intelligence," Proceedings of the IRE, vol. 49, no. 1 (January 1961), pp. 8-30. | Background source for Minsky's research program in the years immediately following Dartmouth; useful for the institutional aftermath scene. | Yellow until specific page anchors are needed. |
+| Shannon-McCarthy correspondence, Stanford McCarthy Papers (archival, not yet accessed). | Anchor for: pre-conference communication between organizers; possible insight into Wiener's exclusion. | Red. Archival access required; not yet attempted. Do not draft scenes from this source until pages are obtained. |
+| Rockefeller Foundation grant records (archival). | Anchor for: actual disbursement of the $7,500 grant; conditions and timeline. | Red. Archival access required; not yet attempted. |
+
+## Secondary Sources
+
+| Source | Use | Verification |
+|---|---|---|
+| Pamela McCorduck, *Machines Who Think* (W. H. Freeman, 1979; 2nd ed. A K Peters, 2004). | Comprehensive narrative history written from interviews with most Dartmouth participants. Anchor for: organizer interactions, attendance patterns, McCarthy's stated motives for the term "Artificial Intelligence." | Yellow until specific page anchors are pulled (estimated Ch.5, pp. 92-130 covers Dartmouth). Edition matters (page numbers shift between 1979 hardback and 2004 reissue). |
+| Daniel Crevier, *AI: The Tumultuous History of the Search for Artificial Intelligence* (Basic Books, 1993). | Secondary narrative drawing on contemporaneous interviews. Anchor for: the unproductive-summer scene, McCarthy's later admissions. | Yellow until specific page anchors are pulled (estimated pp. 27-55). |
+| Nils J. Nilsson, *The Quest for Artificial Intelligence* (Cambridge University Press, 2010). | Comprehensive academic history by a Stanford AI insider. Anchor for: institutional aftermath, ARPA funding patterns. | Yellow until specific page anchors are pulled (estimated pp. 53-72). |
+| James Moor, "The Dartmouth College Artificial Intelligence Conference: The Next Fifty Years," *AI Magazine* vol. 27, no. 4 (Winter 2006), pp. 87-91. | 50th-anniversary commemorative essay with primary-source quotations. | Yellow. Open access via AAAI. |
+| Stuart Russell and Peter Norvig, *Artificial Intelligence: A Modern Approach*, 4th ed. (Pearson, 2020), Section 1.3 "The History of Artificial Intelligence." | Tertiary textbook reference. Useful for cross-checking dates and the conventional narrative the chapter is gently revising. | Yellow. Tertiary; do not anchor load-bearing claims here. |
+| Paul N. Edwards, *The Closed World: Computers and the Politics of Discourse in Cold War America* (MIT Press, 1996). | Source for the Cold War funding context that legitimized AI as a research category in the years after Dartmouth. | Yellow until specific page anchors are pulled. |
+| Grace Solomonoff, *Ray Solomonoff and the Dartmouth Summer Research Project in Artificial Intelligence, 1956* (`dartray.pdf`, Solomonoff Archive). URL: https://raysolomonoff.com/dartmouth/dartray.pdf (verified 2026-04-27) — also at http://world.std.com/~rjs/dartray.pdf | Secondary synthesis with significant primary-document quotation. Anchor for: 8-week duration (June 18-Aug 17, 1956); the three full-time attendees (Ray, Marvin, McCarthy); McCarthy's naming motive (paraphrasing McCorduck 1979 p.53); the alternative names available (cybernetics, automata theory, complex information processing). | **Green** for the specific claims listed in the Scene-Level Claim Table below. Verified by Claude direct `pdftotext` extraction 2026-04-27 against the live URL. |
+
+## Scene-Level Claim Table
+
+| Claim | Scene | Primary Anchor | Independent Confirmation | Status | Notes |
+|---|---|---|---|---|---|
+| McCarthy and three co-organizers submitted a funding proposal dated August 31, 1955 that named the program "Artificial Intelligence." | 1, 2 | Dartmouth Proposal 1955, p.1 (Stanford PDF) | McCorduck 1979 Ch.5; Crevier 1993 Ch.2 | **Green** | Anchor verified by `pdftotext` extraction (Codex 2026-04-27). "Coinage" claim downgraded to "named the program" pending Q4 (pre-1955 informal usage). |
+| The Proposal opens with the conjecture that every aspect of learning or any feature of intelligence can in principle be so precisely described that a machine can be made to simulate it. | 1, 4 | Dartmouth Proposal 1955, p.1 (Stanford PDF) | McCorduck 1979 Ch.5 | **Green** | Anchor verified by `pdftotext` (Codex 2026-04-27). Useful as the chapter's framing claim. |
+| The Proposal listed 7 specific research topics: automatic computers, language programming, neuron nets, theory of size of computation, self-improvement, abstractions, randomness/creativity. | 1 | Dartmouth Proposal 1955, p.2 (Stanford PDF) | McCorduck 1979 Ch.5; Nilsson 2010 pp. 53-72 | **Green** | Anchor verified by `pdftotext` (Codex 2026-04-27). Exact wording extractable. |
+| The Proposal proposed a 2-month, 10-man study at Dartmouth College, Hanover NH, summer 1956. | 1, 3 | Dartmouth Proposal 1955, p.2 (Stanford PDF) | McCorduck 1979 Ch.5; Moor 2006 *AI Magazine* | **Green** | Anchor verified by `pdftotext` (Codex 2026-04-27). |
+| The Proposal requested $13,500 from Rockefeller Foundation. | 1 | Dartmouth Proposal 1955, p.4 (Stanford PDF) | McCorduck 1979 Ch.5; Crevier 1993 Ch.2 | **Green** | Anchor verified by `pdftotext` (Codex 2026-04-27). |
+| The Rockefeller grant was approximately $7,500 (about 55% of the request). | 1 | Rockefeller archives (not yet accessed) | McCorduck 1979 Ch.5; Crevier 1993 Ch.2 | Yellow | Secondary sources widely repeat the figure; primary archival anchor still needed. Stays Yellow. |
+| Shannon planned to attend only partially, per the Proposal's own description of his commitments. | 3 | Dartmouth Proposal 1955, p.5 (Stanford PDF) | McCorduck 1979 Ch.5 | **Green** | Anchor verified by `pdftotext` (Codex 2026-04-27). NB this is *planned* attendance per the Proposal text; whether Shannon's actual attendance matched the plan is a separate Yellow claim. |
+| Shannon's actual attendance was partial. | 3 | Solomonoff Papers (pending hand-verification of image scans) | McCorduck 1979 Ch.5; Crevier 1993 Ch.2 | Yellow | Distinct from the planned-attendance claim above; primary anchor pending. |
+| McCarthy chose "Artificial Intelligence" partly to step outside the disciplinary frame of "cybernetics," "automata theory," and "complex information processing." | 2 | McCarthy 2007 retrospective (passage not yet located on whatisai pages 1-5) | McCorduck 1979 Ch.5; Crevier 1993 Ch.2; G. Solomonoff *dartray.pdf* pp. 5-10 | Yellow | Codex's anchor-hunt did not find the naming-decision passage in the indexed whatisai subpages; specific primary anchor still needed. Per Codex's must-fix, the framing has been narrowed from motive ("escape baggage") to action ("step outside the frame"). |
+| Whether McCarthy's stated rejection of "cybernetics" was specifically a reaction to Wiener's personality (vs. just to the disciplinary scope of the term) is contested across secondary sources. | 2 | None primary | McCorduck 1979 (one reading); Crevier 1993 (another reading) | Yellow — flagged as contested interpretation per Codex review (was previously treated as a near-fact). | Per open-questions.md Q1, do not draft a load-bearing scene that asserts the personality reading. Treat as contested. |
+| Wiener was not invited or did not attend (whether actively excluded, politely uninvited, or never seriously invited is unresolved). | 2, 3 | None primary | McCorduck 1979; Crevier 1993 | Red | Secondary sources conflict. Q1 in open-questions.md. Do not draft a load-bearing scene. |
+| About 6 attendees stayed for substantial portions of the summer; the proposal's "10-man" framing was never realized. | 3 | Solomonoff Papers (image scans, hand-verification pending) | McCorduck 1979 pp. ~100-115; Crevier 1993 pp. 30-50; G. Solomonoff *dartray.pdf* | Yellow | Codex confirmed Solomonoff archive structure but image-only OCR was too noisy for Green. |
+| Solomonoff stayed the longest of any non-organizer. | 3 | Solomonoff Papers (image scans, hand-verification pending) | McCorduck 1979; G. Solomonoff *dartray.pdf* | Yellow | Same image-only caveat. |
+| Newell and Simon arrived at Dartmouth with a working Logic Theorist program; this was the only substantial running demonstration during the summer. | 3 | Newell & Simon 1956 IRE paper (post-summer publication); Solomonoff Papers | McCorduck 1979; Crevier 1993; Nilsson 2010 | Yellow | Newell-Simon paper publication date is post-conference; primary anchor for the in-summer demonstration specifically still needs the Solomonoff hand-verification or archival correspondence. |
+| McCarthy was the consistent on-site presence throughout the summer as host. | 3 | None primary yet | Multiple secondary sources | Yellow | Standard secondary claim; would benefit from a Solomonoff or McCarthy correspondence anchor. |
+| Most other discussions during the summer involved circulating ideas rather than running programs. | 3, 4 | None primary yet | McCarthy 2007; McCorduck 1979; Crevier 1993 | Yellow | This claim depends on the McCarthy 2007 retrospective passage that Codex could not yet locate on the indexed pages. |
+| The conference produced no proceedings volume and no shared definition of intelligence. | 4 | Confirmed by absence in literature; McCarthy 2007 retrospective likely confirms | McCorduck 1979; Crevier 1993; Nilsson 2010 | Yellow | "Absence" claims need careful framing — primary verification ideally via the McCarthy 2007 passage. |
+| McCarthy later characterized the conference as a disappointment in interviews and the 2007 retrospective. | 4 | McCarthy 2007 retrospective (specific passage not yet located) | McCorduck 1979; Crevier 1993 | Yellow | Confirm exact wording before quoting. |
+| The phrase "Artificial Intelligence" appeared in funding proposals, paper titles, and curriculum descriptions in 1957-1958. | 5 | None primary yet | McCorduck 1979 pp. 115-130; Nilsson 2010 pp. 53-72 | Yellow | Specific examples with dates needed before any "within months" prose. |
+| The four organizers became the field's institutional gatekeepers — McCarthy at Stanford (post-1962), Minsky at MIT, Rochester at IBM, Shannon continuing at Bell Labs/MIT. | 5 | None primary yet | Standard secondary sources; institutional dates need verification | Yellow | Per Codex must-fix #2: previously a scene-sketches beat with no claim-table row. Now tracked. |
+| The Logic Theorist (Newell-Simon) and McCarthy's later LISP work became the most-cited next-generation symbolic-AI programs after Dartmouth. | 5 | None primary yet | Multiple secondary sources; cross-link Ch12, Ch13 | Yellow | Per Codex must-fix #2: previously a scene-sketches beat with no claim-table row. Now tracked. |
+| By the early 1960s, "Artificial Intelligence" was the established label for symbolic and computational learning research, separate from cybernetics and automata theory. | 5 | None primary yet | Multiple secondary sources; specific anchor in Edwards 1996 or Nilsson 2010 pending | Yellow | Per Codex must-fix #2: previously a scene-sketches beat with no claim-table row. Now tracked. |
+| ARPA's later AI funding (~1962+) used Dartmouth-era vocabulary in its program documents. | 5 | ARPA program documents (not yet accessed) | Edwards 1996; Nilsson 2010 | Yellow | Specific anchor in Edwards 1996 chapter on Cold War AI funding pending. |
+| The workshop ran approximately eight weeks, from about June 18 to August 17, 1956. The often-repeated "six weeks" figure (e.g. McCorduck 1979 p.53) is contradicted by Ray Solomonoff's contemporaneous notes. | 1, 3 | dartray.pdf p.~7 (citing Ray Solomonoff's notes [34]); Trenchard More's notes; Marvin Minsky's notes | dartray.pdf p.~7 confirms the three contemporaneous note-takers agree | **Green** | Verified by Claude `pdftotext` 2026-04-27. Use this anchor wherever a date claim is made; do NOT repeat the secondary "6 weeks" myth. |
+| Three people — Ray Solomonoff, Marvin Minsky, and John McCarthy — were the only attendees who spent the whole eight weeks at the workshop. Solomonoff was the only non-organizer to do so. | 3 | dartray.pdf p.~3 (line "Ray, Marvin, and McCarthy were the only three who spent the whole time at the Workshop") | Trenchard More 3-week attendance corroborates partial attendance pattern | **Green** | Verified by Claude `pdftotext` 2026-04-27. Replaces the prior vaguer "Solomonoff stayed the longest" claim. |
+| McCarthy chose the name "Artificial Intelligence" partly for its neutrality, avoiding "automata theory" (too narrow), avoiding "cybernetics" (which was tied to analog feedback control), and avoiding having to accept Norbert Wiener as field guru or argue with him. | 2 | dartray.pdf p.~6 (paraphrasing); McCorduck 1979 p.53 (original attribution per dartray's citation [26, p.53]) | dartray + McCorduck convergence | **Green** for the dartray paraphrase chain | Verified by Claude `pdftotext` 2026-04-27 against dartray.pdf line 144-150. **Verification chain:** dartray paraphrases what McCorduck reports from her McCarthy interview. Independent McCorduck p.53 verification still pending physical book access. **NB:** Gemini's review cited a verbatim McCarthy quote at `http://jmc.stanford.edu/history/dartmouth/dartmouth.html` — that URL returned 404 when Claude verified. Gemini subsequently admitted to systemic URL hallucination (epic commit `03640e20`, Issue #421). The dartray paraphrase chain is genuine; the Stanford URL is fabricated and is NOT being used. Frame the Wiener-avoidance carefully: it is NOT a Wiener-personality smear; the primary framing per dartray is "neutral name avoiding existing camps." |
+| The other contemporary names for the field circa 1956 were "cybernetics," "automata theory," "complex information processing," and informally "thinking machines." | 2 | dartray.pdf p.~22 (line "Some other names were cybernetics, automata theory, complex information processing, [16, p. 115] or just 'thinking machines'") | Multiple secondary sources | **Green** | Verified by Claude `pdftotext` 2026-04-27. Useful for grounding the naming-decision scene without overclaiming McCarthy's individual reasoning. |
+| **Conflict Note: Proposal date.** Codex anchored "August 31, 1955" via the Stanford-hosted PDF cover; dartray.pdf p.~6 says "September 2, 1955" was when the proposal "was sent" to the Rockefeller Foundation. Both can be true (drafted/signed Aug 31; mailed Sep 2). | 1 | Stanford PDF cover (Aug 31) AND dartray.pdf p.~6 (Sep 2 sent) | Both verified | **Green for both dates** | Use phrasing like "drafted on August 31, 1955 and sent to Rockefeller in early September." Do NOT pick one date silently. |
+| ~~In March 1956 ... Mauchly used "artificial intelligence" at the IRE National Convention~~ — **REMOVED 2026-04-27.** | — | — | — | — | Gemini cited this in his Ch11 review with a specific citation (IRE Transactions on Electronic Computers, Vol. EC-5, No. 3, Sept 1956). Gemini subsequently admitted via user message 2026-04-27 to systemic URL/anchor hallucination across 37 chapters (commit `03640e20` on epic; Issue #421 tracks the cleanup). Claude could not independently verify the Mauchly/IRE claim in dartray.pdf or any verified secondary source. Per `feedback_citation_verify_or_remove.md`: unverified = lie. Removed rather than carried as Yellow. If the claim turns out to be real via legitimate primary research, it can come back. |
+
+## Page Anchor Worklist
+
+Anchors to extract before drafting unlocks:
+
+### Done (Codex anchor-hunt 2026-04-27)
+
+- ✅ **Dartmouth Proposal 1955 PDF** — opening conjecture (p.1), 2-month/10-man framing and Hanover NH (p.2), 7-topic list (p.2), $13,500 request (p.4), Shannon's planned partial attendance (p.5). Verified by `curl` + `pdftotext` on `http://jmc.stanford.edu/articles/dartmouth/dartmouth.pdf`. Five Scene-Level Claim Table rows promoted to Green.
+
+### Done (Claude anchor-hunt 2026-04-27 via dartray.pdf)
+
+- ✅ **G. Solomonoff *dartray.pdf*** — fetched from `https://raysolomonoff.com/dartmouth/dartray.pdf`, processed via local `pdftotext`. Promoted six new Green claims: workshop ran 8 weeks (June 18–Aug 17, 1956); the "6 weeks" myth corrected; three full-time attendees (Ray, Marvin, McCarthy); McCarthy's naming-motive paraphrase (dartray citing McCorduck 1979 p.53); the alternative names list (cybernetics, automata theory, complex information processing, thinking machines); Trenchard More 3-week rotation in place of Rochester. Plus surfaced a date conflict (Aug 31 cover date vs Sep 2 mailing date — both now Green and reconciled in claim table).
+
+### Tractable but not yet done
+
+- Newell & Simon 1956 IRE paper — confirmation of in-summer demonstration. IRE Transactions on Information Theory, IT-2(3), pp. 61-79. Tractable via library access.
+- Moor 2006 *AI Magazine* — primary quotations. AAAI open access.
+
+### Investigated 2026-04-27 — both leads dead-end (kept for transparency)
+
+- ❌ **Solomonoff mirror at `world.std.com/~rjs/dartray.pdf`** — handoff suggested fetching this for naming/attendance synthesis at pp. 5-10. URL returned HTTP 404 on Claude's fetch 2026-04-27. The same file is preserved at `https://raysolomonoff.com/dartmouth/dartray.pdf` (already anchored above); no second mirror to extract from.
+- ❌ **McCarthy "What is AI?" retrospective deeper crawl** — handoff suggested deeper crawl of `www-formal.stanford.edu/jmc/whatisai/node{N}.html` (Codex tried 1-5). Claude probed nodes 1-15: only nodes 1-6 exist; 7-15 return HTTP 404. Text extraction via stdlib HTML parser plus keyword grep across all 6 nodes for `dartmouth|chose|cybernet|name|term|automata|wiener` surfaced no naming-decision passage. Conclusion: McCarthy's whatisai retrospective does not contain the naming passage; the McCorduck-1979-via-dartray paraphrase chain remains the strongest available anchor without physical book access. Recorded so the next session does not re-investigate.
+
+### Removed — Gemini hallucination cleanup 2026-04-27
+
+- ❌ **`http://jmc.stanford.edu/history/dartmouth/dartmouth.html`** — URL Gemini cited in Ch11 review as anchor for verbatim McCarthy quote on naming choice. URL returns 404. Per Gemini's own admission via user message 2026-04-27 (epic commit `03640e20`, Issue #421), Gemini systemically hallucinated URLs and page anchors across 37 chapters; cleanup script run by Gemini scrubbed his side. Chapter Ch11's McCarthy-naming-motive claim is anchored via dartray paraphrase + McCorduck 1979 p.53 instead — substance preserved, fabricated URL not used.
+- ❌ **Mauchly / IRE National Convention March 1956** — claim Gemini included in his Ch11 review, citing IRE Transactions Vol. EC-5 No. 3 (Sept 1956). Not findable in dartray.pdf. Per `feedback_gemini_hallucinates_anchors.md`, removed from claim table rather than carried as Yellow placeholder. May reappear in a future revision if a legitimate primary source surfaces.
+
+### Image-only / OCR was too noisy for Green promotion (Codex tried)
+
+- Solomonoff archive items: `rayattend.pdf`, `trenattend.pdf`, `mccarthylist.pdf`. Per Codex: archive structure confirmed, content is image-only. Hand-verification or better-quality scans needed.
+
+### Archive-blocked (deferred — physical access required)
+
+- McCorduck 1979 — exact pages for naming, attendance, McCarthy's later assessments. Physical copy or scan.
+- Crevier 1993 — exact pages for unproductive-summer scene. Physical copy or scan.
+- Nilsson 2010 — exact pages for institutional aftermath and ARPA roll-forward. Physical copy or scan.
+- McCarthy-to-Morison 1956 letter, McCarthy December 1956 postmortem report, McCarthy letter mentioning Newell/Simon invite. Stanford McCarthy Papers.
+- Allen Newell oral history. CHM (Computer History Museum).
+- Trenchard More attendance/report documents. Solomonoff archive linkage; potentially CHM.
+- McCorduck interview tapes. CHM.
+- Rockefeller Foundation archival records — actual disbursement of the ~$7,500 grant. RAC, North Tarrytown NY.
+
+## Conflict Notes
+
+- "Founding of AI" framing — disputed. See chapter brief.md *Conflict Notes* and *Boundary Contract*.
+- Wiener's exclusion — sources conflict; do not draft a load-bearing scene until resolved.
+- Attendance counts — vary across secondary sources; defer to Solomonoff contemporaneous notes where available.
+- The "10-man" headline — the proposal's framing was never realized. Several secondary sources reproduce the headline number uncritically.
+
+## Open Items for Cross-Family Review
+
+When this contract is sent to Codex or Gemini for cross-family review:
+
+- Is the boundary contract sharp enough? The chapter argues 1956 was a *naming* moment, not a *founding* moment. Reviewers should stress-test that thesis.
+- Is the Prose Capacity Plan honest? Each layer is currently Yellow. Reviewers should flag any layer where the secondary-source-only path could not honestly produce the budgeted word range without padding.
+- Are there primary sources I should be using that this list omits? (Likely candidates: McCarthy's 1959 "Programs with Common Sense" paper for the post-conference research direction; correspondence in the Marvin Minsky Papers at MIT.)

--- a/docs/research/ai-history/chapters/ch-11-the-summer-ai-named-itself/status.yaml
+++ b/docs/research/ai-history/chapters/ch-11-the-summer-ai-named-itself/status.yaml
@@ -1,1 +1,34 @@
-status: researching
+status: capacity_plan_anchored
+review_state: codex_approved_2026-04-27;gemini_substance_integrated_with_hallucination_filter_2026-04-27
+green_claims: 13
+yellow_claims: 12
+red_claims: 1
+notes: |
+  Codex cross-family review (gpt-5.4) 2026-04-27: NEEDS_CHANGES with 4 must-fixes,
+  all integrated. Codex anchor-extraction via `pdftotext` on Stanford Dartmouth
+  Proposal PDF promoted 7 claims to Green. Codex APPROVED the integrated contract.
+
+  Gemini cross-family review (gemini-3-flash-preview) 2026-04-27: NEEDS_CHANGES
+  with 4 must-fixes. Gemini subsequently admitted via user message 2026-04-27
+  (epic commit 03640e20, Issue #421) to systemic URL/anchor hallucination across
+  37 chapters. Gemini's substantive findings were partially correct but multiple
+  citations were fabricated:
+   - The McCarthy "I chose it to avoid cybernetics" verbatim quote URL was 404.
+   - The Mauchly IRE March 1956 claim was not verifiable in dartray.pdf.
+
+  Claude independently fetched dartray.pdf and ran local pdftotext extraction,
+  which promoted 6 more claims to Green via the legitimate dartray + McCorduck
+  paraphrase chain (8-week duration corrects the "6-week" myth; 3 full-time
+  attendees; McCarthy naming motive substance; alternative-names list; Trenchard
+  More 3-week rotation; date conflict reconciliation Aug 31 drafted vs Sep 2
+  sent). The fabricated Gemini citations were removed rather than carried as
+  Yellow placeholders, per feedback_citation_verify_or_remove.md.
+
+  Total Green: 13 (Codex 7 + Claude 6 via dartray). Yellow: 12. Red: 1 (Wiener
+  exclusion remains archive-blocked). Gemini's actual review must-fixes #2-#4
+  (Solomonoff precision, McCarthy motive promotion via verified chain, Moor
+  framing) all integrated using verified anchors. Must-fix #1 (Mauchly IRE)
+  declined as unverifiable.
+
+  Pending: Claude/human final pass before drafting unlocks. This contract has
+  cleared dual cross-family review with hallucination-cleanup applied.

--- a/docs/research/ai-history/chapters/ch-11-the-summer-ai-named-itself/status.yaml
+++ b/docs/research/ai-history/chapters/ch-11-the-summer-ai-named-itself/status.yaml
@@ -1,10 +1,27 @@
-status: capacity_plan_anchored
-review_state: codex_approved_2026-04-27;gemini_substance_integrated_with_hallucination_filter_2026-04-27
+status: prose_ready
+prose_word_cap: 5100
+review_state: codex_approved_2026-04-27;gemini_substance_integrated_with_hallucination_filter_2026-04-27;dual_cross_family_verdict_2026-04-28
 green_claims: 13
 yellow_claims: 12
 red_claims: 1
+verdicts:
+  gemini:
+    model: gemini-3-flash-preview
+    date: 2026-04-28
+    verdict: READY_TO_DRAFT
+    word_cap: null
+    bridge_msg: 2938
+  codex:
+    model: gpt-5.5
+    date: 2026-04-28
+    verdict: READY_TO_DRAFT_WITH_CAP
+    word_cap: 5100
+    bridge_msg: 2946
+  resolved: READY_TO_DRAFT_WITH_CAP
+  resolved_word_cap: 5100
+  resolution_rule: most_conservative_verdict_wins
 notes: |
-  Codex cross-family review (gpt-5.4) 2026-04-27: NEEDS_CHANGES with 4 must-fixes,
+  Codex cross-family review (gpt-5.5) 2026-04-27: NEEDS_CHANGES with 4 must-fixes,
   all integrated. Codex anchor-extraction via `pdftotext` on Stanford Dartmouth
   Proposal PDF promoted 7 claims to Green. Codex APPROVED the integrated contract.
 
@@ -30,5 +47,17 @@ notes: |
   framing) all integrated using verified anchors. Must-fix #1 (Mauchly IRE)
   declined as unverifiable.
 
-  Pending: Claude/human final pass before drafting unlocks. This contract has
-  cleared dual cross-family review with hallucination-cleanup applied.
+  Dual cross-family verdict pass 2026-04-28:
+   - Gemini (gemini-3-flash-preview): READY_TO_DRAFT, no cap. Stayed in lane
+     per feedback_gemini_hallucinates_anchors.md, no URLs cited (msg #2938).
+   - Codex (gpt-5.5): READY_TO_DRAFT_WITH_CAP at 5,100 words. Spot-checked
+     major Green anchors via curl on Stanford-hosted proposal HTML mirror and
+     dartray.pdf; no shaky Greens. 12 Yellows are honestly Yellow with no
+     unexploited anchors. Wiener-exclusion correctly Red. Bound the chapter
+     at 5,100 because the 7k stretch depends on Yellow aftermath and
+     archive-blocked claims (msg #2946).
+   - Resolution: most_conservative_verdict_wins -> READY_TO_DRAFT_WITH_CAP
+     at 5,100 words.
+
+  Status advances from capacity_plan_anchored to prose_ready. Drafting may
+  begin on a claude/394-ch11-prose branch off main, capped at 5,100 words.

--- a/docs/research/ai-history/chapters/ch-11-the-summer-ai-named-itself/timeline.md
+++ b/docs/research/ai-history/chapters/ch-11-the-summer-ai-named-itself/timeline.md
@@ -1,1 +1,28 @@
-# Timeline: Chapter 11
+# Timeline: Chapter 11 — The Summer AI Named Itself
+
+Chapter-specific dates. Verification status indicates how confident the chapter can be in the date when drafting.
+
+| Date | Event | Verification |
+|---|---|---|
+| 1943 | McCulloch & Pitts publish "A Logical Calculus of the Ideas Immanent in Nervous Activity" — neural-network model that the Dartmouth Proposal would later cite as part of "neuron nets." | Yellow — well-documented secondary; primary is *Bulletin of Mathematical Biophysics* 5, 115-133. Anchor for Ch5 not Ch11; cross-link only. |
+| 1948 | Wiener publishes *Cybernetics: Or Control and Communication in the Animal and the Machine*. The disciplinary shadow McCarthy would later define "Artificial Intelligence" against. | Yellow — secondary sources well-documented. Cross-link to Ch6 (Cybernetics Movement). |
+| 1948 | Shannon's "A Mathematical Theory of Communication." | Yellow — context only; cross-link to Ch10 or wherever Shannon-the-information-theorist lands. |
+| October 1950 | Turing's "Computing Machinery and Intelligence" published in *Mind*. | Yellow — primary anchor at Mind 59 (236), 433-460. Cross-link to Ch10 (The Imitation Game). |
+| Spring–Summer 1955 | McCarthy, Minsky, Rochester, Shannon discuss the proposal informally before drafting. | Yellow — secondary (McCorduck, Crevier). Specific dates of pre-proposal correspondence are open question. |
+| August 31, 1955 | "A Proposal for the Dartmouth Summer Research Project on Artificial Intelligence" drafted/dated. Cover page lists McCarthy (Dartmouth), Minsky (Harvard), Rochester (IBM), Shannon (Bell Labs). | **Green** — Stanford PDF cover, verified by Codex `pdftotext` 2026-04-27. |
+| ~September 2, 1955 | Proposal sent to the Rockefeller Foundation. (Date conflict with Aug 31 cover-page date may reflect drafted-vs-mailed gap.) | **Green** — dartray.pdf p.~6 line "On September 2, 1955, the four sent a proposal," verified by Claude `pdftotext` 2026-04-27. |
+| Spring 1956 | Rockefeller approves funding at ~$7,500 against the ~$13,500 request. Specific approval date and disbursement schedule remain Red. | Red→Yellow — secondary sources widely cite the funding amount; primary archival anchor (Rockefeller Foundation archives) not yet accessed. |
+| June 18 – August 17, 1956 | The Dartmouth Summer Research Project on Artificial Intelligence runs at Dartmouth College, Hanover NH. **Approximately 8 weeks** — corrects the often-repeated "6 weeks" figure. | **Green** — dartray.pdf p.~7 citing Ray Solomonoff's contemporaneous notes, with corroboration from Marvin Minsky and Trenchard More notes. Verified by Claude `pdftotext` 2026-04-27. |
+| ~Aug 17, 1956 | Ray Solomonoff gives the final talk; workshop concludes. | **Green** — dartray.pdf p.~7. |
+| Summer 1956 | Newell and Simon arrive at Dartmouth with a working version of the Logic Theorist program. The only substantial running demonstration of the summer per attendee accounts. | Yellow — multiple secondary sources converge; primary is Solomonoff's contemporaneous notes (pending archival access) and Newell & Simon's September 1956 IRE paper. |
+| August/September 1956 | Conference disperses without published proceedings. Most participants leave with their pre-existing research programs unchanged. | Yellow — McCarthy's later admissions and McCorduck/Crevier interviews. Primary anchor in McCarthy 2007 retrospective pending. |
+| September 1956 | Newell & Simon, "The Logic Theory Machine — A Complex Information Processing System," IRE Transactions on Information Theory IT-2(3), 61-79. | Yellow — primary publication well-documented; specific page anchors pending. |
+| 1957–1958 | "Artificial Intelligence" begins appearing in funding proposals and curriculum descriptions. | Yellow — secondary sources cite specific examples; primary verification requires period-specific document access. |
+| 1959 | McCarthy publishes "Programs with Common Sense" — direct line from Dartmouth program toward symbolic AI research. | Yellow — primary anchor at *Mechanisation of Thought Processes* (HMSO 1959), 75-91. Cross-link to Ch12. |
+| ~1962 | ARPA begins funding AI research using Dartmouth-era vocabulary. Specific date depends on which ARPA program is counted as the first. | Yellow — Edwards 1996 *The Closed World* anchors the funding-context claim; specific contract anchors require ARPA program documents. |
+
+## Notes on dating
+
+- The Proposal date (August 31, 1955) is the most-cited single anchor of the chapter and should land Green as soon as the cover page of the Stanford-hosted PDF is verified.
+- The conference dates (June–August 1956) are widely repeated but vary by week across secondary sources. Solomonoff's contemporaneous notes are the source-of-truth.
+- The "founding date of AI" question is not settled by this timeline. Multiple plausible dates exist (1943, 1948, 1950, 1955, 1956, ~1962). The chapter's stance per `brief.md` is that 1956 was a *naming* moment, not a founding moment. The timeline reflects that — there is no single "AI was born here" entry.


### PR DESCRIPTION
## Summary

Research contract for Chapter 11 ("The Summer AI Named Itself") on the AI History Epic #394 / Part 3 #401.

Per One-Branch-One-PR-One-Phase workflow (TEAM_WORKFLOW.md §0). Decomposed from the long-lived multi-chapter PR #419 into a focused per-chapter research PR, matching the practice Codex and Gemini are now using for Ch17, Ch28-31, etc.

**Status:** \`capacity_plan_anchored\`
**Counts:** 13 Green / 12 Yellow / 1 Red
**Single Red:** Wiener exclusion (archive-blocked)

## Cross-family review record (see \`gap-analysis.md\`)

- **Codex (gpt-5.4)** review #1 returned \`NEEDS_CHANGES\` with 4 must-fixes — all addressed; 7 claims promoted to Green via \`pdftotext\` on the Stanford-hosted Dartmouth Proposal PDF.
- **Gemini (gemini-3-flash-preview)** review #2 returned \`NEEDS_CHANGES\` with 4 findings — integrated with hallucination filter (Mauchly/IRE 1956 declined as unverifiable; verbatim McCarthy URL declined as 404).
- **Claude independent \`dartray.pdf\` pass** added 6 more Green claims beyond Codex's 7 (8-week duration, 3 full-time attendees, naming-motive paraphrase chain, alternative-names list, More rotation, date reconciliation).

## What's needed before \`accepted\`

- [ ] Reviewer re-verify pass with formal verdicts (\`READY_TO_DRAFT\` / \`READY_TO_DRAFT_WITH_CAP\` / \`NEEDS_ANCHORS\`). Previous verdicts were \`NEEDS_CHANGES\`; integration complete but not formally re-approved.
- [ ] McCarthy 2007 retrospective naming-decision passage (Codex couldn't locate on subpages 1-5).
- [ ] Resolve or drop Mauchly/IRE March 1956 claim.

## Replaces

This PR supersedes Ch11 portion of #419 (long-lived multi-chapter branch — being decomposed per workflow).

## Test plan

- [ ] Codex anchor verification (re-verify post must-fix integration; confirm 13 Green primary anchors hold)
- [ ] Gemini gap analysis re-verify with formal verdict
- [ ] Once both reviewers Green, advance status.yaml to \`accepted\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)