### PR TITLE
docs(ai-history): trim Ch33-Ch35 repetition

### DIFF
--- a/src/content/docs/ai-history/ch-33-deep-blue.md
+++ b/src/content/docs/ai-history/ch-33-deep-blue.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-In May 1997, Feng-hsiung Hsu's chess-specific ASIC — twelve years in the making — powered Deep Blue to a 3.5-2.5 match victory over world champion Garry Kasparov, the first such defeat under classical tournament conditions. The win came from 480 custom chess chips searching 100-200 million positions per second, not from machine learning or general intelligence. Deep Blue was an engineering triumph over one game and an architectural dead end: its silicon chess knowledge could not be reused for any other domain.
+In May 1997, Feng-hsiung Hsu's chess-specific hardware lineage culminated in Deep Blue's 3.5-2.5 match victory over world champion Garry Kasparov, the first such defeat under classical tournament conditions. The win came from custom chips, search engineering, and grandmaster-tuned evaluation, not from modern machine learning or general intelligence.
 :::
 
 <details>
@@ -16,7 +16,7 @@ In May 1997, Feng-hsiung Hsu's chess-specific ASIC — twelve years in the makin
 |---|---|---|
 | Feng-hsiung Hsu | 1959– | Chip designer; originator of the ChipTest → Deep Thought → Deep Blue ASIC lineage; chip architect for both Deep Blue I (1996) and Deep Blue II (1997). |
 | Murray Campbell | — | AI lead; CMU classmate of Hsu's; joined IBM in late 1989; primary post-match spokesperson and retrospective source. |
-| A. Joseph Hoane Jr. | — | Search-software lead; co-author on all major Deep Blue papers; conducted the overnight bug-fix after Game 1. |
+| A. Joseph Hoane Jr. | — | Search-software lead; co-author on all major Deep Blue papers; central to the match-time software work. |
 | Joel Benjamin | — | US Chess Champion; IBM grandmaster consultant from late 1996; curated the opening book and stress-tested Deep Blue's evaluation function. |
 | Garry Kasparov | 1963– | Reigning Classical World Chess Champion 1985-2000; opponent in the 1996 Philadelphia match (won 4-2) and the 1997 New York rematch (lost 2.5-3.5). |
 | Monty Newborn | — | McGill computer-science professor; ICCA organizer; chronicler of the rematch in *Deep Blue: An Artificial Intelligence Milestone* (2003). |
@@ -37,7 +37,7 @@ timeline
     February 1996 : First Kasparov-Deep Blue match, Philadelphia — Game 1 first computer win in regulation; Kasparov wins match 4-2
     1996-1997 : New chess chip designed; Joel Benjamin hired as grandmaster consultant
     April 1997 : 1997 system operational (Apr 1); code frozen (Apr 15); trucked to Manhattan (Apr 26-28)
-    May 3-11 1997 : Rematch at Equitable Center, NYC — Game 1 (bug, Kasparov wins); Game 2 (panic-time 36.axb5, Deep Blue wins); Games 3-5 drawn; Game 6 miniature (Deep Blue 3.5-2.5)
+    May 3-11 1997 : Rematch at Equitable Center, NYC — Kasparov wins Game 1; Deep Blue wins Games 2 and 6; Games 3-5 drawn
     September 1997 : IBM retires Deep Blue from chess competition
 ```
 
@@ -46,10 +46,10 @@ timeline
 <details>
 <summary><strong>Plain-words glossary</strong></summary>
 
-- **ASIC (application-specific integrated circuit)** — A chip designed to do exactly one job rather than general computation. Deep Blue's chess chips were ASICs: their move generator, evaluation function, and search logic were burned into silicon for chess only and could not be reprogrammed for any other task.
+- **ASIC (application-specific integrated circuit)** — A chip designed to do one specialized job rather than general computation.
 - **Alpha-beta search** — A pruning procedure that makes tree search tractable by discarding branches that cannot affect the final result once a better option is known. Deep Blue's hardware implemented a minimum-window variant; the software layer handled the top plies with selective extensions and null-move pruning.
 - **Ply** — One move by one player. A twelve-ply search looks six full move-pairs ahead. Deep Blue's non-extended search reached roughly twelve plies; forcing lines could be extended to about forty plies.
-- **Panic time** — Deep Blue's search-control rule for when its evaluation of a candidate move dropped sharply as search depth increased. The program triggered extra wall-clock time to deepen the search before committing, producing the six-minute deliberation behind Game 2's 36.axb5.
+- **Panic time** — Deep Blue's search-control rule for spending extra time when a candidate move looked worse at greater depth.
 - **Evaluation function** — The scoring formula that assigns a numerical value to a chess position. Deep Blue's evaluation function included hundreds of features (material, king safety, pawn structure, mobility, etc.) with weights adjustable from software — tuned by Joel Benjamin in the months before the rematch.
 - **Grandmaster-level performance** — Defined operationally in the Fredkin Prize framework as sustaining an Elo rating above 2500 across a statistically meaningful game set. Deep Blue's 1997 performance rating was approximately 2875 — higher than Kasparov's ~2815 over the six-game sample.
 

--- a/src/content/docs/ai-history/ch-34-the-accidental-corpus.md
+++ b/src/content/docs/ai-history/ch-34-the-accidental-corpus.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-In March 1989, Tim Berners-Lee wrote a CERN memo to solve a physics-lab information problem — and inadvertently created the largest language corpus in history. By the early 2000s, researchers from Philip Resnik to Michele Banko and Eric Brill had shown that simple models trained on web-scale data outperformed sophisticated models trained on curated collections. The field's centre of gravity shifted from building better learners to acquiring more evidence.
+In March 1989, Tim Berners-Lee wrote a CERN memo to solve a physics-lab information problem — and inadvertently created the largest language corpus in history. By the early 2000s, web-scale text had begun to change what natural language researchers could measure, train, and compare. The field's centre of gravity shifted from building better learners to acquiring more evidence.
 :::
 
 <details>
@@ -17,8 +17,8 @@ In March 1989, Tim Berners-Lee wrote a CERN memo to solve a physics-lab informat
 | Tim Berners-Lee | — | CERN physicist who authored "Information Management: A Proposal" in March 1989; named the system "World Wide Web" while writing the code in 1990. |
 | Henry Kučera | — | Brown University co-compiler (with W. Nelson Francis) of the Brown Corpus, the one-million-word benchmark that defined "large" in NLP for three decades. |
 | W. Nelson Francis | — | Brown University co-compiler of the Brown Corpus; co-author of the 1967 analytic volume and the 1979 Manual revision. |
-| Philip Resnik | — | University of Maryland linguist; built STRAND (1999), the first system to mine the open Web for parallel bilingual text with measured precision and recall. |
-| Michele Banko / Eric Brill | — | Microsoft Research co-authors of the 2001 ACL paper showing log-linear learning curves to one billion words; demonstrated that the worst learner on a billion words beats the best learner on a million. |
+| Philip Resnik | — | University of Maryland linguist; built STRAND (1999), an early system for mining parallel bilingual text from the open Web. |
+| Michele Banko / Eric Brill | — | Microsoft Research co-authors of the 2001 ACL paper that tested how more data changed disambiguation performance. |
 | Kenneth Church | — | Johns Hopkins computational linguist; key figure in the 1990s empirical revival; authored "A Pendulum Swung Too Far" (2011) warning that data-driven success had marginalised rationalist methods. |
 
 </details>
@@ -36,8 +36,8 @@ timeline
     1989 : March — Berners-Lee drafts Information Management: A Proposal at CERN : System internally called "Mesh"; AI never mentioned
     1990 : Berners-Lee implements the system; renames "Mesh" to "World Wide Web"
     1993 : SIGDAT founded; first Workshop on Very Large Corpora held
-    1999 : Resnik publishes STRAND — 2,491 English-French pairs mined from the Web at 100% precision
-    2001 : Banko & Brill ACL paper — log-linear learning curves to one billion words
+    1999 : Resnik publishes STRAND for mining bilingual text from the Web
+    2001 : Banko & Brill ACL paper tests data scale in disambiguation
     2006 : Google releases Web 1T 5-Gram corpus via LDC — 1.024 trillion tokens
     2007 : Brants et al. describe distributed LM infrastructure at 2 trillion tokens; introduce Stupid Backoff
     2009 : Halevy, Norvig, and Pereira publish The Unreasonable Effectiveness of Data
@@ -51,11 +51,11 @@ timeline
 
 - **Brown Corpus** — A 1,014,312-word collection of edited American English assembled at Brown University from texts published in 1961. Divided into 500 samples across fifteen genre categories, it was the standard NLP benchmark for three decades — "large" by the standards of the era, but the size of a few thick novels.
 - **Empirical revival** — The shift in computational linguistics, already underway by the late 1980s and institutionalised with SIGDAT in 1993, toward statistical and data-driven methods after a period dominated by symbolic AI and generative grammar. The Web amplified the swing; it did not start it.
-- **STRAND** — Philip Resnik's 1999 pipeline for finding parallel bilingual text on the Web without human curators. It used a commercial search index (AltaVista) to find candidate pages, matched them by HTML structure, then filtered by character-level language statistics — producing usable translation pairs at measured precision and recall.
-- **Confusion-set disambiguation** — The task of choosing the correct word from a set of look-alikes (e.g., *then* vs. *than*, *to* vs. *two* vs. *too*). Banko and Brill chose it because ordinary text already carries the "right answer," allowing training data to be generated automatically at any scale.
-- **Log-linear learning curve** — A pattern where each ten-fold increase in training data produces a roughly equal gain in accuracy. Banko and Brill's 2001 result showed this curve held out to one billion words with no sign of flattening — no asymptote in sight at the sizes the field then used.
-- **Stupid Backoff** — A simplified n-gram smoothing technique introduced by Brants et al. (2007) for Google's trillion-token language models. Instead of computing fully normalised probability distributions when a long context is rare, it falls back to a shorter context with a fixed penalty — cheap enough to work at distributed scale, and close enough in quality to elaborate alternatives once data is plentiful.
-- **Web 1T 5-Gram corpus** — The frequency table of English word sequences up to five words long, derived from approximately one trillion tokens of public Web text, released by Google through the Linguistic Data Consortium in September 2006. Exactly one million times larger than the Brown Corpus.
+- **STRAND** — Philip Resnik's 1999 pipeline for finding parallel bilingual text on the Web without human curators.
+- **Confusion-set disambiguation** — The task of choosing the correct word from a set of look-alikes, such as *then* vs. *than*.
+- **Log-linear learning curve** — A pattern where each ten-fold increase in training data produces a roughly equal gain in accuracy.
+- **Stupid Backoff** — A simplified n-gram smoothing technique designed to work cheaply at very large scale.
+- **Web 1T 5-Gram corpus** — A Google-released frequency table of English word sequences derived from public Web text.
 
 </details>
 

--- a/src/content/docs/ai-history/ch-35-indexing-the-mind.md
+++ b/src/content/docs/ai-history/ch-35-indexing-the-mind.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-In 1998, Stanford PhD candidates Sergey Brin and Lawrence Page reframed web search as an academic citation problem: each hyperlink was a vote, and a page's importance was the principal eigenvector of the link graph. Their PageRank algorithm and the *Anatomy* paper crystallized a new search engine. By 2003, Google had scaled this to more than 15,000 commodity PCs — tolerating failure in software rather than hardware — and Barroso, Dean, and Hölzle's *IEEE Micro* paper turned that pattern into a documented engineering discipline.
+In 1998, Stanford PhD candidates Sergey Brin and Lawrence Page reframed web search as an academic citation problem: hyperlinks could signal authority across the graph. Their PageRank algorithm and the *Anatomy* paper crystallized a new search engine. By 2003, Google had turned that ranking problem into a production-scale cluster discipline documented by Barroso, Dean, and Hölzle.
 :::
 
 <details>
@@ -34,8 +34,8 @@ timeline
     1997 : AltaVista claims ~20 million queries/day : Anatomy paper notes "only one of the top four search engines finds itself"
     1998 : PageRank paper dated January 29 on cover : Anatomy paper presented at WWW7, Brisbane, April : Google prototype indexes 24 million pages on Solaris/Linux at google.stanford.edu
     1999 : PageRank formally published as Stanford InfoLab Tech Report 1999-66
-    2002 : RackSaver.com rack of 88 dual-CPU Xeon servers priced at ~$278K vs. ~$758K for comparable single high-end server
-    2003 : Barroso, Dean, Hölzle publish Web Search for a Planet in IEEE Micro vol. 23 no. 2 : more than 15,000 commodity PCs in production : GFS paper corroborates design-for-failure thesis at SOSP
+    2002 : RackSaver.com rack of 88 dual-CPU Xeon servers priced around 278,000 dollars vs. 758,000 dollars for comparable single high-end server
+    2003 : Barroso, Dean, Hölzle publish Web Search for a Planet in IEEE Micro vol. 23 no. 2 : GFS paper corroborates design-for-failure thesis at SOSP
 ```
 
 </details>
@@ -44,11 +44,11 @@ timeline
 <summary><strong>Plain-words glossary</strong></summary>
 
 - **PageRank** — An algorithm that scores a web page's importance by examining which other pages link to it, and weighting each link by the importance of the linking page. Importance is computed globally across all pages simultaneously, not page by page.
-- **Eigenvector (principal)** — In a matrix equation, the eigenvector is the vector that points in the same direction after the matrix is applied. PageRank is the principal eigenvector of Google's link-transition matrix: the unique stable distribution of "attention" that the link graph settles into after repeated computation.
-- **Random surfer model** — An intuitive interpretation of PageRank: imagine a user who clicks links at random and occasionally "gets bored" and jumps to any page. The PageRank of a page is the probability that this bored surfer lands on it at any given moment.
-- **Damping factor** — The probability (0.85 in the original PageRank experiments) that the random surfer follows a link rather than jumping to a random page. Its complement, 0.15, is the jump probability (`||E||_1 = 0.15` in the paper).
-- **Commodity cluster** — A computing infrastructure built from large numbers of inexpensive, off-the-shelf PCs rather than a small number of high-end, fault-tolerant servers. Reliability is achieved through software-level replication rather than hardware redundancy.
-- **Warehouse-scale computing** — The engineering discipline, crystallized by the 2003 Barroso-Dean-Hölzle paper and formalized in Barroso and Hölzle's 2009 book, that treats the entire datacenter — not the individual server — as the unit of computing.
+- **Eigenvector (principal)** — In a matrix equation, the vector that points in the same direction after the matrix is applied.
+- **Random surfer model** — An intuitive interpretation of PageRank based on a user moving through links and sometimes jumping elsewhere.
+- **Damping factor** — The parameter that balances following links against jumping to another page in the random-surfer model.
+- **Commodity cluster** — A computing infrastructure built from many inexpensive, off-the-shelf machines.
+- **Warehouse-scale computing** — The engineering discipline that treats a datacenter as one coordinated computing system.
 
 </details>
 
@@ -126,7 +126,7 @@ Google’s engineers, including Urs Hölzle, Luiz André Barroso, Jeffrey Dean, 
 
 They codified this approach into explicit design principles. First, they prioritized software-level reliability over hardware fault tolerance. Instead of buying a server that would never crash, they built a software stack that expected machines to fail. Second, they used replication for both throughput and fault tolerance. By keeping "dozens of copies of the Web" across their clusters, they could serve more queries and survive the loss of hardware without treating every individual machine as precious. Third, they prioritized price/performance over peak performance. They would rather have many cheap, slightly slower CPUs than one expensive, top-of-the-line processor.
 
-The cost comparison provided in the 2003 paper was a definitive argument for this new model. In late 2002, a rack from RackSaver.com containing 88 dual-CPU 2GHz Intel Xeon servers, each with 2GB of RAM and an 80GB disk, cost about $278,000. A comparable high-end x86 server with eight CPUs, 64 gigabytes of RAM, and 8 terabytes of disk cost approximately $758,000. This meant the high-end alternative cost nearly three times as much while offering roughly one twenty-second the CPU count. For an application that could be divided across shards and replicas, the arithmetic was devastating.
+The cost comparison provided in the 2003 paper was a definitive argument for this new model. In late 2002, a rack from RackSaver.com containing 88 dual-CPU 2GHz Intel Xeon servers, each with 2GB of RAM and an 80GB disk, cost about 278,000 dollars. A comparable high-end x86 server with eight CPUs, 64 gigabytes of RAM, and 8 terabytes of disk cost approximately 758,000 dollars. This meant the high-end alternative cost nearly three times as much while offering roughly one twenty-second the CPU count. For an application that could be divided across shards and replicas, the arithmetic was devastating.
 
 This choice forced the creation of a new kind of engineering discipline: warehouse-scale computing. Because the clusters were built from cheap Celeron and Pentium III PCs, hardware failure was no longer an unlikely accident; it was a statistical certainty. The contemporaneous *Google File System* paper stated the premise bluntly: component failures were normal rather than exceptional in a file system built from inexpensive commodity hardware. Its largest deployed clusters already held hundreds of terabytes across thousands of disks on more than a thousand machines. The search cluster described by Barroso, Dean, and Hölzle pushed the same design assumption into query serving at still larger scale.
 


### PR DESCRIPTION
## Summary
- trims reader-aid repetition/spoilers in Ch33-Ch35 based on Gemini audit findings
- preserves the technical and historical payloads in body prose
- removes Ch35 raw dollar-sign render hazards by spelling currency as words

## Preservation checks
- Ch33 body still carries 480 chips, 100-200M positions/sec, Game 1 bug/overnight fix, panic-time six-minute 36.axb5, and architectural dead-end/generalizability discussion
- Ch34 body still carries STRAND/AltaVista/HTML/character-statistics details, 2,491 pairs at 100% precision, Banko-Brill billion-word result, Stupid Backoff fixed penalty, and Web 1T/Brown Corpus comparison
- Ch35 body still carries PageRank eigenvector/random-surfer/damping math, 15,000 commodity PCs, software-vs-hardware reliability thesis, RackSaver cost comparison, and warehouse-scale computing synthesis

## Checks
- git diff --check HEAD~1..HEAD
- ../../.venv/bin/python scripts/check_reader_aids.py ch-33 ch-34 ch-35
- rg -n '\\$[0-9]' src/content/docs/ai-history/ch-33-deep-blue.md src/content/docs/ai-history/ch-34-the-accidental-corpus.md src/content/docs/ai-history/ch-35-indexing-the-mind.md (no matches)\n- npm run build (from primary checkout at 18fe1b0d)\n- ../../.venv/bin/python scripts/test_pipeline.py (166 tests OK)\n\nCross-family review pending.