### PR TITLE
docs(ai-history): trim Ch63-Ch65 repetition

### DIFF
--- a/src/content/docs/ai-history/ch-63-inference-economics.md
+++ b/src/content/docs/ai-history/ch-63-inference-economics.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-Once large models entered products, the cost story moved from training to serving. Autoregressive generation makes every output token a serial step on scarce accelerators. From 2022 to 2024 the field reframed inference as a systems discipline: Orca scheduled by iteration, FlashAttention shrank attention's memory traffic, vLLM/PagedAttention made the KV cache a paged resource, SmoothQuant/FlexGen/speculative decoding traded precision, memory tier, or pass count for cost, and DistServe split prefill from decode for goodput under SLOs.
+Once large models entered products, the cost story moved from training to serving. Autoregressive generation made every output token a serial step on scarce accelerators, and product latency turned memory, scheduling, precision, offload, speculation, and phase-aware routing into economic questions. From 2022 to 2024, inference became a systems discipline measured not just by raw throughput, but by timely, usable work.
 :::
 
 <details>
@@ -18,8 +18,8 @@ Once large models entered products, the cost story moved from training to servin
 | Tri Dao | — | Lead author of FlashAttention (Stanford); IO-aware exact attention, HBM/SRAM traffic as the bottleneck (May 2022) |
 | Guangxuan Xiao | — | Lead author of SmoothQuant (MIT); post-training W8A8 quantization that migrates activation outliers to weights (Nov 2022) |
 | Ying Sheng | — | Lead author of FlexGen (Stanford); GPU/CPU/disk offload for high-throughput inference under limited GPU memory (Mar 2023) |
-| Woosuk Kwon | — | Lead author of vLLM/PagedAttention (Berkeley); virtual-memory-style paging for the KV cache (SOSP 2023) |
-| Yaniv Leviathan, Matan Kalman, Yossi Matias; Charlie Chen et al. | — | Speculative decoding/sampling authors (Google; DeepMind); draft-and-verify decoding that preserves the target distribution (2022/2023) |
+| Woosuk Kwon | — | Lead author of vLLM/PagedAttention (Berkeley); KV-cache management for high-throughput serving (SOSP 2023) |
+| Yaniv Leviathan, Matan Kalman, Yossi Matias; Charlie Chen et al. | — | Speculative decoding/sampling authors (Google; DeepMind); faster generation through proposal-and-verification methods (2022/2023) |
 
 </details>
 
@@ -32,10 +32,10 @@ timeline
     May 2022 : FlashAttention reframes attention speed around HBM/SRAM IO, not just FLOPs
     Jul 2022 : Orca (OSDI) proposes iteration-level scheduling and selective batching for generative Transformer serving
     Nov 2022 : SmoothQuant shows a post-training W8A8 path for LLM inference
-    Nov 2022 / Feb 2023 : Speculative decoding (Leviathan, Kalman, Matias) and speculative sampling (Chen et al.) — draft-and-verify with preserved distribution
+    Nov 2022 / Feb 2023 : Speculative decoding and speculative sampling papers target the serial decoding loop
     Mar 2023 : FlexGen demonstrates GPU/CPU/disk offload for throughput-oriented generation on a single T4
-    Sep / Oct 2023 : vLLM / PagedAttention (SOSP) makes KV-cache paging a first-class serving primitive
-    2024 : DistServe (OSDI) disaggregates prefill and decode onto different GPU pools for goodput under SLOs
+    Sep / Oct 2023 : vLLM / PagedAttention makes KV-cache management a first-class serving primitive
+    2024 : DistServe (OSDI) separates serving phases to improve SLO-compliant capacity
 ```
 
 </details>
@@ -49,13 +49,13 @@ timeline
 
 **Iteration-level scheduling** — Orca's scheduling unit. Instead of treating each user request as a single batch member from start to finish, the serving system decides at every model iteration which active requests continue, which finished requests leave, and which newly arrived requests join. Required for generative workloads where requests have wildly different lengths.
 
-**PagedAttention** — vLLM's KV-cache memory manager. It borrows operating-system virtual-memory paging: store the KV cache in non-contiguous fixed-size blocks, then let the attention kernel treat them as a coherent sequence. Reduces fragmentation, allows higher concurrency, and is the mechanism behind vLLM's 2–4× throughput claim over FasterTransformer/Orca.
+**PagedAttention** — vLLM's KV-cache memory manager for reducing waste and improving serving concurrency.
 
-**TTFT and TPOT (time to first token, time per output token)** — DistServe's two-axis latency model. TTFT is the delay before the user sees any output — it is dominated by *prefill* (processing the prompt). TPOT is the rhythm of streaming — it is dominated by *decode* (the per-token loop). Optimising one can hurt the other, which is why DistServe runs them on different GPU pools.
+**TTFT and TPOT (time to first token, time per output token)** — two latency measures that separate when an answer starts from how smoothly it streams.
 
-**Goodput** — Useful work completed within a service-level objective. A request finished after its SLO deadline is throughput but not goodput. Inference serving is paid, in effect, for goodput, which is why average throughput numbers can hide tail-latency failures.
+**Goodput** — useful work completed within a service-level objective, not merely work completed eventually.
 
-**Speculative decoding / sampling** — A small "draft" model proposes several next tokens; the larger "target" model verifies them in a single parallel pass and accepts or rejects under a rejection-sampling rule that preserves the target's output distribution. Trades cheap draft compute for fewer expensive target-model passes; speedup depends on draft acceptance and overhead.
+**Speculative decoding / sampling** — a serving technique that uses cheaper proposals to reduce the number of expensive decoding passes.
 
 </details>
 
@@ -178,4 +178,3 @@ Every operator who has run a chat assistant, copilot, or agent at scale has met 
 :::
 
 The user sees an answer appear in a chat window. Underneath, a scheduling system is making thousands of small economic decisions. Which requests share a batch? Which tokens occupy cache? Which precision is acceptable? Which phase gets which GPU? Which work can be drafted, compressed, offloaded, or delayed? Inference economics is the name for that hidden discipline.
-

--- a/src/content/docs/ai-history/ch-64-the-edge-compute-bottleneck.md
+++ b/src/content/docs/ai-history/ch-64-the-edge-compute-bottleneck.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-Moving AI onto phones did not shrink the cloud — it created a second frontier with different physics: battery, heat, DRAM, flash bandwidth, privacy. MobileNets (2017) and Apple's A11 Neural Engine were the pre-generative pattern. By 2023–2024 Gemini Nano in AICore, Qualcomm's Snapdragon 8 Gen 3, Apple Intelligence's ~3B AFM-on-device, the LLM-in-a-flash paper, and MobileLLM made the bottleneck explicit. Edge AI became a routing discipline: some work runs locally, larger work routes to Private Cloud Compute or Pixel Video Boost.
+Moving AI onto phones did not shrink the cloud. It created a second frontier with different physics: battery, heat, DRAM, flash bandwidth, privacy, operating-system services, and uneven device capability. Edge AI became a routing discipline. Some work runs locally because locality matters; larger or heavier work still routes elsewhere because the phone is not a small datacenter.
 :::
 
 <details>
@@ -32,8 +32,8 @@ timeline
     Apr 2017 : MobileNets frames neural-network architecture as a mobile and embedded deployment problem
     Sep 2017 : Apple announces iPhone X with A11 Bionic Neural Engine and on-device Face ID processing
     Oct 2023 : Qualcomm Snapdragon 8 Gen 3 product brief markets phone silicon for on-device multimodal generative AI up to 10B parameters
-    Dec 2023 : Google ships Gemini Nano on Pixel 8 Pro for Recorder Summarize and Smart Reply; Video Boost shows cloud fallback
-    Dec 2023 : Apple's "LLM in a flash" paper studies models exceeding available DRAM by streaming weights from flash
+    Dec 2023 : Google ships Gemini Nano on Pixel 8 Pro while Video Boost shows cloud fallback
+    Dec 2023 : Apple's "LLM in a flash" paper studies edge memory limits
     Feb 2024 : MobileLLM develops sub-billion-parameter language models for mobile use cases (June 2024 revision follows)
     Jun 2024 : Apple Intelligence introduced — ~3B on-device language model plus Private Cloud Compute for larger requests
     Jul 2024 : Apple publishes the Apple Intelligence Foundation Language Models report (AFM-on-device architecture, quantization, deployment)
@@ -47,7 +47,7 @@ timeline
 
 **Neural Engine / NPU** — A piece of dedicated silicon on a phone for running neural-network inference efficiently. Apple's A11 Neural Engine (2017) and Qualcomm's Hexagon NPU on the Snapdragon 8 Gen 3 are the two product-era examples this chapter uses; both let a phone run ML workloads without leaning on the general-purpose CPU or GPU.
 
-**Depthwise separable convolution** — The architectural trick MobileNets used to reduce computation: split a standard convolution into a depthwise step (spatial filtering per channel) and a pointwise step (channel mixing). Reduced compute and memory enough to make accurate vision models fit a mobile latency and power budget.
+**Depthwise separable convolution** — the efficient convolution pattern MobileNets used to make mobile vision models cheaper to run.
 
 **Grouped-query attention (GQA)** — An attention variant that shares key/value projections across groups of query heads, reducing the size of the KV cache the model has to hold during inference. Apple's AFM-on-device and MobileLLM both use it specifically because cache memory is one of the tightest constraints on a phone.
 
@@ -55,7 +55,7 @@ timeline
 
 **KV cache** — The intermediate keys and values the Transformer accumulates while generating tokens. It grows with context length and is one of the dominant memory costs of running an LLM, on a phone or in a datacenter.
 
-**AICore (Android)** — A system service that hosts Gemini Nano on Android devices, manages model updates, safety boundaries, and access to hardware accelerators, and exposes the on-device model to apps without each app shipping its own weights.
+**AICore (Android)** — a system service for exposing Gemini Nano capabilities to Android apps on supported devices.
 
 **Private Cloud Compute (Apple)** — Apple's server-side fallback path for Apple Intelligence: when a request is judged larger than the on-device model can handle, it routes to Apple-operated server hardware. The architecture's role in the chapter is to mark the boundary where local processing stops, not to certify the privacy model.
 
@@ -196,4 +196,3 @@ The edge compute bottleneck is the name for that sequence of compromises. Intell
 :::note[Why this still matters today]
 Every assistant feature on a modern phone — keyboard rewriting, recording summary, on-device search, biometric unlock — sits inside the same envelope this chapter describes. Battery, DRAM, flash bandwidth, and thermals still set the local capacity ceiling, and the operating system still has to decide what runs locally, what routes to a private or public cloud, and what should not be offered at all. A practitioner deploying any AI feature to a constrained device — phone, watch, vehicle, embedded sensor — inherits the same routing discipline, the same memory-hierarchy questions, and the same need to scope the task narrowly enough that local execution is honest rather than aspirational.
 :::
-

--- a/src/content/docs/ai-history/ch-65-the-open-weights-rebellion.md
+++ b/src/content/docs/ai-history/ch-65-the-open-weights-rebellion.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-Open weights changed deployment power without resolving open source, open data, or open governance. Stable Diffusion (August 2022) was the public precedent. LLaMA (February 2023) made a 7B–65B family portable for research; LoRA and QLoRA cut adaptation cost so Alpaca and Vicuna could wrap LLaMA in instruction behavior under non-commercial limits. Llama 2 (July 2023) opened commercial use; Mistral 7B (September 2023) shipped under Apache 2.0. The rebellion was a license-and-access ladder, not a single category.
+Open weights changed deployment power without resolving open source, open data, or open governance. From public image-model releases to portable language-model families, adapters, community fine-tunes, commercial licenses, and permissive releases, the center of gravity moved away from API-only access. The rebellion was a license-and-access ladder, not a single category.
 :::
 
 <details>
@@ -17,7 +17,7 @@ Open weights changed deployment power without resolving open source, open data, 
 | Robin Rombach / CompVis / Stability AI / RunwayML | — | Carried the Stable Diffusion public-release precedent (Aug 2022) into the language-model era; in this chapter the access layer, not the diffusion math (Ch58 owns that) |
 | Hugo Touvron and Meta AI LLaMA teams | — | Lead authors on LLaMA (research-community release) and Llama 2 (general-public research/commercial release); the chapter's central institutional actor |
 | Edward J. Hu et al. | — | LoRA authors (June 2021); freezing pretrained weights and training low-rank adapters made fine-tuning modular and cheap |
-| Tim Dettmers and QLoRA collaborators | — | QLoRA authors (May 2023); 4-bit quantization plus LoRA pushed 65B fine-tuning onto a single 48GB GPU |
+| Tim Dettmers and QLoRA collaborators | — | QLoRA authors (May 2023); quantized fine-tuning made large-model adaptation more accessible |
 | Stanford CRFM Alpaca team / LMSYS Vicuna team | — | Early academic and community instruction-tuned descendants of LLaMA (March 2023) under explicit non-commercial and evaluation caveats |
 | Mistral AI team | — | Permissive-release counterpoint via Mistral 7B (Sept 2023) under Apache 2.0 |
 
@@ -29,12 +29,12 @@ Open weights changed deployment power without resolving open source, open data, 
 ```mermaid
 timeline
     title Chapter 65 — The Open Weights Rebellion
-    Jun 2021 : LoRA published — freeze pretrained weights, train low-rank matrices, large reductions in trainable parameters and GPU memory
+    Jun 2021 : LoRA published — adapter-based fine-tuning around frozen pretrained weights
     Aug 2022 : Stability AI public release of Stable Diffusion — weights, code, model card, license, consumer-GPU framing
     Feb 2023 : Meta publishes LLaMA — 7B–65B family, public-data framing, released to the research community
-    Mar 2023 : Stanford Alpaca — LLaMA 7B fine-tuned on 52K text-davinci-003 demonstrations, academic-only and non-commercial
-    Mar 2023 : LMSYS Vicuna-13B — LLaMA-derived chatbot trained on ShareGPT, project-reported ~$300 cost, non-scientific GPT-4 evaluation
-    May 2023 : QLoRA — 4-bit quantization plus LoRA, 65B fine-tuning on a single 48GB GPU
+    Mar 2023 : Stanford Alpaca — academic LLaMA instruction-tuning project with non-commercial limits
+    Mar 2023 : LMSYS Vicuna-13B — community LLaMA-derived chatbot with evaluation caveats
+    May 2023 : QLoRA — quantized LoRA fine-tuning lowers the hardware barrier
     Jul 2023 : Meta publishes Llama 2 — 7B/13B/70B pretrained and chat models for research and commercial use under license and AUP
     Sep 2023 : Mistral AI announces Mistral 7B under Apache 2.0 — permissive license, no usage restrictions in license terms
 ```
@@ -48,13 +48,13 @@ timeline
 
 **Open source** — Code is released under a license that allows inspection, modification, and redistribution. A model can be open-weight without being open-source if its training code, pipeline, or data preparation are not also released under such a license.
 
-**LoRA (Low-Rank Adaptation)** — A fine-tuning method (Hu et al., 2021) that freezes the original pretrained weights and trains small low-rank matrices alongside them. The base model stays fixed; the adaptation lives in a small module. The paper reports up to 10,000x fewer trainable parameters and 3x less GPU memory than full fine-tuning for a cited GPT-3 configuration.
+**LoRA (Low-Rank Adaptation)** — a fine-tuning method that freezes the original pretrained weights and trains small low-rank adapter modules alongside them.
 
-**QLoRA** — A 2023 extension by Dettmers et al. that backpropagates through a frozen 4-bit quantized model into LoRA adapters. Uses NF4 quantization, double quantization, and paged optimizers to fine-tune a 65B model on a single 48GB GPU, where naive fine-tuning would require more than 780GB.
+**QLoRA** — a 2023 extension that combines quantization with LoRA adapters to make large-model fine-tuning fit a much smaller memory envelope.
 
 **Adapter** — A small set of additional trainable parameters layered onto a frozen base model (LoRA matrices are one example). Adapters become portable behavioral modifications: a few-MB file rather than a many-GB model copy, which is why the open-weight ecosystem began trading in adapters as distribution objects.
 
-**Instruction tuning** — Fine-tuning a base language model on prompt/response pairs so it follows instructions in a chat-assistant style. Alpaca generated those pairs from text-davinci-003 outputs; Vicuna used user-shared ShareGPT conversations. Non-commercial restrictions on both sets of inputs constrained the resulting models' allowable downstream uses.
+**Instruction tuning** — fine-tuning a base language model on prompt/response pairs so it follows instructions in a chat-assistant style.
 
 **Permissive license** — A software license such as Apache 2.0 or MIT that allows commercial use, modification, and redistribution with minimal conditions (typically attribution and patent-grant terms). Mistral 7B's Apache 2.0 release contrasts sharply with LLaMA 1's research-only access and Llama 2's commercial-with-AUP license.
 
@@ -215,4 +215,3 @@ That is why "rebellion" is the right word even though the story includes large c
 :::note[Why this still matters today]
 Every "is this model open?" argument a practitioner walks into runs on the four-layer ladder this chapter installs: open weights, open source, open data, open governance. A release can be strong on one and weak on another, and the layer that matters most depends on what is being built. A regulated deployment may need permissive licensing and AUP clarity above all else. A reproducibility audit needs data and training code, not just downloadable weights. A safety review cares about governance and update channels. Every model card, license argument, fine-tune disclosure, and "open-source AI" definition fight from the OSI's OSAID process onward is contesting the same gaps Stable Diffusion, LLaMA, Alpaca, Vicuna, Llama 2, and Mistral 7B made unavoidable in 2022–2023.
 :::
-


### PR DESCRIPTION
## Summary
- trim Ch63 serving-mechanism summaries from reader aids while preserving PagedAttention, speculative decoding, and DistServe body anchors
- compress Ch64 edge-device TL;DR/timeline/glossary entries so the body carries MobileNets, AICore, and flash-memory explanations
- remove repeated LoRA/QLoRA and Alpaca/Vicuna empirical details from Ch65 reader aids while retaining them in the narrative

## Checks
- git diff --check origin/main..HEAD
- ../../.venv/bin/python scripts/check_reader_aids.py ch-63 ch-64 ch-65
- rg -n "\$[0-9]" changed files (only legitimate Vicuna reported $300 body anchor)
- ../../.venv/bin/python scripts/test_pipeline.py (166 tests)
- npm run build (primary checkout detached at fdebec76; restored to main)

Cross-family review will be posted before merge.