### PR TITLE
docs(ai-history): mark ch58 prose ready (#406)

### DIFF
--- a/docs/research/ai-history/README.md
+++ b/docs/research/ai-history/README.md
@@ -9,7 +9,7 @@ This directory contains the operational research files for the definitive 72-cha
 - **Part 6 (The Rise of Data & Distributed Compute):** Ch32-37 dual-cleared `prose_ready` 2026-04-28 (caps 5,600 / 4,900 / 5,200 / 4,300 / 5,000 / 5,000); Ch38-40 not yet rebuilt.
 - **Part 4 (The First Winter):** Ch17-23 cross-family cleared for capped prose drafting; Ch21 carries a Yellow-caveated Bachant/McDermott mirror-source guardrail.
 - **Part 5 (The Mathematical Resurrection):** Ch24-31 prose `accepted`.
-- **Part 8 (The Transformer, Scale & Open Source):** Ch50-57 dual-cleared `prose_ready`; Ch58 rebuilt to `capacity_plan_anchored` 2026-04-28 and awaits Gemini gap/capacity audit.
+- **Part 8 (The Transformer, Scale & Open Source):** Ch50-58 dual-cleared `prose_ready`; Ch58 cap is 5,200 words.
 - **Part 9 (The Product Shock & Physical Limits):** Ch59-Ch61 rebuilt to `capacity_plan_anchored` 2026-04-28 and await Gemini gap/capacity audit; Ch62 and Ch63 dual-cleared `prose_ready` with 4,800- and 4,500-word caps.
 
 All drafting is paused for any chapter whose contract is not at `prose_ready` or beyond.

--- a/docs/research/ai-history/chapters/ch-58-the-math-of-noise/status.yaml
+++ b/docs/research/ai-history/chapters/ch-58-the-math-of-noise/status.yaml
@@ -1,29 +1,29 @@
-status: capacity_plan_anchored
+status: prose_ready
 owner: Codex
 part: 8
 chapter: 58
-review_state: awaiting_claude_source_review_and_gemini_gap_audit
+review_state: dual_cross_family_verdict_accepted
 last_updated: 2026-04-28
 green_claims: 16
 yellow_claims: 3
 red_claims: 0
 guardrail_count: 6
-prose_word_cap_recommendation: 5800
-word_count_range: "4000-5800"
+prose_word_cap_recommendation: 5200
+word_count_range: "4000-5200"
 verdicts:
   claude:
-    model: null
-    date: null
-    verdict: null
-    review_url: null
+    model: claude-opus-4-7
+    date: 2026-04-28
+    verdict: APPROVE
+    review_url: https://github.com/kube-dojo/kube-dojo.github.io/pull/507#issuecomment-4339255007
   gemini:
-    model: null
-    date: null
-    verdict: null
-    word_cap: null
-    review_url: null
-  resolved: null
-  resolved_word_cap: null
+    model: gemini-3-flash-preview
+    date: 2026-04-28
+    verdict: READY_TO_DRAFT_WITH_CAP
+    word_cap: 5200
+    review_url: https://github.com/kube-dojo/kube-dojo.github.io/pull/507#issuecomment-4339289194
+  resolved: READY_TO_DRAFT_WITH_CAP
+  resolved_word_cap: 5200
   resolution_rule: dual_cross_family_verdict_with_cap
 notes: |
   Rebuilt from scrubbed/yellow skeleton into an anchored research contract using
@@ -46,7 +46,6 @@ notes: |
   Stable Diffusion first-party adoption claims, and the transition to
   open-weights/copyright politics. No Red claims remain in the drafting spine.
 
-  Safe prose range is 4,000-5,800 words. The chapter should not exceed that
-  unless a reviewer adds independent adoption/public-impact anchors. Do not pad
+  Safe prose range is 4,000-5,200 words after Gemini gap/capacity audit. Do not pad
   with Midjourney internals, copyright/labor analysis, or open-weights politics;
   those belong to later chapters.

--- a/src/content/docs/ai-history/index.md
+++ b/src/content/docs/ai-history/index.md
@@ -174,7 +174,7 @@ Scaling laws, Attention, and the democratization of AI through open weights.
 | 55 | The Scaling Laws | accepted | no |
 | 56 | The Megacluster | accepted | no |
 | 57 | The Alignment Problem | accepted | no |
-| 58 | The Math of Noise | capacity_plan_anchored | no |
+| 58 | The Math of Noise | prose_ready | no |
 
 ## Part 9 — The Product Shock & Physical Limits (2022–Present)
 
@@ -205,8 +205,8 @@ Consumer adoption, edge constraints, and AI transitioning to heavy industry.
 |---|---:|
 | `accepted` (drafted, all reviews cleared) | 29 |
 | `prose_review` (drafted, in review) | 0 |
-| `prose_ready` (contract dual-cleared, awaiting prose draft) | 17 |
-| `capacity_plan_anchored` (contract anchored, awaiting verdict) | 4 |
+| `prose_ready` (contract dual-cleared, awaiting prose draft) | 18 |
+| `capacity_plan_anchored` (contract anchored, awaiting verdict) | 3 |
 | `researching` with prose merged on legacy contract | 5 |
 | `researching` (no prose yet) | 17 |
 | **Total** | **72** |


### PR DESCRIPTION
## Summary
- records Claude and Gemini verdicts for Ch58 The Math of Noise
- lowers accepted Ch58 cap to Gemini's 5,200-word natural cap
- updates AI History README and public index so Part 8 is fully prose-ready

## Checks
- git diff --check
- YAML sanity check for Ch58 status
- npm run astro -- sync (passes; existing cloudformation/haproxy highlighter warnings only)

## Review evidence
- Claude source review: https://github.com/kube-dojo/kube-dojo.github.io/pull/507#issuecomment-4339255007
- Gemini gap/capacity audit: https://github.com/kube-dojo/kube-dojo.github.io/pull/507#issuecomment-4339289194