### PR TITLE
docs(ai-history): anchor ch68 data labor research (#407)

### DIFF
--- a/docs/research/ai-history/README.md
+++ b/docs/research/ai-history/README.md
@@ -10,7 +10,7 @@ This directory contains the operational research files for the definitive 72-cha
 - **Part 4 (The First Winter):** Ch17-23 cross-family cleared for capped prose drafting; Ch21 carries a Yellow-caveated Bachant/McDermott mirror-source guardrail.
 - **Part 5 (The Mathematical Resurrection):** Ch24-31 prose `accepted`.
 - **Part 8 (The Transformer, Scale & Open Source):** Ch50-58 dual-cleared `prose_ready`; Ch58 cap is 5,200 words.
-- **Part 9 (The Product Shock & Physical Limits):** Ch59-Ch61 rebuilt to `capacity_plan_anchored` 2026-04-28; Ch62-Ch67 dual-cleared `prose_ready` with 4,800-, 4,500-, 5,000-, 5,300-, 5,400-, and 5,400-word caps.
+- **Part 9 (The Product Shock & Physical Limits):** Ch59-Ch61 and Ch68 rebuilt to `capacity_plan_anchored` 2026-04-28; Ch62-Ch67 dual-cleared `prose_ready` with 4,800-, 4,500-, 5,000-, 5,300-, 5,400-, and 5,400-word caps.
 
 All drafting is paused for any chapter whose contract is not at `prose_ready` or beyond.
 

--- a/docs/research/ai-history/README.md
+++ b/docs/research/ai-history/README.md
@@ -10,7 +10,7 @@ This directory contains the operational research files for the definitive 72-cha
 - **Part 4 (The First Winter):** Ch17-23 cross-family cleared for capped prose drafting; Ch21 carries a Yellow-caveated Bachant/McDermott mirror-source guardrail.
 - **Part 5 (The Mathematical Resurrection):** Ch24-31 prose `accepted`.
 - **Part 8 (The Transformer, Scale & Open Source):** Ch50-58 dual-cleared `prose_ready`; Ch58 cap is 5,200 words.
-- **Part 9 (The Product Shock & Physical Limits):** Ch59-Ch61 and Ch68 rebuilt to `capacity_plan_anchored` 2026-04-28; Ch62-Ch67 dual-cleared `prose_ready` with 4,800-, 4,500-, 5,000-, 5,300-, 5,400-, and 5,400-word caps.
+- **Part 9 (The Product Shock & Physical Limits):** Ch59-Ch61 rebuilt to `capacity_plan_anchored` 2026-04-28; Ch62-Ch68 dual-cleared `prose_ready` with 4,800-, 4,500-, 5,000-, 5,300-, 5,400-, 5,400-, and 5,500-word caps.
 
 All drafting is paused for any chapter whose contract is not at `prose_ready` or beyond.
 

--- a/docs/research/ai-history/chapters/ch-68-data-labor-and-the-copyright-reckoning/brief.md
+++ b/docs/research/ai-history/chapters/ch-68-data-labor-and-the-copyright-reckoning/brief.md
@@ -51,23 +51,23 @@ deals made the hidden supply chain visible.
 
 ## Prose Capacity Plan
 
-Target range: 4,500-5,600 words after source verification.
+Target range: 4,500-5,500 words after source verification.
 
-- 500-700 words: bridge from Ch67's platform gates to the less visible data
+- 500-650 words: bridge from Ch67's platform gates to the less visible data
   gate: the model stack needs people and rights-cleared material, not just
   compute.
-- 900-1,100 words: the human filter. Use Ch57/Ouyang for the research pipeline
+- 850-1,000 words: the human filter. Use Ch57/Ouyang for the research pipeline
   and TIME for Sama/Kenya reporting. Do not turn anonymous workers into scenery.
-- 850-1,050 words: the scraped corpus. Explain Common Crawl, GPT-3's training
+- 800-950 words: the scraped corpus. Explain Common Crawl, GPT-3's training
   mixture, The Pile's 825 GiB/22-subset design, and Books3 as a named book
   component that later becomes legally salient.
-- 850-1,100 words: the image flashpoint. LAION-5B, Stable Diffusion v1-4, Getty's
+- 800-1,000 words: the image flashpoint. LAION-5B, Stable Diffusion v1-4, Getty's
   claim of copied images/captions/metadata, and watermark/trademark allegations.
-- 950-1,200 words: the news/book courtroom phase. NYT allegations, OpenAI's fair
+- 900-1,100 words: the news/book courtroom phase. NYT allegations, OpenAI's fair
   use/opt-out/regurgitation framing, the 2025 NYT motion-to-dismiss narrowing,
   and the Bartz/Anthropic order's split between training copies, purchased
   scanning, and pirated library copies.
-- 650-850 words: enclosure close. Robots.txt/crawler controls, publisher
+- 600-800 words: enclosure close. Robots.txt/crawler controls, publisher
   licensing, Reddit Data API, and handoff to Ch69's question: what happens when
   high-quality human data becomes scarce, expensive, or legally fenced?
 

--- a/docs/research/ai-history/chapters/ch-68-data-labor-and-the-copyright-reckoning/brief.md
+++ b/docs/research/ai-history/chapters/ch-68-data-labor-and-the-copyright-reckoning/brief.md
@@ -1,32 +1,88 @@
 # Brief: Chapter 68 - Data Labor and the Copyright Reckoning
 
 ## Thesis
-The modern AI race was not powered only by GPUs and algorithms; it also depended on hidden labor and contested data rights. This chapter separates the human/legal story from the later physical "data exhaustion" story: RLHF labeling, content moderation labor, web scraping, books and image datasets, opt-outs, and copyright lawsuits turned training data from an ambient resource into a political battlefield.
+The modern AI race was not powered only by GPUs, scaling laws, and model
+architecture. It also depended on human labor that made model behavior usable
+and on contested data pipelines that converted the web, books, images, captions,
+and news archives into training material. Ch68 explains how data stopped looking
+like an ambient public resource and became a labor, rights, licensing, and court
+fight. The chapter does not decide the legal merits. It shows the historical
+turn: first the work was hidden in labeling queues and scraped corpora; then
+workers, artists, authors, publishers, courts, robots.txt files, and licensing
+deals made the hidden supply chain visible.
 
 ## Scope
-- IN SCOPE: RLHF/content moderation labor, Sama/Kenya-style labor controversies, Books3, Common Crawl, LAION/image dataset disputes, Getty v. Stability, NYT v. OpenAI/Microsoft, opt-outs, data licensing, and the shift from open web harvesting to negotiated data rights.
-- OUT OF SCOPE: detailed legal analysis beyond source-supported claims, all copyright lawsuits, and the technical synthetic-data wall covered in Chapter 69.
+- IN SCOPE: RLHF labeler work already introduced in Ch57; safety/content
+  labeling labor; Sama/Kenya reporting with careful attribution; GPT-3-style
+  Common Crawl/books mixtures; The Pile and Books3; LAION and Stable Diffusion;
+  Getty v. Stability as an image-rights flashpoint; New York Times v.
+  OpenAI/Microsoft as a news-rights flashpoint; Bartz v. Anthropic as the
+  clearest 2025 book-corpus court record; crawler opt-outs; publisher/platform
+  licensing deals; data access as strategic infrastructure.
+- OUT OF SCOPE: comprehensive legal survey; predictions about case outcomes;
+  treating complaint allegations as adjudicated facts; all AI copyright suits;
+  full social-media content-moderation history; technical synthetic-data and
+  data-exhaustion strategies covered in Ch69; physical datacenter limits covered
+  in Ch70 and Ch72.
 
 ## Required Scenes
-1. **The Human Filter:** Alignment and safety data require people reading, ranking, and labeling difficult content.
-2. **The Scraped Library:** Web pages, books, and images become training fuel, often before rights holders understand the extraction.
-3. **The Image Dataset Flashpoint:** Stable Diffusion/LAION/Getty-style disputes make image copyright visible.
-4. **The Newspaper And Book Reckoning:** Text data lawsuits turn web-scale scraping into a courtroom problem.
-5. **From Commons To Enclosure:** The chapter closes with licensing, opt-outs, and data access becoming strategic assets.
+
+1. **The Human Filter:** Ouyang et al. show the respectable research version of
+   human-feedback labor: demonstrations, rankings, reward models, PPO, and about
+   40 contractors. TIME's Sama reporting shows a harsher safety-labeling layer:
+   outsourced workers handling toxic or explicit material under contested
+   conditions. Keep the two evidence types separate.
+2. **The Scraped Corpus:** GPT-3, The Pile, Common Crawl, and Books3 show the
+   normal research language of "datasets" and "corpora." The prose should show
+   how this language made web pages and books look like input material before
+   rights holders had a stable response.
+3. **The Image Dataset Flashpoint:** LAION-5B and the Stable Diffusion model
+   card make image-caption training concrete; Getty's statement and complaint
+   show how image owners translated dataset use into copyright, trademark,
+   metadata, and watermark claims.
+4. **The Newspaper And Book Reckoning:** The NYT complaint, OpenAI response,
+   2025 motion-to-dismiss opinion, and Bartz/Anthropic fair-use order show the
+   courtroom phase. Allegations, company defenses, and court rulings must be
+   lexically separated.
+5. **From Commons To Enclosure:** GPTBot/OAI-SearchBot rules, Reddit's Data API
+   partnership, and publisher deals with Axel Springer, the Financial Times, and
+   News Corp show the endpoint: data access becomes negotiated, blocked,
+   attributed, licensed, or priced.
 
 ## Prose Capacity Plan
 
-Target range: 4,600-5,800 words after source verification.
+Target range: 4,500-5,600 words after source verification.
 
-- 700-900 words: bridge from open weights/monopoly to hidden labor and data rights.
-- 900-1,100 words: RLHF/content moderation labor.
-- 900-1,100 words: books/web/Common Crawl and dataset construction.
-- 900-1,100 words: image datasets and copyright disputes.
-- 800-1,000 words: text lawsuits, licensing, opt-outs, and transition to data exhaustion.
+- 500-700 words: bridge from Ch67's platform gates to the less visible data
+  gate: the model stack needs people and rights-cleared material, not just
+  compute.
+- 900-1,100 words: the human filter. Use Ch57/Ouyang for the research pipeline
+  and TIME for Sama/Kenya reporting. Do not turn anonymous workers into scenery.
+- 850-1,050 words: the scraped corpus. Explain Common Crawl, GPT-3's training
+  mixture, The Pile's 825 GiB/22-subset design, and Books3 as a named book
+  component that later becomes legally salient.
+- 850-1,100 words: the image flashpoint. LAION-5B, Stable Diffusion v1-4, Getty's
+  claim of copied images/captions/metadata, and watermark/trademark allegations.
+- 950-1,200 words: the news/book courtroom phase. NYT allegations, OpenAI's fair
+  use/opt-out/regurgitation framing, the 2025 NYT motion-to-dismiss narrowing,
+  and the Bartz/Anthropic order's split between training copies, purchased
+  scanning, and pirated library copies.
+- 650-850 words: enclosure close. Robots.txt/crawler controls, publisher
+  licensing, Reddit Data API, and handoff to Ch69's question: what happens when
+  high-quality human data becomes scarce, expensive, or legally fenced?
 
 ## Guardrails
 
 - Do not make legal conclusions the sources do not support.
 - Do not conflate labor conditions across vendors or countries without evidence.
 - Do not treat all scraping as legally identical.
-- Do not let this become the technical synthetic-data chapter; that is Chapter 69.
+- Do not say "training is legal" or "training is illegal" as a general rule.
+  The 2025 Bartz/Anthropic order is one district-court order with a narrow
+  posture and a split result.
+- Do not imply OpenAI, Stability, Anthropic, Meta, or any other lab used a
+  dataset unless a primary source, court record, model card, or company
+  statement supports that specific claim.
+- Do not let this become the technical synthetic-data chapter; that is Chapter
+  69.
+- Date all legal status statements. As of April 28, 2026, several AI copyright
+  disputes remain active or settlement-finality-sensitive.

--- a/docs/research/ai-history/chapters/ch-68-data-labor-and-the-copyright-reckoning/infrastructure-log.md
+++ b/docs/research/ai-history/chapters/ch-68-data-labor-and-the-copyright-reckoning/infrastructure-log.md
@@ -2,19 +2,43 @@
 
 ## Systems To Track
 
-- RLHF and safety-labeling pipelines.
-- Dataset collection pipelines for web text, books, images, and captions.
-- Deduplication, filtering, opt-out, and provenance mechanisms.
-- Data licensing and access controls.
-- Legal discovery/complaint claims only when source-bound.
+- **RLHF pipeline:** demonstrations, rankings, reward model, PPO, and the narrow
+  representativeness of labeler/researcher/API-customer preferences.
+- **Safety labeling pipeline:** toxic-content examples become labels for filters
+  and moderation tools; source-specific to TIME's Sama/OpenAI reporting.
+- **Web/text corpora:** Common Crawl as public web data; GPT-3's filtered Common
+  Crawl/books/Wikipedia mixture; The Pile as an 825 GiB, 22-subset corpus.
+- **Book corpora:** Books3 is a Pile component and later a legally salient book
+  source in Bartz/Anthropic. Do not treat all book datasets as legally identical.
+- **Image-caption corpora:** LAION-5B and LAION-2B(en) subsets; Stable Diffusion
+  model-card disclosures; captions and metadata matter legally as well as
+  technically.
+- **Crawler controls:** OAI-SearchBot and GPTBot as separate robots.txt surfaces
+  for search and training in OpenAI's docs.
+- **Licensing/API access:** Axel Springer, FT, News Corp, and Reddit deals show
+  content moving through attribution, archive/current-content access, model
+  improvement rights, Data API access, and commercial partnership language.
+- **Court records:** complaints allege; opinions/orders decide only the issues
+  before them; settlement process may not set precedent.
 
 ## Metrics To Verify
 
-- Dataset sizes only from primary documentation.
-- Labor vendor/task details only from reliable reporting or primary/legal sources.
-- Lawsuit dates and parties from filings.
-- Licensing/access claims from official announcements or filings.
+- Ouyang: about 40 contractors; use Ch57 for fuller dataset-size details.
+- TIME/Sama: wage and task claims only with TIME attribution plus company
+  response caveats.
+- GPT-3: 410B filtered Common Crawl tokens and training-mix components only from
+  Ch53/GPT-3 anchors.
+- The Pile: 825 GiB and 22 subsets; Books3 listed as one component.
+- LAION: 5.85B image-text pairs, 2.32B English pairs.
+- Stable Diffusion: LAION-2B(en)/aesthetics subsets and training-step details
+  from model card only.
+- Getty: "more than 12 million" is an allegation in the amended complaint.
+- NYT: complaint allegations and 2025 procedural opinion; do not state final
+  liability.
+- Bartz: quote the split result by use/acquisition path, not a broad legal rule.
 
 ## Boundary
 
-Chapter 68 is about labor, legality, and data rights. Chapter 69 is about technical data exhaustion and synthetic-data strategies.
+Chapter 68 is about labor, legality, and data rights. Chapter 69 is about
+technical data exhaustion and synthetic-data strategies. Ch70/72 own power and
+datacenter limits. Ch67 owns platform concentration.

--- a/docs/research/ai-history/chapters/ch-68-data-labor-and-the-copyright-reckoning/open-questions.md
+++ b/docs/research/ai-history/chapters/ch-68-data-labor-and-the-copyright-reckoning/open-questions.md
@@ -1,6 +1,28 @@
 # Open Questions: Chapter 68 - Data Labor and the Copyright Reckoning
 
-- Which labor source set is strong enough to support a careful RLHF/content-moderation scene?
-- Which lawsuits should be in scope without turning the chapter into legal survey?
-- Should Books3 be the central books scene, or should it be part of a broader open-corpus scene?
-- How much Common Crawl mechanics should be explained before moving to rights disputes?
+## Resolved For Drafting
+
+- **Which labor sources are strong enough?** Use Ouyang et al. for the RLHF
+  research pipeline and TIME for the Sama/Kenya safety-labeling controversy.
+  Keep them separate.
+- **Which lawsuits are in scope?** Getty v. Stability for images, NYT v.
+  OpenAI/Microsoft for news, and Bartz v. Anthropic for books because it has the
+  strongest court-order anchor. Mention other suits only as background if
+  source-reviewed later.
+- **Should Books3 be central?** It should appear first as one component of The
+  Pile, then return in Bartz/Anthropic as a legally salient source. It should not
+  carry the whole chapter.
+- **How much Common Crawl?** Enough to explain petabyte-scale public web
+  infrastructure and GPT-3/Pile reliance, then move quickly to rights disputes.
+
+## Still Needs Prose-Time Caution
+
+- Recheck Bartz/Anthropic settlement status before prose if settlement
+  finality is mentioned. As of April 28, 2026, use only a freshness caveat.
+- Consider whether to include the exact TIME wage figures in prose. If included,
+  include Sama's disputed higher range and OpenAI's vendor-management caveat.
+- Do not include graphic content examples from TIME unless a human editor
+  explicitly asks; they are not necessary to make the labor point.
+- If prose wants a broader "all AI copyright lawsuits" sentence, add a
+  dedicated survey source. Current contract supports three exemplar disputes,
+  not a complete legal map.

--- a/docs/research/ai-history/chapters/ch-68-data-labor-and-the-copyright-reckoning/people.md
+++ b/docs/research/ai-history/chapters/ch-68-data-labor-and-the-copyright-reckoning/people.md
@@ -1,12 +1,30 @@
 # People: Chapter 68 - Data Labor and the Copyright Reckoning
 
-## People / Groups To Verify
+## People / Groups
 
-- RLHF/content moderation workers and vendors, only where sourced responsibly.
-- Artists, authors, publishers, and news organizations involved in major disputes.
-- Dataset builders for Books3, LAION, The Pile, and related corpora.
-- Lab/company representatives only when primary statements are available.
+- **OpenAI labelers/contractors in Ouyang et al.:** anonymous contractors hired
+  for demonstrations/rankings. Use only as a group; do not invent identities.
+- **Sama workers in Kenya:** TIME's anonymous sources and document review support
+  a source-specific labor scene. Handle categories and conditions carefully; do
+  not sensationalize graphic examples.
+- **Sama / OpenAI representatives:** TIME includes company responses from both.
+  Use those responses when discussing disputed wages, targets, counseling, and
+  project scope.
+- **Dataset builders:** The Pile authors and LAION authors are safe to name as
+  project teams if needed, but the prose should focus on corpus infrastructure,
+  not lone inventors.
+- **Rights holders and plaintiffs:** Getty Images, The New York Times, authors in
+  Bartz v. Anthropic, and publishers/platforms in licensing deals.
+- **Company executives in licensing announcements:** Mathias Doepfner, John
+  Ridding, Robert Thomson, Sam Altman, Brad Lightcap, and Steve Huffman appear in
+  company announcements. Use only if a quote/role is necessary.
+- **Judges/courts:** Sidney H. Stein for the NYT/OpenAI motion-to-dismiss
+  opinion; William Alsup for the 2025 Bartz/Anthropic fair-use order. Avoid
+  personalizing the law beyond the orders.
 
 ## Guardrail
 
-This chapter must avoid turning vulnerable workers into narrative decoration. Use labor details only when they are sourced, relevant, and handled with care.
+This chapter must avoid turning vulnerable workers into narrative decoration.
+Use labor details only when they are sourced, relevant, and handled with care.
+The best prose will make the production system visible without dwelling on
+trauma for atmosphere.

--- a/docs/research/ai-history/chapters/ch-68-data-labor-and-the-copyright-reckoning/scene-sketches.md
+++ b/docs/research/ai-history/chapters/ch-68-data-labor-and-the-copyright-reckoning/scene-sketches.md
@@ -1,20 +1,68 @@
 # Scene Sketches: Chapter 68 - Data Labor and the Copyright Reckoning
 
 ## Scene 1: The Labeling Queue
-- **Action:** Human workers rate, filter, or label content that models later appear to handle automatically.
-- **Guardrail:** Keep work conditions source-specific.
+
+Action: Start with the apparent magic of a chatbot refusing harmful content or
+following user intent, then move behind the interface. Ouyang et al. give the
+clean research diagram: demonstrations, rankings, reward model, PPO, about 40
+contractors. TIME gives the harsher safety-labor scene: workers in Kenya reading
+and labeling toxic text for a filtering system.
+
+Guardrail: do not merge Ouyang's RLHF contractors with Sama's reported
+content-labeling workers. Do not reproduce graphic examples; categories are
+enough.
 
 ## Scene 2: The Scraped Corpus
-- **Action:** Books, pages, images, captions, and metadata become datasets.
-- **Guardrail:** Do not imply every source was used by every model.
+
+Action: Show the rhetorical transformation from "web pages" and "books" into
+"corpora." Common Crawl is petabytes of web data; GPT-3 uses filtered Common
+Crawl and book datasets; The Pile turns many named sources into an 825 GiB
+language-model dataset and includes Books3. The scene should explain why this
+felt normal inside ML before it became explosive outside ML.
+
+Guardrail: do not imply every source was used by every model. Keep Books3 as a
+named Pile component and later legal object, not as shorthand for all books.
 
 ## Scene 3: The Artist Finds Their Work
-- **Action:** Image-generation disputes make dataset provenance legible to creators.
-- **Guardrail:** Avoid legal conclusions not in court records.
+
+Action: Move from text to images. LAION-5B names the open image-caption scale;
+Stable Diffusion v1-4's model card names LAION subsets. Then Getty translates
+the same dataset practice into rights language: images, captions, metadata,
+watermarks, licensing, and market substitution.
+
+Guardrail: say "Getty alleges" for complaint claims. Do not say the case proved
+copyright infringement.
 
 ## Scene 4: The Newspaper Sues
-- **Action:** News/books lawsuits frame model training as a rights and market conflict.
-- **Guardrail:** Distinguish complaint allegations from adjudicated facts.
 
-## Scene 5: Data Becomes Property Again
-- **Action:** Opt-outs, licensing deals, and restricted access turn open-web data into strategic enclosure.
+Action: Use the NYT complaint as the news-industry version of the same shock:
+search indexing and narrow licenses are different from GenAI use, in the Times'
+framing. Then use OpenAI's response: fair use, opt-outs, partnerships, and
+regurgitation as rare/misuse. Bring in the 2025 motion-to-dismiss opinion to
+show that the courtroom is narrowing issues rather than delivering a clean
+public slogan.
+
+Guardrail: distinguish complaint allegations, OpenAI company framing, and court
+procedural rulings.
+
+## Scene 5: The Book Case Draws A Line
+
+Action: Bartz/Anthropic is the clearest court-record scene. The order describes
+Books3/LibGen/PiLiMi, then separates uses: training copies were fair use in that
+order, purchased-print scanning was fair use for another reason, and pirated
+central-library copies were not justified by fair use. This scene should teach
+readers why acquisition path matters.
+
+Guardrail: do not generalize the order into "AI training is legal" or "AI
+training is illegal." Date the ruling and note the settlement-finality caveat if
+the prose mentions settlement.
+
+## Scene 6: Data Becomes Property Again
+
+Action: Close with the visible shift from open harvesting to control surfaces:
+GPTBot and OAI-SearchBot controls, publisher licensing, Reddit Data API access,
+and attribution/linking deals. Data becomes a negotiated asset rather than an
+ambient commons.
+
+Guardrail: this is a market-structure close, not Ch69's technical data-scarcity
+chapter.

--- a/docs/research/ai-history/chapters/ch-68-data-labor-and-the-copyright-reckoning/sources.md
+++ b/docs/research/ai-history/chapters/ch-68-data-labor-and-the-copyright-reckoning/sources.md
@@ -1,29 +1,77 @@
 # Sources: Chapter 68 - Data Labor and the Copyright Reckoning
 
-## Research Status
+## Verification Key
 
-No claims are verified yet. This placeholder reserves labor/copyright/data-rights history as a first-class chapter.
+- Green: claim has direct support from a paper, model card, official statement,
+  court filing/order, or source-specific investigative report.
+- Green/Yellow: claim is usable but must carry source-type caveats such as
+  "the complaint alleges," "OpenAI says," "TIME reported," or "company framing."
+- Yellow: chronology or context support only; do not make it load-bearing.
+- Red: not currently supported; do not draft.
 
-## Candidate Source Families To Verify
+## Primary / Near-Primary Source Spine
 
-- Ouyang/InstructGPT and related RLHF labor sources from Chapter 57 for continuity.
-- Primary reporting and legal filings on Sama/Kenya/content moderation labor.
-- Books3 / The Pile documentation and related primary materials.
-- Common Crawl documentation and dataset-use papers.
-- LAION documentation and Stable Diffusion primary materials.
-- Getty Images v. Stability AI filings and official statements.
-- New York Times v. OpenAI/Microsoft complaint and responses.
-- Publisher/data-licensing announcements where relevant.
+| Source | Use In Chapter | Anchor Notes |
+|---|---|---|
+| Long Ouyang et al., "Training language models to follow instructions with human feedback," arXiv:2203.02155. PDF: https://arxiv.org/pdf/2203.02155 | Research-grade RLHF labor pipeline: demonstrations, rankings, reward model, PPO, about 40 contractors, and representativeness limits. | Green: PDF lines 8-26 summarize demonstrations, rankings, RLHF, and measured results; lines 65-79 say OpenAI hired about 40 contractors, collected demonstrations/comparisons, trained a reward model, used PPO, and aligned to preferences of a specific group rather than all human values. Ch57 has fuller anchors. |
+| Billy Perrigo, "OpenAI Used Kenyan Workers on Less Than $2 Per Hour to Make ChatGPT Less Toxic," TIME, Jan. 18, 2023. https://time.com/6247678/openai-chatgpt-kenya-workers/ | Investigative labor source for Sama/Kenya safety-labeling work and worker-condition caveats. | Green/Yellow: TIME lines 41, 54, 62, 73-74, 80-90, 96-111, and 113-115. Use as reported investigation plus quoted company responses, not as primary OpenAI payroll data. |
+| Tom B. Brown et al., "Language Models are Few-Shot Learners," arXiv:2005.14165. PDF: https://arxiv.org/pdf/2005.14165 | GPT-3 training mixture and Common Crawl/books baseline from prior Part 8 context. | Green via Ch53 contract: Section 2.2/Table 2.2 anchor filtered Common Crawl, WebText2, Books1, Books2, and Wikipedia, with 410B filtered Common Crawl tokens and book datasets. |
+| Common Crawl, "Overview." https://commoncrawl.org/overview | Public web-corpus infrastructure. | Green: lines 23-25 say the corpus contains petabytes of data regularly collected since 2008; lines 220-227 say it contains raw web page data, metadata extracts, and text extracts, stored on AWS public datasets and free to access. |
+| Gao et al., "The Pile: An 825 GiB Dataset of Diverse Text for Language Modeling," arXiv:2101.00027. PDF: https://arxiv.org/pdf/2101.00027 | Open-corpus scene; Books3 as a named component; Common Crawl reliance. | Green: lines 11-13 and 46-47 identify 825 GiB and 22 diverse subsets; lines 32-35 say large language models turned to Common Crawl for most/all data; lines 59-63 list Books3, Project Gutenberg/PG-19, OpenSubtitles, Wikipedia, Enron, and others. |
+| LAION-5B arXiv abstract page, "LAION-5B: An open large-scale dataset for training next generation image-text models." https://arxiv.org/abs/2210.08402 | Image-caption dataset scale and open dataset framing. | Green: line 43 says LAION-5B consists of 5.85 billion CLIP-filtered image-text pairs, including 2.32B English pairs, and discusses replication/fine-tuning of CLIP, GLIDE, and Stable Diffusion. |
+| CompVis Stable Diffusion v1-4 model card. https://huggingface.co/CompVis/stable-diffusion-v1-4 | Stable Diffusion dataset/model-card bridge. | Green: lines 230-233 say the model was trained on LAION-5B/LAION-2B(en) subsets and warn about adult material and cultural bias; lines 240-256 list LAION-2B(en), LAION aesthetics subsets, training steps, and hardware. |
+| Getty Images, "Getty Images Statement," Jan. 17, 2023. https://newsroom.gettyimages.com/en/getty-images/getty-images-statement | Getty's official UK-proceeding framing and licensing-position source. | Green/Yellow: lines 13-17 say Getty commenced High Court proceedings, claims copying/processing of millions of images and metadata without a license, and says Getty licenses content for AI training. Use as Getty's position. |
+| Getty Images (US), Inc. v. Stability AI, Inc., amended complaint, D. Del., Mar. 29, 2023. Justia mirror: https://docs.justia.com/cases/federal/district-courts/delaware/dedce/1:2023cv00135/81407/13 | US image lawsuit allegations: images, captions, metadata, trademarks/watermarks, licensing market. | Green/Yellow: lines 46-63 provide the nature of action and allegations; lines 47-60 allege more than 12 million copied photographs/captions/metadata and direct competition; lines 61-63 allege watermark/trademark confusion. Complaint allegations only. |
+| The New York Times Company v. Microsoft/OpenAI, complaint, S.D.N.Y., Dec. 27, 2023. CourtListener PDF: https://storage.courtlistener.com/recap/gov.uscourts.nysd.612697/gov.uscourts.nysd.612697.1.0.pdf | News-rights flashpoint and publisher-market framing. | Green/Yellow: lines 74-83 allege unlicensed use, fair-use dispute, substitute products, and damages; lines 290-347 describe paywall/archive/API/licensing/search distinction and no GenAI permission. Complaint allegations only. |
+| OpenAI, "OpenAI and journalism," Jan. 8, 2024. https://openai.com/index/openai-and-journalism/ | OpenAI's response: fair use, opt-out, partnerships, regurgitation framing. | Green/Yellow: lines 43-47 summarize OpenAI's four-point position; lines 50-61 discuss publisher partnerships, fair use position, and opt-out; lines 64-75 discuss memorization/regurgitation and NYT dispute. Company framing. |
+| The New York Times Company v. Microsoft/OpenAI, Opinion on motions to dismiss, S.D.N.Y., Apr. 4, 2025. PDF: https://cdn.openai.com/pdf/gov.uscourts.nysd.612697.514.0_1.pdf | Legal-status freshness for NYT/OpenAI: narrowed claims and surviving/dismissed DMCA pieces. | Green: lines 101-129 summarize grants/denials; lines 131-133 state complaint facts are assumed true for Rule 12(b)(6); lines 1548-1554 repeat DMCA dismissal/denial results. Do not turn into merits finding. |
+| Bartz et al. v. Anthropic PBC, Order on Fair Use, N.D. Cal., June 23, 2025. CourtListener/RECAP PDF: https://storage.courtlistener.com/recap/gov.uscourts.cand.434709/gov.uscourts.cand.434709.231.0_4.pdf | Book-corpus court record; Books3/LibGen/PiLiMi and fair-use split. | Green: lines 42-51 frame the issue; lines 147-160 discuss Books3/LibGen/PiLiMi and seven million book copies; lines 1800-1844 say training copies and print-to-digital copies were fair use, while pirated central-library copies were not justified by fair use; lines 1860-1865 grant/deny summary judgment and set trial for pirated copies/damages. OpenAI CDN copy was used as a mirror during initial extraction, but CourtListener/RECAP is the canonical contract anchor. |
+| Authors Alliance, "Bartz v. Anthropic Settlement Hearing Moved to May 14, 2026," Apr. 14, 2026. https://www.authorsalliance.org/2026/04/14/bartz-v-anthropic-settlement-update-new-date-and-time-for-the-fairness-hearing-you-can-join-online-and-unsealed-objections/ | Freshness note for settlement status as of Apr. 28, 2026. | Yellow: use only to say the settlement-finality hearing had been moved to May 14, 2026. Prefer the court order if available before prose. |
+| OpenAI, "Overview of OpenAI Crawlers." https://platform.openai.com/docs/bots | Opt-out/crawler control endpoint. | Green/Yellow: lines 622-631 say OpenAI uses OAI-SearchBot and GPTBot robots.txt tags; webmasters can allow search while disallowing training; GPTBot crawls content that may be used for training foundation models. Company docs; do not imply all companies honor the same protocol. |
+| OpenAI/Axel Springer partnership announcement, Dec. 13, 2023. https://openai.com/index/axel-springer-partnership/ | Licensing/enclosure example. | Green/Yellow: lines 35-40 say the partnership gives ChatGPT summaries/attribution/links and involves Axel Springer content for advancing OpenAI models. Company framing. |
+| OpenAI/Financial Times partnership announcement, Apr. 29, 2024. https://openai.com/index/content-partnership-with-financial-times/ | Licensing/enclosure example. | Green/Yellow: lines 33-40 say the strategic partnership/licensing agreement enhances ChatGPT with attributed FT content, improves model usefulness with FT journalism, and includes transparency/attribution/compensation framing. |
+| OpenAI/Reddit partnership announcement, May 16, 2024. https://openai.com/index/openai-and-reddit-partnership/ | Platform-data API enclosure example. | Green/Yellow: lines 35-45 say OpenAI will access Reddit's Data API for real-time structured content, Reddit will build AI features, OpenAI becomes an ad partner, and Sam Altman's shareholder disclosure. |
+| OpenAI/News Corp partnership announcement, May 22, 2024. https://openai.com/index/news-corp-and-openai-sign-landmark-multi-year-global-partnership/ | Licensing/enclosure example. | Green/Yellow: lines 34-39 say OpenAI has permission to display News Corp content, access current/archive material from named mastheads, and receive journalistic expertise. |
+| Wikipedia pages on AI copyright, Books3, LAION, Stable Diffusion, NYT v. OpenAI, Getty v. Stability. | Source discovery only. | Yellow: useful for finding filings, dates, and case names. Not evidence for prose claims. |
 
-## Required Claim Categories
+## Scene-Level Claim Table
 
-- What labor was performed and by whom, with source-specific boundaries.
-- What datasets were used or alleged, and what source proves the claim.
-- What lawsuits allege versus what courts have decided.
-- How opt-outs/licensing changed data access.
+| Claim | Scene | Primary Anchor | Confirmation | Status | Notes |
+|---|---|---|---|---|---|
+| InstructGPT-style RLHF depended on human demonstrations, rankings, reward modeling, and PPO rather than architecture alone. | Human Filter | Ouyang PDF lines 8-26, 65-79 | Ch57 source contract | Green | Reuse sparingly; Ch57 owns method details. |
+| Ouyang et al. report hiring about 40 contractors to label data, and warn that the system aligned to a specific group of labelers/researchers rather than all human values. | Human Filter | Ouyang PDF lines 65-79 | Ch57 claim table | Green | Good bridge from method to labor. |
+| TIME reported that OpenAI outsourced toxic-content labeling to Sama workers in Kenya, including tens of thousands of snippets beginning in Nov. 2021. | Human Filter | TIME lines 41, 54, 57, 62 | TIME OpenAI/Sama responses lines 73-74, 88-97 | Green/Yellow | Reporting plus company responses; do not overgeneralize. |
+| TIME reported take-home wages around $1.32-$2/hour for the OpenAI project, with Sama disputing some details and giving a higher possible range. | Human Filter | TIME lines 62, 89-94 | TIME company-response lines 93-97 | Green/Yellow | Attribute every wage claim to TIME and include Sama/OpenAI caveats. |
+| GPT-3 used a mixture including filtered Common Crawl, WebText2, Books1, Books2, and Wikipedia, making web/books a normal foundation-model input category. | Scraped Corpus | Ch53 GPT-3 Section 2.2/Table 2.2 anchors | GPT-3 paper | Green | This is historical baseline; do not imply later models used identical mix. |
+| Common Crawl presents itself as petabytes of web data regularly collected since 2008, containing raw web page data, metadata, and text extracts. | Scraped Corpus | Common Crawl lines 23-25, 220-227 | The Pile lines 32-35 | Green | Avoid saying it is a rights-cleared corpus. |
+| The Pile is an 825 GiB English corpus built from 22 subsets and includes Books3 among other components. | Scraped Corpus | The Pile lines 11-13, 46-47, 59-63 | Bartz order lines 147-160 for later Books3 salience | Green | Use Books3 as a named component, not the whole Pile. |
+| LAION-5B consists of 5.85B CLIP-filtered image-text pairs and enabled open image-model research, including Stable Diffusion experiments. | Image Flashpoint | LAION abstract line 43 | Stable Diffusion model card lines 230-256 | Green | Dataset source; not a copyright finding. |
+| Stable Diffusion v1-4 model card says Stable Diffusion v1 was trained on LAION-2B(en) and LAION subsets, with documented safety/bias caveats. | Image Flashpoint | Stable Diffusion model card lines 230-256 | LAION line 43 | Green | Use the model card, not rumor. |
+| Getty officially said it commenced UK proceedings in Jan. 2023 and claimed Stability copied/processed millions of images and metadata without a license. | Image Flashpoint | Getty statement lines 13-17 | Getty complaint lines 46-63 | Green/Yellow | Getty's position. |
+| Getty's US amended complaint alleges more than 12M copied photographs plus captions/metadata, direct competition, and watermark/trademark confusion. | Image Flashpoint | Getty complaint lines 47-63 | Getty statement lines 13-17 | Green/Yellow | Complaint allegations only. |
+| The NYT complaint alleges Microsoft/OpenAI used Times content without permission, disputes fair use, and frames GenAI outputs as substitutes for Times products. | Newspaper/Book Reckoning | NYT complaint lines 74-83 | NYT complaint lines 290-347 | Green/Yellow | Complaint allegations only. |
+| The NYT complaint distinguishes search indexing/licensed use from GenAI use and says The Times had not given GenAI permission. | Newspaper/Book Reckoning | NYT complaint lines 290-347 | OpenAI response lines 50-61 | Green/Yellow | Good "search vs training" scene. |
+| OpenAI responded that training on publicly available internet materials is fair use, that it offers publisher opt-outs, and that regurgitation is a rare bug/misuse issue. | Newspaper/Book Reckoning | OpenAI journalism lines 43-61, 64-75 | OpenAI crawler docs lines 622-631 | Green/Yellow | Company defense; not court finding. |
+| The Apr. 4, 2025 NYT/OpenAI opinion narrowed some claims while assuming complaint facts true at motion-to-dismiss stage. | Newspaper/Book Reckoning | NYT opinion lines 101-133, 1548-1554 | OpenAI current NYT page if needed | Green | Do not call this final merits adjudication. |
+| Bartz/Anthropic order records Books3/LibGen/PiLiMi book-copy facts and draws a split: training copies fair use, pirated central-library copies not justified by fair use. | Newspaper/Book Reckoning | Bartz order lines 42-51, 147-160, 1800-1844, 1860-1865 | Authors Alliance freshness note | Green | This is the strongest legal-status scene; date it June 23, 2025. |
+| As of Apr. 28, 2026, final settlement approval in Bartz/Anthropic remained pending after the hearing was moved to May 14, 2026. | Newspaper/Book Reckoning | Authors Alliance Apr. 14, 2026 update | Need court order before prose if possible | Yellow | Freshness guardrail; avoid if not needed. |
+| OpenAI crawler docs distinguish OAI-SearchBot/search from GPTBot/training and say webmasters can disallow GPTBot for training use. | Enclosure | OpenAI crawler docs lines 622-631 | OpenAI journalism opt-out lines 56-61 | Green/Yellow | Company protocol, not universal law. |
+| OpenAI publisher/platform partnerships in 2023-2024 show content access becoming attributed, licensed, API-mediated, and commercially negotiated. | Enclosure | Axel lines 35-40; FT lines 33-40; News Corp lines 34-39; Reddit lines 35-45 | OpenAI journalism lines 50-55 | Green/Yellow | Synthesis across official company announcements. |
+| The endpoint of the chapter is not "data is exhausted" but "high-quality data becomes controlled, contested, or priced." | Close | Synthesis from crawler/licensing/lawsuit sources | Ch69 boundary | Yellow | Interpretive; keep source-bound. |
 
 ## Conflict Notes
 
-- Allegations are not findings. Label them clearly.
-- Do not infer exact training-set contents unless a primary source supports it.
-- Do not draft until source anchors are extracted.
+- Allegations are not findings. Use "alleges," "claims," "OpenAI says," "Getty
+  says," "the court held," and "TIME reported" with discipline.
+- Do not infer exact training-set contents unless a model card, paper, court
+  order, complaint, or company statement supports that specific claim.
+- Do not claim all scraping is unlawful or all AI training is fair use. The
+  strongest court anchor here is narrow and split by use/acquisition path.
+- Do not imply the Sama/TIME story is identical to Ouyang's Upwork/ScaleAI RLHF
+  contractors. One is a paper-described RLHF pipeline; the other is
+  investigative reporting on a safety-labeling/content-moderation project.
+- Do not quote or narrate graphic worker examples in detail. It is enough to
+  state categories and conditions with care.
+- Do not treat publisher deals as proof that pre-deal training required a
+  license; they prove the market moved toward negotiated access.
+- Wikipedia was checked for source discovery and chronology only.

--- a/docs/research/ai-history/chapters/ch-68-data-labor-and-the-copyright-reckoning/status.yaml
+++ b/docs/research/ai-history/chapters/ch-68-data-labor-and-the-copyright-reckoning/status.yaml
@@ -1,15 +1,37 @@
-status: researching
+status: capacity_plan_anchored
 owner: Codex
 part: 9
 chapter: 68
-review_state: not_started
+review_state: awaiting_claude_source_review_and_gemini_gap_audit
 last_updated: 2026-04-28
-green_claims: 0
-yellow_claims: 0
+green_claims: 9
+yellow_claims: 11
 red_claims: 0
-guardrail_count: 4
-prose_word_cap_recommendation: null
+guardrail_count: 8
+prose_word_cap_recommendation: 5600
+word_count_range: "4500-5600"
+verdicts:
+  claude:
+    model: null
+    date: null
+    verdict: null
+    review_url: null
+  gemini:
+    model: null
+    date: null
+    verdict: null
+    word_cap: null
+    review_url: null
+  resolved: null
+  resolved_word_cap: null
+  resolution_rule: dual_cross_family_verdict_with_cap
 notes: |
-  New chapter added by the modern-era coverage pass after Claude/Gemini
-  structural consultation. It separates labor/copyright/data-rights history
-  from the technical data-exhaustion chapter.
+  Built from placeholder into an anchored labor/data-rights/copyright contract.
+  Core anchors are Ouyang/InstructGPT, TIME/Sama reporting, GPT-3/Pile/Common
+  Crawl, LAION/Stable Diffusion model card, Getty/NYT filings, OpenAI responses
+  and crawler/licensing pages, and the 2025 Bartz/Anthropic fair-use order.
+
+  Safe draft range is 4,500-5,600 words pending Claude source review and Gemini
+  capacity audit. Allegations, company positions, and court holdings must remain
+  lexically separate. Recheck Bartz/Anthropic settlement status before prose if
+  settlement finality appears in the chapter.

--- a/docs/research/ai-history/chapters/ch-68-data-labor-and-the-copyright-reckoning/status.yaml
+++ b/docs/research/ai-history/chapters/ch-68-data-labor-and-the-copyright-reckoning/status.yaml
@@ -1,29 +1,29 @@
-status: capacity_plan_anchored
+status: prose_ready
 owner: Codex
 part: 9
 chapter: 68
-review_state: awaiting_claude_source_review_and_gemini_gap_audit
+review_state: dual_cross_family_approved
 last_updated: 2026-04-28
 green_claims: 9
 yellow_claims: 11
 red_claims: 0
 guardrail_count: 8
-prose_word_cap_recommendation: 5600
-word_count_range: "4500-5600"
+prose_word_cap_recommendation: 5500
+word_count_range: "4500-5500"
 verdicts:
   claude:
-    model: null
-    date: null
-    verdict: null
-    review_url: null
+    model: claude-opus-4-7
+    date: 2026-04-28
+    verdict: APPROVE
+    review_url: https://github.com/kube-dojo/kube-dojo.github.io/pull/529#issuecomment-4339611990
   gemini:
-    model: null
-    date: null
-    verdict: null
-    word_cap: null
-    review_url: null
-  resolved: null
-  resolved_word_cap: null
+    model: gemini-3.1-pro-preview
+    date: 2026-04-28
+    verdict: READY_TO_DRAFT_WITH_CAP
+    word_cap: 5500
+    review_url: https://github.com/kube-dojo/kube-dojo.github.io/pull/529#issuecomment-4339635161
+  resolved: READY_TO_DRAFT_WITH_CAP
+  resolved_word_cap: 5500
   resolution_rule: dual_cross_family_verdict_with_cap
 notes: |
   Built from placeholder into an anchored labor/data-rights/copyright contract.
@@ -31,7 +31,7 @@ notes: |
   Crawl, LAION/Stable Diffusion model card, Getty/NYT filings, OpenAI responses
   and crawler/licensing pages, and the 2025 Bartz/Anthropic fair-use order.
 
-  Safe draft range is 4,500-5,600 words pending Claude source review and Gemini
-  capacity audit. Allegations, company positions, and court holdings must remain
+  Claude approved source fidelity and Gemini approved gap/capacity at a
+  5,500-word cap. Allegations, company positions, and court holdings must remain
   lexically separate. Recheck Bartz/Anthropic settlement status before prose if
   settlement finality appears in the chapter.

--- a/docs/research/ai-history/chapters/ch-68-data-labor-and-the-copyright-reckoning/timeline.md
+++ b/docs/research/ai-history/chapters/ch-68-data-labor-and-the-copyright-reckoning/timeline.md
@@ -1,8 +1,32 @@
 # Timeline: Chapter 68 - Data Labor and the Copyright Reckoning
 
-- **2010s-2020s:** Web-scale corpora, book datasets, and image-caption datasets become central model inputs.
-- **2020-2022:** RLHF and safety-labeling work becomes central to assistant behavior.
-- **2022-2023:** Stable Diffusion and image datasets make copyright and artist consent a public flashpoint.
-- **2023-2025:** Major text and image lawsuits, opt-outs, and licensing deals turn data access into strategic infrastructure.
-
-Dates are placeholders until primary anchors are extracted.
+- **2008 onward:** Common Crawl regularly collects web data at petabyte scale,
+  later becoming part of the language-model data ecosystem.
+- **2020:** GPT-3 reports a training mixture including filtered Common Crawl,
+  WebText2, Books1, Books2, and Wikipedia.
+- **2020-2021:** The Pile formalizes an 825 GiB English language-model corpus
+  with 22 subsets, including Books3.
+- **November 2021-March 2022:** TIME reports that Sama workers in Kenya labeled
+  toxic text for OpenAI safety/filtering work; Sama delivered its last labeled
+  batch in March 2022.
+- **March 2022:** Ouyang et al. publish InstructGPT/RLHF, describing
+  demonstrations, rankings, reward modeling, PPO, and about 40 contractors.
+- **2022:** LAION-5B and Stable Diffusion make open image-caption datasets
+  visible to a mass public and to creators whose work may appear in web-scale
+  image corpora.
+- **January-March 2023:** Getty commences UK proceedings against Stability AI
+  and files/amends a US complaint alleging copied images, captions, metadata,
+  and watermark/trademark harms.
+- **December 27, 2023:** The New York Times sues Microsoft and OpenAI.
+- **January 8, 2024:** OpenAI publishes its "OpenAI and journalism" response,
+  arguing fair use, opt-outs, partnerships, and anti-regurgitation measures.
+- **December 2023-May 2024:** OpenAI announces publisher/platform partnerships
+  with Axel Springer, the Financial Times, Reddit, and News Corp.
+- **April 4, 2025:** The NYT/OpenAI motion-to-dismiss opinion narrows some
+  claims and keeps others in play; complaint facts are assumed true at that
+  procedural stage.
+- **June 23, 2025:** Bartz v. Anthropic fair-use order distinguishes training
+  copies, purchased print-to-digital copies, and pirated central-library copies.
+- **April 2026:** As of April 28, 2026, Bartz/Anthropic settlement finality
+  remains time-sensitive; verify again before prose if the settlement appears
+  in the chapter.

--- a/src/content/docs/ai-history/index.md
+++ b/src/content/docs/ai-history/index.md
@@ -193,7 +193,7 @@ Consumer adoption, edge constraints, and AI transitioning to heavy industry.
 | 65 | The Open Weights Rebellion | prose_ready | no |
 | 66 | Benchmark Wars | prose_ready | no |
 | 67 | The Monopoly | prose_ready | no |
-| 68 | Data Labor and the Copyright Reckoning | capacity_plan_anchored | no |
+| 68 | Data Labor and the Copyright Reckoning | prose_ready | no |
 | 69 | The Data Exhaustion Limit | researching | no |
 | 70 | The Energy Grid Collision | researching | no |
 | 71 | The Chip War | researching | no |
@@ -205,8 +205,8 @@ Consumer adoption, edge constraints, and AI transitioning to heavy industry.
 |---|---:|
 | `accepted` (drafted, all reviews cleared) | 29 |
 | `prose_review` (drafted, in review) | 0 |
-| `prose_ready` (contract dual-cleared, awaiting prose draft) | 22 |
-| `capacity_plan_anchored` (contract anchored, awaiting verdict) | 4 |
+| `prose_ready` (contract dual-cleared, awaiting prose draft) | 23 |
+| `capacity_plan_anchored` (contract anchored, awaiting verdict) | 3 |
 | `researching` with prose merged on legacy contract | 5 |
 | `researching` (no prose yet) | 12 |
 | **Total** | **72** |

--- a/src/content/docs/ai-history/index.md
+++ b/src/content/docs/ai-history/index.md
@@ -193,7 +193,7 @@ Consumer adoption, edge constraints, and AI transitioning to heavy industry.
 | 65 | The Open Weights Rebellion | prose_ready | no |
 | 66 | Benchmark Wars | prose_ready | no |
 | 67 | The Monopoly | prose_ready | no |
-| 68 | Data Labor and the Copyright Reckoning | researching | no |
+| 68 | Data Labor and the Copyright Reckoning | capacity_plan_anchored | no |
 | 69 | The Data Exhaustion Limit | researching | no |
 | 70 | The Energy Grid Collision | researching | no |
 | 71 | The Chip War | researching | no |
@@ -206,7 +206,7 @@ Consumer adoption, edge constraints, and AI transitioning to heavy industry.
 | `accepted` (drafted, all reviews cleared) | 29 |
 | `prose_review` (drafted, in review) | 0 |
 | `prose_ready` (contract dual-cleared, awaiting prose draft) | 22 |
-| `capacity_plan_anchored` (contract anchored, awaiting verdict) | 3 |
+| `capacity_plan_anchored` (contract anchored, awaiting verdict) | 4 |
 | `researching` with prose merged on legacy contract | 5 |
-| `researching` (no prose yet) | 13 |
+| `researching` (no prose yet) | 12 |
 | **Total** | **72** |


### PR DESCRIPTION
## Summary

- rebuilds Ch68 `Data Labor and the Copyright Reckoning` into an anchored research contract
- adds source spine, claim matrix, scene sketches, timeline, people, infrastructure notes, open questions, and status metadata
- updates the AI History status boards to show Ch68 at `capacity_plan_anchored`

## Review focus

- Keep allegations, company positions, reporting, and court holdings lexically separate.
- Check the Bartz/Anthropic treatment: June 23, 2025 order has a split result; settlement status is freshness-sensitive as of April 28, 2026.
- Confirm Sama/TIME labor reporting is handled as source-specific reporting, not generalized across all RLHF/data work.
- Confirm the contract does not imply exact training-set contents without a paper, model card, filing, order, or company statement.
- Confirm Ch69 boundary: this chapter is labor/data rights/copyright, not synthetic data or technical data exhaustion.

## Checks

- `git diff --check`
- `../../.venv/bin/python` YAML sanity check for Ch68 status
- Ch68 contract ASCII scan
- `npm run astro -- sync` (passes; pre-existing expressive-code warnings for unsupported `cloudformation` and `haproxy` highlighter languages)

Refs #407