### PR TITLE
feat(388): rewrite module-3.8-ai-ml-cloud-native (#388 pilot)

### DIFF
--- a/src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.8-ai-ml-cloud-native.md
+++ b/src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.8-ai-ml-cloud-native.md
@@ -414,7 +414,7 @@ spec:
 
 ### Step 1: Start with the controller, then inspect the Pod
 
-A beginner often starts by changing YAML immediately, but a stronger habit is to inspect what Kubernetes created. The Deployment owns a ReplicaSet, and the ReplicaSet owns Pods. If the Deployment has unavailable replicas, the next useful evidence is usually the Pod status and events, and the following commands show the controller view before the Pod-level view.
+A beginner often starts by changing YAML immediately, but a stronger habit is to inspect what Kubernetes created. The Deployment owns a ReplicaSet, and the ReplicaSet owns Pods. If the Deployment has unavailable replicas, inspect the controller first and then move to the Pod status and scheduler events.
 
 ```bash
 k get deployment image-ranker
@@ -431,7 +431,7 @@ NAME                             READY   STATUS    RESTARTS   AGE
 image-ranker-6c9d7f8d9b-hp2lm    0/1     Pending   0          2m
 ```
 
-Pending means the container has not started. That is different from CrashLoopBackOff, where the Pod was scheduled and a container started but failed. For scheduling problems, the `describe pod` output is the main source of truth because it includes scheduler events, and the event in this scenario names the missing extended resource directly.
+Pending means the container has not started. That is different from CrashLoopBackOff, where the Pod was scheduled and a container started but failed. For scheduling problems, the `describe pod` output is the main source of truth because it includes scheduler events. In this scenario, the event names the missing extended resource directly.
 
 ```bash
 k describe pod -l app=image-ranker
@@ -450,7 +450,7 @@ Events:
 
 The scheduler says it cannot find enough `nvidia.com/gpu` capacity. That does not prove the cluster has no physical GPU. It proves the Kubernetes scheduler does not currently see allocatable free capacity for that resource. The cause could be missing device plugin, no GPU nodes, a consumed GPU, a node taint without toleration, or node affinity that excludes the right node.
 
-The next command checks whether any node advertises GPU capacity. If no node shows `nvidia.com/gpu` under allocatable resources, the problem is lower than the workload manifest. The platform team needs to confirm GPU nodes, drivers, and the device plugin, while a healthy GPU node would include a line like the one shown below somewhere under `Allocatable`.
+The next command checks whether any node advertises GPU capacity. If no node shows `nvidia.com/gpu` under allocatable resources, the problem is lower than the workload manifest. The platform team needs to confirm GPU nodes, drivers, and the device plugin. A healthy GPU node includes a line like the one shown below under `Allocatable`.
 
 ```bash
 k describe nodes | grep -A5 -E "Name:|Allocatable:"
@@ -464,7 +464,7 @@ If no such line appears, deploying more model replicas will not help. The schedu
 
 ### Step 3: Check whether the workload is missing placement rules
 
-Suppose a node does advertise `nvidia.com/gpu`, but the Pod is still Pending. The next useful question is whether the node has taints that repel ordinary Pods. GPU nodes are commonly tainted because they are expensive, and the platform team wants only GPU-aware workloads to land there, so the following command checks the taint policy before you change the Deployment.
+Suppose a node does advertise `nvidia.com/gpu`, but the Pod is still Pending. The next useful question is whether the node has taints that repel ordinary Pods. GPU nodes are commonly tainted because they are expensive, and the platform team wants only GPU-aware workloads to land there. Check the taint policy before changing the Deployment.
 
 ```bash
 k describe node gpu-node-1 | grep -A4 Taints

--- a/src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.8-ai-ml-cloud-native.md
+++ b/src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.8-ai-ml-cloud-native.md
@@ -3,7 +3,10 @@ title: "Module 3.8: AI/ML on Cloud Native Infrastructure"
 slug: k8s/kcna/part3-cloud-native-architecture/module-3.8-ai-ml-cloud-native
 sidebar:
   order: 9
+revision_pending: false
 ---
+
+# Module 3.8: AI/ML on Cloud Native Infrastructure
 
 > **Complexity**: `[MEDIUM]` - Cloud native architecture and workload design
 >
@@ -11,19 +14,15 @@ sidebar:
 >
 > **Prerequisites**: Module 3.1 (Cloud Native Principles), Module 3.3 (Cloud Native Patterns), basic familiarity with Pods, Deployments, Jobs, and scheduling
 
----
-
 ## What You'll Be Able to Do
 
-After completing this module, you will be able to:
+After completing this module, you will be able to make architecture and operations decisions for AI/ML workloads that run on Kubernetes 1.35 or newer, including selecting the right workload controller, validating accelerator scheduling, and explaining the trade-offs behind self-hosted model serving.
 
 1. **Apply** Kubernetes resource and scheduling concepts to choose appropriate runtime patterns for AI/ML training, fine-tuning, batch inference, and real-time inference workloads.
 2. **Compare** GPU-enabled Kubernetes components such as device plugins, node labels, taints, autoscaling, and specialized schedulers in realistic platform design scenarios.
 3. **Design** a basic cloud native serving architecture for a model endpoint that balances privacy, latency, scaling behavior, and operational responsibility.
 4. **Debug** common AI/ML scheduling failures by reading Pod status, scheduler events, node capacity, and accelerator resource requests.
-5. **Evaluate** when ecosystem tools such as Kubeflow, KServe, Ray, vLLM, GPU Operator, and Volcano fit the problem instead of treating every model workload as an ordinary web service.
-
----
+5. **Evaluate** ecosystem tools such as Kubeflow, KServe, Ray, vLLM, GPU Operator, and Volcano by matching each tool to a concrete lifecycle problem, assessment item, or hands-on troubleshooting task instead of treating every model workload as an ordinary web service.
 
 ## Why This Module Matters
 
@@ -33,7 +32,7 @@ That failure is common because AI/ML workloads look familiar from a distance but
 
 KCNA does not expect you to become a machine learning engineer or install every tool in the ecosystem. It does expect you to reason about why Kubernetes is used for AI/ML, how accelerators become schedulable resources, why training and inference need different workload patterns, and how cloud native practices apply to systems that may cost more per hour than the rest of the cluster combined. This module builds that reasoning step by step, starting with the platform problem and ending with a hands-on scheduler investigation.
 
----
+The practical lesson is that AI/ML infrastructure fails at the boundary between application thinking and platform thinking. A model developer may correctly say that the code needs a GPU, while the scheduler only sees a Pod that requests an extended resource, a set of node labels, a possible taint, and a queue of other workloads competing for capacity. The useful platform engineer translates between those views without pretending the model is magic. That translation is why this module spends as much time on workload shape, rollout safety, and evidence-driven debugging as it spends on the accelerator name itself.
 
 ## 1. Kubernetes Is Useful for AI/ML Because It Coordinates Scarce Infrastructure
 
@@ -79,7 +78,9 @@ A useful mental model is to separate Kubernetes into two layers. The core platfo
 
 The answer is that the Pod can only run where the requested extended resource is available. If the GPU is already allocated, the Pod remains Pending because GPU resources are non-compressible. CPU can sometimes be oversubscribed and throttled, but a Pod that requests an integer GPU either receives the device or it does not start.
 
----
+That non-compressible property changes how you evaluate capacity. A CPU-heavy Deployment might limp along while throttled, which gives an operator time to add nodes or tune requests. A GPU-bound inference replica that cannot receive a device does not become a slower replica; it never starts, and the Service has no additional endpoint to receive traffic. This distinction is especially important during autoscaling because an HPA can create more Pods faster than the cluster can create accelerator nodes, download drivers, start the device plugin, pull a large model image, and warm the model server.
+
+Cloud native AI/ML platforms therefore need a capacity story before they need a tool story. The team should know which namespaces are allowed to consume accelerators, which node groups contain which GPU models, whether production inference can preempt experimental training, and which metrics prove that a model endpoint is healthy. Kubernetes gives you the vocabulary for those decisions, but it does not decide the business priority. If an expensive node pool is shared by researchers, notebooks, batch scoring jobs, and customer-facing inference, policy is part of the architecture rather than a governance document someone reads after an outage.
 
 ## 2. How GPUs Become Schedulable Kubernetes Resources
 
@@ -153,7 +154,9 @@ spec:
 
 Notice the separation of concerns in this Deployment. The `nodeSelector` and toleration steer the Pod toward the GPU node group, while the GPU limit reserves the accelerator. CPU and memory requests tell the scheduler how much ordinary capacity the Pod needs, and the memory limit prevents one model server from exhausting the node. This is the kind of combined reasoning KCNA expects: not just naming a feature, but applying several platform mechanisms together.
 
----
+The resource request also becomes an operational contract between the application team and the platform team. If the platform exposes full GPUs, the application asks for full GPUs and pays the scheduling cost of exclusive allocation. If the platform exposes MIG slices or time-sliced resources, the application may request smaller advertised resources, but the team must understand the isolation and performance trade-off. A manifest that says `nvidia.com/gpu: 1` is not just syntax; it is a claim about hardware, accounting, and failure behavior.
+
+War story: a team once moved a prototype image classifier from a single development node to a shared cluster and kept the same `nodeSelector` but accidentally dropped the GPU limit during a chart refactor. The Pod still landed on the GPU node because the selector matched, so the deployment looked correct during a quick review. Under load, the container failed when the model runtime could not find an assigned device, and ordinary CPU workloads also started landing on the expensive node because the taint policy was inconsistent. The fix was not one magic label; the fix was to make selectors, taints, tolerations, and extended resource requests tell the same story.
 
 ## 3. Training, Fine-Tuning, Batch Inference, and Real-Time Inference Are Different Workloads
 
@@ -214,7 +217,9 @@ Batch inference sits between those two patterns. It uses a trained model to scor
 
 A good answer chooses a Job or workflow task because the process has a clear end condition. A Deployment would keep restarting the classifier after it finishes, and a DaemonSet would run one copy on every matching node whether or not the data pipeline needs that. The decision comes from workload shape, not from the fact that a model is involved.
 
----
+When you design these workloads, start by writing the sentence "success means..." before you write the YAML. For training, success means the run completes and produces a model artifact, metrics, or checkpointed state. For batch inference, success means every input item is scored once, failures are retryable, and duplicate output is controlled. For real-time inference, success means the endpoint stays available, latency remains inside the service objective, and rollouts do not send traffic to cold or incompatible replicas. Those success definitions naturally point to different controllers, probes, autoscaling signals, and storage patterns.
+
+Fine-tuning deserves its own judgment because it often feels small enough to improvise yet expensive enough to cause platform tension. A team adapting a pretrained model may need fewer GPUs than a full training run, but it still needs repeatability, dataset access, checkpointing, and clear ownership of output artifacts. If every fine-tune is launched by hand from a privileged notebook, the organization will struggle to answer which data was used, which image produced the weights, and whether the result can be reproduced. Kubernetes Jobs, workflow systems, or training operators are not bureaucracy in that situation; they are the audit trail that makes a useful experiment promotable.
 
 ## 4. Distributed Training Needs Scheduling Guarantees That Default Kubernetes May Not Provide
 
@@ -251,7 +256,9 @@ Distributed training also makes storage and networking more important. Workers m
 
 Priorities and quotas matter because GPU clusters are shared. A research notebook, a production inference endpoint, and a training run should not all compete without policy. ResourceQuota, PriorityClass, queueing systems, and separate node pools are ways to express business intent. The platform should answer questions such as "Can an experiment preempt production inference?" and "How many GPUs can one namespace consume?" before a traffic spike or training deadline forces the issue.
 
----
+Default scheduling is still valuable, and the point is not that every AI/ML workload needs a custom scheduler. A single-replica model endpoint, a small batch scoring Job, or a CPU-only preprocessing stage may work perfectly with normal Kubernetes scheduling. The architectural skill is recognizing when independent Pod placement becomes the wrong abstraction. If the useful unit of work is "all workers in this training gang," then queue admission should happen at that unit. If the useful unit is "one independent scorer per data shard," ordinary Job parallelism may be enough.
+
+Storage can be the hidden constraint after scheduling succeeds. A training job that starts all workers but reads a multi-terabyte dataset through an overloaded network path may waste GPU hours waiting on data. A batch inference job that writes results without idempotency may create duplicate rows after retries. A model server that downloads weights from object storage on every start may create slow rollouts and noisy dependency failures. The platform decision is therefore broader than "GPU or no GPU"; it includes data locality, checkpoint location, restart behavior, and whether the workload can resume from an interrupted state.
 
 ## 5. Model Serving Adds Latency, Rollout, and Privacy Trade-Offs
 
@@ -323,7 +330,11 @@ spec:
 
 This Deployment teaches two subtle points. First, readiness is about serving capability, not container existence. Second, resource limits and probes must match the model's real behavior. If the model takes four minutes to load but the startup probe gives it only one minute, Kubernetes will create a crash loop even though the image and code are correct.
 
----
+Rollouts are another place where ordinary web-service habits need adjustment. A small API can often start in seconds, accept traffic quickly, and roll back with little cost. A large model server may need to pull gigabytes of image layers or model weights, allocate GPU memory, compile kernels, and warm request caches before the first useful prediction. If the Deployment strategy allows too many old replicas to terminate before new replicas are truly ready, the system can lose serving capacity during an otherwise routine release. Readiness gates, conservative surge settings, and clear rollback criteria are part of the serving architecture, not optional polish.
+
+Privacy and compliance also affect the architecture in ways that Kubernetes cannot solve alone. Self-hosting keeps data inside controlled infrastructure only if the surrounding system respects that boundary: logs must not leak prompts, traces must avoid sensitive payloads, access controls must protect model endpoints, and storage paths must follow retention rules. The Kubernetes pieces, such as Secrets, NetworkPolicy, service accounts, namespaces, and audit logs, are enabling mechanisms. They become a privacy design only when the team defines what data may cross which boundary and verifies that every component follows the rule.
+
+Before running this in a real platform, what output would convince you that the model endpoint is ready for users rather than merely alive as a process? A strong answer names evidence from several layers: the Pod is Running, the readiness endpoint reports loaded model state, the Service has ready endpoints, latency metrics are within target, GPU memory is allocated as expected, and a synthetic prediction succeeds. That evidence chain prevents a common failure where an operator sees a green Pod and misses the fact that the model server is still warming or rejecting requests.
 
 ## 6. Ecosystem Tools Solve Different Parts of the AI/ML Lifecycle
 
@@ -362,7 +373,9 @@ KServe focuses on model serving. It provides abstractions for inference services
 
 A practical answer might start with a Job for retraining and a Deployment or KServe-based inference endpoint, then add Kubeflow only when repeated workflows, notebooks, or multi-team standardization justify the overhead. Tool selection should follow workflow pain. Installing a large platform before the team has a lifecycle problem can create more work than it removes.
 
----
+The same reasoning applies to GPU operations tools. The NVIDIA GPU Operator can simplify driver, runtime, monitoring, and device plugin management, especially across multiple node pools or managed environments with repeatable setup needs. It is not a substitute for understanding what the device plugin advertises, what the scheduler sees, or how the workload requests a resource. If a Pod is Pending with `Insufficient nvidia.com/gpu`, the operator may be part of the repair path, but the debugging question remains evidence-driven: do nodes exist, do they advertise allocatable GPU resources, are those resources already allocated, and are placement policies compatible with the Pod?
+
+Large language model serving adds another dimension because runtime choice affects capacity as much as Kubernetes configuration. Engines such as vLLM improve throughput through batching and memory management strategies, but those optimizations still live inside a Pod that needs GPU capacity, readiness behavior, observability, and rollout control. A team that tunes the runtime but ignores Kubernetes scheduling may still fail to scale. A team that writes perfect Kubernetes YAML but chooses an unsuitable serving runtime may burn GPU hours on poor batching. The platform design has to connect both layers.
 
 ## 7. Worked Example: Debug a Pending GPU Inference Deployment
 
@@ -401,14 +414,14 @@ spec:
 
 ### Step 1: Start with the controller, then inspect the Pod
 
-A beginner often starts by changing YAML immediately, but a stronger habit is to inspect what Kubernetes created. The Deployment owns a ReplicaSet, and the ReplicaSet owns Pods. If the Deployment has unavailable replicas, the next useful evidence is usually the Pod status and events.
+A beginner often starts by changing YAML immediately, but a stronger habit is to inspect what Kubernetes created. The Deployment owns a ReplicaSet, and the ReplicaSet owns Pods. If the Deployment has unavailable replicas, the next useful evidence is usually the Pod status and events, and the following commands show the controller view before the Pod-level view.
 
 ```bash
 k get deployment image-ranker
 k get pods -l app=image-ranker
 ```
 
-Example output:
+The output below shows a healthy controller object with no available replica because the only created Pod is still Pending.
 
 ```text
 NAME            READY   UP-TO-DATE   AVAILABLE   AGE
@@ -418,13 +431,13 @@ NAME                             READY   STATUS    RESTARTS   AGE
 image-ranker-6c9d7f8d9b-hp2lm    0/1     Pending   0          2m
 ```
 
-Pending means the container has not started. That is different from CrashLoopBackOff, where the Pod was scheduled and a container started but failed. For scheduling problems, the `describe pod` output is the main source of truth because it includes scheduler events.
+Pending means the container has not started. That is different from CrashLoopBackOff, where the Pod was scheduled and a container started but failed. For scheduling problems, the `describe pod` output is the main source of truth because it includes scheduler events, and the event in this scenario names the missing extended resource directly.
 
 ```bash
 k describe pod -l app=image-ranker
 ```
 
-Example event:
+The scheduler event below is the critical clue because it describes node availability from the scheduler's perspective.
 
 ```text
 Events:
@@ -437,13 +450,11 @@ Events:
 
 The scheduler says it cannot find enough `nvidia.com/gpu` capacity. That does not prove the cluster has no physical GPU. It proves the Kubernetes scheduler does not currently see allocatable free capacity for that resource. The cause could be missing device plugin, no GPU nodes, a consumed GPU, a node taint without toleration, or node affinity that excludes the right node.
 
-The next command checks whether any node advertises GPU capacity. If no node shows `nvidia.com/gpu` under allocatable resources, the problem is lower than the workload manifest. The platform team needs to confirm GPU nodes, drivers, and the device plugin.
+The next command checks whether any node advertises GPU capacity. If no node shows `nvidia.com/gpu` under allocatable resources, the problem is lower than the workload manifest. The platform team needs to confirm GPU nodes, drivers, and the device plugin, while a healthy GPU node would include a line like the one shown below somewhere under `Allocatable`.
 
 ```bash
 k describe nodes | grep -A5 -E "Name:|Allocatable:"
 ```
-
-A healthy GPU node would include a line like this somewhere under `Allocatable`:
 
 ```text
 nvidia.com/gpu:  1
@@ -453,13 +464,13 @@ If no such line appears, deploying more model replicas will not help. The schedu
 
 ### Step 3: Check whether the workload is missing placement rules
 
-Suppose a node does advertise `nvidia.com/gpu`, but the Pod is still Pending. The next useful question is whether the node has taints that repel ordinary Pods. GPU nodes are commonly tainted because they are expensive, and the platform team wants only GPU-aware workloads to land there.
+Suppose a node does advertise `nvidia.com/gpu`, but the Pod is still Pending. The next useful question is whether the node has taints that repel ordinary Pods. GPU nodes are commonly tainted because they are expensive, and the platform team wants only GPU-aware workloads to land there, so the following command checks the taint policy before you change the Deployment.
 
 ```bash
 k describe node gpu-node-1 | grep -A4 Taints
 ```
 
-Example output:
+The output below shows the classic taint that requires a matching toleration before scheduling can proceed.
 
 ```text
 Taints: accelerator=gpu:NoSchedule
@@ -492,7 +503,77 @@ k describe pod -l app=image-ranker
 
 The key lesson is the order of investigation. Start with the observed status, read scheduler events, confirm node allocatable resources, then inspect placement constraints such as taints, tolerations, selectors, and affinity. That same pattern works for the hands-on exercise later in the module, even when your local cluster has no real GPU hardware.
 
----
+This example also shows why "Pending" is not a vague status. It narrows the problem to scheduling and admission before the container runtime starts the workload. If the Pod later moves to `ContainerCreating`, you investigate image pulls, volume mounts, runtime classes, and node-level setup. If it moves to `CrashLoopBackOff`, you investigate command, environment, model files, permissions, and application logs. Good Kubernetes debugging is a sequence of narrowing questions, and GPU workloads reward that discipline because blindly changing manifests can hide the actual scarcity signal.
+
+## Patterns & Anti-Patterns
+
+Patterns are reusable decisions that make scarce accelerator capacity predictable. They are not rules to copy blindly, because the right answer depends on the workload shape, the cost of the hardware, and the operational maturity of the team. In AI/ML platforms, the most durable patterns make intent visible to both Kubernetes and humans: the manifest says what the workload needs, the node pool policy says who may use it, and the observability path shows whether the decision worked.
+
+| Pattern | When to Use It | Why It Works | Scaling Consideration |
+|---------|----------------|--------------|-----------------------|
+| **Dedicated accelerator node pools** | Production inference or expensive training needs predictable access to known GPU models. | Labels, taints, quotas, and autoscaling policies can be tuned for accelerator workloads without disrupting CPU services. | Keep separate pools for incompatible GPU models or isolation levels so scheduling decisions stay explainable. |
+| **Finite work as Jobs or workflows** | Training, fine-tuning, and batch inference have a clear completion condition. | Completion, retries, backoff, and artifact handoff match the workload better than continuously reconciled replicas. | Add checkpointing and idempotent output so retries do not waste large runs or duplicate results. |
+| **Serving endpoints with model-aware readiness** | Real-time inference is part of a user or service request path. | Readiness reports prediction capability rather than process existence, which protects callers during startup and rollout. | Combine readiness with latency, queue depth, and GPU metrics because CPU alone may not show saturation. |
+| **Batch schedulers for grouped workers** | Distributed training needs all or most workers to start together. | Gang scheduling and queues prevent partial placement from holding GPUs while the job cannot progress. | Define queue priority and fair sharing before several teams compete for the same accelerator pool. |
+
+Anti-patterns usually appear when a team treats an AI/ML workload as either completely special or completely ordinary. If it is treated as completely special, the platform becomes a pile of bespoke scripts with no repeatability. If it is treated as ordinary, the team misses accelerator scheduling, model load behavior, and lifecycle differences. The healthier middle ground is to use Kubernetes primitives where they fit and add specialized controllers only where the model lifecycle demands them.
+
+| Anti-Pattern | What Goes Wrong | Better Alternative |
+|--------------|-----------------|--------------------|
+| **One giant ML platform for one simple model** | The team operates notebooks, pipelines, identity integrations, and serving abstractions before those problems exist. | Start with a Job, a Deployment or KServe endpoint, and clear artifact storage, then expand when workflow repetition justifies it. |
+| **GPU nodes without admission policy** | Experiments, notebooks, and production inference compete on cost rather than priority, causing surprise Pending Pods or noisy incidents. | Use taints, tolerations, ResourceQuota, PriorityClass, and separate node pools to encode the intended sharing model. |
+| **Autoscaling on the wrong signal** | CPU-based scaling looks healthy while GPU memory, request queues, or latency are already saturated. | Scale inference with metrics that represent the bottleneck and validate that accelerator node groups can scale too. |
+| **Ignoring the model artifact path** | Pods start slowly or fail during rollout because every replica downloads large weights from an overloaded or unavailable store. | Treat model storage, caching, image layering, and startup probes as part of the deployment design. |
+
+## Decision Framework
+
+Use the following framework when someone asks, "How should we run this model on Kubernetes?" The first decision is whether the process is finite or continuous, because that separates training and batch scoring from serving. The second decision is whether the workload needs accelerators, because that introduces device plugins, extended resources, node pools, and cost policy. The third decision is whether the workload is independent or grouped, because distributed training may need batch scheduling semantics that ordinary Deployments do not provide.
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│              AI/ML WORKLOAD DECISION PATH                  │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│  Does the process finish?                                   │
+│       │                                                     │
+│       ├── yes ──▶ Training, fine-tuning, or batch inference │
+│       │          Use Job, workflow, or training operator    │
+│       │                                                     │
+│       └── no ───▶ Real-time or internal inference service   │
+│                  Use Deployment, Service, probes, scaling   │
+│                                                             │
+│  Does it need accelerators?                                 │
+│       │                                                     │
+│       ├── yes ──▶ Verify device plugin, GPU resources,      │
+│       │          taints, tolerations, labels, autoscaling   │
+│       │                                                     │
+│       └── no ───▶ Treat as ordinary CPU/memory workload     │
+│                  but keep artifact and data paths explicit  │
+│                                                             │
+│  Do workers need to start together?                         │
+│       │                                                     │
+│       ├── yes ──▶ Consider Volcano or training operators    │
+│       └── no ───▶ Default scheduler may be sufficient       │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+| Decision Point | Choose This When | Trade-Off to Accept |
+|----------------|------------------|---------------------|
+| **Job or workflow** | The model task has a clear end condition and produces artifacts or batch output. | You must design retries, checkpointing, and output idempotency instead of relying on always-on replicas. |
+| **Deployment plus Service** | The model answers requests continuously and callers need stable network access. | You must handle readiness, rollout timing, autoscaling metrics, and warm capacity. |
+| **KServe or serving abstraction** | Many teams need consistent model serving, canaries, scaling conventions, or model server integration. | You add another control plane surface that platform engineers must operate and debug. |
+| **Kubeflow or broader ML platform** | The organization needs shared notebooks, pipelines, training workflows, and multi-team lifecycle governance. | You accept installation, upgrades, identity integration, and user-support complexity. |
+| **Ray or distributed framework** | The workload needs flexible distributed Python execution, data processing, or serving patterns beyond one Pod. | You must operate the framework runtime as well as the Kubernetes resources beneath it. |
+| **Volcano or batch scheduler** | Grouped workers, queues, gang scheduling, or fair sharing are central to workload success. | You must define queue policy and teach users how batch scheduling differs from default Pod placement. |
+
+Which approach would you choose for a nightly batch scoring job that runs on CPU today but may need one GPU next quarter, and why? A practical answer might start with a Job or workflow now, keep data input and output idempotent, and avoid installing a full ML platform until repeated workflow needs appear. The future GPU requirement should influence how you name resources, isolate namespaces, and document the scheduling path, but it should not force the team to operate every ecosystem component before the workload needs it.
+
+There is one final check that experienced platform teams use before approving an AI/ML design: they ask what evidence would prove the design is wrong. If a training Job cannot resume from checkpoints, then a single node failure can waste the whole run. If an inference Deployment scales replicas but the cluster cannot add GPU nodes, then autoscaling creates Pending Pods without adding serving capacity. If a serving endpoint is private but prompt payloads appear in logs, then the privacy argument collapses even though the model never called an external API. Thinking this way turns architecture review into testable claims rather than preferences.
+
+The same review should include the human workflow around the cluster. Data scientists need a repeatable way to request capacity, understand queue status, and find scheduler events without paging the platform team for every Pending Pod. Application teams need a contract for model versions, rollout windows, latency objectives, and rollback ownership. Platform teams need cost visibility, namespace quotas, and a support boundary for specialized runtimes such as Ray, vLLM, or KServe. Kubernetes supplies shared APIs for these conversations, but the organization still has to decide who owns each decision when the system is under pressure.
+
+For KCNA-level reasoning, the important habit is to keep connecting symptoms back to Kubernetes objects. A slow model endpoint might be a runtime tuning issue, but Pending replicas point first to scheduling. A failed training run might be bad code, but partial worker placement points first to workload grouping and queue policy. A privacy concern might involve the model, but the enforceable boundary appears in namespaces, identities, network paths, logging choices, and storage destinations.
 
 ## Did You Know?
 
@@ -504,130 +585,68 @@ The key lesson is the order of investigation. Start with the observed status, re
 
 4. **Kubernetes won AI/ML infrastructure work through extensibility rather than original design.** Device plugins, custom controllers, operators, and specialized schedulers let the platform adapt to accelerators and ML workflows without requiring every feature in the core API.
 
----
-
 ## Common Mistakes
 
-| Mistake | Why It Hurts | Correct Understanding |
-|---------|--------------|----------------------|
-| Thinking Kubernetes automatically detects GPUs after installation. | Pods request `nvidia.com/gpu`, but nodes advertise no such resource, so scheduling fails. | Install and verify the vendor device plugin or GPU operator before deploying GPU workloads. |
-| Using a Deployment for a training script that should finish. | A successful training container exits, then the Deployment starts it again because it wants continuous replicas. | Use a Job, workflow engine, or training operator for finite training and batch inference tasks. |
-| Relying only on node labels for GPU workloads. | A Pod may target a GPU node without actually reserving a GPU, or request a GPU without tolerating the node taint. | Combine resource limits, selectors or affinity, and tolerations according to the node pool policy. |
-| Scaling inference only on CPU utilization. | GPU memory, request queue depth, or latency may saturate while CPU looks moderate. | Choose autoscaling signals that match the model server's real bottleneck and user-facing objective. |
-| Ignoring model load time during rollouts. | Kubernetes may send traffic before the model is ready, causing errors during deployments or scale-ups. | Use startup and readiness probes that reflect actual model-serving readiness. |
-| Treating GPU time-slicing as equivalent to hardware isolation. | Shared GPUs can create noisy-neighbor effects and unpredictable latency for sensitive workloads. | Use whole GPUs or MIG where isolation matters, and reserve time-slicing for suitable light workloads. |
-| Installing a full ML platform before defining the workflow problem. | The team inherits operational complexity before it has repeatable notebooks, pipelines, or multi-team needs. | Start with the smallest pattern that solves the workload, then adopt Kubeflow or KServe when their abstractions pay off. |
-| Forgetting that cluster autoscaling must understand GPU node groups. | Pending GPU Pods may not cause useful scale-out if the autoscaler can only add CPU nodes. | Configure autoscaling for accelerator node pools and verify that Pending events trigger the expected capacity path. |
-
----
+| Mistake | Why It Happens | How to Fix It |
+|---------|----------------|---------------|
+| Thinking Kubernetes automatically detects GPUs after installation. | Teams see a physical GPU on a node and assume the scheduler can allocate it without the device plugin path. | Install and verify the vendor device plugin or GPU Operator, then confirm nodes advertise `nvidia.com/gpu` as allocatable capacity. |
+| Using a Deployment for a training script that should finish. | Deployments are familiar, so a finite script gets wrapped in a controller that expects continuous replicas. | Use a Job, workflow engine, or training operator for training, fine-tuning, and batch inference tasks with completion semantics. |
+| Relying only on node labels for GPU workloads. | A label feels like placement control, but it does not allocate the accelerator or bypass a taint. | Combine resource limits, selectors or affinity, and tolerations so placement and device reservation match the node pool policy. |
+| Scaling inference only on CPU utilization. | Generic web-service autoscaling examples are copied even when GPU memory, queue depth, or latency is the bottleneck. | Choose autoscaling signals that match the model server's real bottleneck and verify that GPU node groups can add capacity. |
+| Ignoring model load time during rollouts. | The container process starts before weights are loaded, so operators mistake Running for ready. | Use startup and readiness probes that reflect actual model-serving readiness, and tune rollout settings for warm capacity. |
+| Treating GPU time-slicing as equivalent to hardware isolation. | Utilization goals hide the fact that shared GPUs can create noisy-neighbor effects and unpredictable latency. | Use whole GPUs or MIG where isolation matters, and reserve time-slicing for suitable development or light workloads. |
+| Installing a full ML platform before defining the workflow problem. | Tool diagrams make every component look mandatory before the team has repeated lifecycle pain. | Start with the smallest pattern that solves the workload, then adopt Kubeflow, KServe, Ray, or Volcano when their abstractions pay off. |
+| Forgetting that cluster autoscaling must understand GPU node groups. | The HPA creates Pods, but the autoscaler can only add CPU nodes or cannot satisfy accelerator labels and taints. | Configure autoscaling for accelerator node pools and verify that Pending events trigger the expected scale-out path. |
 
 ## Quiz
 
-**1. Your team deploys a real-time recommendation model as a Deployment with three replicas. During a traffic spike, the HorizontalPodAutoscaler creates more replicas, but the new Pods stay Pending with `Insufficient nvidia.com/gpu`. The web tier continues scaling normally. What should you investigate first, and why?**
-
-A) Whether the model image contains the newest Python dependencies, because Pending usually means the container crashed before startup.  
-B) Whether GPU node groups and the device plugin expose enough allocatable accelerator capacity, because the scheduler cannot place Pods without free extended resources.  
-C) Whether the Service selector points to the right Pods, because a wrong selector prevents the scheduler from binding replicas.  
-D) Whether the Deployment strategy is set to Recreate, because rolling updates are unsupported for GPU workloads.
-
 <details>
-<summary>Answer</summary>
+<summary>1. Your team deploys a real-time recommendation model as a Deployment with three replicas. During a traffic spike, the HPA creates more replicas, but the new Pods stay Pending with `Insufficient nvidia.com/gpu`. What should you investigate first?</summary>
 
-**B) Whether GPU node groups and the device plugin expose enough allocatable accelerator capacity.** Pending means the Pod has not been scheduled, so image dependencies and runtime crashes are not the first issue. The event names the missing extended resource, which points to GPU capacity, device plugin health, existing allocations, or autoscaler configuration for GPU nodes.
+Investigate whether GPU node groups and the device plugin expose enough allocatable accelerator capacity. Pending means the Pod has not been scheduled, so image dependencies and runtime crashes are not the first issue. The event names the missing extended resource, which points to GPU capacity, device plugin health, existing allocations, or autoscaler configuration for GPU nodes. The web tier can scale normally because CPU nodes do not satisfy a GPU request.
 </details>
 
-**2. A data science team has a script that trains a model for twelve hours, writes checkpoints every hour, uploads final weights, and then exits successfully. They ask you to run it as a Deployment so Kubernetes will "keep it reliable." What should you recommend?**
-
-A) Use a Job or training operator, because the process has a clear completion condition and should not be restarted after success.  
-B) Use a DaemonSet, because every node should participate in training automatically.  
-C) Use a StatefulSet, because every machine learning workload needs a stable network identity.  
-D) Use a Deployment with one replica, because Deployments are the only Kubernetes resource that supports restarts.
-
 <details>
-<summary>Answer</summary>
+<summary>2. A data science team has a script that trains a model for twelve hours, writes checkpoints every hour, uploads final weights, and then exits successfully. They ask you to run it as a Deployment so Kubernetes will keep it reliable. What should you recommend?</summary>
 
-**A) Use a Job or training operator.** The workload is finite: it starts, performs training, writes output, and exits. A Deployment tries to maintain continuously running replicas, so it would restart the training after successful completion and could waste expensive resources or duplicate output.
+Recommend a Job, workflow engine, or training operator because the workload is finite. It starts, performs training, writes output, and exits, so success is completion rather than continuous availability. A Deployment tries to maintain continuously running replicas, which means it may restart the training after successful completion and duplicate expensive output. Checkpointing and artifact upload still matter, but they belong in a batch-oriented controller.
 </details>
 
-**3. A distributed training run needs eight GPU workers to start together. Four workers are Running and holding GPUs, while four are Pending because the cluster has no remaining capacity. The Running workers wait indefinitely for peers. Which platform change best addresses the architecture problem?**
-
-A) Add a readiness probe to the worker Pods so Kubernetes sends traffic only when all workers are ready.  
-B) Add gang scheduling through a batch scheduler so either the full worker group is admitted or none is scheduled yet.  
-C) Convert the training job into a Service so the Pending workers can be load balanced.  
-D) Remove GPU limits so the scheduler can place all workers on CPU nodes.
-
 <details>
-<summary>Answer</summary>
+<summary>3. A distributed training run needs eight GPU workers to start together. Four workers are Running and holding GPUs, while four are Pending because the cluster has no remaining capacity. Which platform change best addresses the architecture problem?</summary>
 
-**B) Add gang scheduling through a batch scheduler.** The failure is partial placement of a distributed workload, not HTTP readiness or service discovery. Gang scheduling prevents a subset of workers from consuming GPUs when the full set cannot run, which improves utilization and makes queue behavior clearer.
+Add gang scheduling through a batch scheduler such as Volcano, or use a training operator that integrates with suitable scheduling semantics. The failure is partial placement of a distributed workload, not HTTP readiness or service discovery. Gang scheduling prevents a subset of workers from consuming GPUs when the full set cannot run, which improves utilization and makes queue behavior clearer. The key is that the useful scheduling unit is the worker group, not each independent Pod.
 </details>
 
-**4. A compliance team requires that customer documents used in prompts must not leave company-controlled infrastructure. Product leadership also requires low latency because the model response is part of an interactive workflow. Which design best fits those constraints?**
-
-A) Self-host the inference service close to the application on Kubernetes, while accepting responsibility for GPU capacity, model rollout, and monitoring.  
-B) Run training as a CronJob once per day, because scheduled training automatically satisfies prompt privacy.  
-C) Send requests to any public model API and rely on Kubernetes NetworkPolicy to hide the data from the provider.  
-D) Use a DaemonSet on every node so each application Pod has a local model server.
-
 <details>
-<summary>Answer</summary>
+<summary>4. A compliance team requires customer documents used in prompts to stay inside company-controlled infrastructure, and product leadership requires low latency for an interactive workflow. Which serving design best fits those constraints?</summary>
 
-**A) Self-host the inference service close to the application.** Keeping inference in controlled infrastructure helps address data handling constraints, and co-location can reduce network latency. The trade-off is operational: the team now owns accelerator nodes, model-server readiness, scaling, rollout safety, and incident response.
+Self-host the inference service close to the application on Kubernetes, while accepting responsibility for accelerator capacity, model rollout, observability, and incident response. Keeping inference in controlled infrastructure helps address data handling constraints, and co-location can reduce network latency. Kubernetes can provide deployment, networking, access-control, and rollout mechanisms, but it does not remove the operational cost of running model servers. The design should also prevent sensitive prompts from leaking through logs, traces, or unmanaged storage paths.
 </details>
 
-**5. A platform team has one weekly fraud-model retraining job and one internal fraud inference endpoint. They are considering installing a large end-to-end ML platform immediately. What is the most defensible first step?**
-
-A) Install Kubeflow before defining workflows, because every Kubernetes ML system requires notebooks and pipelines.  
-B) Start with a Job for retraining and a Deployment or serving-focused abstraction for inference, then add larger platform components when repeated workflow pain appears.  
-C) Avoid Kubernetes completely because model workloads cannot be scheduled with ordinary Pods.  
-D) Run both retraining and serving in the same long-running Deployment to reduce YAML.
-
 <details>
-<summary>Answer</summary>
+<summary>5. A platform team has one weekly fraud-model retraining job and one internal fraud inference endpoint. They are considering installing a large end-to-end ML platform immediately. What is the most defensible first step?</summary>
 
-**B) Start with the smallest pattern that solves the workload.** A weekly finite retraining task maps naturally to a Job or workflow, and the internal endpoint maps to serving infrastructure. Kubeflow can be valuable later, but adopting it before the team needs notebooks, pipelines, or multi-team governance may add avoidable operational complexity.
+Start with the smallest pattern that solves the workload: a Job or workflow for retraining and a Deployment or serving-focused abstraction for inference. A weekly finite retraining task maps naturally to batch execution, while the internal endpoint maps to serving infrastructure with readiness and rollout controls. Kubeflow can be valuable later, but adopting it before notebooks, pipelines, or multi-team governance are real needs may add avoidable operational complexity. The decision should evaluate ecosystem tools against workflow pain rather than tool popularity.
 </details>
 
-**6. A model-serving Pod is Running, but users receive errors for the first few minutes after every rollout. Logs show the container is downloading weights and warming the model during that time. What should you change in the Kubernetes configuration?**
-
-A) Add or adjust startup and readiness probes so traffic is withheld until the model server can actually answer requests.  
-B) Remove memory limits because readiness problems are always caused by resource limits.  
-C) Convert the Deployment to a Job so the model can finish loading and exit.  
-D) Add more replicas without changing probes, because Services only route to warm model servers automatically.
-
 <details>
-<summary>Answer</summary>
+<summary>6. A model-serving Pod is Running, but users receive errors for the first few minutes after every rollout. Logs show the container is downloading weights and warming the model during that time. What should you change?</summary>
 
-**A) Add or adjust startup and readiness probes.** Running only means the container process exists; it does not prove the model is loaded and ready. Readiness should reflect prediction capability, and startup probes can give slow-loading models enough time before liveness checks or restarts interfere.
+Add or adjust startup and readiness probes so traffic is withheld until the model server can actually answer requests. Running only means the container process exists; it does not prove the model is loaded, GPU memory is allocated, and prediction calls are safe. A startup probe can give a slow-loading model enough time before restarts interfere, while readiness keeps the Service from routing requests too early. The rollout strategy should also preserve enough warm replicas while new ones become ready.
 </details>
 
-**7. A development cluster has one GPU shared by several lightweight notebook users. Whole-GPU allocation leaves most of the accelerator idle, but production workloads are not allowed on this cluster. Which approach could improve utilization while preserving a reasonable understanding of the trade-off?**
-
-A) Configure GPU time-slicing for suitable development workloads and document that isolation and latency predictability are weaker than whole-GPU allocation.  
-B) Remove all GPU resource requests so every notebook can be scheduled on the same node.  
-C) Use a DaemonSet to start one notebook on every node, regardless of who needs the GPU.  
-D) Replace the device plugin with CPU requests because Kubernetes can emulate GPUs through CPU throttling.
-
 <details>
-<summary>Answer</summary>
+<summary>7. A development cluster has one GPU shared by several lightweight notebook users. Whole-GPU allocation leaves most of the accelerator idle, and production workloads are not allowed on this cluster. Which approach could improve utilization while preserving the right trade-off?</summary>
 
-**A) Configure GPU time-slicing for suitable development workloads.** Time-slicing can improve utilization when workloads are light and strict isolation is not required. It is not the same as hardware isolation, so it should be used deliberately and separated from production latency-sensitive workloads.
+Configure GPU time-slicing for suitable development workloads and document that isolation and latency predictability are weaker than whole-GPU allocation. Time-slicing can improve utilization when notebooks are light and strict isolation is not required. It should not be presented as the same thing as MIG or exclusive allocation because noisy-neighbor behavior is possible. The answer is acceptable precisely because the scenario keeps production latency-sensitive workloads out of that shared environment.
 </details>
 
-**8. An inference Deployment requests `nvidia.com/gpu: 1` and the cluster has a GPU node with allocatable capacity. The Pod is still Pending. `kubectl describe node` shows the node has the taint `accelerator=gpu:NoSchedule`. What is the most likely fix?**
-
-A) Add a matching toleration to the Pod, and optionally add node selection or affinity to make the intended GPU node pool explicit.  
-B) Remove the GPU resource limit because taints only apply to Pods that request extended resources.  
-C) Change the container port because the scheduler validates ports before taints.  
-D) Convert the Pod to a ConfigMap so it can tolerate node taints.
-
 <details>
-<summary>Answer</summary>
+<summary>8. An inference Deployment requests `nvidia.com/gpu: 1` and the cluster has a GPU node with allocatable capacity. The Pod is still Pending, and node inspection shows the taint `accelerator=gpu:NoSchedule`. What is the most likely fix?</summary>
 
-**A) Add a matching toleration and make placement explicit.** A taint repels Pods unless they have a matching toleration. The GPU request reserves the device, while the toleration permits scheduling onto the tainted node; selectors or affinity can also express the intended hardware pool.
+Add a matching toleration to the Pod, and optionally add node selection or affinity to make the intended GPU node pool explicit. A taint repels Pods unless they have a matching toleration, even if the node has the resource the Pod requests. The GPU limit reserves the device, while the toleration permits scheduling onto the tainted node. Selectors or affinity then make the placement intent easier to review and debug.
 </details>
-
----
 
 ## Hands-On Exercise: Simulate and Debug a GPU Scheduling Request
 
@@ -657,11 +676,23 @@ spec:
           nvidia.com/gpu: 1
 ```
 
+<details>
+<summary>Solution for task 1</summary>
+
+The important field is the extended resource limit under `resources.limits`. In a real GPU cluster, the NVIDIA device plugin or GPU Operator must advertise `nvidia.com/gpu` on at least one node before this Pod can run. The `restartPolicy: Never` setting fits the lab because the Pod is a one-time scheduling test rather than a long-running service.
+</details>
+
 2. Apply the manifest to your current Kubernetes context. Use a disposable namespace if your environment requires one, but keep the Pod name unchanged so the later commands match.
 
 ```bash
 k apply -f gpu-pod.yaml
 ```
+
+<details>
+<summary>Solution for task 2</summary>
+
+The expected command is `k apply -f gpu-pod.yaml` after defining `alias k=kubectl`, or the equivalent full `kubectl apply -f gpu-pod.yaml`. If your context points at a shared cluster, use the namespace policy your environment requires and keep the Pod name stable. The apply operation only asks the API server to create the object; it does not prove that scheduling has succeeded.
+</details>
 
 3. Check the Pod status and observe whether it starts. In a CPU-only cluster, it should remain Pending because no node advertises the extended GPU resource.
 
@@ -669,11 +700,23 @@ k apply -f gpu-pod.yaml
 k get pod gpu-test-pod
 ```
 
+<details>
+<summary>Solution for task 3</summary>
+
+In a CPU-only lab, the useful result is a Pending Pod, not a failure of the exercise. Pending tells you the container has not started because the scheduler has not found a suitable node. If the Pod runs in your environment, that means your cluster has a GPU scheduling path available, and you should still inspect the node and event evidence to prove why it worked.
+</details>
+
 4. Describe the Pod and read the scheduler events near the bottom of the output. Look for a `FailedScheduling` event that mentions `nvidia.com/gpu`, because that event connects the symptom to the missing schedulable resource.
 
 ```bash
 k describe pod gpu-test-pod
 ```
+
+<details>
+<summary>Solution for task 4</summary>
+
+The strongest evidence is an event from the scheduler that names insufficient `nvidia.com/gpu` capacity. That event means the scheduler could not find a node with free allocatable extended resources that also satisfied the Pod's other placement rules. Do not change the image or command first, because a Pending Pod has not reached the point where the container runtime could execute them.
+</details>
 
 5. Inspect node allocatable resources to connect the Pod event to cluster state. If no node lists `nvidia.com/gpu`, Kubernetes has no GPU capacity to allocate, even if a physical machine somewhere in the environment has accelerator hardware but no device plugin integration.
 
@@ -681,13 +724,25 @@ k describe pod gpu-test-pod
 k describe nodes
 ```
 
+<details>
+<summary>Solution for task 5</summary>
+
+Search the `Allocatable` sections for `nvidia.com/gpu`. If no node advertises that resource, the workload manifest cannot be the only fix because Kubernetes has no schedulable accelerator capacity. In a real platform, the next checks would include GPU node pool existence, driver installation, device plugin health, node taints, and whether another Pod already consumed the available GPU.
+</details>
+
 6. Clean up the Pod after you have captured the result. Leaving a Pending Pod behind is harmless in a lab, but cleanup is part of good cluster hygiene.
 
 ```bash
 k delete pod gpu-test-pod
 ```
 
-**Success Criteria:**
+<details>
+<summary>Solution for task 6</summary>
+
+The cleanup command removes the test Pod and clears the Pending object from the namespace. Cleanup matters because repeated labs can leave misleading scheduler events or names that collide with later attempts. If deletion hangs, check whether your current context and namespace match the object you created.
+</details>
+
+Use this success criteria checklist to verify that you practiced the whole troubleshooting path rather than only creating the YAML:
 
 - [ ] You created `gpu-pod.yaml` with a container resource limit requesting `nvidia.com/gpu: 1`.
 - [ ] You applied the manifest with `kubectl` or the `k` alias after defining the alias.
@@ -699,7 +754,22 @@ k delete pod gpu-test-pod
 
 For extra practice, modify the manifest by adding a fake node selector such as `accelerator: nvidia` and apply it again. Compare the scheduler event with the previous result. The exact wording may differ by Kubernetes version, but the reasoning should be the same: the scheduler can only bind a Pod when resource requests, node labels, taints, tolerations, and available capacity all line up.
 
----
+## Sources
+
+- [Kubernetes documentation: Device Plugins](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/)
+- [Kubernetes documentation: Extended resources for a container](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#extended-resources)
+- [Kubernetes documentation: Assign Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/)
+- [Kubernetes documentation: Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
+- [Kubernetes documentation: Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/job/)
+- [Kubernetes documentation: Configure Liveness, Readiness and Startup Probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
+- [Kubernetes documentation: Resource Quotas](https://kubernetes.io/docs/concepts/policy/resource-quotas/)
+- [NVIDIA GPU Operator documentation](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/index.html)
+- [NVIDIA Kubernetes device plugin documentation](https://github.com/NVIDIA/k8s-device-plugin)
+- [Kubeflow documentation](https://www.kubeflow.org/docs/)
+- [KServe documentation](https://kserve.github.io/website/latest/)
+- [Ray documentation: Ray on Kubernetes](https://docs.ray.io/en/latest/cluster/kubernetes/index.html)
+- [vLLM documentation](https://docs.vllm.ai/en/latest/)
+- [Volcano documentation](https://volcano.sh/en/docs/)
 
 ## Next Module
 


### PR DESCRIPTION
## Summary
- Rewrote `src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.8-ai-ml-cloud-native.md` for #388 density, structure, alignment, and anti-leak gates.
- Cleared `revision_pending: false`.

## Verifier
- `.venv/bin/python scripts/quality/verify_module.py --glob src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.8-ai-ml-cloud-native.md --skip-source-check --summary --quiet`
- Result: tier T0; body_words=5053, mean_wpp=66.5, median_wpp=65.0, short_rate=0.026, max_run=1; failure_gates={}

## Protected Assets
- Preserved existing protected examples and tables; before counts were code_blocks=26, ascii_diagrams=0, mermaid_diagrams=0, tables=4.
- After rewrite counts are code_blocks=27, ascii_diagrams=0, mermaid_diagrams=0, tables=7; additions are the decision-framework code block and framework tables.
- Source URLs: 14 primary/vendor URLs present; live source reachability intentionally skipped per verifier command.

## Commit
- 012e5475a1b38182e606326a8e6960ecec9093dd