### PR TITLE
docs(ai-history): trim Ch51-Ch53 repetition

### DIFF
--- a/src/content/docs/ai-history/ch-51-the-open-source-distribution-layer.md
+++ b/src/content/docs/ai-history/ch-51-the-open-source-distribution-layer.md
@@ -15,10 +15,10 @@ Modern AI did not spread through papers alone. By the late 2010s a distribution 
 | Name | Lifespan | Role |
 |---|---|---|
 | Paul Ginsparg | — | Cornell physicist; founded arXiv in 1991 as a curated, no-fee, moderated preprint server |
-| Google TensorFlow team | — | Institutional actor; 2015-11-09 open-source announcement framed working code as a faster medium for exchanging ML ideas than papers alone |
-| PyTorch maintainers (Meta/Facebook AI) | — | Institutional actor; 2018-05-02 PyTorch 1.0 announcement positioned the framework as a research-to-production bridge |
+| Google TensorFlow team | — | Institutional actor; opened a major corporate ML framework to public use in 2015 |
+| PyTorch maintainers (Meta/Facebook AI) | — | Institutional actor; made dynamic deep-learning workflows central to research and deployment |
 | Hugging Face | — | Institutional actor; created the `huggingface/transformers` GitHub repository on 2018-10-29 (detailed model-hub treatment belongs to Chapter 54) |
-| Papers with Code team | — | Partner with arXiv; the 2021 Annual Report described a code/dataset integration that expanded from AI/ML categories to all arXiv |
+| Papers with Code team | — | Partner with arXiv; helped make paper, code, dataset, and benchmark links easier to discover together |
 | Open-source ML maintainers and users | — | Collective infrastructure community: contributors, package maintainers, tutorial authors, and reproducibility auditors who kept the layer running |
 
 </details>
@@ -31,13 +31,13 @@ timeline
     title Chapter 51 — The Open Source Distribution Layer
     1991 : arXiv is founded by Paul Ginsparg — moderated, no-fee, not peer-reviewed
     2012 : arXiv monthly-submissions CSV totals 84,603 submissions for the year
-    Nov 2015 : tensorflow/tensorflow GitHub repository created (Nov 7); Google announces TensorFlow as open source (Nov 9) and frames working code as faster than papers
+    Nov 2015 : tensorflow/tensorflow GitHub repository created (Nov 7); Google announces TensorFlow as open source (Nov 9)
     Aug 2016 : pytorch/pytorch GitHub repository created
     2017 : arXiv monthly-submissions CSV totals 123,523 submissions — Transformer paper appears on arXiv this year
-    May 2018 : Meta/Facebook announces PyTorch 1.0 as an open-source AI framework bridging research and production
+    May 2018 : Meta/Facebook announces PyTorch 1.0 as an open-source AI framework
     Oct 2018 : huggingface/transformers GitHub repository created (Chapter 54 treats the model hub in detail)
     2020 : arXiv monthly-submissions CSV totals 178,329 submissions for the year
-    2021 : arXiv Annual Report — Papers with Code integration expanded from AI/ML to all arXiv; 70,000+ papers with code links, 60,000+ with dataset links
+    2021 : arXiv Annual Report describes expanded Papers with Code integration and added dataset links
 ```
 
 </details>
@@ -51,11 +51,11 @@ timeline
 
 **Repository (GitHub)** — A public Git project hosting source code, tests, issue tracker, pull requests, releases, and commit history. A research artifact's repository often supplies implementation choices the paper compresses (tensor shapes, training loops, masking conventions, dependency versions).
 
-**Open-source framework** — A publicly licensed software toolkit through which models can be expressed, trained, and deployed. TensorFlow (2015) and PyTorch (2016/2018) are the dominant ML examples; their framings ("exchange ideas through code", "research-to-production") differ even though the licenses overlap.
+**Open-source framework** — A publicly licensed software toolkit through which models can be expressed, trained, and deployed. TensorFlow and PyTorch are the dominant ML examples in this chapter, with different design cultures around graph execution, eager experimentation, and deployment.
 
-**Paper-to-code index** — A discovery layer that links a paper to its implementations and datasets so a reader does not have to search project pages manually. Papers with Code is the canonical example; arXiv's 2021 Annual Report describes the integration expanding from AI/ML to all arXiv.
+**Paper-to-code index** — A discovery layer that links a paper to its implementations and datasets so a reader does not have to search project pages manually. Papers with Code is the canonical example.
 
-**Reproducibility** — The ability of an independent reader to obtain the paper's reported results from the published artifacts. *Code availability is not the same as reproducibility*: a 2019 study of 1,700+ AI-paper repositories documented abandonment, inactivity, and missing dependency or data information.
+**Reproducibility** — The ability of an independent reader to obtain the paper's reported results from the published artifacts. Code availability helps, but it does not by itself guarantee maintained dependencies, complete data instructions, or enough implementation detail to recover the result.
 
 **Distribution layer (vs. library)** — A library helps an individual write code; a distribution layer changes what the field expects to exist around an idea. The chapter's narrow claim is that arXiv + GitHub + frameworks + paper-to-code indexes together form a distribution layer, not just a collection of tools.
 

--- a/src/content/docs/ai-history/ch-52-bidirectional-context.md
+++ b/src/content/docs/ai-history/ch-52-bidirectional-context.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-BERT, published October 2018 by Devlin, Chang, Lee, and Toutanova at Google AI, took the Transformer encoder, pre-trained it with masked language modeling and next-sentence prediction on 3.3 billion words of BooksCorpus and Wikipedia, and released the trained weights. BERTBASE (110M parameters) and BERTLARGE (340M) trained for four days on Cloud TPU Pods. Fine-tuning the released checkpoint reached state-of-the-art on 11 NLP tasks. The reusable artifact stopped being an algorithm and became a set of trained parameters.
+BERT, published in October 2018 by Devlin, Chang, Lee, and Toutanova at Google AI, turned the Transformer encoder into a reusable bidirectional checkpoint. It used masked-token pre-training and sentence-pair training on large unlabeled text, then released weights that could be fine-tuned across many NLP tasks. The reusable artifact stopped being an algorithm and became a set of trained parameters.
 :::
 
 <details>
@@ -32,7 +32,7 @@ timeline
     Oct 11 2018 : BERT paper appears on arXiv (1810.04805)
     Oct 25 2018 : google-research/bert GitHub repository created
     2018 : Google Research blog announces open-source release of BERT code + pre-trained models
-    2018 : BERTBASE and BERTLARGE report state-of-the-art on 11 NLP tasks (GLUE, SQuAD, SWAG)
+    2018 : BERT reports broad benchmark gains across language-understanding tasks
 ```
 
 </details>
@@ -46,9 +46,9 @@ timeline
 
 **Bidirectional context** — The condition where every layer of the model can condition on both left- and right-side tokens when computing each position's representation. Distinct from ELMo's late concatenation of two independently trained directions: BERT fuses both directions through every layer of the encoder.
 
-**Masked language modeling (MLM)** — BERT's pre-training objective: pick 15% of WordPiece positions, replace 80% with `[MASK]`, 10% with a random token, and 10% unchanged, then ask the model to predict the original token at the selected positions. The 80/10/10 schedule reduces pre-training/fine-tuning mismatch (real fine-tuning inputs do not contain `[MASK]`).
+**Masked language modeling (MLM)** — BERT's pre-training objective: hide or perturb selected WordPiece positions, then ask the model to predict the original tokens from both left and right context. It turns ordinary text into a self-supervised training signal for the encoder.
 
-**Next sentence prediction (NSP)** — BERT's second pre-training objective. Given two spans, the model predicts whether span B is the actual follow-on to span A in the source corpus. Tied to downstream tasks involving sentence-pair reasoning. Later work questioned NSP's necessity, but BERT's 2018 ablations treat it as a useful component.
+**Next sentence prediction (NSP)** — BERT's second pre-training objective for teaching the model to reason over paired text spans. Later work questioned NSP's necessity, but BERT's 2018 ablations treat it as a useful component.
 
 **WordPiece tokenization** — A subword tokenization scheme; BERT uses a 30,000-token WordPiece vocabulary. Subword units handle rare and morphologically complex words by composition, avoiding both character-level shortness and word-level vocabulary explosions.
 

--- a/src/content/docs/ai-history/ch-53-the-dawn-of-few-shot-learning.md
+++ b/src/content/docs/ai-history/ch-53-the-dawn-of-few-shot-learning.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-In February 2019 OpenAI's GPT-2 paper showed that a 1.5-billion-parameter Transformer language model trained on WebText could perform NLP tasks zero-shot — without per-task gradient updates. In May 2020 GPT-3 (175 billion parameters, 300 billion training tokens) made the prompt itself the task specification: examples sat inside a 2048-token context, weights stayed frozen. The reusable artifact stopped being a fine-tuned checkpoint and became a frozen model conditioned by text. Few-shot learning was the new interface.
+In February 2019 OpenAI's GPT-2 paper showed that a large Transformer language model trained on WebText could perform some NLP tasks zero-shot. In May 2020 GPT-3 made the prompt itself the task specification: examples sat inside the input context and the weights stayed frozen. The reusable artifact stopped being a fine-tuned checkpoint and became a model conditioned by text. Few-shot learning was the new interface.
 :::
 
 <details>
@@ -30,10 +30,7 @@ In February 2019 OpenAI's GPT-2 paper showed that a 1.5-billion-parameter Transf
 timeline
     title Chapter 53 — The Dawn of Few-Shot Learning
     2018 : OpenAI's first GPT establishes Transformer LM pre-training as a reusable NLP base
-    Feb 2019 : GPT-2 paper published — 1.5B-parameter model + WebText held back; 124M model released
-    May 2019 : 355M GPT-2 model released along with output datasets from all four sizes
-    Aug 2019 : 774M GPT-2 model released; first version of release-strategy / social-impact report
-    Nov 2019 : 1.5B GPT-2 model released; report and repository updated
+    Feb-Nov 2019 : OpenAI stages GPT-2 model releases and updates its release-strategy / social-impact report
     May 2020 : GPT-3 paper published — 175B parameters, 300B training tokens, 2048-token context, evaluated zero-/one-/few-shot without gradient updates
 ```
 
@@ -44,7 +41,7 @@ timeline
 
 **Autoregressive language model** — A model that generates a sequence one token at a time, each token conditioned on all previous tokens. GPT-style models use the Transformer's decoder side with causal masking; the next-token-prediction objective is what links GPT-2's web-scale pre-training to GPT-3's prompt interface.
 
-**Zero-shot / one-shot / few-shot evaluation** — Three levels of in-context conditioning. *Zero-shot:* the model receives only a task description in natural language, no demonstrations. *One-shot:* one example. *Few-shot:* several examples up to what fits in the context window. None involve gradient updates.
+**Zero-shot / one-shot / few-shot evaluation** — Three levels of in-context conditioning. *Zero-shot:* the model receives only a task description in natural language, no demonstrations. *One-shot:* one example. *Few-shot:* several examples up to what fits in the context window. The prompt, rather than a separate training run, supplies the task setup.
 
 **In-context learning** — The behavioural pattern where task performance is conditioned by examples placed inside the input prompt rather than by parameter updates. GPT-3 popularised the term while remaining careful: the paper does not claim the model learns a *new* task during the forward pass; it may be recognising patterns from pre-training.
 
@@ -52,9 +49,9 @@ timeline
 
 **Context window** — The maximum number of tokens the model can attend over at once. GPT-2: 1024 tokens. GPT-3: 2048 tokens. Both small by 2026 standards, but already large enough to hold instructions, several demonstrations, and a query for many benchmark tasks.
 
-**WebText** — The corpus OpenAI assembled for GPT-2 from outbound Reddit links with ≥3 karma, deduplicated and cleaned to about 8M documents (~40 GB). Wikipedia was deliberately excluded to reduce evaluation overlap. The dataset shows how upstream platform behaviour (Reddit upvoting) became part of the AI training pipeline.
+**WebText** — The corpus OpenAI assembled for GPT-2 from web pages selected through Reddit-linked URLs, then deduplicated and cleaned. The dataset shows how upstream platform behaviour became part of the AI training pipeline.
 
-**Staged release** — OpenAI's GPT-2 release pattern: paper + smallest model first (Feb 2019), then 355M (May), 774M (Aug), 1.5B (Nov), each accompanied by misuse-risk analysis. Made model-weight release a public-governance question, not just a research artifact decision.
+**Staged release** — OpenAI's GPT-2 release pattern: smaller public artifacts first, larger model weights later, each accompanied by misuse-risk analysis. Made model-weight release a public-governance question, not just a research artifact decision.
 
 </details>
 


### PR DESCRIPTION
## Summary
- Trim repeated reader-aid details from Ch51 TensorFlow/PyTorch/Papers with Code/reproducibility framing while preserving the sourced body anchors.
- Broaden Ch52 BERT TL;DR/timeline/glossary entries so exact pretraining, parameter, and objective mechanics remain in the body.
- Consolidate Ch53 GPT-2 staged-release details and move repeated GPT-2/GPT-3 specifics out of TL;DR/glossary.

## Checks
- git diff --check origin/main..HEAD
- ../../.venv/bin/python scripts/check_reader_aids.py ch-51 ch-52 ch-53
- rg -n '\\$[0-9]' changed Ch51-Ch53 files (no matches)\n- ../../.venv/bin/python scripts/test_pipeline.py (166 tests OK)\n- npm run build from primary checkout at 9f07506a\n\n## Notes\n- Narrow repetition-only pass; no new factual claims or source changes.\n- Diff: 3 files, 18 insertions, 21 deletions.