### PR TITLE
docs(ai-history): trim Ch57-Ch59 repetition

### DIFF
--- a/src/content/docs/ai-history/ch-57-the-alignment-problem.md
+++ b/src/content/docs/ai-history/ch-57-the-alignment-problem.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-On January 27, 2022 OpenAI announced InstructGPT — a layer over GPT-3 that turned next-token predictors into instruction-followers using RLHF: about 40 contracted labelers wrote demonstrations, ranked outputs, and trained a reward model that PPO then optimized. The method traced back to Christiano et al. 2017 (preferences over Atari clips) via Stiennon et al. 2020 (summarization). InstructGPT became the default API model. Alignment became a trainable behavioural layer — but only over sampled preferences, not "humanity."
+On January 27, 2022 OpenAI announced InstructGPT — a layer over GPT-3 that used human feedback to turn next-token predictors into better instruction-followers. The method drew on earlier preference-learning work and became the default API model. Alignment became a trainable behavioural layer, improving the assistant interface without settling the broader alignment problem.
 :::
 
 <details>
@@ -14,12 +14,12 @@ On January 27, 2022 OpenAI announced InstructGPT — a layer over GPT-3 that tur
 
 | Name | Lifespan | Role |
 |---|---|---|
-| Paul Christiano | — | Co-author of the 2017 "Deep RL from human preferences" paper; co-author of InstructGPT; method-lineage protagonist for reward learning from comparisons |
-| Long Ouyang | — | Lead author of the March 2022 "Training language models to follow instructions with human feedback" paper detailing the InstructGPT pipeline |
+| Paul Christiano | — | Co-author of the 2017 "Deep RL from human preferences" paper; co-author of InstructGPT |
+| Long Ouyang | — | Lead author of the March 2022 "Training language models to follow instructions with human feedback" paper |
 | Jan Leike | — | OpenAI alignment lead; co-author of the InstructGPT blog and paper |
 | Ryan Lowe | — | OpenAI alignment co-lead; co-author of the InstructGPT blog and paper |
-| Nisan Stiennon | — | Lead author of the 2020 "Learning to Summarize from Human Feedback" paper; bridge from preference-RL to language-model outputs |
-| OpenAI labelers (~40 contractors via Upwork & ScaleAI) | — | Central human-labour layer per Ouyang §3.4: screened and trained to write demonstrations, rank outputs, and evaluate model behaviour |
+| Nisan Stiennon | — | Lead author of the 2020 "Learning to Summarize from Human Feedback" paper |
+| OpenAI labelers | — | Central human-labour layer for demonstrations, rankings, and model-behaviour evaluation |
 
 </details>
 
@@ -29,11 +29,11 @@ On January 27, 2022 OpenAI announced InstructGPT — a layer over GPT-3 that tur
 ```mermaid
 timeline
     title Chapter 57 — The Alignment Problem
-    2017 : Christiano et al. publish "Deep RL from Human Preferences" — comparison-trained reward model on Atari and simulated robotics
-    2020 : Stiennon et al. publish "Learning to Summarize from Human Feedback" — comparison/reward-model/PPO pattern applied to language outputs
+    2017 : Christiano et al. publish "Deep RL from Human Preferences"
+    2020 : Stiennon et al. publish "Learning to Summarize from Human Feedback"
     Jan 2021 : Earlier InstructGPT version deployed in OpenAI API Playground; prompts later filtered into training source
     Jan 27 2022 : OpenAI publishes "Aligning language models to follow instructions" blog — InstructGPT becomes default API model
-    Mar 2022 : Ouyang et al. release detailed paper on arXiv — full RLHF pipeline, results, and limitations
+    Mar 2022 : Ouyang et al. release detailed InstructGPT paper on arXiv
 ```
 
 </details>
@@ -43,15 +43,15 @@ timeline
 
 **Alignment** — The problem of making powerful AI systems pursue goals compatible with what their users (and broader society) actually want. *Narrow* alignment is the InstructGPT scope: making a model follow user intent on a measured prompt distribution. *Broad* alignment includes truthfulness, refusal of harm, value pluralism, and robust behaviour outside the training distribution.
 
-**RLHF (Reinforcement Learning from Human Feedback)** — The InstructGPT recipe in three stages. (1) *SFT*: fine-tune the base model on human-written demonstrations. (2) *Reward modelling*: collect ranked comparisons of model outputs from labellers; train a reward model to predict which output a human would prefer. (3) *RL*: use PPO to optimize the language model against the reward model, with a KL penalty against the SFT model to prevent over-optimization.
+**RLHF (Reinforcement Learning from Human Feedback)** — A training approach that uses human judgments about model outputs to steer a pretrained model toward preferred behaviour. In InstructGPT, it supplied a behavioural layer on top of GPT-3 rather than replacing pretraining.
 
-**Reward model** — A learned model that takes a prompt + candidate response and returns a scalar score predicting human preference. A *proxy* for human judgment: usable by an optimizer, but inheriting the limits of the labellers, instructions, interface, and prompt distribution that produced its training data.
+**Reward model** — A learned proxy for human judgment that scores candidate responses. It is usable by an optimizer, but it inherits the limits of the labellers, instructions, interface, and prompt distribution that produced its training data.
 
-**PPO (Proximal Policy Optimization)** — The reinforcement-learning algorithm Ouyang et al. used to optimize the language model against the reward model. The *proximal* part keeps each policy update close to the previous policy via a clipped objective, which prevents destabilizing collapse during training.
+**PPO (Proximal Policy Optimization)** — A reinforcement-learning algorithm used to update a policy while keeping changes controlled enough to avoid destabilizing jumps.
 
 **Preference comparison** — A data point of the form "given prompt P, response A is better than response B." Easier for humans to produce than absolute scores or full rule specifications. Christiano's 2017 insight: comparisons can replace explicit reward engineering when the true goal is hard to specify in code.
 
-**Demonstration / supervised fine-tuning (SFT)** — Stage 1 of RLHF. Labellers write the desired response to a prompt, and the base model is fine-tuned on `(prompt, response)` pairs in a standard supervised-learning setup. SFT alone produces a usable instruction-follower; RLHF adds the reward-model + PPO stages on top.
+**Demonstration / supervised fine-tuning (SFT)** — Human-written examples of desired responses used to teach the base model the shape of instruction-following behaviour.
 
 **Instruction following** — The behavioural property RLHF was designed to install: when given an instruction, the model attempts to do the instructed task rather than continuing the most-likely-next-text continuation that pretraining alone would produce. Distinct from *capability*: a base GPT-3 already had the capability; RLHF added the linkage between user intent and model response.
 

--- a/src/content/docs/ai-history/ch-58-the-math-of-noise.md
+++ b/src/content/docs/ai-history/ch-58-the-math-of-noise.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-Image generation crossed a different threshold than text. In 2015, Sohl-Dickstein et al. framed generation as forward diffusion (data → noise) plus a learned reverse diffusion (noise → data). Ho et al. (2020) made the recipe practical with DDPMs and noise-prediction training. Dhariwal and Nichol (2021) beat GANs on benchmarks. Rombach et al. (2021/22) moved denoising from pixel space into a compressed autoencoder *latent* with cross-attention conditioning. On August 22, 2022 Stability AI released Stable Diffusion publicly. Noise had become a medium.
+Image generation crossed a different threshold than text. In 2015, Sohl-Dickstein et al. framed generation as a controlled path from data to noise and back again. Ho et al. (2020) made diffusion models practical for high-quality images. Dhariwal and Nichol (2021) beat GANs on benchmarks. Rombach et al. (2021/22) moved the expensive work into a cheaper latent representation, feeding the Stable Diffusion release in August 2022. Noise had become a medium.
 :::
 
 <details>
@@ -15,11 +15,11 @@ Image generation crossed a different threshold than text. In 2015, Sohl-Dickstei
 | Name | Lifespan | Role |
 |---|---|---|
 | Jascha Sohl-Dickstein | — | Lead author of the 2015 nonequilibrium-thermodynamics diffusion paper; physics/Markov-chain origin story |
-| Jonathan Ho | — | Lead author of DDPM (2020) and co-author of classifier-free guidance; noise-prediction parameterization |
+| Jonathan Ho | — | Lead author of DDPM (2020) and co-author of classifier-free guidance |
 | Pieter Abbeel | — | DDPM co-author (Berkeley); broader RL/robotics lab context for the diffusion line |
 | Prafulla Dhariwal & Alex Nichol | — | OpenAI authors of "Diffusion Models Beat GANs on Image Synthesis" (2021); benchmark-break + classifier guidance |
-| Robin Rombach & Patrick Esser | — | Latent-diffusion authors (CompVis/LMU + Runway); compressed-latent shift that feeds Stable Diffusion |
-| Stability AI / CompVis / Runway | — | Institutional actors: CompVis built latent diffusion; Stability AI funded the 4,000-A100 training run and published Stable Diffusion v1 |
+| Robin Rombach & Patrick Esser | — | Latent-diffusion authors (CompVis/LMU + Runway); research line that feeds Stable Diffusion |
+| Stability AI / CompVis / Runway | — | Institutional actors: CompVis built latent diffusion; Stability AI funded the training run and published Stable Diffusion v1 |
 
 </details>
 
@@ -30,10 +30,10 @@ Image generation crossed a different threshold than text. In 2015, Sohl-Dickstei
 timeline
     title Chapter 58 — The Math of Noise
     2015 : Sohl-Dickstein et al. publish "Deep Unsupervised Learning using Nonequilibrium Thermodynamics" — generation as forward diffusion + learned reverse
-    2020 : Ho, Jain, Abbeel publish DDPM — noise-prediction parameterisation, U-Net backbone, high-quality image synthesis
+    2020 : Ho, Jain, Abbeel publish DDPM — diffusion becomes a practical high-quality image model
     2021 : Dhariwal and Nichol publish "Diffusion Models Beat GANs on Image Synthesis" — classifier guidance + improved architecture
-    2021/22 : Rombach et al. publish latent diffusion — denoise in autoencoder latent space, cross-attention conditioning
-    Aug 10 2022 : Stability AI announces researcher release of Stable Diffusion — 4,000-A100 cluster, LAION-Aesthetics
+    2021/22 : Rombach et al. publish latent diffusion
+    Aug 10 2022 : Stability AI announces researcher release of Stable Diffusion
     Aug 22 2022 : Stability AI publicly releases Stable Diffusion v1.4 — weights + code + model card + safety classifier under OpenRAIL-M license
 ```
 
@@ -44,17 +44,17 @@ timeline
 
 **Forward diffusion / reverse diffusion** — Two coupled Markov chains. *Forward* gradually corrupts a data sample by adding small amounts of Gaussian noise across many timesteps until the sample is indistinguishable from pure noise. *Reverse* is the learned chain that walks back: given a noisy state and a timestep, produce a slightly less-noisy state. Generation is sampling random noise and running the reverse chain to completion.
 
-**DDPM (Denoising Diffusion Probabilistic Model)** — Ho, Jain, and Abbeel 2020. Specifies the forward chain as fixed-variance Gaussian noise on a schedule, the reverse chain as learned Gaussian transitions, and reparameterizes the training target to *predict the noise* added at each step rather than the clean image directly. This noise-prediction simplification is what made diffusion practical.
+**DDPM (Denoising Diffusion Probabilistic Model)** — Ho, Jain, and Abbeel's 2020 formulation that made diffusion a practical image-generation method by turning the reverse process into a learnable denoising problem.
 
-**Noise-prediction objective ($\epsilon$-prediction)** — During training, sample a clean image $x_0$, sample noise $\epsilon$, and a timestep $t$; produce the noisy state $x_t$ from a known formula; train the network to predict $\epsilon$. Loss is mean-squared error between predicted and actual noise. At sampling time, the same network's prediction is used to step $x_t \to x_{t-1}$.
+**Noise-prediction objective ($\epsilon$-prediction)** — A DDPM training target where the network learns to identify the noise component in a corrupted sample. The math box gives the exact sampling formula and loss.
 
-**U-Net backbone** — The convolutional encoder-decoder architecture (originally for biomedical segmentation) DDPM used as its denoiser. Combines broad-context downsampling with skip connections that preserve spatial detail; well-suited to image-shape outputs that diffusion needs at every step.
+**U-Net backbone** — A convolutional encoder-decoder architecture used as the denoiser in many diffusion models. Its shape helps combine broad image context with local spatial detail.
 
 **Classifier guidance / classifier-free guidance** — Two ways to make conditional samples follow a target class or text. *Classifier guidance* uses a separate classifier to push samples toward the desired class. *Classifier-free guidance* (Ho & Salimans) trains conditional and unconditional models jointly and mixes their score estimates at sampling time — the underlying mechanism behind "prompt strength" in modern image generators.
 
-**Latent diffusion** — Rombach et al. 2021/22. Train an autoencoder that compresses an image (e.g., 512×512) into a much smaller latent (e.g., 64×64), then run the diffusion process *in the latent space* rather than in pixels. Cuts compute cost by roughly the spatial-compression factor while preserving perceptual quality. This is what made Stable Diffusion runnable on consumer GPUs.
+**Latent diffusion** — Rombach et al.'s shift from running diffusion directly over pixels to running it inside a compressed learned representation. The point is cheaper iterative generation while preserving perceptual quality.
 
-**Cross-attention conditioning** — The mechanism by which latent diffusion accepts text prompts: text is encoded (CLIP text encoder, in Stable Diffusion v1), then the diffusion U-Net's intermediate layers attend over the text embeddings via cross-attention. Conditioning is mixed in at every layer, not just at the start.
+**Cross-attention conditioning** — A conditioning mechanism that lets the denoising model use information from another source, such as text embeddings, while it updates the image representation.
 
 </details>
 
@@ -101,7 +101,7 @@ flowchart LR
     DEC --> OUT["Output pixel image"]
 ```
 
-The frozen autoencoder is what makes latent diffusion cheap; the U-Net with cross-attention is where text conditioning enters at every layer; the schedule $\{\beta_t\}$ is fixed at training time and reused at sampling. Stable Diffusion v1 ran ~50 sampling steps to produce a 512×512 image on a single consumer GPU — a constant the public shock would build on.
+The frozen autoencoder is what makes latent diffusion cheap; the U-Net with cross-attention is where text conditioning enters at every layer; the schedule $\{\beta_t\}$ is fixed at training time and reused at sampling.
 
 </details>
 

--- a/src/content/docs/ai-history/ch-59-the-product-shock.md
+++ b/src/content/docs/ai-history/ch-59-the-product-shock.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-On November 30, 2022 OpenAI launched ChatGPT as a free research preview — a chat box wrapping a GPT-3.5 model fine-tuned with RLHF on Azure supercomputing. The break was not new science but packaging: conversational turn-taking turned model behaviour into consumer habit. Reuters/UBS estimated 100M monthly active users by January 2023, the fastest-growing consumer application at that time. Stack Overflow banned generated answers, NYC schools blocked it, and Microsoft's Bing and Google's Bard launched within ten days of each other.
+On November 30, 2022 OpenAI launched ChatGPT as a free research preview — a chat box wrapping a GPT-3.5 model fine-tuned with RLHF on Azure supercomputing. The break was not new science but packaging: conversational turn-taking turned model behaviour into consumer habit. Record-breaking consumer adoption forced institutions, competitors, and users to react, while Microsoft's Bing and Google's Bard launched within ten days of each other.
 :::
 
 <details>
@@ -19,7 +19,7 @@ On November 30, 2022 OpenAI launched ChatGPT as a free research preview — a ch
 | Satya Nadella | — | Microsoft CEO; anchors the January 2023 OpenAI partnership extension and the Bing/search response |
 | Yusuf Mehdi | — | Microsoft executive author of the February 7, 2023 AI-powered Bing and Edge announcement |
 | Sundar Pichai | — | Google/Alphabet CEO; author of the February 6, 2023 Bard and AI-Search post |
-| Jenna Lyle | — | NYC education department spokesperson quoted by Chalkbeat on the school-device/network block |
+| Jenna Lyle | — | NYC education department spokesperson quoted by Chalkbeat during the early school-policy reaction |
 
 </details>
 
@@ -30,9 +30,9 @@ On November 30, 2022 OpenAI launched ChatGPT as a free research preview — a ch
 timeline
     title Chapter 59 — The Product Shock
     Nov 30 2022 : OpenAI launches ChatGPT as a free research preview
-    Dec 5 2022 : Stack Overflow posts the temporary ban on generative AI content; Altman reports ChatGPT crossed 1M users
-    Jan 3 2023 : NYC education department confirms ChatGPT blocked on school devices and networks
-    Jan 2023 : Reuters relays UBS estimate of 100M monthly active users
+    Dec 5 2022 : Early public adoption and moderation pressure become visible
+    Jan 3 2023 : NYC education department confirms an early ChatGPT school-access restriction
+    Jan 2023 : Reuters relays UBS estimate of record consumer adoption
     Jan 23 2023 : Microsoft announces the third phase of its OpenAI partnership
     Feb 1 2023 : OpenAI announces ChatGPT Plus at $20/month
     Feb 6 2023 : Google announces Bard and AI-powered Search features
@@ -46,11 +46,11 @@ timeline
 <details>
 <summary><strong>Plain-words glossary</strong></summary>
 
-**Research preview** — OpenAI's framing for the ChatGPT launch: free public access while the company gathered user feedback to find strengths, weaknesses, and failure modes. The label sounded provisional, but the product was deployed at scale to millions of users from day one.
+**Research preview** — OpenAI's framing for the ChatGPT launch: free public access while the company gathered user feedback to find strengths, weaknesses, and failure modes.
 
 **RLHF (Reinforcement Learning from Human Feedback)** — The training method that shaped ChatGPT's conversational behaviour: supervised fine-tuning on dialogues written by human AI trainers, comparison/ranking data, a learned reward model, and Proximal Policy Optimization. Inherited from InstructGPT (Ch57); ChatGPT made it the default assistant interface.
 
-**Monthly active users (MAU)** — A standard product metric: distinct users who interact with a service in a 30-day window. The Reuters/UBS estimate of 100M MAU in January 2023 is what made ChatGPT a coordination problem for executives, schools, regulators, and competitors rather than a research demo.
+**Monthly active users (MAU)** — A standard product metric: distinct users who interact with a service in a 30-day window. In this chapter it matters because adoption scale turned ChatGPT from a research demo into an institutional coordination problem.
 
 **ChatGPT Plus** — OpenAI's first paid tier, announced February 1, 2023 at $20/month. It sold reliability under load — general access during peak times, faster responses, priority on new features — while preserving the free tier. Demand had made inference itself a consumer expectation.
 
@@ -58,7 +58,7 @@ timeline
 
 **Jailbreak / adversarial prompting** — User prompts crafted to route around a model's safety policy or refusal behaviour. The GPT-4 System Card (March 2023) explicitly treats jailbreaks as a deployment surface: mitigations reduce but do not eliminate them, and Figure 10 walks through example exploits against GPT-4-launch.
 
-**Hallucination** — Plausible but incorrect output. OpenAI's launch page warned ChatGPT could produce confident wrong answers, and the GPT-4 page kept the warning. Plausible wrongness is what made Stack Overflow and NYC schools react: cheap to produce, expensive to verify.
+**Hallucination** — Plausible but incorrect output. OpenAI's launch page warned ChatGPT could produce confident wrong answers, and the GPT-4 page kept the warning. Plausible wrongness is cheap to produce and expensive to verify.
 
 </details>
 
@@ -189,4 +189,3 @@ That question belongs to the next chapter. The product shock was the moment the 
 :::note[Why this still matters today]
 Almost every consumer-facing AI product after late 2022 borrows ChatGPT's grammar — a chat box, conversational turn-taking, visible refusals, a feedback button, a paid tier sold on capacity rather than only capability. Search engines now ship synthesised answers above link lists. Productivity tools embed conversational drafting into documents, mail, and code editors. Schools, publishers, and Q&A communities still litigate the line between fluent generation and verifiable expertise that Stack Overflow and NYC schools first hit in late 2022. The product shock also normalised release rhythm — usage caps, waitlists, subscription tiers, and capacity warnings — as part of how frontier capability reaches users.
 :::
-


### PR DESCRIPTION
## Summary
- trim repeated RLHF pipeline details from Ch57 reader aids while leaving the full body explanation intact
- broaden Ch58 diffusion/latent-diffusion reader aids so the math and body carry the exact mechanics
- reduce Ch59 preview/adoption/school-policy echoes while preserving the body anchors

## Checks
- git diff --check origin/main..HEAD
- ../../.venv/bin/python scripts/check_reader_aids.py ch-57 ch-58 ch-59
- rg -n "\$[0-9]" src/content/docs/ai-history/ch-57-the-alignment-problem.md src/content/docs/ai-history/ch-58-the-math-of-noise.md src/content/docs/ai-history/ch-59-the-product-shock.md (only legitimate ChatGPT Plus $20 anchors)
- ../../.venv/bin/python scripts/test_pipeline.py (166 tests)
- npm run build (primary checkout detached at 7910d84c; restored to main)

Cross-family review will be posted before merge.