### PR TITLE
docs(ai-history): anchor ch66 benchmark research (#407)

### DIFF
--- a/docs/research/ai-history/README.md
+++ b/docs/research/ai-history/README.md
@@ -10,7 +10,7 @@ This directory contains the operational research files for the definitive 72-cha
 - **Part 4 (The First Winter):** Ch17-23 cross-family cleared for capped prose drafting; Ch21 carries a Yellow-caveated Bachant/McDermott mirror-source guardrail.
 - **Part 5 (The Mathematical Resurrection):** Ch24-31 prose `accepted`.
 - **Part 8 (The Transformer, Scale & Open Source):** Ch50-58 dual-cleared `prose_ready`; Ch58 cap is 5,200 words.
-- **Part 9 (The Product Shock & Physical Limits):** Ch59-Ch61 and Ch66 rebuilt to `capacity_plan_anchored` 2026-04-28; Ch62-Ch65 dual-cleared `prose_ready` with 4,800-, 4,500-, 5,000-, and 5,300-word caps.
+- **Part 9 (The Product Shock & Physical Limits):** Ch59-Ch61 rebuilt to `capacity_plan_anchored` 2026-04-28; Ch62-Ch66 dual-cleared `prose_ready` with 4,800-, 4,500-, 5,000-, 5,300-, and 5,400-word caps.
 
 All drafting is paused for any chapter whose contract is not at `prose_ready` or beyond.
 

--- a/docs/research/ai-history/README.md
+++ b/docs/research/ai-history/README.md
@@ -10,7 +10,7 @@ This directory contains the operational research files for the definitive 72-cha
 - **Part 4 (The First Winter):** Ch17-23 cross-family cleared for capped prose drafting; Ch21 carries a Yellow-caveated Bachant/McDermott mirror-source guardrail.
 - **Part 5 (The Mathematical Resurrection):** Ch24-31 prose `accepted`.
 - **Part 8 (The Transformer, Scale & Open Source):** Ch50-58 dual-cleared `prose_ready`; Ch58 cap is 5,200 words.
-- **Part 9 (The Product Shock & Physical Limits):** Ch59-Ch61 rebuilt to `capacity_plan_anchored` 2026-04-28; Ch62-Ch65 dual-cleared `prose_ready` with 4,800-, 4,500-, 5,000-, and 5,300-word caps.
+- **Part 9 (The Product Shock & Physical Limits):** Ch59-Ch61 and Ch66 rebuilt to `capacity_plan_anchored` 2026-04-28; Ch62-Ch65 dual-cleared `prose_ready` with 4,800-, 4,500-, 5,000-, and 5,300-word caps.
 
 All drafting is paused for any chapter whose contract is not at `prose_ready` or beyond.
 

--- a/docs/research/ai-history/chapters/ch-66-benchmark-wars/brief.md
+++ b/docs/research/ai-history/chapters/ch-66-benchmark-wars/brief.md
@@ -1,28 +1,47 @@
 # Brief: Chapter 66 - Benchmark Wars
 
 ## Thesis
+
 Benchmarks were once mostly scientific instruments; in the frontier-model era they became product claims, market signals, policy evidence, and competitive weapons. This chapter should connect the older common-task tradition to the modern leaderboard economy, then show how MMLU, HELM, Chatbot Arena, contamination disputes, and benchmark gaming turned evaluation into a political economy.
 
-## Scope
-- IN SCOPE: MMLU, BIG-bench/HELM-style broad evaluation, Chatbot Arena/LMSYS, open leaderboards, benchmark contamination, evals as marketing, evals as safety/policy evidence, and Goodhart's law as a recurring risk.
-- OUT OF SCOPE: every benchmark result, detailed leaderboard-by-leaderboard chronology, and unsourced claims that one model was definitively "best."
+## Boundary Contract
+
+- IN SCOPE: common-task evaluation lineage; MMLU as a generality scorecard;
+  BIG-bench and HELM as broad/holistic evaluation attempts; GPT-4's exam and
+  benchmark tables as product-release evidence; OpenAI Evals as deployment-time
+  evaluation infrastructure; MT-Bench and Chatbot Arena as human-preference /
+  LLM-as-judge public comparison; contamination and benchmark-specific
+  optimization; SWE-bench as harder real-world benchmark design; Goodhart effects
+  when metrics become targets.
+- OUT OF SCOPE: detailed leaderboard chronology; timeless model rankings;
+  benchmark-by-benchmark score tables; data/copyright fights (Ch68); open-weight
+  licensing (Ch65); product launch narrative (Ch59); agentic tool use (Ch60);
+  software-agent capability history beyond SWE-bench as an evaluation example.
+- Transition from Ch65: open weights created many comparable models; Ch66
+  explains how reputation moved to benchmarks, leaderboards, and evaluation
+  rituals.
+- Transition to Ch67/68: once evaluation becomes a market signal, platforms,
+  data provenance, and copyright pressure become harder to separate from
+  "capability."
 
 ## Required Scenes
 1. **From Common Task To Scoreboard:** Connect DARPA/ImageNet-style shared evaluation to modern foundation-model leaderboards.
-2. **The Frontier Scorecard:** MMLU and broad benchmark suites become a way to claim generality.
-3. **Arena As Courtroom:** Pairwise human preference arenas turn model comparison into public spectacle and product signal.
-4. **Contamination And Goodhart:** The more benchmarks matter, the more training leakage, prompt tuning, and benchmark-specific optimization matter.
-5. **Evaluation As Power:** Scores influence users, investors, regulators, procurement, and open-vs-closed narratives.
+2. **The Frontier Scorecard:** MMLU, BIG-bench, HELM, and GPT-4's release tables make "general capability" look legible while also showing how much benchmark design shapes the story.
+3. **Arena As Courtroom:** MT-Bench and Chatbot Arena turn pairwise preference into public model reputation, while LLM-as-judge turns evaluation into scalable but biased infrastructure.
+4. **Contamination And Goodhart:** The more scores matter, the more leakage checks, benchmark-specific optimization, prompt choices, and metric gaming become part of the system.
+5. **Harder Tests, Moving Targets:** SWE-bench shows the next stage: benchmarks that try to follow real work rather than short-answer test items, while still becoming targets.
+6. **Evaluation As Power:** Close on scores influencing users, investors, regulators, procurement, and open-vs-closed narratives.
 
 ## Prose Capacity Plan
 
-Target range: 4,300-5,300 words after source verification.
+Target range: 4,300-5,400 words.
 
-- 600-800 words: bridge from historical evaluation culture to modern scoreboards.
-- 900-1,100 words: broad benchmark suites and generality claims.
-- 900-1,100 words: Chatbot Arena/open leaderboards and public comparison.
-- 900-1,100 words: contamination, Goodharting, and benchmark politics.
-- 600-800 words: close on evaluation as institutional power.
+- 550-750 words: bridge from historical evaluation culture to modern scoreboards.
+- 900-1,100 words: MMLU, BIG-bench, HELM, and GPT-4 release tables as generality scorecards.
+- 800-1,000 words: MT-Bench, Chatbot Arena, LLM-as-judge, and public preference rankings.
+- 750-950 words: contamination checks, benchmark-specific optimization, and Goodhart effects.
+- 650-850 words: SWE-bench and the move toward harder real-world evaluations.
+- 650-750 words: close on evaluation as institutional power and handoff to Ch67/68.
 
 ## Guardrails
 
@@ -30,3 +49,7 @@ Target range: 4,300-5,300 words after source verification.
 - Do not treat leaderboard movement as timeless fact.
 - Do not present benchmark scores as direct measures of intelligence.
 - Do not make contamination accusations without primary or highly reliable evidence.
+- Do not make GPT-4 / Chatbot Arena / Mistral-style performance claims without
+  naming the source and date.
+- Keep "evaluation as power" institutional; do not invent private investor,
+  regulator, or lab reactions.

--- a/docs/research/ai-history/chapters/ch-66-benchmark-wars/infrastructure-log.md
+++ b/docs/research/ai-history/chapters/ch-66-benchmark-wars/infrastructure-log.md
@@ -27,8 +27,9 @@
   prior average scenario coverage 17.9%, improved to 96.0%.
 - GPT-4 report: simulated bar exam top 10%; MMLU 86.4%; contamination checks;
   GSM-8K training-set inclusion disclosure; Evals framework.
-- MT-Bench / Arena: 80 MT-Bench questions; 3K expert votes; 30K conversations;
-  over 80% GPT-4/human agreement; bias/failure caveats.
+- MT-Bench / Arena: 80 MT-Bench questions; over 80% GPT-4/human agreement;
+  bias/failure caveats. Re-verify any exact vote/conversation counts before
+  surfacing them in prose because public Arena figures evolved quickly.
 - SWE-bench: 2,294 tasks from 12 Python repositories; Claude 2 1.96% initial
   solve rate; about 90,000 PRs filtered to benchmark instances.
 

--- a/docs/research/ai-history/chapters/ch-66-benchmark-wars/infrastructure-log.md
+++ b/docs/research/ai-history/chapters/ch-66-benchmark-wars/infrastructure-log.md
@@ -2,18 +2,35 @@
 
 ## Systems To Track
 
-- Static benchmark suites.
-- Human preference arenas.
-- Hosted leaderboard infrastructure.
-- Evaluation harnesses and prompt templates.
-- Contamination detection and dataset provenance tooling.
+- **Static benchmark suites:** MMLU, BIG-bench, HELM, HumanEval, TruthfulQA, and
+  other table entries become common release-report grammar.
+- **Human preference arenas:** MT-Bench and Chatbot Arena collect pairwise human
+  votes and/or use strong LLMs as scalable judges.
+- **Evaluation harnesses:** OpenAI Evals and benchmark APIs turn evaluation into
+  reusable tooling, not one-off paper scripts.
+- **Prompt and adaptation settings:** few-shot prompts, validation choices,
+  benchmark-specific tuning, and held-out tests become part of the result.
+- **Contamination checks:** GPT-4 report, BIG-bench, and SWE-bench show that data
+  overlap must be managed explicitly.
+- **Execution-based tests:** SWE-bench uses code patches and repository tests,
+  making evaluation closer to work but more expensive and infrastructure-heavy.
+- **Leaderboards:** public rankings become dated social artifacts; prose should
+  avoid freezing any leaderboard as timeless truth.
 
 ## Metrics To Verify
 
-- Benchmark task composition.
-- Evaluation methodology.
-- Date-specific leaderboard positions only when needed.
-- Known limitations from benchmark authors.
+- MMLU: 57 subjects; 15,908 questions; largest GPT-3 at 43.9% in the original
+  paper; expert-level gap.
+- BIG-bench: 204 tasks; 450 authors; 132 institutions; 24-task BIG-bench Lite;
+  direct leakage impossible for reported models but indirect leakage possible.
+- HELM: 7 metric categories; 16 core scenarios; 42 total scenarios; 30 models;
+  prior average scenario coverage 17.9%, improved to 96.0%.
+- GPT-4 report: simulated bar exam top 10%; MMLU 86.4%; contamination checks;
+  GSM-8K training-set inclusion disclosure; Evals framework.
+- MT-Bench / Arena: 80 MT-Bench questions; 3K expert votes; 30K conversations;
+  over 80% GPT-4/human agreement; bias/failure caveats.
+- SWE-bench: 2,294 tasks from 12 Python repositories; Claude 2 1.96% initial
+  solve rate; about 90,000 PRs filtered to benchmark instances.
 
 ## Boundary
 

--- a/docs/research/ai-history/chapters/ch-66-benchmark-wars/open-questions.md
+++ b/docs/research/ai-history/chapters/ch-66-benchmark-wars/open-questions.md
@@ -1,6 +1,23 @@
 # Open Questions: Chapter 66 - Benchmark Wars
 
-- Which benchmark should carry the main "frontier scorecard" scene?
-- How much historical continuity should be drawn back to DARPA common-task evaluation and ImageNet?
-- Which contamination case is strong enough to include without overclaiming?
-- Should safety evals be a separate subsection or part of the policy/power close?
+## Resolved For Drafting
+
+- **Which benchmark carries the frontier scorecard scene?** MMLU carries the
+  clean scorecard arc, with BIG-bench and HELM broadening the frame.
+- **How much continuity should be drawn to DARPA/ImageNet?** Short bridge only.
+  Ch32 and Ch43 own those histories; Ch66 starts from the fact that shared tasks
+  made scientific comparison possible and then shows the product-era mutation.
+- **Which contamination case is safe?** Use source-disclosed contamination
+  handling only: GPT-4 report's contamination checks/GSM-8K disclosure,
+  BIG-bench leakage note, and SWE-bench disjoint-repository design. Do not make
+  independent accusations.
+- **Should safety evals be a separate section?** No. Keep safety evals inside
+  the "evaluation as power" close unless a later reviewer requests expansion.
+
+## Remaining Reviewer Focus
+
+- Verify that the GPT-4 report is framed as first-party release evidence rather
+  than neutral external validation.
+- Check that SWE-bench does not pull the chapter into agentic coding history.
+- Confirm the 4,300-5,400 range has enough capacity without duplicating Ch60,
+  Ch65, or Ch68.

--- a/docs/research/ai-history/chapters/ch-66-benchmark-wars/people.md
+++ b/docs/research/ai-history/chapters/ch-66-benchmark-wars/people.md
@@ -1,15 +1,16 @@
 # People: Chapter 66 - Benchmark Wars
 
-## Research Leads To Verify
-
-- Authors behind MMLU, HELM, BIG-bench, Chatbot Arena/LMSYS, and benchmark-contamination research chosen for the final contract.
-
-## Institutional Actors
-
-- Frontier labs using benchmarks in release materials.
-- Open-source communities using leaderboards to coordinate model comparison.
-- Policymakers and safety institutes using evaluations as evidence, if source-supported.
-
-## Guardrail
-
-Keep the chapter institutional; do not turn benchmark debates into personality drama unless primary sources justify it.
+- **MMLU authors / Dan Hendrycks et al.:** represent the shift from narrow
+  language tasks to broad academic/professional scorecards.
+- **BIG-bench community:** represents large collaborative benchmark-building and
+  the recognition that benchmark lifespans are short.
+- **Stanford CRFM / HELM authors:** represent transparency, standardization, and
+  multi-metric evaluation instead of single-score claims.
+- **OpenAI GPT-4 / Evals teams:** represent benchmark tables as release evidence
+  and eval tooling as deployment infrastructure.
+- **LMSYS / Chatbot Arena authors:** represent public preference comparison and
+  LLM-as-judge methodology.
+- **SWE-bench authors:** represent the move to real-world, execution-tested tasks
+  as older benchmarks saturate.
+- **Labs, cloud vendors, open-weight communities, regulators, and procurement
+  teams:** institutional background. Avoid inventing private motives or meetings.

--- a/docs/research/ai-history/chapters/ch-66-benchmark-wars/scene-sketches.md
+++ b/docs/research/ai-history/chapters/ch-66-benchmark-wars/scene-sketches.md
@@ -1,20 +1,51 @@
 # Scene Sketches: Chapter 66 - Benchmark Wars
 
 ## Scene 1: The Table In The Model Card
-- **Action:** A model announcement points to a benchmark table as evidence of frontier status.
-- **Guardrail:** Do not use unsourced or stale rankings.
+
+- **Action:** A model announcement points to a benchmark table as evidence of
+  frontier status. GPT-4's report can carry this scene: exams, MMLU, HumanEval,
+  contamination notes, safety metrics, and Evals all appear as release evidence.
+- **Guardrail:** Say "OpenAI reported" for release-report claims. Do not convert
+  first-party score tables into neutral proof of intelligence.
 
 ## Scene 2: The Arena Vote
-- **Action:** Users compare two hidden model answers and vote; public preference becomes a leaderboard.
-- **Guardrail:** Explain methodology limits.
+
+- **Action:** Users compare two hidden model answers and vote; public preference
+  becomes a leaderboard. MT-Bench and Chatbot Arena turn human taste, GPT-4
+  judging, and anonymous pairwise voting into reputation infrastructure.
+- **Guardrail:** Explain position bias, verbosity bias, self-enhancement bias,
+  math/reasoning failures, and date-bound public rankings.
 
 ## Scene 3: The Contamination Dispute
-- **Action:** A benchmark result is questioned because training data may have included test material.
-- **Guardrail:** Do not accuse without strong sources.
+
+- **Action:** A benchmark result becomes less trustworthy when the test set may
+  have entered training, or when optimization targets the benchmark itself.
+  GPT-4 contamination notes, BIG-bench leakage notes, and SWE-bench disjoint-repo
+  design let the scene discuss the problem without inventing accusations.
+- **Guardrail:** Do not accuse a named model unless the source itself reports the
+  overlap or check.
 
 ## Scene 4: The Policy Hearing
-- **Action:** Evaluation language migrates from papers into safety reports, procurement, and regulation.
-- **Guardrail:** Keep policy claims source-bound.
 
-## Scene 5: The Score Is Not The System
-- **Action:** Close with Goodhart's law: when the metric becomes valuable, it becomes part of the system being optimized.
+- **Action:** Evaluation language migrates from papers into safety reports,
+  product pages, procurement checklists, and regulation. HELM's transparency
+  agenda and OpenAI Evals make evaluation look like governance infrastructure.
+- **Guardrail:** Keep policy/procurement claims as institutional synthesis unless
+  a specific primary source is added.
+
+## Scene 5: The Harder Benchmark
+
+- **Action:** SWE-bench shows the arms race moving toward work-like tasks:
+  real GitHub issues, codebase edits, and tests. The benchmark starts hard, but
+  the chapter should imply the same cycle will return: once a hard metric becomes
+  valuable, models and systems adapt to it.
+- **Guardrail:** Keep SWE-bench as evaluation history, not a full coding-agent
+  chapter.
+
+## Scene 6: The Score Is Not The System
+
+- **Action:** Close with Goodhart's law: when the metric becomes valuable, it
+  becomes part of the system being optimized. The war is not one leaderboard
+  beating another; it is the recurring fight over what the score can represent.
+- **Guardrail:** Do not become cynical. Benchmarks remain necessary; the point is
+  that they are institutions with incentives.

--- a/docs/research/ai-history/chapters/ch-66-benchmark-wars/sources.md
+++ b/docs/research/ai-history/chapters/ch-66-benchmark-wars/sources.md
@@ -1,27 +1,54 @@
 # Sources: Chapter 66 - Benchmark Wars
 
-## Research Status
+## Status Legend
 
-No claims are verified yet. This placeholder reserves benchmark/evaluation politics as a first-class chapter.
+- Green: claim has direct primary support from a benchmark paper, technical
+  report, or first-party methodology source.
+- Yellow: claim is usable only with a caveat: release-report/product framing,
+  time-sensitive leaderboard meaning, or synthesis from multiple sources.
+- Red: do not draft without new verification.
 
-## Candidate Source Families To Verify
+## Primary Source Spine
 
-- MMLU paper and later benchmark suite papers.
-- BIG-bench and HELM papers/reports.
-- LMSYS / Chatbot Arena primary papers and leaderboard methodology.
-- Open LLM Leaderboard / EleutherAI or Hugging Face evaluation materials.
-- Papers or reports on benchmark contamination and data leakage.
-- Policy/safety evaluation reports where benchmarks are used as evidence.
+| Source | Use In Chapter | Anchor Notes |
+|---|---|---|
+| Dan Hendrycks et al., "Measuring Massive Multitask Language Understanding," arXiv:2009.03300. PDF: https://arxiv.org/pdf/2009.03300 | MMLU as the frontier scorecard for broad academic/professional knowledge. | Green: PDF downloaded 2026-04-28. Abstract/page 1 says MMLU covers 57 tasks including math, US history, computer science, law, and more; models need broad world knowledge/problem solving; largest GPT-3 reaches 43.9%; and models remain below expert-level accuracy. Body reports 15,908 questions, 5-shot dev set, and expert/human baselines. |
+| BIG-bench authors, "Beyond the Imitation Game: Quantifying and extrapolating the capabilities of language models," arXiv:2206.04615. PDF: https://arxiv.org/pdf/2206.04615 | Broad benchmark expansion; benchmark saturation and short useful lifespan; leakage caveats. | Green: PDF downloaded 2026-04-28. Abstract says BIG-bench has 204 tasks by 450 authors across 132 institutions; covers linguistics, reasoning, math, commonsense, biology, physics, social bias, software development, etc.; human expert raters provide baselines; performance/calibration improve with scale but remain poor. Section 1.2 discusses restricted benchmark scope and short useful lifespans. Section 2 says tasks were contributed openly on GitHub and notes direct leakage impossible for the reported models but indirect leakage possible. |
+| Percy Liang et al., "Holistic Evaluation of Language Models," arXiv:2211.09110. PDF: https://arxiv.org/pdf/2211.09110 | HELM as a transparency/multi-metric response to single-score benchmark culture. | Green: PDF downloaded 2026-04-28. Abstract says HELM taxonomizes scenarios/metrics, measures 7 metrics across 16 core scenarios where possible, performs targeted evaluations across 26 scenarios, evaluates 30 prominent models on 42 scenarios, and improves scenario overlap from 17.9% to 96.0%. Body argues accuracy-only evaluation treats other desiderata as second-class. |
+| OpenAI, "GPT-4 Technical Report," arXiv:2303.08774. PDF: https://arxiv.org/pdf/2303.08774 | Benchmarks as release/product evidence; contamination disclosure; OpenAI Evals as infrastructure. | Green/Yellow: PDF downloaded 2026-04-28. Abstract and intro claim GPT-4 human-level performance on professional/academic benchmarks and simulated bar exam top 10%. Section 4 reports exam and benchmark tables including MMLU 86.4%, states contamination checks were run, and discloses GSM-8K training-set inclusion. Lines around 461-464 say OpenAI is open-sourcing Evals for creating/running benchmarks and tracking deployed models. Use as OpenAI release-report framing, not neutral proof of intelligence. |
+| Lianmin Zheng et al., "Judging LLM-as-a-Judge with MT-Bench and Chatbot Arena," arXiv:2306.05685. PDF: https://arxiv.org/pdf/2306.05685 | Preference arenas and LLM-as-judge as public comparison infrastructure. | Green: PDF downloaded 2026-04-28. Abstract says existing benchmarks are inadequate for open-ended human preferences, introduces MT-Bench and Chatbot Arena, and reports GPT-4 judge agreement over 80%, similar to human-human agreement. Body defines MT-Bench as 80 high-quality multi-turn questions, Chatbot Arena as anonymous pairwise crowdsourcing, and documents position, verbosity, self-enhancement, and math/reasoning judge failures. |
+| Jimenez et al., "SWE-bench: Can Language Models Resolve Real-World GitHub Issues?" arXiv:2310.06770. PDF: https://arxiv.org/pdf/2310.06770 | Harder, real-world benchmark design and moving-target evaluation. | Green: PDF downloaded 2026-04-28. Abstract says SWE-bench has 2,294 software engineering problems from GitHub issues and pull requests across 12 Python repos; models edit a codebase and pass tests; Claude 2 solves 1.96% in initial setup. Body says existing benchmarks are saturated, construction filters PRs from about 90,000 to 2,294 tasks, and training data repositories are disjoint to reduce contamination risk. |
+| David Manheim and Scott Garrabrant, "Categorizing Variants of Goodhart's Law," arXiv:1803.04585. PDF: https://arxiv.org/pdf/1803.04585 | Conceptual anchor for metrics becoming targets and overoptimization failure. | Green: PDF downloaded 2026-04-28. Abstract defines Goodhart-like failures as overoptimization on metrics until further optimization becomes ineffective or harmful; body defines regressional, extremal, causal, and adversarial variants. |
+| Wikipedia pages for MMLU, BIG-bench, HELM, Chatbot Arena, and Goodhart's law. | Source-discovery only. | Yellow: useful for locating primary links and chronology; not evidence for prose claims. |
 
-## Required Claim Categories
+## Scene-Level Claim Table
 
-- What each benchmark measures and does not measure.
-- How evaluation becomes a product/marketing signal.
-- How leaderboards shape open/closed competition.
-- How contamination and Goodharting undermine trust.
+| Claim | Scene | Primary Anchor | Confirmation | Status | Notes |
+|---|---|---|---|---|---|
+| Modern foundation-model releases use benchmark tables as capability claims, not merely scientific appendices. | Table In Model Card | GPT-4 Technical Report Section 4 | MMLU/HELM/BIG-bench papers | Yellow | Synthesis; keep release-report framing. |
+| MMLU covers 57 academic/professional subjects and was designed to test broad world knowledge/problem solving. | Frontier Scorecard | MMLU p.1 and dataset section | GPT-4 report MMLU usage | Green | Strong scorecard anchor. |
+| MMLU authors report largest GPT-3 at 43.9% and below expert-level accuracy, showing the benchmark initially exposed gaps. | Frontier Scorecard | MMLU p.1/results | MMLU Table 1 | Green | Historical, not current ranking. |
+| BIG-bench broadened evaluation to 204 tasks by 450 authors across 132 institutions. | Frontier Scorecard | BIG-bench abstract | BIG-bench Section 2 | Green | Use to show expansion pressure. |
+| BIG-bench authors argued many benchmarks had restricted scope and short useful lifespans. | Contamination / Goodhart | BIG-bench Section 1.2 | SuperGLUE saturation figure | Green | Good bridge to benchmark arms race. |
+| HELM explicitly targets transparency, multi-metric measurement, and standardized model comparison. | Frontier Scorecard | HELM abstract | HELM Sections 1.1 / multi-metric | Green | Avoid reducing HELM to leaderboard. |
+| HELM evaluates beyond accuracy: calibration, robustness, fairness, bias, toxicity, and efficiency. | Frontier Scorecard | HELM abstract/body | HELM Figure 3 discussion | Green | Important anti-single-score scene. |
+| GPT-4 report uses professional/academic exams, MMLU, HumanEval, and other benchmarks as release evidence. | Table In Model Card | GPT-4 Technical Report Section 4 | GPT-4 abstract | Yellow | First-party technical report. |
+| GPT-4 report discloses contamination checks and notes GSM-8K training-set inclusion. | Contamination / Goodhart | GPT-4 Section 4 footnotes/table notes | Appendix references | Green | Do not overstate beyond report. |
+| OpenAI Evals is presented as a framework for creating/running benchmarks and tracking model performance in deployment. | Evaluation As Power | GPT-4 report lines around Evals | OpenAI Evals footnote in report | Green | Infrastructure anchor. |
+| MT-Bench and Chatbot Arena were introduced because conventional benchmarks missed open-ended human preferences. | Arena Courtroom | Zheng et al. abstract/introduction | MT-Bench/Chatbot Arena sections | Green | Core public-comparison scene. |
+| Chatbot Arena uses anonymous pairwise voting and public preference data to compare models. | Arena Courtroom | Zheng et al. Section 2.3 | Abstract release note | Green | Date-bound methodology. |
+| GPT-4-as-judge can align with human preferences at over 80% agreement, but judge bias/failure modes are documented. | Arena Courtroom | Zheng et al. abstract + limitations | Position/verbosity/self-bias sections | Green | Balanced claim. |
+| Goodhart effects explain why optimizing a proxy benchmark can degrade its relation to the real goal. | Contamination / Goodhart | Manheim/Garrabrant abstract | Goodhart variant sections | Green | Conceptual, not benchmark-specific accusation. |
+| BIG-bench and SWE-bench both treat leakage/contamination as a design problem rather than a rumor. | Contamination / Goodhart | BIG-bench leakage note; SWE-bench disjoint repos | GPT-4 contamination checks | Green | Good no-accusation guardrail. |
+| SWE-bench was built from real GitHub issues/PRs and execution tests to make software evaluation less toy-like. | Harder Tests | SWE-bench abstract/Sections 2-3 | SWE-bench construction pipeline | Green | Handoff to agentic coding but not Ch60. |
+| SWE-bench initial results showed models solved only a small fraction of tasks, keeping the benchmark useful at release. | Harder Tests | SWE-bench abstract/results | SWE-bench tables | Green | Date-bound. |
+| Public leaderboards and arena scores shape product perception, procurement, and open-vs-closed narratives. | Evaluation As Power | GPT-4 release framing + Arena public ranking + HELM transparency | Ch65 open weights context | Yellow | Institutional synthesis; do not invent specific decisions. |
+| Benchmark scores are time-sensitive and do not settle model quality. | Close | HELM multi-metric argument; Zheng judge limitations; Goodhart | MMLU/BIG-bench saturation discussion | Green | Core moral. |
 
 ## Conflict Notes
 
 - Benchmark scores are time-sensitive. Always date them.
 - Do not imply one benchmark settles model quality.
 - Do not draft until source anchors are extracted.
+- Do not accuse a model/lab of contamination unless the source itself reports a
+  contamination check or discloses overlap.

--- a/docs/research/ai-history/chapters/ch-66-benchmark-wars/status.yaml
+++ b/docs/research/ai-history/chapters/ch-66-benchmark-wars/status.yaml
@@ -1,8 +1,8 @@
-status: capacity_plan_anchored
+status: prose_ready
 owner: Codex
 part: 9
 chapter: 66
-review_state: awaiting_claude_source_review_and_gemini_gap_audit
+review_state: dual_cross_family_verdict_accepted
 last_updated: 2026-04-28
 green_claims: 16
 yellow_claims: 3
@@ -12,25 +12,25 @@ prose_word_cap_recommendation: 5400
 word_count_range: "4300-5400"
 verdicts:
   claude:
-    model: null
-    date: null
-    verdict: null
-    review_url: null
+    model: claude-opus-4-7
+    date: 2026-04-28
+    verdict: APPROVE
+    review_url: https://github.com/kube-dojo/kube-dojo.github.io/pull/524#issuecomment-4339452573
   gemini:
-    model: null
-    date: null
-    verdict: null
-    word_cap: null
-    review_url: null
-  resolved: null
-  resolved_word_cap: null
+    model: gemini-3.1-pro-preview
+    date: 2026-04-28
+    verdict: READY_TO_DRAFT_WITH_CAP
+    word_cap: 5400
+    review_url: https://github.com/kube-dojo/kube-dojo.github.io/pull/524#issuecomment-4339449025
+  resolved: READY_TO_DRAFT_WITH_CAP
+  resolved_word_cap: 5400
   resolution_rule: dual_cross_family_verdict_with_cap
 notes: |
-  Built into an anchored benchmark-politics contract. Core anchors are MMLU,
-  BIG-bench, HELM, GPT-4 Technical Report / OpenAI Evals, MT-Bench / Chatbot
-  Arena, SWE-bench, and a Goodhart-law source.
+  Built into a dual-cleared prose_ready benchmark-politics contract. Core
+  anchors are MMLU, BIG-bench, HELM, GPT-4 Technical Report / OpenAI Evals,
+  MT-Bench / Chatbot Arena, SWE-bench, and a Goodhart-law source.
 
-  Safe draft range is 4,300-5,400 words pending Claude source review and Gemini
-  capacity audit. Keep benchmark rankings dated and source-bound, do not treat
-  scores as direct intelligence measures, and avoid unsourced contamination
+  Safe draft range is 4,300-5,400 words after Claude source review and Gemini
+  gap/capacity audit. Keep benchmark rankings dated and source-bound, do not
+  treat scores as direct intelligence measures, and avoid unsourced contamination
   accusations.

--- a/docs/research/ai-history/chapters/ch-66-benchmark-wars/status.yaml
+++ b/docs/research/ai-history/chapters/ch-66-benchmark-wars/status.yaml
@@ -1,15 +1,36 @@
-status: researching
+status: capacity_plan_anchored
 owner: Codex
 part: 9
 chapter: 66
-review_state: not_started
+review_state: awaiting_claude_source_review_and_gemini_gap_audit
 last_updated: 2026-04-28
-green_claims: 0
-yellow_claims: 0
+green_claims: 16
+yellow_claims: 3
 red_claims: 0
-guardrail_count: 4
-prose_word_cap_recommendation: null
+guardrail_count: 6
+prose_word_cap_recommendation: 5400
+word_count_range: "4300-5400"
+verdicts:
+  claude:
+    model: null
+    date: null
+    verdict: null
+    review_url: null
+  gemini:
+    model: null
+    date: null
+    verdict: null
+    word_cap: null
+    review_url: null
+  resolved: null
+  resolved_word_cap: null
+  resolution_rule: dual_cross_family_verdict_with_cap
 notes: |
-  New chapter added by the modern-era coverage pass after Claude/Gemini
-  structural consultation. It reserves evaluation/benchmark politics as a
-  first-class chapter instead of burying them inside Product Shock or Monopoly.
+  Built into an anchored benchmark-politics contract. Core anchors are MMLU,
+  BIG-bench, HELM, GPT-4 Technical Report / OpenAI Evals, MT-Bench / Chatbot
+  Arena, SWE-bench, and a Goodhart-law source.
+
+  Safe draft range is 4,300-5,400 words pending Claude source review and Gemini
+  capacity audit. Keep benchmark rankings dated and source-bound, do not treat
+  scores as direct intelligence measures, and avoid unsourced contamination
+  accusations.

--- a/docs/research/ai-history/chapters/ch-66-benchmark-wars/timeline.md
+++ b/docs/research/ai-history/chapters/ch-66-benchmark-wars/timeline.md
@@ -1,8 +1,14 @@
 # Timeline: Chapter 66 - Benchmark Wars
 
-- **2020-2021:** Broad multitask benchmark suites become increasingly central to foundation-model claims.
-- **2022:** HELM/BIG-bench-style evaluation efforts broaden the measurement problem.
-- **2023:** Chatbot Arena and public leaderboards become prominent comparison infrastructure.
-- **2023-2025:** Contamination, benchmark saturation, and benchmark-specific optimization become major credibility problems.
-
-Dates are placeholders until primary anchors are extracted.
+- **2020:** MMLU is introduced as a broad multitask benchmark covering 57
+  academic and professional subjects.
+- **2022:** BIG-bench and HELM broaden evaluation beyond narrow task suites:
+  BIG-bench through 204 community-contributed tasks, HELM through multi-metric
+  standardized evaluation.
+- **2023-03:** GPT-4 Technical Report turns professional exams, MMLU, HumanEval,
+  contamination checks, safety metrics, and OpenAI Evals into release evidence.
+- **2023-06:** MT-Bench and Chatbot Arena formalize LLM-as-judge and pairwise
+  preference arenas as scalable comparison infrastructure.
+- **2023-10:** SWE-bench introduces a real-world GitHub issue/PR benchmark for
+  software engineering tasks, showing that new benchmarks move toward harder,
+  work-like tests as older ones saturate.

--- a/src/content/docs/ai-history/index.md
+++ b/src/content/docs/ai-history/index.md
@@ -191,7 +191,7 @@ Consumer adoption, edge constraints, and AI transitioning to heavy industry.
 | 63 | Inference Economics | prose_ready | no |
 | 64 | The Edge Compute Bottleneck | prose_ready | no |
 | 65 | The Open Weights Rebellion | prose_ready | no |
-| 66 | Benchmark Wars | capacity_plan_anchored | no |
+| 66 | Benchmark Wars | prose_ready | no |
 | 67 | The Monopoly | researching | no |
 | 68 | Data Labor and the Copyright Reckoning | researching | no |
 | 69 | The Data Exhaustion Limit | researching | no |
@@ -205,8 +205,8 @@ Consumer adoption, edge constraints, and AI transitioning to heavy industry.
 |---|---:|
 | `accepted` (drafted, all reviews cleared) | 29 |
 | `prose_review` (drafted, in review) | 0 |
-| `prose_ready` (contract dual-cleared, awaiting prose draft) | 20 |
-| `capacity_plan_anchored` (contract anchored, awaiting verdict) | 4 |
+| `prose_ready` (contract dual-cleared, awaiting prose draft) | 21 |
+| `capacity_plan_anchored` (contract anchored, awaiting verdict) | 3 |
 | `researching` with prose merged on legacy contract | 5 |
 | `researching` (no prose yet) | 14 |
 | **Total** | **72** |

--- a/src/content/docs/ai-history/index.md
+++ b/src/content/docs/ai-history/index.md
@@ -191,7 +191,7 @@ Consumer adoption, edge constraints, and AI transitioning to heavy industry.
 | 63 | Inference Economics | prose_ready | no |
 | 64 | The Edge Compute Bottleneck | prose_ready | no |
 | 65 | The Open Weights Rebellion | prose_ready | no |
-| 66 | Benchmark Wars | researching | no |
+| 66 | Benchmark Wars | capacity_plan_anchored | no |
 | 67 | The Monopoly | researching | no |
 | 68 | Data Labor and the Copyright Reckoning | researching | no |
 | 69 | The Data Exhaustion Limit | researching | no |
@@ -206,7 +206,7 @@ Consumer adoption, edge constraints, and AI transitioning to heavy industry.
 | `accepted` (drafted, all reviews cleared) | 29 |
 | `prose_review` (drafted, in review) | 0 |
 | `prose_ready` (contract dual-cleared, awaiting prose draft) | 20 |
-| `capacity_plan_anchored` (contract anchored, awaiting verdict) | 3 |
+| `capacity_plan_anchored` (contract anchored, awaiting verdict) | 4 |
 | `researching` with prose merged on legacy contract | 5 |
-| `researching` (no prose yet) | 15 |
+| `researching` (no prose yet) | 14 |
 | **Total** | **72** |


### PR DESCRIPTION
## Summary

Anchors Ch66 `Benchmark Wars` from placeholder to `capacity_plan_anchored`.

Scope:
- Builds full research contract: brief, sources, timeline, people, scene sketches, infrastructure log, open questions, status.
- Adds Ch66 to README and public index as `capacity_plan_anchored`.
- Keeps boundaries explicit: Ch65 owns open weights, Ch68 owns data/copyright, Ch60 owns agents/tool use.

Review focus:
- GPT-4 report is framed as first-party release evidence, not neutral proof of intelligence.
- Chatbot Arena / LLM-as-judge includes bias and failure-mode guardrails.
- Contamination is handled only through source-disclosed checks or benchmark-design choices, not accusations.
- SWE-bench is used as harder evaluation design, not as a coding-agent history chapter.

Checks:
- `git diff --check`
- YAML sanity via `.venv/bin/python`
- `npm run astro -- sync` (passes; unrelated existing expressive-code warnings for `cloudformation`/`haproxy` languages)

Requested reviewers:
- Claude: source-fidelity review
- Gemini: gap/capacity audit only

Refs #407
