### PR TITLE
docs(ch63): Tier 1 + Tier 3 (pull-quote + plain-reading) reader aids — Inference Economics (#562, #394)

### DIFF
--- a/docs/research/ai-history/chapters/ch-63-inference-economics/status.yaml
+++ b/docs/research/ai-history/chapters/ch-63-inference-economics/status.yaml
@@ -59,5 +59,5 @@ notes: |
 # Lifecycle fields (added 2026-04-30 to decouple reader-aid rollout state
 # from research-phase `status` field; see Codex review forwarded by user).
 prose_state: published_on_main            # research_only | published_on_main
-reader_aids: none                      # none | pr_open | landed
+reader_aids: pr_open                   # none | pr_open | landed
 lifecycle_updated: 2026-04-30

--- a/docs/research/ai-history/chapters/ch-63-inference-economics/tier3-proposal.md
+++ b/docs/research/ai-history/chapters/ch-63-inference-economics/tier3-proposal.md
@@ -1,0 +1,85 @@
+# Chapter 63 — Tier 3 reader-aid proposal
+
+Author: Claude (claude-opus-4-7), 2026-04-30
+Reviewer (cross-family): Codex (gpt-5.5)
+Spec: `docs/research/ai-history/READER_AIDS.md` Tier 3 (elements 8, 9, 10).
+
+## Element 8 — Inline parenthetical definition
+
+**SKIPPED.** Per the spec, every chapter skips this element until a non-destructive Astro `<Tooltip>` component lands. The Tier 1 *Plain-words glossary* covers autoregressive generation, KV cache, iteration-level scheduling, PagedAttention, TTFT/TPOT, goodput, and speculative decoding/sampling.
+
+## Element 9 — Pull-quote (`:::note[]` callout)
+
+**PROPOSED-by-concept (Codex, please fetch and verify the verbatim wording).** The chapter has several plausible primary-source pull-quotes; my preferred candidate is the **DistServe (Zhong et al., OSDI 2024) goodput-framing sentence** because the chapter paraphrases the goodput argument heavily (lines 88, 90, "the system is paid, in effect, for timely work") but never block-quotes the paper's own definition.
+
+### Candidate A (preferred): DistServe goodput definition
+
+**Primary source:** Yinmin Zhong et al., "DistServe: Disaggregating Prefill and Decoding for Goodput-optimized Large Language Model Serving," OSDI 2024. PDF: <https://www.usenix.org/system/files/osdi24-zhong-yinmin.pdf>.
+
+**Conceptual content** (Codex must fetch and supply verbatim): the abstract / Section 1 sentence that establishes (a) prefill and decoding are colocated/batched in existing systems, (b) this causes interference and resource coupling, and (c) DistServe disaggregates the two phases for *goodput* under SLOs. The chapter's prose paraphrases all three clauses at line 86 ("Zhong and collaborators argued that colocating prefill and decoding on the same GPUs can create interference and resource coupling…") but never quotes the paper.
+
+**Insertion anchor:** immediately after the chapter paragraph beginning "DistServe separated the phases onto different GPUs and optimized for goodput under service-level objectives…" (the paragraph that reports the 7.4x / 12.6x numbers but not the verbatim framing sentence).
+
+**Tentative annotation (1 sentence, doing new work):** The paper's own framing makes "goodput" — not throughput — the load-bearing economic metric, which is why disaggregating prefill from decode counts as an architecture change rather than a tuning choice.
+
+### Candidate B (fallback): FlashAttention IO-awareness sentence
+
+**Primary source:** Tri Dao et al., "FlashAttention: Fast and Memory-Efficient Exact Attention with IO-Awareness," arXiv:2205.14135. PDF: <https://arxiv.org/pdf/2205.14135>.
+
+**Conceptual content** (Codex must fetch and supply verbatim): the abstract sentence (or the page 1/2 statement) asserting that Transformers are slow and memory-hungry on long sequences and that FlashAttention reduces reads/writes between HBM and SRAM to get wall-clock speedups *without approximating* attention.
+
+**Insertion anchor:** immediately after the chapter paragraph beginning "FlashAttention showed why attention performance was not only about arithmetic…" (line 34) — the chapter paraphrases the IO-awareness claim but does not block-quote the paper.
+
+**Tentative annotation:** Note that the speedup is on *exact* attention — the IO-aware redesign costs no approximation, which is why the result transferred to production serving rather than staying a research curiosity.
+
+### Candidate C (alternative fallback): PagedAttention KV-cache framing
+
+**Primary source:** Woosuk Kwon et al., "Efficient Memory Management for Large Language Model Serving with PagedAttention," SOSP 2023 / arXiv:2309.06180.
+
+**Risk:** the chapter line 48 paraphrases the abstract closely ("Kwon and collaborators described KV cache memory as huge, dynamic, and prone to waste through fragmentation and duplication"). Adjacency-repetition risk is HIGH unless Codex finds a sentence on a *different* facet (e.g., the per-request KV cache "10x more expensive than a traditional keyword query" framing, but `sources.md` explicitly flags that as Yellow).
+
+### What Codex should do
+
+1. Fetch the DistServe PDF and locate the verbatim sentence(s) closest to the conceptual content above for **Candidate A**. If a single ≤30-word verbatim sentence captures the goodput-framing claim, APPROVE Candidate A with that wording.
+2. If Candidate A's wording is too long or splits across sentences, REVISE with a tighter primary-source sentence (e.g., from Section 2 or the Introduction) that still does the framing work.
+3. If Candidate A is fully covered in the chapter's surrounding prose (adjacency-repetition risk too high), REJECT Candidate A and substitute **Candidate B** (FlashAttention IO-awareness).
+4. If both A and B fail adjacency-repetition or fidelity bars, try **Candidate C** with care to pick a *different* facet from what line 48 paraphrases.
+5. If no candidate clears the bars, REJECT the element entirely. Per the Ch01 prototype calibration, refusing the pull-quote is a legitimate outcome.
+
+**Word budget:** sentence ~25–30 words + annotation ~25–30 words ≈ ≤60 words.
+
+## Element 10 — Plain-reading aside (`:::tip[Plain reading]`)
+
+**PROPOSED.** Ch63 has one paragraph that is *symbolically* dense in the spec's sense — not formula-dense, but **stacked-abstract-definitions** dense, which the spec explicitly admits as a qualifying form.
+
+**Target paragraph** (chapter, currently around line 16 of the original prose):
+
+> That loop turns latency into a compound problem. There is time to first token, the delay before a user sees the answer begin. There is time per output token, the rhythm at which the answer continues. There is throughput, the number of requests or tokens a serving system can handle. There is utilization, the fraction of expensive accelerator capacity doing useful work. There is goodput, the useful work completed while meeting the service-level objective rather than merely producing tokens too late to matter.
+
+**Why this qualifies as symbolically dense:** the paragraph stacks five distinct abstract performance definitions (TTFT, TPOT, throughput, utilization, goodput) in five consecutive sentences. The reader hits five novel terms in roughly fifty words; each term will recur load-bearingly later in the chapter (Orca scene, vLLM scene, DistServe scene). A first-time reader who does not internalise these now will lose the rest of the chapter. This is exactly the spec's "abstract definitions stacked" case.
+
+**Insertion anchor:** immediately after that paragraph (before "These quantities pull against one another…").
+
+**Proposed aside (3 sentences):**
+
+```
+:::tip[Plain reading]
+Five definitions are stacked in one paragraph, and the rest of the chapter leans on all of them: TTFT (how long until the first word appears), TPOT (how fast subsequent words stream), throughput (tokens or requests per second across the system), utilization (fraction of GPU capacity actually doing work), and goodput (work that finishes within the user's SLO and therefore counts). Goodput is the load-bearing one — Orca, vLLM, and DistServe each restructure the serving stack to lift goodput rather than raw throughput. When the chapter later reports a paper's "Nx throughput improvement," read it as "Nx more *goodput*-shaped throughput in that paper's setup," not as a universal speedup.
+:::
+```
+
+**Word count:** ~115 words across 3 sentences. The spec allows 1–3 sentences; this proposal sits at the upper edge. If Codex judges this verbose, REVISE to ~2 sentences focused on the goodput-vs-throughput distinction.
+
+**Why this aside does new work:** the chapter paragraph defines each term but does *not* tell the reader (a) which one is load-bearing, (b) how to read later "Nx improvement" claims through the goodput lens, or (c) why the field eventually converged on goodput rather than throughput. The aside installs the meta-frame the rest of the chapter relies on.
+
+**Codex check:** REJECT if you judge the surrounding prose already does this meta-framing work, or if the paragraph is narratively dense rather than symbolically dense (i.e., if reading it feels like history-of-people rather than abstract-vocabulary-loading). REVISE the wording or trim to 2 sentences if it is too verbose. APPROVE only if the aside genuinely loads the goodput frame the rest of the chapter assumes.
+
+## Summary
+
+| Element | Author proposal | Rationale |
+|---|---|---|
+| 8 | SKIP | Bit-identity rule (no Tooltip component yet) |
+| 9 | PROPOSE-by-concept | DistServe goodput framing (preferred); FlashAttention IO-awareness (fallback); PagedAttention KV-cache (alt fallback) — Codex must verify verbatim |
+| 10 | PROPOSE | Stacked-abstract-definitions paragraph (TTFT / TPOT / throughput / utilization / goodput); rest of chapter depends on these terms |
+
+**Awaiting Codex adversarial review.** Be willing to REJECT either or both elements. The Ch01 prototype's calibration (2 of 5 candidates landing) is the explicit benchmark — Tier 3 is the place to refuse.

--- a/docs/research/ai-history/chapters/ch-63-inference-economics/tier3-review.md
+++ b/docs/research/ai-history/chapters/ch-63-inference-economics/tier3-review.md
@@ -1,0 +1,45 @@
+# Chapter 63 — Tier 3 reader-aid review (Codex)
+
+Reviewer: gpt-5.5, 2026-04-30
+
+## Element 8: APPROVE skip
+
+The skip is correct. `docs/research/ai-history/READER_AIDS.md:43` says Element 8 is skipped for every chapter until a non-destructive tooltip component exists.
+
+## Element 9: REVISE
+
+Do not approve the concept-only wording as submitted. I fetched the DistServe PDF and the preferred claim is split across multiple sentences. Use this verified replacement from the DistServe abstract instead.
+
+Primary source: Zhong et al., DistServe, OSDI 2024, USENIX PDF: https://www.usenix.org/system/files/osdi24-zhong-yinmin.pdf
+
+```markdown
+:::note
+> As a result, DistServe significantly improves LLM serving performance in terms of the maximum rate that can be served within both TTFT and TPOT constraints on each GPU.
+
+This quote forces the metric down to per-GPU SLO-compliant work: the economic unit is not raw token flow, but requests that land inside TTFT/TPOT limits.
+:::
+```
+
+Suggested anchor: after the paragraph at `src/content/docs/ai-history/ch-63-inference-economics.md:88` (the "DistServe's goodput framing matters because throughput alone can be misleading…" paragraph), **not** after the "DistServe separated the phases…" paragraph at line 90. That avoids adjacent repetition with the existing "optimized for goodput under service-level objectives" sentence.
+
+## Element 10: REVISE
+
+The paragraph at `src/content/docs/ai-history/ch-63-inference-economics.md:16` genuinely qualifies as symbolically dense: it stacks TTFT, TPOT, throughput, utilization, and goodput as abstract definitions. But the proposed aside is too long and overstates Orca/vLLM as "goodput" systems.
+
+Use a tighter version:
+
+```markdown
+:::tip[Plain reading]
+Keep two axes separate: TTFT and TPOT describe what one user feels, while throughput and utilization describe how full the system is. Goodput is the bridge between them: work only counts economically when it finishes inside the product's latency promise, so later speedup numbers should be read as paper-specific capacity claims under stated latency constraints.
+:::
+```
+
+## Summary
+
+| Element | Codex verdict | Action |
+|---|---|---|
+| 8 | APPROVE skip | Skip — bit-identity rule |
+| 9 | REVISE | Land Codex's verified DistServe abstract verbatim, anchored after the "DistServe's goodput framing matters…" paragraph |
+| 10 | REVISE | Land Codex's tighter wording (2-axis frame; goodput as bridge) |
+
+**Tier 3 yield: 2 of 3 candidates landing** (1 SKIP-by-spec + 2 REVISEs applied).

--- a/src/content/docs/ai-history/ch-63-inference-economics.md
+++ b/src/content/docs/ai-history/ch-63-inference-economics.md
@@ -5,6 +5,60 @@ sidebar:
   order: 63
 ---
 
+:::tip[In one paragraph]
+Once large models entered products, the cost story moved from training to serving. Autoregressive generation makes every output token a serial step on scarce accelerators. From 2022 to 2024 the field reframed inference as a systems discipline: Orca scheduled by iteration, FlashAttention shrank attention's memory traffic, vLLM/PagedAttention made the KV cache a paged resource, SmoothQuant/FlexGen/speculative decoding traded precision, memory tier, or pass count for cost, and DistServe split prefill from decode for goodput under SLOs.
+:::
+
+<details>
+<summary><strong>Cast of characters</strong></summary>
+
+| Name | Lifespan | Role |
+|---|---|---|
+| Gyeong-In Yu, Joo Seong Jeong, Geon-Woo Kim, Soojeong Kim, Byung-Gon Chun | — | Orca authors (Seoul National University / FriendliAI); iteration-level scheduling and selective batching for generative Transformer serving (OSDI 2022) |
+| Tri Dao | — | Lead author of FlashAttention (Stanford); IO-aware exact attention, HBM/SRAM traffic as the bottleneck (May 2022) |
+| Guangxuan Xiao | — | Lead author of SmoothQuant (MIT); post-training W8A8 quantization that migrates activation outliers to weights (Nov 2022) |
+| Ying Sheng | — | Lead author of FlexGen (Stanford); GPU/CPU/disk offload for high-throughput inference under limited GPU memory (Mar 2023) |
+| Woosuk Kwon | — | Lead author of vLLM/PagedAttention (Berkeley); virtual-memory-style paging for the KV cache (SOSP 2023) |
+| Yaniv Leviathan, Matan Kalman, Yossi Matias; Charlie Chen et al. | — | Speculative decoding/sampling authors (Google; DeepMind); draft-and-verify decoding that preserves the target distribution (2022/2023) |
+
+</details>
+
+<details>
+<summary><strong>Timeline (May 2022 – 2024)</strong></summary>
+
+```mermaid
+timeline
+    title Chapter 63 — Inference Economics
+    May 2022 : FlashAttention reframes attention speed around HBM/SRAM IO, not just FLOPs
+    Jul 2022 : Orca (OSDI) proposes iteration-level scheduling and selective batching for generative Transformer serving
+    Nov 2022 : SmoothQuant shows a post-training W8A8 path for LLM inference
+    Nov 2022 / Feb 2023 : Speculative decoding (Leviathan, Kalman, Matias) and speculative sampling (Chen et al.) — draft-and-verify with preserved distribution
+    Mar 2023 : FlexGen demonstrates GPU/CPU/disk offload for throughput-oriented generation on a single T4
+    Sep / Oct 2023 : vLLM / PagedAttention (SOSP) makes KV-cache paging a first-class serving primitive
+    2024 : DistServe (OSDI) disaggregates prefill and decode onto different GPU pools for goodput under SLOs
+```
+
+</details>
+
+<details>
+<summary><strong>Plain-words glossary</strong></summary>
+
+**Autoregressive generation** — A language model produces output one token at a time, feeding each new token back as input for the next step. A long answer is therefore a chain of serial model passes, not a single forward computation. This is why generation latency compounds and why scheduling has to look at iterations rather than whole requests.
+
+**KV cache (key/value cache)** — The per-request store of attention keys and values from prior tokens, kept so the model does not recompute them at every decoding step. It grows with prompt length, output length, and concurrent users. Because model weights are static but the KV cache is dynamic, KV cache memory — not parameter count — often determines how many requests fit on an accelerator.
+
+**Iteration-level scheduling** — Orca's scheduling unit. Instead of treating each user request as a single batch member from start to finish, the serving system decides at every model iteration which active requests continue, which finished requests leave, and which newly arrived requests join. Required for generative workloads where requests have wildly different lengths.
+
+**PagedAttention** — vLLM's KV-cache memory manager. It borrows operating-system virtual-memory paging: store the KV cache in non-contiguous fixed-size blocks, then let the attention kernel treat them as a coherent sequence. Reduces fragmentation, allows higher concurrency, and is the mechanism behind vLLM's 2–4× throughput claim over FasterTransformer/Orca.
+
+**TTFT and TPOT (time to first token, time per output token)** — DistServe's two-axis latency model. TTFT is the delay before the user sees any output — it is dominated by *prefill* (processing the prompt). TPOT is the rhythm of streaming — it is dominated by *decode* (the per-token loop). Optimising one can hurt the other, which is why DistServe runs them on different GPU pools.
+
+**Goodput** — Useful work completed within a service-level objective. A request finished after its SLO deadline is throughput but not goodput. Inference serving is paid, in effect, for goodput, which is why average throughput numbers can hide tail-latency failures.
+
+**Speculative decoding / sampling** — A small "draft" model proposes several next tokens; the larger "target" model verifies them in a single parallel pass and accepts or rejects under a rejection-sampling rule that preserves the target's output distribution. Trades cheap draft compute for fewer expensive target-model passes; speedup depends on draft acceptance and overhead.
+
+</details>
+
 Training made frontier AI look expensive. Inference made it operationally expensive.
 
 The distinction became unavoidable once large models moved from research demos into products. A lab might train a model once, or a few times, at enormous cost. But a product has to run the model every time a user asks a question, uploads a document, requests a summary, calls a tool, or speaks into a microphone. The meter starts again with every prompt. Each output token consumes compute, memory bandwidth, scheduling attention, and latency budget.
@@ -14,6 +68,10 @@ This was the quiet shift underneath the product shock. The public saw chat inter
 Autoregressive generation is the first reason. A conventional classifier can often process an input once and produce a result. A large language model generating text loops. It reads the prompt, produces a token, then feeds the growing sequence back through the model to produce the next token. A long answer is not one model run. It is a chain of repeated decoding steps.
 
 That loop turns latency into a compound problem. There is time to first token, the delay before a user sees the answer begin. There is time per output token, the rhythm at which the answer continues. There is throughput, the number of requests or tokens a serving system can handle. There is utilization, the fraction of expensive accelerator capacity doing useful work. There is goodput, the useful work completed while meeting the service-level objective rather than merely producing tokens too late to matter.
+
+:::tip[Plain reading]
+Keep two axes separate: TTFT and TPOT describe what one user feels, while throughput and utilization describe how full the system is. Goodput is the bridge between them: work only counts economically when it finishes inside the product's latency promise, so later speedup numbers should be read as paper-specific capacity claims under stated latency constraints.
+:::
 
 These quantities pull against one another. A serving system can often improve throughput by batching requests together, but batching can make individual users wait. It can reduce latency by serving smaller batches, but that may strand accelerator capacity. It can accept longer contexts, but those contexts consume memory that might otherwise serve more users. Product AI is therefore not only model science. It is queueing, memory management, and systems engineering.
 
@@ -87,6 +145,12 @@ Zhong and collaborators argued that colocating prefill and decoding on the same 
 
 The distinction also makes "fast" less vague. A system can have a low time to first token and then generate slowly. It can start slowly and then stream quickly. It can satisfy average latency while violating the tail latency that users notice during spikes. DistServe's goodput framing matters because throughput alone can be misleading: a request completed after its SLO is not equally useful to the product. The serving system is paid, in effect, for timely work.
 
+:::note
+> As a result, DistServe significantly improves LLM serving performance in terms of the maximum rate that can be served within both TTFT and TPOT constraints on each GPU.
+
+This quote forces the metric down to per-GPU SLO-compliant work: the economic unit is not raw token flow, but requests that land inside TTFT/TPOT limits.
+:::
+
 DistServe separated the phases onto different GPUs and optimized for goodput under service-level objectives. Its reported results were large: up to 7.4x more requests or 12.6x tighter SLOs than state-of-the-art baselines in its evaluation. The exact numbers belong to the paper's setup. The enduring idea is that inference serving became phase-aware. A product system could no longer treat a request as one undifferentiated blob of computation.
 
 The prefill/decode split also explains why product requirements complicate hardware planning. A long prompt with a short answer stresses the system differently from a short prompt with a long answer. A retrieval-augmented workflow that stuffs many documents into context may increase prefill work. A chatty assistant producing long responses may emphasize decode. A voice product may make both phases more latency-sensitive because silence feels awkward. The serving architecture has to match the workload.
@@ -109,4 +173,9 @@ This is why inference became a discipline of margins. A small reduction in waste
 
 Inference economics also sets up the next constraints. If serving every request consumes scarce memory and accelerator time, edge deployment becomes attractive but difficult. If low latency matters, geography and device placement matter. If tokens become industrial workload, power and datacenter planning become central. The product era did not end the training race. It added a second race: making intelligence cheap enough, fast enough, and available enough to be used all day.
 
+:::note[Why this still matters today]
+Every operator who has run a chat assistant, copilot, or agent at scale has met this chapter's vocabulary. Capacity planning is no longer just "how many GPUs" — it is goodput under TTFT and TPOT targets. Open-source serving stacks (vLLM, TGI, TensorRT-LLM, SGLang) ship the techniques described here as defaults: paged KV cache, continuous batching, quantized weights, speculative decoders, prefill/decode disaggregation. The shape of a product feature — long context, streaming voice, retrieval-augmented agents — translates directly into memory pressure, scheduler load, and serving cost. When practitioners argue about API price per token, they are arguing about the same trade-offs Orca, FlashAttention, vLLM, and DistServe formalised between 2022 and 2024.
+:::
+
 The user sees an answer appear in a chat window. Underneath, a scheduling system is making thousands of small economic decisions. Which requests share a batch? Which tokens occupy cache? Which precision is acceptable? Which phase gets which GPU? Which work can be drafted, compressed, offloaded, or delayed? Inference economics is the name for that hidden discipline.
+


### PR DESCRIPTION
## Summary

Reader-aids on bit-identical prose for **Chapter 63: Inference Economics**.

**Tier 1**: TL;DR (75w) · Cast (6 rows) · Timeline (Mermaid, May 2022 – 2024) · Glossary (7 terms: autoregressive generation, KV cache, iteration-level scheduling, PagedAttention, TTFT/TPOT, goodput, speculative decoding/sampling).

**No Tier 2** (Ch63 not on the math/architecture list per spec).

**Why-still** (110w): the chapter's vocabulary is now standard operator language; capacity planning is goodput under TTFT/TPOT, and modern serving stacks (vLLM, TGI, TensorRT-LLM, SGLang) ship paged KV cache, continuous batching, quantized weights, speculative decoders, and prefill/decode disaggregation as defaults.

**Tier 3 — Codex review verdicts**: E8 SKIP · E9 REVISE (Codex fetched the DistServe PDF and supplied a verified verbatim sentence from the abstract; anchored after the "DistServe's goodput framing matters…" paragraph to avoid adjacent repetition) · E10 REVISE (Codex tightened the proposed wording to a 2-axis frame on the TTFT/TPOT/throughput/utilization/goodput stacked-definitions paragraph). **Tier 3 yield: 2 of 3.**

Bit-identity verified (`git diff main … | grep '^-[^-]'` returns 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)