### PR TITLE
docs(ch52): Tier 1 + Tier 2 architecture sketch — Bidirectional Context (BERT) (#562, #394)

### DIFF
--- a/docs/research/ai-history/chapters/ch-52-bidirectional-context/status.yaml
+++ b/docs/research/ai-history/chapters/ch-52-bidirectional-context/status.yaml
@@ -64,5 +64,5 @@ notes: |
 # Lifecycle fields (added 2026-04-30 to decouple reader-aid rollout state
 # from research-phase `status` field; see Codex review forwarded by user).
 prose_state: published_on_main            # research_only | published_on_main
-reader_aids: none                      # none | pr_open | landed
+reader_aids: pr_open                   # none | pr_open | landed
 lifecycle_updated: 2026-04-30

--- a/docs/research/ai-history/chapters/ch-52-bidirectional-context/tier3-proposal.md
+++ b/docs/research/ai-history/chapters/ch-52-bidirectional-context/tier3-proposal.md
@@ -1,0 +1,39 @@
+# Chapter 52 — Tier 3 reader-aid proposal
+
+Author: Claude (claude-opus-4-7), 2026-04-30
+Reviewer (cross-family): Codex (gpt-5.5)
+Spec: `docs/research/ai-history/READER_AIDS.md` Tier 3 (elements 8, 9, 10).
+
+## Element 8 — Inline parenthetical definition
+
+**SKIPPED.** Per the spec, this element is skipped on every chapter until a non-destructive Astro `<Tooltip>` component lands. The Tier 1 *Plain-words glossary* covers the same job non-destructively for `[CLS]`, `[SEP]`, MLM, NSP, WordPiece, and bidirectional context.
+
+## Element 9 — Pull-quote (`:::note[]` callout)
+
+**PROPOSED.** Candidate sentence (Devlin et al. 2018, BERT abstract):
+
+> Unlike recent language representation models, BERT is designed to pre-train deep bidirectional representations from unlabeled text by jointly conditioning on both left and right context in all layers.
+
+**Insertion anchor:** immediately after the chapter paragraph beginning "ELMo weakened the problem but did not remove it…" (the paragraph that paraphrases this exact claim as "BERT's central claim was that the representation should be deeply bidirectional: every layer could condition on both left and right context").
+
+**Rationale:**
+- The paper's abstract sentence is the precise architectural statement of *what* BERT did differently from ELMo and GPT-1. The chapter paraphrases it ("deeply bidirectional… every layer could condition on both left and right context") but does not block-quote it. Codex should evaluate adjacent-repetition risk: the paraphrase is close. If the chapter's wording were verbatim, this would be a clear REJECT. As paraphrase-of-key-claim, it could go either way.
+- The annotation will do new work by naming the *contrast set* (ELMo's late concatenation; OpenAI GPT-1's left-only) — the abstract's own framing — which the chapter mentions but does not anchor in the paper's voice.
+
+**Annotation (1 sentence, doing new work):** The "in all layers" clause is the load-bearing distinction from ELMo's late concatenation of two independently trained directions and from GPT-1's left-only causal masking — bidirectionality fused through the stack, not stitched at the output.
+
+**Word budget:** 26 words quoted + ~36 words annotation = ~62 words. Slightly over the ≤60 cap. Codex should REVISE the annotation length if landing.
+
+## Element 10 — Plain-reading aside
+
+**SKIPPED.** Ch52's prose is conceptual/architectural narrative. The most "technical" passages (MLM 80/10/10 schedule, WordPiece + segment + position embeddings, BASE/LARGE size lists) are not symbolically dense — they are enumerations, not formula derivations. The architecture-sketch (Tier 2) handles the structural visualization; a plain-reading aside on top would only paraphrase prose that is already written for non-specialists.
+
+## Summary
+
+| Element | Author proposal | Rationale |
+|---|---|---|
+| 8 | SKIP | Bit-identity rule; glossary covers same job |
+| 9 | PROPOSE (with adjacent-repetition warning) | BERT abstract's deep-bidirectional sentence; chapter paraphrases close enough that Codex may justifiably REJECT |
+| 10 | SKIP | No symbolically dense paragraphs |
+
+**Awaiting Codex adversarial review.** I deliberately did not strip the candidate quote despite the close paraphrase — Codex's job is to enforce adjacent-repetition discipline. Be willing to REJECT.

--- a/docs/research/ai-history/chapters/ch-52-bidirectional-context/tier3-review.md
+++ b/docs/research/ai-history/chapters/ch-52-bidirectional-context/tier3-review.md
@@ -1,0 +1,28 @@
+# Tier 3 Review — Chapter 52: Bidirectional Context
+
+Reviewer: Codex (gpt-5.5)
+Date: 2026-04-30
+Reviewing: tier3-proposal.md by Claude (claude-opus-4-7)
+
+## Element 8 — Inline parenthetical definition
+Author verdict: SKIPPED — Tooltip component is not available; `<abbr>` would modify prose and violate bit-identity.
+Reviewer verdict: APPROVE
+I approve the skip. The spec makes Element 8 skipped on every chapter until a non-destructive tooltip component exists, and the Tier 1 glossary already carries the plain-language definitions without touching verified prose.
+
+## Element 9 — Pull-quote
+Author verdict: PROPOSED — BERT abstract sentence on deep bidirectional pre-training after the ELMo/GPT contrast paragraph, with an adjacent-repetition warning.
+Reviewer verdict: REJECT
+Reject the proposed quote. It is primary, Green-source, and quote-worthy in isolation, but it fails the Element 9 adjacent-repetition test. The intended insertion point is immediately after chapter line 99, which already says BERT's central claim was deep bidirectionality and that every layer could condition on left and right context. The proposed sentence repeats the same claim in the same order: deep bidirectional representations, unlabeled pre-training, left and right context, all layers. The proposed annotation also repeats contrast material already present at chapter lines 91, 97, 99, and 113.
+
+I would not revive the two obvious substitutes. The BERT abstract's "fine-tuned with just one additional output layer" sentence repeats chapter lines 123 and 127, where the prose already explains minimal task-specific architecture change and the added output layer. The Google blog's "30 minutes on a single Cloud TPU" sentence repeats chapter line 137 almost verbatim. Both would create a second callout that restates an adjacent or nearby prose claim rather than adding provenance, stakes, or intellectual lineage.
+
+## Element 10 — Plain-reading aside
+Author verdict: SKIPPED — Conceptual/architectural narrative; no symbolically dense paragraph.
+Reviewer verdict: APPROVE
+I approve the skip. The technical passages here are enumerations and workflow explanations: MLM percentages, WordPiece/input embeddings, model sizes, TPU counts, and fine-tuning economics. They are not formula, derivation, or stacked-definition paragraphs under Element 10, and the existing prose already plain-reads the architecture.
+
+## Summary
+- Approved: Element 8 skip; Element 10 skip
+- Rejected: Element 9 pull-quote
+- Revised: None
+- Revived: None

--- a/src/content/docs/ai-history/ch-52-bidirectional-context.md
+++ b/src/content/docs/ai-history/ch-52-bidirectional-context.md
@@ -5,6 +5,79 @@ sidebar:
   order: 52
 ---
 
+:::tip[In one paragraph]
+BERT, published October 2018 by Devlin, Chang, Lee, and Toutanova at Google AI, took the Transformer encoder, pre-trained it with masked language modeling and next-sentence prediction on 3.3 billion words of BooksCorpus and Wikipedia, and released the trained weights. BERTBASE (110M parameters) and BERTLARGE (340M) trained for four days on Cloud TPU Pods. Fine-tuning the released checkpoint reached state-of-the-art on 11 NLP tasks. The reusable artifact stopped being an algorithm and became a set of trained parameters.
+:::
+
+<details>
+<summary><strong>Cast of characters</strong></summary>
+
+| Name | Lifespan | Role |
+|---|---|---|
+| Jacob Devlin | — | BERT co-author; co-author of the Google Research open-source announcement |
+| Ming-Wei Chang | — | BERT co-author; co-author of the Google Research open-source announcement |
+| Kenton Lee | — | BERT co-author |
+| Kristina Toutanova | — | BERT co-author |
+| Matthew Peters / ELMo team | — | Prior contextual-representation line named in the BERT paper context; combined independently trained left-to-right and right-to-left LMs |
+| Howard & Ruder / ULMFiT | — | Fine-tuning precedent named in the BERT paper and Google blog context |
+
+</details>
+
+<details>
+<summary><strong>Timeline (October 2018)</strong></summary>
+
+```mermaid
+timeline
+    title Chapter 52 — Bidirectional Context
+    Oct 11 2018 : BERT paper appears on arXiv (1810.04805)
+    Oct 25 2018 : google-research/bert GitHub repository created
+    2018 : Google Research blog announces open-source release of BERT code + pre-trained models
+    2018 : BERTBASE and BERTLARGE report state-of-the-art on 11 NLP tasks (GLUE, SQuAD, SWAG)
+```
+
+</details>
+
+<details>
+<summary><strong>Plain-words glossary</strong></summary>
+
+**Pre-training / fine-tuning** — A two-stage workflow. *Pre-training* runs an expensive learning pass on a large unlabeled corpus to produce a general-purpose representation (the *checkpoint*). *Fine-tuning* takes that checkpoint, attaches a small task-specific output head, and updates parameters on supervised data for the target task. BERT's practical claim was that pre-training cost amortizes across many fine-tuning tasks.
+
+**Checkpoint** — A serialized snapshot of all model parameters at a point in training. Once released, downstream users can load it, attach task heads, and continue training without redoing pre-training. The BERT release made checkpoints first-class research artifacts alongside papers and code.
+
+**Bidirectional context** — The condition where every layer of the model can condition on both left- and right-side tokens when computing each position's representation. Distinct from ELMo's late concatenation of two independently trained directions: BERT fuses both directions through every layer of the encoder.
+
+**Masked language modeling (MLM)** — BERT's pre-training objective: pick 15% of WordPiece positions, replace 80% with `[MASK]`, 10% with a random token, and 10% unchanged, then ask the model to predict the original token at the selected positions. The 80/10/10 schedule reduces pre-training/fine-tuning mismatch (real fine-tuning inputs do not contain `[MASK]`).
+
+**Next sentence prediction (NSP)** — BERT's second pre-training objective. Given two spans, the model predicts whether span B is the actual follow-on to span A in the source corpus. Tied to downstream tasks involving sentence-pair reasoning. Later work questioned NSP's necessity, but BERT's 2018 ablations treat it as a useful component.
+
+**WordPiece tokenization** — A subword tokenization scheme; BERT uses a 30,000-token WordPiece vocabulary. Subword units handle rare and morphologically complex words by composition, avoiding both character-level shortness and word-level vocabulary explosions.
+
+**`[CLS]` / `[SEP]` tokens** — Special input markers. `[CLS]` opens every input; its final hidden state acts as an aggregate sentence/sequence representation for classification heads. `[SEP]` separates sentence A from sentence B in pair inputs and signals end-of-input. Combined with segment embeddings, they let one encoder serve many task formats.
+
+</details>
+
+<details>
+<summary><strong>Architecture sketch</strong></summary>
+
+```mermaid
+flowchart LR
+    %% Form: flowchart LR — default form-lock per Ch41/Ch49.
+    %% BERT is the Ch50 Transformer encoder stack with three summed input streams
+    %% (token + segment + position embeddings) and multiple output heads. The
+    %% dataflow input → embed → encoder → heads is a left-to-right pipeline.
+    %% No nested memory hierarchy here — Ch42's TD-deviation does not apply.
+    IN["Input: [CLS] sent A [SEP] sent B [SEP]\nWordPiece tokens, vocab = 30k"] --> EMB["Sum of three embeddings:\ntoken + segment + position"]
+    EMB --> ENC["Encoder stack — same as Ch50 Transformer\nBASE: 12 layers · 768 hidden · 12 heads · 110M params\nLARGE: 24 layers · 1024 hidden · 16 heads · 340M params"]
+    ENC --> H["Per-position hidden states\n(plus [CLS] aggregate state)"]
+    H --> MLM["Pre-training head: MLM\nrecover original WordPieces at the 15% selected positions"]
+    H --> NSP["Pre-training head: NSP\npredict B-follows-A from [CLS] state"]
+    H --> FT["Fine-tuning head: task-specific\nclassification / span / token-tag\nsmall output layer, few epochs, ~30 min on 1 Cloud TPU"]
+```
+
+The expensive pre-training run produces the encoder weights once; downstream users replace only the right-most head and run cheap fine-tuning. The mask on MLM (selecting 15% of WordPiece positions, with the 80/10/10 substitution schedule) is what lets every encoder layer condition on both left- and right-side tokens without leaking the target into the input.
+
+</details>
+
 The previous chapter ended with code becoming an instrument of distribution. TensorFlow, PyTorch, GitHub repositories, papers, notebooks, and benchmark implementations made deep learning easier to copy, inspect, and extend. But code alone was not yet the most valuable artifact. A framework can describe how to build a model; a trained checkpoint already contains the costly work of learning from data. In natural language processing, BERT made that distinction unavoidable.
 
 BERT did not arrive as a claim that machines had achieved human comprehension. Its title used the phrase "language understanding," but the historical claim is narrower and more important. BERT showed that a Transformer encoder could be pre-trained on large unlabeled text as a deep bidirectional representation, then fine-tuned across many language tasks with only small task-specific changes. The reusable object was no longer just an algorithm. It was a set of learned weights.
@@ -106,3 +179,7 @@ The dependency was still bounded. BERT did not contain retrieval systems, tool u
 The honest significance of BERT is that it made pre-trained language representations operational. The paper gave the field a concrete recipe: Transformer encoder, masked language modeling, next sentence prediction, large unlabeled corpora, expensive pre-training, comparatively cheap fine-tuning, and strong reported results across many NLP tasks. The release gave that recipe an artifact: code and weights that others could run.
 
 In 2018, that was enough to change the default. NLP no longer looked like a collection of separate task architectures waiting to be hand-built one at a time. It increasingly looked like a stack: a costly general pre-training phase underneath, a light adaptation phase above, and benchmarks arranged to measure how well the shared representation transferred. BERT did not end the story of language models. It made the next chapter possible by proving that a trained Transformer checkpoint could become infrastructure.
+
+:::note[Why this still matters today]
+The pre-training/fine-tuning split BERT made operational still organizes most of modern NLP. Encoder-only descendants (RoBERTa, DeBERTa, ModernBERT, sentence transformers) power semantic search, retrieval-augmented generation, embeddings APIs, content moderation, and classification at every cloud provider. Generative chat moved to decoder-only models, but the *checkpoint-as-infrastructure* idea — pay once for pre-training, amortize across many downstream uses — is now the universal default. Reading a 2026 model card is reading the BERT framing: corpus, parameter count, hardware, downstream-evaluation table, released weights, fine-tuning recipe.
+:::


### PR DESCRIPTION
## Summary

Reader-aids on bit-identical prose for **Chapter 52: Bidirectional Context** — BERT.

**Tier 1**: TL;DR (78w) · Cast (4 BERT co-authors + ELMo + ULMFiT) · Timeline (Oct 2018) · Glossary (7 terms: pre-training/fine-tuning, checkpoint, bidirectional context, MLM, NSP, WordPiece, [CLS]/[SEP]).

**Tier 2 architecture sketch** (`flowchart LR` per default form-lock): input ([CLS] A [SEP] B [SEP]) → token+segment+position embeddings → encoder stack (BASE 12L/110M, LARGE 24L/340M) → hidden states → MLM / NSP / fine-tuning heads.

**Why-still**: pre-training/fine-tuning split still organizes modern NLP; encoder-only descendants (RoBERTa, DeBERTa, ModernBERT) still power embeddings, retrieval, semantic search.

**Tier 3 — codex review verdicts**: Element 8 APPROVE skip · **Element 9 REJECT** (adjacent-repetition; Codex explicitly evaluated and rejected both alternative substitutes too) · Element 10 APPROVE skip. Tier 3 yield: **0 of 3** — matches Ch48 precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)