### PR TITLE
docs(ch68): Tier 1 + Tier 3 pull-quote reader aids — Data Labor and the Copyright Reckoning (#562, #394)

### DIFF
--- a/docs/research/ai-history/chapters/ch-68-data-labor-and-the-copyright-reckoning/status.yaml
+++ b/docs/research/ai-history/chapters/ch-68-data-labor-and-the-copyright-reckoning/status.yaml
@@ -62,5 +62,5 @@ notes: |
 # Lifecycle fields (added 2026-04-30 to decouple reader-aid rollout state
 # from research-phase `status` field; see Codex review forwarded by user).
 prose_state: published_on_main            # research_only | published_on_main
-reader_aids: none                      # none | pr_open | landed
+reader_aids: pr_open                   # none | pr_open | landed
 lifecycle_updated: 2026-04-30

--- a/docs/research/ai-history/chapters/ch-68-data-labor-and-the-copyright-reckoning/tier3-proposal.md
+++ b/docs/research/ai-history/chapters/ch-68-data-labor-and-the-copyright-reckoning/tier3-proposal.md
@@ -1,0 +1,48 @@
+# Chapter 68 — Tier 3 reader-aid proposal
+
+Author: Claude (claude-opus-4-7), 2026-04-30
+Reviewer (cross-family): Codex (gpt-5.5)
+Spec: `docs/research/ai-history/READER_AIDS.md` Tier 3 (elements 8, 9, 10).
+
+## Element 8 — Inline parenthetical definition
+
+**SKIPPED.** Per the spec, every chapter skips this element until a non-destructive Astro `<Tooltip>` component lands. The Tier 1 *Plain-words glossary* (RLHF, Common Crawl, The Pile/Books3, LAION-5B, fair use, motion to dismiss, robots.txt/GPTBot) covers the same job non-destructively.
+
+## Element 9 — Pull-quote (`:::note[]` callout)
+
+**PROPOSED-BY-CONCEPT.** The chapter's strongest legal anchor is the June 23, 2025 Bartz v. Anthropic fair-use order (Alsup, J., N.D. Cal.), which the prose treats as the load-bearing court record. The order itself is the chapter's source of the "split" between training use, purchased print-to-digital scanning, and pirated central-library copies. The chapter paraphrases this split (lines beginning "In that order, training copies were treated as fair use…") but does *not* block-quote any operative sentence from the order.
+
+**Candidate insertion anchor:** immediately *after* the chapter paragraph beginning "In June 2025, the Bartz v. Anthropic order drew distinctions that should shape how the whole chapter is read…" — i.e., the paragraph that paraphrases the split.
+
+**Source target (Codex must fetch + confirm verbatim):** *Bartz et al. v. Anthropic PBC*, Order on Fair Use, N.D. Cal., June 23, 2025. Anchors per `sources.md`: lines 42-51 (issue framing), lines 1800-1844 (the operative split), lines 1860-1865 (summary-judgment grants/denials). CourtListener PDF: https://storage.courtlistener.com/recap/gov.uscourts.cand.434709/gov.uscourts.cand.434709.231.0_4.pdf
+
+**Why this element:**
+- It is the chapter's single most narrowly cited legal anchor and the only one that gives the whole chapter its anti-slogan ethic ("not 'training is legal,' not 'training is illegal'").
+- The chapter paraphrases but does not block-quote, so adjacent-repetition risk is low.
+- A direct sentence from Alsup's order would put the reader inside the actual judicial language, not the chapter's narrative voice.
+
+**Proposed annotation (≤1 sentence, doing new work):** Note Alsup's order is *one* district-court ruling on a narrow procedural posture and a split fact pattern — the chapter's wider claim that "data became infrastructure someone could block, price, license, or sue over" rests on that narrowness, not on a sweeping merits answer.
+
+**Word budget:** verbatim-dependent. Aim for ≤40 words quoted + ~25 words annotation ≤ 60-word cap. Codex should REVISE or trim if the chosen verbatim sentence runs longer.
+
+**Codex verification request:** Please fetch the order PDF and:
+1. Either confirm a verbatim sentence on the training-vs-piracy split that fits the ≤60-word combined cap, **or**
+2. REVIVE with a different verbatim from a different primary source — the strongest alternatives are:
+   - **OpenAI, "OpenAI and journalism" (Jan. 8, 2024)** — a verbatim sentence on training as fair use or on the regurgitation framing. The chapter paraphrases OpenAI's four-point position; a primary-source sentence would balance the Bartz/court voice with the OpenAI/company voice. URL: https://openai.com/index/openai-and-journalism/ (sources.md anchors lines 43-47, 50-61, 64-75).
+   - **Getty Images statement (Jan. 17, 2023)** — a verbatim sentence stating Getty licenses content for AI training. URL: https://newsroom.gettyimages.com/en/getty-images/getty-images-statement (sources.md anchors lines 13-17).
+   - **NYT v. OpenAI motion-to-dismiss opinion (Stein, J., Apr. 4, 2025)** — a verbatim sentence on the assumed-true posture or on which DMCA claims survived/were dismissed. URL: https://cdn.openai.com/pdf/gov.uscourts.nysd.612697.514.0_1.pdf (sources.md anchors lines 101-129, 131-133, 1548-1554).
+3. Or REJECT entirely if no candidate sentence is genuinely quote-worthy without paraphrase-of-paraphrase risk.
+
+## Element 10 — Plain-reading aside
+
+**SKIPPED.** Ch68 is narrative/historical: labor reporting, dataset chronology, complaint allegations, court orders, and licensing announcements. There are no symbolically dense paragraphs (no formulas, no derivations, no stacked abstract definitions). The closest candidate — the Bartz split paragraph — is *legally* dense but not symbolically dense; the spec reserves Plain-reading asides for symbolic density (formulas, derivations, definitions stacked), not narrative or legal density. The Tier 1 glossary already explains "fair use" and "motion to dismiss" in plain words.
+
+## Summary
+
+| Element | Author proposal | Rationale |
+|---|---|---|
+| 8 | SKIP | Bit-identity rule (every chapter, until Astro `<Tooltip>` lands) |
+| 9 | PROPOSE-BY-CONCEPT | Bartz/Anthropic split language is the chapter's load-bearing legal anchor and is paraphrased, not quoted; Codex to fetch + confirm verbatim or REVIVE from OpenAI / Getty / NYT-opinion |
+| 10 | SKIP | No symbolic density; chapter is narrative/historical/legal, not formula-driven |
+
+**Awaiting Codex adversarial review.** Be willing to REJECT (if no verbatim sentence in the Bartz order both fits the cap and does work the prose has not done), REVISE (annotation length), or REVIVE (a different verbatim sentence from OpenAI's "OpenAI and journalism" post, Getty's January 2023 statement, or the NYT/OpenAI motion-to-dismiss opinion). For Element 9 you MUST fetch the cited primary source(s) and either confirm verbatim or supply a verified replacement.

--- a/docs/research/ai-history/chapters/ch-68-data-labor-and-the-copyright-reckoning/tier3-review.md
+++ b/docs/research/ai-history/chapters/ch-68-data-labor-and-the-copyright-reckoning/tier3-review.md
@@ -1,0 +1,39 @@
+# Chapter 68 — Tier 3 reader-aid review (Codex)
+
+Reviewer: gpt-5.5, 2026-04-30
+Model invocation: `codex exec -m gpt-5.5 -c model_reasoning_effort="high" --dangerously-bypass-approvals-and-sandbox`
+Verdict file: `tier3-proposal.md` reviewed against `docs/research/ai-history/READER_AIDS.md` Tier 3 spec.
+
+## Summary
+
+| Element | Verdict | One-line reason |
+|---|---|---|
+| 8 | APPROVE-skip | Spec rule: every chapter skips until a non-destructive Astro `<Tooltip>` lands. |
+| 9 | REVISE | Concept correct; Codex fetched the Bartz order PDF and supplied a tighter verified verbatim sentence + a one-sentence annotation. |
+| 10 | APPROVE-skip | Bartz section is legally/narratively dense, not symbolically dense; no formula/derivation/stacked-definition density anywhere in chapter. |
+
+**Tier 3 yield: 1 of 3** (E8 skip per spec, E9 land with revision, E10 skip on density grounds).
+
+## Codex verdict (verbatim)
+
+Element 8: **APPROVE skip.** The spec explicitly says Element 8 is skipped for every chapter until a non-destructive tooltip component exists.
+
+Element 9: **REVISE.** I fetched the Bartz/Anthropic fair-use order from the cited CourtListener RECAP PDF and confirmed a better short verbatim sentence. Use this pull quote after the Bartz paragraph:
+
+```markdown
+:::note[]
+> A separate justification was required for each use.
+
+This one district-court order matters because it separates use from acquisition path; it does not turn AI training into a universal yes or no.
+:::
+```
+
+Source: *Bartz et al. v. Anthropic PBC*, Order on Fair Use, N.D. Cal., June 23, 2025, CourtListener PDF: https://storage.courtlistener.com/recap/gov.uscourts.cand.434709/gov.uscourts.cand.434709.231.0_4.pdf
+
+Reason: the proposal's concept is sound, but it needed a verified sentence and a tighter annotation. This quote is short, not already present verbatim in the chapter, and captures the chapter's anti-slogan legal point without overclaiming.
+
+Element 10: **APPROVE skip.** The Bartz section is legally and narratively dense, not symbolically dense. No formula/derivation/stacked abstract definition is present, so a Plain-reading aside would violate the Tier 3 rule.
+
+## Application
+
+Apply Codex's revised verbatim sentence and annotation as Element 9. Insertion anchor remains: immediately after the chapter paragraph beginning "In June 2025, the Bartz v. Anthropic order drew distinctions that should shape how the whole chapter is read…" Skip Elements 8 and 10 per spec/density rules.

--- a/src/content/docs/ai-history/ch-68-data-labor-and-the-copyright-reckoning.md
+++ b/src/content/docs/ai-history/ch-68-data-labor-and-the-copyright-reckoning.md
@@ -5,6 +5,60 @@ sidebar:
   order: 68
 ---
 
+:::tip[In one paragraph]
+Frontier AI needed people and rights-cleared material, not just compute. Ouyang et al. 2022 described about 40 RLHF contractors; TIME reported Sama workers in Kenya labeling toxic content for OpenAI safety filtering. GPT-3, The Pile, Books3, LAION-5B, and Stable Diffusion turned web pages, books, and images into training inputs. Getty (2023), New York Times (2023), and Bartz v. Anthropic (2025) put that pipeline into court records. Crawler controls and publisher licensing closed the loop: data became negotiated, blocked, or priced.
+:::
+
+<details>
+<summary><strong>Cast of characters</strong></summary>
+
+| Name | Lifespan | Role |
+|---|---|---|
+| OpenAI labelers / Ouyang et al. contractors | — | About 40 contractors who wrote demonstrations and rankings for InstructGPT/RLHF (March 2022). |
+| Sama workers in Kenya | — | TIME's anonymous sources for toxic-content labeling on an OpenAI safety-filtering project (Nov. 2021–March 2022). |
+| Getty Images | — | Stock-image licensor; commenced UK proceedings against Stability AI and amended a US complaint in 2023. |
+| The New York Times | — | News publisher; sued Microsoft/OpenAI on December 27, 2023. |
+| Sidney H. Stein | — | US District Judge, S.D.N.Y.; authored the April 4, 2025 NYT/OpenAI motion-to-dismiss opinion. |
+| William Alsup | — | US District Judge, N.D. Cal.; authored the June 23, 2025 Bartz v. Anthropic fair-use order. |
+
+</details>
+
+<details>
+<summary><strong>Timeline (2008–2026)</strong></summary>
+
+```mermaid
+timeline
+    title Data labor and the copyright reckoning
+    2008 : Common Crawl begins petabyte-scale web collection
+    2020 : GPT-3 reports filtered Common Crawl, WebText2, Books1, Books2, Wikipedia mixture
+    2020-2021 : The Pile formalizes 825 GiB / 22 subsets, including Books3
+    Nov 2021-Mar 2022 : TIME reports Sama/Kenya safety-labeling work for OpenAI
+    Mar 2022 : Ouyang et al. publish InstructGPT/RLHF (about 40 contractors)
+    2022 : LAION-5B and Stable Diffusion publish open image-caption work
+    Jan-Mar 2023 : Getty commences UK proceedings; files/amends US complaint
+    Dec 27 2023 : New York Times sues Microsoft and OpenAI
+    Jan 8 2024 : OpenAI publishes "OpenAI and journalism" response
+    Dec 2023-May 2024 : OpenAI announces Axel Springer, FT, Reddit, News Corp deals
+    Apr 4 2025 : NYT/OpenAI motion-to-dismiss opinion narrows some claims
+    Jun 23 2025 : Bartz v. Anthropic fair-use order splits training, purchase, piracy
+    Apr 2026 : Bartz settlement-finality hearing pending
+```
+
+</details>
+
+<details>
+<summary><strong>Plain-words glossary</strong></summary>
+
+- **RLHF (Reinforcement Learning from Human Feedback):** Training a language model to prefer answers that human labelers ranked higher; Ouyang et al. 2022 used demonstrations, rankings, a reward model, and PPO.
+- **Common Crawl:** A public web corpus collected at petabyte scale since 2008, distributed as raw web pages, metadata, and text extracts.
+- **The Pile / Books3:** An 825 GiB English language-model dataset of 22 subsets; Books3 is one named book component that later became legally salient in book-corpus litigation.
+- **LAION-5B:** An open dataset of 5.85 billion CLIP-filtered image-text pairs used to train and study image-generation models such as Stable Diffusion v1-4.
+- **Fair use:** A US copyright defense that excuses some unlicensed copying based on factors including transformativeness, purpose, market harm, and amount used; the defense is fact-specific, not a general permission.
+- **Motion to dismiss:** An early procedural request asking a court to throw out claims; at this stage the court assumes complaint facts are true to test legal sufficiency, not to find liability.
+- **Robots.txt / GPTBot:** A web-server file telling crawlers which paths they may visit; OpenAI documents OAI-SearchBot and GPTBot tags so site owners can allow search while disallowing training-related crawling.
+
+</details>
+
 The model stack did not begin with the model.
 
 Chapter 67 followed the visible gates: GPUs, cloud capacity, partnerships, enterprise distribution, and platform contracts. Ch68 turns to a quieter gate underneath them. Frontier AI needed more than compute. It needed people to make outputs usable, corpora to make language broad, images and captions to make generation visual, books and articles to make systems literate, and legal theories to explain why any of that was allowed.
@@ -119,6 +173,12 @@ Books produced the sharpest court-record lesson.
 
 In June 2025, the Bartz v. Anthropic order drew distinctions that should shape how the whole chapter is read. The order described book-copy sources including Books3, LibGen, and PiLiMi and discussed millions of book copies. It then separated uses and acquisition paths. In that order, training copies were treated as fair use, purchased print-to-digital copies were treated differently and also found fair for that use, while pirated central-library copies were not justified by fair use. The order granted and denied summary judgment in a split way and set remaining issues, including pirated copies and damages, for further proceedings.
 
+:::note
+> A separate justification was required for each use.
+
+This one district-court order matters because it separates use from acquisition path; it does not turn AI training into a universal yes or no. — *Bartz et al. v. Anthropic PBC*, Order on Fair Use, N.D. Cal., June 23, 2025.
+:::
+
 The order was especially important because books carry a different cultural weight from web pages. A book is an authored object, a commercial object, a library object, and often a registered copyright object. When book corpora entered foundation-model training debates, authors did not have to argue in the abstract about "the web." They could point to titles, libraries, scans, downloads, and acquisition paths.
 
 That is a narrow legal posture, but a historically powerful one.
@@ -164,3 +224,8 @@ That realization connects backward and forward. Ch67 showed platform concentrati
 The model stack needed people and culture before it needed predictions.
 
 The reckoning began when those people and that culture asked who had been counted as infrastructure.
+
+:::note[Why this still matters today]
+Every modern assistant inherits this supply chain. Behind a chat reply sits a chain of contractors, safety labelers, scraped pages, image-text corpora, books, and platform APIs — each with its own permission and labor story. Court orders, robots.txt distinctions between search and training crawlers, and publisher licensing deals are now standard parts of how AI products are built and sold. Procurement, indemnity, and dataset provenance are no longer back-office concerns; they are gates on shipping. The chapter's split — training use, acquisition path, market harm, and worker conditions — is the working vocabulary practitioners read in model cards, terms of use, and risk disclosures today.
+:::
+


### PR DESCRIPTION
## Summary

Reader-aids on bit-identical prose for **Chapter 68: Data Labor and the Copyright Reckoning**.

**Tier 1**: TL;DR (80w) · Cast (6 rows) · Timeline · Glossary (7 terms).

**No Tier 2** (Ch68 not on math/architecture list).

**Why-still** (105w): the chapter's split — training use, acquisition path, market harm, worker conditions — is the working practitioner vocabulary now visible in model cards, terms of use, and risk disclosures.

**Tier 3 — codex review verdicts** (gpt-5.5, 2026-04-30):
- E8 APPROVE-skip (spec rule until `<Tooltip>` lands)
- E9 REVISE — Codex fetched the Bartz/Anthropic order PDF, supplied verified verbatim sentence ("A separate justification was required for each use.") with tighter annotation; landed as bare `:::note` pull-quote after the Bartz paragraph
- E10 APPROVE-skip — Bartz section is legally/narratively dense, not symbolically dense

**Tier 3 yield: 1 of 3.**

Bit-identity verified: `git diff main | grep '^-[^-]'` returns empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)