### PR TITLE
docs(ai-history): trim Ch27-Ch29 repetition

### DIFF
--- a/src/content/docs/ai-history/ch-27-the-convolutional-breakthrough.md
+++ b/src/content/docs/ai-history/ch-27-the-convolutional-breakthrough.md
@@ -7,7 +7,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-In 1989, Yann LeCun and Bell Labs colleagues trained a backpropagation network to read handwritten zip codes from U.S. mail — but only by constraining the architecture. Local receptive fields, shared weights, and subsampling encoded what a fully connected network would have to rediscover: nearby pixels matter together, and useful detectors should apply across positions. The 1998 LeNet-5 paper extended that insight into a full document-recognition pipeline reading millions of bank checks. Neural networks became practical when architecture stopped pretending all inputs were shapeless vectors.
+In 1989, Yann LeCun and Bell Labs colleagues trained a backpropagation network to read handwritten zip codes from U.S. mail by constraining the architecture for images. The design reused local detectors across positions and reduced sensitivity to small shifts instead of treating pixels as a shapeless vector. The 1998 LeNet-5 paper extended that insight into a document-recognition pipeline. Neural networks became practical when architecture matched the problem.
 :::
 
 <details>
@@ -15,7 +15,7 @@ In 1989, Yann LeCun and Bell Labs colleagues trained a backpropagation network t
 
 | Name | Lifespan | Role |
 |---|---|---|
-| Kunihiko Fukushima | — | NHK researcher; originator of the neocognitron (1980), the hierarchical, shift-tolerant visual-recognition model that forms the architectural prehistory of convolutional networks. |
+| Kunihiko Fukushima | — | NHK researcher; originator of the neocognitron, an important architectural predecessor to convolutional networks. |
 | Yann LeCun | — | Bell Labs researcher; lead author on the 1989 zip-code recognizer and the 1998 LeNet-5 / document-recognition synthesis. |
 | Bernhard Boser | — | Bell Labs co-author on the 1989 and 1990 handwritten zip-code and digit recognition papers. |
 | Lawrence D. Jackel | — | Bell Labs co-author on the 1989 and 1990 papers; neural-network researcher in the Bell Labs environment. |
@@ -30,7 +30,7 @@ In 1989, Yann LeCun and Bell Labs colleagues trained a backpropagation network t
 ```mermaid
 timeline
     title The Convolutional Breakthrough, 1980–1998
-    1980 : Fukushima publishes the neocognitron — hierarchical, shift-tolerant visual recognition using S-cells and C-cells
+    1980 : Fukushima publishes the neocognitron as a hierarchical visual-recognition model
     1986 : Backpropagation revival makes supervised training of multilayer networks salient again
     1989 : LeCun et al. publish "Backpropagation Applied to Handwritten Zip Code Recognition" — USPS Buffalo digits, 7,291/2,007 train/test, local receptive fields, shared weights
     1990 : LeCun et al. NIPS account corroborates architecture and DSP throughput on AT&T DSP-32C hardware
@@ -42,12 +42,12 @@ timeline
 <details>
 <summary><strong>Plain-words glossary</strong></summary>
 
-- **Local receptive field** — Each detector in a convolutional layer looks at only a small patch of the input image, not the whole picture at once. This means the network learns what small shapes look like before combining them into larger evidence.
-- **Shared weights (weight sharing)** — The same set of learned parameters (filter) is applied at every position across the image. A single edge detector trained on one part of the image automatically works in other parts, reducing the total number of independent parameters the network must learn.
-- **Subsampling / pooling** — After feature detection, the spatial map is reduced in resolution, so small shifts in where a feature appears have less effect on downstream layers. The 1989 paper called this undersampling; later literature uses pooling.
+- **Local receptive field** — A detector in a convolutional layer looks at a small patch of the input image rather than the whole image at once.
+- **Shared weights (weight sharing)** — The same learned filter is applied at many positions across the image.
+- **Subsampling / pooling** — A step that reduces a feature map's spatial resolution after feature detection. The 1989 paper called this undersampling; later literature uses pooling.
 - **Feature map** — The output of applying one filter (one shared-weight detector) across all positions in the image — a new image whose pixel values record how strongly each location matched that filter.
-- **Parameter reduction** — Because weights are shared across positions, a convolutional network needs far fewer independent parameters than a fully connected network of comparable visual reach. In 1989, the zip-code recognizer used 9,760 independent parameters.
-- **Neocognitron** — Fukushima's 1980 hierarchical neural-network model for visual recognition. It used S-cells (feature-selective) and C-cells (position-tolerant) in a cascade, achieving shift tolerance without backpropagation-style supervised training.
+- **Parameter reduction** — The drop in independent weights when a network reuses the same detector across many image positions instead of learning separate weights everywhere.
+- **Neocognitron** — Fukushima's 1980 hierarchical neural-network model for visual recognition, an important predecessor to later convolutional architectures.
 
 </details>
 
@@ -57,7 +57,7 @@ timeline
 The key mathematical ideas behind the 1989 zip-code network and LeNet-5.
 
 - **Discrete convolution (one feature map):** For a filter $w$ of size $k \times k$ applied to input $x$, the output at position $(i,j)$ is $y_{ij} = \sum_{m=0}^{k-1}\sum_{n=0}^{k-1} w_{mn} \cdot x_{i+m,\, j+n}$. The same $w$ is used at every $(i,j)$: this is the weight-sharing claim in one equation.
-- **Weight-sharing parameter count:** A fully connected layer mapping an $H \times W$ input to an $H' \times W'$ output needs $H \cdot W \cdot H' \cdot W'$ parameters. A single $k \times k$ convolutional filter needs only $k^2$ regardless of image size — the 1989 paper's 9,760 figure reflects this compression.
+- **Weight-sharing parameter count:** A fully connected layer mapping an $H \times W$ input to an $H' \times W'$ output needs $H \cdot W \cdot H' \cdot W'$ parameters. A single $k \times k$ convolutional filter needs only $k^2$ regardless of image size.
 - **Subsampling (average pooling):** $s_{ij} = \frac{1}{p^2}\sum_{m=0}^{p-1}\sum_{n=0}^{p-1} y_{i \cdot p + m,\, j \cdot p + n}$. Reducing spatial resolution by factor $p$ makes the representation less sensitive to exact feature position.
 - **Gradient flow through a convolutional layer:** Backpropagation still applies — the chain rule gives $\frac{\partial L}{\partial w_{mn}} = \sum_{i,j} \frac{\partial L}{\partial y_{ij}} \cdot x_{i+m,\,j+n}$. Crucially, the gradient with respect to $w$ is a sum over all positions, so every patch in the image contributes to learning the same filter. This is why examples in one part of the image help train behavior everywhere.
 - **Translation tolerance from shared weights:** If the same filter $w$ fires on a stroke at position $(i,j)$, shifting the stroke to $(i+\delta, j)$ produces the same filter response at position $(i+\delta, j)$ — the feature map shifts, but the learned response does not change. Subsampling then absorbs small $\delta$, giving the architecture its tolerance to slight position variation.
@@ -149,10 +149,10 @@ conditions. Convolution says the family should not waste that richness. It
 should match the structure of the problem.
 
 The engineering payoff was parameter reduction. The 1989 paper described an
-architecture with far fewer independent parameters than a fully connected
-alternative would require. That mattered because the available data and
-compute were limited. Good architecture was not decoration. It was a way to
-make backpropagation tractable on a real visual task.
+architecture with 9,760 independent parameters, far fewer than a fully connected
+alternative of comparable visual reach would require. That mattered because the
+available data and compute were limited. Good architecture was not decoration.
+It was a way to make backpropagation tractable on a real visual task.
 
 The distinction is important because it separates expressiveness from
 learnability. A large fully connected network might have enough expressive
@@ -542,4 +542,3 @@ Every modern vision model — from ResNet to Vision Transformers — inherits th
 > Fukushima, the 1989/1990 Bell Labs digit recognizers, later MNIST context,
 > and the 1998 LeNet-5 document pipeline are kept in separate chronological
 > lanes.
-

--- a/src/content/docs/ai-history/ch-28-the-second-ai-winter.md
+++ b/src/content/docs/ai-history/ch-28-the-second-ai-winter.md
@@ -7,7 +7,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-The second AI winter arrived not because AI ideas were proven wrong, but because organizations discovered what it cost to keep them running. Expert systems such as XCON encoded real domain expertise but demanded relentless rule maintenance. The knowledge-acquisition bottleneck made building them slow and expensive. DARPA's Jack Schwartz cut budgets when AI failed to scale. Symbolics lost its hardware moat to cheaper workstations. By 1993, Strategic Computing had been quietly renamed High Performance Computing.
+The second AI winter arrived not because AI ideas were proven wrong, but because organizations discovered what it cost to keep them running. Expert systems encoded real domain expertise but demanded relentless maintenance. Knowledge acquisition made building them slow and expensive. DARPA funding priorities shifted as demonstrations struggled to scale. Specialized AI hardware lost its moat to cheaper workstations. The winter was an infrastructure correction, not a simple intellectual collapse.
 :::
 
 <details>
@@ -15,8 +15,8 @@ The second AI winter arrived not because AI ideas were proven wrong, but because
 
 | Name | Lifespan | Role |
 |---|---|---|
-| Bernd Neumann | — | Author of the 1988 XCON case study documenting 6,200+ rules, annual rule churn, and the rule-order control problem. |
-| Jack Schwartz | — | DARPA ISTO director whose scaling skepticism drove AI and expert-system budget cuts from 1987 onward. |
+| Bernd Neumann | — | Author of the 1988 XCON case study documenting the maintenance problem inside large configuration expert systems. |
+| Jack Schwartz | — | DARPA ISTO director who oversaw the late-1980s budget shift away from AI and expert-system expansion. |
 | John McDermott | — | CMU researcher associated with XCON/R1 and later defense expert-system technology-transfer work. |
 | Gerald L. Atkinson | — | Author of the IAAI-90 account of automated knowledge-acquisition tools for defense technology transfer. |
 | Tohru Moto-oka | — | Late professor credited with initiating Japan's Fifth Generation Computer Systems project in 1982. |
@@ -33,12 +33,12 @@ timeline
     1982 : Japan's Fifth Generation Computer Systems project begins, targeting knowledge-processing computers for the 1990s
     1983 : DARPA launches Strategic Computing partly in response to FGCS competitive pressure
     Mid-1980s : Expert systems spread through industry and defense; knowledge acquisition remains the limiting step
-    1986–1988 : DARPA expert-system funding rises from $3.6M to $5.2M under Amarel
-    1987 : Schwartz review turns skeptical of AI scaling; AI and robotics budgets begin to fall
-    May 1988 : Symbolics lays off 225 of 640 workers nationwide; $24.8M nine-month loss signals hardware market correction
-    1989–1990 : DARPA expert-system funding cut to $3M; AI and robotics budgets fall below $31M
+    1986–1988 : DARPA expert-system funding rises from 3.6 million dollars to 5.2 million dollars under Amarel
+    1987 : DARPA review turns skeptical of AI scaling; AI and robotics budgets begin to fall
+    May 1988 : Symbolics layoffs signal a hardware market correction
+    1989–1990 : DARPA expert-system funding cut to 3 million dollars; AI and robotics budgets fall below 31 million dollars
     1992 : FGCS'92 presents final ten-year results as research prototypes, not commercial products
-    1993 : Strategic Computing vanishes as a DARPA budget line and is transmuted into High Performance Computing
+    1993 : Strategic Computing vanishes as a DARPA budget line amid a broader reallocation
 ```
 
 </details>
@@ -49,9 +49,9 @@ timeline
 - **Expert system** — A software program that encodes human specialist knowledge as explicit if-then rules and uses an inference engine to apply those rules to new cases. Unlike a database, it can draw conclusions, not just retrieve stored facts.
 - **Knowledge acquisition** — The process of extracting informal expertise from human specialists and translating it into machine-readable rules. A persistent bottleneck because tacit professional judgement is difficult to verbalize.
 - **Knowledge-acquisition bottleneck** — The practical limit on how fast expert systems could be built and maintained, caused by the mismatch between the AI technologist's "how" knowledge and the domain expert's "what" knowledge.
-- **Rule maintenance** — The ongoing work of updating, correcting, and reorganizing the rules inside an expert system as the underlying domain changes. At XCON scale (6,200+ rules), this was effectively continuous software engineering.
+- **Rule maintenance** — The ongoing work of updating, correcting, and reorganizing the rules inside an expert system as the underlying domain changes.
 - **Lisp machine** — A workstation built specifically to run Lisp efficiently, optimized for AI software of the 1970s–1980s. Lost its economic advantage once commodity Unix workstations (Sun, Apollo) became fast enough for most AI tasks.
-- **Strategic Computing** — DARPA's 1983–1993 program to connect microelectronics, computer architecture, AI software, and military applications into a path toward machine intelligence; wound down into High Performance Computing by 1993.
+- **Strategic Computing** — DARPA's 1983–1993 program to connect microelectronics, computer architecture, AI software, and military applications into a path toward machine intelligence.
 - **Fifth Generation Computer Systems (FGCS)** — Japan's 1982–1992 national research program, coordinated by MITI, to build knowledge-processing computers using logic programming and parallel inference hardware (KL1/PIM). Its international announcement raised U.S. competitive alarm and helped sell Strategic Computing.
 
 </details>
@@ -264,9 +264,10 @@ scale. New ideas could not be forced into existence by a crash program.
 
 That judgement mattered because it turned optimism into budget pressure. In
 1987, the combined basic and Strategic Computing budgets for AI and robotics
-programs in ISTO were about $47 million. By 1989, Schwartz's budget in those
-areas was under $31 million. Expert systems were cut as well: funding rose to
-$5.2 million in 1988, then fell to $3 million by 1990.
+programs in ISTO were about 47 million dollars. By 1989, Schwartz's budget in
+those areas was under 31 million dollars. Expert systems were cut as well:
+funding rose to 5.2 million dollars in 1988, then fell to 3 million dollars by
+1990.
 
 The cuts were not evenly anti-AI. That nuance is important. Schwartz increased
 support for speech work that was making progress with standard benchmark
@@ -383,10 +384,10 @@ like a necessary foundation for serious AI work.
 The economics changed as workstations improved. A concrete business signal
 appeared at Symbolics in 1988. The Los Angeles Times reported that Symbolics
 laid off 225 of its 640 workers nationwide, including 90 workers at its
-Chatsworth plant. The company expected the layoffs to save $15 million a year.
+Chatsworth plant. The company expected the layoffs to save 15 million dollars a year.
 It had once employed more than 1,000 people; after the cuts it had slightly
-more than 400. The same article reported a $4.9 million quarterly loss and a
-$24.8 million nine-month loss on $65.2 million in revenue. It also identified
+more than 400. The same article reported a 4.9 million dollar quarterly loss and
+a 24.8 million dollar nine-month loss on 65.2 million dollars in revenue. It also identified
 competition from less expensive workstations by Sun Microsystems and Apollo
 Computer.
 
@@ -531,4 +532,3 @@ whose knowledge can scale with the infrastructure around them.
 :::note[Why this still matters today]
 Every AI deployment cycle still hits the same constraints the second winter exposed. Large language models require ongoing prompt engineering, fine-tuning, and guardrail maintenance — a distributed form of the knowledge-acquisition bottleneck. Specialized AI accelerators (TPUs, custom inference chips) face the same commodity-hardware threat that ended Lisp machines: general GPUs keep improving. DARPA's shift from Strategic Computing to benchmarks and measurable transition goals now appears in every enterprise AI evaluation: demos are not deployments. The winter's core lesson — that brittle hand-coded knowledge cannot scale without the infrastructure to build, update, and finance it — is the same lesson driving investment in retrieval, fine-tuning, and data pipelines today.
 :::
-

--- a/src/content/docs/ai-history/ch-29-support-vector-machines.md
+++ b/src/content/docs/ai-history/ch-29-support-vector-machines.md
@@ -7,7 +7,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-After the second AI winter, Vladimir Vapnik and colleagues gave machine learning a disciplined new promise: pick the separating hyperplane with the widest margin between classes, use kernel functions to work in high-dimensional feature spaces without building them explicitly, and solve a convex optimization problem with a unique global solution. Tested on handwritten-digit benchmarks in the 1990s, SVMs showed that generalization could be an engineering argument — one backed by statistical learning theory — not just a hope.
+After the second AI winter, Vladimir Vapnik and colleagues gave machine learning a disciplined new promise: choose decision boundaries using geometry, kernels, optimization, and statistical learning theory rather than expert rules or unchecked fitting. Tested on handwritten-digit benchmarks in the 1990s, support vector machines showed that generalization could be argued mathematically and evaluated operationally, not merely hoped for.
 :::
 
 <details>
@@ -44,11 +44,10 @@ timeline
 <summary><strong>Plain-words glossary</strong></summary>
 
 - **Support vector** — A training example that lies on or nearest to the decision boundary; the final classifier depends only on these examples, not on the full training set.
-- **Margin** — The width of the empty strip between the two classes on either side of a separating hyperplane. Maximum-margin classifiers choose the hyperplane that makes this strip as wide as possible.
-- **Kernel function** — A function that computes the inner product of two points in a high-dimensional feature space without constructing that space explicitly; allows SVMs to draw curved decision boundaries in the original input space.
-- **VC dimension (Vapnik-Chervonenkis dimension)** — A measure of a classifier's capacity: roughly, the largest set of points the classifier can separate in every possible way. Higher capacity risks overfitting; VC theory bounds the gap between training and test error.
-- **Soft margin** — An extension that allows some training examples to violate the margin or be misclassified, penalizing violations rather than demanding perfect separation; makes SVMs practical for noisy, overlapping real-world data.
-- **Convex optimization** — An optimization problem in which any local solution is also a global solution; SVM training is formulated this way, making the result independent of starting conditions.
+- **Hyperplane** — A flat decision surface used to separate classes in a feature space.
+- **Margin** — The width of the empty strip between the two classes on either side of a separating hyperplane.
+- **Kernel function** — A function that computes an inner product after an implicit feature transformation.
+- **Convex optimization** — An optimization problem in which any local solution is also a global solution.
 
 </details>
 
@@ -511,4 +510,3 @@ SVM ideas remain embedded in modern machine learning infrastructure. Kernel meth
   *Data Mining and Knowledge Discovery* 2, 121-167 (1998): tutorial anchor for
   margins, support vectors, convex quadratic programming, kernels, Mercer
   conditions, implementation concerns, VC dimension, and generalization.
-


### PR DESCRIPTION
## Summary
- trims reader-aid and prose repetition in Ch27-Ch29 based on Gemini repetition audit findings
- keeps exact factual/detail payloads in the body where reader aids were over-teaching
- removes raw dollar-sign render hazards from touched Ch28 passages

## Checks
- git diff --check HEAD~1..HEAD
- ../../.venv/bin/python scripts/check_reader_aids.py src/content/docs/ai-history/ch-27-the-convolutional-breakthrough.md src/content/docs/ai-history/ch-28-the-second-ai-winter.md src/content/docs/ai-history/ch-29-support-vector-machines.md
- rg -n '\\$[0-9]' src/content/docs/ai-history/ch-28-the-second-ai-winter.md (no matches)\n- npm run build (from primary checkout at ceb63dfa)\n- ../../.venv/bin/python scripts/test_pipeline.py (166 tests OK)\n\nCross-family review pending.