### PR TITLE
docs(ai-history): mark Chapter 17 accepted (#402)

### DIFF
--- a/docs/research/ai-history/chapters/ch-17-the-perceptron-s-fall/status.yaml
+++ b/docs/research/ai-history/chapters/ch-17-the-perceptron-s-fall/status.yaml
@@ -1,8 +1,8 @@
-status: prose_review
+status: accepted
 owner: Codex
 part: 4
 chapter: 17
-review_state: needs_cross_family_prose_review
+review_state: gemini_and_claude_prose_approved
 last_updated: 2026-04-28
 prose_path: src/content/docs/ai-history/ch-17-the-perceptron-s-fall.md
 prose_words: 4360
@@ -19,4 +19,4 @@ notes:
   - "Claude source-fidelity review approved PR #464; Codex applied optional nits on continuation domains and forward-looking Part 5 phrasing."
   - "Gemini narrative review approved PR #464; Codex applied optional prose nits on repetition, section title, and explicit parity framing."
   - "Current prose markdown is 4,360 words after review nits."
-  - "Next transition: accepted after final PR checks and merge."
+  - "PR #464 passed GitHub checks and merged; Ch17 prose is accepted."


### PR DESCRIPTION
## Summary

Metadata-only follow-up after PR #464 merged.

- Marks Ch17 status as `accepted`.
- Records Claude+Gemini prose approval in `review_state`.
- Leaves prose and source content unchanged.

## Verification

- `git diff --check`
- `LC_ALL=C rg -n "[^\x00-\x7F]" docs/research/ai-history/chapters/ch-17-the-perceptron-s-fall/status.yaml || true`

No npm build: metadata-only research status update.

Part of #402.