### PR TITLE
docs(ai-history): trim Ch22-Ch23 repetition

### DIFF
--- a/src/content/docs/ai-history/ch-22-the-lisp-machine-bubble.md
+++ b/src/content/docs/ai-history/ch-22-the-lisp-machine-bubble.md
@@ -7,7 +7,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-In the late 1970s, MIT's AI programmers had outgrown time-shared PDP-10s — address limits, swapping, and slow response time were strangling large interactive Lisp systems. The Lisp Machine Group's answer was a personal processor and memory for each programmer, a 24-bit virtual address space, writable microcode, and an environment written almost entirely in Lisp. Commercialized as LMI and Symbolics (culminating in the 3600), the machines were technically coherent; the bubble formed when specialized hardware economics could no longer outrun improving stock workstations and portable Common Lisp.
+In the late 1970s, MIT's AI programmers had outgrown time-shared PDP-10s: large interactive Lisp systems needed more room, faster response, and a machine that served one programmer at a time. The Lisp Machine Group answered with personal processors, writable microcode, and an environment written almost entirely in Lisp. Commercialization through LMI and Symbolics turned a coherent lab solution into a fragile business bet on specialized AI hardware.
 :::
 
 <details>
@@ -15,7 +15,7 @@ In the late 1970s, MIT's AI programmers had outgrown time-shared PDP-10s — add
 
 | Name | Lifespan | Role |
 |---|---|---|
-| Thomas F. Knight Jr. | — | MIT AI Lab hardware designer; designed CONS, the first Lisp Machine prototype; co-authored the CADR memo. |
+| Thomas F. Knight Jr. | — | MIT AI Lab hardware designer and Lisp Machine Group figure; co-authored the CADR memo. |
 | Jack Holloway | — | MIT Lisp Machine Group member; co-authored the CADR memo alongside Knight. |
 | David A. Moon | — | MIT Lisp Machine Group member; co-authored the CADR memo and the Lisp Machine Manual; key Symbolics figure. |
 | Daniel Weinreb | — | MIT Lisp Machine Group member; co-authored the Lisp Machine Manual with Moon. |
@@ -31,14 +31,14 @@ In the late 1970s, MIT's AI programmers had outgrown time-shared PDP-10s — add
 timeline
     title Lisp Machines: from MIT lab to commercial bubble, 1974–1983
     1974 : MIT AI Lab initiates Lisp Machine project — personal networked computer for Lisp and symbolic software
-    1976 : CONS, the first Lisp Machine prototype designed by Tom Knight, running
-    Early 1977 : CONS gains memory, disk, terminal, keyboard, mouse, display, paging, and PDP-10 file I/O
+    1976 : First Lisp Machine prototype running at MIT
+    Early 1977 : Prototype gains enough peripherals and paging to host larger Lisp work
     August 1977 : MIT AI Memo 444 published — documents time-sharing problem, CONS status, LUNAR conversion, plan for seven more machines
-    1978 : CADR replaces CONS as the improved Lisp Machine processor
+    1978 : Improved CADR processor follows the prototype
     May 1979 : MIT AI Memo 528 published — documents CADR processor design with writable microcode, stack support, and virtual memory
-    1980 : Symbolics and LMI both formed from MIT commercialization; both initially make CADR clones
-    1981 : Symbolics introduces LM-2 — CADR repackaged for reliability; ARPA Lisp Community Meeting triggers Common Lisp effort
-    February 1983 : Symbolics publishes 3600 Technical Summary — 36-bit single-user symbolic workstation pitched as fourth-generation Lisp Machine
+    1980 : Symbolics and LMI formed from MIT commercialization
+    1981 : Symbolics introduces LM-2; ARPA Lisp Community Meeting triggers Common Lisp effort
+    February 1983 : Symbolics publishes 3600 Technical Summary for its mature symbolic workstation
 ```
 
 </details>
@@ -49,7 +49,7 @@ timeline
 - **Time-sharing** — A mode of computer operation in which a single central machine divides its processor time among many logged-in users in rapid rotation, giving each the illusion of a private machine. Project MAC built interactive AI on time-sharing; by the mid-1970s the shared resource had become too crowded for large Lisp programs.
 - **Tagged architecture** — A design in which each word of memory carries extra "tag" bits recording what kind of object it holds (symbol, integer, list pointer, function, etc.). Hardware and microcode can then act on type information directly, without software inspecting every value. The Lisp Machine used 4 tag bits per 32-bit word.
 - **Writable microcode** — Microprogram memory that can be updated at runtime, unlike the read-only microcode of most commercial processors. Writable microcode let the Lisp Machine's implementation of the Lisp runtime stay close to the processor and be tuned as the system evolved.
-- **Virtual address space** — The range of memory addresses a program can name, independent of how much physical RAM is installed. The PDP-10 had a 256K-word (18-bit) address limit that large Lisp programs were outgrowing; the CADR gave each Lisp Machine a 24-bit virtual space, supporting far larger programs.
+- **Virtual address space** — The range of memory addresses a program can name, independent of how much physical RAM is installed. Large Lisp programs were pressing against severe PDP-10 limits; Lisp Machine designs gave each programmer much more room.
 - **Zetalisp** — The Lisp dialect that ran on the MIT Lisp Machines and their commercial successors. A descendant of Maclisp, it added object-oriented programming (Flavors), closures, and operating-system-like facilities, all accessible from the same Lisp environment.
 - **Common Lisp** — A portable Lisp standard assembled from Maclisp, Interlisp, Spice Lisp, and Lisp-machine dialects after ARPA's 1981 community meeting. Its portability across stock hardware weakened the assumption that serious Lisp required a specialized machine.
 
@@ -111,9 +111,10 @@ resource to recover.
 The MIT Lisp Machine Group described this pressure directly. Lisp had become
 central to AI work, especially in Maclisp and related systems, but the programs
 kept growing. Language changes could hide some pain, but not all of it. Large
-systems such as MACSYMA and Woods's LUNAR pressed against address-space limits.
-The group imagined future intelligent systems that might need many times the
-address space of the PDP-10. The problem was not that Lisp was unsuitable for
+systems such as MACSYMA and Woods's LUNAR pressed against the PDP-10's 18-bit,
+256K-word address-space limit. The group imagined future intelligent systems
+that might need many times the address space of the PDP-10. The problem was not
+that Lisp was unsuitable for
 AI. The problem was that the hardware and operating assumptions around it were
 becoming too small.
 
@@ -542,5 +543,3 @@ lose the economic race around it.
 :::note[Why this still matters today]
 The Lisp machine's core ideas did not die with the companies. Tagged-word architectures influenced later managed-runtime designs. The all-Lisp development environment — editor, debugger, compiler, and runtime as one inspectable world — is the ancestor of modern integrated REPLs, live-reload development tools, and notebook computing. The bubble itself is a durable economic lesson: a specialized stack is defensible only as long as its integration advantage outpaces general-purpose alternatives. Every wave of AI-specific hardware — from vector processors to tensor processing units — inherits the same race. The Lisp machine lost it first.
 :::
-
-

--- a/src/content/docs/ai-history/ch-23-the-japanese-threat.md
+++ b/src/content/docs/ai-history/ch-23-the-japanese-threat.md
@@ -7,7 +7,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-In 1982, Japan's Ministry of International Trade and Industry launched the Fifth Generation Computer Systems project, creating ICOT to pursue knowledge information processing on logic-programming languages and highly parallel inference machines. The Western reaction was larger than the project: observers read a coherent national research bet as a strategic threat that might leapfrog existing software and hardware advantages. FGCS built real machines, languages, and researchers, but did not deliver the popular AI revolution — a recurring caution about mistaking a research hypothesis for an industrial forecast.
+In 1982, Japan's MITI launched the Fifth Generation Computer Systems project and created ICOT to pursue knowledge information processing on logic-programming languages and parallel inference machines. The Western reaction was larger than the project: observers read a national research bet as a strategic threat that might leapfrog existing software and hardware advantages. FGCS built real machines, languages, and researchers, but did not produce the popular AI revolution.
 :::
 
 <details>
@@ -15,11 +15,11 @@ In 1982, Japan's Ministry of International Trade and Industry launched the Fifth
 
 | Name | Lifespan | Role |
 |---|---|---|
-| Kazuhiro Fuchi | — | ICOT Research Center director; articulated the original predicate-logic/kernel-language philosophy in his 1984 keynote and distinguished the project's actual goals from its exaggerated public image in his 1992 retrospective. |
+| Kazuhiro Fuchi | — | ICOT Research Center director; articulated the original predicate-logic/kernel-language philosophy in his 1984 keynote. |
 | H. Kinoshita | — | Director-General of MITI's Machinery and Information Industries Bureau; framed FGCS within Japan's software crisis and the ambition for an advanced information society in his 1984 keynote. |
-| Koichi Furukawa | — | ICOT researcher and author of TR-228 (1986/1987); supplied the mid-project technical frame — knowledge information processing above logic programming above highly parallel architecture and VLSI. |
-| Takashi Kurozumi | — | ICOT author of the 1992 ten-year overview; documented the 1979–1981 preliminary study, 1982 launch, staged R&D, PSI/PIM hardware progression, and budget. |
-| H. Gallaire | — | External evaluator at the 1992 FGCS evaluation workshop; offered the balanced outside verdict: limited real-world application use, but strong technical work in parallel OS, hardware, and logic programming. |
+| Koichi Furukawa | — | ICOT researcher and author of TR-228 (1986/1987), a key mid-project technical account. |
+| Takashi Kurozumi | — | ICOT author of the 1992 ten-year overview; documented the preliminary study, launch, staged R&D, and budget. |
+| H. Gallaire | — | External evaluator at the 1992 FGCS evaluation workshop. |
 | T. Moto-oka | — | Conference and project figure; edited the 1982 FGCS proceedings that announced the project to international audiences. |
 
 </details>
@@ -31,13 +31,13 @@ In 1982, Japan's Ministry of International Trade and Industry launched the Fifth
 timeline
     title Japan's Fifth Generation Computer Systems Project, 1979–1995
     1979 : Fifth Generation Computer Research Committee and subcommittee established : Preliminary study stage begins
-    October 1981 : FGCS'81 conference announces committee results to international researchers : Fuchi later says this generated a sensational, exaggerated worldwide image
+    October 1981 : FGCS'81 conference announces committee results to international researchers
     1982 : MITI launches the FGCS national project : ICOT created as the core research institute
-    1982–1984 : Initial stage — R&D on basic fifth-generation technologies : Prolog on DEC machines as the working environment
+    1982–1984 : Initial stage — R&D on basic fifth-generation technologies using existing machines
     1984 : FGCS'84 conference — Fuchi restates original philosophy; Kinoshita frames software-crisis rationale
-    1985–1988 : Intermediate stage — small and medium subsystems : ESP on PSI/SIMPOS as the main environment
-    1988 : Multi-PSI and PIMOS demonstrated at FGCS'88
-    1989–1992 : Final stage — KL1, Multi-PSI/PIM, PIMOS prototype system : Stage extended to four years for evaluation
+    1985–1988 : Intermediate stage — small and medium subsystems and a workstation environment
+    1988 : Parallel inference work demonstrated at FGCS'88
+    1989–1992 : Final stage — prototype system work and evaluation; stage extended to four years
     1992 : FGCS'92 marks project end; free disclosure of ICOT software announced : Evaluation workshop collects international assessments
     April 1993 : Two-year FGCS Follow-on Project begins : KLIC ports KL1 to Unix-based sequential and parallel machines
     1994–1995 : ICOT Free Software distributed; ICOT closes March 1995
@@ -553,5 +553,3 @@ future of AI for a plan announced at a conference.
 :::note[Why this still matters today]
 Every decade produces a version of the FGCS story: a government-backed AI initiative, a credible technical bet, and a threat narrative larger than the project. Today's practitioners encounter the same pattern in national AI strategies, large-model race coverage, and claims that one architecture will make existing software irrelevant. The FGCS legacy offers two calibration points: research programs can produce real technical output — languages, machines, trained people — without delivering the industrial revolution observers feared; and software tied to proprietary hardware spreads less easily than software portable to commodity platforms. Both lessons remain live.
 :::
-
-


### PR DESCRIPTION
## Summary
- trim repeated reader-aid details in Ch22 around the Lisp machine prototype, memory specifics, and commercialization milestones
- trim Ch23 reader-aid repetition around FGCS project setup, staged acronyms, and evaluation spoilers
- preserve the body-level factual detail while reducing frontmatter/timeline echo before human proofreading

## Checks
- git diff --check HEAD~1..HEAD
- ../../.venv/bin/python scripts/check_reader_aids.py ch-22 ch-23
- npm run build (from primary checkout at 007a528b)
- ../../.venv/bin/python scripts/test_pipeline.py (166 tests OK)

Cross-family review pending before merge.