### PR TITLE
feat(388): rewrite module-2.3-storage (#388 pilot)

### DIFF
--- a/src/content/docs/k8s/kcna/part2-container-orchestration/module-2.3-storage.md
+++ b/src/content/docs/k8s/kcna/part2-container-orchestration/module-2.3-storage.md
@@ -1,61 +1,44 @@
 ---
 title: "Module 2.3: Storage Orchestration"
 slug: k8s/kcna/part2-container-orchestration/module-2.3-storage
+revision_pending: false
 sidebar:
   order: 4
 ---
 
-> **Complexity**: `[MEDIUM]` - Storage concepts
->
-> **Time to Complete**: 45-60 minutes
->
-> **Prerequisites**: Module 2.2 (Scaling)
+# Module 2.3: Storage Orchestration
+
+**Complexity**: `[MEDIUM]` - Storage concepts. **Time to Complete**: 45-60 minutes. **Prerequisites**: Module 2.2 (Scaling). All commands in this module assume Kubernetes 1.35 or newer and use the standard shell shortcut `alias k=kubectl`, so `k get pods` means the same API request as the longer command while keeping examples readable.
 
 ---
 
-## What You'll Be Able to Do
+## Learning Outcomes
 
-After completing this exhaustive module, you will be capable of mastering the complexities of stateful workloads in a distributed environment. Specifically, you will be able to:
+After completing this module, you will be able to:
 
-1. **Design** an optimal persistent storage architecture for stateful workloads, carefully differentiating between the performance characteristics of block, file, and object storage requirements.
-2. **Implement** dynamic storage provisioning pipelines utilizing StorageClasses and PersistentVolumeClaims to fully automate volume life cycles without administrator intervention.
-3. **Diagnose** common storage binding failures, permission constraints, and access mode conflicts that frequently plague multi-node Kubernetes clusters.
-4. **Compare** the mechanical behaviors of the Retain, Delete, and Recycle reclaim policies to ensure critical production data is never accidentally destroyed.
-5. **Evaluate** the Container Storage Interface (CSI) architecture to determine exactly how external storage providers integrate seamlessly with the core Kubernetes control plane.
-
----
+1. **Design** a persistent storage architecture for stateful Kubernetes workloads by comparing block, file, object, ephemeral, and persistent storage behaviors.
+2. **Implement** dynamic storage provisioning with StorageClasses and PersistentVolumeClaims so volume creation follows workload demand instead of manual ticket queues.
+3. **Diagnose** storage binding failures, topology mismatches, permission constraints, and access mode conflicts that prevent Pods from starting.
+4. **Compare** Retain, Delete, and legacy Recycle reclaim policies so production data is protected during application decommissioning.
+5. **Evaluate** Container Storage Interface (CSI) responsibilities and explain how vendor drivers integrate with the Kubernetes control plane and kubelet.
 
 ## Why This Module Matters
 
-In January 2017, GitLab—a multi-billion dollar code hosting and DevOps platform—experienced a catastrophic database incident that sent shockwaves through the global engineering community. A fatigued systems administrator, attempting to clear out a failing database replication process during a late-night troubleshooting session, accidentally executed a recursive directory deletion command on the primary production database server instead of the secondary node. Over 300 gigabytes of production data vanished in milliseconds. The financial and operational impact was severe: engineering operations halted globally, enterprise clients lost critical repository data, and the company's reputation took a massive, public hit while they spent eighteen grueling hours live-streaming their frantic recovery efforts from fragile, partially corrupted backups.
+In January 2017, GitLab.com experienced one of the most public database incidents in modern operations. During an exhausting recovery attempt, an administrator removed data from the wrong database node while trying to repair replication, and roughly 300 gigabytes of production data disappeared before the team could stop the damage. The company spent hours broadcasting the recovery effort, rebuilding from incomplete backups, and explaining to customers why a platform built to host critical source code had lost some of its own state.
 
-While this specific incident occurred on traditional infrastructure, it perfectly illustrates the absolute, terrifying fragility of state. In the world of Kubernetes, containers are fundamentally ephemeral. By design, any data written to a container's local internal file system is instantly destroyed the moment that container crashes, scales down, or is forcefully evicted by the orchestrator to make room for higher-priority workloads. Without a robust, decoupled storage architecture, a Kubernetes cluster is nothing more than a transient compute engine, completely incapable of reliably hosting databases, message queues, or persistent caches. 
+That incident did not happen inside Kubernetes, but it exposes the same uncomfortable truth that every platform engineer eventually faces: compute is replaceable, state is not. A stateless web Pod can vanish and return somewhere else without drama because its useful data lives behind another API. A database Pod, message broker, search index, or artifact registry cannot treat its local files as disposable scratch space. If the orchestrator deletes the Pod, reschedules it to another node, or evicts it during pressure, the application needs a storage contract that survives the compute lifecycle.
 
-This module matters because stateful applications represent the most critical and financially sensitive workloads in any enterprise environment. You will learn exactly how Kubernetes decouples storage from compute, allowing your critical data to survive pod terminations, node kernel panics, and massive data center outages. Mastering PersistentVolumes, Claims, and the Container Storage Interface (CSI) is the fundamental difference between building resilient, enterprise-grade platforms and building fragile systems waiting for a single catastrophic event to erase millions of dollars of corporate value.
-
----
+Kubernetes storage orchestration is the set of abstractions that creates that contract. The hard part is not memorizing the names PersistentVolume, PersistentVolumeClaim, StorageClass, or CSI driver; the hard part is predicting what happens when they interact with real failure domains, access modes, reclaim policies, and node placement. By the end of this module, you should be able to look at a stuck database Pod, a Pending claim, or a risky StorageClass default and reason through the operational consequence before it becomes a production incident.
 
 ## The Anatomy of Kubernetes Storage: Ephemeral vs. Persistent
 
-To truly grasp Kubernetes storage orchestration, we must first understand the fundamental design philosophy of containerization. Containers are built from immutable, static images. When a container is launched, the container runtime provisions a thin, read-write layer on top of that immutable image. However, this read-write layer is intimately tied to the exact lifecycle of the container itself. 
+Containers start from immutable images, but every running container also gets a writable layer for files created after startup. That layer is convenient for logs, temporary downloads, PID files, and caches that can be rebuilt, but it belongs to the container lifecycle. When the container is replaced, the layer is discarded with it. Kubernetes is intentionally comfortable destroying and recreating containers because that is how the platform repairs unhealthy workloads, rolls out new versions, and moves work away from failing nodes.
 
-Think of a container's internal file system exactly like the Random Access Memory (RAM) in your personal computer. When you are typing a document, the data lives in the highly responsive RAM. But if someone kicks the power cord out of the wall, the computer shuts down, the RAM is cleared, and your unsaved document is lost forever. If a container crashes due to an out-of-memory error and the `kubelet` restarts it, the read-write layer is wiped entirely clean. The application starts fresh from the immutable image.
+The first storage distinction is therefore not cloud versus on-premises or SSD versus network filesystem; it is whether the data must survive the thing that is writing it. An `emptyDir` volume survives individual container restarts inside the same Pod because the volume is attached to the Pod sandbox rather than to one container process. That makes it useful when a sidecar reads files written by the main container, or when an init container prepares data before the application starts. It does not make the data durable, because the volume still disappears when the Pod object is removed from the node.
 
-To solve this inherent amnesia, Kubernetes introduced the concept of **Volumes**. A Volume in Kubernetes is essentially a directory containing data, accessible to the containers running within a specific Pod. Unlike standard Docker volumes, Kubernetes volumes have an explicitly defined lifecycle that perfectly matches the Pod that encloses them. This means a volume outlives any individual container restarts that occur within the Pod, ensuring that data is preserved if the application simply crashes and reboots. 
+Think of `emptyDir` like a hotel room desk. You can leave a notebook there while you step into the hallway, and another person sharing the room can read it. When checkout happens, housekeeping clears the desk for the next guest. The hotel building might still be standing, but the room assignment ended, so anything treated as part of that assignment is gone. A Pod deletion, scale-down, replacement after node pressure, or recreation by a controller is Kubernetes checking out of the room.
 
-However, we must strictly divide volumes into two categories: Ephemeral and Persistent.
-
-### Ephemeral Storage: The `emptyDir`
-
-The most widely utilized ephemeral volume type is the `emptyDir`. As the name directly implies, when a Pod is scheduled and assigned to a specific worker node, an `emptyDir` volume is immediately created on that node's local disk. It begins its life completely empty. All containers within the Pod can read and write to the exact same files within the `emptyDir`, making it an exceptional tool for sharing temporary data between a main application container and a sidecar container (such as an application writing log files that a sidecar agent reads and forwards to a central logging server).
-
-The critical danger of the `emptyDir` lies in its lifecycle boundary. The `emptyDir` is strictly bound to the Pod. When the Pod is permanently removed from the node for any reason—whether due to a deliberate scale-down event, a node hardware failure, or an administrator manually executing a delete command—the data within the `emptyDir` is permanently deleted from the host disk. It cannot be recovered. It is the definition of ephemeral.
-
-### Persistent Storage: Breaking the Pod Boundary
-
-For true stateful applications like PostgreSQL, MongoDB, or Kafka, ephemeral storage is completely unacceptable. These applications require storage that exists entirely independently of the Pod lifecycle. If a database Pod is deleted by the orchestrator and recreated five minutes later on a completely different physical server located in a different rack in the data center, it must be able to reconnect to its exact same historical data. 
-
-This requires network-attached persistent storage, which brings us to the core abstractions of Kubernetes storage orchestration: PersistentVolumes and PersistentVolumeClaims.
+Persistent storage breaks that boundary. Instead of tying the data directory to the Pod, Kubernetes ties the Pod to a storage object that can exist before the Pod starts and after the Pod dies. The volume might be a cloud block disk, a managed network filesystem, a storage array LUN, or a local-path provisioned directory in a small lab cluster. The exact backend matters for performance and failure behavior, but the key Kubernetes idea is that the workload asks for storage through the API and receives a mount whose lifecycle is deliberately separate from the compute process.
 
 ```mermaid
 flowchart TD
@@ -79,20 +62,23 @@ flowchart TD
     end
 ```
 
-> **Pause and predict**: We know that `emptyDir` is ephemeral and lost when a Pod is deleted. There is another volume type called `hostPath` which mounts a file or directory directly from the host node's underlying filesystem into the Pod. Based on your understanding of the Kubernetes scheduler, why is utilizing `hostPath` considered highly dangerous and generally prohibited for stateful applications in a multi-node cluster?
+Notice the careful wording in the persistent path: Kubernetes does not magically make every write safe across every disaster. It coordinates attachment, mount, and scheduling against the capabilities of the storage backend. If the backend is a single-zone block disk, the data may survive a Pod deletion but still be unavailable from another zone. If the backend is a shared filesystem, many nodes may mount it, but application-level file locking and latency become part of the design. Persistent storage gives you a survivable abstraction, not a free replacement for backup, replication, or database correctness.
 
----
+Pause and predict: if a Pod uses `hostPath` to mount `/var/lib/app` directly from the worker node, what happens when the scheduler replaces that Pod on a different node? The answer should feel uncomfortable. The new Pod sees the new node's filesystem, not the old node's files, which means `hostPath` couples the workload to a specific machine while Kubernetes is trying to manage a pool of machines. That is why `hostPath` is usually reserved for node-level agents and tightly controlled platform components, not ordinary stateful applications.
 
-## Deconstructing the Abstraction: PVs, PVCs, and StorageClasses
+A useful storage design starts by classifying the data. Scratch files, render buffers, and temporary decompression directories can often use `emptyDir`, especially when the application can recreate the content after restart. Database data directories, broker logs, uploads, and user-generated files need persistent storage because the business cares about the bytes after the Pod is gone. Large static datasets, model files, and shared media libraries may need read-only or read-write sharing across many nodes, which changes the backend choice before you write a single manifest.
 
-Kubernetes was fundamentally designed to abstract away the underlying infrastructure. A software developer deploying a microservice should not need to know whether the cluster is running on Amazon Web Services, Google Cloud Platform, Microsoft Azure, or a bare-metal rack deep inside a private corporate datacenter. They simply know their application logic requires a specific amount of storage with specific performance characteristics. 
+The KCNA-level trap is assuming that a volume is automatically durable because it appears under `volumes:` in a Pod spec. A Kubernetes volume only says how a directory is made available to containers in the Pod. Durability comes from the volume type and the external system behind it. That is why the same `volumeMounts:` syntax can represent disposable scratch space, a single-node block device, or a managed distributed filesystem with replication and snapshots.
 
-To achieve this elegant separation of concerns, Kubernetes introduces two primary, heavily utilized API resources: the **PersistentVolume (PV)** and the **PersistentVolumeClaim (PVC)**.
+This distinction also affects how you read application documentation. Many upstream projects say "mount a volume here" without explaining whether that path contains state, cache, configuration, or generated output. A platform engineer has to translate that path into a Kubernetes lifecycle decision. If the path contains rebuildable cache, ephemeral storage may be fine. If it contains the only copy of user uploads, a PVC alone may still be incomplete because the application may need backup hooks, object storage migration, or a storage backend that supports multi-writer behavior.
 
-### The PersistentVolume (PV): The Physical Asset
-A PersistentVolume is a piece of actual, physical storage within the cluster that has been manually provisioned by a cluster administrator or automatically provisioned by dynamic infrastructure. It is a **cluster-level resource**. This means it belongs to the entire cluster itself, completely independent of any specific namespace. 
+The safest habit is to draw the lifecycle boundary before writing YAML. Ask what creates the bytes, who else reads them, whether another copy exists, how quickly the data changes, and what the business consequence is if the directory starts empty after a restart. Those questions sound slower than copying a manifest, but they prevent a common failure mode where the cluster appears healthy while the application quietly loses the state that made it useful.
 
-You can visualize a PersistentVolume as a physical hard drive sitting on a desk in a datacenter, waiting to be plugged into a server. It possesses immutable characteristics such as its total storage capacity, the ways it can be accessed, and the specific underlying storage protocol it utilizes (such as NFS, iSCSI, or cloud-provider-specific block storage like AWS EBS).
+## PersistentVolumes and PersistentVolumeClaims
+
+Kubernetes separates storage ownership from storage consumption with two API objects. A PersistentVolume, or PV, represents a storage asset the cluster can use. A PersistentVolumeClaim, or PVC, represents an application's request for storage. This division is deliberate because platform teams and application teams need different levels of detail. Platform teams care about providers, zones, disk classes, encryption, reclaim behavior, and driver configuration. Application teams usually care about capacity, access mode, and the name they can mount into a Pod.
+
+A PersistentVolume is cluster-scoped, which means it does not live inside a namespace. It can be provisioned manually by an administrator or created dynamically by a provisioner. In older static setups, administrators created PVs in advance, describing capacity, access modes, reclaim policy, and a backend-specific implementation. The following preserved example shows that style with a legacy AWS EBS in-tree field; on Kubernetes 1.35, production AWS clusters should use the EBS CSI driver, but the manifest is still useful for understanding the anatomy of a PV object found in older estates.
 
 ```yaml
 # Example: A static PersistentVolume definition
@@ -113,12 +99,7 @@ spec:
     fsType: ext4
 ```
 
-### The PersistentVolumeClaim (PVC): The User Request
-A PersistentVolumeClaim, conversely, is a strict request for storage created by a user or an application manifest. It is a **namespace-scoped resource**. If a PV represents the actual physical hard drive, the PVC is the IT helpdesk ticket submitted by the developer stating, "I urgently need a 100-gigabyte hard drive formatted with a filesystem that I can read and write to exclusively."
-
-When a developer submits a PVC to the API server, the Kubernetes control plane continuously watches the state of the cluster. It immediately attempts to find an available PV that perfectly matches the criteria specified within the PVC—specifically, it checks that the requested capacity is met or exceeded, and that the requested access modes are supported.
-
-If a suitable PV is located, the control plane permanently **binds** the PVC to the PV. This binding process forms a strict, unbreakable one-to-one mapping.
+A PersistentVolumeClaim is namespace-scoped, which means the consuming Pod and the claim must be in the same namespace. The PVC is not a disk; it is a request that says, in effect, "find or create storage that satisfies these constraints." The control plane compares the claim to available PVs by checking capacity, access mode, storage class, volume mode, and selector requirements. When a compatible PV is found, Kubernetes binds the claim and the volume in a one-to-one relationship.
 
 ```yaml
 # Example: A user's PersistentVolumeClaim
@@ -136,28 +117,19 @@ spec:
   storageClassName: manual-slow-hdd # Must explicitly match the PV's class
 ```
 
-### The Inefficiency of Static Provisioning
-Notice a critical mechanical flaw in the one-to-one binding relationship: If a developer creates a PVC requesting exactly 50 Gigabytes of storage, and the cluster only has a single 100 Gigabyte PV available, the Kubernetes control plane will bind the 50Gi claim to the 100Gi volume. 
+That one-to-one binding is one of the most important rules in storage troubleshooting. If a PVC asks for 50Gi and the only matching PV is 100Gi, Kubernetes can bind the claim to the larger volume, but the leftover capacity is not returned to a shared pool for another claim. The entire PV becomes dedicated to that single PVC. This surprises teams coming from filesystems where many directories share one disk, but Kubernetes treats the PV as the allocation unit.
 
-The remaining 50 Gigabytes of empty space on that physical disk are completely inaccessible to any other application in the entire cluster. The resource is entirely dedicated to that single claim. Furthermore, relying on administrators to manually create thousands of static PVs in advance of developers needing them is an operational nightmare that cannot scale in modern cloud-native environments.
+Static provisioning is useful when a storage asset already exists and must be preserved, such as a restored database disk, a forensic copy, or a manually prepared volume with special compliance handling. It scales poorly as a normal developer workflow because someone must create enough PVs of the right size, class, zone, and policy before applications request them. In a busy platform, that becomes a ticket queue disguised as infrastructure-as-code, and every mismatch shows up as a Pending PVC that blocks deployment.
 
----
+Before running this in a lab, what output would you expect from `k get pvc database-storage-claim -n production` if no PV matches `manual-slow-hdd`? The claim remains `Pending`, and `k describe pvc` shows events explaining that no persistent volumes are available for the claim and no StorageClass can dynamically satisfy it. That event stream is usually more useful than staring at the YAML because it tells you which part of the matching contract failed.
+
+The relationship between a Pod and a PVC is simple in the manifest but strict in execution. The Pod references the claim by name under `volumes:`, and each container mounts that volume at a chosen path. The kubelet on the selected node coordinates with the volume plugin or CSI node component to attach, format if needed, mount, and expose the storage into the container namespace. If any step fails, the Pod may sit in `Pending` or `ContainerCreating` while events mention attach errors, mount errors, or access mode conflicts.
+
+That strictness is useful because it turns storage into an auditable API contract. You can inspect the claim, see which volume it bound, check the class that shaped provisioning, and follow events from the scheduler to the node. Without these objects, a failed mount would be a local mystery inside one machine. With them, the cluster leaves a trail that explains whether the problem is missing capacity, a wrong namespace, a driver failure, a topology mismatch, or an unsafe attachment that Kubernetes refused to perform.
 
 ## Dynamic Provisioning and StorageClasses
 
-To completely eliminate the administrative bottleneck of static provisioning, Kubernetes provides dynamic volume provisioning powered by the **StorageClass** API resource. 
-
-A StorageClass provides a streamlined way for cluster administrators to define and describe the "classes" of storage they offer within their specific environment. Different classes might seamlessly map to varying quality-of-service levels (such as ultra-fast NVMe SSDs versus cheap, slow magnetic HDDs), distinct backup policies, or any arbitrary policies determined by the infrastructure team.
-
-When a StorageClass is correctly configured, it references a specific "provisioner"—a dedicated internal or external software component responsible for actually communicating over the network with the underlying storage backend's API. 
-
-### The Dynamic Automation Pipeline
-
-When dynamic provisioning is enabled, the developer experience completely transforms. The developer creates a standard PVC and simply specifies the desired `storageClassName`. 
-
-The Kubernetes control plane observes the PVC and notes that no static PVs exist to satisfy the claim. Instead of leaving the claim trapped in a `Pending` state indefinitely, the control plane immediately triggers the provisioner associated with the requested StorageClass.
-
-The provisioner autonomously communicates with the cloud provider or storage array API, requests the creation of the physical disk, waits for it to format, and then automatically generates the corresponding PersistentVolume object within Kubernetes, immediately binding it to the user's PVC. This entire complex infrastructure sequence executes in seconds, completely eliminating human intervention.
+Dynamic provisioning removes the need for administrators to pre-create every PV. Instead, the administrator defines StorageClasses that describe available storage offerings, and applications request one of those classes through their PVCs. A StorageClass is a policy and driver reference, not a volume itself. It says which provisioner should create storage, what backend parameters to use, whether expansion is allowed, how reclaim should behave, and when the physical volume should be bound relative to Pod scheduling.
 
 ```yaml
 # Example: A dynamic StorageClass definition
@@ -174,48 +146,57 @@ allowVolumeExpansion: true          # Allow resizing the disk later
 volumeBindingMode: WaitForFirstConsumer # Crucial for multi-zone clusters
 ```
 
-### The Topology Trap: `volumeBindingMode`
+The StorageClass is where platform intent becomes visible. A class named `extreme-performance-ssd` should not merely be a pretty label; it should map to a backend with performance, durability, cost, and operational policies that justify the name. In a mature cluster, you might see a cheap class for disposable CI workspaces, a retained encrypted class for production databases, and a shared filesystem class for content libraries. Each class lets application manifests express intent without embedding provider-specific API calls.
 
-Within the StorageClass definition, there is a seemingly minor field that holds catastrophic implications for multi-zone clusters: the `volumeBindingMode`. 
+The dynamic pipeline begins when a PVC references a StorageClass. If no suitable static PV already exists, the external provisioner associated with that class asks the storage backend to create a new volume. After the backend returns a volume identifier, the provisioner creates a PV object that points at the new storage and binds it to the waiting claim. From the developer's perspective, the claim changed from Pending to Bound; behind that small status transition, the platform created real infrastructure.
 
-By default, this mode is set to `Immediate`. This means the physical volume is provisioned and bound the absolute millisecond the PVC is submitted to the API server. However, in distributed cloud environments spread across multiple geographic Availability Zones, this behavior is a trap. 
+This automation is powerful enough to be dangerous. A developer deleting and recreating a namespace can trigger storage creation and destruction depending on reclaim policy. A typo in `storageClassName` can leave a workload blocked because the provisioner never receives a valid request. A default StorageClass can accidentally catch claims that forgot to specify a class, which is convenient for demos but risky for production if the default class uses cheap disks, the wrong zone behavior, or destructive cleanup.
 
-If a developer submits a PVC, and the provisioner `Immediate`-ly creates the physical disk in Availability Zone A, the volume is now physically trapped in Zone A. Seconds later, the Kubernetes scheduler analyzes the cluster and determines that the Pod requiring that volume must be placed in Availability Zone B because Zone A has run out of available CPU resources. The Pod will never successfully start. It will crash repeatedly because an Availability Zone B compute node physically cannot attach a block storage volume located in Availability Zone A.
+The most subtle StorageClass field for distributed clusters is `volumeBindingMode`. With `Immediate`, provisioning happens as soon as the PVC is created. That is fine when the backend is not topology-constrained, but many block storage systems are tied to a zone. If a disk is created in Zone B before the scheduler selects a node, and the Pod later needs a GPU that only exists in Zone A, the workload cannot start because the disk cannot attach across zones.
 
-Setting the `volumeBindingMode` to `WaitForFirstConsumer` gracefully solves this architectural nightmare. It explicitly instructs the storage provisioner to delay the creation of the physical storage volume until the exact moment the Kubernetes scheduler has finalized the node placement for the consuming Pod. The volume is then guaranteed to be created in the exact same topological zone as the node, eliminating the conflict entirely.
+`WaitForFirstConsumer` defers provisioning until a Pod that uses the claim is scheduled. The scheduler considers Pod resource requests, affinity, taints, topology constraints, and the PVC together, then the provisioner creates the volume in a place compatible with the chosen node. This one field turns storage provisioning from a blind first-come action into a coordinated scheduling decision. For multi-zone clusters, it is usually the safer default for block storage classes.
 
-> **Stop and think**: If a StorageClass is configured with `volumeBindingMode: WaitForFirstConsumer`, and a developer creates a PVC but completely forgets to deploy the Pod that actually uses it, what state will the PVC be in, and will the physical cloud provider disk cost any money yet?
+Stop and think: if a PVC uses a `WaitForFirstConsumer` class but no Pod ever references that PVC, should a cloud disk exist yet? In a correct late-binding flow, the claim can remain Pending without creating a billable physical volume because there is no first consumer. That Pending status is not automatically a failure; it is the storage system waiting for scheduling context.
 
----
+Volume expansion is another dynamic provisioning feature that needs operational discipline. A StorageClass with `allowVolumeExpansion: true` lets a user increase the requested size on an existing PVC. Kubernetes can coordinate the backend resize and filesystem expansion for supported drivers, but shrinking is not the normal path because filesystems and block devices do not safely discard capacity on demand. Treat expansion as a planned maintenance action for important workloads, even when the API makes the YAML edit look easy.
 
-## Access Modes and Reclaim Policies: The Rules of Engagement
+A practical debugging sequence starts with the claim, then follows the chain outward. Run `k get pvc -A` to find claims that are Pending, `k describe pvc <name> -n <namespace>` to read binding events, `k get storageclass` to confirm the class exists, and `k describe storageclass <name>` to inspect provisioner, reclaim policy, and binding mode. If the claim is Bound but the Pod is stuck, shift to `k describe pod` and look for attach or mount events from the kubelet and CSI components.
 
-Every PersistentVolume must explicitly define how it can be mechanically accessed by the physical nodes participating in the cluster. These constraints are known as Access Modes. It is absolutely critical to understand that Access Modes dictate how *physical nodes* mount the volume at the operating system level, not how individual Pods access it.
+StorageClass defaults deserve special review during platform onboarding. Many clusters mark one StorageClass as default so a PVC without `storageClassName` still gets provisioned. That is friendly for tutorials, but it can hide important decisions in production because the application team may not realize which reclaim policy, binding mode, encryption settings, or performance tier they inherited. A mature platform usually documents the default class plainly, limits who can create new classes, and uses admission policy or review standards for workloads that need production-grade retention.
 
-1. **ReadWriteOnce (RWO)**: The volume can be mounted as read-write by one, and only one, physical node in the cluster. Multiple distinct Pods running on that exact same node can access the volume simultaneously, but no other node in the cluster can mount it. This is the rigid, standard mode for highly performant block storage solutions like AWS EBS, Azure Disk, or GCP Persistent Disk.
-2. **ReadOnlyMany (ROX)**: The volume can be mounted as read-only by an unlimited number of nodes simultaneously. This mode is exceptionally ideal for globally distributing static web assets, application configuration data, or massive machine learning models to dozens of parallel worker nodes without risking data corruption.
-3. **ReadWriteMany (RWX)**: The volume can be mounted as read-write by many nodes simultaneously. This facilitates a true, distributed shared file system architecture. However, it requires highly specialized network storage backends engineered to handle distributed file locking, such as NFS, CephFS, or AWS EFS. Standard block storage physically cannot support this mode without instantly corrupting the filesystem.
-4. **ReadWriteOncePod (RWOP)**: A modern access mode engineered for strict, zero-trust security. It ensures the volume can be mounted as read-write by only a single specific Pod in the entire cluster. Even if a malicious or misconfigured Pod is scheduled onto the exact same physical node, the operating system will fiercely deny it access to the volume.
+Dynamic provisioning should also be tested under quota pressure, not only under happy-path creation. Cloud accounts and storage arrays have limits for total volumes, capacity, IOPS, snapshots, and attachments. If a provisioner cannot create another disk, the PVC remains Pending and the application never starts, even though the manifest is syntactically correct. That is why storage observability should include provisioner errors, backend quota dashboards, and alerts on claims that remain Pending longer than an expected provisioning window.
 
-### The Reclaim Policy: Predicting Destruction
+## Access Modes, Reclaim Policies, and Failure Behavior
 
-When an application is decommissioned and a developer deletes the PersistentVolumeClaim, the PersistentVolume's `persistentVolumeReclaimPolicy` makes the final, irreversible decision regarding the fate of the underlying data.
+Access modes describe how a volume may be mounted by nodes, not how many containers can see the mounted path inside one Pod. `ReadWriteOnce` allows the volume to be mounted read-write by a single node. Multiple Pods on that same node might be able to use the same RWO volume depending on the workload and controller, but another node cannot attach it at the same time. That is why RWO is a natural fit for many block storage-backed databases and a poor fit for shared web uploads across replicas.
 
-- **Retain**: The PV is transitioned to a protected "Released" state. The physical storage asset and all its internal data are kept perfectly intact in the cloud provider. The volume cannot be automatically claimed by any new PVC. An administrator must manually inspect the data, back it up if necessary, and then manually delete both the PV object and the underlying physical disk. This is the absolute mandatory policy for critical production databases.
-- **Delete**: The moment the PVC is deleted, the Kubernetes control plane instantly deletes the PV object and immediately fires an API command to the storage provider to physically destroy the underlying disk. All data is irretrievably and permanently lost. This is the highly convenient default policy for dynamically provisioned volumes, making it ideal for ephemeral CI/CD test environments where cleanup is essential.
-- **Recycle**: This legacy policy is officially deprecated. It previously attempted to perform a basic command-line file deletion (`rm -rf /thevolume/*`) to recursively scrub the disk and make the volume available for a new PVC. Modern clusters handle recycling far more securely by simply deleting the disk and provisioning a fresh one.
+`ReadOnlyMany` allows many nodes to mount the volume read-only. It is useful for static datasets, shared application assets, or model files that many workers need to read without modifying. `ReadWriteMany` allows many nodes to mount the same volume read-write, which requires a backend built for distributed file access and locking, such as NFS, CephFS, or a managed cloud filesystem. Standard block storage is not a shared filesystem; presenting one raw disk to several kernels as writable is a path to corruption.
 
----
+`ReadWriteOncePod` is stricter than RWO because it limits read-write access to one Pod across the cluster. This matters when the security or correctness requirement is "one active writer Pod," not merely "one active writer node." In Kubernetes 1.35-era clusters with supported CSI drivers, RWOP can protect workloads where two Pods on the same node must not accidentally share the same data directory. It is a useful mode for single-writer stateful applications that need stronger scheduling enforcement.
 
-## The Container Storage Interface (CSI): The Pluggable Future
+Reclaim policy answers a different question: what should happen to the underlying storage when the PVC is deleted? `Delete` removes the PV and asks the backend to delete the physical storage. That is efficient for temporary environments, CI workspaces, and caches that should clean themselves up. It is unacceptable as an unreviewed default for critical production databases because an ordinary claim deletion can become a provider-level disk deletion.
 
-In the chaotic early days of the Kubernetes project, storage integrations were entirely "in-tree." This meant that the highly specific, proprietary source code required to connect to AWS EBS, Google Persistent Disk, VMware vSphere, or GlusterFS was compiled directly into the core, centralized Kubernetes binary executables. 
+`Retain` keeps the underlying storage after the claim is deleted. The PV moves to a Released state, and an administrator must inspect, back up, wipe, or manually rebind the asset before reuse. This is slower and more hands-on, but it creates a human checkpoint around valuable data. In real incident response, that checkpoint is often the difference between "we accidentally deleted the application object" and "we accidentally destroyed the only copy of the data."
 
-This monolithic architecture rapidly became an unsustainable operational disaster. If a storage vendor discovered a critical security vulnerability or wanted to release a minor bug fix in their driver, they were entirely paralyzed. They had to submit a pull request to the core Kubernetes repository and wait months for the next official global Kubernetes release cycle. Furthermore, it forced the core Kubernetes maintainers—who were experts in container orchestration, not storage hardware—to relentlessly review and maintain millions of lines of complex, third-party storage code.
+`Recycle` is legacy behavior and should be treated as historical context rather than a modern design choice. It attempted to scrub a volume and return it to availability, but modern clusters generally prefer deleting and recreating storage or using explicit administrative workflows. For KCNA purposes, remember that Retain protects, Delete cleans up, and Recycle is deprecated legacy behavior that should not be selected for new designs.
 
-To permanently resolve this architectural flaw, the industry collaborative introduced the **Container Storage Interface (CSI)**. 
+Storage failures often look like scheduling failures because the Pod is the visible symptom. A Pod may remain Pending because its claim is not Bound, or it may enter ContainerCreating because the claim is Bound but the kubelet cannot attach or mount the volume. Events are the map. If events mention "unbound immediate PersistentVolumeClaims," investigate PVC and StorageClass binding. If they mention multi-attach errors, investigate access mode, existing attachments, and whether the previous Pod or node released the disk.
 
-CSI is a standardized, universal specification designed to expose arbitrary block and file storage systems to containerized workloads. With CSI, the Kubernetes core control plane no longer knows absolutely anything about specific storage providers. It simply knows how to speak the standardized, highly structured CSI protocol over high-speed gRPC connections.
+Consider a production database running as a StatefulSet on `Node-Alpha`. A network failure isolates that node from the control plane, so Kubernetes marks it NotReady and tries to maintain availability by creating a replacement Pod for `Node-Bravo`. The new Pod cannot start because the cloud provider still sees the RWO disk attached to `Node-Alpha`. From the provider's point of view, force-attaching the disk elsewhere could create split-brain writes if `Node-Alpha` is alive but partitioned.
+
+Kubernetes tracks that physical relationship through a `VolumeAttachment` object for CSI-managed volumes. The control plane, attach-detach controller, kubelet, and CSI driver cooperate to ensure a disk is detached before it is attached somewhere else. That conservatism can feel frustrating during an outage, but it protects the filesystem from two kernels writing to the same block device. Manual force-detach is sometimes necessary, yet it should happen only after an operator confirms the old node cannot still be writing.
+
+Permissions create another storage failure class that looks different from binding but is just as common. The volume may attach and mount successfully, while the container process cannot write because filesystem ownership, security context, SELinux labels, or driver mount options do not match the image's runtime user. In those cases the Pod may start and the application logs show permission errors rather than Kubernetes events. The fix belongs in the workload security context, image design, or storage class mount options, not in repeated claim deletion and recreation.
+
+For stateful workloads, the best incident response posture is to treat storage events as data integrity signals rather than mere availability noise. A multi-attach error, mount timeout, or failed detach may be protecting you from corruption, not simply blocking your deployment. Slow down before overriding it. Confirm which node last wrote, whether the application can recover from an unclean shutdown, whether a snapshot should be taken first, and whether the driver documentation describes a supported force-detach path.
+
+Which approach would you choose for a payment database: a dynamically provisioned class with `Delete`, or a retained class with explicit recovery procedures? The retained class is slower to clean up, but it encodes the value of the data into the platform. Cleanup convenience is not worth much if a bad pipeline run can remove the storage backing a regulated system.
+
+## The Container Storage Interface (CSI)
+
+Early Kubernetes storage integrations were in-tree, meaning provider-specific storage code lived inside the core Kubernetes source tree and release process. That created a maintenance problem for everyone. Storage vendors had to wait for Kubernetes releases to ship driver changes, Kubernetes maintainers had to review specialized provider code, and users inherited storage behavior tied to cluster upgrades rather than driver upgrades. The model did not scale with the number of clouds, arrays, filesystems, and backup tools that wanted to integrate.
+
+CSI solves that by defining a standard interface between container orchestrators and storage systems. Kubernetes can call external CSI components through well-defined operations such as creating a volume, attaching it to a node, publishing it into a Pod, expanding it, or taking a snapshot when supported. The core control plane no longer needs built-in knowledge of every storage provider. It needs to coordinate API objects and call the driver that owns the backend.
 
 ```mermaid
 flowchart TD
@@ -251,105 +232,108 @@ flowchart TD
     NODE -. "mounts" .-> ContainerFS
 ```
 
-Storage vendors now engineer, compile, and distribute their CSI drivers completely independently of the Kubernetes release cycle. A standard CSI deployment within a cluster typically consists of two highly specialized components:
-1. **The Controller Plugin**: Running as a highly available StatefulSet or Deployment, this component listens to the Kubernetes API. When a volume needs to be created dynamically, it receives the `CreateVolume` gRPC request and communicates securely with the vendor's cloud API to provision the raw storage.
-2. **The Node Plugin**: Running as a DaemonSet on absolutely every worker node in the cluster. When a Pod is scheduled to a specific node, the local `kubelet` sends a `NodePublishVolume` gRPC request to this local plugin. The Node Plugin performs the highly privileged, complex host-level operating system commands required to format the disk, mount the physical device into the Linux file hierarchy, and expose it into the container's isolated namespace.
+A typical CSI deployment has controller-side components and node-side components. The controller plugin handles backend-level operations such as provisioning a new disk, deleting it, attaching it to a node, detaching it, and coordinating snapshots. It usually runs as a Deployment or StatefulSet with sidecars like an external provisioner, attacher, resizer, or snapshotter depending on the driver's capabilities. These sidecars watch Kubernetes API objects and translate state changes into CSI calls.
 
-This brilliant pluggable architecture has catalyzed an explosion of innovation, enabling hundreds of niche and massive storage vendors to integrate seamlessly with Kubernetes without modifying a single line of core upstream code.
+The node plugin runs on every worker node, usually as a DaemonSet, because each node needs local privileged code that can mount devices into the host filesystem. When the scheduler places a Pod on a node, the kubelet asks the local CSI node plugin to publish the volume. That step may involve discovering the device, formatting it if needed, mounting it at a staging path, and bind-mounting it into the Pod's container namespace. The application sees a directory; the node plugin performed the host-level work required to make that directory real.
 
----
+CSI also makes storage features more modular. Volume snapshots, expansion, cloning, and topology awareness can be supported by drivers that implement the relevant parts of the specification and deploy the necessary sidecars. This does not mean every CSI driver supports every feature. A platform engineer must read the driver documentation, test the behavior in the cluster, and expose only the StorageClasses that match the organization's reliability and security requirements.
 
-## Real-World 'War Story': The Split-Brain Volume Attachment
+When diagnosing a CSI-backed volume, follow the responsibility boundary. If the PVC never becomes Bound, inspect the StorageClass, provisioner, and controller-side logs. If the PV is Bound but the Pod cannot mount it, inspect Pod events, node plugin logs, and `VolumeAttachment` objects. If a snapshot object never becomes ready, inspect snapshot controller and driver support. CSI gives you cleaner integration points, but it also gives you more components whose health matters.
 
-To truly master storage orchestration, you must understand how it degrades under severe infrastructure stress. Consider a critical production database running as a highly available StatefulSet on worker node `Node-Alpha`. 
+## Patterns & Anti-Patterns
 
-Suddenly, a catastrophic hardware failure in the datacenter's core networking equipment completely severs `Node-Alpha`'s connection to the rest of the network, isolating it entirely from the Kubernetes control plane. The control plane's node controller detects the missed heartbeats and marks `Node-Alpha` with a `NotReady` status. Because the StatefulSet controller is ruthlessly designed to ensure high availability, it immediately attempts to heal the cluster by scheduling a replacement database Pod onto a perfectly healthy node, `Node-Bravo`.
+One reliable pattern is to design StorageClasses as service tiers rather than as provider trivia. A class called `prod-retained-rwo` or `shared-rwx` communicates behavior to application teams better than a name copied from a cloud disk SKU. The platform team can still tune provider parameters underneath, but the application manifest expresses the operational contract: retention, sharing model, binding mode, expansion, and expected workload type.
 
-However, the new database Pod on `Node-Bravo` remains stubbornly stuck in the `ContainerCreating` state indefinitely. The application remains entirely offline. Why? 
+Another strong pattern is to use StatefulSets with `volumeClaimTemplates` for replicated stateful applications. Each replica receives its own stable claim, and the identity of the Pod matches the identity of its storage. This fits systems such as databases, queues, and consensus members where each replica owns distinct data. It also avoids the mistake of making several replicas fight over one RWO claim, which usually fails at scheduling time or corrupts assumptions at application time.
 
-Because the underlying cloud block storage volume is strictly configured with the ReadWriteOnce (RWO) access mode. From the perspective of the cloud provider's external API, the physical volume is still firmly attached to the isolated, silent `Node-Alpha`. The cloud provider absolutely refuses to attach the volume to `Node-Bravo` to prevent a catastrophic data corruption scenario known as "split-brain"—a terrifying situation where two separate operating system kernels attempt to write data to the exact same block device simultaneously, instantly destroying the filesystem structure.
+A third pattern is to pair Retain policies with documented recovery runbooks. Retain alone is not a backup plan; it only prevents automatic deletion. The runbook should explain who may rebind a Released volume, how to validate the data, how to snapshot before repair attempts, and how to wipe storage before reuse. Without that procedure, retained PVs accumulate as confusing leftovers, and operators may delete them later without understanding their value.
 
-Kubernetes tracks this complex physical connection state using an internal API object called a `VolumeAttachment`. Because the control plane cannot communicate with `Node-Alpha` to definitively confirm that the original container has been successfully terminated and the disk safely unmounted, it waits. It relies on a safety timeout (typically hardcoded to 6 minutes) before it dares to attempt forcefully detaching the volume via the cloud provider API. 
+A common anti-pattern is treating a PVC as if it were a portable global disk. A claim is namespace-scoped, bound to one PV, and constrained by the backend's access modes and topology. Copying a Pod manifest into another namespace without creating the claim there will fail. Moving a workload across zones may fail if the volume lives in a different zone. Sharing one dataset across teams may require a shared filesystem or object storage rather than a single block PV.
 
-If the underlying storage backend does not support safe, API-driven force-detachment, the automated orchestrator is paralyzed. The cluster administrator must manually intervene. They must log into the cloud provider's web console, verify that `Node-Alpha` is genuinely powered off and not just suffering a network hiccup, forcefully detach the volume from the ghost node, and manually delete the stuck `VolumeAttachment` object in Kubernetes. This harrowing war story highlights that storage orchestration is inextricably coupled to cluster networking and node health, and understanding the mechanical sequence of volume attachment is vital for debugging severe, career-defining outages.
+Another anti-pattern is using dynamic provisioning as an excuse to ignore cost and quotas. StorageClasses can create real disks in seconds, and those disks may persist after workloads are forgotten depending on reclaim policy. Cloud providers also enforce attachment limits, throughput limits, and regional constraints. A cluster with many small RWO volumes can run out of per-node attachment slots before it runs out of CPU, which makes scheduling failures appear even when compute capacity looks healthy.
 
----
+A final anti-pattern is solving application-level replication with Kubernetes volume sharing. RWX storage can let several Pods write to the same directory, but it does not turn an application into a safe distributed system. Databases, brokers, and indexes still need their own consistency model, locking behavior, and recovery design. Use shared storage where the application expects a shared filesystem, not as a shortcut around proper clustering.
+
+## Decision Framework
+
+Start the storage decision by asking whether the data must survive Pod deletion. If the answer is no, use ephemeral storage such as `emptyDir` and keep the capacity bounded so node disks do not become accidental dumping grounds. If the answer is yes, ask whether exactly one writer needs high-performance block semantics, many readers need the same immutable content, or many writers need a shared filesystem. That access pattern narrows the backend before capacity or price enters the conversation.
+
+For single-writer databases and queues, choose an RWO or RWOP class backed by a reliable block storage driver, use `WaitForFirstConsumer` in topology-constrained clusters, and set reclaim policy according to data value. For shared media libraries, content management uploads, and build artifact directories, choose an RWX-capable filesystem and test application locking under concurrent writes. For large immutable datasets or public assets, object storage may be the cleaner architecture even if Kubernetes can mount a filesystem, because object APIs often scale better for distribution and lifecycle management.
+
+Next, decide how much automation should be allowed at deletion time. Development namespaces often benefit from `Delete` because stale volumes waste money and slow experiments. Production systems usually deserve `Retain`, snapshots, backup integration, and an explicit decommissioning workflow. The best choice is not the one with the fewest YAML fields; it is the one where the storage lifecycle matches the consequence of losing the data.
+
+Finally, decide what evidence you will use when something goes wrong. PVC status tells you whether binding succeeded. Pod events tell you whether scheduling, attachment, or mounting failed. StorageClass fields tell you whether late binding, reclaim, expansion, and provisioner selection match the design. CSI logs and `VolumeAttachment` objects tell you whether the backend and node plugins completed their side of the contract. A good storage design includes this diagnostic path before the first incident.
 
 ## Did You Know?
 
-- In December 2021, with the landmark release of Kubernetes 1.23, the long-awaited Container Storage Interface (CSI) migration reached General Availability, officially deprecating legacy in-tree volume plugins and forcing the ecosystem to adopt the pluggable architecture.
-- Amazon Web Services Nitro-based EC2 instances have a strict, hard limit of exactly twenty-eight attached Elastic Block Store volumes per node (which includes the root volume), severely limiting node density for stateful workloads if administrators do not carefully monitor attachment counts.
-- Kubernetes version 1.20 introduced stable, native support for Volume Snapshots, finally enabling third-party backup vendors to integrate directly with the Kubernetes API to orchestrate and capture point-in-time copies of storage assets.
-- The highly secure `ReadWriteOncePod` access mode was introduced as an alpha feature in Kubernetes 1.22 specifically to solve a critical security flaw where multiple disparate pods scheduled on the exact same physical node could read and write to a volume intended for a single, specific pod.
-
----
+- In December 2021, with Kubernetes 1.23, CSI migration reached general availability for several major in-tree plugins, marking a major step away from provider code compiled into core Kubernetes binaries.
+- AWS Nitro-based EC2 instances document a practical EBS attachment ceiling of 28 volumes for many instance families, and the root volume counts toward that limit.
+- Kubernetes 1.20 introduced stable VolumeSnapshot API support, which gave backup vendors a Kubernetes-native way to coordinate point-in-time storage copies through CSI drivers.
+- `ReadWriteOncePod` reached stable status in Kubernetes 1.29, giving supported CSI drivers a stricter single-Pod write mode than classic ReadWriteOnce node-level attachment.
 
 ## Common Mistakes
 
-| Mistake | Why It Hurts | Correct Understanding / Fix |
-|---------|--------------|----------------------|
-| **Using `emptyDir` for databases** | Data is permanently and irretrievably erased the moment the pod is evicted, rescheduled, or scaled down. | Exclusively implement PersistentVolumeClaims backed by a highly available StorageClass for all stateful data. |
-| **Assuming block storage supports RWX** | Standard block devices corrupt instantly if mounted to multiple operating system kernels concurrently. | You must utilize specialized network file systems (NFS, AWS EFS) designed for concurrent multi-node file locking. |
-| **Ignoring `volumeBindingMode`** | Pods fail to schedule because the storage was provisioned in a different Availability Zone than the compute node. | Always configure `WaitForFirstConsumer` in multi-zone clusters to ensure zone-aware volume provisioning. |
-| **Leaving `reclaimPolicy` as Delete** | Deleting the PVC instantly issues an API call destroying the physical cloud disk and all production data. | Strictly enforce `reclaimPolicy: Retain` on StorageClasses utilized for critical production workloads. |
-| **Misunderstanding PVC namespaces** | A Pod will fail to start if it attempts to mount a PVC that exists in a completely different namespace. | You must deploy the PersistentVolumeClaim in the exact same namespace as the Pod consuming it. |
-| **Relying on legacy in-tree drivers** | You suffer from a lack of updates, vendor lock-in, and missing modern features like native volume snapshots. | Migrate all storage backends to modern, independently updated Container Storage Interface (CSI) drivers. |
-| **Over-provisioning static PVs** | Manually creating massive PVs in advance wastes enormous amounts of expensive cloud storage budget. | Implement dynamic provisioning via StorageClasses to create right-sized volumes completely on-demand. |
-
----
+| Mistake | Why It Happens | How to Fix It |
+|---------|----------------|---------------|
+| **Using `emptyDir` for databases** | Teams see files survive a container restart and assume the storage is durable across Pod deletion. | Use a PersistentVolumeClaim for state that must survive rescheduling, and reserve `emptyDir` for scratch data. |
+| **Assuming block storage supports RWX** | A single disk looks like shared capacity, so engineers expect many nodes to mount it safely. | Use an RWX-capable filesystem such as NFS, CephFS, or a managed cloud filesystem when many nodes need writes. |
+| **Ignoring `volumeBindingMode`** | The claim binds before the scheduler knows which zone or node can run the Pod. | Prefer `WaitForFirstConsumer` for topology-constrained block storage in multi-zone clusters. |
+| **Leaving production classes on `Delete`** | Dynamic provisioning examples optimize cleanup and accidentally become production defaults. | Use `Retain` for valuable data and document the manual recovery and cleanup workflow. |
+| **Mounting a PVC from the wrong namespace** | Teams copy Pod manifests between namespaces and forget that PVCs are namespace-scoped. | Create the PVC in the same namespace as the consuming Pod, or redesign the sharing boundary explicitly. |
+| **Treating Retain as backup** | Retain prevents automatic deletion but does not create another copy or validate recoverability. | Combine Retain with snapshots, backups, restore tests, and an ownership process for Released volumes. |
+| **Skipping CSI driver capability checks** | Engineers assume every CSI driver supports snapshots, expansion, topology, and RWOP equally. | Read the driver documentation, test required features, and expose StorageClasses only for supported behavior. |
 
 ## Quiz
 
-1. **A junior engineer complains that their carefully configured `emptyDir` volume loses its database records every time the replica count is scaled down and back up, even though the underlying worker Node itself never rebooted. They argue that because the Node is still running perfectly, the `emptyDir` should persist. Diagnose the fundamental flaw in their understanding of ephemeral storage orchestration.**
-   <details>
-   <summary>Answer</summary>
-   The engineer fails to understand that the `emptyDir` volume lifecycle is strictly and irreversibly bound to the Pod's lifecycle, not the underlying Node. When a scale-down event occurs, the Kubernetes control plane sends a termination signal to the Pod. As part of the Pod's strict cleanup sequence, the kubelet entirely destroys the `emptyDir` directory on the host filesystem to free up space. The Node's uptime is completely irrelevant; the abstraction boundary is the Pod itself. To survive scale-down events, the workload must transition to utilizing a PersistentVolumeClaim bound to external persistent storage.
-   </details>
+<details><summary>Question 1: A team stores PostgreSQL data in an `emptyDir` volume because the files survive container crashes during local tests. After a deployment scales the Pod to zero and back to one, the database is empty. Diagnose the mistake and name the safer Kubernetes storage object.</summary>
 
-2. **You are tasked with designing the architecture for a highly available content management system where twelve distinct Pods distributed across three different Availability Zones must read and write image assets to the exact same shared directory simultaneously. Evaluate the storage architecture required and explain why standard AWS Elastic Block Store (EBS) or GCP Persistent Disk volumes will immediately fail in this scenario.**
-   <details>
-   <summary>Answer</summary>
-   This specific architecture fundamentally requires a ReadWriteMany (RWX) access mode, which safely allows multiple distinct physical nodes to mount the exact same storage volume concurrently. Standard block storage solutions like AWS EBS and GCP Persistent Disk are inherently restricted to ReadWriteOnce (RWO) because attaching a single raw block device to multiple operating system kernels simultaneously causes immediate file system corruption and catastrophic split-brain scenarios. You must implement a network-attached file system engineered to handle concurrent distributed file locks, such as an NFS server, AWS Elastic File System (EFS), or a distributed CephFS cluster.
-   </details>
+The team confused container restart survival with Pod lifecycle survival. `emptyDir` can survive restarts of containers inside the same Pod, but Kubernetes deletes the directory when the Pod itself is removed from the node. A database needs storage whose lifecycle is independent of the Pod, so the safer object is a PersistentVolumeClaim backed by a suitable PersistentVolume. The fix is not merely "use a volume"; it is to use a persistent volume type with a reclaim and backup policy appropriate for database data.
 
-3. **A development team deployed a massive, mission-critical PostgreSQL database utilizing a dynamically provisioned PersistentVolume. After accidentally deleting the PersistentVolumeClaim during a flawed CI/CD pipeline run, they discovered the physical cloud disk was instantly wiped, destroying all production data. Diagnose the StorageClass configuration error that allowed this catastrophe, and describe the necessary fix.**
-   <details>
-   <summary>Answer</summary>
-   The devastating incident occurred because the dynamically utilized StorageClass was configured with the default `reclaimPolicy` of `Delete`. When a PVC is deleted under this specific policy, the Kubernetes control plane immediately cascades the deletion to the bound PersistentVolume object and issues a highly privileged API call to the cloud provider to permanently destroy the underlying physical storage asset. To prevent this, the StorageClass must be explicitly configured with `reclaimPolicy: Retain`. Under the Retain policy, deleting the PVC simply transitions the PV to a safe 'Released' state, leaving the physical disk and all its data perfectly intact for manual administrative recovery.
-   </details>
+</details>
 
-4. **A newly scheduled machine learning Pod is indefinitely stuck in the `Pending` state. The Kubernetes event logs reveal a critical scheduling conflict: the Pod strictly requires a specific GPU instance type that is only physically available in Availability Zone A, but the `volumeBindingMode` on the StorageClass was set to `Immediate`, causing the provisioner to arbitrarily create the 500GB volume in Availability Zone B. Implement the architectural change required to resolve this topology mismatch.**
-   <details>
-   <summary>Answer</summary>
-   The storage architecture must be immediately redesigned to utilize late binding. You must update the StorageClass definition to use `volumeBindingMode: WaitForFirstConsumer`. This pivotal configuration modification instructs the storage provisioner to completely halt the immediate creation of the physical volume when the PVC is initially submitted. Instead, the provisioner waits patiently until the Kubernetes scheduler has finalized the node placement for the Pod based on all complex constraints (such as the GPU hardware requirement). Only then does it provision the physical volume in the exact same Availability Zone as the chosen node, completely eliminating topology conflicts.
-   </details>
+<details><summary>Question 2: Your image-processing service runs twelve replicas across three zones, and every replica must read and write the same uploaded media directory. The team proposes one RWO cloud block disk because it is fast. Evaluate the design.</summary>
 
-5. **A cluster administrator notices that a worker node has suffered a catastrophic kernel panic and is completely isolated from the network, showing as `NotReady` in the control plane. The StatefulSet controller creates a replacement Pod on a healthy node, but the new Pod cannot start because the volume remains locked to the dead node. Diagnose the mechanical reason the Kubernetes control plane refuses to automatically detach the volume, and evaluate the risk of manual intervention.**
-   <details>
-   <summary>Answer</summary>
-   The Kubernetes control plane utilizes an internal `VolumeAttachment` API object to track the physical connection between a node and a disk. Because the dead node cannot communicate its status over the network, the control plane cannot definitively confirm that the original container has terminated and stopped writing to the disk. Automatically force-detaching the volume could lead to a split-brain scenario and severe data corruption if the original node is actually still alive but merely experiencing a temporary network partition. Manual intervention is required to confirm the original node is physically powered off before forcefully deleting the VolumeAttachment, effectively transferring the immense risk of data corruption from the automated orchestrator directly to the human administrator.
-   </details>
+The design does not match the access pattern. RWO block storage can be mounted read-write by one node, so replicas across several nodes cannot all write to that disk safely. The workload needs an RWX-capable shared filesystem or a redesign that stores uploaded objects in object storage and keeps Pods stateless. The right answer depends on application semantics, but a single RWO disk is not a safe multi-node shared directory.
 
-6. **Two different project teams require access to the exact same massive dataset stored on a 500Gi PersistentVolume. Team Alpha creates a PVC and successfully binds to the PV. Team Bravo then creates an identical PVC requesting 500Gi, hoping to bind to the same PV since it contains the necessary data. Predict the exact outcome of Team Bravo's request and explain the fundamental rule of Kubernetes storage orchestration that dictates this result.**
-   <details>
-   <summary>Answer</summary>
-   Team Bravo's PersistentVolumeClaim will remain indefinitely trapped in the `Pending` state. Kubernetes enforces a strict, exclusive one-to-one binding relationship between a PersistentVolume and a PersistentVolumeClaim. Once Team Alpha's PVC successfully bound to the PV, that physical storage resource became completely dedicated to their claim, regardless of the PV's access mode capabilities or massive excess capacity. To successfully share the data, both teams must configure their respective Pods to mount Team Alpha's original PVC, provided the underlying PV physically supports a ReadOnlyMany or ReadWriteMany access mode to allow concurrent multi-node access.
-   </details>
+</details>
 
-7. **You are a platform architect auditing a legacy Kubernetes cluster inherited from an acquisition. You discover all stateful workloads rely on "in-tree" volume plugins for AWS EBS and vSphere. When you propose a massive migration project to transition entirely to the Container Storage Interface (CSI), the CTO pushes back, questioning the return on investment for such a disruptive change. Formulate a compelling technical argument for the migration, explaining the specific operational and security bottlenecks the CSI architecture eliminates.**
-   <details>
-   <summary>Answer</summary>
-   Legacy in-tree plugins required storage hardware vendors to compile their highly proprietary driver code directly into the core Kubernetes binary executables. This created massive, unsustainable operational bottlenecks: vendors could only release critical bug fixes or new features alongside official, slow-moving Kubernetes release cycles, and the Kubernetes core maintainers were burdened with reviewing millions of lines of third-party code. The CSI architecture decoupled storage entirely, establishing a standard gRPC API for external communication. This allows storage vendors to develop, release, and patch their drivers entirely independently as standard containerized deployments. Ultimately, this enables rapid innovation, eliminates vendor lock-in to legacy upgrade paths, and significantly reduces the security attack surface of your core Kubernetes control plane.
-   </details>
+<details><summary>Question 3: A production namespace deletion removes a PVC, and the cloud disk disappears too. Which StorageClass setting allowed this, and how would you change the production class?</summary>
 
----
+The StorageClass used `reclaimPolicy: Delete`, either explicitly or through a default that was never reviewed for production. With Delete, removing the claim cascades to the PV and instructs the backend to remove the physical storage. For production data, create or select a class with `reclaimPolicy: Retain`, then add a runbook for inspecting, snapshotting, rebinding, or deleting Released volumes. Retain is not a substitute for backups, but it creates a critical manual checkpoint.
+
+</details>
+
+<details><summary>Question 4: A GPU Pod can only run in Zone A, but its PVC was already provisioned as a block disk in Zone B. The Pod remains Pending even though the cluster has free CPU and memory. What StorageClass behavior caused the mismatch?</summary>
+
+The StorageClass likely used `volumeBindingMode: Immediate`, so the physical disk was created before the scheduler selected a node for the Pod. In a zone-constrained backend, that early decision can place the disk somewhere the eventual Pod cannot use it. The fix is to use `WaitForFirstConsumer` for that class, allowing the scheduler to choose a compatible node first and then provisioning the disk in the matching topology. Existing mismatched volumes may need migration or recreation depending on data value.
+
+</details>
+
+<details><summary>Question 5: A StatefulSet replacement Pod is stuck in ContainerCreating after its old node becomes NotReady. Events mention a multi-attach error for the volume. What should you inspect before forcing anything?</summary>
+
+Inspect the Pod events, the old node state, the bound PV and PVC, and any `VolumeAttachment` object associated with the volume. The storage backend may still believe the RWO disk is attached to the old node, and Kubernetes avoids attaching it elsewhere because simultaneous writers could corrupt the filesystem. Before a manual force-detach, an operator should verify that the old node is truly powered off or unable to write. Force-detach is a recovery action with data integrity risk, not a normal scheduling shortcut.
+
+</details>
+
+<details><summary>Question 6: A PVC is Pending with a StorageClass that uses `WaitForFirstConsumer`, but no Pod references the claim yet. Is the Pending status automatically a fault?</summary>
+
+No, not by itself. With `WaitForFirstConsumer`, the provisioner waits until a consuming Pod exists so the scheduler can account for node and topology constraints. The claim may remain Pending because Kubernetes deliberately has no placement context yet, and a physical disk may not have been created. It becomes a fault when a Pod does reference the claim and events show that scheduling or provisioning still cannot complete.
+
+</details>
+
+<details><summary>Question 7: An acquired cluster still uses legacy in-tree storage plugins, and leadership questions the value of CSI migration. Give the technical argument for moving to CSI-backed drivers.</summary>
+
+CSI decouples storage driver release cycles from Kubernetes core releases. Vendors can patch drivers, add features, and support backend-specific behavior through external components instead of waiting for changes to land inside Kubernetes itself. The architecture also clarifies responsibilities between controller-side provisioning and node-side mounting, which improves troubleshooting and feature development. Migration reduces long-term operational risk, but it should be planned and tested because storage changes affect the most valuable workloads in the cluster.
+
+</details>
 
 ## Hands-On Exercise
 
-In this comprehensive exercise, you will manually construct a complete dynamic storage provisioning pipeline, deploy a workload to consume it, and empirically verify data persistence by destroying the consuming workload.
+In this exercise, you will build a small dynamic provisioning flow, consume the claim from a Pod, and prove that data survives compute deletion. The lab uses the `rancher.io/local-path` provisioner commonly present in lightweight clusters such as k3s and some local environments; if your cluster uses a different default provisioner, keep the learning goal but adjust the provisioner name to one that exists in your environment. The important behaviors are late binding, PVC binding, Pod mounting, persistence across Pod replacement, and reclaim policy cleanup.
 
 ### Task 1: Define the Storage Foundation
-Create a robust `StorageClass` definition named `local-delayed`. Configure it to utilize the `rancher.io/local-path` provisioner (which simulates dynamic provisioning on lightweight clusters like kind or minikube). Crucially, you must explicitly configure the `volumeBindingMode` to ensure the storage is not provisioned until a consumer is scheduled.
+
+Create a `StorageClass` named `local-delayed`. Configure it to use the `rancher.io/local-path` provisioner and `WaitForFirstConsumer`, so the volume is not provisioned until a Pod needs it.
 
 <details>
 <summary>Solution</summary>
@@ -364,11 +348,12 @@ provisioner: rancher.io/local-path
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
 ```
-Apply with: `kubectl apply -f storageclass.yaml`
+Apply with: `k apply -f storageclass.yaml`
 </details>
 
 ### Task 2: Claim the Storage
-Write a `PersistentVolumeClaim` named `web-content-claim` requesting exactly 2Gi of storage. It must specify the `ReadWriteOnce` access mode and explicitly reference your newly created `local-delayed` StorageClass. After applying, check its status. Why is it stuck in `Pending`?
+
+Write a `PersistentVolumeClaim` named `web-content-claim` requesting exactly 2Gi of storage. It must specify `ReadWriteOnce` and explicitly reference the `local-delayed` StorageClass. After applying, check its status with `k get pvc web-content-claim`.
 
 <details>
 <summary>Solution</summary>
@@ -387,12 +372,12 @@ spec:
       storage: 2Gi
   storageClassName: local-delayed
 ```
-Apply with: `kubectl apply -f pvc.yaml`
-It remains in `Pending` because the StorageClass uses `WaitForFirstConsumer`. The volume will not be provisioned until a Pod is actually scheduled to use it.
+Apply with: `k apply -f pvc.yaml`. It remains Pending because the StorageClass uses `WaitForFirstConsumer`, so the physical storage is not created until a Pod is scheduled to use the claim.
 </details>
 
 ### Task 3: Deploy the Stateful Workload
-Create an NGINX Pod named `persistent-web` that mounts your claim to `/usr/share/nginx/html`. To prove the storage works, utilize an `initContainer` running a lightweight busybox image to write an `index.html` file containing the phrase "Storage Orchestration Successful" into the mounted volume before the main NGINX container even starts.
+
+Create an NGINX Pod named `persistent-web` that mounts the claim to `/usr/share/nginx/html`. Use an init container to write an `index.html` file before the main container starts.
 
 <details>
 <summary>Solution</summary>
@@ -424,36 +409,51 @@ spec:
     persistentVolumeClaim:
       claimName: web-content-claim
 ```
-Apply with: `kubectl apply -f pod.yaml`
+Apply with: `k apply -f pod.yaml`
 </details>
 
 ### Task 4: Verify Persistence Through Destruction
-Execute `kubectl port-forward pod/persistent-web 8080:80` and `curl localhost:8080` to verify the message exists. Then, completely destroy the Pod using `kubectl delete pod persistent-web`. Recreate the exact same Pod utilizing your manifest from Task 3, but **remove** the `initContainer` section before applying. Port-forward again. Did the custom message survive the total destruction of the compute layer?
+
+Run `k port-forward pod/persistent-web 8080:80` in one terminal and `curl 127.0.0.1:8080` in another terminal to verify the message. Delete the Pod with `k delete pod persistent-web`, remove the init container section from the manifest, recreate the same Pod, and run the port-forward check again. The custom page should still appear because the storage survived the compute replacement.
 
 <details>
 <summary>Solution</summary>
 
-Yes. When you remove the `initContainer` and recreate the Pod, NGINX starts up and mounts the exact same PersistentVolume. Because the PV lifecycle is entirely independent of the Pod lifecycle, the `index.html` file created during the first run is still perfectly intact on the disk. `curl localhost:8080` will still return "Storage Orchestration Successful".
+Yes. When you remove the init container and recreate the Pod, NGINX starts and mounts the same PersistentVolume through the same claim. Because the PV lifecycle is independent of the Pod lifecycle, the `index.html` file created during the first run is still present on disk. `curl 127.0.0.1:8080` should still return `Storage Orchestration Successful`.
 </details>
 
 ### Task 5: Execute the Reclaim Policy
-Execute `kubectl get pv` to observe the bound PersistentVolume. Now, execute `kubectl delete pvc web-content-claim`. Run `kubectl get pv` immediately afterward. Based on the configuration in Task 1, what happened to the physical volume?
+
+Run `k get pv` to observe the bound PersistentVolume. Then delete the claim with `k delete pvc web-content-claim` and run `k get pv` again. Explain what happened based on the StorageClass reclaim policy.
 
 <details>
 <summary>Solution</summary>
 
-Because the StorageClass was configured with `reclaimPolicy: Delete`, the moment you deleted the PersistentVolumeClaim, the Kubernetes control plane instantly cascaded the deletion. The PersistentVolume object was destroyed, and the underlying provisioner wiped the physical directory from the local disk. The `kubectl get pv` command will return no resources found.
+Because the StorageClass was configured with `reclaimPolicy: Delete`, deleting the PersistentVolumeClaim cascaded cleanup to the bound PersistentVolume and the local-path provisioner removed the underlying storage directory. In a lab, this is useful because it cleans up automatically. In production, the same behavior would be dangerous for valuable state unless backups, snapshots, and explicit deletion controls were in place.
 </details>
 
 **Success Checklist:**
-- [x] StorageClass successfully created with late binding.
-- [x] PVC remains `Pending` until the Pod is deployed.
-- [x] Pod successfully writes data via initContainer and serves it via NGINX.
-- [x] Data successfully survives the deliberate destruction and recreation of the Pod.
-- [x] PV is cleanly destroyed upon PVC deletion due to the Delete policy.
 
----
+- [ ] StorageClass is created with `volumeBindingMode: WaitForFirstConsumer`.
+- [ ] PVC remains Pending until a consuming Pod is created, then becomes Bound.
+- [ ] Pod writes data through the init container and serves it through NGINX.
+- [ ] Data survives deleting and recreating the Pod without rerunning the init container.
+- [ ] PV cleanup matches the configured `Delete` reclaim policy after the PVC is removed.
+
+## Sources
+
+- [Kubernetes: Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
+- [Kubernetes: Storage Classes](https://kubernetes.io/docs/concepts/storage/storage-classes/)
+- [Kubernetes: Dynamic Volume Provisioning](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/)
+- [Kubernetes: Volumes](https://kubernetes.io/docs/concepts/storage/volumes/)
+- [Kubernetes: Ephemeral Volumes](https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/)
+- [Kubernetes: Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/)
+- [Kubernetes: Storage Capacity](https://kubernetes.io/docs/concepts/storage/storage-capacity/)
+- [Kubernetes CSI Developer Documentation](https://kubernetes-csi.github.io/docs/)
+- [Kubernetes CSI Drivers](https://kubernetes-csi.github.io/docs/drivers.html)
+- [AWS EC2: Amazon EBS Volume Limits](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/volume_limits.html)
+- [GitLab: GitLab.com Database Incident](https://about.gitlab.com/blog/2017/02/01/gitlab-dot-com-database-incident/)
 
 ## Next Module
 
-[Module 2.4: Configuration and Secrets](../module-2.4-configuration/) - Now that you understand how to persist heavy data on physical disks, prepare to learn how to securely inject lightweight, dynamic configuration data and highly sensitive cryptographic passwords directly into your applications without ever hardcoding them into your container images.
+[Module 2.4: Configuration and Secrets](../module-2.4-configuration/) - Now that you can persist application data safely, the next module shows how to inject configuration and sensitive values into workloads without baking them into container images.

--- a/src/content/docs/k8s/kcna/part2-container-orchestration/module-2.3-storage.md
+++ b/src/content/docs/k8s/kcna/part2-container-orchestration/module-2.3-storage.md
@@ -452,7 +452,7 @@ Because the StorageClass was configured with `reclaimPolicy: Delete`, deleting t
 - [Kubernetes CSI Developer Documentation](https://kubernetes-csi.github.io/docs/)
 - [Kubernetes CSI Drivers](https://kubernetes-csi.github.io/docs/drivers.html)
 - [AWS EC2: Amazon EBS Volume Limits](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/volume_limits.html)
-- [GitLab: GitLab.com Database Incident](https://about.gitlab.com/blog/2017/02/01/gitlab-dot-com-database-incident/)
+- [GitLab: GitLab.com Database Incident](https://about.gitlab.com/blog/gitlab-dot-com-database-incident/)
 
 ## Next Module
 


### PR DESCRIPTION
## Summary
- Rewrote `src/content/docs/k8s/kcna/part2-container-orchestration/module-2.3-storage.md` for #388 density, structure, alignment, and anti-leak gates.
- Cleared `revision_pending: false`.

## Verifier
- `verify_module.py --skip-source-check`: tier T0; body_words=5050, mean_wpp=71.1, median_wpp=77, short_rate=0.042, max_run=2.
- Protected assets preserved: before code_blocks=8, mermaid_diagrams=2, ascii_diagrams=0, tables=1; after code_blocks=8, mermaid_diagrams=2, ascii_diagrams=0, tables=1.
- Sources: 11 URLs present; live source check skipped per dispatch command.
- Commit SHA: 3784a27f6e8da1e1e468a6c2251768d71fb7036a

## Checks
- `../../.venv/bin/python scripts/quality/verify_module.py --glob src/content/docs/k8s/kcna/part2-container-orchestration/module-2.3-storage.md --skip-source-check --summary --quiet` passes T0.
- `git diff --check` clean.
- Forbidden-token grep: no matches.
- `../../.venv/bin/python scripts/test_pipeline.py`: 166 tests OK.
- `npm run build` from primary checkout temporary build branch: passed, 2013 pages built.
