### PR TITLE
docs(ai-history): rebuild chapter 51 research contract (#406)

### DIFF
--- a/docs/research/ai-history/chapters/ch-51-the-open-source-distribution-layer/brief.md
+++ b/docs/research/ai-history/chapters/ch-51-the-open-source-distribution-layer/brief.md
@@ -1,25 +1,45 @@
 # Brief: Chapter 51 - The Open Source Distribution Layer
 
 ## Thesis
-Deep learning accelerated exponentially because its primary infrastructure was not just hardware, but open-source distribution. Platforms like GitHub and arXiv bypassed the traditional, slow academic publishing cycle, allowing global teams to replicate, modify, and build upon breakthroughs within days of their discovery.
+
+The Transformer era did not spread through hardware alone. It also rode on distribution infrastructure: arXiv made papers available before journal publication, GitHub made implementations and frameworks inspectable, and specialized layers such as Papers with Code began linking papers to code and datasets. This did not abolish corporate advantage or make reproduction automatic, but it changed the default rhythm of machine-learning work from waiting for polished publication to reading, cloning, testing, and extending.
 
 ## Scope
-- IN SCOPE: The shift from closed journals to arXiv, the rise of GitHub for code sharing, the culture of open-sourcing model code.
-- OUT OF SCOPE: Hugging Face (Chapter 54).
+
+- IN SCOPE: arXiv as open research-sharing infrastructure; arXiv growth and category taxonomy; GitHub repositories as research-code distribution; TensorFlow and PyTorch as open-source framework anchors; Papers with Code/arXiv integration as a paper-to-code index; reproduction limits and code-quality caveats.
+- OUT OF SCOPE: Hugging Face as the model/weights hub (Chapter 54); BERT itself (Chapter 52); GPT-2 release strategy and staged release debates (Chapter 53); formal scaling-law math (Chapter 55).
+
+## Boundary Contract
+
+Do not say open source "broke the corporate lab monopoly." The safer claim is that open distribution lowered the cost of inspection, replication, teaching, and extension, while compute, data, hiring, and production infrastructure still favored large labs.
+
+Do not invent a 14-month review wait or an overnight replication scene unless a source is added. The current contract supports distribution mechanics and examples, not a specific researcher anecdote.
 
 ## Scenes Outline
-1. **The Academic Bottleneck:** Traditional peer review takes months or years, stalling rapid iteration in the fast-moving deep learning space.
-2. **The Preprint Revolution:** Researchers begin publishing directly to arXiv, prioritizing speed and open access over prestige.
-3. **Code as Infrastructure:** Releasing papers is no longer enough; researchers release the accompanying code on GitHub, creating a massive, composable open-source engine.
+
+1. **The Paper Server Becomes a Daily Feed:** arXiv, founded in 1991 and now spanning computer science and statistics, becomes the place where ML readers can see work before traditional publication.
+2. **Machine Learning Gets Its Shelf:** arXiv category taxonomy gives cs.LG and stat.ML explicit homes; overall arXiv yearly submissions grow from 84,603 in 2012 to 123,523 in 2017 and 178,329 in 2020 in the official monthly-submissions CSV.
+3. **Code Stops Being Optional Context:** Google frames TensorFlow's 2015 release as a way for the community to exchange ideas through working code rather than just research papers.
+4. **Frameworks Become Distribution Channels:** PyTorch, TensorFlow, and later Transformers repositories show that research infrastructure could be cloned, forked, starred, patched, and taught as software.
+5. **The Index Layer:** arXiv's annual report records Papers with Code integration expanding from AI/ML to all arXiv and linking tens of thousands of papers to code and datasets.
+6. **The Reproducibility Caveat:** Code on GitHub is not the same as reproducible science. A 2019 study of AI-paper repositories found abandonment, missing setup, and documentation problems.
 
 ## 4k-7k Prose Capacity Plan
 
-This chapter can support a long narrative only if it is built from verified layers rather than padding:
+This chapter can support a 4,000-5,000 word draft if it stays infrastructural rather than anecdotal:
 
-- 500-800 words: Historical context and setup, bridging from the previous era.
-- 933-1233 words: Detailed narrative surrounding The Academic Bottleneck:, heavily anchored to primary sources.
-- 933-1233 words: Detailed narrative surrounding The Preprint Revolution:, heavily anchored to primary sources.
-- 933-1233 words: Detailed narrative surrounding Code as Infrastructure:, heavily anchored to primary sources.
-- 400-700 words: Honest close that summarizes the infrastructural shift and transitions to the next chapter.
+- 500-700 words: bridge from Chapter 50, explaining why a new architecture needed distribution rails before it could become an ecosystem.
+- 650-850 words: arXiv origin, scope, moderation/non-peer-review boundary, category taxonomy, and official submission-growth numbers.
+- 650-850 words: TensorFlow and PyTorch as open-source framework examples, using corporate posts and GitHub API metadata without turning the chapter into a framework history.
+- 600-800 words: GitHub as the clone/fork/workflow layer, anchored by repository metadata and the 2019 study of AI-paper repositories.
+- 550-750 words: Papers with Code/arXiv integration as the paper-to-code index layer, including the 2021 annual-report numbers.
+- 500-700 words: caveat section on reproducibility, corporate advantage, and why "open" did not mean equally usable.
+- 300-500 words: transition to BERT/Hugging Face, where open papers and repositories become model distribution and fine-tuning infrastructure.
 
-Most layers now have page-level anchors. Do not invent lab drama or dialogue to reach the top of the range. If the verified evidence runs out, cap the chapter.
+Do not force 7,000 words from this contract. A larger chapter needs more primary sources on ML conference code policies, framework adoption at labs, or first-person accounts from maintainers.
+
+## Citation Bar
+
+- Minimum primary sources before prose review: arXiv About, arXiv monthly-submissions CSV, arXiv category taxonomy, arXiv 2021 annual report, GitHub API records, Google TensorFlow post, Meta PyTorch post.
+- Minimum secondary sources before prose review: one empirical study of AI-paper GitHub repositories or paper-code traceability.
+- Current status: source layer supports a capped 4,000-5,000 word infrastructure chapter. No specific human scene is currently anchored.

--- a/docs/research/ai-history/chapters/ch-51-the-open-source-distribution-layer/brief.md
+++ b/docs/research/ai-history/chapters/ch-51-the-open-source-distribution-layer/brief.md
@@ -19,27 +19,27 @@ Do not invent a 14-month review wait or an overnight replication scene unless a 
 
 1. **The Paper Server Becomes a Daily Feed:** arXiv, founded in 1991 and now spanning computer science and statistics, becomes the place where ML readers can see work before traditional publication.
 2. **Machine Learning Gets Its Shelf:** arXiv category taxonomy gives cs.LG and stat.ML explicit homes; overall arXiv yearly submissions grow from 84,603 in 2012 to 123,523 in 2017 and 178,329 in 2020 in the official monthly-submissions CSV.
-3. **Code Stops Being Optional Context:** Google frames TensorFlow's 2015 release as a way for the community to exchange ideas through working code rather than just research papers.
-4. **Frameworks Become Distribution Channels:** PyTorch, TensorFlow, and later Transformers repositories show that research infrastructure could be cloned, forked, starred, patched, and taught as software.
-5. **The Index Layer:** arXiv's annual report records Papers with Code integration expanding from AI/ML to all arXiv and linking tens of thousands of papers to code and datasets.
+3. **Working Code Becomes a Distribution Argument:** Google frames TensorFlow's 2015 release as a way for the community to exchange ideas through working code rather than just research papers. This supports a corporate-led code-distribution layer, not a universal code mandate.
+4. **Clashing Distribution Philosophies:** TensorFlow and PyTorch both move through GitHub, but their public framing differs: TensorFlow emphasizes a scalable system used inside Google, while PyTorch emphasizes rapid research prototyping and a path to production.
+5. **The Index Layer Matures:** arXiv's 2021 annual report records Papers with Code integration expanding from AI/ML to all arXiv and linking tens of thousands of papers to code and datasets. This is a maturation of the layer, not the cause of the first Transformer-era spread.
 6. **The Reproducibility Caveat:** Code on GitHub is not the same as reproducible science. A 2019 study of AI-paper repositories found abandonment, missing setup, and documentation problems.
 
 ## 4k-7k Prose Capacity Plan
 
-This chapter can support a 4,000-5,000 word draft if it stays infrastructural rather than anecdotal:
+This chapter can support a 4,000-word draft if it stays infrastructural rather than anecdotal:
 
 - 500-700 words: bridge from Chapter 50, explaining why a new architecture needed distribution rails before it could become an ecosystem.
-- 650-850 words: arXiv origin, scope, moderation/non-peer-review boundary, category taxonomy, and official submission-growth numbers.
-- 650-850 words: TensorFlow and PyTorch as open-source framework examples, using corporate posts and GitHub API metadata without turning the chapter into a framework history.
+- 400-500 words: arXiv origin, scope, moderation/non-peer-review boundary, category taxonomy, and official submission-growth numbers, with no ML-specific growth claim unless another source is added.
+- 650-800 words: TensorFlow and PyTorch as contrasting distribution philosophies, using corporate posts and GitHub API metadata without turning the chapter into a framework history.
 - 600-800 words: GitHub as the clone/fork/workflow layer, anchored by repository metadata and the 2019 study of AI-paper repositories.
-- 550-750 words: Papers with Code/arXiv integration as the paper-to-code index layer, including the 2021 annual-report numbers.
+- 450-600 words: Papers with Code/arXiv integration as later maturation of the paper-to-code index layer, including the 2021 annual-report numbers.
 - 500-700 words: caveat section on reproducibility, corporate advantage, and why "open" did not mean equally usable.
 - 300-500 words: transition to BERT/Hugging Face, where open papers and repositories become model distribution and fine-tuning infrastructure.
 
-Do not force 7,000 words from this contract. A larger chapter needs more primary sources on ML conference code policies, framework adoption at labs, or first-person accounts from maintainers.
+Do not force 5,000-7,000 words from this contract. A larger chapter needs primary sources on ML conference code policies, framework adoption at labs, or first-person accounts from maintainers.
 
 ## Citation Bar
 
 - Minimum primary sources before prose review: arXiv About, arXiv monthly-submissions CSV, arXiv category taxonomy, arXiv 2021 annual report, GitHub API records, Google TensorFlow post, Meta PyTorch post.
 - Minimum secondary sources before prose review: one empirical study of AI-paper GitHub repositories or paper-code traceability.
-- Current status: source layer supports a capped 4,000-5,000 word infrastructure chapter. No specific human scene is currently anchored.
+- Current status: source layer supports a capped 4,000 word infrastructure chapter. No specific human scene is currently anchored.

--- a/docs/research/ai-history/chapters/ch-51-the-open-source-distribution-layer/infrastructure-log.md
+++ b/docs/research/ai-history/chapters/ch-51-the-open-source-distribution-layer/infrastructure-log.md
@@ -1,5 +1,29 @@
 # Infrastructure Log: Chapter 51
 
 ## Technical Metrics & Constraints
-- **Distribution Speed:**
-  - Shift: Reduced the time from algorithmic discovery to global replication from 1-2 years (journal cycle) to 1-2 days (arXiv + GitHub).
+- **arXiv distribution:**
+  - Founded in 1991 by Paul Ginsparg, per arXiv About.
+  - Moderated but not peer-reviewed; no submission fees.
+  - Official monthly-submissions CSV annual totals extracted on 2026-04-28: 2012 = 84,603; 2017 = 123,523; 2020 = 178,329; 2022 = 185,692; 2025 = 284,486.
+  - Category taxonomy gives machine learning explicit shelves through cs.LG and stat.ML.
+
+- **GitHub repository layer:**
+  - GitHub API extraction on 2026-04-28:
+    - `tensorflow/tensorflow` created 2015-11-07.
+    - `pytorch/pytorch` created 2016-08-13.
+    - `huggingface/transformers` created 2018-10-29.
+  - Stars/forks are dynamic and should only be used with an extraction date if needed; creation dates are the safer historical anchors.
+
+- **Framework announcements:**
+  - Google TensorFlow post, 2015-11-09: open-sourcing TensorFlow to let the ML community exchange ideas through working code rather than just research papers.
+  - Meta PyTorch post, 2018-05-02: PyTorch 1.0 as open-source AI framework for rapid research prototyping and production deployment.
+
+- **Paper-to-code index:**
+  - arXiv Annual Report 2021 says Papers with Code integration expanded from AI/ML categories to all arXiv and linked over 70,000 papers to code and over 60,000 to datasets.
+
+## Do Not Say
+
+- Do not quantify distribution speed as "1-2 years to 1-2 days" without a source.
+- Do not claim all papers had code.
+- Do not use current GitHub popularity metrics as if they were known in 2017.
+- Do not imply arXiv endorsement or peer review.

--- a/docs/research/ai-history/chapters/ch-51-the-open-source-distribution-layer/open-questions.md
+++ b/docs/research/ai-history/chapters/ch-51-the-open-source-distribution-layer/open-questions.md
@@ -1,3 +1,20 @@
 # Open Questions
 
-- SCRUBBED: All claims downgraded to Yellow. Need REAL, empirical page/section anchors from verified online PDFs or archives. Do not hallucinate.
+## Blocking Before Draft?
+
+No blocker for a capped 4,000-5,000 word draft after cross-family approval. The core infrastructure layers are anchored, but the chapter should stay honest about the lack of specific human scenes.
+
+## Expansion Targets
+
+- Find an accessible source for ML-specific arXiv submission growth by category if the draft wants to say ML, rather than arXiv overall, exploded during 2012-2020.
+- Find primary GitHub history/founding source if the prose needs more than repository metadata.
+- Find conference policy sources on code submission/reproducibility if the chapter needs a stronger "code became expected" claim.
+- Find first-person maintainer accounts for TensorFlow, PyTorch, Papers with Code, or early Transformers repositories if the prose needs more human texture.
+
+## Red-Line Warnings
+
+- No fake paywall/waiting-room anecdote.
+- No "open source broke the monopoly."
+- No "all papers had code."
+- No "arXiv is peer review."
+- No current-star-count claims unless dated.

--- a/docs/research/ai-history/chapters/ch-51-the-open-source-distribution-layer/open-questions.md
+++ b/docs/research/ai-history/chapters/ch-51-the-open-source-distribution-layer/open-questions.md
@@ -2,7 +2,7 @@
 
 ## Blocking Before Draft?
 
-No blocker for a capped 4,000-5,000 word draft after cross-family approval. The core infrastructure layers are anchored, but the chapter should stay honest about the lack of specific human scenes.
+No blocker for a capped 4,000 word draft after cross-family approval. The core infrastructure layers are anchored, but the chapter should stay honest about the lack of specific human scenes.
 
 ## Expansion Targets
 

--- a/docs/research/ai-history/chapters/ch-51-the-open-source-distribution-layer/people.md
+++ b/docs/research/ai-history/chapters/ch-51-the-open-source-distribution-layer/people.md
@@ -1,5 +1,12 @@
 # People: Chapter 51
 
 ## Verified Protagonists
-- **Paul Ginsparg:** Founder of arXiv.
-- **The Open Source ML Community:** The collective researchers who shifted the publishing paradigm.
+- **Paul Ginsparg:** Founder of arXiv, per arXiv About.
+- **Google TensorFlow team / Google Research:** Institutional actor behind the 2015 TensorFlow open-source announcement. Do not invent individual motivations unless a named source is added.
+- **Meta/Facebook AI and PyTorch maintainers:** Institutional actor behind the PyTorch 1.0 announcement. Do not turn this into a named-maintainer chapter unless additional primary sources are gathered.
+- **Papers with Code team:** Partner referenced in arXiv's annual report as the group behind code/dataset integrations and ML expertise used in classification tooling.
+- **Open-source ML maintainers and users:** Collective actor only. Use as infrastructure community, not as a faceless heroic protagonist.
+
+## Guardrail
+
+This chapter currently has institutions and infrastructure more than character scenes. That is acceptable. Do not invent individual researcher anecdotes to create drama.

--- a/docs/research/ai-history/chapters/ch-51-the-open-source-distribution-layer/scene-sketches.md
+++ b/docs/research/ai-history/chapters/ch-51-the-open-source-distribution-layer/scene-sketches.md
@@ -1,10 +1,31 @@
 # Scene Sketches: Chapter 51
 
-## Scene 1: The Paywall
-- **Action:** A researcher in 2010 waits 14 months for their paper to be peer-reviewed and published in a closed journal.
+## Scene 1: The Paper Server
+- **Action:** Begin with infrastructure, not a fictional person: arXiv is a submission, discovery, API, moderation, and preservation system that made papers reachable before journal publication.
+- **Evidence anchors:** arXiv About; arXiv Monthly Submissions.
+- **Drafting warning:** Do not write a fake "researcher waits 14 months" anecdote.
 
-## Scene 2: The Midnight Upload
-- **Action:** A team uploads a breakthrough paper to arXiv at midnight, and by morning, a lab across the world is already testing it.
+## Scene 2: Machine Learning Gets Its Shelf
+- **Action:** Show the taxonomy: cs.LG and stat.ML give ML work discoverable shelves; the monthly-submissions CSV shows arXiv's overall scale rising during the deep-learning era.
+- **Evidence anchors:** arXiv Category Taxonomy; arXiv monthly CSV extracted totals.
+- **Drafting warning:** Overall arXiv growth is Green; ML-specific growth is Yellow unless another source is added.
 
-## Scene 3: git clone
-- **Action:** The realization that equations aren't enough. Researchers start cloning each other's PyTorch code, creating an interlocking, open-source tech tree.
+## Scene 3: Working Code Rather Than Just Papers
+- **Action:** Use Google's TensorFlow announcement as the cleanest primary scene: open-sourcing a machine-learning system so researchers, engineers, and hobbyists could exchange ideas through code.
+- **Evidence anchors:** Google TensorFlow post; GitHub TensorFlow API metadata.
+- **Drafting warning:** Keep the corporate incentive visible. Google was opening a framework, not dissolving its internal advantage.
+
+## Scene 4: Frameworks as Distribution
+- **Action:** Place PyTorch alongside TensorFlow as research infrastructure that moved through open repositories, tutorials, cloud support, and model/code sharing.
+- **Evidence anchors:** Meta PyTorch 1.0 post; GitHub PyTorch API metadata.
+- **Drafting warning:** Do not make this a TensorFlow-vs-PyTorch product comparison. The chapter's object is distribution infrastructure.
+
+## Scene 5: The Index Layer
+- **Action:** Papers with Code becomes a visible connector between arXiv papers, code, and datasets. This is the step from "paper is online" to "paper is linked to implementable artifacts."
+- **Evidence anchors:** arXiv Annual Report 2021.
+- **Drafting warning:** Hugging Face and model weights stay for Chapter 54.
+
+## Scene 6: The Reproduction Gap
+- **Action:** Close the chapter's argument by showing the limits: public GitHub repositories can be inactive, undocumented, or hard to run.
+- **Evidence anchors:** Zhang et al. 2019 AI-paper GitHub repository study.
+- **Drafting warning:** This caveat is mandatory; otherwise the chapter reads like open-source marketing.

--- a/docs/research/ai-history/chapters/ch-51-the-open-source-distribution-layer/scene-sketches.md
+++ b/docs/research/ai-history/chapters/ch-51-the-open-source-distribution-layer/scene-sketches.md
@@ -15,13 +15,13 @@
 - **Evidence anchors:** Google TensorFlow post; GitHub TensorFlow API metadata.
 - **Drafting warning:** Keep the corporate incentive visible. Google was opening a framework, not dissolving its internal advantage.
 
-## Scene 4: Frameworks as Distribution
-- **Action:** Place PyTorch alongside TensorFlow as research infrastructure that moved through open repositories, tutorials, cloud support, and model/code sharing.
+## Scene 4: Clashing Distribution Philosophies
+- **Action:** Place TensorFlow and PyTorch side by side as different public framings of open ML software: Google's scalable system made external, and Meta/Facebook's research-prototyping tool presented as a path toward production.
 - **Evidence anchors:** Meta PyTorch 1.0 post; GitHub PyTorch API metadata.
 - **Drafting warning:** Do not make this a TensorFlow-vs-PyTorch product comparison. The chapter's object is distribution infrastructure.
 
-## Scene 5: The Index Layer
-- **Action:** Papers with Code becomes a visible connector between arXiv papers, code, and datasets. This is the step from "paper is online" to "paper is linked to implementable artifacts."
+## Scene 5: The Index Layer Matures
+- **Action:** Papers with Code becomes a visible connector between arXiv papers, code, and datasets. This is the later step from "paper is online" to "paper is linked to implementable artifacts."
 - **Evidence anchors:** arXiv Annual Report 2021.
 - **Drafting warning:** Hugging Face and model weights stay for Chapter 54.
 

--- a/docs/research/ai-history/chapters/ch-51-the-open-source-distribution-layer/sources.md
+++ b/docs/research/ai-history/chapters/ch-51-the-open-source-distribution-layer/sources.md
@@ -1,16 +1,60 @@
-# Sources: Chapter 51
+# Sources: Chapter 51 - The Open Source Distribution Layer
 
-## Claim Matrix
+## Verification Key
 
-| Claim | Scene | Primary Source | Secondary Confirmation | Verification | Conflict |
+- Green: claim has primary evidence plus independent confirmation or internally consistent official data.
+- Yellow: claim has one strong source, current/dynamic metadata, or a broad cultural inference.
+- Red: claim should not be drafted except as blocked framing.
+
+## Primary Sources
+
+| Source | Use | Verification |
+|---|---|---|
+| arXiv, "About arXiv." URL: https://arxiv.org/about | Founding, scope, moderation boundary, and non-peer-review guardrail. | Green: page states arXiv is a curated research-sharing platform, hosts more than three million scholarly articles, serves fields including computer science and statistics, was founded by Paul Ginsparg in 1991, charges no submission fees, and is moderated but not peer-reviewed. |
+| arXiv, "Category Taxonomy." URL: https://arxiv.org/category_taxonomy | Machine-learning category shelf. | Green: page defines cs.LG as Machine Learning and says it covers supervised, unsupervised, reinforcement learning, bandit problems, robustness, explanation, fairness, methodology, and applications; also lists stat.ML as Machine Learning. |
+| arXiv, "Monthly Submissions" and CSV endpoint. URLs: https://arxiv.org/stats/monthly_submissions and https://arxiv.org/stats/get_monthly_submissions | Official submission-growth data. | Green for overall arXiv growth: local extraction on 2026-04-28 summed monthly CSV rows to 84,603 submissions in 2012, 123,523 in 2017, 178,329 in 2020, 185,692 in 2022, and 284,486 in 2025. Yellow for ML-specific growth unless a category-level source is added. |
+| arXiv Annual Report 2021. URL: https://static.arxiv.org/static/arxiv.marxdown/0.1/about/reports/2021_arXiv_annual_report.pdf | Papers with Code integration and paper-to-code/dataset indexing. | Green: report states the Papers with Code integration was well received, expanded from AI and Machine Learning categories to all arXiv, added dataset links in May 2021, and had over 70,000 arXiv papers with at least one code link and over 60,000 with at least one dataset link. |
+| Google, "TensorFlow: smarter machine learning, for everyone," 2015-11-09. URL: https://blog.google/technology/ai/tensorflow-smarter-machine-learning-for/ | TensorFlow open-source announcement and "working code rather than just research papers" framing. | Green: post announces TensorFlow, says Google is open-sourcing it, and explicitly hopes the ML community can exchange ideas more quickly through working code rather than just research papers. |
+| Meta Engineering, "Announcing PyTorch 1.0 for both research and production," 2018-05-02. URL: https://engineering.fb.com/2018/05/02/ai-research/announcing-pytorch-1-0-for-both-research-and-production/ | PyTorch as open-source research-to-production framework. | Green: post presents PyTorch 1.0 as the next version of Facebook's open-source AI framework, describes rapid prototyping/research and production transition, and says opening papers, code, and models lets researchers and practitioners advance faster. |
+| GitHub REST API repository records for `tensorflow/tensorflow`, `pytorch/pytorch`, and `huggingface/transformers`. URLs: https://api.github.com/repos/tensorflow/tensorflow, https://api.github.com/repos/pytorch/pytorch, https://api.github.com/repos/huggingface/transformers | Concrete repository metadata: creation date, current stars/forks, and repo existence. | Green for creation dates extracted on 2026-04-28: TensorFlow repo created 2015-11-07; PyTorch repo created 2016-08-13; Hugging Face Transformers repo created 2018-10-29. Yellow for stars/forks because they are dynamic current metrics, not historical adoption numbers. |
+
+## Secondary and Context Sources
+
+| Source | Use | Verification |
+|---|---|---|
+| Zhang et al., "An Explorative Study of GitHub Repositories of AI Papers," arXiv:1903.01555, 2019. URL: https://arxiv.org/pdf/1903.01555 | Empirical caveat: GitHub-hosted AI-paper code can be hard to reproduce, inactive, or poorly documented. | Green/Yellow: abstract and body state the study analyzed over 1,700 GitHub repositories of AI papers; it identifies abandoned/inactive repositories and reproducibility/documentation issues. Use as caveat, not as proof that all ML research code was open. |
+| arXiv + Papers with Code public pages and blog posts. | Optional context for the code-tab integration. | Yellow unless the source is accessible without Cloudflare blocks; arXiv annual report is currently the stronger anchor. |
+| Wikipedia pages on arXiv, GitHub, TensorFlow, PyTorch, and Papers with Code. | Discovery aid only. | Yellow/Red for citation: use only to find leads, never as a final prose anchor. |
+
+## Scene-Level Claim Table
+
+| Claim | Scene | Primary Anchor | Independent Confirmation | Status | Notes |
 |---|---|---|---|---|---|
-| arXiv usage for machine learning papers exploded post-2012 | 2 | arXiv submission statistics / API data | Sutton 2019 | Yellow | Need exact verified page/section anchors. |
-| Releasing code alongside papers became the standard in ML | 3 | GitHub repository metrics for popular ML frameworks | N/A | Yellow | Need a specific secondary source documenting this cultural shift in ML. |
+| arXiv is an open research-sharing platform founded by Paul Ginsparg in 1991, covering computer science and statistics among other fields. | Paper Server | arXiv About | arXiv monthly-submissions page | Green | Good opening infrastructure anchor. |
+| arXiv is moderated but not peer-reviewed, so it accelerates circulation without replacing evaluation. | Paper Server | arXiv About | Later reproducibility caveat | Green | Blocks "arXiv replaced peer review" overclaim. |
+| arXiv gives machine learning explicit category homes through cs.LG and stat.ML. | Machine Learning Gets Its Shelf | arXiv Category Taxonomy | arXiv About field list | Green | Do not claim ML-specific submission explosion unless another source is added. |
+| Overall arXiv submissions grew substantially across the deep-learning era. | Machine Learning Gets Its Shelf | arXiv monthly-submissions CSV | arXiv About scale statement | Green | Use exact extracted totals with extraction date. |
+| TensorFlow's open-source announcement explicitly framed working code as a faster medium for exchanging ML ideas than research papers alone. | Code Stops Being Optional Context | Google TensorFlow post | GitHub TensorFlow repo metadata | Green | Strongest "code as infrastructure" quote anchor. |
+| PyTorch was framed by Meta/Facebook as an open-source AI framework bridging research prototyping and production deployment. | Frameworks Become Distribution Channels | Meta PyTorch 1.0 post | GitHub PyTorch repo metadata | Green | Keep as framework-distribution example, not full PyTorch history. |
+| Major ML framework/model-library repositories were public GitHub projects created during 2015-2018. | Frameworks Become Distribution Channels | GitHub API repo records | Google/Meta posts | Green/Yellow | Green for creation dates; Yellow for current popularity metrics. |
+| arXiv's Papers with Code integration linked papers to code and datasets at large scale by 2021. | Index Layer | arXiv Annual Report 2021 | Papers with Code public context optional | Green | Good bridge toward Chapter 54, but keep Hugging Face separate. |
+| GitHub code availability did not guarantee reproducibility or maintenance. | Reproducibility Caveat | Zhang et al. 2019 | arXiv non-peer-review guardrail | Green/Yellow | Essential balance against open-source boosterism. |
+| A 4,000-5,000 word chapter is feasible if it stays on infrastructure layers and avoids invented human scenes. | All | This source table and brief capacity plan | Ch24/Ch50 contract pattern | Green/Yellow | Larger draft needs more primary accounts or policy sources. |
 
-## Bibliography
-### Primary
-- **arXiv.org. Submission statistics and history.**
-- **GitHub. Repository creation and fork statistics for ML frameworks (TensorFlow, PyTorch).**
+## Conflict Notes
 
-### Secondary
-- **Sutton, Richard S. "The bitter lesson." *Incomplete Ideas (blog)* 13, no. 1 (2019).**
+- Do not claim arXiv was peer review. It explicitly is not.
+- Do not claim GitHub code release became universal or mandatory. The safe claim is "increasingly expected and infrastructural, but uneven."
+- Do not claim open source broke corporate dominance. It lowered distribution friction while compute, data, and production still mattered.
+- Do not use current GitHub stars/forks as historical evidence without date-stamping them.
+- Do not turn Chapter 51 into Hugging Face. That belongs to Chapter 54.
+
+## Page/Section Anchor Worklist
+
+- arXiv About: Done for founding, scope, non-peer-review/moderation boundary, no-fee submission, and scale.
+- arXiv Category Taxonomy: Done for cs.LG and stat.ML machine-learning category definitions.
+- arXiv Monthly Submissions CSV: Done for overall annual totals; ML-specific category growth remains optional/Yellow.
+- arXiv Annual Report 2021: Done for Papers with Code expansion and 70k/60k code/dataset link counts.
+- Google TensorFlow post: Done for 2015 date and "working code rather than just research papers" framing.
+- Meta PyTorch post: Done for open-source framework, research-to-production bridge, and papers/code/models framing.
+- GitHub API: Done for repo creation dates and current metadata extraction date.

--- a/docs/research/ai-history/chapters/ch-51-the-open-source-distribution-layer/sources.md
+++ b/docs/research/ai-history/chapters/ch-51-the-open-source-distribution-layer/sources.md
@@ -34,19 +34,21 @@
 | arXiv is moderated but not peer-reviewed, so it accelerates circulation without replacing evaluation. | Paper Server | arXiv About | Later reproducibility caveat | Green | Blocks "arXiv replaced peer review" overclaim. |
 | arXiv gives machine learning explicit category homes through cs.LG and stat.ML. | Machine Learning Gets Its Shelf | arXiv Category Taxonomy | arXiv About field list | Green | Do not claim ML-specific submission explosion unless another source is added. |
 | Overall arXiv submissions grew substantially across the deep-learning era. | Machine Learning Gets Its Shelf | arXiv monthly-submissions CSV | arXiv About scale statement | Green | Use exact extracted totals with extraction date. |
-| TensorFlow's open-source announcement explicitly framed working code as a faster medium for exchanging ML ideas than research papers alone. | Code Stops Being Optional Context | Google TensorFlow post | GitHub TensorFlow repo metadata | Green | Strongest "code as infrastructure" quote anchor. |
+| TensorFlow's open-source announcement explicitly framed working code as a faster medium for exchanging ML ideas than research papers alone. | Working Code Becomes a Distribution Argument | Google TensorFlow post | GitHub TensorFlow repo metadata | Green | Strongest "code as infrastructure" quote anchor; do not generalize to universal code mandates. |
 | PyTorch was framed by Meta/Facebook as an open-source AI framework bridging research prototyping and production deployment. | Frameworks Become Distribution Channels | Meta PyTorch 1.0 post | GitHub PyTorch repo metadata | Green | Keep as framework-distribution example, not full PyTorch history. |
 | Major ML framework/model-library repositories were public GitHub projects created during 2015-2018. | Frameworks Become Distribution Channels | GitHub API repo records | Google/Meta posts | Green/Yellow | Green for creation dates; Yellow for current popularity metrics. |
-| arXiv's Papers with Code integration linked papers to code and datasets at large scale by 2021. | Index Layer | arXiv Annual Report 2021 | Papers with Code public context optional | Green | Good bridge toward Chapter 54, but keep Hugging Face separate. |
+| arXiv's Papers with Code integration linked papers to code and datasets at large scale by 2021. | Index Layer Matures | arXiv Annual Report 2021 | Papers with Code public context optional | Green | Use as later maturation signal and bridge toward Chapter 54, but keep Hugging Face separate. |
 | GitHub code availability did not guarantee reproducibility or maintenance. | Reproducibility Caveat | Zhang et al. 2019 | arXiv non-peer-review guardrail | Green/Yellow | Essential balance against open-source boosterism. |
-| A 4,000-5,000 word chapter is feasible if it stays on infrastructure layers and avoids invented human scenes. | All | This source table and brief capacity plan | Ch24/Ch50 contract pattern | Green/Yellow | Larger draft needs more primary accounts or policy sources. |
+| A 4,000 word chapter is feasible if it stays on infrastructure layers and avoids invented human scenes. | All | This source table and brief capacity plan | Gemini gap audit; Ch24/Ch50 contract pattern | Green/Yellow | Larger draft needs ML-specific arXiv data, conference code-policy sources, or primary maintainer accounts. |
 
 ## Conflict Notes
 
 - Do not claim arXiv was peer review. It explicitly is not.
 - Do not claim GitHub code release became universal or mandatory. The safe claim is "increasingly expected and infrastructural, but uneven."
+- Do not claim conference code policies drove the shift unless a conference-policy source is added.
 - Do not claim open source broke corporate dominance. It lowered distribution friction while compute, data, and production still mattered.
 - Do not use current GitHub stars/forks as historical evidence without date-stamping them.
+- Do not treat the 2021 Papers with Code/arXiv integration as the cause of the 2017-2019 Transformer-era spread. It is a later maturation signal.
 - Do not turn Chapter 51 into Hugging Face. That belongs to Chapter 54.
 
 ## Page/Section Anchor Worklist

--- a/docs/research/ai-history/chapters/ch-51-the-open-source-distribution-layer/status.yaml
+++ b/docs/research/ai-history/chapters/ch-51-the-open-source-distribution-layer/status.yaml
@@ -1,1 +1,21 @@
 status: researching
+owner: Codex
+part: 8
+chapter: 51
+review_state: codex_rebuilt_scrubbed_contract_needs_cross_family_review
+last_updated: 2026-04-28
+green_claims: 8
+yellow_claims: 4
+red_claims: 5
+prose_word_cap_recommendation: 5000
+notes: |
+  Rebuilt the scrubbed/yellow contract from verified online sources: arXiv About,
+  arXiv category taxonomy, arXiv monthly-submissions CSV, arXiv Annual Report
+  2021, GitHub API repository metadata, Google TensorFlow announcement, Meta
+  PyTorch 1.0 announcement, and Zhang et al. 2019.
+
+  Strongest safe prose range: 4,000-5,000 words. The chapter is infrastructure-
+  heavy and character-light. Do not invent individual anecdotes or claim open
+  source erased corporate advantage. Expansion above 5,000 words needs stronger
+  primary sources on ML-specific arXiv growth, conference code norms, or named
+  maintainer histories.

--- a/docs/research/ai-history/chapters/ch-51-the-open-source-distribution-layer/status.yaml
+++ b/docs/research/ai-history/chapters/ch-51-the-open-source-distribution-layer/status.yaml
@@ -1,21 +1,45 @@
-status: researching
+status: prose_ready
 owner: Codex
 part: 8
 chapter: 51
-review_state: codex_rebuilt_scrubbed_contract_needs_cross_family_review
+review_state: claude_source_approved_2026-04-28;gemini_gap_ready_with_cap_2026-04-28
 last_updated: 2026-04-28
 green_claims: 8
 yellow_claims: 4
 red_claims: 5
-prose_word_cap_recommendation: 5000
+prose_word_cap_recommendation: 4000
+prose_word_cap: 4000
+verdicts:
+  claude:
+    model: claude-opus-4-7
+    date: 2026-04-28
+    verdict: APPROVE
+    note: source-fidelity review posted to PR #491
+  gemini:
+    model: gemini-3-flash-preview
+    requested_model: gemini-3.1-pro-preview
+    date: 2026-04-28
+    verdict: READY_WITH_CAP
+    word_cap: 4000
+    review_url: https://github.com/kube-dojo/kube-dojo.github.io/pull/491#issuecomment-4333630718
+  resolved: READY_TO_DRAFT_WITH_CAP
+  resolved_word_cap: 4000
+  resolution_rule: dual_cross_family_verdict_with_cap
 notes: |
   Rebuilt the scrubbed/yellow contract from verified online sources: arXiv About,
   arXiv category taxonomy, arXiv monthly-submissions CSV, arXiv Annual Report
   2021, GitHub API repository metadata, Google TensorFlow announcement, Meta
   PyTorch 1.0 announcement, and Zhang et al. 2019.
 
-  Strongest safe prose range: 4,000-5,000 words. The chapter is infrastructure-
-  heavy and character-light. Do not invent individual anecdotes or claim open
-  source erased corporate advantage. Expansion above 5,000 words needs stronger
-  primary sources on ML-specific arXiv growth, conference code norms, or named
-  maintainer histories.
+  Strongest safe prose target: 4,000 words. The chapter is infrastructure-heavy
+  and character-light. Do not invent individual anecdotes or claim open source
+  erased corporate advantage. Expansion above 4,000 words needs stronger primary
+  sources on ML-specific arXiv growth, conference code norms, or named maintainer
+  histories.
+
+  Claude source-fidelity review approved all load-bearing anchors. Gemini
+  gap/capacity audit returned READY_WITH_CAP at 4,000 words, correctly rejecting
+  the original 5,000-word stretch without ML-specific arXiv growth, conference
+  code-policy, or named-maintainer sources. Follow-up edits reduced the cap,
+  reframed TensorFlow/PyTorch as contrasting distribution philosophies, and made
+  Papers with Code a later maturation layer.

--- a/docs/research/ai-history/chapters/ch-51-the-open-source-distribution-layer/timeline.md
+++ b/docs/research/ai-history/chapters/ch-51-the-open-source-distribution-layer/timeline.md
@@ -1,5 +1,12 @@
 # Timeline: Chapter 51
 
-- **1991:** arXiv is founded (originally for physics).
-- **2008:** GitHub is founded.
-- **Mid-2010s:** ML researchers en masse shift to arXiv preprints and open-sourcing code.
+- **1991:** arXiv is founded by Paul Ginsparg.
+- **2012:** Official arXiv monthly-submissions CSV sums to 84,603 submissions for the year.
+- **2015-11-07:** GitHub API reports `tensorflow/tensorflow` repository creation.
+- **2015-11-09:** Google announces TensorFlow and says it is open-sourcing the system.
+- **2016-08-13:** GitHub API reports `pytorch/pytorch` repository creation.
+- **2017:** Official arXiv monthly-submissions CSV sums to 123,523 submissions for the year.
+- **2018-05-02:** Meta/Facebook announces PyTorch 1.0 as an open-source AI framework for research and production.
+- **2018-10-29:** GitHub API reports `huggingface/transformers` repository creation; detailed Hugging Face treatment belongs to Chapter 54.
+- **2020:** Official arXiv monthly-submissions CSV sums to 178,329 submissions for the year.
+- **2021:** arXiv Annual Report says Papers with Code integration expanded from AI/ML categories to all arXiv and added dataset links.


### PR DESCRIPTION
## Summary
- Rebuilds Chapter 51 from a scrubbed/yellow skeleton into a verified distribution-infrastructure contract.
- Anchors arXiv, GitHub, TensorFlow, PyTorch, Papers with Code, and reproducibility caveats without claiming open source erased corporate advantage.
- Sets a 4,000-5,000 word cap and blocks fictional paywall/overnight-replication scenes.

## Sources Verified
- arXiv About, category taxonomy, monthly-submissions CSV, and 2021 Annual Report.
- GitHub API repo records for TensorFlow, PyTorch, and Transformers.
- Google TensorFlow open-source announcement and Meta PyTorch 1.0 announcement.
- Zhang et al. 2019 study of GitHub repositories tied to AI papers.

## Checks
- git diff --check -- docs/research/ai-history/chapters/ch-51-the-open-source-distribution-layer
- ASCII scan clean on changed Chapter 51 files
- Guardrail scan run for scrubbed/risky phrases; remaining matches are explicit do-not-say warnings only

## Review Requested
- Claude: source-fidelity / anchor review.
- Gemini: gap and prose-capacity audit only; no URL or page-anchor generation.

Tracks #406.