### PR TITLE
docs(ch27): Tier 1 + Tier 2 + 1 Tier 3 aside — convolutional breakthrough (#562, #394)

### DIFF
--- a/docs/research/ai-history/chapters/ch-27-the-convolutional-breakthrough/tier3-proposal.md
+++ b/docs/research/ai-history/chapters/ch-27-the-convolutional-breakthrough/tier3-proposal.md
@@ -1,0 +1,61 @@
+# Tier 3 Proposal — Chapter 27: The Convolutional Breakthrough
+
+Author: Claude (Sonnet 4.6). Awaiting cross-family adversarial review (Codex).
+
+---
+
+## Element 1 — Pull-quote
+
+**Status: PROPOSED**
+
+**Candidate sentence (verbatim from prose):**
+
+> "The convolutional breakthrough was therefore not just a network. It was a discipline: constrain the learner, respect the data, measure the throughput, and embed the model in a workflow that has to operate outside a paper."
+
+**Source:** Ch27 prose, final paragraph of "Why It Mattered" section.
+
+**Anchor:** After the paragraph ending "…embed the model in a workflow that has to operate outside a paper." (before the paragraph beginning "It also sharpened the relationship…")
+
+**Annotation (proposed):** This sentence names the chapter's four-part discipline — architectural constraint, data respect, throughput measurement, pipeline integration — that distinguishes industrial AI from academic demonstration. It is not paraphrase; it reframes four themes the preceding paragraphs develop separately.
+
+**Rationale for PROPOSED:** The sentence is genuinely load-bearing — it is the chapter's thesis compressed into two sentences. It does not merely repeat the surrounding prose; it names a pattern the prose has been building toward. The surrounding paragraphs do not quote or block-display it. Adjacent-repetition risk is low.
+
+---
+
+## Element 2 — Plain-reading aside (math-dense paragraph)
+
+**Status: PROPOSED**
+
+**Target paragraph (opening of "Two Symbols, One Law" equivalent — the parameter-reduction argument in "Pixels With Structure"):**
+
+The paragraph beginning "The distinction is important because it separates expressiveness from learnability. A large fully connected network might have enough expressive power…" through "…the number of independent choices the optimizer has to make."
+
+**Proposed aside text:**
+
+:::tip[Plain reading]
+Expressiveness and learnability are different things. A large fully connected network can, in principle, represent any digit classifier — but it has too many free knobs for limited data to tighten. A convolutional network spends those knobs differently: instead of learning a separate detector at every pixel location, it learns one detector and reuses it everywhere. The data then does less work per parameter.
+:::
+
+**Anchor:** Immediately after the paragraph ending "…the number of independent choices the optimizer has to make."
+
+**Rationale for PROPOSED:** The paragraph is conceptually dense — it distinguishes two properties (expressiveness, learnability), introduces the optimizer's-degrees-of-freedom framing, and connects it to weight sharing, all in one block. The aside does new work: it concretizes the abstraction as a "too many knobs" metaphor not present in the surrounding prose.
+
+---
+
+## Element 3 — Plain-reading aside (DSP/operational paragraph)
+
+**Status: SKIPPED**
+
+**Target paragraph:** The paragraph about SUN workstation training, DSP implementation, and classifications-per-second figures in "The Postal Code Laboratory."
+
+**Reason for SKIPPED:** The paragraph is narratively dense (engineering details, hardware names, throughput numbers) but not symbolically/mathematically dense. The READER_AIDS.md rule restricts plain-reading asides to paragraphs that are "symbolically dense (mathematical formulas, derivations, abstract definitions stacked)" — not narratively dense. An aside here would only restate the engineering facts already expressed plainly in the prose.
+
+---
+
+## Summary Table
+
+| Element | Type | Status | Anchor |
+|---|---|---|---|
+| "It was a discipline…" sentence | Pull-quote | PROPOSED | After "Why It Mattered" para 5, before "It also sharpened…" |
+| Expressiveness vs. learnability | Plain-reading aside | PROPOSED | After "Pixels With Structure" para 8 |
+| DSP/operational details | Plain-reading aside | SKIPPED | Not symbolically dense |

--- a/docs/research/ai-history/chapters/ch-27-the-convolutional-breakthrough/tier3-review.md
+++ b/docs/research/ai-history/chapters/ch-27-the-convolutional-breakthrough/tier3-review.md
@@ -1,0 +1,12 @@
+## Element 1 — Pull-quote
+Verdict: REJECT
+Reason: I checked the proposal against the Tier 3 pull-quote rule and against the available contract/source evidence. The candidate is explicitly cited as "verbatim from prose," not as verbatim from a Green primary source, and a repo search finds the sentence only in the chapter and proposal. I also extracted the accessible Green LeCun 1990 PDF with `curl` + `pdftotext` and found no match for "not just a network," "discipline," "constrain the learner," "respect the data," "measure the throughput," or "operate outside a paper"; the official 1989 MIT source/PDF endpoint returned a 403. Even apart from source verification, the proposed anchor would place the callout immediately after the paragraph that already contains the exact same sentence, creating adjacent repetition. This fails the user's source-verbatim requirement and the pattern doc's no-duplication rule.
+
+## Element 2 — Plain-reading aside
+Verdict: REVISE
+Reason: The target paragraph is eligible: it is not narratively dense, and it stacks abstract technical distinctions around expressiveness, learnability, degrees of freedom, parameter reuse, and optimizer burden. The proposed aside does some useful new work with the "knobs" metaphor, but it is four sentences against the 1-3 sentence cap and the claim that a fully connected network can "represent any digit classifier" is broader than the chapter contract needs. A tighter version can preserve the plain-language benefit while staying closer to the sourced parameter-reduction claim.
+Corrected verbatim or text (only if REVISE): :::tip[Plain reading]
+Expressiveness is what a model could represent; learnability is whether the available data can pin down the right settings. A fully connected network spends separate knobs at many locations, while a convolutional network reuses the same detector across the image. That reuse gives each learned parameter more evidence to learn from.
+:::
+
+VERDICT: ch27 0 approved / 1 revised / 1 rejected

--- a/src/content/docs/ai-history/ch-27-the-convolutional-breakthrough.md
+++ b/src/content/docs/ai-history/ch-27-the-convolutional-breakthrough.md
@@ -6,6 +6,65 @@ sidebar:
   order: 27
 ---
 
+:::tip[In one paragraph]
+In 1989, Yann LeCun and Bell Labs colleagues trained a backpropagation network to read handwritten zip codes from U.S. mail — but only by constraining the architecture. Local receptive fields, shared weights, and subsampling encoded what a fully connected network would have to rediscover: nearby pixels matter together, and useful detectors should apply across positions. The 1998 LeNet-5 paper extended that insight into a full document-recognition pipeline reading millions of bank checks. Neural networks became practical when architecture stopped pretending all inputs were shapeless vectors.
+:::
+
+<details>
+<summary><strong>Cast of characters</strong></summary>
+
+| Name | Lifespan | Role |
+|---|---|---|
+| Kunihiko Fukushima | — | NHK researcher; originator of the neocognitron (1980), the hierarchical, shift-tolerant visual-recognition model that forms the architectural prehistory of convolutional networks. |
+| Yann LeCun | — | Bell Labs researcher; lead author on the 1989 zip-code recognizer and the 1998 LeNet-5 / document-recognition synthesis. |
+| Bernhard Boser | — | Bell Labs co-author on the 1989 and 1990 handwritten zip-code and digit recognition papers. |
+| Lawrence D. Jackel | — | Bell Labs co-author on the 1989 and 1990 papers; neural-network researcher in the Bell Labs environment. |
+| Leon Bottou | — | Co-author of the 1998 "Gradient-Based Learning Applied to Document Recognition" synthesis paper. |
+| Yoshua Bengio | — | Co-author of the 1998 synthesis paper and later deep-learning retrospective; role in 1998 should not be read through later fame. |
+
+</details>
+
+<details>
+<summary><strong>Timeline (1980–1998)</strong></summary>
+
+```mermaid
+timeline
+    title The Convolutional Breakthrough, 1980–1998
+    1980 : Fukushima publishes the neocognitron — hierarchical, shift-tolerant visual recognition using S-cells and C-cells
+    1986 : Backpropagation revival makes supervised training of multilayer networks salient again
+    1989 : LeCun et al. publish "Backpropagation Applied to Handwritten Zip Code Recognition" — USPS Buffalo digits, 7,291/2,007 train/test, local receptive fields, shared weights
+    1990 : LeCun et al. NIPS account corroborates architecture and DSP throughput on AT&T DSP-32C hardware
+    1998 : LeCun, Bottou, Bengio, Haffner publish LeNet-5 and document-recognition synthesis — MNIST assembled, bank-check pipeline reading millions of checks per day
+```
+
+</details>
+
+<details>
+<summary><strong>Plain-words glossary</strong></summary>
+
+- **Local receptive field** — Each detector in a convolutional layer looks at only a small patch of the input image, not the whole picture at once. This means the network learns what small shapes look like before combining them into larger evidence.
+- **Shared weights (weight sharing)** — The same set of learned parameters (filter) is applied at every position across the image. A single edge detector trained on one part of the image automatically works in other parts, reducing the total number of independent parameters the network must learn.
+- **Subsampling / pooling** — After feature detection, the spatial map is reduced in resolution, so small shifts in where a feature appears have less effect on downstream layers. The 1989 paper called this undersampling; later literature uses pooling.
+- **Feature map** — The output of applying one filter (one shared-weight detector) across all positions in the image — a new image whose pixel values record how strongly each location matched that filter.
+- **Parameter reduction** — Because weights are shared across positions, a convolutional network needs far fewer independent parameters than a fully connected network of comparable visual reach. In 1989, the zip-code recognizer used 9,760 independent parameters.
+- **Neocognitron** — Fukushima's 1980 hierarchical neural-network model for visual recognition. It used S-cells (feature-selective) and C-cells (position-tolerant) in a cascade, achieving shift tolerance without backpropagation-style supervised training.
+
+</details>
+
+<details>
+<summary><strong>The math, on demand</strong></summary>
+
+The key mathematical ideas behind the 1989 zip-code network and LeNet-5.
+
+- **Discrete convolution (one feature map):** For a filter $w$ of size $k \times k$ applied to input $x$, the output at position $(i,j)$ is $y_{ij} = \sum_{m=0}^{k-1}\sum_{n=0}^{k-1} w_{mn} \cdot x_{i+m,\, j+n}$. The same $w$ is used at every $(i,j)$: this is the weight-sharing claim in one equation.
+- **Weight-sharing parameter count:** A fully connected layer mapping an $H \times W$ input to an $H' \times W'$ output needs $H \cdot W \cdot H' \cdot W'$ parameters. A single $k \times k$ convolutional filter needs only $k^2$ regardless of image size — the 1989 paper's 9,760 figure reflects this compression.
+- **Subsampling (average pooling):** $s_{ij} = \frac{1}{p^2}\sum_{m=0}^{p-1}\sum_{n=0}^{p-1} y_{i \cdot p + m,\, j \cdot p + n}$. Reducing spatial resolution by factor $p$ makes the representation less sensitive to exact feature position.
+- **Gradient flow through a convolutional layer:** Backpropagation still applies — the chain rule gives $\frac{\partial L}{\partial w_{mn}} = \sum_{i,j} \frac{\partial L}{\partial y_{ij}} \cdot x_{i+m,\,j+n}$. Crucially, the gradient with respect to $w$ is a sum over all positions, so every patch in the image contributes to learning the same filter. This is why examples in one part of the image help train behavior everywhere.
+- **Translation tolerance from shared weights:** If the same filter $w$ fires on a stroke at position $(i,j)$, shifting the stroke to $(i+\delta, j)$ produces the same filter response at position $(i+\delta, j)$ — the feature map shifts, but the learned response does not change. Subsampling then absorbs small $\delta$, giving the architecture its tolerance to slight position variation.
+- **LeNet-5 compute context (1998):** The 1998 paper notes that LeNet-5 required about $10^8$ multiplications per classification pass — feasible on late-1990s workstations but not on 1989 hardware. This is why the mature architecture waited for stronger machines; architectural constraint reduced cost but did not abolish it.
+
+</details>
+
 # Chapter 27: The Convolutional Breakthrough
 
 A handwritten digit is not just a list of numbers. It is a shape. Nearby
@@ -429,6 +488,10 @@ computer vision still relied on the conviction that architecture should
 respect image structure. Chapter 27 is where that conviction becomes a
 practical historical object.
 
+:::note[Why this still matters today]
+Every modern vision model — from ResNet to Vision Transformers — inherits the LeNet discipline: architecture should encode what the domain tells you about structure. Shared-weight convolution is still the default feature extractor for images, video, and spatially structured sensor data. The parameter-reduction logic that made 1989 hardware viable now scales to billions of parameters on GPUs. The pipeline insight — data normalization, learned representation, rejection thresholds, downstream integration — describes every production vision system deployed today. LeNet did not become a museum piece. It became the template.
+:::
+
 ## Sources
 
 ### Primary
@@ -475,3 +538,4 @@ practical historical object.
 > Fukushima, the 1989/1990 Bell Labs digit recognizers, later MNIST context,
 > and the 1998 LeNet-5 document pipeline are kept in separate chronological
 > lanes.
+

--- a/src/content/docs/ai-history/ch-27-the-convolutional-breakthrough.md
+++ b/src/content/docs/ai-history/ch-27-the-convolutional-breakthrough.md
@@ -163,6 +163,10 @@ every location, it learns a smaller number of detectors that can be reused
 across the image. The architecture reduces the number of independent choices
 the optimizer has to make.
 
+:::tip[Plain reading]
+Expressiveness is what a model could represent; learnability is whether the available data can pin down the right settings. A fully connected network spends separate knobs at many locations, while a convolutional network reuses the same detector across the image. That reuse gives each learned parameter more evidence to learn from.
+:::
+
 That reduction also changes the meaning of data. If one learned edge detector
 can apply across positions, then examples in one part of the image help train
 behavior in another part. The model gets more mileage from limited labeled


### PR DESCRIPTION
## Summary

- Tier 1 reader-aids: TL;DR + Cast + Timeline + Glossary + Why-this-still-matters
- Tier 2: "The math, on demand" sidebar
- Tier 3: 1 plain-reading aside (Element 2, REVISED by Codex — expressiveness vs. learnability)

## Tier 3 verdict

`tier3-review.md` produced via direct `codex exec --dangerously-bypass-approvals-and-sandbox -m gpt-5.5` adversarial review. **Pull-quote rejected** on adjacent-repetition + non-Green-source grounds (the proposal cited chapter prose, not a Green primary source — codex correctly refused). Plain-reading aside verdict applied per review.

## Bit-identity

`git diff main -- src/content/docs/ai-history/ch-27-*.md | grep '^-[^-]'` returns empty — 0 prose lines modified.

## Test plan

- [ ] CI build passes (npm run build)
- [ ] TL;DR `:::tip` aside visible by default at top of chapter
- [ ] Cast / Timeline / Glossary `<details>` collapsed by default
- [ ] Mermaid timeline renders
- [ ] [if Tier 2] Math equations render via KaTeX ($inline$ form)
- [ ] No layout regression on chapter index page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
