### PR TITLE
docs(ch60): Tier 1 + Tier 3 pull-quote reader aids — The Agent Turn (#562, #394)

### DIFF
--- a/docs/research/ai-history/chapters/ch-60-the-agent-turn/status.yaml
+++ b/docs/research/ai-history/chapters/ch-60-the-agent-turn/status.yaml
@@ -62,5 +62,5 @@ notes: |
 # Lifecycle fields (added 2026-04-30 to decouple reader-aid rollout state
 # from research-phase `status` field; see Codex review forwarded by user).
 prose_state: published_on_main            # research_only | published_on_main
-reader_aids: none                      # none | pr_open | landed
+reader_aids: pr_open                      # none | pr_open | landed
 lifecycle_updated: 2026-04-30

--- a/docs/research/ai-history/chapters/ch-60-the-agent-turn/tier3-proposal.md
+++ b/docs/research/ai-history/chapters/ch-60-the-agent-turn/tier3-proposal.md
@@ -1,0 +1,44 @@
+# Chapter 60 — Tier 3 reader-aid proposal
+
+Author: Claude (claude-opus-4-7), 2026-04-30
+Reviewer (cross-family): Codex (gpt-5.5)
+Spec: `docs/research/ai-history/READER_AIDS.md` Tier 3 (elements 8, 9, 10).
+
+## Element 8 — Inline parenthetical definition
+
+**SKIPPED.** Per the spec, every chapter skips this element until a non-destructive Astro `<Tooltip>` component lands. The Tier 1 *Plain-words glossary* covers parametric/non-parametric memory, RAG, chain-of-thought, ReAct loop, function calling, and prompt injection.
+
+## Element 9 — Pull-quote (`:::note[]` callout)
+
+**PROPOSED.** Candidate sentence — ReAct paper (Yao et al. 2022, arXiv:2210.03629), abstract:
+
+> we explore the use of LLMs to generate both reasoning traces and task-specific actions in an interleaved manner
+
+**Insertion anchor:** immediately after the chapter paragraph beginning "Shunyu Yao and collaborators described ReAct as interleaving reasoning traces and task-specific actions." (the paragraph that paraphrases this exact abstract claim). The pull-quote installs the paper's voice over the chapter's paraphrase before the loop-mechanics paragraph that follows.
+
+**Rationale:**
+- The chapter explicitly paraphrases this line ("interleaving reasoning traces and task-specific actions") — block-quoting the abstract converts the chapter's summary to documented evidence and lets readers see the exact phrasing the paper uses for the architectural grammar.
+- "Interleaved" is the load-bearing word. The chapter's later "thought, action, observation" framing depends on the interleaving claim. The block-quote anchors the readers' eyes on the paper's own choice of word before the loop is unpacked.
+- The chapter does not block-quote any primary source; pulling one in for the architectural hinge of the chapter is high-yield.
+
+**Annotation (1 sentence, doing new work):** This is the architectural grammar of the agent turn — every later "agentic" framework, from LangChain agents to OpenAI function calling, restates this same interleave of generated reasoning and selected action.
+
+**Word budget:** 18 words quoted + ~32 words annotation ≈ 50 words. Under 60-word cap.
+
+**Alternative if rejected (REVIVE candidate):** The Toolformer abstract sentence "we propose Toolformer, a model trained to decide which APIs to call, when to call them, what arguments to pass, and how to best incorporate the results into future token prediction" (Schick et al. 2023) — fuller technical statement of self-supervised tool-use, but ~35 words quoted alone, leaving little room for annotation.
+
+**Second alternative:** AutoGPT v0.1.0 README "NEXT COMMAND" instruction line — distinctive cultural artifact, but the chapter already paraphrases it explicitly, so adjacent-repetition risk is high.
+
+## Element 10 — Plain-reading aside
+
+**SKIPPED.** Ch60's prose is narrative/architectural — RAG infrastructure description, search workflow framing, ReAct loop grammar, plugin and function-calling product framing. There are no symbolically dense paragraphs (no formula derivations, no stacked technical definitions requiring pause). Plain-reading asides apply only to formula/derivation density per the spec.
+
+## Summary
+
+| Element | Author proposal | Rationale |
+|---|---|---|
+| 8 | SKIP | Bit-identity rule until `<Tooltip>` lands |
+| 9 | PROPOSE | ReAct abstract sentence; chapter paraphrases the architectural hinge but does not block-quote it |
+| 10 | SKIP | No symbolic density |
+
+**Awaiting Codex adversarial review.** Be willing to REJECT (if you judge the chapter's "interleaving reasoning traces and task-specific actions" paragraph paraphrases the same content too closely — adjacent-repetition risk), REVISE (annotation length or anchor placement), or REVIVE (a different verbatim sentence — e.g., the Toolformer abstract, the OpenAI plugins page Overview line, the OpenAI function-calling page line on JSON arguments, or the AutoGPT README "NEXT COMMAND" line).

--- a/docs/research/ai-history/chapters/ch-60-the-agent-turn/tier3-review.md
+++ b/docs/research/ai-history/chapters/ch-60-the-agent-turn/tier3-review.md
@@ -1,0 +1,39 @@
+# Chapter 60 — Tier 3 reader-aid review (Codex)
+
+Reviewer: gpt-5.5, 2026-04-30
+
+## Verdicts
+
+| Element | Verdict | Review |
+|---|---|---|
+| 8 | **APPROVE** | Approve the skip. The spec says Element 8 is skipped on every chapter until a non-destructive tooltip component exists. |
+| 9 | **REVIVE** | The proposed ReAct excerpt is verified in the arXiv abstract, but it is a sentence fragment, not a full pull-quote sentence, and the annotation overclaims with "every later agentic framework." Use a tighter ReAct sentence instead. |
+| 10 | **APPROVE** | Approve the skip. Chapter 60 is architecturally dense, but not symbolically dense in the Tier 3 sense: no formulas, derivations, or stacked abstract definitions needing a `Plain reading` aside. |
+
+## Element 9 Replacement
+
+Primary source: Yao et al., *ReAct: Synergizing Reasoning and Acting in Language Models*, arXiv:2210.03629, Method section / PDF. The abstract also verifies the proposal's original wording on interleaved reasoning/action.
+
+Suggested callout, inserted after the paragraph beginning "The loop is easy to understand…":
+
+```md
+:::note
+> For the tasks where reasoning is of primary importance (Figure 1(1)), we alternate the generation of thoughts and actions so that the task-solving trajectory consists of multiple thought-action-observation steps.
+
+This is the loop claim in its narrow form: ReAct made action part of the trajectory, not just a postscript to reasoning.
+:::
+```
+
+Why this revival: it is a complete verbatim sentence, stays under the 60-word cap with annotation, matches the chapter's loop-mechanics paragraph, and avoids the unsupported "every later framework" lineage claim.
+
+Sources checked:
+- arXiv abstract page for ReAct: https://arxiv.org/abs/2210.03629
+- arXiv PDF/source package (Method section, abstract.tex / method.tex): https://arxiv.org/pdf/2210.03629
+
+## Author response
+
+- Element 8: APPROVE → SKIP confirmed.
+- Element 9: REVIVE → applying Codex's verified-verbatim sentence at the suggested anchor (after "The loop is easy to understand…" paragraph).
+- Element 10: APPROVE → SKIP confirmed.
+
+Tier 3 yield: **1 of 3** (1 landed, 2 SKIP).

--- a/src/content/docs/ai-history/ch-60-the-agent-turn.md
+++ b/src/content/docs/ai-history/ch-60-the-agent-turn.md
@@ -5,6 +5,59 @@ sidebar:
   order: 60
 ---
 
+:::tip[In one paragraph]
+After ChatGPT, the architectural problem shifted from making models talk to letting them act. RAG gave models external memory; WebGPT taught them to search and cite; chain-of-thought made reasoning a visible scratchpad; ReAct and Toolformer fused reasoning with tool calls; OpenAI's plugins and function calling productized the interface; LangChain and AutoGPT made agent loops legible to developers. Early agents were brittle, not autonomous workers — but the center of AI applications moved from a single chat reply to model-plus-retriever-plus-tools systems.
+:::
+
+<details>
+<summary><strong>Cast of characters</strong></summary>
+
+| Name | Lifespan | Role |
+|---|---|---|
+| Patrick Lewis et al. | — | Lead authors of the 2020 RAG paper (parametric + non-parametric memory). |
+| Reiichiro Nakano et al. | — | WebGPT authors (browser-assisted QA with citations and human feedback). |
+| Jason Wei et al. | — | Chain-of-Thought prompting authors (intermediate reasoning steps in large LMs). |
+| Shunyu Yao et al. | — | ReAct authors (interleaved reasoning, action, and observation loops). |
+| Timo Schick et al. | — | Toolformer authors (self-supervised tool-use via API calls). |
+| OpenAI / Significant Gravitas | — | ChatGPT plugins, function calling; AutoGPT v0.1.0 as the visible 2023 agent demo. |
+
+</details>
+
+<details>
+<summary><strong>Timeline</strong></summary>
+
+```mermaid
+timeline
+    title The Agent Turn (2020–2023)
+    2020-05 : Lewis et al. release RAG
+    2021-12 : OpenAI publishes WebGPT
+    2022-01 : Wei et al. release Chain-of-Thought Prompting
+    2022-10 : ReAct on arXiv
+            : LangChain repo created
+    2022-11 : LlamaIndex repo created
+    2023-02 : Toolformer on arXiv
+    2023-03 : AutoGPT repo created
+            : OpenAI announces ChatGPT plugins
+    2023-04 : AutoGPT v0.1.0 README published
+    2023-06 : OpenAI announces function calling
+    2023-07 : LangChain v0.0.1 tag (chains/data-augmented/agents taxonomy)
+```
+
+</details>
+
+<details>
+<summary><strong>Plain-words glossary</strong></summary>
+
+- **Parametric memory** — what the model "knows" because it is baked into the weights from training. Hard to inspect, expensive to update.
+- **Non-parametric memory** — knowledge stored outside the model in documents, indexes, or vector stores. Can be swapped or refreshed without retraining.
+- **Retrieval-augmented generation (RAG)** — a pattern where the model answers using passages fetched from an external store at query time, not just from its weights.
+- **Chain-of-thought** — prompting the model to write intermediate reasoning steps before its final answer; a scratchpad pattern, not a window into the model's actual computation.
+- **ReAct loop** — interleaving thought, action, and observation: the model reasons, calls a tool, reads what came back, then reasons again.
+- **Function calling** — a structured interface where the developer describes functions and the model emits JSON arguments; the surrounding software, not the model, decides whether to execute.
+- **Prompt injection** — instructions hidden inside untrusted text (a webpage, document, or tool output) that try to hijack a tool-using model.
+
+</details>
+
 ChatGPT made the model feel like a conversational partner. That was enough to shock the public, but it also exposed the weakness of the closed chat window. A model could answer fluently, but fluency did not give it current facts, private documents, a calculator, a database connection, a browser, or permission to take an action in the world. The assistant could talk as if it knew, but much of what users wanted required something outside the weights.
 
 That is the hinge from product shock to agent turn.
@@ -81,6 +134,12 @@ Shunyu Yao and collaborators described ReAct as interleaving reasoning traces an
 
 The loop is easy to understand because it resembles ordinary problem solving. If you do not know something, search. If the search result is incomplete, refine. If a tool returns a value, use it. If an action fails, observe the failure and adjust. ReAct turned that structure into a prompting pattern for language models. The model's text was no longer only the final product. Part of the text selected an action. The environment returned an observation. The next model call incorporated that observation.
 
+:::note
+> For the tasks where reasoning is of primary importance (Figure 1(1)), we alternate the generation of thoughts and actions so that the task-solving trajectory consists of multiple thought-action-observation steps.
+
+This is the loop claim in its narrow form: ReAct made action part of the trajectory, not just a postscript to reasoning.
+:::
+
 This was the agent turn in miniature. The model became part of a control loop.
 
 But the loop also multiplied failure modes. A bad thought can choose the wrong action. A wrong action can fetch misleading evidence. A misleading observation can anchor the next step. The model can over-trust a tool result, ignore it, or continue a bad plan. In a closed chat window, the main failure is bad text. In a tool loop, bad text can become bad action. That is why early agent research and product work always carried a safety shadow.
@@ -145,4 +204,9 @@ The deeper lesson is that agency is not a single feature. It is a system propert
 
 This is why the early agent turn should be written with discipline. It was historically important, but not because autonomous AI workers suddenly arrived in 2023. They did not. It was important because the architecture of AI applications changed. The center moved from a single model answering in a chat window toward model-centered systems: retrieval pipelines, search actions, reasoning traces, tool calls, plugin permissions, function schemas, orchestration frameworks, and loops.
 
+:::note[Why this still matters today]
+The architecture this chapter describes is what every modern AI application is made of. When a chatbot answers from your company's docs, that is RAG. When a coding assistant runs a search before replying, that is the WebGPT instinct. When a model thinks step by step before deciding what to do, that is chain-of-thought. When an assistant calls a calculator, schedules a meeting, or queries a database, that is ReAct/Toolformer with a productized function-calling interface. The same chapter also seeded today's hard problems: retrieval quality, source trust, prompt injection, permissions, audit trails, runaway loops, and the cost of every extra tool call. Today's "agentic" systems are still building on this 2020–2023 foundation.
+:::
+
 The public had met the assistant in Chapter 59. In Chapter 60, builders tried to give that assistant memory and hands. The result was powerful, unstable, and unfinished. It pointed toward the next constraint: once models act through tools, the cost of every token, every retrieval, every function call, and every retry starts to matter. The agent turn made language models operational. It also made their limits operational.
+


### PR DESCRIPTION
## Summary

Reader-aids on bit-identical prose for **Chapter 60: The Agent Turn** — RAG, WebGPT, chain-of-thought, ReAct, Toolformer, plugins, function calling, LangChain/LlamaIndex, AutoGPT.

**Tier 1**: TL;DR (80w) · Cast (6 rows) · Timeline (Mermaid, 12 events 2020–2023) · Glossary (7 terms).

**No Tier 2** (Ch60 not on math/architecture sketch list).

**Why-still** (112w): every modern AI app is built from this 2020–2023 architecture — RAG over docs, search-before-replying, chain-of-thought, function calling, with the same hard problems still unsolved (retrieval quality, prompt injection, runaway loops, tool-call cost).

**Tier 3 — Codex review verdicts**: Element 8 SKIP (no `<Tooltip>` component) · Element 9 REVIVE (Codex rejected the proposed ReAct abstract fragment + overclaiming annotation, and supplied a verified-verbatim sentence from the ReAct Method section: "we alternate the generation of thoughts and actions so that the task-solving trajectory consists of multiple thought-action-observation steps"; verified by Codex against arXiv:2210.03629 source package) · Element 10 SKIP (no symbolic density). Tier 3 yield: **1 of 3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)