### PR TITLE
docs(ai-history): trim Ch36-Ch38 repetition

### DIFF
--- a/src/content/docs/ai-history/ch-36-the-multicore-wall.md
+++ b/src/content/docs/ai-history/ch-36-the-multicore-wall.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-For thirty years, software ran faster on new hardware for free — a promise powered by Dennard scaling. That promise ended on May 7, 2004, when Intel cancelled the Tejas Pentium 4 and Jayhawk Xeon and pulled its dual-core roadmap forward by twelve to eighteen months. Herb Sutter named the consequence in December 2004: the single-thread free lunch was over. The Berkeley View report of 2006 named the cause: Power Wall plus Memory Wall plus ILP Wall equalled Brick Wall.
+For thirty years, software ran faster on new hardware for free, a promise powered by Dennard scaling. By 2004, Intel's single-core roadmap had broken, and software developers were being warned that future speedups would require concurrency. The Berkeley View report of 2006 gave the new regime its clearest architectural language.
 :::
 
 <details>
@@ -17,9 +17,9 @@ For thirty years, software ran faster on new hardware for free — a promise pow
 | Robert N. Dennard | 1932–2024 | IBM engineer who laid down the transistor-scaling recipe in the early 1970s; its breakdown is the chapter's founding event. |
 | Shekhar Borkar | — | Intel engineer who warned in a July/August 1999 *IEEE Micro* paper that continued technology scaling would push CPU power density past manageable limits. |
 | Kunle Olukotun | — | Stanford architecture researcher who argued at ASPLOS 1996, eight years before Intel acted, that transistor budgets should be spent on multiple smaller cores. |
-| Herb Sutter | — | Software architect at Microsoft and ISO C++ committee chair; author of "The Free Lunch Is Over" (December 2004 / *Dr. Dobb's Journal* March 2005), the canonical software-industry account of the pivot. |
+| Herb Sutter | — | Software architect at Microsoft and ISO C++ committee chair; author of the canonical software-industry account of the multicore pivot. |
 | Ashlee Vance | — | *The Register* journalist who anchored the Tejas/Jayhawk cancellation in real time on May 7, 2004. |
-| Krste Asanović and David A. Patterson | — | Lead authors of the December 2006 *View from Berkeley* report that formalized the post-2004 regime as "Power Wall + Memory Wall + ILP Wall = Brick Wall." |
+| Krste Asanović and David A. Patterson | — | Lead authors of the December 2006 *View from Berkeley* report that formalized the post-2004 parallel-computing regime. |
 
 </details>
 
@@ -36,10 +36,10 @@ timeline
     2001 : Intel chips reach 2 GHz : IBM ships dual-core POWER4 server processor
     2003 : Intel clock-speed growth visibly flattens; Sutter would later mark this as where the wall appeared
     2004 Jan : AnandTech reports Tejas engineering samples at 2.8 GHz — consuming ~150 W
-    2004 May 7 : Intel confirms cancellation of Tejas and Jayhawk; dual-core schedule pulled 12–18 months forward
-    2004 Dec : Herb Sutter posts "The Free Lunch Is Over" — later published in Dr. Dobb's Journal March 2005
+    2004 May : Intel confirms cancellation of its next single-core Pentium 4 and Xeon successors
+    2004 Dec : Herb Sutter posts his software warning about the multicore pivot
     2005 : Intel ships Pentium D and AMD ships Athlon 64 X2 — first mainstream x86 dual-core desktop chips : Sun ships Niagara 8-core server processor
-    2006 Dec 18 : Berkeley View report names the regime — Power Wall + Memory Wall + ILP Wall = Brick Wall
+    2006 Dec 18 : Berkeley View report names the post-frequency regime
 ```
 
 </details>
@@ -47,11 +47,11 @@ timeline
 <details>
 <summary><strong>Plain-words glossary</strong></summary>
 
-- **Dennard scaling** — The 1970s IBM recipe by which each transistor generation was 30% smaller, 40% faster, and consumed proportionally less power. For three decades it delivered the "free lunch." It stopped paying its full bill around 2003 when voltage could no longer fall cleanly without leakage growing.
+- **Dennard scaling** — The 1970s IBM recipe by which smaller transistors could become faster and more numerous without proportional power growth.
 - **Power Wall** — The limit reached when a chip contains more transistors than it can afford to turn on at full speed without exceeding its heat and power budget. One of the three walls the Berkeley View report identified in 2006.
 - **ILP Wall (Instruction-Level Parallelism Wall)** — The limit at which architects run out of independent instructions inside a single sequential program to execute simultaneously. More transistors can no longer improve single-thread speed because there is not enough hidden parallelism left to exploit.
 - **Memory Wall** — The growing gap between how fast a processor can execute instructions and how fast it can fetch data from main memory. The Berkeley report noted a DRAM access could take ~200 clock cycles while a floating-point multiply took only four.
-- **Brick Wall** — The Berkeley View 2006 term for the combined effect of the Power Wall, Memory Wall, and ILP Wall — the reason the old strategy of faster single-core clocks had no remaining escape route.
+- **Brick Wall** — The Berkeley View 2006 term for the combined limits that ended the old strategy of faster single-core clocks.
 - **Multicore** — A processor die that contains two or more independent execution cores. Where one fast core had previously delivered performance growth, multiple cores offered a way to use additional transistors without violating the power budget.
 - **Concurrency revolution** — Herb Sutter's term for the software-industry consequence of multicore: programs that were not written to do more than one thing at a time would no longer automatically benefit from newer hardware.
 

--- a/src/content/docs/ai-history/ch-37-distributing-the-compute.md
+++ b/src/content/docs/ai-history/ch-37-distributing-the-compute.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-Between 2003 and 2004, Google engineers published two papers — the Google File System (SOSP 2003) and MapReduce (OSDI 2004) — describing production systems that stored and processed hundreds of terabytes across thousands of commodity machines while treating failure as normal. Doug Cutting and Mike Cafarella ported those specifications to Java as Apache Hadoop, splitting it from the Nutch crawler on 28 January 2006. The compute the deep-learning era would later inherit was not built for AI; it was pre-paid by web search.
+Between 2003 and 2004, Google engineers published two papers — the Google File System and MapReduce — describing production systems for storing and processing web-scale data across ordinary machines. Doug Cutting and Mike Cafarella ported those ideas to Java as Apache Hadoop. The compute the deep-learning era would later inherit was not built for AI; it was pre-paid by web search.
 :::
 
 <details>
@@ -18,7 +18,7 @@ Between 2003 and 2004, Google engineers published two papers — the Google File
 | Sanjay Ghemawat | — | Google engineer; lead author of *The Google File System* (SOSP 2003) and co-author of the MapReduce paper. |
 | Howard Gobioff | — | Google engineer; co-author of *The Google File System* (SOSP 2003) with Ghemawat and Leung. |
 | Shun-Tak Leung | — | Google engineer; co-author of *The Google File System* (SOSP 2003) with Ghemawat and Gobioff. |
-| Doug Cutting | — | Author of Lucene (1997); co-creator of Apache Nutch; reporter on Apache JIRA INFRA-700 (28 January 2006) splitting Hadoop out of Nutch; joined Yahoo January 2006. |
+| Doug Cutting | — | Author of Lucene (1997); co-creator of Apache Nutch and Hadoop; joined Yahoo in January 2006. |
 | Mike Cafarella | — | University of Washington graduate student; Cutting's collaborator on Apache Nutch and the Java re-implementation of GFS and MapReduce that became Hadoop. |
 
 </details>
@@ -48,8 +48,8 @@ timeline
 - **Distributed file system** — A file system that stores data across many machines at once, making them appear as one large, reliable store. GFS was Google's version; NDFS (later HDFS) was its open-source Java clone.
 - **Chunkserver** — In GFS, one of many machines that actually holds file data. Files are cut into 64 MB chunks; each chunk lives on multiple chunkservers so that if one machine dies the data is not lost.
 - **MapReduce** — A programming model in which the user writes two functions — Map (transform each record) and Reduce (aggregate matching records) — and the runtime handles splitting the work, running it on many machines, and recovering from failures automatically.
-- **Commodity hardware** — Ordinary, inexpensive off-the-shelf machines rather than specialized fault-tolerant servers. GFS and MapReduce were designed assuming these machines *would* fail, and built failure recovery into the system itself.
-- **Straggler / backup task** — A straggler is a worker machine that runs unusually slowly near the end of a job. MapReduce counters this by launching duplicate backup copies of nearly-finished tasks; whichever copy finishes first is used, cutting total job time significantly.
+- **Commodity hardware** — Ordinary, inexpensive off-the-shelf machines rather than specialized fault-tolerant servers.
+- **Straggler / backup task** — A straggler is a worker machine that runs unusually slowly near the end of a job.
 - **Fault tolerance** — The ability of a system to continue operating correctly when individual components fail. GFS achieved this through replication (three copies of each chunk by default); MapReduce achieved it by detecting dead workers and reassigning their tasks.
 - **Open-source port** — Reimplementing a design described in a research paper as publicly available software anyone can run. Cutting and Cafarella used the GFS and MapReduce papers as specifications and rebuilt them in Java, giving the broader industry access to the same architecture Google had built internally.
 

--- a/src/content/docs/ai-history/ch-38-the-human-api.md
+++ b/src/content/docs/ai-history/ch-38-the-human-api.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-In 2001, Amazon inventors Harinarayan, Rajaraman, and Ranganathan patented a "hybrid machine/human computing arrangement" that routed stubborn perceptual tasks to human-operated nodes through a formal API. When Amazon launched this infrastructure publicly on November 2, 2005 as Mechanical Turk, it rebranded the arrangement as "Artificial Artificial Intelligence." By 2008–2009, Snow et al. and the ImageNet team had proved that callable, metered crowd labor could supply supervised learning with annotation at a scale and cost that expert pipelines could not match.
+Amazon Mechanical Turk turned small human judgments into callable infrastructure. What began in Amazon's catalog-maintenance world became a public web-service API for tasks software could not yet solve alone. By 2008–2009, NLP and vision researchers had shown that metered crowd labor could supply supervised learning with annotation at a scale expert pipelines could not match.
 :::
 
 <details>
@@ -14,12 +14,12 @@ In 2001, Amazon inventors Harinarayan, Rajaraman, and Ranganathan patented a "hy
 
 | Name | Lifespan | Role |
 |---|---|---|
-| Venky Harinarayan | — | Amazon inventor; IEEE Spectrum identifies him as the manager whose patent described the hybrid machine/human computing arrangement. Co-inventor on US7197459B1. |
-| Anand Rajaraman | — | Co-inventor on US7197459B1; listed alongside Harinarayan and Ranganathan with Amazon Technologies Inc. as original assignee. |
-| Anand Ranganathan | — | Co-inventor on US7197459B1. |
+| Venky Harinarayan | — | Amazon inventor; IEEE Spectrum identifies him as a manager behind the internal system that became Mechanical Turk. Co-inventor on US7197459B1. |
+| Anand Rajaraman | — | Co-inventor on US7197459B1, listed with Amazon Technologies Inc. as original assignee. |
+| Anand Ranganathan | — | Co-inventor on US7197459B1, listed with Harinarayan and Rajaraman. |
 | Jeff Bezos | 1964– | Amazon founder/CEO; Computerworld reports his September 27, 2006 MIT keynote grouped MTurk with S3 and EC2 as developer-facing cloud services. |
-| Rion Snow, Brendan O’Connor, Daniel Jurafsky, Andrew Y. Ng | — | Co-authors of the 2008 EMNLP paper "Cheap and Fast — But is it Good?" validating MTurk for five NLP annotation tasks. |
-| Jia Deng, Wei Dong, Richard Socher, Li-Jia Li, Kai Li, Li Fei-Fei | — | Authors of the 2009 ImageNet CVPR paper; used AMT to verify millions of candidate images at 99.7% reported precision. |
+| Rion Snow, Brendan O’Connor, Daniel Jurafsky, Andrew Y. Ng | — | Co-authors of the 2008 EMNLP paper "Cheap and Fast — But is it Good?" on MTurk annotation. |
+| Jia Deng, Wei Dong, Richard Socher, Li-Jia Li, Kai Li, Li Fei-Fei | — | Authors of the 2009 ImageNet CVPR paper; used AMT to verify candidate images at large scale. |
 
 </details>
 
@@ -29,15 +29,15 @@ In 2001, Amazon inventors Harinarayan, Rajaraman, and Ranganathan patented a "hy
 ```mermaid
 timeline
     title Amazon Mechanical Turk and the Human Annotation Infrastructure
-    2001 : March 19 — priority date for US7197459B1 "Hybrid machine/human computing arrangement"
+    2001 : Amazon patent work begins on routing difficult subtasks to human workers
          : October 12 — filing date; inventors Harinarayan, Rajaraman, Ranganathan; assignee Amazon Technologies
     2004 : Von Ahn and Dabbish publish the ESP Game paper at CHI — pre-MTurk human-computation boundary
-    2005 : November 2 — AWS publicly launches Amazon Mechanical Turk as "Artificial Artificial Intelligence" web-services API
+    2005 : AWS publicly launches Amazon Mechanical Turk as a web-services API
     2006 : September 27 — Bezos MIT keynote groups MTurk with S3 and EC2 as "hidden Amazon" developer services
     2007 : March 27 — US7197459B1 granted and published
-    2008 : October — Snow et al. publish "Cheap and Fast - But is it Good?" at EMNLP : five NLP tasks, $2 per 7,000 labels
-    2009 : June — Deng et al. publish ImageNet at CVPR : 5,247 synsets, 3.2M images, AMT cleaning pipeline
-    2018 : Hara et al. CHI wage analysis — median ~$2/h; 4% of workers above US federal minimum wage
+    2008 : October — Snow et al. publish "Cheap and Fast - But is it Good?" at EMNLP
+    2009 : June — Deng et al. publish ImageNet at CVPR with an AMT cleaning pipeline
+    2018 : Hara et al. CHI wage analysis documents low effective worker pay
 ```
 
 </details>
@@ -48,9 +48,9 @@ timeline
 - **Human Intelligence Task (HIT)** — The unit of work on Mechanical Turk. A requester posts a HIT with a title, instructions, a price, and a rule for when it counts as complete. A worker picks it up, does the task, and submits an answer. The HIT structure is what lets software treat human judgment as an addressable request.
 - **Requester** — MTurk vocabulary for the party that posts tasks. A requester could be an individual researcher, a company, or a software system issuing API calls programmatically. Requesters set pay rates, qualifications, and approval or rejection rules.
 - **Turker (worker)** — Colloquial name for people who accept and complete HITs on Amazon Mechanical Turk. Workers browse available tasks, choose which to accept, and receive payment only for work the requester approves.
-- **Synset** — A set of words in WordNet that share a single meaning. ImageNet used WordNet’s roughly 80,000 noun synsets as the concept scaffold for its image hierarchy, aiming to collect 500–1,000 clean images per synset.
-- **Redundancy (annotation)** — The practice of collecting multiple independent labels for the same item instead of trusting a single worker’s answer. Snow et al. used ten annotations per item in their affect task; ImageNet required at least ten votes per image for initial quality thresholds. Aggregating many cheaper judgments is what made MTurk annotation statistically competitive with expert annotation.
-- **Artificial Artificial Intelligence** — Amazon’s deliberate phrase in the 2005 MTurk launch announcement, pointing to the gap between AI ambitions and what software could then achieve alone. A nod to the original eighteenth-century Mechanical Turk illusion: a chess automaton that appeared autonomous but concealed a person inside.
+- **Synset** — A set of words in WordNet that share a single meaning, used by ImageNet as a concept scaffold.
+- **Redundancy (annotation)** — The practice of collecting multiple independent labels for the same item instead of trusting a single worker’s answer.
+- **Artificial Artificial Intelligence** — Amazon’s deliberate phrase for human judgment packaged behind an AI-like interface.
 
 </details>
 
@@ -94,7 +94,7 @@ In that workflow, the unit of annotation was not a classroom exercise or a labor
 
 The choice of tasks was important because the paper was not testing one toy labeling problem. Affect recognition asked workers to judge emotional content. Word similarity asked for semantic closeness. Textual entailment required deciding whether one sentence followed from another. Temporal event ordering asked for judgments about sequence in language. Word sense disambiguation required choosing which meaning of a word was intended in context. Together, those tasks sampled the kinds of small interpretive decisions that made supervised natural language processing expensive. They were easy to describe as individual questions, but hard to automate reliably without examples, and the examples themselves required human judgment.
 
-The paper did not argue that a single anonymous click from the internet was equivalent to the nuanced judgment of a trained linguist. Instead, the researchers relied on careful task design and deliberate redundancy. In their affect recognition experiment, for example, they collected ten independent annotations per item. By using this built-in redundancy, they could study how aggregating multiple non-expert opinions improved the reliability of the final label. The economic results of this approach were striking. The team reported paying $2.00 to collect 7,000 non-expert annotations for the affect task. They interpreted this rate as yielding 3,500 non-expert labels per US dollar. Even after accounting for the need for redundancy and bias correction, they calculated that this provided at least 875 expert-equivalent labels per dollar spent.
+The paper did not argue that a single anonymous click from the internet was equivalent to the nuanced judgment of a trained linguist. Instead, the researchers relied on careful task design and deliberate redundancy. In their affect recognition experiment, for example, they collected ten independent annotations per item. By using this built-in redundancy, they could study how aggregating multiple non-expert opinions improved the reliability of the final label. The economic results of this approach were striking. The team reported paying 2 dollars to collect 7,000 non-expert annotations for the affect task. They interpreted this rate as yielding 3,500 non-expert labels per US dollar. Even after accounting for the need for redundancy and bias correction, they calculated that this provided at least 875 expert-equivalent labels per dollar spent.
 
 Repeated labeling changed the meaning of the individual worker response. A single answer could be noisy, hurried, or mistaken, but a set of answers could be treated statistically. The requester could compare workers to one another, measure agreement, infer which items were difficult, and use aggregation to move from raw clicks toward a usable label. The human API therefore did not eliminate expertise by magic. It replaced one expensive, high-trust judgment with several cheaper, lower-trust judgments plus a method for combining them. That bargain was only attractive because the platform made it cheap enough to ask the same question multiple times.
 
@@ -120,7 +120,7 @@ The reported 99.7 percent average precision on sampled synsets should be read in
 
 This is the point at which Mechanical Turk becomes difficult to separate from the later history of artificial intelligence, even though the direct causal chain must be kept narrow. ImageNet's 2009 paper was not yet the story of the 2012 deep-learning breakthrough. It was the story of how a large, structured visual dataset could be built at all. The contribution of MTurk in that story was not conceptual glamour. It was the unglamorous ability to ask many people, many times, whether a candidate image matched a defined category, then turn those answers into a cleaner corpus than automated web search alone could supply.
 
-However, the success of ImageNet and the broader utility of Mechanical Turk relied on an abstraction that profoundly obscured the reality of the labor involved. The API made human judgment look frictionless, callable, and meterable to the requester, but the human-operated nodes executing the subtasks were actual people operating within a precarious labor market. The costs of this abstraction were later detailed in an empirical analysis by Kotaro Hara, Abigail Adams, Kristy Milland, Saiph Savage, Chris Callison-Burch, and Jeffrey P. Bigham. By recording 2,676 workers performing 3.8 million tasks, they found that the median hourly wage was roughly $2.00, with only 4 percent of workers earning more than the federal minimum wage of $7.25 per hour. Their analysis highlighted the unpaid work components hidden behind the API call: the uncompensated time workers spent searching for tasks, the labor lost when work was rejected by requesters, and the effort expended on tasks that were ultimately not submitted. To the software developer, the human API was a cheap and fast function call; to the workers fulfilling the requests, it was an environment characterized by low median wages, constant search time, and unpaid friction. This hidden labor force provided the crucial verification layer for the datasets that would soon reshape the trajectory of artificial intelligence research.
+However, the success of ImageNet and the broader utility of Mechanical Turk relied on an abstraction that profoundly obscured the reality of the labor involved. The API made human judgment look frictionless, callable, and meterable to the requester, but the human-operated nodes executing the subtasks were actual people operating within a precarious labor market. The costs of this abstraction were later detailed in an empirical analysis by Kotaro Hara, Abigail Adams, Kristy Milland, Saiph Savage, Chris Callison-Burch, and Jeffrey P. Bigham. By recording 2,676 workers performing 3.8 million tasks, they found that the median hourly wage was roughly 2 dollars, with only 4 percent of workers earning more than the federal minimum wage of 7.25 dollars per hour. Their analysis highlighted the unpaid work components hidden behind the API call: the uncompensated time workers spent searching for tasks, the labor lost when work was rejected by requesters, and the effort expended on tasks that were ultimately not submitted. To the software developer, the human API was a cheap and fast function call; to the workers fulfilling the requests, it was an environment characterized by low median wages, constant search time, and unpaid friction. This hidden labor force provided the crucial verification layer for the datasets that would soon reshape the trajectory of artificial intelligence research.
 
 That closing tension is the durable meaning of Mechanical Turk in AI history. The same design that made human judgment usable by software also made the worker easy to overlook. In the requester view, the worker appeared as latency, price, approval rate, and output. In the research view, the worker often appeared as a row in an annotation table or a vote in an aggregation rule. Yet the labels that made supervised systems learn did not fall out of the web by themselves. They were produced through a market whose interface hid search time, rejection risk, and low effective pay behind the smooth language of services.
 


### PR DESCRIPTION
## Summary
- trims reader-aid repetition/spoilers in Ch36-Ch38 based on Gemini audit findings
- preserves detailed factual payloads in body prose
- removes Ch38 raw dollar-sign render hazards by spelling currency as words

## Preservation checks
- Ch36 body still carries May 7 2004, Tejas/Jayhawk, 12-18 month schedule acceleration, Sutter title/framing, and Berkeley Brick Wall formula
- Ch37 body/timeline still carries Apache JIRA INFRA-700, January 28 2006, GFS failure-as-normal quote, and MapReduce straggler backup-task mechanism/results
- Ch38 body still carries patent origin phrase/date, November 2 2005 launch and Artificial Artificial Intelligence wording, Snow task/cost numbers, ImageNet synset/image/precision numbers, and Hara wage figures

## Checks
- git diff --check HEAD~1..HEAD
- ../../.venv/bin/python scripts/check_reader_aids.py ch-36 ch-37 ch-38
- rg -n '\\$[0-9]' src/content/docs/ai-history/ch-36-the-multicore-wall.md src/content/docs/ai-history/ch-37-distributing-the-compute.md src/content/docs/ai-history/ch-38-the-human-api.md (no matches)\n- npm run build (from primary checkout at b0271a00)\n- ../../.venv/bin/python scripts/test_pipeline.py (166 tests OK)\n\nCross-family review pending.