### PR TITLE
feat(388): rewrite module-1.2-jobs-cronjobs (#388 pilot)

### DIFF
--- a/src/content/docs/k8s/ckad/part1-design-build/module-1.2-jobs-cronjobs.md
+++ b/src/content/docs/k8s/ckad/part1-design-build/module-1.2-jobs-cronjobs.md
@@ -1,5 +1,5 @@
 ---
-revision_pending: true
+revision_pending: false
 title: "Module 1.2: Jobs and CronJobs"
 slug: k8s/ckad/part1-design-build/module-1.2-jobs-cronjobs
 sidebar:
@@ -11,45 +11,53 @@ lab:
   difficulty: intermediate
   environment: kubernetes
 ---
-> **Complexity**: `[MEDIUM]` - Essential CKAD skill with specific patterns
+
+# Module 1.2: Jobs and CronJobs
+
+> **Complexity**: `[MEDIUM]` - Essential CKAD skill with specific production tradeoffs
 >
 > **Time to Complete**: 45-50 minutes
 >
-> **Prerequisites**: Module 1.1 (Container Images), understanding of Pods
+> **Prerequisites**: Module 1.1 (Container Images), basic Pod lifecycle knowledge, and a working Kubernetes 1.35+ cluster
+
+The examples in this module use the standard CKAD shortcut `alias k=kubectl`. Create it in your shell before practicing so the commands match the exam-style workflow and the troubleshooting examples below.
+
+```bash
+alias k=kubectl
+```
 
 ---
 
 ## Learning Outcomes
 
 After completing this module, you will be able to:
-- **Create** Jobs and CronJobs with correct completion counts, parallelism, and backoff limits
-- **Configure** CronJob schedules, concurrency policies, and history limits
-- **Debug** failed Jobs by inspecting pod logs, events, and restart behavior
-- **Compare** Jobs vs CronJobs and choose the right resource for one-off vs recurring batch workloads
 
----
+- **Design** Jobs and CronJobs with correct completion counts, parallelism, retry limits, cleanup controls, and schedules.
+- **Configure** CronJob concurrency, deadline, suspension, and history behavior for recurring batch workloads.
+- **Diagnose** failed batch workloads by correlating Job status, Pod events, container logs, restart policy, and controller retry behavior.
+- **Compare** Jobs, CronJobs, Deployments, and ad hoc Pods so you can choose the right controller for one-time, recurring, and long-running work.
 
 ## Why This Module Matters
 
-Not every workload runs forever. Backups run once. Reports generate hourly. Data migrations complete and exit. These are batch workloads, and Kubernetes handles them with Jobs and CronJobs.
+In 2017, GitLab published a detailed incident report after a production database maintenance operation went badly wrong and left the company restoring data under intense customer pressure. The failure was not a Kubernetes Job failure, but the lesson is directly relevant: operational work that feels like "just a script" can become a business incident when retries, scheduling, ownership, and cleanup are vague. A backup, migration, report, or cleanup task is not safer because it is short-lived; it is safer only when the platform knows when it should start, when it should stop, how many times it may retry, and what evidence it should leave behind for diagnosis.
 
-The CKAD heavily tests Jobs because they're a core developer task. You'll see questions like:
-- "Create a Job that runs to completion"
-- "Create a CronJob that runs every 5 minutes"
-- "Fix a failing Job"
-- "Configure parallel Jobs"
+Kubernetes separates this kind of work from Deployments because the desired end state is different. A Deployment tries to keep a number of Pods running indefinitely, while a Job tries to reach a number of successful completions and then stop creating Pods. A CronJob adds time to that model: it creates Jobs on a schedule, applies overlap rules when a previous run is still active, and retains a bounded amount of history so teams can inspect recent successes and failures without letting old Pods fill the namespace.
+
+For CKAD work, Jobs and CronJobs are high-value because they mix API knowledge with debugging judgment. You may be asked to create a Job imperatively, generate YAML for a CronJob, change `parallelism`, fix an invalid `restartPolicy`, or explain why a scheduled backup did not start. This module teaches the mechanics, but it also teaches the operational shape: every batch workload has a start rule, a completion rule, a retry rule, a cleanup rule, and a failure investigation path.
+
+That operational shape is the difference between "a command that happened to run" and "a workload the platform can reason about." If a one-off migration fails on a developer laptop, the evidence may live only in a terminal scrollback. If the same migration runs as a Job, the cluster records status, events, logs, owner references, and retry attempts in places the whole team can inspect. The controller does not make bad scripts good, but it gives good scripts a reliable execution envelope.
+
+CronJobs add another layer of accountability because schedules often outlive the person who wrote them. A cleanup job created during a release crunch may still be running months later, and a backup job may become part of compliance evidence. For that reason, a CronJob manifest should read like an operational policy: when it runs, what happens if it is late, what happens if it overlaps, how much history remains, and how a human can test the same template without waiting for the next scheduled time.
 
 > **The Factory Shift Analogy**
 >
-> Deployments are like permanent factory staff—they clock in and stay until fired. Jobs are like contractors hired for specific tasks—they come in, complete the work, and leave. CronJobs are like scheduled maintenance crews—they arrive at specific times (every night, every Monday), do their job, and depart.
+> Deployments are like permanent factory staff: they clock in and stay until the business changes the staffing plan. Jobs are like contractors hired for a specific piece of work: they arrive, complete the work, and leave records behind. CronJobs are like scheduled maintenance crews: they arrive at specific times, do the work, and follow rules about whether a late or overlapping shift should still happen.
 
----
+## Jobs: Completion Controllers For One-Time Work
 
-## Jobs: One-Time Tasks
+A Job is a controller for finite work. It owns one or more Pods, watches their exit results, and decides whether enough Pods have succeeded to mark the work complete. That distinction matters because Kubernetes does not read your script and infer whether the backup, migration, or report was meaningful; it only sees whether containers exit with status zero or non-zero. Your container command therefore becomes part of the contract between the application and the control plane.
 
-A Job creates one or more Pods and ensures they run to successful completion.
-
-### Creating Jobs Imperatively
+The simplest Job runs one Pod and needs one successful completion. This is the pattern you use for small migrations, smoke reports, and exam tasks where the command does a single piece of work and exits. The imperative command is fast for CKAD tasks, and the dry-run form is useful when you need to add fields that `k create job` does not expose directly.
 
 ```bash
 # Simple job
@@ -62,7 +70,7 @@ k create job report --image=busybox -- /bin/sh -c "date; echo 'Report generated'
 k create job backup --image=busybox --dry-run=client -o yaml -- echo "done" > job.yaml
 ```
 
-### Job YAML Structure
+When you turn that command into YAML, the important part is not the `kind: Job` line by itself. The important part is the nested Pod template and the Job-level controls around it. The template says what work should run; `backoffLimit`, `activeDeadlineSeconds`, `completions`, `parallelism`, and `ttlSecondsAfterFinished` say how the controller should behave when work succeeds, fails, takes too long, or finishes and needs cleanup.
 
 ```yaml
 apiVersion: batch/v1
@@ -81,8 +89,6 @@ spec:
   ttlSecondsAfterFinished: 100  # Auto-cleanup
 ```
 
-### Key Job Properties
-
 | Property | Purpose | Default |
 |----------|---------|---------|
 | `restartPolicy` | What to do on failure | Must be `Never` or `OnFailure` |
@@ -92,27 +98,27 @@ spec:
 | `completions` | Required successful completions | 1 |
 | `parallelism` | Max parallel pods | 1 |
 
-> **Pause and predict**: A Job requires `restartPolicy` to be set to either `Never` or `OnFailure`. Why can't you use `Always` -- the default for Deployments? Think about what a Job is supposed to do, then read the explanation.
+The `restartPolicy` rule is one of the easiest ways to catch a fake Job manifest. Jobs may use `Never` or `OnFailure`; they may not use `Always`, because an always-restarting Pod can never naturally express successful completion. With `Never`, a failed container leaves a failed Pod and the Job controller creates another Pod if retries remain. With `OnFailure`, kubelet restarts the container inside the same Pod, which can be cheaper but sometimes hides the history you wanted to inspect.
 
-### restartPolicy Explained
+The tradeoff between `Never` and `OnFailure` is partly about evidence. `Never` tends to leave a clearer trail because each failed Pod has its own events, status, and logs, which helps when you are learning or when the failure changes between attempts. `OnFailure` can be better for short transient failures because kubelet can restart the container without forcing the Job controller to create a replacement Pod. Neither policy fixes a broken command; each only changes where retries happen and what evidence remains.
+
+> **Pause and predict**: A Job requires `restartPolicy` to be set to either `Never` or `OnFailure`. Why can't you use `Always`, the default style you may associate with long-running controllers? Think about what a Job is supposed to prove before you read the explanation in the next paragraph.
+
+The reason is that a Job is complete only when the controller can count successful Pod completions. A container that restarts forever is useful for a web server, but it is a poor signal for batch work because it keeps moving instead of finishing. If you need a worker process that continuously watches a queue, a Deployment may be the better controller; if you need a bounded number of successful attempts, a Job is the better controller.
 
 ```yaml
 # Never: Don't restart failed containers (create new pod)
 restartPolicy: Never
-# Pod fails → New pod created (up to backoffLimit)
+# Pod fails -> New pod created (up to backoffLimit)
 
 # OnFailure: Restart failed container in same pod
 restartPolicy: OnFailure
-# Container fails → Same pod restarts container
+# Container fails -> Same pod restarts container
 ```
 
----
+The next design choice is how many successful completions you want and how much concurrency the cluster should allow. A single completion is the default and fits one-off work. Multiple sequential completions fit repeatable independent work when order or resource pressure matters. Parallel completions fit a workload where many shards can run at the same time, provided the application can determine which shard to process and can tolerate several Pods executing together.
 
-## Job Patterns
-
-### Pattern 1: Single Completion (Default)
-
-Run one pod, succeed once:
+This is where many learners accidentally over-credit Kubernetes. The Job controller can count successful Pods, but it does not automatically divide your input data into safe units. If ten Pods all run `process-all-files.sh`, you may process the same files ten times unless the script, queue, or indexed-completion design prevents it. Parallelism is a capacity knob, not a correctness guarantee. Correctness still comes from idempotent application behavior, safe task claiming, and output paths that tolerate retries.
 
 ```yaml
 apiVersion: batch/v1
@@ -129,9 +135,9 @@ spec:
       restartPolicy: Never
 ```
 
-### Pattern 2: Multiple Completions (Sequential)
+Sequential completions are useful when the cluster should run the same template several times but keep only one Pod active at a time. This can model a batch import that must respect an external rate limit, a database operation that should not have concurrent writers, or a training task where each completion consumes a separate unit of work from an external system. The key is that Kubernetes counts completions, not business objects, unless your script maps each Pod execution to a specific object.
 
-Run task N times, one at a time:
+In practice, sequential Jobs are also useful as a stepping stone while you harden a batch process. You may begin with `completions: 5` and `parallelism: 1` because you want predictable logs and low pressure on a downstream service. After you prove that each attempt is independent and repeatable, you can raise `parallelism` carefully. This staged approach is slower than jumping to maximum concurrency, but it reveals hidden assumptions before they become production outages.
 
 ```yaml
 apiVersion: batch/v1
@@ -150,9 +156,9 @@ spec:
       restartPolicy: Never
 ```
 
-### Pattern 3: Parallel Processing
+Parallel processing changes the capacity profile. The controller still wants a fixed number of successful completions, but it is allowed to keep several Pods active at the same time. That means you must think about shared resources: a CPU-bound image processor may benefit from parallelism, while a schema migration that writes to one database table may become dangerous if several Pods execute the same mutation concurrently.
 
-Run multiple pods simultaneously:
+The safe way to choose parallelism is to start from the narrowest bottleneck, not from the number of nodes. A cluster may have enough CPU for many Pods, but the external API, database connection pool, object store, or license server may tolerate far fewer simultaneous clients. A Job that overwhelms a dependency can look like a Kubernetes failure even when the controller is behaving perfectly. Resource requests protect the cluster; application-level limits protect the systems your Pods call.
 
 ```yaml
 apiVersion: batch/v1
@@ -171,9 +177,9 @@ spec:
       restartPolicy: Never
 ```
 
-### Pattern 4: Work Queue (Parallelism Without Completions)
+A work-queue Job is slightly different because the queue, not Kubernetes, defines when there is no more work. In that model you often set `parallelism` and omit `completions`, then let workers pull items until each worker exits successfully. This is powerful, but it shifts correctness into the queue protocol: workers must claim work safely, handle duplicate attempts, and exit when the queue is empty rather than sitting idle forever.
 
-Process items until queue is empty:
+Queue-driven Jobs are common in production because they decouple cluster capacity from business demand. If a queue has many items, you can raise `parallelism` and run more workers; if the queue is empty, workers exit and the Job finishes. The danger is that a worker that polls forever will prevent completion, while a worker that exits too early may leave work behind. A reliable worker needs clear empty-queue semantics, timeout behavior, and logging that explains whether it completed work or found nothing to do.
 
 ```yaml
 apiVersion: batch/v1
@@ -192,13 +198,17 @@ spec:
       restartPolicy: Never
 ```
 
----
+A useful way to debug your own design is to state the completion rule in plain language before writing YAML. For example, "run one backup and stop" maps to default completions and parallelism. "Process ten independent shards with at most three Pods active" maps to `completions: 10` and `parallelism: 3`. "Run workers until Redis says no tasks remain" maps to a queue-driven design, where Kubernetes controls worker count but your application controls task ownership.
 
-## CronJobs: Scheduled Tasks
+One more design habit pays off on both the exam and real teams: decide whether failed attempts are valuable evidence or just noise. During development, you may deliberately keep finished Jobs around so you can compare Pods, logs, and events. In stable scheduled work, you usually keep only a small window of history and rely on alerts or metrics for long-term visibility. Retention is not an aesthetic preference; it controls whether operators can see enough evidence without drowning in stale objects.
 
-CronJobs run Jobs on a schedule.
+## CronJobs: Schedules That Create Jobs
 
-### Creating CronJobs Imperatively
+A CronJob is a Job factory with a clock. It does not run your container directly; it creates Jobs from `spec.jobTemplate` whenever the schedule fires, and each created Job then manages its own Pods. This layering is why CronJob debugging often has two levels: first verify whether the CronJob created a Job, then inspect the Job and Pods to learn whether the run succeeded.
+
+The schedule uses the familiar five-field cron format: minute, hour, day of month, month, and day of week. Kubernetes 1.35 CronJobs also support a `timeZone` field, which is safer than relying on controller-manager local time or comments in a manifest. If your schedule represents a business-local deadline, document the time zone directly in the spec so daylight saving changes and operator geography do not become hidden assumptions.
+
+The time-zone detail is easy to underestimate because many lab clusters run everything in UTC and examples often avoid local business rules. Real schedules are rarely that neutral. A payroll export, end-of-day report, or maintenance window may be tied to a region, a legal jurisdiction, or a customer contract. When the schedule is business-local, the manifest should carry that fact. Otherwise, a future platform migration or daylight saving transition can change behavior without any application release.
 
 ```bash
 # Every minute
@@ -214,7 +224,7 @@ k create cronjob daily-cleanup --image=busybox --schedule="0 0 * * *" -- echo "D
 k create cronjob backup --image=busybox --schedule="0 2 * * *" --dry-run=client -o yaml -- /backup.sh > cronjob.yaml
 ```
 
-### CronJob YAML Structure
+The generated YAML deserves careful reading because the Job template is nested more deeply than a normal Job. Fields such as `schedule`, `concurrencyPolicy`, `successfulJobsHistoryLimit`, `failedJobsHistoryLimit`, `startingDeadlineSeconds`, and `suspend` belong to the CronJob. Fields such as `backoffLimit`, `ttlSecondsAfterFinished`, and the Pod template belong under `jobTemplate.spec`, because they configure each Job the CronJob creates.
 
 ```yaml
 apiVersion: batch/v1
@@ -238,7 +248,9 @@ spec:
           restartPolicy: OnFailure
 ```
 
-### Cron Schedule Format
+The cron expression is compact, so use the diagram as a reading tool rather than memorizing examples blindly. The leftmost field changes most often, and the rightmost fields narrow the calendar. In production reviews, the biggest mistake is not a typo; it is a schedule that was technically valid but expressed the wrong business intent because the author confused day-of-month, day-of-week, or UTC.
+
+Cron expressions also hide frequency cost. A schedule of `* * * * *` looks tiny, but it creates up to 1,440 opportunities per day for the controller to create Jobs. That may be fine for a lightweight heartbeat, but it is excessive for a report that pulls large data sets. When you choose a schedule, estimate how many Jobs it creates per day and how much log, event, and object churn that implies. The cost is not only compute; it is also operational noise.
 
 ```
 ┌───────────── minute (0 - 59)
@@ -249,8 +261,6 @@ spec:
 │ │ │ │ │
 * * * * *
 ```
-
-### Common Schedules
 
 | Schedule | Meaning |
 |----------|---------|
@@ -263,15 +273,11 @@ spec:
 | `0 0 1 * *` | Monthly on the 1st at midnight |
 | `30 4 * * 1-5` | 4:30 AM on weekdays |
 
----
+Concurrency policy is the CronJob field that turns a valid schedule into a safe schedule. The default `Allow` means the controller may create a new Job even if the previous one is still running. `Forbid` skips a new run when the previous run has not finished. `Replace` terminates the old run and starts the new one, which can be correct for freshness-oriented work but dangerous for destructive maintenance.
 
-## CronJob Policies
+Choosing among those policies is a business decision disguised as a YAML field. `Allow` says every scheduled time matters independently, even if work overlaps. `Forbid` says completion matters more than strict schedule count, so the system may skip a run to protect shared state. `Replace` says the latest run is more valuable than finishing the previous run. If you cannot explain that choice in one sentence, the CronJob probably needs a design review before it is trusted.
 
-> **Stop and think**: You have a CronJob that runs a database backup every hour, but sometimes the backup takes 75 minutes. What happens when the next scheduled run triggers while the previous one is still running? What policy would you choose: `Allow`, `Forbid`, or `Replace`?
-
-### concurrencyPolicy
-
-What happens if a new schedule triggers while a Job is still running?
+> **Stop and think**: You have a CronJob that runs a database backup every hour, but sometimes the backup takes 75 minutes. What happens when the next scheduled run triggers while the previous one is still running? Which policy would you choose here and why: `Allow`, `Forbid`, or `Replace`?
 
 ```yaml
 spec:
@@ -288,22 +294,24 @@ spec:
 | `Forbid` | Skip if previous running | Avoid resource contention |
 | `Replace` | Stop previous, start new | Latest data matters |
 
-### startingDeadlineSeconds
+`startingDeadlineSeconds` handles missed schedules, not ordinary runtime. If the controller is unavailable, the cluster is under pressure, or the CronJob is otherwise delayed, this field tells Kubernetes how long after the scheduled time a run is still worth starting. A short deadline is useful for work that loses value quickly, such as frequent cache refreshes; a longer deadline is better for work that must eventually happen, such as compliance exports.
 
-How long a Job can be delayed before it's considered missed:
+This field is especially important after outages. Without a clear deadline, a recovered controller may need to decide what to do about missed times according to controller behavior and history. A deadline lets you express intent: a cache refresh that is ten minutes late may be pointless, while a daily accounting export may still matter hours later. The more business meaning a run has, the more deliberate you should be about the missed-start policy.
 
 ```yaml
 spec:
   startingDeadlineSeconds: 100  # Must start within 100s of schedule
 ```
 
-If a Job can't start within this window (cluster issues, resource constraints), it's skipped.
+Suspension is a quieter but important operational control. Setting `spec.suspend: true` stops future schedules without deleting the CronJob, which is useful during incident response, maintenance windows, or risky releases. It does not normally delete already-created Jobs, so you still inspect and clean active Jobs separately. That separation is helpful because stopping future work should not erase the evidence from the current failed run.
 
----
+Manual triggering pairs well with suspension. During a risky change, you can suspend future scheduled runs, create a manual Job from the current template, watch the result, and then resume the schedule when you are confident. This workflow is safer than editing the schedule to an artificial time because it keeps the production schedule intact. It also gives reviewers a clean audit trail: the CronJob was paused, a manual validation ran, and the schedule was resumed.
 
-## Managing Jobs and CronJobs
+## Retry, Cleanup, and Debugging Behavior
 
-### Checking Status
+Troubleshooting batch workloads begins by identifying which controller state you are looking at. A CronJob may be healthy while the Job it created is failing, and a Job may be retrying while individual Pods have already terminated. Start broad with `k get cronjobs`, `k get jobs`, and labels, then narrow to `k describe`, logs, events, and Pod status. This order prevents a common mistake: reading the newest Pod log and assuming it explains the entire Job history.
+
+The controller hierarchy is your map. CronJob status answers scheduling questions, Job status answers completion and retry questions, Pod status answers scheduling and container lifecycle questions, and container logs answer application questions. Moving down the hierarchy too early wastes time because an application log cannot tell you why the CronJob never created a Job. Moving up too late also wastes time because a healthy CronJob does not prove the created Pod had permission to read a ConfigMap or write output.
 
 ```bash
 # List jobs
@@ -322,7 +330,9 @@ k describe job my-job
 k get job my-job -w
 ```
 
-### Viewing Logs
+Logs are easiest when the Job has exactly one active or completed Pod, because `k logs job/my-job` can find the Pod for you. When there have been multiple retries, use the `job-name` label to list Pods and inspect the specific Pod that failed in the way you care about. With `restartPolicy: OnFailure`, remember that the same Pod may contain restarted container attempts, so look at restart counts and previous logs when needed.
+
+Events explain what logs cannot. An image pull error, failed scheduling decision, missing ConfigMap, denied volume mount, or exceeded deadline may happen before your application starts, so there may be no useful application log at all. `k describe` combines status and events in one view, which is why it should be part of every Job investigation. If the container never ran, the fix is usually in the Pod template, permissions, image reference, or cluster capacity rather than in the application script.
 
 ```bash
 # Get logs from job's pod
@@ -335,14 +345,18 @@ k logs my-job-abc12
 k logs -f job/my-job
 ```
 
-### Manual Trigger
+Manual triggering is the safest way to test a CronJob template without waiting for the clock. The command below creates a one-off Job from the CronJob's current template, which lets you verify image pull behavior, command syntax, ConfigMap mounts, and RBAC before relying on the schedule. It does not prove the cron expression is correct, but it proves the Job template can run right now.
+
+This distinction is useful in incident response because it narrows the search quickly. If a manual trigger fails the same way as the scheduled run, focus on the Job template and dependencies. If a manual trigger succeeds but the scheduled run did not appear, focus on the CronJob schedule, suspension state, deadline, time zone, and controller events. Separating those two failure classes keeps you from rewriting working container commands while the real problem is a scheduling rule.
 
 ```bash
 # Create job from cronjob immediately
 k create job manual-backup --from=cronjob/daily-backup
 ```
 
-### Cleanup
+Cleanup should be designed, not treated as an afterthought. Finished Jobs and Pods are useful evidence, but they also create visual noise and consume API objects. CronJob history limits control how many created Jobs remain attached to the CronJob, while `ttlSecondsAfterFinished` lets the TTL controller remove finished Jobs after a delay. Use both when you want recent evidence without keeping every successful run forever.
+
+The right retention window depends on how quickly humans and monitoring systems notice failures. For a frequent cleanup job, keeping three successful runs and one failed run may be enough because the next failure will happen soon and alerts should fire promptly. For a monthly compliance export, you might keep more history or export evidence elsewhere before TTL removes the Job. Kubernetes retention settings should complement, not replace, logs, metrics, and external audit storage.
 
 ```bash
 # Delete job
@@ -355,11 +369,9 @@ k delete cronjob my-cronjob
 # (Automatic if ttlSecondsAfterFinished is set)
 ```
 
----
+When a Job will not complete, read it like a chain of contracts. The image must pull, the Pod must schedule, the command must run, the container must exit with the intended code, and the Job controller must still have retries and time remaining. A non-zero exit code is not inherently bad; it is the application's way of telling Kubernetes that the work did not meet the success contract and should be retried or marked failed.
 
-## Troubleshooting Jobs
-
-### Job Won't Complete
+The exit code contract is why shell wrappers deserve care. A command like `sh -c "step1; step2; echo done"` may print a happy message even when an earlier step failed, depending on how the shell is written. In production scripts, teams often use `set -e` or explicit error checks so the container exits non-zero when the work did not actually succeed. Kubernetes can only act on the exit status it receives, so sloppy scripting can turn real failures into false completions.
 
 ```bash
 # Check status
@@ -375,9 +387,9 @@ k describe job my-job
 k logs $(k get pods -l job-name=my-job -o jsonpath='{.items[0].metadata.name}')
 ```
 
-> **What would happen if**: You create a Job with `backoffLimit: 6` (the default) and `restartPolicy: Never`. The container's script has a bug that always exits with code 1. How many pods will Kubernetes create before giving up?
+> **What would happen if**: You create a Job with `backoffLimit: 6`, which is the default, and `restartPolicy: Never`. The container's script has a bug that always exits with code 1. Before running this, what output do you expect from `k get pods -l job-name=my-job`, and why?
 
-### Job Keeps Retrying
+The controller will keep creating replacement Pods until the failure policy is exhausted. With `restartPolicy: Never`, each failed attempt is visible as a separate failed Pod, which is noisy but very helpful during diagnosis. With `restartPolicy: OnFailure`, you may instead see restarts inside a smaller number of Pods, so your debugging habit must match the restart policy. In both cases, the root fix is the same: inspect the exit reason and application log, then correct the command, image, dependencies, or permissions.
 
 ```bash
 # Check backoffLimit
@@ -387,7 +399,9 @@ k get job my-job -o jsonpath='{.spec.backoffLimit}'
 k describe pods -l job-name=my-job
 ```
 
-### CronJob Not Running
+CronJob failures require one extra question: did the schedule create a Job at all? If `lastScheduleTime` is empty or stale, inspect the schedule, suspension flag, deadline, and controller events. If Jobs exist but fail, shift your attention to the Job and Pods. This split keeps you from changing retry fields when the real issue is a suspended CronJob or a missed schedule.
+
+Names can also guide the investigation. Jobs created by a CronJob normally include the CronJob name plus generated suffixes, and their Pods carry labels that link them back to the Job. Use owner references and labels instead of guessing from timestamps when several batch workloads run in the same namespace. This becomes important during outages, when several CronJobs may all create delayed or failed work around the same time.
 
 ```bash
 # Check cronjob status
@@ -403,63 +417,141 @@ k get cronjob my-cronjob -o jsonpath='{.spec.suspend}'
 k patch cronjob my-cronjob -p '{"spec":{"suspend":false}}'
 ```
 
----
+A practical war story makes the difference concrete. A platform team once scheduled a nightly report generator as a CronJob with the default `Allow` policy because the YAML looked smaller and the first few runs finished quickly. At month end, each run took longer, the next schedule created another Job, and several Pods competed for the same database read replica until dashboard latency spiked. The fix was not exotic: they set `concurrencyPolicy: Forbid`, added a runtime deadline, tuned resource requests, and created an alert when a run was skipped because the previous one was still active.
+
+## Patterns & Anti-Patterns
+
+Good batch design starts by making the work idempotent. A Job may retry after a node failure, a container crash, or a deadline miss, and a CronJob may create a later run after an earlier run partially completed. If your script can safely run twice and converge on the same result, Kubernetes retry behavior becomes an asset instead of a threat. If your script cannot tolerate duplicates, you need external locking, transaction boundaries, or a different workflow.
+
+Idempotency does not mean the work has no side effects. It means repeated attempts produce an acceptable final state. Uploading a file to a deterministic object key, marking a database row processed inside a transaction, or writing output with a unique completion index can all be idempotent designs. Appending blindly to a report, deleting by a broad pattern, or charging a customer inside a retrying Job are dangerous unless the application uses safeguards beyond Kubernetes.
+
+| Pattern | When to Use It | Why It Works | Scaling Consideration |
+|---------|----------------|--------------|-----------------------|
+| Single-completion Job | One migration, one backup test, one report export | The controller needs exactly one successful Pod and then stops | Keep `backoffLimit` low enough that a bad command fails visibly |
+| Fixed parallel completions | Many independent shards or files | `completions` defines total work and `parallelism` caps active Pods | Match parallelism to cluster capacity and downstream rate limits |
+| Queue-driven workers | Work items live in Redis, a database table, or another queue | Kubernetes controls worker count while the queue controls item ownership | Workers must claim items atomically and exit cleanly when no work remains |
+| CronJob with forbidden overlap | Backups, cleanup, compaction, or reports that touch shared state | A new run is skipped instead of stacking onto unfinished work | Alert on missed runs so skipped schedules are visible |
+
+Anti-patterns usually come from treating Jobs as small Deployments or treating CronJobs as ordinary crontab lines. Kubernetes adds controller behavior, status, events, and garbage collection, but it also expects your manifest to define the lifecycle clearly. The safest review question is, "What happens if this command fails halfway through and Kubernetes tries again?"
+
+Another useful review question is, "Who owns the result after the Pod exits?" A Job can tell you that a container exited successfully, but it cannot prove that the backup is restorable, the report is correct, or the cleanup deleted only intended data. Mature batch systems pair Kubernetes controller status with application-level verification, such as checksum validation, row counts, smoke queries, or a restore test. The controller proves execution; the application must prove business correctness.
+
+| Anti-Pattern | What Goes Wrong | Better Alternative |
+|--------------|-----------------|--------------------|
+| Using a Deployment for finite migration work | The Pod restarts after success and the migration may run repeatedly | Use a Job with a clear command, retry limit, and cleanup policy |
+| Leaving CronJob concurrency at `Allow` for shared-state work | Long runs overlap and compete for the same files, locks, or databases | Use `Forbid` or design the task to be safely concurrent |
+| Setting high retries without observability | A broken command burns time and creates many failing Pods before anyone notices | Use a deliberate `backoffLimit`, inspect events, and alert on failed Jobs |
+| Keeping every completed run forever | Namespaces become cluttered and humans stop noticing real failures | Combine history limits with `ttlSecondsAfterFinished` |
+
+The pattern that scales best is the one whose failure mode you have rehearsed. A parallel image processor can retry individual shards if the output path includes the shard identity. A database backup should avoid overlap because two backup streams may overload storage and produce confusing evidence. A report generator may use `Replace` if only the newest data matters, but a cleanup job should rarely be replaced mid-delete unless the cleanup operation is explicitly transactional.
+
+For CKAD, you will not build a complete production batch platform, but the same reasoning helps you answer scenario questions quickly. Identify whether the workload is finite or continuous, decide whether time is part of the requirement, choose the controller, then tune retry, concurrency, and cleanup. Most wrong answers violate one of those steps. They use a Deployment for finite work, forget overlap policy for scheduled work, or debug a Pod log when no Job was ever created.
+
+## Decision Framework
+
+Choose the controller by asking what "healthy" means. If healthy means "there should always be three Pods serving traffic," use a Deployment or another long-running controller. If healthy means "this task should eventually complete once," use a Job. If healthy means "a Job should be created on a calendar," use a CronJob. The controller should encode the desired lifecycle, not just happen to launch a container.
+
+After you choose the controller, choose the failure budget for the work. Expensive or destructive jobs usually deserve fewer retries, stronger observability, and manual review when they fail. Cheap and idempotent jobs can often tolerate more retries because repeated attempts are safe and useful. The mistake is to copy retry values from an example without asking what a retry costs. A failed thumbnail job and a failed data migration do not deserve the same operational policy.
+
+```text
+Need the workload to keep running?
+        |
+        +-- yes --> Use a Deployment, StatefulSet, or another long-running controller.
+        |
+        +-- no --> Is the work scheduled repeatedly?
+                  |
+                  +-- no --> Use a Job with completions, parallelism, retry, and TTL rules.
+                  |
+                  +-- yes --> Use a CronJob with schedule, concurrency, deadline, and history rules.
+```
+
+| Decision | Prefer This | Avoid This |
+|----------|-------------|------------|
+| One migration must run once | Job with `parallelism: 1` and deliberate retries | Deployment that restarts the migration container forever |
+| Hourly backup sometimes exceeds one hour | CronJob with `concurrencyPolicy: Forbid` | Default overlap that launches competing backup Pods |
+| Cache refresh where newest run matters most | CronJob with `Replace` after checking termination safety | Killing non-idempotent work without cleanup guarantees |
+| Hundreds of independent files need processing | Job with fixed `completions` and capped `parallelism` | One enormous Pod that serializes everything and hides partial failures |
+| Queue workers consume until empty | Job with `parallelism` and queue-aware worker logic | Assuming Kubernetes knows how many external queue items remain |
+
+For CKAD speed, build a mental template that you can adapt under pressure. Create or generate the object, inspect the nested spec, set lifecycle controls, run it, then diagnose from controller to Pod. The exam rarely rewards exotic features; it rewards clear resource choice, valid YAML, and practical debugging. In real clusters, the same habits prevent batch jobs from becoming silent background hazards.
+
+For production speed, make the template readable enough that the next engineer can audit it under stress. Put the important lifecycle decisions in fields, not only in comments or runbooks. A CronJob with explicit concurrency, deadline, history, and time-zone behavior is easier to review than a minimal manifest whose behavior depends on defaults. Defaults are not bad, but hidden defaults are expensive when a scheduled task fails at an inconvenient hour and the responder has to infer the original intent.
 
 ## Did You Know?
 
-- **Jobs track completions with a completion index.** In indexed completion mode, each pod knows its index via the `JOB_COMPLETION_INDEX` environment variable. This is useful for processing sharded data.
-
-- **CronJobs use UTC by default.** If you set `schedule: "0 9 * * *"`, it runs at 9 AM UTC, not your local time. Some clusters support timezone annotations.
-
-- **The `activeDeadlineSeconds` applies to the entire Job runtime.** If a Job takes longer than this, Kubernetes terminates it—even if tasks are still running successfully.
-
----
+- **Jobs track completions with a completion index.** In indexed completion mode, each Pod can know its index through `JOB_COMPLETION_INDEX`, which is useful when you shard data and want each Pod to process a different partition.
+- **CronJobs support time zones in modern Kubernetes.** The `spec.timeZone` field lets you say that a business schedule should run in a named time zone instead of relying on the controller's local clock behavior.
+- **The `activeDeadlineSeconds` field limits the whole Job runtime.** If the deadline expires, Kubernetes terminates active Pods for that Job even if some individual attempts were still making progress.
+- **CronJob history limits and Job TTL solve different cleanup problems.** History limits decide how many Jobs a CronJob keeps, while `ttlSecondsAfterFinished` lets the TTL controller remove finished Jobs after a configured delay.
 
 ## Common Mistakes
 
-| Mistake | Why It Hurts | Solution |
-|---------|--------------|----------|
-| `restartPolicy: Always` | Invalid for Jobs | Use `Never` or `OnFailure` |
-| Forgetting `backoffLimit` | Job retries forever | Set a reasonable limit |
-| Wrong cron syntax | Job never runs | Validate with crontab.guru |
-| No `ttlSecondsAfterFinished` | Completed jobs accumulate | Set auto-cleanup |
-| Overlapping CronJobs | Resource contention | Use `concurrencyPolicy: Forbid` |
-
----
+| Mistake | Why It Happens | How to Fix It |
+|---------|----------------|---------------|
+| `restartPolicy: Always` in a Job template | The author copies a Pod or Deployment template and forgets that Jobs must finish | Use `Never` when separate failed Pods help debugging, or `OnFailure` when in-Pod restarts are acceptable |
+| Leaving `backoffLimit` implicit for risky commands | The default feels harmless during creation but can hide repeated application failures | Set an explicit retry limit that matches the cost and safety of the operation |
+| Using the wrong cron field for business time | Cron expressions are compact, and UTC or time zone assumptions are easy to miss | Validate the expression, set `spec.timeZone` when needed, and test with a manual Job trigger |
+| Omitting cleanup controls on frequent CronJobs | Finished Jobs are useful at first, so teams postpone retention decisions | Set `successfulJobsHistoryLimit`, `failedJobsHistoryLimit`, and a Job TTL where appropriate |
+| Allowing overlap for shared-state tasks | `Allow` is the default, and short test runs do not reveal month-end runtime | Use `Forbid` for backups, compaction, and cleanup unless concurrent runs are explicitly safe |
+| Debugging only the newest Pod log | Retries create several Pods or restarts, and the newest attempt may not show the first error | Inspect Job status, events, all Pods with the `job-name` label, and previous logs when using `OnFailure` |
+| Treating `startingDeadlineSeconds` as a runtime limit | The field name sounds like a general timeout, but it controls missed starts | Use `activeDeadlineSeconds` for runtime limits and `startingDeadlineSeconds` for late schedules |
 
 ## Quiz
 
-1. **A developer writes a Job YAML with `restartPolicy: Always` and runs `kubectl apply`. What happens, and what should they use instead?**
-   <details>
-   <summary>Answer</summary>
-   The API server rejects the Job with a validation error. Jobs require `restartPolicy` set to either `Never` or `OnFailure` -- never `Always`. The reason is that Jobs are designed to run to completion and exit. `Always` would restart the container forever, defeating the purpose of a Job. Use `Never` if you want a new pod on each failure (easier to debug via separate pod logs), or `OnFailure` if you want the same pod to retry (uses fewer resources and preserves pod identity).
-   </details>
+<details><summary>Your team deploys a database migration as a Job, but the manifest uses `restartPolicy: Always` because it was copied from a Deployment. What happens, and what should you change?</summary>
 
-2. **Your operations team needs a log cleanup script to run at 4:30 AM on weekdays only. Write the CronJob schedule expression and explain what concurrency policy you'd choose if the cleanup sometimes takes over 24 hours.**
-   <details>
-   <summary>Answer</summary>
-   The schedule is `"30 4 * * 1-5"` -- minute 30, hour 4, any day of month, any month, Monday through Friday (1-5). If cleanup can exceed 24 hours, use `concurrencyPolicy: Forbid` to skip the next scheduled run while the current one is still going. `Replace` would kill the long-running cleanup mid-operation, potentially leaving data in an inconsistent state. `Allow` would stack up concurrent cleanups competing for the same resources.
-   </details>
+The API server rejects the Job because the Pod template for a Job must use `Never` or `OnFailure`. A Job needs Pods that can finish so the controller can count completions, and `Always` describes long-running behavior instead. Use `Never` if you want each failed attempt preserved as a separate Pod for easier postmortem inspection. Use `OnFailure` if restarting inside the same Pod is acceptable and you want fewer replacement Pods.
 
-3. **You need to process 100 images through a thumbnail generator. Each image takes about 10 seconds. You want to finish as fast as possible but your cluster can only handle 5 extra pods at a time. How do you configure the Job?**
-   <details>
-   <summary>Answer</summary>
-   Set `completions: 100` and `parallelism: 5`. Kubernetes will run 5 pods simultaneously, and as each completes, it launches another to maintain 5 active pods until all 100 completions are reached. Total time is roughly 100/5 * 10 seconds = ~200 seconds (about 3.3 minutes), compared to ~1000 seconds (16.7 minutes) if run sequentially. Each pod can use the `JOB_COMPLETION_INDEX` environment variable to know which image to process.
-   </details>
+</details>
 
-4. **Your CronJob runs every 5 minutes, but you notice completed Job pods are piling up -- there are now 200+ finished pods cluttering your namespace. What two settings should you add to prevent this?**
-   <details>
-   <summary>Answer</summary>
-   Add `successfulJobsHistoryLimit: 3` and `failedJobsHistoryLimit: 1` to the CronJob spec to retain only recent Job history. Additionally, add `ttlSecondsAfterFinished: 100` to the Job template spec so completed Job pods are automatically garbage-collected after 100 seconds. The history limits control how many CronJob-created Jobs are kept, while TTL controls when individual Job pods are cleaned up. Without these, Kubernetes keeps all completed Jobs indefinitely by default.
-   </details>
+<details><summary>Your operations team needs a log cleanup script to run at 4:30 AM on weekdays only, and the cleanup sometimes takes more than a day. What schedule and concurrency policy would you choose?</summary>
 
----
+The schedule is `30 4 * * 1-5`, which means minute 30, hour 4, any day of month, any month, Monday through Friday. For the concurrency policy, choose `Forbid` unless the cleanup is proven safe to run concurrently. `Allow` could stack multiple cleanups against the same filesystem or database, and `Replace` could terminate a cleanup halfway through. Skipping an overlapping run is usually safer than multiplying destructive maintenance.
+
+</details>
+
+<details><summary>You need to process 100 images through a thumbnail generator, each image takes about 10 seconds, and the cluster can handle five extra Pods. How should you configure the Job and what must the application handle?</summary>
+
+Set `completions: 100` and `parallelism: 5` so Kubernetes runs at most five Pods while it works toward 100 successful completions. The application still needs a reliable way to map each completion to a specific image, such as an indexed completion strategy or an external queue. Without that mapping, five Pods may all process the same image or skip work. The controller manages completion counts; your application must manage business item ownership.
+
+</details>
+
+<details><summary>A CronJob runs every five minutes, but completed Jobs and Pods are piling up in the namespace. Which controls should you add, and why are there two kinds?</summary>
+
+Add `successfulJobsHistoryLimit` and `failedJobsHistoryLimit` to the CronJob so it keeps only a bounded number of recent Jobs. Add `ttlSecondsAfterFinished` under the Job template when you also want finished Jobs removed after a time delay. The history limits are CronJob retention controls, while TTL is handled for finished Jobs. Using both gives operators recent evidence without letting frequent runs clutter the namespace indefinitely.
+
+</details>
+
+<details><summary>A scheduled backup did not run during a short control-plane outage, and now the CronJob shows no new Job for that schedule. What fields and status would you inspect before changing the image or command?</summary>
+
+First inspect the CronJob with `k describe cronjob` and check `status.lastScheduleTime`, `spec.suspend`, `spec.schedule`, `spec.timeZone`, and `spec.startingDeadlineSeconds`. If the missed schedule exceeded the starting deadline, Kubernetes may correctly skip it rather than starting late. If the CronJob is suspended, no future schedules are created until it is resumed. Only after confirming that a Job was actually created should you move to image, command, Pod, and log debugging.
+
+</details>
+
+<details><summary>A Job with `restartPolicy: Never` and a failing command has several failed Pods. A teammate wants to delete the Job and recreate it immediately. What should you inspect first?</summary>
+
+Inspect `k describe job`, list Pods with `k get pods -l job-name=<name>`, and read logs from the failed Pods before deleting evidence. With `restartPolicy: Never`, each failed attempt can preserve a different event or log sequence, especially if scheduling, image pull, and application failures happened at different times. You should also check `backoffLimit` and any deadline fields to understand whether Kubernetes stopped retrying as configured. Recreating the Job too quickly can erase the trail that explains the root cause.
+
+</details>
+
+<details><summary>Your team is deciding between a Deployment, a Job, and a CronJob for a nightly report generator that exits after publishing a file. Which controller fits, and when would the answer change?</summary>
+
+A CronJob fits because the work is finite and recurring on a schedule. A plain Job would fit for a one-time report, but it would not create future runs by itself. A Deployment would be the wrong default because the desired state is not a continuously running Pod; the report command should exit after success. The answer changes only if the report process is actually a long-running service that watches for requests or queue messages indefinitely.
+
+</details>
 
 ## Hands-On Exercise
 
-**Task**: Create a backup system with Jobs and CronJobs.
+This exercise builds a small backup and cleanup workflow in layers. You will create a one-time Job, trigger a CronJob manually, run parallel completions, observe retry behavior, and finish with a more complete backup CronJob that uses history and TTL controls. Work in a disposable namespace if you have one, and clean up at the end so your later CKAD practice is not polluted by old Jobs.
 
-**Part 1: One-time Job**
+As you work through the tasks, keep a small investigation journal in your terminal or notes: object created, expected controller behavior, command used to verify it, and cleanup command. That may feel formal for tiny examples, but it trains the exact loop you need when batch work fails in a shared namespace. The goal is not only to make the commands pass; it is to connect each command to the controller decision it confirms.
+
+### Task 1: Run and Inspect a One-Time Job
+
+Start with the smallest useful Job: one Pod, one successful completion, one log stream to inspect. This task teaches the basic loop you will use throughout the module: create the object, wait for the controller condition, inspect status, and read logs from the Job-owned Pod.
+
+Before running the command, predict what objects should exist after completion. You should have a Job object and at least one Pod owned by that Job. The Job should report a completed condition, and the Pod should be in a succeeded phase. If your cluster keeps finished Pods for inspection, the log should still be available through the Job reference; if retention or cleanup removes evidence quickly, describe the Job first and capture what remains.
+
 ```bash
 # Create a job that simulates a database backup
 k create job db-backup --image=busybox -- sh -c "echo 'Backing up database' && sleep 5 && echo 'Backup complete'"
@@ -472,7 +564,18 @@ k get job db-backup
 k logs job/db-backup
 ```
 
-**Part 2: Scheduled CronJob**
+<details><summary>Solution notes for Task 1</summary>
+
+The Job should reach the `Complete` condition, and the logs should show both backup messages. If the wait times out, describe the Job and list Pods with the `job-name=db-backup` label before changing anything. That keeps your investigation aligned with the controller hierarchy.
+
+</details>
+
+### Task 2: Create a CronJob and Trigger It Manually
+
+Now create a scheduled controller, but do not wait for the clock to prove the template works. A manual Job created from the CronJob gives quick feedback on the image, command, and Pod template while keeping schedule debugging separate.
+
+This is the workflow many teams use before enabling a new schedule. They create or update the CronJob, trigger one manual Job, inspect logs and status, and only then trust the schedule. It avoids the awkward pattern of waiting until the next hour, discovering an image or command failure, editing under time pressure, and then waiting again. Manual triggering turns a scheduled workload into a testable template.
+
 ```bash
 # Create cronjob for hourly cleanup
 k create cronjob hourly-cleanup \
@@ -488,7 +591,18 @@ k get jobs
 k logs job/manual-cleanup
 ```
 
-**Part 3: Parallel Job**
+<details><summary>Solution notes for Task 2</summary>
+
+You should see the `manual-cleanup` Job complete and print the cleanup timestamp. This proves the Job template can run, but it does not prove the hourly schedule has fired. Use `k describe cronjob hourly-cleanup` when you want to inspect schedule status, last schedule time, and events.
+
+</details>
+
+### Task 3: Run a Parallel Job
+
+The next manifest preserves the original parallel-processing example and gives you a concrete way to observe completions and active Pods. Apply it, watch the Pods, and compare what the Job wants with what the cluster is currently running.
+
+Do not expect every `k get pods` call to show exactly two running Pods, because timing matters. Some Pods may finish between list operations, and the controller may create replacements quickly enough that the snapshot changes from second to second. The important evidence is the trend: the Job progresses toward six completions while maintaining no more than the configured parallelism under normal conditions. If it stalls, describe the Job and then inspect the Pods that did not succeed.
+
 ```bash
 # Create parallel-job.yaml
 cat << 'EOF' > parallel-job.yaml
@@ -512,18 +626,17 @@ k apply -f parallel-job.yaml
 k get pods -l job-name=parallel-process
 ```
 
-**Cleanup:**
-```bash
-k delete job db-backup parallel-process
-k delete job manual-cleanup
-k delete cronjob hourly-cleanup
-```
+<details><summary>Solution notes for Task 3</summary>
 
----
+The Job targets six successful completions while allowing two active Pods at a time. Depending on when you list Pods, you may see running Pods, completed Pods, or a mix. The important observation is that Kubernetes launches more Pods as earlier completions finish until the completion target is reached.
 
-## Practice Drills
+</details>
 
-### Drill 1: Basic Job Creation (Target: 2 minutes)
+### Task 4: Practice Focused CKAD Drills
+
+These drills are short on purpose, but do not treat them as memorization only. After each command, name the controller behavior you expect before checking the output. That habit makes exam debugging faster because you notice when the object behaves differently from the lifecycle you intended.
+
+The retry drill is especially useful because it creates a controlled failure. A failing Job is not an accident here; it is a lab instrument. Watch how failed Pods accumulate with `restartPolicy: Never`, how `backoffLimit` changes when the controller stops trying, and how `k describe job` summarizes the state. Once you have seen intentional failure, accidental failure is much less mysterious.
 
 ```bash
 # Create a job that:
@@ -543,8 +656,6 @@ k logs job/hello-job
 k delete job hello-job
 ```
 
-### Drill 2: CronJob with Schedule (Target: 2 minutes)
-
 ```bash
 # Create a cronjob that:
 # - Named: every-minute
@@ -563,8 +674,6 @@ k logs job/$(k get jobs -o jsonpath='{.items[0].metadata.name}')
 # Cleanup
 k delete cronjob every-minute
 ```
-
-### Drill 3: Job with Retry (Target: 3 minutes)
 
 ```bash
 # Create a job that fails and retries
@@ -595,8 +704,6 @@ k describe job retry-job | grep -A5 Conditions
 k delete job retry-job
 ```
 
-### Drill 4: Parallel Job (Target: 4 minutes)
-
 ```bash
 # Create a parallel job
 cat << 'EOF' | k apply -f -
@@ -626,8 +733,6 @@ k get job parallel
 # Cleanup
 k delete job parallel
 ```
-
-### Drill 5: CronJob with Concurrency (Target: 3 minutes)
 
 ```bash
 # Create cronjob that forbids overlap
@@ -661,9 +766,17 @@ k get jobs | grep no-overlap
 k delete cronjob no-overlap
 ```
 
-### Drill 6: Complete Backup Solution (Target: 8 minutes)
+<details><summary>Solution notes for Task 4</summary>
 
-**Build a full backup system:**
+The basic Job should complete once, the every-minute CronJob should create at least one Job after the schedule fires, the retry Job should show failed attempts until the backoff policy is reached, the parallel Job should run up to two Pods at a time, and the no-overlap CronJob should avoid starting a second active Job while the first one is still running. If your output differs, use `k describe` before deleting anything.
+
+</details>
+
+### Task 5: Build a Complete Backup CronJob
+
+The final task combines a ConfigMap-provided script, a CronJob, forbidden concurrency, history limits, and Job TTL cleanup. This is closer to production shape because the script is separated from the CronJob object and the retention behavior is visible in the spec. In a real cluster, you would also add service account permissions, resource requests, storage credentials from a safe Secret workflow, and monitoring.
+
+Notice that the example still uses BusyBox and simulated output. That is deliberate because the learning target is Kubernetes controller behavior, not storage integration. In a real backup system, the script would need authenticated storage access, encryption decisions, restore validation, and alerting when the backup cannot be verified. The Kubernetes CronJob is the scheduler and execution envelope; it is not a complete backup product by itself.
 
 ```bash
 # 1. Create configmap with backup script
@@ -721,8 +834,34 @@ k delete job test-backup
 k delete configmap backup-script
 ```
 
----
+<details><summary>Solution notes for Task 5</summary>
+
+The manual trigger should create `test-backup`, run the script from the ConfigMap, and print the backup steps. The CronJob should show `Forbid` concurrency and the configured history limits. The TTL value applies to Jobs created from the template after they finish, so do not expect it to delete the CronJob itself.
+
+</details>
+
+### Success Criteria
+
+- [ ] You can create a one-time Job, wait for completion, and read its logs through the Job reference.
+- [ ] You can create a CronJob and manually trigger a Job from its template for fast validation.
+- [ ] You can explain how `completions` and `parallelism` interact in a fixed-size batch.
+- [ ] You can diagnose a failing Job by checking Job status, labeled Pods, events, logs, and retry limits.
+- [ ] You can configure a CronJob with overlap protection, history limits, and finished-Job cleanup.
+- [ ] You can clean up every Job, CronJob, and ConfigMap created during the exercise.
+
+## Sources
+
+- [Kubernetes Documentation: Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/job/)
+- [Kubernetes Documentation: CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/)
+- [Kubernetes Documentation: TTL Mechanism for Finished Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/)
+- [Kubernetes Documentation: Pod Lifecycle](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/)
+- [Kubernetes Documentation: Managing Resources for Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+- [Kubernetes Documentation: Configure a Pod to Use a ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/)
+- [Kubernetes Documentation: Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
+- [Kubernetes Documentation: kubectl create job](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_create/kubectl_create_job/)
+- [Kubernetes Documentation: kubectl create cronjob](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_create/kubectl_create_cronjob/)
+- [Kubernetes API Reference: batch/v1](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/job-v1/)
 
 ## Next Module
 
-[Module 1.3: Multi-Container Pods](../module-1.3-multi-container-pods/) - Sidecar, init, and ambassador patterns.
+[Module 1.3: Multi-Container Pods](../module-1.3-multi-container-pods/) - Sidecar, init, and ambassador patterns help you design Pods where multiple containers cooperate instead of forcing every responsibility into one image.


### PR DESCRIPTION
## Summary

Rewrites `src/content/docs/k8s/ckad/part1-design-build/module-1.2-jobs-cronjobs.md` as a density-first Jobs and CronJobs module for #388. The rewrite keeps the original topic coverage, command/YAML examples, cron diagram, tables, lab URL, and next-module link while adding aligned structure, assessment, hands-on checkboxes, and primary Kubernetes sources.

## Verifier

`verify_module.py` result: tier T0; body_words=5260, mean_wpp=67.4, median_wpp=73.5, short_rate=0.026, max_run=2, mean_sentence_length=21.2. All density, structure, alignment, anti_leak, protected-asset, and source gates pass; live source check returned 10x 200.

Command used: `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/quality/verify_module.py --glob src/content/docs/k8s/ckad/part1-design-build/module-1.2-jobs-cronjobs.md --summary --quiet`

## Protected Assets

Preserved protected assets from the original module: code blocks 29 -> 30, ASCII diagrams 1 -> 1, mermaid diagrams 0 -> 0, markdown tables 4 -> 7. Original lab URL and next-module link are retained.

## Checks

- `git diff --check` clean
- forbidden-token / no-47 scan clean
- verifier T0 with live source reachability passing

Commit: c49dacde9db493e129bd1d2d5b49f8e26d3cdcc2