### PR TITLE
docs(ai-history): trim Ch13-Ch15 repetition

### DIFF
--- a/src/content/docs/ai-history/ch-13-the-list-processor.md
+++ b/src/content/docs/ai-history/ch-13-the-list-processor.md
@@ -15,7 +15,7 @@ LISP did not invent list processing — IPL had already given Logic Theorist and
 | Name | Lifespan | Role |
 |---|---|---|
 | John McCarthy | 1927–2011 | Author of the 1958 MIT AI Memo No. 1, the 1960 CACM paper, and most of the LISP 1.5 manual. Brought the Dartmouth naming agenda into MIT's symbolic-language design. |
-| Steve Russell | — | Early LISP implementer; associated with the realisation that McCarthy's `eval` definition could be hand-compiled into a working interpreter for the IBM 704. |
+| Steve Russell | — | Early LISP implementer credited, with Daniel Edwards, in the LISP 1.5 manual's interpreter lineage. |
 | Daniel J. Edwards | — | Early interpreter implementer with Russell; LISP 1.5 manual co-author. |
 | Timothy P. Hart | — | LISP 1.5 manual co-author and compiler contributor. The macro mechanism is most associated with his line of work. |
 | Michael I. Levin | — | LISP 1.5 manual co-author; prepared the manual for publication and authored Appendix B. |
@@ -43,8 +43,8 @@ timeline
 
 - **S-expression** — A symbolic expression written either as an atom (a name like `X`) or as a parenthesised list of symbolic expressions (e.g. `(A B C)` or `(LAMBDA (X) (CAR X))`). The data structure LISP programs read, write, and execute. Identical in form to LISP source code, which is what makes the language self-modifying.
 - **M-expression** — McCarthy's original *intended* external syntax: a more conventional algebraic notation (e.g. `car[x]`) that programmers would write, and that would translate into S-expression data. M-expressions were largely planned but never adopted; users wrote S-expressions directly, and the irony stuck.
-- **`car` / `cdr` / `cons`** — The three basic LISP cell operations. `car` returns the head of a list; `cdr` returns the rest; `cons` builds a new pair from a head and a tail. The names are direct artefacts of the IBM 704's *Contents of Address Register* and *Contents of Decrement Register* opcodes — LISP is machine-derived math, not Platonic discovery.
-- **`eval`** — A function that takes a symbolic expression representing a LISP form and *runs* it, returning the value. Defined in the 1960 CACM paper; first implemented as an IBM 704 interpreter when Russell realised the definition could be hand-compiled. The hinge that turned LISP from notation into a running language.
+- **`car` / `cdr` / `cons`** — The three basic LISP cell operations. `car` returns the head of a list; `cdr` returns the rest; `cons` builds a new pair from a head and a tail. The names preserve the IBM 704 machinery beneath the mathematical notation.
+- **`eval`** — A function that takes a symbolic expression representing a LISP form and *runs* it, returning the value. The hinge that turned LISP from notation into a running language.
 - **Lambda / recursive functions** — A way of describing functions anonymously and applying them to data, lifted from Church's lambda calculus. Recursive function definitions are the natural control structure when programs work over symbolic structures of unknown depth.
 - **`cond`** — LISP's primitive conditional: a list of test–result pairs, evaluated left to right until a test succeeds. The first general conditional expression to take both its branches as ordinary symbolic data.
 - **Garbage collection / free-storage list** — The runtime discipline of automatically reclaiming list cells that are no longer referenced. The LISP 1.5 manual lays it out as language infrastructure; garbage collection is what makes symbolic programs feel native rather than hand-managed.
@@ -97,7 +97,7 @@ This made lists a good fit for expressions that were naturally nested. A predica
 
 For AI, this was a powerful shift. Logical formulas, plans, theorem fragments, property records, and program forms could all be represented as nested symbolic structures. The shape of the data no longer had to be hidden inside ad hoc arrays or procedural conventions. The shape could be the thing the program inspected.
 
-The same structure also kept LISP from being pure abstraction. Its lists were mathematical enough to support recursive definitions, but concrete enough to live in fixed-size machine words. The tool-vs-theory tension begins here. If one looks only at the definitions, LISP seems like a clean theory of symbolic functions. If one looks only at the cells, registers, and free-storage lists, it seems like a memory management technique for symbolic programs. Historically, it was both at once.
+The same structure also kept LISP from being pure abstraction. Its lists were mathematical enough to support recursive definitions, but concrete enough to live in fixed-size machine words. If one looks only at the definitions, LISP seems like a clean theory of symbolic functions. If one looks only at the cells, registers, and free-storage lists, it seems like a memory management technique for symbolic programs. Historically, it was both at once.
 
 That duality explains why LISP became more than a notation. Symbolic AI needed to create temporary expressions constantly: candidate proofs, transformed formulas, partial plans, lists of differences, lists of properties, and newly constructed program fragments. `cons`, `car`, and `cdr` made those structures cheap to express. They also made their machine cost visible. Every symbolic expression had to occupy cells; every cell had to be allocated; every allocation had to be reclaimed or the machine would fill with abandoned structure.
 
@@ -127,7 +127,7 @@ The practical gravity came from feedback. If the system printed an S-expression,
 
 This is where Steve Russell's presence belongs, though without turning the story into folklore. Russell came out of a hands-on MIT programming culture, later famous for work on *Spacewar!* on the PDP-1. The strongest available source is not biography but the LISP 1.5 manual, which credits Russell and Daniel Edwards with programming the interpreter. That credit is enough to keep the implementation collective. McCarthy supplied the formal language design; Russell, Edwards, Hart, Levin, Minsky, and others helped turn the design into an environment programmers could use.
 
-That collective shape matters for the Tool-vs-Theory reading. A theory can be attributed through papers and formal definitions. A tool accumulates through use, implementation, compiler work, manual writing, and decisions made under machine constraints. LISP's notation story sits exactly at that crossing point. The formal design distinguished M-expressions from S-expressions; the tool culture found that the machine's own symbolic form was good enough, and often better, for the work at hand.
+That collective shape matters because a theory can be attributed through papers and formal definitions, while a tool accumulates through use, implementation, compiler work, manual writing, and decisions made under machine constraints. LISP's notation story sits exactly at that crossing point. The formal design distinguished M-expressions from S-expressions; the tool culture found that the machine's own symbolic form was good enough, and often better, for the work at hand.
 
 It was contingent, not fated.
 
@@ -138,7 +138,7 @@ The most compact way to see LISP's theory side is to follow `eval`.
 :::note[McCarthy on the 1960 formalism]
 > "We believe this formalism has advantages both as a programming language and as a vehicle for developing a theory of computation."
 
-The chapter's Tool-vs-Theory thesis in McCarthy's own published voice. The CACM paper does not present the language as one or the other; it claims the formalism does both jobs.
+McCarthy's own published voice refuses to separate the formalism from its programming use.
 :::
 
 McCarthy's 1958 memo and 1960 CACM paper built the language around recursive functions of symbolic expressions. Lambda notation gave a way to define functions. `cond` gave a way to branch on tests. Elementary operations such as `atom`, `eq`, `car`, `cdr`, and `cons` gave a base vocabulary. Recursive definitions then made it possible to state a procedure by cases: if the expression is empty, stop; if it is an atom, treat it one way; otherwise take the first part, process the rest, and combine the results.
@@ -179,7 +179,7 @@ Mark-and-sweep matched the way list structure worked. The system could begin fro
 
 That integration mattered historically. A symbolic AI program could be written as if list cells were a renewable medium. The programmer still had to understand structure, sharing, and mutation, but the system took responsibility for finding unreachable cells and returning them to free storage. In a language whose basic act was `cons`, that responsibility was not optional.
 
-Garbage collection also sharpens the tool-vs-theory axis. A mathematical account of recursive symbolic functions can ignore the question of where abandoned intermediate expressions go. A working AI system cannot. The moment the elegant notation runs on the IBM 704, the machine has to forget. It has to distinguish live structure from dead structure and make memory reusable.
+Garbage collection makes the same dual character concrete. A mathematical account of recursive symbolic functions can ignore the question of where abandoned intermediate expressions go. A working AI system cannot. The moment the elegant notation runs on the IBM 704, the machine has to forget. It has to distinguish live structure from dead structure and make memory reusable.
 
 The free-storage list gave that forgetting an operational form. Cells not currently in use were not an abstract pool; they were organized so that `cons` could obtain them. Reclamation returned dead cells to that same supply. The programmer could still write in terms of symbolic structure, but the runtime kept a material economy underneath: cells borrowed, linked, traversed, marked, swept, and reused.
 
@@ -217,7 +217,7 @@ The honest chronology is more interesting than the trophy version. FLPL marks th
 
 That bundle made symbolic AI portable in a new way. A researcher could describe symbolic reasoning in the same medium the program manipulated. The language's theory and its tool environment reinforced each other. LISP was mathematical enough to make symbolic functions legible and mechanical enough to make them runnable.
 
-That is the Tool-vs-Theory conclusion. LISP was not only a beautiful theory that happened to get implemented. It was not only a handy tool that later acquired theoretical prestige. Its power came from the overlap. The recursive theory made the tool coherent; the tool made the theory usable in everyday symbolic programming.
+LISP was not only a beautiful theory that happened to get implemented. It was not only a handy tool that later acquired theoretical prestige. Its power came from the overlap. The recursive theory made the tool coherent; the tool made the theory usable in everyday symbolic programming.
 
 That overlap also made the next institutional step possible.
 
@@ -228,7 +228,7 @@ That shift changes the setting.
 The next phase of the story moves from language substrate to institutional substrate. Project MAC and time-sharing would change how programmers encountered machines, making interaction less like submitting isolated jobs and more like living inside a computational environment. That later chapter belongs to the AI-lab and time-sharing world. LISP provided one of the languages ready to inhabit it.
 
 :::note[Why this still matters today]
-Every language that lets a program inspect its own source as data, every macro system that generates code at compile time, every interactive prompt that compiles each typed form before responding, descends from McCarthy's 1958–1962 line. The historiographic point is sharper than the credit: LISP did not invent list processing — IPL did that. What LISP unified was *notation, data, and execution* in one substrate, then made the substrate teachable through a manual. The cost LISP exposed and made portable — that interactive symbolic systems need automatic storage reclamation, anonymous functions, and a programmable conditional — is the cost every modern dynamic language pays in some form.
+Every language that lets a program inspect its own source as data, every macro system that generates code at compile time, every interactive prompt that compiles each typed form before responding, descends from McCarthy's 1958–1962 line. The enduring lesson is not priority over list processing; it is the way `eval` made notation, data, and execution share one substrate, then made that substrate teachable through a manual. The cost LISP exposed and made portable — that interactive symbolic systems need automatic storage reclamation, anonymous functions, and a programmable conditional — is the cost every modern dynamic language pays in some form.
 :::
 
 ## Sources

--- a/src/content/docs/ai-history/ch-14-the-perceptron.md
+++ b/src/content/docs/ai-history/ch-14-the-perceptron.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-Frank Rosenblatt's Perceptron program at the Cornell Aeronautical Laboratory (1958–1962) was a cybernetic research project, not a failed AI system. A 1958 *Psychological Review* paper, IBM 704 simulations, and the Mark I electromechanical machine pursued *learning* — supervised error correction over a random association layer — as engineering practice. The chapter separates three things later commentators tend to collapse: the convergence theorem (mathematics), the Mark I (analog hardware), and the *New York Times* press rhetoric of a machine that would walk, talk, see, and write.
+Frank Rosenblatt's Perceptron program at the Cornell Aeronautical Laboratory (1958–1962) was a cybernetic research project, not a failed AI system. A 1958 *Psychological Review* paper, IBM 704 simulations, and the Mark I electromechanical machine pursued *learning* — supervised error correction over a random association layer — as engineering practice. The later myth came from collapsing a bounded theorem, a real analog machine, and extravagant press rhetoric into one story.
 :::
 
 <details>
@@ -15,9 +15,9 @@ Frank Rosenblatt's Perceptron program at the Cornell Aeronautical Laboratory (19
 | Name | Lifespan | Role |
 |---|---|---|
 | Frank Rosenblatt | 1928–1971 | Psychologist at the Cornell Aeronautical Laboratory in Buffalo; author of the 1958 *Psychological Review* paper and *Principles of Neurodynamics* (1961). Designed the perceptron's S/A/R architecture and the supervised error-correction reinforcement rule. |
-| Charles Wightman | — | Cornell Aeronautical Laboratory engineer; principal Mark I builder. *Principles of Neurodynamics* p. ix records that he and Francis Martin carried out the engineering work on the machine. |
-| Francis Martin | — | Cornell Aeronautical Laboratory engineer; co-built Mark I with Wightman. |
-| John C. Hay | — | Cornell Aeronautical Laboratory experimentalist; ran the experimental programme on Mark I. Co-author with Albert E. Murray of the 1960 *Mark I Perceptron Operators' Manual* (Project PARA). |
+| Charles Wightman | — | Cornell Aeronautical Laboratory engineer associated with the Mark I's construction. |
+| Francis Martin | — | Cornell Aeronautical Laboratory engineer in the Mark I implementation team. |
+| John C. Hay | — | Cornell Aeronautical Laboratory experimentalist and co-author, with Albert E. Murray, of the 1960 *Mark I Perceptron Operators' Manual* (Project PARA). |
 | H. D. Block | — | Perceptron-theory contributor; author of "The Perceptron: A Model for Brain Functioning. I" in *Reviews of Modern Physics* 34(1), January 1962 — the chapter's anchor for independent mathematical legitimacy. |
 | Albert B. J. Novikoff | — | Mathematician who published a tightened convergence proof for the perceptron in 1962, under cleaner separability assumptions. |
 
@@ -31,7 +31,7 @@ timeline
     title The Cornell Perceptron Program, 1957–1962
     July 1957 : Buffalo perceptron program enters ONR support under Contract Nonr-2381(00) (per Principles of Neurodynamics, p. ix)
     1958 : Rosenblatt publishes "The Perceptron" in Psychological Review : Mark I built at Cornell Aeronautical Laboratory, Buffalo
-    July 8 1958 : New York Times prints "New Navy Device Learns by Doing" — press rhetoric of a machine that will walk, talk, see, and write
+    July 8 1958 : New York Times prints "New Navy Device Learns by Doing" — public hype outruns the bounded laboratory claims
     24–27 November 1958 : HMSO Mechanisation of Thought Processes symposium at NPL Teddington : Rosenblatt's "Two Theorems of Statistical Separability," Selfridge's "Pandemonium," and McCarthy's "Programs with Common Sense" share one proceedings volume
     1960 : Hay & Murray Mark I Operators' Manual (February) : Rosenblatt's "Perceptron Simulation Experiments" in Proceedings of the IRE (March) : Navy photo release describing Mark I letter-recognition (June 24)
     1961–1962 : Principles of Neurodynamics CAL report (March 1961) : Block 1962 Reviews of Modern Physics exposition : Novikoff 1962 tightened convergence proof
@@ -130,7 +130,7 @@ In *Principles of Neurodynamics*, the convergence material appears inside a larg
 
 This is why importing the 1969 controversy backward does damage. The later critique matters, and Chapter 17 will take it up, but it should not be used to make the original theorem seem naive. Rosenblatt's result did not secretly claim to solve every recognition problem. It claimed convergence for a learning procedure when a solution was available under the relevant assumptions. The limits that later became famous are limits of that claim, not proof that the claim was empty.
 
-The safest way to teach the theorem is to keep the three layers visible. The mathematics says that a correction procedure can reach a solution under the right separability conditions. The hardware gives one physical way to stage restricted pattern-recognition experiments. The press makes a different kind of claim about future machines. Only the first two belong to the technical program. The third belongs to reception.
+The safest way to teach the theorem is to keep the claims separated. The mathematics says that a correction procedure can reach a solution under the right separability conditions. The hardware gives one physical way to stage restricted pattern-recognition experiments. The press makes a different kind of claim about future machines. Only the first two belong to the technical program. The third belongs to reception.
 
 Chapter 15 will later reinterpret perceptron learning in a more modern optimization language, as kin to gradient descent on a linear classifier. That is a useful bridge, but it is not the vocabulary of this chapter's historical actors. Here the period language is reinforcement, solutions, separability, and convergence. The modern reinterpretation should clarify Rosenblatt's result, not overwrite it.
 
@@ -194,7 +194,7 @@ The press layer is real, but it is not the same as the technical layer. The July
 
 Rosenblatt's own later preface is the safer guide. In *Principles of Neurodynamics*, he complained that popular press treatment had contributed to controversy and emphasized that the perceptron program was first a theory of brain mechanisms, not simply the invention of artificial-intelligence devices. That distinction does not make him modest in ambition. It makes the ambition more precise.
 
-The three-layer separation is the reader's protection against myth. The mathematics supports convergence under separability conditions. The hardware supports restricted learning experiments in an electromechanical system. The press imagined a much larger future. All three belong to the history, but only the first two belong to the demonstrated technical achievement.
+That separation is the reader's protection against myth. The mathematics supports convergence under separability conditions. The hardware supports restricted learning experiments in an electromechanical system. The press imagined a much larger future. All three belong to the history, but only the first two belong to the demonstrated technical achievement.
 
 The later fate of the story also had a human asymmetry. Rosenblatt died in a sailing accident in 1971, after the publication of Minsky and Papert's *Perceptrons* and before the late-1970s and 1980s connectionist revival could fully rewrite the public memory. That fact should not be turned into melodrama, and it does not decide the mathematics. It helps explain why the counter-narrative was muted. The program's most visible defender was no longer available to argue its historical meaning through the next cycle of debate.
 

--- a/src/content/docs/ai-history/ch-15-the-gradient-descent-concept.md
+++ b/src/content/docs/ai-history/ch-15-the-gradient-descent-concept.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-Gradient descent did not arrive in machine learning fully formed. It accumulated across 123 years from four loose pieces: Cauchy's 1847 sketch (no convergence proof, never followed up), Robbins and Monro's 1951 root-finding-under-noise framework, Widrow and Hoff's 1960 IRE WESCON paper that *explicitly* named "the method of steepest descent" on a parabolic loss surface and built it into the lunch-pail Adaline, and Linnainmaa's 1970 master's thesis on rounding errors that gave the first reverse-mode chain-rule machinery for arbitrary computational graphs.
+Gradient descent did not arrive in machine learning fully formed. It accumulated across 123 years from astronomy, mathematical statistics, analog learning hardware, and numerical analysis. The chapter's job is to keep those lineages separate long enough to see why modern machine learning later needed all of them.
 :::
 
 <details>
@@ -56,11 +56,9 @@ timeline
 The four nodes can be stated compactly. None of these formulae appears in only one of the chapter's sources; together they show what each scene contributed.
 
 - **Cauchy's 1847 step.** For $u = f(x, y, z, \dots)$ with partial derivatives $X, Y, Z, \dots$ at the current point and a small positive $\theta$, Cauchy proposed increments $\alpha = -\theta X,\ \beta = -\theta Y,\ \gamma = -\theta Z,\ \dots$ — the first published descent rule.
-- **Cauchy's two variants on the same page.** The line-search variant minimises $\Theta = f(x - \theta X,\ y - \theta Y,\ z - \theta Z,\ \dots)$ along the descent direction; the steepest-descent-proper variant fixes $\theta$ by the univariate stationarity condition $\Theta'_\theta = 0$.
 - **Cauchy's least-squares extension.** A system of equations $u = 0,\ v = 0,\ w = 0,\ \dots$ becomes the single non-negative target $u^2 + v^2 + w^2 + \dots$, attacked by the same iteration.
 - **Robbins–Monro step-size conditions.** Later expositions write the convergence-in-probability requirement as $\sum c_n = \infty$ and $\sum c_n^2 < \infty$ — large enough that the procedure does not freeze, small enough that noise washes out.
 - **Widrow–Hoff LMS rule (1960).** With $a_1, \dots, a_n$ the adjustable gains, the rule changes each gain in proportion to the *gradient of the mean square error* with respect to that gain — the parabolic surface in gain-space the chapter pivots on.
-- **Widrow–Hoff time constant.** For the 4×4-input Adaline, the per-pattern step shrinks the error magnitude by a factor of $1/17$; the one-pattern-at-a-time time constant is $\tau = n + 1 = 17$ patterns. Steepest descent acquires a measurable physical pace.
 
 </details>
 
@@ -167,5 +165,5 @@ Each step removed a different obstacle. Cauchy answered the local-direction ques
 None of these four milestones were intended as a comprehensive algorithm for training artificial neural networks. The realization that Linnainmaa's reverse-mode chain rule could be applied specifically to neural networks to train multiple layers of representations was first published by Paul Werbos in 1981, several years before the technique was widely popularized. That later chain, running from reverse-mode automatic differentiation into neural-network backpropagation, belongs to Chapter 24. Here, the story stops at the hinge: by 1970, the pieces existed, but they had not yet been assembled into the familiar training algorithm for multilayer networks.
 
 :::note[Why this still matters today]
-Every gradient-descent step in every modern training run — every SGD update, every Adam moment, every backpropagated weight change in every neural network — descends from these four nodes. The chapter's discipline matters: Cauchy gave the iteration; Robbins and Monro gave it convergence under noise; Widrow and Hoff gave the *first explicit gradient-method framing* on physical analog hardware; Linnainmaa gave the *machinery* to compute the gradient through any computational graph. None of the four claimed to have invented "neural network training." The unity belongs to the later mathematical reconstruction, not to a single historical project unfolding with one destination in mind.
+Every gradient-descent step in every modern training run — every SGD update, every Adam moment, every backpropagated weight change in every neural network — depends on a long separation between local descent, noisy approximation, hardware learning, and reverse-mode differentiation. None of the researchers in this chapter claimed to have invented "neural network training." The point is precisely that modern training looks unified only after later mathematics and software made these older pieces interoperable.
 :::


### PR DESCRIPTION
## Summary
- trims reader-aid spoilers and repeated meta-framework phrasing in AI History Ch13-Ch15
- keeps detailed historical explanations in the main prose while shortening cast/glossary/math/closing aids
- removes repeated Ch14 press quote from reader aids and reduces Ch15 repeated four-part synthesis

## Checks
- git diff --check HEAD~1..HEAD
- ../../.venv/bin/python scripts/check_reader_aids.py ch-13 ch-14 ch-15
- npm run build (primary checkout on commit a712dc19)
- ../../.venv/bin/python scripts/test_pipeline.py

Cross-family review requested before merge.