### PR TITLE
feat(388): rewrite module-0.1-kcsa-overview (#388 pilot)

### DIFF
--- a/src/content/docs/k8s/kcsa/part0-introduction/module-0.1-kcsa-overview.md
+++ b/src/content/docs/k8s/kcsa/part0-introduction/module-0.1-kcsa-overview.md
@@ -1,48 +1,45 @@
 ---
-revision_pending: true
+revision_pending: false
 title: "Module 0.1: KCSA Exam Overview"
 slug: k8s/kcsa/part0-introduction/module-0.1-kcsa-overview
 sidebar:
   order: 2
 ---
-> **Complexity**: `[QUICK]` - Essential orientation
->
-> **Time to Complete**: 15-20 minutes
->
-> **Prerequisites**: None - this is your starting point!
 
----
+# Module 0.1: KCSA Exam Overview
+
+| Metadata | Value |
+|----------|-------|
+| **Complexity** | `[QUICK]` - Essential orientation |
+| **Time to Complete** | 30-35 minutes |
+| **Prerequisites** | None - this is your starting point |
 
 ## What You'll Be Able to Do
 
 After completing this module, you will be able to:
 
-1. **Explain** the KCSA exam format, domains, and how it fits in the Kubernetes certification path
-2. **Evaluate** your readiness by mapping current skills against the six KCSA exam domains
-3. **Compare** KCSA scope with KCNA (general knowledge) and CKS (hands-on security specialist)
-4. **Design** a study plan that prioritizes high-weight security domains
-
----
+1. **Evaluate** the KCSA exam format, domain weights, and certification fit before choosing a study path.
+2. **Compare** KCSA scope with KCNA and CKS so you can explain what each certification validates.
+3. **Diagnose** readiness gaps across cluster component security, security fundamentals, threat modeling, platform security, cloud native security, and compliance frameworks.
+4. **Design** a proportionate study plan that prioritizes high-weight domains without ignoring lower-weight security topics.
 
 ## Why This Module Matters
 
-The KCSA (Kubernetes and Cloud Native Security Associate) fills a crucial gap in the Kubernetes certification landscape. Before KCSA, you had to choose between general knowledge (KCNA) or jump straight into hands-on security specialist work (CKS). Now there's a bridge.
+A regional payments company once treated Kubernetes security as a specialist concern rather than a shared operating discipline. The platform team owned the cluster, the developers owned the application, and the compliance team owned the audit spreadsheet, but no group could explain how a default service account token, an overly broad RoleBinding, and missing NetworkPolicies combined into a real attack path. When a vulnerable internal service was exploited, the attacker did not need an exotic kernel flaw or a custom exploit chain. They used ordinary Kubernetes behavior to query the API, discover other workloads, and pivot toward data services that the original application never needed to reach.
 
-**The Real-World Cost of Knowledge Gaps**
-Consider a common industry scenario: A development team quickly deployed a new microservice to production. Lacking foundational Kubernetes security knowledge, they left the default service account token mounted in their pods and did not implement network policies. When an attacker found a simple vulnerability in their application code, they used that default token to query the Kubernetes API, discover other services, and move laterally across the cluster. This was not an advanced zero-day exploit; it was a basic misconfiguration that could have been easily avoided. The KCSA curriculum is designed exactly to prevent this scenario by ensuring everyone interacting with the cluster understands the threat landscape and baseline defenses, demonstrating the practical field value of the certification beyond just passing a test.
+The direct financial loss in that kind of incident is rarely limited to the first compromised workload. Engineers spend nights rotating credentials, auditors ask why baseline controls were not mapped to a framework, customers ask whether their data crossed trust boundaries, and product work stalls while leaders decide which environments can be trusted again. The expensive part is not merely that one pod was misconfigured. The expensive part is that several teams had partial knowledge, no shared vocabulary, and no confident way to recognize a basic Kubernetes security failure before production exposed it.
 
-KCSA is perfect for:
-- Security professionals entering the Kubernetes space
-- Developers who need security awareness
-- Compliance and audit professionals
-- Anyone preparing for CKS
-- IT professionals responsible for cloud native security
+The KCSA exam exists for exactly that gap. It is not trying to turn you into a hands-on incident responder in one sitting, and it is not a replacement for CKS-level operational practice. It validates whether you can reason about Kubernetes and cloud native security at the level where good decisions start: what the major attack surfaces are, which controls reduce which risks, how the official domains relate to one another, and why compliance evidence matters even when the exam question is framed as a technical scenario.
 
----
+This module gives you the map before the journey begins. You will see where KCSA sits among KCNA and CKS, how the six exam domains are weighted, why the two largest domains deserve early attention, and how to turn a broad security syllabus into a study plan that is realistic. In later modules you will go deeper into the 4 Cs, control plane security, RBAC, Secrets, Pod Security Standards, NetworkPolicies, threat modeling, platform controls, and compliance. Here, your job is to build enough orientation that every later topic has a place to land.
 
-## What is KCSA?
+## What KCSA Is Really Testing
 
-```
+The Kubernetes and Cloud Native Security Associate is a pre-professional, multiple-choice certification focused on security knowledge in the Kubernetes and cloud native ecosystem. The official Linux Foundation page describes it as a starting point for candidates who want to advance toward professional-level security work, and the current public exam page lists it as online, proctored, multiple choice, 90 minutes, beginner level, and available without prerequisites. That combination matters because KCSA measures judgment before muscle memory: you must recognize risks, choose safer designs, and connect controls to threats even when you are not asked to type commands into a live cluster.
+
+The most useful way to understand KCSA is as a bridge. KCNA gives broad cloud native literacy, KCSA narrows that literacy into security reasoning, and CKS later asks you to implement and troubleshoot security controls under time pressure. A candidate who has only studied general Kubernetes objects may recognize a Deployment, Service, and namespace, but still miss why a workload that can list Secrets or talk to every service has become a lateral movement platform. A candidate who jumps straight into CKS commands without the KCSA foundation may memorize hardening steps without understanding which threat each step is meant to reduce.
+
+```text
 ┌─────────────────────────────────────────────────────────────┐
 │           KUBERNETES SECURITY CERTIFICATION PATH            │
 ├─────────────────────────────────────────────────────────────┤
@@ -72,34 +69,43 @@ KCSA is perfect for:
 └─────────────────────────────────────────────────────────────┘
 ```
 
----
-
-## Exam Format
+There is one important correction to carry forward from the original overview. Older study notes often described the KCSA certification validity as three years, but the current Linux Foundation training page visible in May 2026 lists certification validity as two years. The practical exam-planning facts remain familiar: the exam is multiple choice, the duration is 90 minutes, there are no prerequisites, and the curriculum is organized around six security domains. Treat any exam detail you see in a cached blog post as something to verify against the official page before scheduling, because certification programs can change policy details faster than curriculum sites change prose.
 
 | Aspect | Details |
 |--------|---------|
 | **Duration** | 90 minutes |
-| **Questions** | ~60 multiple choice |
-| **Passing Score** | 75% (~45 correct answers) |
+| **Questions** | About 60 multiple choice |
+| **Passing Score** | 75% target in common study guidance; verify current policy before exam day |
 | **Format** | Online proctored |
 | **Prerequisites** | None |
-| **Validity** | 3 years |
+| **Validity** | 2 years on the current Linux Foundation KCSA page |
 
-### Key Difference from CKS
+The KCSA-versus-CKS distinction is the first decision point most learners ask about. KCSA asks whether you can choose the safer design and explain the risk. CKS asks whether you can make the cluster enforce that design while a clock is running. If KCSA says, "Which control limits pod-to-pod traffic after a workload is compromised?", CKS is more likely to require a working NetworkPolicy manifest in the correct namespace. Both are valuable, but they train different muscles.
 
 | Aspect | KCSA | CKS |
 |--------|------|-----|
 | Format | Multiple choice | Hands-on CLI |
 | Focus | Security concepts | Security implementation |
-| Skills tested | Understanding threats & defenses | Configuring security |
+| Skills tested | Understanding threats and defenses | Configuring security |
 | Prerequisites | None | Active CKA |
 | Duration | 90 min | 120 min |
 
----
+KCSA is perfect for security professionals entering Kubernetes, developers who need better security awareness, compliance and audit professionals who must understand what evidence means, platform engineers preparing for deeper hardening work, and anyone using KCSA as a conceptual runway toward CKS. It is also useful for engineering managers who approve exceptions, because many Kubernetes incidents begin when someone accepts a convenience tradeoff without knowing which attack path it opens. The exam does not require you to become a cluster administrator first, but it does expect you to think like someone whose decisions affect production risk.
 
-## Exam Domains
+When this course uses `k`, it means the standard kubectl command-line tool through a short alias. You do not need command fluency for KCSA, but seeing a few lightweight commands helps connect exam concepts to the real objects behind them. If you already have kubectl installed, define the alias in your shell before optional inspection work:
 
+```bash
+alias k=kubectl
+k version --client
 ```
+
+Pause and predict: if an exam candidate can recite the names RBAC, Secrets, Pod Security Standards, and NetworkPolicies, but cannot explain which risk each control reduces, what kind of KCSA question will expose that gap? The likely failure is not a command question. It is a scenario where several controls sound plausible and only the candidate who connects threat, layer, and control can choose the best answer.
+
+## Reading the Exam Domains as a Risk Map
+
+The six KCSA domains are not just a list of study categories. They are a compressed map of how Kubernetes systems fail, how defenders reason about those failures, and how organizations prove they have reduced risk. Cluster Component Security and Security Fundamentals each carry 22% of the exam, so together they account for a large share of your score. That does not mean the other domains are optional. It means the largest domains become the load-bearing beams for the rest of your study plan.
+
+```text
 ┌─────────────────────────────────────────────────────────────┐
 │              KCSA DOMAIN WEIGHTS                            │
 ├─────────────────────────────────────────────────────────────┤
@@ -125,35 +131,31 @@ KCSA is perfect for:
 └─────────────────────────────────────────────────────────────┘
 ```
 
-> **Stop and think**: Looking at the domain weights, if you only had two weeks to prepare, which domains would you prioritize and why? Consider both the weight percentages and how the domains build on each other.
+Cluster Component Security asks whether you know the parts of Kubernetes that must be protected before workloads can be trusted. The API server is the front door for nearly every administrative action, etcd stores cluster state and sensitive objects, kubelet bridges the control plane to nodes, and networking choices determine which paths exist between components. If these pieces are exposed or weakly authorized, workload hardening becomes a second-line control rather than a complete defense. You do not need to memorize every flag in this opening module, but you should recognize that a cluster is a distributed control system, not a single box.
+
+Security Fundamentals then turns from components to day-to-day controls. RBAC decides who can perform actions, Secrets separate sensitive data from ordinary configuration while still requiring careful protection, Pod Security Standards constrain dangerous pod settings, and NetworkPolicies can reduce lateral movement after a workload is compromised. These controls are where many security conversations become practical: which service account should this controller use, can this namespace deny privileged pods, and should this backend receive traffic from every frontend or only from labeled clients?
+
+The Threat Model domain supplies the attacker-centered lens. Instead of memorizing controls as independent facts, you learn to ask where trust boundaries sit, how data flows, what persistence or privilege escalation might look like, and which compromise paths remain after a control is added. A threat model is the difference between saying "we enabled audit logs" and saying "we need audit logs because attackers who obtain service account permissions may enumerate resources before escalating." The second sentence is more useful because it connects detection to a behavior you care about.
+
+Platform Security expands the view beyond raw Kubernetes primitives. Image repositories, admission control, runtime visibility, service mesh, PKI, connectivity, and observability all shape whether secure intent survives contact with delivery pipelines and production operations. This domain matters because a cluster can have good RBAC and still accept a vulnerable image, run unreviewed manifests, or miss runtime behavior that violates the assumptions made during design. In practice, platform security is where security becomes repeatable rather than heroic.
+
+Cloud Native Security and Compliance Frameworks complete the map. The 4 Cs model helps you reason from cloud infrastructure inward through cluster, container, and code, while compliance frameworks help translate technical controls into evidence that auditors and risk owners can evaluate. Compliance is only 10% of the exam, but it teaches you why organizations ask for repeatable assessments, benchmark results, and mapped controls. A team that ignores the compliance domain may pass many technical questions and still struggle when asked why a CIS recommendation or NIST control exists.
+
+Pause and predict: if you only had two weeks to prepare, which two domains would you start with, and which one would you schedule for short daily review instead of a single cram session? A strong answer usually starts with Cluster Component Security and Security Fundamentals, then keeps Compliance visible through brief recurring review because framework vocabulary is easy to forget when it is isolated from technical examples.
 
 ### Self-Assessment: Where Do You Stand?
 
-Before diving in, take a moment to map your current experience against the six KCSA domains. Ask yourself:
-- **Cluster Component Security (22%)**: Have I ever configured or secured the Kubernetes API server, etcd, or kubelet?
-- **Security Fundamentals (22%)**: Do I regularly write RBAC roles, manage Kubernetes Secrets, or define Network Policies?
-- **Kubernetes Threat Model (16%)**: Can I explain how a container escape happens or identify common Kubernetes attack surfaces?
-- **Platform Security (16%)**: Have I worked with image scanners, admission controllers (like OPA Gatekeeper), or runtime security tools?
-- **Cloud Native Security (14%)**: Am I familiar with the 4 Cs of cloud native security and the shared responsibility model?
-- **Compliance Frameworks (10%)**: Have I ever run a CIS Benchmark assessment or mapped controls to NIST frameworks?
+Before you study, diagnose readiness instead of guessing. For Cluster Component Security, ask whether you can explain the security role of the API server, etcd, kubelet, container runtime, networking, client certificates, and storage without opening notes. For Security Fundamentals, ask whether you can reason about RBAC, service accounts, Secrets, Pod Security Admission, audit logging, isolation, and NetworkPolicies in a scenario where one control is present and another is missing. If either answer feels vague, you have found high-value study time.
 
-> **Pause and predict**: Based on your answers above, which two domains will require the most study time for you personally?
+For the Threat Model domain, test whether you can describe an attack path from initial access to privilege escalation or sensitive data access in Kubernetes terms. For Platform Security, ask whether you can place image scanning, admission control, runtime detection, repository policy, PKI, and observability into a delivery workflow. For Cloud Native Security, check whether the 4 Cs are more than a memorized order. For Compliance Frameworks, decide whether you can explain the difference between a benchmark, a framework, an assessment, and evidence.
 
-### Where to Focus
+The study mistake is to score yourself only on familiarity. "I have heard of NetworkPolicy" is not readiness. A better readiness signal is whether you can evaluate a short story: a pod in a namespace can talk to every backend, the service account can list Secrets, the image came from an untrusted registry, and audit logs are unavailable. If you can decide which risks belong to which domains and which control should come first, you are studying at the level KCSA rewards.
 
-**44% of the exam** comes from two domains:
-- Kubernetes Cluster Component Security (22%)
-- Kubernetes Security Fundamentals (22%)
+## Turning Exam Scope into Security Reasoning
 
-Master these, and you're nearly halfway there.
+KCSA questions generally orbit four kinds of knowledge: concepts, threats, defenses, and compliance. Concepts give you the vocabulary, threats give you the reason for caring, defenses give you the control choices, and compliance gives you a way to justify and measure those choices. If you separate those categories too sharply, the exam becomes harder than it needs to be. A question about Pod Security Standards may ask about a defense, but the reason the answer is correct depends on a threat such as privileged container abuse or host namespace access.
 
----
-
-## What KCSA Tests
-
-### You Need to Know
-
-```
+```text
 ┌─────────────────────────────────────────────────────────────┐
 │              KCSA KNOWLEDGE AREAS                           │
 ├─────────────────────────────────────────────────────────────┤
@@ -184,120 +186,72 @@ Master these, and you're nearly halfway there.
 └─────────────────────────────────────────────────────────────┘
 ```
 
-> **Pause and predict**: The KCSA is multiple-choice while CKS is hands-on. How does this difference change what you need to study? What depth of understanding is "enough" for a concept-based security exam?
+Think of a Kubernetes cluster like an office building with shared corridors, locked rooms, a reception desk, employee badges, maintenance closets, and audit cameras. The API server is the reception desk because requests enter there. RBAC is the badge policy because it decides what an identity can do. NetworkPolicy is a corridor control because it limits which rooms can talk to each other. Pod Security Standards are building rules for what tenants may bring into their rooms. Audit logs are the camera record that helps reconstruct what happened after a suspicious action.
 
-### You Don't Need to Know
+That analogy is imperfect, but it helps with exam reasoning because KCSA often asks for the control that best matches the failure. If a workload can read every Secret in a namespace, the problem is not fixed by image scanning alone. If a compromised frontend can connect to every database, the first conceptual control is not a stricter password rotation schedule. If a privileged pod mounts host paths and joins host namespaces, the issue is not merely that the image tag is mutable. The exam rewards choosing the control that reduces the described risk rather than choosing a security-sounding option.
 
-- Exact kubectl commands for security configuration
-- YAML manifest details
-- Complex troubleshooting procedures
-- Tool-specific command-line syntax
+A worked example makes this concrete. Suppose a team deploys a payment helper service in Kubernetes 1.35, uses the default service account, stores database credentials in a Secret, accepts traffic from every namespace, and has no admission policy restricting privileged pods. A KCSA-style question might ask which combination of controls best reduces lateral movement and privilege escalation. You would identify RBAC and service account scoping for API permissions, NetworkPolicy for traffic restriction, Pod Security Admission for dangerous pod settings, and stronger Secret handling for credential exposure. No single control tells the whole story.
 
----
+Before running this optional inspection, what output do you expect from a namespace that has no explicit workload-specific service account? In many clusters, a pod that omits `serviceAccountName` receives the namespace default service account, which is why KCSA expects you to notice identity even when the manifest author did not mention identity at all.
 
-## Sample Questions
+```bash
+k get serviceaccount -n default
+k get rolebinding,clusterrolebinding -A | head
+```
 
-Here's what KCSA questions look like:
+The key difference from CKS is depth of execution. For KCSA, you should know that RBAC uses Roles, ClusterRoles, RoleBindings, and ClusterRoleBindings to authorize Kubernetes API actions, and you should reason about least privilege. You do not need to build a complex permissions model from memory under exam pressure. For KCSA, you should know that NetworkPolicies are application-centric rules enforced by a compatible networking implementation. You do not need to troubleshoot every CNI plugin behavior in this first module.
 
-### Question 1
-**Which of the following represents the 4 Cs of cloud native security in the correct order from outermost to innermost?**
-- A) Container, Code, Cloud, Cluster
-- B) Cloud, Cluster, Container, Code
-- C) Code, Container, Cluster, Cloud
-- D) Cluster, Cloud, Code, Container
+This distinction should calm your study plan without lowering your standards. Do not spend the first week drilling command syntax at the expense of threat reasoning. Do not ignore commands entirely either, because seeing real resource names makes concepts stick. A balanced approach is to read the official concept page, describe the risk in your own words, look at a minimal manifest or command, and then answer a scenario question that forces you to choose between plausible controls.
 
-<details>
-<summary>Answer</summary>
-B) Cloud, Cluster, Container, Code. Security layers from outermost (infrastructure) to innermost (application).
-</details>
+### How Scenario Questions Hide the Real Domain
 
-### Question 2
-**What Kubernetes feature restricts which users or service accounts can perform actions on cluster resources?**
-- A) Network Policies
-- B) Pod Security Admission
-- C) RBAC (Role-Based Access Control)
-- D) SecurityContext
+KCSA scenario questions often look like they are about one object while they are really testing the relationship between several domains. A question may mention a Secret, but the correct answer may depend on RBAC because the risk is who can read it through the API. A question may mention a compromised container, but the best response may be a NetworkPolicy because the immediate concern is lateral movement rather than the original vulnerability. This is why domain study works best when you practice translating the story into assets, identities, paths, and evidence before looking at the answer choices.
 
-<details>
-<summary>Answer</summary>
-C) RBAC (Role-Based Access Control). RBAC controls who can do what in the cluster through Roles and RoleBindings.
-</details>
+One reliable reading method is to underline four things mentally: the asset being protected, the identity taking action, the path the attacker could use, and the control boundary that is missing or weak. If the asset is sensitive configuration, Secrets and etcd protection enter the conversation. If the identity is a service account or human user, RBAC and authentication matter. If the path is pod-to-pod traffic, network segmentation becomes relevant. If the boundary is a dangerous pod setting, Pod Security Admission and security context choices become more important than a general reminder to "be secure."
 
-### Question 3
-**A container running as root with hostPID: true poses what primary risk?**
-- A) Network bandwidth consumption
-- B) Container escape and host compromise
-- C) Excessive CPU usage
-- D) Storage capacity issues
+This method also protects you from answer choices that are technically true but operationally mismatched. Image scanning is valuable, but it does not restrict a running pod that already has excessive API permissions. Audit logging is valuable, but it does not itself prevent a privileged pod from being admitted. Encryption at rest is valuable, but it does not stop an authorized principal from reading a Secret through the Kubernetes API. KCSA questions often reward that distinction: a control can be good, current, and official while still not be the best answer to the described risk.
 
-<details>
-<summary>Answer</summary>
-B) Container escape and host compromise. These settings allow the container to access host processes, enabling potential escape.
-</details>
+Consider a practice scenario where an internal analytics workload is compromised through an application bug. The pod uses a service account bound to a ClusterRole that can list pods and Secrets across namespaces, there are no NetworkPolicies, and the namespace allows privileged pods. A weak answer says "enable security" or chooses the first familiar control. A stronger answer separates the risks: RBAC scope enables API discovery and Secret access, missing NetworkPolicy enables lateral movement, and permissive pod admission creates a path toward node-level abuse if the attacker can create or modify workloads.
 
----
+The same scenario also illustrates how KCSA differs from a pure implementation exam. You are not expected in this module to write every Role, RoleBinding, NetworkPolicy, and admission label from memory. You are expected to say why each one belongs in the conversation and which one should be selected when the question asks for the best immediate mitigation. That reasoning skill is portable. Later, when you do hands-on work, the commands become easier because you already know the security outcome you are trying to enforce.
 
-## Did You Know?
+### What KCSA Does Not Ask You to Become Overnight
 
-- **KCSA bridges the gap** between KCNA and CKS. You don't need hands-on experience to validate your security knowledge.
+An overview module should also define the boundary of the exam so you do not waste effort. KCSA does not require you to become a forensic analyst, Kubernetes release engineer, cloud provider IAM specialist, service mesh maintainer, or CKS-level cluster hardening operator before you answer your first practice set. Those skills are valuable, but they sit beyond the associate-level target. The exam expects you to recognize foundational cloud native security technologies and reason about their use, not to reproduce every production runbook from memory.
 
-- **Security is everyone's job** - KCSA recognizes that developers, operators, and managers all need security awareness, not just security specialists.
+That boundary is not an excuse to study shallowly. "Conceptual" does not mean "vague." You should be able to explain why default service account behavior matters, why unrestricted egress can preserve an attacker's options, why admission control catches risky manifests before workload creation, why audit logs matter after suspicious activity, and why compliance evidence cannot be reconstructed reliably after the fact. These are conceptual answers, but they are concrete enough to guide real engineering work.
 
-- **75% pass rate** means you can miss about 15 questions and still pass. Focus on understanding concepts, not memorizing details.
+The right depth is often one layer deeper than a definition and one layer shallower than full implementation. For RBAC, know the difference between namespaced and cluster-wide authorization, why broad verbs such as `*` are risky, and how bindings attach permissions to subjects. For Secrets, know that the API object reduces accidental exposure compared with plain configuration but still needs RBAC, etcd protection, workload discipline, and careful mounting. For NetworkPolicies, know that they express allowed traffic for selected pods and require a compatible network plugin. That depth is enough for KCSA orientation and prepares you for later labs.
 
-- **No prerequisites** - Unlike CKS which requires CKA, anyone can attempt KCSA. It's truly entry-level.
+Another boundary is vendor specificity. KCSA is vendor-neutral, so it will not usually ask you to memorize the exact console path for a managed Kubernetes service. It can still ask about shared responsibility, cloud identity, network exposure, managed control planes, and infrastructure choices because those topics shape the outer layers of the 4 Cs model. When a managed service appears in a scenario, look for the security responsibility being tested rather than the brand of the service.
 
----
+This matters for study resources. Product tutorials can be helpful when they show a real workflow, but your primary notes should be anchored in official Kubernetes documentation, Linux Foundation exam materials, CNCF curriculum references, and durable security principles. Vendor blogs age quickly and may optimize for a product feature rather than for the exam's neutral vocabulary. If you use them, translate the lesson back into the KCSA domain language so your notes remain portable.
 
-## Common Mistakes
+### A Worked Study Example
 
-| Mistake | Why It Hurts | Solution |
-|---------|--------------|----------|
-| Focusing on commands | KCSA tests concepts, not CLI | Study "what" and "why," not "how to type" |
-| Ignoring threat model | 16% of exam is about threats | Think like an attacker |
-| Skipping compliance | 10% is frameworks and benchmarks | Learn CIS and NIST basics |
-| Not connecting concepts | Security is layered | Understand how defenses work together |
-| Rushing through questions | Security questions have subtle wording | Read every option carefully |
+Imagine you are starting with the Security Fundamentals domain. A thin study note might say, "RBAC controls access, Secrets store sensitive data, Pod Security Standards restrict pods, and NetworkPolicies restrict traffic." That note is accurate but not yet useful for exam reasoning. A better study note turns the same facts into a scenario: a compromised workload should not be able to list Secrets, create privileged pods, or reach every backend service, so the team needs scoped service accounts, restrictive pod admission, and explicit traffic rules.
 
----
+Now add tradeoffs. Scoped service accounts reduce blast radius, but they require teams to understand what each workload actually needs. Restrictive pod admission blocks dangerous settings, but it may break legacy workloads that expect root privileges or host access. NetworkPolicies reduce lateral movement, but they require accurate labels and a networking implementation that enforces the API. Secrets handling reduces accidental disclosure, but it does not eliminate the need for external rotation, encryption, and careful application behavior.
 
-## Quiz
+Finally, add evidence. For RBAC, evidence might include reviewed Roles, RoleBindings, and `k auth can-i` checks in a non-production environment. For pod security, evidence might include namespace labels enforcing the Restricted profile or an admission policy report. For network segmentation, evidence might include policy manifests and a connectivity test showing that only intended flows work. For Secrets, evidence might include encryption configuration, narrow permissions, and workload reviews showing only required mounts.
 
-1. **A colleague holds a CKA certification and asks whether they should skip KCSA and go straight to CKS. What would you advise, and why?**
-   <details>
-   <summary>Answer</summary>
-   It depends on their security knowledge. CKS focuses on hands-on security implementation and requires an active CKA, which they have. However, KCSA covers security concepts, threat modeling, and compliance frameworks that CKS does not emphasize. If they lack a strong security conceptual foundation — understanding threats, the 4 Cs model, and compliance — KCSA would fill that gap. CKS tests "how to configure," while KCSA tests "why this matters and what could go wrong."
-   </details>
+This three-part note is much stronger than a glossary because it mirrors how security teams think. It names the failure, chooses a control, and identifies proof. It also prepares you for multiple styles of question: one asking for the best control, one asking why an alternative is insufficient, one asking how a compliance reviewer might verify the control, and one asking which domain the scenario belongs to. You are building a reusable reasoning pattern rather than memorizing isolated facts.
 
-2. **You have 90 minutes and roughly 60 questions on exam day. After 45 minutes you've answered 25 questions. Should you be worried? What strategy would you apply for the remaining time?**
-   <details>
-   <summary>Answer</summary>
-   At that pace you'd finish about 55 questions, which is slightly behind. The three-pass strategy helps: use the first pass for quick, confident answers (1-2 min each), mark harder questions for a second pass (3-4 min each), and use remaining time for any questions you flagged. Since the passing score is 75% (~45 correct), you can afford to miss about 15 questions. Focus on answering the ones you know well rather than spending too long on uncertain ones.
-   </details>
+Try applying the same template to Cluster Component Security. Pick the API server, etcd, kubelet, and container runtime. For each one, write what can fail, what control or configuration reduces the risk, and what evidence would show the risk is being managed. Even if your first answers are rough, you will quickly see why this domain has a high exam weight: these components shape the security boundary for every workload that runs on the cluster.
 
-3. **The two highest-weighted KCSA domains together account for 44% of the exam. A study group member suggests ignoring the 10% Compliance domain entirely. Is this a sound strategy?**
-   <details>
-   <summary>Answer</summary>
-   No. With a 75% passing threshold, every domain matters. The 10% Compliance domain represents roughly 6 questions — ignoring them means you'd need to score nearly perfectly on everything else. A better approach is to spend proportionally more time on the 22% domains (Cluster Components and Security Fundamentals) while still covering Compliance at a conceptual level. The domains also reinforce each other: understanding compliance frameworks helps contextualize why specific security controls exist.
-   </details>
+There is also a pacing lesson hidden in this approach. If you cannot explain a component in this three-part form after one reading, do not immediately assume you need a longer article or a harder lab. First, rewrite the component in simpler operational language. The API server receives and authorizes requests. Etcd stores cluster state. Kubelet runs work on a node. The container runtime starts containers. Once those plain statements are stable, security questions become easier because you can ask what happens when each statement is abused.
 
-4. **Your team wants to validate that all members understand Kubernetes security basics before working on a production cluster. Which certification would you recommend and why — KCNA, KCSA, or CKS?**
-   <details>
-   <summary>Answer</summary>
-   KCSA is the best fit. KCNA covers general Kubernetes knowledge but lacks security depth. CKS requires hands-on security implementation skills and a CKA prerequisite, which is overkill for baseline awareness. KCSA validates understanding of security concepts, threats, defenses, and compliance without requiring CLI expertise — exactly the "security awareness" level appropriate for team members who work with production clusters.
-   </details>
+For example, if the API server receives and authorizes requests, then weak authentication, broad authorization, and exposed endpoints are natural risks. If etcd stores cluster state, then access to etcd can expose sensitive objects and undermine the cluster's source of truth. If kubelet runs work on a node, then kubelet access and node permissions matter because attackers may try to move from workload compromise toward node control. If the runtime starts containers, then image trust, privilege settings, and isolation boundaries become part of the risk story.
 
-5. **A KCSA exam question asks about a security concept you've never encountered. You can eliminate two of the four options. What reasoning approach should you use to choose between the remaining two?**
-   <details>
-   <summary>Answer</summary>
-   Apply core security principles: choose the option that follows least privilege (most restrictive access), defense in depth (multiple layers), or default-deny (block unless explicitly allowed). KCSA questions are designed to test security thinking, so the "more secure" option that limits exposure is usually correct. Also consider which C layer (Cloud, Cluster, Container, Code) the question targets — the answer should address the correct layer.
-   </details>
+This is the level of explanation you should expect from yourself before moving a topic from yellow to green. Green does not mean you can recite every configuration flag. It means you can orient the component, name a realistic failure, identify the control family, and explain why a tempting unrelated control would not be enough. That standard is demanding enough to support KCSA success and still realistic for an associate-level learner at the start of the curriculum. It also gives later hands-on practice a clear purpose instead of turning labs into disconnected command repetition.
 
----
+## Building a Readiness and Study Plan
 
-## Curriculum Structure
+Designing a study plan for KCSA starts with the domain weights but should not end there. The two 22% domains deserve the most time because they cover the cluster components and security fundamentals that support nearly every later scenario. The 16% threat model and 16% platform security domains deserve steady attention because they convert isolated controls into attack-path reasoning and delivery-system thinking. The 14% cloud native security domain gives the outer architecture model, while the 10% compliance domain teaches the evidence language that makes security durable inside organizations.
 
-This curriculum follows the exam domains:
+A practical first pass is to divide your preparation into three loops. The orientation loop maps each domain to its purpose and key vocabulary. The reasoning loop uses scenarios to connect a threat to a control and a control to a tradeoff. The assessment loop checks whether you can explain your answer without relying on recognition alone. If you cannot explain why the wrong options are wrong, you probably have memorized a phrase rather than learned a security concept.
+
+The original curriculum structure remains a useful guide because it mirrors the exam domains. Part 0 sets the security mindset and exam approach. Part 1 introduces cloud native security and the 4 Cs. Part 2 moves into cluster component security. Part 3 covers the fundamentals you will use constantly, including RBAC, Secrets, Pod Security, and NetworkPolicies. Part 4 shifts into threat modeling and attack surfaces. Part 5 addresses platform controls. Part 6 closes with compliance frameworks and assessment.
 
 | Part | Domain | Weight | Modules |
 |------|--------|--------|---------|
@@ -309,24 +263,173 @@ This curriculum follows the exam domains:
 | 5 | Platform Security | 16% | Images, admission, runtime, audit |
 | 6 | Compliance Frameworks | 10% | CIS, NIST, assessment |
 
----
+For a short preparation window, prioritize by both weight and dependency. Study Cluster Component Security early because control plane, node, network, and storage concepts make later attack surfaces understandable. Study Security Fundamentals early because RBAC, Secrets, Pod Security Admission, and NetworkPolicies appear in many practical scenarios. Then rotate through Threat Model and Platform Security with examples that show how attacks move through real systems. Keep Cloud Native Security and Compliance in the schedule as smaller recurring reviews, because vocabulary like shared responsibility, 4 Cs, CIS Benchmarks, NIST, and assessment evidence becomes much easier when revisited often.
 
-## Summary
+One useful study artifact is a domain ledger. For each domain, write three columns: "what can fail," "which control helps," and "how I would prove it." A row for Secrets might say that sensitive values can be exposed through broad API access or pod mounts, RBAC and encryption at rest help reduce the risk, and evidence may include role reviews, encryption configuration, and workload manifests. That simple table forces the same concept-threat-defense-compliance connection that KCSA questions often test.
 
-**KCSA validates your security knowledge** for Kubernetes and cloud native:
+Another useful artifact is a confidence map, because KCSA rewards honest self-assessment more than optimistic scheduling. Mark each domain red, yellow, or green based on whether you can explain a realistic scenario without notes. Red means the vocabulary itself is weak. Yellow means you recognize the terms but cannot confidently choose between controls. Green means you can explain the threat, choose a defense, reject tempting alternatives, and describe a reasonable study or operational next step.
 
-- **Format**: 90 minutes, ~60 multiple choice, 75% to pass
-- **Focus**: Security concepts, threats, and defenses
-- **Biggest domains**: Cluster Components (22%) and Security Fundamentals (22%)
-- **Study approach**: Understand threats, know defenses, think in layers
+Which approach would you choose here and why: equal time for every domain, or weighted time with a recurring review slot for lower-weight domains? Weighted time is usually better because 22% domains matter more, but the recurring slot prevents a common failure where candidates treat 10% compliance as expendable and then lose easy questions that would have been cheap to retain.
 
-**KCSA prepares you for CKS**:
-- Learn the "why" before the "how"
-- Understand threats before configuring defenses
-- Build security intuition through concepts
+## Patterns & Anti-Patterns
 
----
+Because this is an introductory module, the most important pattern is to study KCSA as applied security reasoning rather than as a glossary. The exam is multiple choice, but the best preparation is still active: read a concept, place it in the 4 Cs or one of the six domains, imagine a failure, name the control that reduces that failure, and explain the tradeoff. That rhythm turns a large curriculum into a repeatable diagnostic process.
+
+| Pattern | When to Use It | Why It Works | Scaling Consideration |
+|---------|----------------|--------------|-----------------------|
+| Domain-weighted study | You have limited time and need a rational plan | High-weight domains receive enough attention while lower-weight domains stay visible | Review the plan after each practice set, not only at the start |
+| Threat-to-control mapping | A concept feels abstract or disconnected | It forces you to explain why a defense exists and what risk remains | Reuse the same map later for RBAC, Secrets, admission, and audit logging |
+| Explain wrong answers | Practice questions feel too easy | KCSA distractors often sound secure, so rejecting them builds precision | Track repeated wrong-answer patterns as readiness gaps |
+| Light command anchoring | Concepts feel theoretical | Seeing real resources such as service accounts and role bindings makes scenarios concrete | Use commands for recognition, then return to reasoning instead of drilling syntax |
+
+The matching anti-pattern is to treat KCSA as either trivia or a miniature CKS. Trivia study produces brittle recall, because it cannot handle scenario wording that changes the surface details. Mini-CKS study burns time on implementation detail before the learner understands why a control matters. Both approaches can feel productive because they produce notes, flashcards, or terminal output, but they may not improve the judgment that a security associate certification is designed to validate.
+
+| Anti-Pattern | What Goes Wrong | Better Alternative |
+|--------------|-----------------|--------------------|
+| Memorizing acronyms alone | You recognize terms but cannot choose controls in scenarios | Pair every acronym with one threat and one defensive decision |
+| Ignoring lower-weight domains | You lose relatively easy points and miss context for controls | Give lower-weight domains shorter, recurring review blocks |
+| Starting with CKS labs only | Command practice hides conceptual gaps | Learn the concept first, then inspect simple resources with `k` |
+| Treating compliance as paperwork | You miss why benchmarks and frameworks shape real security work | Connect each framework idea to evidence a team could produce |
+
+## When You'd Use This vs Alternatives
+
+Use KCSA when you need a vendor-neutral security foundation for Kubernetes and cloud native systems, especially if your work touches production clusters but does not require immediate hands-on hardening certification. Use KCNA when the main gap is broader Kubernetes and cloud native literacy rather than security specialization. Use CKS when you already have an active CKA, can operate Kubernetes from the command line, and need to demonstrate implementation skill for controls such as admission, runtime security, supply chain hardening, and cluster hardening tasks.
+
+| Goal | Better Fit | Reason |
+|------|------------|--------|
+| Learn general Kubernetes and cloud native concepts | KCNA | It covers broader foundations before security specialization |
+| Validate baseline cloud native security knowledge | KCSA | It focuses on security concepts, threats, controls, and frameworks |
+| Prove hands-on Kubernetes security implementation | CKS | It tests live cluster work and requires active CKA |
+| Align a mixed team around security vocabulary | KCSA | It gives developers, auditors, and operators a shared model |
+| Prepare for deeper security labs later | KCSA then CKS | The conceptual sequence makes implementation choices less mechanical |
+
+The decision is not about prestige. It is about the evidence you need and the work you are preparing to do. A developer who reviews manifests may get immediate value from KCSA because they will spot risky service accounts, privileged pod settings, or missing traffic boundaries earlier. A platform engineer responsible for enforcement will eventually need CKS-level practice because knowing the safer answer is not the same as implementing it correctly. A compliance specialist may not need CKS at all, but KCSA can make audit conversations more concrete and less checklist-driven.
+
+## Did You Know?
+
+- **The KCSA public curriculum weights two domains at 22% each.** Cluster Component Security and Kubernetes Security Fundamentals together make up 44% of the exam blueprint, which is why this course gives them sustained attention.
+- **The official Linux Foundation KCSA page lists 90 minutes and no prerequisites.** That makes KCSA accessible before CKA or CKS, but it also means the exam must test security reasoning without assuming deep administrator experience.
+- **The current public certification page lists KCSA validity as 2 years.** Older notes may say 3 years, so exam logistics should be checked against the official page before scheduling.
+- **Kubernetes 1.35 documentation still emphasizes layered controls.** RBAC, Secrets protection, Pod Security Standards, NetworkPolicy, admission policy, and audit logging appear across the official security guidance because no single control covers the full attack path.
+
+## Common Mistakes
+
+| Mistake | Why It Happens | How to Fix It |
+|---------|----------------|---------------|
+| Focusing on commands instead of concepts | Learners see Kubernetes and assume every certification is CLI-heavy like CKS | Study what each control protects and why it is selected before drilling syntax |
+| Ignoring the threat model domain | Attack-path language feels less concrete than RBAC or Secrets | For every control, write the attacker behavior it is meant to interrupt |
+| Skipping compliance because it is 10% | The domain looks small compared with the two 22% domains | Learn the basic purpose of CIS, NIST, benchmarks, assessments, and evidence |
+| Not connecting concepts across domains | The curriculum is divided into sections, but incidents cross those boundaries | Practice scenarios that combine identity, network, workload, platform, and evidence |
+| Rushing through subtle wording | Multiple-choice questions can include several security-sounding options | Read for the exact asset, threat, layer, and constraint before choosing |
+| Treating KCSA as a miniature CKS | Hands-on labs feel more concrete than conceptual review | Use light `k` inspection for anchoring, then return to scenario reasoning |
+| Trusting stale exam logistics | Blog posts and old notes can outlive policy changes | Verify duration, validity, prerequisites, and curriculum links on official pages |
+
+## Quiz
+
+<details><summary>A colleague holds a CKA certification and asks whether they should skip KCSA and go straight to CKS. What would you advise, and why?</summary>
+
+It depends on the gap they are trying to close. CKS is the right target if they already understand Kubernetes security concepts and need to prove hands-on implementation skill, but KCSA is useful when their security vocabulary, threat modeling, and compliance understanding are uneven. The fact that they hold CKA means they satisfy a CKS prerequisite, not that they automatically understand the KCSA security domains. A strong recommendation is to compare their current knowledge against the KCSA domains, then choose KCSA first if they cannot explain the why behind the controls they would configure in CKS.
+
+</details>
+
+<details><summary>You have 90 minutes and about 60 multiple-choice questions on exam day. After 45 minutes you have answered 25 questions. Should you be worried, and what strategy would you apply?</summary>
+
+You are slightly behind a simple even-time pace, so you should adjust without panicking. The safer strategy is to move through a first pass answering questions you can reason through confidently, mark questions where two options remain plausible, and return later instead of letting one scenario consume too much time. KCSA rewards careful reading, but careful does not mean slow on every item. The goal is to collect the points your preparation has made available while preserving time for the questions that need deeper elimination.
+
+</details>
+
+<details><summary>The two highest-weighted KCSA domains together account for 44% of the blueprint. A study group member suggests ignoring the 10% Compliance Frameworks domain entirely. Is this a sound study plan?</summary>
+
+No, because domain weight should guide time allocation, not create blind spots. Compliance questions are a smaller share, but they are often conceptually approachable if you learn the vocabulary of frameworks, benchmarks, assessments, and evidence. Ignoring the domain also weakens your ability to explain why technical controls matter to organizations. A better study plan gives the 22% domains the largest blocks while reviewing compliance briefly and repeatedly so those points remain available.
+
+</details>
+
+<details><summary>Your team wants every developer who touches production manifests to understand Kubernetes security basics before a new cluster launch. Which certification path is the best fit: KCNA, KCSA, or CKS?</summary>
+
+KCSA is the best fit for that team goal. KCNA is valuable for broad Kubernetes and cloud native literacy, but it does not focus deeply enough on security threats and defenses. CKS is powerful but too implementation-heavy for a shared baseline, and it requires active CKA. KCSA sits in the middle by validating the security reasoning developers need when they review service accounts, pod settings, Secrets, image sources, and traffic boundaries.
+
+</details>
+
+<details><summary>A practice question describes a pod that runs as root, sets hostPID, mounts a host path, and uses a broad service account. Which reasoning path should guide your answer?</summary>
+
+Start by separating workload privilege from API privilege. Running as root, using hostPID, and mounting host paths point toward Pod Security Standards, security contexts, and admission controls because the workload is being allowed dangerous access to the node. The broad service account points toward RBAC and least privilege because the workload may also abuse Kubernetes API permissions. The best answer is likely the one that addresses both the dangerous pod configuration and the identity scope, rather than a control that only sounds generally secure.
+
+</details>
+
+<details><summary>An exam item asks about a security concept you have not seen before, but you can eliminate two of four options. How should you choose between the remaining two?</summary>
+
+Use the core security principles that appear across the KCSA domains. Prefer the option that narrows access, verifies identity, reduces exposed paths, separates duties, or adds a layer that directly matches the described threat. Also check which layer is being discussed: cloud, cluster, container, or code. If one remaining answer protects the wrong layer, the more precise answer is usually the safer choice even if both sound security-related.
+
+</details>
+
+<details><summary>You diagnose your readiness and find that you recognize RBAC, Secrets, NetworkPolicy, and Pod Security Standards, but you cannot explain how they work together in an incident. What should your next study task be?</summary>
+
+Your next task should be a threat-to-control map rather than another glossary pass. Write a short scenario where a vulnerable workload is compromised, then map which control limits API access, which control limits network movement, which control limits dangerous pod settings, and which evidence would show the controls are present. This directly supports the KCSA outcome of diagnosing readiness gaps across domains. It also turns familiar terms into applied reasoning, which is what scenario-based questions tend to test.
+
+</details>
+
+<details><summary>You need to design a final-week study plan after scoring well on Cloud Native Security but poorly on Cluster Component Security and Security Fundamentals. What should change?</summary>
+
+Shift the largest study blocks toward the two weak, high-weight domains while preserving shorter review sessions for the domains you already know. Cluster Component Security and Security Fundamentals are both weighted heavily and support many other security scenarios, so poor results there are more urgent than a weak low-weight topic would be. Do not abandon Cloud Native Security completely; use brief review to maintain it. A proportionate plan fixes the highest-risk gaps without creating new ones.
+
+</details>
+
+## Hands-On Exercise: Build Your KCSA Readiness Map
+
+This exercise is intentionally lightweight because Module 0.1 is about orientation, not deep cluster administration. You can complete it with a notebook, a markdown file, or a spreadsheet. If you have access to a Kubernetes 1.35 or newer practice cluster, the optional `k` commands can help connect terms to real resources, but the main deliverable is your reasoning map.
+
+### Setup
+
+Create a simple document with four columns: domain, what can fail, which control helps, and how I would prove it. Add one row for each KCSA domain before you look at the solution. The point is not to produce a perfect answer on the first attempt. The point is to make your current model visible so later modules can improve it.
+
+### Tasks
+
+- [ ] Evaluate the KCSA exam format, domain weights, and certification fit by writing a three-sentence explanation of why you are taking KCSA instead of, before, or after KCNA or CKS.
+- [ ] Compare KCSA, KCNA, and CKS in your own words, including one sentence about what KCSA validates that the other two do not emphasize in the same way.
+- [ ] Diagnose readiness gaps by rating each of the six KCSA domains red, yellow, or green and writing the evidence for that rating.
+- [ ] Design a two-week study plan that gives the two 22% domains the largest time blocks while scheduling recurring review for the 10% Compliance Frameworks domain.
+- [ ] Map one realistic Kubernetes incident scenario across at least three domains, such as broad service account permissions, missing NetworkPolicies, and weak pod security settings.
+- [ ] Verify your plan against the curriculum structure table and adjust any week where a lower-weight domain has disappeared completely.
+
+### Optional Cluster Anchoring
+
+If you have a non-production practice cluster and the `k` alias is configured, inspect harmless metadata to connect the overview to real Kubernetes objects. These commands are not required for KCSA success, and they should not be run against a production cluster just to complete an introductory exercise.
+
+```bash
+k get namespaces
+k get serviceaccounts -A | head
+k auth can-i list secrets --all-namespaces
+```
+
+<details><summary>Solution guide</summary>
+
+A strong readiness map does not claim equal confidence everywhere. It identifies the high-weight domains, names the specific weak areas, and connects each weak area to a study action. For example, a learner might mark Cluster Component Security yellow because they can name the API server and etcd but cannot explain kubelet or client security, then schedule two focused sessions before moving to threat modeling. A strong study plan also keeps Compliance Frameworks visible even though it is lower weight, because a small recurring review is enough to retain framework vocabulary and protect easy points.
+
+</details>
+
+### Success Criteria
+
+- [ ] Your certification comparison clearly states when KCSA is a better fit than KCNA or CKS.
+- [ ] Your readiness ratings cover all six KCSA domains and include evidence rather than guesses.
+- [ ] Your study plan gives extra time to Cluster Component Security and Security Fundamentals without deleting lower-weight domains.
+- [ ] Your incident map connects at least one threat, one Kubernetes control, and one form of evidence.
+- [ ] Your notes avoid stale logistics by marking official exam details for verification before scheduling.
+
+## Sources
+
+- [Linux Foundation Training: Kubernetes and Cloud Native Security Associate](https://training.linuxfoundation.org/certification/kubernetes-and-cloud-native-security-associate-kcsa/)
+- [CNCF curriculum repository: KCSA Curriculum](https://github.com/cncf/curriculum/blob/master/KCSA%20Curriculum.pdf)
+- [Linux Foundation Candidate Handbook](https://docs.linuxfoundation.org/tc-docs/certification/lf-handbook2)
+- [Kubernetes 1.35 Security Concepts](https://v1-35.docs.kubernetes.io/docs/concepts/security/)
+- [Kubernetes 1.35 Pod Security Standards](https://v1-35.docs.kubernetes.io/docs/concepts/security/pod-security-standards/)
+- [Kubernetes 1.35 RBAC Authorization](https://v1-35.docs.kubernetes.io/docs/reference/access-authn-authz/rbac/)
+- [Kubernetes 1.35 Secrets](https://v1-35.docs.kubernetes.io/docs/concepts/configuration/secret/)
+- [Kubernetes 1.35 Network Policies](https://v1-35.docs.kubernetes.io/docs/concepts/services-networking/network-policies/)
+- [Kubernetes 1.35 Auditing](https://v1-35.docs.kubernetes.io/docs/tasks/debug/debug-cluster/audit/)
+- [Kubernetes 1.35 Securing a Cluster](https://v1-35.docs.kubernetes.io/docs/tasks/administer-cluster/securing-a-cluster/)
+- [Kubernetes 1.35 Admission Controllers](https://v1-35.docs.kubernetes.io/docs/reference/access-authn-authz/admission-controllers/)
+- [Kubernetes 1.35 Images](https://v1-35.docs.kubernetes.io/docs/concepts/containers/images/)
 
 ## Next Module
 
-[Module 0.2: Security Mindset](../module-0.2-security-mindset/) - How to think like a security professional and approach security questions strategically.
+[Module 0.2: Security Mindset](../module-0.2-security-mindset/) - Learn how to think like a security professional, reason from attacker behavior to defensive controls, and approach KCSA scenarios with sharper judgment.


### PR DESCRIPTION
Verifier: T0; body_words=5005, mean_wpp=80.7, median_wpp=83.0, short_rate=0.016, max_run=1, mean_sentence_length=20.8. Sources reachability was skipped per verifier command; sources_min_10 passed with 12 URLs.

Protected assets preserved: before = 3 ASCII code-fence diagrams, 4 markdown tables, 0 source URLs; after = the same 3 original ASCII diagrams retained, 6 code blocks total, 8 markdown tables total, 12 source URLs. Verifier protected_assets reports code_blocks=6, ascii_diagrams=0 by heuristic, mermaid_diagrams=0, tables=8.

Checks run:
- PRIMARY=... .venv/bin/python scripts/quality/verify_module.py --glob src/content/docs/k8s/kcsa/part0-introduction/module-0.1-kcsa-overview.md --skip-source-check --summary --quiet: T0
- git diff --check -- target module: clean
- forbidden-token scan: no matches
- .venv/bin/python scripts/test_pipeline.py: 166 tests OK
- npm run build from primary checkout via temporary build branch: passed

Commit SHA: dcc7caf34d28116989a43a17f6e9bce200e21671