### PR TITLE
docs(ai-history): trim Ch16-Ch18 repetition

### DIFF
--- a/src/content/docs/ai-history/ch-16-the-cold-war-blank-check.md
+++ b/src/content/docs/ai-history/ch-16-the-cold-war-blank-check.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-The "blank check" early symbolic AI received was not literally blank. Before ARPA/IPTO, RAND, ONR, Air Force, and MIT military-lab channels had already funded Logic Theorist, GPS, and the MIT AI Project. What changed after October 1962 was scale, coherence, and tolerance for long horizons. Licklider's IPTO translated command-and-control anxiety into center-based funding for machines, languages, time-sharing, and graduate communities rather than narrowly specified weapons. By 1969 the Mansfield Amendment had begun to tighten the bargain.
+Early symbolic AI did not move from poverty to patronage in one leap. RAND, ONR, Air Force, and MIT military-lab channels were already supporting theorem proving, GPS, and the MIT AI Project. Licklider's IPTO changed the funding ecology: center-scale commitments, shared machines, time-sharing, symbolic languages, and graduate communities could now be justified as future command-and-control infrastructure. By 1969 the Mansfield Amendment had begun to tighten that bargain.
 :::
 
 <details>
@@ -15,10 +15,10 @@ The "blank check" early symbolic AI received was not literally blank. Before ARP
 | Name | Lifespan | Role |
 |---|---|---|
 | J. C. R. Licklider | 1915–1990 | Author of "Man-Computer Symbiosis" (March 1960). First director of ARPA's Information Processing Techniques Office (IPTO) from October 1962. The chapter's central protagonist; translated command-and-control anxiety into center-based funding. |
-| Jack Ruina | 1923–2015 | ARPA director who hired Licklider and personally approved the $3-million Project MAC commitment within days of receiving the proposal. |
+| Jack Ruina | 1923–2015 | ARPA director who hired Licklider and backed Project MAC as one of IPTO's early center-scale commitments. |
 | Allen Newell & Herbert A. Simon | 1927–1992 / 1916–2001 | Carnegie Tech / RAND. Their Logic Theorist (1956) and GPS (1959) were the field's earliest defense-funded symbolic-AI demonstrations. |
-| John McCarthy & Marvin Minsky | 1927–2011 / 1927–2016 | Co-founders of the MIT Artificial Intelligence Project in September 1957 — initially "a room, two programmers, a secretary, and a keypunch machine." McCarthy later founded the Stanford AI Lab on ARPA support beginning June 1963. |
-| Senator Mike Mansfield | 1903–2001 | Sponsor of Public Law 91-121 §203, signed November 19, 1969. The "Mansfield Amendment" required defense research funds to relate to a "direct and apparent" military function. |
+| John McCarthy & Marvin Minsky | 1927–2011 / 1927–2016 | Co-founders of the MIT Artificial Intelligence Project in September 1957. McCarthy later founded the Stanford AI Lab on ARPA support beginning June 1963. |
+| Senator Mike Mansfield | 1903–2001 | Sponsor of Public Law 91-121 §203, signed November 19, 1969, which narrowed how defense research funds had to justify military relevance. |
 | Ivan Sutherland & Robert Taylor | — | Licklider's successors at IPTO. Carried the centers-of-excellence philosophy forward into graphics, networking, and resource-sharing. |
 
 </details>
@@ -32,9 +32,9 @@ timeline
     October 4 1957 : Sputnik launch shocks U.S. national-security planners
     February 7 1958 : ARPA created in the Sputnik aftermath
     March 1960 : Licklider publishes "Man-Computer Symbiosis" — the conceptual vocabulary that would later open the defense budget to symbolic computing
-    October 1962 : Licklider begins as ARPA/IPTO director with a combined IPTO + Behavioral Sciences budget of about $11 million
+    October 1962 : Licklider begins as ARPA/IPTO director with a combined IPTO + Behavioral Sciences budget of about 11 million dollars
     July 1 1963 : Project MAC begins at MIT as a major IPTO experiment in interactive, time-shared computing : Stanford AI Project also begins on ARPA support (June 15, 1963)
-    November 19 1969 : Public Law 91-121 §203 (Mansfield Amendment) — defense research funds must have a "direct and apparent relationship to a specific military function or operation"
+    November 19 1969 : Public Law 91-121 §203 (Mansfield Amendment) requires tighter military-relevance justification for defense research funds
     FY1971 : IPTO program tables show "Intelligent systems," "Speech understanding systems," "Distributed information systems," and "Computer networks" as named categories
 ```
 
@@ -47,8 +47,8 @@ timeline
 - **IPTO** — Information Processing Techniques Office. The ARPA office Licklider directed from October 1962. The chapter's central institutional actor.
 - **Command and control** — The defence-planning frame under which interactive computing, time-sharing, theorem proving, symbolic languages, and machine perception could all be described as future decision infrastructure. The capacious umbrella that made ARPA/IPTO funding plausible to defence officials.
 - **Centers of excellence** — Licklider's term for institutional bets like Project MAC, Carnegie Tech, and Stanford AI: large, broad-mandate funding to a handful of departments rather than scattered grants for narrow deliverables.
-- **Project MAC** — Multiple Access Computer / Machine-Aided Cognition. MIT's IPTO-funded interactive computing experiment, beginning July 1, 1963 with a $3-million commitment from Jack Ruina.
-- **Mansfield Amendment** — Public Law 91-121 §203 (1969). The statute that required defence research funds to relate to a "direct and apparent" military function. The boundary that started to tighten the open-ended bargain.
+- **Project MAC** — Multiple Access Computer / Machine-Aided Cognition. MIT's IPTO-funded interactive computing experiment, beginning July 1, 1963, and one of IPTO's first major center-scale bets.
+- **Mansfield Amendment** — Public Law 91-121 §203 (1969). The statute that tightened how defence research funds had to demonstrate military relevance.
 - **JOHNNIAC** — RAND's copy of the IAS computer, Air Force-funded. Newell, Shaw, and Simon's Logic Theorist ran on it.
 
 </details>
@@ -85,11 +85,11 @@ A similar environment existed at the Massachusetts Institute of Technology. In S
 
 The establishment of IPTO under Licklider radically changed the scale of artificial intelligence research, transforming it from a collection of small, isolated efforts into a large, high-profile academic domain. From the 1960s onward, the defense agency provided the bulk of United States support for artificial intelligence, an influx of resources that helped legitimize it as a permanent discipline. The new feature was not simply a larger pot of money. It was the decision to spend that money on centers, machines, languages, meetings, and continuity.
 
-Licklider managed IPTO and the Behavioral Sciences Office with a combined budget of about $11 million and a lean administrative structure. That combination gave the office unusual leverage. A small staff could move quickly, but the funds it controlled were large enough to alter the lives of entire departments. Licklider's approach represented a departure from ordinary military procurement. Rather than scattering small grants to individual researchers for narrow deliverables, IPTO funded coherent programs and established major centers of excellence. Early commitments clustered around MIT and Carnegie Tech, reflecting his preference for broad institutional bets over isolated experiments.
+Licklider managed IPTO and the Behavioral Sciences Office with a combined budget of about 11 million dollars and a lean administrative structure. That combination gave the office unusual leverage. A small staff could move quickly, but the funds it controlled were large enough to alter the lives of entire departments. Licklider's approach represented a departure from ordinary military procurement. Rather than scattering small grants to individual researchers for narrow deliverables, IPTO funded coherent programs and established major centers of excellence. Early commitments clustered around MIT and Carnegie Tech, reflecting his preference for broad institutional bets over isolated experiments.
 
 The administrative style was personal, but not casual. Licklider looked for researchers who already seemed capable of defining important problems, then tried to place their work in relation to other sponsored efforts. That stance helps explain both the generosity and the limits of the period. A strong investigator might receive support for work whose military payoff was distant, but the work still had to belong to an intelligible program. The office was trying to make interactive computing real: to move from papers about symbiosis to machines that many people could use, languages that could express symbolic procedures, and laboratories where those pieces reinforced each other. In that sense, Licklider's budget was not a prize fund for isolated brilliance. It was a tool for building a distributed research system.
 
-At MIT, Project MAC became one of IPTO's first major investments. The project was conceived as an experiment in interactive computing, aimed broadly at human-computer interaction and general-purpose time-sharing. Licklider was deeply involved in the evaluation of the proposal, and ARPA director Jack Ruina backed a $3-million commitment within days. The speed of that approval helps explain why later participants remembered the period as unusually permissive. Yet the permissiveness had a shape. Project MAC was not a blank order to do anything that seemed interesting. It offered a way to pursue machine-aided cognition, time-sharing, and online computation under the larger premise that future command systems would require more fluent interaction between people and machines.
+At MIT, Project MAC became one of IPTO's first major investments. The project was conceived as an experiment in interactive computing, aimed broadly at human-computer interaction and general-purpose time-sharing. Licklider was deeply involved in the evaluation of the proposal, and ARPA director Jack Ruina backed a three-million-dollar commitment within days. The speed of that approval helps explain why later participants remembered the period as unusually permissive. Yet the permissiveness had a shape. Project MAC was not a blank order to do anything that seemed interesting. It offered a way to pursue machine-aided cognition, time-sharing, and online computation under the larger premise that future command systems would require more fluent interaction between people and machines.
 
 Carnegie Tech offered a different but complementary center. Its proposal drew strength from the combined presence of Simon, Newell, Alan Perlis, and Herbert Green. Licklider wanted to reinforce their ongoing information-processing work and later identified the institution as an essential early center of excellence. The point was not merely to reward famous names. Carnegie joined behavioral science, computer science, programming languages, and problem-solving research in a setting where symbolic AI could be treated as part of a larger inquiry into information processing. That fit Licklider’s criteria: a strong team, a plausible connection to defense problems, and a relationship to the rest of the sponsored portfolio.
 

--- a/src/content/docs/ai-history/ch-17-the-perceptron-s-fall.md
+++ b/src/content/docs/ai-history/ch-17-the-perceptron-s-fall.md
@@ -7,7 +7,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-The perceptron's fall was not one theorem killing neural networks. Frank Rosenblatt's Mark I — a real electromechanical machine backed by the Office of Naval Research — learned simple patterns from examples. Minsky and Papert's 1969 *Perceptrons* proved that local, single-layer systems could not compute global predicates such as connectedness. The winter effect came from how that precise result was absorbed by a field whose funding and authority had already shifted toward symbolic AI.
+The perceptron's fall was not one theorem killing neural networks. Frank Rosenblatt's Mark I — a real electromechanical machine backed by the Office of Naval Research — learned simple patterns from examples. Minsky and Papert's 1969 *Perceptrons* exposed severe limits in a defined class of local, single-layer systems. The winter effect came from how that precise result was absorbed by a field whose funding and authority had already shifted toward symbolic AI.
 :::
 
 <details>
@@ -16,11 +16,11 @@ The perceptron's fall was not one theorem killing neural networks. Frank Rosenbl
 | Name | Lifespan | Role |
 |---|---|---|
 | Frank Rosenblatt | — | Cornell Aeronautical Laboratory psychologist; originator of perceptron theory and director of the ONR/RADC-funded Mark I program. |
-| Marvin Minsky | — | MIT AI leader; co-author of *Perceptrons* (1969). Earlier neural-net researcher who argued that learning machines need prior structure. |
+| Marvin Minsky | — | MIT AI leader; co-author of *Perceptrons* (1969). Earlier neural-net researcher as well as symbolic-AI institution builder. |
 | Seymour Papert | — | Co-author of *Perceptrons*; later explicitly addressed whether he and Minsky had tried to "kill connectionism." |
 | Marvin Denicoff | — | ONR program officer; quoted by Olazaran on the funding scale gap between ONR support for Rosenblatt and ARPA's larger backing of symbolic AI. |
-| Mikel Olazaran | — | Historian and sociologist whose 1996 *Social Studies of Science* analysis separates the technical proof from the "official history" built around it. |
-| Leon Bottou | — | Author of the 2017 MIT Press foreword to *Perceptrons*; provides the key framing that neural-net research became unfashionable and that revival came only with PDP/backprop. |
+| Mikel Olazaran | — | Historian and sociologist whose 1996 *Social Studies of Science* analysis is a key later source on the controversy. |
+| Leon Bottou | — | Author of the 2017 MIT Press foreword to *Perceptrons*; key later commentator on the book's reception. |
 
 </details>
 
@@ -45,10 +45,10 @@ timeline
 
 - **Perceptron** — A computing element that applies weights to features of its input, sums them, and outputs a yes/no decision above a threshold. Rosenblatt's machine adjusted those weights by correcting its own errors during training.
 - **Predicate** — A function that returns true or false about its input. Minsky and Papert asked which predicates a perceptron can compute given that its parts each see only a limited portion of the input field.
-- **Connectedness** — The topological property of a figure whose marked pixels form a single unbroken region. A global predicate: no fixed-size local test can always answer it correctly as the image grows.
+- **Connectedness** — A central example in *Perceptrons*, used to show how an apparently simple visual property can require nonlocal information.
 - **Order (of a perceptron)** — Minsky and Papert's measure of how many input pixels a single partial predicate may examine simultaneously. Higher order means larger and more expensive local tests; the required order grows with problem size for parity and connectedness.
 - **Locality/diameter-limited** — A perceptron whose partial predicates each look only at a bounded neighborhood of the input field. Minsky and Papert's proofs apply specifically to this constrained architecture, not to all possible multilayer systems.
-- **Prior structure** — The representational bias built into a learning system before training begins — the choice of what features to look at, how they combine, and what the architecture can represent. Minsky and Papert's core argument: without appropriate prior structure, even a trainable system scales badly.
+- **Prior structure** — The representational bias built into a learning system before training begins: features, combinations, and architectural constraints.
 
 </details>
 
@@ -308,12 +308,6 @@ computations in some abstract sense, but still have little chance of solving a
 high-order problem efficiently. A big bag of possible features is not the same
 as the right representation.
 
-:::note[The 1969 hinge]
-> "But we do believe that significant learning at a significant rate presupposes some significant prior structure."
-
-The critique was not anti-learning; it shifted the burden from trainable weights to architecture and task-matched features.
-:::
-
 That argument was not anti-AI. It was a demand for theory. It said that learning
 machines could not be judged only by small demonstrations or by biological
 analogy. They needed mathematical accounts of what their architectures could
@@ -519,7 +513,6 @@ The theorem did not close the door. It marked the threshold. For a generation,
 most of AI chose not to walk through it.
 
 :::note[Why this still matters today]
-Every modern deep-learning system still answers the question Minsky and Papert posed: what prior structure makes learning tractable? Convolutional layers encode spatial locality and translation invariance. Attention mechanisms build a different structure for sequence context. Scaling laws depend on the relationship between data, parameters, and compute. The specific architecture of the perceptron lost, but the argument from the perceptron controversy — that trainable weights alone do not guarantee useful generalization — remains the working assumption behind every architecture choice in contemporary machine learning.
+Every modern deep-learning system still answers the question Minsky and Papert posed: what built-in assumptions make learning tractable? Convolutional layers encode spatial locality and translation invariance. Attention mechanisms build a different structure for sequence context. Scaling laws depend on the relationship between data, parameters, and compute. The specific architecture of the perceptron lost, but the argument from the perceptron controversy — that trainable weights alone do not guarantee useful generalization — remains the working assumption behind every architecture choice in contemporary machine learning.
 :::
-
 

--- a/src/content/docs/ai-history/ch-18-the-lighthill-devastation.md
+++ b/src/content/docs/ai-history/ch-18-the-lighthill-devastation.md
@@ -7,7 +7,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-In 1972 the UK Science Research Council asked Cambridge mathematician Sir James Lighthill to survey artificial intelligence. His report separated the field into application automation (A), computer-based brain studies (C), and a disputed bridge category (B) covering general-purpose AI. His argument — that category B had failed to escape combinatorial explosion and deserved no independent funding — triggered a decade-long loss of confidence in British AI. Researchers continued, but under colder labels; the field returned in the 1980s only by rebranding itself as Intelligent Knowledge-Based Systems under the Alvey Programme.
+In 1972 the UK Science Research Council asked Cambridge mathematician Sir James Lighthill to survey artificial intelligence. His report divided the field in a way that isolated general-purpose AI as the weakest funding case, then used combinatorial explosion to argue that broad promises had outrun results. The result was not extinction, but a decade of colder confidence, tighter labels, and narrower expectations for British AI.
 :::
 
 <details>
@@ -16,9 +16,9 @@ In 1972 the UK Science Research Council asked Cambridge mathematician Sir James 
 | Name | Lifespan | Role |
 |---|---|---|
 | Sir James Lighthill | 1924–1998 | Cambridge applied mathematician; commissioned outsider who wrote the 1972 survey that divided AI into categories A, B, and C. |
-| N. S. Sutherland | 1927–1998 | Sussex experimental psychologist; argued that Lighthill's category B should be understood as basic science, not a vague bridge activity. |
-| Donald Michie | 1923–2007 | Edinburgh machine intelligence leader; challenged the classification, demanded US consultation, and made the infrastructure argument for importing DEC System 10 machines. |
-| R. M. Needham | 1931–2003 | Cambridge computer scientist; partially agreed with Lighthill's conclusions, adding balance to the rebuttal. |
+| N. S. Sutherland | 1927–1998 | Sussex experimental psychologist and key respondent in the 1973 published symposium. |
+| Donald Michie | 1923–2007 | Edinburgh machine intelligence leader and key respondent in the 1973 symposium and BBC debate. |
+| R. M. Needham | 1931–2003 | Cambridge computer scientist and key respondent in the 1973 published symposium. |
 | H. C. Longuet-Higgins | 1923–2004 | Edinburgh theoretical psychologist; responded to the report, providing a middle voice between Sutherland and Michie. |
 | Terry Winograd | 1946– | Author of SHRDLU; cited by Lighthill as a remarkable table-top-world achievement that nonetheless illustrated the limits of narrow domain constraint. |
 
@@ -39,7 +39,7 @@ timeline
     June 1973 : BBC broadcasts the Lighthill Controversy debate at the Royal Institution with Lighthill, Michie, Gregory, and McCarthy
     1970s : UK AI continues under tighter application framing; Chilton overview reports a loss of confidence lasting almost a decade
     September 1982 : Research Area Review Meeting on Intelligent Knowledge-Based Systems — the next major UK AI-related effort
-    1980s : IKBS becomes part of the Alvey Programme, reframing AI under an industrially legible policy label
+    1980s : Alvey Programme reframes AI-related work in industrial and application-linked terms
 ```
 
 </details>
@@ -47,11 +47,11 @@ timeline
 <details>
 <summary><strong>Plain-words glossary</strong></summary>
 
-- **ABC classification** — Lighthill's three-part map of AI: Category A (Advanced Automation, work tied to real application domains), Category C (computer-based study of the central nervous system), and Category B (the disputed bridge activity — general-purpose AI including search, language, and robotics). The classification made B the hardest to justify to funders.
+- **ABC classification** — Lighthill's administrative map of AI, used to separate application work, brain-modeling work, and the disputed general-purpose middle. The details matter in Section 2.
 - **Combinatorial explosion** — The problem that arises when a program's search space grows faster than any feasible computation can handle. As a problem widens (more words, more pieces, more states), the number of possibilities multiplies exponentially. Lighthill used this as his central technical argument against general AI.
 - **Universe of discourse** — The bounded world a program operates within. A chess game or a table-top of blocks is a universe of discourse. Lighthill's point was that AI programs worked only when their universe was carefully fenced, and that extending the fence to real-world scope remained unsolved.
 - **Science Research Council (SRC)** — The UK government body responsible for funding academic science in the early 1970s. Its decision to commission Lighthill's review, and the policy weight it gave to the report, made the review consequential beyond its page count.
-- **IKBS / Alvey** — Intelligent Knowledge-Based Systems; the label UK science policy adopted in the early 1980s when it returned to AI-related funding. The Alvey Programme framed AI in more industrial and application-linked terms, deliberately avoiding the open-ended ambitions Lighthill had criticised. IKBS is the evidence that AI survived the winter by changing its promises.
+- **IKBS / Alvey** — The early-1980s UK policy label and programme through which AI-related work re-entered industrial funding debates. Section 6 returns to why the label mattered.
 
 </details>
 
@@ -499,5 +499,4 @@ learning to make smaller promises with better machinery behind them.
 :::note[Why this still matters today]
 Every modern AI funding cycle inherits the Lighthill structure. Funders still ask whether a system works only inside a bounded domain or whether it generalises — the combinatorial explosion argument recurs each time a language model meets an edge case it was not trained on. Research programmes still survive by anchoring claims to applications rather than general intelligence; the rebranding from "AI" to "machine learning" to "foundation models" each time optimism overshoots results repeats the IKBS move. Knowing that this cycle is structural, not new, helps practitioners calibrate expectations and distinguish genuine capability advances from re-labelled promises.
 :::
-
 


### PR DESCRIPTION
## Summary
- trim repeated reader-aid phrasing in Ch16-Ch18 based on the Gemini repetition audit
- keep full explanations in the chapter bodies while reducing duplicated cast, timeline, glossary, and TL;DR language
- normalize Ch16 dollar amounts to avoid Markdown math rendering around money figures

## Checks
- git diff --check HEAD~1..HEAD
- ../../.venv/bin/python scripts/check_reader_aids.py ch-16 ch-17 ch-18
- npm run build (from primary checkout at 8d36e00f)
- ../../.venv/bin/python scripts/test_pipeline.py (166 tests OK)

## Review
- Cross-family review pending; do not merge until posted as a PR comment.