### PR TITLE
docs(ai-history): rebuild chapter 52 research contract (#406)

### DIFF
--- a/docs/research/ai-history/chapters/ch-52-bidirectional-context/brief.md
+++ b/docs/research/ai-history/chapters/ch-52-bidirectional-context/brief.md
@@ -1,25 +1,45 @@
 # Brief: Chapter 52 - Bidirectional Context
 
 ## Thesis
-While early language models read text strictly left-to-right, true comprehension requires understanding the entire context. BERT (Bidirectional Encoder Representations from Transformers) proved that reading a sentence in both directions simultaneously—leveraging the parallel nature of the Transformer—created profoundly deeper semantic representations.
+
+BERT did not prove machine "comprehension" in the human sense. It showed that Transformer encoders could be pre-trained as deep bidirectional language representations, then fine-tuned across many NLP tasks with minimal task-specific architecture changes. The key move was infrastructural: expensive unsupervised pre-training on BooksCorpus plus Wikipedia produced a reusable checkpoint; comparatively cheap fine-tuning moved value from training every task from scratch to adapting a shared representation.
 
 ## Scope
-- IN SCOPE: Jacob Devlin, Google AI, the 2018 BERT paper, Masked Language Modeling (MLM), fine-tuning vs. training from scratch.
-- OUT OF SCOPE: GPT series (Chapter 53).
+
+- IN SCOPE: Devlin, Chang, Lee, and Toutanova; Google AI Language; BERT paper; deep bidirectionality vs. left-to-right GPT and shallow ELMo-style bidirectionality; masked language modeling; next sentence prediction; BooksCorpus/Wikipedia pre-training; Cloud TPU pre-training cost; fine-tuning economics; released code and pre-trained models; GLUE/SQuAD/SWAG results as reported by the paper/blog.
+- OUT OF SCOPE: GPT-2 and left-to-right generative scaling (Chapter 53); Hugging Face model distribution layer (Chapter 54); scaling-law formalism (Chapter 55); later critiques of NSP unless used as a short caveat.
+
+## Boundary Contract
+
+Do not say BERT achieved "true comprehension" or "read both directions simultaneously" as a human analogy. Safer wording: BERT's Transformer encoder uses bidirectional self-attention, and MLM lets training condition token prediction on both left and right context without letting the target trivially see itself.
+
+Do not invent a graduate-student download scene, exact dollar costs, or a single-GPU two-hour story. The paper and Google blog support a narrower claim: fine-tuning from released pre-trained models can take at most one hour on a single Cloud TPU or a few hours on a GPU for the paper's tasks; SQuAD can train around 30 minutes on a single Cloud TPU.
 
 ## Scenes Outline
-1. **The Unidirectional Limit:** Reading left-to-right misses crucial context (e.g., "bank" means different things in "river bank" vs "bank account").
-2. **The Masking Game:** Google researchers train a model by blanking out random words in a sentence and forcing the network to guess them using surrounding context.
-3. **The Fine-Tuning Era:** BERT is released open-source, allowing anyone to download the massive pre-trained model and cheaply fine-tune it for specific tasks, democratizing NLP.
+
+1. **The Left-Context Constraint:** GPT-style Transformer language modeling constrained each token to attend leftward; ELMo combined left-to-right and right-to-left representations but was not deeply bidirectional in every layer.
+2. **The Masking Trick:** BERT masks 15% of WordPiece positions, predicts the originals, and uses an 80/10/10 replacement schedule to reduce the pre-train/fine-tune mismatch.
+3. **Sentence Relationships:** BERT also uses next sentence prediction to train relationships between sentence pairs, which the paper ties to QA and NLI tasks.
+4. **The Checkpoint Economy:** Pre-training is expensive: BooksCorpus plus English Wikipedia, 3.3B words, BERTBASE on 4 Cloud TPUs and BERTLARGE on 16 Cloud TPUs, four days. Fine-tuning from the checkpoint is relatively inexpensive.
+5. **The Benchmark Break:** The paper reports state-of-the-art results on 11 NLP tasks, including GLUE, SQuAD, and SWAG, with the same pre-trained model adapted by fine-tuning.
+6. **The Open Release:** Google open-sources code and pre-trained models, making the checkpoint a distribution artifact that bridges Chapter 51's code layer and Chapter 54's model hub layer.
 
 ## 4k-7k Prose Capacity Plan
 
-This chapter can support a long narrative only if it is built from verified layers rather than padding:
+This chapter can support a 4,000-5,000 word draft from the current source set:
 
-- 500-800 words: Historical context and setup, bridging from the previous era.
-- 933-1233 words: Detailed narrative surrounding The Unidirectional Limit:, heavily anchored to primary sources.
-- 933-1233 words: Detailed narrative surrounding The Masking Game:, heavily anchored to primary sources.
-- 933-1233 words: Detailed narrative surrounding The Fine-Tuning Era:, heavily anchored to primary sources.
-- 400-700 words: Honest close that summarizes the infrastructural shift and transitions to the next chapter.
+- 450-650 words: bridge from Chapter 51, showing how open papers/code become reusable pre-trained checkpoints.
+- 650-850 words: prior representation-learning context from the BERT paper and Google blog: GPT, ELMo, ULMFiT, feature-based vs. fine-tuning strategies.
+- 750-950 words: accessible explanation of MLM, the [MASK] mismatch, the 80/10/10 replacement schedule, and why this enables deep bidirectionality.
+- 450-650 words: NSP and input representation: [CLS], [SEP], segment embeddings, sentence-pair handling.
+- 650-850 words: checkpoint economics: BooksCorpus/Wikipedia, TPU pre-training, 110M/340M parameter sizes, and fine-tuning time claims.
+- 600-800 words: benchmark results on GLUE/SQuAD/SWAG and why "same architecture, task-specific outputs" mattered.
+- 350-500 words: honest close: BERT changed NLP workflow but did not solve language understanding; GPT-style generative modeling remains next.
 
-Most layers now have page-level anchors. Do not invent lab drama or dialogue to reach the top of the range. If the verified evidence runs out, cap the chapter.
+Do not stretch to 7,000 words without additional sources on community adoption, early BERT derivatives, or maintainer/user accounts.
+
+## Citation Bar
+
+- Minimum primary sources before prose review: Devlin et al. 2018 BERT paper, Google Research BERT open-source blog, GitHub API/repo metadata for `google-research/bert`.
+- Minimum secondary/context sources before prose review: optional NLP textbook or survey for modern framing; not required for core claims.
+- Current status: core claims are anchored. Community adoption beyond Google release remains Yellow.

--- a/docs/research/ai-history/chapters/ch-52-bidirectional-context/brief.md
+++ b/docs/research/ai-history/chapters/ch-52-bidirectional-context/brief.md
@@ -18,23 +18,24 @@ Do not invent a graduate-student download scene, exact dollar costs, or a single
 ## Scenes Outline
 
 1. **The Left-Context Constraint:** GPT-style Transformer language modeling constrained each token to attend leftward; ELMo combined left-to-right and right-to-left representations but was not deeply bidirectional in every layer.
-2. **The Masking Trick:** BERT masks 15% of WordPiece positions, predicts the originals, and uses an 80/10/10 replacement schedule to reduce the pre-train/fine-tune mismatch.
-3. **Sentence Relationships:** BERT also uses next sentence prediction to train relationships between sentence pairs, which the paper ties to QA and NLI tasks.
-4. **The Checkpoint Economy:** Pre-training is expensive: BooksCorpus plus English Wikipedia, 3.3B words, BERTBASE on 4 Cloud TPUs and BERTLARGE on 16 Cloud TPUs, four days. Fine-tuning from the checkpoint is relatively inexpensive.
-5. **The Benchmark Break:** The paper reports state-of-the-art results on 11 NLP tasks, including GLUE, SQuAD, and SWAG, with the same pre-trained model adapted by fine-tuning.
-6. **The Open Release:** Google open-sources code and pre-trained models, making the checkpoint a distribution artifact that bridges Chapter 51's code layer and Chapter 54's model hub layer.
+2. **Static vs. Contextual Words:** The Google blog's bank/account vs. bank/river example gives the reader a concrete reason contextual representations mattered before the architecture details arrive.
+3. **The Input and Masking Layer:** BERT uses WordPiece tokenization, token/segment/position embeddings, masks 15% of WordPiece positions, predicts the originals, and uses an 80/10/10 replacement schedule to reduce the pre-train/fine-tune mismatch.
+4. **Sentence Relationships:** BERT also uses next sentence prediction to train relationships between sentence pairs, which the paper ties to QA and NLI tasks.
+5. **The Checkpoint Economy:** Pre-training is expensive: BooksCorpus plus English Wikipedia, 3.3B words, BERTBASE on 4 Cloud TPUs and BERTLARGE on 16 Cloud TPUs, four days. Fine-tuning from the checkpoint is relatively inexpensive.
+6. **The Benchmark Break:** The paper reports state-of-the-art results on 11 NLP tasks, including GLUE, SQuAD, and SWAG, with the same pre-trained model adapted by fine-tuning.
+7. **The Open Release:** Google open-sources code and pre-trained models, making the checkpoint a distribution artifact that bridges Chapter 51's code layer and Chapter 54's model hub layer.
 
 ## 4k-7k Prose Capacity Plan
 
 This chapter can support a 4,000-5,000 word draft from the current source set:
 
 - 450-650 words: bridge from Chapter 51, showing how open papers/code become reusable pre-trained checkpoints.
-- 650-850 words: prior representation-learning context from the BERT paper and Google blog: GPT, ELMo, ULMFiT, feature-based vs. fine-tuning strategies.
-- 750-950 words: accessible explanation of MLM, the [MASK] mismatch, the 80/10/10 replacement schedule, and why this enables deep bidirectionality.
+- 650-850 words: prior representation-learning context from the BERT paper and Google blog: static vs. contextual embeddings, GPT, ELMo, ULMFiT, feature-based vs. fine-tuning strategies.
+- 800-1,000 words: the input and masking layer: WordPiece vocabulary, token/segment/position embeddings, MLM, the [MASK] mismatch, the 80/10/10 replacement schedule, and why this enables deep bidirectionality.
 - 450-650 words: NSP and input representation: [CLS], [SEP], segment embeddings, sentence-pair handling.
 - 650-850 words: checkpoint economics: BooksCorpus/Wikipedia, TPU pre-training, 110M/340M parameter sizes, and fine-tuning time claims.
 - 600-800 words: benchmark results on GLUE/SQuAD/SWAG and why "same architecture, task-specific outputs" mattered.
-- 350-500 words: honest close: BERT changed NLP workflow but did not solve language understanding; GPT-style generative modeling remains next.
+- 550-700 words: released artifact and honest close: code, pre-trained models, checkpoint-as-infrastructure, and the boundary that BERT changed NLP workflow but did not solve language understanding; GPT-style generative modeling remains next.
 
 Do not stretch to 7,000 words without additional sources on community adoption, early BERT derivatives, or maintainer/user accounts.
 

--- a/docs/research/ai-history/chapters/ch-52-bidirectional-context/infrastructure-log.md
+++ b/docs/research/ai-history/chapters/ch-52-bidirectional-context/infrastructure-log.md
@@ -1,5 +1,31 @@
 # Infrastructure Log: Chapter 52
 
 ## Technical Metrics & Constraints
-- **Fine-Tuning Economics:**
-  - Shift: Training BERT from scratch cost thousands of dollars in TPU time. But downloading the pre-trained weights and fine-tuning it on a single GPU cost only a few dollars, creating a new economic model for AI development.
+- **Model sizes:**
+  - BERTBASE: 12 layers, hidden size 768, 12 attention heads, 110M parameters.
+  - BERTLARGE: 24 layers, hidden size 1024, 16 attention heads, 340M parameters.
+
+- **Pre-training corpus:**
+  - BooksCorpus: 800M words.
+  - English Wikipedia: 2,500M words.
+  - Paper emphasizes document-level corpus for long contiguous sequences.
+
+- **Pre-training hardware and time:**
+  - BERTBASE: 4 Cloud TPUs in Pod configuration, 16 TPU chips total.
+  - BERTLARGE: 16 Cloud TPUs, 64 TPU chips total.
+  - Each pre-training run took 4 days.
+
+- **Fine-tuning economics:**
+  - Paper says fine-tuning is relatively inexpensive compared with pre-training.
+  - All paper results can be replicated in at most 1 hour on a single Cloud TPU or a few hours on a GPU, starting from the same pre-trained model.
+  - Google blog says a state-of-the-art question answering system can be trained in about 30 minutes on a single Cloud TPU or a few hours on a single GPU.
+
+- **Release artifact:**
+  - Google blog: release includes TensorFlow source code and pre-trained language representation models.
+  - GitHub API extraction on 2026-04-28: `google-research/bert` created 2018-10-25.
+
+## Do Not Say
+
+- Do not translate hardware time into dollar cost without a source.
+- Do not say fine-tuning equals training BERT from scratch.
+- Do not say BERT "understands" language in an unqualified human sense.

--- a/docs/research/ai-history/chapters/ch-52-bidirectional-context/infrastructure-log.md
+++ b/docs/research/ai-history/chapters/ch-52-bidirectional-context/infrastructure-log.md
@@ -5,6 +5,11 @@
   - BERTBASE: 12 layers, hidden size 768, 12 attention heads, 110M parameters.
   - BERTLARGE: 24 layers, hidden size 1024, 16 attention heads, 340M parameters.
 
+- **Input representation:**
+  - WordPiece embeddings with a 30,000 token vocabulary.
+  - Input representation sums token, segment, and position embeddings.
+  - Sentence pairs use [SEP] and learned sentence A/B segment embeddings; [CLS] is used as aggregate representation for classification.
+
 - **Pre-training corpus:**
   - BooksCorpus: 800M words.
   - English Wikipedia: 2,500M words.
@@ -23,6 +28,7 @@
 - **Release artifact:**
   - Google blog: release includes TensorFlow source code and pre-trained language representation models.
   - GitHub API extraction on 2026-04-28: `google-research/bert` created 2018-10-25.
+  - Treat the repository/checkpoint as a bridge from paper/code distribution to later model-hub infrastructure, not as a full Chapter 54 substitute.
 
 ## Do Not Say
 

--- a/docs/research/ai-history/chapters/ch-52-bidirectional-context/open-questions.md
+++ b/docs/research/ai-history/chapters/ch-52-bidirectional-context/open-questions.md
@@ -1,3 +1,20 @@
 # Open Questions
 
-- SCRUBBED: All claims downgraded to Yellow. Need REAL, empirical page/section anchors from verified online PDFs or archives. Do not hallucinate.
+## Blocking Before Draft?
+
+No blocker for a capped 4,000-5,000 word draft after cross-family review. Core mechanics, data, hardware, benchmark, and release claims are anchored.
+
+## Expansion Targets
+
+- Find an independent NLP survey or textbook anchor if the prose wants to say BERT "became the dominant paradigm" beyond the paper's own reported success.
+- Find early community adoption or derivative-model sources if the chapter needs more than Google's release framing.
+- Check exact Google blog publication date from page metadata if a date beyond year is needed in prose.
+- Optional: add GLUE/SQuAD/SWAG original benchmark papers if reviewer wants independent benchmark context.
+
+## Red-Line Warnings
+
+- No "true comprehension."
+- No invented graduate-student download scene.
+- No dollar-cost estimates.
+- No claim that pre-training was cheap or accessible to everyone.
+- No treating BERT as the end of NLP history; GPT-style generative scaling follows immediately.

--- a/docs/research/ai-history/chapters/ch-52-bidirectional-context/open-questions.md
+++ b/docs/research/ai-history/chapters/ch-52-bidirectional-context/open-questions.md
@@ -10,6 +10,7 @@ No blocker for a capped 4,000-5,000 word draft after cross-family review. Core m
 - Find early community adoption or derivative-model sources if the chapter needs more than Google's release framing.
 - Check exact Google blog publication date from page metadata if a date beyond year is needed in prose.
 - Optional: add GLUE/SQuAD/SWAG original benchmark papers if reviewer wants independent benchmark context.
+- Add a source on WordPiece/OOV history only if the prose wants to discuss out-of-vocabulary problems; current contract only supports WordPiece as BERT's tokenization/input representation.
 
 ## Red-Line Warnings
 
@@ -17,4 +18,5 @@ No blocker for a capped 4,000-5,000 word draft after cross-family review. Core m
 - No invented graduate-student download scene.
 - No dollar-cost estimates.
 - No claim that pre-training was cheap or accessible to everyone.
+- No claim that WordPiece solved OOV unless sourced.
 - No treating BERT as the end of NLP history; GPT-style generative scaling follows immediately.

--- a/docs/research/ai-history/chapters/ch-52-bidirectional-context/people.md
+++ b/docs/research/ai-history/chapters/ch-52-bidirectional-context/people.md
@@ -1,4 +1,18 @@
 # People: Chapter 52
 
 ## Verified Protagonists
-- **Jacob Devlin & Ming-Wei Chang:** Lead authors of the BERT paper at Google AI.
+- **Jacob Devlin:** BERT co-author and co-author of the Google Research open-source announcement.
+- **Ming-Wei Chang:** BERT co-author and co-author of the Google Research open-source announcement.
+- **Kenton Lee:** BERT co-author.
+- **Kristina Toutanova:** BERT co-author.
+- **Google AI Language / Google Research:** Institutional context for the paper, released code, and pre-trained models.
+
+## Context Figures
+
+- **Matthew Peters / ELMo team:** Prior contextual representation line, named by BERT paper and Google blog.
+- **OpenAI GPT team:** Left-to-right Transformer pre-training comparison point, owned by Chapter 53.
+- **Howard and Ruder / ULMFiT:** Fine-tuning precedent named in the Google blog and BERT paper context.
+
+## Guardrail
+
+Do not invent lab scenes, internal meetings, or user stories. The current human layer is paper authorship and public release framing.

--- a/docs/research/ai-history/chapters/ch-52-bidirectional-context/scene-sketches.md
+++ b/docs/research/ai-history/chapters/ch-52-bidirectional-context/scene-sketches.md
@@ -1,10 +1,31 @@
 # Scene Sketches: Chapter 52
 
-## Scene 1: Left to Right
-- **Action:** Pedagogical explanation of why reading sequentially limits understanding.
+## Scene 1: The Left-Context Constraint
+- **Action:** Explain GPT-style constrained self-attention and ELMo-style shallow bidirectionality as the setup for BERT's "deeply bidirectional" claim.
+- **Evidence anchors:** BERT Section 1, Section 3, Figure 3; Google blog "What Makes BERT Different?"
+- **Drafting warning:** Do not say left-to-right models have no value or no context. The precise claim is that they cannot condition each token on both left and right context at every layer during pre-training.
 
-## Scene 2: Fill in the Blank
-- **Action:** The model is given a sentence with missing words and must use both the left and right context to guess them, forcing it to learn deep grammar and semantics.
+## Scene 2: The Masking Trick
+- **Action:** Show why naive bidirectional prediction would let a token see itself, then introduce MLM as the workaround: mask selected tokens and predict the originals.
+- **Evidence anchors:** BERT Section 3.1; Google blog masking example.
+- **Drafting warning:** Keep the 15% and 80/10/10 mechanics exact.
 
-## Scene 3: The Download
-- **Action:** A graduate student downloads the pre-trained BERT model and achieves state-of-the-art results on a custom dataset in just two hours on a single GPU.
+## Scene 3: Sentence-Pair Plumbing
+- **Action:** Explain [CLS], [SEP], segment embeddings, and NSP as infrastructure for QA, NLI, paraphrase, and other paired-input tasks.
+- **Evidence anchors:** BERT Section 3 input representation and NSP; Section 3.2 fine-tuning examples.
+- **Drafting warning:** Later critique of NSP is not a blocker; do not retroactively judge the 2018 result unless sourced.
+
+## Scene 4: The Checkpoint Economy
+- **Action:** Contrast expensive pre-training with relatively cheap fine-tuning from the released checkpoint.
+- **Evidence anchors:** BERT Appendix A.2; BERT Section 3.2; Google blog release.
+- **Drafting warning:** No dollar-cost estimates. Use hardware/time: 4/16 Cloud TPUs for pre-training; one Cloud TPU or a few GPU hours for fine-tuning.
+
+## Scene 5: The Benchmark Break
+- **Action:** Move through GLUE, SQuAD, and SWAG as receipts that the same pre-trained model could be adapted across task families.
+- **Evidence anchors:** BERT Abstract; Section 4; Tables 1-4; Google blog results section.
+- **Drafting warning:** Do not imply leaderboard permanence. Say "reported" or "at the time of the paper/blog."
+
+## Scene 6: The Released Artifact
+- **Action:** End with source code and pre-trained models as distribution artifacts: BERT is a checkpoint people can adapt, not merely a paper to read.
+- **Evidence anchors:** Google blog; GitHub API; BERT paper code note.
+- **Drafting warning:** Hugging Face and general model hubs stay in Chapter 54.

--- a/docs/research/ai-history/chapters/ch-52-bidirectional-context/scene-sketches.md
+++ b/docs/research/ai-history/chapters/ch-52-bidirectional-context/scene-sketches.md
@@ -5,27 +5,32 @@
 - **Evidence anchors:** BERT Section 1, Section 3, Figure 3; Google blog "What Makes BERT Different?"
 - **Drafting warning:** Do not say left-to-right models have no value or no context. The precise claim is that they cannot condition each token on both left and right context at every layer during pre-training.
 
-## Scene 2: The Masking Trick
-- **Action:** Show why naive bidirectional prediction would let a token see itself, then introduce MLM as the workaround: mask selected tokens and predict the originals.
-- **Evidence anchors:** BERT Section 3.1; Google blog masking example.
-- **Drafting warning:** Keep the 15% and 80/10/10 mechanics exact.
+## Scene 2: Static vs. Contextual Words
+- **Action:** Use the Google blog's bank/account and bank/river contrast to explain why context-free embeddings were insufficient for the BERT argument.
+- **Evidence anchors:** Google blog "What Makes BERT Different?"; BERT Section 1.
+- **Drafting warning:** This is a pedagogical hook, not proof of human-like understanding.
 
-## Scene 3: Sentence-Pair Plumbing
+## Scene 3: The Input and Masking Layer
+- **Action:** Show why naive bidirectional prediction would let a token see itself, then introduce BERT's input representation and MLM workaround: WordPiece tokens, token/segment/position embeddings, selected-token masking, and original-token prediction.
+- **Evidence anchors:** BERT Section 3 and Figure 2; BERT Section 3.1; Google blog masking example.
+- **Drafting warning:** Keep the 30,000 WordPiece vocabulary, 15% masking, and 80/10/10 mechanics exact. Do not claim WordPiece solved OOV unless sourced.
+
+## Scene 4: Sentence-Pair Plumbing
 - **Action:** Explain [CLS], [SEP], segment embeddings, and NSP as infrastructure for QA, NLI, paraphrase, and other paired-input tasks.
 - **Evidence anchors:** BERT Section 3 input representation and NSP; Section 3.2 fine-tuning examples.
 - **Drafting warning:** Later critique of NSP is not a blocker; do not retroactively judge the 2018 result unless sourced.
 
-## Scene 4: The Checkpoint Economy
+## Scene 5: The Checkpoint Economy
 - **Action:** Contrast expensive pre-training with relatively cheap fine-tuning from the released checkpoint.
 - **Evidence anchors:** BERT Appendix A.2; BERT Section 3.2; Google blog release.
 - **Drafting warning:** No dollar-cost estimates. Use hardware/time: 4/16 Cloud TPUs for pre-training; one Cloud TPU or a few GPU hours for fine-tuning.
 
-## Scene 5: The Benchmark Break
+## Scene 6: The Benchmark Break
 - **Action:** Move through GLUE, SQuAD, and SWAG as receipts that the same pre-trained model could be adapted across task families.
 - **Evidence anchors:** BERT Abstract; Section 4; Tables 1-4; Google blog results section.
 - **Drafting warning:** Do not imply leaderboard permanence. Say "reported" or "at the time of the paper/blog."
 
-## Scene 6: The Released Artifact
+## Scene 7: The Released Artifact
 - **Action:** End with source code and pre-trained models as distribution artifacts: BERT is a checkpoint people can adapt, not merely a paper to read.
 - **Evidence anchors:** Google blog; GitHub API; BERT paper code note.
 - **Drafting warning:** Hugging Face and general model hubs stay in Chapter 54.

--- a/docs/research/ai-history/chapters/ch-52-bidirectional-context/sources.md
+++ b/docs/research/ai-history/chapters/ch-52-bidirectional-context/sources.md
@@ -1,16 +1,54 @@
-# Sources: Chapter 52
+# Sources: Chapter 52 - Bidirectional Context
 
-## Claim Matrix
+## Verification Key
 
-| Claim | Scene | Primary Source | Secondary Confirmation | Verification | Conflict |
+- Green: claim has primary evidence plus independent confirmation or internally corroborating paper sections/tables.
+- Yellow: claim has one strong source, dynamic metadata, or broad cultural inference.
+- Red: claim should not be drafted except as blocked framing.
+
+## Primary Sources
+
+| Source | Use | Verification |
+|---|---|---|
+| Jacob Devlin, Ming-Wei Chang, Kenton Lee, Kristina Toutanova, "BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding," arXiv:1810.04805, 2018. URL: https://arxiv.org/pdf/1810.04805 | Core source for architecture, MLM, NSP, pre-training/fine-tuning, data, TPU training, benchmark results, and ablations. | Green: Abstract says BERT is designed to pre-train deep bidirectional representations from unlabeled text by conditioning on both left and right context in all layers, and that fine-tuning adds one output layer; Section 1 contrasts feature-based and fine-tuning approaches and says standard language models are unidirectional; Section 3 defines the two-step pre-training/fine-tuning framework; Section 3.1 defines MLM, 15% WordPiece masking, 80/10/10 replacement, and NSP; Section 3.2 says fine-tuning is relatively inexpensive and gives the single Cloud TPU/few GPU-hours claim; Section 4 reports 11 NLP task results; Section 5.1 ablates NSP and left-to-right models; Appendix A.2 gives BooksCorpus/Wikipedia, 4/16 Cloud TPU pre-training, and 4-day runs. |
+| Google Research, "Open Sourcing BERT: State-of-the-Art Pre-training for Natural Language Processing," 2018. URL: https://research.google/blog/open-sourcing-bert-state-of-the-art-pre-training-for-natural-language-processing/ | Release framing, code/model availability, public explanation of bidirectionality, benchmark claims, and infrastructure bridge. | Green: page says Google open sourced BERT; release included TensorFlow source code and pre-trained language representation models; anyone can train a state-of-the-art question-answering system in about 30 minutes on a single Cloud TPU or a few hours on a single GPU; BERT builds on GPT, ELMo, ULMFiT, etc.; it explains bank/account vs bank/river context; states Cloud TPUs and Transformer architecture were critical; reports SQuAD and GLUE improvements. |
+| GitHub REST API record for `google-research/bert`. URL: https://api.github.com/repos/google-research/bert | Repository creation date and current repository metadata. | Green for creation date extracted on 2026-04-28: repo created 2018-10-25. Yellow for stars/forks because they are dynamic current metrics. |
+
+## Secondary and Context Sources
+
+| Source | Use | Verification |
+|---|---|---|
+| Dan Jurafsky and James H. Martin, *Speech and Language Processing*, 3rd ed. draft. | Optional textbook framing for contextual embeddings and Transformer encoders. | Yellow until exact chapter/section anchor is extracted. |
+| GLUE, SQuAD, SWAG benchmark papers and leaderboards. | Optional independent benchmark context. | Yellow unless used directly; BERT paper and Google blog are enough for reported BERT results. |
+| Wikipedia pages on BERT, contextual embeddings, and masked language modeling. | Discovery aid only. | Yellow/Red for citation: do not use as final prose anchor. |
+
+## Scene-Level Claim Table
+
+| Claim | Scene | Primary Anchor | Independent Confirmation | Status | Notes |
 |---|---|---|---|---|---|
-| Unidirectional models failed to capture deep context | 1 | Devlin et al. 2018 (BERT) | Jurafsky & Martin 2024 | Yellow | Need exact verified page/section anchors. |
-| BERT used Masked Language Modeling to train bidirectionally | 2 | Devlin et al. 2018 | Jurafsky & Martin 2024 | Yellow | Need exact verified page/section anchors. |
-| Pre-training and fine-tuning became the dominant NLP paradigm | 3 | Devlin et al. 2018 | N/A | Yellow | Need a secondary source confirming the industry-wide shift. |
+| BERT's distinguishing claim is deep bidirectional pre-training, not human-like comprehension. | Left-Context Constraint | BERT Abstract; Section 1; Google blog "What Makes BERT Different?" | BERT Section 5.1 ablation | Green | Use "representations," not "understanding" except in paper-title context. |
+| GPT-style Transformer pre-training used constrained left-context attention, while BERT used bidirectional self-attention in the encoder. | Left-Context Constraint | BERT Section 3 model architecture; Figure 3 | Google blog architecture comparison | Green | Keep GPT details short; Chapter 53 owns GPT. |
+| MLM masks 15% of WordPiece positions and predicts original tokens; BERT uses 80% [MASK], 10% random token, 10% unchanged token among selected positions. | Masking Trick | BERT Section 3.1 | Google blog explanation | Green | Good pedagogical core. |
+| NSP trains whether sentence B follows sentence A, with 50% IsNext and 50% NotNext examples. | Sentence Relationships | BERT Section 3.1 | BERT Section 5.1 ablation | Green | Later literature may critique NSP; not needed here unless framed as future caveat. |
+| BERT uses [CLS], [SEP], token, segment, and position embeddings to support sentence and sentence-pair tasks. | Sentence Relationships | BERT Section 3; Figure 2 | BERT fine-tuning sections | Green | Useful for explaining why one checkpoint can serve many task formats. |
+| Pre-training used BooksCorpus (800M words) plus English Wikipedia (2,500M words). | Checkpoint Economy | BERT Appendix A.2 / Pre-training data | Google blog says pre-training uses unannotated web text/Wikipedia | Green | Use exact corpus names from paper. |
+| BERTBASE and BERTLARGE had 110M and 340M parameters respectively. | Checkpoint Economy | BERT Section 3 model architecture | BERT Appendix A.2 training setup | Green | Parameter scale helps explain checkpoint value. |
+| BERTBASE trained on 4 Cloud TPUs, BERTLARGE on 16 Cloud TPUs, and each pre-training took 4 days. | Checkpoint Economy | BERT Appendix A.2 | Google blog Cloud TPU discussion | Green | Blocks invented dollar-cost claims. |
+| Fine-tuning was relatively inexpensive compared with pre-training: paper says all results can be replicated in at most 1 hour on a single Cloud TPU or a few hours on a GPU from the same pre-trained model. | Checkpoint Economy | BERT Section 3.2 | Google blog release framing | Green | Use exact wording; no dollar estimates. |
+| BERT reported state-of-the-art results on 11 NLP tasks including GLUE, SQuAD, and SWAG. | Benchmark Break | BERT Abstract; Section 4; Tables 1-4 | Google blog results section | Green | Cite reported results, not permanent leaderboard dominance. |
+| Google open-sourced BERT code and pre-trained models. | Open Release | Google blog; BERT paper code note | GitHub API repo creation date | Green | Bridge to Ch51/Ch54. |
+| A 4,000-5,000 word chapter is feasible from current sources, but community adoption should stay Yellow without more sources. | All | This source table and brief capacity plan | Ch50/Ch51 contract pattern | Green/Yellow | Do not pad with invented user stories. |
 
-## Bibliography
-### Primary
-- **Devlin, Jacob, et al. "Bert: Pre-training of deep bidirectional transformers for language understanding." *arXiv preprint arXiv:1810.04805* (2018).**
+## Conflict Notes
 
-### Secondary
-- **Jurafsky, Dan, and James H. Martin. *Speech and Language Processing*. 3rd ed. draft, 2024.**
+- Do not write "true comprehension" except to reject it.
+- Do not write "anyone could cheaply train BERT from scratch." The release made fine-tuning accessible; pre-training remained expensive.
+- Do not invent dollar costs. Use TPU/GPU time claims from the paper/blog.
+- Do not make BERT a GPT chapter. GPT-style left-to-right modeling is context, not the center.
+- Do not claim BERT was the final dominant NLP paradigm. Later GPT-style generative models change the story in Chapter 53.
+
+## Page/Section Anchor Worklist
+
+- BERT paper: Done for Abstract, Sections 1, 3, 3.1, 3.2, 4, 5.1, Appendix A.2, Tables 1-5, and Figure 3.
+- Google BERT blog: Done for open-source release, public bidirectionality explanation, code/model release, TPU/GPU fine-tuning claims, and results framing.
+- GitHub API: Done for `google-research/bert` creation date.

--- a/docs/research/ai-history/chapters/ch-52-bidirectional-context/sources.md
+++ b/docs/research/ai-history/chapters/ch-52-bidirectional-context/sources.md
@@ -28,6 +28,8 @@
 |---|---|---|---|---|---|
 | BERT's distinguishing claim is deep bidirectional pre-training, not human-like comprehension. | Left-Context Constraint | BERT Abstract; Section 1; Google blog "What Makes BERT Different?" | BERT Section 5.1 ablation | Green | Use "representations," not "understanding" except in paper-title context. |
 | GPT-style Transformer pre-training used constrained left-context attention, while BERT used bidirectional self-attention in the encoder. | Left-Context Constraint | BERT Section 3 model architecture; Figure 3 | Google blog architecture comparison | Green | Keep GPT details short; Chapter 53 owns GPT. |
+| Static/context-free embeddings represent the same word similarly across contexts, while contextual representations vary by surrounding words. | Static vs. Contextual Words | Google blog bank/account vs. bank/river explanation | BERT Section 1 representation-learning framing | Green | Use as pedagogical hook; do not overclaim semantic comprehension. |
+| BERT uses WordPiece embeddings with a 30,000 token vocabulary plus token, segment, and position embeddings. | Input and Masking Layer | BERT Section 3 Input/Output Representations; Figure 2 | MLM mechanics in Section 3.1 | Green | Do not claim WordPiece "solved OOV" unless another source is added. |
 | MLM masks 15% of WordPiece positions and predicts original tokens; BERT uses 80% [MASK], 10% random token, 10% unchanged token among selected positions. | Masking Trick | BERT Section 3.1 | Google blog explanation | Green | Good pedagogical core. |
 | NSP trains whether sentence B follows sentence A, with 50% IsNext and 50% NotNext examples. | Sentence Relationships | BERT Section 3.1 | BERT Section 5.1 ablation | Green | Later literature may critique NSP; not needed here unless framed as future caveat. |
 | BERT uses [CLS], [SEP], token, segment, and position embeddings to support sentence and sentence-pair tasks. | Sentence Relationships | BERT Section 3; Figure 2 | BERT fine-tuning sections | Green | Useful for explaining why one checkpoint can serve many task formats. |
@@ -44,6 +46,7 @@
 - Do not write "true comprehension" except to reject it.
 - Do not write "anyone could cheaply train BERT from scratch." The release made fine-tuning accessible; pre-training remained expensive.
 - Do not invent dollar costs. Use TPU/GPU time claims from the paper/blog.
+- Do not claim WordPiece solved the out-of-vocabulary problem unless a source is added.
 - Do not make BERT a GPT chapter. GPT-style left-to-right modeling is context, not the center.
 - Do not claim BERT was the final dominant NLP paradigm. Later GPT-style generative models change the story in Chapter 53.
 

--- a/docs/research/ai-history/chapters/ch-52-bidirectional-context/status.yaml
+++ b/docs/research/ai-history/chapters/ch-52-bidirectional-context/status.yaml
@@ -1,1 +1,19 @@
 status: researching
+owner: Codex
+part: 8
+chapter: 52
+review_state: codex_rebuilt_scrubbed_contract_needs_cross_family_review
+last_updated: 2026-04-28
+green_claims: 11
+yellow_claims: 3
+red_claims: 5
+prose_word_cap_recommendation: 5000
+notes: |
+  Rebuilt the scrubbed/yellow contract from verified online sources: Devlin et al.
+  2018 BERT paper, Google Research BERT open-source announcement, and GitHub API
+  metadata for google-research/bert.
+
+  Strongest safe prose range: 4,000-5,000 words. Core mechanics, data, training
+  hardware, fine-tuning economics, benchmark claims, and open-release artifacts
+  are anchored. Expansion above 5,000 words needs independent adoption sources,
+  benchmark papers, or maintainer/user accounts.

--- a/docs/research/ai-history/chapters/ch-52-bidirectional-context/status.yaml
+++ b/docs/research/ai-history/chapters/ch-52-bidirectional-context/status.yaml
@@ -1,19 +1,43 @@
-status: researching
+status: prose_ready
 owner: Codex
 part: 8
 chapter: 52
-review_state: codex_rebuilt_scrubbed_contract_needs_cross_family_review
+review_state: claude_source_approved_2026-04-28;gemini_gap_ready_with_cap_2026-04-28
 last_updated: 2026-04-28
-green_claims: 11
+green_claims: 13
 yellow_claims: 3
 red_claims: 5
 prose_word_cap_recommendation: 5000
+prose_word_cap: 5000
+verdicts:
+  claude:
+    model: claude-opus-4-7
+    date: 2026-04-28
+    verdict: APPROVE
+    review_url: https://github.com/kube-dojo/kube-dojo.github.io/pull/492#issuecomment-4333683369
+  gemini:
+    model: gemini-3-flash-preview
+    requested_model: gemini-3.1-pro-preview
+    date: 2026-04-28
+    verdict: READY_WITH_CAP
+    word_cap: 5000
+    review_url: https://github.com/kube-dojo/kube-dojo.github.io/pull/492#issuecomment-4333694220
+  resolved: READY_TO_DRAFT_WITH_CAP
+  resolved_word_cap: 5000
+  resolution_rule: dual_cross_family_verdict_with_cap
 notes: |
   Rebuilt the scrubbed/yellow contract from verified online sources: Devlin et al.
   2018 BERT paper, Google Research BERT open-source announcement, and GitHub API
   metadata for google-research/bert.
 
-  Strongest safe prose range: 4,000-5,000 words. Core mechanics, data, training
-  hardware, fine-tuning economics, benchmark claims, and open-release artifacts
-  are anchored. Expansion above 5,000 words needs independent adoption sources,
+  Strongest safe prose range: 4,000-5,000 words. Core mechanics, input
+  representation, static-vs-contextual framing, data, training hardware,
+  fine-tuning economics, benchmark claims, and open-release artifacts are
+  anchored. Expansion above 5,000 words needs independent adoption sources,
   benchmark papers, or maintainer/user accounts.
+
+  Claude source-fidelity review approved all load-bearing anchors. Gemini
+  gap/capacity audit returned READY_WITH_CAP at 5,000 words and requested
+  stronger use of WordPiece/input representation, static-vs-contextual framing,
+  and the release artifact. Follow-up edits integrated those points while
+  rejecting the unsourced claim that WordPiece solved OOV.

--- a/docs/research/ai-history/chapters/ch-52-bidirectional-context/timeline.md
+++ b/docs/research/ai-history/chapters/ch-52-bidirectional-context/timeline.md
@@ -1,3 +1,6 @@
 # Timeline: Chapter 52
 
-- **2018:** Google AI publishes the BERT paper and open-sources the pre-trained weights.
+- **2018-10-11:** BERT paper appears on arXiv.
+- **2018-10-25:** GitHub API reports creation of `google-research/bert`.
+- **2018:** Google Research blog announces the open-source release of BERT code and pre-trained models.
+- **2018:** BERT paper reports BERTBASE and BERTLARGE results on GLUE, SQuAD, and SWAG.


### PR DESCRIPTION
## Summary
- Rebuilds Chapter 52 from scrubbed/yellow notes into a verified BERT research contract.
- Replaces unsafe comprehension/dollar-cost/download anecdotes with anchored MLM, NSP, pretraining/fine-tuning, benchmark, and release claims.
- Sets a 4,000-5,000 word cap and keeps GPT/Hugging Face/scaling-law material out of scope.

## Sources Verified
- Devlin et al. 2018 BERT paper: Sections 1, 3, 3.1, 3.2, 4, 5.1, Appendix A.2, Tables/Figure anchors.
- Google Research BERT open-source announcement.
- GitHub API metadata for google-research/bert.

## Checks
- git diff --check -- docs/research/ai-history/chapters/ch-52-bidirectional-context
- ASCII scan clean on changed Chapter 52 files
- Guardrail scan run for scrubbed/risky phrases; remaining matches are explicit do-not-say warnings only

## Review Requested
- Claude: source-fidelity / anchor review.
- Gemini: gap and prose-capacity audit only; no URL or page-anchor generation.

Tracks #406.