### PR TITLE
docs(ai-history): sync Part 4 readiness board (#402)

### DIFF
--- a/docs/research/ai-history/README.md
+++ b/docs/research/ai-history/README.md
@@ -6,7 +6,7 @@ This directory contains the operational research files for the definitive 68-cha
 
 - **Golden Research (Parts 1-2, Chapters 1-10):** Currently under revision based on cross-family review (downgraded to `reviewing` while we convert to claim-level anchoring and resolve factual disputes).
 - **Part 3 (The Birth of Symbolic AI):** Ch11-14 dual-cleared `prose_ready` 2026-04-28; Ch15-16 next.
-- **Part 4 (The First Winter):** Ch17-19 at `capacity_plan_anchored`; rest in `researching`.
+- **Part 4 (The First Winter):** Ch17-23 cross-family cleared for capped prose drafting; Ch21 carries a Yellow-caveated Bachant/McDermott mirror-source guardrail.
 - **Part 5 (The Mathematical Resurrection):** Ch24-28 prose `accepted`; Ch29-31 in `prose_review`.
 
 All drafting is paused for any chapter whose contract is not at `prose_ready` or beyond.

--- a/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/status.yaml
+++ b/docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/status.yaml
@@ -2,7 +2,7 @@ status: capacity_plan_anchored
 owner: Codex
 part: 4
 chapter: 21
-review_state: needs_cross_family_review
+review_state: gemini_and_claude_ready_to_draft_with_cap_fixes_applied
 last_updated: 2026-04-28
 notes:
   - "Codex expanded the placeholder into an anchored research contract for R1/XCON and the commercial expert-system turn."
@@ -12,4 +12,6 @@ notes:
   - "Guardrail: do not use unverified savings numbers or first-commercial-system absolutes."
   - "Guardrail: separate R1/XCON from XSEL."
   - "Guardrail: Gemini may gap-audit capacity/narrative only; source-discipline review should come from Claude under the 2026-04-28 role split."
-  - "Next transition: READY_TO_DRAFT after word-budget reconciliation is accepted and Bachant/McDermott 1984 mirror anchors are independently verified or consciously drafted as Yellow-caveated material."
+  - "Claude source-discipline review on PR #450 returned APPROVE after Codex fixed word-budget arithmetic, demoted the Studylib Bachant/McDermott mirror to Yellow, propagated the caveat, and tightened source notes."
+  - "Gemini gap/capacity review on PR #450 returned READY_TO_DRAFT_WITH_CAP; Codex applied narrative fixes for XSEL/ad-hoc constraints as a standalone scene and added technician-floor output texture."
+  - "Next transition: prose drafting at 4,000-5,000 words with Bachant/McDermott 1984 used only as Yellow-caveated material unless an authoritative PDF or independent body-text cross-check is added."


### PR DESCRIPTION
## Summary

Syncs the AI history status board after the merged Part 4 research PRs.

- Marks Part 4 Ch17-23 as cross-family cleared for capped prose drafting.
- Updates Ch21 status to reflect the already-posted Claude and Gemini verdicts on PR #450.
- Keeps the Bachant/McDermott 1984 Studylib mirror as Yellow-caveated material; this PR does not upgrade source status.

## Verification

- `git diff --check`
- `git diff -- docs/research/ai-history/README.md docs/research/ai-history/chapters/ch-21-the-rule-based-fortune/status.yaml | rg -n '^\+.*[^\x00-\x7F]' || true` (no new non-ASCII additions)

No npm build: research-status docs only under `docs/research/**`.

Part of #402.