### PR TITLE
docs(ch44): Tier 1 + Tier 2 math sidebar — Word2Vec / latent space

### DIFF
--- a/docs/research/ai-history/chapters/ch-44-the-latent-space/status.yaml
+++ b/docs/research/ai-history/chapters/ch-44-the-latent-space/status.yaml
@@ -23,5 +23,5 @@ notes:
 # Lifecycle fields (added 2026-04-30 to decouple reader-aid rollout state
 # from research-phase `status` field; see Codex review forwarded by user).
 prose_state: published_on_main            # research_only | published_on_main
-reader_aids: none                      # none | pr_open | landed
+reader_aids: landed                    # none | pr_open | landed
 lifecycle_updated: 2026-04-30

--- a/docs/research/ai-history/chapters/ch-44-the-latent-space/tier3-proposal.md
+++ b/docs/research/ai-history/chapters/ch-44-the-latent-space/tier3-proposal.md
@@ -1,0 +1,59 @@
+# Tier 3 Proposal — Chapter 44: The Latent Space
+
+Per `docs/research/ai-history/READER_AIDS.md` Tier 3 workflow. Author: Claude. Reviewer: Codex (cross-family adversarial).
+
+## Element 8 — Inline parenthetical definition (Starlight tooltip)
+
+**SKIPPED** — universal default per READER_AIDS.md §Tier 3. The Plain-words glossary (Tier 1, item 4) covers all specialist terms non-destructively.
+
+## Element 9 — Pull-quote (at most 1)
+
+Survey of quote-worthy candidates from Green primary sources:
+
+### Candidate A — Harris 1954: distributional definition
+
+Source: S1, p. 146. "The distribution of an element will be understood as the sum of all its environments." This is the chapter's intellectual foundation sentence. **SKIPPED** — the chapter prose paraphrases this directly ("Harris argued that the distribution of a linguistic element should be understood simply as the sum of all its environments—the existing array of its co-occurrents") and the next sentence does the interpretive work. Elevating the verbatim to a callout adjacent to the prose paraphrase creates the repetition READER_AIDS.md §Tier 3, Element 9 explicitly flags as a refusal case.
+
+### Candidate B — Bengio et al. 2003: curse-of-dimensionality illustration
+
+Source: S3, p. 1137. The paper gives the 10^50 illustration. The chapter prose renders this in full narrative: "for a language model predicting sequences of ten consecutive words from a moderate vocabulary of 100,000 words, there are potentially ten to the fiftieth power possible combinations." Same adjacent-repetition problem.
+
+### Candidate C — Mikolov et al. 2013 "Efficient Estimation," p. 1: atomic-index critique
+
+Source: S4, p. 1. The paper states that "most of the current NLP systems and techniques treat words as atomic units — there is no notion of similarity between words." The chapter prose renders this: "the vast majority of systems still treated words as atomic vocabulary indices. In these discrete systems, there was no inherent notion of similarity between words; the discrete index for one concept possessed no geometric relationship to the discrete index for a closely related concept." The paraphrase is faithful and complete; no independent work left for a pull-quote callout.
+
+### Candidate D — Mikolov, Yih, Zweig 2013 "Linguistic Regularities," p. 746: King-Man+Woman analogy
+
+Source: S5, p. 746. This is the most famous sentence in the chapter's primary literature. The chapter prose quotes the result and its evaluation context directly: "The researchers reported that taking the continuous vector representation for the word 'King,' subtracting the vector for 'Man,' and adding the vector for 'Woman' resulted in a point in the high-dimensional space whose nearest neighboring word vector was 'Queen.'" The next two paragraphs do the interpretive work (what the arithmetic means, what "severity" the test carries). A pull-quote would sit adjacent to this already-quoted and interpreted passage.
+
+**Status: SKIPPED.** All four surveyed candidates are either paraphrased-adjacent in the prose (Candidates A, B, C) or already quoted verbatim with full interpretive follow-on (Candidate D). No candidate satisfies the dual condition of being genuinely quote-worthy AND not already represented in the prose with adjacent framing.
+
+## Element 10 — Plain-reading asides (0–3 per chapter)
+
+READER_AIDS.md §Tier 3, Element 10 targets paragraphs that are *symbolically* dense — stacked mathematical formulas, derivations, or abstract definitions requiring multi-step parsing. The chapter is predominantly analytic narrative.
+
+### Candidate E — Curse-of-dimensionality paragraph (Scene 2)
+
+The paragraph beginning "The motivation for introducing learned distributed representations..." includes the $10^{50}$ calculation. However, the very same paragraph supplies its own plain reading: "there are potentially ten to the fiftieth power possible combinations. Because any practical training corpus contains only an infinitesimal fraction of these possible sequences, traditional discrete models fail to generalize..." A callout would restate what the prose already makes explicit.
+
+**Status: SKIPPED.** The paragraph self-decodes its own symbolic moment.
+
+### Candidate F — Vector-offset analogy paragraph (Scene 4)
+
+The paragraph beginning "The arithmetic worked by turning relations into displacement..." unpacks the King-Man+Woman geometry. This paragraph is interpretive prose, not symbolically dense in the LaTeX-stacked sense. It uses no formulas; it is a plain reading of the preceding narrative scene. Adding a `:::tip[Plain reading]` on an already-plain-reading paragraph would be recursive and vacuous.
+
+**Status: SKIPPED.** Paragraph is already a plain reading; not symbolically dense.
+
+### Candidate G — Negative sampling paragraph (Scene 5)
+
+The paragraph beginning "The change was not just an implementation trick..." explains the shift from full softmax to binary discrimination. The math sidebar (Tier 2) supplies the equation; this prose paragraph supplies the motivation without LaTeX. The two aid layers divide the work cleanly. No additional callout needed.
+
+**Status: SKIPPED.** Tier 2 math sidebar handles the symbolic layer; prose paragraph handles the plain-language layer. A `:::tip[Plain reading]` would duplicate the prose paragraph itself.
+
+## Summary verdict
+
+- Element 8: SKIPPED (universal).
+- Element 9: SKIPPED — all four surveyed candidates (A, B, C, D) are either paraphrased-adjacent or already quoted verbatim with interpretive follow-on in the prose.
+- Element 10: SKIPPED — no paragraph is symbolically dense in the stacked-formula sense that READER_AIDS.md targets; all candidate paragraphs already contain their own plain-reading layer.
+
+**Total: 0 PROPOSED, 3 SKIPPED.**

--- a/docs/research/ai-history/chapters/ch-44-the-latent-space/tier3-review.md
+++ b/docs/research/ai-history/chapters/ch-44-the-latent-space/tier3-review.md
@@ -1,0 +1,23 @@
+# Tier 3 Review — Chapter 44: The Latent Space
+
+Reviewer: Codex (gpt-5.5)
+Date: 2026-04-30
+Reviewing: tier3-proposal.md by Claude (sonnet)
+
+## Element 9 — Pull-quote
+Author verdict: SKIPPED
+Reviewer verdict: REJECT
+
+Skip upheld. I verified the strongest candidate sentences against Green primary sources: Harris's distribution definition appears at S1 p.146; Mikolov et al.'s atomic-index critique appears at S4 p.1; and the King - Man + Woman / Queen sentence appears at S5 p.746. Each is already either directly paraphrased or effectively quoted in adjacent prose, so a pull-quote would create the reader-experience repetition Element 9 is meant to prevent; I found no better Green primary sentence in `sources.md` that is both quote-worthy and non-redundant.
+
+## Element 10 — Plain-reading aside
+Author verdict: SKIPPED
+Reviewer verdict: REJECT
+
+Skip upheld. The proposed paragraphs are narratively or interpretively dense rather than symbolically dense: the $10^{50}$ bottleneck paragraph immediately explains the generalization failure, the vector-offset paragraph is already the plain-language interpretation, and the negative-sampling paragraph contains no stacked notation in the prose. The Tier 2 math sidebar carries the symbolic load for this chapter, so adding `:::tip[Plain reading]` callouts would mostly repeat surrounding explanation.
+
+## Summary
+- Approved: none
+- Rejected: Element 9 pull-quote; Element 10 plain-reading aside
+- Revised: none
+- Revived: none

--- a/src/content/docs/ai-history/ch-44-the-latent-space.md
+++ b/src/content/docs/ai-history/ch-44-the-latent-space.md
@@ -5,6 +5,71 @@ sidebar:
   order: 44
 ---
 
+:::tip[In one paragraph]
+In 1954, Zellig Harris argued that a word's meaning could be read from the company it keeps. By 1990 that idea had become a matrix-factorisation algorithm (LSA); by 2003 a neural language model (Bengio et al.) embedded it in learned parameters. In 2013, Mikolov, Chen, Corrado, and Dean stripped away the expensive machinery, leaving two log-linear objectives — CBOW and Skip-gram — that converted co-occurrence signals into dense, reusable vectors fast enough to train on billions of tokens.
+:::
+
+<details>
+<summary><strong>Cast of characters</strong></summary>
+
+| Name | Lifespan | Role |
+|---|---|---|
+| Zellig S. Harris | 1909–1992 | Linguist; 1954 distributional-structure framework |
+| Yoshua Bengio | 1964– | Lead author, 2003 neural probabilistic language model |
+| Tomas Mikolov | 1986– | Lead author, 2013 Word2Vec papers (CBOW, Skip-gram) |
+| Kai Chen / Greg Corrado / Jeffrey Dean | — | Google co-authors on "Efficient Estimation" and NIPS 2013 paper |
+| Wen-tau Yih / Geoffrey Zweig | — | Microsoft Research co-authors, "Linguistic Regularities" analogy paper |
+| Ilya Sutskever | 1986– | Google co-author, NIPS 2013 negative-sampling paper |
+
+</details>
+
+<details>
+<summary><strong>Timeline (1954–2013)</strong></summary>
+
+```mermaid
+timeline
+    title Word2Vec lineage
+    1954 : Harris publishes "Distributional Structure" — language described through occurrence without meaning or history
+    1990 : Deerwester et al. publish LSA — SVD on a term-document matrix produces a latent semantic factor space
+    2003 : Bengio et al. propose learned distributed word feature vectors inside a neural language model
+    2003 : Bengio et al. AP News training — five epochs on 40 CPUs takes approximately three weeks
+    January 2013 : Mikolov, Chen, Corrado, Dean circulate arXiv:1301.3781 — CBOW and Skip-gram architectures
+    June 2013 : Mikolov, Yih, Zweig present "Linguistic Regularities" at NAACL-HLT — vector-offset analogy evaluation
+    2013 : Mikolov, Sutskever et al. publish NIPS paper — negative sampling, subsampling, phrase vectors
+```
+
+</details>
+
+<details>
+<summary><strong>Plain-words glossary</strong></summary>
+
+- **Distributional hypothesis** — the principle that words appearing in similar contexts tend to have similar meanings; the intellectual foundation for co-occurrence-based representations, traced to Harris 1954.
+- **Latent Semantic Analysis (LSA)** — a 1990 technique that applies singular-value decomposition to a term-document matrix to compress it into roughly 100 orthogonal factors, exposing semantic proximity without exact word matching.
+- **Distributed representation** — encoding a concept not as a single symbol but as a pattern across many continuous values; Bengio et al. (2003) placed this inside a language model's learnable parameters.
+- **CBOW / Skip-gram** — the two log-linear architectures in Word2Vec. CBOW predicts a center word from its context; Skip-gram predicts context words from a center word. Both remove the non-linear hidden layer that made earlier models slow.
+- **Negative sampling** — a training shortcut introduced in the 2013 NIPS paper that replaces full-vocabulary softmax with a binary discrimination task: distinguish one true context word from a small set of randomly drawn noise words.
+- **Static embedding** — one fixed vector per vocabulary word, regardless of sentence context; the fundamental architectural constraint of Word2Vec, later superseded by contextual embeddings.
+- **Vector-offset analogy** — the empirical test that word-relation pairs share a roughly constant vector difference, so that King − Man + Woman produces a point near Queen in the trained space.
+
+</details>
+
+<details>
+<summary><strong>The math, on demand</strong></summary>
+
+- **Skip-gram objective (full softmax).** $p(w_O \mid w_I) = \dfrac{\exp(v_{w_O}^{\prime\top} v_{w_I})}{\sum_{w=1}^{W} \exp(v_w^{\prime\top} v_{w_I})}$ — the probability of observing context word $w_O$ given input word $w_I$, normalised over the entire vocabulary $W$; cost is proportional to $W$, which drove the search for cheaper alternatives. Source: S6 (Mikolov et al. NIPS 2013) pp. 2–3.
+
+- **Negative sampling objective.** $\log \sigma(v_{w_O}^{\prime\top} v_{w_I}) + \sum_{i=1}^{k} \mathbb{E}_{w_i \sim P_n(w)}\!\left[\log \sigma(-v_{w_i}^{\prime\top} v_{w_I})\right]$ — replace the vocabulary-wide softmax with a sum over $k$ noise samples drawn from $P_n(w)$; each update checks one positive pair against $k$ negatives rather than all $W$ words. Source: S6 pp. 3–4.
+
+- **Subsampling formula.** $P(\text{discard } w_i) = 1 - \sqrt{\dfrac{t}{f(w_i)}}$ — probability of discarding a training token for word $w_i$ with corpus frequency $f(w_i)$, given threshold $t$; high-frequency words (articles, prepositions) are thinned probabilistically rather than deleted. Source: S6 pp. 4–5.
+
+- **Curse-of-dimensionality bottleneck.** For a language model over sequences of $n$ words from a vocabulary of size $V$, there are up to $V^n$ possible sequences; Bengio et al. illustrate with $V = 100{,}000$, $n = 10$, giving $\approx 10^{50}$ combinations that no training corpus can cover. Distributed vectors share statistical strength across words and reduce the effective dimensionality of the problem. Source: S3 (Bengio et al. 2003) p. 1137.
+
+- **CBOW / Skip-gram training complexity.** Mikolov et al. define model complexity as $O = E \times T \times Q$, where $E$ is epochs, $T$ is training words, and $Q$ is the per-word architecture cost. Removing the non-linear hidden layer collapses $Q$ dramatically; the tradeoff is spent on larger $T$ (more text) rather than a deeper network. Source: S4 (arXiv:1301.3781) pp. 3–4.
+
+- **Vector-offset analogy.** Given word pairs $(a, b)$ and $(c, d)$ sharing a relation, the offset hypothesis predicts $v_b - v_a \approx v_d - v_c$, so $d$ can be found by nearest-neighbour search on $v_b - v_a + v_c$. "Linguistic Regularities" evaluated this on 8,000 syntactic questions and the SemEval-2012 Task 2 semantic battery. Source: S5 (Mikolov, Yih, Zweig 2013) pp. 746–749.
+
+</details>
+
 The understanding that words acquire their operational meaning from the company they keep did not begin with the advent of neural networks. Long before dense vector representations became the default computational substrate for natural language processing, the theoretical foundation for extracting linguistic structure from statistical co-occurrence was laid in structural linguistics. In 1954, Zellig S. Harris published "Distributional Structure" in the journal *WORD*, establishing a formal framework for analyzing language purely through its distributional properties. Harris argued that the description of a language could proceed entirely without any intrusion of other features, explicitly ruling out the necessity of referencing historical etymology or abstract human semantic meaning. Instead, he proposed a strictly empirical definition: the distribution of a linguistic element should be understood simply as the sum of all its environments—the existing array of its co-occurrents within a body of text. In this view, if two words frequently appeared in identical surrounding contexts, they shared a structural relationship that could be formally measured and cataloged. 
 
 That last move was more austere than the later slogan makes it sound. Harris was not offering a psychological theory in which a machine would discover inner meanings; he was describing what could be said from the linguistic record itself. A word's neighbors, substitutions, and recurring positions became evidence. The point was methodological discipline: before importing intention, reference, or etymology, one could first ask what patterns of occurrence were already present in the material. This gave later computational work a narrow but powerful permission. It could treat language as a field of measurable relations without pretending that the measurement exhausted everything speakers know.
@@ -88,3 +153,7 @@ Combined, these engineering optimizations created an extraordinarily efficient p
 Yet, for all its utility, this vector paradigm operated under a fundamental architectural constraint. As subsequent textbook synthesis by Dan Jurafsky and James H. Martin would clarify, these were static embeddings. The system learned exactly one fixed embedding per word in its vocabulary. In the latent space mapped by these 2013 architectures, a single point permanently fused all definitions of a polysemous word into one averaged geometric coordinate. The 2003 neural language model had already recognized the tension created when a word carries multiple senses but receives one point in the representation space. Word2Vec made that point cheaper and more useful; it did not make it context-sensitive.
 
 That boundary is the honest close to the chapter. Word2Vec did not invent distributional meaning, did not make vector arithmetic infallible, and did not give a machine human understanding. Its achievement was narrower, more durable, and more technical. It turned an old idea about co-occurrence, a 1990s matrix factorization tradition, and a 2003 neural language-model insight into fast static embeddings that could be trained on huge corpora, tested by explicit relation benchmarks, and reused as representation infrastructure. Resolving the remaining limitation—allowing a word's vector to shift with the sentence around it—would require abandoning the single-point assumption, marking the boundary where continuous word representations would eventually give way to contextual embeddings.
+
+:::note[Why this still matters today]
+Word2Vec's skip-gram objective and negative sampling remain the reference design for token-level representation learning. The distributional hypothesis it operationalised underlies every embedding layer in modern large language models. The analogy benchmark it popularised still anchors evaluation of semantic geometry in sentence encoders and multilingual models. And the static-versus-contextual boundary it exposed — one fixed point per word, regardless of sentence — defined the next problem that transformer-based architectures were built to solve. Understanding Word2Vec is understanding the floor that every subsequent contextual model stands on.
+:::


### PR DESCRIPTION
## Summary

- **Tier 1** reader aids added to Chapter 44: The Latent Space (Word2Vec / distributional semantics)
- **Tier 2** math sidebar with 6 equations tracing to Green primary sources
- **Tier 3** proposal written; all three elements SKIPPED (documented rationale)
- `status.yaml`: `reader_aids: none` → `reader_aids: landed`

## What landed

### Tier 1

| Aid | Detail |
|---|---|
| TL;DR | 73 words — Harris 1954 → LSA 1990 → Bengio 2003 → Mikolov 2013 lineage |
| Cast of characters | 6 rows: Harris, Bengio, Mikolov, Chen/Corrado/Dean, Yih/Zweig, Sutskever |
| Timeline | 7 in-scope events (1954–2013), sourced from timeline.md |
| Plain-words glossary | 7 terms: distributional hypothesis, LSA, distributed representation, CBOW/Skip-gram, negative sampling, static embedding, vector-offset analogy |

### Tier 2 — The math, on demand

6 equations, all traced to Green primary sources:

1. Skip-gram full-softmax objective — S6 (NIPS 2013) pp. 2–3
2. Negative sampling objective — S6 pp. 3–4
3. Subsampling discard-probability formula — S6 pp. 4–5
4. Curse-of-dimensionality bottleneck (V^n illustration) — S3 (Bengio 2003) p. 1137
5. CBOW/Skip-gram training complexity O = E × T × Q — S4 (arXiv:1301.3781) pp. 3–4
6. Vector-offset analogy evaluation — S5 (NAACL 2013) pp. 746–749

### Tier 3 — tier3-proposal.md

- Element 8 (tooltip): SKIPPED — universal per READER_AIDS.md
- Element 9 (pull-quote): SKIPPED — all four candidates (Harris definition, Bengio 10^50, Mikolov atomic-index, King-Man+Woman) are either paraphrased-adjacent or already quoted verbatim with interpretive follow-on in the prose
- Element 10 (plain-reading aside): SKIPPED — no paragraph is symbolically dense in the stacked-formula sense; all candidate paragraphs self-decode

## Bit-identity

`git diff origin/main -- src/content/docs/ai-history/ch-44-the-latent-space.md | grep '^-[^-]'` returns empty — zero prose lines deleted or modified.

Closes part of #562, #394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)