### PR TITLE
docs(ai-history): trim Ch60-Ch62 repetition

### DIFF
--- a/src/content/docs/ai-history/ch-60-the-agent-turn.md
+++ b/src/content/docs/ai-history/ch-60-the-agent-turn.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-After ChatGPT, the architectural problem shifted from making models talk to letting them act. RAG gave models external memory; WebGPT taught them to search and cite; chain-of-thought made reasoning a visible scratchpad; ReAct and Toolformer fused reasoning with tool calls; OpenAI's plugins and function calling productized the interface; LangChain and AutoGPT made agent loops legible to developers. Early agents were brittle, not autonomous workers — but the center of AI applications moved from a single chat reply to model-plus-retriever-plus-tools systems.
+After ChatGPT, the architectural problem shifted from making models talk to letting them act. The next wave connected language models to memory, search, tools, schemas, and software loops. Early agents were brittle, not autonomous workers, but the center of AI applications moved from a single chat reply toward systems that could consult external state, call capabilities, and report back through a model.
 :::
 
 <details>
@@ -48,11 +48,11 @@ timeline
 <details>
 <summary><strong>Plain-words glossary</strong></summary>
 
-- **Parametric memory** — what the model "knows" because it is baked into the weights from training. Hard to inspect, expensive to update.
-- **Non-parametric memory** — knowledge stored outside the model in documents, indexes, or vector stores. Can be swapped or refreshed without retraining.
+- **Parametric memory** — information represented inside the model's learned weights.
+- **Non-parametric memory** — information kept outside the model in a retrievable store.
 - **Retrieval-augmented generation (RAG)** — a pattern where the model answers using passages fetched from an external store at query time, not just from its weights.
 - **Chain-of-thought** — prompting the model to write intermediate reasoning steps before its final answer; a scratchpad pattern, not a window into the model's actual computation.
-- **ReAct loop** — interleaving thought, action, and observation: the model reasons, calls a tool, reads what came back, then reasons again.
+- **ReAct loop** — a prompting pattern that connects reasoning text with actions in an external environment.
 - **Function calling** — a structured interface where the developer describes functions and the model emits JSON arguments; the surrounding software, not the model, decides whether to execute.
 - **Prompt injection** — instructions hidden inside untrusted text (a webpage, document, or tool output) that try to hijack a tool-using model.
 
@@ -209,4 +209,3 @@ The architecture this chapter describes is what every modern AI application is m
 :::
 
 The public had met the assistant in Chapter 59. In Chapter 60, builders tried to give that assistant memory and hands. The result was powerful, unstable, and unfinished. It pointed toward the next constraint: once models act through tools, the cost of every token, every retrieval, every function call, and every retry starts to matter. The agent turn made language models operational. It also made their limits operational.
-

--- a/src/content/docs/ai-history/ch-61-the-physics-of-scale.md
+++ b/src/content/docs/ai-history/ch-61-the-physics-of-scale.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-The post-GPT era scaled because engineers learned to split one training run across thousands of accelerators. GPipe (2019) introduced micro-batch pipeline parallelism with a bubble tax. Megatron-LM 2019 added intra-layer tensor parallelism on 512 GPUs. ZeRO partitioned optimizer states, gradients, and parameters. Megatron-LM 2021 composed PTD-P across 3072 GPUs at 502 petaFLOP/s; PaLM (2022) trained 540B on 6144 TPU v4 chips. Chinchilla (2022) corrected the slogan: parameter count alone is the wrong axis of scale.
+The post-GPT era scaled because engineers learned to split one training run across many accelerators. Pipeline parallelism, tensor parallelism, optimizer-state sharding, and data parallelism each paid a different tax in memory, communication, or idle time. Megatron-LM and PaLM made thousand-chip training concrete; Chinchilla corrected the slogan: parameter count alone is the wrong axis of scale.
 :::
 
 <details>
@@ -17,8 +17,8 @@ The post-GPT era scaled because engineers learned to split one training run acro
 | Yanping Huang et al. | — | GPipe authors (Google); micro-batch pipeline parallelism, rematerialization, ~6B-parameter Transformer demo |
 | Mohammad Shoeybi et al. | — | Megatron-LM 2019 authors (NVIDIA); intra-layer tensor model parallelism, 8.3B Transformer on 512 GPUs |
 | Samyam Rajbhandari, Jeff Rasley, Olatunji Ruwase, Yuxiong He | — | ZeRO authors (Microsoft); optimizer-state, gradient, and parameter partitioning |
-| Narayanan et al. | — | Megatron-LM 2021 authors (NVIDIA + collaborators); PTD-P composition, 1T-parameter iteration on 3072 GPUs |
-| Aakanksha Chowdhery et al. | — | PaLM/Pathways authors (Google); 540B dense Transformer on 6144 TPU v4 chips, 46.2% MFU |
+| Narayanan et al. | — | Megatron-LM 2021 authors (NVIDIA + collaborators); composed pipeline, tensor, and data parallelism at cluster scale |
+| Aakanksha Chowdhery et al. | — | PaLM/Pathways authors (Google); TPU-side frontier-scale dense Transformer training |
 | Jordan Hoffmann et al. | — | Chinchilla authors (DeepMind); compute-optimal training argument — scale parameters and tokens together |
 
 </details>
@@ -34,9 +34,9 @@ timeline
     2019-10 / 2020-03 : Megatron-LM paper — intra-layer tensor model parallelism, 8.3B Transformer on 512 GPUs
     2019-10 / 2020-05 : ZeRO paper — optimizer-state, gradient, and parameter partitioning for memory-efficient training
     2020-01 : DeepSpeed repository created — open-source ZeRO implementation context
-    2021-04 : Megatron-LM GPU-cluster paper — PTD-P composition, 1T-parameter iteration at 502 petaFLOP/s on 3072 GPUs
+    2021-04 : Megatron-LM GPU-cluster paper — composed pipeline, tensor, and data parallelism
     2022-03 : Chinchilla paper — compute-optimal training scales parameters and tokens together
-    2022-04 / 2022-10 : PaLM paper — 540B dense Transformer on 6144 TPU v4 chips via Pathways
+    2022-04 / 2022-10 : PaLM paper — Pathways-era TPU training at frontier scale
 ```
 
 </details>
@@ -52,11 +52,11 @@ timeline
 
 **Pipeline bubble** — Idle time at the start (later stages waiting for work) and end (earlier stages done while later stages drain) of a pipeline schedule. GPipe amortized the bubble by increasing the micro-batch count, but the tax never fully disappears.
 
-**ZeRO (Zero Redundancy Optimizer)** — Microsoft's three-stage scheme that partitions optimizer states (stage 1), then gradients (stage 2), then parameters (stage 3) across data-parallel workers — eliminating memory redundancy at the cost of additional gather/communicate operations.
+**ZeRO (Zero Redundancy Optimizer)** — Microsoft's scheme for reducing redundant model-state memory across data-parallel workers.
 
-**PTD-P** — Megatron-LM 2021 shorthand for composing **P**ipeline, **T**ensor, and **D**ata parallelism. The system maps each parallelism dimension onto cluster topology: tensor parallelism inside high-bandwidth servers, pipeline across servers, data parallelism across model replicas.
+**PTD-P** — Megatron-LM 2021 shorthand for composing **P**ipeline, **T**ensor, and **D**ata parallelism in one training system.
 
-**Model FLOPs utilization (MFU)** — The fraction of a cluster's theoretical peak FLOPs actually spent on useful model computation, after subtracting communication, idle time, input stalls, and inefficient kernels. PaLM reported 46.2% MFU for the 540B model — high by frontier-training standards.
+**Model FLOPs utilization (MFU)** — the fraction of a cluster's theoretical peak FLOPs actually spent on useful model computation.
 
 </details>
 
@@ -207,4 +207,3 @@ Every modern frontier-model release is the visible tip of a parallelism plan ben
 :::
 
 The next bottlenecks would move again. Once giant models could be trained, they had to be served cheaply and quickly. Tool-using agents would multiply calls. Long context would grow memory pressure. Millions of users would turn training miracles into inference bills. But that is the next chapter's economics. This chapter's lesson is simpler: modern AI did not scale by ignoring physics. It scaled by learning where to cut the model so physics would let the run continue.
-

--- a/src/content/docs/ai-history/ch-62-multimodal-convergence.md
+++ b/src/content/docs/ai-history/ch-62-multimodal-convergence.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-Between 2021 and 2024, frontier AI stopped being text-only. CLIP (2021) and Flamingo (2022) aligned language with images and interleaved video. GPT-4 and GPT-4V (2023) put images into the chat window and exposed new visual risks. Gemini (2023) was framed as jointly trained across image, audio, video, and text. GPT-4o (2024) collapsed speech into real-time interaction. Sora and Veo (2024) pushed generation into video while listing simulator limits. Language stayed the control surface; the model's world became visual, audible, temporal.
+Between 2021 and 2024, frontier AI stopped being text-only. Research systems aligned language with images, then product systems brought vision, speech, mixed-media prompts, and video generation into the assistant frame. Language stayed the control surface, but the model's world became visual, audible, and temporal, with new latency, safety, and evaluation problems attached.
 :::
 
 <details>
@@ -14,7 +14,7 @@ Between 2021 and 2024, frontier AI stopped being text-only. CLIP (2021) and Flam
 
 | Name | Lifespan | Role |
 |---|---|---|
-| Alec Radford et al. (OpenAI CLIP team) | — | Trained image and text encoders on 400M image-text pairs; established natural language as a supervisor for visual concepts. |
+| Alec Radford et al. (OpenAI CLIP team) | — | Established natural language as a supervisor for visual concepts. |
 | Jean-Baptiste Alayrac et al. (Flamingo team) | — | Built a visual language model handling arbitrarily interleaved images, videos, and text with free-form text outputs. |
 | OpenAI GPT-4 / GPT-4V teams | — | Shipped GPT-4 as a multimodal model with image and text inputs, then deployed vision through GPT-4V with documented risk surfaces. |
 | Google Gemini team | — | Framed Gemini as trained jointly across image, audio, video, and text with interleaved multimodal inputs. |
@@ -50,8 +50,8 @@ timeline
 - **Contrastive image-text pretraining.** CLIP's training setup: separate image and text encoders are trained so that matching pairs (a caption and its picture) land near each other in a shared representation space, while mismatched pairs are pushed apart.
 - **Interleaved input.** A prompt that mixes media in order — for example, a screenshot, then a question, then another image — rather than one isolated picture or one block of text. Flamingo and Gemini are described in their reports as supporting interleaved inputs.
 - **Native multimodality.** Used in the Gemini report to mean joint training across image, audio, video, and text in one model family, rather than a text model stitched together with separate specialist systems. Treat as a source-bound term, not a generic adjective.
-- **Spacetime patches.** Sora's representation unit: pieces of video and image latent codes that carry both spatial and temporal information, letting one model handle clips of varying duration, resolution, and aspect ratio.
-- **Three-model voice pipeline.** The earlier ChatGPT Voice Mode setup: one model transcribed audio to text, GPT-3.5 or GPT-4 processed the text, and a third model converted text back to audio. Tone, multiple speakers, background sound, and emotion were lost on the way through.
+- **Spacetime patches.** Sora's representation unit for pieces of video and image latent codes that carry both spatial and temporal information.
+- **Three-model voice pipeline.** The earlier ChatGPT Voice Mode setup that routed speech through separate transcription, language-model, and audio-generation steps.
 - **Image-borne jailbreak.** A prompt-injection attempt that hides instructions inside an image — text written on a sign, a screenshot of a UI, an embedded note — so the model has to decide whether visible text is content to describe, evidence to use, or a command to follow.
 
 </details>
@@ -177,5 +177,4 @@ The interface most people now reach for can read a screenshot, hear a question, 
 :::
 
 Multimodal convergence did not make AI understand the world the way humans do. It made the model's inputs and outputs look more like the world humans inhabit: visual, auditory, temporal, messy, and mixed. That was enough to break the old category.
-
 


### PR DESCRIPTION
## Summary
- compress Ch60 reader aids so RAG/ReAct mechanics land in the body
- trim Ch61 scaling benchmarks and ZeRO/PTD-P/MFU detail from aids while preserving body anchors
- reduce Ch62 multimodal mechanism spoilers in TL;DR/Cast/Glossary while keeping the full narrative explanations

## Checks
- git diff --check origin/main..HEAD
- ../../.venv/bin/python scripts/check_reader_aids.py ch-60 ch-61 ch-62
- rg -n "\$[0-9]" changed files (no hits)
- ../../.venv/bin/python scripts/test_pipeline.py (166 tests)
- npm run build (primary checkout detached at 90be48cc; restored to main)

Cross-family review will be posted before merge.