### PR TITLE
fix(bridge): retry Gemini quota via OAuth (#589)

### DIFF
--- a/scripts/agent_runtime/adapters/base.py
+++ b/scripts/agent_runtime/adapters/base.py
@@ -53,11 +53,11 @@ class InvocationPlan:
             if any. Adapters that use ``codex exec -o <file>`` or
             ``gemini --output-path <file>`` populate this; the runner reads
             it on completion. None if output goes to stdout.
-        env_overrides: Env vars to add to the subprocess environment.
-            Merged onto ``os.environ`` fresh per invocation — NEVER
-            ``os.environ.update()``. Adapters should only set values that
-            are specific to this call (e.g. Gemini auth tokens). Values set
-            here leak nowhere else.
+        env_overrides: Env vars to add to or remove from the subprocess
+            environment. Merged onto ``os.environ`` fresh per invocation —
+            NEVER ``os.environ.update()``. Set a value to ``None`` to remove
+            that variable for this child only (e.g. strip Gemini API keys so
+            the CLI falls through to OAuth). Values set here leak nowhere else.
         liveness_paths: Files whose mtime indicates the agent is alive.
             Used by the runner's stall detector as a fallback when stdout
             is buffered/redirected. Can be empty; if so, only stdout
@@ -67,7 +67,7 @@ class InvocationPlan:
     cwd: Path
     stdin_payload: str = ""
     output_file: Path | None = None
-    env_overrides: dict[str, str] = field(default_factory=dict)
+    env_overrides: dict[str, str | None] = field(default_factory=dict)
     liveness_paths: tuple[Path, ...] = ()
 
 

--- a/scripts/agent_runtime/adapters/gemini.py
+++ b/scripts/agent_runtime/adapters/gemini.py
@@ -120,7 +120,16 @@ class GeminiAdapter:
             cmd.append("--approval-mode=yolo")
 
         # MCP tool restriction via tool_config.
+        env_overrides: dict[str, str | None] = {}
         if tool_config:
+            # API-key auth is the default. When the bridge detects API-key
+            # quota exhaustion, it retries with this flag so the child process
+            # sees no Gemini API keys and the CLI falls through to OAuth creds
+            # in ~/.gemini/oauth_creds.json.
+            if tool_config.get("use_subscription_auth"):
+                env_overrides["GEMINI_API_KEY"] = None
+                env_overrides["GOOGLE_API_KEY"] = None
+
             mcp_server_names = tool_config.get("mcp_server_names")
             if mcp_server_names:
                 if isinstance(mcp_server_names, (list, tuple)):
@@ -141,7 +150,7 @@ class GeminiAdapter:
             cwd=cwd,
             stdin_payload=prompt,
             output_file=None,  # Gemini writes to stdout only.
-            env_overrides={},
+            env_overrides=env_overrides,
             liveness_paths=(),  # stdout streamer is not actually sufficient —
             # see liveness_signal_paths() docstring — but we compute the
             # real paths lazily there because they depend on cwd.

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -13,7 +13,8 @@ Flow (see docs/design/agent-runtime.md § 4.2 for the full spec):
     4. Enforce resume policy: delegate/dispatch entrypoints may not pass
        session_id for agents with resume_policy="bridge_only".
     5. Check has_headroom(agent, model) — raise RateLimitedError pre-call
-       if we're known rate-limited.
+       if we're known rate-limited, unless the caller explicitly skips that
+       check for a distinct quota path (e.g. Gemini API key -> OAuth retry).
     6. Adapter builds the InvocationPlan.
     7. Spawn subprocess via Popen with watchdog (stall detection).
     8. Poll should_kill() every second; on return or kill, stop watchdog.
@@ -233,6 +234,7 @@ def invoke(
     entrypoint: str = "runtime",
     hard_timeout: int = 3600,
     stall_timeout: int = 180,  # accepted but ignored; see docstring
+    skip_headroom_check: bool = False,
 ) -> Result:
     """Single entry point for all agent CLI invocations.
 
@@ -265,6 +267,10 @@ def invoke(
             successful long-running calls were killed as false-positive
             stalls. See watchdog.py::should_kill() docstring for the
             full incident chain. hard_timeout is the only safety net now.
+        skip_headroom_check: Skip the pre-call rate-limit cache. Use only when
+            the caller has deliberately switched to a different quota/auth path
+            from the cached failure, such as Gemini API-key quota exhaustion
+            falling back to OAuth/subscription credentials.
 
     Returns:
         Result with ok, response, timing, session_id, and the full usage
@@ -302,7 +308,10 @@ def invoke(
 
     # ---------- 5. Pre-call rate-limit check ----------
     effective_model = model or adapter.default_model
-    ok, reason = has_headroom(agent_name, effective_model)
+    ok, reason = (True, "") if skip_headroom_check else has_headroom(
+        agent_name,
+        effective_model,
+    )
     if not ok:
         # Record the short-circuit for observability — the caller didn't
         # burn a quota slot, but we still want the usage log to show it.
@@ -340,8 +349,15 @@ def invoke(
 
     # Merge env overrides onto a snapshot of os.environ. We do NOT mutate
     # os.environ itself — this keeps the parent process clean and prevents
-    # leakage to other adapters running concurrently.
-    env = {**os.environ, **plan.env_overrides}
+    # leakage to other adapters running concurrently. ``None`` means "remove
+    # this variable for the child", used by Gemini OAuth fallback to strip API
+    # keys without touching the parent shell.
+    env = os.environ.copy()
+    for key, value in plan.env_overrides.items():
+        if value is None:
+            env.pop(key, None)
+        else:
+            env[key] = value
 
     # ---------- 7–9. Run the subprocess with watchdog ----------
     start_time = time.monotonic()

--- a/scripts/ai_agent_bridge/_gemini.py
+++ b/scripts/ai_agent_bridge/_gemini.py
@@ -9,6 +9,7 @@ usage logging uniformly across agents.
 """
 
 import atexit
+import os
 import subprocess
 import sys
 import time
@@ -54,6 +55,46 @@ try:
     from dispatch import GEMINI_WRITER_MODEL
 except ImportError:  # pragma: no cover - package import path variant
     GEMINI_WRITER_MODEL = _PARENT_ENV.get("KUBEDOJO_WRITER_MODEL", "gemini-3.1-pro-preview")
+
+
+_SWITCH_TO_SUBSCRIPTION = object()
+
+
+def _force_gemini_subscription() -> bool:
+    return os.environ.get("KUBEDOJO_GEMINI_SUBSCRIPTION") == "1"
+
+
+def _gemini_api_key_present() -> bool:
+    return bool(os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY"))
+
+
+def _gemini_rate_limited_text(text: str) -> bool:
+    return (
+        "exhausted your capacity" in text
+        or "429" in text
+        or "quota" in text.lower()
+        or "RESOURCE_EXHAUSTED" in text
+        or "usage limit reached" in text.lower()
+    )
+
+
+def _should_switch_to_subscription(text: str, use_subscription_auth: bool) -> bool:
+    """Return True when an API-key quota hit should retry through OAuth.
+
+    Durable auth rule: Gemini bridge calls use API-key auth first. Only when
+    that path hits quota/rate-limit do we strip GEMINI_API_KEY/GOOGLE_API_KEY
+    for the retry, which makes the Gemini CLI fall through to OAuth creds.
+    """
+    if use_subscription_auth or _force_gemini_subscription():
+        return False
+    return _gemini_api_key_present() and _gemini_rate_limited_text(text)
+
+
+def _should_switch_after_rate_limit_exception(use_subscription_auth: bool) -> bool:
+    """Runtime RateLimitedError is authoritative even when stderr is noisy."""
+    if use_subscription_auth or _force_gemini_subscription():
+        return False
+    return _gemini_api_key_present()
 
 
 def converse_gemini(content: str, task_id: str, model: str = GEMINI_WRITER_MODEL,
@@ -299,11 +340,20 @@ def _run_gemini_sync(msg: dict, message_id: int, model: str, prompt: str,
     base_delay = 30
     _response_sent = False
 
+    use_subscription_auth = _force_gemini_subscription()
+
     try:
         for attempt in range(max_retries):
             result = _run_gemini_attempt(msg, message_id, model, prompt, timeout_val,
                                          stdout_only, output_path, skip_github, attempt,
-                                         max_retries, base_delay)
+                                         max_retries, base_delay, use_subscription_auth)
+            if result is _SWITCH_TO_SUBSCRIPTION:
+                use_subscription_auth = True
+                print(
+                    "\n🔁 Gemini API-key quota exhausted — retrying via OAuth/subscription.",
+                    flush=True,
+                )
+                continue
             if result is None:
                 continue  # Retry (rate limited)
             if result is False:
@@ -319,7 +369,8 @@ def _run_gemini_sync(msg: dict, message_id: int, model: str, prompt: str,
 
 
 def _run_gemini_attempt(msg, message_id, model, prompt, timeout_val, stdout_only,
-                        output_path, skip_github, attempt, max_retries, base_delay):
+                        output_path, skip_github, attempt, max_retries, base_delay,
+                        use_subscription_auth=False):
     """Run a single Gemini CLI attempt via agent_runtime.
 
     Returns None to retry, False to stop, or (response, sent).
@@ -332,6 +383,8 @@ def _run_gemini_attempt(msg, message_id, model, prompt, timeout_val, stdout_only
     prompt_preview = prompt[:200].replace('\n', ' ')
     print(f"  [gemini] attempt {attempt+1}/{max_retries}, model={model}, "
           f"prompt={len(prompt)} chars: {prompt_preview}...", flush=True)
+    if use_subscription_auth:
+        print("  [gemini] auth=oauth/subscription (API keys stripped)", flush=True)
 
     pre_snapshot = None
     if output_path:
@@ -351,9 +404,13 @@ def _run_gemini_attempt(msg, message_id, model, prompt, timeout_val, stdout_only
             session_id=None,  # Gemini CLI has no --resume; bridge multi-turn
                               # is handled via conversation context injection
                               # in the prompt builder, not CLI-level resume.
-            tool_config=None,
+            tool_config=(
+                {"use_subscription_auth": True}
+                if use_subscription_auth else None
+            ),
             entrypoint="bridge",
             hard_timeout=max(timeout_val or 1800, 300),
+            skip_headroom_check=use_subscription_auth,
             # 600s matches dispatch.py. Gemini block-buffers stdout when
             # not a TTY and can stay silent 5+ min during reasoning; the
             # mtime poller on ~/.gemini/tmp/<project>/{logs.json, chats/}
@@ -363,6 +420,8 @@ def _run_gemini_attempt(msg, message_id, model, prompt, timeout_val, stdout_only
             stall_timeout=min(600, timeout_val or 600),
         )
     except RateLimitedError as exc:
+        if _should_switch_after_rate_limit_exception(use_subscription_auth):
+            return _SWITCH_TO_SUBSCRIPTION
         # Rate-limited: treat as retryable per legacy behavior
         print(f"\n⏳ Gemini rate limited: {exc}")
         retry_result = _handle_gemini_error(str(exc), model, attempt, max_retries, base_delay)
@@ -383,6 +442,8 @@ def _run_gemini_attempt(msg, message_id, model, prompt, timeout_val, stdout_only
         # Runtime returned a structured failure. Decide retry vs stop based
         # on stderr signal (legacy _handle_gemini_error).
         stderr_text = result.stderr_excerpt or ""
+        if _should_switch_to_subscription(stderr_text, use_subscription_auth):
+            return _SWITCH_TO_SUBSCRIPTION
         retry_result = _handle_gemini_error(stderr_text, model, attempt, max_retries, base_delay)
         if retry_result == "retry":
             return None
@@ -427,7 +488,7 @@ def _handle_gemini_error(stderr, model, attempt, max_retries, base_delay):
         print("💡 To switch accounts: run 'gemini auth login'")
         return "stop"
 
-    if "exhausted your capacity" in stderr or "429" in stderr or "quota" in stderr.lower():
+    if _gemini_rate_limited_text(stderr):
         delay = base_delay * (2 ** attempt)
         if attempt < max_retries - 1:
             print(f"\n⏳ Rate limited (attempt {attempt + 1}/{max_retries}). Waiting {delay}s...")

--- a/scripts/ai_agent_bridge/_model.py
+++ b/scripts/ai_agent_bridge/_model.py
@@ -1,9 +1,36 @@
 """Model availability checking."""
 
+import os
 import subprocess
 from pathlib import Path
 
 from ._config import _MODEL_CACHE, _MODEL_CACHE_TTL, _PARENT_ENV, GEMINI_CLI
+
+
+def _force_gemini_subscription() -> bool:
+    return os.environ.get("KUBEDOJO_GEMINI_SUBSCRIPTION") == "1"
+
+
+def _subscription_env() -> dict[str, str]:
+    env = _PARENT_ENV.copy()
+    env.pop("GEMINI_API_KEY", None)
+    env.pop("GOOGLE_API_KEY", None)
+    return env
+
+
+def _has_gemini_api_key(env: dict[str, str]) -> bool:
+    return bool(env.get("GEMINI_API_KEY") or env.get("GOOGLE_API_KEY"))
+
+
+def _model_check_quota_exhausted(text: str) -> bool:
+    lowered = text.lower()
+    return (
+        "exhausted" in lowered
+        or "429" in text
+        or "quota" in lowered
+        or "resource_exhausted" in lowered
+        or "usage limit reached" in lowered
+    )
 
 
 def check_model(model: str, timeout: int = 15, force: bool = False) -> bool:
@@ -23,16 +50,37 @@ def check_model(model: str, timeout: int = 15, force: bool = False) -> bool:
             print(f"🔍 Model '{model}': {status} (cached {int(age)}s ago)")
             return available
 
+    env = _subscription_env() if _force_gemini_subscription() else _PARENT_ENV
     try:
         result = subprocess.run(
             [GEMINI_CLI, "-m", model, "-p", "Reply with exactly: MODEL_OK"],
             capture_output=True, text=True, timeout=timeout,
             cwd=str(Path(__file__).parent.parent.parent),
-            env=_PARENT_ENV,
+            env=env,
         )
         if result.returncode == 0 and "MODEL_OK" in result.stdout:
             _MODEL_CACHE[model] = (True, _time.time())
             return True
+        combined = f"{result.stdout}\n{result.stderr}"
+        if (
+            not _force_gemini_subscription()
+            and _has_gemini_api_key(env)
+            and _model_check_quota_exhausted(combined)
+        ):
+            print(
+                f"⚠️  Model '{model}' API-key quota exhausted; "
+                "checking OAuth/subscription path."
+            )
+            oauth_result = subprocess.run(
+                [GEMINI_CLI, "-m", model, "-p", "Reply with exactly: MODEL_OK"],
+                capture_output=True, text=True, timeout=timeout,
+                cwd=str(Path(__file__).parent.parent.parent),
+                env=_subscription_env(),
+            )
+            if oauth_result.returncode == 0 and "MODEL_OK" in oauth_result.stdout:
+                _MODEL_CACHE[model] = (True, _time.time())
+                return True
+            result = oauth_result
         _handle_model_check_failure(result, model, _time)
         _MODEL_CACHE[model] = (False, _time.time())
         return False

--- a/tests/test_bridge_gemini_models.py
+++ b/tests/test_bridge_gemini_models.py
@@ -6,6 +6,9 @@ from types import SimpleNamespace
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
+from agent_runtime.adapters.gemini import GeminiAdapter
+from agent_runtime.errors import RateLimitedError
+from agent_runtime.result import Result
 from ai_agent_bridge import _cli, _gemini
 
 
@@ -154,3 +157,196 @@ def test_launch_gemini_background_uses_configured_python(monkeypatch, tmp_path):
     )
 
     assert captured["cmd"][0] == "custom-python"
+
+
+def test_gemini_adapter_strips_api_keys_for_subscription_auth(tmp_path):
+    plan = GeminiAdapter().build_invocation(
+        prompt="hello",
+        mode="workspace-write",
+        cwd=tmp_path,
+        model="gemini-test",
+        task_id="task-1",
+        session_id=None,
+        tool_config={"use_subscription_auth": True},
+    )
+
+    assert plan.env_overrides["GEMINI_API_KEY"] is None
+    assert plan.env_overrides["GOOGLE_API_KEY"] is None
+
+
+def test_bridge_switches_from_api_key_to_oauth_on_quota(monkeypatch, tmp_path):
+    calls: list[bool] = []
+
+    def fake_runtime_invoke(*_args, **kwargs):
+        calls.append(kwargs["tool_config"] == {"use_subscription_auth": True})
+        if len(calls) == 1:
+            raise RateLimitedError("gemini", "gemini-test", "quota exceeded")
+        return Result(
+            ok=True,
+            agent="gemini",
+            model="gemini-test",
+            mode="workspace-write",
+            response="OAuth response",
+            stderr_excerpt=None,
+            duration_s=0.1,
+            session_id=None,
+            rate_limited=False,
+            stalled=False,
+            returncode=0,
+            usage_record={},
+        )
+
+    monkeypatch.setenv("GEMINI_API_KEY", "api-key")
+    monkeypatch.delenv("KUBEDOJO_GEMINI_SUBSCRIPTION", raising=False)
+    monkeypatch.setattr(_gemini, "runtime_invoke", fake_runtime_invoke)
+    monkeypatch.setattr(_gemini, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(_gemini, "_is_task_locked", lambda *_args: False)
+    monkeypatch.setattr(_gemini, "_write_pid_file", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_gemini, "_remove_pid_file", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_gemini, "_route_gemini_response", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_gemini, "acknowledge", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_gemini, "_send_gemini_error", lambda *_args, **_kwargs: None)
+
+    response = _gemini._run_gemini_sync(
+        {"task_id": "task-1"},
+        123,
+        "gemini-test",
+        "prompt",
+        no_timeout=False,
+        stdout_only=True,
+        output_path=None,
+        allow_write=False,
+        skip_github=True,
+    )
+
+    assert response == "OAuth response"
+    assert calls == [False, True]
+
+
+def test_bridge_switches_to_oauth_when_rate_limit_reason_is_noisy(monkeypatch, tmp_path):
+    calls: list[bool] = []
+
+    def fake_runtime_invoke(*_args, **kwargs):
+        calls.append(kwargs["tool_config"] == {"use_subscription_auth": True})
+        if len(calls) == 1:
+            raise RateLimitedError(
+                "gemini",
+                "gemini-test",
+                "Warning: Basic terminal detected. Visual rendering limited.",
+            )
+        return Result(
+            ok=True,
+            agent="gemini",
+            model="gemini-test",
+            mode="workspace-write",
+            response="OAuth response after noisy rate limit",
+            stderr_excerpt=None,
+            duration_s=0.1,
+            session_id=None,
+            rate_limited=False,
+            stalled=False,
+            returncode=0,
+            usage_record={},
+        )
+
+    monkeypatch.setenv("GEMINI_API_KEY", "api-key")
+    monkeypatch.delenv("KUBEDOJO_GEMINI_SUBSCRIPTION", raising=False)
+    monkeypatch.setattr(_gemini, "runtime_invoke", fake_runtime_invoke)
+    monkeypatch.setattr(_gemini, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(_gemini, "_is_task_locked", lambda *_args: False)
+    monkeypatch.setattr(_gemini, "_write_pid_file", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_gemini, "_remove_pid_file", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_gemini, "_route_gemini_response", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_gemini, "acknowledge", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_gemini, "_send_gemini_error", lambda *_args, **_kwargs: None)
+
+    response = _gemini._run_gemini_sync(
+        {"task_id": "task-1"},
+        123,
+        "gemini-test",
+        "prompt",
+        no_timeout=False,
+        stdout_only=True,
+        output_path=None,
+        allow_write=False,
+        skip_github=True,
+    )
+
+    assert response == "OAuth response after noisy rate limit"
+    assert calls == [False, True]
+
+
+def test_bridge_force_subscription_skips_api_key(monkeypatch, tmp_path):
+    calls: list[dict | None] = []
+
+    def fake_runtime_invoke(*_args, **kwargs):
+        calls.append(kwargs["tool_config"])
+        return Result(
+            ok=True,
+            agent="gemini",
+            model="gemini-test",
+            mode="workspace-write",
+            response="forced OAuth response",
+            stderr_excerpt=None,
+            duration_s=0.1,
+            session_id=None,
+            rate_limited=False,
+            stalled=False,
+            returncode=0,
+            usage_record={},
+        )
+
+    monkeypatch.setenv("GEMINI_API_KEY", "api-key")
+    monkeypatch.setenv("KUBEDOJO_GEMINI_SUBSCRIPTION", "1")
+    monkeypatch.setattr(_gemini, "runtime_invoke", fake_runtime_invoke)
+    monkeypatch.setattr(_gemini, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(_gemini, "_is_task_locked", lambda *_args: False)
+    monkeypatch.setattr(_gemini, "_write_pid_file", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_gemini, "_remove_pid_file", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_gemini, "_route_gemini_response", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_gemini, "acknowledge", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(_gemini, "_send_gemini_error", lambda *_args, **_kwargs: None)
+
+    response = _gemini._run_gemini_sync(
+        {"task_id": "task-1"},
+        123,
+        "gemini-test",
+        "prompt",
+        no_timeout=False,
+        stdout_only=True,
+        output_path=None,
+        allow_write=False,
+        skip_github=True,
+    )
+
+    assert response == "forced OAuth response"
+    assert calls == [{"use_subscription_auth": True}]
+
+
+def test_model_check_falls_back_to_oauth_on_api_quota(monkeypatch):
+    from ai_agent_bridge import _model
+
+    envs: list[dict[str, str]] = []
+
+    def fake_run(*_args, **kwargs):
+        envs.append(kwargs["env"])
+        if len(envs) == 1:
+            return SimpleNamespace(
+                returncode=1,
+                stdout="",
+                stderr="RESOURCE_EXHAUSTED quota exceeded",
+            )
+        return SimpleNamespace(returncode=0, stdout="MODEL_OK", stderr="")
+
+    monkeypatch.setattr(_model, "_PARENT_ENV", {"GEMINI_API_KEY": "api-key"})
+    monkeypatch.setattr(_model.subprocess, "run", fake_run)
+    monkeypatch.delenv("KUBEDOJO_GEMINI_SUBSCRIPTION", raising=False)
+    _model._MODEL_CACHE.clear()
+
+    try:
+        assert _model.check_model("gemini-test")
+    finally:
+        _model._MODEL_CACHE.clear()
+
+    assert envs[0]["GEMINI_API_KEY"] == "api-key"
+    assert "GEMINI_API_KEY" not in envs[1]


### PR DESCRIPTION
## Summary\n- keep Gemini API-key auth as the default bridge/runtime path\n- retry via OAuth/subscription after API-key quota/rate-limit by stripping GEMINI_API_KEY and GOOGLE_API_KEY from the child env only\n- preserve KUBEDOJO_GEMINI_SUBSCRIPTION=1 as an explicit force-OAuth override\n- add model-check fallback and regression tests for the auth switch\n\nFixes #589.\n\n## Tests\n- /Users/krisztiankoos/projects/kubedojo/.venv/bin/ruff check scripts/ai_agent_bridge/_gemini.py scripts/ai_agent_bridge/_model.py scripts/agent_runtime/runner.py scripts/agent_runtime/adapters/base.py scripts/agent_runtime/adapters/gemini.py tests/test_bridge_gemini_models.py\n- /Users/krisztiankoos/projects/kubedojo/.venv/bin/python -m pytest tests/test_bridge_gemini_models.py\n- /Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/test_pipeline.py