### PR TITLE
docs(ai-history): rebuild chapter 54 research contract (#406)

### DIFF
--- a/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/brief.md
+++ b/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/brief.md
@@ -33,3 +33,4 @@ Do not stretch toward 7,000 words without a verified interview or archival sourc
 - Do not claim all models were open, safe, high quality, or production-ready because they appeared on the Hub.
 - Do not invent Dropbox/Google Drive anecdotes unless a source is added. The safe source-backed problem is distribution, caching, fine-tuning, deployment, and framework friction.
 - Do not imply Hugging Face erased corporate advantage. Large pre-training and production deployment still required money, data, expertise, and infrastructure.
+- Do not write "three lines of code" as a sourced claim. The paper's concrete FlauBERT example uses two `from_pretrained(...)` calls.

--- a/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/brief.md
+++ b/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/brief.md
@@ -1,25 +1,35 @@
 # Brief: Chapter 54 - The Hub of Weights
 
 ## Thesis
-As models like BERT and GPT grew massive, the friction of downloading, configuring, and running them became a severe bottleneck. Hugging Face solved this by providing a unified, open-source API and a central hosting hub, becoming the GitHub for machine learning weights and democratizing access to foundation models.
+As Transformer models multiplied, the bottleneck moved from inventing architectures to moving trained weights through a usable ecosystem. Hugging Face did not invent BERT, GPT-2, or pre-training, but Transformers and the Model Hub lowered the practical friction of finding, loading, caching, fine-tuning, comparing, and deploying those models. The chapter should frame Hugging Face as infrastructure for reuse: a layer that made model weights behave less like one-off research artifacts and more like shared software packages.
 
 ## Scope
-- IN SCOPE: Clement Delangue, Thomas Wolf, the pivot of Hugging Face from a chatbot company to the Transformers library, the Model Hub.
-- OUT OF SCOPE: Closed API providers (OpenAI/Anthropic).
+- IN SCOPE: Hugging Face's chatbot origin; the move toward open-source NLP tooling; Transformers as a unified API and framework bridge; the Model Hub as a distribution layer for pretrained/fine-tuned checkpoints; model cards, metadata, inference widgets, caching, two-line loading, and production/deployment bridges.
+- OUT OF SCOPE: Closed API providers except as contrast; post-2023 open-weight LLM politics; safetensors/Xet/Spaces as primary topics unless used as brief present-day epilogue; detailed model internals already covered in Chapters 50-53.
 
 ## Scenes Outline
-1. **The Implementation Nightmare:** Researchers struggle to translate PyTorch code to TensorFlow, or spend days configuring a single model to run locally.
-2. **The Pivot:** A struggling chatbot startup releases a simple open-source wrapper for BERT.
-3. **The GitHub of AI:** The community adopts the Hugging Face Transformers library en masse, standardizing the infrastructure for downloading and running model weights.
+1. **The Research Artifact Problem:** A model paper is not a runnable product. Before a shared distribution layer, users still had to find weights, match tokenizers, load architecture-specific code, choose a framework, and adapt heads for tasks. Use this as a systems problem, not a fictional frustrated developer scene.
+2. **A Chatbot Company Finds the Tooling Problem:** Contemporary TechCrunch coverage establishes Hugging Face's consumer chatbot origin and the 2019 shift toward an open-source NLP library. Present this as a documented company pivot, not as an invented boardroom realization.
+3. **Transformers as an Adapter Layer:** The 2020 EMNLP paper gives the technical center: carefully engineered Transformer variants, a unified API, Auto classes, tokenizers, task heads, PyTorch/TensorFlow interoperability, Rust tokenization, and deployment paths.
+4. **The Model Hub Turns Weights Into Repositories:** The Model Hub makes distribution a community process: 2,097 user models by the paper's 2020 snapshot, canonical names, model pages, model cards, metadata, live inference, and two-line loading from the hub.
+5. **Lowering Friction Without Erasing Power:** Close by balancing the promise and limits. Hugging Face made reuse easier and more communal, but it did not make training cheap, solve model misuse, guarantee model quality, or remove the need to understand licenses, data, bias, and deployment constraints.
 
 ## 4k-7k Prose Capacity Plan
 
-This chapter can support a long narrative only if it is built from verified layers rather than padding:
+Current verified evidence supports a tight 4,000-4,800 word chapter. The infrastructure sources are strong; the human/pivot narrative is thinner and should not be padded with invented internal scenes.
 
-- 500-800 words: Historical context and setup, bridging from the previous era.
-- 933-1233 words: Detailed narrative surrounding The Implementation Nightmare:, heavily anchored to primary sources.
-- 933-1233 words: Detailed narrative surrounding The Pivot:, heavily anchored to primary sources.
-- 933-1233 words: Detailed narrative surrounding The GitHub of AI:, heavily anchored to primary sources.
-- 400-700 words: Honest close that summarizes the infrastructural shift and transitions to the next chapter.
+- 500-700 words: Bridge from GPT-2/GPT-3 and BERT: models were increasingly reusable, but reuse required packaging and distribution.
+- 600-800 words: Hugging Face's chatbot origin and the 2019 TechCrunch pivot evidence.
+- 1,000-1,300 words: Transformers library design: unified API, model/tokenizer/head abstraction, Auto classes, framework interoperability, caching/fine-tuning/deployment.
+- 900-1,100 words: Model Hub mechanics: community uploads, 2,097 models in the 2020 paper snapshot, canonical names, two-line loading, model pages, model cards, live inference, case studies.
+- 500-900 words: Limits and transition: model hubs reduce reuse friction but do not solve compute, quality, licensing, safety, or the scaling-law incentives of Chapter 55.
 
-Most layers now have page-level anchors. Do not invent lab drama or dialogue to reach the top of the range. If the verified evidence runs out, cap the chapter.
+Do not stretch toward 7,000 words without a verified interview or archival source on the internal pivot, community adoption, or early Model Hub operations.
+
+## Guardrails
+
+- Do not write that Hugging Face "solved" access to AI. It lowered practical friction for open/shared models.
+- Do not write "GitHub for AI" as a sourced fact. If used, label it as a metaphor and prefer the grounded phrase "Git-based repository and model hub."
+- Do not claim all models were open, safe, high quality, or production-ready because they appeared on the Hub.
+- Do not invent Dropbox/Google Drive anecdotes unless a source is added. The safe source-backed problem is distribution, caching, fine-tuning, deployment, and framework friction.
+- Do not imply Hugging Face erased corporate advantage. Large pre-training and production deployment still required money, data, expertise, and infrastructure.

--- a/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/infrastructure-log.md
+++ b/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/infrastructure-log.md
@@ -1,5 +1,17 @@
 # Infrastructure Log: Chapter 54
 
 ## Technical Metrics & Constraints
-- **The Standardization Layer:**
-  - Infrastructure: Hugging Face provided the missing middleware. Before, weights were shared via random Dropbox/Google Drive links. The Hub provided version control, APIs, and standardized inference scripts.
+- **Repository creation:** GitHub API reports `huggingface/transformers` was created 2018-10-29. Current stars/forks are dynamic and should not be used as historical facts.
+- **Library scope in the 2020 paper:** Open-source Apache 2.0 library, available on GitHub, maintained by Hugging Face with support from over 400 external contributors.
+- **Core abstractions:** Tokenizer, Transformer base model, and task head. Auto classes provide a unified API for fast switching between models and frameworks.
+- **Model Hub 2020 snapshot:** The Transformers paper reports 2,097 user models in the Model Hub.
+- **Model Hub mechanics:** Uploaded models receive canonical names, model pages, metadata, model cards, and optional live inference widgets. The paper's FlauBERT example loads tokenizer and model with `AutoTokenizer.from_pretrained(...)` and `AutoModel.from_pretrained(...)`.
+- **Framework bridge:** The paper says models are available in PyTorch and TensorFlow with interoperability; legacy v4.0.1 docs describe deep interoperability between TensorFlow 2.0 and PyTorch.
+- **Deployment bridge:** The paper mentions TorchScript, TensorFlow serving options, ONNX, JAX/XLA, TVM, and CoreML as deployment/intermediate-format paths.
+- **Present-day Hub framing:** Current Hub docs describe models, datasets, and spaces as Git repositories, with version control and collaboration as core elements. Use this only as present-day continuity.
+
+## Unknowns / Do Not Invent
+- Exact internal decision process for the chatbot-to-library pivot is not anchored.
+- Exact first release date of the original PyTorch BERT wrapper is not anchored beyond the GitHub repo creation date.
+- Current Hub model counts are not historical 2020 counts.
+- Production success stories beyond the paper's case studies are not anchored.

--- a/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/open-questions.md
+++ b/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/open-questions.md
@@ -1,3 +1,21 @@
 # Open Questions
 
-- SCRUBBED: All claims downgraded to Yellow. Need REAL, empirical page/section anchors from verified online PDFs or archives. Do not hallucinate.
+## Resolved for Drafting
+
+- Transformers paper anchors are available for unified API, abstractions, Model Hub, contributors, 2,097 user models, model cards, two-line loading, and deployment bridges.
+- Legacy v4.0.1 docs anchor the `pytorch-transformers` / `pytorch-pretrained-bert` names, 32+ pretrained models, 100+ languages, and PyTorch/TensorFlow interoperability framing.
+- TechCrunch 2017 and 2019 anchors are available for chatbot origin and contemporary pivot coverage.
+- GitHub API anchors the `huggingface/transformers` repository creation date.
+- Current Hugging Face Hub docs anchor present-day Git repository and Model Hub framing.
+
+## Remaining Gaps
+
+- A first-person or archival account of the internal pivot is not anchored. Do not dramatize it.
+- Exact first public release details for the original BERT wrapper are not anchored beyond repository creation and later docs/paper history.
+- Community reaction beyond TechCrunch-reported download/star snapshots is not anchored.
+- Current model-count statistics are not needed and should not be projected backward.
+- Licensing/safety controversies around model hubs are outside this chapter unless a source is added.
+
+## Prose-Readiness Note
+
+This contract is prose-ready for a 4,000-4,800 word chapter. Expanding beyond that requires stronger sources on the internal pivot, early user adoption, or specific Model Hub operations.

--- a/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/people.md
+++ b/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/people.md
@@ -1,4 +1,11 @@
 # People: Chapter 54
 
 ## Verified Protagonists
-- **Clement Delangue & Thomas Wolf:** Co-founders of Hugging Face.
+- **Clement Delangue:** Hugging Face co-founder and CEO in the 2017 TechCrunch article; safe role is the company-facing protagonist of the chatbot origin and later open-source platform story.
+- **Julien Chaumond:** Named with Delangue as a Hugging Face co-founder in the 2017 TechCrunch article; also a coauthor of the 2020 Transformers paper.
+- **Thomas Wolf:** First author of the 2020 Transformers paper and a central technical protagonist for the library and Model Hub. Do not use the 2017 TechCrunch article to claim he was named in that launch coverage.
+- **Lysandre Debut, Victor Sanh, Clement Delangue, Anthony Moi, Pierric Cistac, Tim Rault, Remi Louf, Morgan Funtowicz, Joe Davison, Sam Shleifer, Patrick von Platen, Clara Ma, Yacine Jernite, Julien Plu, Canwen Xu, Teven Le Scao, Sylvain Gugger, Mariama Drame, Quentin Lhoest, and Alexander M. Rush:** Transformers paper coauthors. Safe role: the broader Hugging Face and community-facing implementation team.
+
+## Mention Carefully
+- **External contributors:** The Transformers paper says the library had over 400 external contributors. Do not invent named contributor stories without another source.
+- **AllenAI, NYU/Jiant, Plotly:** The Transformers paper uses these as Model Hub/community case studies. Use them only in the limited roles described by the paper.

--- a/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/scene-sketches.md
+++ b/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/scene-sketches.md
@@ -1,10 +1,25 @@
-# Scene Sketches: Chapter 54
+# Scene Sketches: Chapter 54 - The Hub of Weights
 
-## Scene 1: The Broken Script
-- **Action:** A developer spends a week trying to get a pre-trained model to run because the original authors used an outdated version of TensorFlow.
+## Scene 1: The Research Artifact Problem
+- **Action:** Begin with the difference between a paper result and a reusable model. A pretrained checkpoint is only useful if the user can find the right architecture, tokenizer, task head, framework, weights, and loading path.
+- **Evidence:** Transformers paper Introduction says pretraining created the need to distribute, fine-tune, deploy, and compress core pretrained models. Related Work says Transformers adds user-facing features for downloading, caching, fine-tuning, and production transition.
+- **Do not say:** "Before Hugging Face everything was random Dropbox links" unless a source is added.
 
-## Scene 2: The Chatbot Pivot
-- **Action:** Delangue and Wolf realize their open-source side project is vastly more popular than their actual chatbot product.
+## Scene 2: The Chatbot Company
+- **Action:** Use TechCrunch 2017 to show the original consumer-app shape: an artificial BFF, a fun digital companion, a chatbot app for teenagers. Then use TechCrunch 2019 to show the same company being covered as an NLP-library company.
+- **Evidence:** TechCrunch 2017 and 2019.
+- **Do not say:** "They realized in a meeting..." or invent internal dialogue.
 
-## Scene 3: Three Lines of Code
-- **Action:** A developer downloads and runs a massive state-of-the-art model using just three lines of Python via the Hugging Face library.
+## Scene 3: The Adapter Layer
+- **Action:** Explain why a unified API matters. Different architectures keep their own details, but common abstractions let users swap models, tokenizers, and heads without rewriting everything.
+- **Evidence:** Transformers paper Section 3: tokenizer/transformer/head abstraction, Auto classes, unified API, Rust tokenizers, framework switching.
+- **Pedagogy:** A short code-shaped example is useful, but keep it generic unless quoting the FlauBERT example from the paper.
+
+## Scene 4: The Model Hub Page
+- **Action:** Put the reader on a model page. A canonical name points to files; metadata and a model card explain training/use/caveats; a widget can run inference; the library can download, cache, and run the model.
+- **Evidence:** Transformers paper Section 4 and Figure 3: 2,097 user models, model cards, canonical names, two-line loading, live inference widgets, SciBERT/BART examples.
+- **Do not say:** "Every model page was complete, safe, or trustworthy."
+
+## Scene 5: Community Infrastructure, Not Magic
+- **Action:** Close with the honest tradeoff. Hugging Face made model reuse more social and package-like, but the underlying compute, licensing, data, safety, and production problems remained. This bridges into Chapter 55's scaling economics.
+- **Evidence:** Transformers paper deployment section; current Hub repository docs for Git-based collaboration; model-card caveats in paper.

--- a/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/sources.md
+++ b/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/sources.md
@@ -47,6 +47,7 @@
 - Do not invent a scene where Delangue/Wolf "realized" the side project was more popular than the chatbot. Use contemporary coverage and paper evidence.
 - Do not say Hugging Face alone created open-source NLP infrastructure. The paper explicitly situates Transformers among Torch Hub, TensorFlow Hub, AllenNLP, Fairseq, OpenNMT, Texar, Megatron-LM, Marian NMT, spaCy, Stanza, and others.
 - Do not use current Model Hub counts as historical 2020 facts.
+- Do not write "three lines of code" unless a separate source is added. The anchored paper example uses two `from_pretrained(...)` calls.
 
 ## Page/Section Anchor Worklist
 

--- a/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/sources.md
+++ b/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/sources.md
@@ -1,15 +1,58 @@
-# Sources: Chapter 54
+# Sources: Chapter 54 - The Hub of Weights
 
-## Claim Matrix
+## Verification Key
 
-| Claim | Scene | Primary Source | Secondary Confirmation | Verification | Conflict |
+- Green: claim has direct primary/near-primary evidence plus paper sections, documentation, or contemporary reporting.
+- Yellow: claim is supported by one source, dynamic metadata, or current documentation that should be phrased as present-day context.
+- Red: claim should not be drafted unless new evidence is added.
+
+## Primary and Near-Primary Sources
+
+| Source | Use | Verification |
+|---|---|---|
+| Thomas Wolf et al., "Transformers: State-of-the-Art Natural Language Processing," EMNLP System Demonstrations, 2020. URL: https://aclanthology.org/2020.emnlp-demos.6.pdf | Core source for Transformers library, unified API, Model Hub, contributors, model count, loading/caching, model cards, inference widgets, case studies, and deployment bridge. | Green: Abstract and Introduction say Transformers is an open-source library to open model-pretraining advances to the wider ML community; the library provides state-of-the-art Transformer architectures under a unified API backed by pretrained models available for the community; the system supports distribution, fine-tuning, deployment, and compression. Section 2 distinguishes Transformers from Torch Hub/TensorFlow Hub by its domain-specific NLP support. Section 3 describes tokenizer/transformer/head abstractions, Auto classes, and framework switching. Section 4 says the Model Hub held 2,097 user models, stores canonical names, model pages, model cards, live inference widgets, and supports two-line download/cache/run for fine-tuning or inference. Section 5 says models are available in PyTorch and TensorFlow with interoperability, plus deployment pathways including TorchScript, TensorFlow serving options, ONNX, JAX/XLA, TVM, and CoreML. |
+| Hugging Face Transformers v4.0.1 documentation, legacy docs. URL: https://huggingface.co/transformers/v4.0.1/index.html | Historical documentation for the library name, supported frameworks, model breadth, and stated low-barrier goals around sharing trained models. | Green/Yellow: docs say Transformers was formerly known as `pytorch-transformers` and `pytorch-pretrained-bert`; it provided BERT, GPT-2, RoBERTa, XLM, DistilBERT, XLNet and others; it claimed 32+ pretrained models in 100+ languages and deep interoperability between TensorFlow 2.0 and PyTorch; feature list says researchers can share trained models instead of always retraining and users can move a single model between TF2/PyTorch. Historical because it is versioned legacy documentation, but still documentation rather than a paper. |
+| GitHub REST API record for `huggingface/transformers`. URL: https://api.github.com/repos/huggingface/transformers | Repository creation date and dynamic current metadata. | Green for creation date extracted on 2026-04-28: repo created 2018-10-29. Yellow for stars/forks because they are dynamic current metrics. |
+| Hugging Face Model Hub documentation. URL: https://huggingface.co/docs/hub/models-the-hub | Present-day description of the Model Hub role. | Yellow: current docs say the Model Hub lets the community host model checkpoints for storage, discovery, and sharing, and download pretrained models with `huggingface_hub`, Transformers, or integrated libraries. Use as present-day continuity, not proof of the 2020 state. |
+| Hugging Face Hub repository documentation. URL: https://huggingface.co/docs/hub/repositories | Present-day anchor for Git-based repository framing. | Yellow: current docs say models, spaces, and datasets are hosted as Git repositories and that version control and collaboration are core elements of the Hub. Use as current infrastructure framing, not a 2020 historical metric. |
+
+## Contemporary Reporting
+
+| Source | Use | Verification |
+|---|---|---|
+| Romain Dillet, "Hugging Face wants to become your artificial BFF," TechCrunch, March 9, 2017. URL: https://techcrunch.com/2017/03/09/hugging-face-wants-to-become-your-artificial-bff/ | Chatbot origin, founders named in 2017 coverage, consumer-app framing. | Green/Yellow: article describes Hugging Face as a new chatbot app for bored teenagers, co-founded by Clement Delangue and Julien Chaumond, with a digital friend/chat interface and AI-for-fun framing. It does not name Thomas Wolf as a co-founder in this article. |
+| Romain Dillet, "Hugging Face raises $15 million to build the definitive natural language processing library," TechCrunch, December 17, 2019. URL: https://techcrunch.com/2019/12/17/hugging-face-raises-15-million-to-build-the-definitive-natural-language-processing-library/ | Contemporary pivot evidence from chatbot app to open-source NLP library and early adoption metrics. | Green/Yellow: article says the company first built an artificial-BFF chatbot app, more recently released an open-source NLP library, and that Transformers had over a million downloads and 19,000 GitHub stars at the time. Treat download/star numbers as reported 2019 snapshots, not current values. |
+
+## Scene-Level Claim Table
+
+| Claim | Scene | Primary Anchor | Independent Confirmation | Status | Notes |
 |---|---|---|---|---|---|
-| Hugging Face originated as a chatbot company before pivoting | 2 | Delangue/Wolf interviews | Forbes/TechCrunch profiles | Yellow | Need specific interview/article anchors. |
-| The Transformers library standardized model access across frameworks | 3 | Wolf et al. 2020 (Transformers: State-of-the-Art Natural Language Processing) | N/A | Yellow | Need exact page anchors for Wolf 2020. |
+| The practical problem after BERT/GPT was not only model invention but distribution, fine-tuning, deployment, compression, framework support, and reuse. | Research Artifact Problem | Transformers paper Abstract/Introduction | Transformers paper Related Work | Green | Use this as the chapter's systems thesis. |
+| Hugging Face began publicly as a consumer chatbot app before becoming known for NLP tooling. | Chatbot Company Finds Tooling Problem | TechCrunch 2017 chatbot article | TechCrunch 2019 funding/library article | Green/Yellow | Do not invent internal motives; "coverage shows" is safe. |
+| By December 2019, TechCrunch framed Hugging Face as building an open-source NLP library, with over a million downloads and 19,000 GitHub stars. | Chatbot Company Finds Tooling Problem | TechCrunch 2019 | GitHub API current metadata as dynamic continuity | Yellow | Reported snapshot only; do not update 2019 values from current API. |
+| Transformers used a unified API over many Transformer model variants and Auto classes to switch between models and frameworks. | Adapter Layer | Transformers paper Section 3 | v4.0.1 docs | Green | Keep the API explanation concrete. |
+| Transformers organizes model use around tokenizers, base Transformer models, and task heads. | Adapter Layer | Transformers paper Section 3 and Figure 2 | Examples in Section 3 | Green | Good pedagogical spine. |
+| Transformers maintained PyTorch/TensorFlow interoperability and supported deployment paths like TorchScript, TensorFlow serving options, ONNX, and CoreML. | Adapter Layer / Limits | Transformers paper Section 5 | v4.0.1 docs framework notes | Green | Do not imply every model worked equally in every framework. |
+| The Model Hub had 2,097 user models in the paper's 2020 snapshot. | Model Hub | Transformers paper Section 4 | Figure 1 download trend | Green | Historical number, not current count. |
+| The Model Hub gave models canonical names and enabled two-line download/cache/run for fine-tuning or inference. | Model Hub | Transformers paper Section 4 | v4.0.1 docs | Green | This is the core "weights become packages" scene. |
+| Model pages could include metadata, model cards, citations, datasets, caveats, live inference widgets, benchmark links, and visualizations. | Model Hub | Transformers paper Section 4 and Figure 3 | Current Model Hub docs | Green/Yellow | Model-card details are Green from paper; current docs are continuity. |
+| Current Hub documentation describes models/datasets/spaces as Git repositories, making version control and collaboration core Hub elements. | Model Hub / Epilogue | Hub repository docs | Current Model Hub docs | Yellow | Present-day epilogue only; do not project current Xet/safetensors details backward to 2020. |
+| Hugging Face lowered friction for open model reuse, but did not erase compute, quality, safety, licensing, or deployment constraints. | Lowering Friction | Transformers paper deployment/limitations by implication | Current docs and model-card caveats | Green/Yellow | Interpretive but essential guardrail. |
 
-## Bibliography
-### Primary
-- **Wolf, Thomas, et al. "Transformers: State-of-the-art natural language processing." In *Proceedings of the 2020 conference on empirical methods in natural language processing: system demonstrations*. 2020.**
+## Conflict Notes
 
-### Secondary
-- **Forbes/TechCrunch profiles on Hugging Face (TBD).**
+- Do not write "Hugging Face solved access to foundation models." It made reuse easier for shared/open models.
+- Do not write "GitHub for AI" as a literal sourced claim. The current docs support Git-based repositories; the phrase is a metaphor at best.
+- Do not claim all model weights were open, safe, or production-ready because they appeared on the Hub.
+- Do not invent a scene where Delangue/Wolf "realized" the side project was more popular than the chatbot. Use contemporary coverage and paper evidence.
+- Do not say Hugging Face alone created open-source NLP infrastructure. The paper explicitly situates Transformers among Torch Hub, TensorFlow Hub, AllenNLP, Fairseq, OpenNMT, Texar, Megatron-LM, Marian NMT, spaCy, Stanza, and others.
+- Do not use current Model Hub counts as historical 2020 facts.
+
+## Page/Section Anchor Worklist
+
+- Transformers paper: Done for Abstract, Introduction, Sections 2, 3, 4, 5, Figures 1/3, and Conclusion.
+- v4.0.1 Transformers docs: Done for former names, model breadth, framework interoperability, and share-rather-than-retrain framing.
+- GitHub API: Done for `huggingface/transformers` creation date.
+- TechCrunch 2017: Done for chatbot app origin and founders named in article.
+- TechCrunch 2019: Done for chatbot-to-library pivot coverage and reported 2019 adoption snapshot.
+- Current Hub docs: Done for Model Hub and Git repository present-day framing.

--- a/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/status.yaml
+++ b/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/status.yaml
@@ -17,3 +17,5 @@ notes: |
   Strongest safe prose range: 4,000-4,800 words. The infrastructure evidence is
   strong; the internal pivot narrative is thin. Do not invent company dialogue,
   user anecdotes, or community reaction to reach the top of the book target.
+  The red_claims count reflects explicit guardrail prohibitions, not rows in
+  the scene-level claim table.

--- a/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/status.yaml
+++ b/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/status.yaml
@@ -4,8 +4,8 @@ part: 8
 chapter: 54
 review_state: awaiting_cross_family_review
 last_updated: 2026-04-28
-green_claims: 9
-yellow_claims: 4
+green_claims: 6
+yellow_claims: 5
 red_claims: 6
 prose_word_cap_recommendation: 4800
 notes: |

--- a/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/status.yaml
+++ b/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/status.yaml
@@ -1,14 +1,31 @@
-status: research_review
+status: prose_ready
 owner: Codex
 part: 8
 chapter: 54
-review_state: awaiting_cross_family_review
+review_state: claude_source_approved_2026-04-28;gemini_gap_ready_with_cap_2026-04-28
 last_updated: 2026-04-28
 green_claims: 6
 yellow_claims: 5
 red_claims: 0
 guardrail_count: 6
 prose_word_cap_recommendation: 4800
+prose_word_cap: 4800
+verdicts:
+  claude:
+    model: claude-opus-4-7
+    date: 2026-04-28
+    verdict: APPROVE
+    review_url: https://github.com/kube-dojo/kube-dojo.github.io/pull/494#issuecomment-4333896947
+  gemini:
+    model: gemini-3-flash-preview
+    requested_model: gemini-3.1-pro-preview
+    date: 2026-04-28
+    verdict: READY_WITH_CAP
+    word_cap: 4800
+    review_url: https://github.com/kube-dojo/kube-dojo.github.io/pull/494#issuecomment-4334441178
+  resolved: READY_TO_DRAFT_WITH_CAP
+  resolved_word_cap: 4800
+  resolution_rule: dual_cross_family_verdict_with_cap
 notes: |
   Rebuilt the scrubbed/yellow contract from verified online sources:
   Transformers EMNLP 2020 PDF, legacy Transformers v4.0.1 docs, GitHub API

--- a/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/status.yaml
+++ b/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/status.yaml
@@ -6,7 +6,8 @@ review_state: awaiting_cross_family_review
 last_updated: 2026-04-28
 green_claims: 6
 yellow_claims: 5
-red_claims: 6
+red_claims: 0
+guardrail_count: 6
 prose_word_cap_recommendation: 4800
 notes: |
   Rebuilt the scrubbed/yellow contract from verified online sources:
@@ -17,5 +18,5 @@ notes: |
   Strongest safe prose range: 4,000-4,800 words. The infrastructure evidence is
   strong; the internal pivot narrative is thin. Do not invent company dialogue,
   user anecdotes, or community reaction to reach the top of the book target.
-  The red_claims count reflects explicit guardrail prohibitions, not rows in
-  the scene-level claim table.
+  Guardrail_count records explicit prohibitions; red_claims is reserved for
+  in-scope claims that fail verification.

--- a/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/status.yaml
+++ b/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/status.yaml
@@ -1,1 +1,19 @@
-status: researching
+status: research_review
+owner: Codex
+part: 8
+chapter: 54
+review_state: awaiting_cross_family_review
+last_updated: 2026-04-28
+green_claims: 9
+yellow_claims: 4
+red_claims: 6
+prose_word_cap_recommendation: 4800
+notes: |
+  Rebuilt the scrubbed/yellow contract from verified online sources:
+  Transformers EMNLP 2020 PDF, legacy Transformers v4.0.1 docs, GitHub API
+  metadata for huggingface/transformers, current Hugging Face Hub docs, and
+  contemporary TechCrunch 2017/2019 coverage.
+
+  Strongest safe prose range: 4,000-4,800 words. The infrastructure evidence is
+  strong; the internal pivot narrative is thin. Do not invent company dialogue,
+  user anecdotes, or community reaction to reach the top of the book target.

--- a/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/timeline.md
+++ b/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/timeline.md
@@ -1,5 +1,8 @@
 # Timeline: Chapter 54
 
-- **2016:** Hugging Face is founded as a chatbot app.
-- **2018:** Hugging Face open-sources a PyTorch port of BERT.
-- **2020:** The official Transformers library paper is published.
+- **2016:** Hugging Face is founded. The current contract does not yet have a primary incorporation source; use this only as broad context unless another source is added.
+- **March 2017:** TechCrunch describes Hugging Face as a chatbot app for bored teenagers and names Clement Delangue and Julien Chaumond as co-founders.
+- **October 29, 2018:** GitHub API reports `huggingface/transformers` repository creation.
+- **December 2019:** TechCrunch reports Hugging Face's move from artificial-BFF chatbot app to open-source NLP library and says Transformers had over a million downloads and 19,000 GitHub stars at that time.
+- **October/November 2020:** Wolf et al. publish "Transformers: State-of-the-Art Natural Language Processing" in the EMNLP System Demonstrations proceedings, describing the library and Model Hub.
+- **2020 paper snapshot:** The Transformers paper reports 2,097 user models in the Model Hub and over 400 external contributors to the library.


### PR DESCRIPTION
## Summary
- rebuilds Ch54 from verified Transformers paper, legacy Hugging Face docs, GitHub API, Hub docs, and TechCrunch 2017/2019 coverage
- replaces scrubbed/yellow skeleton with anchored claims, scene guardrails, and a 4,000-4,800 prose capacity plan
- blocks unsupported claims around 'GitHub for AI', universal access, invented pivot scenes, and current Hub counts projected backward

## Checks
- git diff --check -- docs/research/ai-history/chapters/ch-54-the-hub-of-weights
- ASCII scan clean
- guardrail scan: only caveats/do-not-write warnings matched

Issue: #406