### PR TITLE
docs(ai-history): anchor ch65 open weights research (#407)

### DIFF
--- a/docs/research/ai-history/README.md
+++ b/docs/research/ai-history/README.md
@@ -10,7 +10,7 @@ This directory contains the operational research files for the definitive 72-cha
 - **Part 4 (The First Winter):** Ch17-23 cross-family cleared for capped prose drafting; Ch21 carries a Yellow-caveated Bachant/McDermott mirror-source guardrail.
 - **Part 5 (The Mathematical Resurrection):** Ch24-31 prose `accepted`.
 - **Part 8 (The Transformer, Scale & Open Source):** Ch50-58 dual-cleared `prose_ready`; Ch58 cap is 5,200 words.
-- **Part 9 (The Product Shock & Physical Limits):** Ch59-Ch61 and Ch65 rebuilt to `capacity_plan_anchored` 2026-04-28; Ch62, Ch63, and Ch64 dual-cleared `prose_ready` with 4,800-, 4,500-, and 5,000-word caps.
+- **Part 9 (The Product Shock & Physical Limits):** Ch59-Ch61 rebuilt to `capacity_plan_anchored` 2026-04-28; Ch62-Ch65 dual-cleared `prose_ready` with 4,800-, 4,500-, 5,000-, and 5,300-word caps.
 
 All drafting is paused for any chapter whose contract is not at `prose_ready` or beyond.
 

--- a/docs/research/ai-history/README.md
+++ b/docs/research/ai-history/README.md
@@ -10,7 +10,7 @@ This directory contains the operational research files for the definitive 72-cha
 - **Part 4 (The First Winter):** Ch17-23 cross-family cleared for capped prose drafting; Ch21 carries a Yellow-caveated Bachant/McDermott mirror-source guardrail.
 - **Part 5 (The Mathematical Resurrection):** Ch24-31 prose `accepted`.
 - **Part 8 (The Transformer, Scale & Open Source):** Ch50-58 dual-cleared `prose_ready`; Ch58 cap is 5,200 words.
-- **Part 9 (The Product Shock & Physical Limits):** Ch59-Ch61 rebuilt to `capacity_plan_anchored` 2026-04-28; Ch62, Ch63, and Ch64 dual-cleared `prose_ready` with 4,800-, 4,500-, and 5,000-word caps.
+- **Part 9 (The Product Shock & Physical Limits):** Ch59-Ch61 and Ch65 rebuilt to `capacity_plan_anchored` 2026-04-28; Ch62, Ch63, and Ch64 dual-cleared `prose_ready` with 4,800-, 4,500-, and 5,000-word caps.
 
 All drafting is paused for any chapter whose contract is not at `prose_ready` or beyond.
 

--- a/docs/research/ai-history/chapters/ch-65-the-open-weights-rebellion/brief.md
+++ b/docs/research/ai-history/chapters/ch-65-the-open-weights-rebellion/brief.md
@@ -1,1 +1,91 @@
-# Brief: Chapter 65
+# Brief: Chapter 65 - The Open Weights Rebellion
+
+## Thesis
+
+Open weights changed the politics of frontier AI without cleanly solving the
+politics of AI. Stable Diffusion proved that a capable generative model could
+leave the API and run in public hands. LLaMA then made language models feel
+portable: released weights, cheap instruction tuning, LoRA adapters,
+QLoRA quantization, and permissive releases like Mistral 7B turned the lab moat
+from "only we can run it" into "who controls the best base model, data, license,
+distribution channel, evaluation story, and deployment stack?" This chapter
+should not romanticize "open" as a single category. It should explain the messy
+ladder from research-only access to non-commercial derivatives to commercially
+usable weights, and why that ladder forced closed labs, cloud vendors, regulators,
+and hobbyist communities to react.
+
+## Boundary Contract
+
+- IN SCOPE: Stable Diffusion as the public open-weights precedent; LLaMA 1's
+  research-community release and public-data/open-sourcing claim; LoRA/QLoRA as
+  the adaptation and hardware-barrier reducers; Alpaca/Vicuna as early
+  instruction-tuned community descendants with non-commercial and evaluation
+  caveats; Llama 2's research/commercial release; Mistral 7B's Apache 2.0
+  permissive release; the difference between open weights, open source, open
+  data, and open governance.
+- OUT OF SCOPE: diffusion mathematics and image-generation mechanics (Ch58);
+  inference serving economics (Ch63); edge deployment constraints (Ch64);
+  benchmark politics as a standalone product weapon (Ch66); monopoly/platform
+  power (Ch67); data labor/copyright fights (Ch68); data exhaustion (Ch69);
+  datacenter power/grid constraints (Ch70/72); export controls (Ch71).
+- Transition from Ch64: Ch64 explains why local devices need smaller, quantized,
+  specialized models; Ch65 explains why downloadable weights and cheap adapters
+  made those constraints politically and commercially salient.
+- Transition to Ch66/67/68: once weights circulate, reputation moves to
+  leaderboards, platforms, licenses, and data provenance.
+
+## Required Scenes
+
+1. **The Image Model Leaves The API:** Stable Diffusion is the precedent: weights,
+   code, model card, license, consumer-GPU memory claims, LAION data, and safety
+   caveats all arrive in public view.
+2. **LLaMA Makes Portability Concrete:** Meta's paper frames LLaMA as 7B-65B
+   models trained on public data and released to the research community, with
+   13B/65B performance claims that make smaller downloadable models feel serious.
+3. **Adapters Turn Access Into Modification:** LoRA changes "fine-tune a giant
+   model" into "freeze the base, train small low-rank modules"; QLoRA later pushes
+   large-model tuning onto a single 48GB GPU.
+4. **The Weekend Clone Moment:** Alpaca and Vicuna show how quickly instruction
+   tuning, ShareGPT-style data, and community evaluation can wrap a base model,
+   but their non-commercial licenses, self-reported costs, and evaluation caveats
+   prevent easy triumphalism.
+5. **Commercial Open Weights Arrive:** Llama 2 and Mistral 7B move from research
+   access toward commercially usable and permissively licensed weights; the story
+   becomes not "open versus closed" but "which terms, which data, which safety
+   process, and which ecosystem?"
+6. **The Rebellion Becomes Infrastructure:** close on open weights as a durable
+   ecosystem layer: base models, adapters, quantized forks, leaderboards, hosting,
+   local inference, and legal/governance arguments.
+
+## Prose Capacity Plan
+
+Target range: 4,200-5,300 words.
+
+- 450-600 words: define open weights vs open source vs open data vs open
+  governance; bridge from Ch64's local constraints to Ch65's access politics.
+- 650-800 words: Stable Diffusion as the public precedent, using Ch58's anchored
+  release facts without re-explaining diffusion math.
+- 650-800 words: LLaMA 1 as the language-model portability shock: 7B-65B scale,
+  public-data/open-sourcing framing, and performance claims.
+- 800-950 words: LoRA and QLoRA as the technical reason weights became
+  modifiable by small teams: trainable-parameter, memory, and hardware anchors.
+- 750-900 words: Alpaca and Vicuna as community instruction-tuning case studies,
+  with explicit non-commercial, data, cost, and evaluation caveats.
+- 650-800 words: Llama 2 and Mistral 7B as the commercial/permissive turn,
+  contrasting limited open release with Apache 2.0.
+- 250-450 words: close and handoff to Ch66/67/68.
+
+## Guardrails
+
+- Do not call LLaMA, Llama 2, Stable Diffusion, or Mistral "open source" unless
+  the source/license actually supports that wording. Prefer "open weights" or
+  "released weights" when code/data/governance are not fully open.
+- Do not treat leaked LLaMA access as a verified episode unless a primary or
+  reliable archived source is added later; the current contract can describe
+  rapid community derivatives without asserting leak mechanics.
+- Treat Alpaca/Vicuna cost and benchmark claims as project-reported and caveated,
+  not independent proof of model quality.
+- Do not import Ch66's benchmark-politics chapter except to hand off the
+  evaluation problem.
+- Do not import Ch68's copyright/data-labor chapter except to flag LAION,
+  ShareGPT, and text-davinci data provenance as unresolved governance pressure.

--- a/docs/research/ai-history/chapters/ch-65-the-open-weights-rebellion/infrastructure-log.md
+++ b/docs/research/ai-history/chapters/ch-65-the-open-weights-rebellion/infrastructure-log.md
@@ -1,1 +1,45 @@
-# Infrastructure Log: Chapter 65
+# Infrastructure Log: Chapter 65 - The Open Weights Rebellion
+
+## Systems To Track In Prose
+
+- **Weights as artifacts:** downloadable checkpoints become the central object,
+  separate from papers, APIs, demos, model cards, licenses, and datasets.
+- **Model hubs and distribution:** releases live through Hugging Face-style
+  repositories, GitHub code, torrents/download links, and community mirrors.
+- **Adapters:** LoRA turns customization into small trainable modules layered on
+  a frozen base model.
+- **Quantization:** QLoRA makes the storage precision of the base model part of
+  the access story; a 4-bit frozen model plus adapters changes who can tune.
+- **Instruction data:** Alpaca's generated demonstrations and Vicuna's ShareGPT
+  conversations show that open weights immediately depend on data pipelines with
+  legal and ethical pressure.
+- **Licenses and AUPs:** OpenRAIL-M, LLaMA/Llama 2 terms, non-commercial
+  restrictions, and Apache 2.0 are plot devices, not footnotes.
+- **Evaluation rituals:** project blogs, GPT-4-as-judge, MT-Bench-style scores,
+  and leaderboards become reputation infrastructure; Ch66 owns the full story.
+
+## Metrics And Claims To Keep Source-Bound
+
+- LLaMA 1: 7B-65B; LLaMA-13B outperforms GPT-3 on most benchmarks; LLaMA-65B
+  competitive with Chinchilla-70B and PaLM-540B; released to research community.
+- LoRA: up to 10,000x fewer trainable parameters and 3x lower GPU memory in the
+  abstract; GPT-3 175B example from 1.2TB to 350GB VRAM and 350GB to 35MB
+  checkpoint in a specific Section 4.2 setup.
+- Alpaca: 52K instruction-following demonstrations generated with
+  text-davinci-003; reported <$500 data generation and <$100 fine-tuning cost;
+  academic/non-commercial restrictions.
+- Vicuna: about 70K ShareGPT conversations; around $300 13B training cost; 90%
+  ChatGPT-quality claim explicitly non-scientific.
+- Llama 2: 7B/13B/70B pretrained and chat models released for research and
+  commercial use with license/AUP/responsible-use materials.
+- QLoRA: 65B fine-tuning on one 48GB GPU; >780GB to <48GB memory reduction;
+  NF4, double quantization, paged optimizers; benchmark claims caveated.
+- Mistral 7B: 7.3B parameter model; Apache 2.0; first-party/paper claims of
+  outperforming Llama 2 13B.
+
+## Boundary
+
+- Ch65 owns access, modification, and licensing infrastructure.
+- Ch66 owns the leaderboard and benchmark weaponization that grows out of this.
+- Ch68 owns the data/copyright reckoning around LAION, ShareGPT, generated
+  demonstrations, scraped web/books, and training provenance.

--- a/docs/research/ai-history/chapters/ch-65-the-open-weights-rebellion/open-questions.md
+++ b/docs/research/ai-history/chapters/ch-65-the-open-weights-rebellion/open-questions.md
@@ -16,11 +16,12 @@
   evidence supports it.
 - **Does QLoRA belong here or Ch64?** Here. Ch64 uses quantization for device
   inference; Ch65 uses QLoRA for access/modification economics.
+- **Should Mistral performance be Yellow everywhere?** No. The Apache 2.0
+  release claim is Green, while Mistral performance claims remain Yellow /
+  source-bound first-party or paper-evaluation claims.
 
 ## Remaining Reviewer Focus
 
 - Verify that Stable Diffusion reuse from Ch58 is acceptable as a cross-chapter
   anchor rather than re-fetching all release pages in Ch65.
-- Check whether Mistral performance claims should be marked Yellow everywhere or
-  whether the arXiv paper is enough for Green source-bound paper claims.
 - Confirm the 4,200-5,300 range does not trespass on Ch66/68.

--- a/docs/research/ai-history/chapters/ch-65-the-open-weights-rebellion/open-questions.md
+++ b/docs/research/ai-history/chapters/ch-65-the-open-weights-rebellion/open-questions.md
@@ -1,3 +1,26 @@
 # Open Questions
 
-- SCRUBBED: All claims downgraded to Yellow. Need REAL, empirical page/section anchors from verified online PDFs or archives. Do not hallucinate.
+## Resolved For Drafting
+
+- **Can the chapter mention Stable Diffusion without duplicating Ch58?** Yes.
+  Use only the release/access layer: weights, code, model card, OpenRAIL-M,
+  consumer-GPU memory framing, LAION notes, and limitations. Do not re-explain
+  diffusion math.
+- **Can the chapter mention the LLaMA leak?** Not as a sourced factual scene yet.
+  The current source spine supports LLaMA research-community release and rapid
+  community derivatives, but not a detailed leak narrative.
+- **Can Alpaca/Vicuna support a 4k+ chapter?** Yes, but only if framed as
+  community speed plus caveats, not as proof they matched closed labs.
+- **Should "open source" be used broadly?** No. Use "open weights" by default.
+  Reserve "open source" for source titles or cases where license/code/data
+  evidence supports it.
+- **Does QLoRA belong here or Ch64?** Here. Ch64 uses quantization for device
+  inference; Ch65 uses QLoRA for access/modification economics.
+
+## Remaining Reviewer Focus
+
+- Verify that Stable Diffusion reuse from Ch58 is acceptable as a cross-chapter
+  anchor rather than re-fetching all release pages in Ch65.
+- Check whether Mistral performance claims should be marked Yellow everywhere or
+  whether the arXiv paper is enough for Green source-bound paper claims.
+- Confirm the 4,200-5,300 range does not trespass on Ch66/68.

--- a/docs/research/ai-history/chapters/ch-65-the-open-weights-rebellion/people.md
+++ b/docs/research/ai-history/chapters/ch-65-the-open-weights-rebellion/people.md
@@ -1,1 +1,21 @@
-# People: Chapter 65
+# People: Chapter 65 - The Open Weights Rebellion
+
+- **Robin Rombach / CompVis / Stability AI / RunwayML:** carry the Stable
+  Diffusion precedent from Ch58. In Ch65, use them only for the public-release
+  access layer, not the diffusion-math layer.
+- **Hugo Touvron and Meta AI LLaMA teams:** central to LLaMA and Llama 2. The
+  prose should distinguish research-community release (LLaMA 1) from
+  general-public research/commercial release (Llama 2).
+- **Edward Hu and the LoRA authors:** represent the adapter insight that made
+  fine-tuning modular and cheaper.
+- **Tim Dettmers and QLoRA collaborators:** represent the quantization +
+  adapter step that made large-model fine-tuning much less memory-bound.
+- **Stanford CRFM Alpaca team:** early academic instruction-tuning example with
+  explicit non-commercial and safety caveats.
+- **LMSYS Vicuna team:** early community chatbot example, useful for ShareGPT,
+  low-cost claims, and the start of LLM-as-judge evaluation culture.
+- **Mistral AI team:** permissive open-weight counterpoint through Mistral 7B and
+  Apache 2.0 release framing.
+- **Closed-lab and cloud actors:** mostly background pressure. Mention as the
+  systems the open-weight ecosystem challenged, but avoid inventing internal
+  reactions.

--- a/docs/research/ai-history/chapters/ch-65-the-open-weights-rebellion/scene-sketches.md
+++ b/docs/research/ai-history/chapters/ch-65-the-open-weights-rebellion/scene-sketches.md
@@ -1,1 +1,69 @@
-# Scene Sketches: Chapter 65
+# Scene Sketches: Chapter 65 - The Open Weights Rebellion
+
+## Scene 1: The Image Model Leaves The API
+
+Open with the contrast between an API account and a file on disk. Stable
+Diffusion's release package matters because it made multiple artifacts visible at
+once: weights, code, model card, license, memory footprint, data notes, and
+limitations. Keep this short and explicitly send diffusion mechanics back to
+Ch58. The point is social: once weights are downloadable, the boundary between
+user, developer, artist, platform, and regulator shifts.
+
+Guardrail: do not make Stability's public-release claims independent adoption
+metrics. Say what the release made possible and visible.
+
+## Scene 2: LLaMA Makes Portability Concrete
+
+Move from image generation to language models. LLaMA's paper can carry the whole
+scene: 7B-65B scale, 13B versus GPT-3 claims, 65B versus Chinchilla/PaLM claims,
+publicly available data, and research-community release. The scene should explain
+why the 13B claim mattered: it made "small enough to move" compatible with "good
+enough to care about."
+
+Guardrail: do not narrate leak mechanics without a verified source. The chapter
+can explain rapid derivatives after LLaMA without asserting how every actor got
+the weights.
+
+## Scene 3: Adapters Turn Access Into Modification
+
+This is the technical center. LoRA changes the unit of sharing: not just a base
+model, but a small adapter. QLoRA adds 4-bit quantization, NF4, double
+quantization, and paged optimizers so large-model fine-tuning becomes a hardware
+story, not only a lab-access story. Make this accessible: the base model becomes
+the heavy instrument; adapters become swappable sheet music.
+
+Guardrail: use the LoRA/QLoRA numbers exactly and source-bound. Do not imply any
+single hobbyist can reproduce frontier training.
+
+## Scene 4: The Weekend Clone Moment
+
+Alpaca and Vicuna should feel fast, exciting, and uncomfortable. Stanford's
+Alpaca shows 52K generated demonstrations and a cheap fine-tune claim; Vicuna
+adds ShareGPT conversations, mult-turn chat, and the historically telling
+GPT-4-as-judge evaluation. The prose should let the reader feel why this shocked
+closed labs while also making the caveats explicit: non-commercial licenses,
+upstream terms, user-shared data, content-filter limits, and weak evaluation.
+
+Guardrail: do not celebrate the "90%" claim. It is a scene about evaluation
+pressure and community speed, not settled model quality.
+
+## Scene 5: Commercial Open Weights Arrive
+
+Llama 2 makes the commercial-use pivot. Mistral 7B makes the permissive-license
+pivot. Put them in contrast: Meta couples release with license, AUP, safety
+framing, and responsible-use guidance; Mistral foregrounds Apache 2.0 and
+frictionless reuse. This is where "open" fractures into terms of use,
+governance, data opacity, benchmarks, and distribution.
+
+Guardrail: do not turn the scene into brand advocacy. Use each release to explain
+ecosystem strategy.
+
+## Scene 6: The Rebellion Becomes Infrastructure
+
+Close with the new stack: base weights, adapters, quantized variants, local
+runtimes, leaderboards, model hubs, cloud endpoints, and enterprise policies.
+The rebellion did not end closed labs. It forced everyone to answer a harder
+question: if model weights can travel, what still concentrates power?
+
+Handoff: Ch66 answers reputation/evaluation, Ch67 answers platform power, Ch68
+answers data and copyright.

--- a/docs/research/ai-history/chapters/ch-65-the-open-weights-rebellion/sources.md
+++ b/docs/research/ai-history/chapters/ch-65-the-open-weights-rebellion/sources.md
@@ -1,1 +1,60 @@
-# Sources: Chapter 65
+# Sources: Chapter 65 - The Open Weights Rebellion
+
+## Status Legend
+
+- Green: claim has direct primary evidence from a paper, model card, first-party
+  release post, or project blog, and the prose should stay within that source's
+  wording.
+- Yellow: claim is usable only with a caveat: first-party marketing, project-run
+  benchmark, license/governance synthesis, or background discovery pointer.
+- Red: no claim may be drafted from this row without new verification.
+
+## Primary Source Spine
+
+| Source | Use In Chapter | Anchor Notes |
+|---|---|---|
+| Stability AI, "Stable Diffusion Public Release," August 22, 2022; Stable Diffusion v1-4 model card. Reused from Ch58 anchored contract. | Open-weights precedent before LLaMA; weights/code/model card/license/consumer GPU framing. | Green/Yellow: Ch58 source review verified Stability's Aug. 22 public release, weights/model card/code availability, OpenRAIL-M license, v1.4 memory footprint, LAION training notes, and limitations. Use only as a transition; Ch58 owns diffusion mechanics. |
+| Hugo Touvron et al., "LLaMA: Open and Efficient Foundation Language Models," arXiv:2302.13971. PDF: https://arxiv.org/pdf/2302.13971 | LLaMA 1 scale, public-data framing, research-community release, smaller-model performance claims. | Green: PDF downloaded 2026-04-28 and extracted with pdftotext. Abstract/page 1 says models range 7B-65B; LLaMA-13B outperforms GPT-3 on most benchmarks; LLaMA-65B is competitive with Chinchilla-70B and PaLM-540B; and Meta releases all models to the research community. Intro says the work uses only publicly available data and is compatible with open-sourcing. Conclusion repeats open release and public-data framing. |
+| Edward J. Hu et al., "LoRA: Low-Rank Adaptation of Large Language Models," arXiv:2106.09685. PDF: https://arxiv.org/pdf/2106.09685 | Adapter layer that made community fine-tuning cheaper and more modular. | Green: PDF downloaded 2026-04-28. Abstract says LoRA freezes pretrained weights and injects trainable rank-decomposition matrices; reduces trainable parameters by 10,000x and GPU memory by 3x; and releases a PyTorch package. Section 4.2 reports GPT-3 175B VRAM from 1.2TB to 350GB and checkpoint size from 350GB to 35MB for a cited configuration. |
+| Stanford CRFM, "Alpaca: A Strong, Replicable Instruction-Following Model," March 13, 2023. URL: https://crfm.stanford.edu/2023/03/13/alpaca.html | Early community instruction-tuning from LLaMA 7B using generated demonstrations; release/caveat scene. | Green/Yellow: page fetched 2026-04-28. Lines around 285-299 say Alpaca is fine-tuned from LLaMA 7B on 52K instruction-following demonstrations generated with text-davinci-003 and that Stanford released training recipe/data. Lines around 307-315 say it is academic-only/non-commercial due to LLaMA and OpenAI terms. Cost/evaluation claims are project-reported and must be caveated. |
+| LMSYS, "Vicuna: An Open-Source Chatbot Impressing GPT-4 with 90%* ChatGPT Quality," March 30, 2023. URL: https://lmsys.org/blog/2023-03-30-vicuna/ | Community chat-model fork, ShareGPT data, low training cost, evaluation caveat. | Yellow: project blog fetched 2026-04-28. It says Vicuna-13B was fine-tuned from LLaMA on about 70K user-shared ShareGPT conversations, training cost was around $300, and code/model are available for non-commercial use. The 90% ChatGPT-quality claim is explicitly marked "fun and non-scientific" by the source and must be framed as a historically important but weak evaluation practice. |
+| Hugo Touvron et al., "Llama 2: Open Foundation and Fine-Tuned Chat Models," arXiv:2307.09288. PDF: https://arxiv.org/pdf/2307.09288 | Commercially usable open-weight turn and safety/release framing. | Green: PDF downloaded 2026-04-28. Abstract/page 1 says Meta develops and releases Llama 2, pretrained and fine-tuned models 7B-70B. Intro says models are released to the general public for research and commercial use, includes Llama 2 and Llama 2-Chat variants at 7B, 13B, and 70B, and argues open release can be a net benefit. Later release section says models are available with license, acceptable-use policy, code examples, and Responsible Use Guide. |
+| Tim Dettmers et al., "QLoRA: Efficient Finetuning of Quantized LLMs," arXiv:2305.14314. PDF: https://arxiv.org/pdf/2305.14314 | Quantization/adaptation layer that lowers the hardware barrier for fine-tuning. | Green: PDF downloaded 2026-04-28. Abstract says QLoRA backpropagates through a frozen 4-bit quantized model into LoRA adapters and enables fine-tuning a 65B model on a single 48GB GPU. Intro reports >780GB to <48GB memory reduction, NF4, double quantization, and paged optimizers. Results report Guanaco memory figures and consumer/professional GPU training examples; benchmark wins require caveats. |
+| Mistral AI, "Announcing Mistral 7B," September 27, 2023. URL: https://mistral.ai/en/news/announcing-mistral-7b | Permissive-release climax: Apache 2.0 model, torrent/download culture, strong 7B performance framing. | Green/Yellow: first-party page fetched 2026-04-28. It says Mistral 7B is a 7.3B model, released under Apache 2.0 and usable without restrictions, outperforming Llama 2 13B on Mistral's benchmarks. Treat performance as first-party/product framing unless independently confirmed. |
+| Jiang et al., "Mistral 7B," arXiv:2310.06825. PDF: https://arxiv.org/pdf/2310.06825 | Paper-level support for Mistral 7B architecture/performance/license. | Green: PDF downloaded 2026-04-28. Abstract says Mistral 7B outperforms the best open 13B model, uses grouped-query and sliding-window attention, and models are released under Apache 2.0. Body says release includes reference implementation and deployment support; Table 2 compares against Llama models. |
+| Wikipedia pages for Stable Diffusion, LLaMA, LoRA, and Mistral AI. | Source-discovery only. | Yellow: useful for checking chronology and finding primary links, not used as evidence for prose claims. |
+
+## Scene-Level Claim Table
+
+| Claim | Scene | Primary Anchor | Confirmation | Status | Notes |
+|---|---|---|---|---|---|
+| Stable Diffusion made weights, code, model card, license, and consumer-GPU feasibility public enough to become the open-weights precedent. | Image Model Leaves API | Ch58 verified Stability release + model card | Ch58 source review | Yellow | Transition only; Ch58 owns diffusion details. |
+| LLaMA 1 was presented as 7B-65B models released to the research community. | LLaMA Portability | LLaMA p.1 abstract | LLaMA conclusion | Green | Do not claim fully public/commercial release. |
+| LLaMA 13B/65B performance claims made smaller models look strategically serious. | LLaMA Portability | LLaMA p.1 + benchmark tables | LLaMA conclusion | Green | Paper claims only. |
+| LLaMA was framed as trained on publicly available data and compatible with open-sourcing. | LLaMA Portability | LLaMA intro/public-data paragraph | LLaMA conclusion | Green | Avoid proving data cleanliness. |
+| LoRA freezes base weights and trains low-rank matrices, reducing trainable parameters and memory. | Adapters | LoRA abstract | LoRA Section 4.2 | Green | Core technical explanation. |
+| LoRA's GPT-3 example reduces fine-tuning VRAM/checkpoint size enough to make adapters a distribution object. | Adapters | LoRA Section 4.2 | LoRA abstract | Green | Keep configuration-specific. |
+| Alpaca fine-tuned LLaMA 7B on 52K text-davinci-003 generated demonstrations and released recipe/data. | Weekend Clone | Stanford Alpaca blog | LLaMA base-model paper | Green | Academic/research release framing. |
+| Alpaca was explicitly non-commercial/academic-only because of upstream terms. | Weekend Clone | Stanford Alpaca blog license section | N/A | Green | Important no-overclaim guardrail. |
+| Alpaca's cheap-cost and text-davinci similarity claims were project-reported and evaluation-limited. | Weekend Clone | Stanford Alpaca blog cost/evaluation sections | Blog limitations section | Yellow | Must not become independent benchmark proof. |
+| Vicuna used about 70K ShareGPT conversations and reported roughly $300 training cost for Vicuna-13B. | Weekend Clone | LMSYS Vicuna blog | LMSYS cost table | Yellow | Project-reported; data provenance goes to Ch68. |
+| Vicuna's 90% ChatGPT-quality claim was explicitly non-scientific and illustrates the coming evaluation problem. | Weekend Clone / Handoff | LMSYS caveat line | LMSYS evaluation limitations | Yellow | Handoff to Ch66. |
+| Llama 2 moved the release frame to general public research and commercial use at 7B/13B/70B. | Commercial Open Weights | Llama 2 intro | Llama 2 release section | Green | License/AUP still matter. |
+| Llama 2's paper ties openness to reproducibility, safety research, license, AUP, and responsible-use guidance. | Commercial Open Weights | Llama 2 intro + release section | Llama 2 Section 5.3 | Green | Good governance nuance. |
+| QLoRA enables 65B fine-tuning on a single 48GB GPU through frozen 4-bit quantized models plus LoRA adapters. | Adapters | QLoRA abstract | QLoRA intro | Green | Strong accessibility anchor. |
+| QLoRA's Guanaco benchmark claims need caveats despite the memory/access breakthrough. | Adapters / Weekend Clone | QLoRA abstract/results | QLoRA qualitative failure notes | Yellow | Avoid leaderboard triumphalism. |
+| Mistral 7B was released under Apache 2.0 and framed as usable without restrictions. | Commercial Open Weights | Mistral announcement | Mistral paper abstract | Green | Permissive-release climax. |
+| Mistral 7B performance claims rely on Mistral's evaluation pipeline and should be source-bound. | Commercial Open Weights | Mistral announcement + paper | Mistral Table 2 | Yellow | Say "Mistral reported." |
+| Open weights are not the same as open source, open data, or open governance. | Rebellion Infrastructure | License/source rows above | Alpaca/Llama 2/Mistral contrasts | Green | Synthesis from contract. |
+
+## Conflict Notes
+
+- "Open-source chatbot" appears in some project titles, but prose should prefer
+  "open weights" or "released weights" unless source code, license, data, and
+  governance are actually open.
+- Cost numbers for Alpaca and Vicuna are useful historically because they shaped
+  community perception, but they are not audited total-cost accounting.
+- GPT-4-as-judge/Vicuna quality claims belong mainly to Ch66. Ch65 may use them
+  only to show how open-weight communities immediately needed evaluation rituals.
+- LAION, ShareGPT, generated instruction data, and web/book provenance are
+  handoffs to Ch68, not a full legal analysis here.

--- a/docs/research/ai-history/chapters/ch-65-the-open-weights-rebellion/status.yaml
+++ b/docs/research/ai-history/chapters/ch-65-the-open-weights-rebellion/status.yaml
@@ -1,8 +1,8 @@
-status: capacity_plan_anchored
+status: prose_ready
 owner: Codex
 part: 9
 chapter: 65
-review_state: awaiting_claude_source_review_and_gemini_gap_audit
+review_state: dual_cross_family_verdict_accepted
 last_updated: 2026-04-28
 green_claims: 12
 yellow_claims: 6
@@ -12,25 +12,25 @@ prose_word_cap_recommendation: 5300
 word_count_range: "4200-5300"
 verdicts:
   claude:
-    model: null
-    date: null
-    verdict: null
-    review_url: null
+    model: claude-opus-4-7
+    date: 2026-04-28
+    verdict: APPROVE
+    review_url: https://github.com/kube-dojo/kube-dojo.github.io/pull/523#issuecomment-4339403132
   gemini:
-    model: null
-    date: null
-    verdict: null
-    word_cap: null
-    review_url: null
-  resolved: null
-  resolved_word_cap: null
+    model: gemini-3.1-pro-preview
+    date: 2026-04-28
+    verdict: READY_TO_DRAFT_WITH_CAP
+    word_cap: 5300
+    review_url: https://github.com/kube-dojo/kube-dojo.github.io/pull/523#pullrequestreview-4192773680
+  resolved: READY_TO_DRAFT_WITH_CAP
+  resolved_word_cap: 5300
   resolution_rule: dual_cross_family_verdict_with_cap
 notes: |
-  Built from scrubbed skeleton into an anchored open-weights contract. Core
+  Built from scrubbed skeleton into a dual-cleared prose_ready open-weights contract. Core
   anchors are the Ch58-verified Stable Diffusion release layer, LLaMA, LoRA,
   Alpaca, Vicuna, Llama 2, QLoRA, and Mistral 7B.
 
-  Safe draft range is 4,200-5,300 words pending Claude source review and Gemini
-  capacity audit. Keep "open source" wording narrow, frame Alpaca/Vicuna costs
-  and evaluations as project-reported, and hand benchmark politics to Ch66 and
-  copyright/data labor to Ch68.
+  Safe draft range is 4,200-5,300 words after Claude source review and Gemini
+  gap/capacity audit. Keep "open source" wording narrow, frame Alpaca/Vicuna
+  costs and evaluations as project-reported, and hand benchmark politics to Ch66
+  and copyright/data labor to Ch68.

--- a/docs/research/ai-history/chapters/ch-65-the-open-weights-rebellion/status.yaml
+++ b/docs/research/ai-history/chapters/ch-65-the-open-weights-rebellion/status.yaml
@@ -1,1 +1,36 @@
-status: researching
+status: capacity_plan_anchored
+owner: Codex
+part: 9
+chapter: 65
+review_state: awaiting_claude_source_review_and_gemini_gap_audit
+last_updated: 2026-04-28
+green_claims: 12
+yellow_claims: 6
+red_claims: 0
+guardrail_count: 5
+prose_word_cap_recommendation: 5300
+word_count_range: "4200-5300"
+verdicts:
+  claude:
+    model: null
+    date: null
+    verdict: null
+    review_url: null
+  gemini:
+    model: null
+    date: null
+    verdict: null
+    word_cap: null
+    review_url: null
+  resolved: null
+  resolved_word_cap: null
+  resolution_rule: dual_cross_family_verdict_with_cap
+notes: |
+  Built from scrubbed skeleton into an anchored open-weights contract. Core
+  anchors are the Ch58-verified Stable Diffusion release layer, LLaMA, LoRA,
+  Alpaca, Vicuna, Llama 2, QLoRA, and Mistral 7B.
+
+  Safe draft range is 4,200-5,300 words pending Claude source review and Gemini
+  capacity audit. Keep "open source" wording narrow, frame Alpaca/Vicuna costs
+  and evaluations as project-reported, and hand benchmark politics to Ch66 and
+  copyright/data labor to Ch68.

--- a/docs/research/ai-history/chapters/ch-65-the-open-weights-rebellion/timeline.md
+++ b/docs/research/ai-history/chapters/ch-65-the-open-weights-rebellion/timeline.md
@@ -1,1 +1,21 @@
-# Timeline: Chapter 65
+# Timeline: Chapter 65 - The Open Weights Rebellion
+
+- **2021-06:** Hu et al. publish LoRA, showing that large pretrained models can
+  be adapted by freezing base weights and training small low-rank matrices.
+- **2022-08-22:** Stability AI announces the public Stable Diffusion release,
+  with weights/model card/code/license artifacts visible enough to become a
+  public open-weights precedent.
+- **2023-02:** Meta publishes LLaMA, describing 7B-65B models trained on
+  publicly available data and released to the research community.
+- **2023-03-13:** Stanford CRFM posts Alpaca, a LLaMA 7B instruction-tuned model
+  built from 52K text-davinci-003 generated demonstrations, with academic and
+  non-commercial restrictions.
+- **2023-03-30:** LMSYS posts Vicuna-13B, a LLaMA-derived chatbot trained on
+  ShareGPT conversations, with low reported training cost and explicitly
+  non-scientific GPT-4 evaluation caveats.
+- **2023-05:** Dettmers et al. publish QLoRA, pushing 65B fine-tuning onto a
+  single 48GB GPU through 4-bit quantization plus LoRA adapters.
+- **2023-07:** Meta publishes Llama 2, releasing 7B/13B/70B pretrained and chat
+  models for general-public research and commercial use under license and AUP.
+- **2023-09:** Mistral AI announces Mistral 7B under Apache 2.0, sharpening the
+  contrast between restricted open weights and permissive-weight releases.

--- a/src/content/docs/ai-history/index.md
+++ b/src/content/docs/ai-history/index.md
@@ -190,7 +190,7 @@ Consumer adoption, edge constraints, and AI transitioning to heavy industry.
 | 62 | Multimodal Convergence | prose_ready | no |
 | 63 | Inference Economics | prose_ready | no |
 | 64 | The Edge Compute Bottleneck | prose_ready | no |
-| 65 | The Open Weights Rebellion | capacity_plan_anchored | no |
+| 65 | The Open Weights Rebellion | prose_ready | no |
 | 66 | Benchmark Wars | researching | no |
 | 67 | The Monopoly | researching | no |
 | 68 | Data Labor and the Copyright Reckoning | researching | no |
@@ -205,8 +205,8 @@ Consumer adoption, edge constraints, and AI transitioning to heavy industry.
 |---|---:|
 | `accepted` (drafted, all reviews cleared) | 29 |
 | `prose_review` (drafted, in review) | 0 |
-| `prose_ready` (contract dual-cleared, awaiting prose draft) | 19 |
-| `capacity_plan_anchored` (contract anchored, awaiting verdict) | 4 |
+| `prose_ready` (contract dual-cleared, awaiting prose draft) | 20 |
+| `capacity_plan_anchored` (contract anchored, awaiting verdict) | 3 |
 | `researching` with prose merged on legacy contract | 5 |
 | `researching` (no prose yet) | 15 |
 | **Total** | **72** |

--- a/src/content/docs/ai-history/index.md
+++ b/src/content/docs/ai-history/index.md
@@ -190,7 +190,7 @@ Consumer adoption, edge constraints, and AI transitioning to heavy industry.
 | 62 | Multimodal Convergence | prose_ready | no |
 | 63 | Inference Economics | prose_ready | no |
 | 64 | The Edge Compute Bottleneck | prose_ready | no |
-| 65 | The Open Weights Rebellion | researching | no |
+| 65 | The Open Weights Rebellion | capacity_plan_anchored | no |
 | 66 | Benchmark Wars | researching | no |
 | 67 | The Monopoly | researching | no |
 | 68 | Data Labor and the Copyright Reckoning | researching | no |
@@ -206,7 +206,7 @@ Consumer adoption, edge constraints, and AI transitioning to heavy industry.
 | `accepted` (drafted, all reviews cleared) | 29 |
 | `prose_review` (drafted, in review) | 0 |
 | `prose_ready` (contract dual-cleared, awaiting prose draft) | 19 |
-| `capacity_plan_anchored` (contract anchored, awaiting verdict) | 3 |
+| `capacity_plan_anchored` (contract anchored, awaiting verdict) | 4 |
 | `researching` with prose merged on legacy contract | 5 |
-| `researching` (no prose yet) | 16 |
+| `researching` (no prose yet) | 15 |
 | **Total** | **72** |


### PR DESCRIPTION
## Summary

Anchors Ch65 `The Open Weights Rebellion` from scrubbed shell to `capacity_plan_anchored`.

Scope:
- Builds the full research contract: brief, sources, timeline, people, scene sketches, infrastructure log, open questions, status.
- Adds Ch65 to the AI History README and public index as `capacity_plan_anchored`.
- Keeps boundaries explicit: Ch58 owns diffusion math, Ch66 owns benchmark politics, Ch68 owns data/copyright.

Review focus:
- Stable Diffusion is reused only as the Ch58-verified public-release/open-weights precedent.
- Alpaca/Vicuna costs and quality claims are Yellow and explicitly project-reported.
- Mistral performance claims are caveated as first-party/paper evaluation; Apache 2.0 release is the core Green claim.
- The contract avoids using LLaMA leak mechanics as a factual scene.

Checks:
- `git diff --check`
- YAML sanity via `.venv/bin/python`
- `npm run astro -- sync` (passes; unrelated existing expressive-code warnings for `cloudformation`/`haproxy` languages)

Requested reviewers:
- Claude: source-fidelity review
- Gemini: gap/capacity audit only

Refs #407
