### PR TITLE
docs(ai-history): trim Ch19-Ch21 repetition

### DIFF
--- a/src/content/docs/ai-history/ch-19-rules-experts-and-the-knowledge-bottleneck.md
+++ b/src/content/docs/ai-history/ch-19-rules-experts-and-the-knowledge-bottleneck.md
@@ -7,7 +7,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-After general methods collapsed in the first AI winter, the Stanford Heuristic Programming Project offered a narrower bargain: encode expert knowledge explicitly. MYCIN, an infectious-disease consultation system built by Shortliffe and Buchanan from the early 1970s, separated a rule-based knowledge base from an inference engine, used certainty factors for inexact reasoning, and explained its conclusions. It performed seriously in a blinded evaluation — and exposed the structural price: getting expertise into rules was slow, iterative, and never finally done.
+After general methods collapsed in the first AI winter, the Stanford Heuristic Programming Project offered a narrower bargain: encode expert knowledge explicitly. MYCIN, an infectious-disease consultation system built by Shortliffe and Buchanan from the early 1970s, used modular rules, certainty factors, and explanation to turn specialist judgment into an interactive consultation. It performed seriously in a narrow blinded evaluation — and exposed the structural price: getting expertise into rules was slow, iterative, and never finally done.
 :::
 
 <details>
@@ -17,10 +17,10 @@ After general methods collapsed in the first AI winter, the Stanford Heuristic P
 |---|---|---|
 | Edward H. Shortliffe | — | Principal MYCIN developer; central source for the consultation system, certainty factors, and medical-AI framing. |
 | Bruce G. Buchanan | — | Stanford AI researcher and MYCIN coeditor; bridged DENDRAL, rule systems, and knowledge engineering. |
-| Edward A. Feigenbaum | — | Stanford Heuristic Programming Project leader; named knowledge engineering as an emerging practice. |
-| Randall Davis | — | Developer of TEIRESIAS; demonstrated that explanation was prerequisite to interactive knowledge transfer. |
+| Edward A. Feigenbaum | — | Stanford Heuristic Programming Project leader; helped define the expert-system turn. |
+| Randall Davis | — | Developer of TEIRESIAS, a tool for helping experts inspect and revise rule systems. |
 | William van Melle | — | MYCIN/EMYCIN system builder; key source for architecture and shell generalization. |
-| Victor L. Yu | — | Lead author on the JAMA blinded evaluation of MYCIN's antimicrobial advice. |
+| Victor L. Yu | — | Lead author on a published evaluation of MYCIN's antimicrobial advice. |
 
 </details>
 
@@ -35,10 +35,10 @@ timeline
     1973 : MYCIN grant goals describe consultation, interactive explanation, and acquisition of judgmental therapeutic rules
     1975 : Shortliffe and Buchanan publish the certainty-factor model for inexact medical reasoning
     1976 : Shortliffe completes Computer-Based Medical Consultations: MYCIN
-    1977 : Feigenbaum's IJCAI paper names knowledge engineering as an emerging practice
-    1977–1979 : TEIRESIAS work develops WHY/HOW explanation and interactive transfer of expertise
+    1977 : Feigenbaum's IJCAI paper frames the expert-system approach
+    1977–1979 : TEIRESIAS work develops tools for interactive rule-system revision
     1978 : The MYCIN infectious-disease knowledge base is laid to rest
-    1979 : JAMA evaluation compares MYCIN's antimicrobial advice with human prescribers in a blinded meningitis study
+    1979 : MYCIN evaluation publishes a blinded clinical comparison
     1981 : EMYCIN described as a shell for building rule-based consultation systems
     1984 : Buchanan and Shortliffe publish the full Rule-Based Expert Systems retrospective
 ```
@@ -49,12 +49,12 @@ timeline
 <summary><strong>Plain-words glossary</strong></summary>
 
 - **Expert system** — A program designed to provide solutions at the level of a domain specialist, with knowledge it can explain and update. MYCIN's authors defined this in terms of expert-level solutions, understandability, and the ability to accommodate new knowledge easily.
-- **Knowledge base / inference engine split** — MYCIN separated medical rules (the knowledge base) from the reasoning machinery (the inference engine). This meant expertise could be inspected and changed without rewriting the whole program.
+- **Knowledge base / inference engine split** — MYCIN's architectural separation between domain rules and reasoning machinery. Section 3 explains why that mattered.
 - **Production rule** — An IF/THEN statement encoding a fragment of expert judgment: given certain conditions, draw a conclusion or take an action. Rules are the modular building blocks of the MYCIN knowledge base.
 - **Certainty factor** — A numerical measure attached to facts and conclusions, representing degree of belief on a scale from −1 (definite disconfirmation) to 1 (definite confirmation). The scheme was a practical approximation, not a full probability theory, for cases where clean statistical data were unavailable.
 - **Backward chaining** — A goal-directed inference strategy: start with what you want to establish, then ask which rules and evidence would support it. MYCIN used backward chaining so the consultation asked only for facts its current reasoning actually needed.
 - **Knowledge engineering** — Feigenbaum's term for the craft of acquiring expert knowledge, representing it in a formal system, and building a program that can use it. The knowledge engineer stands between domain specialist and software.
-- **TEIRESIAS** — Randall Davis's tool for interactive knowledge transfer. It let an expert inspect the program's reasoning path, identify where it went wrong, and teach it a better rule — making explanation a prerequisite for maintenance.
+- **TEIRESIAS** — Randall Davis's tool for helping experts inspect and revise a rule-based system.
 
 </details>
 
@@ -503,5 +503,3 @@ could not be wished away.
 :::note[Why this still matters today]
 The MYCIN architecture's core tension — separable knowledge and inference, modular rules, explanation as engineering — anticipates questions every production AI system faces today. Modern rule engines, decision-service platforms, and clinical decision-support tools still separate a knowledge store from an execution layer. The knowledge bottleneck MYCIN named — that encoded expertise must be acquired, validated, maintained, and kept current — remains the price of any system that claims to reason. The gap between a strong evaluation result and a deployed clinical product, which MYCIN revealed in 1979, is still the central challenge in translating AI research into institutional practice.
 :::
-
-

--- a/src/content/docs/ai-history/ch-20-project-mac.md
+++ b/src/content/docs/ai-history/ch-20-project-mac.md
@@ -7,7 +7,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-Founded at MIT on July 1, 1963, under ARPA/ONR backing, Project MAC was not merely an AI laboratory — its name carried two meanings: Multiple-Access Computer and Machine-Aided Cognition. By building CTSS, then Multics and ITS, and equipping them with MACLISP, MATHLAB/MACSYMA, and PLANNER, the project turned computing from a batch chore into an interactive research environment. It did not solve intelligence; it changed the working conditions under which intelligence could be attempted.
+Founded at MIT on July 1, 1963, under ARPA/ONR backing, Project MAC was not merely an AI laboratory. By building CTSS, then Multics and ITS, and equipping them with MACLISP, MATHLAB/MACSYMA, and PLANNER, the project turned computing from a batch chore into an interactive research environment. It did not solve intelligence; it changed the working conditions under which intelligence could be attempted.
 :::
 
 <details>
@@ -17,7 +17,7 @@ Founded at MIT on July 1, 1963, under ARPA/ONR backing, Project MAC was not mere
 |---|---|---|
 | Robert M. Fano | 1917–2016 | Founding Project MAC director; primary voice for the computer-utility vision and the "project, not laboratory" institutional model. |
 | Fernando J. Corbato | 1926–2019 | Led CTSS and Multics; the systems half of Project MAC and the principal architect of practical time-sharing at MIT. |
-| J. C. R. Licklider | 1915–1990 | ARPA/IPTO director who backed the $3-million Project MAC contract; later served as Project MAC director himself. |
+| J. C. R. Licklider | 1915–1990 | ARPA/IPTO director who backed Project MAC's early contract; later served as Project MAC director himself. |
 | Edward Fredkin | 1934–2023 | Project MAC director in the early 1970s reorganization phase; oversaw the shift toward automatic programming. |
 | Marvin Minsky | 1927–2016 | AI group leader within Project MAC; connected the shared infrastructure to vision, robotics, and symbolic AI. |
 | Carl Hewitt | 1944– | Creator of PLANNER; key figure for automatic-programming and knowledge-based programming work in Project MAC. |
@@ -31,7 +31,7 @@ Founded at MIT on July 1, 1963, under ARPA/ONR backing, Project MAC was not mere
 timeline
     title Project MAC: from CTSS roots to reorganization, 1960–1973
     1960-1961 : CTSS begins at MIT Computation Center and is demonstrated — predates Project MAC
-    Spring 1963 : Project MAC organized under ONR acting for ARPA : DARPA approves $3-million contract
+    Spring 1963 : Project MAC organized under ONR acting for ARPA : DARPA approves a major contract
     July 1 1963 : MIT MAC50 gives this as Project MAC's official founding date
     Fall 1963 : Substantially improved CTSS installation at Project MAC per Fano's 1967 account
     1964-1965 : IBM 7094 CTSS service continues : Multics launched as second-generation system with Bell Labs and GE
@@ -48,12 +48,12 @@ timeline
 <summary><strong>Plain-words glossary</strong></summary>
 
 - **Time-sharing** — A method of running a computer so that many users interact with it simultaneously, each seeing the machine as if they had it to themselves. Instead of waiting for a batch job to complete, a user types a command and sees the result in seconds. The key shift: the machine adapts to human thought-rhythm rather than the reverse.
-- **CTSS (Compatible Time-Sharing System)** — The IBM 7094 operating system that gave Project MAC its practical foundation. It supported roughly 30 simultaneous users, persistent files, shared commands, passwords, and online manuals — the core conventions of interactive computing culture.
-- **Multics** — Project MAC's second-generation time-sharing system, built jointly with Bell Labs and General Electric on the GE 645. Aimed at dependable utility-scale service: security, hierarchical storage, many concurrent users, and long-term operation.
-- **ITS (Incompatible Timesharing System)** — The AI group's PDP-6/PDP-10 environment. Deliberately different from Multics, optimized for high-interaction AI work: real-time device control, display interaction, and maximum researcher access to the machine's internals.
+- **CTSS (Compatible Time-Sharing System)** — The IBM 7094 operating system that gave Project MAC its first practical time-sharing foundation.
+- **Multics** — Project MAC's second-generation time-sharing system, built jointly with Bell Labs and General Electric on the GE 645.
+- **ITS (Incompatible Timesharing System)** — The AI group's PDP-6/PDP-10 time-sharing environment within Project MAC.
 - **MACLISP** — The AI group's primary programming language and environment, built around Lisp. Came with editing, debugging, display packages, and arithmetic support — making it possible to develop and inspect symbolic programs while they ran.
 - **MACSYMA** — An interactive system for symbolic algebraic manipulation, evolved from MATHLAB. It encoded mathematical knowledge so the computer could carry out symbolic transformations, not just numerical calculations. One of the clearest early examples of knowledge built into a program.
-- **Computer utility** — Fano's and Licklider's framing for time-sharing as a social resource, like electricity or the telephone: available when needed, shared across a community, woven into everyday intellectual work rather than reserved for occasional batch jobs.
+- **Computer utility** — Fano's and Licklider's framing for time-sharing as shared infrastructure woven into everyday intellectual work rather than reserved for occasional batch jobs.
 
 </details>
 
@@ -188,7 +188,7 @@ to be technically possible, and it had to be intellectually useful.
 
 ARPA's role also needs to stay visible. Project MAC was organized under ONR
 acting for ARPA, and Licklider was closely involved in the proposal and review.
-Norberg and O'Neill describe a $3-million contract endorsed with striking
+Norberg and O'Neill describe a three-million-dollar contract endorsed with striking
 speed. That number should not be treated as a mere budget curiosity. It shows
 that time-sharing was becoming a national research bet. The agency wanted more
 than a campus service. It wanted an R&D enterprise that could develop
@@ -528,5 +528,4 @@ research imagination.
 :::note[Why this still matters today]
 Every cloud IDE, shared notebook, collaborative coding environment, and hosted AI inference endpoint descends, culturally and technically, from the computer-utility idea Project MAC demonstrated. Interactive computing is now so ordinary that its infrastructure is invisible — but software that can be edited, run, debugged, and shared in real time still depends on the same habit: the machine responds to human thought, not the reverse. The hunger Project MAC revealed — memory, responsiveness, specialized languages, network protocols — is the same appetite that drove cloud computing, GPU clusters, and large-model serving infrastructure. The machine room is still part of the history of ideas.
 :::
-
 

--- a/src/content/docs/ai-history/ch-21-the-rule-based-fortune.md
+++ b/src/content/docs/ai-history/ch-21-the-rule-based-fortune.md
@@ -7,7 +7,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-R1/XCON, developed at Carnegie Mellon beginning in December 1978 and deployed by Digital Equipment Corporation in January 1980, was the first expert system to become industrial infrastructure. John McDermott's production-rule program configured VAX computer orders — translating customer requests into buildable hardware descriptions — by matching thousands of component facts and constraints rather than searching blindly. Its commercial success validated the expert-system boom; its maintenance story revealed the permanent cost: encoding expertise creates a knowledge base that must be fed, tested, and repaired indefinitely.
+R1/XCON, developed at Carnegie Mellon and deployed by Digital Equipment Corporation around 1980, was the first expert system to become industrial infrastructure. John McDermott's production-rule program configured VAX computer orders — translating customer requests into buildable hardware descriptions — by matching thousands of component facts and constraints rather than searching blindly. Its commercial success validated the expert-system boom; its maintenance story revealed the permanent cost: encoding expertise creates a knowledge base that must be fed, tested, and repaired indefinitely.
 :::
 
 <details>
@@ -18,7 +18,7 @@ R1/XCON, developed at Carnegie Mellon beginning in December 1978 and deployed by
 | John McDermott | — | CMU researcher; primary architect of R1 and author of the 1982 *Artificial Intelligence* paper documenting its task, rules, and manufacturing deployment. |
 | Judith Bachant | — | DEC Intelligent Systems Technology Group; co-author of the 1984 "R1 Revisited" retrospective anchoring the four-year production and maintenance account. |
 | Barbara Steele | — | Co-author of the 1981 IJCAI paper on ad-hoc constraints; her chapter relevance is the XSEL/R1 extension and customer-specific configuration advice. |
-| Charles L. Forgy | — | Creator of the OPS-family production-system languages (OPS4, OPS5) that provided R1's rule-matching substrate. |
+| Charles L. Forgy | — | Creator of the OPS-family production-system languages that provided R1's rule-matching substrate. |
 | Allen Newell | 1927–1992 | Pittsburgh cognitive scientist whose Match method and production-system tradition underpinned R1's recognize-act architecture. |
 | Reid G. Smith | — | Schlumberger researcher and author of the 1984 commercial expert-systems article that framed the engineering discipline R1 instantiated. |
 
@@ -31,14 +31,14 @@ R1/XCON, developed at Carnegie Mellon beginning in December 1978 and deployed by
 timeline
     title R1/XCON: From CMU Lab to DEC Manufacturing, 1978–1984
     December 1978 : McDermott begins R1 — short tutoring period, manuals, first implementation focused on central capabilities
-    April 1979 : Initial R1 demo version has about 250 rules
-    October-November 1979 : Formal validation on 50 orders; six experts spend 1–2 hours per order; 12 pieces of errorful knowledge found and fixed
+    April 1979 : Initial R1 demo version handles central capabilities
+    October-November 1979 : Formal validation testing prepares R1 for manufacturing integration
     January 1980 : DEC manufacturing begins using R1 in regular production; configures almost all VAX-11 systems shipped
-    April-July 1980 : R1 rewritten from OPS4 to OPS5 at CMU; more capable with fewer rules through generalization
-    End of 1980 : About 850 rules; DEC builds organizational capacity around R1
+    April-July 1980 : R1 rewritten at CMU into a more capable production-system implementation
+    End of 1980 : DEC builds organizational capacity around R1
     March 1981 : R1 extended to configure VAX-11/750 systems
-    1982 : Scope expands to VAX-11/730 and PDP-11/23+; knowledge base reaches about 2000 rules
-    November 1983 : About 3300 rules and 5500 component descriptions; R1 can configure all DEC systems sold in significant volume
+    1982 : Scope expands to VAX-11/730 and PDP-11/23+
+    November 1983 : R1 can configure all DEC systems sold in significant volume
     Fall 1984 : "R1 Revisited" publishes the four-year production account
 ```
 
@@ -47,13 +47,13 @@ timeline
 <details>
 <summary><strong>Plain-words glossary</strong></summary>
 
-- **Production system** — A rule-based program architecture in which knowledge is stored as individual if/then rules (productions). Each rule specifies a pattern that must match the current program state and an action to take when it matches. R1 used the OPS4 and later OPS5 production-system language.
+- **Production system** — A rule-based program architecture in which knowledge is stored as individual if/then rules (productions). Each rule specifies a pattern that must match the current program state and an action to take when it matches.
 - **Working memory** — The production system's dynamic store of the current situation: for R1, the partial configuration in progress, active subtasks, selected components, and facts retrieved so far. Rules fire by pattern-matching against working memory and update it with each action.
 - **Recognize-act cycle** — The basic rhythm of a production system: scan all rules to find those whose conditions match working memory, select one, execute its action, and repeat. R1's intelligence came not from the cycle itself but from encoding enough domain knowledge for the cycle to produce useful configurations.
 - **Expert system** — A program that applies a domain-specific body of knowledge, typically extracted from human specialists, to produce outputs useful within a narrow task. R1 is an expert system because its rules encode the configuration constraints that experienced DEC engineers knew but could not easily state as a formula.
 - **Knowledge engineering** — The discipline of extracting, encoding, testing, and maintaining the knowledge that drives an expert system. The Ch21 development and maintenance narrative is primarily a knowledge-engineering story: experts tutor, inspect output, identify missing cases, and the knowledge base grows accordingly.
-- **Match (OPS5)** — The step in the recognize-act cycle where the interpreter finds all rules whose left-hand-side conditions are satisfied by the current working memory. OPS5's Rete algorithm made this efficient even when the rule base was large, allowing R1 to select locally relevant rules without exhaustive search.
-- **OPS5** — The production-system language (successor to OPS4) that R1 was rewritten into during April–July 1980. Developed at CMU with DARPA and Air Force Avionics Laboratory support; its Rete network made large rule bases feasible for manufacturing-scale use.
+- **Match** — The step in the recognize-act cycle where the interpreter finds rules whose left-hand-side conditions are satisfied by the current working memory.
+- **OPS5** — The production-system language R1 used for its manufacturing-scale implementation.
 
 </details>
 
@@ -234,6 +234,13 @@ domain structure to decide what to do next when enough information was
 available. The system worked because the domain had enough local regularity for
 rules to recognize meaningful situations.
 
+The implementation history made that practical issue concrete. R1 began in the
+OPS production-system family and was rewritten from OPS4 into OPS5 at CMU during
+April-July 1980. OPS5's Rete matching network mattered because the interpreter
+had to find relevant rules efficiently as the rule base grew. Without that
+matching machinery, the recognize-act rhythm would have been an elegant
+description of a system too expensive to run at manufacturing scale.
+
 That distinction separates R1 from both brute-force search and magical
 expertise. The program did not enumerate every possible VAX system and score
 them. It used rules to recognize the next relevant configuration situation. If
@@ -374,11 +381,12 @@ story. The 1982 paper shows how R1 worked and how it entered manufacturing.
 The later account shows what happened after production use made the system
 important.
 
-By the early 1980s, the R1 organization had grown. The knowledge base had
-expanded from hundreds of rules to thousands. Component descriptions multiplied.
-The system handled more product families and more orders. DEC built a group
-around knowledge-based systems, and R1 remained a continuing maintenance
-project rather than a finished artifact.
+By the early 1980s, the R1 organization had grown. The knowledge base moved from
+about 250 rules in the April 1979 demonstration to about 850 by the end of 1980,
+roughly 2000 in 1982, and about 3300 rules plus 5500 component descriptions by
+November 1983. The system handled more product families and more orders. DEC
+built a group around knowledge-based systems, and R1 remained a continuing
+maintenance project rather than a finished artifact.
 
 The four-year account described a system that had become both more capable and
 more dependent on its support organization. It reported growth in rules,
@@ -526,4 +534,3 @@ kept feeding the machinery what it needed to know.
 :::note[Why this still matters today]
 The R1/XCON pattern reappears in every era of applied AI. Modern knowledge bases — whether stored as rules, embeddings, or retrieval indexes — still face the same maintenance contract: domain drift erodes accuracy, new products create coverage gaps, and deployment exposes exceptional cases that no training set anticipated. The distinction between a narrow, structured task that can be made operational and a broad domain that resists encoding remains the central engineering judgment in applied AI. R1 proved the distinction is real, not theoretical, and that success in the former does not licence ambition in the latter.
 :::
-


### PR DESCRIPTION
## Summary
- trim repeated reader-aid phrasing in Ch19-Ch21 based on the Gemini repetition audits
- keep core explanations in the body while reducing duplicated cast, timeline, glossary, and TL;DR language
- move Ch21 OPS5/Rete and rule-growth details from reader aids into the prose where the audit said they belong
- normalize Ch20 dollar amount wording to avoid Markdown math rendering around money figures

## Checks
- git diff --check HEAD~1..HEAD
- ../../.venv/bin/python scripts/check_reader_aids.py ch-19 ch-20 ch-21
- npm run build (from primary checkout at 8235a685)
- ../../.venv/bin/python scripts/test_pipeline.py (166 tests OK)

## Review
- Cross-family review pending; do not merge until posted as a PR comment.