### PR TITLE
fix(multi-cluster): density re-pass on module 5.6 Gardener (#388 prep)

### DIFF
--- a/src/content/docs/on-premises/multi-cluster/module-5.6-gardener.md
+++ b/src/content/docs/on-premises/multi-cluster/module-5.6-gardener.md
@@ -1275,7 +1275,7 @@ Node rollout may take longer than control-plane rollout because nodes must be re
 
 ### Task 6: Rotate Kubeconfig Credentials and Delete the Shoot
 
-Use gardenctl to target the local Shoot.
+Use gardenctl to target the local Shoot before changing credentials, because this step makes the active Garden, Project, and Shoot explicit in your shell. Treat the target selection as part of the safety procedure, not as a convenience shortcut.
 
 ```bash
 gardenctl target --garden local --project local --shoot local
@@ -1283,13 +1283,13 @@ eval "$(gardenctl kubectl-env bash)"
 k get ns
 ```
 
-Rotate the Shoot's kubeconfig credentials with the operator workflow requested for this module.
+Rotate the Shoot's kubeconfig credentials with the operator workflow requested for this module, then watch the Shoot status rather than assuming the command completed every phase instantly. Credential rotation is a reconciled lifecycle operation, so status is the source of truth.
 
 ```bash
 gardenctl rotate-kubeconfig --garden local --project local --shoot local
 ```
 
-If your installed gardenctl does not provide that exact command, use the Gardener credential-rotation annotations:
+If your installed gardenctl does not provide that exact command, use the Gardener credential-rotation annotations shown below as the equivalent API-level path. This keeps the exercise aligned with Gardener's reconciliation model while avoiding dependence on one particular gardenctl release.
 
 ```bash
 k --kubeconfig "$PWD/example/gardener-local/kind/local/kubeconfig" \


### PR DESCRIPTION
## Summary
Reflows the Task 6 short-paragraph cluster into fuller instructional prose. Brings `max_consecutive_short_run` from **3 → 2** (boundary fail closed).

## Density metrics

| Metric | Before | After |
|--------|--------|-------|
| body_words | 6789 | 6873 |
| mean_wpp | 54.31 | 54.98 |
| median_wpp | 58 | 58 |
| short_paragraph_rate | 10.40% | 8.00% |
| max_consecutive_short_run | 3 | 2 |
| mean_sentence_length | 12.48 | 12.54 |

All density gates pass.

## Protected assets (unchanged)
- 33 fenced blocks → 33
- 1 mermaid → 1
- 49 markdown table lines → 49

## Section counts (unchanged)
- DYK=4, Common Mistakes=7, Quiz=7 with `<details>`, Hands-On=34 checkboxes
- bare 47 count: 0

## Test plan
- [ ] `npm run build` passes (verified by codex worktree)
- [ ] Cross-family Gemini review (next)

Per `scripts/prompts/module-rewriter-388.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)