### PR TITLE
docs(ai-history): anchor chapter 21 research contract (#402)

### DIFF
--- a/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/brief.md
+++ b/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/brief.md
@@ -75,10 +75,12 @@ and why production use exposed a different class of problems from research use.
    to 3300, 5500 component descriptions, new system types, reliability/testing,
    performance metrics, mentors, and errors caused by missing parts or changing
    products.
-7. **Advice, Customers, and Commercial Reality:** use the ad-hoc constraints
-   paper and Smith to show that successful commercial expert systems had to
-   accept customer-specific constraints, avoid demo mentality, involve domain
-   experts, and survive technology transfer.
+7. **Advice, Customers, and Commercial Reality:** give XSEL/ad-hoc constraints
+   a standalone scene: customer-specific commands temporarily bend R1's clean
+   ordinary-case configuration flow, then ordinary rules resume. Use Smith to
+   show that successful commercial expert systems had to accept customer
+   pressure, avoid demo mentality, involve domain experts, and survive
+   technology transfer.
 8. **The Fortune and the Trap:** close with the expert-system boom's legitimate
    excitement and the hidden cost: rule-based systems could make money when
    narrow, structured, and maintained, but their value depended on permanent
@@ -112,8 +114,8 @@ economic claims or the 1993 "R1/XCON at age 12" retrospective.
   correctness metric, more than 80,000 orders, missing/incorrect rules falling
   below one in a thousand orders, and why early high-volume deployment would
   have been dangerous, anchored by Bachant/McDermott 1984 pp.28-32.
-- 300-400 words: ad-hoc/customer constraints and XSEL relationship, anchored by
-  McDermott/Steele 1981 pp.824-828.
+- 300-400 words: standalone ad-hoc/customer-constraints scene and XSEL
+  relationship, anchored by McDermott/Steele 1981 pp.824-828.
 - 300-400 words: broader commercial expert-system lesson: avoid demonstration
   mentality, use domain experts and knowledge engineers, plan transfer and
   progressive releases, anchored by Smith 1984 pp.66-69.

--- a/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/brief.md
+++ b/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/brief.md
@@ -1,1 +1,128 @@
-# Brief: Chapter 21
+# Brief: Chapter 21 - The Rule-Based Fortune
+
+## Thesis
+
+R1/XCON made the expert-system boom feel commercially real because it moved a
+rule-based AI program out of a laboratory demonstration and into Digital
+Equipment Corporation's manufacturing workflow. Its achievement was not general
+intelligence. It was a narrow but valuable fit between a structured industrial
+task, a large body of ad hoc component knowledge, a production-rule architecture,
+and an organization willing to maintain the knowledge base as products and users
+changed. The fortune came from making expertise operational at scale; the warning
+was that the same success created a permanent maintenance burden.
+
+## Scope
+
+This chapter should bridge Ch20's interactive infrastructure and Ch22's
+AI-hardware commercialization. It owns the first convincing commercial
+expert-system success story: DEC's VAX configuration problem, McDermott's R1
+rule base, its later XCON name, OPS4/OPS5 production systems, XSEL/ad-hoc
+customer constraints, the maintenance organization at DEC, and the broader
+lesson that commercial expert systems had to be engineered, tested, transferred,
+and maintained like products.
+
+The chapter should make XCON a scene, not a slogan. The reader should understand
+why VAX configuration was hard, why rules were a plausible representation, why
+R1 avoided broad search, why deployment succeeded despite imperfect knowledge,
+and why production use exposed a different class of problems from research use.
+
+## Boundary Contract
+
+- Do not claim R1/XCON was a general AI breakthrough. It worked because the VAX
+  configuration domain had enough structure for the Match method and enough
+  local constraints for production rules to recognize what to do.
+- Do not claim R1 eliminated human experts. Experts tutored the system, examined
+  output, supplied missing exceptional cases, validated configurations, mentored
+  production use, and maintained/extended the knowledge base.
+- Do not use famous savings numbers unless a verified page anchor is added.
+  Current contract supports commercial usefulness and high-volume deployment,
+  but not a dollar-savings claim.
+- Do not treat the 1982 paper and the 1984 R1 Revisited paper as identical
+  evidence. The 1982 paper proves the technical task and initial deployment; the
+  1984 paper proves four years of growth, performance measurement, and
+  maintenance pressure.
+- Do not collapse R1/XCON and XSEL. XSEL was the sales-assistant system under
+  development; R1/XCON was the configuration program that fleshed out and
+  configured orders.
+- Do not narrate the Lisp-machine company story here. Ch22 owns the hardware
+  commercialization and bubble. Ch21 may mention Lisp/OPS runtime context only
+  as implementation background.
+- Do not narrate the Japanese Fifth Generation project here except as a brief
+  handoff if needed. Ch23 owns national-scale expert-system/logic-programming
+  ambitions.
+- Do not overstate commercial expert-system maturity from one success. Smith's
+  1984 commercial-development article should be used to show why industrial
+  expert systems imposed different engineering constraints from research systems.
+
+## Narrative Spine
+
+1. **A Factory Problem, Not a Toy:** open inside DEC's VAX order/configuration
+   process: customer orders, missing components, cabinet/backplane/cable
+   relationships, technicians who need diagrams before assembly.
+2. **Knowledge as Constraints:** explain why configuration was a knowledge
+   problem: hundreds of components, thousands of component properties, many
+   design constraints whose justifications were not reducible to clean theory.
+3. **Rules That Recognize:** show R1's production-rule architecture, OPS4/OPS5,
+   working memory, recognize-act cycles, Match, little backtracking, and the
+   division between domain-specific and general rules.
+4. **Knowledge Engineering in the Trenches:** narrate the tutoring, manuals,
+   first-stage demo, expert review, exceptional cases, rule splitting, context
+   spawning, and formal validation.
+5. **Into DEC Manufacturing:** move from validation to regular manufacturing
+   use, same-day field-office screening, hundreds then tens of thousands of
+   orders, and a DEC group that grew around knowledge-base maintenance.
+6. **The System Keeps Growing:** use R1 Revisited to show rule growth from 750
+   to 3300, 5500 component descriptions, new system types, reliability/testing,
+   performance metrics, mentors, and errors caused by missing parts or changing
+   products.
+7. **Advice, Customers, and Commercial Reality:** use the ad-hoc constraints
+   paper and Smith to show that successful commercial expert systems had to
+   accept customer-specific constraints, avoid demo mentality, involve domain
+   experts, and survive technology transfer.
+8. **The Fortune and the Trap:** close with the expert-system boom's legitimate
+   excitement and the hidden cost: rule-based systems could make money when
+   narrow, structured, and maintained, but their value depended on permanent
+   human and organizational work.
+
+## Prose Capacity Plan
+
+Word Count Discipline label: `4k-5k confirmed; 5k-5.6k requires stretch unlocks`
+
+Core range: 4,000-5,000 words supported by current verified anchors. Stretch
+range: 5,000-5,600 words only if a verified source is added for later XCON
+economic claims or the 1993 "R1/XCON at age 12" retrospective.
+
+- 450-650 words: open with the DEC manufacturing scene and the difference
+  between a customer order and a buildable VAX system, anchored by McDermott
+  1982 pp.39-40 and Bachant/McDermott 1984 p.21.
+- 650-850 words: explain the configuration task as knowledge work: VAX-11/780
+  variation, 420 components, over 3300 component facts, 480 extracted rules, and
+  ad hoc constraints, anchored by McDermott 1982 pp.40-42.
+- 650-850 words: describe R1's production-system machinery and Match without
+  drowning the reader in implementation detail, anchored by McDermott 1982
+  pp.45-46, p.58, and pp.64-66.
+- 600-800 words: knowledge acquisition and validation narrative: December 1978
+  start, simple-orders demo, expert scrutiny, exceptional cases, rule splitting,
+  50-order validation, anchored by McDermott 1982 pp.68-70.
+- 650-900 words: four-year production growth: DEC organization, 77-person
+  Intelligent Systems Technologies group, 4 worker-years/year on R1 knowledge,
+  3300 rules, 5500 component descriptions, structured release/testing, and
+  never-finished maintenance, anchored by Bachant/McDermott 1984 pp.21-27.
+- 450-650 words: performance and deployment discipline: mentors, all-or-nothing
+  correctness metric, more than 80,000 orders, missing/incorrect rules falling
+  below one in a thousand orders, and why early high-volume deployment would
+  have been dangerous, anchored by Bachant/McDermott 1984 pp.28-32.
+- 350-550 words: ad-hoc/customer constraints and XSEL relationship, anchored by
+  McDermott/Steele 1981 pp.824-828.
+- 350-550 words: broader commercial expert-system lesson: avoid demonstration
+  mentality, use domain experts and knowledge engineers, plan transfer and
+  progressive releases, anchored by Smith 1984 pp.61-73.
+- 250-400 words: close with handoff to Ch22/Ch23: commercial legitimacy without
+  general intelligence; expert systems became a business proposition and a
+  maintenance promise.
+
+Honesty close: If prose cannot reach 4,000 words without padding the production
+system internals or repeating maintenance claims, stop below 4,000 and flag the
+missing later economic/retrospective source. The chapter should spend words on
+how R1 worked and why production changed the problem, not on generic "AI in
+business" hype.

--- a/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/brief.md
+++ b/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/brief.md
@@ -92,32 +92,32 @@ Core range: 4,000-5,000 words supported by current verified anchors. Stretch
 range: 5,000-5,600 words only if a verified source is added for later XCON
 economic claims or the 1993 "R1/XCON at age 12" retrospective.
 
-- 450-650 words: open with the DEC manufacturing scene and the difference
+- 450-550 words: open with the DEC manufacturing scene and the difference
   between a customer order and a buildable VAX system, anchored by McDermott
   1982 pp.39-40 and Bachant/McDermott 1984 p.21.
-- 650-850 words: explain the configuration task as knowledge work: VAX-11/780
+- 550-700 words: explain the configuration task as knowledge work: VAX-11/780
   variation, 420 components, over 3300 component facts, 480 extracted rules, and
   ad hoc constraints, anchored by McDermott 1982 pp.40-42.
-- 650-850 words: describe R1's production-system machinery and Match without
+- 550-700 words: describe R1's production-system machinery and Match without
   drowning the reader in implementation detail, anchored by McDermott 1982
   pp.45-46, p.58, and pp.64-66.
-- 600-800 words: knowledge acquisition and validation narrative: December 1978
+- 550-700 words: knowledge acquisition and validation narrative: December 1978
   start, simple-orders demo, expert scrutiny, exceptional cases, rule splitting,
   50-order validation, anchored by McDermott 1982 pp.68-70.
-- 650-900 words: four-year production growth: DEC organization, 77-person
+- 600-700 words: four-year production growth: DEC organization, 77-person
   Intelligent Systems Technologies group, 4 worker-years/year on R1 knowledge,
   3300 rules, 5500 component descriptions, structured release/testing, and
   never-finished maintenance, anchored by Bachant/McDermott 1984 pp.21-27.
-- 450-650 words: performance and deployment discipline: mentors, all-or-nothing
+- 450-550 words: performance and deployment discipline: mentors, all-or-nothing
   correctness metric, more than 80,000 orders, missing/incorrect rules falling
   below one in a thousand orders, and why early high-volume deployment would
   have been dangerous, anchored by Bachant/McDermott 1984 pp.28-32.
-- 350-550 words: ad-hoc/customer constraints and XSEL relationship, anchored by
+- 300-400 words: ad-hoc/customer constraints and XSEL relationship, anchored by
   McDermott/Steele 1981 pp.824-828.
-- 350-550 words: broader commercial expert-system lesson: avoid demonstration
+- 300-400 words: broader commercial expert-system lesson: avoid demonstration
   mentality, use domain experts and knowledge engineers, plan transfer and
-  progressive releases, anchored by Smith 1984 pp.61-73.
-- 250-400 words: close with handoff to Ch22/Ch23: commercial legitimacy without
+  progressive releases, anchored by Smith 1984 pp.66-69.
+- 250-300 words: close with handoff to Ch22/Ch23: commercial legitimacy without
   general intelligence; expert systems became a business proposition and a
   maintenance promise.
 

--- a/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/gap-analysis.md
+++ b/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/gap-analysis.md
@@ -30,7 +30,9 @@ Word Count Discipline label: `4k-5k confirmed; 5k-5.6k requires stretch unlocks`
   support regular DEC manufacturing use, almost all VAX-11 systems shipped, and
   the 15-person maintenance group.
 - **Ad-hoc/customer constraints:** McDermott/Steele 1981 supports XSEL commands,
-  customer-specific constraints, and the bounded extension to R1.
+  customer-specific constraints, and the bounded extension to R1. This should be
+  drafted as a standalone scene because it shows commercialization forcing a
+  rule system to absorb customer exceptions.
 - **Commercial expert-system context:** Smith 1984 supports the broader lesson:
   commercial systems are not demos and require domain experts, knowledge
   engineering, programming support, progressive releases, and transfer planning.
@@ -70,12 +72,15 @@ Natural supported range: 4,000-5,000 words.
 Path to 4,000 without bloat:
 
 - Open with a DEC order and the factory need for diagrams.
+- Keep the physical output visible: diagrams, backplane placement, cables, and
+  technicians using R1's configuration descriptions.
 - Explain configuration as ad-hoc constraint knowledge rather than abstract
   theorem proving.
 - Spend real space on how production rules and Match made the task tractable.
 - Use the expert-review/validation story as the human center.
 - Move into production growth, mentors, problem reporting, and 80,000 orders.
-- Use XSEL/ad-hoc constraints as a short pressure scene.
+- Use XSEL/ad-hoc constraints as a full pressure scene, not only a bridge
+  paragraph.
 - Close with Smith's commercial-development frame and the maintenance promise.
 
 Path to 5,000-5,600 without bloat:

--- a/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/gap-analysis.md
+++ b/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/gap-analysis.md
@@ -1,0 +1,93 @@
+# Gap Analysis: Chapter 21 - The Rule-Based Fortune
+
+## Current Verdict
+
+`REVIEW_REQUESTED`
+
+The chapter has enough anchored evidence for a 4,000-5,000 word draft if it
+keeps R1/XCON as a narrow industrial expert-system success and treats the
+commercial lesson as maintenance, product integration, and source-backed
+engineering discipline. It should not use unverified savings numbers or broad
+market claims.
+
+Word Count Discipline label: `4k-5k confirmed; 5k-5.6k requires stretch unlocks`
+
+## Green Scenes
+
+- **Factory problem:** McDermott 1982 supports the customer-order-to-assembly
+  scene and the need to add missing components and produce diagrams.
+- **Configuration knowledge:** McDermott 1982 supports 420 components, over
+  3300 component facts, 480 extracted rules, and the ad-hoc nature of many
+  constraints.
+- **Production-rule machinery:** McDermott 1982 supports OPS4, working memory,
+  recognize-act cycles, Match, 772 rules, and sparse rule use per order.
+- **Knowledge acquisition:** McDermott 1982 supports tutoring, manuals, early
+  simple-order success, expert output review, exceptional cases, rule splitting,
+  and validation.
+- **Manufacturing integration:** McDermott 1982 and McDermott/Steele 1981
+  support regular DEC manufacturing use, almost all VAX-11 systems shipped, and
+  the 15-person maintenance group.
+- **Four-year maintenance:** Bachant/McDermott 1984 supports rule growth,
+  component-description growth, four worker-years per year, release testing,
+  mentors, more than 80,000 orders, and continuing incompleteness.
+- **Ad-hoc/customer constraints:** McDermott/Steele 1981 supports XSEL commands,
+  customer-specific constraints, and the bounded extension to R1.
+- **Commercial expert-system context:** Smith 1984 supports the broader lesson:
+  commercial systems are not demos and require domain experts, knowledge
+  engineering, programming support, progressive releases, and transfer planning.
+
+## Yellow / Thin Areas
+
+- **Economic value:** The chapter can claim usefulness and commercial
+  credibility, but not exact savings or ROI. Savings claims need a parsed source.
+- **Later XCON retrospective:** McDermott 1993 is identified but not parsed; it
+  should remain a stretch unlock.
+- **Broader market boom:** Smith 1984 is enough for product-development context,
+  but not for market-size claims or industry-wide success rates.
+- **Publisher-hosted R1 Revisited PDF:** The current extraction is from a
+  mirror. The article metadata and pages are verified, but a publisher-hosted
+  PDF would be cleaner if retrievable.
+
+## Red / Excluded Claims
+
+- "XCON saved DEC $25 million per year."
+- "R1/XCON was the first commercial expert system."
+- "R1 learned automatically from experience."
+- "R1 replaced all human experts."
+- "R1 configured all DEC systems."
+- "XSEL and R1 were the same system."
+- "Expert systems were generally commercially proven because R1 worked."
+- "Production rules removed the maintenance burden."
+
+## Word Count Readiness
+
+Natural supported range: 4,000-5,000 words.
+
+Path to 4,000 without bloat:
+
+- Open with a DEC order and the factory need for diagrams.
+- Explain configuration as ad-hoc constraint knowledge rather than abstract
+  theorem proving.
+- Spend real space on how production rules and Match made the task tractable.
+- Use the expert-review/validation story as the human center.
+- Move into production growth, mentors, problem reporting, and 80,000 orders.
+- Use XSEL/ad-hoc constraints as a short pressure scene.
+- Close with Smith's commercial-development frame and the maintenance promise.
+
+Path to 5,000-5,600 without bloat:
+
+- Parse McDermott 1993 and add later reflective lessons.
+- Add a verified source for economic impact if a dollar-value scene is needed.
+- Add one broader in-period business source on expert-system adoption, without
+  making R1 stand in for the whole market.
+
+## Reviewer Questions
+
+1. Is the mirror-sourced R1 Revisited PDF acceptable for current Green status,
+   or should this be downgraded until an AAAI-hosted PDF is found?
+2. Does the chapter have enough commercial context from Smith 1984 without a
+   separate market-boom source?
+3. Should the draft aim for 4,000-4,500 words rather than pushing toward 5,000
+   until the 1993 retrospective or economic source is parsed?
+4. Are the XSEL/ad-hoc constraints important enough for their own scene, or
+   should they remain a bridge paragraph?

--- a/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/gap-analysis.md
+++ b/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/gap-analysis.md
@@ -8,7 +8,9 @@ The chapter has enough anchored evidence for a 4,000-5,000 word draft if it
 keeps R1/XCON as a narrow industrial expert-system success and treats the
 commercial lesson as maintenance, product integration, and source-backed
 engineering discipline. It should not use unverified savings numbers or broad
-market claims.
+market claims. Bachant/McDermott 1984 remains a Yellow provenance risk until an
+independent copy is checked, so any draft using its four-year production claims
+must re-verify those anchors first.
 
 Word Count Discipline label: `4k-5k confirmed; 5k-5.6k requires stretch unlocks`
 
@@ -27,9 +29,6 @@ Word Count Discipline label: `4k-5k confirmed; 5k-5.6k requires stretch unlocks`
 - **Manufacturing integration:** McDermott 1982 and McDermott/Steele 1981
   support regular DEC manufacturing use, almost all VAX-11 systems shipped, and
   the 15-person maintenance group.
-- **Four-year maintenance:** Bachant/McDermott 1984 supports rule growth,
-  component-description growth, four worker-years per year, release testing,
-  mentors, more than 80,000 orders, and continuing incompleteness.
 - **Ad-hoc/customer constraints:** McDermott/Steele 1981 supports XSEL commands,
   customer-specific constraints, and the bounded extension to R1.
 - **Commercial expert-system context:** Smith 1984 supports the broader lesson:
@@ -40,6 +39,11 @@ Word Count Discipline label: `4k-5k confirmed; 5k-5.6k requires stretch unlocks`
 
 - **Economic value:** The chapter can claim usefulness and commercial
   credibility, but not exact savings or ROI. Savings claims need a parsed source.
+- **Four-year maintenance:** Bachant/McDermott 1984 supplies rule growth,
+  component-description growth, four worker-years per year, release testing,
+  mentors, more than 80,000 orders, and continuing incompleteness, but the
+  current copy is a mirror and must be independently checked before prose uses
+  those claims as Green.
 - **Later XCON retrospective:** McDermott 1993 is identified but not parsed; it
   should remain a stretch unlock.
 - **Broader market boom:** Smith 1984 is enough for product-development context,
@@ -76,6 +80,7 @@ Path to 4,000 without bloat:
 
 Path to 5,000-5,600 without bloat:
 
+- Verify Bachant/McDermott 1984 against an independent copy.
 - Parse McDermott 1993 and add later reflective lessons.
 - Add a verified source for economic impact if a dollar-value scene is needed.
 - Add one broader in-period business source on expert-system adoption, without

--- a/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/infrastructure-log.md
+++ b/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/infrastructure-log.md
@@ -1,1 +1,45 @@
-# Infrastructure Log: Chapter 21
+# Infrastructure Log: Chapter 21 - The Rule-Based Fortune
+
+## Technical Substrate
+
+- **VAX-11 systems:** The configured product family. The task involved CPUs,
+  memory, MASSBUS/UNIBUS interfaces, peripheral devices, cabinets, boxes,
+  backplanes, cables, floor layout, and customer-specific constraints.
+- **Production systems:** R1 represented constraint knowledge as productions:
+  condition/action rules over working memory, executed through a recognize-act
+  cycle.
+- **OPS4 / OPS5:** R1 was originally implemented in OPS4 and later rewritten in
+  OPS5. The language substrate matters because R1's maintainability argument is
+  partly about production rules being easy to split, specialize, and extend.
+- **Match method:** R1 avoided broad search by ordering decisions dynamically so
+  that enough information was available before each action. This only works in
+  domains with the right local structure.
+- **Component database:** R1 used a database of component descriptions. By 1984
+  it had about 5500 descriptions, but DEC had more than 100,000 possible parts
+  that might appear on an order.
+- **Output diagrams/configuration descriptions:** R1's output was operational:
+  technicians used it before physically assembling systems.
+
+## Operational Infrastructure
+
+- **Manufacturing process:** R1 was not merely consulted by researchers; it was
+  integrated into the workflow that checked orders and prepared assembly
+  descriptions.
+- **Regional field-office screening:** McDermott 1982 reports R1 beginning to
+  configure orders on the day they were booked at several regional offices.
+- **Mentor/review process:** Bachant/McDermott 1984 report that people who had
+  been technical editors watched R1's configurations and reported problems.
+- **Release/testing process:** As DEC depended more on R1, planned release dates
+  were preceded by extensive testing.
+- **Maintenance labor:** R1 required continuing knowledge collection, rule
+  encoding, component-description work, and problem reporting; this is the core
+  infrastructure of the "fortune."
+
+## Implementation Guardrails
+
+- Do not describe R1 as a neural system, statistical learner, or automated
+  optimizer. It is a rule-based production system.
+- Do not imply R1 learned automatically from orders. Humans extracted,
+  represented, tested, and corrected knowledge.
+- Do not treat the component database as passive trivia. Missing or incomplete
+  part descriptions were a major operational problem.

--- a/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/open-questions.md
+++ b/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/open-questions.md
@@ -1,3 +1,46 @@
-# Open Questions
+# Open Questions: Chapter 21 - The Rule-Based Fortune
 
-- SCRUBBED: All claims downgraded to Yellow. Need REAL, empirical page/section anchors from verified online PDFs or archives. Do not hallucinate.
+## Resolved for Research Contract
+
+- Located and locally parsed McDermott 1982 from a WPI-hosted scanned PDF using
+  page-image OCR. Anchors cover the VAX configuration task, Match, production
+  rules, rule counts, sample runs, knowledge acquisition, validation, and
+  manufacturing integration.
+- Located and locally parsed McDermott/Steele 1981 IJCAI PDF. Anchors cover
+  XSEL, ad-hoc constraints, 15-person DEC maintenance group, 20 commands, 87
+  command-recognition rules, and the bounded nature of the extension.
+- Located and locally parsed the Bachant/McDermott 1984 "R1 Revisited" AI
+  Magazine PDF via a mirror after the AAAI/OJS route returned empty content.
+  Anchors cover four-year production use, DEC organization growth, 3300 rules,
+  5500 component descriptions, performance metrics, 80,000 orders, mentors, and
+  maintenance conclusions.
+- Located and locally parsed Smith 1984 "On the Development of Commercial
+  Expert Systems" from a scanned compilation. Anchors cover commercial
+  constraints, teams, rapid prototyping, successive refinement, and transfer.
+- Verified that current evidence supports a 4,000-5,000 word chapter without
+  savings numbers or later retrospective claims.
+
+## Still Open / Stretch Unlocks
+
+- Find and parse an accessible copy of McDermott 1993, "R1 ('XCON') at age 12:
+  lessons from an elementary school achiever." This could safely unlock a later
+  retrospective paragraph and may support a 5,000-5,600 word range.
+- Locate a verified, page-anchored source for the commonly repeated XCON savings
+  number before using any dollar claim.
+- Locate an official AAAI-hosted PDF for "R1 Revisited" if possible. Current
+  mirror extraction is adequate but should be replaced with a publisher-hosted
+  source if it becomes retrievable.
+- Consider adding one source on the broader expert-system business boom only if
+  Ch21 needs more market context. Smith 1984 is enough for the core draft.
+
+## Do Not Draft Without Support
+
+- "XCON saved DEC $25 million per year" or any other exact savings figure.
+- "R1/XCON was the first commercial expert system."
+- "R1 learned from its mistakes automatically."
+- "R1 replaced all human configuration experts."
+- "R1 configured all DEC systems."
+- "XSEL and R1 were the same system."
+- "Production rules made maintenance easy" without also showing the permanent
+  labor, ad-hoc growth, and problem-reporting burden.
+- "Expert systems were commercially proven in general" based only on R1.

--- a/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/people.md
+++ b/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/people.md
@@ -1,1 +1,45 @@
-# People: Chapter 21
+# People: Chapter 21 - The Rule-Based Fortune
+
+## Principal People
+
+- **John McDermott:** CMU researcher and primary author of the 1982 R1 paper.
+  He frames R1 as a production-rule configurer whose success depends on
+  task-specific constraint knowledge, Match, and iterative knowledge extraction.
+- **Judith Bachant:** DEC Intelligent Systems Technology Group; coauthor of the
+  1984 "R1 Revisited" paper. Her role anchors the production-maintenance story
+  from inside DEC rather than only from the CMU research side.
+- **Barbara Steele:** Coauthor of the 1981 IJCAI paper on ad-hoc constraints.
+  Her chapter relevance is the XSEL/R1 extension and the problem of
+  customer-specific configuration advice.
+- **Charles L. Forgy:** Creator of OPS-family production-system technology.
+  Ch21 does not need his biography, but OPS4/OPS5 should be recognized as part
+  of the technical substrate R1 used.
+- **Allen Newell:** Acknowledged influence/reviewer in the R1 ecosystem; his
+  Match/problem-solving framing and production-system tradition sit behind R1.
+  Do not over-expand here; Ch21 is not a Newell chapter.
+- **Reid G. Smith:** Schlumberger researcher and author of the 1984 commercial
+  expert-systems article. Use him as a contemporary guide to the broader
+  industrial product-development problem.
+
+## Institutional Actors
+
+- **Digital Equipment Corporation manufacturing organization:** The operational
+  home of R1/XCON. This is where the system becomes historically important:
+  order checking, configuration descriptions, assembly support, field-office
+  screening, and continuing maintenance.
+- **DEC Intelligent Systems Technologies group:** The organizational layer that
+  grew around R1 and other knowledge-based systems. Bachant/McDermott report it
+  grew from five people to 77 people responsible for eight systems.
+- **Carnegie Mellon University:** Research environment where R1 began and where
+  OPS/production-system expertise supported its development.
+- **DARPA/Air Force Avionics Laboratory:** Funding context for OPS4/OPS5
+  language research, not the sponsor of DEC's whole commercial deployment.
+
+## Do Not Over-Credit
+
+- Do not make R1 a lone-genius story. Its sources repeatedly show experts,
+  maintainers, mentors, validation teams, and product-data maintainers.
+- Do not make DEC merely a user. DEC funded R1 development, deployed it, and
+  built the organizational capacity needed to keep it useful.
+- Do not make XSEL the protagonist. It is important as a pressure source and
+  interface for customer-specific constraints, but R1/XCON owns the chapter.

--- a/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/scene-sketches.md
+++ b/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/scene-sketches.md
@@ -5,7 +5,9 @@
 Start with a DEC customer order that names a CPU, memory, devices, and options,
 but is not yet a buildable system. The factory needs to know what is missing,
 where the pieces go, which backplanes and cables are possible, and what a
-technician should assemble.
+technician should assemble. Ground the opening in the physical artifact R1 made
+useful: configuration descriptions and diagrams that could guide cabinet,
+backplane, cable, and floor-layout work.
 
 ## Scene 2: The Knowledge Hidden in Constraints
 
@@ -31,7 +33,9 @@ This is where the knowledge-acquisition bottleneck becomes visual and human.
 
 Render the 50-order validation stage: six experts, one to two hours per order,
 12 pieces of errorful knowledge, rules modified, orders resubmitted, then the
-decision to integrate R1 into manufacturing.
+decision to integrate R1 into manufacturing. Keep the validation concrete: the
+experts are not grading an abstraction, they are inspecting output diagrams and
+asking whether a technician could actually assemble the resulting machine.
 
 ## Scene 6: The Mentor Beside the Expert System
 
@@ -49,7 +53,8 @@ never stops being maintained.
 
 Introduce XSEL and ad-hoc constraints. A customer-specific need enters as a
 command, temporarily takes control, reshapes part of the configuration, and then
-lets ordinary rules continue.
+lets ordinary rules continue. Treat this as a full scene, not a passing bridge:
+commercial use means customers push exceptions back into the rule base.
 
 ## Scene 9: Fortune With a Maintenance Contract
 

--- a/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/scene-sketches.md
+++ b/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/scene-sketches.md
@@ -1,1 +1,59 @@
-# Scene Sketches: Chapter 21
+# Scene Sketches: Chapter 21 - The Rule-Based Fortune
+
+## Scene 1: The Order That Is Not Yet a Machine
+
+Start with a DEC customer order that names a CPU, memory, devices, and options,
+but is not yet a buildable system. The factory needs to know what is missing,
+where the pieces go, which backplanes and cables are possible, and what a
+technician should assemble.
+
+## Scene 2: The Knowledge Hidden in Constraints
+
+Move from the order to the knowledge problem. Hundreds of components and
+thousands of component facts are only the visible layer; the hard part is the
+ad-hoc constraint knowledge experts carry in exceptions, local practices, and
+"unless" cases.
+
+## Scene 3: The Recognize-Act Machine
+
+Explain R1 as a machine that does not dream or search broadly. It looks at
+working memory, finds a rule whose conditions match, performs an action, and
+repeats. The drama is in how much real-world knowledge must be encoded so this
+simple rhythm can work.
+
+## Scene 4: Experts Looking Strangely at the Output
+
+Use McDermott's development story: early R1 handles simple orders, fails on
+complex ones, and experts examine diagrams to expose missing exceptional cases.
+This is where the knowledge-acquisition bottleneck becomes visual and human.
+
+## Scene 5: Validation Before the Factory
+
+Render the 50-order validation stage: six experts, one to two hours per order,
+12 pieces of errorful knowledge, rules modified, orders resubmitted, then the
+decision to integrate R1 into manufacturing.
+
+## Scene 6: The Mentor Beside the Expert System
+
+In production, former technical editors watch R1's work. They become mentors:
+not replaced instantly, but repositioned as reviewers who feed problems back to
+the development group.
+
+## Scene 7: Four Years in the Trenches
+
+Show the growth: five people become a 77-person group, R1 grows to 3300 rules
+and 5500 component descriptions, and the system is useful precisely because it
+never stops being maintained.
+
+## Scene 8: Customers Push Back Into the Rules
+
+Introduce XSEL and ad-hoc constraints. A customer-specific need enters as a
+command, temporarily takes control, reshapes part of the configuration, and then
+lets ordinary rules continue.
+
+## Scene 9: Fortune With a Maintenance Contract
+
+Close on the lesson commercial buyers did not always hear: expert systems could
+be valuable products, but their value came with testing, data maintenance,
+domain experts, progressive releases, and a willingness to keep fixing the
+boundary between rules and the world.

--- a/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/sources.md
+++ b/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/sources.md
@@ -1,1 +1,90 @@
-# Sources: Chapter 21
+# Sources: Chapter 21 - The Rule-Based Fortune
+
+## Source Table
+
+| Source | Type | Anchor | Use | Status |
+|---|---|---|---|---|
+| John McDermott, [*"R1: A Rule-Based Configurer of Computer Systems"*](https://web.cs.wpi.edu/Research/aidg/CS540/papers/McDermott-R1-XCON.pdf), *Artificial Intelligence* 19, 1982, pp.39-88 | Primary technical paper / scanned PDF OCR | pp.39-40, 41-42, 45-46, 58, 64-66, 68-70 | Core technical description of R1, VAX configuration task, production rules, Match, rule counts, development history, validation, manufacturing integration | Green |
+| John McDermott and Barbara Steele, [*"Extending a Knowledge-Based System to Deal with Ad Hoc Constraints"*](https://www.ijcai.org/Proceedings/81-2/Papers/047.pdf), IJCAI 1981, pp.824-828 | Primary conference paper | pp.824-828 | XSEL/R1 relationship, customer-specific constraints, OPS5, 850 rules, "almost all VAX-11 systems shipped," 15-person maintenance group, 20 commands, 87 command-recognition rules | Green |
+| John McDermott and Judith Bachant, [*"R1 Revisited: Four Years in the Trenches"*](https://studylib.net/doc/13831835/ri--revisited--judith--bachant-john--mcdermott), *AI Magazine* 5(3), Fall 1984, pp.21-32 | Primary deployment/maintenance retrospective; AI Magazine PDF mirror locally extracted | pp.21-32 | Four-year production use, rule/data-base growth, DEC organization, testing/release process, performance data, 80,000 orders, maintenance conclusions | Green |
+| Reid G. Smith, [*"On the Development of Commercial Expert Systems"*](https://ngds.egi.utah.edu/files/GL01352/GL01352.pdf), *AI Magazine* 5(3), Fall 1984, pp.61-73 | Primary/in-period commercial expert-system reflection; scanned PDF compilation | pp.61-73 | Broader commercial expert-system context: real problem vs demo, domain experts, knowledge engineering, rapid prototyping, technology transfer, progressive releases | Green |
+| Reid G. Smith, [personal bibliography entry for "On the Development of Commercial Expert Systems"](https://www.reidgsmith.com/) | Author bibliography / source-discovery check | 1984 section | Confirms bibliographic metadata for Smith 1984 article | Yellow |
+| AAAI AI Magazine bibliography, [Volume 5, Issue 3 listing](https://auld.aaai.org/Magazine/bibliography.php) | Publisher bibliography / source-discovery check | Fall 1984 issue listing | Confirms McDermott/Bachant and Smith AI Magazine issue placement and page ranges | Yellow |
+| John McDermott, [*"R1 ('XCON') at Age 12: Lessons from an Elementary School Achiever"*](https://doi.org/10.1016/0004-3702(93)90192-E), *Artificial Intelligence* 59(1-2), 1993, pp.241-247 | Later retrospective | DOI/metadata only; full text not extracted | Potential stretch unlock for later XCON lessons; do not use for factual prose until full text is available and parsed | Red |
+
+## Claim Matrix
+
+| Claim | Scene | Anchor | Status | Notes |
+|---|---|---|---|---|
+| R1 configured VAX-11/780 systems from customer orders, added missing components when needed, and produced diagrams used for physical assembly. | Factory Problem | McDermott 1982 pp.39-40 | Green | Keep "VAX-11/780" precise for the 1982 paper. |
+| In 1982 R1 was in regular use by DEC manufacturing and implemented as a production system using Match, with enough domain knowledge to recognize what to do with little search. | Rules That Recognize | McDermott 1982 p.39 | Green | Avoid turning this into general intelligence. |
+| VAX configuration was nontrivial because the architecture permitted many system variations and peripheral combinations. | Knowledge as Constraints | McDermott 1982 p.41 | Green | Use to justify why configuration deserved expert-system treatment. |
+| A VAX configurer needed about eight properties for each of roughly 420 supported components, yielding over 3300 pieces of component information. | Knowledge as Constraints | McDermott 1982 p.41 | Green | Exact figures from OCR; article page 41. |
+| McDermott extracted 480 rules from experts: 96 for initiating subtasks and 384 for extending partial configurations. | Knowledge as Constraints | McDermott 1982 p.42 | Green | Good concrete anchor for "knowledge engineering." |
+| Many configuration constraints had an ad hoc flavor and were not easily derived from general knowledge. | Knowledge as Constraints | McDermott 1982 p.42 | Green | This is a key anti-hype sentence. |
+| R1 was implemented in OPS4; productions consisted of conditions and actions operating over working memory in a recognize-act cycle. | Rules That Recognize | McDermott 1982 p.45 | Green | Technical exposition should stay readable. |
+| R1's domain-specific knowledge, including control knowledge, was in productions; each rule embodied a piece of constraint knowledge. | Rules That Recognize | McDermott 1982 p.45 | Green | Explains why rules are not just if/then trivia. |
+| OPS4 interpreting R1 had an average cycle time of about 150 milliseconds, and R1 had 772 rules in the 1982 account. | Rules That Recognize | McDermott 1982 p.46 | Green | Use only if runtime texture helps. |
+| Of R1's 772 rules, 480 were directly configuration-related and 292 were more general; domain rules covered context generation, prerequisites, association, retrieval, and computation. | Rules That Recognize | McDermott 1982 p.58 | Green | Good for source-backed taxonomy, but avoid list padding. |
+| In 20 sample runs, only about 40-50 percent of available knowledge was required on a particular order, with average configuration runtime about 1.76 CPU minutes excluding output. | Rules That Recognize / Deployment | McDermott 1982 pp.64-66 | Green | Useful for explaining sparse rule use and practical runtime. |
+| R1 development began in December 1978; after five or six days of tutoring and manuals, an initial version under 200 domain rules handled simple orders but failed on complex ones. | Knowledge Engineering | McDermott 1982 p.68 | Green | Strong narrative scene. |
+| The second development stage used expert examination of output; R1's domain knowledge almost tripled, and exceptional cases proved hard for experts to produce on demand. | Knowledge Engineering | McDermott 1982 pp.68-69 | Green | Explains the knowledge-acquisition bottleneck in industrial form. |
+| Rule splitting/context spawning made refinement relatively straightforward, with negative side effects usually confined to related contexts. | Knowledge Engineering | McDermott 1982 p.69 | Green | Balance with later maintenance burden. |
+| Formal validation in October-November 1979 used 50 orders and six experts spending one to two hours per order; 12 pieces of errorful knowledge were found and fixed. | Knowledge Engineering / Deployment | McDermott 1982 pp.69-70 | Green | Avoid saying "perfect"; it passed a validation process. |
+| After validation R1 was integrated into manufacturing, used to produce configuration descriptions before assembly, and began same-day screening at regional field offices. | Into DEC Manufacturing | McDermott 1982 p.70 | Green | This is the deployment bridge. |
+| McDermott and Steele state that since January 1980 R1 had been used by DEC manufacturing to configure almost all VAX-11 systems shipped, and DEC had 15 people maintaining/extending it. | Into DEC Manufacturing | McDermott/Steele 1981 p.824 | Green | Use carefully: "VAX-11 systems" in that paper, not all DEC systems. |
+| XSEL was under development as a sales assistant; it selected a skeletal order and passed it to R1 for fleshing out and configuration. | Advice, Customers | McDermott/Steele 1981 pp.824-825 | Green | Keep XSEL separate from R1/XCON. |
+| R1 was not initially designed for customer-specific constraints, but the authors added a relatively small set of rules rather than redesigning the system. | Advice, Customers | McDermott/Steele 1981 p.825 | Green | Good example of extension vs redesign. |
+| R1 understood 20 XSEL commands; 87 rules recognized XSEL commands, and about 20 ordinary rules were changed in adding the capability. | Advice, Customers | McDermott/Steele 1981 pp.826-827 | Green | Use as concrete capacity, not as a detour. |
+| The ad-hoc constraints extension made R1 more flexible within the configuration task, not beyond it. | Advice, Customers / Close | McDermott/Steele 1981 p.828 | Green | Important scope guardrail. |
+| By 1984 R1/XCON had been used in DEC manufacturing since January 1980 and configured systems made of roughly 50-150 components. | Into DEC Manufacturing | Bachant/McDermott 1984 p.21 | Green | Complements 1982 paper with four-year perspective. |
+| The authors expected R1 might eventually enter maintenance mode, but by 1984 found it hard to believe R1 would ever be done. | System Keeps Growing | Bachant/McDermott 1984 p.21 | Green | Core maintenance thesis. |
+| Early performance expectations were wrong: 90-95 percent perfect configurations took three years to reach, and the system was useful before that because humans did not demand more than they demanded of predecessors. | Deployment Discipline | Bachant/McDermott 1984 p.22 | Green | Avoid sloppy "success from day one." |
+| DEC's Intelligent Systems Technologies group grew from five people with no AI background to 77 people responsible for eight knowledge-based systems, one of which was R1. | System Keeps Growing | Bachant/McDermott 1984 p.22 | Green | Useful for "fortune" and organizational growth. |
+| The R1 technical group remained about eight people, with less distinction over time between knowledge collection and knowledge encoding. | System Keeps Growing | Bachant/McDermott 1984 p.22 | Green | Shows ongoing labor. |
+| Over four years, work devoted to adding R1 knowledge stayed around four worker-years per year. | System Keeps Growing | Bachant/McDermott 1984 p.23 | Green | Strong maintenance metric. |
+| By November 1983 R1 had about 3300 rules and around 5500 component descriptions, and work would continue to extend and deepen expertise. | System Keeps Growing | Bachant/McDermott 1984 p.23 | Green | Source-backed growth number. |
+| As DEC depended more on R1, planned releases were preceded by extensive testing. | System Keeps Growing | Bachant/McDermott 1984 p.23 | Green | Shows commercial engineering discipline. |
+| About 65 percent of the 2526 rules added since 1980 extended general configuration capabilities, while at least 15 percent of those corrected/refined known subtasks. | System Keeps Growing | Bachant/McDermott 1984 pp.24-25 | Green | Use if prose needs growth analysis. |
+| Bachant/McDermott conclude that R1's development would never be finished because its domain kept changing and users kept asking it to do more. | System Keeps Growing | Bachant/McDermott 1984 pp.27-28 | Green | Do not make this sound like failure; it is success pressure. |
+| R1 began as a technical editor with mentors; every order it configured was examined more or less closely, and problems were reported to developers. | Deployment Discipline | Bachant/McDermott 1984 p.28 | Green | Human-in-the-loop deployment scene. |
+| R1 had configured more than 80,000 orders by 1984, but still had seen only a fraction of possible situations. | Deployment Discipline | Bachant/McDermott 1984 p.29 | Green | Key scale plus humility anchor. |
+| By 1984 fewer than one in a thousand orders was misconfigured because of rule problems. | Deployment Discipline | Bachant/McDermott 1984 p.29 | Green | Exact claim from performance discussion; keep category precise. |
+| Missing part descriptions were a persistent problem because R1 knew about about 5500 of more than 100,000 possible parts that could appear on an order. | Deployment Discipline | Bachant/McDermott 1984 p.29 | Green | Shows data maintenance, not only rules. |
+| The authors warn that near-perfection during the first few years of production use is unrealistic and that waiting for complete knowledge before production use is a poor strategy. | Deployment Discipline / Close | Bachant/McDermott 1984 pp.31-32 | Green | Good closing lesson. |
+| Smith argues commercial expert systems solve real problems rather than test architectures, so developers should avoid a demonstration mentality. | Commercial Reality | Smith 1984 pp.66-67 | Green | Generalize from R1 with care. |
+| Smith identifies domain expertise, knowledge engineering, expert-system tool design, and programming support as typical commercial expert-system development skills. | Commercial Reality | Smith 1984 p.67 | Green | Useful for "team" and organization. |
+| Smith argues rapid prototyping and successive refinement help but complicate technology transfer because systems stay in flux. | Commercial Reality | Smith 1984 pp.67-69 | Green | Supports broader commercial-engineering frame. |
+| Smith says incremental development is accepted, but commercial settings are reluctant to throw away Mark-I code; progressive releases are likelier. | Commercial Reality | Smith 1984 p.69 | Green | Use as bridge from demo to product. |
+
+## Citation Bar
+
+Minimum sources before prose:
+
+- McDermott 1982 pp.39-42 for task, components, constraints, and early rule extraction.
+- McDermott 1982 pp.45-46, 58, 64-66 for production-system architecture, rule counts, and runtime/knowledge-use data.
+- McDermott 1982 pp.68-70 for development history, exceptional cases, validation, and manufacturing integration.
+- McDermott/Steele 1981 pp.824-828 for XSEL, ad-hoc constraints, 15-person DEC maintenance group, and "almost all VAX-11 systems shipped."
+- Bachant/McDermott 1984 pp.21-32 for four-year deployment, growth, performance, 80,000 orders, and maintenance conclusions.
+- Smith 1984 pp.61-73 for broader commercial expert-system development and technology-transfer context.
+
+## Source Discipline Notes
+
+- The R1 1982 PDF is scanned; local extraction used `pdftoppm` plus
+  `tesseract`. Verify any quoted sentence against page images before final
+  prose. Page mapping is `[[page-01.txt]] = article p.39`.
+- The R1 Revisited AAAI/OJS download route returned an empty stream during
+  extraction. The Studylib mirror was downloaded as a PDF and its metadata
+  identifies *R1 Revisited: Four Years in the Trenches*, AI Magazine Volume 5
+  Number 3. Treat it as Green for anchored research, but a reviewer should
+  prefer an AAAI-hosted PDF if one becomes retrievable.
+- The Smith 1984 file is a scanned compilation that includes several articles;
+  local text extraction places "On the Development of Commercial Expert
+  Systems" at the AI Magazine article pages. Use article page numbers, not PDF
+  page numbers.
+- Wikipedia may be useful for discovery and date sanity checks, but do not use
+  it as a prose anchor for this chapter.
+- Do not upgrade the 1993 "R1/XCON at age 12" retrospective until the full text
+  is fetched and parsed. Metadata alone is not an anchor.
+- Do not cite unverified savings numbers, "first commercial expert system"
+  absolutes, or exact market-size claims without a parsed source.

--- a/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/sources.md
+++ b/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/sources.md
@@ -6,10 +6,10 @@
 |---|---|---|---|---|
 | John McDermott, [*"R1: A Rule-Based Configurer of Computer Systems"*](https://web.cs.wpi.edu/Research/aidg/CS540/papers/McDermott-R1-XCON.pdf), *Artificial Intelligence* 19, 1982, pp.39-88 | Primary technical paper / scanned PDF OCR | pp.39-40, 41-42, 45-46, 58, 64-66, 68-70 | Core technical description of R1, VAX configuration task, production rules, Match, rule counts, development history, validation, manufacturing integration | Green |
 | John McDermott and Barbara Steele, [*"Extending a Knowledge-Based System to Deal with Ad Hoc Constraints"*](https://www.ijcai.org/Proceedings/81-2/Papers/047.pdf), IJCAI 1981, pp.824-828 | Primary conference paper | pp.824-828 | XSEL/R1 relationship, customer-specific constraints, OPS5, 850 rules, "almost all VAX-11 systems shipped," 15-person maintenance group, 20 commands, 87 command-recognition rules | Green |
-| John McDermott and Judith Bachant, [*"R1 Revisited: Four Years in the Trenches"*](https://studylib.net/doc/13831835/ri--revisited--judith--bachant-john--mcdermott), *AI Magazine* 5(3), Fall 1984, pp.21-32 | Primary deployment/maintenance retrospective; AI Magazine PDF mirror locally extracted | pp.21-32 | Four-year production use, rule/data-base growth, DEC organization, testing/release process, performance data, 80,000 orders, maintenance conclusions | Green |
+| John McDermott and Judith Bachant, [*"R1 Revisited: Four Years in the Trenches"*](https://studylib.net/doc/13831835/ri--revisited--judith--bachant-john--mcdermott), *AI Magazine* 5(3), Fall 1984, pp.21-32 | Primary deployment/maintenance retrospective; AI Magazine PDF mirror locally extracted | pp.21-32 | Four-year production use, rule/data-base growth, DEC organization, testing/release process, performance data, 80,000 orders, maintenance conclusions | Yellow |
 | Reid G. Smith, [*"On the Development of Commercial Expert Systems"*](https://ngds.egi.utah.edu/files/GL01352/GL01352.pdf), *AI Magazine* 5(3), Fall 1984, pp.61-73 | Primary/in-period commercial expert-system reflection; scanned PDF compilation | pp.61-73 | Broader commercial expert-system context: real problem vs demo, domain experts, knowledge engineering, rapid prototyping, technology transfer, progressive releases | Green |
 | Reid G. Smith, [personal bibliography entry for "On the Development of Commercial Expert Systems"](https://www.reidgsmith.com/) | Author bibliography / source-discovery check | 1984 section | Confirms bibliographic metadata for Smith 1984 article | Yellow |
-| AAAI AI Magazine bibliography, [Volume 5, Issue 3 listing](https://auld.aaai.org/Magazine/bibliography.php) | Publisher bibliography / source-discovery check | Fall 1984 issue listing | Confirms McDermott/Bachant and Smith AI Magazine issue placement and page ranges | Yellow |
+| DBLP, [record for McDermott and Bachant, "R1 Revisited"](https://dblp.org/rec/journals/aim/McDermottB84) | Bibliographic index / source-discovery check | AI Magazine 5(3), pp.21-32 | Confirms McDermott/Bachant AI Magazine issue placement and page range | Yellow |
 | John McDermott, [*"R1 ('XCON') at Age 12: Lessons from an Elementary School Achiever"*](https://doi.org/10.1016/0004-3702(93)90192-E), *Artificial Intelligence* 59(1-2), 1993, pp.241-247 | Later retrospective | DOI/metadata only; full text not extracted | Potential stretch unlock for later XCON lessons; do not use for factual prose until full text is available and parsed | Red |
 
 ## Claim Matrix
@@ -37,21 +37,21 @@
 | R1 was not initially designed for customer-specific constraints, but the authors added a relatively small set of rules rather than redesigning the system. | Advice, Customers | McDermott/Steele 1981 p.825 | Green | Good example of extension vs redesign. |
 | R1 understood 20 XSEL commands; 87 rules recognized XSEL commands, and about 20 ordinary rules were changed in adding the capability. | Advice, Customers | McDermott/Steele 1981 pp.826-827 | Green | Use as concrete capacity, not as a detour. |
 | The ad-hoc constraints extension made R1 more flexible within the configuration task, not beyond it. | Advice, Customers / Close | McDermott/Steele 1981 p.828 | Green | Important scope guardrail. |
-| By 1984 R1/XCON had been used in DEC manufacturing since January 1980 and configured systems made of roughly 50-150 components. | Into DEC Manufacturing | Bachant/McDermott 1984 p.21 | Green | Complements 1982 paper with four-year perspective. |
-| The authors expected R1 might eventually enter maintenance mode, but by 1984 found it hard to believe R1 would ever be done. | System Keeps Growing | Bachant/McDermott 1984 p.21 | Green | Core maintenance thesis. |
-| Early performance expectations were wrong: 90-95 percent perfect configurations took three years to reach, and the system was useful before that because humans did not demand more than they demanded of predecessors. | Deployment Discipline | Bachant/McDermott 1984 p.22 | Green | Avoid sloppy "success from day one." |
-| DEC's Intelligent Systems Technologies group grew from five people with no AI background to 77 people responsible for eight knowledge-based systems, one of which was R1. | System Keeps Growing | Bachant/McDermott 1984 p.22 | Green | Useful for "fortune" and organizational growth. |
-| The R1 technical group remained about eight people, with less distinction over time between knowledge collection and knowledge encoding. | System Keeps Growing | Bachant/McDermott 1984 p.22 | Green | Shows ongoing labor. |
-| Over four years, work devoted to adding R1 knowledge stayed around four worker-years per year. | System Keeps Growing | Bachant/McDermott 1984 p.23 | Green | Strong maintenance metric. |
-| By November 1983 R1 had about 3300 rules and around 5500 component descriptions, and work would continue to extend and deepen expertise. | System Keeps Growing | Bachant/McDermott 1984 p.23 | Green | Source-backed growth number. |
-| As DEC depended more on R1, planned releases were preceded by extensive testing. | System Keeps Growing | Bachant/McDermott 1984 p.23 | Green | Shows commercial engineering discipline. |
-| About 65 percent of the 2526 rules added since 1980 extended general configuration capabilities, while at least 15 percent of those corrected/refined known subtasks. | System Keeps Growing | Bachant/McDermott 1984 pp.24-25 | Green | Use if prose needs growth analysis. |
-| Bachant/McDermott conclude that R1's development would never be finished because its domain kept changing and users kept asking it to do more. | System Keeps Growing | Bachant/McDermott 1984 pp.27-28 | Green | Do not make this sound like failure; it is success pressure. |
-| R1 began as a technical editor with mentors; every order it configured was examined more or less closely, and problems were reported to developers. | Deployment Discipline | Bachant/McDermott 1984 p.28 | Green | Human-in-the-loop deployment scene. |
-| R1 had configured more than 80,000 orders by 1984, but still had seen only a fraction of possible situations. | Deployment Discipline | Bachant/McDermott 1984 p.29 | Green | Key scale plus humility anchor. |
-| By 1984 fewer than one in a thousand orders was misconfigured because of rule problems. | Deployment Discipline | Bachant/McDermott 1984 p.29 | Green | Exact claim from performance discussion; keep category precise. |
-| Missing part descriptions were a persistent problem because R1 knew about about 5500 of more than 100,000 possible parts that could appear on an order. | Deployment Discipline | Bachant/McDermott 1984 p.29 | Green | Shows data maintenance, not only rules. |
-| The authors warn that near-perfection during the first few years of production use is unrealistic and that waiting for complete knowledge before production use is a poor strategy. | Deployment Discipline / Close | Bachant/McDermott 1984 pp.31-32 | Green | Good closing lesson. |
+| By 1984 R1/XCON had been used in DEC manufacturing since January 1980 and configured systems made of roughly 50-150 components. | Into DEC Manufacturing | Bachant/McDermott 1984 p.21 | Yellow | Mirror-sourced; per-order component count, distinct from the 420 supported component types in McDermott 1982 p.41. |
+| The authors expected R1 might eventually enter maintenance mode, but by 1984 found it hard to believe R1 would ever be done. | System Keeps Growing | Bachant/McDermott 1984 p.21 | Yellow | Mirror-sourced; needs publisher/independent verification before prose. |
+| Early performance expectations were wrong: 90-95 percent perfect configurations took three years to reach, and the system was useful before that because humans did not demand more than they demanded of predecessors. | Deployment Discipline | Bachant/McDermott 1984 p.22 | Yellow | Mirror-sourced; avoid sloppy "success from day one." |
+| DEC's Intelligent Systems Technologies group grew from five people with no AI background to 77 people responsible for eight knowledge-based systems, one of which was R1. | System Keeps Growing | Bachant/McDermott 1984 p.22 | Yellow | Mirror-sourced; useful for "fortune" and organizational growth if independently verified. |
+| The R1 technical group remained about eight people, with less distinction over time between knowledge collection and knowledge encoding. | System Keeps Growing | Bachant/McDermott 1984 p.22 | Yellow | Mirror-sourced; shows ongoing labor. |
+| Over four years, work devoted to adding R1 knowledge stayed around four worker-years per year. | System Keeps Growing | Bachant/McDermott 1984 p.23 | Yellow | Mirror-sourced; strong maintenance metric if independently verified. |
+| By November 1983 R1 had about 3300 rules and around 5500 component descriptions, and work would continue to extend and deepen expertise. | System Keeps Growing | Bachant/McDermott 1984 p.23 | Yellow | Mirror-sourced growth number; verify before prose. |
+| As DEC depended more on R1, planned releases were preceded by extensive testing. | System Keeps Growing | Bachant/McDermott 1984 p.23 | Yellow | Mirror-sourced; shows commercial engineering discipline if verified. |
+| About 65 percent of the 2526 rules added since 1980 extended general configuration capabilities; at least 15 percent of the total added rules corrected or refined known subtasks. | System Keeps Growing | Bachant/McDermott 1984 pp.24-25 | Yellow | Mirror-sourced and should be rechecked against page image before prose. |
+| Bachant/McDermott conclude that R1's development would never be finished because its domain kept changing and users kept asking it to do more. | System Keeps Growing | Bachant/McDermott 1984 pp.27-28 | Yellow | Mirror-sourced; do not make this sound like failure; it is success pressure. |
+| R1 began as a technical editor with mentors; every order it configured was examined more or less closely, and problems were reported to developers. | Deployment Discipline | Bachant/McDermott 1984 p.28 | Yellow | Mirror-sourced human-in-the-loop deployment scene. |
+| R1 had configured more than 80,000 orders by 1984, but still had seen only a fraction of possible situations. | Deployment Discipline | Bachant/McDermott 1984 p.29 | Yellow | Mirror-sourced scale plus humility anchor. |
+| By 1984 fewer than one in a thousand orders was misconfigured because of rule problems. | Deployment Discipline | Bachant/McDermott 1984 p.29 | Yellow | Mirror-sourced; exact category must stay precise if used. |
+| Missing part descriptions were a persistent problem because R1 knew about about 5500 of more than 100,000 possible parts that could appear on an order. | Deployment Discipline | Bachant/McDermott 1984 p.29 | Yellow | Mirror-sourced; shows data maintenance, not only rules. |
+| The authors warn that near-perfection during the first few years of production use is unrealistic and that waiting for complete knowledge before production use is a poor strategy. | Deployment Discipline / Close | Bachant/McDermott 1984 pp.31-32 | Yellow | Mirror-sourced closing lesson. |
 | Smith argues commercial expert systems solve real problems rather than test architectures, so developers should avoid a demonstration mentality. | Commercial Reality | Smith 1984 pp.66-67 | Green | Generalize from R1 with care. |
 | Smith identifies domain expertise, knowledge engineering, expert-system tool design, and programming support as typical commercial expert-system development skills. | Commercial Reality | Smith 1984 p.67 | Green | Useful for "team" and organization. |
 | Smith argues rapid prototyping and successive refinement help but complicate technology transfer because systems stay in flux. | Commercial Reality | Smith 1984 pp.67-69 | Green | Supports broader commercial-engineering frame. |
@@ -65,8 +65,8 @@ Minimum sources before prose:
 - McDermott 1982 pp.45-46, 58, 64-66 for production-system architecture, rule counts, and runtime/knowledge-use data.
 - McDermott 1982 pp.68-70 for development history, exceptional cases, validation, and manufacturing integration.
 - McDermott/Steele 1981 pp.824-828 for XSEL, ad-hoc constraints, 15-person DEC maintenance group, and "almost all VAX-11 systems shipped."
-- Bachant/McDermott 1984 pp.21-32 for four-year deployment, growth, performance, 80,000 orders, and maintenance conclusions.
-- Smith 1984 pp.61-73 for broader commercial expert-system development and technology-transfer context.
+- Bachant/McDermott 1984 pp.21-32 for four-year deployment, growth, performance, 80,000 orders, and maintenance conclusions, after mirror-source verification.
+- Smith 1984 pp.66-69 for broader commercial expert-system development and technology-transfer context.
 
 ## Source Discipline Notes
 
@@ -76,8 +76,9 @@ Minimum sources before prose:
 - The R1 Revisited AAAI/OJS download route returned an empty stream during
   extraction. The Studylib mirror was downloaded as a PDF and its metadata
   identifies *R1 Revisited: Four Years in the Trenches*, AI Magazine Volume 5
-  Number 3. Treat it as Green for anchored research, but a reviewer should
-  prefer an AAAI-hosted PDF if one becomes retrievable.
+  Number 3. Treat it as Yellow until an AAAI/archive/publisher-hosted PDF is
+  retrieved or at least two specific anchors are cross-checked against an
+  independent copy.
 - The Smith 1984 file is a scanned compilation that includes several articles;
   local text extraction places "On the Development of Commercial Expert
   Systems" at the AI Magazine article pages. Use article page numbers, not PDF

--- a/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/status.yaml
+++ b/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/status.yaml
@@ -1,1 +1,14 @@
-status: researching
+status: capacity_plan_anchored
+owner: Codex
+part: 4
+chapter: 21
+review_state: needs_cross_family_review
+last_updated: 2026-04-28
+notes:
+  - "Codex expanded the placeholder into an anchored research contract for R1/XCON and the commercial expert-system turn."
+  - "Core frame: R1/XCON made expert systems commercially credible because a narrow, structured, high-value manufacturing task fit production rules and sustained maintenance."
+  - "Primary anchors include McDermott 1982, McDermott/Steele 1981, Bachant/McDermott 1984, and Smith 1984."
+  - "Capacity target: 4,000-5,000 words confirmed; 5,000-5,600 only after later XCON retrospective or economic anchors are parsed."
+  - "Guardrail: do not use unverified savings numbers or first-commercial-system absolutes."
+  - "Guardrail: separate R1/XCON from XSEL."
+  - "Guardrail: Gemini may gap-audit capacity/narrative only; source-discipline review should come from Claude under the 2026-04-28 role split."

--- a/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/status.yaml
+++ b/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/status.yaml
@@ -12,3 +12,4 @@ notes:
   - "Guardrail: do not use unverified savings numbers or first-commercial-system absolutes."
   - "Guardrail: separate R1/XCON from XSEL."
   - "Guardrail: Gemini may gap-audit capacity/narrative only; source-discipline review should come from Claude under the 2026-04-28 role split."
+  - "Next transition: READY_TO_DRAFT after word-budget reconciliation is accepted and Bachant/McDermott 1984 mirror anchors are independently verified or consciously drafted as Yellow-caveated material."

--- a/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/timeline.md
+++ b/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/timeline.md
@@ -1,1 +1,38 @@
-# Timeline: Chapter 21
+# Timeline: Chapter 21 - The Rule-Based Fortune
+
+## Core Timeline
+
+- **December 1978:** McDermott begins work on R1, a rule-based VAX
+  configuration program, with a short tutoring period, manuals, and a first
+  implementation focused on central capabilities.
+- **April 1979:** The initial R1 demonstration version has about 250 rules
+  according to Bachant/McDermott's later reconstruction.
+- **October-November 1979:** R1 undergoes formal validation on 50 orders; six
+  experts spend one to two hours per order, find 12 pieces of errorful
+  knowledge, and the rules are modified.
+- **January 1980:** DEC manufacturing begins using R1 in regular production
+  workflow. McDermott/Steele later state it configured almost all VAX-11 systems
+  shipped.
+- **April-July 1980:** R1 is rewritten from OPS4 to OPS5 at CMU; the rewrite
+  yields a more capable system with fewer rules because existing knowledge can
+  be generalized.
+- **End of 1980:** R1 has about 850 rules; DEC focuses on component
+  descriptions and building an organization that can continue development.
+- **1981:** R1's knowledge is extended and refined; the ad-hoc constraints work
+  connects R1 to XSEL commands and customer-specific configuration constraints.
+- **March 1981:** DEC extends R1 to configure VAX-11/750 systems.
+- **1982:** R1's scope expands to VAX-11/730 and PDP-11/23+ systems; by midyear
+  its knowledge base reaches about 2000 rules.
+- **November 1983:** R1 can configure all systems sold by DEC in significant
+  volume; Bachant/McDermott report about 3300 rules and about 5500 component
+  descriptions.
+- **Fall 1984:** "R1 Revisited" publishes the four-year production account,
+  arguing that the system's development will probably never be finished.
+
+## Handoff Dates
+
+- **1984:** Smith's "On the Development of Commercial Expert Systems" frames the
+  broader commercial expert-system lesson: real products require teams,
+  engineering, successive refinement, and transfer discipline.
+- **1993:** McDermott publishes the later "R1 ('XCON') at age 12" retrospective;
+  current contract treats it as a stretch source only until full text is parsed.


### PR DESCRIPTION
## Summary

Anchors Chapter 21 research for Part 4: R1/XCON as the commercial expert-system turn.

## Scope

- Expands Ch21 placeholder into thesis, boundary contract, narrative spine, source table, claim matrix, evidence-layer word budget, and gap analysis.
- Uses McDermott 1982, McDermott/Steele 1981, Bachant/McDermott 1984, and Smith 1984 as core parsed sources.
- Explicitly excludes unverified XCON savings numbers, first-commercial-system absolutes, and any claim that R1 learned automatically or replaced all human experts.
- Separates R1/XCON from XSEL and keeps Lisp-machine commercialization for Ch22.

## Verification

- `git diff --check`
- `git diff --cached --check`
- `LC_ALL=C rg -n "[^\\x00-\\x7F]" docs/research/ai-history/chapters/ch-21-the-rule-based-fortune || true`

No npm build: research-only docs under `docs/research/**`, no site content touched.

## Review Requests

Claude: please review source discipline and prose readiness. Specific questions:

1. Are the page anchors sufficient for `READY_TO_DRAFT` or should the Studylib mirror for `R1 Revisited` be downgraded until an AAAI-hosted PDF is found?
2. Is the McDermott 1982 scanned/OCR source handled conservatively enough?
3. Are any claims too broad given the parsed sources, especially around commercial success and production deployment?
4. Is the 4,000-5,000 word capacity plan defensible without a later economic/retrospective source?

Gemini: please gap-audit narrative capacity only under the 2026-04-28 role split. Do not validate source URLs or anchors. Specific questions:

1. Does the narrative spine naturally support 4,000-5,000 words without bloat?
2. Are there missing scenes needed for prose readiness?
3. Should XSEL/ad-hoc constraints be a full scene or a bridge paragraph?
4. Is the commercial expert-system context sufficient from Smith 1984, or does the draft need a separate market-boom source before prose?

Part of #402; this PR covers Ch21 only.
