### PR TITLE
docs(ai-history): trim Ch24-Ch26 repetition

### DIFF
--- a/src/content/docs/ai-history/ch-24-the-math-that-waited-for-the-machine.md
+++ b/src/content/docs/ai-history/ch-24-the-math-that-waited-for-the-machine.md
@@ -7,7 +7,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-The chain rule that powers every modern neural network did not appear in 1986. Paul Werbos described backward derivative propagation for trainable systems in his 1974 thesis, and reverse-mode automatic differentiation had its own earlier lineage. What Rumelhart, Hinton, and Williams did in 1986 was make the method convincing: they demonstrated that hidden layers could learn useful internal representations through repeated error-driven weight updates, reopening the path multilayer learning needed after the perceptron era.
+The calculus behind backpropagation was older than the 1986 neural-network revival. What David Rumelhart, Geoffrey Hinton, and Ronald Williams did was make the method convincing inside the hidden-layer problem: they turned error assignment into a repeatable procedure and showed that internal representations could be learned rather than hand-coded. The chapter separates mathematical priority from historical impact.
 :::
 
 <details>
@@ -18,7 +18,7 @@ The chain rule that powers every modern neural network did not appear in 1986. P
 | David E. Rumelhart | — | Cognitive scientist and PDP co-leader; framed backpropagation as the key to training hidden-unit internal representations. |
 | Geoffrey E. Hinton | — | Neural-network researcher; co-author of the 1986 Nature and PDP backpropagation papers; helped make representation learning the central claim. |
 | Ronald J. Williams | — | Co-author of the 1986 Nature and PDP papers; essential to the algorithmic error-propagation presentation. |
-| Paul J. Werbos | — | Harvard PhD student whose 1974 thesis described backward derivative propagation for adaptive systems, predating the PDP revival. |
+| Paul J. Werbos | — | Earlier backpropagation pioneer whose thesis became part of the priority story behind the PDP revival. |
 | Seppo Linnainmaa | — | Automatic-differentiation researcher whose 1976 work on reverse accumulation of rounding-error derivatives anchors the separate mathematical lineage. |
 | James L. McClelland | — | PDP co-editor and connectionist collaborator; context figure for why 1986 landed as a cognitive-science movement, not only an optimization result. |
 
@@ -31,7 +31,7 @@ The chain rule that powers every modern neural network did not appear in 1986. P
 timeline
     title The Math That Waited for the Machine, 1969–1989
     1969 : Minsky and Papert's Perceptrons crystallizes limits of single-layer networks and makes hidden-unit training the central unresolved problem
-    1974 : Paul Werbos submits Beyond Regression, describing ordered derivatives and backward derivative calculation for adaptive prediction systems
+    1974 : Paul Werbos submits a Harvard thesis later central to the backpropagation priority debate
     1976 : Linnainmaa publishes reverse accumulation of rounding-error derivatives in BIT Numerical Mathematics
     1985 : Rumelhart, Hinton, and Williams circulate Learning internal representations by error propagation through the UCSD/PDP research context
     1986 : PDP chapter on internal representations by error propagation published with generalized delta rule and symmetry/encoder demonstrations
@@ -46,8 +46,6 @@ timeline
 
 - **Hidden layer** — A layer of units inside a neural network that sits between the raw input and the final output. Because hidden units receive no direct teacher signal, training them requires a method for assigning credit or blame for the final error.
 - **Backpropagation** — The algorithm that runs the chain rule backward through a layered network: compute the forward pass, measure the output error, then propagate error sensitivities layer by layer back to every weight.
-- **Chain rule** — A calculus rule for differentiating a composed function: if $z$ depends on $y$ and $y$ depends on $x$, then $\frac{dz}{dx} = \frac{dz}{dy} \cdot \frac{dy}{dx}$. Backpropagation applies this recursively across every layer.
-- **Reverse-mode automatic differentiation** — A computational strategy that sweeps backward through a recorded graph of arithmetic operations to find how a scalar output depends on every input, reusing intermediate values from the forward pass.
 - **Generalized delta rule** — The weight-update formula derived in the 1986 PDP chapter: each weight changes in proportion to the error sensitivity that backpropagation assigns to it, times the activation that arrived at that weight during the forward pass.
 - **Internal representation** — The encoding a hidden layer develops through training. Instead of a programmer prescribing which features the hidden units should detect, the learning rule shapes them through repeated error correction.
 - **Credit assignment** — The problem of deciding which weights in a layered network should be held responsible for a final output error, and by how much — the core obstacle that backpropagation solved for hidden layers.
@@ -529,4 +527,3 @@ Every training run in modern deep learning descends from the 1986 infrastructure
 > account separates older reverse-mode derivative work, Werbos's trainable
 > systems thesis, and the 1986 PDP demonstration instead of collapsing them into
 > one origin myth.
-

--- a/src/content/docs/ai-history/ch-25-the-universal-approximation-theorem-1989.md
+++ b/src/content/docs/ai-history/ch-25-the-universal-approximation-theorem-1989.md
@@ -7,7 +7,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-In 1989, George Cybenko proved that finite sums of sigmoidal units can uniformly approximate any continuous function on the unit hypercube. The same year, Hornik, Stinchcombe, and White showed multilayer feedforward networks are universal approximators, and Funahashi gave a parallel continuous-mapping result. The 1989 cluster did not make neural networks easy to train; it ended a representational doubt left by the perceptron backlash, giving researchers mathematical permission to keep building hidden-layer systems.
+In 1989, several approximation results made multilayer neural networks mathematically plausible again. George Cybenko, Hornik/Stinchcombe/White, and Ken-ichi Funahashi each showed, in different forms, that networks with nonlinear hidden units could approximate broad classes of continuous functions. The results did not make neural networks easy to train; they answered a representational doubt left by the perceptron backlash.
 :::
 
 <details>
@@ -15,7 +15,7 @@ In 1989, George Cybenko proved that finite sums of sigmoidal units can uniformly
 
 | Name | Lifespan | Role |
 |---|---|---|
-| George Cybenko | — | Author of the 1989 sigmoidal-superposition theorem; proved finite sums of sigmoidal units are dense in continuous functions on compact domains. |
+| George Cybenko | — | Author of a 1989 theorem showing sigmoidal neural networks had broad approximation power. |
 | Kurt Hornik | — | Co-author of the 1989 "Multilayer feedforward networks are universal approximators" paper in *Neural Networks*. |
 | Maxwell Stinchcombe | — | Co-author of Hornik/Stinchcombe/White 1989; contributed the multi-author framing of universal approximation for feedforward networks. |
 | Halbert White | — | Co-author of Hornik/Stinchcombe/White 1989; brought econometric and statistical-learning context to the universal-approximation result. |
@@ -45,12 +45,12 @@ timeline
 <summary><strong>Plain-words glossary</strong></summary>
 
 - **Feedforward network** — A neural network in which information flows in one direction only: from inputs, through one or more hidden layers, to the output. No cycles, no feedback loops.
-- **Universal approximator** — A model family is a universal approximator if, for any continuous target function on a compact domain and any desired error tolerance, some member of the family can come within that tolerance. The phrase describes representational richness, not training ease.
+- **Universal approximator** — A model family that can approximate every target in a specified function class to any desired tolerance, under the theorem's assumptions.
 - **Uniform approximation** — A guarantee that a network can get close to a target function everywhere on the domain simultaneously, not just on average or at scattered points. Cybenko's theorem is phrased in terms of uniform approximation.
 - **Sigmoidal function** — A smooth, bounded, S-shaped activation function that is nondecreasing and approaches distinct limits as its input goes to positive and negative infinity. The logistic function is the canonical example.
 - **Compact domain** — A closed and bounded region, such as the unit hypercube $[0,1]^n$. Compactness is a key assumption in classical universal-approximation theorems; it rules out unbounded or open domains.
-- **Density** — In approximation theory, a family of functions is dense in a larger class if every function in that class can be approximated arbitrarily closely by some member of the family. Density is what the theorem proves; it is not the same as saying a specific network exists that is ready to use.
-- **Existence result** — A mathematical statement that guarantees some object with a desired property exists, without providing a method to find or construct it. Universal approximation is an existence result: it promises a suitable network is in the family, not that training will locate it.
+- **Density** — In approximation theory, a family of functions is dense in a larger class if every function in that class can be approximated arbitrarily closely by some member of the family.
+- **Existence result** — A mathematical statement that guarantees some object with a desired property exists, without providing a method to find or construct it.
 
 </details>
 
@@ -63,8 +63,7 @@ The 1989 results established that multilayer networks with nonlinear activations
 - **Cybenko 1989 — discriminatory functions (Theorem 2):** A sigmoidal function $\sigma$ is discriminatory: if $\int \sigma(\mathbf{w}^\top \mathbf{x} + \theta) \, d\mu(\mathbf{x}) = 0$ for all $\mathbf{w}, \theta$ implies $\mu = 0$, then finite sums of $\sigma$-units are dense in $C(I_n)$. This is the technical engine that makes Theorem 1 possible.
 - **Hornik, Stinchcombe, and White 1989:** Any nonconstant, bounded, and continuous activation function makes a standard multilayer feedforward network a universal approximator of measurable functions (in a suitable $L^p$ sense). The result generalises beyond the sigmoidal special case.
 - **Funahashi 1989 — Theorem 1:** For any continuous mapping $f : K \to \mathbb{R}^m$ on a compact set $K \subset \mathbb{R}^n$ and any $\varepsilon > 0$, there exists a three-layer neural network (input, one hidden layer, output) that approximates $f$ to within $\varepsilon$ uniformly on $K$.
-- **Barron 1993 — approximation rate:** For functions whose Fourier transform satisfies a first-moment bound $C_f = \int |\omega| |\hat{f}(\omega)| \, d\omega < \infty$, a one-hidden-layer sigmoidal network with $n$ units achieves integrated squared error bounded by $O(C_f^2 / n)$. This is an efficiency result: it says how fast approximation error can fall as units are added, and shows that some well-behaved functions are approximated efficiently — but it does not remove the computational cost of training.
-- **Key separations the math enforces:** (1) $\exists$ a network that approximates $\not\Rightarrow$ gradient descent finds it; (2) approximation on compact domain $\not\Rightarrow$ generalisation from finite samples; (3) "finite" network $\not\Rightarrow$ computationally affordable network.
+- **Barron 1993 — approximation rate:** For functions whose Fourier transform satisfies a first-moment bound $C_f = \int |\omega| |\hat{f}(\omega)| \, d\omega < \infty$, a one-hidden-layer sigmoidal network with $n$ units achieves integrated squared error bounded by $O(C_f^2 / n)$.
 
 </details>
 
@@ -554,4 +553,3 @@ Every modern deep-learning framework rests, at some level, on the assurance the 
 > as proof that neural networks can learn any task. The sources support a
 > careful capacity claim under assumptions; they do not support a blanket story
 > about training, generalization, or practical deployment.
-

--- a/src/content/docs/ai-history/ch-26-bayesian-networks.md
+++ b/src/content/docs/ai-history/ch-26-bayesian-networks.md
@@ -7,7 +7,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-Bayesian networks gave AI a disciplined infrastructure for reasoning under uncertainty. Judea Pearl's 1986 belief-network paper showed how directed acyclic graphs could store expert knowledge as conditional probability tables and propagate evidence locally through singly connected networks. Pearl's 1988 book and independent work by Lauritzen and Spiegelhalter placed probability — not symbolic rules alone — at the centre of expert-system reasoning. The price: exact inference in general networks is NP-hard.
+Bayesian networks gave AI a disciplined infrastructure for reasoning under uncertainty. Judea Pearl's belief-network work showed how directed acyclic graphs could store expert knowledge as conditional probability tables and use graph structure to update beliefs. Pearl's 1988 book and independent work by Lauritzen and Spiegelhalter placed probability — not symbolic rules alone — at the centre of expert-system reasoning. The framework made uncertainty structured, while leaving computation as the central bill.
 :::
 
 <details>
@@ -18,7 +18,7 @@ Bayesian networks gave AI a disciplined infrastructure for reasoning under uncer
 | Judea Pearl | 1936– | Computer scientist at UCLA; developed belief-network propagation (1986) and authored *Probabilistic Reasoning in Intelligent Systems* (1988), establishing probabilistic graphs as a core AI framework. |
 | Steffen L. Lauritzen | — | Statistician; co-author of the 1988 local-computation paper on graphical probabilistic structures and their application to expert systems. |
 | David J. Spiegelhalter | 1953– | Statistician; co-author with Lauritzen (1988); helped broaden the graphical-model framework beyond Pearl's AI context. |
-| Gregory F. Cooper | — | AI researcher; proved in 1990 that probabilistic inference in general Bayesian belief networks is NP-hard, setting the computational bounds for the field. |
+| Gregory F. Cooper | — | AI researcher whose 1990 complexity result clarified the computational bounds of Bayesian-network inference. |
 | Eugene Charniak | 1946– | AI researcher; wrote the 1991 *AI Magazine* tutorial "Bayesian Networks without Tears," making the framework accessible to a broad audience. |
 
 </details>
@@ -30,10 +30,10 @@ Bayesian networks gave AI a disciplined infrastructure for reasoning under uncer
 timeline
     title Bayesian Networks, 1980s–1991
     1970s-early 1980s : Rule-based expert systems grow, using informal certainty factors and quasi-probabilistic schemes (MYCIN, PROSPECTOR, CASNET, INTERNIST) to handle uncertainty
-    1986 : Pearl publishes "Fusion, propagation, and structuring in belief networks" — establishes DAG belief networks and local propagation in singly connected networks
+    1986 : Pearl publishes "Fusion, propagation, and structuring in belief networks" — establishes DAG belief networks and local propagation
     1988 : Pearl publishes Probabilistic Reasoning in Intelligent Systems — book-length framework for probabilistic reasoning and belief updating by network propagation
-    1988 : Lauritzen and Spiegelhalter publish local computations with probabilities on graphical structures — expert-system context, MUNIN, and probabilistic exactness argument
-    1990 : Cooper proves probabilistic inference in general Bayesian belief networks is NP-hard, requiring special-case and approximation algorithms
+    1988 : Lauritzen and Spiegelhalter publish local computations with probabilities on graphical structures for expert-system reasoning
+    1990 : Cooper publishes a complexity result that bounds what exact Bayesian-network inference can promise
     1991 : Charniak publishes "Bayesian Networks without Tears" — accessible tutorial anchoring the framework in the AI community
 ```
 
@@ -44,10 +44,10 @@ timeline
 
 - **Directed acyclic graph (DAG)** — A network of nodes connected by arrows where no path loops back to its starting point. In a Bayesian network, each arrow means "this node can directly influence that one."
 - **Conditional probability table (CPT)** — A small table attached to each node listing the probability of each state that node can be in, given every combination of its parents' states. The tables together define the model's joint distribution.
-- **Belief propagation** — Pearl's algorithm for updating probability estimates across a network when new evidence arrives. In singly connected networks, messages pass locally through the graph rather than requiring a global recalculation.
-- **Singly connected network** — A Bayesian network in which there is at most one undirected path between any two nodes. This structure allows efficient local message passing; multiply connected networks require more expensive inference methods.
-- **Conditional independence** — Two variables are conditionally independent given a third when knowing the third makes the first two irrelevant to each other. Bayesian networks encode these assumptions in graph structure, compressing what would otherwise be an enormous joint probability table.
-- **NP-hard inference** — Cooper's 1990 result: for general (multiply connected) Bayesian networks, computing exact probabilities is at least as hard as the hardest problems in NP. Practical systems need restricted topologies or approximation algorithms.
+- **Belief propagation** — An algorithmic family for updating probability estimates across a network when new evidence arrives, using the graph to route messages.
+- **Singly connected network** — A Bayesian network in which there is at most one undirected path between any two nodes.
+- **Conditional independence** — Two variables are conditionally independent given a third when knowing the third makes the first two irrelevant to each other.
+- **NP-hard inference** — A complexity label meaning a problem is at least as hard as the hardest problems in NP.
 
 </details>
 
@@ -533,4 +533,3 @@ Bayesian networks are the direct ancestor of modern probabilistic graphical mode
 > uncertainty, tutorial definitions, and computational limits are carried by
 > Lauritzen/Spiegelhalter, Charniak, and Cooper, where page anchors are
 > available in the research contract.
-


### PR DESCRIPTION
## Summary
- trim Ch24 reader-aid echoes around Werbos priority, chain-rule definitions, and the 1986 synthesis
- trim Ch25 TL;DR/cast/glossary/math-box spoilers while keeping formal theorem details in the math/body sections
- trim Ch26 reader-aid repetition around Pearl propagation, Cooper complexity, MUNIN, and conditional-independence compression

## Checks
- git diff --check HEAD~1..HEAD
- ../../.venv/bin/python scripts/check_reader_aids.py ch-24 ch-25 ch-26
- rg -n "\$[0-9]" src/content/docs/ai-history/ch-24-the-math-that-waited-for-the-machine.md src/content/docs/ai-history/ch-25-the-universal-approximation-theorem-1989.md src/content/docs/ai-history/ch-26-bayesian-networks.md (no matches)
- npm run build (from primary checkout at 8b01c7b3)
- ../../.venv/bin/python scripts/test_pipeline.py (166 tests OK)

Cross-family review pending before merge.