### PR TITLE
docs(ch59): Tier 1 + Tier 3 pull-quote reader aids — The Product Shock (#562, #394)

### DIFF
--- a/docs/research/ai-history/chapters/ch-59-the-product-shock/status.yaml
+++ b/docs/research/ai-history/chapters/ch-59-the-product-shock/status.yaml
@@ -65,5 +65,5 @@ notes: |
 # Lifecycle fields (added 2026-04-30 to decouple reader-aid rollout state
 # from research-phase `status` field; see Codex review forwarded by user).
 prose_state: published_on_main            # research_only | published_on_main
-reader_aids: none                      # none | pr_open | landed
+reader_aids: pr_open                      # none | pr_open | landed
 lifecycle_updated: 2026-04-30

--- a/docs/research/ai-history/chapters/ch-59-the-product-shock/tier3-proposal.md
+++ b/docs/research/ai-history/chapters/ch-59-the-product-shock/tier3-proposal.md
@@ -1,0 +1,44 @@
+# Chapter 59 — Tier 3 reader-aid proposal
+
+Author: Claude (claude-opus-4-7), 2026-04-30
+Reviewer (cross-family): Codex (gpt-5.5)
+Spec: `docs/research/ai-history/READER_AIDS.md` Tier 3 (elements 8, 9, 10).
+
+## Element 8 — Inline parenthetical definition
+
+**SKIPPED.** Per the spec, every chapter skips this element until a non-destructive Astro `<Tooltip>` component lands. The Tier 1 *Plain-words glossary* covers research preview, RLHF, MAU, ChatGPT Plus, Bing/Bard, jailbreak/adversarial prompting, and hallucination.
+
+## Element 9 — Pull-quote (`:::note[]` callout)
+
+**PROPOSED-by-concept (Codex, please fetch and verify the verbatim wording).** Candidate primary source: OpenAI, "Introducing ChatGPT," November 30, 2022 (https://openai.com/index/chatgpt/).
+
+The chapter's load-bearing thesis is that the conversational *interface* — not new science — is what shocked the world. The OpenAI launch page says, in its introductory paragraph, that ChatGPT can answer follow-up questions, admit mistakes, challenge incorrect premises, and reject inappropriate requests. The chapter's prose paraphrases this list at line 18 ("ChatGPT could answer follow-up questions, admit mistakes, challenge incorrect premises, and reject inappropriate requests") — adjacency-repetition risk is HIGH if I block-quote that exact sentence again.
+
+A safer candidate is the page's *framing* sentence describing the dialogue interface. Per `sources.md`, the OpenAI ChatGPT page opens with language to the effect of: *"The dialogue format makes it possible for ChatGPT to answer follow-up questions, admit its mistakes, challenge incorrect premises, and reject inappropriate requests."* The chapter prose paraphrases the second half of this sentence but not the first half (the *dialogue-format-makes-it-possible* framing). Block-quoting the full sentence would install OpenAI's own causal claim — that the *format* unlocks the behaviours — at the moment the chapter is making the same argument from the outside.
+
+**Insertion anchor:** immediately after the chapter paragraph beginning "OpenAI's launch page described exactly that surface…" (the paragraph that paraphrases the four behaviours but not the dialogue-format causal claim).
+
+**Tentative annotation (1 sentence, doing new work):** OpenAI's own framing puts the work on the *format* rather than the model — a subtle but load-bearing claim, since it is what lets the chapter argue the shock was packaging, not new science.
+
+**What Codex should do:**
+1. Fetch https://openai.com/index/chatgpt/ and locate the verbatim opening sentence about the dialogue format.
+2. If the verbatim sentence exists and is ≤30 words, APPROVE with the exact wording captured.
+3. If the wording differs from my reconstruction, REVISE with the actual sentence.
+4. If the page no longer carries this sentence (post-launch edits), REVIVE with a different verbatim candidate from one of the primary sources in `sources.md` — Microsoft Bing post, Google Bard post, Stack Overflow ban policy post, or Chalkbeat. Each of those carries one or two genuinely quote-worthy sentences.
+5. If no candidate clears adjacency-repetition AND verbatim-fidelity bars, REJECT.
+
+**Word budget:** sentence ~25 words + annotation ~30 words ≈ 55 words. Under the ≤60 cap.
+
+## Element 10 — Plain-reading aside
+
+**SKIPPED.** Ch59 is narrative/historical: launch chronology, adoption-metric anchoring, institutional reaction, product-race timeline. No paragraph is *symbolically* dense (no formulas, derivations, or stacked abstract definitions). Plain-reading asides apply only to symbolic density per the spec.
+
+## Summary
+
+| Element | Author proposal | Rationale |
+|---|---|---|
+| 8 | SKIP | Bit-identity rule (no Tooltip component yet) |
+| 9 | PROPOSE-by-concept | OpenAI ChatGPT page dialogue-format opening sentence — chapter paraphrases the four behaviours but not the causal-frame; needs Codex verbatim verification |
+| 10 | SKIP | No symbolic density — narrative/historical chapter |
+
+**Awaiting Codex adversarial review.** Be willing to REJECT (if you judge the chapter's "OpenAI's launch page described exactly that surface…" paragraph paraphrases the same content too closely), REVISE (with the exact verbatim wording from the page), or REVIVE (a different verbatim sentence — e.g., from the Stack Overflow ban policy post about "low average correctness" plus "plausible-looking" or from the Microsoft Bing reinventing-search post).

--- a/docs/research/ai-history/chapters/ch-59-the-product-shock/tier3-review.md
+++ b/docs/research/ai-history/chapters/ch-59-the-product-shock/tier3-review.md
@@ -1,0 +1,38 @@
+# Chapter 59 — Tier 3 reader-aid review (Codex)
+
+Reviewer: Codex (gpt-5.5, model_reasoning_effort=high)
+Date: 2026-04-30
+Spec: `docs/research/ai-history/READER_AIDS.md` Tier 3
+Chapter checked: `.worktrees/ch59-reader-aids/src/content/docs/ai-history/ch-59-the-product-shock.md`
+
+## Element 8 — APPROVE
+
+Approve the skip. Tier 3 Element 8 is explicitly skipped for every chapter until a non-destructive Astro tooltip component exists. The Tier 1 glossary already covers the needed terms.
+
+## Element 9 — REVISE
+
+The concept is valid, but the proposal's wording is reconstructed. Use the verified OpenAI sentence exactly:
+
+> The dialogue format makes it possible for ChatGPT to answer followup questions, admit its mistakes, challenge incorrect premises, and reject inappropriate requests.
+
+OpenAI's causal framing matters: dialogue is presented as the product mechanism, not just a neutral wrapper around the model.
+
+Primary source: https://openai.com/index/chatgpt/
+
+Reason: the page still carries the sentence. The chapter paraphrases the behavior list nearby, but does not block-quote the same sentence and does not preserve the source's "dialogue format makes it possible" causal frame.
+
+## Element 10 — APPROVE
+
+Approve the skip. Chapter 59 is narratively dense, not symbolically dense: no formulas, derivations, or stacked abstract definitions need a `:::tip[Plain reading]` aside.
+
+---
+
+## Apply summary
+
+| Element | Verdict | Action |
+|---|---|---|
+| 8 | APPROVE skip | No element landed |
+| 9 | REVISE | Land OpenAI ChatGPT page verbatim sentence — "The dialogue format makes it possible for ChatGPT to answer followup questions, admit its mistakes, challenge incorrect premises, and reject inappropriate requests." |
+| 10 | APPROVE skip | No element landed |
+
+**Tier 3 yield: 1 of 3 candidates landed.**

--- a/src/content/docs/ai-history/ch-59-the-product-shock.md
+++ b/src/content/docs/ai-history/ch-59-the-product-shock.md
@@ -5,6 +5,63 @@ sidebar:
   order: 59
 ---
 
+:::tip[In one paragraph]
+On November 30, 2022 OpenAI launched ChatGPT as a free research preview — a chat box wrapping a GPT-3.5 model fine-tuned with RLHF on Azure supercomputing. The break was not new science but packaging: conversational turn-taking turned model behaviour into consumer habit. Reuters/UBS estimated 100M monthly active users by January 2023, the fastest-growing consumer application at that time. Stack Overflow banned generated answers, NYC schools blocked it, and Microsoft's Bing and Google's Bard launched within ten days of each other.
+:::
+
+<details>
+<summary><strong>Cast of characters</strong></summary>
+
+| Name | Lifespan | Role |
+|---|---|---|
+| Sam Altman | — | OpenAI CEO; public framing of adoption and monetization, including the early 1M-users tweet |
+| John Schulman | — | Named on the OpenAI ChatGPT launch page among the contributor list for the research preview |
+| Satya Nadella | — | Microsoft CEO; anchors the January 2023 OpenAI partnership extension and the Bing/search response |
+| Yusuf Mehdi | — | Microsoft executive author of the February 7, 2023 AI-powered Bing and Edge announcement |
+| Sundar Pichai | — | Google/Alphabet CEO; author of the February 6, 2023 Bard and AI-Search post |
+| Jenna Lyle | — | NYC education department spokesperson quoted by Chalkbeat on the school-device/network block |
+
+</details>
+
+<details>
+<summary><strong>Timeline (Nov 2022 – Mar 2023)</strong></summary>
+
+```mermaid
+timeline
+    title Chapter 59 — The Product Shock
+    Nov 30 2022 : OpenAI launches ChatGPT as a free research preview
+    Dec 5 2022 : Stack Overflow posts the temporary ban on generative AI content; Altman reports ChatGPT crossed 1M users
+    Jan 3 2023 : NYC education department confirms ChatGPT blocked on school devices and networks
+    Jan 2023 : Reuters relays UBS estimate of 100M monthly active users
+    Jan 23 2023 : Microsoft announces the third phase of its OpenAI partnership
+    Feb 1 2023 : OpenAI announces ChatGPT Plus at $20/month
+    Feb 6 2023 : Google announces Bard and AI-powered Search features
+    Feb 7 2023 : Microsoft announces the new AI-powered Bing and Edge in preview
+    Mar 1 2023 : OpenAI releases GPT-3.5 Turbo and Whisper APIs
+    Mar 14 2023 : OpenAI announces GPT-4
+```
+
+</details>
+
+<details>
+<summary><strong>Plain-words glossary</strong></summary>
+
+**Research preview** — OpenAI's framing for the ChatGPT launch: free public access while the company gathered user feedback to find strengths, weaknesses, and failure modes. The label sounded provisional, but the product was deployed at scale to millions of users from day one.
+
+**RLHF (Reinforcement Learning from Human Feedback)** — The training method that shaped ChatGPT's conversational behaviour: supervised fine-tuning on dialogues written by human AI trainers, comparison/ranking data, a learned reward model, and Proximal Policy Optimization. Inherited from InstructGPT (Ch57); ChatGPT made it the default assistant interface.
+
+**Monthly active users (MAU)** — A standard product metric: distinct users who interact with a service in a 30-day window. The Reuters/UBS estimate of 100M MAU in January 2023 is what made ChatGPT a coordination problem for executives, schools, regulators, and competitors rather than a research demo.
+
+**ChatGPT Plus** — OpenAI's first paid tier, announced February 1, 2023 at $20/month. It sold reliability under load — general access during peak times, faster responses, priority on new features — while preserving the free tier. Demand had made inference itself a consumer expectation.
+
+**Bing / Bard** — The search-side response: Microsoft's AI-powered Bing and Edge preview (Feb 7, 2023), built on a "next-generation OpenAI model" Microsoft called Prometheus, and Google's Bard (Feb 6, 2023), opened to trusted testers and based on LaMDA. The product race shifted from chatbot novelty to interface competition over how users find information.
+
+**Jailbreak / adversarial prompting** — User prompts crafted to route around a model's safety policy or refusal behaviour. The GPT-4 System Card (March 2023) explicitly treats jailbreaks as a deployment surface: mitigations reduce but do not eliminate them, and Figure 10 walks through example exploits against GPT-4-launch.
+
+**Hallucination** — Plausible but incorrect output. OpenAI's launch page warned ChatGPT could produce confident wrong answers, and the GPT-4 page kept the warning. Plausible wrongness is what made Stack Overflow and NYC schools react: cheap to produce, expensive to verify.
+
+</details>
+
 ChatGPT did not invent the Transformer. It did not invent reinforcement learning from human feedback. It did not invent the internet-scale language model, the autocomplete interface, the chatbot, or the dream of a conversational computer. Almost every layer underneath it had already appeared in the previous chapters: attention, scale, data, RLHF, alignment work, cloud supercomputers, and the public fascination with generative systems.
 
 What changed on November 30, 2022 was packaging.
@@ -16,6 +73,12 @@ The interface made the model social.
 Earlier language-model demos could be impressive, but they often required technical framing. ChatGPT compressed the machinery into ordinary turn-taking. A user did not need to know what a token was, how RLHF worked, why GPT-3.5 mattered, or what Azure supercomputing had supplied. The model behaved enough like a conversational partner that the research lineage disappeared behind the product surface. The public shock was not only that a model could generate text. It was that millions of people could immediately find a use for that generation inside a familiar human pattern: ask, answer, refine.
 
 OpenAI's launch page described exactly that surface. ChatGPT could answer follow-up questions, admit mistakes, challenge incorrect premises, and reject inappropriate requests. Those behaviors were not decorative. They were the whole product grammar. The model was no longer only completing a prompt. It was occupying a conversational role, with memory of the immediate dialogue and a safety policy visible enough for users to encounter it directly.
+
+:::note
+> The dialogue format makes it possible for ChatGPT to answer followup questions, admit its mistakes, challenge incorrect premises, and reject inappropriate requests.
+
+OpenAI's own framing puts the work on the *format* — not the model — making the chapter's "shock was packaging, not new science" thesis the launch page's own causal claim.
+:::
 
 That visibility mattered because ChatGPT turned alignment from an internal research topic into a public interaction. InstructGPT and RLHF had already shown that models could be trained to better follow human preferences. But most people did not meet RLHF as a method. They met it as an assistant that sometimes refused a request, softened a tone, avoided certain outputs, or tried to explain its own limits. Safety behavior became part of the user experience.
 
@@ -122,3 +185,8 @@ The honest conclusion is narrower than the hype. ChatGPT was not a mind suddenly
 By March 2023, the direction was clear. ChatGPT had become a subscription. Its underlying model family had become an API. Microsoft and Google had moved search into the conversational race. GPT-4 had turned the surprise into a cadence of higher-capability releases under safety and capacity pressure. The next step was obvious: if a chat box could answer, could it browse, retrieve, call tools, take actions, and behave less like a text generator and more like an agent?
 
 That question belongs to the next chapter. The product shock was the moment the public met the assistant. The agent turn began when companies and researchers tried to give that assistant hands.
+
+:::note[Why this still matters today]
+Almost every consumer-facing AI product after late 2022 borrows ChatGPT's grammar — a chat box, conversational turn-taking, visible refusals, a feedback button, a paid tier sold on capacity rather than only capability. Search engines now ship synthesised answers above link lists. Productivity tools embed conversational drafting into documents, mail, and code editors. Schools, publishers, and Q&A communities still litigate the line between fluent generation and verifiable expertise that Stack Overflow and NYC schools first hit in late 2022. The product shock also normalised release rhythm — usage caps, waitlists, subscription tiers, and capacity warnings — as part of how frontier capability reaches users.
+:::
+


### PR DESCRIPTION
## Summary

Reader-aids on bit-identical prose for **Chapter 59: The Product Shock** — ChatGPT as consumer product / Nov 30 2022 launch / 100M MAU estimate (UBS/Reuters Jan 2023, fastest-growing consumer app *at the time*; Threads later surpassed in July 2023) / Stack Overflow + NYC schools moderation / Microsoft–Bing / Google–Bard / GPT-4 aftershock.

**Tier 1**: TL;DR (80w) · Cast (6 rows) · Timeline (10 events, Nov 2022 – Mar 2023) · Glossary (7 terms).

**No Tier 2** (Ch59 not on math/architecture list per `docs/research/ai-history/READER_AIDS.md`).

**Why-still**: chat box, conversational refusals, paid tiers sold on capacity, search-results-as-synthesis, and waitlist/usage-cap release rhythm all descend from late-2022/early-2023 ChatGPT.

**Tier 3 — codex review verdicts** (`tier3-proposal.md` → `tier3-review.md`):

- **Element 8**: APPROVE skip (no Tooltip component yet)
- **Element 9**: REVISE → REVIVE-with-verbatim. Codex fetched openai.com/index/chatgpt/ and supplied the verified opening dialogue-format sentence: *"The dialogue format makes it possible for ChatGPT to answer followup questions, admit its mistakes, challenge incorrect premises, and reject inappropriate requests."* Landed as a `:::note` callout immediately after the chapter's "OpenAI's launch page described exactly that surface…" paragraph. Annotation foregrounds OpenAI's *causal* frame ("the format makes it possible") — the chapter's "shock was packaging" thesis is the launch page's own claim.
- **Element 10**: APPROVE skip (no symbolic density — narrative/historical chapter)

**Tier 3 yield: 1 of 3.**

Bit-identity verified: `git diff main -- ch-59*.md | grep '^-[^-]'` is empty. Build clean: 1955 pages, 0 errors.

Flips `reader_aids: none → pr_open` in status.yaml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)