### PR TITLE
feat(388): rewrite module-3.1-cloud-native-principles (#388 pilot)

### DIFF
--- a/src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.1-cloud-native-principles.md
+++ b/src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.1-cloud-native-principles.md
@@ -553,6 +553,8 @@ Use the framework as a conversation tool with application teams. Instead of aski
 
 ## Quiz
 
+Test your judgment on these architecture scenarios before moving into the refactoring exercise.
+
 <details><summary>Your team moved a legacy monolith into a container and deployed it on Kubernetes. The app still writes uploads to `/app/uploads`, reads a hardcoded database URL, and exposes no readiness endpoint. Is it cloud native, and what would you change first?</summary>
 
 It is containerized, but it is not yet cloud native in the operational sense. The local upload path violates stateless process design because Pod replacement can lose data, and the hardcoded database URL violates externalized configuration and backing-service attachment. I would first move durable files to object storage or another backing service, inject the database URL through a Secret, and add readiness so Services only route to instances that can handle traffic.

--- a/src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.1-cloud-native-principles.md
+++ b/src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.1-cloud-native-principles.md
@@ -1,38 +1,39 @@
 ---
-revision_pending: true
+revision_pending: false
 title: "Module 3.1: Cloud Native Principles"
 slug: k8s/kcna/part3-cloud-native-architecture/module-3.1-cloud-native-principles
 sidebar:
   order: 2
 ---
-> **Complexity**: `[MEDIUM]` - Architecture concepts
->
-> **Time to Complete**: 30-35 minutes
->
-> **Prerequisites**: Part 2 (Container Orchestration)
 
----
+# Module 3.1: Cloud Native Principles
+
+**Complexity**: `[MEDIUM]` architecture concepts. **Time to Complete**: 45-55 minutes. **Prerequisites**: Part 2, Container Orchestration, including basic familiarity with Pods, Deployments, Services, and the difference between desired state and actual state.
 
 ## What You'll Be Able to Do
 
-After completing this module, you will be able to:
+After completing this module, you will be able to use the following outcomes as review criteria during architecture discussions and Kubernetes workload inspections:
 
-1. **Explain** the CNCF definition of cloud native and its core principles
-2. **Compare** cloud native applications with traditional monolithic architectures
-3. **Identify** the twelve-factor app principles and how they apply to Kubernetes workloads
-4. **Evaluate** whether an application design follows cloud native best practices
-
----
+1. **Evaluate** whether an application follows cloud native principles by tracing its configuration, state, logging, and failure behavior.
+2. **Compare** monolithic and microservice designs, then choose service boundaries that reduce blast radius without adding needless distributed complexity.
+3. **Design** a Kubernetes 1.35+ workload manifest that applies 12-factor practices with environment configuration, replicas, probes, and stdout logging.
+4. **Diagnose** deployment anti-patterns such as mutable server changes, hardcoded backing services, local container state, and imperative-only operations.
 
 ## Why This Module Matters
 
-Cloud native is more than just containers—it's a set of principles for building scalable, resilient applications. The KCNA exam tests your understanding of what makes an application truly "cloud native." This module covers the foundational concepts.
+In August 2012, Knight Capital deployed new trading software across eight production servers. Seven servers received the updated code, one server kept an older path active, and the mismatch triggered automated trades that cost the firm about 460 million dollars in roughly 45 minutes. The failure was not simply a bad application bug; it was an architecture and operations failure where mutable infrastructure, manual rollout steps, and weak deployment control allowed production machines that were supposed to be identical to behave differently under real market pressure.
 
----
+That story matters for Kubernetes learners because cloud native architecture is often reduced to a shallow phrase: "put it in a container." A container can package a broken operating model just as easily as it can package a resilient one. If the application still depends on local disk, hardcoded database addresses, hand-edited servers, or one giant process that fails as a unit, Kubernetes can restart it, but Kubernetes cannot magically make the design scalable, observable, or safe to change.
 
-## What is Cloud Native?
+The KCNA exam expects you to recognize cloud native principles as a design system, not a product label. You will connect the CNCF definition, 12-factor application design, microservice tradeoffs, immutable infrastructure, declarative APIs, and failure-oriented thinking into one operational model. The goal is practical judgment: when you review a workload, you should be able to say which parts are cloud native, which parts are merely containerized, and which changes would make the application safer to run on Kubernetes 1.35+.
 
-```
+## What Cloud Native Really Means
+
+Cloud native describes applications and platforms built for modern, dynamic environments where nodes change, networks fail, capacity shifts, and releases happen frequently. The important word is not "cloud"; the important word is "native." A cloud native application behaves as if movement, replacement, automation, and partial failure are normal conditions, just as a native speaker does not translate every sentence back through another language before responding.
+
+The Cloud Native Computing Foundation definition names containers, service meshes, microservices, immutable infrastructure, and declarative APIs because those technologies support that operating model. Containers give you a repeatable runtime package, service meshes can move cross-cutting network behavior out of application code, microservices allow independent change when boundaries are well chosen, immutable infrastructure eliminates drift, and declarative APIs let a control plane reconcile desired state. None of those tools is sufficient by itself, but together they change how teams design and operate software.
+
+```text
 ┌─────────────────────────────────────────────────────────────┐
 │              CLOUD NATIVE DEFINITION                        │
 ├─────────────────────────────────────────────────────────────┤
@@ -60,13 +61,29 @@ Cloud native is more than just containers—it's a set of principles for buildin
 └─────────────────────────────────────────────────────────────┘
 ```
 
----
+The diagram is deliberately explicit about a common exam trap: cloud native is not the same thing as running in a public cloud. A legacy application lifted onto a large virtual machine in a hyperscaler region may still be tightly coupled to one host, one filesystem path, and one manual recovery procedure. Meanwhile, an application running on an on-premises Kubernetes cluster can be cloud native if it is packaged, configured, scaled, observed, and replaced through the same principles.
 
-## The 12-Factor App
+Think of cloud native as a contract between application and platform. The application promises to be portable, externally configurable, disposable, observable through standard streams and health signals, and tolerant of replacement. The platform promises to schedule it, restart it, scale it, connect it to backing services, enforce declared policy, and keep moving actual state toward desired state.
 
-The **12-Factor App** methodology is foundational to cloud native:
+A useful review question is: "What would happen if this Pod disappeared during a normal business hour?" If the answer is "the Deployment creates another Pod, traffic shifts away while readiness catches up, logs remain available, and durable data lives elsewhere," you are seeing cloud native behavior. If the answer is "someone must SSH to the node, recover files from local disk, and rerun a setup script from memory," the container is hiding a traditional operating model.
 
-```
+Pause and predict: what do you think happens if a single-container monolith is moved into Kubernetes without changing where it stores uploads, how it reads configuration, or how it reports health? The scheduling layer becomes more modern, but the application still carries the same fragile assumptions. Kubernetes will reveal those assumptions quickly because rescheduling, restarting, and replacing Pods are ordinary cluster events.
+
+This distinction also explains why cloud native architecture is not automatically microservice architecture. A modular monolith that follows 12-factor practices, exposes useful health checks, writes logs to stdout, and treats its database as an attached resource may be more cloud native than a swarm of tiny services sharing one fragile database and requiring coordinated releases. The principle is to design for automation and resilience first, then split services when the split pays for itself.
+
+The first practical skill is therefore evaluation. Before changing YAML, inspect the application contract: where does state live, how is configuration supplied, what happens during shutdown, what signal says the instance is ready, and how can an operator reproduce the running version from source and manifests? Those questions map directly to Kubernetes objects you already know: Deployments, Services, ConfigMaps, Secrets, probes, Jobs, and controllers.
+
+A second useful skill is separating platform capability from application responsibility. Kubernetes can place Pods, restart failed containers, and update endpoints, but it cannot know whether a checkout request is safe to retry or whether a recommendation response is optional. Those choices belong to the application and product teams, and the platform works best when those choices are exposed through clear contracts such as health endpoints, timeouts, idempotent handlers, and meaningful exit behavior.
+
+Cloud native review also benefits from thinking in replacement events instead of steady-state diagrams. Ask what happens when the image changes, when a node drains, when a Secret rotates, when one dependency slows down, and when a second region needs the same release. Designs that seem acceptable during calm traffic often reveal hidden coupling during those transitions, because replacement forces every assumption about state, identity, and configuration into the open.
+
+## The 12-Factor App in Kubernetes
+
+The 12-factor methodology gives cloud native architecture a vocabulary for application behavior. It came from Heroku's operational experience running large numbers of applications, but the ideas fit Kubernetes because both models assume automation, repeatability, and separation between code, configuration, runtime process, and attached services. The factors are not a checklist to memorize; they are pressure tests for whether an application can move safely through environments and recover cleanly from platform events.
+
+The first six factors focus on packaging and runtime boundaries. One codebase can produce many deploys, dependencies must be explicit, configuration belongs outside the code, backing services should be replaceable attachments, build and run stages must be separated, and application processes should be stateless. Kubernetes reinforces these ideas by turning the container image into the build artifact while ConfigMaps, Secrets, Services, and controllers supply environment-specific runtime behavior.
+
+```text
 ┌─────────────────────────────────────────────────────────────┐
 │              THE 12 FACTORS                                 │
 ├─────────────────────────────────────────────────────────────┤
@@ -96,7 +113,11 @@ The **12-Factor App** methodology is foundational to cloud native:
 │     State lives in backing services, not memory           │
 │                                                             │
 └─────────────────────────────────────────────────────────────┘
+```
 
+The next six factors describe how a process participates in an automated platform. Port binding makes the application self-contained, concurrency favors more process instances instead of one enormous host, disposability requires fast startup and graceful shutdown, dev/prod parity reduces surprises between environments, logs flow as event streams, and administrative tasks run as one-off processes. Kubernetes gives concrete forms to those ideas through container ports, replicas, termination grace periods, shared images, container log collection, and Jobs.
+
+```text
 ┌─────────────────────────────────────────────────────────────┐
 │              THE 12 FACTORS (continued)                     │
 ├─────────────────────────────────────────────────────────────┤
@@ -128,9 +149,11 @@ The **12-Factor App** methodology is foundational to cloud native:
 └─────────────────────────────────────────────────────────────┘
 ```
 
-> **Pause and predict**: Factor 6 says "execute the app as stateless processes." But databases need to store data. Does this mean databases cannot be cloud native? How does Kubernetes handle the tension between statelessness and the need for persistent data?
+The stateless process factor creates productive tension for beginners because real systems obviously store data. Stateless does not mean "no data exists." It means the running web or worker process does not depend on memory, local container files, or a specific node as the system of record. Databases, object storage, queues, and caches can absolutely be part of a cloud native system, but they are treated as backing services with explicit contracts, durability choices, and lifecycle management.
 
-### 12-Factor in Kubernetes Context
+Factor 3 and Factor 4 often appear together during Kubernetes migrations. A legacy application may connect to `localhost:5432`, write uploads under `/app/uploads`, and log to `/var/log/app.log` because it was designed for one server. In Kubernetes, that design collides with Pod scheduling because localhost means the Pod itself, local files disappear with the container, and file logs are harder for cluster-level collectors to preserve.
+
+Here is the same factor list translated into Kubernetes terms. The table is not meant to imply a one-to-one mechanical mapping for every production system, but it gives you exam-ready language for recognizing how a workload expresses cloud native behavior inside a cluster. When you evaluate a design, look for the underlying principle rather than only the object name.
 
 | Factor | Kubernetes Implementation |
 |--------|--------------------------|
@@ -144,14 +167,86 @@ The **12-Factor App** methodology is foundational to cloud native:
 | Concurrency | Horizontal scaling (replicas) |
 | Disposability | Fast container startup |
 | Dev/prod parity | Same images everywhere |
-| Logs | Stdout → log aggregation |
+| Logs | Stdout -> log aggregation |
 | Admin processes | Jobs and CronJobs |
 
----
+In the command examples for this module, `kubectl` is shortened with the common shell alias `k`. Define it once in your shell, then use `k get pods`, `k apply`, and related commands in the same way you would use the full command. The alias does not change Kubernetes behavior; it only makes repeated practice less noisy.
 
-## Microservices Architecture
-
+```bash
+alias k=kubectl
+k version --client
 ```
+
+A minimal 12-factor Deployment does not need exotic Kubernetes features. It needs a stable image, environment-driven configuration, a port, enough replicas to tolerate replacement, and probes that tell the Service when a Pod can receive traffic. That foundation is more important than adding advanced networking before the application has a clean runtime contract.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: checkout
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: checkout
+  template:
+    metadata:
+      labels:
+        app: checkout
+    spec:
+      containers:
+        - name: checkout
+          image: ghcr.io/example/checkout:1.8.0
+          ports:
+            - containerPort: 8080
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: checkout-db
+                  key: url
+            - name: LOG_FORMAT
+              value: json
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 20
+```
+
+Before running this, what output do you expect from `k get deploy checkout` after applying a manifest like this in a healthy cluster? You should expect Kubernetes to report three desired replicas and, after startup and readiness succeed, three available replicas. If the image pulls but readiness fails, the Deployment may show Pods running while the Service still keeps them out of endpoints, which is exactly the separation a cloud native workload needs.
+
+```bash
+k apply -f checkout-deployment.yaml
+k get deploy checkout
+k get pods -l app=checkout
+k logs -l app=checkout --tail=20
+```
+
+The worked example also demonstrates why "configuration in the environment" is not the same as "all configuration is harmless." A database URL usually belongs in a Secret because it may contain credentials, while a feature flag or log format may belong in a ConfigMap or plain environment value. The principle is externalization; the security decision depends on sensitivity and access control.
+
+War story: one platform team migrated a payments worker to Kubernetes and kept a daily migration command inside the container entrypoint because it worked on a single VM. When the Deployment scaled to three replicas, three Pods tried to run the migration at the same time, and one process held a lock long enough to delay startup for the others. The durable fix was not a bigger timeout; it was moving the administrative task into a separate Kubernetes Job so normal web processes stayed disposable and predictable.
+
+Notice how many factors are involved in that single story. The image was reusable, but the run command mixed serving traffic with administration. The process was stateless enough to scale, but startup behavior was not disposable because it depended on a global database lock. The better Kubernetes design did not require a new programming language or a service mesh; it required matching the 12-factor process model to Kubernetes controllers with a Deployment for serving and a Job for migration.
+
+Another migration pattern is to externalize one dependency at a time and observe the result. Moving configuration into a Secret should make environment promotion easier, while moving uploads into object storage should make Pod replacement less risky. If a change does not improve replacement, portability, observability, or failure behavior, it may still be useful, but it is not necessarily advancing the cloud native contract.
+
+When you read KCNA scenarios, translate symptoms into factors. "The team rebuilt the image to change the database host" points to configuration. "Users lose carts during rollout" points to stateless processes and backing services. "Logs disappear after restart" points to event streams. "Three replicas all run migrations" points to administrative processes. The exam usually describes behavior before naming the principle, so practice moving from symptom to design correction.
+
+## Monoliths, Microservices, and Service Boundaries
+
+Microservices are one of the most visible cloud native patterns, but they are also one of the easiest to misuse. A microservice is not just a small process or a repository with a REST API. A good service boundary gives a team independent ownership of a business capability, isolates failure and scaling pressure, and reduces coordination for changes that happen frequently.
+
+A monolith is not automatically bad. Many successful systems begin as monoliths because a single deployable unit is easier to reason about while the team is still learning the domain. The failure mode is not "one process exists"; the failure mode is that unrelated capabilities become so tightly coupled that every release, incident, and scaling decision has to involve the entire application.
+
+```text
 ┌─────────────────────────────────────────────────────────────┐
 │              MONOLITH vs MICROSERVICES                      │
 ├─────────────────────────────────────────────────────────────┤
@@ -189,7 +284,9 @@ The **12-Factor App** methodology is foundational to cloud native:
 └─────────────────────────────────────────────────────────────┘
 ```
 
-### Microservices Characteristics
+The diagram shows the attractive side of microservices: independent deployments, independent scaling, and smaller blast radius. If the payment service fails, the product catalog should still be able to serve browsing traffic, and the shipping service should not need to redeploy because the payment team changed a gateway integration. That independence is valuable when the business capability has different traffic, risk, and release pressure from the rest of the system.
+
+The diagram also hides costs that become real the moment the system runs in production. Service calls now cross a network, logs are spread across processes, data consistency becomes a design choice, and every team needs deployment, observability, security, and versioning discipline. A poorly chosen microservice boundary can make a simple feature require changes in five repositories and a carefully choreographed release.
 
 | Characteristic | Description |
 |----------------|-------------|
@@ -200,11 +297,29 @@ The **12-Factor App** methodology is foundational to cloud native:
 | **Failure isolation** | One failure doesn't crash all |
 | **Team ownership** | Small teams own services |
 
----
+The phrase "each service owns its data" deserves special attention. It does not mean every service must run a database on day one, and it does not mean data modeling becomes easier. It means other services should not casually reach into private tables and make hidden coupling stronger than the API contract. Shared databases are tempting because they make early integration fast, but they often prevent independent deployment later.
 
-## Immutable Infrastructure
+Stop and think: your company runs a monolithic e-commerce app, and a bug in the payment module crashes the entire process, including the shopping cart and product catalog. How would a microservices architecture change the blast radius of this failure? The payment flow might fail or degrade, but browsing and cart operations could remain available if the services, data paths, and user experience were designed to tolerate that partial outage.
 
-```
+The practical boundary question is not "how many services should we have?" A better question is "which capability changes at a different pace, scales under different load, or fails with a different business consequence?" Payment, search, recommendation, and image processing often have different operational profiles. Splitting along those lines can be valuable, but splitting every controller method into its own service usually creates coordination pain without meaningful isolation.
+
+Kubernetes supports both choices. A cloud native monolith can run as a Deployment with replicas, probes, external configuration, and centralized logs. A microservice system can run many Deployments and Services with separate rollout strategies, resource requests, network policies, and autoscaling rules. The architectural maturity comes from matching the platform shape to the application and team, not from chasing a service count.
+
+War story: a retail engineering group split a checkout system into order, inventory, payment, coupon, and shipping services before they had tracing, versioned contracts, or local development parity. The first holiday incident was not caused by Kubernetes; it was caused by humans being unable to answer which service owned a failing discount calculation. They kept the microservices, but only after adding ownership maps, contract tests, distributed tracing, and a rule that a service boundary needed a business owner as well as a repository.
+
+That story illustrates why service boundaries should follow change boundaries. If coupons and payments always change together, forcing them into separate services can create a distributed transaction problem without delivering independent release value. If recommendations change many times a week and checkout changes carefully under stricter controls, separating them may reduce risk. The cloud native answer depends on the economic shape of change, not on an abstract preference for smaller deployables.
+
+There is also a data boundary hidden behind every service boundary. A service that owns data must provide an API or event stream for other services to use, and it must absorb the operational cost of schema evolution. If other services bypass that API and read tables directly, the system keeps the deployment overhead of microservices but loses their independence. This is why experienced teams treat database ownership as part of the architecture, not as an implementation detail.
+
+For KCNA purposes, be ready to defend both choices. A monolith can be the right answer when one team needs fast iteration and the workload can still be replicated, configured externally, and observed cleanly. Microservices become the stronger answer when separate teams need separate deployment authority, a hot path needs independent scaling, or an optional feature should fail without taking down the core user journey. Cloud native judgment is the ability to explain the tradeoff.
+
+## Immutable and Declarative Operations
+
+Immutable infrastructure is the discipline of replacing running units instead of mutating them by hand. In a traditional server model, an operator might SSH into a machine, install a package, edit a config file, restart a daemon, and write a ticket update afterward. That can be fast during a crisis, but it also creates drift because the machine now contains history that may not exist in Git, a build artifact, or a repeatable deployment path.
+
+Cloud native systems prefer replacement because replacement is testable and reversible. If a container image contains version 1.8.0 of your application, every Pod created from that image should start from the same filesystem contents. When you need version 1.8.1, you build a new image, update the Deployment, and let the controller replace old Pods with new Pods according to the declared rollout strategy.
+
+```text
 ┌─────────────────────────────────────────────────────────────┐
 │              IMMUTABLE INFRASTRUCTURE                       │
 ├─────────────────────────────────────────────────────────────┤
@@ -237,14 +352,11 @@ The **12-Factor App** methodology is foundational to cloud native:
 └─────────────────────────────────────────────────────────────┘
 ```
 
-> **War Story: Knight Capital's Mutable Infrastructure Disaster**
-> In 2012, Knight Capital lost $460 million in 45 minutes due to a deployment error. They were manually updating 8 servers with new trading software (mutable infrastructure). One server was missed and ran old code alongside new code, triggering a massive automated trading loss. With immutable infrastructure—like deploying a new container image to all nodes simultaneously via a declarative manifest—this mismatch would have been impossible.
+Knight Capital is a severe example of what happens when production units diverge. One missed server was enough to run old behavior beside new behavior, and the system had no safe automated reconciliation loop to force uniform state. Kubernetes does not eliminate every deployment risk, but a Deployment controller gives you a stronger primitive: desired image, desired replicas, rollout status, and rollback history are all visible through the API.
 
----
+Declarative operation is the partner of immutability. Imperative commands describe steps: run this, scale that, expose this port, patch that field. Declarative configuration describes the desired end state: this Deployment should exist, it should run this image, it should have three replicas, and it should expose these labels and probes. The controller then keeps comparing actual state to desired state.
 
-## Declarative vs Imperative
-
-```
+```text
 ┌─────────────────────────────────────────────────────────────┐
 │              DECLARATIVE vs IMPERATIVE                      │
 ├─────────────────────────────────────────────────────────────┤
@@ -282,13 +394,45 @@ The **12-Factor App** methodology is foundational to cloud native:
 └─────────────────────────────────────────────────────────────┘
 ```
 
----
+Imperative commands are still useful for learning, debugging, and emergency inspection. The anti-pattern is running production primarily from a sequence of commands that nobody can reproduce. If the only record of the desired state is a terminal history, another engineer cannot review the change before it happens, and the cluster cannot tell whether the current state is intentional.
 
-> **Stop and think**: Your company runs a monolithic e-commerce app. A bug in the payment module crashes the entire application, including the shopping cart and product catalog. How would a microservices architecture change the blast radius of this failure?
+The declarative model becomes powerful when it is version controlled. A pull request can show that replicas changed from two to three, an image tag changed from 1.8.0 to 1.8.1, or a readiness path changed from `/ready` to `/health/ready`. Reviewers can reason about the intended state before it reaches the cluster, and Git history becomes part of the operational audit trail.
 
-## Design for Failure
-
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: checkout
+spec:
+  selector:
+    app: checkout
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
 ```
+
+```bash
+k apply -f checkout-service.yaml
+k describe service checkout
+k rollout status deployment/checkout
+```
+
+Which approach would you choose here and why: a one-line `k scale deployment checkout --replicas=5` during a traffic surge, or a pull request that changes the Deployment manifest and lets automation apply it? In a live incident, a temporary imperative scale may be reasonable if your team records and reconciles it afterward. For durable desired capacity, the manifest should win because it prevents the next apply from silently undoing the manual change.
+
+The cloud native lesson is not "never type a command." The lesson is that durable production intent belongs in declarative state, and one-off commands should either inspect the system or create temporary changes that are later folded back into that state. Kubernetes controllers are reconciliation engines, so your operating model should give them clear desired state to reconcile.
+
+Rollbacks show the value of immutability and declarative state together. If a new image causes errors, the team can point the Deployment back to the previous image or use rollout history rather than repairing individual containers. The old version is not reconstructed from memory; it is an artifact that already exists. This lowers cognitive load during an incident because the recovery path is another declared state, not a series of handcrafted machine edits.
+
+Declarative state also improves security and compliance reviews. A reviewer can inspect who changed an image, which Secret name is referenced, whether privileged settings appeared, and whether resource requests were removed. Manual changes may be fast, but they often leave the weakest evidence trail at the exact moment when the organization needs to understand what changed. Versioned manifests make production change a reviewable artifact instead of a rumor.
+
+There are still cases where imperative commands are the right tool. You may use `k logs` to inspect a crash, `k describe pod` to see scheduling events, or `k rollout restart` as part of a documented operational procedure. The difference is intent. Inspection commands gather facts, temporary commands buy time, and declarative changes define the steady state that should survive the next reconciliation loop.
+
+## Design for Failure Instead of Hoping for Stability
+
+Traditional infrastructure often treats failure as an exception to be prevented. Cloud native infrastructure treats failure as a normal input to design. Nodes are drained, Pods are evicted, networks drop packets, dependencies slow down, and deployments introduce bad versions. A resilient system does not avoid every failure; it limits the blast radius, detects unhealthy instances, and recovers without requiring a human to rebuild the service by hand.
+
+```text
 ┌─────────────────────────────────────────────────────────────┐
 │              DESIGN FOR FAILURE                             │
 ├─────────────────────────────────────────────────────────────┤
@@ -323,145 +467,297 @@ The **12-Factor App** methodology is foundational to cloud native:
 └─────────────────────────────────────────────────────────────┘
 ```
 
-> **War Story: Chaos Monkey at Netflix**
-> Netflix pioneered the concept of "Chaos Engineering" by creating Chaos Monkey, a tool that randomly terminates virtual machines and containers in their production environment during business hours. Why? To force their engineers to build services that inherently expect and survive failure without user impact, strictly enforcing the "Design for Failure" principle.
+Redundancy is the most visible pattern in Kubernetes. A Deployment with three replicas gives the Service more than one endpoint, so a single Pod crash does not have to become a user-visible outage. Redundancy is not free, because every replica consumes resources and may increase pressure on databases or downstream APIs, but it is often the simplest way to make disposable processes practical.
 
----
+Health checks are the communication channel between application and platform. A liveness probe answers whether the container should be restarted, while a readiness probe answers whether the Pod should receive traffic. Confusing those signals causes real incidents: if a slow dependency makes readiness fail, removing the Pod from endpoints may be correct; if the same dependency makes liveness fail, Kubernetes might restart every replica and amplify the outage.
+
+Circuit breakers, timeouts, retries, and graceful degradation handle failures beyond the Pod itself. A checkout service calling a payment gateway should not let every request wait indefinitely when the gateway is slow. A timeout bounds waiting, a circuit breaker stops repeated calls for a short interval, retry with backoff avoids hammering a recovering service, and graceful degradation gives the user a reduced but controlled experience.
+
+Netflix popularized Chaos Monkey to randomly terminate production instances during business hours, which sounds reckless until you understand the goal. The point was to force engineers to build services that survive routine loss rather than depend on perfect infrastructure. Kubernetes creates a milder version of that reality every day because scheduling, rescheduling, rolling updates, and node maintenance are ordinary parts of cluster life.
+
+The KCNA-level skill is recognizing which layer owns which recovery behavior. Kubernetes can restart a crashed container, stop routing to an unready Pod, and create replacement replicas. Your application still needs safe startup, graceful shutdown, idempotent request handling, bounded dependency calls, and data stored somewhere durable enough for the business requirement.
+
+Consider a recommendation service that enriches a product page. If recommendation calls fail, the page can still show product details, reviews, and a generic "popular items" list. That is graceful degradation. If the same failure prevents every product page from rendering, the architecture turned an optional feature into a hard dependency, and Kubernetes cannot infer that business priority from a manifest.
+
+Before adding a retry policy, pause and predict what happens if every client retries immediately when a dependency starts timing out. The failing service receives more traffic exactly when it has less capacity, and the retry storm can delay recovery. Backoff and jitter exist because cloud native systems include feedback loops, and careless feedback loops can make incidents worse.
+
+Designing for failure also means deciding what not to automate. Restarting a process is helpful when the process is stuck, but harmful when the real issue is a database outage and every restart discards useful caches. Retrying a request is helpful when the failure is transient, but harmful when the operation is not idempotent and the payment gateway might process the first attempt later. Cloud native systems are automated, but good automation encodes domain knowledge rather than blindly repeating actions.
+
+Readiness is one of the clearest examples of that domain knowledge. A service may be alive but not ready because it is warming a cache, loading a model, waiting for a dependency, or draining before shutdown. Sending traffic to that instance too early creates user-facing errors, while restarting it through liveness may reset progress. A well-designed readiness endpoint tells Kubernetes when routing is safe without pretending that every temporary dependency issue should kill the process.
+
+Graceful shutdown matters for the same reason. Kubernetes sends a termination signal and gives the container time to exit, but the application must stop accepting new work, finish or hand off in-flight requests, and close resources cleanly. A service that ignores shutdown can lose messages during every rollout, which makes routine replacement feel dangerous. A service that handles shutdown well turns replacement into a normal maintenance action.
+
+Failure design should be tested before the first major incident. Delete a non-production Pod and watch whether traffic recovers. Break a dependency in a staging environment and observe whether readiness, logs, and user experience match the design. Slow a downstream call and check whether timeouts protect the caller. These exercises are small, but they build confidence that the written architecture is reflected in runtime behavior.
+
+## Patterns & Anti-Patterns
+
+Patterns are reusable decisions that make the cloud native contract easier to keep under pressure. They are not decorations to add after the application works; they are ways to make replacement, scaling, observation, and failure handling ordinary. The patterns below are deliberately tied to symptoms you can see in a Kubernetes review, because KCNA questions often describe behavior and ask which principle is being violated.
+
+| Pattern | When to Use It | Why It Works | Scaling Consideration |
+|---------|----------------|--------------|-----------------------|
+| Externalized configuration | Values differ by environment, region, tenant, or release stage | The same image can run in dev, staging, and production with different ConfigMaps or Secrets | Keep sensitive values in Secrets and rotate them without rebuilding images |
+| Stateless web or worker replicas | Requests can be handled by any healthy instance | Pods can be replaced, rescheduled, and scaled horizontally | Move sessions, uploads, and durable data to backing services |
+| Declarative manifests in version control | Production state must be reviewable and reproducible | Pull requests show desired changes before controllers reconcile them | Use GitOps or CI/CD to reduce manual drift between clusters |
+| Health-aware traffic routing | Startup or dependency readiness can vary between instances | Readiness keeps bad endpoints out of Services while liveness handles stuck processes | Tune probes to avoid restarting healthy but temporarily unready containers |
+
+Anti-patterns usually appear because the old approach was convenient in a smaller environment. A local upload directory is easy on one VM, a hardcoded database URL is fast for a prototype, and SSH edits feel efficient during an outage. Cloud native architecture asks whether those conveniences still work when Pods move, teams grow, releases accelerate, and failure is expected.
+
+| Anti-Pattern | What Goes Wrong | Better Alternative |
+|--------------|-----------------|--------------------|
+| Containerized snowflake | The image is identical, but operators change running containers or nodes manually | Rebuild images or update declarative config, then roll out replacements |
+| Shared database for unrelated services | Teams cannot deploy independently because schema changes affect everyone | Give services explicit data ownership and communicate through APIs or events |
+| Local session or upload state | Pod replacement logs users out or loses files when scheduling changes | Store sessions in Redis or another backing service and uploads in object storage |
+| Liveness probe checks every dependency | A downstream outage restarts otherwise healthy Pods and expands the incident | Use readiness for dependency availability and liveness for stuck process detection |
+
+The scaling consideration is organizational as much as technical. A team that cannot operate one service safely will not become safer by operating many services. Start with the smallest architecture that honors the cloud native contract, then split where the split reduces a real bottleneck or failure domain.
+
+Patterns should be introduced in the order that reduces the most risk for the least complexity. Externalized configuration is often early because it makes the same image portable. Probes usually follow because they let Kubernetes route traffic based on application readiness. Separate Jobs for administrative work become important once replicas increase. A service mesh or advanced progressive delivery system should come after the team understands the simpler contracts it is trying to automate.
+
+Anti-patterns are often defended with true but incomplete statements. A local disk is fast, but it is not durable across Pod replacement. A shared database is convenient, but it couples independent services. A manual hotfix restores service, but it creates drift if it never becomes code or configuration. The review task is not to shame those choices; it is to ask whether they still fit the operating model the team wants.
+
+When you are unsure, describe the failure you are trying to survive. If the failure is one Pod crashing, replicas and readiness may be enough. If the failure is a whole node disappearing, local node state becomes a problem. If the failure is a downstream service slowing down, timeouts and graceful degradation matter more than extra replicas. The right pattern follows from the failure mode.
+
+## Decision Framework
+
+Use this framework when you evaluate whether a workload is cloud native enough for Kubernetes. Start with state, because state determines whether the platform can replace Pods freely. Then inspect configuration, rollout method, observability, health signaling, and service boundaries. If any answer depends on a person remembering manual steps, the design needs more declarative control.
+
+| Decision Question | Cloud Native Answer | Warning Sign | Kubernetes Object or Practice |
+|-------------------|--------------------|--------------|-------------------------------|
+| Where does durable state live? | In a backing service with a defined lifecycle | Files under the container filesystem or node-local paths | Managed database, PersistentVolume, object storage, Redis, StatefulSet when appropriate |
+| How does configuration change? | Environment-specific values come from declarative sources | Rebuild image or edit running server for every environment | ConfigMap, Secret, Helm values, Kustomize overlays |
+| How is desired state recorded? | Manifests live in version control and are applied through automation | Production depends on command history or manual SSH | GitOps, CI/CD, `k apply` from reviewed YAML |
+| What happens when a Pod dies? | Replacement starts, traffic avoids unready instances, data remains safe | A human must recover files or restart a specific host | Deployment replicas, readiness probes, external state |
+| When should a service split? | Different ownership, scaling pressure, release cadence, or failure impact | Splitting only to look modern | Separate Deployment and Service with clear API and data ownership |
+| How are logs and admin tasks handled? | Logs go to stdout, migrations run as one-off Jobs | Logs stay inside files and migrations run in every replica | Cluster logging, Job, CronJob |
+
+You can turn the table into a practical review sequence. First, ask whether a Pod can disappear without losing business data. Second, ask whether the same image can run across environments with only configuration changes. Third, ask whether the current cluster state can be recreated from source control. Fourth, ask whether the team can observe, roll back, and degrade the service during a dependency failure.
+
+This framework also protects you from tool-first architecture. A service mesh can add retries and traffic policy, but it cannot fix a service that is unsafe to retry. A GitOps controller can reconcile YAML, but it cannot make an undocumented manual database migration safe. Kubernetes is powerful because it automates clearly declared intent, so unclear intent remains a design problem.
+
+For new systems, choose a modular monolith when the domain is still changing quickly and one team owns the whole product. Keep it cloud native by externalizing config, writing logs to stdout, avoiding local durable state, and using Deployments with probes. Choose microservices when team ownership, scaling pressure, or failure isolation justifies the added network, data, and operational complexity.
+
+For existing systems, migrate risk in layers instead of trying to fix everything at once. You might first containerize the application, then externalize configuration, then move uploads to object storage, then add readiness and liveness probes, then split a high-change capability. Each layer should make the next failure easier to understand, not merely add another platform feature.
+
+Use the framework as a conversation tool with application teams. Instead of asking whether they are "cloud native," ask where the system stores durable data, how a new environment is configured, how they know an instance is ready, and what they do when a dependency is slow. Specific questions reduce defensiveness and expose concrete next steps. They also produce better architecture decisions than a generic demand to modernize.
+
+The framework is intentionally conservative for KCNA learners. It does not require you to design a global multi-region platform or choose every CNCF project. It asks whether a workload can be packaged, configured, observed, replaced, scaled, and recovered in ways Kubernetes understands. If you can evaluate those properties clearly, you can reason about more advanced platform patterns later without losing the fundamentals.
 
 ## Did You Know?
 
-- **12-factor started at Heroku** - Created by developers at Heroku in 2011 based on their experience running millions of apps.
-
-- **Beyond 12 factors** - Some propose additional factors like API-first, telemetry, and authentication/authorization.
-
-- **Microservices aren't always better** - They add complexity (networking, debugging, deployment). Start simple, split when needed.
-
-- **Netflix pioneered many patterns** - Circuit breakers (Hystrix), service discovery (Eureka), and API gateway (Zuul) came from Netflix's cloud journey.
-
----
+- **12-factor started at Heroku in 2011** - The methodology came from operators who had seen many applications fail in similar ways across deployment environments.
+- **Cloud native is older than Kubernetes** - Kubernetes became a CNCF project in 2015, but the architectural ideas behind disposability, automation, and external configuration were already established.
+- **Microservices are a tradeoff, not a badge** - Independent deployment can reduce blast radius, but distributed tracing, contract testing, and data ownership become mandatory engineering concerns.
+- **Netflix made failure testing mainstream** - Chaos Monkey pushed teams to prove that instance loss during business hours did not have to become a customer outage.
 
 ## Common Mistakes
 
-| Mistake | Why It Hurts | Correct Understanding |
-|---------|--------------|----------------------|
-| "Cloud native = in the cloud" | Miss the architectural principles | Cloud native is about HOW you build |
-| Starting with microservices | Over-engineering | Start monolith, split when needed |
-| Storing state in containers | Data loss on restart | Use external state stores |
-| Imperative management | Hard to reproduce/audit | Use declarative YAML |
-
----
-
-## Hands-On Exercise: 12-Factor Refactoring
-
-In this exercise, you will evaluate and refactor a traditional application deployment into a cloud native Kubernetes manifest.
-
-**Scenario**: You have inherited a monolithic Node.js application. Currently, it stores user uploads in a local `/app/uploads` directory, connects to a database at `localhost:5432`, and writes logs to `/var/log/app.log`. 
-
-**Step 1: Identify the Anti-Patterns**
-Review the application's current state against the 12-Factor principles.
-- [ ] Identify the violation of Factor 4 (Backing Services).
-- [ ] Identify the violation of Factor 6 (Processes/Statelessness).
-- [ ] Identify the violation of Factor 11 (Logs).
-
-**Step 2: Design the Cloud Native Solution**
-Plan how to adapt the application for Kubernetes.
-- [ ] Reconfigure the app to read the database connection string from an environment variable (Factor 3: Config).
-- [ ] Change the application code to output logs to `stdout` instead of a file (Factor 11: Logs).
-- [ ] Migrate the local file uploads to an external object storage service like AWS S3 (Factor 6: Processes).
-
-**Step 3: Draft the Deployment Manifest**
-Write a basic Kubernetes Deployment YAML that implements your design.
-- [ ] Define a `Deployment` with 3 replicas for concurrency.
-- [ ] Inject the database URL via a `Secret` reference in the `env` section.
-- [ ] Ensure no local volumes are mounted for stateful data storage.
-
----
+| Mistake | Why It Happens | How to Fix It |
+|---------|----------------|---------------|
+| Treating "runs in cloud" as "cloud native" | The infrastructure changed, but the application still assumes one stable host and manual repair | Evaluate config, state, logs, probes, rollout, and failure behavior before calling the design cloud native |
+| Starting with many microservices before boundaries are understood | Teams copy the visible shape of large platforms without the operational maturity behind it | Start with a modular monolith, then split services when ownership, scaling, or failure domains justify it |
+| Storing uploads or sessions in the container filesystem | Local files are easy during development and appear to work until a Pod moves | Use object storage, Redis, a database, or a properly managed persistent data pattern |
+| Hardcoding database addresses or credentials in source code | Early prototypes value speed over environment portability | Inject configuration through ConfigMaps and Secrets so the same image can run across environments |
+| Using liveness probes to check every dependency | Teams want Kubernetes to restart anything involved in a failed request | Use readiness for dependency availability and reserve liveness for stuck or unrecoverable local process failures |
+| Fixing production by SSH and leaving the change there | Manual edits feel faster during an incident | Convert the fix into an image or manifest change, roll it out declaratively, and remove drift |
+| Running migrations inside every web replica | The startup path seems like a convenient place for setup code | Run migrations as a separate Job so web Pods remain disposable and horizontally scalable |
 
 ## Quiz
 
-1. **A colleague says "we moved our monolith to a container on Kubernetes, so now we are cloud native." Is this statement correct? What would actually make their application cloud native?**
-   <details>
-   <summary>Answer</summary>
-   Simply containerizing a monolith is not cloud native -- it is "lift and shift." Cloud native is about how you design applications, not just where they run. To be truly cloud native, the application should be broken into microservices that scale independently, use declarative configuration (ConfigMaps/Secrets rather than hardcoded values), treat backing services as attached resources, write logs to stdout for collection, start quickly for disposability, and be designed for failure with health checks, retries, and graceful degradation. You can run cloud native apps on-premises and non-cloud-native apps in the cloud.
-   </details>
+<details><summary>Your team moved a legacy monolith into a container and deployed it on Kubernetes. The app still writes uploads to `/app/uploads`, reads a hardcoded database URL, and exposes no readiness endpoint. Is it cloud native, and what would you change first?</summary>
 
-2. **Your application connects to a PostgreSQL database using a hardcoded connection string in the source code. When migrating from a local database to AWS RDS, the team must rebuild and redeploy the container. Which 12-Factor principle does this violate, and how would Kubernetes solve it?**
-   <details>
-   <summary>Answer</summary>
-   This violates Factor 3 (Config: store config in the environment) and Factor 4 (Backing Services: treat as attached resources). The database connection string should not be in the source code. In Kubernetes, store it in a Secret or ConfigMap and inject it as an environment variable or mounted file. Switching from local PostgreSQL to AWS RDS then requires only updating the Secret value -- no code change, no image rebuild, no redeployment of the application container.
-   </details>
+It is containerized, but it is not yet cloud native in the operational sense. The local upload path violates stateless process design because Pod replacement can lose data, and the hardcoded database URL violates externalized configuration and backing-service attachment. I would first move durable files to object storage or another backing service, inject the database URL through a Secret, and add readiness so Services only route to instances that can handle traffic.
+</details>
 
-3. **An operations engineer SSHs into a production server to manually update a configuration file and restart a service. This fixes the immediate issue, but a week later the same server behaves differently from other servers running the "same" application. What principle was violated, and what is the cloud native alternative?**
-   <details>
-   <summary>Answer</summary>
-   This violates immutable infrastructure. Manual changes create "snowflake servers" -- each server diverges over time, making behavior unpredictable and unreproducible. The cloud native alternative is to never modify running infrastructure. Instead, fix the configuration in the source (Dockerfile, Helm chart, ConfigMap), build a new container image, and deploy it through the CI/CD pipeline. If the fix is configuration-only, update the ConfigMap or Secret and let Kubernetes roll out the change. The old container is replaced, never modified, ensuring all instances are identical.
-   </details>
+<details><summary>A checkout service has three replicas, but each Pod stores user sessions in memory. During a rolling update, some users lose carts. Which principle is being violated, and how should the design change?</summary>
 
-4. **A startup is building a new e-commerce platform and wants to start with 15 microservices for every feature (user auth, product catalog, shopping cart, payment, shipping, etc.). A senior engineer pushes back. Why might starting with microservices be a mistake, and what approach does the cloud native community recommend?**
-   <details>
-   <summary>Answer</summary>
-   Starting with many microservices adds enormous complexity before you understand your domain boundaries: distributed debugging, inter-service networking, data consistency, deployment coordination, and operational overhead for a small team. The recommended approach is to start with a well-structured monolith and split into microservices when specific components need to scale independently or when team boundaries justify separation. Microservices solve organizational and scaling problems, but they create operational problems. If you do not yet have those scaling problems, microservices are premature over-engineering.
-   </details>
+The workload violates the stateless process expectation behind cloud native concurrency and disposability. Kubernetes is allowed to replace Pods during a rollout, so any data that must survive replacement cannot live only in one process memory space. The session state should move to a backing service such as Redis or a database, and the application should treat any replica as able to serve the next request.
+</details>
 
-5. **Your payment service calls an external payment gateway. During peak hours, the gateway becomes slow (5-second response times instead of 200ms). Without any failure handling, your payment service threads are all blocked waiting for responses, and soon the entire service becomes unresponsive. What cloud native "design for failure" patterns would prevent this cascading failure?**
-   <details>
-   <summary>Answer</summary>
-   Multiple patterns work together: a circuit breaker detects repeated slow responses and stops calling the gateway temporarily, failing fast instead of blocking. Timeouts ensure no request waits more than a defined threshold. Retry with exponential backoff retries failed requests with increasing delays to avoid overwhelming the recovering gateway. Graceful degradation could queue payment requests for later processing instead of failing entirely. In Kubernetes, readiness probes would remove the unhealthy payment Pods from Service endpoints so they stop receiving new traffic. A service mesh like Istio can implement circuit breaking and retries at the infrastructure level.
-   </details>
+<details><summary>A startup wants ten microservices for a two-week launch because "microservices are cloud native." The team has no tracing, no contract tests, and one product squad. How would you evaluate that design?</summary>
 
-6. **A developer deploys a Node.js application to Kubernetes. The app is configured to write its application logs to `/var/log/app/output.log`. When the Pod crashes and restarts, the developer notices all previous logs are gone. Which 12-Factor principle is violated, and what is the cloud native solution?**
-   <details>
-   <summary>Answer</summary>
-   This violates Factor 11 (Logs). The 12-Factor methodology states that an application should not concern itself with routing or storage of its output stream. It should write logs directly to `stdout` and `stderr`. In Kubernetes, container runtimes capture `stdout`/`stderr` automatically, allowing cluster-level logging agents (like Fluentd or Promtail) to collect and forward them to a central logging system (like Elasticsearch or Loki) where they survive Pod restarts.
-   </details>
+The design is likely premature because it adds distributed-system complexity before the team has boundaries, ownership, and operations in place. A modular monolith can still be cloud native if it uses external configuration, stdout logging, replicas, probes, and durable backing services. I would split only the capabilities that already have distinct scaling pressure, release cadence, failure impact, or ownership.
+</details>
 
-7. **Your team uses a lightweight SQLite database for local development and the CI pipeline, but connects to a managed PostgreSQL cluster in production. Recently, a feature that passed all tests in staging caused a critical error in production due to a SQL syntax difference. Which principle does this violate?**
-   <details>
-   <summary>Answer</summary>
-   This is a violation of Factor 10 (Dev/Prod Parity). The principle mandates keeping development, staging, and production as similar as possible. Using different backing services (SQLite vs. PostgreSQL) creates a high risk of environments behaving differently, leading to bugs that only appear in production. The solution is to use PostgreSQL (via a local Docker container) in development and CI to ensure complete parity across all stages.
-   </details>
+<details><summary>An engineer runs `k scale deployment checkout --replicas=5` during a traffic spike, but the manifest in Git still says three replicas. What risk did the team create?</summary>
 
-8. **You are reviewing a Kubernetes YAML manifest for a new microservice. You notice a `hostPath` volume is mounted so the application can store user session data directly on the worker node's disk. Why is this an anti-pattern in a cloud native architecture?**
-   <details>
-   <summary>Answer</summary>
-   This violates Factor 6 (Processes), which requires applications to execute as stateless processes. Storing session data on the local node's disk means the application is stateful. If the Pod is rescheduled to a different worker node (due to a node failure or scaling event), the new Pod will not have access to the previous session data, resulting in logged-out users. The cloud native approach is to store stateful session data in an external backing service, such as a Redis cache or a managed database.
-   </details>
+The manual scale may be reasonable as a temporary incident action, but it created drift between actual state and declared desired state. The next automated apply can return the Deployment to three replicas with no obvious link to the incident decision. The durable fix is to update the version-controlled manifest or autoscaling policy so Kubernetes reconciliation reflects reviewed intent.
+</details>
 
----
+<details><summary>A liveness probe calls the database, payment gateway, and recommendation service. When the payment gateway slows down, Kubernetes restarts every checkout Pod. What is wrong with this probe design?</summary>
 
-## What Would You Do?
+The liveness probe is checking dependency availability instead of whether the local process is alive and recoverable through restart. Restarting healthy checkout Pods during a payment outage removes capacity and can amplify the incident. Dependency checks usually belong in readiness or application-level degradation logic, while liveness should detect a stuck process that needs replacement.
+</details>
 
-**Scenario**: You are the lead architect for a startup launching a new mobile app backend. The CEO wants to launch in 2 weeks. The team is arguing about architecture:
-- Developer A wants to build 10 microservices to be "cloud native."
-- Developer B wants to build a single monolith to move fast.
-- Operations wants to run the database inside a Kubernetes Deployment so "everything is containerized."
+<details><summary>A team runs schema migrations from the web container entrypoint. After scaling from one replica to three, startup becomes slow and sometimes fails due to migration locks. Which 12-factor idea applies?</summary>
 
-**Your Decision**: 
-You should side with Developer B to build a monolith initially (start simple, avoid premature microservices), but ensure the monolith follows 12-Factor principles (stateless, config in environment, logs to stdout). You must veto the Operations proposal to run the database in a standard Deployment without persistent volumes; stateful data requires careful handling (StatefulSets or managed cloud databases) to survive container disposability.
+This violates the separation between normal application processes and administrative processes. Web replicas should start quickly and be disposable, while migrations are one-off operational tasks with their own lifecycle and failure handling. In Kubernetes, the migration should run as a Job before or during the release process, and the web Deployment should start only the serving process.
+</details>
 
----
+<details><summary>A product page depends on a recommendation service. When recommendations fail, the whole page returns an error even though product details are available. Which cloud native failure pattern would improve the experience?</summary>
 
-## Summary
+Graceful degradation would let the page render core product details while replacing recommendations with a generic list or hiding that section. Timeouts and circuit breakers would prevent the recommendation dependency from consuming all request time and capacity. The key is deciding which capabilities are optional during partial failure and encoding that business priority in application behavior.
+</details>
 
-**Cloud Native is**:
-- Containers + microservices + automation
-- Designed for scale and resilience
-- Not just "running in the cloud"
+## Hands-On Exercise: 12-Factor Refactoring
 
-**12-Factor App**:
-- Codebase, dependencies, config
-- Backing services, build/release/run, processes
-- Port binding, concurrency, disposability
-- Dev/prod parity, logs, admin processes
+In this exercise, you will evaluate and refactor a traditional application deployment into a cloud native Kubernetes design. You do not need a full application repository to complete the reasoning work, but the commands assume you have a Kubernetes 1.35+ cluster available and the `k` alias already defined. Treat the scenario as an architecture review before you write the final manifest.
 
-**Key principles**:
-- **Microservices**: Small, independent services
-- **Immutable infrastructure**: Replace, don't modify
-- **Declarative**: Describe what, not how
-- **Design for failure**: Expect and handle failures
+**Scenario**: You have inherited a monolithic Node.js application. Currently, it stores user uploads in a local `/app/uploads` directory, connects to a database at `localhost:5432`, writes logs to `/var/log/app.log`, and runs a migration script during every container startup. The product manager wants three replicas before the next campaign.
 
----
+### Task 1: Identify the Anti-Patterns
+
+Review the application's current state against the 12-factor and cloud native principles, and write down the operational consequence of each violation before choosing a fix.
+
+- [ ] Identify the violation of Factor 4, Backing Services.
+- [ ] Identify the violation of Factor 6, Processes and statelessness.
+- [ ] Identify the violation of Factor 11, Logs.
+- [ ] Identify the administrative-process problem created by startup migrations.
+
+<details><summary>Solution guidance</summary>
+
+The database connection should not point to `localhost:5432` unless the database is intentionally running in the same Pod, which is not the normal web workload pattern. Uploads under `/app/uploads` are local container state and can disappear during replacement or rescheduling. Logs should go to stdout and stderr so Kubernetes and cluster logging agents can collect them. Migrations should run as a Job, not inside every web replica.
+</details>
+
+### Task 2: Design the Cloud Native Solution
+
+Plan how to adapt the application for Kubernetes before writing YAML, because the manifest should express a design decision rather than hide an unresolved application assumption.
+
+- [ ] Reconfigure the app to read the database connection string from an environment variable supplied by a Secret.
+- [ ] Change the application to output logs to stdout instead of a file under `/var/log`.
+- [ ] Migrate local file uploads to an external object storage service.
+- [ ] Move schema migrations into a Kubernetes Job that runs separately from web replicas.
+
+<details><summary>Solution guidance</summary>
+
+The same container image should run in dev, staging, and production, with environment-specific values supplied at release time. Object storage or another durable backing service removes node affinity from uploads. A separate Job gives the migration an explicit lifecycle and avoids duplicate migration attempts when the web Deployment scales horizontally. The web process becomes disposable, which allows Kubernetes to replace Pods safely.
+</details>
+
+### Task 3: Draft the Deployment Manifest
+
+Write a basic Kubernetes Deployment YAML that implements the serving part of your design and leaves durable state, migrations, and environment-specific values outside the web replica.
+
+- [ ] Define a `Deployment` with 3 replicas for concurrency.
+- [ ] Inject the database URL through a `Secret` reference in the `env` section.
+- [ ] Ensure no local volumes are mounted for stateful user uploads.
+- [ ] Add readiness and liveness probes with different purposes.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dojo-shop
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: dojo-shop
+  template:
+    metadata:
+      labels:
+        app: dojo-shop
+    spec:
+      containers:
+        - name: web
+          image: ghcr.io/example/dojo-shop:2.3.0
+          ports:
+            - containerPort: 8080
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: dojo-shop-db
+                  key: url
+            - name: UPLOAD_BUCKET
+              value: dojo-shop-uploads
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            periodSeconds: 20
+```
+
+<details><summary>Solution guidance</summary>
+
+The Deployment expresses concurrency with replicas, externalizes the database URL, and avoids mounting a local path for durable uploads. The readiness probe should represent whether the app can receive traffic, while liveness should represent whether the local process is stuck and needs restart. In a real system, you would also define the Secret, Service, resource requests, and rollout strategy.
+</details>
+
+### Task 4: Add the Migration Job
+
+Separate the administrative process from the web process so normal serving Pods remain disposable, horizontally scalable, and safe to replace during a rollout.
+
+- [ ] Define a `Job` that uses the same image but runs a migration command.
+- [ ] Inject the same database Secret into the Job.
+- [ ] Keep the Job separate from the web Deployment lifecycle.
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: dojo-shop-migrate
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: migrate
+          image: ghcr.io/example/dojo-shop:2.3.0
+          command: ["npm", "run", "migrate"]
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: dojo-shop-db
+                  key: url
+```
+
+<details><summary>Solution guidance</summary>
+
+The Job makes the migration visible as an administrative task rather than hiding it inside every web Pod. This helps operators see whether the migration succeeded, retry it intentionally, and avoid lock contention from multiple replicas. The Job still uses the same image, so build and release remain connected while run behavior stays separated.
+</details>
+
+### Task 5: Verify the Review
+
+Use inspection commands to confirm the shape of the workload and connect each observed field back to one of the cloud native principles in this module.
+
+- [ ] Run `k get deploy dojo-shop` and confirm three desired replicas.
+- [ ] Run `k describe deploy dojo-shop` and confirm Secret-based environment configuration.
+- [ ] Run `k logs -l app=dojo-shop --tail=20` and confirm logs are emitted through the container stream.
+- [ ] Confirm the Deployment manifest does not include a local upload volume.
+
+<details><summary>Solution guidance</summary>
+
+The expected result is not just a running Pod; it is a workload whose behavior matches the cloud native contract. The app should be replaceable because durable state lives outside the container, configurable because environment values come from Kubernetes objects, observable because logs flow through stdout and stderr, and safer to scale because migrations no longer run in every replica.
+</details>
+
+### Success Criteria
+
+- [ ] The design identifies the original backing-service, statelessness, logging, and admin-process violations.
+- [ ] The Deployment uses three replicas without depending on local durable state.
+- [ ] Database configuration is injected from a Secret instead of hardcoded in the image.
+- [ ] Logs are expected on stdout or stderr rather than in a file inside the container.
+- [ ] The migration runs as a separate Job.
+- [ ] You can explain why this is more cloud native than simply placing the old app in a container.
 
 ## Next Module
 
-[Module 3.2: CNCF Ecosystem](../module-3.2-cncf-ecosystem/) - Understanding the Cloud Native Computing Foundation and its landscape.
+[Module 3.2: CNCF Ecosystem](../module-3.2-cncf-ecosystem/) - Next you will map these cloud native principles to the CNCF projects and categories that implement them in real platforms.
+
+## Sources
+
+- [CNCF Cloud Native Definition](https://github.com/cncf/toc/blob/main/DEFINITION.md)
+- [The Twelve-Factor App](https://12factor.net/)
+- [Kubernetes Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)
+- [Kubernetes Services](https://kubernetes.io/docs/concepts/services-networking/service/)
+- [Kubernetes ConfigMaps](https://kubernetes.io/docs/concepts/configuration/configmap/)
+- [Kubernetes Secrets](https://kubernetes.io/docs/concepts/configuration/secret/)
+- [Kubernetes Probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
+- [Kubernetes Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/job/)
+- [Kubernetes Logging Architecture](https://kubernetes.io/docs/concepts/cluster-administration/logging/)
+- [Kubernetes Horizontal Pod Autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
+- [Kubernetes StatefulSets](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/)
+- [CNCF Cloud Native Interactive Landscape](https://landscape.cncf.io/)

--- a/src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.1-cloud-native-principles.md
+++ b/src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.1-cloud-native-principles.md
@@ -61,13 +61,9 @@ The Cloud Native Computing Foundation definition names containers, service meshe
 └─────────────────────────────────────────────────────────────┘
 ```
 
-The diagram is deliberately explicit about a common exam trap: cloud native is not the same thing as running in a public cloud. A legacy application lifted onto a large virtual machine in a hyperscaler region may still be tightly coupled to one host, one filesystem path, and one manual recovery procedure. Meanwhile, an application running on an on-premises Kubernetes cluster can be cloud native if it is packaged, configured, scaled, observed, and replaced through the same principles.
-
 Think of cloud native as a contract between application and platform. The application promises to be portable, externally configurable, disposable, observable through standard streams and health signals, and tolerant of replacement. The platform promises to schedule it, restart it, scale it, connect it to backing services, enforce declared policy, and keep moving actual state toward desired state.
 
 A useful review question is: "What would happen if this Pod disappeared during a normal business hour?" If the answer is "the Deployment creates another Pod, traffic shifts away while readiness catches up, logs remain available, and durable data lives elsewhere," you are seeing cloud native behavior. If the answer is "someone must SSH to the node, recover files from local disk, and rerun a setup script from memory," the container is hiding a traditional operating model.
-
-Pause and predict: what do you think happens if a single-container monolith is moved into Kubernetes without changing where it stores uploads, how it reads configuration, or how it reports health? The scheduling layer becomes more modern, but the application still carries the same fragile assumptions. Kubernetes will reveal those assumptions quickly because rescheduling, restarting, and replacing Pods are ordinary cluster events.
 
 This distinction also explains why cloud native architecture is not automatically microservice architecture. A modular monolith that follows 12-factor practices, exposes useful health checks, writes logs to stdout, and treats its database as an attached resource may be more cloud native than a swarm of tiny services sharing one fragile database and requiring coordinated releases. The principle is to design for automation and resilience first, then split services when the split pays for itself.
 
@@ -149,7 +145,7 @@ The next six factors describe how a process participates in an automated platfor
 └─────────────────────────────────────────────────────────────┘
 ```
 
-The stateless process factor creates productive tension for beginners because real systems obviously store data. Stateless does not mean "no data exists." It means the running web or worker process does not depend on memory, local container files, or a specific node as the system of record. Databases, object storage, queues, and caches can absolutely be part of a cloud native system, but they are treated as backing services with explicit contracts, durability choices, and lifecycle management.
+Stateless does not mean "no data exists." It means the running web or worker process does not use memory, local container files, or a specific node as the system of record; durable state belongs in backing services with explicit lifecycle and recovery contracts.
 
 Factor 3 and Factor 4 often appear together during Kubernetes migrations. A legacy application may connect to `localhost:5432`, write uploads under `/app/uploads`, and log to `/var/log/app.log` because it was designed for one server. In Kubernetes, that design collides with Pod scheduling because localhost means the Pod itself, local files disappear with the container, and file logs are harder for cluster-level collectors to preserve.
 
@@ -284,10 +280,6 @@ A monolith is not automatically bad. Many successful systems begin as monoliths 
 └─────────────────────────────────────────────────────────────┘
 ```
 
-The diagram shows the attractive side of microservices: independent deployments, independent scaling, and smaller blast radius. If the payment service fails, the product catalog should still be able to serve browsing traffic, and the shipping service should not need to redeploy because the payment team changed a gateway integration. That independence is valuable when the business capability has different traffic, risk, and release pressure from the rest of the system.
-
-The diagram also hides costs that become real the moment the system runs in production. Service calls now cross a network, logs are spread across processes, data consistency becomes a design choice, and every team needs deployment, observability, security, and versioning discipline. A poorly chosen microservice boundary can make a simple feature require changes in five repositories and a carefully choreographed release.
-
 | Characteristic | Description |
 |----------------|-------------|
 | **Single responsibility** | Each service does one thing well |
@@ -297,7 +289,7 @@ The diagram also hides costs that become real the moment the system runs in prod
 | **Failure isolation** | One failure doesn't crash all |
 | **Team ownership** | Small teams own services |
 
-The phrase "each service owns its data" deserves special attention. It does not mean every service must run a database on day one, and it does not mean data modeling becomes easier. It means other services should not casually reach into private tables and make hidden coupling stronger than the API contract. Shared databases are tempting because they make early integration fast, but they often prevent independent deployment later.
+Use that table as a tradeoff check, not a scoring sheet. Microservices help when a capability needs independent ownership, scaling, deployment, or failure isolation; they hurt when the split adds network calls, data consistency work, tracing requirements, and coordinated releases without giving the team real independence.
 
 Stop and think: your company runs a monolithic e-commerce app, and a bug in the payment module crashes the entire process, including the shopping cart and product catalog. How would a microservices architecture change the blast radius of this failure? The payment flow might fail or degrade, but browsing and cart operations could remain available if the services, data paths, and user experience were designed to tolerate that partial outage.
 
@@ -539,8 +531,6 @@ For new systems, choose a modular monolith when the domain is still changing qui
 For existing systems, migrate risk in layers instead of trying to fix everything at once. You might first containerize the application, then externalize configuration, then move uploads to object storage, then add readiness and liveness probes, then split a high-change capability. Each layer should make the next failure easier to understand, not merely add another platform feature.
 
 Use the framework as a conversation tool with application teams. Instead of asking whether they are "cloud native," ask where the system stores durable data, how a new environment is configured, how they know an instance is ready, and what they do when a dependency is slow. Specific questions reduce defensiveness and expose concrete next steps. They also produce better architecture decisions than a generic demand to modernize.
-
-The framework is intentionally conservative for KCNA learners. It does not require you to design a global multi-region platform or choose every CNCF project. It asks whether a workload can be packaged, configured, observed, replaced, scaled, and recovered in ways Kubernetes understands. If you can evaluate those properties clearly, you can reason about more advanced platform patterns later without losing the fundamentals.
 
 ## Did You Know?
 


### PR DESCRIPTION
## Summary

Rewrite `module-3.1-cloud-native-principles` for the #388 density and structure verifier gates while preserving the original module coverage: CNCF definition, 12-factor principles, microservices, immutable infrastructure, declarative APIs, and design-for-failure guidance.

## Verifier

Verifier summary: tier=T0; body_words=5352; mean_wpp=63.0; median_wpp=65; short_rate=0.0; max_run=0; mean_sentence_length=20.7. Sources reachability check was skipped per the required verifier command.

## Protected Assets

Protected assets preserved with counts: before code_blocks=6, ascii_diagrams=0, mermaid_diagrams=0, tables=3, source_urls=0; after code_blocks=14, ascii_diagrams=0, mermaid_diagrams=0, tables=6, source_urls=12. The original ASCII/code diagrams and comparison tables are retained and expanded with additional runnable Kubernetes examples and source references.

## Commit

Commit SHA: 2bf44332936d2a6e0e03913fd2d2f9c551d54672

## Checks

- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/quality/verify_module.py --glob src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.1-cloud-native-principles.md --skip-source-check --summary --quiet` passed T0.
- `git diff --check -- src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.1-cloud-native-principles.md` passed.
- `npm run build` not run: this worktree has no local `node_modules`, and the task explicitly prohibited modifying files outside the target module path.