### PR TITLE
docs(ai-history): trim Ch69-Ch71 repetition

### DIFF
--- a/src/content/docs/ai-history/ch-69-the-data-exhaustion-limit.md
+++ b/src/content/docs/ai-history/ch-69-the-data-exhaustion-limit.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-In March 2022, DeepMind's Chinchilla showed compute-optimal training must scale model size and tokens together. Two years later, Llama 3's 15T-token model card and FineWeb made the public web feel countable. Villalobos and Epoch AI then estimated public human text could be fully utilized between 2026 and 2032 if trends continued. Engineers answered with a portfolio — filter, deduplicate, repeat, transcribe audio, synthesize textbooks — and each workaround changed the signal. Benchmark contamination spread the exhaustion problem into evaluation.
+In March 2022, DeepMind's Chinchilla made tokens a co-equal scaling variable. Two years later, Llama 3's 15T-token model card and FineWeb made the public web feel countable. Villalobos and Epoch AI then put a near-term clock on public-text exhaustion if trends continued. Engineers answered with a portfolio — filter, deduplicate, repeat, transcribe audio, synthesize textbooks — and each workaround changed the signal. Benchmark contamination spread the exhaustion problem into evaluation.
 :::
 
 <details>
@@ -14,10 +14,10 @@ In March 2022, DeepMind's Chinchilla showed compute-optimal training must scale 
 
 | Name | Lifespan | Role |
 |---|---|---|
-| Jordan Hoffmann | — | Lead author of the 2022 Chinchilla paper; argued compute-optimal training scales parameters and tokens together |
-| Pablo Villalobos | — | Lead author of the Epoch AI "Will we run out of data?" analysis; put a 2026–2032 date range on public-text exhaustion |
+| Jordan Hoffmann | — | Lead author of the 2022 Chinchilla paper; made data allocation central to compute-optimal scaling |
+| Pablo Villalobos | — | Lead author of the Epoch AI "Will we run out of data?" analysis; framed public text as a measurable scaling stock |
 | Niklas Muennighoff | — | Lead author of "Scaling Data-Constrained Language Models"; characterised repetition, filtering, and code augmentation under finite data |
-| Alec Radford | — | Lead author of Whisper; demonstrated 680,000 hours of internet audio paired with transcripts as a multilingual supervision corpus |
+| Alec Radford | — | Lead author of Whisper; demonstrated internet audio paired with transcripts as multilingual supervision |
 | Sebastien Bubeck | — | Senior author of phi-1 / "Textbooks Are All You Need"; argued curated synthetic textbook data could alter scaling in code |
 | Ilia Shumailov | — | Lead author of "The Curse of Recursion"; defined model collapse as recursive training on generated data erasing distribution tails |
 
@@ -29,15 +29,15 @@ In March 2022, DeepMind's Chinchilla showed compute-optimal training must scale 
 ```mermaid
 timeline
     title Chapter 69 — The Data Exhaustion Limit
-    Mar 2022 : Hoffmann et al. publish Chinchilla — compute-optimal training scales model size and tokens together
+    Mar 2022 : Hoffmann et al. publish Chinchilla — tokens become a co-equal scaling variable
     Nov 2022 : Villalobos et al. first post the data-exhaustion analysis
     Dec 2022 : Self-Instruct shows a model-generated instruction-data pipeline
-    Dec 2022 : Whisper paper — 680,000 hours of internet audio paired with transcripts
+    Dec 2022 : Whisper paper — internet audio becomes multilingual supervision
     May 2023 : Muennighoff et al. release data-constrained scaling work on repeated data
     Jun 2023 : Phi-1 paper — synthetic textbook and exercise data produce strong code performance
     Mar 2023 / Mar 2024 : GPT-4 technical report and revisions describe contamination checks and synthetic comparison data
     Apr 2024 : Meta releases Llama 3 model card — 15T+ public-source pretraining tokens
-    Jun 2024 : Villalobos/Epoch v2 — public human text could be fully utilized between 2026 and 2032
+    Jun 2024 : Villalobos/Epoch v2 — public human text gets a near-term exhaustion model
     Jun 2024 / Oct 2024 : FineWeb — 15T-token Common Crawl dataset and 1.3T FineWeb-Edu subset
     Jul 2024 : Shumailov et al. popularise "model collapse" as a recursive synthetic-data risk
     Apr 2025 : LiveBench ICLR version frames contamination as a reason for monthly updated benchmarks
@@ -48,7 +48,7 @@ timeline
 <details>
 <summary><strong>Plain-words glossary</strong></summary>
 
-**Chinchilla-optimal scaling** — Hoffmann et al.'s 2022 finding that, for a fixed compute budget, language-model training should scale parameters and training tokens together rather than pour compute into ever-larger models on fixed datasets. The headline comparison: a 70B-parameter model trained on 1.4T tokens beat a much larger model trained less optimally with the same compute.
+**Chinchilla-optimal scaling** — The idea that a fixed compute budget has to be allocated across model size and training tokens, rather than spent only on ever-larger parameter counts.
 
 **Token** — The unit a language model trains on, roughly a sub-word fragment. "15T tokens" describes the volume of text a model has seen; it is not the same as 15T unique words, since a token vocabulary mixes whole words, word pieces, punctuation, and code symbols.
 
@@ -245,4 +245,3 @@ But it had stopped being free infinity.
 :::note[Why this still matters today]
 Every modern AI training run is now a logistical operation built on the lessons of this turn. Public model cards routinely cite trillion-token budgets, and dataset teams treat filtering, deduplication, and contamination checks as engineering disciplines with their own ablations and benchmarks. Synthetic data is part of mainstream pipelines for instruction tuning, code generation, and safety work — paired with filtering rather than trusted on its own. Model-collapse arguments shape how labs think about recursive training and provenance. Evaluation has shifted toward fresh, contamination-limited benchmarks that update faster than crawls. The data machine — crawlers, transcribers, synthesizers, annotators, legal review — has become as load-bearing as the architecture it feeds.
 :::
-

--- a/src/content/docs/ai-history/ch-70-the-energy-grid-collision.md
+++ b/src/content/docs/ai-history/ch-70-the-energy-grid-collision.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-AI data centers stopped looking like background internet infrastructure and became visible grid actors. The IEA estimated about 415 TWh in 2024 and projected about 945 TWh by 2030, still under 3% of global electricity. The collision was local: EPRI saw frontier training at 100-150 MW now and possibly 1-2 GW by 2028; FERC rejected PJM's amended Susquehanna ISA on November 1, 2024; Microsoft, Google, and Meta turned nuclear procurement into AI infrastructure strategy.
+AI data centers stopped looking like background internet infrastructure and became visible grid actors. Global demand projections stayed modest as a share of electricity, but the collision was local: concentrated AI loads arrived faster than interconnection studies, transmission upgrades, and firm generation usually move. FERC's Susquehanna order made the tariff questions concrete, while Microsoft, Google, and Meta turned firm clean power into AI infrastructure strategy.
 :::
 
 <details>
@@ -46,17 +46,17 @@ timeline
 <details>
 <summary><strong>Plain-words glossary</strong></summary>
 
-**Interconnection service agreement (ISA)** — The contract that governs how a generator or load connects to a regional transmission system. PJM's amended ISA at Susquehanna sought to raise co-located load from 300 MW to 480 MW; FERC rejected the amendment because PJM had not met the high burden required for non-conforming provisions on the record.
+**Interconnection service agreement (ISA)** — The contract that governs how a generator or load connects to a regional transmission system, including the technical and tariff terms for that connection.
 
-**Co-located load** — A large customer (here, an AWS data-center campus) sited next to a generator (the Susquehanna nuclear plant) and electrically arranged so that some or all of its supply comes from that plant rather than across the public transmission grid. The arrangement raises questions about backup service, market dispatch, and who pays for grid reliability.
+**Co-located load** — A large customer sited next to a generator and electrically arranged so that some or all of its supply comes from that nearby plant rather than through an ordinary grid-delivery path.
 
 **Power purchase agreement (PPA)** — A long-term contract under which a buyer agrees to take electricity (or its clean-energy attributes) from a specific generator. Microsoft/Constellation, Meta/Constellation, and Google/Kairos all signed PPAs; a PPA can finance a plant's operation without electrons physically flowing from that plant to the buyer's data center.
 
-**Behind the meter** — A load located on the generator's side of the utility billing meter rather than the public grid's side. The phrase makes the arrangement sound private, but if the load needs backup supply or affects market dispatch, the public system retains an interest.
+**Behind the meter** — A load located on the generator's side of the utility billing meter rather than the public grid's side.
 
 **Firm clean power** — Low-carbon electricity available continuously, including overnight, during heat waves, and during low-wind periods. Hourly matching is a stricter claim than annual matching. Nuclear, hydro with reservoirs, geothermal, and storage-paired renewables qualify in different degrees; intermittent solar and wind alone do not.
 
-**Small modular reactor (SMR)** — A class of advanced nuclear reactor designed to be built in factory modules and deployed at smaller unit sizes than conventional plants. Google's Kairos Power agreement targets first deployment by 2030 and up to 500 MW by 2035. SMRs face technology, licensing, construction, cost, and fuel uncertainties.
+**Small modular reactor (SMR)** — A class of advanced nuclear reactor designed to be built in factory modules and deployed at smaller unit sizes than conventional plants.
 
 **Interconnection queue** — The ordered list of generation and large-load projects awaiting study and approval to connect to a transmission system. Data centers can be operational in two to three years; queue studies, transmission upgrades, and generator builds typically move on longer clocks. The mismatch is the chapter's structural tension.
 
@@ -239,4 +239,3 @@ Every cloud region a developer chooses sits inside a regulated power system with
 The cloud had become infrastructure in the old sense.
 
 Steel, wires, fuel, permits, regulators, and clocks.
-

--- a/src/content/docs/ai-history/ch-71-the-chip-war.md
+++ b/src/content/docs/ai-history/ch-71-the-chip-war.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::tip[In one paragraph]
-In 2022 the United States began treating advanced AI accelerators as instruments of geopolitical power. BIS's October 7, 2022 controls linked advanced computing ICs, supercomputers, AI, military modernization, WMD design, and surveillance, then expanded across 2023 and December 2024 to cover HBM, manufacturing equipment, and software tools. ASML, TSMC, the Netherlands, and Japan became part of the rulebook. CHIPS funded slow re-shoring; China answered with materials controls. Frontier AI capability became a negotiated property of supply chains and law.
+In 2022 the United States began treating advanced AI accelerators as instruments of geopolitical power. BIS's October 7, 2022 controls linked advanced computing ICs, supercomputers, AI, military modernization, WMD design, and surveillance, then expanded across 2023 and 2024 from chips into the manufacturing stack. ASML, TSMC, the Netherlands, and Japan became part of the rulebook. CHIPS funded slow re-shoring; China answered with materials controls. Frontier AI capability became a negotiated property of supply chains and law.
 :::
 
 <details>
@@ -16,7 +16,7 @@ In 2022 the United States began treating advanced AI accelerators as instruments
 |---|---|---|
 | Gina Raimondo (BIS / U.S. Commerce) | — | Public face of the 2023/2024 export-control announcements |
 | Alan Estevez / Thea Rozman Kendler / Jeffery Kessler (BIS) | — | BIS leadership voices through the 2025 policy pivot |
-| Jensen Huang (NVIDIA) | — | Company-side witness to product-threshold adaptation through H20 |
+| Jensen Huang (NVIDIA) | — | Company-side witness to product-threshold adaptation |
 | C.C. Wei (TSMC) | — | Annual-report voice for advanced-node and CoWoS packaging capacity |
 | ASML management / investor relations | — | Institutional witness for EUV/DUV and export-control exposure |
 | MOFCOM / China's Bureau of Industrial Security | — | Counterparty in the December 2024 materials-control notice |
@@ -50,15 +50,15 @@ timeline
 
 **Export controls** — A government's legal authority to restrict the shipment of items, technology, software, services, and U.S.-person support across borders. BIS's October 2022 rule used controls to link advanced computing ICs, supercomputers, and AI applications to national-security rationale.
 
-**Foreign direct product (FDP) rule** — A jurisdictional reach that brings items made outside the United States under U.S. export controls when they are direct products of certain U.S. technology or software. The 2022 BIS package used FDP and Entity List footnotes to extend reach across a globally distributed semiconductor industry.
+**Foreign direct product (FDP) rule** — A jurisdictional hook that can bring items made outside the United States under U.S. export controls when they are direct products of certain U.S. technology or software.
 
-**Semiconductor manufacturing equipment (SME)** — The machines that produce advanced chips: lithography systems, deposition tools, etch tools, metrology, and process-control equipment. The December 2024 BIS package added controls on additional SME types and software tools used in chip manufacturing.
+**Semiconductor manufacturing equipment (SME)** — The machines that produce advanced chips: lithography systems, deposition tools, etch tools, metrology, and process-control equipment.
 
-**EUV / DUV lithography** — Two patterning technologies used to print circuit features onto wafers. EUV uses 13.5 nanometer light and prints the smallest, highest-density features at advanced nodes. ASML is the world's only manufacturer of EUV systems; DUV immersion remains important and entered the December 2024 control conversation.
+**EUV / DUV lithography** — Two patterning technologies used to print circuit features onto wafers. EUV uses 13.5 nanometer light for the smallest, highest-density features at advanced nodes; DUV immersion remains important across mature and advanced process flows.
 
-**High-bandwidth memory (HBM)** — Stacked memory packaged close to an accelerator to feed it data fast enough for AI training and inference at scale. The December 2024 BIS package added HBM controls because raw arithmetic units cannot be used efficiently without enough memory bandwidth.
+**High-bandwidth memory (HBM)** — Stacked memory packaged close to an accelerator to feed it data fast enough for AI training and inference at scale.
 
-**Advanced packaging / CoWoS** — The back-end manufacturing step that integrates compute dies, memory, and substrates into a single accelerator package. TSMC's CoWoS capacity sat alongside its 3nm and 2nm wafer capacity as a strategic bottleneck for frontier AI chips.
+**Advanced packaging / CoWoS** — The back-end manufacturing step that integrates compute dies, memory, and substrates into a single accelerator package.
 
 **Entity List** — A BIS-published list of foreign persons and organizations that require licenses for items subject to U.S. export controls. The December 2024 package added 140 entities and modified 14 more, often with FDP footnotes that extend reach.
 
@@ -249,4 +249,3 @@ Every frontier model launch you read about in the late 2020s sits inside this st
 At the beginning of AI history, intelligence looked like a theorem, a neuron, a program, or a search tree.
 
 By the 2020s, it also looked like an export license.
-


### PR DESCRIPTION
## Summary
- Trim repeated Ch69 reader-aid detail for Chinchilla, Epoch data exhaustion, and Whisper while preserving the body anchors.
- Compress Ch70 TL;DR/glossary material so grid-demand numbers, Susquehanna details, and SMR deal specifics land in the prose.
- Reduce Ch71 export-control reader-aid echoes around H20, FDP/SME, HBM, lithography, and advanced packaging.

## Verification
- git diff --check origin/main..HEAD
- ../../.venv/bin/python scripts/check_reader_aids.py ch-69 ch-70 ch-71
- rg -n -o '\\$[0-9][0-9A-Za-z.,]*' changed chapter files: only legitimate Ch71 currency anchors\n- ../../.venv/bin/python scripts/test_pipeline.py: 166 passed\n- npm run build from primary checkout detached at b1180e57: passed\n\nCross-family review requested before merge.