### PR TITLE
docs(ai-history): trim Ch07-Ch09 repetition

### DIFF
--- a/src/content/docs/ai-history/ch-07-the-analog-bottleneck.md
+++ b/src/content/docs/ai-history/ch-07-the-analog-bottleneck.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-Between 1948 and 1949, the neurophysiologist W. Grey Walter built two electronic tortoises — Elmer and Elsie — at the Burden Neurological Institute in Bristol. With two miniature radio tubes, one photocell, one touch contact, and two motors, they explored, sought light, avoided obstacles, and self-recharged. Walter's *Machina speculatrix* proved life-like behaviour did not require a brain. But behaviour was the wiring; revising it meant rebuilding the circuit. In January 1952, von Neumann's Caltech lectures quantified the scaling wall — a multiplexing factor of N ≈ 14,000 to make a 2,500-tube machine reliable enough to run for 8 hours.
+Between 1948 and 1949, the neurophysiologist W. Grey Walter built two electronic tortoises — Elmer and Elsie — at the Burden Neurological Institute in Bristol. With a tiny set of sensors, tubes, motors, and contacts, they explored, sought light, avoided obstacles, and self-recharged. Walter's *Machina speculatrix* proved life-like behaviour did not require a brain, but behaviour was the wiring; revising it meant rebuilding the circuit. In January 1952, von Neumann's Caltech lectures quantified the scaling wall for reliable machines built from unreliable parts.
 :::
 
 <details>
@@ -49,9 +49,9 @@ timeline
 - **Photoelectric cell (photocell)** — A device whose electrical output varies with the light falling on it. The tortoise's "eye" was a single photocell shrouded so that it saw only what lay directly in front of the front drive wheel; voltage from the photocell controlled the first stage of the two-tube amplifier.
 - **Multivibrator** — A two-stage electronic oscillator that flips back and forth between two states. In the tortoise, the obstacle-avoidance circuit converted the ordinary two-stage amplifier into a multivibrator whenever the shell-mounted contact closed; relays RL1 and RL2 then oscillated, producing the characteristic butt–withdraw–sidestep pattern.
 - **Tropism (positive / negative)** — Walter's term for orientation toward (positive) or away from (negative) a stimulus. The tortoise exhibited a positive tropism toward moderate light and a negative tropism away from intense light, with the threshold built into the amplifier's saturation behaviour.
-- **Multiplexing (von Neumann sense)** — A reliability technique in which each computational line is replaced by a bundle of N parallel lines, the true state determined by majority vote among them. Von Neumann's January 1952 Caltech lectures showed that N grows quickly with target reliability — for a 2,500-tube machine running 8 hours, N ≈ 14,000.
-- **Mean free path (between errors)** — Borrowed from physics, where it means the average distance a particle travels between collisions. Von Neumann used the phrase for the average time a computing machine runs before a system-crashing error; his worked example asked for an 8-hour mean free path.
-- **Hardware-as-program** — The arrangement in which a machine's behaviour is fixed by the physical layout of its components: to revise the behaviour, you open the shell and rewire. Elmer and Elsie were the canonical case; the architectural escape route — separating *what* a machine does from *how* its parts are wired — is the subject of Chapter 8.
+- **Multiplexing (von Neumann sense)** — A reliability technique in which each computational line is replaced by a bundle of parallel lines, the true state determined by majority vote among them. Von Neumann's January 1952 Caltech lectures showed that the bundle size grows quickly with target reliability.
+- **Mean free path (between errors)** — Borrowed from physics, where it means the average distance a particle travels between collisions. Von Neumann used the phrase for the average time a computing machine runs before a system-crashing error.
+- **Hardware-as-program** — The arrangement in which a machine's behaviour is fixed by the physical layout of its components. Elmer and Elsie were the canonical case; the architectural escape route — separating *what* a machine does from *how* its parts are wired — is the subject of Chapter 8.
 
 </details>
 
@@ -139,7 +139,7 @@ Instead, von Neumann had mapped the scaling wall. The challenge of building high
 
 The two stories should not be forced into a direct line of influence. The anchored record here contains no evidence that Walter and von Neumann corresponded about the tortoises, or that either man read the other's work at the relevant moment. Their connection is structural. Walter showed how much behaviour could be obtained from a tiny hardwired organism in a real environment. Von Neumann showed how punishing it would be to build a large reliable organism by multiplying unreliable components. Put together, they make the analog bottleneck more precise: small hardwired machines could surprise observers, but reliability and revisability did not scale by simply adding more physical parts.
 
-## The Bridge, Not the Funeral
+## What Came Next
 
 Yet, the realization of this bottleneck did not result in a sudden funeral for Walter's cybernetic work. Walter himself never portrayed the tortoises as a defeated methodology, and Holland's account follows the line forward through CORA, *Machina docilis*, and later IRMA work rather than stopping at Elmer and Elsie (Holland 2003, pp. 2110–2114). In fact, even as the original scrap-built tortoises were struggling to maintain their physical integrity, Walter was already looking beyond them. In the final, forward-looking paragraph of his May 1950 *Scientific American* article, he announced his next conceptual leap.
 
@@ -156,4 +156,3 @@ Ultimately, Walter's electronic tortoises were an essential bridge in the histor
 :::note[Why this still matters today]
 Two of this chapter's themes still shape working systems. *Hardware-as-program* — behaviour fixed by wiring — is still how custom silicon and FPGAs work; the answer Walter could not yet reach, separating logic from physical layout, is now the default in everything from microcontrollers running firmware to GPUs running tensor kernels. *Reliability from unreliable parts* — von Neumann's framing of error as essential rather than incidental — is the design principle of every modern distributed system, from RAID arrays and blockchain consensus to Kubernetes leader election. Walter's tortoises also anticipated a quieter idea: that goal-directed behaviour can come from a small number of well-chosen feedback loops, not from a central controller.
 :::
-

--- a/src/content/docs/ai-history/ch-08-the-stored-program.md
+++ b/src/content/docs/ai-history/ch-08-the-stored-program.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-On June 30, 1945, John von Neumann's *First Draft of a Report on the EDVAC* — a 100-page mimeographed typescript bearing only his name — proposed dividing a digital computing system into five logical organs and storing instructions in writable memory alongside data. A year later, Burks, Goldstine, and von Neumann's IAS *Preliminary Discussion* (June 28, 1946) sharpened the rule. The *First Draft*'s mailed circulation invalidated Eckert and Mauchly's patent claim. The phrase "stored program" itself was not coined until May 1949, in an internal IBM report by Nathaniel Rochester.
+On June 30, 1945, John von Neumann's *First Draft of a Report on the EDVAC* — a 100-page mimeographed typescript bearing only his name — proposed dividing a digital computing system into five logical organs and storing instructions in writable memory alongside data. A year later, Burks, Goldstine, and von Neumann's IAS *Preliminary Discussion* (June 28, 1946) sharpened the rule. The *First Draft*'s mailed circulation invalidated Eckert and Mauchly's patent claim. The phrase "stored program" itself arrived later, in an internal IBM report.
 :::
 
 <details>
@@ -16,7 +16,7 @@ On June 30, 1945, John von Neumann's *First Draft of a Report on the EDVAC* — 
 |---|---|---|
 | John von Neumann | 1903–1957 | IAS mathematician; Moore School EDVAC consultant from summer 1944; sole signatory of the *First Draft* (June 30, 1945); co-author of the IAS *Preliminary Discussion* (1946). |
 | J. Presper Eckert Jr. | 1919–1995 | Chief electrical engineer of the Moore School ENIAC project; co-developer with Mauchly of the EDVAC successor concept; resigned March 1946 over patent assignment; gave the 1977 OH 13 oral history. |
-| John Mauchly | 1907–1980 | Physics professor at Ursinus College; proposed ENIAC in his August 1942 Moore School memorandum; co-developer of EDVAC with Eckert; mentioned exactly once in the *First Draft* body. |
+| John Mauchly | 1907–1980 | Physics professor at Ursinus College; proposed ENIAC in his August 1942 Moore School memorandum; co-developer of EDVAC with Eckert. |
 | Herman H. Goldstine | 1913–2004 | Army Ordnance liaison at the Moore School; mailed copies of the *First Draft* in summer 1945; co-author of the IAS *Preliminary Discussion*. |
 | Jean Jennings Bartik | 1924–2011 | One of the original six ENIAC programmers; led the four-programmer team that retrofitted ENIAC's function tables to hold a 60-instruction order code in 1948. |
 | Nathaniel Rochester | 1919–2001 | IBM Poughkeepsie engineer; author of the May 17, 1949 internal report "A Calculator Using Electrostatic Storage and a Stored Program" — the earliest located written use of the phrase. |
@@ -50,9 +50,9 @@ timeline
 - **ENIAC** — The Electronic Numerical Integrator and Computer, completed at the Moore School of Electrical Engineering at the University of Pennsylvania in 1945. Programmed by physically rearranging cables and switches until the 1948 retrofit gave it a 60-instruction order code held in its function tables.
 - **EDVAC** — The Electronic Discrete Variable Automatic Computer, the proposed successor to the ENIAC and the subject of the *First Draft*. The architecture survived the document; the actual EDVAC was completed only in 1951.
 - **Stored program** — The arrangement in which a machine's instructions are held in writable electronic memory alongside its data, so that a new program can be loaded by writing it into memory rather than by rewiring the machine. The phrase itself was not used in any 1940s publication before May 1949.
-- **Modern code paradigm** — Haigh, Priestley, and Rope's term for the execution of writable instructions held in main memory. One of three distinct ideas they extract from the catch-all label "stored-program concept"; the others are the von Neumann architecture paradigm and the EDVAC hardware paradigm.
+- **Modern code paradigm** — Haigh, Priestley, and Rope's term for the execution of writable instructions held in main memory, distinct from the other ideas later compressed into the catch-all label "stored-program concept."
 - **Von Neumann architecture** — The decomposition of a computing machine into specialized logical "organs": a central arithmetical part (CA), a central control (CC), a memory (M), and input/output (I, O). Stated tentatively in the *First Draft* and crisply in the 1946 IAS report.
-- **Order code** — The set of numerical codes that a machine treats as instructions. The 1948 ENIAC retrofit used a 60-order code held in its function tables; later machines used much larger and more flexible instruction sets.
+- **Order code** — The set of numerical codes that a machine treats as instructions. Early retrofits used small numerical order codes; later machines used much larger and more flexible instruction sets.
 
 </details>
 
@@ -141,4 +141,3 @@ Ultimately, the *First Draft* did not invent the digital computer out of whole c
 :::note[Why this still matters today]
 Two ideas in this chapter still shape every working computer. The decomposition into specialized organs — arithmetic, control, memory, input, output — survives, in only mildly modified form, as the layout of every CPU and microcontroller built since. And the unified-memory rule — that instructions and data live in the same writable store — is what makes ordinary software loadable, updatable, and patchable in place. The phrase "stored program" feels invisible now precisely because the alternative, programming a machine by rewiring it, has receded so far that few practitioners ever see it. The credit dispute is also still with us: every modern argument about whose work counts as "the design" of a system, when many hands shape it, descends from the same patent-vs-publication tension the *First Draft* exposed.
 :::
-

--- a/src/content/docs/ai-history/ch-09-the-memory-miracle.md
+++ b/src/content/docs/ai-history/ch-09-the-memory-miracle.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-In 1947, Manchester's Williams tube held a bit for 0.2 seconds and demanded constant refresh; mercury delay lines stored data by sending shock-waves down a column of mercury. MIT's Project Whirlwind needed memory that did not forget. Jay Forrester's 1947 three-dimensional coincident-current concept used neon glow tubes that drifted with temperature. In 1949 he switched to magnetic materials with rectangular hysteresis. Three parallel inventors — Forrester at MIT, Jan Rajchman at RCA, An Wang at Harvard — converged on magnetic-core memory between 1949 and 1953. SAGE turned MIT's variant into the IBM 704's industrial standard.
+In 1947, Manchester's Williams tube showed how fragile stored-program memory could be, while mercury delay lines stored data by sending shock-waves down a column of mercury. MIT's Project Whirlwind needed memory that did not forget. Jay Forrester's three-dimensional coincident-current concept first used neon glow tubes that drifted with temperature, then shifted to magnetic materials with rectangular hysteresis. Three parallel inventors — Forrester at MIT, Jan Rajchman at RCA, An Wang at Harvard — converged on magnetic-core memory between 1949 and 1953. SAGE turned MIT's variant into the IBM 704's industrial standard.
 :::
 
 <details>
@@ -17,7 +17,7 @@ In 1947, Manchester's Williams tube held a bit for 0.2 seconds and demanded cons
 | Jay W. Forrester | 1918–2016 | Director, MIT Digital Computer Laboratory (1946–1951); led Project Whirlwind and the SAGE memory effort; conceived the 3D coincident-current store in 1947 and switched to magnetic materials in 1949. |
 | Frederic C. Williams | 1911–1977 | Professor of Electrical Engineering, University of Manchester; co-author of the September 1948 *Nature* Letter that announced a working stored-program experimental machine using the Williams-tube electrostatic CRT memory. |
 | Tom Kilburn | 1921–2001 | Manchester researcher under Williams; author of the December 1, 1947 internal report "A Storage System for Use with Binary Digital Computing Machines" — the chapter's primary anchor for Williams-tube operating limits. |
-| Jan A. Rajchman | 1911–1989 | RCA Laboratories (Camden NJ); developed the Selectron tube (1946–1947); pursued ferrite-core matrix memory in parallel with Forrester; coined "myriabit" in his October 1953 *Proc. IRE* paper. |
+| Jan A. Rajchman | 1911–1989 | RCA Laboratories (Camden NJ); developed the Selectron tube (1946–1947); pursued ferrite-core matrix memory in parallel with Forrester. |
 | An Wang | 1920–1990 | Research fellow at Harvard's Computation Laboratory under Howard Aiken; filed US Patent 2,708,722 ("Pulse Transfer Controlling Device") on October 21, 1949, eighteen months before Forrester's filing. |
 | Kenneth H. "Ken" Olsen | 1926–2011 | MIT research assistant under Norman Taylor; co-builder of the Memory Test Computer that validated coincident-current core memory at scale before transplanting it into Whirlwind. |
 
@@ -43,7 +43,7 @@ timeline
     Oct 1953 : Rajchman publishes 'A Myriabit Magnetic-Core Matrix Memory' in Proc. IRE 41(10)
     1954 : IBM 704 announced — first IBM mainframe with magnetic-core memory standard
     May 17 1955 : Wang's patent 2,708,722 issues
-    1956 : IBM purchases Wang's patent for approximately $500,000 ; Forrester's patent 2,736,880 issues on Feb 28
+    1956 : IBM purchases Wang's patent for approximately 500,000 dollars ; Forrester's patent 2,736,880 issues on Feb 28
 ```
 
 </details>
@@ -51,7 +51,7 @@ timeline
 <details>
 <summary><strong>Plain-words glossary</strong></summary>
 
-- **Williams tube** — An electrostatic memory that stored binary digits as a charge pattern on the inner phosphor screen of a commercial cathode-ray tube. Fast random access but volatile: the 1947 Kilburn report specified short-term retention "of the order of 0.2 seconds" and a refresh frequency greater than 5 cycles per second.
+- **Williams tube** — An electrostatic memory that stored binary digits as a charge pattern on the inner phosphor screen of a commercial cathode-ray tube. Fast random access but volatile, requiring constant refresh.
 - **Mercury delay line** — A serial memory in which a bit travelled as an acoustic shock-wave down a roughly one-metre tube of mercury, was sensed at the far end, and was reinjected to keep the bit alive. Robust but slow; access time was set by waiting for a specific bit to emerge from the tube.
 - **Rectangular hysteresis loop** — A magnetic material's response curve in which magnetisation snaps cleanly between two saturation states with a sharp threshold between them. The "rectangular" shape — almost no intermediate response — is what made coincident-current selection trustworthy.
 - **Coincident-current selection** — The addressing trick at the heart of magnetic-core memory: each coordinate line carries only half the current needed to switch a core, so only the core at the intersection of two activated lines flips. Half-selected cores along the same row or column remain unchanged.
@@ -109,7 +109,7 @@ The search for a robust memory led to the three-dimensional coincident-current m
 
 In his oral history, Forrester recalled that in about 1947 he began thinking about the geometry of storage: "if we had one-dimensional storage and two-dimensional storage, what's the possibility of a three-dimensional storage." He arrived at a logical structure that satisfied the requirements, but the initial physical implementation relied on neon glow-discharge tubes.
 
-The appeal of the geometry was selectivity. A one-dimensional store required a long line or a serial stream. A two-dimensional matrix allowed one coordinate to select a row and another to select a column. A three-dimensional arrangement promised a still better scaling relation: more stored bits without a separate wire for every bit. Forrester's later patent would express that advantage compactly as "3 ∛number of cores" input leads for a three-dimensional array. The phrase is mathematically terse, but the engineering point is direct. If the memory grew by volume while the wiring grew by edge length, memory could scale without drowning the machine in connections.
+The appeal of the geometry was selectivity. A one-dimensional store required a long line or a serial stream. A two-dimensional matrix allowed one coordinate to select a row and another to select a column. A three-dimensional arrangement promised a still better scaling relation: more stored bits without a separate wire for every bit. If the memory grew by volume while the wiring grew by edge length, memory could scale without drowning the machine in connections.
 
 The 1947 glow-tube concept already incorporated the key mechanism that would define magnetic core memory: coincident-current selection. As Forrester described it, "You could activate a wire say in the 'x' axis and another one crossing in the 'y' axis and only the glow tube at the intersection would have enough voltage on it to break down and begin to discharge." The team conducted tests on individual units, but the physical reality of the glow tubes proved insurmountable. Their "characteristics … change with temperature and age," Forrester recalled. This drift made them unsuitable for reliable long-term discrimination, so the team "didn't really pursue it."
 
@@ -137,7 +137,7 @@ Simultaneously, crucial work was underway at the Harvard Computation Laboratory.
 
 Wang's claim cut at a different but equally practical part of the problem. A magnetic state could represent a bit, but a usable random-access memory also needed a reliable cycle for sensing and restoring that state. The patent language about residual flux density was not decorative physics. It specified how strongly the material should remember after the applied pulse ended. In a memory technology, remanence was the point: the device had to retain a distinction without continuous power or mechanical motion.
 
-These parallel developments generated overlapping claims. The priority dispute appears not to have been resolved by a definitive judicial ruling in a patent court, but rather by the force of commercial licensing. A major commercial resolution came in 1956 when, according to widespread historical accounts, IBM purchased Wang's patent for approximately $500,000. That transaction absorbed Wang's foundational claims into IBM's portfolio and helped settle the patent war commercially.
+These parallel developments generated overlapping claims. The priority dispute appears not to have been resolved by a definitive judicial ruling in a patent court, but rather by the force of commercial licensing. A major commercial resolution came in 1956 when, according to widespread historical accounts, IBM purchased Wang's patent for approximately 500,000 dollars. That transaction absorbed Wang's foundational claims into IBM's portfolio and helped settle the patent war commercially.
 
 ## Commercialization
 
@@ -170,8 +170,7 @@ This military investment quickly produced commercial dividends. Secondary accoun
 The timing of this commercialization arc was critical. By the time researchers gathered for the Dartmouth Summer Research Project on Artificial Intelligence in the summer of 1956, the von Neumann architecture's most glaring physical vulnerability had been substantially resolved. The symbolic-AI agenda inherited a memory infrastructure that was fast, non-volatile, and scaling industrially. That did not make computers cheap, small, or easy to program. It did change the question. For the large institutional machines that symbolic AI initially used, hardware memory was no longer the primary load-bearing constraint; the next bottleneck would be the software itself (see Chapter 11).
 
 :::note[Why this still matters today]
-The chapter's two engineering ideas still organise modern computing. *Coincident-current selection* — addressing a single bit by the agreement of two coordinates that each carry only half the activation force — is the direct ancestor of every memory cell that distinguishes "selected" from "half-selected" by analog margin. DRAM sense amplifiers, flash memory's threshold-voltage cells, and content-addressable lookups in network routers all descend from the same threshold-and-coincidence trick. *Parallel invention with commercial resolution* — the Forrester / Rajchman / Wang convergence settled by IBM's $500,000 patent purchase rather than a court ruling — is also still with us: most modern hardware patent disputes resolve through licensing rather than litigation, for the same institutional reasons that drove SAGE-era memory.
+The chapter's two engineering ideas still organise modern computing. *Coincident-current selection* — addressing a single bit by the agreement of two coordinates that each carry only half the activation force — is the direct ancestor of every memory cell that distinguishes "selected" from "half-selected" by analog margin. DRAM sense amplifiers, flash memory's threshold-voltage cells, and content-addressable lookups in network routers all descend from the same threshold-and-coincidence trick. *Parallel invention with commercial resolution* — the Forrester / Rajchman / Wang convergence settled by IBM's 500,000-dollar patent purchase rather than a court ruling — is also still with us: most modern hardware patent disputes resolve through licensing rather than litigation, for the same institutional reasons that drove SAGE-era memory.
 :::
 
 [^1]: Multiple secondary sources credit An Wang and Way-Dong Woo at the Harvard Computation Laboratory with the 1949 magnetic-core invention. However, US Patent 2,708,722 names only An Wang as the inventor of record on its face-sheet. The co-inventorship remains a matter of historical dispute.
-


### PR DESCRIPTION
## Summary
- trims repeated reader-aid/prose echoes in AI History Ch07-Ch09
- keeps factual details in body prose while reducing TL;DR/glossary/cast repetition
- rewrites Ch09 raw dollar-sign currency as words to avoid Markdown math rendering issues

## Checks
- git diff --check HEAD~1..HEAD
- npm run build (from primary checkout on commit 395d5f0b)
- ../../.venv/bin/python scripts/test_pipeline.py (166 tests OK)

## Review
- cross-family review required before merge