### PR TITLE
docs(ai-history): trim Ch42-Ch44 repetition

### DIFF
--- a/src/content/docs/ai-history/ch-42-cuda.md
+++ b/src/content/docs/ai-history/ch-42-cuda.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-Before 2006, harnessing GPU arithmetic for non-graphics work required disguising computations as pixel-shader tricks. CUDA ended that era. By marrying Ian Buck's C-like programming model to NVIDIA's G80 unified architecture — with its 128 stream processors, shared on-chip memory, and a grid/block/thread execution hierarchy — NVIDIA converted GPGPU from a research curiosity into a stable, vendor-supported infrastructure platform. The GPU did not stop rendering; it became a parallel compute engine that scientists could program without first becoming graphics specialists.
+Before 2006, harnessing GPU arithmetic for non-graphics work required disguising computations as pixel-shader tricks. CUDA ended that era. By pairing a C-like programming surface with NVIDIA's rebuilt GPU architecture, NVIDIA converted GPGPU from a research curiosity into a stable, vendor-supported infrastructure platform. The GPU did not stop rendering; it became a parallel compute engine that scientists could program without first becoming graphics specialists.
 :::
 
 <details>
@@ -14,11 +14,11 @@ Before 2006, harnessing GPU arithmetic for non-graphics work required disguising
 
 | Name | Lifespan | Role |
 |---|---|---|
-| Ian Buck | — | Stanford PhD researcher, Brook development lead; joined NVIDIA to start CUDA (date conflict: NVIDIA bio says 2004, Buck said 2005). |
+| Ian Buck | — | Stanford PhD researcher and GPU-computing abstraction pioneer; joined NVIDIA to help start CUDA (date conflict: NVIDIA bio says 2004, Buck said 2005). |
 | Pat Hanrahan | — | Stanford graphics professor and Buck's co-author on the 2003 data-parallel computation report and the 2004 Brook SIGGRAPH paper. |
-| John Nickolls | — | NVIDIA director of architecture for GPU computing; co-author of the 2008 ACM Queue CUDA article documenting the programming model. |
-| Michael Garland | — | NVIDIA researcher; co-author of the 2008 ACM Queue CUDA article. |
-| Kevin Skadron | — | University of Virginia professor, on sabbatical with NVIDIA Research; co-author of the 2008 ACM Queue CUDA article. |
+| John Nickolls | — | NVIDIA director of architecture for GPU computing and public technical explainer of CUDA's programming model. |
+| Michael Garland | — | NVIDIA researcher involved in public technical documentation of CUDA's early programming model. |
+| Kevin Skadron | — | University of Virginia professor, on sabbatical with NVIDIA Research during CUDA's early technical-publication period. |
 | Jensen Huang | — | NVIDIA CEO; later reporting describes him marketing programmable GPUs to the supercomputing community in 2006. |
 
 </details>
@@ -31,12 +31,12 @@ timeline
     title CUDA — Key Events
     1999 : NVIDIA introduces GeForce; GPU branding established
     2003 : Buck and Hanrahan publish Stanford tech report arguing that a correct abstraction over graphics hardware is necessary; Brook named as implementation
-    2004 : Buck et al. publish "Brook for GPUs" at SIGGRAPH — stream kernels, C extension, compiler/runtime abstraction
+    2004 : Buck et al. publish "Brook for GPUs" at SIGGRAPH
     2004/2005 : Buck moves from Stanford to NVIDIA; CUDA project begins (date conflict in sources)
     2006 : Summer 2002–2006 G80 hardware design arc culminates; GeForce 8800 GTX launches with 128 unified stream processors
     2006 : CUDA announced during GeForce 8800 launch week (trade coverage: November 8, 13, 16)
     2007 : CUDA released to developers; CUDA Programming Guide 1.1 cited in later technical writing
-    2008 : Nickolls, Buck, Garland, Skadron publish "Scalable Parallel Programming with CUDA" in ACM Queue; tens of thousands of developers reported
+    2008 : Nickolls, Buck, Garland, Skadron publish "Scalable Parallel Programming with CUDA" in ACM Queue
 ```
 
 </details>
@@ -44,11 +44,11 @@ timeline
 <details>
 <summary><strong>Plain-words glossary</strong></summary>
 
-- **Kernel (CUDA)** — A C-like function written once by the programmer but executed simultaneously by thousands of GPU threads. The programmer writes the logic for one thread; CUDA launches it across the entire grid.
-- **Grid / thread block / thread** — The three-level hierarchy CUDA uses to organize parallel work. A kernel launch specifies a grid of blocks; each block contains a set of cooperating threads; threads inside a block can share data and synchronize with barriers. Blocks are independent of one another, which lets the hardware schedule them freely.
+- **Kernel (CUDA)** — A C-like function written once by the programmer and executed many times by GPU threads.
+- **Grid / thread block / thread** — CUDA's nested labels for grouping parallel work, from a whole launch down to individual execution instances.
 - **SIMT (Single-Instruction, Multiple-Thread)** — CUDA's execution model: the hardware issues the same instruction to many threads at once, each operating on its own data. It differs from classical SIMD in that individual threads can take divergent code paths, at a performance cost.
-- **Shared memory** — A small, fast, on-chip memory space available to all threads within a block. On Tesla-architecture GPUs it maps to low-latency SRAM, making it a software-managed cache that threads can use to cooperate without hitting the slower board DRAM.
-- **Host / device split** — CUDA's term for the CPU-side ("host") and GPU-side ("device") memory spaces. Data must be explicitly copied between them; this transfer cost shapes how CUDA programs are designed, encouraging programmers to keep large computations on the GPU side rather than shuttling results back and forth.
+- **Shared memory** — A fast scratchpad-style memory space that threads in the same local group can use to cooperate.
+- **Host / device split** — CUDA's term for the CPU-side ("host") and GPU-side ("device") parts of a program and their separate memory spaces.
 
 </details>
 

--- a/src/content/docs/ai-history/ch-42-cuda.md
+++ b/src/content/docs/ai-history/ch-42-cuda.md
@@ -14,7 +14,7 @@ Before 2006, harnessing GPU arithmetic for non-graphics work required disguising
 
 | Name | Lifespan | Role |
 |---|---|---|
-| Ian Buck | — | Stanford PhD researcher and GPU-computing abstraction pioneer; joined NVIDIA to help start CUDA (date conflict: NVIDIA bio says 2004, Buck said 2005). |
+| Ian Buck | — | Stanford PhD researcher and Brook project lead; joined NVIDIA to help start CUDA (date conflict: NVIDIA bio says 2004, Buck said 2005). |
 | Pat Hanrahan | — | Stanford graphics professor and Buck's co-author on the 2003 data-parallel computation report and the 2004 Brook SIGGRAPH paper. |
 | John Nickolls | — | NVIDIA director of architecture for GPU computing and public technical explainer of CUDA's programming model. |
 | Michael Garland | — | NVIDIA researcher involved in public technical documentation of CUDA's early programming model. |
@@ -45,10 +45,10 @@ timeline
 <summary><strong>Plain-words glossary</strong></summary>
 
 - **Kernel (CUDA)** — A C-like function written once by the programmer and executed many times by GPU threads.
-- **Grid / thread block / thread** — CUDA's nested labels for grouping parallel work, from a whole launch down to individual execution instances.
+- **Grid / thread block / thread** — CUDA's nested labels for grouping parallel work. A kernel launch specifies a grid of blocks; threads inside a block can share data and synchronize.
 - **SIMT (Single-Instruction, Multiple-Thread)** — CUDA's execution model: the hardware issues the same instruction to many threads at once, each operating on its own data. It differs from classical SIMD in that individual threads can take divergent code paths, at a performance cost.
 - **Shared memory** — A fast scratchpad-style memory space that threads in the same local group can use to cooperate.
-- **Host / device split** — CUDA's term for the CPU-side ("host") and GPU-side ("device") parts of a program and their separate memory spaces.
+- **Host / device split** — CUDA's term for the CPU-side ("host") and GPU-side ("device") parts of a program and their separate memory spaces. Data must be explicitly copied between them, so transfer cost shapes program design.
 
 </details>
 

--- a/src/content/docs/ai-history/ch-43-the-imagenet-smash.md
+++ b/src/content/docs/ai-history/ch-43-the-imagenet-smash.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-In 2012, Alex Krizhevsky, Ilya Sutskever, and Geoffrey Hinton entered the ImageNet Large Scale Visual Recognition Challenge under the name SuperVision and posted 15.3% top-5 error against the runner-up's 26.2% — a gap too large to explain away. The result did not invent neural networks or GPU computing; it turned scale into public, benchmarked proof that learned visual features could beat hand-built feature-engineering pipelines on their own contest.
+In 2012, Alex Krizhevsky, Ilya Sutskever, and Geoffrey Hinton entered the ImageNet Large Scale Visual Recognition Challenge under the name SuperVision and won by a margin too large to explain away. The result did not invent neural networks or GPU computing; it turned scale into public, benchmarked proof that learned visual features could beat hand-built feature-engineering pipelines on their own contest.
 :::
 
 <details>
@@ -36,7 +36,7 @@ timeline
        : Submission deadline (September 30)
        : Preliminary results released to participants (October 8)
        : ILSVRC2012 workshop at ECCV (October 12)
-       : Full results released — SuperVision 15.3 % top-5 error vs ISI 26.2 % (October 13)
+       : Full results released — SuperVision wins by an unprecedented margin (October 13)
        : Krizhevsky et al. publish AlexNet paper at NIPS 2012
   2013 : Vast majority of ILSVRC entries use deep convolutional neural networks
   2014 : Almost all ILSVRC teams use CNNs as the basis for their submissions
@@ -52,13 +52,13 @@ timeline
 
 **Top-5 error:** The fraction of test images for which the correct label is absent from the model's five highest-scoring guesses. A model may return up to five candidate labels; the prediction is wrong only if none of them match. Used by ILSVRC because many natural photographs are genuinely ambiguous.
 
-**Convolutional neural network (CNN):** A network that applies learned filters sliding across local image regions rather than connecting every pixel to every unit independently. Early layers detect local patterns; deeper layers combine those into more abstract features. AlexNet used five convolutional layers followed by three fully connected layers.
+**Convolutional neural network (CNN):** A network that applies learned filters sliding across local image regions rather than connecting every pixel to every unit independently. Early layers detect local patterns; deeper layers combine those into more abstract features.
 
-**ReLU (Rectified Linear Unit):** A nonlinearity that returns zero for negative inputs and grows linearly for positive ones. Avoids the slow learning seen in earlier saturating units; the AlexNet paper reported ReLU networks trained several times faster, which mattered when training already took five to six days.
+**ReLU (Rectified Linear Unit):** A nonlinearity that returns zero for negative inputs and grows linearly for positive ones, often making optimization easier than with saturating units.
 
 **Dropout:** A regularization method that randomly sets each neuron's output to zero with some probability during training. Prevents the network from relying on fragile patterns among particular units, helping a large model generalize rather than memorize the training set.
 
-**Fisher vector:** A compact encoding that summarizes how a collection of local image descriptors deviates from a statistical model. Together with SIFT and LBP descriptors, Fisher vectors defined the competitive feature-engineering regime that AlexNet defeated in ILSVRC2012.
+**Fisher vector:** A compact encoding that summarizes how a collection of local image descriptors deviates from a statistical model.
 
 </details>
 

--- a/src/content/docs/ai-history/ch-43-the-imagenet-smash.md
+++ b/src/content/docs/ai-history/ch-43-the-imagenet-smash.md
@@ -36,7 +36,7 @@ timeline
        : Submission deadline (September 30)
        : Preliminary results released to participants (October 8)
        : ILSVRC2012 workshop at ECCV (October 12)
-       : Full results released — SuperVision wins by an unprecedented margin (October 13)
+       : Full results released — SuperVision 15.3 % top-5 error vs ISI 26.2 % (October 13)
        : Krizhevsky et al. publish AlexNet paper at NIPS 2012
   2013 : Vast majority of ILSVRC entries use deep convolutional neural networks
   2014 : Almost all ILSVRC teams use CNNs as the basis for their submissions
@@ -58,7 +58,7 @@ timeline
 
 **Dropout:** A regularization method that randomly sets each neuron's output to zero with some probability during training. Prevents the network from relying on fragile patterns among particular units, helping a large model generalize rather than memorize the training set.
 
-**Fisher vector:** A compact encoding that summarizes how a collection of local image descriptors deviates from a statistical model.
+**Fisher vector:** A compact encoding that summarizes how a collection of local image descriptors deviates from a statistical model. In this chapter, it marks the competitive feature-engineering regime AlexNet had to beat.
 
 </details>
 

--- a/src/content/docs/ai-history/ch-44-the-latent-space.md
+++ b/src/content/docs/ai-history/ch-44-the-latent-space.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-In 1954, Zellig Harris argued that a word's meaning could be read from the company it keeps. By 1990 that idea had become a matrix-factorisation algorithm (LSA); by 2003 a neural language model (Bengio et al.) embedded it in learned parameters. In 2013, Mikolov, Chen, Corrado, and Dean stripped away the expensive machinery, leaving two log-linear objectives — CBOW and Skip-gram — that converted co-occurrence signals into dense, reusable vectors fast enough to train on billions of tokens.
+In 1954, Zellig Harris argued that a word's meaning could be read from the company it keeps. By 1990 that idea had become a matrix-factorisation algorithm (LSA); by 2003 a neural language model (Bengio et al.) embedded it in learned parameters. In 2013, Mikolov, Chen, Corrado, and Dean stripped away the expensive machinery, using fast log-linear objectives to convert co-occurrence signals into dense, reusable vectors trained on very large corpora.
 :::
 
 <details>
@@ -46,10 +46,10 @@ timeline
 - **Distributional hypothesis** — the principle that words appearing in similar contexts tend to have similar meanings; the intellectual foundation for co-occurrence-based representations, traced to Harris 1954.
 - **Latent Semantic Analysis (LSA)** — a 1990 technique that applies singular-value decomposition to a term-document matrix to compress it into roughly 100 orthogonal factors, exposing semantic proximity without exact word matching.
 - **Distributed representation** — encoding a concept not as a single symbol but as a pattern across many continuous values; Bengio et al. (2003) placed this inside a language model's learnable parameters.
-- **CBOW / Skip-gram** — the two log-linear architectures in Word2Vec. CBOW predicts a center word from its context; Skip-gram predicts context words from a center word. Both remove the non-linear hidden layer that made earlier models slow.
-- **Negative sampling** — a training shortcut introduced in the 2013 NIPS paper that replaces full-vocabulary softmax with a binary discrimination task: distinguish one true context word from a small set of randomly drawn noise words.
+- **CBOW / Skip-gram** — the two simplified log-linear architectures introduced in the 2013 Word2Vec papers.
+- **Negative sampling** — a training shortcut introduced in the 2013 NIPS paper that replaces full-vocabulary softmax with a cheaper sampled objective.
 - **Static embedding** — one fixed vector per vocabulary word, regardless of sentence context; the fundamental architectural constraint of Word2Vec, later superseded by contextual embeddings.
-- **Vector-offset analogy** — the empirical test that word-relation pairs share a roughly constant vector difference, so that King − Man + Woman produces a point near Queen in the trained space.
+- **Vector-offset analogy** — the empirical test that word-relation pairs share a roughly constant vector difference in the trained space.
 
 </details>
 

--- a/src/content/docs/ai-history/ch-44-the-latent-space.md
+++ b/src/content/docs/ai-history/ch-44-the-latent-space.md
@@ -46,10 +46,10 @@ timeline
 - **Distributional hypothesis** — the principle that words appearing in similar contexts tend to have similar meanings; the intellectual foundation for co-occurrence-based representations, traced to Harris 1954.
 - **Latent Semantic Analysis (LSA)** — a 1990 technique that applies singular-value decomposition to a term-document matrix to compress it into roughly 100 orthogonal factors, exposing semantic proximity without exact word matching.
 - **Distributed representation** — encoding a concept not as a single symbol but as a pattern across many continuous values; Bengio et al. (2003) placed this inside a language model's learnable parameters.
-- **CBOW / Skip-gram** — the two simplified log-linear architectures introduced in the 2013 Word2Vec papers.
-- **Negative sampling** — a training shortcut introduced in the 2013 NIPS paper that replaces full-vocabulary softmax with a cheaper sampled objective.
+- **CBOW / Skip-gram** — the two simplified log-linear architectures introduced in the 2013 Word2Vec papers. CBOW predicts a center word from its context; Skip-gram predicts context words from a center word.
+- **Negative sampling** — a training shortcut introduced in the 2013 NIPS paper that replaces full-vocabulary softmax with a cheaper task: distinguish one true context word from a small set of randomly drawn noise words.
 - **Static embedding** — one fixed vector per vocabulary word, regardless of sentence context; the fundamental architectural constraint of Word2Vec, later superseded by contextual embeddings.
-- **Vector-offset analogy** — the empirical test that word-relation pairs share a roughly constant vector difference in the trained space.
+- **Vector-offset analogy** — the empirical test that word-relation pairs share a roughly constant vector difference, so that King - Man + Woman produces a point near Queen in the trained space.
 
 </details>
 


### PR DESCRIPTION
## Summary
- Trimmed repeated reader-aid details in Ch42-Ch44 while preserving body evidence and narrative beats.
- Removed exact CUDA hierarchy/memory pre-teaching, AlexNet score/architecture spoilers, and Word2Vec mechanics/analogy spoilers from front-loaded aids.
- Kept changes scoped to reader aids; no body rewrites.

## Verification
- `git diff --check origin/main..HEAD`
- `../../.venv/bin/python scripts/check_reader_aids.py ch-42 ch-43 ch-44`
- `rg -n '\\$[0-9]' src/content/docs/ai-history/ch-42-cuda.md src/content/docs/ai-history/ch-43-the-imagenet-smash.md src/content/docs/ai-history/ch-44-the-latent-space.md` (no matches)\n- `npm run build` from primary checkout at commit `07a3fe79`, then restored primary to `main`\n- `../../.venv/bin/python scripts/test_pipeline.py` (166 tests, OK)\n\nCross-family review will be posted as a PR comment before merge.