### PR TITLE
docs(ai-history): trim Ch66-Ch68 repetition

### DIFF
--- a/src/content/docs/ai-history/ch-66-benchmark-wars.md
+++ b/src/content/docs/ai-history/ch-66-benchmark-wars.md
@@ -14,8 +14,8 @@ Benchmarks began as scientific instruments and became market signals. In 2020 MM
 
 | Name | Lifespan | Role |
 |---|---|---|
-| Dan Hendrycks et al. (MMLU authors) | — | Introduced MMLU (2020) — 57 academic and professional subjects compressed into a broad scorecard for language-model knowledge |
-| BIG-bench community | — | 450 authors across 132 institutions contributed 204 tasks (2022) — broad benchmark expansion plus explicit recognition of short benchmark lifespans |
+| Dan Hendrycks et al. (MMLU authors) | — | Introduced MMLU (2020) as a broad scorecard for language-model knowledge |
+| BIG-bench community | — | Expanded benchmark culture through a large community task collection and explicit recognition of short benchmark lifespans |
 | Stanford CRFM / HELM authors (Percy Liang et al.) | — | Authored Holistic Evaluation of Language Models (2022) — transparency, multi-metric measurement, and standardized comparison instead of single-score rankings |
 | OpenAI GPT-4 / Evals teams | — | Released the GPT-4 Technical Report (March 2023) — benchmark tables as release evidence, contamination disclosure, and OpenAI Evals as deployment infrastructure |
 | Lianmin Zheng et al. (MT-Bench / Chatbot Arena, LMSYS) | — | Introduced MT-Bench and Chatbot Arena (June 2023) — pairwise preference arenas and LLM-as-judge methodology |
@@ -29,8 +29,8 @@ Benchmarks began as scientific instruments and became market signals. In 2020 MM
 ```mermaid
 timeline
     title Chapter 66 — Benchmark Wars
-    2020 : MMLU introduced — 57 academic and professional subjects; largest GPT-3 reaches 43.9% (Hendrycks et al.)
-    2022 : BIG-bench (204 tasks, 450 authors, 132 institutions) and HELM (multi-metric standardized evaluation) broaden benchmark culture
+    2020 : MMLU introduced as a broad academic/professional knowledge benchmark
+    2022 : BIG-bench and HELM broaden benchmark culture beyond single-task accuracy
     March 2023 : GPT-4 Technical Report turns professional exams, MMLU, HumanEval, contamination checks, and OpenAI Evals into release evidence
     June 2023 : MT-Bench and Chatbot Arena formalize LLM-as-judge and pairwise-preference public arenas (Zheng et al.)
     October 2023 : SWE-bench introduces real GitHub issue/PR benchmark — Claude 2 solves 1.96% in initial setup (Jimenez et al.)
@@ -41,19 +41,19 @@ timeline
 <details>
 <summary><strong>Plain-words glossary</strong></summary>
 
-**MMLU (Measuring Massive Multitask Language Understanding)** — Hendrycks et al. 2020. A multiple-choice benchmark covering 57 academic and professional subjects (math, US history, computer science, law, medicine, ethics, and more) with 15,908 questions and a 5-shot dev set. Designed to test broad world knowledge, not a single task; the original paper reported the largest GPT-3 at 43.9% — far below expert level.
+**MMLU (Measuring Massive Multitask Language Understanding)** — Hendrycks et al. 2020. A multiple-choice benchmark designed to test broad academic and professional knowledge, not a single narrow task.
 
-**BIG-bench (Beyond the Imitation Game)** — A 2022 community benchmark of 204 tasks contributed by 450 authors across 132 institutions, openly developed on GitHub. Probes reasoning, math, commonsense, social bias, software, science, and edge categories. The authors explicitly discussed how benchmarks have restricted scope and short useful lifespans, and noted that direct leakage was impossible for the reported models but indirect leakage could not be ruled out.
+**BIG-bench (Beyond the Imitation Game)** — a 2022 community benchmark collection designed to probe many forms of language-model behavior and to surface the limits of benchmark lifespan.
 
-**HELM (Holistic Evaluation of Language Models)** — Stanford CRFM, 2022. A multi-metric evaluation framework arguing that accuracy alone is not enough. Measures 7 metrics across 16 core scenarios, with targeted evaluations across 26 scenarios and 30 prominent models on 42 scenarios; raises evaluated-scenario overlap from 17.9% to 96.0%. Calibration, robustness, fairness, bias, toxicity, and efficiency sit alongside accuracy.
+**HELM (Holistic Evaluation of Language Models)** — Stanford CRFM, 2022. A multi-metric evaluation framework arguing that accuracy alone is not enough; calibration, robustness, fairness, bias, toxicity, and efficiency sit alongside accuracy.
 
 **MT-Bench / Chatbot Arena** — Zheng et al. 2023. *MT-Bench* is 80 high-quality multi-turn questions scored by an LLM judge. *Chatbot Arena* is anonymous pairwise crowdsourced voting between two model answers. Together they introduced public preference comparison as a continuously updating model-reputation layer beyond static test items.
 
-**LLM-as-judge** — Using a strong language model (e.g., GPT-4) to score or compare other models' outputs at scale. Zheng et al. reported GPT-4 judge agreement with humans over 80%, comparable to human-human agreement in their setup, but documented position bias, verbosity bias, self-enhancement bias, and math/reasoning failures.
+**LLM-as-judge** — using a strong language model to score or compare other models' outputs at scale.
 
 **Contamination / leakage** — When benchmark questions appear (directly or indirectly) in a model's training data, scores reflect memorization rather than capability. Modern reports treat this as a design problem: the GPT-4 report ran contamination checks and disclosed GSM-8K training-set inclusion; SWE-bench separated training-data repositories from evaluation repositories to limit overlap.
 
-**Goodhart's law** — Manheim & Garrabrant 2018 (preprint). When a measure becomes a target, it ceases to be a good measure. They categorize four variants — regressional, extremal, causal, and adversarial. In benchmark culture, the warning is that once a score becomes valuable, actors optimize against it and the score's connection to the underlying goal weakens.
+**Goodhart's law** — Manheim & Garrabrant 2018 (preprint). A warning about measurements changing behavior once people optimize for them.
 
 </details>
 
@@ -258,4 +258,3 @@ The war over benchmarks is the war over who gets to say what the system is.
 :::note[Why this still matters today]
 Every public AI scoreboard you read today — provider release tables, third-party leaderboards, agentic-coding benchmarks, multi-metric harnesses, public preference arenas — sits inside the institutional pattern this chapter traces. MMLU's broad-knowledge scorecard, HELM's anti-single-score push, GPT-4's release-table framing, Chatbot Arena's pairwise voting, and SWE-bench's execution-tested tasks each hardened into a standard format. The Goodhart cycle still runs: every benchmark that becomes valuable becomes a target, gets gamed, and gets replaced. Contamination checks, time-stamped results, evaluation harnesses, and "evals as deployment infrastructure" are now table stakes for serious model launches, procurement, and regulatory conversations — and the score, as the chapter warns, still is not the system.
 :::
-

--- a/src/content/docs/ai-history/ch-67-the-monopoly.md
+++ b/src/content/docs/ai-history/ch-67-the-monopoly.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-AI's late-era "monopoly" was not one firm but a stack of bottlenecks: NVIDIA accelerators, hyperscaler clouds, frontier-lab partnerships, IP licenses, enterprise distribution, and compliance. Microsoft/OpenAI (2019) set the template — exclusive cloud, preferred commercialization — replicated by Amazon/Anthropic and Google/Anthropic. The FTC opened a 6(b) inquiry (January 2024) and US/EU/UK regulators (July 2024) named key-input concentration. The April 27, 2026 Microsoft/OpenAI amendment shows exclusivity mutating, not vanishing. Platform power changed shape, not substance.
+AI's late-era "monopoly" was not one firm but a stack of bottlenecks: accelerators, hyperscaler clouds, frontier-lab partnerships, IP licenses, enterprise distribution, and compliance. The Microsoft/OpenAI template was followed by other hyperscaler-lab partnerships, regulators began naming key-input concentration, and later contract revisions showed exclusivity mutating rather than disappearing. Platform power changed shape, not substance.
 :::
 
 <details>
@@ -14,11 +14,11 @@ AI's late-era "monopoly" was not one firm but a stack of bottlenecks: NVIDIA acc
 
 | Name | Lifespan | Role |
 |---|---|---|
-| NVIDIA | — | Data Center revenue reached $47.5B in fiscal 2024, up 217%; large cloud providers represented more than half of Q4 FY2024 Data Center revenue, and about 40% of FY2024 Data Center revenue was estimated for AI inference (FY2024 10-K). The accelerator supplier whose chips became the upstream bottleneck. |
-| Microsoft / OpenAI | — | July 22, 2019 announcement: $1B investment, Azure AI supercomputing, Microsoft as exclusive cloud provider and preferred commercialization partner. Terms revised October 2025, clarified February 2026, and amended April 27, 2026. The original cloud-partnership template. |
+| NVIDIA | — | Accelerator supplier whose chips became the upstream bottleneck for frontier training and inference. |
+| Microsoft / OpenAI | — | Original cloud-partnership template linking frontier research, Azure capacity, IP rights, and enterprise commercialization. |
 | Amazon / Anthropic | — | September 2023 strategic collaboration with AWS as primary cloud provider and Amazon investment; November 22, 2024 deepening with an additional $4B investment, AWS as primary training partner, and Trainium use. Replication of the hyperscaler-frontier-lab template with custom silicon. |
 | Google Cloud / Anthropic | — | February 3, 2023 partnership: Anthropic selected Google Cloud as cloud provider, used GPU and TPU clusters to train, scale, and deploy systems. Third instance of the template. |
-| FTC | — | January 25, 2024: 6(b) inquiry into Alphabet, Amazon, Anthropic, Microsoft, and OpenAI; January 2025 staff report on Microsoft-OpenAI, Amazon-Anthropic, and Alphabet-Anthropic partnerships. Regulator that named the pattern. |
+| FTC | — | Regulator that used a 6(b) inquiry and staff report to study hyperscaler/frontier-lab partnerships. |
 | US/EU/UK competition authorities | — | July 23, 2024 joint statement on competition in generative AI: warned about restriction of key inputs, existing market power extending into AI, and partnerships/investments that could steer market outcomes. |
 
 </details>
@@ -36,9 +36,9 @@ timeline
     2024-07-23 : US/EU/UK competition authorities publish joint statement on competition in generative AI foundation models
     2024-11-22 : Amazon announces deeper Anthropic collaboration — additional $4B investment, AWS as primary training partner, Trainium use
     2025-01 : FTC staff report describes Microsoft-OpenAI, Amazon-Anthropic, and Alphabet-Anthropic as the study's largest cloud/AI-developer partnerships
-    2025-10-28 : Microsoft revises OpenAI agreement — exclusive IP rights / Azure API exclusivity preserved with some third-party flexibility
-    2026-02-27 : Microsoft/OpenAI joint statement clarifies Azure exclusivity for stateless OpenAI APIs and first-party products
-    2026-04-27 : OpenAI/Microsoft amendment — Microsoft remains primary cloud partner, OpenAI can serve products across any cloud, license becomes non-exclusive
+    2025-10-28 : Microsoft revises OpenAI agreement, preserving some controls while adding flexibility
+    2026-02-27 : Microsoft/OpenAI joint statement clarifies the scope of Azure exclusivity
+    2026-04-27 : OpenAI/Microsoft amendment shifts from exclusive toward primary-partner and non-exclusive-license language
 ```
 
 </details>
@@ -50,11 +50,11 @@ timeline
 
 **6(b) inquiry** — A non-enforcement information-gathering study under Section 6(b) of the FTC Act. The FTC issues orders compelling firms to provide information for an industry-wide market study. The January 2024 6(b) inquiry into Alphabet, Amazon, Anthropic, Microsoft, and OpenAI sought information about key inputs and competitive impact of cloud/AI-developer partnerships, not a finding of wrongdoing.
 
-**Exclusive cloud provider** — In the OpenAI 2019 announcement, the term meant Microsoft would be OpenAI's sole cloud-infrastructure host. By the October 2025 Microsoft statement and the April 27, 2026 amendment, exclusivity had become granular: "Azure API exclusivity" for stateless OpenAI APIs, "primary cloud partner" rather than "exclusive," first-ship-on-Azure rather than only-on-Azure. The chapter dates each phrasing rather than treating "exclusive" as timeless.
+**Exclusive cloud provider** — a cloud-partnership term whose scope changed across the Microsoft/OpenAI relationship; the chapter dates each phrasing rather than treating "exclusive" as timeless.
 
 **AWS Trainium** — Amazon's custom AI training accelerator. Per Amazon's November 22, 2024 announcement, Anthropic named AWS its primary training partner and would use Trainium to train and deploy its largest foundation models. Custom-silicon usage matters because it deepens technical lock-in beyond renting generic compute.
 
-**Stateless API** — In the Microsoft/OpenAI February 2026 framing, "stateless" describes API calls that do not retain server-side context across requests. Azure's exclusivity for "stateless OpenAI APIs" became a load-bearing technical scope: it specifies a precise boundary of what runs only on Azure rather than committing to total cloud exclusivity.
+**Stateless API** — API calls that do not retain server-side context across requests; in this chapter, the term matters because it narrowed a cloud-exclusivity claim.
 
 **Vertical control / horizontal rivalry** — Horizontal competition is firms competing at the same layer (model labs vs. model labs). Vertical control is one firm shaping outcomes at the layers above and below it (e.g., a cloud provider influencing which model labs can scale because it controls compute and distribution). The July 2024 joint statement warned about both, with vertical/incumbent-extension risk being the chapter's central concern.
 
@@ -231,4 +231,3 @@ Benchmarks made capability visible. Platforms turned capability into markets. Th
 :::note[Why this still matters today]
 Today's AI procurement still routes through the stack this chapter names. When you choose a model, you also choose an accelerator family (often NVIDIA), a cloud (Azure, AWS, or Google), a billing/identity/compliance posture, and a partnership channel into enterprise software. The Microsoft/OpenAI, Amazon/Anthropic, and Google/Anthropic relationships continue to shape which model ships first inside which cloud marketplace. Open-weight models partially route around API exclusivity, but frontier training and hyperscale serving still concentrate around a handful of firms. Reading any current "AI strategy" announcement — cloud expansion, exclusive distribution, custom-silicon investment — is reading another revision of the stack this chapter mapped.
 :::
-

--- a/src/content/docs/ai-history/ch-68-data-labor-and-the-copyright-reckoning.md
+++ b/src/content/docs/ai-history/ch-68-data-labor-and-the-copyright-reckoning.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-Frontier AI needed people and rights-cleared material, not just compute. Ouyang et al. 2022 described about 40 RLHF contractors; TIME reported Sama workers in Kenya labeling toxic content for OpenAI safety filtering. GPT-3, The Pile, Books3, LAION-5B, and Stable Diffusion turned web pages, books, and images into training inputs. Getty (2023), New York Times (2023), and Bartz v. Anthropic (2025) put that pipeline into court records. Crawler controls and publisher licensing closed the loop: data became negotiated, blocked, or priced.
+Frontier AI needed people and rights-cleared material, not just compute. RLHF contractors and safety labelers made human judgment part of the model stack, while GPT-3, The Pile, Books3, LAION-5B, and Stable Diffusion turned web pages, books, and images into training inputs. Getty, New York Times, and Bartz v. Anthropic put that pipeline into court records. Crawler controls and publisher licensing closed the loop: data became negotiated, blocked, or priced.
 :::
 
 <details>
@@ -14,7 +14,7 @@ Frontier AI needed people and rights-cleared material, not just compute. Ouyang 
 
 | Name | Lifespan | Role |
 |---|---|---|
-| OpenAI labelers / Ouyang et al. contractors | — | About 40 contractors who wrote demonstrations and rankings for InstructGPT/RLHF (March 2022). |
+| OpenAI labelers / Ouyang et al. contractors | — | Contractors who wrote demonstrations and rankings for InstructGPT/RLHF (March 2022). |
 | Sama workers in Kenya | — | TIME's anonymous sources for toxic-content labeling on an OpenAI safety-filtering project (Nov. 2021–March 2022). |
 | Getty Images | — | Stock-image licensor; commenced UK proceedings against Stability AI and amended a US complaint in 2023. |
 | The New York Times | — | News publisher; sued Microsoft/OpenAI on December 27, 2023. |
@@ -33,14 +33,14 @@ timeline
     2020 : GPT-3 reports filtered Common Crawl, WebText2, Books1, Books2, Wikipedia mixture
     2020-2021 : The Pile formalizes 825 GiB / 22 subsets, including Books3
     Nov 2021-Mar 2022 : TIME reports Sama/Kenya safety-labeling work for OpenAI
-    Mar 2022 : Ouyang et al. publish InstructGPT/RLHF (about 40 contractors)
+    Mar 2022 : Ouyang et al. publish InstructGPT/RLHF
     2022 : LAION-5B and Stable Diffusion publish open image-caption work
     Jan-Mar 2023 : Getty commences UK proceedings; files/amends US complaint
     Dec 27 2023 : New York Times sues Microsoft and OpenAI
     Jan 8 2024 : OpenAI publishes "OpenAI and journalism" response
     Dec 2023-May 2024 : OpenAI announces Axel Springer, FT, Reddit, News Corp deals
     Apr 4 2025 : NYT/OpenAI motion-to-dismiss opinion narrows some claims
-    Jun 23 2025 : Bartz v. Anthropic fair-use order splits training, purchase, piracy
+    Jun 23 2025 : Bartz v. Anthropic fair-use order separates key copying and acquisition questions
     Apr 2026 : Bartz settlement-finality hearing pending
 ```
 
@@ -55,7 +55,7 @@ timeline
 - **LAION-5B:** An open dataset of 5.85 billion CLIP-filtered image-text pairs used to train and study image-generation models such as Stable Diffusion v1-4.
 - **Fair use:** A US copyright defense that excuses some unlicensed copying based on factors including transformativeness, purpose, market harm, and amount used; the defense is fact-specific, not a general permission.
 - **Motion to dismiss:** An early procedural request asking a court to throw out claims; at this stage the court assumes complaint facts are true to test legal sufficiency, not to find liability.
-- **Robots.txt / GPTBot:** A web-server file telling crawlers which paths they may visit; OpenAI documents OAI-SearchBot and GPTBot tags so site owners can allow search while disallowing training-related crawling.
+- **Robots.txt / GPTBot:** A web-server control surface for telling crawlers which paths they may visit.
 
 </details>
 
@@ -228,4 +228,3 @@ The reckoning began when those people and that culture asked who had been counte
 :::note[Why this still matters today]
 Every modern assistant inherits this supply chain. Behind a chat reply sits a chain of contractors, safety labelers, scraped pages, image-text corpora, books, and platform APIs — each with its own permission and labor story. Court orders, robots.txt distinctions between search and training crawlers, and publisher licensing deals are now standard parts of how AI products are built and sold. Procurement, indemnity, and dataset provenance are no longer back-office concerns; they are gates on shipping. The chapter's split — training use, acquisition path, market harm, and worker conditions — is the working vocabulary practitioners read in model cards, terms of use, and risk disclosures today.
 :::
-


### PR DESCRIPTION
## Summary
- Trim repeated reader-aid numeric detail in Ch66 benchmark summaries while keeping the body anchors intact.
- Reduce Ch67 cloud/monopoly reader-aid echoes around NVIDIA, Microsoft/OpenAI, FTC, and amended partnership terms.
- Reduce Ch68 repeated RLHF/copyright/crawler detail without changing the factual body discussion.

## Verification
- git diff --check origin/main..HEAD
- ../../.venv/bin/python scripts/check_reader_aids.py ch-66 ch-67 ch-68
- rg -n '\\$[0-9]' changed chapter files: only legitimate Ch67/Ch68 money/wage anchors found\n- ../../.venv/bin/python scripts/test_pipeline.py: 166 passed\n- npm run build from primary checkout detached at a78b325d: passed\n\nCross-family review requested before merge.