### PR TITLE
research: Ch40 — Data Becomes Infrastructure (#394)

### DIFF
--- a/docs/research/ai-history/chapters/ch-40-data-becomes-infrastructure/brief.md
+++ b/docs/research/ai-history/chapters/ch-40-data-becomes-infrastructure/brief.md
@@ -1,25 +1,56 @@
 # Brief: Chapter 40 - Data Becomes Infrastructure
 
 ## Thesis
-Fei-Fei Li realized that data was not just a testing benchmark; it was the core infrastructure of intelligence. By combining WordNet's semantic hierarchy with the human labor of Amazon Mechanical Turk, she created ImageNet—a dataset so massive it fundamentally broke and then remade the field of artificial intelligence.
+
+ImageNet was not simply a larger benchmark. It turned labeled visual data into research infrastructure: WordNet supplied a semantic scaffold, web search supplied noisy candidate images, Amazon Mechanical Turk supplied scalable human verification, and the 2009 ImageNet paper made the pipeline visible as an engineering system. The chapter's claim is narrower than the later deep-learning triumph: before AlexNet, ImageNet mattered because it reframed object recognition around organized, clean, high-volume data that could be shared, benchmarked, and extended.
 
 ## Scope
-- IN SCOPE: Fei-Fei Li, Christiane Fellbaum/George Miller (WordNet), the construction of ImageNet, scraping the web, massive MTurk orchestration.
-- OUT OF SCOPE: The 2012 AlexNet victory (belongs to Part 7).
+
+- IN SCOPE: ImageNet's 2006-2009 construction arc; WordNet as the ontology of synsets and semantic relations; Fei-Fei Li's shift from model-centered visual recognition toward data-centered infrastructure; the Princeton ImageNet team around Jia Deng, Wei Dong, Richard Socher, Li-Jia Li, Kai Li, and Li Fei-Fei; web-image candidate collection; multilingual query expansion; AMT verification; redundancy and quality control; the 2009 CVPR paper; the creation of the ILSVRC handoff as a sparse forward pointer.
+- OUT OF SCOPE: a full labor history of MTurk (Ch38); the PASCAL VOC wall and hand-engineered feature stack (Ch39); AlexNet, GPUs, and the 2012 error-rate break (Ch43); ImageNet bias, privacy, and people-subtree remediation except as a brief caveat if needed later; modern foundation-model dataset pipelines.
+
+## Boundary Contract
+
+This chapter must not claim that ImageNet by itself caused the deep-learning revolution. It can say ImageNet created a large, shared, manually verified visual-data infrastructure later used by ILSVRC and AlexNet, but the GPU/CNN breakthrough belongs to Ch43. It must not portray PASCAL VOC as a failure; Ch39 treats it as disciplined benchmark infrastructure whose scale limits became visible. It must not turn MTurk into an ImageNet-only invention; Ch38 owns the broader "human API" story.
+
+The chapter must also avoid unanchored internal motives. Fei-Fei Li's public talks and later interviews support a broad "shift from modeling to data" framing, but precise private conversations, reviewer reactions, poster-session indifference, and claims that colleagues "ignored" the 2009 CVPR work remain Yellow or Red unless a page/slide/interview anchor is added. Use the 2017 ACM slide deck and the 2009 paper for verified scenes, not invented lab drama.
 
 ## Scenes Outline
-1. **The Radical Idea:** Fei-Fei Li decides to map the entire visual world, moving from 20 classes to tens of thousands.
-2. **The Backbone:** Using WordNet as the semantic blueprint.
-3. **The Mechanical Turkers:** Scraping millions of images and orchestrating a massive, global army of MTurk workers to label them, establishing Data as the ultimate infrastructure.
 
-## 4k-7k Prose Capacity Plan
+1. **From Model Tuning to Data Scale.** Li's later ACM talk frames the move as a shift in visual recognition from modeling to data, after earlier few-shot/object-recognition work. The scene bridges from Ch39's benchmark wall without blaming PASCAL.
+2. **WordNet Becomes a Visual Skeleton.** WordNet's synsets and semantic relations become ImageNet's backbone: not a folder of labels, but an ontology of visual concepts.
+3. **Candidate Images From the Web.** The team turns each synset into search queries, expands those queries with parent-synset terms, translates them into other languages, and gathers noisy candidate pools large enough to survive cleaning.
+4. **The Human Verification Machine.** AMT workers do not "label from scratch"; they verify candidate images against synset definitions. Multiple independent votes, confidence tables, and thresholds convert scattered human judgments into a clean dataset.
+5. **A Dataset Becomes a Benchmark.** The 2009 paper reports 12 subtrees, 5,247 synsets, and 3.2 million images, then ILSVRC turns ImageNet into an annual benchmark. The closing pointer stops before AlexNet.
 
-This chapter can support a long narrative only if it is built from verified layers rather than padding:
+## Prose Capacity Plan
 
-- 500-800 words: Historical context and setup, bridging from the previous era.
-- 933-1233 words: Detailed narrative surrounding The Radical Idea:, heavily anchored to primary sources.
-- 933-1233 words: Detailed narrative surrounding The Backbone:, heavily anchored to primary sources.
-- 933-1233 words: Detailed narrative surrounding The Mechanical Turkers:, heavily anchored to primary sources.
-- 400-700 words: Honest close that summarizes the infrastructural shift and transitions to the next chapter.
+This chapter can support a substantial but capped narrative if it spends words on the verified infrastructure layers:
 
-Most layers now have page-level anchors. Do not invent lab drama or dialogue to reach the top of the range. If the verified evidence runs out, cap the chapter.
+- 550-750 words: **From model tuning to data scale** - introduce the late-2000s transition from modeling emphasis to data emphasis, using Li's 2017 ACM talk as a retrospective primary anchor and Ch39 only as a short bridge. Anchored to: Green G13 (ACM slide deck pp.17-18, shift from modeling to data), G14 (slides pp.27-31, failed launch attempts and MTurk emergence), and Yellow Y01 for the 2006 origin. Scene: 1.
+- 650-900 words: **WordNet as the semantic skeleton** - explain synsets, semantic relations, and why ImageNet's unit was a WordNet concept rather than an ad hoc class label. Anchored to: Green G01-G04 (WordNet PDF pp.1-6 and p.66) and G05-G07 (Deng et al. 2009 p.248 and p.249). Scene: 2.
+- 650-900 words: **Candidate-image collection as infrastructure** - show the web-search pipeline, noisy search results, duplicate removal, parent-synset query expansion, and multilingual expansion. Anchored to: Green G08-G10 (Deng et al. 2009 Section 3.1, CVPR p.251). Scene: 3.
+- 850-1,150 words: **AMT verification and quality control** - center the strongest operational scene on humans verifying each candidate image, the global labor platform, multiple independent votes, at least 10 votes in initial subsets, confidence thresholds, and reported precision. Anchored to: Green G11-G12 (Deng et al. 2009 Section 3.2, CVPR pp.251-252), G16 (ACM slide deck p.31 for 49k workers/167 countries), and G20-G21 from Ch38 for MTurk mechanics if a one-paragraph bridge is needed. Scene: 4.
+- 700-1,000 words: **From ImageNet paper to benchmark handoff** - present the 2009 paper's scale, compare it carefully with earlier datasets, and close with ILSVRC's annual benchmark structure as a forward pointer. Anchored to: Green G17-G19 (Russakovsky et al. 2015 pp.1-3), G06/G23 (Deng et al. 2009 p.248/p.249), and G18 (ILSVRC 2010 scale). Scene: 5.
+
+Total: **3,400-4,700 words**. Label: `3k-5k likely`.
+
+If the verified evidence runs out, cap the chapter.
+
+## Citation Bar
+
+- Minimum primary/near-primary anchors before prose: Miller et al. WordNet PDF; Deng et al. 2009 ImageNet CVPR paper; Fei-Fei Li 2017 ACM TechTalk page/slides; Russakovsky et al. 2015 ILSVRC paper.
+- Minimum secondary/context anchors before prose: Gershgorn 2017 only for public-memory framing if exact accessible anchors are located; Denton et al. 2021/2022 dataset genealogy only for later critique if page anchors are extracted; Li 2023 memoir only with edition-specific page anchors.
+- The legacy Gemini prose is not an evidentiary source. It only identified likely scene scope.
+
+## Conflict Notes
+
+- **2009 paper scale vs later ImageNet scale:** Deng et al. report 3.2 million images across 5,247 synsets in the current 2009 version; Russakovsky et al. later report 14,197,122 annotated images across 21,841 synsets as of August 2014. Do not collapse those into one timeless number.
+- **"15 million images" shorthand:** Li's 2017 slides use 15M total images for later ImageNet. The 2009 chapter scene should use the 2009 paper's 3.2M figure unless explicitly moving to later growth.
+- **Motivation and reception:** "In 2006 Li started ruminating" and "reviewers ignored the dataset" are secondary/journalistic or memoir-dependent until page anchors are located. Keep them Yellow.
+- **Causality:** Green sources support scale, organization, annotation, and benchmark creation. They do not prove ImageNet alone "made deep learning work."
+- **Labor:** Li's slides give 49k workers from 167 countries for 2007-2010. Wage, conditions, and MTurk-origin claims belong mostly to Ch38 unless a short ethical caveat is necessary.
+
+## Honest Prose-Capacity Estimate
+
+The verified evidence supports a natural **3,400-4,700 word** chapter. The middle two scenes are strong because Deng et al. give implementation detail and Li's slides give a retrospective construction arc. The upper end would require edition-specific page anchors from *The Worlds I See*, a clean transcript of Li's 2017/2019 talks, or archival/interview anchors about reception at CVPR 2009. Without those, draft near 4,000 words and avoid invented conference drama.

--- a/docs/research/ai-history/chapters/ch-40-data-becomes-infrastructure/infrastructure-log.md
+++ b/docs/research/ai-history/chapters/ch-40-data-becomes-infrastructure/infrastructure-log.md
@@ -1,7 +1,35 @@
-# Infrastructure Log: Chapter 40
+# Infrastructure Log: Chapter 40 - Data Becomes Infrastructure
 
-## Technical Metrics & Constraints
-- **ImageNet (2009):**
-  - Scale: 15 million images across 22,000 visual categories.
-  - Labor: Required nearly 50,000 Amazon Mechanical Turk workers across 167 countries.
-  - Significance: It was the first dataset large enough to train deep neural networks without catastrophic overfitting, setting the stage for the Deep Learning revolution.
+## Scene 1: From Model Tuning to Data Scale
+
+- **Conceptual infrastructure:** Li's retrospective ACM slides frame the project as moving visual recognition emphasis from modeling to data and "lots of data." Source: G13.
+- **Failed launch infrastructure:** The slide-deck calculation for a psychophysics/undergraduate approach reaches about 19 years under the stated assumptions, motivating scalable labor. Source: G15.
+
+## Scene 2: WordNet Becomes a Visual Skeleton
+
+- **Lexical database:** WordNet organizes word meanings as synsets and connects them through semantic relations. Sources: G02-G04.
+- **Ontology transfer:** ImageNet uses WordNet's hierarchy as the backbone for visual categories. Sources: G05-G06.
+- **Boundary:** WordNet was not built for ImageNet or computer vision. It was a lexical/psycholinguistic database repurposed as visual infrastructure. Source: R05.
+
+## Scene 3: Candidate Images From the Web
+
+- **Search engines:** ImageNet queried multiple image search engines for each synset using WordNet synonyms. Source: G09.
+- **Query expansion:** The team added parent-synset terms when the same word appeared in a target gloss, e.g. expanding a specific term with a broader animal/category term. Source: G09.
+- **Multilingual expansion:** Candidate pools were diversified using Chinese, Spanish, Dutch, and Italian translations from other WordNets. Source: G10.
+- **Noise constraint:** The paper reports average search-result accuracy around 10%, requiring large candidate pools before cleaning. Source: G09.
+
+## Scene 4: The Human Verification Machine
+
+- **AMT service layer:** AMT provided the online labor platform; Ch38 anchors requesters, HITs, workers/Turkers, rewards, qualifications, approval, and bonuses. Sources: G20-G21.
+- **Verification task:** Workers saw candidate images and a target synset definition and verified whether the image contained that synset. Source: G11.
+- **Redundancy/quality:** Multiple independent votes, at least 10 votes on initial subsets, confidence score tables, and threshold stopping rules turned individual judgments into a dataset-cleaning process. Source: G12.
+- **Scale:** Li's 2017 slides report 49k workers from 167 countries during 2007-2010. Source: G16.
+- **Reported accuracy:** Deng et al. report 99.7% precision on sampled synsets. Source: G23.
+
+## Scene 5: A Dataset Becomes a Benchmark
+
+- **2009 state:** The paper reports 12 subtrees, 5,247 synsets, and 3.2 million images. Source: G07.
+- **Later scale:** As of August 2014, Russakovsky et al. report 21,841 synsets and 14,197,122 annotated images. Source: G19.
+- **Benchmark infrastructure:** ILSVRC has a public dataset plus annual competition/workshop and hidden test annotations/evaluation flow. Source: G17.
+- **Scale jump from VOC:** ILSVRC 2010 moved to 1,000 classes and 1,461,406 images from PASCAL VOC 2010's 20 classes and 19,737 images. Source: G18.
+- **Boundary:** The GPU/CNN training infrastructure and AlexNet result are deferred to Ch43.

--- a/docs/research/ai-history/chapters/ch-40-data-becomes-infrastructure/open-questions.md
+++ b/docs/research/ai-history/chapters/ch-40-data-becomes-infrastructure/open-questions.md
@@ -1,3 +1,30 @@
-# Open Questions
+# Open Questions: Chapter 40 - Data Becomes Infrastructure
 
-- SCRUBBED: All claims downgraded to Yellow. Need REAL, empirical page/section anchors from verified online PDFs or archives. Do not hallucinate.
+## Yellow Claims To Resolve Before Prose Expansion
+
+- **Y01 - 2006 origin.** Need an extractable Quartz body, Li memoir page, talk transcript, or interview page confirming when Li began formulating ImageNet and how she described the data bottleneck at the time.
+- **Y02 - CVPR 2009 reception.** The legacy prose says the reception was muted. Do not draft poster-session indifference without a memoir/interview/reviewer anchor.
+- **Y03 - Jia Deng's engineering role.** First authorship is Green, but "Deng engineered the scraping and MTurk pipeline" needs a role-specific source.
+- **Y04 - undergraduates/failed launch texture.** Li's slides have shorthand, but a transcript or memoir page would be better before writing a vivid human scene.
+- **Y05 - ImageNet as direct response to PASCAL.** Russakovsky et al. and Li's slides support PASCAL as inspiration and ILSVRC scaling, but direct original-design causality needs a stronger source.
+- **Y07 - 15M count.** Reconcile Li's slide-deck 15M shorthand with Russakovsky et al.'s 14,197,122 as of August 2014 before using a precise later total.
+
+## Red Claims To Keep Out
+
+- ImageNet by itself proved deep learning was fundamentally sound.
+- CVPR attendees literally ignored Li's poster.
+- ImageNet was the first dataset large enough to train deep neural networks without overfitting.
+- Exact ImageNet-period MTurk wages or hourly label rates.
+- WordNet was built for computer vision.
+
+## Archival Or Access Needs
+
+- Fei-Fei Li, *The Worlds I See* (2023), edition-specific pages for ImageNet origin, project reception, and collaborators' roles.
+- A transcript or timestamped recording of Li's 2017 ACM TechTalk or 2019 "Where did ImageNet come from?" talk.
+- Accessible full text of Gershgorn 2017 or another interview with line anchors.
+- Any CVPR 2009 proceedings notes, reviews, or interviews that describe the paper/poster reception.
+- Project-history material from Princeton/Stanford that assigns pipeline roles to Jia Deng, Wei Dong, and other collaborators.
+
+## Prose Readiness
+
+The chapter is draftable with a cap at `3k-5k likely` if it stays procedural and evidentiary: WordNet, candidate collection, AMT verification, quality control, 2009 scale, and ILSVRC handoff. It should not attempt a high-drama lab narrative until memoir/interview anchors are available.

--- a/docs/research/ai-history/chapters/ch-40-data-becomes-infrastructure/people.md
+++ b/docs/research/ai-history/chapters/ch-40-data-becomes-infrastructure/people.md
@@ -1,6 +1,19 @@
-# People: Chapter 40
+# People: Chapter 40 - Data Becomes Infrastructure
 
-## Verified Protagonists
-- **Fei-Fei Li:** Visionary computer scientist who led the creation of ImageNet.
-- **Christiane Fellbaum & George Miller:** Psychologists who created WordNet, the hierarchical dictionary that structured ImageNet.
-- **Jia Deng:** PhD student who engineered the massive scraping and MTurk pipeline.
+## Core Actors
+
+- **Fei-Fei Li / Li Fei-Fei:** Co-author of the 2009 ImageNet paper and, per ACM's 2017 TechTalk page, inventor of ImageNet and the ImageNet Challenge. Her 2017 slides provide the chapter's strongest primary retrospective framing: visual recognition should shift from modeling to data. Sources: G13, G22.
+- **Jia Deng:** First author of the 2009 ImageNet paper and a named ImageNet/ILSVRC contributor in Li's 2017 slides. His exact individual engineering role in the scraping/MTurk pipeline remains Yellow until memoir/interview anchors are found. Sources: Deng et al. 2009 p.248 author line; Li 2017 ACM slides pp.22-23 and pp.39-40; Y03.
+- **Wei Dong, Richard Socher, Li-Jia Li, and Kai Li:** Co-authors of the 2009 ImageNet paper. Kai Li appears in Li's 2017 slides as a Princeton comrade; the others should be identified through the paper author list unless more role-specific anchors are added. Source: Deng et al. 2009 p.248 lines 0-3; Li slides pp.22-23.
+- **Olga Russakovsky, Hao Su, Jonathan Krause, Sanjeev Satheesh, Sean Ma, Zhiheng Huang, Andrej Karpathy, Aditya Khosla, Michael Bernstein, and Alexander C. Berg:** Later ILSVRC paper co-authors and challenge contributors. They belong in the benchmark handoff, not the 2009 construction story. Source: Russakovsky et al. 2015 p.1 lines 2-37; G17-G19.
+
+## WordNet Actors
+
+- **George A. Miller:** Lead WordNet author; part of the Princeton group that turned psycholinguistic lexical-memory ideas into an online lexical database. Source: G01-G02.
+- **Christiane Fellbaum:** WordNet co-author; Li's 2017 slides identify her as a Princeton senior research scholar and Global WordNet Consortium president. Sources: G01; Li slides pp.20-21.
+- **Richard Beckwith, Derek Gross, and Katherine Miller:** Co-authors of the WordNet introduction used here for the semantic/synset anchors. Source: G01.
+
+## Collective Actors
+
+- **Amazon Mechanical Turk workers:** Li's 2017 slides report 49k workers from 167 countries during 2007-2010. In prose, identify them as distributed verifiers in an AMT pipeline, not as a faceless "army" unless the labor abstraction is explicitly discussed. Source: G16.
+- **PASCAL VOC organizers and computer-vision benchmark community:** Relevant as the previous benchmark discipline and inspiration for ILSVRC, but their full story belongs to Ch39. Source: G18; Ch39 contract.

--- a/docs/research/ai-history/chapters/ch-40-data-becomes-infrastructure/scene-sketches.md
+++ b/docs/research/ai-history/chapters/ch-40-data-becomes-infrastructure/scene-sketches.md
@@ -1,11 +1,41 @@
-# Scene Sketches: Chapter 40
+# Scene Sketches: Chapter 40 - Data Becomes Infrastructure
 
-## Scene 1: The Poster Session
-- **Setting:** CVPR conference (2009).
-- **Action:** Fei-Fei Li presents the ImageNet poster. Most researchers ignore it, still believing algorithms matter more than data.
+## Scene 1: From Model Tuning to Data Scale
 
-## Scene 2: The Ontology
-- **Action:** Pedagogical explanation. ImageNet isn't just a folder of photos; it's a mathematical tree of semantic meaning (WordNet), mapping "mammal" -> "dog" -> "golden retriever".
+Open with the conceptual pivot, not with a fabricated conference scene. Ch39 has just shown a computer-vision culture disciplined by features, classifiers, datasets, and evaluation servers. Li's 2017 ACM slides offer a clean retrospective bridge: visual recognition needed to shift from modeling to data, and then to lots of data. The scene can briefly mention her earlier few-shot/object-recognition work only as background if sourced elsewhere; the Green center is the slide-deck framing.
 
-## Scene 3: The Assembly Line
-- **Action:** Jia Deng writes the scripts that pipe scraped images to thousands of MTurk workers, transforming human clicks into the infrastructural bedrock of modern AI.
+The strongest dramatic material is the failed scaling math. The slide deck describes an early psychophysics/undergraduate approach and a calculation involving 40,000 synsets, 10,000 candidate images per synset, 2-5 verifiers, and a result of about 19 years. Treat this as Li's retrospective slide calculation, not as a formal archival budget. The point is that data infrastructure forced a labor and systems question before it became a model question.
+
+Anchors: G13, G14, G15. Yellow texture: Y01, Y04.
+
+## Scene 2: WordNet Becomes a Visual Skeleton
+
+Turn WordNet into the chapter's first concrete machine. WordNet was a Princeton lexical database, not a vision dataset. It organized meanings as synsets and connected them with semantic relations such as hypernym/hyponym pointers. That mattered because ImageNet needed categories that were disambiguated before images were attached to them. A "bank" could not simply be a word; it had to be a specific sense.
+
+Then show ImageNet's move: the 2009 paper says ImageNet is a large-scale ontology of images built on WordNet, aiming at most of WordNet's roughly 80,000 noun synsets with 500-1,000 clean full-resolution images each. The scene should make the ontology visible as infrastructure: a semantic skeleton that let the project ask for dog breeds, vehicles, instruments, flowers, and other visual concepts systematically rather than by ad hoc benchmark labels.
+
+Anchors: G01-G06.
+
+## Scene 3: Candidate Images From the Web
+
+This scene is procedural. Each synset becomes a search problem. The team queries image search engines with WordNet synonyms, faces the search engines' retrieval limits and noise, expands queries with parent-synset terms, and translates queries into Chinese, Spanish, Dutch, and Italian to widen the candidate pool. The paper's detail lets the prose avoid vague "scraping millions of images" language.
+
+The key tension is that the internet was abundant but dirty. Deng et al. report average search-result accuracy around 10% and a target of 500-1,000 clean images per synset, so the system must overcollect candidates before cleaning. That is the infrastructure story: scale first creates a quality problem, then the pipeline has to solve it.
+
+Anchors: G08-G10.
+
+## Scene 4: The Human Verification Machine
+
+Center the chapter's strongest operational scene here. AMT workers are not magic label generators; they verify candidate images against target synset definitions. The task page presents image sets and a definition, and users decide whether each image contains objects of that synset. This is where Ch38's human-API abstraction becomes a concrete computer-vision data factory.
+
+The prose should spend real time on redundancy and disagreement. Deng et al. explain that users make mistakes, not all users follow instructions, and subtle synsets create disagreement. The solution is multiple independent votes, initial subsets with at least 10 votes per image, confidence score tables, and threshold-based stopping for remaining images. Li's later slides add scale: 49k workers from 167 countries over 2007-2010. The scene should respect the workers as people while keeping the labor-history deep dive in Ch38.
+
+Anchors: G11-G12, G16, G20-G21, G23.
+
+## Scene 5: A Dataset Becomes a Benchmark
+
+Close with publication and handoff. In 2009, the paper reports 12 subtrees, 5,247 synsets, and 3.2 million images. It also argues that ImageNet is larger, more diverse, and more accurate than contemporary image datasets, and it demonstrates uses in object recognition, classification, and clustering. Keep those as reported claims, not omniscient hindsight.
+
+Then move one step forward to ILSVRC. Russakovsky et al. say ILSVRC has run annually since 2010 as a public dataset plus annual competition/workshop. The scale jump from PASCAL VOC 2010 to ILSVRC 2010 makes the infrastructural shift legible: 20 classes and 19,737 images becomes 1,000 classes and 1,461,406 images. End with a pointer that this infrastructure will matter when neural networks and GPUs arrive in Ch43, but do not draft the AlexNet argument here.
+
+Anchors: G07, G17-G19, G23. Yellow texture: Y02, Y07.

--- a/docs/research/ai-history/chapters/ch-40-data-becomes-infrastructure/sources.md
+++ b/docs/research/ai-history/chapters/ch-40-data-becomes-infrastructure/sources.md
@@ -1,16 +1,96 @@
-# Sources: Chapter 40
+# Sources: Chapter 40 - Data Becomes Infrastructure
 
-## Claim Matrix
+## Verification Key
 
-| Claim | Scene | Primary Source | Secondary Confirmation | Verification | Conflict |
+- **Green**: claim has a verified page, section, line, DOI, or stable document anchor.
+- **Yellow**: source is credible, but the specific claim lacks a page/slide anchor, needs edition-specific verification, or should be hedged.
+- **Red**: no verifiable anchor yet; do not draft as fact.
+
+## Primary and Near-Primary Sources
+
+| Source | Use | Verification |
+|---|---|---|
+| George A. Miller, Richard Beckwith, Christiane Fellbaum, Derek Gross, and Katherine Miller, "Introduction to WordNet: An On-line Lexical Database," revised August 1993, in the Princeton WordNet five-paper PDF. URL: https://wordnetcode.princeton.edu/5papers.pdf | WordNet origin, synsets, semantic relations, and noun hierarchy background for ImageNet's ontology. | **Green** for PDF pp.1-6 and p.66 via browser extraction: online lexical reference/system design lines 0-7; 1985 Princeton group and "WordNet is the result" lines 53-58; 1990 report line 29; synset representation lines 229-232; semantic relations and pointers lines 250-262; hypernym/hyponym table p.66 lines 2629-2684. |
+| Jia Deng, Wei Dong, Richard Socher, Li-Jia Li, Kai Li, and Li Fei-Fei, "ImageNet: A Large-Scale Hierarchical Image Database," CVPR 2009, pp.248-255. DOI: 10.1109/CVPR.2009.5206848. URL: https://image-net.org/static_files/papers/imagenet_cvpr09.pdf | Load-bearing primary source for ImageNet's design, scale, WordNet backbone, web candidate collection, AMT cleaning, and quality control. | **Green** for DOI/pages via Princeton/CoLab metadata; PDF verified via browser extraction: abstract CVPR p.248 lines 4-19; WordNet and 80,000 noun-synset ambition p.248 lines 33-40; 12 subtrees/5,247 synsets/3.2M images p.248 lines 41-47; Section 3 construction pp.251-252 lines 242-326; precision pp.249-250 lines 127-143. Direct shell `curl` failed with DNS resolution errors in this sandbox. |
+| Fei-Fei Li, "ImageNet: Where Have We Gone? Where Are We Going?" ACM TechTalk, September 21, 2017, with slides. Page: https://learning.acm.org/techtalks/ImageNet. Slides: https://learning.acm.org/binaries/content/assets/leaning-center/webinar-slides/2017/imagenet_2017_acm_webinar_compressed.pdf | Retrospective primary/near-primary source for Li's data-centered framing, construction attempts, WordNet explanation, team acknowledgments, 49k AMT workers/167 countries, and the ILSVRC handoff. | **Green** for ACM page lines 145-155 and slide PDF pp.17-38: shift from modeling to data pp.17-18; WordNet/synset slides pp.19-23; launch attempts pp.27-31; 49k workers/167 countries and 2007-2010 p.31; 15M later scale p.36; ILSVRC 2010-2017 pp.38-39. |
+| Olga Russakovsky et al., "ImageNet Large Scale Visual Recognition Challenge," arXiv:1409.0575v3 / IJCV 2015. URL: https://arxiv.org/pdf/1409.0575 | Anchor for the benchmark handoff, ILSVRC annual structure, ImageNet 2014 scale, and PASCAL comparison. | **Green** for arXiv PDF pp.1-3: annual challenge since 2010 and benchmark structure lines 43-55; PASCAL-to-ILSVRC scaling p.2 lines 75-83; ImageNet as ILSVRC backbone and 14,197,122 images/21,841 synsets as of Aug. 2014 p.3 lines 136-147; PASCAL VOC 2012 vs ILSVRC2012 scale p.3 lines 163-170. |
+
+## Secondary and Context Sources
+
+| Source | Use | Verification |
+|---|---|---|
+| Dave Gershgorn, "The data that transformed AI research-and possibly the world," *Quartz*, July 26, 2017. URL: https://qz.com/1034972/the-data-that-changed-the-direction-of-ai-research-and-possibly-the-world | Public narrative for 2006 origin and Li's belief that data, not only algorithms, was the bottleneck. | Yellow. Search snippet exposes the headline/date and 2006/motivation framing, but the page body was not extractable here beyond title. Do not use for exact quotes or detailed claims. |
+| Denton et al., "On the genealogy of machine learning datasets: A critical history of ImageNet," 2021/2022. | Later critical history of ImageNet construction and dataset politics. | Yellow. Search result shows relevant discussion of failed labeling attempts and cites Li 2017, but exact open PDF/page anchors were not extracted. |
+| Fei-Fei Li, *The Worlds I See* (Flatiron, 2023). | Memoir context for personal origin, reception, and stakes. | Yellow. No edition-specific page anchors extracted; do not use for Green claims yet. |
+
+## Green Claim Table
+
+| ID | Claim | Scene | Anchor | Status | Notes |
 |---|---|---|---|---|---|
-| ImageNet was built using WordNet as its semantic ontology | 2 | Deng et al. 2009 (ImageNet paper) | Gershgorn 2017 | Yellow | Need exact verified page/section anchors. |
-| Fei-Fei Li used MTurk to label millions of images, creating unprecedented scale | 3 | Deng et al. 2009 | Fei-Fei Li, *The Worlds I See* (2023) | Yellow | Need exact verified page/section anchors. |
+| G01 | WordNet was developed by a Princeton group beginning in 1985 and was reported in the five-paper WordNet collection as of 1990. | 2 | Miller et al. WordNet PDF p.1 lines 53-58; p.1 line 29. | **Green** | Good people/timeline anchor. |
+| G02 | WordNet is an online lexical reference system inspired by psycholinguistic theories, with nouns, verbs, and adjectives organized into synonym sets linked by relations. | 2 | Miller et al. WordNet PDF p.1 lines 0-7. | **Green** | Use concise paraphrase. |
+| G03 | WordNet represents meanings through synonym sets or "synsets"; the paper gives examples where synsets disambiguate meanings. | 2 | Miller et al. WordNet PDF pp.5-6 lines 229-232. | **Green** | Explains why ImageNet can attach images to concepts, not spellings. |
+| G04 | WordNet's semantic relations are pointers between synsets; its relation table includes noun hyponym and hypernym relations. | 2 | Miller et al. WordNet PDF p.6 lines 250-262; p.66 lines 2629-2684. | **Green** | Supports the hierarchy/skeleton scene. |
+| G05 | The ImageNet paper introduces ImageNet as a large-scale ontology of images built on the WordNet structure. | 2 | Deng et al. 2009 p.248 lines 4-12; p.248 lines 29-33. | **Green** | Load-bearing thesis anchor. |
+| G06 | ImageNet aimed to populate most of WordNet's roughly 80,000 noun synsets with 500-1,000 clean full-resolution images each. | 2, 5 | Deng et al. 2009 p.248 lines 33-40. | **Green** | Ambition, not 2009 completion. |
+| G07 | The 2009 paper reports 12 subtrees, 5,247 synsets, and 3.2 million images in the current ImageNet version. | 5 | Deng et al. 2009 p.248 lines 13-18; p.248 lines 41-47. | **Green** | Use 2009-specific wording. |
+| G08 | ImageNet's construction section says its goal was around 50 million images and describes the method for ensuring scale/accuracy/diversity. | 3 | Deng et al. 2009 Section 3, CVPR p.251 lines 242-247. | **Green** | Goal claim; avoid implying achieved by 2009. |
+| G09 | Candidate-image collection queried several image search engines using WordNet synonyms, then expanded queries with parent-synset words when useful. | 3 | Deng et al. 2009 Section 3.1, CVPR p.251 lines 249-263. | **Green** | Specific pipeline detail. |
+| G10 | The candidate pool was enlarged and diversified by translating queries into Chinese, Spanish, Dutch, and Italian using WordNets in those languages. | 3 | Deng et al. 2009 Section 3.1, CVPR p.251 lines 264-267. | **Green** | Good infrastructure detail. |
+| G11 | ImageNet relied on humans using AMT to verify each candidate image for a given synset, presenting image sets and target-synset definitions. | 4 | Deng et al. 2009 Section 3.2, CVPR p.251 lines 268-282. | **Green** | Use "verify," not "label from scratch." |
+| G12 | ImageNet quality control used multiple independent users, initial subsets with at least 10 votes per image, confidence score tables, and thresholds for remaining candidate images. | 4 | Deng et al. 2009 p.251-252 lines 303-326. | **Green** | Prevents "raw clicks" overclaim. |
+| G13 | Li's 2017 ACM slide deck frames ImageNet as a shift in visual recognition from modeling to data and "lots of data." | 1 | Li 2017 ACM slides pp.17-18 lines 118-124. | **Green** | Retrospective framing; do not quote beyond short phrase. |
+| G14 | Li's 2017 slides describe three launch attempts: a psychophysics/undergraduate approach, a human-in-the-loop idea, and crowdsourced labor via AMT. | 1, 4 | Li 2017 ACM slides pp.27-31 lines 185-216. | **Green** | Supports scene shape; slide-deck shorthand needs prose care. |
+| G15 | Li's 2017 slides show the psychophysics attempt calculation reaching about 19 years for 40,000 synsets, 10,000 candidate images per synset, and 2-5 verifiers. | 1, 4 | Li 2017 ACM slides p.28 lines 192-198. | **Green** | Use as retrospective slide calculation, not a formal project estimate. |
+| G16 | Li's 2017 slides state ImageNet used 49k workers from 167 countries during 2007-2010. | 4 | Li 2017 ACM slides p.31 lines 210-216. | **Green** | Stronger than legacy "nearly 50,000" but still slide-deck source. |
+| G17 | ILSVRC has run annually since 2010 and consists of a public dataset plus annual competition/workshop. | 5 | Russakovsky et al. 2015 p.1 lines 43-55. | **Green** | Handoff only; stop before AlexNet. |
+| G18 | Scaling from PASCAL VOC 2010 to ILSVRC 2010 meant moving from 19,737 images/20 classes to 1,461,406 images/1,000 classes, making small-group annotation infeasible and motivating crowdsourcing. | 5 | Russakovsky et al. 2015 p.2 lines 75-83. | **Green** | Good Ch39-to-Ch40 bridge if needed. |
+| G19 | As of August 2014, ImageNet contained 14,197,122 annotated images organized by WordNet hierarchy across 21,841 synsets. | 5 | Russakovsky et al. 2015 p.3 lines 136-147. | **Green** | Later-scale claim; keep distinct from G07. |
+| G20 | AMT mechanics in the period used requesters, workers/Turkers, HITs, rewards, qualifications, approvals, bonuses, and Amazon-mediated transactions. | 4 | Ch38 sources.md Green G15: Snow et al. 2008 p.255 lines 113-142. | **Green** | Imported bridge anchor from Ch38; cite Ch38 if used. |
+| G21 | Amazon publicly announced MTurk on November 2, 2005 as a web-services API for "Artificial Artificial Intelligence." | 4 | Ch38 sources.md Green G6-G9: AWS announcement title/date/body lines 27-32. | **Green** | Short bridge only; Ch38 owns full MTurk origin. |
+| G22 | ACM's TechTalk page describes Li as the inventor of ImageNet and the ImageNet Challenge, and as an associate professor at Stanford/director of SAIL at the time. | 1, 5 | ACM TechTalk page lines 145-155. | **Green** | Good people-file anchor. |
+| G23 | The 2009 paper reports ImageNet achieved about 99.7% precision on sampled synsets. | 4, 5 | Deng et al. 2009 pp.249-250 lines 127-143. | **Green** | "Reported" precision; do not universalize. |
 
-## Bibliography
-### Primary
-- **Deng, Jia, Wei Dong, Richard Socher, Li-Jia Li, Kai Li, and Li Fei-Fei. "Imagenet: A large-scale hierarchical image database." In *CVPR*, 2009.**
-- **Li, Fei-Fei. *The Worlds I See*. Flatiron Books, 2023.**
+## Yellow Claim Table
 
-### Secondary
-- **Gershgorn, Dave. "The data that transformed AI research—and possibly the world." *Quartz*, 2017.**
+| ID | Claim | Scene | Source | Status | Needed Anchor |
+|---|---|---|---|---|---|
+| Y01 | In 2006, Fei-Fei Li began formulating the idea that a much larger visual dataset was the field's bottleneck. | 1 | Gershgorn 2017 search snippet; Li 2017 slides imply the arc but do not date the first idea precisely. | Yellow | Exact article lines, memoir pages, or talk transcript. |
+| Y02 | CVPR 2009 reception was muted, with many researchers treating ImageNet as "just data" rather than science. | 5 | Legacy prose; common journalistic retelling. | Yellow | Need page/quote from Li memoir, interview, conference report, or reviewer account. |
+| Y03 | Jia Deng personally engineered the main scraping/MTurk pipeline. | 3, 4 | Legacy prose and common accounts; 2009 paper author list includes Deng first. | Yellow | Need Li memoir/interview or project-history page assigning individual engineering role. |
+| Y04 | Undergraduates were miserable or the early psychophysics labeling attempt failed due to worker burden. | 1, 4 | Li 2017 slides p.27 says "Miserable Undergrads" but slide shorthand is not enough for detailed prose. | Yellow | Transcript or memoir page for exact context. |
+| Y05 | ImageNet's creators explicitly designed it as a direct answer to PASCAL VOC's scale limit. | 1, 5 | Russakovsky et al. supports PASCAL-to-ILSVRC scaling; Li slides call PASCAL an inspiration. | Yellow | Direct interview/talk transcript or paper statement tying ImageNet's original design to VOC. |
+| Y06 | ImageNet's ontology was underused by later deep-learning practitioners. | 5 | Li 2017 slides pp.58-64 say "Ontological Structure Not Used as Much" and "Most works still use 1M images." | Yellow | Could be Green if this later reflection is needed, but it is mostly Ch43/later and not central here. |
+| Y07 | The project had about 15 million images by 2010. | 5 | Li 2017 slides p.36 says 15M; Russakovsky 2015 gives 14,197,122 as of Aug. 2014. | Yellow | Need version/date reconciliation before using as a precise dated claim. |
+
+## Red Claim Table
+
+| ID | Claim | Scene | Why Red |
+|---|---|---|---|
+| R01 | ImageNet proved deep-learning algorithms were fundamentally sound. | 5 | That is a Ch43/AlexNet interpretation, not supported by the 2009 construction sources alone. |
+| R02 | Researchers at CVPR 2009 literally ignored Li's poster or walked past it. | 5 | No conference-floor source or memoir page anchor. |
+| R03 | ImageNet was the first dataset large enough to train deep neural networks without overfitting. | 5 | Needs technical and historical comparison; false or at least overbroad without Ch43 anchors. |
+| R04 | MTurk workers in ImageNet were paid a specific wage or completed a specific number of labels per hour. | 4 | No ImageNet-period wage/task-rate anchor extracted. Ch38 has later wage studies only. |
+| R05 | WordNet was created specifically for AI vision or for ImageNet. | 2 | WordNet predates ImageNet and was a lexical/psycholinguistic database. |
+
+## Page Anchor Worklist
+
+### Done
+
+- WordNet five-paper PDF: origin, synsets, semantic relations, and hypernym/hyponym table anchors extracted.
+- Deng et al. 2009 ImageNet PDF: ontology, scale, web-image collection, AMT verification, quality control, and precision anchors extracted.
+- Fei-Fei Li 2017 ACM TechTalk page/slides: data-shift framing, construction attempts, 49k/167 worker slide, WordNet slides, and ILSVRC slide anchors extracted.
+- Russakovsky et al. 2015 ILSVRC PDF: annual benchmark structure, PASCAL scaling comparison, and 2014 ImageNet scale anchors extracted.
+
+### Still Needed
+
+- Edition-specific anchors from Fei-Fei Li, *The Worlds I See* (2023), for personal motivation, reception, and individual project roles.
+- Extractable Quartz article body or another accessible interview for the 2006 origin story.
+- A transcript/video timestamp for Li's 2017 ACM or 2019 talk if the prose needs richer scene texture than slide text supports.
+- A primary source assigning specific engineering ownership to Jia Deng beyond first authorship.
+- Historical reception evidence from CVPR 2009, reviewer comments, or interviews before drafting the "muted reception" scene.
+
+## Verification Notes
+
+- Per workflow, shell `curl` was attempted first for the ImageNet and WordNet PDFs, but DNS resolution failed in this sandbox. Browser verification was used for public PDFs/pages, and the Ch38 contract's prior `pdftotext` anchors were cross-checked where relevant.
+- No legacy Gemini source or prose claim was promoted without independent anchoring.

--- a/docs/research/ai-history/chapters/ch-40-data-becomes-infrastructure/status.yaml
+++ b/docs/research/ai-history/chapters/ch-40-data-becomes-infrastructure/status.yaml
@@ -1,1 +1,25 @@
-status: researching
+status: capacity_plan_anchored
+chapter: ch-40-data-becomes-infrastructure
+issue: 394
+owned_by: Codex
+updated: 2026-04-29
+word_count_discipline: 3k-5k likely
+prose_capacity:
+  min_words: 3400
+  max_words: 4700
+claims:
+  green: 23
+  yellow: 7
+  red: 5
+required_files:
+  brief: complete
+  sources: complete
+  timeline: complete
+  people: complete
+  infrastructure_log: complete
+  scene_sketches: complete
+  open_questions: complete
+notes:
+  - Every Prose Capacity Plan layer cites at least one Green source anchor in sources.md.
+  - Shell curl was attempted for public PDFs but DNS resolution failed; browser verification and existing Ch38 anchors were used.
+  - Legacy Gemini prose was used only for scope, not as evidence.

--- a/docs/research/ai-history/chapters/ch-40-data-becomes-infrastructure/timeline.md
+++ b/docs/research/ai-history/chapters/ch-40-data-becomes-infrastructure/timeline.md
@@ -1,5 +1,12 @@
-# Timeline: Chapter 40
+# Timeline: Chapter 40 - Data Becomes Infrastructure
 
-- **2006:** Fei-Fei Li begins conceptualizing a massive dataset.
-- **2009:** The ImageNet paper is published at CVPR (and initially receives little fanfare).
-- **2010:** The first ILSVRC (ImageNet Large Scale Visual Recognition Challenge) is held.
+- **1985:** A Princeton group of psychologists and linguists begins developing WordNet as a lexical database for conceptual, not merely alphabetical, access to word meanings. Source: G01.
+- **1990:** The WordNet paper collection reports the state of WordNet, including synsets and semantic relations. Source: G01-G04.
+- **2005-11-02:** Amazon publicly announces Mechanical Turk as a web-services API for routing tasks humans still do better than computers. Source: G21.
+- **2006:** Fei-Fei Li reportedly begins formulating the ImageNet idea around data scale and visual learning. Source: Y01; do not draft as Green until memoir/interview pages are anchored.
+- **2007-2010:** Li's 2017 slide deck places the crowdsourced-labor phase in this window and reports 49k workers from 167 countries. Source: G16.
+- **2009-06:** Deng, Dong, Socher, Li-Jia Li, Kai Li, and Li Fei-Fei publish "ImageNet: A Large-Scale Hierarchical Image Database" at CVPR, reporting 12 subtrees, 5,247 synsets, and 3.2 million images. Source: G07.
+- **2010:** ILSVRC begins as an annual large-scale visual recognition benchmark built from ImageNet. Source: G17.
+- **2010:** The ILSVRC classification benchmark scales beyond PASCAL VOC 2010, from 20 classes/19,737 images to 1,000 classes/1,461,406 images. Source: G18.
+- **2014-08:** Russakovsky et al. report ImageNet at 21,841 WordNet synsets and 14,197,122 annotated images. Source: G19.
+- **2017-09-21:** Li gives the ACM TechTalk "ImageNet: Where Have We Gone? Where Are We Going?" and retrospectively frames the project as a shift from modeling to data. Source: G13, G22.


### PR DESCRIPTION
Capacity-plan-anchored contract for Chapter 40: ImageNet as data infrastructure.

5 scenes, 3,400-4,700 word range, 23G/7Y/5R.

- Scene 1: WordNet's semantic scaffold (1995-2006 origin)
- Scene 2: Web-scale image collection mechanics
- Scene 3: AMT verification pipeline (2008-2009)
- Scene 4: CVPR 2009 paper, ImageNet structure (12 subtrees / 5,247 synsets / 3.2M images)
- Scene 5: Benchmark handoff — ILSVRC 2010-2012

Boundary: AlexNet / GPU causality kept OUT of scope (Ch43).

Verdict pass next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)