### PR TITLE
docs(ch47): Tier 1 reader-aids — the depths of vision (#562, #394)

### DIFF
--- a/docs/research/ai-history/chapters/ch-47-the-depths-of-vision/status.yaml
+++ b/docs/research/ai-history/chapters/ch-47-the-depths-of-vision/status.yaml
@@ -24,5 +24,5 @@ notes:
 # Lifecycle fields (added 2026-04-30 to decouple reader-aid rollout state
 # from research-phase `status` field; see Codex review forwarded by user).
 prose_state: published_on_main            # research_only | published_on_main
-reader_aids: none                      # none | pr_open | landed
+reader_aids: pr_open                   # none | pr_open | landed
 lifecycle_updated: 2026-04-30

--- a/docs/research/ai-history/chapters/ch-47-the-depths-of-vision/tier3-proposal.md
+++ b/docs/research/ai-history/chapters/ch-47-the-depths-of-vision/tier3-proposal.md
@@ -1,0 +1,61 @@
+# Tier 3 Proposal — Chapter 47: The Depths of Vision
+
+Per `docs/research/ai-history/READER_AIDS.md` Tier 3 workflow. Author: Claude. Reviewer: Codex (cross-family).
+
+## Element 8 — Inline parenthetical definition (Starlight tooltip)
+
+**SKIPPED** — universal default per READER_AIDS.md.
+
+## Element 9 — Pull-quote (at most 1)
+
+The chapter draws on the ResNet paper (Green, G1–G26) as its central primary source. Survey of candidate sentences from the Green primary sources in sources.md:
+
+### Candidate A — ResNet paper: the identity-mapping argument
+
+The ResNet paper (sources.md primary, Green) contains the core framing sentence: if a shallower architecture is used as a reference, the added layers in the deeper model need only learn identity mappings to match the shallower network's training error — and yet the optimizer fails to achieve this. The chapter prose renders this argument in full (paragraphs beginning "The authors framed the problem by construction" and "The argument did not require the added layers to discover..."). The paper itself does not produce a single pithy quotable sentence for this argument; its exposition is equation-dense and spread across Sections 1 and 3.1 of the PDF. The chapter's paraphrase is already more accessible than any isolated sentence would be.
+
+**Status: SKIPPED.** No single sentence from the primary source carries the argument independently. The paper presents the identity-mapping argument formally across multiple paragraphs with equations; lifting one sentence would strip essential context. The chapter's prose already does the explanatory work. Pull-quote would either duplicate the paraphrase or excerpt an equation fragment, neither of which earns pull-quote status under READER_AIDS.md rules.
+
+### Candidate B — ResNet paper: the residual mapping definition
+
+The paper defines the residual mapping formally (F(x) := H(x) − x) at Section 3.1. This appears in-prose in the chapter in equation form. The chapter quotes the mathematical notation directly in the prose body.
+
+**Status: SKIPPED.** The prose already quotes the mathematical definition verbatim. Duplicating it as a pull-quote creates adjacent repetition, which is an explicit refusal condition under READER_AIDS.md (rule b for Element 9).
+
+### Candidate C — AlexNet paper context sentences
+
+The AlexNet paper (G1, Green) anchors the starting point of the chapter. The chapter renders AlexNet's contribution narratively without verbatim quotation from the paper. However, AlexNet's result sentences (top-1 / top-5 error, GPU description) are data claims, not prose with intellectual weight worth pull-quoting independently.
+
+**Status: SKIPPED.** Data rows and numerical results are not quote-worthy in the pull-quote sense; they lack the intellectual or historiographical framing that earns pull-quote status. The chapter handles these as factual anchors, which is the right treatment.
+
+## Element 10 — Plain-reading asides (0–3 per chapter)
+
+Survey of symbolically dense paragraphs (mathematical formulas, derivations, stacked abstract definitions — not narratively dense history or biography):
+
+### Candidate D — Residual mapping formulation paragraph
+
+The paragraph beginning "The Microsoft Research team reformulated the problem through residual learning..." introduces F(x) := H(x) − x and the addition F(x) + x. This involves a mathematical reformulation, but the chapter immediately follows it with a plain-English explanation of what the algebra means ("If the optimal mapping is closer to an identity function..."). The two paragraphs together constitute a pedagogical unit where the formal statement is followed by the interpretation. The chapter prose therefore already does the plain-reading job.
+
+**Status: SKIPPED.** The surrounding prose provides the plain reading immediately. An aside would restate what the next paragraph already says.
+
+### Candidate E — Residual block formalization paragraph
+
+The paragraph beginning "The residual block was formalized elegantly as y = F(x, {Wi}) + x..." is the equation-dense moment. It introduces the formal notation and cites the projection shortcut variant y = F(x, {Wi}) + Ws x. However, the paragraph immediately follows with the interpretation: "This design... added neither extra parameters nor computational complexity." The structural explanation (shortcut, branch, addition) is built into the surrounding prose.
+
+**Status: SKIPPED.** The paragraph is technically dense but the surrounding text already plain-reads the notation. An aside would duplicate the prose immediately below the equations.
+
+### Candidate F — Bottleneck architecture paragraph
+
+The paragraph beginning "To afford these extreme depths, the authors redesigned the residual block for networks of fifty layers and deeper..." describes the three-layer bottleneck (1×1, 3×3, 1×1). This is an architectural description rather than symbolic mathematics. The "bottleneck" metaphor is self-explanatory in the prose.
+
+**Status: SKIPPED.** Not symbolically dense; architectural description with a self-glossing metaphor. No formulas or derivations. The comprehension gap that plain-reading asides are designed to bridge does not exist here.
+
+## Summary verdict
+
+- Element 8: SKIP (universal).
+- Element 9: 0 PROPOSED, 3 SKIPPED (Candidates A, B, C — no candidate earns pull-quote status; either the prose already quotes or paraphrases the load-bearing content, or the source sentences are data rows without independent intellectual weight).
+- Element 10: 0 PROPOSED, 3 SKIPPED (Candidates D, E, F — mathematically dense moments are immediately followed by plain-English interpretation in-prose; no comprehension gap requiring a separate aside).
+
+**Total: 0 PROPOSED, 6 SKIPPED.**
+
+The chapter's prose structure explains each technical concept immediately before or after introducing it formally. Tier 3 aids would add repetition, not comprehension. All three elements are skipped.

--- a/docs/research/ai-history/chapters/ch-47-the-depths-of-vision/tier3-review.md
+++ b/docs/research/ai-history/chapters/ch-47-the-depths-of-vision/tier3-review.md
@@ -1,0 +1,21 @@
+# Tier 3 Review — Chapter 47: The Depths of Vision
+
+Reviewer: Codex (gpt-5.5)
+Date: 2026-04-30
+Reviewing: tier3-proposal.md by Claude (sonnet)
+
+## Element 9 — Pull-quote
+Author verdict: SKIPPED
+Reviewer verdict: REVIVE
+Claude is right to reject the ResNet identity-mapping and residual-formula candidates: the chapter already paraphrases those arguments adjacent to the likely insertion points. However, AlexNet provides a Green primary-source sentence worth reviving: “All of our experiments suggest that our results can be improved simply by waiting for faster GPUs and bigger datasets to become available” (Krizhevsky et al. 2012 PDF, p. 1; verified in local `pdftotext` extraction at lines 74–77). This is not just a result row; it crystallizes the scale assumption that the ResNet chapter later complicates, and the chapter does not already repeat that sentence’s “waiting for faster GPUs and bigger datasets” phrasing adjacent to the AlexNet setup.
+
+## Element 10 — Plain-reading aside
+Author verdict: SKIPPED
+Reviewer verdict: REJECT
+The only genuinely symbol-heavy paragraphs are the residual mapping, residual block, and projection shortcut paragraphs, and each is immediately followed or surrounded by prose that explains the notation in plain language. A separate `:::tip[Plain reading]` would mostly restate the chapter’s existing explanation of `F(x) + x`, identity shortcuts, and `Ws x`, so it fails the non-repetition test for Element 10.
+
+## Summary
+- Approved: none
+- Rejected: Element 10 plain-reading aside; ResNet pull-quote candidates A and B as adjacent repetition; AlexNet data/result framing in Candidate C as originally stated
+- Revised: none
+- Revived: Element 9 pull-quote from AlexNet on faster GPUs and bigger datasets

--- a/src/content/docs/ai-history/ch-47-the-depths-of-vision.md
+++ b/src/content/docs/ai-history/ch-47-the-depths-of-vision.md
@@ -61,6 +61,14 @@ timeline
 
 In 2012, visual recognition was transformed by the realization that scale, both in model capacity and computational power, could unlock performance previously thought unattainable. Alex Krizhevsky, Ilya Sutskever, and Geoffrey Hinton introduced an architecture for the ImageNet Large Scale Visual Recognition Challenge that firmly established deep convolutional neural networks as the dominant approach. Their model, often referred to as AlexNet, was large for its era. It consisted of five convolutional layers followed by three fully connected layers, containing roughly sixty million parameters and 650,000 neurons. Training such a network required specialized infrastructure. The team utilized two NVIDIA GTX 580 GPUs, each with three gigabytes of memory, and ran the training process for five to six days. The resulting performance on ImageNet demonstrated that a deep architecture, given enough data and parallel compute, could achieve breakthrough accuracy.
 
+:::note
+> "All of our experiments suggest that our results can be improved simply by waiting for faster GPUs and bigger datasets to become available."
+>
+> — Krizhevsky et al. 2012, p.1
+
+AlexNet's own forward bet on scale, which Ch47 complicates: depth itself, not just data and compute, becomes the constraint.
+:::
+
 The lesson was not simply that neural networks had become fashionable again. AlexNet made the machinery of scale visible. A contest built around more than a million natural images had become a proving ground for learned feature hierarchies, and the winning system depended on both algorithmic decisions and the practical ability to keep a large convolutional model moving through data. Its split across two GPUs was not an incidental footnote; it showed that the architecture was already pressing against memory and throughput limits. The five convolutional layers extracted increasingly abstract visual patterns, while the fully connected layers turned those patterns into ImageNet class decisions. The system's success made a once-risky proposition feel empirical: if the data and compute were available, deeper learned vision systems could outperform hand-engineered recognition pipelines.
 
 Following this success, the field naturally asked how far the principle of scale could be pushed. If an eight-layer network produced a massive leap in capability, perhaps a deeper network could do even better. This intuition drove subsequent research, most notably by Karen Simonyan and Andrew Zisserman at the University of Oxford. Their work on Very Deep Convolutional Networks, known as VGG, pushed the depth of ImageNet models to between sixteen and nineteen weight layers. To manage the complexity of deeper networks, the VGG architecture standardized the use of small, three-by-three convolutional filters, demonstrating that stacking more layers of simple filters improved ImageNet accuracy compared to fewer layers of larger filters.

--- a/src/content/docs/ai-history/ch-47-the-depths-of-vision.md
+++ b/src/content/docs/ai-history/ch-47-the-depths-of-vision.md
@@ -5,6 +5,60 @@ sidebar:
   order: 47
 ---
 
+:::tip[In one paragraph]
+In 2015, He, Zhang, Ren, and Sun at Microsoft Research discovered that adding layers to a neural network could worsen training error — not from vanishing gradients but because the optimizer failed to find even an identity mapping. Their fix was a shortcut connection carrying the input around a stack of learned layers, letting the stack correct the residual. The 152-layer ResNet won ILSVRC 2015 with 3.57 percent top-5 error; residual connections became a default grammar for deep learning.
+:::
+
+<details>
+<summary><strong>Cast of characters</strong></summary>
+
+| Name | Lifespan | Role |
+|---|---|---|
+| Kaiming He | — | First author of the ResNet paper at Microsoft Research |
+| Xiangyu Zhang | — | Co-author of the ResNet paper at Microsoft Research |
+| Shaoqing Ren | — | Co-author of the ResNet paper at Microsoft Research |
+| Jian Sun | — | Co-author of the ResNet paper at Microsoft Research |
+| Alex Krizhevsky | — | First author of the 2012 AlexNet paper; anchors the chapter's starting point |
+| Karen Simonyan | — | Co-author of the VGG paper that pushed ImageNet CNNs to 16–19 weight layers |
+
+</details>
+
+<details>
+<summary><strong>Timeline (2012–2016)</strong></summary>
+
+```mermaid
+timeline
+    title The Depths of Vision
+    2012 : Krizhevsky, Sutskever, and Hinton publish AlexNet — five convolutional and three fully connected layers, two GTX 580 GPUs, five to six days of training
+    September 2014 : Simonyan and Zisserman release the VGG paper — ImageNet depth pushed to 16–19 weight layers with 3x3 filters
+    2014 : GoogLeNet and VGG make "very deep" ImageNet models the state of the art, with leading architectures at roughly 16 to 30 layers
+    February–July 2015 : Batch Normalization appears at ICML 2015, addressing gradient instability and enabling tens-layer networks to begin converging
+    December 10 2015 : He, Zhang, Ren, and Sun post ResNet to arXiv — residual learning with identity shortcuts, up to 152 layers, 3.57% ensemble ImageNet error
+    ILSVRC / COCO 2015 : ResNet team wins first place in ImageNet classification, detection, localization, COCO detection, and COCO segmentation
+    June 2016 : ResNet paper published at CVPR 2016, pp. 770–778
+```
+
+</details>
+
+<details>
+<summary><strong>Plain-words glossary</strong></summary>
+
+**Optimization degradation** — The phenomenon where adding more layers to a neural network makes training error *worse*, not better. This is distinct from overfitting, which reduces training error while worsening test error. Optimization degradation means the optimizer itself is failing.
+
+**Residual mapping** — Instead of asking a stack of layers to learn the target function H(x) directly, residual learning reformulates the task as learning F(x) = H(x) − x, the difference between the desired output and the input. The original mapping is then recovered as F(x) + x.
+
+**Shortcut connection** — A path in the neural network's computational graph that carries the input directly around one or more learned layers and adds it to their output. In ResNet, the default shortcut is a parameter-free identity function.
+
+**Bottleneck block** — A residual block design used for networks of 50 layers and deeper. It uses three layers (1×1, 3×3, 1×1 convolutions) instead of two, first reducing dimensions, then expanding them, reducing arithmetic cost while preserving depth.
+
+**FLOP (floating-point operation)** — A single arithmetic step a processor performs. FLOP counts measure how much computation a model requires per forward pass; the 152-layer ResNet used 11.3 billion FLOPs, fewer than VGG-19's 19.6 billion.
+
+**Projection shortcut** — A shortcut connection that applies a learned linear transformation to the input before addition, used when the input and output of a residual block have different dimensions. The ResNet paper showed identity shortcuts were sufficient to resolve degradation; projection provides only marginal gains.
+
+**ILSVRC (ImageNet Large Scale Visual Recognition Challenge)** — The annual competition on the ImageNet dataset that benchmarked visual recognition systems from 2010 through 2017. Winning results from this challenge drove major architectural advances in convolutional neural networks.
+
+</details>
+
 In 2012, visual recognition was transformed by the realization that scale, both in model capacity and computational power, could unlock performance previously thought unattainable. Alex Krizhevsky, Ilya Sutskever, and Geoffrey Hinton introduced an architecture for the ImageNet Large Scale Visual Recognition Challenge that firmly established deep convolutional neural networks as the dominant approach. Their model, often referred to as AlexNet, was large for its era. It consisted of five convolutional layers followed by three fully connected layers, containing roughly sixty million parameters and 650,000 neurons. Training such a network required specialized infrastructure. The team utilized two NVIDIA GTX 580 GPUs, each with three gigabytes of memory, and ran the training process for five to six days. The resulting performance on ImageNet demonstrated that a deep architecture, given enough data and parallel compute, could achieve breakthrough accuracy.
 
 The lesson was not simply that neural networks had become fashionable again. AlexNet made the machinery of scale visible. A contest built around more than a million natural images had become a proving ground for learned feature hierarchies, and the winning system depended on both algorithmic decisions and the practical ability to keep a large convolutional model moving through data. Its split across two GPUs was not an incidental footnote; it showed that the architecture was already pressing against memory and throughput limits. The five convolutional layers extracted increasingly abstract visual patterns, while the fully connected layers turned those patterns into ImageNet class decisions. The system's success made a once-risky proposition feel empirical: if the data and compute were available, deeper learned vision systems could outperform hand-engineered recognition pipelines.
@@ -94,3 +148,7 @@ However, the authors were careful to identify the limits of their approach, ensu
 Yet, this optimization success did not translate into a generalization victory. The 1202-layer model produced a test error of 7.93 percent, which was worse than the performance of a shallower 110-layer residual model. The authors straightforwardly attributed this drop in test performance to overfitting, noting that the 1202-layer network was likely unnecessarily large for the CIFAR-10 dataset. This was the clean inverse of the earlier degradation problem. In the plain networks, more layers could not even reduce training error properly. In the 1202-layer residual network, training error nearly vanished, but test performance worsened. Residual learning had solved one failure mode while exposing another.
 
 This boundary defined the true legacy of the paper. Residual connections did not make arbitrary depth automatically useful for generalization, nor did they guarantee that more layers would always improve performance on unseen data. Instead, they separated the problem of optimization from the problem of capacity. Identity shortcuts made very deep networks trainable by changing what the stacked layers had to learn. Once that obstacle moved, the remaining questions became the familiar ones of data, regularization, computational cost, and whether additional capacity actually served the task. ResNet transformed extreme depth from a brittle aspiration into an engineering choice, turning shortcut connections from a local design option into a default grammar for deep learning.
+
+:::note[Why this still matters today]
+Residual connections are now a structural default across deep learning. Every major vision backbone, the transformer architectures powering large language models, and the diffusion networks behind image generation all carry skip connections that descend directly from the ResNet shortcut. The bottleneck block's principle — reduce dimensions, operate, restore — reappears in transformer feed-forward layers and efficient convolutional networks alike. The conceptual split ResNet introduced between optimization tractability and capacity remains the frame practitioners use when deciding whether a deeper or wider model is the right answer for a given task and dataset.
+:::


### PR DESCRIPTION
## Summary

- Adds Tier 1 reader-aids to `ch-47-the-depths-of-vision.md`: TL;DR (79w), Cast of characters (6 rows), Timeline (2012–2016, 7 in-scope events), Plain-words glossary (7 terms), Why this still matters today (92w).
- Writes `docs/research/ai-history/chapters/ch-47-the-depths-of-vision/tier3-proposal.md` — all Tier 3 elements skipped: no pull-quote candidate survives adjacent-repetition or data-row tests; no paragraph is symbolically dense without immediate in-prose plain reading.
- Flips `status.yaml` `reader_aids: none` → `pr_open`, `lifecycle_updated: 2026-04-30`.

## Bit-identity

`git diff origin/main -- src/content/docs/ai-history/ch-47-the-depths-of-vision.md | grep '^-[^-]'` returns empty — zero prose lines removed or modified.

## Tier 3 verdicts

| Element | Verdict | Reason |
|---|---|---|
| 8 (tooltip) | SKIP | Universal default |
| 9 (pull-quote) | SKIP × 3 | Candidate A: load-bearing argument spans multiple paragraphs with equations; no single sentence is extractable. Candidate B: equation already quoted in-prose; adjacent repetition. Candidate C: AlexNet result sentences are data rows, not intellectually quote-worthy. |
| 10 (plain-reading aside) | SKIP × 3 | Candidates D/E/F: each technically dense paragraph is immediately followed by in-prose plain-English interpretation; no comprehension gap to bridge. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)