### PR TITLE
docs(ch54): Tier 1 + Tier 3 pull-quote (Codex REVIVE) — Hub of Weights (#562, #394)

### DIFF
--- a/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/status.yaml
+++ b/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/status.yaml
@@ -61,5 +61,5 @@ notes: |
 # Lifecycle fields (added 2026-04-30 to decouple reader-aid rollout state
 # from research-phase `status` field; see Codex review forwarded by user).
 prose_state: published_on_main            # research_only | published_on_main
-reader_aids: none                      # none | pr_open | landed
+reader_aids: pr_open                   # none | pr_open | landed
 lifecycle_updated: 2026-04-30

--- a/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/tier3-proposal.md
+++ b/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/tier3-proposal.md
@@ -1,0 +1,31 @@
+# Chapter 54 — Tier 3 reader-aid proposal
+
+Author: Claude (claude-opus-4-7), 2026-04-30
+Reviewer (cross-family): Codex (gpt-5.5)
+
+## Element 8 — SKIPPED (Tooltip component not available; Tier 1 glossary covers the same job non-destructively)
+
+## Element 9 — Pull-quote
+
+**SKIPPED.** I considered candidates from the Wolf et al. 2020 EMNLP Transformers paper:
+
+1. The abstract sentence stating Transformers is "an open-source library exposing modern transformer architectures" — but the chapter at the paragraph beginning "The Transformers library answered with an adapter layer" already paraphrases this with the same content density. Codex's Ch52 precedent (REJECT on adjacent-repetition for paraphrase-of-headline) suggests this would also be rejected.
+2. The "trained models for the wider machine learning community" framing — same risk; chapter prose at line 14 ("Hugging Face became important because it attacked that practical layer") already does this work.
+3. The specific 2,097-user-models snapshot — that is a number, not a quote-worthy sentence; numbers belong in timelines/tables, not pull-quotes.
+4. The "two `from_pretrained(...)` calls" example from §4 — that's an API line, not a sentence doing intellectual work.
+
+The chapter is genuinely a *systems-history* chapter rather than a paper-result chapter; the load-bearing claims are already made in the chapter's authorial voice. A pull-quote here would be ornamental rather than evidentiary. Per the Ch48 / Ch52 precedent, I author-skip Element 9. Codex should be willing to REVIVE if it finds a verbatim sentence I missed that does new work.
+
+## Element 10 — SKIPPED
+
+Ch54 is a packaging/infrastructure narrative — repository culture, naming conventions, tokenizer companions, task heads, model cards, deployment paths. No symbolically dense paragraphs (no formulas, no derivations). Plain-reading asides do not apply.
+
+## Summary
+
+| Element | Author proposal | Rationale |
+|---|---|---|
+| 8 | SKIP | Bit-identity rule |
+| 9 | SKIP | All viable candidates fail adjacent-repetition or are not quote-worthy sentences |
+| 10 | SKIP | No symbolic density |
+
+**Awaiting Codex adversarial review.** Be willing to REVIVE Element 9 if you locate a paper sentence I missed, or APPROVE all three skips per the Ch48 precedent.

--- a/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/tier3-review.md
+++ b/docs/research/ai-history/chapters/ch-54-the-hub-of-weights/tier3-review.md
@@ -1,0 +1,34 @@
+# Tier 3 Review — Chapter 54: The Hub of Weights
+
+Reviewer: Codex (gpt-5.5)
+Date: 2026-04-30
+Reviewing: tier3-proposal.md by Claude (claude-opus-4-7)
+
+## Element 8 — Inline parenthetical definition
+Author verdict: SKIPPED — Tooltip component is not available; `<abbr>` would modify prose and violate bit-identity.
+Reviewer verdict: APPROVE
+I approve the skip. The spec makes Element 8 skipped on every chapter until a non-destructive tooltip component exists, and the Tier 1 glossary already defines checkpoint, tokenizer, task head, Auto classes, Model Hub, model card, and inference widget without touching verified prose.
+
+## Element 9 — Pull-quote
+Author verdict: SKIPPED — All considered Wolf et al. 2020 candidates either repeat nearby chapter claims, are numeric/table material, or are API snippets rather than quote-worthy sentences.
+Reviewer verdict: REVIVE
+Revive one pull-quote, but not from the author's surveyed candidates. The abstract/library-scope sentences fail adjacent repetition for the reasons given in the proposal: the chapter already states the unified API, pretrained-model community, Model Hub count, and two-call loading path in prose. The TechCrunch 2017/2019 candidates also mostly repeat the chatbot-origin and pivot paragraphs already present.
+
+Use this exact quoted sentence:
+
+> The concept of providing easy caching for pretrained models stemmed from AllenNLP (Gardner et al., 2018).
+
+Primary anchor: Wolf et al. 2020, "Transformers: State-of-the-Art Natural Language Processing," Section 2 "Related Work," p. 39.
+
+Recommended insertion anchor: immediately after the paragraph beginning "Caching mattered for the same reason." The quote does new work there because the chapter explains why caching matters but does not name AllenNLP as the inherited convention. The annotation should be one sentence and should frame the quote as intellectual lineage, not as a new technical claim. For example: "This lineage matters: Hugging Face's packaging layer borrowed caching practice from AllenNLP while extending it into a hub-and-library distribution workflow."
+
+## Element 10 — Plain-reading aside
+Author verdict: SKIPPED — Packaging/infrastructure narrative; no formulas, derivations, or symbolically dense paragraphs.
+Reviewer verdict: APPROVE
+I approve the skip. The chapter has technical vocabulary and workflow detail, but the dense passages are narrative or architectural rather than symbolic. A plain-reading aside would mostly restate already-accessible prose about tokenizers, task heads, model cards, caching, and deployment paths.
+
+## Summary
+- Approved: Element 8 skip; Element 10 skip
+- Rejected: None
+- Revised: None
+- Revived: Element 9 pull-quote from Wolf et al. 2020 Related Work on AllenNLP as the caching lineage

--- a/src/content/docs/ai-history/ch-54-the-hub-of-weights.md
+++ b/src/content/docs/ai-history/ch-54-the-hub-of-weights.md
@@ -125,6 +125,12 @@ The widget also blurred the boundary between repository and application. A repos
 
 Caching mattered for the same reason. If model files are large, repeated downloads are wasteful and brittle. A library that knows where to fetch a model and how to cache it turns a remote artifact into a local dependency. This is infrastructure work, not headline science. But without it, open weights remain difficult to use at scale. A hub of weights requires a logistics layer.
 
+:::note
+> The concept of providing easy caching for pretrained models stemmed from AllenNLP (Gardner et al., 2018).
+
+This lineage matters: Hugging Face's packaging layer borrowed caching practice from AllenNLP while extending it into a hub-and-library distribution workflow. — *Wolf et al. 2020, "Transformers: State-of-the-Art Natural Language Processing," §2 Related Work, p. 39.*
+:::
+
 Fine-tuning fit naturally into that logistics layer. A user could start from a shared checkpoint, attach or select the appropriate head, and adapt it to a downstream task. The important change was not that fine-tuning became trivial. It was that fine-tuning could begin from a standardized loading path rather than a custom reconstruction of a paper's artifacts. The system made the first steps repeatable.
 
 Deployment pathways pushed the system beyond notebooks. The Transformers paper mentions TorchScript, TensorFlow serving options, ONNX, JAX/XLA, TVM, and CoreML as routes toward production or intermediate formats. That list should not be overread as a guarantee that every model could be deployed easily everywhere. It shows that the library's ambition extended from research use to the transition toward production environments.

--- a/src/content/docs/ai-history/ch-54-the-hub-of-weights.md
+++ b/src/content/docs/ai-history/ch-54-the-hub-of-weights.md
@@ -5,6 +5,58 @@ sidebar:
   order: 54
 ---
 
+:::tip[In one paragraph]
+Hugging Face began as a 2017 chatbot app for bored teenagers, then pivoted. The October 2018 `huggingface/transformers` repository grew into a library that turned BERT, GPT-2, and dozens of other Transformer architectures into shared infrastructure: tokenizer + base model + task head, loaded from a canonical name through Auto classes. By the 2020 EMNLP paper, the Model Hub held 2,097 user models with 400+ external contributors. The trained checkpoint became a software-package-like artifact.
+:::
+
+<details>
+<summary><strong>Cast of characters</strong></summary>
+
+| Name | Lifespan | Role |
+|---|---|---|
+| Clement Delangue | — | Hugging Face co-founder and CEO; named in the 2017 TechCrunch chatbot-app coverage and the 2020 Transformers paper coauthor list |
+| Julien Chaumond | — | Hugging Face co-founder; named in the 2017 chatbot coverage; coauthor of the 2020 Transformers paper |
+| Thomas Wolf | — | First author of the 2020 EMNLP "Transformers: State-of-the-Art Natural Language Processing" paper; central technical protagonist for the library and Model Hub |
+| Lysandre Debut | — | 2020 Transformers paper coauthor; library implementation team |
+| Victor Sanh | — | 2020 Transformers paper coauthor; led DistilBERT, an example of model compression on the Hub |
+| Alexander M. Rush | — | 2020 Transformers paper coauthor; "Annotated Transformer" (Ch51 reference) brings the academic-pedagogy continuity |
+
+</details>
+
+<details>
+<summary><strong>Timeline (2017–2020)</strong></summary>
+
+```mermaid
+timeline
+    title Chapter 54 — The Hub of Weights
+    Mar 2017 : TechCrunch describes Hugging Face as a chatbot app for bored teenagers — Delangue and Chaumond named as co-founders
+    Oct 2018 : huggingface/transformers GitHub repository created (Oct 29)
+    Dec 2019 : TechCrunch reports the pivot — Transformers library has 1M+ downloads and 19,000 GitHub stars
+    Oct 2020 : Wolf et al. publish "Transformers: State-of-the-Art Natural Language Processing" at EMNLP System Demonstrations
+    2020 : Paper snapshot — Model Hub holds 2,097 user models; 400+ external contributors to the library
+```
+
+</details>
+
+<details>
+<summary><strong>Plain-words glossary</strong></summary>
+
+**Model checkpoint** — A serialized snapshot of all trained parameters of a model. Distinct from source code: the *weights file* carries the expensive learning result; without it, the architecture is empty. The checkpoint plus its tokenizer plus its config plus its task head is the runnable artifact.
+
+**Tokenizer (model-specific)** — The pipeline that converts raw text into the integer IDs the model expects. BERT's WordPiece, GPT-2's byte-level BPE, and SentencePiece variants are not interchangeable: a model trained against one tokenizer breaks if loaded with another. The tokenizer is a *companion artifact* to the weights, not a preprocessing footnote.
+
+**Task head** — A small output layer that adapts a base model to a specific task: classification, token labeling, span prediction, generation. The Transformers library kept the *base model + head* relationship explicit so one pre-trained encoder could serve many task layouts.
+
+**Auto classes** — `AutoTokenizer`, `AutoModel`, `AutoModelForSequenceClassification`, etc. — convenience classes that read a model's config file and instantiate the right architecture-specific class for that name. Make `from_pretrained("bert-base-uncased")` work the same way `from_pretrained("gpt2")` does.
+
+**Model Hub** — Hugging Face's web platform where models live as named, versioned repositories with metadata, downloads, and (later) live inference widgets. The 2020 paper's snapshot of 2,097 user models is historical; the Hub now holds millions.
+
+**Model card** — A documentation file accompanying a model, describing what it was trained on, what tasks it is intended for, known limitations, biases, license, and citation. Origin: Mitchell et al. 2019 "Model Cards for Model Reporting." Distribution proximity (the card sits on the model page) is what makes the convention practical.
+
+**Live inference widget** — An interactive box on a Hub model page that lets a visitor send input and receive output without writing code. Blurs the boundary between "this model exists" and "I just used it"; foreshadows the Spaces / hosted-demo layer that follows.
+
+</details>
+
 GPT-3 made the prompt feel like a new interface to intelligence, but the model itself remained a hard object to reproduce. A paper can describe an architecture. A blog post can show examples. A checkpoint can carry the expensive result of training. None of those artifacts automatically become easy to find, load, compare, fine-tune, cache, deploy, or trust. After BERT, GPT-2, and the first wave of Transformer systems, the next bottleneck was not only invention. It was circulation.
 
 The field needed a way to treat trained weights less like isolated research debris and more like software packages. A user who wanted to try a model needed the right architecture, tokenizer, vocabulary, configuration, task head, framework, and weight file. If any one of those pieces mismatched, the model might fail to load or produce meaningless output. The paper result was not the same as a runnable system. The checkpoint was not the same as an ecosystem.
@@ -120,3 +172,7 @@ This packaging layer also affected education. A student learning modern NLP coul
 The same lower friction increased responsibility. If more people can load powerful models, more people can misuse them, misunderstand them, or deploy them carelessly. The solution is not to pretend friction is safety. It is to pair reuse infrastructure with documentation, evaluation, licenses, and norms. The Model Hub was part of that pairing, not a final answer. It made the artifact easier to reach and made some context easier to attach, while leaving hard governance questions open.
 
 The honest ending is modest but consequential. Hugging Face did not solve access to artificial intelligence. It did not guarantee quality, safety, legality, or fairness. It did not remove the cost of training frontier systems. But it helped make Transformer weights behave more like shared infrastructure for researchers, educators, and builders working across many different institutions. A model could have a name, a page, a card, a tokenizer, a loading path, a cache, a task head, and a community around it. That was enough to change the everyday practice of AI.
+
+:::note[Why this still matters today]
+Hugging Face is still THE central distribution layer for open-weights models — Llama, Mistral, DeepSeek, Qwen, Gemma, and most fine-tuned derivatives flow through it. The model-card convention is now industry-standard; almost every model release includes one. The packaging discipline (canonical name → tokenizer + config + weights + card) is now followed by Ollama, llama.cpp, GGUF tooling, and modern model registries. The hub-vs-API divide the chapter foreshadows is the central tension of 2026: open-weights communities on the Hub vs. closed frontier models accessible only through serving endpoints.
+:::


### PR DESCRIPTION
## Summary

Reader-aids on bit-identical prose for **Chapter 54: The Hub of Weights** — Hugging Face.

**Tier 1**: TL;DR (73w) · Cast (Delangue, Chaumond, Wolf, Debut, Sanh, Rush) · Timeline (Mar 2017 chatbot → Oct 2020 EMNLP paper) · Glossary (7 terms).

**No Tier 2** (Ch54 not on math/architecture list).

**Why-still**: HF still THE central distribution layer for open-weights; model-card convention now industry-standard; hub-vs-API divide is the central tension of 2026.

**Tier 3 — codex review verdicts**: Element 8 APPROVE skip · **Element 9 REVIVE** (Codex found a sentence I missed in Wolf et al. 2020 §2 Related Work — the AllenNLP caching-lineage attribution; does new work because the chapter explains *why* caching matters but doesn't name the lineage) · Element 10 APPROVE skip. Tier 3 yield: **1 of 3** (saved by Codex's revive — would have been 0 like Ch48/Ch52).

🤖 Generated with [Claude Code](https://claude.com/claude-code)