### PR TITLE
docs(ai-history): trim Ch54-Ch56 repetition

### DIFF
--- a/src/content/docs/ai-history/ch-54-the-hub-of-weights.md
+++ b/src/content/docs/ai-history/ch-54-the-hub-of-weights.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-Hugging Face began as a 2017 chatbot app for bored teenagers, then pivoted. The October 2018 `huggingface/transformers` repository grew into a library that turned BERT, GPT-2, and dozens of other Transformer architectures into shared infrastructure: tokenizer + base model + task head, loaded from a canonical name through Auto classes. By the 2020 EMNLP paper, the Model Hub held 2,097 user models with 400+ external contributors. The trained checkpoint became a software-package-like artifact.
+Hugging Face pivoted from a consumer chatbot into Transformer infrastructure. The October 2018 `huggingface/transformers` repository grew into a library and Model Hub that made checkpoints easier to find, load, document, fine-tune, and deploy across architectures. By the 2020 EMNLP paper, the Hub already held thousands of user models. The trained checkpoint became a software-package-like artifact.
 :::
 
 <details>
@@ -14,8 +14,8 @@ Hugging Face began as a 2017 chatbot app for bored teenagers, then pivoted. The 
 
 | Name | Lifespan | Role |
 |---|---|---|
-| Clement Delangue | — | Hugging Face co-founder and CEO; named in the 2017 TechCrunch chatbot-app coverage and the 2020 Transformers paper coauthor list |
-| Julien Chaumond | — | Hugging Face co-founder; named in the 2017 chatbot coverage; coauthor of the 2020 Transformers paper |
+| Clement Delangue | — | Hugging Face co-founder and CEO; named in the 2020 Transformers paper coauthor list |
+| Julien Chaumond | — | Hugging Face co-founder; coauthor of the 2020 Transformers paper |
 | Thomas Wolf | — | First author of the 2020 EMNLP "Transformers: State-of-the-Art Natural Language Processing" paper; central technical protagonist for the library and Model Hub |
 | Lysandre Debut | — | 2020 Transformers paper coauthor; library implementation team |
 | Victor Sanh | — | 2020 Transformers paper coauthor; led DistilBERT, an example of model compression on the Hub |
@@ -29,11 +29,11 @@ Hugging Face began as a 2017 chatbot app for bored teenagers, then pivoted. The 
 ```mermaid
 timeline
     title Chapter 54 — The Hub of Weights
-    Mar 2017 : TechCrunch describes Hugging Face as a chatbot app for bored teenagers — Delangue and Chaumond named as co-founders
+    Mar 2017 : TechCrunch covers Hugging Face's early consumer chatbot phase
     Oct 2018 : huggingface/transformers GitHub repository created (Oct 29)
     Dec 2019 : TechCrunch reports the pivot — Transformers library has 1M+ downloads and 19,000 GitHub stars
     Oct 2020 : Wolf et al. publish "Transformers: State-of-the-Art Natural Language Processing" at EMNLP System Demonstrations
-    2020 : Paper snapshot — Model Hub holds 2,097 user models; 400+ external contributors to the library
+    2020 : Paper snapshot presents the Model Hub and a large external contributor base
 ```
 
 </details>
@@ -41,15 +41,15 @@ timeline
 <details>
 <summary><strong>Plain-words glossary</strong></summary>
 
-**Model checkpoint** — A serialized snapshot of all trained parameters of a model. Distinct from source code: the *weights file* carries the expensive learning result; without it, the architecture is empty. The checkpoint plus its tokenizer plus its config plus its task head is the runnable artifact.
+**Model checkpoint** — A serialized snapshot of all trained parameters of a model. Distinct from source code: the *weights file* carries the expensive learning result; without it, the architecture is empty.
 
-**Tokenizer (model-specific)** — The pipeline that converts raw text into the integer IDs the model expects. BERT's WordPiece, GPT-2's byte-level BPE, and SentencePiece variants are not interchangeable: a model trained against one tokenizer breaks if loaded with another. The tokenizer is a *companion artifact* to the weights, not a preprocessing footnote.
+**Tokenizer (model-specific)** — The pipeline that converts raw text into the integer IDs the model expects. Tokenizers are companion artifacts to weights because a model is trained against a particular text-to-token convention.
 
-**Task head** — A small output layer that adapts a base model to a specific task: classification, token labeling, span prediction, generation. The Transformers library kept the *base model + head* relationship explicit so one pre-trained encoder could serve many task layouts.
+**Task head** — A small output layer that adapts a model body to a specific task such as classification, token labeling, span prediction, or generation.
 
-**Auto classes** — `AutoTokenizer`, `AutoModel`, `AutoModelForSequenceClassification`, etc. — convenience classes that read a model's config file and instantiate the right architecture-specific class for that name. Make `from_pretrained("bert-base-uncased")` work the same way `from_pretrained("gpt2")` does.
+**Auto classes** — Convenience classes that read model metadata and instantiate the appropriate tokenizer or architecture-specific model class, so users do not have to select every implementation detail manually.
 
-**Model Hub** — Hugging Face's web platform where models live as named, versioned repositories with metadata, downloads, and (later) live inference widgets. The 2020 paper's snapshot of 2,097 user models is historical; the Hub now holds millions.
+**Model Hub** — Hugging Face's web platform where models live as named, versioned repositories with metadata, downloads, and later live inference widgets.
 
 **Model card** — A documentation file accompanying a model, describing what it was trained on, what tasks it is intended for, known limitations, biases, license, and citation. Origin: Mitchell et al. 2019 "Model Cards for Model Reporting." Distribution proximity (the card sits on the model page) is what makes the convention practical.
 
@@ -105,7 +105,7 @@ Task heads gave reuse another layer. A base language model might be useful for m
 
 The head abstraction also helped explain why pretrained models were not finished applications. A base encoder can represent text, but a user still has to decide what task is being solved and how outputs should be interpreted. The library could provide common heads and examples, but the downstream problem remained real. That distinction kept the infrastructure honest: reuse reduces friction; it does not remove the need for task design.
 
-The Model Hub extended the pattern from code to distribution. In the 2020 paper's snapshot, the Model Hub held 2,097 user models. That number should be treated as historical, not current. Its importance is that the hub already existed as a community distribution mechanism by the time the paper was written. Models could have canonical names, model pages, metadata, model cards, citations, datasets, caveats, live inference widgets, benchmark links, and visualizations.
+The Model Hub extended the pattern from code to distribution. In the 2020 paper's snapshot, the Model Hub held 2,097 user models, and the library had more than 400 external contributors. Those numbers should be treated as historical, not current. Their importance is that the hub already existed as a community distribution mechanism by the time the paper was written. Models could have canonical names, model pages, metadata, model cards, citations, datasets, caveats, live inference widgets, benchmark links, and visualizations.
 
 The canonical name is a small but powerful device. A model with a stable name can be referenced in code, documentation, examples, and discussions. A user can load it, cache it, and share instructions that others can repeat. The paper's example using FlauBERT shows the shape: one call loads the tokenizer, another loads the model. The point is not a marketing claim about "three lines of code"; it is that the hub and library together made download, cache, and run behavior part of a common workflow.
 

--- a/src/content/docs/ai-history/ch-55-the-scaling-laws.md
+++ b/src/content/docs/ai-history/ch-55-the-scaling-laws.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-In January 2020, Kaplan, McCandlish, and OpenAI colleagues published "Scaling Laws for Neural Language Models": over more than seven orders of magnitude, autoregressive Transformer cross-entropy loss followed power-law relationships with parameters (N), tokens (D), and compute (C), with all three needed in tandem. Compute-optimal training favoured larger models stopped short of convergence. In March 2022 Hoffmann et al.'s Chinchilla refined the recipe — model size and tokens should scale roughly equally. Scaling became forecastable engineering.
+In January 2020, Kaplan, McCandlish, and OpenAI colleagues published "Scaling Laws for Neural Language Models": over more than seven orders of magnitude, autoregressive Transformer cross-entropy loss followed power-law relationships with parameters (N), tokens (D), and compute (C), with all three needed in tandem. Compute-optimal training made scale feel like a planning problem, and Chinchilla later revised the allocation by putting more weight on training data. Scaling became forecastable engineering.
 :::
 
 <details>
@@ -18,8 +18,8 @@ In January 2020, Kaplan, McCandlish, and OpenAI colleagues published "Scaling La
 | Sam McCandlish | — | Equal-contribution lead author of Kaplan et al. 2020 |
 | Tom B. Brown | — | Kaplan paper coauthor; later GPT-3 lead author (Ch53) |
 | Dario Amodei | — | Kaplan paper coauthor (project guidance); later Anthropic co-founder |
-| Richard S. Sutton | 1959– | Author of "The Bitter Lesson" (2019); philosophical framing for general methods that leverage computation |
-| Jordan Hoffmann | — | DeepMind lead author of "Training Compute-Optimal Large Language Models" (2022) — the Chinchilla correction |
+| Richard S. Sutton | 1959– | Author of "The Bitter Lesson" (2019); philosophical backdrop to the scaling-law era |
+| Jordan Hoffmann | — | DeepMind lead author of "Training Compute-Optimal Large Language Models" (2022) |
 
 </details>
 
@@ -29,10 +29,10 @@ In January 2020, Kaplan, McCandlish, and OpenAI colleagues published "Scaling La
 ```mermaid
 timeline
     title Chapter 55 — The Scaling Laws
-    2019 : Sutton publishes "The Bitter Lesson" — general methods that leverage computation tend to win
+    2019 : Sutton publishes "The Bitter Lesson"
     Jan 2020 : Kaplan et al. publish "Scaling Laws for Neural Language Models" (arXiv:2001.08361) — power-law fits across 7+ orders of magnitude
     May 2020 : GPT-3 paper (Ch53) cites scaling-law frame as part of the rationale for testing 175B parameters
-    Mar 2022 : Hoffmann et al. publish "Training Compute-Optimal Large Language Models" — Chinchilla; many prior LLMs were undertrained
+    Mar 2022 : Hoffmann et al. publish "Training Compute-Optimal Large Language Models" — Chinchilla revises compute-optimal allocation
 ```
 
 </details>
@@ -42,17 +42,15 @@ timeline
 
 **Cross-entropy loss** — How surprised the model is by the next token in held-out text. Lower is better. The scaling laws are about *this* number: not "intelligence", not benchmark accuracy, not user satisfaction — just the prediction loss on autoregressive language modelling.
 
-**Power law** — A relation $y = a \cdot x^{-\alpha}$ where output changes as input is raised to a power. Plotted on log–log axes, power laws appear as approximately straight lines. The chapter's "smoothness" claim is this visual regularity.
-
 **Parameters (N), tokens (D), compute (C)** — The three knobs Kaplan studied. *Parameters* are the model's adjustable numbers (capacity). *Tokens* are the text the model trains on (experience). *Compute* is FLOPs spent during training (work). The paper's "all three must scale in tandem" rule means a bottleneck in any one stalls the gain from the other two.
 
-**Compute-optimal training** — Under a *fixed* compute budget, the question of which N and D minimise loss. Kaplan's 2020 answer favoured training very large models for relatively few steps. Chinchilla's 2022 answer was *equal* scaling: doubling compute should double both parameters and tokens.
+**Compute-optimal training** — Under a *fixed* compute budget, the question of how to allocate model size, training data, and run length to minimise loss. The answer is empirical and can change as measurement improves.
 
 **Sample efficiency** — How well a model uses each training token. Kaplan reports that larger models reach a target loss with fewer optimisation steps and fewer training points than smaller models — which is what makes "bigger but shorter" sensible under a compute budget.
 
-**The Bitter Lesson** — Sutton's 2019 essay arguing that, across decades of AI history (chess, Go, speech, vision), general methods that scale with computation eventually win against approaches that hand-encode human knowledge. Cultural backdrop to Kaplan; not evidence for the equations.
+**The Bitter Lesson** — Sutton's 2019 essay that became a cultural backdrop to the scaling-law era. It is a research instinct and historical argument, not evidence for the Kaplan equations.
 
-**Kaplan vs. Chinchilla allocation** — Two empirical answers to the compute-optimal question. Kaplan ≈ "model bigger, train shorter." Chinchilla ≈ "scale model and data equally." Both are *empirical fits* in tested regimes, not natural laws.
+**Kaplan vs. Chinchilla allocation** — Two empirical answers to the compute-optimal question. Both are *empirical fits* in tested regimes, not natural laws.
 
 </details>
 

--- a/src/content/docs/ai-history/ch-56-the-megacluster.md
+++ b/src/content/docs/ai-history/ch-56-the-megacluster.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-On March 11, 2019 OpenAI announced OpenAI LP — a capped-profit structure under nonprofit control, designed to raise the billions in capital its scaling roadmap required. Four months later (July 22, 2019) a $1B Microsoft investment locked in an exclusive Azure computing partnership. By May 19, 2020 Microsoft had publicly disclosed an Azure supercomputer built for OpenAI: 285,000+ CPU cores, 10,000 GPUs, 400 Gbps per GPU server. Scaling-law forecasts had become datacenter procurement.
+In 2019 OpenAI changed its corporate structure so it could raise the capital its scaling roadmap required, then formed a major Azure computing partnership with Microsoft. By May 2020 Microsoft had publicly disclosed an Azure supercomputer built for OpenAI. Scaling-law forecasts had become datacenter procurement.
 :::
 
 <details>
@@ -29,10 +29,10 @@ On March 11, 2019 OpenAI announced OpenAI LP — a capped-profit structure under
 ```mermaid
 timeline
     title Chapter 56 — The Megacluster
-    Mar 11 2019 : OpenAI announces OpenAI LP — capped-profit structure under nonprofit control
-    Jul 22 2019 : Microsoft and OpenAI announce $1B exclusive computing partnership; OpenAI services move to Azure
-    Feb 13 2020 : Microsoft Research announces Turing-NLG (17B params) — DeepSpeed, ZeRO, model parallelism
-    May 19 2020 : Microsoft discloses Azure supercomputer for OpenAI — 285,000+ CPU cores, 10,000 GPUs, 400 Gbps per GPU server
+    Mar 11 2019 : OpenAI announces OpenAI LP
+    Jul 22 2019 : Microsoft and OpenAI announce a major Azure computing partnership
+    Feb 13 2020 : Microsoft Research announces Turing-NLG alongside DeepSpeed, ZeRO, and model parallelism
+    May 19 2020 : Microsoft discloses an Azure supercomputer for OpenAI
     May 2020 : Microsoft frames the supercomputer as part of "AI at Scale" — large models + tools + supercomputing on Azure
 ```
 
@@ -41,7 +41,7 @@ timeline
 <details>
 <summary><strong>Plain-words glossary</strong></summary>
 
-**Capped-profit structure** — A hybrid corporate form OpenAI introduced in March 2019. Investor and employee returns are limited to a multiple of investment; returns beyond the cap flow to the OpenAI Nonprofit, which retains control. Designed to raise the billions of dollars compute and talent require while keeping mission-first governance.
+**Capped-profit structure** — A hybrid corporate form in which investor and employee returns are limited while a nonprofit parent retains control. In OpenAI's case, the structure was presented as a way to fund compute-intensive scaling while preserving mission-first governance.
 
 **Hyperscaler / hyperscale cloud** — A small set of cloud providers (Microsoft Azure, Amazon AWS, Google Cloud) operating at the global-datacenter scale where they can offer customers the kind of infrastructure customers cannot easily build themselves. Frontier-AI training is now a hyperscaler-only workload.
 
@@ -49,9 +49,9 @@ timeline
 
 **Distributed training (model parallelism, data parallelism, pipeline parallelism)** — The systems-software layer that splits a model and its training batches across many devices. *Data parallelism* replicates the model and partitions the batch. *Model parallelism* partitions the model itself across devices. *Pipeline parallelism* stages forward and backward passes through the model. Modern frameworks like DeepSpeed and ZeRO combine all three.
 
-**DeepSpeed / ZeRO** — Microsoft Research's open-source distributed-training stack. *ZeRO* (Zero Redundancy Optimizer) shards optimizer state, gradients, and (later) parameters across data-parallel workers, dramatically reducing per-GPU memory. Made Turing-NLG (17B parameters) trainable on the available hardware in early 2020.
+**DeepSpeed / ZeRO** — Microsoft Research's open-source distributed-training stack. *ZeRO* (Zero Redundancy Optimizer) shards optimizer state, gradients, and later parameters across data-parallel workers, reducing per-GPU memory pressure.
 
-**400 Gbps per GPU server** — The Azure supercomputer's per-server interconnect bandwidth as publicly disclosed. Necessary because gradient synchronisation across 10,000 GPUs becomes the bottleneck before compute does; without high-bandwidth networking, the cluster behaves like many small clusters rather than one machine.
+**GPU-server interconnect bandwidth** — The network capacity linking accelerator servers during distributed training. Necessary because gradient synchronisation can become the bottleneck before compute does; without high-bandwidth networking, a large cluster behaves like many small clusters rather than one machine.
 
 **AI at Scale** — Microsoft's 2020 platform-level framing for the OpenAI supercomputer + DeepSpeed + Turing-NLG bundle: large models, training optimisation tools, and supercomputing made available through Azure AI services and GitHub.
 


### PR DESCRIPTION
## Summary
- Trim Ch54 reader-aid echoes around Hugging Face origin details, Model Hub counts, and adapter-layer glossary spoilers while preserving body anchors.
- Trim Ch55 Chinchilla/Sutton/power-law reader-aid repetition while leaving the math box and sourced prose intact.
- Trim Ch56 corporate-structure, Microsoft partnership, Turing-NLG, and Azure supercomputer statistic echoes while preserving the body evidence.

## Checks
- git diff --check origin/main..HEAD
- ../../.venv/bin/python scripts/check_reader_aids.py ch-54 ch-55 ch-56
- rg -n '\\$[0-9]' changed Ch54-Ch56 files (only legitimate `$1 billion` body anchors in Ch56)\n- ../../.venv/bin/python scripts/test_pipeline.py (166 tests OK)\n- npm run build from primary checkout at 5de1363f\n\n## Notes\n- Narrow repetition-only pass; no new source claims or citation changes.\n- Diff: 3 files, 26 insertions, 28 deletions.