### PR TITLE
docs(ch25): Tier 1 + Tier 2 + 1 Tier 3 aside — universal approximation theorem (#562, #394)

### DIFF
--- a/docs/research/ai-history/chapters/ch-25-the-universal-approximation-theorem-1989/tier3-proposal.md
+++ b/docs/research/ai-history/chapters/ch-25-the-universal-approximation-theorem-1989/tier3-proposal.md
@@ -1,0 +1,80 @@
+# Tier 3 Proposal — Chapter 25: The Universal Approximation Theorem
+
+Author: Claude (Sonnet 4.6). Awaiting adversarial review by Codex before any element lands in prose.
+
+---
+
+## Element 1 — Pull-quote
+
+**Status: PROPOSED**
+
+**Candidate sentence:**
+
+> "That was narrower than the myth and more important than the myth. The theorem did not make neural networks practical. It made them worth continuing to make practical."
+
+**Verbatim source attribution:** Ch25 prose, "Existence, Not Recipe" section, paragraph 4 (lines immediately following the four-sentence "The cluster of results around 1989..." paragraph).
+
+**Insertion anchor:** Immediately after the paragraph ending "…multilayer networks were not merely heuristic gadgets. Under real assumptions, they had representational power." — i.e., after the 1989-cluster summary paragraph and before the explicit "That was narrower than the myth" sentence.
+
+**Rationale:** This two-sentence passage does the intellectual work of the entire chapter in the most compressed form available in the prose. It names the actual historical claim (legitimacy, not practicality), names the historiographical correction (the myth), and draws the correct causal arrow. It is also structurally self-contained: a reader who read only this block would understand the chapter's thesis. The sentence is not currently displayed as a blockquote in the prose — it appears as ordinary running text — so a pull-quote would not create adjacent repetition.
+
+**Risk:** The prose immediately precedes "That was narrower than the myth and more important than the myth." If the pull-quote is placed after the paragraph that introduces it, the reader sees the sentence twice in close proximity (once as ordinary prose, once as the callout). Reviewer should evaluate whether the repetition is adjacent enough to violate the "refuse if prose paragraph already quotes the sentence verbatim" rule. The sentence is not quoted in the paragraph above; it is the paragraph's closing line. Proposer assessment: acceptable because the callout is pedagogically distinct (it frames the thesis, not just restates it), but this is the strongest objection and should be weighed carefully.
+
+---
+
+## Element 2 — Selective dense-paragraph aside (Plain reading)
+
+**Status: PROPOSED**
+
+**Target paragraph:** The paragraph in "Existence, Not Recipe" that begins "The words around that claim carry much of the discipline. Continuous functions are not arbitrary functions. Compact domains are not the whole uncontrolled world. Sigmoidal units are not every possible activation. 'There exists' is not 'we know how to find.' 'Finite' is not 'small.' Approximation is not exact symbolic reasoning. Uniform approximation is a particular mathematical demand, not a general certificate of intelligence."
+
+**Proposed aside text:**
+
+:::tip[Plain reading]
+This paragraph strips five assumptions from the theorem's headline. Each sentence is a one-line check: the result covers *continuous* functions (not arbitrary ones), on *compact* domains (not the whole real world), using *sigmoidal* units (one specific activation family), and says only that some suitable network *exists* — not that anyone can find it, or that it will be small enough to build.
+:::
+
+**Insertion anchor:** Immediately after the paragraph ending "…not a general certificate of intelligence." in the "Existence, Not Recipe" section.
+
+**Rationale:** This paragraph is symbolically dense in the relevant sense: it stacks five paired distinctions (continuous/arbitrary, compact/whole world, sigmoidal/every activation, exists/find, finite/small, approximation/symbolic, uniform/general) in rapid succession. A reader who is not already fluent in approximation theory needs to slow down and reprocess each pair independently. The aside does new work by numbering and summarising the five qualifications as a checklist, which the prose does not do explicitly.
+
+**Risk:** The paragraph is clear in natural-language terms — it uses no mathematical notation and no jargon that the Tier 1 glossary does not cover. A reviewer may judge it narratively dense rather than symbolically dense, in which case the aside should be refused. Proposer assessment: borderline. The density is conceptual (stacked logical negations, paired distinctions) rather than notational. Worth review.
+
+---
+
+## Element 3 — Selective dense-paragraph aside (Plain reading)
+
+**Status: PROPOSED**
+
+**Target paragraph:** The paragraph beginning "Barron's work helps sharpen the issue. Once one asks how approximation error falls as units are added, the slogan becomes a cost question..." through "...how efficiently, under what assumptions, and with what training procedure?"
+
+**Proposed aside text:**
+
+:::tip[Plain reading]
+Barron's result reframes the theorem as an engineering question: not just "can a network approximate this?" but "how many units does it take, and how fast does error fall as you add more?" A family can be universal and still be impractical if error falls only slowly — you need too many units to get close enough.
+:::
+
+**Insertion anchor:** Immediately after the paragraph ending "…'how efficiently, under what assumptions, and with what training procedure?'" in "The Cost of Being Universal."
+
+**Rationale:** This passage introduces Barron's rate-of-convergence framing, which is the move from an existence claim to an efficiency claim. The conceptual step (existence → rate → cost) requires readers to hold two distinct mathematical ideas in parallel. The aside makes that logical step explicit by naming the reframe.
+
+**Risk:** Similar to Element 2 — the paragraph is not mathematically notated, so reviewers may judge it narratively rather than symbolically dense. Proposer leans toward keeping it because the cost-vs-existence distinction is the chapter's most practically important point and the prose moves through it quickly.
+
+---
+
+## Element 4 — Inline parenthetical definition (Starlight tooltip)
+
+**Status: SKIPPED**
+
+**Reason:** Skipped on every chapter per READER_AIDS.md §Tier 3 item 8. No non-destructive tooltip component exists in the Starlight build; using `<abbr>` modifies the prose line and violates the bit-identity rule.
+
+---
+
+## Summary table
+
+| Element | Type | Status | Key risk for reviewer |
+|---|---|---|---|
+| "That was narrower than the myth..." | Pull-quote | PROPOSED | Potential adjacent repetition — sentence appears as prose immediately after the callout insertion point |
+| "The words around that claim carry much of the discipline..." | Plain reading aside | PROPOSED | May be conceptually dense rather than symbolically dense; reviewer call |
+| "Barron's work helps sharpen the issue..." | Plain reading aside | PROPOSED | Same density-type question; reviewer call |
+| Inline tooltip | Tooltip | SKIPPED | Component does not exist; destructive to prose |

--- a/docs/research/ai-history/chapters/ch-25-the-universal-approximation-theorem-1989/tier3-review.md
+++ b/docs/research/ai-history/chapters/ch-25-the-universal-approximation-theorem-1989/tier3-review.md
@@ -1,0 +1,16 @@
+## Element 1 — Pull-quote
+Verdict: REJECT
+Reason: I checked the proposed attribution and the chapter prose around the insertion point. The candidate is not attributed to a Green primary source; it is attributed to Ch25 prose. The sentence is verbatim in the chapter immediately after the proposed anchor: "That was narrower than the myth and more important than the myth. The theorem did not make neural networks practical. It made them worth continuing to make practical." Because the pull-quote would be inserted immediately before the same running-prose sentence, it creates adjacent repetition. READER_AIDS.md §Tier 3 requires refusing pull-quotes when the prose paragraph already quotes the sentence verbatim, so this should not land.
+
+## Element 2 — Plain-reading aside
+Verdict: REVISE
+Reason: I checked the target paragraph against the Tier 3 density rule. It is eligible: the paragraph stacks abstract mathematical constraints and distinctions in quick succession, including continuous versus arbitrary functions, compact domains, sigmoidal units, existence versus construction, finite versus small, approximation versus symbolic reasoning, and uniform approximation versus a general intelligence certificate. The proposed aside is directionally useful, but it says "five assumptions" while the paragraph names more than five constraints, and it mostly repeats the local sentences instead of compressing the governing idea. A tighter version can do new work by naming the whole paragraph as the theorem's guardrail list.
+Corrected verbatim or text (only if REVISE): :::tip[Plain reading]
+Read this as the theorem's guardrail list. "Universal" here means: for continuous targets on bounded domains, with sigmoidal units, some finite network can get uniformly close. It does not mean arbitrary tasks, exact symbolic reasoning, easy training, or a small network.
+:::
+
+## Element 3 — Plain-reading aside
+Verdict: REJECT
+Reason: I checked the target paragraph in "The Cost of Being Universal." It is conceptually important, but it is not symbolically dense in the Tier 3 sense: there are no formulas, derivations, or stacked abstract definitions. The paragraph is already plain explanatory prose about cost, approximation error, size, assumptions, and training procedure. The proposed aside repeats that same cost-versus-existence framing, including the "how many units" and "how fast does error fall" questions, rather than adding a new plain-language decoding layer. Tier 3 should refuse this.
+
+VERDICT: ch25 0 approved / 1 revised / 2 rejected

--- a/src/content/docs/ai-history/ch-25-the-universal-approximation-theorem-1989.md
+++ b/src/content/docs/ai-history/ch-25-the-universal-approximation-theorem-1989.md
@@ -189,6 +189,10 @@ world. Sigmoidal units are not every possible activation. "There exists" is not
 symbolic reasoning. Uniform approximation is a particular mathematical demand,
 not a general certificate of intelligence.
 
+:::tip[Plain reading]
+Read this as the theorem's guardrail list. "Universal" here means: for continuous targets on bounded domains, with sigmoidal units, some finite network can get uniformly close. It does not mean arbitrary tasks, exact symbolic reasoning, easy training, or a small network.
+:::
+
 These conditions are why the theorem is powerful without being magic. It tells
 us that a certain kind of network can, in principle, build complicated
 input-output relationships by combining many simple nonlinear responses. Each

--- a/src/content/docs/ai-history/ch-25-the-universal-approximation-theorem-1989.md
+++ b/src/content/docs/ai-history/ch-25-the-universal-approximation-theorem-1989.md
@@ -6,6 +6,68 @@ sidebar:
   order: 25
 ---
 
+:::tip[In one paragraph]
+In 1989, George Cybenko proved that finite sums of sigmoidal units can uniformly approximate any continuous function on the unit hypercube. The same year, Hornik, Stinchcombe, and White showed multilayer feedforward networks are universal approximators, and Funahashi gave a parallel continuous-mapping result. The 1989 cluster did not make neural networks easy to train; it ended a representational doubt left by the perceptron backlash, giving researchers mathematical permission to keep building hidden-layer systems.
+:::
+
+<details>
+<summary><strong>Cast of characters</strong></summary>
+
+| Name | Lifespan | Role |
+|---|---|---|
+| George Cybenko | — | Author of the 1989 sigmoidal-superposition theorem; proved finite sums of sigmoidal units are dense in continuous functions on compact domains. |
+| Kurt Hornik | — | Co-author of the 1989 "Multilayer feedforward networks are universal approximators" paper in *Neural Networks*. |
+| Maxwell Stinchcombe | — | Co-author of Hornik/Stinchcombe/White 1989; contributed the multi-author framing of universal approximation for feedforward networks. |
+| Halbert White | — | Co-author of Hornik/Stinchcombe/White 1989; brought econometric and statistical-learning context to the universal-approximation result. |
+| Ken-ichi Funahashi | — | Author of the 1989 continuous-mapping approximation result; showed three-layer networks can approximate continuous mappings. |
+| A. N. Kolmogorov | 1903–1987 | Soviet mathematician whose 1957 theorem on superpositions of one-variable functions forms the mathematical prehistory of 1989 neural-network approximation results. |
+
+</details>
+
+<details>
+<summary><strong>Timeline (1957–1989)</strong></summary>
+
+```mermaid
+timeline
+    title The Road to Universal Approximation, 1957–1989
+    1957 : Kolmogorov publishes a theorem showing continuous multivariable functions can be represented by superpositions of one-variable functions
+    1969 : Minsky and Papert's Perceptrons sharpens attention on representational limits of single-layer perceptrons
+    1986 : Backpropagation revival shows multilayer networks can be trained — creating a practical reason to care about approximation capacity
+    1988 : Cybenko submits and revises work on sigmoidal superpositions
+    1989 : Funahashi publishes a continuous-mapping approximation result in Neural Networks
+    1989 : Hornik, Stinchcombe, and White publish "Multilayer feedforward networks are universal approximators" in Neural Networks
+    December 1989 : Cybenko's "Approximation by superpositions of a sigmoidal function" appears in Mathematics of Control, Signals, and Systems
+```
+
+</details>
+
+<details>
+<summary><strong>Plain-words glossary</strong></summary>
+
+- **Feedforward network** — A neural network in which information flows in one direction only: from inputs, through one or more hidden layers, to the output. No cycles, no feedback loops.
+- **Universal approximator** — A model family is a universal approximator if, for any continuous target function on a compact domain and any desired error tolerance, some member of the family can come within that tolerance. The phrase describes representational richness, not training ease.
+- **Uniform approximation** — A guarantee that a network can get close to a target function everywhere on the domain simultaneously, not just on average or at scattered points. Cybenko's theorem is phrased in terms of uniform approximation.
+- **Sigmoidal function** — A smooth, bounded, S-shaped activation function that is nondecreasing and approaches distinct limits as its input goes to positive and negative infinity. The logistic function is the canonical example.
+- **Compact domain** — A closed and bounded region, such as the unit hypercube $[0,1]^n$. Compactness is a key assumption in classical universal-approximation theorems; it rules out unbounded or open domains.
+- **Density** — In approximation theory, a family of functions is dense in a larger class if every function in that class can be approximated arbitrarily closely by some member of the family. Density is what the theorem proves; it is not the same as saying a specific network exists that is ready to use.
+- **Existence result** — A mathematical statement that guarantees some object with a desired property exists, without providing a method to find or construct it. Universal approximation is an existence result: it promises a suitable network is in the family, not that training will locate it.
+
+</details>
+
+<details>
+<summary><strong>The math, on demand</strong></summary>
+
+The 1989 results established that multilayer networks with nonlinear activations could approximate continuous functions arbitrarily well. Here are the key mathematical claims.
+
+- **Cybenko 1989 — core theorem (Theorem 1):** Let $\sigma$ be a continuous sigmoidal function. Then finite sums of the form $\sum_{j=1}^{N} \alpha_j \sigma(\mathbf{w}_j^\top \mathbf{x} + \theta_j)$ are dense in $C(I_n)$, the space of continuous functions on the unit hypercube $I_n = [0,1]^n$. In words: for any continuous target $f$ and any $\varepsilon > 0$, there exists a one-hidden-layer sigmoidal network that approximates $f$ to within $\varepsilon$ uniformly on $I_n$.
+- **Cybenko 1989 — discriminatory functions (Theorem 2):** A sigmoidal function $\sigma$ is discriminatory: if $\int \sigma(\mathbf{w}^\top \mathbf{x} + \theta) \, d\mu(\mathbf{x}) = 0$ for all $\mathbf{w}, \theta$ implies $\mu = 0$, then finite sums of $\sigma$-units are dense in $C(I_n)$. This is the technical engine that makes Theorem 1 possible.
+- **Hornik, Stinchcombe, and White 1989:** Any nonconstant, bounded, and continuous activation function makes a standard multilayer feedforward network a universal approximator of measurable functions (in a suitable $L^p$ sense). The result generalises beyond the sigmoidal special case.
+- **Funahashi 1989 — Theorem 1:** For any continuous mapping $f : K \to \mathbb{R}^m$ on a compact set $K \subset \mathbb{R}^n$ and any $\varepsilon > 0$, there exists a three-layer neural network (input, one hidden layer, output) that approximates $f$ to within $\varepsilon$ uniformly on $K$.
+- **Barron 1993 — approximation rate:** For functions whose Fourier transform satisfies a first-moment bound $C_f = \int |\omega| |\hat{f}(\omega)| \, d\omega < \infty$, a one-hidden-layer sigmoidal network with $n$ units achieves integrated squared error bounded by $O(C_f^2 / n)$. This is an efficiency result: it says how fast approximation error can fall as units are added, and shows that some well-behaved functions are approximated efficiently — but it does not remove the computational cost of training.
+- **Key separations the math enforces:** (1) $\exists$ a network that approximates $\not\Rightarrow$ gradient descent finds it; (2) approximation on compact domain $\not\Rightarrow$ generalisation from finite samples; (3) "finite" network $\not\Rightarrow$ computationally affordable network.
+
+</details>
+
 # Chapter 25: The Universal Approximation Theorem
 
 The Universal Approximation Theorem is one of the most useful ways to say
@@ -445,6 +507,10 @@ was narrowed into an architecture built for images and characters.
 The Universal Approximation Theorem did not solve AI. It changed what kind of
 unsolved problem AI had.
 
+:::note[Why this still matters today]
+Every modern deep-learning framework rests, at some level, on the assurance the 1989 cluster provided: nonlinear multilayer networks are not representationally impoverished. Transformers, diffusion models, and large language models inherit that assurance. But they also confirm the theorem's honest limits — none of them work because of the existence proof alone. They work because architecture encodes inductive bias, because optimisation has improved, because data is abundant, and because compute has scaled. Universal approximation is still the floor; the building above it is everything the theorem declined to specify.
+:::
+
 ## Sources
 
 ### Primary
@@ -484,3 +550,4 @@ unsolved problem AI had.
 > as proof that neural networks can learn any task. The sources support a
 > careful capacity claim under assumptions; they do not support a blanket story
 > about training, generalization, or practical deployment.
+


### PR DESCRIPTION
## Summary

- Tier 1 reader-aids: TL;DR + Cast + Timeline + Glossary + Why-this-still-matters
- Tier 2: "The math, on demand" sidebar
- Tier 3: 1 plain-reading aside (Element 2, REVISED by Codex — universal approximation guardrails)

## Tier 3 verdict

`tier3-review.md` produced via direct `codex exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.5` adversarial review. **Pull-quote rejected** on adjacent-repetition + non-Green-source grounds (the proposal cited chapter prose, not a Green primary source — codex correctly refused). Plain-reading aside verdict applied per review.

## Bit-identity

`git diff main -- src/content/docs/ai-history/ch-25-*.md | grep '^-[^-]'` returns empty — 0 prose lines modified.

## Test plan

- [ ] CI build passes (npm run build)
- [ ] TL;DR `:::tip` aside visible by default at top of chapter
- [ ] Cast / Timeline / Glossary `<details>` collapsed by default
- [ ] Mermaid timeline renders
- [ ] [if Tier 2] Math equations render via KaTeX ($inline$ form)
- [ ] No layout regression on chapter index page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
