### PR TITLE
docs(ai-history): rebuild Ch57 alignment contract (#406)

### DIFF
--- a/docs/research/ai-history/chapters/ch-57-the-alignment-problem/brief.md
+++ b/docs/research/ai-history/chapters/ch-57-the-alignment-problem/brief.md
@@ -1,25 +1,39 @@
 # Brief: Chapter 57 - The Alignment Problem
 
 ## Thesis
-Raw language models trained on internet text are powerful but alien and unsafe; they simply predict the next word, often generating toxic or unhelpful text. Reinforcement Learning from Human Feedback (RLHF) was the critical behavioral infrastructure that aligned these models with human intent, making products like ChatGPT possible.
+InstructGPT made the next-token predictor usable as an assistant not by discovering a new foundation model architecture, but by adding a behavioral training pipeline around GPT-3. The chapter should explain the mismatch between internet-text prediction and user intent, then show how reinforcement learning from human feedback (RLHF) converted demonstrations and preference rankings into a reward model and PPO fine-tuning loop. The honest ending is not "alignment was solved." It is narrower: OpenAI showed that a comparatively small amount of human-feedback infrastructure could make language models more helpful, truthful, and less toxic on the measured distribution, while leaving major questions about refusal, representation, misuse, and whose preferences were being optimized.
 
 ## Scope
-- IN SCOPE: InstructGPT, RLHF, the alignment problem, human labelers ranking outputs, the transition from raw prediction to helpful assistants.
-- OUT OF SCOPE: Regulatory legislation (Part 9).
+- IN SCOPE: Christiano et al. 2017 as the preference-learning ancestor; Stiennon et al. 2020 as a language-model/summarization bridge; Ouyang et al. 2022 and the OpenAI InstructGPT blog as the core source base; the next-token objective mismatch; human demonstrations; human comparisons/rankings; reward modeling; PPO; labeler pipeline; InstructGPT evaluation results; alignment tax; limitations and "who are we aligning to?"
+- OUT OF SCOPE: ChatGPT launch narrative, Constitutional AI, RLHF alternatives after 2022, red-team policy operations after deployment, regulatory legislation, jailbreak culture, and claims about solving full AI alignment.
 
 ## Scenes Outline
-1. **The Alien Shoggoth:** Raw GPT-3 is prompted with a question and, instead of answering, it just generates more questions. It is mimicking internet forums, not acting as an assistant.
-2. **The Human Raters:** OpenAI hires contractors to read different model outputs and rank them from best to worst, building a dataset of human preference.
-3. **The Reward Model:** Pedagogical explanation of RLHF. A secondary neural network learns to predict human preference, and then trains the primary model to behave safely and helpfully.
+1. **The Objective Mismatch:** GPT-3 can be prompted into many tasks, but the pretraining objective is next-token prediction on internet text, not "follow the user's instruction helpfully and safely." Use this as the clean replacement for the unsafe "alien shoggoth" framing.
+2. **Preference Learning Before Language Assistants:** Christiano et al. train agents from human preferences over short behavior clips; Stiennon et al. adapt the pattern to summaries. This gives the method a history before InstructGPT.
+3. **The Labeler Pipeline:** Ouyang et al. collect labeler demonstrations, comparison/ranking data, and API/labeler-written prompts; about 40 contractors are hired through Upwork and ScaleAI. This is a labor-and-data scene, not a pure algorithm scene.
+4. **Reward Model And PPO:** Labelers rank model outputs; a reward model learns to predict which output humans prefer; PPO optimizes the supervised policy against that learned reward, with a pretraining mix used to reduce regressions.
+5. **Smaller, More Useful:** InstructGPT results show labeler preference gains over GPT-3, including the striking 1.3B InstructGPT preference over 175B GPT-3, truthfulness improvements, reduced toxicity in measured settings, and lower alignment cost than pretraining.
+6. **Not Full Alignment:** The sources explicitly limit the claim. The system aligns to labeler/researcher/API-customer preferences, not all human values; it remains unsafe in important cases; refusal for harmful requests remains future work.
 
 ## 4k-7k Prose Capacity Plan
 
-This chapter can support a long narrative only if it is built from verified layers rather than padding:
+Current verified evidence supports a 4,800-5,800 word chapter. It can reach the target range naturally because the chapter has three layers: conceptual mismatch, human-feedback production pipeline, and measured/caveated results.
 
-- 500-800 words: Historical context and setup, bridging from the previous era.
-- 933-1233 words: Detailed narrative surrounding The Alien Shoggoth:, heavily anchored to primary sources.
-- 933-1233 words: Detailed narrative surrounding The Human Raters:, heavily anchored to primary sources.
-- 933-1233 words: Detailed narrative surrounding The Reward Model:, heavily anchored to primary sources.
-- 400-700 words: Honest close that summarizes the infrastructural shift and transitions to the next chapter.
+- 500-700 words: Bridge from the megacluster. The infrastructure could train huge predictors, but product behavior required a separate behavioral layer.
+- 700-900 words: Explain the objective mismatch: next-token prediction versus helpful, honest, harmless instruction following.
+- 600-800 words: Preference-learning prehistory: Christiano 2017 and Stiennon 2020 establish comparisons, reward models, and RL optimization before InstructGPT.
+- 1,000-1,200 words: The InstructGPT data pipeline: API prompts, labeler-written prompts, demonstrations, comparison data, 40 contractors, ranking K outputs, and datasets for SFT/RM/PPO.
+- 900-1,100 words: Reward model and PPO pedagogy: how a learned preference model becomes a scalar reward, why KL/pretraining mix matters, and what "alignment tax" means.
+- 800-1,000 words: Results: preference wins, 1.3B versus 175B, truthfulness, toxicity, minimal public-NLP regressions, and deployment as default API models.
+- 500-700 words: Limitations and transition: labeler demographics, no broad human-values solution, refusal remains open, misuse risk, and why Chapter 58 can move toward product/platform shock.
 
-Most layers now have page-level anchors. Do not invent lab drama or dialogue to reach the top of the range. If the verified evidence runs out, cap the chapter.
+Do not add fictional harmful prompts, imagined labeler conversations, or ChatGPT-era scenes to inflate the chapter. If the prose cannot exceed 4,800 words without those moves, cap honestly.
+
+## Guardrails
+
+- Do not say RLHF "solved alignment." The anchored claim is narrower: it improved alignment to user intent and labeler preferences on the tested distribution.
+- Do not use the "shoggoth" metaphor as factual description. If used at all in prose, it must be framed as later folk imagery, not a source claim.
+- Do not invent examples of bomb-making, medical, or illegal prompts. Use source-level categories such as toxic, biased, harmful, untruthful, or not following instructions.
+- Do not say InstructGPT was universally safer. Ouyang reports improvements on some measures and no significant improvement on others; the limitations section remains central.
+- Do not collapse "human preferences" into "all humanity." The paper explicitly discusses labelers, researchers, API customers, and representativeness limits.
+- Do not make ChatGPT the main character. This chapter is about the RLHF/InstructGPT behavioral pipeline that made assistant products plausible.

--- a/docs/research/ai-history/chapters/ch-57-the-alignment-problem/infrastructure-log.md
+++ b/docs/research/ai-history/chapters/ch-57-the-alignment-problem/infrastructure-log.md
@@ -1,5 +1,34 @@
-# Infrastructure Log: Chapter 57
+# Infrastructure Log: Chapter 57 - The Alignment Problem
 
-## Technical Metrics & Constraints
-- **The Reward Model:**
-  - Infrastructure Shift: Training shifted from pure unsupervised learning (reading the web) to a complex, multi-model pipeline where one AI acts as a judge for another AI, based on human preference data.
+## Behavioral Training Infrastructure
+
+- **Base model:** GPT-3 pretrained language models, adaptable to tasks but poorly characterized for deployed assistant behavior.
+- **Objective mismatch:** next-token prediction on internet text versus following instructions helpfully and safely.
+- **Supervised fine-tuning (SFT):** labeler-written demonstrations of desired behavior on prompts from API/labeler distributions.
+- **Reward model (RM):** model trained to take a prompt and response and output a scalar reward predicting labeler preference.
+- **Policy optimization:** PPO fine-tunes the supervised policy against the reward model.
+- **Pretraining mix:** PPO-ptx mixes PPO updates with pretraining-gradient updates to reduce regressions on public NLP datasets.
+
+## Human Data Infrastructure
+
+- **Prompt sources:** earlier InstructGPT Playground prompts plus labeler-written prompts; production API data excluded according to Ouyang Section 3.2.
+- **Data handling:** PII filtered, prompts deduplicated, user IDs limited, train/validation/test split by user ID.
+- **Dataset sizes:** about 13k SFT training prompts, 33k reward-model training prompts, and 31k PPO training prompts.
+- **Labeler team:** about 40 contractors hired through Upwork and ScaleAI, screened for performance on sensitive prompts, onboarded with instructions and shared chat support.
+- **Ranking interface:** labelers ranked K=4 to K=9 outputs for a prompt, producing pairwise comparisons for reward-model training.
+
+## Results / Metrics Infrastructure
+
+- **Preference results:** 1.3B InstructGPT preferred over 175B GPT-3 on the prompt distribution; 175B InstructGPT preferred over 175B GPT-3 85 +/- 3% of the time and over few-shot 175B GPT-3 71 +/- 4% of the time.
+- **Truthfulness:** InstructGPT generated truthful and informative answers on TruthfulQA about twice as often as GPT-3, according to Ouyang's summary.
+- **Hallucination:** On closed-domain API tasks, InstructGPT made up information not present in the input about half as often as GPT-3 in the reported summary.
+- **Toxicity:** InstructGPT generated about 25% fewer toxic outputs than GPT-3 when prompted to be respectful, but did not significantly improve over GPT-3 on some bias datasets.
+- **Alignment cost:** Ouyang reports 175B SFT at 4.9 petaflops/s-days and 175B PPO-ptx at 60 petaflops/s-days, compared with GPT-3 pretraining at 3,640 petaflops/s-days.
+
+## Limits / Constraints
+
+- **Preference source:** labelers, researchers, and API-customer prompt distribution, not a representative sample of humanity.
+- **Language/culture limit:** data mostly English; labelers mostly English-speaking and located in the United States or Southeast Asia, per Ouyang's caveat.
+- **Safety limit:** models still generated toxic, biased, false, sexual, or violent content in some cases.
+- **Refusal limit:** Ouyang says training models to be harmless despite harmful user instructions remained important future work.
+- **Misuse limit:** better instruction following can also make misuse easier.

--- a/docs/research/ai-history/chapters/ch-57-the-alignment-problem/open-questions.md
+++ b/docs/research/ai-history/chapters/ch-57-the-alignment-problem/open-questions.md
@@ -1,3 +1,16 @@
-# Open Questions
+# Open Questions: Chapter 57 - The Alignment Problem
 
-- SCRUBBED: All claims downgraded to Yellow. Need REAL, empirical page/section anchors from verified online PDFs or archives. Do not hallucinate.
+## Not Blocking Draft
+
+- Should the prose include a short note that InstructGPT was a predecessor to ChatGPT? This is historically useful, but it must not turn Chapter 57 into the ChatGPT launch chapter.
+- Can we find a primary source on the exact user-facing names of the default API InstructGPT models in January 2022? Current contract only needs the OpenAI blog's "default language models" claim.
+- Should the prose mention ScaleAI/Upwork by name? Ouyang and the OpenAI blog support it, but the chapter may read better if this appears in the labor/data section rather than the opening.
+- Should the prose use the phrase "alignment tax"? Ouyang uses it; include only with explanation, not as jargon.
+
+## Drafting Watchpoints
+
+- Do not add fabricated examples of unsafe prompts or labeler conversations.
+- Do not overstate "truthfulness" as factual reliability in all settings; Ouyang uses TruthfulQA and specific closed-domain tasks.
+- Do not imply that human-feedback training captures broad democratic values.
+- Do not omit the misuse caveat: better instruction following can also make harmful use easier.
+- Do not make refusal behavior sound solved in InstructGPT; it is explicitly future work in the sources.

--- a/docs/research/ai-history/chapters/ch-57-the-alignment-problem/people.md
+++ b/docs/research/ai-history/chapters/ch-57-the-alignment-problem/people.md
@@ -1,6 +1,19 @@
-# People: Chapter 57
+# People: Chapter 57 - The Alignment Problem
 
 ## Verified Protagonists
-- **Paul Christiano:** Early pioneer of RLHF.
-- **Long Ouyang et al.:** Lead authors of the InstructGPT paper.
-- **The Human Raters:** The contractors whose preferences defined the "alignment" of the models.
+
+- **Paul Christiano:** Co-author of the 2017 human-preferences paper and later InstructGPT paper. Safe role: method-lineage protagonist for reward learning from human comparisons.
+- **Jan Leike and Ryan Lowe:** OpenAI alignment leads and authors of the OpenAI InstructGPT blog. Safe role: public OpenAI framing of the instruction-following work.
+- **Long Ouyang:** Lead author of the InstructGPT paper. Safe role: research-paper protagonist for the detailed RLHF pipeline and evaluation claims.
+- **Nisan Stiennon:** Lead author of the 2020 summarization-with-human-feedback paper. Safe role: bridge from general preference learning to language-model outputs.
+- **OpenAI labelers/contractors:** About 40 contractors hired through Upwork and ScaleAI, screened and trained to write demonstrations, rank outputs, and evaluate model behavior. Safe role: central human labor layer, not anonymous scenery.
+
+## Institutional Actors
+
+- **OpenAI Alignment team:** Joint project context for InstructGPT; use as the research group rather than inventing individual lab scenes.
+- **OpenAI API / Playground users:** Source of many prompts in the Ouyang training/evaluation pipeline, with important representativeness caveats.
+- **ScaleAI and Upwork:** Hiring sources for labelers in Ouyang Section 3.4 and OpenAI blog footnotes.
+
+## Representation Caveat
+
+The chapter should explicitly avoid equating the labelers' preferences with "humanity." Ouyang Section 5.2 says the process reflects labelers, researchers, API customers, and policy/instruction design, with limits around language, geography, and stakeholder representation.

--- a/docs/research/ai-history/chapters/ch-57-the-alignment-problem/scene-sketches.md
+++ b/docs/research/ai-history/chapters/ch-57-the-alignment-problem/scene-sketches.md
@@ -1,10 +1,31 @@
-# Scene Sketches: Chapter 57
+# Scene Sketches: Chapter 57 - The Alignment Problem
 
-## Scene 1: The Prompt Failure
-- **Action:** A user asks a raw LLM, "How do I make a bomb?" The LLM happily completes the text because it saw a spy novel on the internet. It has no moral compass.
+## Scene 1: The Objective Mismatch
+- **Action:** Explain the clean technical mismatch: GPT-3 was trained to predict the next token in internet text, while users wanted a system that followed instructions helpfully and safely.
+- **Texture:** The model is not evil or magical. It is optimizing the wrong training objective for the assistant role.
+- **Guardrail:** Do not invent a harmful prompt example. Use the paper's categories: untruthful, toxic, biased, harmful, or not following instructions.
 
-## Scene 2: The Ranking Task
-- **Action:** A human worker reads three outputs from a model and clicks a button to rank them. This data is fed back into the system.
+## Scene 2: Learning From Preferences
+- **Action:** Step back to Christiano 2017 and Stiennon 2020. Humans compare short behavior clips or pairs of summaries; a reward model learns which output humans prefer; RL optimizes against that learned reward.
+- **Texture:** This is the conceptual invention: when a goal is hard to write as code, ask humans for comparisons and train a model to approximate the preference signal.
+- **Guardrail:** Keep the prehistory short enough that it supports InstructGPT rather than becoming a robotics/summarization chapter.
 
-## Scene 3: The Polish
-- **Action:** The model is no longer an alien text predictor; it is now a polite, helpful, refusal-aware assistant.
+## Scene 3: The Labeler Pipeline
+- **Action:** Ouyang et al. build a production-like pipeline: prompts from the API Playground and labeler-written prompts, demonstrations, 33k reward-model prompts, 31k PPO prompts, about 40 contractors, screening, instructions, onboarding, and chat support.
+- **Texture:** The assistant is partly made of human labor. The "alignment layer" is a data-production system as much as an algorithm.
+- **Guardrail:** Do not romanticize or vilify the labelers. Stick to the published workflow and limits.
+
+## Scene 4: Reward Model And PPO
+- **Action:** Labelers rank four to nine responses for a prompt. Those rankings become pairwise comparisons. A reward model predicts preferred outputs; PPO fine-tunes the policy to get higher reward.
+- **Texture:** Make the math readable: the reward model is a learned judge, not a moral oracle.
+- **Guardrail:** Do not imply the reward model knows truth or safety directly. It predicts labeler preference under instructions.
+
+## Scene 5: A Smaller Model Wins The Preference Test
+- **Action:** Show the headline result: 1.3B InstructGPT preferred over 175B GPT-3, and 175B InstructGPT strongly preferred over 175B GPT-3 and few-shot GPT-3 on the tested prompt distribution.
+- **Texture:** The story is not that size stopped mattering. It is that behavior tuning could unlock usefulness that raw scale alone did not deliver.
+- **Guardrail:** Do not claim global superiority across all tasks.
+
+## Scene 6: The Unfinished Problem
+- **Action:** Close with the caveats: alignment to a particular labeler/researcher/customer pipeline, not all people; residual toxic/biased/false outputs; refusal of harmful instructions as future work; misuse risk.
+- **Texture:** This ending sets up the product era honestly: RLHF made assistants viable, but it also created the next layer of governance and safety questions.
+- **Guardrail:** No triumphalist "alignment solved" ending.

--- a/docs/research/ai-history/chapters/ch-57-the-alignment-problem/sources.md
+++ b/docs/research/ai-history/chapters/ch-57-the-alignment-problem/sources.md
@@ -1,17 +1,53 @@
-# Sources: Chapter 57
+# Sources: Chapter 57 - The Alignment Problem
 
-## Claim Matrix
+## Verification Key
 
-| Claim | Scene | Primary Source | Secondary Confirmation | Verification | Conflict |
+- Green: claim has direct primary evidence from a paper/blog section or abstract.
+- Yellow: claim is interpretive, source-limited, or requires careful caveated wording.
+- Red: claim should not be drafted unless new evidence is added.
+
+## Primary Sources
+
+| Source | Use | Verification |
+|---|---|---|
+| Long Ouyang et al., "Training language models to follow instructions with human feedback," arXiv:2203.02155, 2022. URL: https://arxiv.org/pdf/2203.02155 | Core source for InstructGPT, RLHF pipeline, labeler workflow, preference comparisons, reward model, PPO, results, and limitations. | Green: Abstract says bigger language models do not inherently follow user intent and can be untruthful, toxic, or unhelpful; the method collects labeler demonstrations and rankings, trains a reward model, and fine-tunes with RLHF. Section 3 gives the three-step method, dataset sizes, about 40 contractors, K=4 to K=9 ranked outputs, and PPO. Sections 3.6/4 and Discussion give preference, truthfulness, toxicity, alignment-tax, and limitation claims. |
+| Ryan Lowe and Jan Leike, "Aligning language models to follow instructions," OpenAI, January 27, 2022. URL: https://openai.com/index/instruction-following/ | Public OpenAI framing of InstructGPT deployment and method. | Green: blog says InstructGPT models were much better at following user intentions than GPT-3, were trained with humans in the loop, and became default API models. It describes GPT-3's next-word internet-text objective as misaligned with safely performing the desired task, and summarizes demonstrations, rankings, reward model, and PPO. It also lists limitations and refusal as future work. |
+| Paul F. Christiano et al., "Deep reinforcement learning from human preferences," arXiv:1706.03741, 2017. URL: https://arxiv.org/pdf/1706.03741 | Prehistory of learning reward functions from human comparisons. | Green: Abstract and Introduction say the method learns from non-expert human preferences between pairs of trajectory segments, solves Atari and simulated robotics tasks without access to the reward function, uses feedback on less than 1% of interactions, and fits a reward function while training a policy to optimize predicted reward. |
+| Nisan Stiennon et al., "Learning to summarize from human feedback," arXiv:2009.01325, 2020. URL: https://arxiv.org/pdf/2009.01325 | Bridge from general preference RL to language-model outputs before InstructGPT. | Green: Abstract and Method say the authors collect human comparisons between summaries, train a reward model to predict human-preferred summaries, and use it as a reward function for PPO. Main results say human-feedback summaries outperform much larger supervised summarization models on TL;DR. |
+
+## Scene-Level Claim Table
+
+| Claim | Scene | Primary Anchor | Independent Confirmation | Status | Notes |
 |---|---|---|---|---|---|
-| Raw language models struggle to follow human instructions | 1 | Ouyang et al. 2022 (Training language models to follow instructions) | N/A | Yellow | Need exact page anchors. |
-| RLHF uses human rankings to train a reward model | 2, 3 | Ouyang et al. 2022 | Christiano et al. 2017 (Deep RL from human preferences) | Yellow | Need exact page anchors. |
-| InstructGPT models were highly preferred over raw GPT-3 | 3 | Ouyang et al. 2022 | N/A | Yellow | Need exact page anchors. |
+| GPT-style language-model pretraining optimizes next-token prediction, which differs from safely and helpfully following user instructions. | Objective Mismatch | Ouyang Abstract and Introduction | OpenAI InstructGPT blog opening/method | Green | Core thesis; do not anthropomorphize. |
+| Larger language models do not inherently become better at following user intent and can be untruthful, toxic, biased, or unhelpful. | Objective Mismatch | Ouyang Abstract and Introduction | OpenAI blog | Green | Say "can," not "always." |
+| Christiano et al. learned reward functions from human preferences over short behavior clips and optimized policies against those learned rewards. | Preference Prehistory | Christiano Abstract, Introduction, method overview | Ouyang cites Christiano as RLHF lineage | Green | Keep robotics/Atari examples brief. |
+| Stiennon et al. applied human-feedback reward modeling to summarization by collecting comparisons, training a reward model, and optimizing with PPO. | Preference Prehistory | Stiennon Abstract and Method | Ouyang Section 3.1 cites Stiennon method | Green | Useful bridge into language. |
+| InstructGPT used three stages: supervised fine-tuning on demonstrations, reward-model training from comparisons/rankings, and PPO optimization against the reward model. | Reward Model And PPO | Ouyang Figure 2 and Section 3.1 | OpenAI blog Methods | Green | This is the technical spine of the chapter. |
+| Ouyang et al. used prompts from an earlier InstructGPT Playground plus labeler-written prompts, filtered PII, deduplicated prompts, and split by user ID. | Labeler Pipeline | Ouyang Section 3.2 | N/A | Green | Shows data governance and product coupling. |
+| The SFT dataset contained about 13k training prompts, the reward-model dataset 33k training prompts, and the PPO dataset 31k training prompts. | Labeler Pipeline | Ouyang Section 3.2 | N/A | Green | Use approximate wording. |
+| OpenAI hired about 40 contractors through Upwork and ScaleAI, screened them, trained them, and used detailed instructions/shared chat for the labeling work. | Labeler Pipeline | Ouyang Section 3.4 | OpenAI blog acknowledgments note labelers | Green | Important labor scene. |
+| Labelers ranked K=4 to K=9 responses per prompt, producing pairwise comparisons used to train the reward model. | Reward Model And PPO | Ouyang Section 3.5 Reward modeling | N/A | Green | Good pedagogical anchor. |
+| Ouyang et al. report that 1.3B InstructGPT outputs were preferred over 175B GPT-3 outputs despite 100x fewer parameters. | Smaller, More Useful | Ouyang Abstract and results | OpenAI blog Results | Green | Avoid implying capability dominance on every task. |
+| Ouyang et al. report 175B InstructGPT was preferred over 175B GPT-3 85 +/- 3% of the time and over few-shot 175B GPT-3 71 +/- 4% of the time. | Smaller, More Useful | Ouyang results summary | N/A | Green | Strong but distribution-specific result. |
+| InstructGPT improved truthfulness and reduced toxic output generation in measured settings, but did not significantly improve some bias/toxicity-related metrics. | Smaller, More Useful | Ouyang results and limitations | OpenAI blog Results/Limitations | Green | Keep nuance. |
+| RLHF cost was modest relative to GPT-3 pretraining: Ouyang reports 175B SFT at 4.9 petaflops/s-days and 175B PPO-ptx at 60 versus GPT-3 at 3,640. | Reward Model And PPO | Ouyang Discussion 5.1 | N/A | Green | Good infrastructure/economics detail. |
+| Ouyang et al. explicitly say their procedure aligned to labelers/researchers/API-customer influences, not to all human values. | Not Full Alignment | Ouyang Section 5.2 | OpenAI blog Generalizing/Limitations | Green | Must appear in close. |
+| InstructGPT remained not fully aligned or safe, could generate toxic/biased/false/sexual/violent content, and refusing harmful instructions was future work. | Not Full Alignment | Ouyang Limitations/Open Questions; OpenAI blog Limitations | N/A | Green | Prevents triumphalist ending. |
+| RLHF made assistant-style products plausible by converting behavior into a trainable layer around large pretrained models. | Thesis/Close | Synthesis from Ouyang/OpenAI | Ch56 infrastructure context | Yellow | Interpretive; keep grounded in source claims. |
 
-## Bibliography
-### Primary
-- **Ouyang, Long, et al. "Training language models to follow instructions with human feedback." *Advances in neural information processing systems* 35 (2022): 27730-27744.**
-- **Christiano, Paul F., et al. "Deep reinforcement learning from human preferences." *Advances in neural information processing systems* 30 (2017).**
+## Conflict Notes
 
-### Secondary
-- **TBD**
+- Do not claim RLHF solved alignment or made models safe.
+- Do not claim InstructGPT is ChatGPT; keep ChatGPT as downstream context only if needed.
+- Do not invent scary prompt examples. Source-supported categories are enough.
+- Do not say "human preferences" without specifying the preference sources and representativeness limits.
+- Do not imply smaller InstructGPT was better than GPT-3 on all capabilities; the key result is labeler preference on the prompt distribution.
+- Do not omit the alignment-tax caveat or the fact that PPO/pretraining mix was used to reduce regressions.
+
+## Anchor Worklist
+
+- Ouyang 2022: Done for Abstract, Introduction, Figure 2/Section 3.1 method, Section 3.2 datasets, Section 3.4 labelers, Section 3.5 reward modeling, results summary, Discussion 5.1, Section 5.2 "Who are we aligning to?", and Limitations/Open Questions.
+- OpenAI 2022 blog: Done for public product framing, default API deployment, method summary, limitations, and refusal as future work.
+- Christiano 2017: Done for human comparisons over trajectory segments and learned reward functions.
+- Stiennon 2020: Done for language-model summarization bridge, human comparisons, reward model, PPO, and preference results.

--- a/docs/research/ai-history/chapters/ch-57-the-alignment-problem/status.yaml
+++ b/docs/research/ai-history/chapters/ch-57-the-alignment-problem/status.yaml
@@ -1,1 +1,42 @@
-status: researching
+status: prose_ready
+owner: Codex
+part: 8
+chapter: 57
+review_state: claude_source_approved_2026-04-28;gemini_gap_ready_with_cap_2026-04-28
+last_updated: 2026-04-28
+green_claims: 15
+yellow_claims: 1
+red_claims: 0
+guardrail_count: 6
+prose_word_cap_recommendation: 5800
+prose_word_cap: 5800
+verdicts:
+  claude:
+    model: claude-opus-4-7
+    date: 2026-04-28
+    verdict: APPROVE
+    review_url: https://github.com/kube-dojo/kube-dojo.github.io/pull/502#issuecomment-4335562074
+  gemini:
+    model: gemini-3.1-pro-preview
+    requested_model: gemini-3.1-pro-preview
+    date: 2026-04-28
+    verdict: READY_WITH_CAP
+    word_cap: 5800
+    review_url: https://github.com/kube-dojo/kube-dojo.github.io/pull/502#issuecomment-4335551182
+  resolved: READY_TO_DRAFT_WITH_CAP
+  resolved_word_cap: 5800
+  resolution_rule: dual_cross_family_verdict_with_cap
+notes: |
+  Rebuilt the scrubbed/yellow contract from verified online sources: Ouyang et
+  al. 2022 InstructGPT, OpenAI's January 2022 instruction-following blog,
+  Christiano et al. 2017 human-preferences RL, and Stiennon et al. 2020
+  summarization from human feedback.
+
+  Strongest safe prose range: 4,800-5,800 words. The chapter has enough
+  evidence for a full treatment if it balances technical pedagogy, labor/data
+  infrastructure, measured results, and limitations. It must not claim RLHF
+  solved alignment or equate labeler preferences with all human values.
+
+  Claude source-fidelity review approved all 15 Green claims and confirmed the
+  single Yellow claim is correctly interpretive. Gemini gap/capacity audit
+  returned READY_WITH_CAP at 5,800 words using gemini-3.1-pro-preview.

--- a/docs/research/ai-history/chapters/ch-57-the-alignment-problem/timeline.md
+++ b/docs/research/ai-history/chapters/ch-57-the-alignment-problem/timeline.md
@@ -1,4 +1,7 @@
-# Timeline: Chapter 57
+# Timeline: Chapter 57 - The Alignment Problem
 
-- **2017:** Christiano et al. publish early work on RL from human preferences.
-- **Early 2022:** OpenAI publishes the InstructGPT paper, demonstrating RLHF on large language models.
+- **2017:** Christiano et al. publish "Deep reinforcement learning from human preferences," showing that policies can be trained from human comparisons over trajectory segments and learned reward models.
+- **2020:** Stiennon et al. publish "Learning to summarize from human feedback," applying the comparison/reward-model/PPO pattern to language-model summarization.
+- **January 2021:** According to the OpenAI InstructGPT blog footnotes, an earlier version of InstructGPT was deployed in the API Playground; prompts from this setting later became part of the training source after filtering.
+- **January 27, 2022:** OpenAI publishes "Aligning language models to follow instructions," describing InstructGPT models as default API models trained with humans in the loop.
+- **March 2022:** Ouyang et al. release "Training language models to follow instructions with human feedback" on arXiv, giving the detailed research account of InstructGPT, RLHF, results, and limitations.


### PR DESCRIPTION
## Summary
- rebuild Ch57 from verified RLHF/InstructGPT sources after scrubbed placeholder state
- replace invented harmful-prompt scenes with source-grounded objective-mismatch and preference-learning framing
- add source matrix, prose capacity plan, labor/data infrastructure, limitations, and guardrails against 'RLHF solved alignment' overclaims

## Checks
- git diff --check -- docs/research/ai-history/chapters/ch-57-the-alignment-problem
- ASCII scan clean for Ch57 contract files
- book-only PR: skipped curriculum pipeline and Astro build per AGENTS.md exception

## Review
- awaiting Claude source-fidelity review
- awaiting Gemini gap/capacity review