### PR TITLE
docs(ai-history): anchor ch63 inference research (#407)

### DIFF
--- a/docs/research/ai-history/README.md
+++ b/docs/research/ai-history/README.md
@@ -10,7 +10,7 @@ This directory contains the operational research files for the definitive 72-cha
 - **Part 4 (The First Winter):** Ch17-23 cross-family cleared for capped prose drafting; Ch21 carries a Yellow-caveated Bachant/McDermott mirror-source guardrail.
 - **Part 5 (The Mathematical Resurrection):** Ch24-31 prose `accepted`.
 - **Part 8 (The Transformer, Scale & Open Source):** Ch50-57 dual-cleared `prose_ready`; Ch58 rebuilt to `capacity_plan_anchored` 2026-04-28 and awaits Gemini gap/capacity audit.
-- **Part 9 (The Product Shock & Physical Limits):** Ch59-Ch61 and Ch63 rebuilt to `capacity_plan_anchored` 2026-04-28 and await Gemini gap/capacity audit; Ch62 dual-cleared `prose_ready` with a 4,800-word cap.
+- **Part 9 (The Product Shock & Physical Limits):** Ch59-Ch61 rebuilt to `capacity_plan_anchored` 2026-04-28 and await Gemini gap/capacity audit; Ch62 and Ch63 dual-cleared `prose_ready` with 4,800- and 4,500-word caps.
 
 All drafting is paused for any chapter whose contract is not at `prose_ready` or beyond.
 

--- a/docs/research/ai-history/README.md
+++ b/docs/research/ai-history/README.md
@@ -10,7 +10,7 @@ This directory contains the operational research files for the definitive 72-cha
 - **Part 4 (The First Winter):** Ch17-23 cross-family cleared for capped prose drafting; Ch21 carries a Yellow-caveated Bachant/McDermott mirror-source guardrail.
 - **Part 5 (The Mathematical Resurrection):** Ch24-31 prose `accepted`.
 - **Part 8 (The Transformer, Scale & Open Source):** Ch50-57 dual-cleared `prose_ready`; Ch58 rebuilt to `capacity_plan_anchored` 2026-04-28 and awaits Gemini gap/capacity audit.
-- **Part 9 (The Product Shock & Physical Limits):** Ch59-Ch61 rebuilt to `capacity_plan_anchored` 2026-04-28 and await Gemini gap/capacity audit; Ch62 dual-cleared `prose_ready` with a 4,800-word cap.
+- **Part 9 (The Product Shock & Physical Limits):** Ch59-Ch61 and Ch63 rebuilt to `capacity_plan_anchored` 2026-04-28 and await Gemini gap/capacity audit; Ch62 dual-cleared `prose_ready` with a 4,800-word cap.
 
 All drafting is paused for any chapter whose contract is not at `prose_ready` or beyond.
 

--- a/docs/research/ai-history/chapters/ch-63-inference-economics/brief.md
+++ b/docs/research/ai-history/chapters/ch-63-inference-economics/brief.md
@@ -1,1 +1,82 @@
-# Brief: Chapter 63
+# Brief: Chapter 63 - Inference Economics
+
+## Thesis
+
+The product era changed the economics of AI. Training a frontier model was still
+expensive, but the daily business problem became serving: every prompt, token,
+image, and tool call consumed accelerator time, memory bandwidth, scheduler
+attention, and latency budget. This chapter should explain why inference became
+an industrial discipline: the hard part was not merely "run the model," but run
+many autoregressive requests cheaply enough, fast enough, and reliably enough
+for a product.
+
+## Boundary Contract
+
+- IN SCOPE: autoregressive serving loop; batching and latency trade-offs; KV
+  cache memory; FlashAttention as memory-hierarchy awareness; Orca and
+  iteration-level scheduling; vLLM/PagedAttention; quantization and offload as
+  cost levers; speculative decoding/sampling; prefill/decode separation and
+  goodput/SLO framing.
+- OUT OF SCOPE: training-scale physics (Ch61), multimodal UX/product category
+  shifts except as handoff from Ch62, benchmark politics (Ch66), open-weights
+  governance (Ch65), data labor/copyright (Ch68), energy-grid siting and power
+  procurement (Ch70), chip geopolitics/export controls (Ch71), and detailed
+  datacenter construction strategy (Ch72).
+- Transition from Ch62: multimodal products raised latency and media payload
+  expectations; Ch63 explains the serving machinery underneath the product.
+- Transition to Ch64/70/72: inference economics exposes why edge deployment,
+  power, memory bandwidth, and datacenter topology become separate constraints.
+
+## Required Scenes
+
+1. **The Meter Starts Running:** Product AI turns inference into a repeated
+   cost, not a one-time training bill. Every generated token is a serial step.
+2. **Batching Meets Autoregression:** Orca shows why ordinary request-level
+   batching wastes latency for generation workloads and why iteration-level
+   scheduling matters.
+3. **The Memory Wall Moves Into Serving:** FlashAttention and vLLM show that
+   memory access, not just FLOPs, governs the economics of long-context serving.
+4. **The KV Cache Becomes The Bill:** PagedAttention makes the serving problem
+   concrete: model weights are static, but per-request KV cache grows, fragments,
+   and limits batch size.
+5. **Compression, Offload, And Speculation:** SmoothQuant, FlexGen, and
+   speculative decoding/sampling show three families of cost reduction:
+   smaller arithmetic, more memory tiers, and fewer expensive target-model
+   decoding passes.
+6. **Prefill And Decode Split Apart:** DistServe turns inference into a
+   two-phase SLO problem: time to first token and time per output token pull on
+   different resource knobs.
+7. **Economics Becomes Architecture:** Close by showing why product AI labs had
+   to become serving-system operators, not only model trainers.
+
+## Prose Capacity Plan
+
+Target range: 4,600-5,400 words.
+
+- 500-700 words: bridge from multimodal/product interfaces to repeated
+  per-token serving cost; define TTFT, TPOT, throughput, latency, and goodput.
+- 650-850 words: autoregressive generation and Orca's scheduling critique:
+  request-level batching, iteration-level scheduling, selective batching.
+- 750-950 words: memory hierarchy and attention IO using FlashAttention; explain
+  why "faster math" is not enough when HBM/SRAM movement dominates.
+- 900-1,100 words: KV cache as the central serving object; vLLM/PagedAttention,
+  fragmentation, continuous batching, and throughput improvement.
+- 750-950 words: cost levers: SmoothQuant, FlexGen, speculative
+  decoding/sampling. Keep this comparative, not a catalog.
+- 650-850 words: DistServe and prefill/decode separation: TTFT vs TPOT, phase
+  interference, per-GPU goodput, and SLO-driven resource allocation.
+- 350-550 words: close on architecture consequences and handoff to Ch64/70/72.
+
+## Guardrails
+
+- Do not use unsourced rumors about ChatGPT per-day operating cost.
+- Do not quote current API prices as stable historical facts unless a dated
+  source is added and the prose clearly labels the date.
+- Do not turn the chapter into a benchmark leaderboard; Ch66 owns benchmark
+  politics.
+- Do not claim one serving trick "solved" inference economics. The source spine
+  shows trade-offs among latency, throughput, memory, and quality.
+- Do not overstate speculative decoding as universally free: draft acceptance,
+  batch size, and decoding method affect speedups.
+- Do not let energy-grid or datacenter siting overwhelm this chapter. Those are
+  Ch70 and Ch72.

--- a/docs/research/ai-history/chapters/ch-63-inference-economics/brief.md
+++ b/docs/research/ai-history/chapters/ch-63-inference-economics/brief.md
@@ -51,21 +51,21 @@ for a product.
 
 ## Prose Capacity Plan
 
-Target range: 4,600-5,400 words.
+Target range: 3,400-4,500 words.
 
-- 500-700 words: bridge from multimodal/product interfaces to repeated
+- 400-550 words: bridge from multimodal/product interfaces to repeated
   per-token serving cost; define TTFT, TPOT, throughput, latency, and goodput.
-- 650-850 words: autoregressive generation and Orca's scheduling critique:
+- 500-650 words: autoregressive generation and Orca's scheduling critique:
   request-level batching, iteration-level scheduling, selective batching.
-- 750-950 words: memory hierarchy and attention IO using FlashAttention; explain
+- 600-750 words: memory hierarchy and attention IO using FlashAttention; explain
   why "faster math" is not enough when HBM/SRAM movement dominates.
-- 900-1,100 words: KV cache as the central serving object; vLLM/PagedAttention,
+- 650-800 words: KV cache as the central serving object; vLLM/PagedAttention,
   fragmentation, continuous batching, and throughput improvement.
-- 750-950 words: cost levers: SmoothQuant, FlexGen, speculative
+- 500-700 words: cost levers: SmoothQuant, FlexGen, speculative
   decoding/sampling. Keep this comparative, not a catalog.
-- 650-850 words: DistServe and prefill/decode separation: TTFT vs TPOT, phase
+- 550-700 words: DistServe and prefill/decode separation: TTFT vs TPOT, phase
   interference, per-GPU goodput, and SLO-driven resource allocation.
-- 350-550 words: close on architecture consequences and handoff to Ch64/70/72.
+- 200-350 words: close on architecture consequences and handoff to Ch64/70/72.
 
 ## Guardrails
 

--- a/docs/research/ai-history/chapters/ch-63-inference-economics/infrastructure-log.md
+++ b/docs/research/ai-history/chapters/ch-63-inference-economics/infrastructure-log.md
@@ -1,1 +1,54 @@
-# Infrastructure Log: Chapter 63
+# Infrastructure Log: Chapter 63 - Inference Economics
+
+## Systems To Track In Prose
+
+- **Autoregressive decode loop:** A generated output is a sequence of repeated
+  model invocations, not one model call. This creates token-by-token latency and
+  per-token cost.
+- **Request-level vs iteration-level scheduling:** Orca's core insight is that
+  a fixed batch is wrong for variable-length generation. The scheduler needs to
+  admit new requests and release finished ones at iteration granularity.
+- **Selective batching:** Some Transformer operations can be batched cleanly
+  while attention over variable-length histories needs special handling.
+- **GPU memory hierarchy:** FlashAttention gives the reader the hardware reason
+  that attention and long contexts are constrained by memory traffic between HBM
+  and SRAM.
+- **KV cache lifecycle:** KV cache is per-request state. It grows during
+  decoding, fragments memory, determines possible batch size, and can be shared
+  or paged depending on the serving engine.
+- **PagedAttention/vLLM:** Treat KV cache blocks like virtual-memory pages,
+  reducing reserved/internal/external fragmentation and allowing higher serving
+  throughput.
+- **Quantization:** SmoothQuant shows the inference-specific problem of
+  activation outliers and the economic appeal of W8A8 matrix multiplication.
+- **Offload:** FlexGen adds CPU and disk memory to the serving design space when
+  throughput matters more than low latency.
+- **Speculation:** Draft/target decoding tries to turn several serial target
+  model calls into one verification pass, but speedup depends on draft quality,
+  acceptance rate, and overhead.
+- **Prefill/decode disaggregation:** DistServe separates prompt processing from
+  token generation and optimizes for TTFT and TPOT separately.
+
+## Metrics And Claims To Keep Source-Bound
+
+- Orca: 36.9x throughput improvement at same latency versus FasterTransformer
+  under its GPT-3-scale evaluation.
+- FlashAttention: 7.6x attention-computation speedup on GPT-2 in Figure 1; exact
+  attention with fewer HBM accesses.
+- SmoothQuant: up to 1.56x speedup and 2x memory reduction; W8A8 quantization.
+- FlexGen: up to 100x maximum throughput for OPT-175B under its single-T4,
+  offloading/compression setup.
+- vLLM: 2-4x serving-throughput improvement at same latency; KV cache near-zero
+  waste claim.
+- Speculative decoding/sampling: 2x-3x and 2-2.5x speedups in the cited setups,
+  with distribution-preservation caveats.
+- DistServe: up to 7.4x more requests or 12.6x tighter SLOs; TTFT/TPOT framing.
+
+## Boundary
+
+- Ch63 owns serving economics and architecture. Ch64 owns edge deployment
+  constraints; Ch70 owns energy-grid collision; Ch72 owns datacenter scale-out.
+- Ch66 owns public benchmarks and evaluation politics. Ch63 may cite paper
+  evaluation numbers only as engineering evidence for serving trade-offs.
+- Ch68 owns data provenance and labor. Do not smuggle copyright into this
+  chapter through API pricing or product economics.

--- a/docs/research/ai-history/chapters/ch-63-inference-economics/infrastructure-log.md
+++ b/docs/research/ai-history/chapters/ch-63-inference-economics/infrastructure-log.md
@@ -32,7 +32,7 @@
 ## Metrics And Claims To Keep Source-Bound
 
 - Orca: 36.9x throughput improvement at same latency versus FasterTransformer
-  under its GPT-3-scale evaluation.
+  under its GPT-3 175B evaluation.
 - FlashAttention: 7.6x attention-computation speedup on GPT-2 in Figure 1; exact
   attention with fewer HBM accesses.
 - SmoothQuant: up to 1.56x speedup and 2x memory reduction; W8A8 quantization.

--- a/docs/research/ai-history/chapters/ch-63-inference-economics/open-questions.md
+++ b/docs/research/ai-history/chapters/ch-63-inference-economics/open-questions.md
@@ -1,3 +1,24 @@
-# Open Questions
+# Open Questions: Chapter 63 - Inference Economics
 
-- SCRUBBED: All claims downgraded to Yellow. Need REAL, empirical page/section anchors from verified online PDFs or archives. Do not hallucinate.
+## Resolved For This Contract
+
+- **Use live API pricing?** No. It changes too often and would require dated,
+  provider-specific caveats. This chapter can explain the economics structurally
+  from serving-system papers without relying on unstable price tables.
+- **Include product-cost rumors?** No. Unsourced claims about ChatGPT daily cost
+  are excluded. vLLM's "10x traditional keyword query" estimate is retained only
+  as Yellow source-attributed framing.
+- **Include energy and datacenter scale?** Only as handoff. Ch70/72 own power
+  and datacenter arguments.
+- **Include benchmark politics?** No. Paper speedups are allowed as local
+  engineering evidence; public benchmark warfare belongs to Ch66.
+- **Use DistServe?** Yes. It provides a clean late-era architecture frame:
+  prefill/decode disaggregation, TTFT/TPOT, SLOs, and goodput.
+
+## Still Needed Before Prose Drafting
+
+- Claude source-fidelity review of page anchors and paper-specific claims.
+- Gemini gap/capacity audit of the 4,600-5,400 word plan, especially whether the
+  cost-levers scene should be capped below 950 words to avoid becoming a catalog.
+- Optional: add a dated official provider pricing page only if the reviewer wants
+  a short product-price sidebar. Default is to avoid it.

--- a/docs/research/ai-history/chapters/ch-63-inference-economics/people.md
+++ b/docs/research/ai-history/chapters/ch-63-inference-economics/people.md
@@ -1,1 +1,35 @@
-# People: Chapter 63
+# People: Chapter 63 - Inference Economics
+
+## Research And Systems Actors
+
+- **Gyeong-In Yu, Joo Seong Jeong, Geon-Woo Kim, Soojeong Kim, Byung-Gon Chun /
+  Orca team:** Use as the serving-systems inflection for generative Transformers:
+  iteration-level scheduling and selective batching.
+- **Tri Dao et al. / FlashAttention team:** Use as the memory-hierarchy anchor.
+  The chapter should emphasize the IO-aware idea rather than author biography.
+- **Guangxuan Xiao et al. / SmoothQuant team:** Use for quantization as an
+  inference-serving technique, especially activation outliers and W8A8
+  deployment.
+- **Ying Sheng et al. / FlexGen team:** Use for offload and throughput-oriented
+  inference under limited GPU memory.
+- **Woosuk Kwon et al. / vLLM and PagedAttention team:** Use for KV-cache memory
+  management, virtual-memory analogy, and open serving engine impact.
+- **Yaniv Leviathan, Matan Kalman, Yossi Matias; Charlie Chen et al.:** Use for
+  speculative decoding/sampling, draft-target verification, and latency
+  reduction with distribution preservation.
+- **Yinmin Zhong et al. / DistServe team:** Use for prefill/decode
+  disaggregation and SLO/goodput framing.
+
+## Institutional Actors
+
+- Systems research groups at Berkeley, Stanford, Seoul National University,
+  FriendliAI, MIT, NVIDIA, Google, DeepMind, and related labs appear through the
+  papers. Mention institutions only when they clarify the systems lineage.
+- Cloud AI providers are part of the product context, but the chapter should not
+  speculate about private cost structures.
+
+## Guardrail
+
+Do not turn this into a founder or lab rivalry chapter. The protagonist is the
+serving stack: schedulers, memory managers, quantizers, offload planners,
+speculative decoders, and SLO-driven routers.

--- a/docs/research/ai-history/chapters/ch-63-inference-economics/scene-sketches.md
+++ b/docs/research/ai-history/chapters/ch-63-inference-economics/scene-sketches.md
@@ -1,1 +1,80 @@
-# Scene Sketches: Chapter 63
+# Scene Sketches: Chapter 63 - Inference Economics
+
+## Scene 1: The Meter Starts Running
+
+- **Action:** Open with the product shift. Training is a capital shock, but
+  inference is a meter: every user request creates work that must be scheduled,
+  cached, batched, and billed against scarce accelerators.
+- **Evidence Layer:** Orca p.1; vLLM p.1; DistServe pp.1-2.
+- **Narrative Job:** Give non-specialist readers the basic variables: throughput,
+  latency, TTFT, TPOT, batch size, utilization, and goodput.
+- **Guardrail:** Do not use unsourced operating-cost rumors or live API prices.
+
+## Scene 2: Batching Meets Autoregression
+
+- **Action:** Show why a generative model is unlike an image classifier. It does
+  not simply process a request once; it loops. Orca's fixed-batch critique makes
+  the product pain concrete: finished requests wait, new requests wait, and
+  variable output length makes simple batching inefficient.
+- **Evidence Layer:** Orca abstract/page 1; Orca intro/background pp.1-3.
+- **Narrative Job:** Explain iteration-level scheduling and selective batching
+  in plain terms.
+- **Guardrail:** Do not imply Orca is the current production winner; use it as a
+  historical systems inflection.
+
+## Scene 3: The Memory Wall Moves Into Serving
+
+- **Action:** Pivot from scheduling to hardware. FlashAttention gives a clean
+  demonstration that attention performance depends on moving data through GPU
+  memory hierarchy, not merely on inventing a lower-FLOP formula.
+- **Evidence Layer:** FlashAttention pp.1-2, Figure 1, algorithm discussion.
+- **Narrative Job:** Make HBM/SRAM intuitive: the expensive part is often moving
+  the attention data, not just multiplying it.
+- **Guardrail:** FlashAttention was also important for training, but here its job
+  is to explain serving/long-context economics.
+
+## Scene 4: The KV Cache Becomes The Bill
+
+- **Action:** Introduce the KV cache as the hidden object users never see. It is
+  per-request memory that grows as the conversation grows. vLLM/PagedAttention
+  makes this visible through fragmentation, virtual-memory pages, and throughput
+  gains.
+- **Evidence Layer:** vLLM pp.1-3, Figures 1-3.
+- **Narrative Job:** Translate "context window" into a cost story: more
+  concurrent users and longer histories compete for GPU memory.
+- **Guardrail:** Do not generalize vLLM's 13B/A100 memory split to every model.
+
+## Scene 5: Compression, Offload, And Speculation
+
+- **Action:** Compare three families of economic tricks. SmoothQuant reduces
+  bytes and uses cheaper integer arithmetic. FlexGen moves tensors through GPU,
+  CPU, and disk for throughput-oriented work. Speculative decoding pays for a
+  small draft model to avoid some expensive serial target-model passes.
+- **Evidence Layer:** SmoothQuant p.1; FlexGen pp.1-3; speculative decoding p.1;
+  speculative sampling pp.1 and 7-8.
+- **Narrative Job:** Show that "make inference cheaper" is not one technique; it
+  is a portfolio of trade-offs.
+- **Guardrail:** Keep FlexGen separated from low-latency chat; keep speculative
+  speedups tied to acceptance/overhead.
+
+## Scene 6: Prefill And Decode Split Apart
+
+- **Action:** DistServe names the mature serving split. Prompt processing and
+  output-token generation have different latency measures and different hardware
+  preferences, so colocating them can create interference.
+- **Evidence Layer:** DistServe pp.1-3.
+- **Narrative Job:** Make TTFT and TPOT the chapter's final conceptual tool.
+  This sets up why inference becomes infrastructure planning.
+- **Guardrail:** Do not claim disaggregation is always best; the source frames it
+  around goodput and SLOs.
+
+## Scene 7: Economics Becomes Architecture
+
+- **Action:** Close by reframing the AI lab. A product lab is now a serving
+  operator: schedulers, caches, memory managers, quantizers, routers, and SLOs
+  become part of the model's public behavior.
+- **Evidence Layer:** Synthesize only from the cited serving papers.
+- **Narrative Job:** Handoff to Ch64, Ch70, and Ch72: once inference dominates
+  the product bill, edge constraints, power, and datacenters become narrative
+  centerpieces.
+- **Guardrail:** No new source-free claims about total industry spending.

--- a/docs/research/ai-history/chapters/ch-63-inference-economics/sources.md
+++ b/docs/research/ai-history/chapters/ch-63-inference-economics/sources.md
@@ -1,1 +1,68 @@
-# Sources: Chapter 63
+# Sources: Chapter 63 - Inference Economics
+
+## Research Status
+
+Contract is `capacity_plan_anchored` as of 2026-04-28. Sources below were
+verified from arXiv and USENIX PDFs using local `curl` + `pdftotext`. The
+chapter still needs Claude source-fidelity review and Gemini gap/capacity audit
+before prose drafting.
+
+## Primary Source Spine
+
+| Source | Use | Verification |
+|---|---|---|
+| Gyeong-In Yu et al., "Orca: A Distributed Serving System for Transformer-Based Generative Models," OSDI 2022. PDF: https://www.usenix.org/system/files/osdi22-yu.pdf | Autoregressive serving, iteration-level scheduling, selective batching, latency/throughput trade-off. | Green: PDF downloaded 2026-04-28. Abstract/page 1 says generation requires multiple model iterations, existing request-level batching blocks finished and newly arrived requests, Orca proposes iteration-level scheduling and selective batching, and evaluation on GPT-3 175B shows 36.9x throughput improvement at same latency versus FasterTransformer. |
+| Tri Dao et al., "FlashAttention: Fast and Memory-Efficient Exact Attention with IO-Awareness," arXiv:2205.14135. PDF: https://arxiv.org/pdf/2205.14135 | Memory hierarchy: attention speed depends on HBM/SRAM reads and writes, not only FLOPs. | Green: PDF downloaded 2026-04-28. Abstract/page 1 says Transformers are slow and memory-hungry on long sequences; FlashAttention is IO-aware, reduces reads/writes between HBM and SRAM, and gets wall-clock speedups. Page 2/Figure 1 says it avoids reading/writing the large N x N attention matrix to HBM and reports 7.6x attention-computation speedup on GPT-2. |
+| Guangxuan Xiao et al., "SmoothQuant: Accurate and Efficient Post-Training Quantization for Large Language Models," arXiv:2211.10438. PDF: https://arxiv.org/pdf/2211.10438 | Quantization as inference cost lever; activation outliers; W8A8 serving. | Green: PDF downloaded 2026-04-28. Abstract/page 1 says quantization reduces memory and accelerates inference; SmoothQuant enables W8A8 quantization by migrating activation outlier difficulty to weights, with up to 1.56x speedup and 2x memory reduction. Introduction/page 1 says GPT-3 175B needs at least 350GB memory in FP16. |
+| Ying Sheng et al., "FlexGen: High-Throughput Generative Inference of Large Language Models with a Single GPU," arXiv:2303.06865. PDF: https://arxiv.org/pdf/2303.06865 | Offload and memory-tier economics for latency-insensitive/high-throughput inference. | Green: PDF downloaded 2026-04-28. Abstract/page 1 defines high-throughput generation with limited GPU memory, aggregates GPU/CPU/disk memory, and claims 100x higher maximum throughput for OPT-175B on a single T4 with compression/offloading. Introduction/page 2 gives concrete memory hierarchy and batch/latency trade-offs. |
+| Woosuk Kwon et al., "Efficient Memory Management for Large Language Model Serving with PagedAttention," SOSP 2023 / arXiv:2309.06180. PDF: https://arxiv.org/pdf/2309.06180 | KV cache as serving bottleneck; PagedAttention/vLLM; fragmentation and throughput. | Green: PDF downloaded 2026-04-28. Abstract/page 1 says KV cache memory is huge, dynamic, and wasted by fragmentation/duplication; PagedAttention uses virtual-memory-inspired paging; vLLM achieves near-zero KV cache waste and 2-4x throughput improvement at same latency versus FasterTransformer/Orca. Page 1 says an LLM request can be 10x more expensive than a traditional keyword query, but use as Yellow framing because it cites an external estimate. |
+| Yaniv Leviathan, Matan Kalman, Yossi Matias, "Fast Inference from Transformers via Speculative Decoding," ICML 2023 / arXiv:2211.17192. PDF: https://arxiv.org/pdf/2211.17192 | Speculative decoding: fewer target-model serial passes without changing output distribution. | Green: PDF downloaded 2026-04-28. Abstract/page 1 says decoding K tokens normally takes K serial model runs; speculative decoding uses a faster model to draft several tokens and the target model to verify them concurrently without changing distribution, reporting 2x-3x latency improvement. |
+| Charlie Chen et al., "Accelerating Large Language Model Decoding with Speculative Sampling," arXiv:2302.01318. PDF: https://arxiv.org/pdf/2302.01318 | Independent speculative-sampling confirmation and limitations: draft acceptance, latency, decoding method. | Green: PDF downloaded 2026-04-28. Abstract/page 1 says speculative sampling uses a faster draft model and modified rejection sampling to preserve target distribution; Chinchilla 70B benchmarks show 2-2.5x decoding speedup. Later sections note speedup plateaus/regresses with larger draft length depending on acceptance and overhead. |
+| Yinmin Zhong et al., "DistServe: Disaggregating Prefill and Decoding for Goodput-optimized Large Language Model Serving," OSDI 2024. PDF: https://www.usenix.org/system/files/osdi24-zhong-yinmin.pdf | Prefill/decode split, TTFT/TPOT, phase interference, per-GPU goodput. | Green: PDF downloaded 2026-04-28. Abstract/page 1 says existing systems colocate/batch prefill and decoding, causing interference and resource coupling; DistServe assigns phases to different GPUs and can serve up to 7.4x more requests or meet 12.6x tighter SLOs. Pages 1-3 define TTFT/TPOT and explain prefill as compute-bound and decoding as constrained by memory/I/O. |
+
+## Scene-Level Claim Table
+
+| Claim | Scene | Primary Anchor | Independent Confirmation | Status | Notes |
+|---|---|---|---|---|---|
+| Autoregressive generation runs a model repeatedly, one or a few tokens at a time, making inference a recurring product cost. | Meter Starts Running | Orca p.1 | vLLM p.1; DistServe pp.1-2 | Green | Use to define why inference differs from one-shot classification. |
+| Traditional request-level batching is poorly matched to variable-length generation because finished requests and new arrivals wait for the batch. | Batching Meets Autoregression | Orca p.1 | vLLM background | Green | Core latency scene. |
+| Orca proposes iteration-level scheduling and selective batching for generative Transformer serving. | Batching Meets Autoregression | Orca p.1 and pp.2-5 | vLLM cites Orca as prior state of art | Green | Avoid diving into implementation minutiae. |
+| Orca reports 36.9x throughput improvement at the same latency against FasterTransformer for GPT-3-scale serving. | Batching Meets Autoregression | Orca p.1 | Orca intro p.2 | Green | Treat as paper evaluation, not universal production result. |
+| FlashAttention identifies attention as memory/IO-bound and reduces HBM/SRAM reads and writes. | Memory Wall | FlashAttention p.1 | FlashAttention Fig. 1/page 2 | Green | Use to explain memory hierarchy, not only training. |
+| FlashAttention avoids materializing the full N x N attention matrix in HBM and reports 7.6x attention-computation speedup on GPT-2. | Memory Wall | FlashAttention Fig. 1/page 2 | Algorithm section pp.4-5 | Green | Good concrete anchor. |
+| In LLM serving, model weights are mostly static but KV cache grows dynamically per request and can consume close to 30% of A100 memory in the vLLM example. | KV Cache Becomes The Bill | vLLM p.1/Fig. 1 | vLLM Section 3 | Green | Do not generalize 30% to all systems. |
+| Inefficient KV cache management limits batch size and throughput. | KV Cache Becomes The Bill | vLLM pp.1-3 | DistServe decoding memory discussion | Green | Central economic mechanism. |
+| PagedAttention borrows OS paging to store KV cache in non-contiguous blocks and reduce fragmentation. | KV Cache Becomes The Bill | vLLM pp.1-2 | Figure 2 | Green | Strong explanatory analogy. |
+| vLLM reports 2-4x serving-throughput improvement at same latency versus FasterTransformer/Orca. | KV Cache Becomes The Bill | vLLM abstract/p.2 | Evaluation sections | Green | Paper evaluation only. |
+| SmoothQuant treats quantization as both memory reduction and inference acceleration, enabling W8A8 quantization for LLM matrix multiplications. | Compression/Offload/Speculation | SmoothQuant p.1 | SmoothQuant prelims | Green | Explain activation outliers carefully. |
+| SmoothQuant reports up to 1.56x speedup and 2x memory reduction with negligible accuracy loss. | Compression/Offload/Speculation | SmoothQuant p.1 | Results sections | Green | Paper-specific result. |
+| FlexGen shows latency-insensitive, batched inference can trade latency for throughput by offloading across GPU, CPU, and disk memory. | Compression/Offload/Speculation | FlexGen pp.1-3 | Figure 1 | Green | Boundary: not real-time chat default. |
+| FlexGen reports OPT-175B on a single 16GB T4 with high-throughput/offload trade-offs and up to 100x higher maximum throughput versus offloading baselines under its setup. | Compression/Offload/Speculation | FlexGen pp.1-3 | Evaluation setup | Green | Keep as constrained benchmark. |
+| Speculative decoding uses a small/draft model to propose tokens and a larger target model to verify them, preserving the target distribution. | Compression/Offload/Speculation | Speculative Decoding p.1 | Speculative Sampling p.1 | Green | Do not imply quality shortcuts. |
+| Speculative decoding/sampling reports roughly 2x-3x or 2-2.5x speedups in evaluated setups, with acceptance/overhead limits. | Compression/Offload/Speculation | Speculative Decoding p.1; Speculative Sampling pp.1, 7-8 | Both papers | Green | Include plateau/regression caveat. |
+| DistServe frames serving around TTFT for prefill and TPOT for decoding. | Prefill And Decode Split | DistServe pp.1-2 | DistServe Section 2 | Green | Useful definitions for readers. |
+| DistServe argues colocating prefill and decoding creates interference and resource coupling. | Prefill And Decode Split | DistServe p.1 and Section 2.3 | Figures 1-2 | Green | Main architecture shift. |
+| DistServe describes prefill as often compute-bound and decoding as constrained by similar I/O per step despite one-token processing. | Prefill And Decode Split | DistServe pp.2-3 | DistServe Section 3 | Green | Avoid absolute phrasing; "often" and setup-specific. |
+| DistServe reports up to 7.4x more requests or 12.6x tighter SLOs versus state-of-art baselines. | Prefill And Decode Split | DistServe p.1 | Evaluation sections | Green | Paper evaluation only. |
+| vLLM cites an estimate that an LLM request can be 10x more expensive than a traditional keyword query. | Meter Starts Running | vLLM p.1 | External estimate cited by paper, not independently fetched here | Yellow | Use only as source-attributed framing, not as a measured claim of this chapter. |
+
+## Conflict Notes
+
+- Do not quote current cloud/API prices as if they are stable historical facts.
+- Do not convert paper benchmark speedups into production guarantees.
+- Distinguish latency-sensitive chat from throughput-oriented batch/offline
+  inference; FlexGen is mainly the latter.
+- Distinguish prefill (prompt processing, TTFT) from decode (sequential output,
+  TPOT). This is the chapter's cleanest explanatory axis.
+- Keep energy and physical power-grid consequences as handoffs to Ch70/72.
+
+## Anchor Worklist For Prose
+
+- Use Orca p.1 for the "ordinary batching breaks on generation" scene.
+- Use FlashAttention pp.1-2 to explain IO-aware attention and HBM/SRAM.
+- Use vLLM pp.1-3 for KV cache, fragmentation, PagedAttention, and 2-4x
+  throughput claims.
+- Use SmoothQuant p.1 and FlexGen pp.1-3 for compression/offload cost levers.
+- Use speculative decoding/sampling p.1 plus later caveat sections for the
+  "draft and verify" scene.
+- Use DistServe pp.1-3 for TTFT/TPOT, prefill/decode interference, and goodput.

--- a/docs/research/ai-history/chapters/ch-63-inference-economics/sources.md
+++ b/docs/research/ai-history/chapters/ch-63-inference-economics/sources.md
@@ -5,7 +5,8 @@
 Contract is `capacity_plan_anchored` as of 2026-04-28. Sources below were
 verified from arXiv and USENIX PDFs using local `curl` + `pdftotext`. The
 chapter still needs Claude source-fidelity review and Gemini gap/capacity audit
-before prose drafting.
+before prose drafting. Gemini's first gap audit requested a tighter 3,400-4,500
+word natural cap to prevent the cost-lever scene from becoming a catalog.
 
 ## Primary Source Spine
 

--- a/docs/research/ai-history/chapters/ch-63-inference-economics/status.yaml
+++ b/docs/research/ai-history/chapters/ch-63-inference-economics/status.yaml
@@ -1,1 +1,35 @@
-status: researching
+status: capacity_plan_anchored
+owner: Codex
+part: 9
+chapter: 63
+review_state: awaiting_claude_source_review_and_gemini_gap_audit
+last_updated: 2026-04-28
+green_claims: 20
+yellow_claims: 1
+red_claims: 0
+guardrail_count: 6
+prose_word_cap_recommendation: 5400
+word_count_range: "4600-5400"
+verdicts:
+  claude:
+    model: null
+    date: null
+    verdict: null
+    review_url: null
+  gemini:
+    model: null
+    date: null
+    verdict: null
+    word_cap: null
+    review_url: null
+  resolved: null
+  resolved_word_cap: null
+  resolution_rule: dual_cross_family_verdict_with_cap
+notes: |
+  Built from a scrubbed shell into a capacity_plan_anchored inference-serving
+  contract. Core anchors are Orca, FlashAttention, SmoothQuant, FlexGen,
+  vLLM/PagedAttention, speculative decoding/sampling, and DistServe.
+
+  Safe draft range is 4,600-5,400 words pending Gemini capacity audit. Avoid
+  live API-price claims, unsourced product-cost rumors, benchmark politics,
+  copyright/data-labor disputes, and power-grid/datacenter expansion material.

--- a/docs/research/ai-history/chapters/ch-63-inference-economics/status.yaml
+++ b/docs/research/ai-history/chapters/ch-63-inference-economics/status.yaml
@@ -1,8 +1,8 @@
-status: capacity_plan_anchored
+status: prose_ready
 owner: Codex
 part: 9
 chapter: 63
-review_state: awaiting_gemini_recheck_after_capacity_trim
+review_state: dual_cross_family_verdict_accepted
 last_updated: 2026-04-28
 green_claims: 20
 yellow_claims: 1
@@ -17,13 +17,13 @@ verdicts:
     verdict: APPROVE
     review_url: https://github.com/kube-dojo/kube-dojo.github.io/pull/518#issuecomment-4339038245
   gemini:
-    model: null
-    date: null
-    verdict: null
-    word_cap: null
-    review_url: null
-  resolved: null
-  resolved_word_cap: null
+    model: gemini-3.1-pro-preview
+    date: 2026-04-28
+    verdict: READY_TO_DRAFT_WITH_CAP
+    word_cap: 4500
+    review_url: https://github.com/kube-dojo/kube-dojo.github.io/pull/518#issuecomment-4339054749
+  resolved: READY_TO_DRAFT_WITH_CAP
+  resolved_word_cap: 4500
   resolution_rule: dual_cross_family_verdict_with_cap
 notes: |
   Built from a scrubbed shell into a capacity_plan_anchored inference-serving

--- a/docs/research/ai-history/chapters/ch-63-inference-economics/status.yaml
+++ b/docs/research/ai-history/chapters/ch-63-inference-economics/status.yaml
@@ -2,20 +2,20 @@ status: capacity_plan_anchored
 owner: Codex
 part: 9
 chapter: 63
-review_state: awaiting_claude_source_review_and_gemini_gap_audit
+review_state: awaiting_gemini_recheck_after_capacity_trim
 last_updated: 2026-04-28
 green_claims: 20
 yellow_claims: 1
 red_claims: 0
 guardrail_count: 6
-prose_word_cap_recommendation: 5400
-word_count_range: "4600-5400"
+prose_word_cap_recommendation: 4500
+word_count_range: "3400-4500"
 verdicts:
   claude:
-    model: null
-    date: null
-    verdict: null
-    review_url: null
+    model: claude-opus-4-7
+    date: 2026-04-28
+    verdict: APPROVE
+    review_url: https://github.com/kube-dojo/kube-dojo.github.io/pull/518#issuecomment-4339038245
   gemini:
     model: null
     date: null
@@ -30,6 +30,7 @@ notes: |
   contract. Core anchors are Orca, FlashAttention, SmoothQuant, FlexGen,
   vLLM/PagedAttention, speculative decoding/sampling, and DistServe.
 
-  Safe draft range is 4,600-5,400 words pending Gemini capacity audit. Avoid
-  live API-price claims, unsourced product-cost rumors, benchmark politics,
-  copyright/data-labor disputes, and power-grid/datacenter expansion material.
+  Safe draft range is 3,400-4,500 words after Gemini's first capacity audit.
+  Avoid live API-price claims, unsourced product-cost rumors, benchmark
+  politics, copyright/data-labor disputes, and power-grid/datacenter expansion
+  material.

--- a/docs/research/ai-history/chapters/ch-63-inference-economics/timeline.md
+++ b/docs/research/ai-history/chapters/ch-63-inference-economics/timeline.md
@@ -1,1 +1,22 @@
-# Timeline: Chapter 63
+# Timeline: Chapter 63 - Inference Economics
+
+- **2022-05:** FlashAttention reframes attention speed around GPU memory
+  hierarchy, arguing that wall-clock performance depends on IO between HBM and
+  SRAM as much as asymptotic FLOPs.
+- **2022-07:** Orca appears at OSDI, identifying autoregressive Transformer
+  generation as a serving-systems problem and proposing iteration-level
+  scheduling plus selective batching.
+- **2022-11:** SmoothQuant shows a post-training path to W8A8 LLM inference,
+  linking quantization directly to serving memory and speed.
+- **2022-11 / 2023-02:** Speculative decoding and speculative sampling show how
+  a draft model can reduce target-model serial decoding passes while preserving
+  the target distribution under a rejection/verification scheme.
+- **2023-03:** FlexGen demonstrates that, for throughput-oriented workloads,
+  LLM inference can trade latency for higher throughput by coordinating GPU,
+  CPU, and disk memory plus compression.
+- **2023-09 / 2023-10:** vLLM/PagedAttention makes KV-cache memory management a
+  first-class serving primitive, borrowing virtual-memory paging ideas to reduce
+  fragmentation and increase throughput.
+- **2024:** DistServe formalizes the next serving split: prefill and decode have
+  different latency metrics, resource preferences, and interference patterns, so
+  they can be scheduled on different GPU pools.

--- a/src/content/docs/ai-history/index.md
+++ b/src/content/docs/ai-history/index.md
@@ -188,7 +188,7 @@ Consumer adoption, edge constraints, and AI transitioning to heavy industry.
 | 60 | The Agent Turn | capacity_plan_anchored | no |
 | 61 | The Physics of Scale | capacity_plan_anchored | no |
 | 62 | Multimodal Convergence | prose_ready | no |
-| 63 | Inference Economics | capacity_plan_anchored | no |
+| 63 | Inference Economics | prose_ready | no |
 | 64 | The Edge Compute Bottleneck | researching | no |
 | 65 | The Open Weights Rebellion | researching | no |
 | 66 | Benchmark Wars | researching | no |
@@ -205,8 +205,8 @@ Consumer adoption, edge constraints, and AI transitioning to heavy industry.
 |---|---:|
 | `accepted` (drafted, all reviews cleared) | 29 |
 | `prose_review` (drafted, in review) | 0 |
-| `prose_ready` (contract dual-cleared, awaiting prose draft) | 16 |
-| `capacity_plan_anchored` (contract anchored, awaiting verdict) | 5 |
+| `prose_ready` (contract dual-cleared, awaiting prose draft) | 17 |
+| `capacity_plan_anchored` (contract anchored, awaiting verdict) | 4 |
 | `researching` with prose merged on legacy contract | 5 |
 | `researching` (no prose yet) | 17 |
 | **Total** | **72** |

--- a/src/content/docs/ai-history/index.md
+++ b/src/content/docs/ai-history/index.md
@@ -188,7 +188,7 @@ Consumer adoption, edge constraints, and AI transitioning to heavy industry.
 | 60 | The Agent Turn | capacity_plan_anchored | no |
 | 61 | The Physics of Scale | capacity_plan_anchored | no |
 | 62 | Multimodal Convergence | prose_ready | no |
-| 63 | Inference Economics | researching | no |
+| 63 | Inference Economics | capacity_plan_anchored | no |
 | 64 | The Edge Compute Bottleneck | researching | no |
 | 65 | The Open Weights Rebellion | researching | no |
 | 66 | Benchmark Wars | researching | no |
@@ -206,7 +206,7 @@ Consumer adoption, edge constraints, and AI transitioning to heavy industry.
 | `accepted` (drafted, all reviews cleared) | 29 |
 | `prose_review` (drafted, in review) | 0 |
 | `prose_ready` (contract dual-cleared, awaiting prose draft) | 16 |
-| `capacity_plan_anchored` (contract anchored, awaiting verdict) | 4 |
+| `capacity_plan_anchored` (contract anchored, awaiting verdict) | 5 |
 | `researching` with prose merged on legacy contract | 5 |
-| `researching` (no prose yet) | 18 |
+| `researching` (no prose yet) | 17 |
 | **Total** | **72** |


### PR DESCRIPTION
## Summary
- rebuilds Ch63 Inference Economics from scrubbed shell to capacity_plan_anchored contract
- anchors serving economics around Orca, FlashAttention, SmoothQuant, FlexGen, vLLM/PagedAttention, speculative decoding/sampling, and DistServe
- updates AI History README and public index roll-up for Ch63 status

## Checks
- git diff --check
- YAML sanity check for Ch63 status
- npm run astro -- sync (passes; existing cloudformation/haproxy highlighter warnings only)

## Review focus
Please verify source fidelity for paper-specific speedups and boundary discipline: no live API pricing, no unsourced cost rumors, no benchmark-politics drift, no power-grid/datacenter material beyond handoff.