### PR TITLE
Make Gemini primary writer for all quality rewrites (#388)

### DIFF
--- a/scripts/quality/queue.py
+++ b/scripts/quality/queue.py
@@ -42,7 +42,7 @@ from .state import (
 # routing to whichever the order ended up.
 
 PRIMARY_BEGINNER = "gemini-3.1-pro-preview"
-PRIMARY_ADVANCED = "gpt-5.5"
+PRIMARY_ADVANCED = "gemini-3.1-pro-preview"
 TERTIARY = "claude-opus-4-7"
 
 # Map writer-model identifiers (returned by route_writer / stored in the
@@ -52,7 +52,6 @@ TERTIARY = "claude-opus-4-7"
 # corresponding case in scripts/dispatch.py.
 _MODEL_TO_AGENT: dict[str, tuple[str, str]] = {
     PRIMARY_BEGINNER: ("gemini", PRIMARY_BEGINNER),
-    PRIMARY_ADVANCED: ("codex", PRIMARY_ADVANCED),
     TERTIARY: ("claude", TERTIARY),
 }
 
@@ -112,17 +111,8 @@ def _read_complexity(module_path: Path) -> str | None:
 def _beginner_writer() -> str:
     """Resolve the beginner-track writer, honouring a runtime degraded
     fallback.
-
-    During the 2026-04-26 batch run, Gemini-3.1-pro-preview hit a peak-hour
-    capacity window where ~75% of writes returned truncated output (odd
-    triple-backtick count = unclosed code fence). Setting
-    ``KUBEDOJO_BEGINNER_FALLBACK=codex`` reroutes the beginner-track
-    modules to Codex gpt-5.5 for the duration. Unset to restore the
-    Gemini default once capacity returns.
     """
     fallback = os.environ.get("KUBEDOJO_BEGINNER_FALLBACK", "").lower().strip()
-    if fallback in {"codex", "gpt-5.5"}:
-        return PRIMARY_ADVANCED
     if fallback in {"claude", "claude-opus", "claude-opus-4-7"}:
         return TERTIARY
     return PRIMARY_BEGINNER
@@ -130,16 +120,8 @@ def _beginner_writer() -> str:
 
 def _tertiary_writer() -> str:
     """Resolve the tertiary writer, honouring a runtime degraded fallback.
-
-    Same shape as ``_beginner_writer``. Anthropic-side throttling on
-    consecutive heavy claude calls (~10 min cool-down) made Claude an
-    unreliable batch writer during the 2026-04-26 run; setting
-    ``KUBEDOJO_TERTIARY_FALLBACK=codex`` reroutes any module that would
-    otherwise default to Claude (unenumerated tracks) to Codex gpt-5.5.
     """
     fallback = os.environ.get("KUBEDOJO_TERTIARY_FALLBACK", "").lower().strip()
-    if fallback in {"codex", "gpt-5.5"}:
-        return PRIMARY_ADVANCED
     if fallback in {"gemini", "gemini-3.1-pro-preview"}:
         return PRIMARY_BEGINNER
     return TERTIARY

--- a/scripts/quality/stages.py
+++ b/scripts/quality/stages.py
@@ -289,7 +289,7 @@ def route_one(slug: str) -> None:
         if claim_result.writer is None:
             return  # blocked, no transition; retry on next sweep
         agent, writer_model = queue.model_to_agent(claim_result.writer)
-        reviewer = "claude" if agent != "claude" else "codex"
+        reviewer = "claude" if agent != "claude" else "gemini"
 
         state.transition(
             st, "AUDITED", "ROUTED",

--- a/tests/test_quality_queue.py
+++ b/tests/test_quality_queue.py
@@ -40,7 +40,7 @@ def _seed_module(repo: Path, rel: str, *, complexity: str | None = None, with_st
 
 def test_model_to_agent_known_models():
     assert queue.model_to_agent(queue.PRIMARY_BEGINNER) == ("gemini", queue.PRIMARY_BEGINNER)
-    assert queue.model_to_agent(queue.PRIMARY_ADVANCED) == ("codex", queue.PRIMARY_ADVANCED)
+    assert queue.model_to_agent(queue.PRIMARY_ADVANCED) == ("gemini", queue.PRIMARY_ADVANCED)
     assert queue.model_to_agent(queue.TERTIARY) == ("claude", queue.TERTIARY)
 
 

--- a/tests/test_quality_stages.py
+++ b/tests/test_quality_stages.py
@@ -222,7 +222,7 @@ def test_route_rewrite_when_score_below_threshold(fake_repo, monkeypatch):
     st = state.load_state(slug)
     assert st["stage"] == "WRITE_PENDING"
     assert st["route"]["track"] == "rewrite"
-    assert st["writer"] == "codex"  # module_index=0 → even → codex writes
+    assert st["writer"] == "gemini"  # module_index=0 → even → gemini writes
     assert st["reviewer"] == "claude"
 
 
@@ -274,7 +274,7 @@ def test_write_one_happy_path_creates_worktree_commit(fake_repo, monkeypatch):
     st = state.load_state(slug)
     assert st["stage"] == "WRITE_DONE"
     assert st["write"]["commit_sha"]
-    assert st["write"]["agent"] == "codex"
+    assert st["write"]["agent"] == "gemini"
     # The worktree should exist with the new content.
     wt = worktree.worktree_dir(fake_repo, slug)
     assert wt.exists()


### PR DESCRIPTION
Updates pipeline v5 routing to use Gemini for all rewrite tiers, completely removing Codex from the queue fallback and stages routing. Claude remains the tertiary fallback and is the universal reviewer for all Gemini rewrites.