### PR TITLE
docs(ai-history): trim Ch39-Ch41 repetition

### DIFF
--- a/src/content/docs/ai-history/ch-39-the-vision-wall.md
+++ b/src/content/docs/ai-history/ch-39-the-vision-wall.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-From 2004 to 2011, computer vision matured into an empirical science. Lowe's SIFT and Dalal and Triggs's HOG encoded invariance and edge structure by hand; PASCAL VOC supplied fixed classes, hidden test labels, and an evaluation server. Then Torralba and Efros showed the ceiling: datasets have signatures, and car detectors trained on one collection dropped from 53.4% to 27.5% AP on another. The wall was not failure — it proved that scale and variety, not only cleverness, were needed next.
+From 2004 to 2011, computer vision matured into an empirical science. Hand-designed features made recognition measurable; PASCAL VOC supplied fixed classes, hidden test labels, and an evaluation server. Then Torralba and Efros showed the ceiling: systems could perform well inside one collection while weakening sharply on another. The wall was not failure — it proved that scale and variety, not only cleverness, were needed next.
 :::
 
 <details>
@@ -14,11 +14,11 @@ From 2004 to 2011, computer vision matured into an empirical science. Lowe's SIF
 
 | Name | Lifespan | Role |
 |---|---|---|
-| David G. Lowe | — | Author of the 2004 IJCV SIFT article; established scale- and rotation-invariant local features as the foundation of object recognition. |
-| Navneet Dalal and Bill Triggs | — | Co-authors of HOG (CVPR 2005); introduced gradient-histogram descriptors evaluated with a linear SVM for human detection. |
+| David G. Lowe | — | Author of the 2004 IJCV SIFT article, a major reference point for local feature-based object recognition. |
+| Navneet Dalal and Bill Triggs | — | Co-authors of HOG (CVPR 2005), a foundational hand-designed descriptor for human detection. |
 | Mark Everingham | —–2012 | Key organiser of PASCAL VOC; died 2012; the ECCV 2012 VOC workshop was dedicated to his memory. |
 | Luc van Gool, Chris Williams, John Winn, Andrew Zisserman | — | Listed VOC2012 co-organisers, spread across ETH Zurich, Edinburgh, Microsoft Research Cambridge, and Oxford. |
-| Antonio Torralba and Alexei A. Efros | — | Authors of "Unbiased Look at Dataset Bias" (CVPR 2011); made dataset signatures and cross-dataset generalisation failures numerically visible. |
+| Antonio Torralba and Alexei A. Efros | — | Authors of "Unbiased Look at Dataset Bias" (CVPR 2011), a key critique of benchmark distribution limits. |
 | Pedro Felzenszwalb, Ross Girshick, David McAllester, Deva Ramanan | — | Developers of the discriminatively trained part-based HOG/latent-SVM detection model, the organiser-supplied VOC detection example for all 20 classes. |
 
 </details>
@@ -43,12 +43,12 @@ timeline
 <details>
 <summary><strong>Plain-words glossary</strong></summary>
 
-- **SIFT (Scale-Invariant Feature Transform)** — A method for finding and describing small, distinctive patches in an image that remain recognisable even when the image is taken from a different distance, angle, or under different lighting. Published by Lowe in 2004.
-- **HOG (Histograms of Oriented Gradients)** — A descriptor that represents an image region by measuring the direction and strength of edges across a grid of overlapping blocks, then normalising for lighting variation. Introduced by Dalal and Triggs in 2005 for human detection.
+- **SIFT (Scale-Invariant Feature Transform)** — A method for finding and describing distinctive local image patches so they can be matched across photographs. Published by Lowe in 2004.
+- **HOG (Histograms of Oriented Gradients)** — A descriptor that summarizes edge-orientation patterns in an image region. Introduced by Dalal and Triggs in 2005 for human detection.
 - **Bag of visual words** — A recognition technique that converts a set of local image descriptors into a histogram of how often each "visual word" (a cluster centroid from a dictionary of descriptor types) appears, discarding spatial arrangement. A dominant VOC classification approach before deep learning.
 - **Mean Average Precision (mAP / AP)** — The evaluation metric used in PASCAL VOC: for each object class, precision is measured at each recall threshold, averaged into an Average Precision figure; mAP averages AP across classes. Higher is better; a random baseline is far below 50%.
-- **Cross-dataset generalisation** — How well a model trained on one image collection performs when tested on images from a different collection. Torralba and Efros showed it was much lower than within-dataset performance, revealing that models learned dataset-specific signatures.
-- **Negative-set bias** — In object detection, the system must learn what "not the target object" looks like. If the training set samples non-object backgrounds unevenly (e.g. mostly open water near boats), the detector becomes brittle when the background distribution changes.
+- **Cross-dataset generalisation** — How well a model trained on one image collection performs when tested on images from a different collection.
+- **Negative-set bias** — In object detection, a brittleness caused by the limited and uneven examples used to represent everything outside the target class.
 - **Evaluation server** — A centralised submission system that scores algorithm results against hidden test labels, preventing researchers from tuning directly on test answers. Adopted by VOC from 2008; it made leaderboard numbers harder to game.
 
 </details>

--- a/src/content/docs/ai-history/ch-40-data-becomes-infrastructure.md
+++ b/src/content/docs/ai-history/ch-40-data-becomes-infrastructure.md
@@ -33,7 +33,7 @@ timeline
     1990 : WordNet paper collection reports synsets and semantic relations
     2005 : Amazon announces Mechanical Turk (November 2) as a web-services API for distributable microtasks
     2007 : ImageNet crowdsourced-verification phase begins — 49k workers across 167 countries
-    2009 : Deng, Dong, Socher, Li-Jia Li, Kai Li, and Li Fei-Fei publish ImageNet at CVPR : an initial large-scale hierarchical image database is reported
+    2009 : Deng, Dong, Socher, Li-Jia Li, Kai Li, and Li Fei-Fei publish ImageNet at CVPR : 5,247 synsets and 3.2 million verified images reported
     2010 : ILSVRC begins as an annual large-scale visual recognition benchmark built from ImageNet
     2014 : ImageNet reaches 21,841 synsets and 14,197,122 annotated images (August)
 ```
@@ -46,10 +46,10 @@ timeline
 - **WordNet** — An online lexical database developed at Princeton from 1985. Instead of listing words alphabetically, it groups English nouns, verbs, and adjectives into synonym sets linked by semantic relations such as hypernym (broader category) and hyponym (more specific instance).
 - **Synset** — A synonym set in WordNet: a cluster of words that all name the same underlying concept. ImageNet's unit of organization was the synset, not a bare word or arbitrary tag.
 - **Hypernym / hyponym** — WordNet terms for conceptual hierarchy: hypernyms are broader categories, while hyponyms are more specific instances.
-- **Amazon Mechanical Turk (AMT)** — A crowdsourcing marketplace for routing small tasks to distributed workers.
+- **Amazon Mechanical Turk (AMT)** — A crowdsourcing marketplace for routing small tasks to distributed workers. ImageNet used it to verify whether each candidate image contained the target synset's object, not to generate labels from scratch.
 - **ILSVRC (ImageNet Large Scale Visual Recognition Challenge)** — An annual benchmark competition that began in 2010, built on the ImageNet database. It provided a common training set, held-out evaluation images, and a workshop; it scaled from PASCAL VOC's 20 classes and ~20,000 images to 1,000 classes and over 1.4 million images.
 - **Query expansion** — A search-strategy technique that widens or clarifies a search by adding related terms instead of relying on one literal keyword.
-- **Precision (ImageNet sense)** — The fraction of collected images correctly showing the target concept after verification.
+- **Precision (ImageNet sense)** — The fraction of collected images correctly showing the target concept after verification; the ImageNet paper reported about 99.7 percent after verification versus about 10 percent average raw search-result accuracy.
 
 </details>
 

--- a/src/content/docs/ai-history/ch-40-data-becomes-infrastructure.md
+++ b/src/content/docs/ai-history/ch-40-data-becomes-infrastructure.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-Between 2007 and 2009, Fei-Fei Li and a Princeton team built ImageNet by grafting a web-image-harvesting pipeline and Amazon Mechanical Turk verification onto WordNet's semantic hierarchy of synsets. The 2009 CVPR paper reported 5,247 synsets and 3.2 million verified images. The chapter's claim is not that ImageNet caused the deep-learning revolution — that belongs later — but that it turned labeled visual data into shared research infrastructure before any revolution could use it.
+Between 2007 and 2009, Fei-Fei Li and a Princeton team built ImageNet by grafting a web-image-harvesting pipeline and crowdsourced verification onto WordNet's semantic hierarchy. The chapter's claim is not that ImageNet caused the deep-learning revolution — that belongs later — but that it turned labeled visual data into shared research infrastructure before any revolution could use it.
 :::
 
 <details>
@@ -33,7 +33,7 @@ timeline
     1990 : WordNet paper collection reports synsets and semantic relations
     2005 : Amazon announces Mechanical Turk (November 2) as a web-services API for distributable microtasks
     2007 : ImageNet crowdsourced-verification phase begins — 49k workers across 167 countries
-    2009 : Deng, Dong, Socher, Li-Jia Li, Kai Li, and Li Fei-Fei publish ImageNet at CVPR : 12 subtrees, 5,247 synsets, 3.2 million verified images reported
+    2009 : Deng, Dong, Socher, Li-Jia Li, Kai Li, and Li Fei-Fei publish ImageNet at CVPR : an initial large-scale hierarchical image database is reported
     2010 : ILSVRC begins as an annual large-scale visual recognition benchmark built from ImageNet
     2014 : ImageNet reaches 21,841 synsets and 14,197,122 annotated images (August)
 ```
@@ -44,12 +44,12 @@ timeline
 <summary><strong>Plain-words glossary</strong></summary>
 
 - **WordNet** — An online lexical database developed at Princeton from 1985. Instead of listing words alphabetically, it groups English nouns, verbs, and adjectives into synonym sets linked by semantic relations such as hypernym (broader category) and hyponym (more specific instance).
-- **Synset** — A synonym set in WordNet: a cluster of words that all name the same underlying concept. "Whippet," "whippet dog," and the breed's formal taxonomic name might share a synset. ImageNet's unit of organization was the synset, not a bare word or arbitrary tag.
-- **Hypernym / hyponym** — WordNet terms for conceptual hierarchy. A hypernym is a broader category (dog is a hypernym of whippet); a hyponym is a more specific instance (whippet is a hyponym of dog). ImageNet inherited this structure so that correctly recognizing a whippet could also count as recognizing a dog and an animal.
-- **Amazon Mechanical Turk (AMT)** — A crowdsourcing marketplace Amazon publicly announced on November 2, 2005, for routing small tasks to distributed workers. ImageNet used it not to generate labels from scratch but to verify whether each candidate image actually contained the target synset's object.
+- **Synset** — A synonym set in WordNet: a cluster of words that all name the same underlying concept. ImageNet's unit of organization was the synset, not a bare word or arbitrary tag.
+- **Hypernym / hyponym** — WordNet terms for conceptual hierarchy: hypernyms are broader categories, while hyponyms are more specific instances.
+- **Amazon Mechanical Turk (AMT)** — A crowdsourcing marketplace for routing small tasks to distributed workers.
 - **ILSVRC (ImageNet Large Scale Visual Recognition Challenge)** — An annual benchmark competition that began in 2010, built on the ImageNet database. It provided a common training set, held-out evaluation images, and a workshop; it scaled from PASCAL VOC's 20 classes and ~20,000 images to 1,000 classes and over 1.4 million images.
-- **Query expansion** — A search-strategy technique used in ImageNet's image-collection pipeline: rather than querying only the synset's name, the system automatically appended parent-synset terms (hypernyms) and translated queries into Chinese, Spanish, Dutch, and Italian to widen and disambiguate the pool of candidate images.
-- **Precision (ImageNet sense)** — The fraction of collected images correctly showing the target synset's object after verification. The 2009 paper reported approximately 99.7 percent precision on sampled synsets, contrasting with a raw search-engine accuracy of around 10 percent before the AMT verification stage.
+- **Query expansion** — A search-strategy technique that widens or clarifies a search by adding related terms instead of relying on one literal keyword.
+- **Precision (ImageNet sense)** — The fraction of collected images correctly showing the target concept after verification.
 
 </details>
 
@@ -146,4 +146,3 @@ ImageNet had succeeded in its primary infrastructural goal. It had systematicall
 :::note[Why this still matters today]
 Every modern image-recognition system, foundation model, and vision-language model was trained on or benchmarked against datasets that follow ImageNet's blueprint: semantic hierarchies, crowdsourced verification, web-scale candidate harvesting, and quality-control redundancy. The insight that data must be organized as infrastructure — not gathered ad hoc — became a design axiom for the entire field. Today's data pipelines for autonomous vehicles, medical imaging, and satellite analysis all grapple with the same core tradeoff ImageNet solved first: how do you route millions of small human judgments through a system and recover a dataset clean enough to trust?
 :::
-

--- a/src/content/docs/ai-history/ch-41-the-graphics-hack.md
+++ b/src/content/docs/ai-history/ch-41-the-graphics-hack.md
@@ -14,10 +14,10 @@ Between 2004 and 2005, researchers Kyoung-Su Oh, Keechul Jung, Dave Steinkraus, 
 
 | Name | Lifespan | Role |
 |---|---|---|
-| Dave Steinkraus | — | Co-author of the 2005 ICDAR paper applying graphics-card shaders to machine-learning primitives. |
+| Dave Steinkraus | — | Co-author of the 2005 ICDAR paper applying graphics-card shaders to machine-learning primitives on a GeForce 6800 Ultra. |
 | Ian Buck | — | Co-author of both Steinkraus et al. 2005 and Brook for GPUs (2004); appeared in both the ML-GPU and stream-abstraction lines of the chapter. |
 | Patrice Y. Simard | — | Co-author of Steinkraus et al. 2005; the paper's handwriting-recognition setting supplied the CPU-bottleneck and speedup anchors. |
-| Kyoung-Su Oh | — | Co-author of Oh and Jung 2004; helped show how neural-network arithmetic could be organized for a graphics card. |
+| Kyoung-Su Oh | — | Co-author of Oh and Jung 2004; helped show how neural-network arithmetic could be organized for an ATI Radeon 9700 Pro. |
 | Keechul Jung | — | Co-author of Oh and Jung 2004; same neural-network GPU implementation and speedup evidence. |
 
 </details>
@@ -39,11 +39,11 @@ timeline
 <details>
 <summary><strong>Plain-words glossary</strong></summary>
 
-- **Pixel shader** — A small program that graphics hardware runs to determine the output for generated pixels in a rendered scene.
+- **Pixel shader** — A small program that graphics hardware runs to determine the output for generated pixels in a rendered scene. Because many pixels are processed independently at once, researchers could repurpose shaders for parallel numerical work.
 - **GPGPU (General-Purpose computing on Graphics Processing Units)** — Using a graphics card to perform computations that have nothing to do with rendering images. In the shader era, this required disguising the computation as graphics operations; later, dedicated APIs like CUDA removed the disguise.
-- **Texture** — In graphics, a 2-D image applied to a surface to give it color or detail.
+- **Texture** — In graphics, a 2-D image applied to a surface to give it color or detail. In the GPGPU hack, textures were repurposed as flat numerical arrays for weights or input data.
 - **Stream kernel (Brook's framing)** — Brook's abstraction for a computation applied identically across an ordered collection of data elements (a "stream"). The term recast the GPU's pixel-shader invocations as a general-purpose parallel loop, hiding the graphics vocabulary beneath a more mathematical one.
-- **AGP bus** — The Accelerated Graphics Port, the physical link between a PC's CPU and its graphics card in this era.
+- **AGP bus** — The Accelerated Graphics Port, the physical link between a PC's CPU and its graphics card in this era. Its uneven bandwidth made GPU-to-CPU read-back costly, pushing researchers to keep intermediate training data on the card.
 - **Multilayer perceptron (MLP)** — A class of neural network organized into layers, where each unit in a layer computes a weighted sum of the previous layer's outputs. Oh and Jung showed that these weighted sums can be organized as matrix multiplication, which is the mathematical bridge that made GPU acceleration possible for their workload.
 
 </details>

--- a/src/content/docs/ai-history/ch-41-the-graphics-hack.md
+++ b/src/content/docs/ai-history/ch-41-the-graphics-hack.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-Between 2004 and 2005, researchers Kyoung-Su Oh, Keechul Jung, Dave Steinkraus, Ian Buck, and Patrice Y. Simard proved that consumer graphics cards could accelerate neural-network training — not because GPUs were designed for machine learning, but because matrix operations could be disguised as pixel-shader rendering. The hack delivered real speedups (up to 20-fold for Oh and Jung; 3.3x for Steinkraus et al.) while also making clear that the graphics API was the wrong long-term abstraction.
+Between 2004 and 2005, researchers Kyoung-Su Oh, Keechul Jung, Dave Steinkraus, Ian Buck, and Patrice Y. Simard proved that consumer graphics cards could accelerate neural-network training. The gains were real, but the programming route was awkward: machine-learning arithmetic had to pass through graphics concepts that were never meant to be the field's long-term abstraction.
 :::
 
 <details>
@@ -14,10 +14,10 @@ Between 2004 and 2005, researchers Kyoung-Su Oh, Keechul Jung, Dave Steinkraus, 
 
 | Name | Lifespan | Role |
 |---|---|---|
-| Dave Steinkraus | — | Co-author of the 2005 ICDAR paper applying DirectX 9 shaders to machine-learning primitives; reported a 3.3x speedup on a GeForce 6800 Ultra. |
+| Dave Steinkraus | — | Co-author of the 2005 ICDAR paper applying graphics-card shaders to machine-learning primitives. |
 | Ian Buck | — | Co-author of both Steinkraus et al. 2005 and Brook for GPUs (2004); appeared in both the ML-GPU and stream-abstraction lines of the chapter. |
 | Patrice Y. Simard | — | Co-author of Steinkraus et al. 2005; the paper's handwriting-recognition setting supplied the CPU-bottleneck and speedup anchors. |
-| Kyoung-Su Oh | — | Co-author of Oh and Jung 2004; mapped MLP inner products to matrix multiplication on an ATI Radeon 9700 Pro and reported up to a 20-fold speedup. |
+| Kyoung-Su Oh | — | Co-author of Oh and Jung 2004; helped show how neural-network arithmetic could be organized for a graphics card. |
 | Keechul Jung | — | Co-author of Oh and Jung 2004; same neural-network GPU implementation and speedup evidence. |
 
 </details>
@@ -28,9 +28,9 @@ Between 2004 and 2005, researchers Kyoung-Su Oh, Keechul Jung, Dave Steinkraus, 
 ```mermaid
 timeline
     title The Graphics Hack — Key Events
-    2004 : Oh and Jung publish "GPU implementation of neural networks" — MLP as matrix multiplication on ATI Radeon 9700 Pro
+    2004 : Oh and Jung publish "GPU implementation of neural networks" — MLP computation on a commodity graphics card
     2004 : Buck et al. publish "Brook for GPUs" — stream kernels as an abstraction over graphics hardware
-    2005 : Steinkraus, Buck, and Simard publish "Using GPUs for Machine Learning Algorithms" at ICDAR — DirectX 9 shaders, 3.3x speedup
+    2005 : Steinkraus, Buck, and Simard publish "Using GPUs for Machine Learning Algorithms" at ICDAR
     2007 : Owens et al. publish GPGPU survey in Computer Graphics Forum — retrospective synthesis of general computation on graphics hardware
 ```
 
@@ -39,11 +39,11 @@ timeline
 <details>
 <summary><strong>Plain-words glossary</strong></summary>
 
-- **Pixel shader** — A small program that the graphics hardware runs once for every pixel generated in a scene. Because millions of pixels are processed independently and simultaneously, the chip runs many copies of the shader in parallel. Researchers exploited this to run the same numerical operation over many data elements at once.
+- **Pixel shader** — A small program that graphics hardware runs to determine the output for generated pixels in a rendered scene.
 - **GPGPU (General-Purpose computing on Graphics Processing Units)** — Using a graphics card to perform computations that have nothing to do with rendering images. In the shader era, this required disguising the computation as graphics operations; later, dedicated APIs like CUDA removed the disguise.
-- **Texture** — In graphics, a 2-D image applied to a surface to give it color or detail. In the GPGPU hack, textures were repurposed as flat numerical arrays: a matrix of weights or input data packed into the color channels of an image the GPU could read at high speed.
+- **Texture** — In graphics, a 2-D image applied to a surface to give it color or detail.
 - **Stream kernel (Brook's framing)** — Brook's abstraction for a computation applied identically across an ordered collection of data elements (a "stream"). The term recast the GPU's pixel-shader invocations as a general-purpose parallel loop, hiding the graphics vocabulary beneath a more mathematical one.
-- **AGP bus** — The Accelerated Graphics Port, the physical link between a PC's CPU and its graphics card in this era. Its bandwidth was asymmetric: fast in the CPU-to-GPU direction (sending textures and geometry) and much slower reading back from the GPU. This asymmetry forced researchers to keep weights and intermediate results on the card throughout training.
+- **AGP bus** — The Accelerated Graphics Port, the physical link between a PC's CPU and its graphics card in this era.
 - **Multilayer perceptron (MLP)** — A class of neural network organized into layers, where each unit in a layer computes a weighted sum of the previous layer's outputs. Oh and Jung showed that these weighted sums can be organized as matrix multiplication, which is the mathematical bridge that made GPU acceleration possible for their workload.
 
 </details>


### PR DESCRIPTION
## Summary
- Trimmed repeated reader-aid details in Ch39-Ch41 while leaving body claims intact.
- Removed repeated exact metrics/examples from TL;DR, cast, timeline, and glossary entries where the body already carries the evidence.
- Verified no literal long duplicate paragraphs in this batch.

## Verification
- `git diff --check HEAD~1..HEAD`
- `../../.venv/bin/python scripts/check_reader_aids.py ch-39 ch-40 ch-41`
- `rg -n '\\$[0-9]' src/content/docs/ai-history/ch-39-the-vision-wall.md src/content/docs/ai-history/ch-40-data-becomes-infrastructure.md src/content/docs/ai-history/ch-41-the-graphics-hack.md` (no matches)\n- `npm run build` from primary checkout at commit `124278fe`, then restored primary to `main`\n- `../../.venv/bin/python scripts/test_pipeline.py` (166 tests, OK)\n\nCross-family review will be posted as a PR comment before merge.