### PR TITLE
docs(ch55): Tier 1 + Tier 2 math sidebar + Tier 3 pull-quote — The Scaling Laws (#562, #394)

### DIFF
--- a/docs/research/ai-history/chapters/ch-55-the-scaling-laws/status.yaml
+++ b/docs/research/ai-history/chapters/ch-55-the-scaling-laws/status.yaml
@@ -46,5 +46,5 @@ notes: |
 # Lifecycle fields (added 2026-04-30 to decouple reader-aid rollout state
 # from research-phase `status` field; see Codex review forwarded by user).
 prose_state: published_on_main            # research_only | published_on_main
-reader_aids: none                      # none | pr_open | landed
+reader_aids: pr_open                   # none | pr_open | landed
 lifecycle_updated: 2026-04-30

--- a/docs/research/ai-history/chapters/ch-55-the-scaling-laws/tier3-proposal.md
+++ b/docs/research/ai-history/chapters/ch-55-the-scaling-laws/tier3-proposal.md
@@ -1,0 +1,36 @@
+# Chapter 55 — Tier 3 reader-aid proposal
+
+Author: Claude (claude-opus-4-7), 2026-04-30
+
+## Element 8 — SKIPPED (tooltip component not available)
+
+## Element 9 — Pull-quote
+
+**PROPOSED.** Candidate sentence (Sutton 2019 essay):
+
+> The biggest lesson that can be read from 70 years of AI research is that general methods that leverage computation are ultimately the most effective, and by a large margin.
+
+**Insertion anchor:** immediately after the chapter paragraph beginning "The philosophical background was Richard Sutton's 2019 essay..." (the paragraph that paraphrases the Bitter Lesson but does not block-quote this sentence).
+
+**Rationale:**
+- This is *the* canonical statement of the Bitter Lesson. The chapter paraphrases its content ("the largest lesson from decades of AI was that general methods leveraging computation tend to win over approaches that build in human knowledge") but does not verbatim-quote the headline sentence.
+- The "by a large margin" clause is load-bearing — the chapter softens it to "tend to win," but Sutton wrote a stronger claim. Block-quoting installs Sutton's actual rhetoric in the reader's eye.
+- Annotation will do new work by naming what Sutton wrote it *as* (not a refereed paper but a personal blog essay) — a provenance fact the chapter does not foreground.
+
+**Annotation (1 sentence, doing new work):** Sutton wrote the essay as a personal blog post, not a peer-reviewed paper, which makes the strength of "by a large margin" rhetorical rather than empirical — context that matters when the chapter pairs it with Kaplan's measured empirical fits.
+
+**Word budget:** 31 words quoted + ~36 annotation = ~67 words. Over the ≤60 cap. Codex should REVISE the annotation to fit.
+
+## Element 10 — SKIPPED
+
+The chapter pairs its math sidebar (Tier 2) with prose explanations of the same equations. Per the Ch44 (Word2Vec) precedent, when a math sidebar carries the symbolic load, plain-reading asides on top would only paraphrase already-natural-language prose. No formula/derivation paragraphs are stacked in the prose body.
+
+## Summary
+
+| Element | Author proposal | Rationale |
+|---|---|---|
+| 8 | SKIP | Bit-identity rule |
+| 9 | PROPOSE | Sutton "Bitter Lesson" headline sentence; chapter paraphrases but does not block-quote |
+| 10 | SKIP | Math sidebar carries symbolic load (Ch44 precedent) |
+
+**Awaiting Codex adversarial review.** Be willing to (a) REJECT on adjacent-repetition, (b) REVISE annotation length, or (c) REVIVE a different sentence (e.g., the Kaplan abstract "loss scales as a power-law... seven orders of magnitude" sentence) if Sutton's reads as duplicative.

--- a/docs/research/ai-history/chapters/ch-55-the-scaling-laws/tier3-review.md
+++ b/docs/research/ai-history/chapters/ch-55-the-scaling-laws/tier3-review.md
@@ -1,0 +1,41 @@
+# Tier 3 Review — Chapter 55: The Scaling Laws
+
+Reviewer: Codex (gpt-5.5)
+Date: 2026-04-30
+Reviewing: tier3-proposal.md by Claude (claude-opus-4-7)
+
+## Element 8 — Inline parenthetical definition
+Author verdict: SKIPPED — Tooltip component is not available; `<abbr>` would modify prose and violate bit-identity.
+Reviewer verdict: APPROVE
+I approve the skip. The spec makes Element 8 skipped on every chapter until a non-destructive tooltip component exists, and the Tier 1 glossary already defines cross-entropy loss, power law, N/D/C, compute-optimal training, sample efficiency, the Bitter Lesson, and the Kaplan-vs-Chinchilla allocation without touching verified prose.
+
+## Element 9 — Pull-quote
+Author verdict: PROPOSED — Sutton 2019 "Bitter Lesson" opening sentence after the paragraph introducing Sutton's philosophical setup.
+Reviewer verdict: REVISE
+The Sutton sentence should land, but with a shorter annotation. It is primary, quote-worthy, and not verbatim-repeated in the prose. The adjacent paragraph paraphrases Sutton's thesis, but the pull-quote still does new work by preserving the force of the sentence's closing phrase and marking the claim as philosophical backdrop rather than Kaplan-style measurement.
+
+Use Sutton's complete opening sentence from this anchor. Compliant excerpt:
+
+> The biggest lesson that can be read from 70 years of AI research is that general methods that leverage computation are ultimately the most effective...
+
+New annotation: This provenance matters: Sutton's blog framed a research instinct, not a fitted law; Kaplan later supplied the measured loss curves.
+
+Primary anchor: Sutton 2019, "The Bitter Lesson," opening paragraph.
+
+Do not revive the Kaplan abstract alternative. It is primary and chapter-central, but the chapter already says Kaplan reported power-law relationships with model size, dataset size, and training compute and immediately notes the abstract's seven-orders-of-magnitude framing. A pull-quote there would mostly restate adjacent prose.
+
+## Element 10 — Plain-reading aside
+Author verdict: SKIPPED — Math sidebar carries the symbolic load; prose already explains the equations in natural language.
+Reviewer verdict: APPROVE
+I approve the skip. The chapter has a real math sidebar, but the prose body is explanatory rather than symbolically dense: the N/D/C bottleneck paragraphs, compute-optimal training paragraphs, and Chinchilla correction all unpack the ideas in plain language. A `:::tip[Plain reading]` aside would repeat rather than clarify.
+
+## Summary
+- Approved: Element 8 skip; Element 10 skip
+- Rejected: None
+- Revised: Element 9 pull-quote annotation
+- Revived: None
+
+## Math sidebar verification
+The Kaplan values are mostly correct, but the compute exponent needs notation tightening. Kaplan §1.2 gives `alpha_N ~ 0.076`, `alpha_D ~ 0.095`, and `alpha_C^min ~ 0.050` for optimally allocated compute `C_min`; Appendix A/Table 5 also lists a separate naive/fixed-batch `alpha_C = 0.057`. The sidebar should therefore write the compute law as `L(C_min) \propto C_min^{-alpha_C^min}` with `alpha_C^min \approx 0.050`, or use `alpha_C \approx 0.057` if it means the naive fixed-batch compute trend.
+
+The compute-optimal allocation exponents are correct: Kaplan §1.2 / Eq. 1.7 says `N_opt \propto C_min^0.73`, `B \propto C_min^0.24`, and `S \propto C_min^0.03`; the paper also gives `D_opt \propto C_min^0.27` for one epoch.

--- a/src/content/docs/ai-history/ch-55-the-scaling-laws.md
+++ b/src/content/docs/ai-history/ch-55-the-scaling-laws.md
@@ -59,11 +59,11 @@ timeline
 <details>
 <summary><strong>The math, on demand</strong></summary>
 
-- **Three power laws.** $L(N) \propto N^{-\alpha_N}$, $L(D) \propto D^{-\alpha_D}$, and $L(C) \propto C^{-\alpha_C}$ — cross-entropy loss decreases as a power of model parameters $N$, dataset tokens $D$, or training compute $C$, each measured when the other two are *not* the bottleneck. The exponents are small ($\alpha_N \approx 0.076$, $\alpha_D \approx 0.095$, $\alpha_C \approx 0.050$ in Kaplan's fit), so each tenfold scale increase yields a modest but compounding loss reduction. Source: Kaplan et al. 2020 §1.2 / §3.
+- **Three power laws.** $L(N) \propto N^{-\alpha_N}$, $L(D) \propto D^{-\alpha_D}$, and $L(C_{\min}) \propto C_{\min}^{-\alpha_C^{\min}}$ — cross-entropy loss decreases as a power of model parameters $N$, dataset tokens $D$, or *optimally allocated* training compute $C_{\min}$, each measured when the other two are *not* the bottleneck. The exponents are small ($\alpha_N \approx 0.076$, $\alpha_D \approx 0.095$, $\alpha_C^{\min} \approx 0.050$ in Kaplan's fit; the naive fixed-batch compute trend gives $\alpha_C \approx 0.057$ instead), so each tenfold scale increase yields a modest but compounding loss reduction. Source: Kaplan et al. 2020 §1.2 / Appendix A / Table 5.
 
 - **Bottleneck rule.** $L(N, D) \to L(N)$ only when $D$ is large enough; otherwise loss is bounded by the data, not the model. Symmetrically for $D$ vs. $N$. The clean power-law shape appears only when the studied resource is the binding constraint; outside that regime, the curves bend. Source: Kaplan et al. 2020 §1 Summary, §4 overfitting analysis.
 
-- **Kaplan compute-optimal allocation.** Under a fixed compute budget $C$, Kaplan recommends $N_{\text{opt}} \propto C^{\sim 0.73}$, batch size $B_{\text{opt}} \propto C^{\sim 0.24}$, and number of steps $S_{\text{opt}} \propto C^{\sim 0.03}$ — i.e., spend most additional compute on a *bigger* model and stop training well short of convergence. Source: Kaplan et al. 2020 §6 / Figure 3.
+- **Kaplan compute-optimal allocation.** Under a fixed compute budget $C_{\min}$, Kaplan recommends $N_{\text{opt}} \propto C_{\min}^{0.73}$, batch size $B \propto C_{\min}^{0.24}$, number of steps $S \propto C_{\min}^{0.03}$, and one-epoch tokens $D_{\text{opt}} \propto C_{\min}^{0.27}$ — i.e., spend most additional compute on a *bigger* model and stop training well short of convergence. Source: Kaplan et al. 2020 §1.2 / Eq. 1.7 / §6.
 
 - **Chinchilla correction (2022).** Hoffmann et al. argue Kaplan's allocation is suboptimal in practice and that the empirically compute-optimal frontier is closer to $N \propto C^{0.5}$ *and* $D \propto C^{0.5}$ — model size and token count should scale roughly equally. Concretely, doubling compute means roughly $\sqrt{2}$ more parameters and $\sqrt{2}$ more training tokens, not (mostly) more parameters. Chinchilla (70B parameters, ~1.4T tokens) outperformed the larger 280B-parameter Gopher under the same compute budget. Source: Hoffmann et al. 2022 Abstract / Introduction / Table 3.
 
@@ -82,6 +82,12 @@ The result did not prove a universal law of intelligence. It did not say that en
 Cross-entropy loss is not a household term, but its role is straightforward. A language model assigns probabilities to possible next tokens. If it assigns high probability to the token that actually appears, loss is lower. If it is surprised by the text, loss is higher. Training pushes the model to become less surprised by the distribution it sees. The scaling-law paper studied how that surprise changed as the model, data, and compute grew.
 
 The philosophical background was Richard Sutton's 2019 essay "The Bitter Lesson." Sutton argued that the largest lesson from decades of AI was that general methods leveraging computation tend to win over approaches that build in human knowledge. He pointed to search and learning as the main methods that scale with computation, using examples from chess, Go, speech recognition, and computer vision. The essay was not evidence for the Kaplan equations, but it provided a warning label for the era: do not bet too heavily on hand-coded cleverness when computation keeps getting cheaper and larger.
+
+:::note
+> The biggest lesson that can be read from 70 years of AI research is that general methods that leverage computation are ultimately the most effective, and by a large margin.
+
+This provenance matters: Sutton's blog framed a research instinct, not a fitted law; Kaplan later supplied the measured loss curves. — *Sutton 2019, "The Bitter Lesson," opening paragraph.*
+:::
 
 That argument had a long history behind it. Expert systems had tried to encode knowledge directly. Hand-engineered vision pipelines had tried to build the right features. Symbolic systems had tried to place human abstractions into machines. Those approaches often worked in constrained domains, but they repeatedly struggled when the world became too varied. Sutton's essay gave a name to the pattern that deep learning researchers had been living through: methods that learn from data and exploit computation can look wasteful until the scale arrives, and then the waste becomes the advantage.
 

--- a/src/content/docs/ai-history/ch-55-the-scaling-laws.md
+++ b/src/content/docs/ai-history/ch-55-the-scaling-laws.md
@@ -5,6 +5,72 @@ sidebar:
   order: 55
 ---
 
+:::tip[In one paragraph]
+In January 2020, Kaplan, McCandlish, and OpenAI colleagues published "Scaling Laws for Neural Language Models": over more than seven orders of magnitude, autoregressive Transformer cross-entropy loss followed power-law relationships with parameters (N), tokens (D), and compute (C), with all three needed in tandem. Compute-optimal training favoured larger models stopped short of convergence. In March 2022 Hoffmann et al.'s Chinchilla refined the recipe — model size and tokens should scale roughly equally. Scaling became forecastable engineering.
+:::
+
+<details>
+<summary><strong>Cast of characters</strong></summary>
+
+| Name | Lifespan | Role |
+|---|---|---|
+| Jared Kaplan | — | Equal-contribution lead author of Kaplan et al. 2020 "Scaling Laws for Neural Language Models" |
+| Sam McCandlish | — | Equal-contribution lead author of Kaplan et al. 2020 |
+| Tom B. Brown | — | Kaplan paper coauthor; later GPT-3 lead author (Ch53) |
+| Dario Amodei | — | Kaplan paper coauthor (project guidance); later Anthropic co-founder |
+| Richard S. Sutton | 1959– | Author of "The Bitter Lesson" (2019); philosophical framing for general methods that leverage computation |
+| Jordan Hoffmann | — | DeepMind lead author of "Training Compute-Optimal Large Language Models" (2022) — the Chinchilla correction |
+
+</details>
+
+<details>
+<summary><strong>Timeline (2019–2022)</strong></summary>
+
+```mermaid
+timeline
+    title Chapter 55 — The Scaling Laws
+    2019 : Sutton publishes "The Bitter Lesson" — general methods that leverage computation tend to win
+    Jan 2020 : Kaplan et al. publish "Scaling Laws for Neural Language Models" (arXiv:2001.08361) — power-law fits across 7+ orders of magnitude
+    May 2020 : GPT-3 paper (Ch53) cites scaling-law frame as part of the rationale for testing 175B parameters
+    Mar 2022 : Hoffmann et al. publish "Training Compute-Optimal Large Language Models" — Chinchilla; many prior LLMs were undertrained
+```
+
+</details>
+
+<details>
+<summary><strong>Plain-words glossary</strong></summary>
+
+**Cross-entropy loss** — How surprised the model is by the next token in held-out text. Lower is better. The scaling laws are about *this* number: not "intelligence", not benchmark accuracy, not user satisfaction — just the prediction loss on autoregressive language modelling.
+
+**Power law** — A relation $y = a \cdot x^{-\alpha}$ where output changes as input is raised to a power. Plotted on log–log axes, power laws appear as approximately straight lines. The chapter's "smoothness" claim is this visual regularity.
+
+**Parameters (N), tokens (D), compute (C)** — The three knobs Kaplan studied. *Parameters* are the model's adjustable numbers (capacity). *Tokens* are the text the model trains on (experience). *Compute* is FLOPs spent during training (work). The paper's "all three must scale in tandem" rule means a bottleneck in any one stalls the gain from the other two.
+
+**Compute-optimal training** — Under a *fixed* compute budget, the question of which N and D minimise loss. Kaplan's 2020 answer favoured training very large models for relatively few steps. Chinchilla's 2022 answer was *equal* scaling: doubling compute should double both parameters and tokens.
+
+**Sample efficiency** — How well a model uses each training token. Kaplan reports that larger models reach a target loss with fewer optimisation steps and fewer training points than smaller models — which is what makes "bigger but shorter" sensible under a compute budget.
+
+**The Bitter Lesson** — Sutton's 2019 essay arguing that, across decades of AI history (chess, Go, speech, vision), general methods that scale with computation eventually win against approaches that hand-encode human knowledge. Cultural backdrop to Kaplan; not evidence for the equations.
+
+**Kaplan vs. Chinchilla allocation** — Two empirical answers to the compute-optimal question. Kaplan ≈ "model bigger, train shorter." Chinchilla ≈ "scale model and data equally." Both are *empirical fits* in tested regimes, not natural laws.
+
+</details>
+
+<details>
+<summary><strong>The math, on demand</strong></summary>
+
+- **Three power laws.** $L(N) \propto N^{-\alpha_N}$, $L(D) \propto D^{-\alpha_D}$, and $L(C) \propto C^{-\alpha_C}$ — cross-entropy loss decreases as a power of model parameters $N$, dataset tokens $D$, or training compute $C$, each measured when the other two are *not* the bottleneck. The exponents are small ($\alpha_N \approx 0.076$, $\alpha_D \approx 0.095$, $\alpha_C \approx 0.050$ in Kaplan's fit), so each tenfold scale increase yields a modest but compounding loss reduction. Source: Kaplan et al. 2020 §1.2 / §3.
+
+- **Bottleneck rule.** $L(N, D) \to L(N)$ only when $D$ is large enough; otherwise loss is bounded by the data, not the model. Symmetrically for $D$ vs. $N$. The clean power-law shape appears only when the studied resource is the binding constraint; outside that regime, the curves bend. Source: Kaplan et al. 2020 §1 Summary, §4 overfitting analysis.
+
+- **Kaplan compute-optimal allocation.** Under a fixed compute budget $C$, Kaplan recommends $N_{\text{opt}} \propto C^{\sim 0.73}$, batch size $B_{\text{opt}} \propto C^{\sim 0.24}$, and number of steps $S_{\text{opt}} \propto C^{\sim 0.03}$ — i.e., spend most additional compute on a *bigger* model and stop training well short of convergence. Source: Kaplan et al. 2020 §6 / Figure 3.
+
+- **Chinchilla correction (2022).** Hoffmann et al. argue Kaplan's allocation is suboptimal in practice and that the empirically compute-optimal frontier is closer to $N \propto C^{0.5}$ *and* $D \propto C^{0.5}$ — model size and token count should scale roughly equally. Concretely, doubling compute means roughly $\sqrt{2}$ more parameters and $\sqrt{2}$ more training tokens, not (mostly) more parameters. Chinchilla (70B parameters, ~1.4T tokens) outperformed the larger 280B-parameter Gopher under the same compute budget. Source: Hoffmann et al. 2022 Abstract / Introduction / Table 3.
+
+- **Why log–log axes are the natural plot.** Taking $\log$ of $L \propto X^{-\alpha}$ gives $\log L = -\alpha \log X + \text{const}$ — a straight line with slope $-\alpha$. That is why scaling-law plots in the literature are uniformly log–log: the eye reads multiplicative changes as linear movements, and a deviation from straight is visible as a deviation from the law. Source: Kaplan et al. 2020 figures throughout; standard scientific-plotting convention.
+
+</details>
+
 By the time model hubs made checkpoints easier to find and reuse, the field had a new question. If larger models kept improving, how far could the curve be pushed? A stronger checkpoint could now travel farther through the ecosystem. A better language model could be adapted, loaded, benchmarked, wrapped, compared, and discussed more easily than before. That made the reward for training a stronger model larger. It also made the cost question sharper.
 
 Training bigger models had always been tempting, but temptation is not a plan. Researchers needed to know whether more parameters, more data, and more compute were likely to produce predictable gains or merely expensive surprises. In ordinary research, a bigger experiment can fail for many reasons: the architecture might break, optimization might stall, the data might be poor, or the benchmark might stop responding. The scaling-law moment mattered because it suggested that language-model loss could be plotted, extrapolated, and budgeted with unusual smoothness.
@@ -126,3 +192,7 @@ The result also changed what counted as a bottleneck. If loss could keep improvi
 The honest ending is narrow and large at the same time. Kaplan et al. measured empirical power laws in language-model loss across model size, dataset size, and compute. The result did not prove intelligence scales automatically. It did not remove the need for architecture, data quality, evaluation, or safety. It did not survive unchanged; Chinchilla refined the compute-optimal allocation. But it changed the field's planning imagination. It made language-model progress look less like a sequence of isolated miracles and more like an engineering frontier with knobs, budgets, curves, and bottlenecks.
 
 That was enough to reshape modern AI. Once researchers believed they could forecast returns to scale, the race moved toward the systems capable of buying those returns: bigger datasets, larger models, longer runs, faster interconnects, better schedulers, and clusters designed around training. The next chapter is the story of that machine.
+
+:::note[Why this still matters today]
+Every modern frontier model release card cites parameter count, training-token count, and a Chinchilla-aware ratio. The Chinchilla recipe (equal model/data scaling) is the empirical default for Llama, Mistral, DeepSeek, Qwen, and most academic LLMs. Scaling-law thinking still drives the largest compute decisions — what a 1B-parameter Chinchilla-scale Llama 3 needs in tokens, why Anthropic, OpenAI, and Google plan training runs years in advance, and why the 2024–2026 "data exhaustion" debate (Ch69) directly threatens further scaling. The curve is still the planning instrument.
+:::


### PR DESCRIPTION
## Summary

Reader-aids on bit-identical prose for **Chapter 55: The Scaling Laws** — Kaplan and Chinchilla.

**Tier 1**: TL;DR (75w) · Cast (Kaplan, McCandlish, Brown, Amodei, Sutton, Hoffmann) · Timeline (2019 Bitter Lesson → 2022 Chinchilla) · Glossary (7 terms).

**Tier 2 math sidebar** (5 entries):
- Three power laws L(N), L(D), L(C_min) with Kaplan exponents (α_N≈0.076, α_D≈0.095, α_C^min≈0.050; naive α_C≈0.057)
- Bottleneck rule
- Kaplan compute-optimal: N∝C_min^0.73, B∝C_min^0.24, S∝C_min^0.03, D_opt∝C_min^0.27
- Chinchilla correction: N∝C^0.5 AND D∝C^0.5 (equal scaling)
- Why log-log axes

**Why-still**: every modern frontier model release card cites Chinchilla-aware ratio; data-exhaustion debate (Ch69) is downstream.

**Tier 3 — codex review verdicts**: Element 8 APPROVE skip · **Element 9 REVISE** (Sutton headline sentence + Codex's tighter annotation; landed COMPLETE sentence per Ch43 precedent) · Element 10 APPROVE skip · **Math-sidebar correction** (Codex caught α_C → α_C^min notation imprecision and reminded me to include D_opt). Tier 3 yield: **1 of 3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)