### PR TITLE
docs(ai-history): trim Ch45-Ch47 repetition

### DIFF
--- a/src/content/docs/ai-history/ch-45-generative-adversarial-networks.md
+++ b/src/content/docs/ai-history/ch-45-generative-adversarial-networks.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-In 2014, Ian Goodfellow and seven collaborators at the Université de Montréal reframed image generation as a two-player game. A generator transforms random noise into synthetic samples; a discriminator tries to expose them as fake. Backpropagation trains both simultaneously, bypassing Markov chains and variational approximations. DCGAN stabilized the architecture in 2016; NVIDIA's Progressive GAN and StyleGAN extended it to photorealistic 1024×1024 faces by 2019. The price was a new problem: finding a Nash equilibrium instead of minimizing a simple loss.
+In 2014, Ian Goodfellow and seven collaborators at the Université de Montréal reframed image generation as a two-player game. A generator transforms random noise into synthetic samples; a discriminator tries to expose them as fake. Backpropagation trains both simultaneously, bypassing Markov chains and variational approximations. Later convolutional and high-resolution variants made adversarial image generation culturally visible. The price was training instability: the model now had to balance two opponents rather than minimize one simple loss.
 :::
 
 <details>
@@ -17,9 +17,9 @@ In 2014, Ian Goodfellow and seven collaborators at the Université de Montréal 
 | Ian Goodfellow | — | First author of the 2014 GAN paper; origin-story protagonist of the Montreal bar-night narrative. |
 | Yoshua Bengio | — | CIFAR Senior Fellow and co-author; head of the Montreal lab that produced the paper. |
 | Jurgen Schmidhuber | — | Author of predictability minimization (1992), named by the 2014 paper as the most relevant prior work with competing neural networks. |
-| Alec Radford | — | Lead author of DCGAN; introduced convolutional architecture constraints that stabilized adversarial training in most settings. |
+| Alec Radford | — | Lead author of DCGAN; helped make adversarial image generation more repeatable through convolutional design rules. |
 | Soumith Chintala | — | DCGAN co-author at Facebook AI Research; the DCGAN paper thanks NVIDIA for a Titan-X GPU used in the work. |
-| Tero Karras | — | Lead author on Progressive GAN (2018) and StyleGAN (2019) at NVIDIA Research; drove the 1024×1024 photorealistic face-generation arc. |
+| Tero Karras | — | NVIDIA Research author central to the high-resolution GAN work that pushed synthetic faces into public view. |
 
 </details>
 
@@ -31,12 +31,12 @@ timeline
     title Generative Adversarial Networks
     1992 : Schmidhuber publishes predictability minimization — opposing neural forces as the most relevant GAN precursor
     2014 : GAN concept reported to emerge at Les 3 Brasseurs, Montreal
-         : Goodfellow et al. publish "Generative Adversarial Nets" at NeurIPS — generator/discriminator minimax game
+         : Goodfellow et al. publish "Generative Adversarial Nets" at NeurIPS — adversarial generative framework
          : First experiments on MNIST, Toronto Face Database, and CIFAR-10 using Theano and Pylearn2
     2016 : Radford, Metz, and Chintala release DCGAN — convolutional constraints stabilize training; latent-vector arithmetic demonstrated
          : Goodfellow presents NeurIPS 2016 GAN tutorial
-    2018 : Karras, Aila, Laine, and Lehtinen publish Progressive GAN — progressive resolution growth to 1024x1024 CelebA-HQ images
-    2019 : Karras, Laine, and Aila publish StyleGAN at CVPR — style/noise separation and FFHQ photorealistic faces
+    2018 : NVIDIA Research high-resolution GAN work scales synthetic face generation
+    2019 : NVIDIA Research face-generation work advances photorealistic control
 ```
 
 </details>
@@ -48,11 +48,11 @@ timeline
 
 **Discriminator** — The half of a GAN that classifies inputs as real or fake. It receives a mixture of genuine training examples and generator outputs, and it outputs a probability. Its gradients flow back to the generator, making the discriminator the mechanism through which the generator learns.
 
-**Minimax game** — The mathematical structure of GAN training. The discriminator maximizes its ability to tell real from fake; the generator minimizes the same objective. The two networks play against each other in every update round rather than optimizing toward a shared target.
+**Minimax game** — A training setup in which two objectives are opposed, so one model's improvement changes the other model's problem.
 
-**Mode collapse** — A training failure in which the generator learns to produce only a narrow subset of plausible outputs (a single digit, for example, rather than all ten) because those few examples reliably fool the current discriminator. The 2014 paper called an extreme version the "Helvetica scenario."
+**Mode collapse** — A training failure in which the generator covers only a narrow part of the data distribution because those few outputs fool the current discriminator.
 
-**Nash equilibrium** — The theoretical endpoint of the minimax game, reached when neither player can improve by changing strategy unilaterally. In the GAN formulation, this occurs when the generator distribution matches the training data distribution and the discriminator can do no better than guessing. Reaching this point with finite networks and stochastic gradients is not guaranteed.
+**Nash equilibrium** — A game state where no player can improve by changing strategy alone. GAN training borrows this concept but rarely reaches the ideal cleanly in finite neural networks.
 
 **Latent vector** — The random noise vector fed into the generator as input. DCGAN demonstrated that arithmetic operations on latent vectors (addition, subtraction) produce semantically interpretable changes in the generated output, suggesting the generator organizes visual factors in a structured internal space.
 

--- a/src/content/docs/ai-history/ch-46-the-recurrent-bottleneck.md
+++ b/src/content/docs/ai-history/ch-46-the-recurrent-bottleneck.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-Recurrent neural networks promised to learn from sequences of any length, but gradient descent failed across long gaps: error signals vanished or exploded during backpropagation through time. In 1997, Hochreiter and Schmidhuber introduced Long Short-Term Memory, a gated architecture whose constant error carousel kept gradients stable across thousands of steps. LSTM powered speech recognition and machine translation at scale, yet its inherently sequential computation prevented parallelisation within a single sequence — the bottleneck Vaswani et al. named explicitly in 2017.
+Recurrent neural networks promised to learn from sequences of any length, but gradient descent failed across long gaps: error signals vanished or exploded during backpropagation through time. In 1997, Hochreiter and Schmidhuber introduced Long Short-Term Memory, a gated architecture that made long-range learning practical. LSTM powered speech recognition and machine translation at scale, yet its step-by-step computation exposed a hardware bottleneck that Vaswani et al. named explicitly in 2017.
 :::
 
 <details>
@@ -19,7 +19,7 @@ Recurrent neural networks promised to learn from sequences of any length, but gr
 | Yoshua Bengio | — | Co-author of the 1994 paper that independently formalized the difficulty of learning long-term dependencies with gradient descent. |
 | Ilya Sutskever, Oriol Vinyals, and Quoc V. Le | — | Authors of the 2014 sequence-to-sequence LSTM paper; provide the chapter's infrastructure detail: deep LSTMs, 8 GPUs, ten-day training. |
 | Felix A. Gers and Fred Cummins | — | Co-authors with Schmidhuber on the 2000 paper that introduced the adaptive forget gate for continual LSTM streams. |
-| Ashish Vaswani et al. | — | Authors of "Attention Is All You Need" (2017); named the sequential parallelisation constraint of recurrent models that concludes this chapter's arc. |
+| Ashish Vaswani et al. | — | Authors of "Attention Is All You Need" (2017); made the recurrent sequential bottleneck central to the Transformer argument. |
 
 </details>
 
@@ -44,13 +44,13 @@ timeline
 <details>
 <summary><strong>Plain-words glossary</strong></summary>
 
-- **Backpropagation through time (BPTT)** — The standard method for training recurrent networks: the network is conceptually unrolled across every time step, then ordinary backpropagation is applied to the resulting deep structure. Error signals must travel backward through every step, which creates the vanishing- and exploding-gradient problem at long distances.
+- **Backpropagation through time (BPTT)** — The standard method for training recurrent networks: the network is conceptually unrolled across time, then ordinary backpropagation is applied to that unfolded structure.
 - **Vanishing gradient** — When error signals shrink toward zero as they travel backward through many time steps, the network can no longer assign credit to inputs far in the past. Training may appear stable while the model silently ignores distant dependencies.
-- **Constant error carousel (CEC)** — The self-connected, linear memory-cell path at the centre of an LSTM unit. Its self-connection weight is fixed at 1.0, so the gradient passing through it is multiplied by 1 at each step, neither shrinking nor exploding over long sequences.
-- **Gate (LSTM)** — A multiplicative mechanism that controls whether information can enter a memory cell, leave it, or be discarded. The input gate controls writing, the output gate controls reading, and the forget gate (added in 2000) controls selective erasure of stored content.
+- **Constant error carousel (CEC)** — The protected memory path at the centre of an LSTM unit, designed to preserve error flow across long spans.
+- **Gate (LSTM)** — A learned multiplicative control that regulates what information is written, exposed, or erased inside an LSTM memory cell.
 - **Sequence-to-sequence learning** — A framework in which one recurrent network encodes a variable-length input into a fixed-size vector, and a second recurrent network decodes that vector into a variable-length output. Used in the 2014 Sutskever et al. paper for English-French machine translation.
-- **Model parallelism** — Splitting a single neural network across multiple hardware devices (e.g. one LSTM layer per GPU) so the model fits and runs, as opposed to data parallelism, which runs copies of the same model on different batches. The 2014 seq2seq paper and 2016 GNMT system both relied on model parallelism to handle deep recurrent stacks.
-- **Sequential operations** — Computations that must be performed in order because each depends on the previous result. Vaswani et al. 2017 quantified recurrent layers as requiring O(n) sequential operations for a sequence of length n, versus O(1) for self-attention — the architectural signature of the recurrent bottleneck.
+- **Model parallelism** — Splitting one neural network across multiple hardware devices so pieces of a large model can fit and run together.
+- **Sequential operations** — Computations that must be performed in order because each result depends on the previous result.
 
 </details>
 

--- a/src/content/docs/ai-history/ch-47-the-depths-of-vision.md
+++ b/src/content/docs/ai-history/ch-47-the-depths-of-vision.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-In 2015, He, Zhang, Ren, and Sun at Microsoft Research discovered that adding layers to a neural network could worsen training error — not from vanishing gradients but because the optimizer failed to find even an identity mapping. Their fix was a shortcut connection carrying the input around a stack of learned layers, letting the stack correct the residual. The 152-layer ResNet won ILSVRC 2015 with 3.57 percent top-5 error; residual connections became a default grammar for deep learning.
+In 2015, He, Zhang, Ren, and Sun at Microsoft Research discovered that adding layers to a neural network could make training worse even when the model had more capacity. Their fix routed information around learned layers so the network could use depth without forcing every stack to relearn what should pass through unchanged. A 152-layer ResNet won ILSVRC 2015, and residual connections became a default grammar for deep learning.
 :::
 
 <details>
@@ -33,7 +33,7 @@ timeline
     September 2014 : Simonyan and Zisserman release the VGG paper — ImageNet depth pushed to 16–19 weight layers with 3x3 filters
     2014 : GoogLeNet and VGG make "very deep" ImageNet models the state of the art, with leading architectures at roughly 16 to 30 layers
     February–July 2015 : Batch Normalization appears at ICML 2015, addressing gradient instability and enabling tens-layer networks to begin converging
-    December 10 2015 : He, Zhang, Ren, and Sun post ResNet to arXiv — residual learning with identity shortcuts, up to 152 layers, 3.57% ensemble ImageNet error
+    December 10 2015 : He, Zhang, Ren, and Sun post ResNet to arXiv — residual learning makes very deep ImageNet models trainable
     ILSVRC / COCO 2015 : ResNet team wins first place in ImageNet classification, detection, localization, COCO detection, and COCO segmentation
     June 2016 : ResNet paper published at CVPR 2016, pp. 770–778
 ```
@@ -43,15 +43,15 @@ timeline
 <details>
 <summary><strong>Plain-words glossary</strong></summary>
 
-**Optimization degradation** — The phenomenon where adding more layers to a neural network makes training error *worse*, not better. This is distinct from overfitting, which reduces training error while worsening test error. Optimization degradation means the optimizer itself is failing.
+**Optimization degradation** — The phenomenon where adding more layers to a neural network makes training harder or causes training error to get worse.
 
-**Residual mapping** — Instead of asking a stack of layers to learn the target function H(x) directly, residual learning reformulates the task as learning F(x) = H(x) − x, the difference between the desired output and the input. The original mapping is then recovered as F(x) + x.
+**Residual mapping** — A formulation where a stack of layers learns a correction to its input rather than the whole desired transformation from scratch.
 
-**Shortcut connection** — A path in the neural network's computational graph that carries the input directly around one or more learned layers and adds it to their output. In ResNet, the default shortcut is a parameter-free identity function.
+**Shortcut connection** — A path in the neural network's computational graph that carries activations around learned layers so they can be combined later.
 
-**Bottleneck block** — A residual block design used for networks of 50 layers and deeper. It uses three layers (1×1, 3×3, 1×1 convolutions) instead of two, first reducing dimensions, then expanding them, reducing arithmetic cost while preserving depth.
+**Bottleneck block** — A residual block design that reduces arithmetic cost while preserving enough depth for very large networks.
 
-**FLOP (floating-point operation)** — A single arithmetic step a processor performs. FLOP counts measure how much computation a model requires per forward pass; the 152-layer ResNet used 11.3 billion FLOPs, fewer than VGG-19's 19.6 billion.
+**FLOP (floating-point operation)** — A single arithmetic step a processor performs. FLOP counts estimate how much computation a model requires per forward pass.
 
 **Projection shortcut** — A shortcut connection that applies a learned linear transformation to the input before addition, used when the input and output of a residual block have different dimensions. The ResNet paper showed identity shortcuts were sufficient to resolve degradation; projection provides only marginal gains.
 


### PR DESCRIPTION
## Summary
- trim repeated GAN minimax, mode-collapse, and high-resolution face details from Ch45 reader aids
- simplify Ch46 LSTM and recurrent bottleneck reader aids so mechanics land in the body
- reduce Ch47 ResNet frontmatter pre-teaching of residual math, bottleneck FLOPs, and ILSVRC numbers

## Checks
- git diff --check origin/main..HEAD
- ../../.venv/bin/python scripts/check_reader_aids.py ch-45 ch-46 ch-47
- rg -n '\\$[0-9]' src/content/docs/ai-history/ch-45-generative-adversarial-networks.md src/content/docs/ai-history/ch-46-the-recurrent-bottleneck.md src/content/docs/ai-history/ch-47-the-depths-of-vision.md (no matches)\n- npm run build (from primary checkout at 72d76b8a)\n- ../../.venv/bin/python scripts/test_pipeline.py (166 tests OK)\n\n## Scope\nBook-only AI History repetition pass. No generated artifacts included.