### PR TITLE
docs(ai-history): trim Ch10-Ch12 repetition

### DIFF
--- a/src/content/docs/ai-history/ch-10-the-imitation-game.md
+++ b/src/content/docs/ai-history/ch-10-the-imitation-game.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-Between 1947 and 1952, Alan Turing replaced the unanswerable question "Can machines think?" with an empirical protocol: a typed parlour game routed through a teleprinter, in which an interrogator decides whether the hidden party is human or machine. Turing did not found AI as a research field — that came in 1956. He set the empirical goalpost. Later commentators rebranded the Imitation Game as the "Turing Test" and stripped its original gender-disambiguation structure.
+Between 1947 and 1952, Alan Turing turned machine intelligence from a definition hunt into a controlled comparison of performances. Turing did not found AI as a research field — that came in 1956. He supplied a testable setup, a way to bracket bodily cues, and a provocation later readers would simplify under the name "Turing Test."
 :::
 
 <details>
@@ -41,7 +41,7 @@ timeline
 <summary><strong>Plain-words glossary</strong></summary>
 
 - **Imitation Game** — Turing's 1950 protocol for testing machine intelligence: a typed exchange in which an interrogator, hidden from the other parties, tries to identify which of two unseen respondents is the human and which is the machine. Turing's term; the rebrand to "Turing Test" came later.
-- **Teleprinter** — A 1950s electromechanical device that sent typed text over a wire to another teleprinter. Turing called it "the ideal arrangement" for the game because it strips away voice, face, body, and any other non-linguistic evidence the interrogator might use.
+- **Teleprinter** — A 1950s electromechanical device that sent typed text over a wire. In Turing's game it made the exchange text-only, so the interrogator judged linguistic behaviour rather than bodily cues.
 - **Discrete-state machine** — In Turing's 1950 framing, a system whose future behaviour is determined by its current state and input, moving through a finite (if enormous) space of configurations. The class to which Turing argues a digital computer belongs.
 - **Universality argument** — Turing's claim that a single discrete-state machine, given adequate storage, speed, and the right programme, can imitate any other discrete-state machine. The argumentative bridge from the parlour game to actual digital hardware.
 - **Unorganized machine** — Turing's 1948 term for a discrete-state random network of simple logical units (A-type machines used NAND-like elements). Its initial state is deliberately unformed; he proposed the human infant cortex as a biological analogue.
@@ -165,5 +165,5 @@ Whether this abstraction was faithful to Turing's intent remains disputed. Diane
 Regardless of whether the gender structure was load-bearing, Turing's core epistemic move survived. By substituting an empirical, teleprinter-bound imitation game for the unanswerable question of whether machines can think, Turing set an operational baseline. The rest of the field would repeatedly argue about whether the baseline was sufficient, fair, too behavioural, too linguistic, too anthropomorphic, or too easy to game. But those arguments took place on the ground Turing had cleared: do not begin with a definition of thinking; begin with a test of what a machine can make a competent interrogator believe.
 
 :::note[Why this still matters today]
-Every benchmark that asks whether a model can hold a conversation indistinguishable from a person's descends from Turing's move. So does every "AI evaluation" panel that compares a model's typed output against a human's, every chatbot transcript a tester scores, every adversarial probe designed to catch a machine in a tell. The framing is so naturalised that it is easy to forget it had to be invented — and that the invention was an act of refusal: refusal of the definitional debate over the word "thinking," in favour of an empirical protocol. The arguments about whether the protocol is sufficient have not stopped; they take place on the ground Turing cleared.
+Every benchmark that asks whether a model can hold a conversation indistinguishable from a person's descends from Turing's move. So does every "AI evaluation" panel that compares a model's typed output against a human's, every chatbot transcript a tester scores, every adversarial probe designed to catch a machine in a tell. The framing is so naturalised that it is easy to forget it had to be invented — and that the invention was an act of refusal. The adequacy of the setup remains disputed; its durability lies in forcing the dispute into observable behaviour.
 :::

--- a/src/content/docs/ai-history/ch-11-the-summer-ai-named-itself.md
+++ b/src/content/docs/ai-history/ch-11-the-summer-ai-named-itself.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-The 1956 Dartmouth Summer Research Project did not invent the ideas of artificial intelligence — those came from McCulloch-Pitts, Wiener, Shannon, Turing, Solomonoff, and others. What it did was give the cluster a name, four credentialed organizers, and a fundable proposal. Most attendees came partway, produced no shared theory, and left with their pre-existing research programs unchanged. Dartmouth's durable achievement was institutional condensation: a phrase that funders, students, and rival programmes could thereafter recognise.
+The 1956 Dartmouth Summer Research Project did not invent the ideas of artificial intelligence — those came from McCulloch-Pitts, Wiener, Shannon, Turing, Solomonoff, and others. What it did was give the cluster a name, four credentialed organizers, and a fundable proposal. Most attendees came partway, produced no shared theory, and left with their pre-existing research programs unchanged. Dartmouth mattered because a thin summer meeting made an institutional label stick.
 :::
 
 <details>
@@ -18,7 +18,7 @@ The 1956 Dartmouth Summer Research Project did not invent the ideas of artificia
 | Marvin Minsky | 1927–2016 | Junior Fellow at Harvard in Math and Neurology, soon moving to MIT. Co-organizer; wrote the proposal's "neural nets" section. One of three full-time attendees of the eight-week workshop. |
 | Nathaniel Rochester | 1919–2001 | Manager of the IBM 701 development team. Co-organizer; brought industrial computing weight and IBM access. The proposal's only direct industrial-research voice. |
 | Claude Shannon | 1916–2001 | Bell Labs; already famous for the 1948 information-theory paper. Co-organizer; gave the proposal the star name it needed to clear Rockefeller's review. Conference attendance partial. |
-| Ray Solomonoff | 1926–2009 | Independent researcher from the Technical Research Group, New York. The only non-organizer to attend for the full eight weeks; his contemporaneous handwritten notes are the chapter's most reliable record of what actually happened. |
+| Ray Solomonoff | 1926–2009 | Independent researcher from the Technical Research Group, New York. Full-summer attendee whose contemporaneous handwritten notes are the chapter's most reliable record of what actually happened. |
 | Allen Newell & Herbert Simon | 1927–1992 / 1916–2001 | Newell at RAND; Simon at Carnegie Tech. Arrived partway through the summer with a working version of the Logic Theorist program — the only substantial running demonstration of the conference. |
 
 </details>
@@ -31,7 +31,7 @@ timeline
     title The Dartmouth Project, 1955–1956
     August 31 1955 : "A Proposal for the Dartmouth Summer Research Project on Artificial Intelligence" drafted : Cover page lists McCarthy (Dartmouth), Minsky (Harvard), Rochester (IBM), Shannon (Bell Labs)
     September 2 1955 : Proposal sent to the Rockefeller Foundation
-    Spring 1956 : Rockefeller approves approximately $7,500 against the $13,500 request
+    Spring 1956 : Rockefeller approves approximately 7,500 dollars against the 13,500-dollar request
     June 18 1956 : Workshop begins at Dartmouth College, Hanover, New Hampshire
     August 17 1956 : Solomonoff delivers the final talk; workshop concludes after eight weeks
 ```
@@ -42,12 +42,12 @@ timeline
 <summary><strong>Plain-words glossary</strong></summary>
 
 - **Dartmouth Summer Research Project on Artificial Intelligence** — The eight-week workshop convened at Dartmouth College in 1956. The first event whose proposal used the phrase "Artificial Intelligence" as a research-programme label. It did not adopt a unified theory or publish proceedings.
-- **Cybernetics** — Norbert Wiener's 1948 framework for control and communication in animals and machines. McCarthy's choice of "Artificial Intelligence" was deliberately a way to name a programme that was not Wiener's; the chapter's thesis turns on that distancing.
+- **Cybernetics** — Norbert Wiener's 1948 framework for control and communication in animals and machines. McCarthy's choice of "Artificial Intelligence" distinguished the Dartmouth agenda from Wiener's existing banner.
 - **Logic Theorist** — Newell and Simon's 1956 program demonstrated at Dartmouth. It searched for proofs of theorems from *Principia Mathematica*. The summer's only substantial running demonstration; ahead of the organizers' less concrete agenda.
 - **Information theory** — Claude Shannon's 1948 mathematical theory of communication. One of the older banners the proposal drew on without folding the new field into.
 - **McCulloch-Pitts neuron** — Warren McCulloch and Walter Pitts's 1943 model of an artificial neuron as a binary logical gate. The intellectual ancestry of the proposal's "neural nets" topic.
 - **Inductive inference** — Solomonoff's research programme on machine learning from data, developed both before and after the summer. His Dartmouth talks introduced what would become algorithmic probability.
-- **Rockefeller Foundation** — The American philanthropic foundation that approved roughly $7,500 of the proposal's $13,500 ask. Rockefeller's willingness to fund the proposal — chiefly on the strength of Shannon's name — is the institutional precondition that turned a private memo into a sponsored event.
+- **Rockefeller Foundation** — The American philanthropic foundation that approved roughly 7,500 dollars of the proposal's 13,500-dollar ask. Rockefeller's willingness to fund the proposal — chiefly on the strength of Shannon's name — turned a private memo into a sponsored event.
 
 </details>
 
@@ -77,7 +77,7 @@ The document also listed the research areas that made "Artificial Intelligence" 
 
 Read as a document, the list is revealing because it is not a syllabus for a mature discipline. It is a map of unresolved claims. Some topics are about hardware, some about programming, some about mathematical limits, and some about behavior that would have been difficult even to define cleanly. The proposal did not prove that these belonged together. It asserted that they were close enough to study under one roof, for one summer, with one funder.
 
-The budget made the same point in institutional form. The organizers asked Rockefeller for $13,500. Secondary histories generally report that the award was smaller, roughly $7,500, and the primary Rockefeller disbursement record remains the missing anchor. Even the requested amount tells the scale. This was not a national laboratory program or a military crash project. It was a modest foundation-funded summer study, built around travel, salaries, and the credibility of the people asking.
+The budget made the same point in institutional form. The organizers asked Rockefeller for 13,500 dollars. Secondary histories generally report that the award was smaller, roughly 7,500 dollars, and the primary Rockefeller disbursement record remains the missing anchor. Even the requested amount tells the scale. This was not a national laboratory program or a military crash project. It was a modest foundation-funded summer study, built around travel, salaries, and the credibility of the people asking.
 
 The modesty is easy to lose because the later phrase became so large. Nothing in the budget suggests an event that already knew it would become an origin story. The proposal reads more like a bid to create a temporary zone of permission: bring the right people together, suspend ordinary academic schedules for a summer, and see whether a set of hard problems could be made precise enough to attack.
 

--- a/src/content/docs/ai-history/ch-12-logic-theorist-gps.md
+++ b/src/content/docs/ai-history/ch-12-logic-theorist-gps.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-Allen Newell, Herbert Simon, and J. C. Shaw built two different symbol machines. Logic Theorist (1956) searched for proofs in the sentential calculus of *Principia Mathematica* using heuristics rather than blind enumeration. GPS (1959) tried to lift that success into a reusable architecture — objects, operators, differences, goals, means-ends analysis. The chapter's hinge: turning problem solving into inspectable symbol manipulation, then discovering how much infrastructure and task knowledge a "general" architecture still required.
+Allen Newell, Herbert Simon, and J. C. Shaw built two different symbol machines. Logic Theorist (1956) searched for proofs in the sentential calculus of *Principia Mathematica* using heuristics rather than blind enumeration. GPS (1959) tried to turn that success into a broader architecture for problem solving. The chapter's hinge is the move from a working theorem prover to a "general" system whose reach still depended on hand-built representations.
 :::
 
 <details>
@@ -17,7 +17,7 @@ Allen Newell, Herbert Simon, and J. C. Shaw built two different symbol machines.
 | Allen Newell | 1927–1992 | Co-designer of LT and GPS at RAND. Brought non-numerical computing, organizational simulation, and symbolic-processing ambitions into the collaboration. |
 | Herbert A. Simon | 1916–2001 | Co-designer at Carnegie Tech. Organizational theorist and cognitive scientist; later 1978 Nobel laureate in economics — out of scope here. |
 | J. C. "Cliff" Shaw | — | RAND programmer; central to making LT and GPS programmable rather than only conceptual specifications. Author of the IPL programming languages on which LT and GPS ran. |
-| Oliver Selfridge | 1926–2008 | MIT/Lincoln Lab researcher whose mid-November 1954 RAND talk Newell later credited with making arbitrary information processing, symbolic processing, and adaptive processing clear to him. |
+| Oliver Selfridge | 1926–2008 | MIT/Lincoln Lab researcher whose mid-November 1954 RAND talk Newell later remembered as a turning point toward symbolic processing. |
 | Alfred N. Whitehead & Bertrand Russell | 1861–1947 / 1872–1970 | Authors of *Principia Mathematica* (1910–1913). The sentential calculus from Chapter 2 was LT's task domain — its theorems the program's targets. |
 
 </details>
@@ -42,12 +42,12 @@ timeline
 <summary><strong>Plain-words glossary</strong></summary>
 
 - **Logic Theorist (LT)** — Newell, Shaw, and Simon's 1956 program that searched for proofs of theorems in the sentential calculus of *Principia Mathematica*, using a small set of heuristics rather than exhaustive enumeration.
-- **GPS (General Problem Solver)** — Newell, Shaw, and Simon's 1959 successor: a problem-solving architecture in which any task is recast as objects, operators, differences (between current and goal states), and a tree of goals and subgoals.
-- **Means-ends analysis** — GPS's signature heuristic. Compute the difference between the current state and the goal; choose an operator that *reduces* that specific kind of difference; recurse on whatever new subgoals the chosen operator opens up.
+- **GPS (General Problem Solver)** — Newell, Shaw, and Simon's 1959 successor, designed to test whether problem solving could be described through a reusable symbolic architecture rather than one theorem-proving task.
+- **Means-ends analysis** — GPS's signature heuristic: compare the current state with the goal, then choose actions aimed at reducing the relevant difference.
 - **Sentential calculus / propositional logic** — The logical system of *Principia Mathematica* Chapter 2 — propositions combined by AND, OR, NOT, IMPLIES — the formal domain LT searched.
 - **IPL (Information Processing Language)** — Shaw's family of list-processing languages (IPL-I through IPL-V, 1956–1960). LT and GPS ran on IPL. The languages were designed for symbolic, not numerical, computation.
 - **JOHNNIAC** — RAND's copy of the IAS computer, built 1952–1953. The hardware on which Shaw eventually ran LT.
-- **Performance vs. simulation** — The chapter's organising distinction. A *performance* program is judged by whether it solves the problem; a *simulation* program is judged by whether the *trace* of its work resembles a human's. LT was performance-oriented; GPS shifted toward simulation.
+- **Performance vs. simulation** — The chapter's organising distinction between solving a task and modelling the trace of human problem solving.
 
 </details>
 


### PR DESCRIPTION
## Summary
- trims repeated reader-aid phrasing in AI History Ch10-Ch12
- keeps body explanations intact while reducing TL;DR/glossary echoes
- rewrites Ch11 dollar figures as words to avoid accidental Markdown math rendering

## Checks
- git diff --check HEAD~1..HEAD
- npm run build (primary checkout on commit 5f94750d)
- ../../.venv/bin/python scripts/test_pipeline.py

Cross-family review requested before merge.