### PR TITLE
docs(ai-history): trim Ch48-Ch50 repetition

### DIFF
--- a/src/content/docs/ai-history/ch-48-alphago.md
+++ b/src/content/docs/ai-history/ch-48-alphago.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-In March 2016, Google DeepMind's AlphaGo defeated Lee Sedol — the best Go player of the prior decade — four games to one in Seoul, arriving roughly a decade before experts had predicted. The system won not by brute force but by combining convolutional policy and value networks trained on expert games and self-play with Monte Carlo tree search. The result corrected a persistent myth: crossing a hard AI threshold required learning to guide search, not a choice between them.
+In March 2016, Google DeepMind's AlphaGo defeated Lee Sedol — the best Go player of the prior decade — in Seoul, arriving roughly a decade before experts had predicted. The system won not by brute force but by combining learned judgment with Monte Carlo tree search. The result corrected a persistent myth: crossing a hard AI threshold required learning to guide search, not a choice between them.
 :::
 
 <details>
@@ -17,8 +17,8 @@ In March 2016, Google DeepMind's AlphaGo defeated Lee Sedol — the best Go play
 | David Silver | — | Lead AlphaGo researcher and co-corresponding author of the *Nature* paper |
 | Demis Hassabis | — | DeepMind CEO and co-founder; co-corresponding author; wrote the official Google announcements |
 | Aja Huang | — | AlphaGo co-author; placed AlphaGo's moves on the physical board during the Lee Sedol match |
-| Lee Sedol | — | Korean 9-dan professional; Google's designated opponent; won Game 4 but lost the match 4-1 |
-| Fan Hui | — | Reigning three-time European Go champion; lost to AlphaGo 5-0 in a closed-door October 2015 match — the first professional full-board defeat |
+| Lee Sedol | — | Korean 9-dan professional; Google's designated opponent in the public Seoul match |
+| Fan Hui | — | Reigning three-time European Go champion; AlphaGo's closed-door professional full-board threshold opponent |
 | Michael Redmond | — | 9-dan professional commentator for the English-language match broadcast |
 
 </details>
@@ -30,9 +30,9 @@ In March 2016, Google DeepMind's AlphaGo defeated Lee Sedol — the best Go play
 timeline
     title AlphaGo — key dates
     1997 : IBM Deep Blue defeats Kasparov at chess — Go remains unsolved
-    2015 : AlphaGo defeats Fan Hui 5-0 in closed-door match at DeepMind (first professional full-board victory)
+    2015 : AlphaGo defeats Fan Hui in a closed-door match at DeepMind
     2016 : Nature paper published — policy networks, value network, MCTS architecture detailed (January 28)
-    2016 : Lee Sedol match — Seoul, five games (March 9–15); AlphaGo wins 4-1; Move 37 becomes defining moment
+    2016 : Lee Sedol match — Seoul, five games (March 9–15); AlphaGo wins the public series
 ```
 
 </details>
@@ -40,11 +40,11 @@ timeline
 <details>
 <summary><strong>Plain-words glossary</strong></summary>
 
-**Monte Carlo tree search (MCTS)** — A search method that evaluates positions by simulating many possible continuations and concentrating exploration where earlier simulations looked promising, rather than exhaustively checking every legal move.
+**Monte Carlo tree search (MCTS)** — A search method that samples possible futures and spends more attention on lines that look promising.
 
-**Policy network** — A neural network trained to estimate which moves are worth exploring; it reduces the breadth of the search by ranking candidates rather than treating all legal moves equally.
+**Policy network** — A neural network trained to estimate which moves are worth considering from a given board position.
 
-**Value network** — A neural network trained to estimate, from any board position, which player is more likely to win, without needing to play the game to its conclusion. It replaces deep search with a fast learned judgment.
+**Value network** — A neural network trained to estimate which player is more likely to win from a given board position.
 
 **Self-play reinforcement learning** — Training in which a system plays games against itself, updating its parameters based on wins and losses rather than imitation of human examples.
 

--- a/src/content/docs/ai-history/ch-49-the-custom-silicon.md
+++ b/src/content/docs/ai-history/ch-49-the-custom-silicon.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-In 2013 a single projection forced Google's hardware decision: three minutes of daily voice search per user would require doubling the company's entire datacenter capacity under conventional CPUs. The answer was the Tensor Processing Unit — a custom ASIC for 8-bit matrix arithmetic, built and deployed in fifteen months, running in production a year before its 2016 announcement. TPU v1 delivered 15–30x the speed and 30–80x the performance-per-watt of contemporary CPUs and GPUs across Google's six dominant inference workloads.
+In 2013 a voice-search projection forced Google's hardware decision: neural-network inference threatened to become a datacenter-capacity problem under conventional CPUs. The answer was the Tensor Processing Unit — a custom ASIC for production inference, built and deployed quickly enough to run in production before its 2016 announcement. TPU v1 turned neural-network arithmetic into an order-of-magnitude infrastructure efficiency gain.
 :::
 
 <details>
@@ -30,7 +30,7 @@ In 2013 a single projection forced Google's hardware decision: three minutes of 
 timeline
     title Chapter 49 — The Custom Silicon
     2006 : Google discusses GPU / FPGA / ASIC options for datacenter acceleration — idea not yet compelling
-    2013 : Voice-search projection reveals doubling-datacenter problem — high-priority custom ASIC project begins
+    2013 : Voice-search projection reveals neural-network inference capacity problem — high-priority custom ASIC project begins
     2015 : TPU v1 deployed in Google datacenters for neural-network inference
     March 2016 : TPU provides inference for AlphaGo during Lee Sedol matches
     May 2016 : Google publicly announces the Tensor Processing Unit — already running more than a year
@@ -47,13 +47,13 @@ timeline
 
 **ASIC (Application-Specific Integrated Circuit)** — A chip designed to do one specific job rather than general computation. TPU v1 is an ASIC for neural-network inference; unlike a CPU or GPU it cannot easily be repurposed for unrelated work.
 
-**Systolic array** — A grid of arithmetic units where data flows through in coordinated waves, each cell performing a multiply-add as values pass through, rather than each cell fetching its own data from a central store. The name comes from the rhythmic pumping motion, like a heartbeat.
+**Systolic array** — A grid of arithmetic units arranged so values move through neighboring cells while repeated multiply-add work happens locally.
 
-**Quantization** — Compressing a trained model's weights from 32-bit floating-point numbers down to narrower integers (often 8-bit). Inference tolerates this loss of precision; the payoff is that 8-bit arithmetic units are far smaller and cheaper in power than 32-bit ones.
+**Quantization** — Compressing a trained model's weights from high-precision numbers into narrower integer formats that inference can often tolerate.
 
 **Inference** — Using an already-trained neural network to answer a question (classify an image, translate a sentence, rank a search result). Contrasts with training, which adjusts the weights. TPU v1 was built solely for inference.
 
-**Performance-per-watt** — A datacenter's practical measure of efficiency: how much useful computation fits within a fixed power and cooling budget. TPU v1's 30–80x advantage over contemporaries meant the same inference load required far less electricity and heat.
+**Performance-per-watt** — A datacenter's practical measure of efficiency: how much useful computation fits within a fixed power and cooling budget.
 
 **PCIe coprocessor** — A chip that plugs into a server's PCI Express slot, augmenting but not replacing the host CPU. TPU v1 used this form factor so it could enter Google's existing rack infrastructure without rebuilding it.
 

--- a/src/content/docs/ai-history/ch-50-attention-is-all-you-need.md
+++ b/src/content/docs/ai-history/ch-50-attention-is-all-you-need.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-In June 2017, Vaswani and seven Google co-authors proposed the Transformer: an encoder-decoder architecture that replaced the recurrent time-step dependency of LSTMs with stacked self-attention, feed-forward layers, residual paths, layer normalization, and positional encodings. Trained on one machine with 8 P100 GPUs, it reached 28.4 BLEU on WMT 2014 English-German translation. Attention was not new — Bahdanau et al. had introduced it in 2014 — but the Transformer made it the layer operation, freeing sequence models to scale on matrix-friendly hardware.
+In June 2017, Vaswani and seven Google co-authors proposed the Transformer: an encoder-decoder architecture that replaced recurrent sequence steps with attention-centered layers. Attention was not new — Bahdanau et al. had introduced it in 2014 — but the Transformer made it the main way sequence positions exchanged information, freeing sequence models to scale on matrix-friendly hardware.
 :::
 
 <details>
@@ -32,7 +32,7 @@ timeline
     2014 : Sutskever, Vinyals, Le publish seq2seq LSTM — multilayer LSTM encodes input into a fixed-dimensional vector; second LSTM decodes the target
     2014 : Bahdanau, Cho, Bengio introduce neural machine translation with learned soft alignment — recurrent encoder-decoder with attention
     June 2017 : Vaswani et al. submit "Attention Is All You Need" to arXiv (1706.03762) — proposes the Transformer architecture
-    December 2017 : Paper appears at NeurIPS 2017 — reported machine-translation experiments use one machine with 8 NVIDIA P100 GPUs
+    December 2017 : Paper appears at NeurIPS 2017 — attention-only sequence transduction enters the main conference record
 ```
 
 </details>
@@ -40,17 +40,17 @@ timeline
 <details>
 <summary><strong>Plain-words glossary</strong></summary>
 
-**Sequence transduction** — A learning task where an input sequence (a sentence, a phoneme stream) maps to an output sequence (a translation, a transcription). Translation is the canonical example. The Transformer paper places itself inside this older problem class rather than claiming a wholly new task.
+**Sequence transduction** — A learning task where an input sequence maps to an output sequence, such as a sentence becoming a translation.
 
-**Recurrent neural network (RNN) / LSTM** — A model that processes a sequence one position at a time, carrying a hidden state forward across positions. The Long Short-Term Memory variant added gates that helped the state survive across longer sequences. The chapter's core complaint is not that LSTMs failed but that their per-position dependency limited how much of a layer's work could run in parallel.
+**Recurrent neural network (RNN) / LSTM** — A model that processes a sequence one position at a time while carrying state forward across positions.
 
-**Attention (Bahdanau-style)** — A mechanism that lets a decoder consult the encoder's per-position annotations as it produces each output token, retrieving relevant source-side information instead of relying on one compressed vector. Predates the Transformer and runs inside a recurrent encoder-decoder.
+**Attention (Bahdanau-style)** — A pre-Transformer mechanism that lets a decoder consult source-side positions while producing output.
 
-**Self-attention** — Attention applied within a single sequence: every position attends to every other position in the same layer. The Transformer's distinctive substitution — self-attention replaces the recurrent step as the way representations flow across positions.
+**Self-attention** — Attention applied within a single sequence so positions can exchange information directly inside a layer.
 
-**Multi-head attention** — Running several scaled dot-product attention operations in parallel with different learned projections, then concatenating the outputs. Lets the model attend to information from different representation subspaces in the same layer.
+**Multi-head attention** — Running several attention operations in parallel so the model can learn multiple relational views of the same sequence.
 
-**Positional encoding** — A signal added to the input embeddings to mark each token's position in the sequence. Because the Transformer removed recurrence and convolution, it needed an explicit order signal. The 2017 paper used sinusoidal encodings and reported similar results from learned positional embeddings.
+**Positional encoding** — An added signal that marks token order when a model no longer receives order from recurrence.
 
 **Autoregressive decoding (with masking)** — At generation time the decoder still produces one token at a time, conditioning on earlier outputs. During training, masking blocks each position from attending to later target positions so many positions can be processed in parallel without leaking the future.
 
@@ -61,13 +61,11 @@ timeline
 
 - **Scaled dot-product attention.** $\text{Attention}(Q, K, V) = \text{softmax}\!\left(\dfrac{Q K^{\top}}{\sqrt{d_k}}\right) V$ — queries $Q$, keys $K$, and values $V$ are matrices of projected token representations. The dot products score every query against every key, the softmax turns the scores into weights, and the weighted sum over values is the layer output. The $\sqrt{d_k}$ scaling keeps softmax gradients trainable as the key dimension grows. Source: Vaswani et al. 2017 §3.2.1.
 
-- **Multi-head attention.** $\text{MultiHead}(Q, K, V) = \text{Concat}(\text{head}_1, \dots, \text{head}_h)\, W^{O}$, with each $\text{head}_i = \text{Attention}(Q W_i^{Q}, K W_i^{K}, V W_i^{V})$ — the model learns $h$ sets of projections, runs $h$ attention operations in parallel, and recombines them. The paper uses $h = 8$ in the base model so each head sees a slice of dimension $d_k = d_v = d_{model} / h = 64$. Source: Vaswani et al. 2017 §3.2.2.
+- **Multi-head attention.** $\text{MultiHead}(Q, K, V) = \text{Concat}(\text{head}_1, \dots, \text{head}_h)\, W^{O}$, with each $\text{head}_i = \text{Attention}(Q W_i^{Q}, K W_i^{K}, V W_i^{V})$ — the model learns several projection sets, runs attention in parallel, and recombines the results. Base model: $h = 8$, $d_k = d_v = 64$. Source: Vaswani et al. 2017 §3.2.2.
 
 - **Sinusoidal positional encoding.** $PE_{(pos, 2i)} = \sin\!\left(pos / 10000^{2i / d_{model}}\right)$ and $PE_{(pos, 2i+1)} = \cos\!\left(pos / 10000^{2i / d_{model}}\right)$ — each dimension is a sinusoid of geometrically growing wavelength. The motivation given in the paper is that the relative offset between two positions can be expressed as a linear function of the encodings, which the model may exploit to learn relative-position behaviour. Source: Vaswani et al. 2017 §3.5.
 
-- **Per-layer complexity comparison (Table 1).** Self-attention runs in $O(n^2 \cdot d)$ per layer with $O(1)$ sequential operations and a maximum path length of $O(1)$ between any two positions; recurrent layers are $O(n \cdot d^2)$ per layer with $O(n)$ sequential operations and $O(n)$ path length; convolutional layers are $O(k \cdot n \cdot d^2)$ with $O(1)$ sequential operations but $O(\log_k n)$ or $O(n / k)$ path length depending on dilation. The Transformer trades quadratic sequence cost for short paths and short critical compute chains. Source: Vaswani et al. 2017 §4 / Table 1.
-
-- **The trade, in one inequality.** For sequence length $n$ and representation dimension $d$, self-attention is cheaper than a recurrent layer when $n < d$ — i.e. the regime of typical 2017 translation. As $n$ grows, the $n^2$ term dominates and the trade flips, which is why long-context attention later became its own engineering subfield. Source: Vaswani et al. 2017 §4 (sentence-length caveat and "restricted self-attention" remark).
+- **The key trade.** Self-attention makes distant positions directly reachable inside a layer, but it compares positions against one another, so long sequences later became their own engineering problem. Table 1 lists recurrent layers at $O(n \cdot d^2)$ with $O(n)$ sequential operations, and convolutional layers at $O(k \cdot n \cdot d^2)$ with shorter critical chains than recurrence. Source: Vaswani et al. 2017 §4 / Table 1.
 
 </details>
 


### PR DESCRIPTION
## Summary
- trim Ch48 reader-aid scoreline and AlphaGo architecture echoes while preserving body match details
- broaden Ch49 TPU origin, architecture, and performance reader aids so exact numbers land in the chapter body
- reduce Ch50 Transformer TL;DR/glossary/math pre-teaching while restoring non-duplicated math-sidebar anchors flagged in review

## Checks
- git diff --check origin/main..HEAD
- ../../.venv/bin/python scripts/check_reader_aids.py ch-48 ch-49 ch-50
- rg -n '\\$[0-9]' on changed chapter files (only legitimate Ch48 `$1 million` body references)\n- npm run build (from primary checkout at 56924fc3)\n- ../../.venv/bin/python scripts/test_pipeline.py (166 tests OK)\n\n## Scope\nBook-only AI History repetition pass. No generated artifacts included.