### PR TITLE
docs(ch24): Tier 1 + Tier 2 + 1 Tier 3 aside — math that waited for the machine (#562, #394)

### DIFF
--- a/docs/research/ai-history/chapters/ch-24-the-math-that-waited-for-the-machine/tier3-proposal.md
+++ b/docs/research/ai-history/chapters/ch-24-the-math-that-waited-for-the-machine/tier3-proposal.md
@@ -1,0 +1,76 @@
+# Tier 3 Proposal: Chapter 24 — The Math That Waited for the Machine
+
+Author: Claude (Sonnet 4.6), 2026-04-30
+
+---
+
+## Element 1 — Pull-quote (PROPOSED)
+
+**Candidate sentence:**
+
+> "That is the reason backpropagation became one of the central infrastructures of modern AI. It was not a magic spark. It was a disciplined way to make the chain rule do industrial work."
+
+**Source attribution:** Chapter 24 prose, final paragraph of "The Door It Opened."
+
+**Insertion anchor:** Immediately after the paragraph ending "…It was a disciplined way to make the chain rule do industrial work." (the paragraph before `## Sources`).
+
+**Annotation (proposed):** The "industrial work" framing separates this chapter's claim from the mythology of a sudden invention: the chain rule was old; what changed was its embedding in a repeatable, machine-executable procedure.
+
+**Rationale for PROPOSE:** The sentence is the chapter's load-bearing thesis restated at peak compression — it names the key historiographical correction (not a spark, but infrastructure) in 19 words. It is not already rendered as a blockquote in-prose, so insertion would not create adjacent repetition. The annotation does new work by naming the mythology it corrects.
+
+---
+
+## Element 2 — Plain-reading aside: the "bookkeeping" walkthrough (PROPOSED)
+
+**Target paragraph** (in "Turning the Chain Rule into Machinery"):
+
+> "During the forward pass, each unit receives numbers from earlier units, multiplies them by weights, adds them up, and passes the result through a nonlinear function. The network stores enough of those intermediate values to know what happened. At the end, the output is compared with the target. The question is then reversed: if the final error changed a little, how much would each earlier quantity have contributed to that change?"
+
+**Proposed aside:**
+
+```
+:::tip[Plain reading]
+Think of the forward pass as filling in a spreadsheet row by row, keeping every cell. The backward pass asks: if the answer in the last cell changed by a tiny amount, which earlier cells drove it, and by how much? Backpropagation answers that question once per pass by walking the spreadsheet in reverse — no re-derivation for each cell.
+:::
+```
+
+**Rationale for PROPOSE:** This paragraph stacks abstract operations (receive, multiply, add, pass through nonlinear function, store intermediate values, compare, reverse the question) without a concrete model for a non-specialist. The aside provides a single concrete analogy (spreadsheet) that does work the surrounding prose does not: it makes the cache-and-reuse intuition visible before the symbolic equations appear in the math sidebar. The paragraph is symbolically dense in the sense relevant to Tier 3 — it describes a multi-step computation at the level of operations rather than as a narrative.
+
+**Insertion anchor:** Immediately after the paragraph beginning "During the forward pass, each unit receives numbers…" in section "Turning the Chain Rule into Machinery."
+
+---
+
+## Element 3 — Plain-reading aside: the hidden-unit error signal (PROPOSED)
+
+**Target paragraph** (in "Turning the Chain Rule into Machinery"):
+
+> "The backward pass answers that question recursively. For an output unit, the connection between its activation and the error is direct. For a hidden unit, the effect is indirect, so the algorithm uses the sensitivities already computed for later units. A hidden unit receives a combined signal from the downstream errors it helped produce. The same pattern repeats layer by layer. Each weight update is based on two facts: what arrived during the forward pass, and how sensitive the final error is to that connection during the backward pass."
+
+**Proposed aside:**
+
+```
+:::tip[Plain reading]
+An output unit gets a direct grade: "you were wrong by this much." A hidden unit has no direct grade — it only knows it influenced later units. Backpropagation gives it a weighted average of those later units' grades, scaled by how strongly it contributed to each. That weighted average is the hidden unit's error signal, and updating by it is what makes hidden-layer training possible.
+:::
+```
+
+**Rationale for PROPOSE:** The paragraph is the conceptual crux of the chapter and is written at the level of recursive sensitivity propagation — abstract enough that the mechanism can be read without the reader grasping why a hidden unit receives a signal at all. The aside supplies the "why": no direct grade exists, so a proxy is constructed from downstream grades. This does new work the surrounding prose does not: it names the proxy construction explicitly in non-technical terms.
+
+**Insertion anchor:** Immediately after the paragraph beginning "The backward pass answers that question recursively…" in section "Turning the Chain Rule into Machinery."
+
+---
+
+## Element 4 — Inline tooltip (SKIPPED)
+
+**Reason:** Per READER_AIDS.md §Tier 3 item 8, the inline `<abbr title="…">` tooltip modifies the prose line and violates the bit-identity rule. No non-destructive Astro `<Tooltip>` component is available. The Plain-words glossary (Tier 1, item 4) covers the same job. SKIPPED on this and every chapter until a non-destructive component ships.
+
+---
+
+## Summary
+
+| Element | Status | Notes |
+|---|---|---|
+| Pull-quote | PROPOSED | Load-bearing thesis; no adjacent repetition; annotation does new work |
+| Plain-reading aside 1 (forward-pass bookkeeping) | PROPOSED | Symbolically dense; spreadsheet analogy not in surrounding prose |
+| Plain-reading aside 2 (hidden-unit error signal) | PROPOSED | Conceptual crux; proxy-grade framing not in surrounding prose |
+| Inline tooltip | SKIPPED | No non-destructive component available |

--- a/docs/research/ai-history/chapters/ch-24-the-math-that-waited-for-the-machine/tier3-review.md
+++ b/docs/research/ai-history/chapters/ch-24-the-math-that-waited-for-the-machine/tier3-review.md
@@ -1,0 +1,16 @@
+## Element 1 — Pull-quote
+Verdict: REJECT
+Reason: I could not verify this as verbatim from a Green primary source. The proposal cites "Chapter 24 prose" rather than a primary Green source, and I fetched the PDP PDF plus the Nature article page and grepped for distinctive phrases from the candidate quote ("industrial work", "magic spark", "central infrastructures", "disciplined way") with no match. It also fails the adjacent-repetition rule: the proposed insertion point is immediately after the prose paragraph that already contains the same three sentences, including the exact final sentence.
+
+## Element 2 — Plain-reading aside
+Verdict: REJECT
+Reason: The target paragraph is operationally explanatory, not symbolically dense in the Tier 3 sense. It contains no formulas, derivation, or stacked abstract definitions; it is already a plain-language walkthrough using the chapter's own ledger/bookkeeping framing. The proposed spreadsheet analogy mostly restates what the paragraph and immediately following prose already say: store intermediate values, reverse the question, and avoid separate hand derivations for every weight. That is useful classroom language, but too redundant for a selective Tier 3 aside.
+
+## Element 3 — Plain-reading aside
+Verdict: REVISE
+Reason: This target paragraph is the strongest Tier 3 candidate because it compresses the hidden-unit error recurrence into prose: output error is direct, hidden-unit influence is indirect, downstream sensitivities are reused, and the update depends on forward activation plus backward sensitivity. The proposed aside does new work by turning that into a nontechnical "direct grade versus constructed hidden signal" explanation. However, "weighted average" is technically off: the chapter's own math sidebar gives a weighted sum of downstream error signals, scaled by the hidden unit's activation derivative, not an average. Revise the aside to preserve the plain-reading value while matching the formula.
+Corrected verbatim or text (only if REVISE): :::tip[Plain reading]
+An output unit gets a direct grade: "your contribution changed the final error by this much." A hidden unit has no direct target, so backpropagation builds its signal from the downstream units it fed: add up their error signals weighted by the outgoing connections, then scale that by how responsive the hidden unit was at that moment. That constructed signal is what lets hidden-layer weights be updated from the same forward-pass activity.
+:::
+
+VERDICT: ch24 0 approved / 1 revised / 2 rejected

--- a/src/content/docs/ai-history/ch-24-the-math-that-waited-for-the-machine.md
+++ b/src/content/docs/ai-history/ch-24-the-math-that-waited-for-the-machine.md
@@ -6,6 +6,66 @@ sidebar:
   order: 24
 ---
 
+:::tip[In one paragraph]
+The chain rule that powers every modern neural network did not appear in 1986. Paul Werbos described backward derivative propagation for trainable systems in his 1974 thesis, and reverse-mode automatic differentiation had its own earlier lineage. What Rumelhart, Hinton, and Williams did in 1986 was make the method convincing: they demonstrated that hidden layers could learn useful internal representations through repeated error-driven weight updates, reopening the path multilayer learning needed after the perceptron era.
+:::
+
+<details>
+<summary><strong>Cast of characters</strong></summary>
+
+| Name | Lifespan | Role |
+|---|---|---|
+| David E. Rumelhart | — | Cognitive scientist and PDP co-leader; framed backpropagation as the key to training hidden-unit internal representations. |
+| Geoffrey E. Hinton | — | Neural-network researcher; co-author of the 1986 Nature and PDP backpropagation papers; helped make representation learning the central claim. |
+| Ronald J. Williams | — | Co-author of the 1986 Nature and PDP papers; essential to the algorithmic error-propagation presentation. |
+| Paul J. Werbos | — | Harvard PhD student whose 1974 thesis described backward derivative propagation for adaptive systems, predating the PDP revival. |
+| Seppo Linnainmaa | — | Automatic-differentiation researcher whose 1976 work on reverse accumulation of rounding-error derivatives anchors the separate mathematical lineage. |
+| James L. McClelland | — | PDP co-editor and connectionist collaborator; context figure for why 1986 landed as a cognitive-science movement, not only an optimization result. |
+
+</details>
+
+<details>
+<summary><strong>Timeline (1969–1989)</strong></summary>
+
+```mermaid
+timeline
+    title The Math That Waited for the Machine, 1969–1989
+    1969 : Minsky and Papert's Perceptrons crystallizes limits of single-layer networks and makes hidden-unit training the central unresolved problem
+    1974 : Paul Werbos submits Beyond Regression, describing ordered derivatives and backward derivative calculation for adaptive prediction systems
+    1976 : Linnainmaa publishes reverse accumulation of rounding-error derivatives in BIT Numerical Mathematics
+    1985 : Rumelhart, Hinton, and Williams circulate Learning internal representations by error propagation through the UCSD/PDP research context
+    1986 : PDP chapter on internal representations by error propagation published with generalized delta rule and symmetry/encoder demonstrations
+    1986 : Nature publishes Learning representations by back-propagating errors, putting the result before a broad scientific audience
+    1989 : Francis Crick publishes a contemporary Nature critique cautioning against over-reading artificial neural networks as brain models
+```
+
+</details>
+
+<details>
+<summary><strong>Plain-words glossary</strong></summary>
+
+- **Hidden layer** — A layer of units inside a neural network that sits between the raw input and the final output. Because hidden units receive no direct teacher signal, training them requires a method for assigning credit or blame for the final error.
+- **Backpropagation** — The algorithm that runs the chain rule backward through a layered network: compute the forward pass, measure the output error, then propagate error sensitivities layer by layer back to every weight.
+- **Chain rule** — A calculus rule for differentiating a composed function: if $z$ depends on $y$ and $y$ depends on $x$, then $\frac{dz}{dx} = \frac{dz}{dy} \cdot \frac{dy}{dx}$. Backpropagation applies this recursively across every layer.
+- **Reverse-mode automatic differentiation** — A computational strategy that sweeps backward through a recorded graph of arithmetic operations to find how a scalar output depends on every input, reusing intermediate values from the forward pass.
+- **Generalized delta rule** — The weight-update formula derived in the 1986 PDP chapter: each weight changes in proportion to the error sensitivity that backpropagation assigns to it, times the activation that arrived at that weight during the forward pass.
+- **Internal representation** — The encoding a hidden layer develops through training. Instead of a programmer prescribing which features the hidden units should detect, the learning rule shapes them through repeated error correction.
+- **Credit assignment** — The problem of deciding which weights in a layered network should be held responsible for a final output error, and by how much — the core obstacle that backpropagation solved for hidden layers.
+
+</details>
+
+<details>
+<summary><strong>The math, on demand</strong></summary>
+
+- **Chain rule (single composition):** $\frac{dz}{dx} = \frac{dz}{dy} \cdot \frac{dy}{dx}$ — the calculus identity that lets backpropagation multiply local sensitivities layer by layer without re-deriving each weight from scratch.
+- **Reverse-mode sweep (Linnainmaa / Werbos lineage):** for a composed function $f = f_n \circ \cdots \circ f_1$, the adjoint (sensitivity) at each intermediate node is $\bar{x}_i = \bar{x}_{i+1} \cdot f'_i(x_i)$ — computed in one backward pass reusing the cached forward values.
+- **Generalized delta rule (output unit):** $\Delta w_{ji} = \varepsilon \, \delta_j \, a_i$ — weight update is learning rate $\varepsilon$ times the error signal $\delta_j$ times the incoming activation $a_i$ from the forward pass.
+- **Hidden-unit error signal:** $\delta_j = a_j (1 - a_j) \sum_k \delta_k w_{kj}$ — the hidden unit's signal is its own activation derivative times the weighted sum of downstream error signals, implementing the backward chain rule recursively.
+- **Logistic activation:** $a_j = \frac{1}{1 + e^{-\text{net}_j}}$ — the nonlinear function the 1986 PDP chapter uses; its derivative is $a_j(1 - a_j)$, which appears directly in the hidden-unit error signal above.
+- **Memory cost of reverse mode:** storing all forward-pass activations to reuse during the backward pass costs $O(n)$ memory in the number of intermediate operations — the checkpointing tradeoff Griewank's history identifies as the signature infrastructure constraint of the method.
+
+</details>
+
 # Chapter 24: The Math That Waited for the Machine
 
 Backpropagation is often told as a sudden rediscovery of neural networks: the
@@ -426,6 +486,10 @@ That is the reason backpropagation became one of the central infrastructures of
 modern AI. It was not a magic spark. It was a disciplined way to make the chain
 rule do industrial work.
 
+:::note[Why this still matters today]
+Every training run in modern deep learning descends from the 1986 infrastructure story: forward computation, loss, backward sensitivities, weight updates, repeat. Autodiff libraries — PyTorch's autograd, JAX's grad transforms — are direct industrializations of reverse-mode automatic differentiation. The hidden-unit credit-assignment solution backpropagation provided is still the default mechanism in transformers, convolutional networks, and diffusion models alike. The compute scale changed by many orders of magnitude; the algorithmic shape did not.
+:::
+
 ## Sources
 
 ### Primary
@@ -461,3 +525,4 @@ rule do industrial work.
 > account separates older reverse-mode derivative work, Werbos's trainable
 > systems thesis, and the 1986 PDP demonstration instead of collapsing them into
 > one origin myth.
+

--- a/src/content/docs/ai-history/ch-24-the-math-that-waited-for-the-machine.md
+++ b/src/content/docs/ai-history/ch-24-the-math-that-waited-for-the-machine.md
@@ -190,6 +190,10 @@ errors it helped produce. The same pattern repeats layer by layer. Each weight
 update is based on two facts: what arrived during the forward pass, and how
 sensitive the final error is to that connection during the backward pass.
 
+:::tip[Plain reading]
+An output unit gets a direct grade: "your contribution changed the final error by this much." A hidden unit has no direct target, so backpropagation builds its signal from the downstream units it fed: add up their error signals weighted by the outgoing connections, then scale that by how responsive the hidden unit was at that moment. That constructed signal is what lets hidden-layer weights be updated from the same forward-pass activity.
+:::
+
 Rumelhart, Hinton, and Williams were not simply saying "use calculus." They
 described a procedure: a forward pass through the network, a backward pass
 computing error signals, and a generalized delta rule that could adjust


### PR DESCRIPTION
## Summary

- Tier 1 reader-aids: TL;DR + Cast + Timeline + Glossary + Why-this-still-matters
- Tier 2: "The math, on demand" sidebar
- Tier 3: 1 plain-reading aside (Element 3, REVISED by Codex — hidden-unit error signal)

## Tier 3 verdict

`tier3-review.md` produced via direct `codex exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.5` adversarial review. **Pull-quote rejected** on adjacent-repetition + non-Green-source grounds (the proposal cited chapter prose, not a Green primary source — codex correctly refused). Plain-reading aside verdict applied per review.

## Bit-identity

`git diff main -- src/content/docs/ai-history/ch-24-*.md | grep '^-[^-]'` returns empty — 0 prose lines modified.

## Test plan

- [ ] CI build passes (npm run build)
- [ ] TL;DR `:::tip` aside visible by default at top of chapter
- [ ] Cast / Timeline / Glossary `<details>` collapsed by default
- [ ] Mermaid timeline renders
- [ ] [if Tier 2] Math equations render via KaTeX ($inline$ form)
- [ ] No layout regression on chapter index page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
