### PR TITLE
research: Ch43 — The ImageNet Smash (#394)

### DIFF
--- a/docs/research/ai-history/chapters/ch-43-the-imagenet-smash/brief.md
+++ b/docs/research/ai-history/chapters/ch-43-the-imagenet-smash/brief.md
@@ -1,25 +1,58 @@
 # Brief: Chapter 43 - The ImageNet Smash
 
 ## Thesis
-The convergence of massive data (ImageNet), deep neural networks (CNNs), and parallel infrastructure (GPUs) created the "Big Bang" of modern AI. In 2012, AlexNet completely obliterated traditional computer vision algorithms, proving that empirical scale had finally triumphed over hand-engineered features.
+
+AlexNet did not make deep learning real by magic, by rhetoric, or by one clever trick. It made a measurable public argument on a benchmark whose rules, data scale, hidden test labels, and annual scoreboard had been carefully built before it arrived. In 2012, the University of Toronto "SuperVision" submission joined three infrastructures that earlier chapters have kept separate: ImageNet/ILSVRC as shared data and evaluation, CUDA-era GPUs as affordable parallel compute, and convolutional neural networks as a long-running but still contested research program. The result was not merely first place. It was a 15.3% top-5 test error entry against a 26.2% second-best entry, with the runner-up still representing the Fisher-vector/SIFT feature-engineering regime. The chapter's argument is that AlexNet turned scale from a premise into a public proof: if the dataset, GPU memory, training time, and architecture were large enough, learned features could beat hand-built vision pipelines on their own benchmark.
 
 ## Scope
-- IN SCOPE: The 2012 ILSVRC, Geoffrey Hinton, Alex Krizhevsky, Ilya Sutskever, AlexNet architecture, the margin of victory.
-- OUT OF SCOPE: ResNet (Chapter 47).
+
+- IN SCOPE: ILSVRC as public dataset plus hidden-test evaluation infrastructure; the 2010-2012 hand-engineered feature baseline; Geoffrey Hinton, Alex Krizhevsky, and Ilya Sutskever at the University of Toronto; the SuperVision/AlexNet architecture; ReLUs, dropout, data augmentation, and two-GPU model partitioning at a historical level; the 2012 classification/localization result; the immediate 2013-2014 shift in ILSVRC submissions toward deep convolutional networks.
+- OUT OF SCOPE: the full construction of ImageNet and AMT labor pipeline (Ch40); CUDA's invention and NVIDIA platform strategy before 2012 (Ch42); the full prehistory of CNNs and LeNet (Ch27); ResNet, batch normalization, ImageNet human-level comparisons, and later benchmark saturation (see later chapters); corporate acquisitions, startup auctions, or broad "all of industry changed overnight" claims unless separately anchored in a later prose phase.
+
+## Boundary Contract
+
+This chapter must not say AlexNet invented CNNs, invented GPU computing, or single-handedly created modern AI. It should say AlexNet made a public, benchmarked, empirically difficult-to-ignore demonstration that large supervised CNNs trained on GPUs could beat the strongest feature-engineering systems on ImageNet-scale object recognition.
+
+The chapter must also not invent a bedroom/apartment scene, heat and fan noise, conference shock, reviewer disbelief, exact announcement timestamps, or private Hinton/Krizhevsky/Sutskever dialogue. The available Green record supports the hardware, training time, architecture, result table, and later ILSVRC adoption pattern; it does not yet support a dramatic domestic lab scene.
+
+Forward references should be sparse. Use Ch44 or later chapters for GoogLeNet, VGG, ResNet, batch normalization, modern accelerator economics, and foundation-model scale arguments.
 
 ## Scenes Outline
-1. **The Underdogs:** Hinton's team at the University of Toronto working on marginalized neural networks.
-2. **The GPUs in the Bedroom:** Krizhevsky and Sutskever wiring together GTX 580 consumer GPUs to train the massive model.
-3. **The Smash:** The 2012 competition results are published. AlexNet wins by a staggering 10.8% margin, stunning the academic establishment.
 
-## 4k-7k Prose Capacity Plan
+1. **The Scoreboard Was Already Waiting.** ILSVRC had converted ImageNet into a yearly public contest with a training set, hidden test labels, evaluation server, and workshop. Before 2012, SIFT, LBP, Fisher vectors, and SVM-style systems defined the competitive baseline.
+2. **A Neural-Network Team Enters a Feature-Engineering Field.** Hinton, Krizhevsky, and Sutskever submit SuperVision from Toronto, with a large CNN whose size and training recipe only make sense against ImageNet-scale data and GPU compute.
+3. **The Two-GPU Machine.** The architecture is constrained by GTX 580 memory and training time: the network is split across two 3GB GPUs, trained for five to six days, with communication only at certain layers.
+4. **The Smash.** Official results and the AlexNet paper converge: SuperVision posts 0.15315/15.3% top-5 error with extra ImageNet Fall 2011 data, while the best non-CNN competitor reports 0.26172/26.2% using Fisher-vector feature pipelines.
+5. **The Field Moves.** Russakovsky et al. later call 2012 a turning point; by ILSVRC2013 the vast majority of entries use deep CNNs, and by 2014 almost all teams do. The close should keep the claim measured: a benchmark turn, not a complete replacement of every vision method everywhere.
 
-This chapter can support a long narrative only if it is built from verified layers rather than padding:
+## Prose Capacity Plan
 
-- 500-800 words: Historical context and setup, bridging from the previous era.
-- 933-1233 words: Detailed narrative surrounding The Underdogs:, heavily anchored to primary sources.
-- 933-1233 words: Detailed narrative surrounding The GPUs in the Bedroom:, heavily anchored to primary sources.
-- 933-1233 words: Detailed narrative surrounding The Smash:, heavily anchored to primary sources.
-- 400-700 words: Honest close that summarizes the infrastructural shift and transitions to the next chapter.
+This chapter can support a substantial but not sprawling narrative if it spends words on the benchmark, technical constraints, and measured aftermath rather than unsupported lab drama:
 
-Most layers now have page-level anchors. Do not invent lab drama or dialogue to reach the top of the range. If the verified evidence runs out, cap the chapter.
+- 650-900 words: **The benchmark as the stage** - show why ImageNet/ILSVRC was not just "a dataset" but a public contest with hidden test labels, annual workshops, 1,000 classes, and roughly 1.2 million training images. Scene: 1. Anchored to `sources.md` G01 (Russakovsky et al. 2015 p.1 lines 43-55), G02 (p.2 lines 163-170), G03 (AlexNet PDF p.1 lines 61-66), and G04 (Russakovsky et al. 2015 p.17 lines 1115-1122).
+- 700-1,000 words: **Toronto's deep CNN as a scale argument** - introduce the SuperVision team, the long neural-network skepticism context, and the architecture's learned-layer claim without implying CNNs began here. Scene: 2. Anchored to `sources.md` G05 (NeurIPS proceedings metadata lines 5-14), G06 (AlexNet PDF p.1 lines 44-55), G07 (p.0 lines 12-21), G08 (ACM Turing Award page lines 239-247), and G09 (Russakovsky et al. 2015 p.17 lines 1134-1140).
+- 900-1,200 words: **The two-GPU constraint** - narrate the compute mechanics: GTX 580 memory, split model, selective cross-GPU communication, ReLU speed, dropout/augmentation, 90 passes over 1.2M images, and five-to-six-day training. Scene: 3. Anchored to `sources.md` G10 (AlexNet PDF p.1 lines 56-59), G11 (p.2 lines 120-136), G12 (p.4 lines 223-241), G13 (p.5-6 lines 321-325), and G14 (p.2 lines 95-112).
+- 800-1,100 words: **The 2012 result table** - make the "smash" quantitative: top-5 metric, official ILSVRC results page, 0.15315 vs 0.26172, SuperVision team abstract, and runner-up feature engineering. Scene: 4. Anchored to `sources.md` G15 (official ILSVRC results lines 14-21), G16 (official results lines 64-65), G17 (AlexNet PDF p.6 lines 342-356), and G18 (Russakovsky et al. 2015 p.23 lines 1363-1426).
+- 650-950 words: **Aftermath without overreach** - use the ILSVRC follow-up paper to show the next two competitions moving toward deep CNNs and a 2012-2014 error drop, then close with the bounded lesson: data, compute, and CNNs became a shared empirical program. Scene: 5. Anchored to `sources.md` G19 (Russakovsky et al. 2015 p.17 lines 1153-1177), G20 (p.21-22 lines 1267-1302), G21 (p.32 lines 1921-1930), and G22 (ACM Turing Award page lines 263-269).
+
+Total: **3,700-5,150 words**. Label: `3k-5k likely`. The low-to-middle range is strongly supported by anchored primary/near-primary evidence. The upper end is possible only if the prose patiently explains benchmark mechanics and two-GPU architecture; it should not be reached by inventing a Toronto apartment scene or generalized industry reaction.
+
+If the verified evidence runs out, cap the chapter.
+
+## Citation Bar
+
+- Minimum primary/near-primary anchors before prose: Krizhevsky, Sutskever, and Hinton 2012 PDF; NeurIPS proceedings metadata; official ILSVRC 2012 results page; ILSVRC 2012 analysis page; Russakovsky et al. 2015 ILSVRC paper.
+- Minimum secondary/context anchors before prose: ACM 2018 Turing Award page for neural-network skepticism and later recognition; Ch40 source contract for ImageNet construction handoff; Ch42 source contract for CUDA handoff.
+- Every Prose Capacity Plan layer above cites at least one Green claim in `sources.md` with page/section/line anchors.
+
+## Conflict Notes
+
+- **15.3% vs 16.4%.** Official ILSVRC results list SuperVision 0.15315 using extra ImageNet Fall 2011 data and 0.16422 using only supplied training data. Krizhevsky et al. Table 2 reports the 15.3% model as seven CNNs with pretraining on the Fall 2011 release. Use both numbers with their conditions, not interchangeably.
+- **1.2M vs 1.3M training images.** The accessible PDF and CACM text use roughly 1.2 million training images for ILSVRC; NeurIPS metadata exposes 1.3 million in the abstract snippet. Prefer the paper's dataset section for prose and flag the metadata discrepancy only if needed.
+- **"Traditional computer vision died."** Too broad. The Green claim is narrower: the 2012 ILSVRC runner-up used Fisher-vector/dense-feature pipelines, and after SuperVision's success most 2013/2014 ILSVRC entries used deep CNNs.
+- **Bedroom/heat/noise anecdote.** Not Green. The paper anchors two GTX 580 GPUs and five-to-six-day training; no Green source locates the machine in a bedroom or describes physical conditions.
+- **Corporate/industry aftermath.** The chapter may say the benchmark field moved rapidly in ILSVRC. It should not claim every company pivoted, that Google paid a specific amount for Hinton's startup, or that AlexNet directly caused later foundation models without separate later-chapter anchors.
+
+## Honest Prose-Capacity Estimate
+
+Anchored estimate: **3,700-5,150 words**. Confidence in 3,700-4,600 words is high because the benchmark and architecture sources are dense. Confidence above 5,000 words is medium and depends on careful exposition of ILSVRC mechanics, model partitioning, and post-2012 competition adoption. Word Count Discipline label: `3k-5k likely`.

--- a/docs/research/ai-history/chapters/ch-43-the-imagenet-smash/infrastructure-log.md
+++ b/docs/research/ai-history/chapters/ch-43-the-imagenet-smash/infrastructure-log.md
@@ -1,6 +1,35 @@
-# Infrastructure Log: Chapter 43
+# Infrastructure Log: Chapter 43 - The ImageNet Smash
 
-## Technical Metrics & Constraints
-- **AlexNet Compute:**
-  - Hardware: Two Nvidia GTX 580 3GB GPUs.
-  - Training Time: It took five to six days to train the 60-million parameter model.
+## Scene 1: Benchmark Infrastructure
+
+- **Dataset/evaluation form:** ILSVRC consisted of a public dataset plus annual competition/workshop, with hidden test annotations submitted through an evaluation server. Sources: G01; Russakovsky et al. 2015 p.1 lines 60-67.
+- **Scale:** ILSVRC2012 standardized 1,000 classes and 1,431,167 annotated images, far beyond PASCAL VOC 2012's 20 classes and 21,738 images. Source: G02.
+- **AlexNet paper's working subset:** roughly 1.2M training images, 50K validation images, and 150K test images across 1,000 categories. Source: G03.
+- **Metric:** Top-5 error counts an image as correct if the true label is among up to five predicted classes. Source: AlexNet PDF p.1 lines 67-72; ILSVRC analysis lines 661-663.
+
+## Scene 2: Model Infrastructure
+
+- **Architecture size:** about 60M parameters and 650K neurons, with five convolutional and three fully connected layers. Source: G07.
+- **Input pipeline:** images were downsampled to 256x256, then 224x224 crops and horizontal reflections were used during training/testing. Sources: AlexNet PDF p.1 lines 73-77; G12.
+- **Training techniques:** ReLUs for faster learning, dropout in the first two fully connected layers, data augmentation, local response normalization, overlapping pooling, and SGD with momentum/weight decay. Sources: G12-G14; AlexNet PDF pp.3-6.
+
+## Scene 3: GPU Infrastructure
+
+- **Hardware:** two NVIDIA GTX 580 3GB GPUs. Sources: G10-G13.
+- **Memory constraint:** one GTX 580 had only 3GB, so the model was split across two GPUs. Source: G11.
+- **Communication pattern:** GPUs communicated only at selected layers; Figure 2 explicitly delineates layer responsibilities across the two GPUs. Source: G11.
+- **Training duration:** roughly 90 cycles through 1.2M images, five to six days on the two GPUs. Source: G13.
+- **Boundary:** No Green source places the GPUs in a bedroom, apartment, or describes heat/noise. Keep physical atmosphere generic or omit it. Source: Y01.
+
+## Scene 4: Scoreboard Infrastructure
+
+- **Official Task 1 result:** SuperVision 0.15315 top-5 error with extra Fall 2011 data; SuperVision 0.16422 using supplied data; ISI 0.26172. Source: G15.
+- **Paper result framing:** Krizhevsky et al. report 15.3% for seven CNNs pre-trained on ImageNet Fall 2011, compared with 26.2% for the second-best entry. Source: G17.
+- **Statistical follow-up:** Russakovsky et al. Table 8 gives 99.9% confidence intervals and says winners/runners-up were significantly different at that level. Source: G18.
+
+## Scene 5: Post-2012 Infrastructure
+
+- **Adoption in the benchmark:** vast majority of ILSVRC2013 entries and almost all ILSVRC2014 teams used deep CNNs as the basis of submissions. Source: G19.
+- **Measured progress:** ILSVRC classification error fell from 16.4% to 6.7% between 2012 and 2014 on the unchanged post-2012 dataset. Source: G20.
+- **Lesson:** ILSVRC organizers later argued that major object-recognition breakthroughs would not have been possible on a smaller scale. Source: G21.
+- **Boundary:** This chapter stops at the benchmark turn. Later accelerator stacks, cuDNN, Tensor Cores, ResNet, and foundation-model scaling should not be backfilled into 2012.

--- a/docs/research/ai-history/chapters/ch-43-the-imagenet-smash/open-questions.md
+++ b/docs/research/ai-history/chapters/ch-43-the-imagenet-smash/open-questions.md
@@ -1,3 +1,32 @@
-# Open Questions
+# Open Questions: Chapter 43 - The ImageNet Smash
 
-- SCRUBBED: All claims downgraded to Yellow. Need REAL, empirical page/section anchors from verified online PDFs or archives. Do not hallucinate.
+## Claims Still Yellow
+
+- **Physical training scene:** The two GTX 580 GPUs, 3GB memory limit, network split, and five-to-six-day training are Green. The "bedroom/apartment heat and noise" scene is not. Needed: Krizhevsky/Sutskever/Hinton interview, lab photo caption, memoir passage, or contemporaneous blog/email.
+- **Immediate human reaction:** The result gap is Green. Claims that reviewers, organizers, or competitors thought the result was a mistake are Yellow. Needed: ILSVRC workshop report, organizer interview, or participant recollection with date/source.
+- **Acquisition/business aftermath:** The chapter should not use a specific Google acquisition amount or causal chain from AlexNet to a corporate pivot unless company or reliable press anchors are added.
+- **Fei-Fei Li reaction:** Her ImageNet construction role is covered in Ch40. A Ch43 scene about her reaction to AlexNet needs memoir/interview page anchors.
+- **Broader replacement of feature engineering:** Current anchors support a fast ILSVRC shift toward deep CNNs in 2013-2014. They do not support saying all hand-engineered vision methods immediately disappeared.
+
+## Claims Marked Red
+
+- AlexNet invented CNNs.
+- GPUs alone caused the deep-learning revolution.
+- Hand-engineered vision died everywhere immediately.
+- The model was trained on a datacenter cluster.
+- AlexNet directly caused modern foundation models or ChatGPT.
+
+## Archival or Source Access That Would Help
+
+- Full accessible CACM 2017 article/prologue text, or ACM Digital Library access, for any extra authorial framing not present in the NIPS PDF.
+- Oral histories or long-form interviews with Krizhevsky, Sutskever, Hinton, Fei-Fei Li, Olga Russakovsky, or 2012 ISI/VGG participants.
+- ECCV 2012 / PASCAL VOC workshop materials beyond the official schedule and results page, especially slides or discussion notes from SuperVision and ISI.
+- Fei-Fei Li, *The Worlds I See* (2023), with edition-specific page anchors for ImageNet reception and the 2012 moment.
+- NVIDIA annual reports or executive interviews if later prose wants to discuss when AlexNet became visible inside NVIDIA strategy.
+
+## Drafting Guidance
+
+- Draft from Green claims only for the core narrative.
+- Yellow claims may appear only as explicitly hedged gaps or omitted entirely.
+- Red claims should not appear in prose.
+- If a writer wants more atmosphere, source it first. The existing Green contract supports a strong infrastructure chapter without invented lab drama.

--- a/docs/research/ai-history/chapters/ch-43-the-imagenet-smash/people.md
+++ b/docs/research/ai-history/chapters/ch-43-the-imagenet-smash/people.md
@@ -1,4 +1,26 @@
-# People: Chapter 43
+# People: Chapter 43 - The ImageNet Smash
 
-## Verified Protagonists
-- **Alex Krizhevsky, Ilya Sutskever, Geoffrey Hinton:** The Toronto team that built AlexNet.
+## Core Actors
+
+- **Alex Krizhevsky:** University of Toronto researcher and first author of the 2012 AlexNet paper. Official ILSVRC2012 results list him as a SuperVision team member. His chapter role is technical builder/lead author of the large deep CNN system, but individual labor split inside the Toronto team remains Yellow unless a first-person source is added. Sources: G05, G16.
+- **Ilya Sutskever:** University of Toronto co-author and SuperVision team member. The chapter can identify him as part of the Toronto team and paper, but should not assign unanchored implementation details or dialogue. Sources: G05, G16.
+- **Geoffrey E. Hinton:** University of Toronto co-author and long-running neural-network advocate. ACM's Turing Award page frames Hinton, LeCun, and Bengio as among a small group who kept working on neural networks through skepticism, and specifically names the 2012 work with Krizhevsky and Sutskever. Sources: G05, G08, G22.
+
+## Benchmark and Dataset Actors
+
+- **Olga Russakovsky, Jia Deng, Hao Su, Jonathan Krause, Sanjeev Satheesh, Sean Ma, Zhiheng Huang, Andrej Karpathy, Aditya Khosla, Michael Bernstein, Alexander C. Berg, and Li Fei-Fei:** Authors of the ILSVRC retrospective. Their chapter role is the benchmark historian/organizer voice that explains why 2012 was a turning point and what changed in 2013-2014. Source: Russakovsky et al. 2015 title/author page; G01, G09, G19-G21.
+- **Li Fei-Fei / Fei-Fei Li:** Co-creator of ImageNet and later ILSVRC organizer. Chapter 40 owns her full ImageNet construction story; Ch43 uses her only as part of the benchmark infrastructure inherited by AlexNet. Sources: Ch40 sources G22; Russakovsky et al. author list.
+- **Jia Deng:** First author of the 2009 ImageNet paper and co-author of the ILSVRC retrospective. Chapter 40 owns the ImageNet construction role; Ch43 uses him mainly for the ILSVRC/data handoff. Sources: Ch40 sources G07; Russakovsky et al. author list.
+
+## Competitor Teams
+
+- **ISI team:** Official 2012 Task 1 runner-up behind SuperVision. The results page lists Naoyuki Gunji, Takayuki Higuchi, Koki Yasumoto, Hiroshi Muraoka, Yoshitaka Ushiku, Tatsuya Harada, and Yasuo Kuniyoshi, and describes a system built from multiple image features including SIFT/FV, LBP/FV, GIST/FV, and CSIFT/FV. Sources: G15, G24.
+- **Oxford VGG team:** A major 2012 competitor in classification/localization; the results page lists Karen Simonyan, Yusuf Aytar, Andrea Vedaldi, and Andrew Zisserman. VGG's later deep-learning story belongs mostly to later chapters. Source: G24.
+- **Clarifai / Matthew Zeiler:** ILSVRC2013 classification winner with deep CNN ensembles after SuperVision. Include only as one sentence of aftermath if needed. Source: G19.
+- **GoogLeNet team:** ILSVRC2014 classification winner. This belongs to the next benchmark chapter, not Ch43's main narrative. Source: G20; boundary only.
+
+## Boundary Notes
+
+- Do not create scenes from private conversations among Krizhevsky, Sutskever, and Hinton unless a first-person source is added.
+- Do not assign detailed individual engineering ownership inside SuperVision beyond authorship and team membership.
+- Do not turn Li, Deng, or Russakovsky into Ch43 protagonists. They are infrastructure/benchmark actors here; Ch40 owns ImageNet construction.

--- a/docs/research/ai-history/chapters/ch-43-the-imagenet-smash/scene-sketches.md
+++ b/docs/research/ai-history/chapters/ch-43-the-imagenet-smash/scene-sketches.md
@@ -1,10 +1,41 @@
-# Scene Sketches: Chapter 43
+# Scene Sketches: Chapter 43 - The ImageNet Smash
 
-## Scene 1: The Marginalized Lab
-- **Action:** Hinton has kept the neural network flame alive for decades while the rest of the field focused on SVMs.
+## Scene 1: The Scoreboard Was Already Waiting
 
-## Scene 2: Heat and Noise
-- **Action:** Krizhevsky's apartment gets incredibly hot as the two gaming GPUs run at 100% capacity for nearly a week.
+Start with the contest rather than the neural network. ILSVRC had already turned ImageNet into a public ritual: teams received training data, submitted predictions against hidden test labels, and gathered around an annual workshop where progress could be compared. This matters because AlexNet's result was persuasive precisely because the target was not private. The benchmark inherited ImageNet's scale and WordNet organization from Ch40, but Ch43 should not retell the whole data-construction story. The new beat is the scoreboard: 1,000 categories, roughly 1.2 million training images in the AlexNet paper's working set, and a hidden-test discipline that could expose a real gap.
 
-## Scene 3: The Margin of Victory
-- **Action:** The results are released. Traditional feature engineering is dead. Deep learning has arrived.
+The scene should also establish the old regime without caricature. The pre-2012 winners were not fools; they represented sophisticated feature engineering and large-scale classification practice. Russakovsky et al. describe SIFT, LBP, Fisher-vector, compression, and SVM/linear-classifier systems as strong across the early years. That lets the prose say what AlexNet beat without claiming "computer vision was dead."
+
+Anchors: G01, G02, G03, G04, G24.
+
+## Scene 2: A Neural-Network Team Enters a Feature-Engineering Field
+
+Move from the scoreboard to Toronto. The SuperVision team is Krizhevsky, Sutskever, and Hinton, and the system is a large deep CNN trained on raw RGB pixel values. The chapter can use ACM's later Turing Award framing to show that neural networks had been a minority commitment through skepticism, but it should stay disciplined: this is a background condition, not a license for invented underdog dialogue.
+
+The technical center of the scene is scale as design pressure. The paper's abstract gives the architecture in one compact inventory: 60 million parameters, 650,000 neurons, five convolutional layers, and three fully connected layers. The prose should explain why this differs from feature-engineering pipelines: the system learns internal features from pixels, but only because ImageNet-scale data and GPU implementation make the experiment plausible.
+
+Anchors: G05, G06, G07, G08, G09, G16.
+
+## Scene 3: The Two-GPU Constraint
+
+This is the chapter's main infrastructure scene, but keep it factual. The verified story is not a bedroom with heat shimmer; it is a memory and communication problem. A single GTX 580 had 3GB of memory, and the network was too large for one card. Krizhevsky et al. therefore split the network across two GPUs and allowed communication only at certain layers. Figure 2 shows the two halves; the architecture text describes where kernels connect across or stay within GPU partitions.
+
+The prose should make the hardware constraint legible to non-specialists: this model was not simply "run on GPUs"; it was shaped by GPU memory, training time, and the need to keep communication below the cost of computation. Add the training rhythm: roughly 90 passes through 1.2 million images, five to six days on two GTX 580 3GB GPUs. Then show the supporting recipe: ReLUs made large experiments train faster, dropout and augmentation fought overfitting, and the system used raw RGB patches rather than hand-designed local descriptors.
+
+Anchors: G10, G11, G12, G13, G14.
+
+## Scene 4: The Smash
+
+The result scene should be numerical and calm. Official ILSVRC Task 1 results list SuperVision at 0.15315 top-5 error using extra ImageNet Fall 2011 data and 0.16422 using only supplied training data. The ISI runner-up entry reports 0.26172 and describes a feature-fusion pipeline using SIFT/FV, LBP/FV, GIST/FV, and CSIFT/FV. The AlexNet paper tells the same basic story as 15.3% versus 26.2%, and Russakovsky et al. later give the same range with 99.9% confidence intervals.
+
+Avoid vague awe language. The gap is strong enough without saying the establishment "was stunned" unless a source is found. The scene should instead explain the error metric, the data-condition caveat, and why a 10.9-point top-5 gap on a hidden test set was hard to dismiss. The "smash" is the public measurement, not a private emotional reaction.
+
+Anchors: G15, G16, G17, G18, G23, G24.
+
+## Scene 5: The Field Moves
+
+End with the aftermath that is actually anchored. Russakovsky et al. say SuperVision's influence was clearly visible in ILSVRC2013 and ILSVRC2014: the vast majority of 2013 entries used deep CNNs, and almost all 2014 teams did. They also report that image-classification error fell from 16.4% to 6.7% between 2012 and 2014 on the unchanged post-2012 dataset. ACM's later Turing Award page gives the wider retrospective recognition: the 2012 Hinton/Krizhevsky/Sutskever work improved CNNs with ReLUs and dropout and almost halved object-recognition error.
+
+The close should return to the thesis. AlexNet did not erase earlier vision work, invent CNNs, or prove that more compute alone wins. It showed that a public benchmark, a massive labeled dataset, a deep CNN, and commodity GPU parallelism could make learned features beat the strongest hand-engineered pipelines. That is enough. The next chapters can take up the platform race and deeper architectures.
+
+Anchors: G19, G20, G21, G22.

--- a/docs/research/ai-history/chapters/ch-43-the-imagenet-smash/sources.md
+++ b/docs/research/ai-history/chapters/ch-43-the-imagenet-smash/sources.md
@@ -1,17 +1,105 @@
-# Sources: Chapter 43
+# Sources: Chapter 43 - The ImageNet Smash
 
-## Claim Matrix
+## Verification Key
 
-| Claim | Scene | Primary Source | Secondary Confirmation | Verification | Conflict |
+- **Green**: claim has a verified page, section, line, DOI, or stable page anchor.
+- **Yellow**: source exists, but the exact claim needs a stronger page/line anchor, is interpretive, or should be hedged.
+- **Red**: no verifiable anchor yet; do not draft as fact.
+
+Note: shell `curl` was attempted first for the AlexNet, ImageNet, and ILSVRC PDFs/pages, but DNS resolution failed in this sandbox. Browser extraction was used for public PDFs/pages. No legacy Gemini prose claim was promoted without an independent anchor.
+
+## Primary and Near-Primary Sources
+
+| Source | Use | Verification |
+|---|---|---|
+| Alex Krizhevsky, Ilya Sutskever, and Geoffrey E. Hinton, "ImageNet Classification with Deep Convolutional Neural Networks," NIPS 2012. NeurIPS page: https://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks. PDF mirror used for extraction: https://www.nvidia.com/content/tesla/pdf/machine-learning/imagenet-classification-with-deep-convolutional-nn.pdf | Load-bearing primary technical source for AlexNet architecture, ImageNet/ILSVRC dataset details, GPU training, ReLU/dropout/augmentation, and 2012 result table. | **Green** for NeurIPS metadata lines 5-14; PDF p.0 lines 12-21; p.1 lines 41-66; p.2 lines 95-136; pp.3-6 architecture/training details; p.6 lines 342-356; p.7 lines 399-411. |
+| Official ILSVRC2012 results page. URL: https://image-net.org/challenges/LSVRC/2012/results | Official scoreboard for task 1 classification, task 2 localization, team abstracts, and competitor descriptions. | **Green** for Task 1 table lines 14-21; team abstract lines 64-65; ISI/VGG descriptions lines 51-64; task 2 lines 32-41. |
+| Official ILSVRC2012 main page. URL: https://image-net.org/challenges/LSVRC/2012/ | Challenge schedule, task description, validation/test/training-data description, top-5 error definition, and news dates. | **Green** for news lines 16-29; workshop schedule lines 30-36; introduction/data lines 37-47; Task 1 metric lines 50-53; timetable lines 61-66. |
+| Official ILSVRC2012 analysis page. URL: https://www.image-net.org/challenges/LSVRC/2012/analysis/ | Official analysis of 2012 classification performance across categories and comparison of SuperVision to ISI. | **Green** for classification challenge method lines 661-665; overview line 13; categories section lines 673-723 if prose needs category examples. |
+| Olga Russakovsky et al., "ImageNet Large Scale Visual Recognition Challenge," arXiv:1409.0575v3 / IJCV 2015. URL: https://arxiv.org/pdf/1409.0575. DOI: 10.1007/s11263-015-0816-y | Near-primary retrospective by ILSVRC organizers: benchmark structure, scale, pre-2012 methods, 2012 turning point, post-2012 adoption, statistical significance, and later error reductions. | **Green** for DOI via Princeton metadata; arXiv p.1 lines 43-55; p.2 lines 163-170; p.16-17 lines 1106-1158; p.17 lines 1171-1177; p.18-19 lines 1191-1193; p.21-23 lines 1267-1426; p.32 lines 1921-1930. |
+| Jia Deng et al., "ImageNet: A Large-Scale Hierarchical Image Database," CVPR 2009, pp.248-255. DOI: 10.1109/CVPR.2009.5206848. URL: https://image-net.org/static_files/papers/imagenet_cvpr09.pdf | Background only: ImageNet construction and scale. Chapter 40 owns the full ImageNet construction story. | **Green via Ch40 contract** for p.248 lines 4-19; p.248 lines 33-47; p.251-252 lines 242-326. Use only for brief handoff, not a full scene. |
+| ACM, "2018 ACM A.M. Turing Award." URL: https://awards.acm.org/about/2018-turing | Context source for Hinton/LeCun/Bengio persistence, early-2000s skepticism, and ACM's later statement that Hinton's 2012 work with Krizhevsky and Sutskever almost halved object-recognition error. | **Green** for lines 239-247, 256-259, and 263-269. Use as retrospective context and do not overload it as a 2012 participant account. |
+| Fei-Fei Li, "ImageNet: Where Have We Gone? Where Are We Going?" ACM TechTalk slides, September 21, 2017. | Background on ImageNet/ILSVRC handoff and data-centered framing. Chapter 40 owns this source. | **Green via Ch40 contract** for slides pp.17-18, pp.31, pp.38-39. Use only as continuity if needed. |
+
+## Secondary and Context Sources
+
+| Source | Use | Verification |
+|---|---|---|
+| CACM version of Krizhevsky, Sutskever, and Hinton, "ImageNet Classification with Deep Convolutional Neural Networks," June 2017. URL: https://cacm.acm.org/research/imagenet-classification-with-deep-convolutional-neural-networks/ | Useful because it reprints the AlexNet paper with prologue/epilogue and clean web sections. | Yellow. Browser search exposed the page body and table of contents, but direct open returned 403. Use the NIPS PDF mirror for Green anchors. |
+| Dave Gershgorn, "The data that transformed AI research-and possibly the world," Quartz, July 26, 2017. URL: https://qz.com/1034972/the-data-that-changed-the-direction-of-ai-research-and-possibly-the-world | Public narrative for ImageNet's social reception and later significance. | Yellow. Ch40 found only search-snippet-level access. Do not use for quotes or Green claims without full article extraction. |
+| Fei-Fei Li, *The Worlds I See* (Flatiron, 2023). | Possible source for richer ImageNet reception and project motivation. | Yellow. No edition-specific page anchors extracted in this worktree. |
+| Ian Goodfellow, Yoshua Bengio, and Aaron Courville, *Deep Learning* (MIT Press, 2016). | Textbook context for CNN/deep learning history. | Yellow. Useful for technical background, but no page anchors extracted for this contract. |
+| Later NVIDIA/Tom's Hardware/New Yorker reporting on AlexNet and NVIDIA's AI turn. | Potential context for corporate aftermath. | Yellow. Not needed for this chapter's Green core; avoid corporate pivot claims unless page anchors are added. |
+
+## Green Claim Table
+
+| ID | Claim | Scene | Anchor | Independent Confirmation | Status | Notes |
+|---|---|---|---|---|---|---|
+| G01 | ILSVRC had been running annually since 2010 and consisted of a public dataset plus annual competition/workshop. | 1 | Russakovsky et al. 2015 p.1 lines 43-55. | Ch40 sources G17. | **Green** | Establishes benchmark infrastructure. |
+| G02 | ILSVRC2012 scaled standardized evaluation to 1,000 object classes and 1,431,167 annotated images, compared with PASCAL VOC 2012's 20 classes and 21,738 images. | 1 | Russakovsky et al. 2015 p.2 lines 163-170. | Ch40 sources G18 gives related 2010 scaling. | **Green** | Use "ILSVRC2012," not all ImageNet. |
+| G03 | The AlexNet paper describes the ILSVRC subset as roughly 1.2M training images, 50K validation images, and 150K testing images across 1,000 categories. | 1 | AlexNet PDF p.1 lines 61-66. | Russakovsky et al. 2015 p.3-4 task description. | **Green** | Strong dataset-size anchor for Ch43. |
+| G04 | Pre-2012 ILSVRC classification leaders used SIFT/LBP/Fisher-vector style feature pipelines with SVMs or linear classifiers. | 1 | Russakovsky et al. 2015 p.17 lines 1115-1133. | Official results page lines 51-63 for ISI/VGG descriptions. | **Green** | Avoid "all of vision"; say ILSVRC leaders. |
+| G05 | The NeurIPS proceedings page identifies "ImageNet Classification with Deep Convolutional Neural Networks" as a NIPS 2012 paper by Krizhevsky, Sutskever, and Hinton. | 2 | NeurIPS page lines 5-14. | PDF title/authors p.0 lines 0-10. | **Green** | Bibliographic anchor. |
+| G06 | The AlexNet paper says the authors trained one of the largest CNNs to date on ILSVRC-2010/2012 subsets and achieved the best results then reported on those datasets. | 2 | AlexNet PDF p.1 lines 44-55. | Russakovsky et al. 2015 p.17 lines 1134-1140. | **Green** | Use as authors' claim plus organizer confirmation. |
+| G07 | The network had about 60 million parameters, 650,000 neurons, five convolutional layers, and three fully connected layers. | 2 | AlexNet PDF p.0 lines 12-21. | Official results team abstract lines 64-65. | **Green** | Do not mix with NeurIPS metadata's 500,000-neuron abstract discrepancy. |
+| G08 | By the early 2000s, ACM describes LeCun, Hinton, and Bengio as among a small group committed to neural networks despite skepticism. | 2 | ACM Turing Award page lines 239-247. | ACM media release mirrors same wording. | **Green** | Retrospective award framing; do not overdramatize. |
+| G09 | Russakovsky et al. call ILSVRC2012 a turning point when large-scale deep neural networks entered the scene, and identify SuperVision as the undisputed winner of classification and localization. | 2, 4 | Russakovsky et al. 2015 p.17 lines 1134-1140. | Official results lines 14-18 and 32-35. | **Green** | "Undisputed" is source wording; paraphrase if possible. |
+| G10 | The AlexNet paper says the network size was limited mainly by GPU memory and tolerable training time, and that it trained five to six days on two GTX 580 3GB GPUs. | 3 | AlexNet PDF p.1 lines 56-59. | AlexNet PDF p.6 lines 321-325. | **Green** | Core infrastructure detail. |
+| G11 | A single GTX 580 had 3GB memory; the authors spread the network across two GPUs and allowed communication only in certain layers. | 3 | AlexNet PDF p.2 lines 120-136. | Figure 2 caption p.4 lines 210-214. | **Green** | Hardware constraint, not bedroom anecdote. |
+| G12 | AlexNet used data augmentation and dropout to reduce overfitting in a 60M-parameter network. | 3 | AlexNet PDF p.4 lines 223-241; p.5 lines 262-275. | Abstract p.0 lines 15-21. | **Green** | Keep at historical/technical level. |
+| G13 | The model was trained for roughly 90 cycles through 1.2M images, taking five to six days on two NVIDIA GTX 580 3GB GPUs. | 3 | AlexNet PDF p.5-6 lines 321-325. | G10. | **Green** | Distinct from introductory summary. |
+| G14 | ReLUs trained several times faster than saturating units; the paper says this enabled experiments with such large networks. | 3 | AlexNet PDF p.2 lines 95-112. | Abstract p.0 lines 17-18. | **Green** | Good for explaining not just "more layers." |
+| G15 | Official ILSVRC2012 Task 1 results list SuperVision at 0.15315 top-5 error with extra ImageNet Fall 2011 data, and 0.16422 using only supplied training data. | 4 | Official ILSVRC results lines 14-18. | Russakovsky et al. 2015 p.18-19 lines 1191-1193. | **Green** | Use conditions carefully. |
+| G16 | Official ILSVRC results identify SuperVision as Alex Krizhevsky, Ilya Sutskever, and Geoffrey Hinton from University of Toronto, with a large deep CNN trained on raw RGB pixels and two NVIDIA GPUs for about a week. | 2, 4 | Official ILSVRC results lines 64-65. | AlexNet PDF p.0 lines 0-21; p.1 lines 56-59. | **Green** | Good people/infrastructure anchor. |
+| G17 | The AlexNet paper reports 15.3% top-5 test error for a seven-CNN averaged model pre-trained on ImageNet Fall 2011, compared with 26.2% for the second-best entry. | 4 | AlexNet PDF p.6 lines 342-356. | Official results lines 16-18. | **Green** | This is the canonical 10.9-point comparison; legacy "10.8%" is acceptable rounded from 26.2-15.3. |
+| G18 | Russakovsky et al. Table 8 reports 2012 SuperVision at 15.32% top-5 error with external data, 16.42% without, and ISI at 26.17%, with 99.9% confidence intervals. | 4 | Russakovsky et al. 2015 p.23 lines 1363-1426. | Official results lines 16-18. | **Green** | Statistical significance anchor. |
+| G19 | Following SuperVision's 2012 success, Russakovsky et al. say the vast majority of ILSVRC2013 entries used deep CNNs, and almost all ILSVRC2014 teams did. | 5 | Russakovsky et al. 2015 p.17 lines 1153-1177. | Table 6/7 entries p.19-21. | **Green** | This supports benchmark-field shift, not all computer vision. |
+| G20 | From 2012 to 2014, with the dataset unchanged since 2012, image classification error fell from 16.4% to 6.7%. | 5 | Russakovsky et al. 2015 p.21-22 lines 1267-1302. | Table 8 p.23 lines 1363-1385. | **Green** | Use as ILSVRC progress, not solely AlexNet causation. |
+| G21 | Russakovsky et al. conclude that major object-recognition breakthroughs would not have been possible on a smaller scale. | 5 | Russakovsky et al. 2015 p.32 lines 1921-1930. | AlexNet PDF p.1 lines 41-59. | **Green** | Good closing anchor for scale thesis. |
+| G22 | ACM's Turing Award page says Hinton's 2012 work with Krizhevsky and Sutskever improved CNNs with ReLUs/dropout and almost halved object-recognition error in ImageNet. | 5 | ACM Turing Award page lines 263-269. | Russakovsky Table 8 and AlexNet result table. | **Green** | Use as retrospective confirmation. |
+| G23 | The official ILSVRC2012 analysis says SuperVision consistently outperformed ISI in the classification challenge. | 4 | ILSVRC2012 analysis lines 661-665. | Official results lines 16-18. | **Green** | Supports "across categories" without overclaiming every category. |
+| G24 | The official ILSVRC2012 results page describes ISI and VGG systems with SIFT/Fisher-vector/GIST/LBP/color-statistics feature pipelines and linear/SVM classifiers. | 1, 4 | Official ILSVRC results lines 51-63 and 77-79. | Russakovsky et al. 2015 p.17 lines 1140-1148. | **Green** | Concrete "feature engineering" comparison. |
+
+## Yellow Claim Table
+
+| ID | Claim | Scene | Source | Status | Needed Anchor |
 |---|---|---|---|---|---|
-| AlexNet was trained on consumer GTX 580 GPUs | 2 | Krizhevsky et al. 2012 (ImageNet classification) | Goodfellow et al. 2016 | Yellow | Need exact verified page/section anchors. |
-| AlexNet defeated traditional algorithms by a margin of 10.8% | 3 | ILSVRC 2012 official results | Gershgorn 2017 | Yellow | Need exact verified page/section anchors. |
+| Y01 | Krizhevsky and Sutskever trained the model in an apartment or bedroom, with heat/noise from the GPUs. | 3 | Legacy prose; later popular retellings. | Yellow | First-person interview, memoir, photo caption, or contemporaneous account. Do not draft as fact. |
+| Y02 | Reviewers or conference attendees initially thought the result was a mistake. | 4 | Common narrative; prior citation-seed audit marked this unsalvageable without source. | Yellow | Traceable interview or conference report. |
+| Y03 | The ImageNet result directly triggered a specific Google acquisition price for Hinton's startup. | 5 | Popular accounts. | Yellow | Primary acquisition reporting or company/legal source with amount and causal framing. |
+| Y04 | Fei-Fei Li's personal reaction to AlexNet in 2012 can be narrated in detail. | 5 | Possible memoir/interview source. | Yellow | *The Worlds I See* page anchors or transcript timestamps. |
+| Y05 | AlexNet "ended feature engineering" across all computer vision. | 5 | Interpretive shorthand. | Yellow | Broader bibliometric evidence; current Green supports ILSVRC adoption only. |
+| Y06 | NVIDIA internally pivoted toward AI immediately because of AlexNet. | 5 | Later NVIDIA-centered journalism. | Yellow | NVIDIA annual reports, executive interview transcript, or dated strategy source. |
+| Y07 | The exact date/time/place when the final ILSVRC results reached the Toronto team. | 4 | Legacy-style anecdote. | Yellow | Email, blog, interview, or official announcement timestamp tied to the team. |
 
-## Bibliography
-### Primary
-- **Krizhevsky, Alex, Ilya Sutskever, and Geoffrey E. Hinton. "Imagenet classification with deep convolutional neural networks." *Advances in neural information processing systems* 25 (2012).**
-- **ILSVRC 2012 Results Archive: image-net.org/challenges/LSVRC/2012/**
+## Red Claim Table
 
-### Secondary
-- **Goodfellow, Ian, Yoshua Bengio, and Aaron Courville. *Deep Learning*. MIT Press, 2016.**
-- **Gershgorn, Dave. "The data that transformed AI research." *Quartz*, 2017.**
+| ID | Claim | Scene | Status | Reason |
+|---|---|---|---|---|
+| R01 | AlexNet invented convolutional neural networks. | 2 | Red | False; CNN history belongs to Ch27. |
+| R02 | AlexNet proved that GPUs alone caused the deep-learning revolution. | 3, 5 | Red | Sources show data, architecture, regularization, training method, and benchmark infrastructure all mattered. |
+| R03 | The 2012 result made all hand-engineered vision systems obsolete immediately. | 4, 5 | Red | ILSVRC 2013/2014 adoption shifted quickly, but broader immediate obsolescence is unsupported. |
+| R04 | The Toronto system was trained on a datacenter GPU cluster. | 3 | Red | The paper anchors two GTX 580 3GB GPUs. |
+| R05 | AlexNet directly caused modern foundation models or ChatGPT. | 5 | Red | Later scale/deep-learning continuity belongs to later chapters and needs separate causal evidence. |
+
+## Page Anchor Worklist
+
+### Done
+
+- AlexNet PDF: dataset, architecture, ReLU, multi-GPU split, dropout/data augmentation, training time, and ILSVRC2012 result table anchors extracted via browser PDF text.
+- Official ILSVRC2012 results page: Task 1 score table, Task 2 score table, team abstracts, and feature-engineering competitor descriptions anchored.
+- Official ILSVRC2012 analysis page: classification metric and SuperVision-vs-ISI category-level comparison anchored.
+- Russakovsky et al. 2015 ILSVRC paper: benchmark structure, PASCAL comparison, pre-2012 methods, 2012 turning point, 2013/2014 adoption, Table 8 significance, and conclusion anchors extracted.
+- Ch40 imported ImageNet construction anchors remain available but should be used only as handoff background.
+
+### Still Needed
+
+- First-person or archival anchor for physical training environment, if the prose wants a domestic hardware scene.
+- Fei-Fei Li memoir/interview page anchors for human reaction and ImageNet reception.
+- Company/press anchors for the Hinton startup acquisition and post-2012 corporate acceleration, if later prose wants a business aftermath.
+- Better line-located open access for the CACM 2017 reprint/prologue; direct open returned 403 here.
+
+## Verification Notes
+
+- Direct shell network extraction failed with DNS errors for `papers.nips.cc`, `image-net.org`, and `arxiv.org`; browser extraction supplied stable line/page anchors.
+- The source table deliberately keeps the dramatic "GPU bedroom" and "reviewers thought it was a mistake" claims Yellow. They are usable only as open questions, not prose facts.

--- a/docs/research/ai-history/chapters/ch-43-the-imagenet-smash/status.yaml
+++ b/docs/research/ai-history/chapters/ch-43-the-imagenet-smash/status.yaml
@@ -1,1 +1,39 @@
-status: researching
+status: capacity_plan_anchored
+chapter: ch-43-the-imagenet-smash
+issue: 394
+owner: Codex
+last_updated: 2026-04-29
+word_count_discipline: 3k-5k likely
+prose_capacity:
+  min_words: 3700
+  max_words: 5150
+  layers:
+    - scene: 1
+      range: "650-900"
+      anchors: [G01, G02, G03, G04]
+    - scene: 2
+      range: "700-1000"
+      anchors: [G05, G06, G07, G08, G09]
+    - scene: 3
+      range: "900-1200"
+      anchors: [G10, G11, G12, G13, G14]
+    - scene: 4
+      range: "800-1100"
+      anchors: [G15, G16, G17, G18, G23, G24]
+    - scene: 5
+      range: "650-950"
+      anchors: [G19, G20, G21, G22]
+claim_counts:
+  green: 24
+  yellow: 7
+  red: 5
+verification:
+  capacity_plan_layers_anchor_to_sources: true
+  shell_curl_attempted: true
+  shell_curl_result: "failed_dns_resolution_in_sandbox"
+  browser_extraction_used_for_public_pdfs_pages: true
+  legacy_prose_trusted: false
+notes:
+  - "Do not draft bedroom/heat/noise scene unless Y01 is anchored."
+  - "Use 15.3% only with extra Fall 2011 data caveat; use 16.4% for supplied-data SuperVision run."
+  - "Ch40 owns ImageNet construction; Ch42 owns CUDA."

--- a/docs/research/ai-history/chapters/ch-43-the-imagenet-smash/timeline.md
+++ b/docs/research/ai-history/chapters/ch-43-the-imagenet-smash/timeline.md
@@ -1,3 +1,18 @@
-# Timeline: Chapter 43
+# Timeline: Chapter 43 - The ImageNet Smash
 
-- **2012:** The AlexNet paper is published and the ILSVRC results are announced.
+- **2009:** Deng, Dong, Socher, Li-Jia Li, Kai Li, and Li Fei-Fei publish "ImageNet: A Large-Scale Hierarchical Image Database" at CVPR. The 2009 paper reports 12 subtrees, 5,247 synsets, and 3.2 million images in that version of ImageNet. Source: Ch40 sources G07; Deng et al. 2009 p.248 lines 13-18 and 41-47.
+- **2010:** ILSVRC begins as an annual benchmark with a public dataset, competition, and workshop. Source: G01.
+- **2010:** First ILSVRC classification winner uses SIFT/LBP/coding/SVM-style methods; Fisher-vector methods are already strong. Source: G04.
+- **2011:** ILSVRC classification winner is the 2010 runner-up XRCE, using high-dimensional signatures, compression, and one-vs-all linear SVMs. Source: G04.
+- **2012-05-07:** ILSVRC2012 organizers announce preparation for the 2012 challenge. Source: official ILSVRC2012 page, news list.
+- **2012-06-16:** ILSVRC2012 development kit, training, and validation data are released. Source: official ILSVRC2012 page, news list.
+- **2012-09-30:** Submission deadline after extension. Source: official ILSVRC2012 page, news list.
+- **2012-10-08:** Preliminary ILSVRC2012 results are released to participants. Source: official ILSVRC2012 page, news list.
+- **2012-10-12:** ILSVRC2012 workshop is held with the PASCAL VOC workshop at ECCV 2012. Source: official ILSVRC2012 page, workshop schedule.
+- **2012-10-13:** Full ILSVRC2012 results are released. Source: official ILSVRC2012 page, news list.
+- **2012:** SuperVision submits a large deep CNN by Krizhevsky, Sutskever, and Hinton; official Task 1 results list 0.15315 top-5 error with extra Fall 2011 ImageNet data and 0.16422 using only supplied data. Source: G15-G16.
+- **2012:** The second-best Task 1 entry, ISI, reports 0.26172 top-5 error and uses Fisher-vector/GIST/LBP/SIFT-style feature pipelines. Source: G15, G24.
+- **2012:** Krizhevsky et al. publish "ImageNet Classification with Deep Convolutional Neural Networks" in NIPS 2012. Source: G05.
+- **2013:** Following SuperVision's success, Russakovsky et al. report that the vast majority of ILSVRC2013 entries use deep convolutional neural networks. Source: G19.
+- **2014:** Russakovsky et al. report that almost all ILSVRC2014 teams use convolutional neural networks as the basis for their submissions. Source: G19.
+- **2015:** Russakovsky et al. publish the ILSVRC retrospective in IJCV/arXiv, reporting a 2012-2014 drop in image-classification error from 16.4% to 6.7% on the unchanged post-2012 dataset. Source: G20.


### PR DESCRIPTION
Capacity-plan-anchored contract for Ch43: AlexNet's 2012 ILSVRC win.

5 scenes, 3,700-5,150w, 24G/7Y/5R. Bounded to the benchmark turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)