### PR TITLE
feat(388): rewrite module-1.8-namespaces-labels (#388 pilot)

### DIFF
--- a/src/content/docs/k8s/kcna/part1-kubernetes-fundamentals/module-1.8-namespaces-labels.md
+++ b/src/content/docs/k8s/kcna/part1-kubernetes-fundamentals/module-1.8-namespaces-labels.md
@@ -1,45 +1,40 @@
 ---
-revision_pending: true
+revision_pending: false
 title: "Module 1.8: Namespaces and Labels"
 slug: k8s/kcna/part1-kubernetes-fundamentals/module-1.8-namespaces-labels
 sidebar:
   order: 9
 ---
-> **Complexity**: `[QUICK]` - Organization concepts
->
-> **Time to Complete**: 20-25 minutes
->
-> **Prerequisites**: Modules 1.5-1.7
 
----
+# Module 1.8: Namespaces and Labels
 
-Imagine a warehouse with 10,000 boxes and no labels, no sections, and no organization system. Finding what you need would be impossible. That's exactly what a Kubernetes cluster would be like without namespaces and labels. In this module, we'll learn how to bring order to the chaos.
+**Complexity**: `[QUICK]` - Organization concepts. **Time to Complete**: 35-40 minutes. **Prerequisites**: Modules 1.5-1.7. This is a fundamentals module, but it deliberately treats namespaces and labels as production reliability tools rather than vocabulary flashcards.
 
-## What You'll Be Able to Do
+This module assumes Kubernetes 1.35 or newer and uses `k` as the short alias for `kubectl`. If your shell does not already define it, run `alias k=kubectl` before the hands-on section so the commands match the examples and your muscle memory starts forming around the same compact workflow operators use during troubleshooting.
 
-After completing this module, you will be able to:
+## Learning Outcomes
 
-1. **Explain** how namespaces provide logical isolation and resource organization
-2. **Choose the correct mechanism** (namespace, label, or annotation) given a scenario
-3. **Compare** namespace-scoped and cluster-scoped resources
-4. **Evaluate** label selector expressions used by Services, Deployments, and NetworkPolicies
-5. **Write** a set-based selector expression
+After completing this module, you will be able to make namespace and metadata choices that hold up under normal releases, multi-team ownership, and outage debugging. Each outcome below is assessed later through scenario questions or the hands-on selector drift exercise.
 
----
+1. **Design** a namespace strategy that separates teams, environments, and applications without mistaking namespaces for full security boundaries.
+2. **Compare** namespace-scoped and cluster-scoped resources, then diagnose why a command or policy applies in one scope but not another.
+3. **Implement** a consistent label and annotation scheme that supports Services, Deployments, NetworkPolicies, audits, and human ownership.
+4. **Evaluate** equality-based and set-based label selectors used by Services, Deployments, and NetworkPolicies under realistic change scenarios.
+5. **Debug** routing or rollout failures caused by selector drift, label typos, and misplaced metadata.
 
 ## Why This Module Matters
 
-Namespaces and labels are how Kubernetes organizes resources. Labels enable Services to find Pods, Deployments to manage ReplicaSets, and operators to select resources. KCNA tests your understanding of these organizational primitives.
+During a holiday release freeze, a payments team at a large online retailer pushed what looked like a harmless Deployment metadata cleanup. The Pods stayed healthy, the Deployment reported the desired replica count, and the nodes had plenty of capacity, yet customer checkout traffic suddenly returned errors because the production Service no longer had any endpoints. The actual change was tiny: a Pod template label moved from `app: payment` to `app: payment-v2`, while the Service selector continued looking for `app: payment`.
 
----
+The outage was expensive because every layer above Kubernetes saw only a missing backend, not an obvious crash. Application logs were quiet, the health checks passed inside the Pods, and the control plane had done exactly what it was told to do. The failure lived in the organization layer of the cluster, where names, labels, selectors, and scope decide which resources belong together and which resources should never collide.
 
-## Namespaces
+Namespaces and labels are easy to describe and surprisingly easy to misuse. Namespaces divide the shared cluster into named work areas, while labels attach queryable identity to objects inside and across those areas. The KCNA exam expects you to recognize these primitives, but real operations work expects more: you must predict the blast radius of a label change, know when namespace boundaries help, know when they do not, and choose annotation metadata without accidentally turning the API server into a noisy search index.
 
-To bring order to our chaotic warehouse, the first step is building distinct rooms or zones. In Kubernetes, we call these namespaces.
+## Namespaces as Shared-Cluster Boundaries
 
-### What is a Namespace?
+Imagine a warehouse with 10,000 boxes and no labels, no sections, and no organization system. Finding what you need would be impossible, and preventing one team from moving another team's material would depend on luck instead of design. Kubernetes without namespaces has the same operational smell: every Pod, Service, ConfigMap, and Secret can pile into the `default` namespace until names collide, permissions blur, and cleanup becomes risky.
 
-A **namespace** is a way to divide cluster resources between multiple users or teams. Think of them as virtual clusters backed by the same physical cluster:
+To bring order to that warehouse, the first step is building distinct rooms or zones. In Kubernetes, a namespace is a logical partition inside one physical cluster, not a separate cluster with separate nodes and control-plane components. The namespace changes the name scope and gives policies a place to attach, but the API server, scheduler, nodes, container runtime, and networking fabric remain shared infrastructure.
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -75,9 +70,9 @@ A **namespace** is a way to divide cluster resources between multiple users or t
 └─────────────────────────────────────────────────────────────┘
 ```
 
-### Default Namespaces
+A namespace gives you name scoping first. Two teams can both run a Deployment named `backend`, because the full identity is effectively `production/backend` or `staging/backend`, not just `backend`. That sounds small until you see a shared `default` namespace where every team has an `app-config`, a `web`, and a `db-migration` Job, and nobody is sure which one is safe to restart during an incident.
 
-Every cluster has these built-in namespaces:
+Every Kubernetes cluster starts with several built-in namespaces, and knowing their purpose helps you avoid two common mistakes. You should not treat `default` as a production application boundary, and you should not casually deploy application workloads into `kube-system` just because system Pods live there. The built-ins exist so the cluster can organize itself before you add your own team, environment, or application namespaces.
 
 | Namespace | Purpose |
 |-----------|---------|
@@ -86,7 +81,7 @@ Every cluster has these built-in namespaces:
 | **kube-public** | Publicly readable resources (rarely used, mostly for cluster info) |
 | **kube-node-lease** | Node heartbeat leases to track node health |
 
-### What Namespaces Provide
+Namespaces become powerful when paired with other Kubernetes controls. RBAC Roles and RoleBindings can grant a team access inside one namespace without granting cluster-wide permissions. ResourceQuotas can cap how much CPU, memory, object count, or storage a namespace consumes, and LimitRanges can set default requests or limits so a forgotten field does not turn into a noisy neighbor incident.
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -113,11 +108,9 @@ Every cluster has these built-in namespaces:
 └─────────────────────────────────────────────────────────────┘
 ```
 
-> **Pause and predict**: Two teams share the same Kubernetes cluster. Team A accidentally deploys a Pod named "backend" that conflicts with Team B's "backend" Pod. How could namespaces have prevented this, and what other isolation benefits would they provide?
+Pause and predict: two teams share the same Kubernetes cluster, and Team A accidentally deploys a Pod named `backend` that appears to conflict with Team B's `backend` Pod. How could namespaces have prevented this, and what other isolation benefits would they provide? The key prediction is that the name collision disappears when each `backend` lives in a different namespace, while RBAC and quotas can then be attached to those namespace boundaries for access and consumption control.
 
-### Namespace Strategy Trade-offs
-
-How should you divide your cluster? Here are the most common real-world strategies:
+Namespace strategy is an architecture choice, not a naming exercise. A small company might use `dev`, `staging`, and `prod` because teams coordinate closely and the simplest mental model wins. A larger organization may prefer `payments-prod`, `payments-dev`, `search-prod`, and `search-dev` because billing, RBAC, NetworkPolicy, and incident blast radius all need to line up with both ownership and environment.
 
 | Strategy | Pros | Cons | Best For |
 |----------|------|------|----------|
@@ -125,9 +118,17 @@ How should you divide your cluster? Here are the most common real-world strategi
 | **Namespace per Team** (e.g., `team-frontend`, `team-data`) | Great isolation between teams, clear billing and RBAC. | Harder to separate production from dev traffic within the team. | Medium organizations where teams manage their own full stacks. |
 | **Namespace per App/Env** (e.g., `payment-prod`, `payment-dev`) | Maximum granular control, tight blast radius. | Sprawl. You might end up managing hundreds of namespaces. | Large enterprises with complex, critical microservices. |
 
-### What's NOT Namespaced
+The tradeoff is administrative load. More namespaces give you tighter control and clearer ownership, but they also create more objects to configure, monitor, document, and clean up. If every preview branch creates a namespace, you need automation for quotas, RBAC, labels, network policy defaults, and deletion, or your cluster becomes a landfill of abandoned environments.
 
-Not everything lives inside a namespace. Some resources are **cluster-scoped** (they exist globally across the entire cluster):
+The cleanest way to think about namespace design is to ask what should be true during an incident. If the database team says, "show me everything production checkout can touch," the namespace layout should make the first search obvious instead of forcing people to remember tribal naming rules. If the security team says, "which developers can modify production Secrets," the RoleBindings should point at clear namespace boundaries rather than one shared bucket with complicated exceptions.
+
+There is also a lifecycle question hiding inside every namespace strategy. A namespace created for a long-lived production application should be treated like durable infrastructure, with reviewable manifests and clear ownership. A namespace created for a short-lived preview environment should have an expiration path, because abandoned namespaces still consume human attention even when their Pods are gone. Reliable platforms make those lifecycle differences explicit instead of relying on a cleanup day months later.
+
+You will often see platforms combine strategies instead of choosing only one. A company might run `platform-system` for shared platform controllers, `payments-prod` for a critical service, `payments-dev` for team development, and ephemeral `payments-pr-123` namespaces for pull request previews. That looks like sprawl until the platform automates policy application and deletion; then the extra names become a precise map of responsibility, risk, and expected lifetime.
+
+Some resources do not live inside namespaces at all because they describe the shared substrate of the cluster. A Node represents a machine that may run Pods from many namespaces, a PersistentVolume represents storage capacity that may later be claimed by a namespaced object, and a ClusterRole describes permissions that can be bound across many namespaces. This is why `k get nodes -n production` is conceptually wrong even if a CLI accepts or ignores the namespace flag in some contexts.
+
+The scope difference matters most when you attach policy. A Role grants namespaced permissions, while a ClusterRole describes permissions that may apply cluster-wide or be bound into a namespace through a RoleBinding. A ResourceQuota limits consumption inside one namespace, while node capacity and scheduling constraints are handled through different APIs. When a command surprises you, ask whether the object is application-scoped or infrastructure-scoped before assuming Kubernetes ignored your intent.
 
 | Cluster-Scoped | Why |
 |----------------|-----|
@@ -137,22 +138,15 @@ Not everything lives inside a namespace. Some resources are **cluster-scoped** (
 | **ClusterRoles** | Permissions that apply across all namespaces. |
 | **StorageClasses** | Configurations for how storage is provisioned globally. |
 
-> **Pause and predict**: List which of these 8 resources are cluster-scoped vs namespace-scoped: 1) Pod, 2) Node, 3) PersistentVolume, 4) ConfigMap, 5) Secret, 6) Namespace, 7) Service, 8) StorageClass.
-> <details>
-> <summary>Check your answer</summary>
-> <strong>Namespace-scoped:</strong> Pod, ConfigMap, Secret, Service. These belong to specific applications or teams.<br>
-> <strong>Cluster-scoped:</strong> Node, PersistentVolume, Namespace, StorageClass. These represent fundamental cluster infrastructure.
-> </details>
+Pause and predict: list which of these resources are cluster-scoped versus namespace-scoped: Pod, Node, PersistentVolume, ConfigMap, Secret, Namespace, Service, and StorageClass. Pods, ConfigMaps, Secrets, and Services belong to a namespace because they describe application-level behavior or configuration. Nodes, PersistentVolumes, Namespaces, and StorageClasses are cluster-scoped because they describe infrastructure, allocation boundaries, or global policy.
 
----
+A useful diagnostic habit is to read object scope from the noun before you reach for a command flag. If the object represents something an application owns, such as a ConfigMap, Secret, Service, Pod, or Deployment, expect namespace scope unless documentation says otherwise. If the object represents shared infrastructure, global policy, or the namespace system itself, expect cluster scope. That habit prevents a surprising number of wrong-path investigations, especially for KCNA questions that mix resource names with namespace flags.
 
-## Labels
+## Labels, Annotations, and Queryable Identity
 
-Now that we have rooms (namespaces), we need a way to categorize the individual boxes inside them. That's where labels come in. Think of labels as sticky notes, and label selectors as a database `WHERE` clause asking for all boxes with specific sticky notes.
+Now that we have rooms in the warehouse, we need a way to categorize the individual boxes inside them. Labels are those sticky notes, but in Kubernetes they are more than human decoration because controllers and APIs use them as selectors. A Service does not maintain a handwritten list of Pod names, because Pods are replaced often; it asks the API for Pods whose labels match its selector.
 
-### What are Labels?
-
-**Labels** are key-value pairs attached to resources for identification:
+Labels are key-value pairs stored under `metadata.labels`. They should represent stable, queryable identity such as the application name, environment, tier, component, version, or owning team. They are intentionally small because Kubernetes indexes and evaluates them; if you store long build notes or unique timestamps as labels, you are asking the control plane to optimize data that selectors should never use.
 
 ```yaml
 metadata:
@@ -163,11 +157,13 @@ metadata:
     version: v2.1.0
 ```
 
-Labels can be any key-value pair, you can attach multiple labels per resource, and most importantly, they are used by Kubernetes to **select and group** resources.
+The most important design rule is to label for decisions you expect Kubernetes, automation, or operators to make. If you will select all production Pods, route traffic to the `frontend` app, restrict network ingress to the `backend` tier, or report cost by team, those are label candidates. If you need a Git commit hash, build URL, pager channel, or long description, that belongs in annotations unless a selector truly needs it.
 
-### How Labels are Used
+Good labels also need controlled vocabulary. `env=prod`, `environment=production`, and `stage=live` might all mean the same thing to humans, but they are different facts to Kubernetes. If three teams invent three names for the same concept, selectors become brittle and dashboards become incomplete. Mature clusters usually solve this through templates, Helm chart helpers, platform starter kits, or admission policy that rejects objects missing required labels.
 
-Services, Deployments, and NetworkPolicies don't track Pods by their IP addresses or exact names (since Pods are ephemeral). Instead, they track them by labels.
+Cardinality is another practical concern. A label with a small set of repeated values, such as `team=payments` or `tier=frontend`, is easy to query and reason about. A label whose value is unique on every Pod, such as a full commit hash or timestamp, is usually poor selector material because it creates many tiny groups that controllers rarely need. High-cardinality facts can still be valuable, but annotations are normally the right place for them.
+
+Services, Deployments, and NetworkPolicies do not track Pods by their IP addresses or exact names because Pods are disposable. A Deployment creates ReplicaSets, ReplicaSets create Pods, Services create endpoint lists, and NetworkPolicies allow or deny traffic by asking which Pods match a selector at a point in time. Labels are the shared vocabulary that lets those independent controllers agree on the same group of objects.
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -199,62 +195,13 @@ Services, Deployments, and NetworkPolicies don't track Pods by their IP addresse
 └─────────────────────────────────────────────────────────────┘
 ```
 
-### Label Selector Types
+The diagram shows a selector with only `app: web`, so both production and staging Pods match if they share that label in the same selector scope. That can be correct for a demonstration and dangerous in production, depending on namespace strategy and Service design. If production and staging run in separate namespaces, a Service in one namespace normally selects Pods in that namespace, but if both environments share one namespace, a broad selector can mix traffic in a way the application never expected.
 
-There are two ways to query these labels. We'll start with the simplest: equality-based.
+This is why labels and namespaces should be designed together. A label that is safe inside one namespace layout may be dangerously broad in another layout. If each environment has its own namespace, `app=web` may be sufficient for the Service. If multiple environments share a namespace, the Service probably needs an environment label too, or the team should revisit why those environments share a namespace in the first place.
 
-```yaml
-# EQUALITY-BASED (Simple exact match)
-# Give me Pods where the 'app' label exactly equals 'frontend'
-selector:
-  app: frontend        
+Annotations are also key-value metadata, but they are not meant for selection. Controllers, admission webhooks, deployment tools, humans, and documentation systems often read annotations for extra context or configuration hints. The practical difference is not whether a value looks important; the difference is whether the value should participate in grouping, routing, policy, or query operations.
 
-# Or using the formal matchLabels syntax:
-selector:
-  matchLabels:
-    app: frontend
-    env: production    # Must match BOTH (Logical AND)
-```
-
-Sometimes you need more complex logic. What if you want Pods from multiple environments, or want to exclude a specific environment? That requires set-based selectors.
-
-```yaml
-# SET-BASED (More powerful expressions)
-selector:
-  matchExpressions:
-  - key: app
-    operator: In
-    values: [frontend, backend]    # App is EITHER frontend OR backend
-  - key: env
-    operator: NotIn
-    values: [development]          # Env is NOT development
-```
-
-Operators available for set-based selectors are `In`, `NotIn`, `Exists` (key exists, regardless of value), and `DoesNotExist`.
-
-> **Stop and think**: Write a `matchExpressions` selector that selects Pods where the `tier` is `cache` and the `environment` is NOT `production`.
-> <details>
-> <summary>Check your answer</summary>
-> 
-> ```yaml
-> selector:
->   matchExpressions:
->   - key: tier
->     operator: In
->     values: [cache]
->   - key: environment
->     operator: NotIn
->     values: [production]
-> ```
-> </details>
-
----
-
-## Annotations
-
-Not all metadata is used for filtering and selecting. Sometimes you just need to attach detailed notes to a resource. This is the job of annotations.
-
-### Labels vs Annotations
+Annotations can still influence behavior when a specific controller decides to read them, so "not used for selection" does not mean "never used by software." Ingress controllers, service meshes, backup tools, and deployment systems often use annotations as configuration surfaces. The difference is that Kubernetes label selectors do not use annotation values to decide group membership. Treat annotations as rich object notes or tool-specific settings, and treat labels as the indexed identity language of the API.
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -282,18 +229,9 @@ Not all metadata is used for filtering and selecting. Sometimes you just need to
 └─────────────────────────────────────────────────────────────┘
 ```
 
-> **Pause and predict**: Label or annotation? Classify these 6 pieces of metadata: 1) `app=web`, 2) `git-commit=8a3f9b`, 3) `environment=staging`, 4) `build-date=2023-10-25`, 5) `tier=backend`, 6) `on-call-slack=#team-alpha`.
-> <details>
-> <summary>Check your answer</summary>
-> <strong>Labels:</strong> 1, 3, 5. These are short, identifiable categories you would likely want to query or filter by.<br>
-> <strong>Annotations:</strong> 2, 4, 6. These are longer, highly specific pieces of metadata useful for tooling or humans, but you would never use a Kubernetes selector to say "route traffic to the pod built on 2023-10-25".
-> </details>
+Pause and predict: label or annotation? Classify `app=web`, `git-commit=8a3f9b`, `environment=staging`, `build-date=2023-10-25`, `tier=backend`, and `on-call-slack=#team-alpha`. `app`, `environment`, and `tier` are labels because you would reasonably select, group, route, or report by them. The commit hash, build date, and contact channel are annotations because they describe provenance and ownership rather than selection identity.
 
----
-
-## Real-World Labeling Scheme
-
-Kubernetes recommends a standard set of labels to keep things consistent across tools. Here is what a well-labeled Deployment looks like in the real world:
+Kubernetes recommends common application labels so tools can agree on what names mean. A Helm chart, a dashboard, a cost report, and an incident script all become more useful when they can rely on `app.kubernetes.io/name` for the application, `app.kubernetes.io/instance` for a specific installation, and `app.kubernetes.io/part-of` for the larger product. You can still keep shorter labels like `app` or `env`, but standardized labels make multi-tool operations less fragile.
 
 | Label | Purpose | Example |
 |-------|---------|---------|
@@ -304,11 +242,54 @@ Kubernetes recommends a standard set of labels to keep things consistent across 
 | `app.kubernetes.io/part-of` | Higher-level system | `ecommerce-platform` |
 | `app.kubernetes.io/managed-by` | Provisioning tool | `helm` |
 
----
+A good labeling scheme is boring in the best way. It gives every workload enough identity to answer common questions without forcing operators to remember team-specific conventions. When an incident starts, `k get pods -A -l app.kubernetes.io/part-of=checkout` is useful only if every team applied the label consistently before the incident, not after someone starts searching.
 
-## How Services and Deployments Use Labels
+Standard labels also reduce coupling between teams and platform tools. A dashboard should not need to know that one team uses `service=checkout`, another uses `app_name=checkout`, and a third uses `component=checkout-api` for the same category. When the platform publishes a shared label contract, product teams can move faster because their resources automatically appear in inventory views, cost reports, alert routes, and ownership maps.
 
-Understanding how the "chain" of labels connects resources is crucial. 
+One subtle label design choice is whether a label describes the object itself or the system around it. `app.kubernetes.io/name=payment-web` describes the workload, while `app.kubernetes.io/part-of=checkout-platform` describes the larger product. Both are useful, but they answer different questions. During a payment incident you might start with the product label to find the whole checkout surface, then narrow to the application label when you know which component is misbehaving.
+
+## Selectors as Contracts Between Controllers
+
+Selectors are the contracts that turn labels into behavior. Equality-based selectors ask for exact matches, while set-based selectors express membership, exclusion, existence, or non-existence. Both are logical filters, and when multiple requirements appear together they usually combine as logical AND, which means every requirement must match for an object to be selected.
+
+```yaml
+# EQUALITY-BASED (Simple exact match)
+# Give me Pods where the 'app' label exactly equals 'frontend'
+selector:
+  app: frontend
+
+# Or using the formal matchLabels syntax:
+selector:
+  matchLabels:
+    app: frontend
+    env: production    # Must match BOTH (Logical AND)
+```
+
+Equality selectors are clear and readable, which makes them excellent for Services that should find one application tier. A Service selector such as `app: frontend` is easy to inspect during an outage, and a Deployment selector that matches its Pod template labels is straightforward to reason about. The weakness is expressiveness: equality selectors cannot say "frontend or backend" or "anything except development" without introducing additional labels or separate objects.
+
+The apparent simplicity can hide a contract that is stricter than people expect. In the formal `matchLabels` form, every listed key and value must match. If a Service selector includes `app=frontend` and `env=production`, a Pod missing only the `env` label is invisible to that Service even if every other detail is correct. When debugging, do not ask whether the Pod has "basically the right labels"; ask whether it satisfies every selector requirement exactly.
+
+Sometimes you need more complex logic. A NetworkPolicy may need to allow traffic from either `frontend` or `api` tiers while excluding experimental workloads, or an operator may need to list Pods that belong to several components during a migration. Set-based selectors handle this by using operators such as `In`, `NotIn`, `Exists`, and `DoesNotExist`.
+
+Set-based selectors are powerful because they express intent without multiplying objects. One NetworkPolicy can allow several trusted tiers, and one CLI query can find all workloads missing an expected label by using existence tests. The tradeoff is readability: once a selector has several expressions, operators need to slow down and evaluate each requirement. A short comment in a manifest or a clear policy name can save time later.
+
+```yaml
+# SET-BASED (More powerful expressions)
+selector:
+  matchExpressions:
+  - key: app
+    operator: In
+    values: [frontend, backend]    # App is EITHER frontend OR backend
+  - key: env
+    operator: NotIn
+    values: [development]          # Env is NOT development
+```
+
+Before running this, what output do you expect from `k get pods -l 'app in (frontend,backend),env notin (development)'` if one Pod has `app=frontend,env=production`, another has `app=backend,env=development`, and a third has `app=api,env=production`? Only the first Pod should appear, because the second fails the environment exclusion and the third fails the application membership test. This prediction exercise matters because selectors often look permissive until you apply the full logical AND.
+
+Services and Deployments both use selectors, but they use them with different consequences. A Deployment selector identifies the Pods that belong to that Deployment's desired state, and in the `apps/v1` API the selector is effectively part of the controller's identity. A Service selector identifies live traffic backends, so a selector change can instantly add or remove endpoints even if no Pod restarted.
+
+This distinction explains why a label change can feel inconsistent. If you change only a Pod template label that the Deployment selector depends on, Kubernetes may reject the change or create ownership confusion because the Deployment must be able to recognize the Pods it manages. If you change a Service selector, Kubernetes can accept the change and immediately recalculate endpoints. Both behaviors are logical once you remember which controller is using the selector and what relationship it controls.
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -341,135 +322,342 @@ Understanding how the "chain" of labels connects resources is crucial.
 └─────────────────────────────────────────────────────────────┘
 ```
 
-> **Stop and think**: A Service uses the selector `app: frontend` to find its Pods. If you add a new label `version: v2` to some Pods but not others, will the Service still route traffic to all of them? What would happen if you changed the Service selector to require both `app: frontend` AND `version: v2`?
+Stop and think: a Service uses the selector `app: frontend` to find its Pods. If you add a new label `version: v2` to some Pods but not others, the Service still routes to all Pods that keep `app: frontend` because extra labels do not hurt a match. If you change the Service selector to require both `app: frontend` and `version: v2`, the Service immediately narrows to only the versioned Pods, which may be a controlled canary or an accidental partial outage.
 
----
+A selector is safest when the selected label is stable for the life of the relationship. Application identity, component, and instance labels tend to be stable; release version labels change often. That is why many teams use stable labels for Service selection and use version labels for observability, rollout tracking, or temporary analysis rather than for the main production Service selector.
 
-## Real-World War Story: The Silent Outage
+There are legitimate exceptions, such as canary Services that intentionally select `track=canary` or `version=v2` for a limited traffic path. The point is not that version labels are forbidden in selectors; the point is that they should be used deliberately where traffic shape depends on version. The stable production Service and the experimental canary Service can coexist if their purposes and selectors are clear.
 
-It's 2 AM on a Friday. The production payment Service suddenly stops routing traffic. The Pods are running, the nodes are healthy, but zero requests are getting through. What happened? 
+## Namespace and Label Operations with `k`
 
-A junior developer updated the Payment Deployment. They wanted to signify that it was a new release, so they changed the Pod template label from `app: payment` to `app: payment-v2`. 
+The mechanics are simple, but the operational habit matters: always make scope visible when inspecting resources. `k get pods` shows only the current namespace, while `k get pods -A` shows all namespaces. In incident response, a missing `-n` or missing `-A` can send you searching in the wrong room, especially when multiple environments use the same resource names.
 
-**The impact:** The existing Payment Service was still strictly looking for `app: payment`. Because the labels no longer matched, the Service instantly dropped all the Pods from its endpoints list. The Service was empty. A single label typo caused a 30-minute total outage. Labels are the glue of Kubernetes; if the glue fails, the pieces fall apart.
+```bash
+alias k=kubectl
+k get namespaces
+k create namespace payments-dev
+k get pods -n payments-dev
+k get pods -A -l app.kubernetes.io/name=checkout
+```
 
----
+Creating a namespace is only the start of a useful boundary. In a real platform, namespace creation is usually wrapped by automation that also applies owner labels, default NetworkPolicies, ResourceQuotas, LimitRanges, and RoleBindings. Without those companion objects, you have a named bucket, but you do not yet have a reliable operating contract for a team or application.
+
+That automation can be as simple as a checked-in namespace manifest for a small team or as formal as a platform API that provisions namespaces through a request workflow. The important part is repeatability. If production namespaces always receive the same baseline deny policy, quota shape, owner labels, and support annotations, then operators can trust the environment instead of reverse-engineering it each time a new service appears.
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: payments-dev
+  labels:
+    app.kubernetes.io/part-of: checkout-platform
+    environment: development
+    team: payments
+```
+
+The namespace labels above are not the same as Pod labels, but they serve the same queryable identity purpose at a different scope. You might use them in admission policy, cost reporting, inventory views, or automation that applies baseline policies to all namespaces owned by a team. The principle is consistent: labels describe categories you expect machines and people to query.
+
+Namespace labels are especially useful for cross-cutting platform tasks. A policy controller can look for namespaces labeled `environment=production` and require stricter settings, while a cost report can group all namespaces labeled `team=payments`. This keeps the policy expression tied to declared metadata rather than to a manually maintained list of namespace names. If a namespace changes ownership, updating the label changes how platform automation sees it.
+
+```bash
+k label namespace payments-dev cost-center=cc-1234
+k annotate namespace payments-dev owner-email=payments-team@example.com
+k get namespaces -l team=payments
+```
+
+The `k label` and `k annotate` commands are convenient, but changing live labels deserves caution. Adding a label is usually safe when no selector depends on it, while changing or removing a selector label can immediately alter controller behavior. Before mutating labels on Pods controlled by a Deployment, prefer changing the Deployment template through versioned manifests so the desired state and future Pods stay consistent.
+
+Directly labeling an individual Pod is often a debugging shortcut, not a durable fix. If the Pod belongs to a Deployment, the next replacement Pod comes from the Deployment template and may not carry your manual change. Durable metadata belongs in the controller template or in the manifest source that creates the object. This is another reason operators inspect both the live Pod labels and the Deployment template when a selector problem appears.
+
+```bash
+k get svc -n production payment -o yaml
+k get endpointslice -n production -l kubernetes.io/service-name=payment
+k get pods -n production -l app=payment --show-labels
+```
+
+Those three commands form a practical Service debugging chain. First inspect the Service selector, then inspect the generated EndpointSlices, then list Pods with the same selector and visible labels. If the Service has no endpoints but matching Pods exist, look for readiness gates or port mismatches; if matching Pods do not exist, the selector and labels have drifted apart.
+
+EndpointSlices are useful because they show the result of selection after the control plane has processed the Service and Pod state. A Service manifest tells you intent, Pod labels tell you candidates, and EndpointSlices tell you what Kubernetes is actually publishing for traffic. When those three views disagree, you have narrowed the problem dramatically. That is the difference between guessing at networking and following the object relationships.
 
 ## Worked Example: Labeling a Microservices App End-to-End
 
-Let's look at how we tie this all together for a two-tier application (Web UI and Redis Cache).
+Let's look at how we tie this all together for a two-tier application with a Web UI and Redis cache. The Web Pods get `app: web`, `tier: frontend`, and `env: prod`, while the Redis Pods get `app: redis`, `tier: backend`, and `env: prod`. This gives Services a stable application label and gives NetworkPolicies a tier label they can use without hard-coding individual Pod names.
 
-**Step 1: Define the Pods (via Deployment templates)**
-* Web Pods get labels: `app: web`, `tier: frontend`, `env: prod`
-* Redis Pods get labels: `app: redis`, `tier: backend`, `env: prod`
+The Web Service should balance traffic across only the web Pods, so its selector can be `app: web`. The Redis Service should point internal traffic to the cache Pods, so its selector can be `app: redis`. Those selectors are intentionally narrow enough to avoid crossing application boundaries, but not so narrow that a normal version rollout removes healthy Pods from service.
 
-**Step 2: Connect the Services**
-* The Web Service needs to balance traffic across the web Pods. 
-  * Its selector is: `app: web`
-* The Redis Service needs to point internal traffic to the cache.
-  * Its selector is: `app: redis`
+If the team later adds a second web Deployment for canary traffic, it has choices. It can keep both stable and canary Pods behind the main Service by preserving `app: web`, or it can introduce `track=stable` and `track=canary` selectors for separate Services. Neither choice is universally correct. The right answer depends on whether the traffic split belongs in Kubernetes Services, an ingress controller, a service mesh, or the application release system.
 
-**Step 3: Secure with NetworkPolicies (Set-based)**
-* We want to ensure ONLY the frontend can talk to Redis.
-* We create a NetworkPolicy on the Redis Pods that allows ingress from:
-  ```yaml
-  matchExpressions:
-  - key: tier
-    operator: In
-    values: [frontend]
-  ```
+NetworkPolicy adds a second use for the same scheme. If Redis should accept ingress only from the frontend tier, the policy can select Redis Pods as the destination and allow sources whose labels say they are frontend workloads. This is where a consistent label vocabulary pays off, because the network rule can express intent without naming every Deployment that might scale or roll during the day.
 
-By designing a consistent labeling scheme, networking, routing, and scaling all snap into place automatically.
+The danger is that a label used for security becomes a permission signal. If any developer can label any Pod `tier=frontend`, then a policy allowing frontend traffic is only as strong as the governance around labels. Production clusters often pair NetworkPolicies with RBAC, admission policies, or deployment templates so teams cannot casually grant themselves network reach by editing metadata. Labels are powerful precisely because controllers believe them.
 
----
+```yaml
+matchExpressions:
+- key: tier
+  operator: In
+  values: [frontend]
+```
+
+By designing a consistent labeling scheme, networking, routing, and scaling snap into place automatically. By designing a careless one, you create a cluster where every team has to rediscover which labels are safe to select and which labels were added for a one-time migration. The difference is not academic; it is the difference between a two-minute endpoint diagnosis and a long outage where every object looks healthy in isolation.
+
+A worked example should also include failure thinking. Ask what would break if Redis Pods accidentally used `app: web`, or if Web Pods omitted `tier: frontend`. The first mistake could route cache traffic to the wrong Pods if a Service selector were too broad, while the second could block legitimate Redis access under a NetworkPolicy. Labels are small fields, but they sit directly in the path of routing, ownership, and policy decisions.
+
+Real-world war story: it is 2 AM on a Friday, and the production payment Service suddenly stops routing traffic. The Pods are running, nodes are healthy, and the Deployment reports the desired count, but requests fail because the Service endpoints list is empty. A developer changed the Pod template label from `app: payment` to `app: payment-v2` to show a new release, while the Service still selected `app: payment`; one label drift caused a total outage until the selector contract was restored.
+
+Which approach would you choose here and why: should the team change the Service selector to `app: payment-v2`, or should it restore the stable `app: payment` label and add `version: v2` as a separate label? The safer default is to keep the stable application label for routing and add version as separate metadata, because release identity changes more often than application identity. You can still use version labels for canaries, metrics, and temporary analysis without tying the main Service to every release name.
+
+## Patterns & Anti-Patterns
+
+Good namespace and label design usually follows a few repeatable patterns. The first pattern is stable routing identity: Services select labels that describe what the workload is, not which build happens to be running today. The second pattern is owner-visible namespace boundaries: every namespace carries labels and annotations that identify team, environment, product, and lifecycle. The third pattern is policy-ready taxonomy: labels such as `tier`, `environment`, and `app.kubernetes.io/part-of` are present before NetworkPolicies, quotas, or cost reports need them.
+
+These patterns work because they make the desired relationships obvious in the object metadata. A Service selector reads like the intended backend group, a namespace label reads like the owner and environment, and an annotation reads like support context. When metadata tells a coherent story, new operators can learn the cluster from the API itself instead of depending on a separate spreadsheet that may be stale.
+
+| Pattern | When to Use It | Why It Works | Scaling Consideration |
+|---------|----------------|--------------|-----------------------|
+| Stable Service selector labels | Any workload that receives traffic through a Service | Keeps rollouts from emptying endpoints when versions change | Reserve version labels for observability or controlled canary selectors |
+| Namespace per app/environment | Critical services with separate ownership and blast-radius needs | Aligns RBAC, quotas, policy, and incident scope | Automate namespace bootstrap so policy remains consistent |
+| Recommended application labels | Shared tooling, Helm-managed apps, dashboards, and audits | Gives tools a common vocabulary for grouping resources | Enforce through templates or admission checks rather than memory |
+| Annotation for provenance | Build hashes, source URLs, contacts, and deployment notes | Keeps long metadata out of selector indexes | Decide which annotations are required for incident response |
+
+Anti-patterns tend to appear when teams treat labels as decorative strings instead of controller contracts. A broad selector such as `app: web` inside a mixed namespace can join unrelated environments. A unique label such as `pod-template-hash` can make a Service follow only one ReplicaSet when the next rollout arrives. A namespace named `prod` without RBAC, quotas, or network rules can create false confidence because the boundary looks meaningful but does little by itself.
+
+The social cause is usually speed. Someone ships the first version with just enough labels to make a Service work, the next team copies that manifest, and six months later the platform has a de facto standard nobody designed. The repair is not to rename everything in one risky burst. Start by documenting the target scheme, add the new labels alongside old ones, migrate selectors carefully, and remove obsolete labels only after controllers and dashboards no longer depend on them.
+
+| Anti-Pattern | What Goes Wrong | Better Alternative |
+|--------------|-----------------|--------------------|
+| Using `default` for shared production apps | Names collide, permissions blur, and cleanup is risky | Create explicit namespaces with owner and environment labels |
+| Selecting traffic by release version by default | Normal rollouts can remove healthy Pods from a Service | Select stable app identity and track version separately |
+| Putting build metadata in labels | Long or high-cardinality values waste selector-oriented metadata | Put commit hashes, build URLs, and contacts in annotations |
+| Assuming namespaces isolate network traffic | Pods may still communicate across namespaces unless policy says otherwise | Add NetworkPolicies and test allowed paths explicitly |
+
+When this does not apply: tiny local clusters used for a single tutorial can run many examples in `default` because speed matters more than operational boundaries. The risk starts when a habit from a laptop cluster moves into a shared environment. As soon as multiple people, services, environments, or policies share a cluster, namespace and label design stops being optional housekeeping and becomes part of the system's reliability model.
+
+There is one more anti-pattern worth naming: over-modeling. A beginner sometimes reacts to label mistakes by inventing a dozen required labels before the organization knows what decisions those labels support. That creates its own drift because teams fill required fields with low-quality values. Prefer a small mandatory core that supports real selectors, ownership, and reporting, then add specialized labels when a controller, policy, or operational workflow needs them.
+
+## Decision Framework
+
+Start with the question you are trying to answer, not with the metadata field you want to fill. If the question is "who may access these objects?" or "how much capacity may this group consume?", you are probably designing a namespace boundary plus RBAC or quota. If the question is "which objects should this controller, Service, policy, or report select?", you are designing labels. If the question is "what extra detail should humans or tooling see after selecting the object?", you are designing annotations.
+
+The same resource may use all three mechanisms at once. A Deployment can live in the `payments-prod` namespace, carry labels that say it is part of checkout and implements the frontend tier, and include annotations pointing to the runbook and build provenance. That is not duplication when each layer answers a different question. The namespace scopes policy and names, the labels support grouping and selectors, and the annotations preserve explanatory detail.
+
+| Decision | Use Namespace When... | Use Label When... | Use Annotation When... |
+|----------|-----------------------|-------------------|------------------------|
+| Organizing ownership | A team or app needs its own permission and quota boundary | You need to query resources owned by a team across scopes | You need a contact, ticket, or runbook link |
+| Separating environments | Dev, staging, and production need different policies | One namespace contains multiple environment categories | A build or deployment note describes one object |
+| Routing traffic | The Service and Pods are in a clear namespace scope | The Service must find matching Pods by stable identity | Never; annotations do not select endpoints |
+| Debugging incidents | You need to limit the search area quickly | You need to list all matching workloads or endpoints | You need provenance after finding the object |
+
+Use a namespace when the boundary should carry policy, quota, or name scoping. Use a label when a controller or operator will filter resources by that value. Use an annotation when the value explains, documents, or configures an object but should not determine group membership. That decision sequence prevents the common mistake of asking labels to be a documentation store or asking namespaces to be a security wall by themselves.
+
+When you are unsure, imagine the value changing during a release. If changing it should move traffic, alter policy membership, or change an inventory query, it is probably a label and deserves careful rollout planning. If changing it should merely update the explanation attached to the object, it is probably an annotation. If the change should redefine who owns the workspace or what policies apply to a group of resources, you are probably looking at namespace design.
 
 ## Did You Know?
 
-- **Namespaces don't provide network isolation** - By default, Pods in different namespaces can communicate. Use NetworkPolicies for isolation.
-- **Labels have length limits** - Keys can be up to 63 characters (253 with prefix). Values up to 63 characters.
-- **You can query by labels** - `kubectl get pods -l app=frontend,env=prod` shows pods matching both labels.
-- **Namespace names are DNS subdomains** - They must be lowercase, alphanumeric, with hyphens allowed.
-
----
+- **Namespaces do not provide network isolation by default** - Pods in different namespaces can often communicate unless NetworkPolicies and a compatible network plugin restrict the path.
+- **Label keys and values have documented size rules** - A label name segment is limited to 63 characters, and an optional DNS-prefix portion can be up to 253 characters.
+- **Selectors can be used directly from the CLI** - `k get pods -l app=frontend,env=prod` returns Pods that match both labels, which is a logical AND.
+- **Namespace names follow DNS label rules** - They must be lowercase and DNS-compatible, which is why names like `Payments_Prod` are rejected.
 
 ## Common Mistakes
 
-| Mistake | Why It Hurts | Specific Impact | Correct Understanding |
-|---------|--------------|-----------------|----------------------|
-| Thinking namespaces isolate network | Security risk | A compromised dev Pod can reach a prod database | Use NetworkPolicies for network isolation |
-| Label key typos | Selectors don't match | **Service loses all backends, causing a total outage** | Double-check label names in Services/Deployments |
-| Too few labels | Hard to organize/select | Cannot target specific environments or versions during rollouts | Use a consistent labeling scheme (like `app.kubernetes.io/*`) |
-| Labels for long metadata | Wrong tool | Wastes API server resources; hits 63-character limit | Use annotations for descriptions, git hashes, and build info |
-
----
+| Mistake | Why It Happens | How to Fix It |
+|---------|----------------|---------------|
+| Thinking namespaces isolate network traffic | The word "namespace" sounds like a hard security boundary, and RBAC can be namespace-scoped. | Treat namespaces as organization and policy attachment points, then add NetworkPolicies for traffic isolation. |
+| Changing a stable Service selector label during a rollout | Teams want labels to reflect the new release and accidentally mutate routing identity. | Keep labels such as `app: payment` stable, then add `version` or recommended application labels for release detail. |
+| Putting every workload into `default` | Tutorials and quick experiments use `default`, and the habit carries into shared clusters. | Create explicit namespaces for teams, applications, or environments before deploying shared workloads. |
+| Using labels for long metadata | Labels are visible and easy to add, so teams put build hashes, timestamps, and contact details there. | Use annotations for provenance, contact, runbook, and build metadata that selectors should not query. |
+| Forgetting that some resources are cluster-scoped | Commands with `-n` feel universal, so operators expect every object to live in a namespace. | Learn the scope of Nodes, PersistentVolumes, StorageClasses, Namespaces, and ClusterRoles before applying policy. |
+| Writing selectors that are too broad | A short selector works in a small demo and later matches unrelated Pods in a shared namespace. | Include stable labels that distinguish application, instance, environment, or component as needed. |
+| Assuming a matching label means traffic is ready | A Service selector can match Pods that are not ready or expose the wrong port. | Inspect Service selectors, EndpointSlices, Pod readiness, and target ports together during debugging. |
 
 ## Quiz
 
-1. **Your company has three teams sharing one Kubernetes cluster. Team A complains that Team B accidentally deleted their ConfigMap because both teams named it "app-config" in the default namespace. How would you restructure the cluster to prevent this, and what additional protections could namespaces provide?**
-   <details>
-   <summary>Answer</summary>
-   Create separate namespaces for each team (e.g., `team-a`, `team-b`, `team-c`). Namespaces provide name scoping, so both teams can have a ConfigMap called "app-config" without conflict. Additionally, apply RBAC so each team can only access their own namespace, and set ResourceQuotas to prevent any single team from consuming all cluster resources. Namespaces are the primary organizational unit for multi-team clusters.
-   </details>
+<details><summary>Your company has three teams sharing one Kubernetes cluster. Team A complains that Team B accidentally deleted their ConfigMap because both teams named it `app-config` in the `default` namespace. How would you restructure the cluster, and what else would you add?</summary>
 
-2. **A new engineer wants to set resource quotas on Nodes to limit how much CPU each physical server can allocate. Why won't this work with namespace-level ResourceQuotas, and what type of resource are Nodes?**
-   <details>
-   <summary>Answer</summary>
-   Nodes are cluster-scoped resources, not namespace-scoped. ResourceQuotas only apply within namespaces and control resources like Pods, Services, ConfigMaps, and compute requests/limits. Since Nodes exist outside of any namespace (they are physical or virtual machines shared by the entire cluster), they cannot be managed by namespace-level quotas. Other cluster-scoped resources include PersistentVolumes, ClusterRoles, and Namespaces themselves.
-   </details>
+Create separate namespaces for each team or for each team/environment combination, such as `team-a-dev` and `team-a-prod` if environment separation matters. Namespaces provide name scoping, so both teams can own a ConfigMap named `app-config` without collision. Add RoleBindings so each team can manage only its namespaces, and add ResourceQuotas so one team cannot consume the shared cluster unchecked. This design satisfies the namespace strategy outcome because it pairs organization with enforceable access and capacity controls.
 
-3. **You need to create a NetworkPolicy that selects Pods from either the 'frontend' or 'api' tier, but strictly excludes any Pods marked as 'experimental'. Which selector mechanism is required for this scenario?**
-   <details>
-   <summary>Answer</summary>
-   You must use a set-based selector with `matchExpressions`. An equality-based selector (`matchLabels`) only supports exact logical AND matches. To satisfy "EITHER frontend OR api" and "NOT experimental", you would write an expression using the `In` operator for `[frontend, api]` and the `NotIn` operator for `[experimental]`.
-   </details>
+</details>
 
-4. **Your team stores build timestamps, Git commit hashes, and team contact emails on Kubernetes resources. A colleague puts all of these as labels. What problem might this cause, and what should they use instead for some of this metadata?**
-   <details>
-   <summary>Answer</summary>
-   Labels have a 63-character value limit and are indexed by the API server, so using them for long or frequently changing metadata wastes resources and can hit length limits (Git commit hashes are 40+ characters). More importantly, labels are meant for identification and selection by Kubernetes -- using them for metadata that no selector will ever query is wasteful. Git commit hashes, build timestamps, and contact emails should be stored as annotations, which can hold longer values and are designed for tool and human metadata rather than selection.
-   </details>
+<details><summary>A new engineer wants to set namespace-level ResourceQuotas on Nodes to limit CPU per physical server. Why will that plan not work, and how should you explain the scope problem?</summary>
 
-5. **A security engineer says "we put our teams in separate namespaces, so they are isolated from each other." Is this statement fully correct? What critical piece might be missing?**
-   <details>
-   <summary>Answer</summary>
-   This is only partially correct. Namespaces provide name scoping and can be used with RBAC for access control and ResourceQuotas for resource limits, but they do NOT provide network isolation by default. Pods in different namespaces can still communicate freely over the network. To achieve true network isolation, you must apply NetworkPolicies that restrict cross-namespace traffic. Without NetworkPolicies, a compromised Pod in one namespace can reach any Pod in any other namespace.
-   </details>
+Nodes are cluster-scoped resources, not namespace-scoped resources, so a namespace ResourceQuota cannot attach to an individual Node. ResourceQuotas limit namespaced consumption such as Pods and their requested CPU or memory inside a namespace. The Node itself is shared infrastructure that may run Pods from many namespaces at the same time. To diagnose this class of issue, first decide whether the resource belongs to the application scope or the cluster infrastructure scope.
 
+</details>
+
+<details><summary>Your team deploys `payment-v2`, changes Pod labels from `app=payment` to `app=payment-v2`, and the Service loses every endpoint. What do you check first, and what is the durable fix?</summary>
+
+Check the Service selector, then list Pods with the same selector and visible labels using `k get pods -n production -l app=payment --show-labels`. The likely failure is selector drift: the Service still selects `app=payment`, but the new Pods no longer carry that stable label. Restore `app=payment` as the routing identity and add `version=v2` or recommended application version labels as separate metadata. That fix keeps future rollouts from breaking the Service contract.
+
+</details>
+
+<details><summary>A NetworkPolicy must select Pods from either the `frontend` or `api` tier while excluding workloads labeled `track=experimental`. Which selector mechanism should you use, and why?</summary>
+
+Use set-based `matchExpressions`, because equality-based `matchLabels` cannot express an OR membership test or an exclusion. The tier requirement needs `operator: In` with values such as `[frontend, api]`, and the track exclusion needs `operator: NotIn` with `[experimental]`. Remember that both expressions combine as logical AND, so a Pod must satisfy the allowed tier and avoid the experimental track. This evaluates the selector outcome instead of merely recalling the operator names.
+
+</details>
+
+<details><summary>An audit script needs to find all checkout resources across namespaces, while incident responders need the Git commit and runbook for each object. Which metadata belongs in labels, and which belongs in annotations?</summary>
+
+The product grouping, application name, component, environment, and team should be labels because the audit script needs to select and group by them. The Git commit, build URL, runbook link, and contact details should be annotations because they provide detail after the resource is found. This split keeps queryable identity small and stable while still preserving rich operational context. It also avoids high-cardinality or long values in labels.
+
+</details>
+
+<details><summary>A platform lead says, "We put production and development in separate namespaces, so the environments are isolated." What is accurate about the statement, and what is missing?</summary>
+
+The statement is accurate for name scoping and as a foundation for RBAC, quotas, and policy attachment. It is incomplete because namespaces do not automatically block network traffic between Pods in different namespaces. If production and development require network isolation, the team needs NetworkPolicies enforced by the cluster networking implementation. A good answer distinguishes organizational isolation from traffic isolation instead of treating namespaces as magic walls.
+
+</details>
+
+<details><summary>You run `k get pods -n production -l app=web` and see both stable and canary Pods. The main Service should send traffic only to stable Pods. What selector change is reasonable, and what risk should you check?</summary>
+
+The Service could select both `app=web` and `track=stable` if every stable Pod carries that label and canary Pods carry a different track. Before making the change, check that the stable label exists on all intended backends; otherwise the Service may lose capacity or all endpoints. Also confirm that the Deployment selector and Pod template labels remain consistent, because controller ownership and Service routing are related but separate contracts. This is an evaluation problem because the correct selector depends on the rollout model and current labels.
+
+</details>
+
+## Hands-On Exercise
+
+In this exercise, you will create a small namespace and labeling model for a payments application, then use selectors to prove which Pods and Services belong together. Use a disposable local cluster such as kind, minikube, or a remote training cluster where you have permission to create namespaces and Deployments. The goal is not to build a production app; it is to practice the exact inspection chain you need when namespace scope or selector drift causes confusion.
+
+As you work through the lab, keep a small mental model of three layers. The namespace is the room, the labels are the sticky notes Kubernetes can query, and the annotations are the notes you read after you have found the right box. Every task asks you to prove which layer is doing the work. That is the fastest way to turn the vocabulary into an operational habit.
+
+### Setup
+
+Run these commands from a shell where `k` points to `kubectl`. The manifests use `nginx` because the container starts quickly and keeps the exercise focused on Kubernetes object organization rather than application code. If you already have a `payments-dev` namespace from another lab, delete it only if it is safe in your environment, or choose a different namespace name consistently.
+
+```bash
+alias k=kubectl
+k create namespace payments-dev
+k label namespace payments-dev team=payments environment=development app.kubernetes.io/part-of=checkout-platform
+```
+
+Apply a Deployment and Service with stable routing labels plus version metadata. Notice that the Service selector uses only `app: payment-web`, while the Pod template also includes `tier`, `environment`, and `version`. That split lets the Service keep routing during a normal version label change.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payment-web
+  namespace: payments-dev
+  labels:
+    app.kubernetes.io/name: payment-web
+    app.kubernetes.io/part-of: checkout-platform
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: payment-web
+  template:
+    metadata:
+      labels:
+        app: payment-web
+        tier: frontend
+        environment: development
+        version: v1
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.29
+        ports:
+        - containerPort: 80
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: payment-web
+  namespace: payments-dev
+spec:
+  selector:
+    app: payment-web
+  ports:
+  - port: 80
+    targetPort: 80
+```
 
-## Summary
-
-**Namespaces**:
-- Divide cluster resources (like rooms in a warehouse)
-- Provide name scoping
-- Enable RBAC and quotas
-- Don't isolate network (use NetworkPolicies)
-
-**Labels**:
-- Key-value pairs for identification (like sticky notes)
-- Used by selectors (Services, Deployments)
-- Enable organization and selection
-
-**Annotations**:
-- Key-value pairs for metadata
-- NOT used for selection
-- For tools, humans, longer descriptions
-
-**Common patterns**:
-- `app`, `environment`, `version` labels
-- Namespaces per team or environment
-- Consistent labeling across resources
-
+```bash
+k apply -f - <<'YAML'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payment-web
+  namespace: payments-dev
+  labels:
+    app.kubernetes.io/name: payment-web
+    app.kubernetes.io/part-of: checkout-platform
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: payment-web
+  template:
+    metadata:
+      labels:
+        app: payment-web
+        tier: frontend
+        environment: development
+        version: v1
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.29
+        ports:
+        - containerPort: 80
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: payment-web
+  namespace: payments-dev
+spec:
+  selector:
+    app: payment-web
+  ports:
+  - port: 80
+    targetPort: 80
+YAML
+```
 
-## Part 1 Complete!
+### Tasks
 
-You've finished **Kubernetes Fundamentals** (46% of the exam). You now understand:
-- What Kubernetes is and why it exists
-- Containers and how they work
-- Control plane and node components
-- Pods, Deployments, ReplicaSets
-- Services and discovery
-- Namespaces and labels
+- [ ] List the namespace with its labels, then explain which labels describe ownership and which describe environment.
+- [ ] List Pods in `payments-dev` with `--show-labels`, then identify the labels the Service depends on.
+- [ ] Use an equality selector to list only `app=payment-web` Pods and a set-based selector to list Pods where `tier in (frontend)` and `environment notin (production)`.
+- [ ] Inspect the Service and EndpointSlices, then explain why endpoints appear when the selector and Pod labels agree.
+- [ ] Add an annotation named `runbook` with the value `https://example.com/runbooks/payment-web`, then explain why it is not a label.
+- [ ] Patch the Service selector in a controlled way to require `version: v2`, observe the endpoint impact, and restore the original selector.
 
-**Next Part**: [Part 2: Container Orchestration](/k8s/kcna/part2-container-orchestration/module-2.1-scheduling/) - How Kubernetes manages workloads at scale.
+<details><summary>Solution guide</summary>
+
+Start by checking namespace identity with `k get namespace payments-dev --show-labels`. Ownership labels such as `team=payments` and product labels such as `app.kubernetes.io/part-of=checkout-platform` help platform tools group the namespace, while `environment=development` tells you the lifecycle role. Then run `k get pods -n payments-dev --show-labels` and confirm that `app=payment-web` appears on every Pod because the Service depends on that stable label.
+
+Use `k get pods -n payments-dev -l app=payment-web` for the equality selector. Use `k get pods -n payments-dev -l 'tier in (frontend),environment notin (production)'` for the set-based selector. The same Pods should match both filters in this small lab, but the filters answer different operational questions: one asks for application identity, while the other asks for workload role and environment exclusion.
+
+Inspect routing with `k get svc -n payments-dev payment-web -o yaml` and `k get endpointslice -n payments-dev -l kubernetes.io/service-name=payment-web`. The EndpointSlices should include ready endpoints because the Service selector matches the Pod labels and the Pods become ready. Add the annotation with `k annotate deployment -n payments-dev payment-web runbook=https://example.com/runbooks/payment-web`, then inspect it with `k get deployment -n payments-dev payment-web -o yaml`.
+
+To observe selector drift safely, patch the Service with `k patch service -n payments-dev payment-web --type merge -p '{"spec":{"selector":{"app":"payment-web","version":"v2"}}}'`. EndpointSlices should lose matching endpoints because no current Pod has `version=v2`. Restore the selector with `k patch service -n payments-dev payment-web --type merge -p '{"spec":{"selector":{"app":"payment-web"}}}'`, then confirm endpoints return. Clean up with `k delete namespace payments-dev` when the lab is complete and safe to remove.
+
+</details>
+
+### Success Criteria
+
+- [ ] You can explain why `payments-dev` is a namespace boundary but not an automatic network isolation boundary.
+- [ ] You can point to the exact Pod label the Service selector uses for routing.
+- [ ] You can run both equality-based and set-based selector queries with `k`.
+- [ ] You can explain why the runbook URL is an annotation rather than a label.
+- [ ] You can reproduce and repair a selector drift problem without changing unrelated resources.
+
+## Sources
+
+- [Kubernetes documentation: Namespaces](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/)
+- [Kubernetes documentation: Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
+- [Kubernetes documentation: Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
+- [Kubernetes documentation: Recommended Labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/)
+- [Kubernetes documentation: Services](https://kubernetes.io/docs/concepts/services-networking/service/)
+- [Kubernetes documentation: Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)
+- [Kubernetes documentation: Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
+- [Kubernetes documentation: Resource Quotas](https://kubernetes.io/docs/concepts/policy/resource-quotas/)
+- [Kubernetes documentation: RBAC Authorization](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
+- [Kubernetes kubectl reference: label](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_label/)
+
+## Next Module
+
+[Part 2: Container Orchestration](/k8s/kcna/part2-container-orchestration/module-2.1-scheduling/) - How Kubernetes schedules workloads, reacts to capacity, and keeps applications running at cluster scale.


### PR DESCRIPTION
## Summary

Rewrites `module-1.8-namespaces-labels.md` for #388 density, structure, alignment, and anti-leak gates, while clearing `revision_pending: false`.

Verifier summary: tier T0; body_words=5276, mean_wpp=66.0, median_wpp=67.0, short_rate=0.0, max_run=0; all density, structure, alignment, anti_leak, and source-count gates passed with source reachability skipped per verifier command.

Protected assets preserved: code blocks 10 before / 16 after; ASCII diagrams 1 before / 1 after; mermaid diagrams 0 before / 0 after; tables 5 before / 8 after; source URLs 0 before / 10 after.

Commit SHA: cde79e2cfb6ccaa662c9069d9dc27155702ff3cd

## Verification

- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/quality/verify_module.py --glob src/content/docs/k8s/kcna/part1-kubernetes-fundamentals/module-1.8-namespaces-labels.md --skip-source-check --summary --quiet` -> T0
- `git diff --check` -> clean
- `npm run build` from primary checkout with the branch module temporarily applied -> passed
- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/test_pipeline.py` -> 166 tests passed