### PR TITLE
fix(security): sanitize agent env and redact egress secrets (#770)

### DIFF
--- a/scripts/agent_runtime/adapters/base.py
+++ b/scripts/agent_runtime/adapters/base.py
@@ -54,10 +54,10 @@ class InvocationPlan:
             ``gemini --output-path <file>`` populate this; the runner reads
             it on completion. None if output goes to stdout.
         env_overrides: Env vars to add to or remove from the subprocess
-            environment. Merged onto ``os.environ`` fresh per invocation —
-            NEVER ``os.environ.update()``. Set a value to ``None`` to remove
-            that variable for this child only (e.g. strip Gemini API keys so
-            the CLI falls through to OAuth). Values set here leak nowhere else.
+            environment. Merged onto a sanitized environment snapshot fresh
+            per invocation. Set a value to ``None`` to remove that variable
+            for this child only (e.g. strip Gemini API keys so the CLI falls
+            through to OAuth). Values set here leak nowhere else.
         liveness_paths: Files whose mtime indicates the agent is alive.
             Used by the runner's stall detector as a fallback when stdout
             is buffered/redirected. Can be empty; if so, only stdout

--- a/scripts/agent_runtime/env_sanitize.py
+++ b/scripts/agent_runtime/env_sanitize.py
@@ -1,0 +1,130 @@
+"""Environment sanitizing for child LLM/agent processes.
+
+Agent CLIs should not inherit the full login shell environment. The parent
+process can keep GitHub, cloud, npm, and other credentials for orchestration,
+but child model processes only need normal shell settings plus the credential
+for the provider being invoked.
+"""
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Mapping
+
+_SENSITIVE_NAME_RE = re.compile(
+    r"(TOKEN|SECRET|PASSWORD|PASSWD|PRIVATE|CREDENTIAL|API[_-]?KEY|"
+    r"ACCESS[_-]?KEY|AUTH|COOKIE)",
+    re.IGNORECASE,
+)
+
+_SECRET_VALUE_RES = (
+    re.compile(r"^github_pat_[A-Za-z0-9_]{20,}$"),
+    re.compile(r"^gh[pousr]_[A-Za-z0-9_]{20,}$"),
+    re.compile(r"^sk-[A-Za-z0-9_-]{20,}$"),
+    re.compile(r"^xox[baprs]-[A-Za-z0-9-]{20,}$"),
+    re.compile(r"^hf_[A-Za-z0-9]{20,}$"),
+    re.compile(r"^npm_[A-Za-z0-9]{20,}$"),
+    re.compile(r"^AKIA[0-9A-Z]{16}$"),
+    re.compile(r"^AIza[0-9A-Za-z_-]{20,}$"),
+)
+
+_SAFE_NAME_ALLOWLIST = {
+    "AB_CLAUDE_MODEL",
+    "AB_DB_PATH",
+    "AB_GEMINI_FALLBACK_MODEL",
+    "AB_GEMINI_MODEL",
+    "AB_GEMINI_REVIEW_MODEL",
+    "AB_PID_DIR",
+    "AB_PIPELINE_ENV_KEY",
+    "AB_PYTHON",
+    "AB_REPO_ROOT",
+    "CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS",
+    "CLAUDE_PROJECT_DIR",
+    "CODEX_BRIDGE_MODE",
+    "GEMINI_SESSION",
+    "HOME",
+    "KUBEDOJO_GEMINI_SUBSCRIPTION",
+    "KUBEDOJO_IGNORE_PEAK_HOURS",
+    "KUBEDOJO_MAX_CLAUDE_CALLS",
+    "KUBEDOJO_PIPELINE",
+    "KUBEDOJO_QUIET",
+    "KUBEDOJO_WRITER_MODEL",
+    "LANG",
+    "LC_ALL",
+    "LOGNAME",
+    "PATH",
+    "PWD",
+    "SHELL",
+    "SSH_AUTH_SOCK",
+    "TERM",
+    "TMP",
+    "TMPDIR",
+    "USER",
+    "VIRTUAL_ENV",
+    "XDG_CACHE_HOME",
+    "XDG_CONFIG_HOME",
+    "XDG_DATA_HOME",
+    "XDG_STATE_HOME",
+}
+
+_PROVIDER_SECRET_ALLOWLIST = {
+    "codex": {"OPENAI_API_KEY", "CODEX_API_KEY"},
+    "claude": {"ANTHROPIC_API_KEY", "CLAUDE_API_KEY"},
+    "gemini": {"GEMINI_API_KEY", "GOOGLE_API_KEY"},
+}
+_PROVIDER_SECRET_ALLOWLIST["bridge"] = set().union(
+    *_PROVIDER_SECRET_ALLOWLIST.values()
+)
+
+
+def _value_looks_secret(value: str) -> bool:
+    stripped = value.strip()
+    return any(pattern.match(stripped) for pattern in _SECRET_VALUE_RES)
+
+
+def _provider_allowed_secrets(provider: str | None) -> set[str]:
+    if provider is None:
+        return set()
+    return set(_PROVIDER_SECRET_ALLOWLIST.get(provider, set()))
+
+
+def build_agent_env(
+    *,
+    provider: str | None = None,
+    base: Mapping[str, str] | None = None,
+    overrides: Mapping[str, str | None] | None = None,
+    extra_allow: set[str] | frozenset[str] | None = None,
+) -> dict[str, str]:
+    """Return a child-process environment with unrelated secrets removed.
+
+    ``provider`` controls which provider credential may pass through. For
+    example, ``provider="gemini"`` may keep ``GEMINI_API_KEY`` while still
+    dropping ``GITHUB_TOKEN`` and cloud/npm/HF credentials. ``overrides`` are
+    applied before filtering; a value of ``None`` removes a name.
+    """
+    source: dict[str, str] = dict(os.environ if base is None else base)
+    for key, value in (overrides or {}).items():
+        if value is None:
+            source.pop(key, None)
+        else:
+            source[key] = value
+
+    safe_names = _SAFE_NAME_ALLOWLIST | set(extra_allow or ())
+    allowed_secrets = _provider_allowed_secrets(provider)
+    sanitized: dict[str, str] = {}
+
+    for key, value in source.items():
+        if key in allowed_secrets:
+            sanitized[key] = value
+            continue
+        if key in safe_names or key.startswith("LC_"):
+            if not _value_looks_secret(value):
+                sanitized[key] = value
+            continue
+        if _SENSITIVE_NAME_RE.search(key):
+            continue
+        if _value_looks_secret(value):
+            continue
+        sanitized[key] = value
+
+    return sanitized

--- a/scripts/agent_runtime/redact.py
+++ b/scripts/agent_runtime/redact.py
@@ -1,0 +1,79 @@
+"""Redact token-shaped secrets before logs, brokers, or GitHub egress."""
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+REDACTION = "[REDACTED_SECRET]"
+
+_SENSITIVE_KEY_RE = re.compile(
+    r"(TOKEN|SECRET|PASSWORD|PASSWD|PRIVATE|CREDENTIAL|API[_-]?KEY|"
+    r"ACCESS[_-]?KEY|AUTH|COOKIE)",
+    re.IGNORECASE,
+)
+
+_PRIVATE_KEY_RE = re.compile(
+    r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?"
+    r"-----END [A-Z0-9 ]*PRIVATE KEY-----",
+    re.DOTALL,
+)
+
+_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b([A-Z0-9_-]*(?:TOKEN|SECRET|PASSWORD|PASSWD|PRIVATE|"
+    r"CREDENTIAL|API[_-]?KEY|ACCESS[_-]?KEY|AUTH|COOKIE)[A-Z0-9_-]*)"
+    r"\s*([:=])\s*(?:\"[^\r\n\"]*\"|'[^\r\n']*'|[^\s;,]+)"
+)
+
+_TOKEN_PATTERNS = (
+    re.compile(r"github_pat_[A-Za-z0-9_]{20,}"),
+    re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\bsk-proj-[A-Za-z0-9_-]{20,}\b"),
+    re.compile(r"\bsk-ant-[A-Za-z0-9_-]{20,}\b"),
+    re.compile(r"\bsk-[A-Za-z0-9_-]{20,}\b"),
+    re.compile(r"\bAIza[0-9A-Za-z_-]{20,}\b"),
+    re.compile(r"\bhf_[A-Za-z0-9]{20,}\b"),
+    re.compile(r"\bnpm_[A-Za-z0-9]{20,}\b"),
+    re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{20,}\b"),
+    re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b"),
+    re.compile(r"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b"),
+)
+
+
+def redact_text(value: Any) -> str:
+    """Return ``value`` as text with common secret formats redacted."""
+    text = "" if value is None else str(value)
+    text = _PRIVATE_KEY_RE.sub(REDACTION, text)
+    text = _ASSIGNMENT_RE.sub(lambda m: f"{m.group(1)}{m.group(2)}{REDACTION}", text)
+    for pattern in _TOKEN_PATTERNS:
+        text = pattern.sub(REDACTION, text)
+    return text
+
+
+def redact_jsonable(value: Any) -> Any:
+    """Recursively redact string leaves in JSON-like data structures."""
+    if isinstance(value, str):
+        return redact_text(value)
+    if isinstance(value, list):
+        return [redact_jsonable(item) for item in value]
+    if isinstance(value, tuple):
+        return [redact_jsonable(item) for item in value]
+    if isinstance(value, dict):
+        return {
+            str(key): (
+                REDACTION
+                if _SENSITIVE_KEY_RE.search(str(key))
+                else redact_jsonable(item)
+            )
+            for key, item in value.items()
+        }
+    return value
+
+
+def redact_json_string(value: str) -> str:
+    """Redact a JSON string while preserving JSON when possible."""
+    try:
+        parsed = json.loads(value)
+    except (TypeError, json.JSONDecodeError):
+        return redact_text(value)
+    return json.dumps(redact_jsonable(parsed), ensure_ascii=False)

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -29,7 +29,6 @@ from __future__ import annotations
 
 import contextlib
 import importlib
-import os
 import subprocess
 import time
 from datetime import UTC, datetime
@@ -37,11 +36,13 @@ from pathlib import Path
 from typing import Any
 
 from .adapters.base import AgentAdapter
+from .env_sanitize import build_agent_env
 from .errors import (
     AgentTimeoutError,
     AgentUnavailableError,
     RateLimitedError,
 )
+from .redact import redact_text
 from .registry import AGENTS, get_agent_entry
 from .result import ParseResult, Result
 from .usage import has_headroom, write_record
@@ -216,7 +217,9 @@ def _build_usage_record(
         "outcome": outcome,
         "rate_limited": rate_limited,
         "stalled": stalled,
-        "stderr_excerpt": (stderr_excerpt or "")[:500] if stderr_excerpt else None,
+        "stderr_excerpt": (
+            redact_text(stderr_excerpt)[:500] if stderr_excerpt else None
+        ),
         "tokens": tokens,
     }
 
@@ -347,17 +350,12 @@ def invoke(
         tool_config=tool_config,
     )
 
-    # Merge env overrides onto a snapshot of os.environ. We do NOT mutate
-    # os.environ itself — this keeps the parent process clean and prevents
-    # leakage to other adapters running concurrently. ``None`` means "remove
-    # this variable for the child", used by Gemini OAuth fallback to strip API
-    # keys without touching the parent shell.
-    env = os.environ.copy()
-    for key, value in plan.env_overrides.items():
-        if value is None:
-            env.pop(key, None)
-        else:
-            env[key] = value
+    # Build a sanitized child environment. We do NOT mutate os.environ itself:
+    # the parent may need broad orchestration credentials, but model child
+    # processes should only inherit normal shell settings plus the credential
+    # for the provider being invoked. ``None`` in env_overrides removes a name
+    # for this child only, used by Gemini OAuth fallback to strip API keys.
+    env = build_agent_env(provider=agent_name, overrides=plan.env_overrides)
 
     # ---------- 7–9. Run the subprocess with watchdog ----------
     start_time = time.monotonic()

--- a/scripts/ai_agent_bridge/__init__.py
+++ b/scripts/ai_agent_bridge/__init__.py
@@ -49,6 +49,7 @@ from ._config import (
     PID_DIR,
     PYTHON_CMD,
     REPO_ROOT,
+    agent_child_env,
 )
 from ._db import get_db, get_session, init_db, set_session
 from ._gemini import ask_gemini, process_and_respond
@@ -104,6 +105,7 @@ __all__ = [
     "_write_pid_file",
     "acknowledge",
     "acknowledge_all",
+    "agent_child_env",
     # Claude
     "ask_claude",
     "ask_codex",

--- a/scripts/ai_agent_bridge/_channels.py
+++ b/scripts/ai_agent_bridge/_channels.py
@@ -58,6 +58,8 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+from agent_runtime.redact import redact_jsonable, redact_text
+
 from ._config import REPO_ROOT
 from ._db import get_db
 
@@ -699,6 +701,14 @@ def post(
     (tests, synthetic posts, system announcements) can pass explicit
     values or set ``auto_snapshot=False``.
     """
+    body = redact_text(body)
+    attachments = redact_jsonable(attachments) if attachments else None
+    monitor_state_snapshot = (
+        redact_jsonable(monitor_state_snapshot)
+        if monitor_state_snapshot is not None
+        else None
+    )
+
     _validate_agent(from_agent)
     _validate_kind(kind)
     for agent in to_agents or []:
@@ -730,7 +740,7 @@ def post(
             )
         if monitor_state_snapshot is None:
             # Best-effort — returns None on any failure, which is fine.
-            monitor_state_snapshot = fetch_monitor_state()
+            monitor_state_snapshot = redact_jsonable(fetch_monitor_state())
 
     # Normalize sentinel Nones so the DB stores empty string rather
     # than nullable columns having inconsistent semantics.
@@ -909,12 +919,16 @@ def _row_to_message(row) -> dict[str, Any]:
         "from_agent": row["from_agent"],
         "from_model": row["from_model"],
         "kind": row["kind"],
-        "body": row["body"],
-        "attachments": json.loads(row["attachments"]) if row["attachments"] else None,
+        "body": redact_text(row["body"]),
+        "attachments": (
+            redact_jsonable(json.loads(row["attachments"]))
+            if row["attachments"]
+            else None
+        ),
         "context_rev_shared": row["context_rev_shared"],
         "context_rev_channel": row["context_rev_channel"],
         "monitor_state_snapshot": (
-            json.loads(row["monitor_state_snapshot"])
+            redact_jsonable(json.loads(row["monitor_state_snapshot"]))
             if row["monitor_state_snapshot"]
             else None
         ),

--- a/scripts/ai_agent_bridge/_claude.py
+++ b/scripts/ai_agent_bridge/_claude.py
@@ -27,7 +27,7 @@ from agent_runtime.errors import (
 from agent_runtime.runner import invoke as runtime_invoke
 
 from ._broker import _is_task_locked, _remove_pid_file, _write_pid_file
-from ._config import _PARENT_ENV, CLAUDE_CMD, CLAUDE_DEFAULT_MODEL, REPO_ROOT
+from ._config import CLAUDE_CMD, CLAUDE_DEFAULT_MODEL, REPO_ROOT, agent_child_env
 from ._db import get_db, get_session, set_session
 from ._messaging import acknowledge, send_message
 from ._prompts import build_claude_prompt
@@ -284,7 +284,7 @@ def _launch_claude_background(msg, message_id, new_session):
             stdout=lf,
             stderr=subprocess.STDOUT,
             cwd=str(REPO_ROOT),
-            env=_PARENT_ENV,
+            env=agent_child_env("claude"),
             start_new_session=True
         )
         lf.close()

--- a/scripts/ai_agent_bridge/_config.py
+++ b/scripts/ai_agent_bridge/_config.py
@@ -4,6 +4,11 @@ import os
 import shutil
 from pathlib import Path
 
+try:
+    from agent_runtime.env_sanitize import build_agent_env
+except ImportError:  # pragma: no cover - package import mode
+    from scripts.agent_runtime.env_sanitize import build_agent_env
+
 # Repo root for path resolution
 REPO_ROOT = Path(
     os.environ.get("AB_REPO_ROOT", str(Path(__file__).parent.parent.parent))
@@ -51,14 +56,33 @@ if not GEMINI_DEFAULT_MODEL:
     except ImportError:
         GEMINI_DEFAULT_MODEL = GEMINI_FALLBACK_MODEL
 
-# Snapshot environment for passing to detached children
-# Set GEMINI_SESSION so .bashrc disables hostile aliases (eza, bat, zoxide)
-_PARENT_ENV = os.environ.copy()
-_PARENT_ENV["GEMINI_SESSION"] = "1"
 _PIPELINE_ENV_KEY = os.environ.get(
     "AB_PIPELINE_ENV_KEY", "KUBEDOJO_PIPELINE"
 )
-_PARENT_ENV[_PIPELINE_ENV_KEY] = "1"  # Suppress inbox hooks during pipeline runs
+_BASE_AGENT_ENV_OVERRIDES = {
+    "GEMINI_SESSION": "1",
+    _PIPELINE_ENV_KEY: "1",  # Suppress inbox hooks during pipeline runs.
+}
+
+
+def agent_child_env(
+    provider: str | None = None,
+    overrides: dict[str, str | None] | None = None,
+) -> dict[str, str]:
+    """Return a sanitized env scoped to one bridge child provider."""
+    merged_overrides = {**_BASE_AGENT_ENV_OVERRIDES}
+    if overrides:
+        merged_overrides.update(overrides)
+    env = build_agent_env(provider=provider, overrides=merged_overrides)
+    if provider == "gemini" and os.environ.get("KUBEDOJO_GEMINI_SUBSCRIPTION") == "1":
+        env.pop("GEMINI_API_KEY", None)
+        env.pop("GOOGLE_API_KEY", None)
+    return env
+
+
+# Generic sanitized snapshot for compatibility. Provider subprocesses should
+# call agent_child_env("gemini"|"claude"|"codex") instead of using this.
+_PARENT_ENV = agent_child_env()
 # Gemini auth: CLI prefers GEMINI_API_KEY when set; otherwise falls
 # through to OAuth/subscription creds in ~/.gemini/oauth_creds.json.
 # When the API-key tier is rate-limited, set

--- a/scripts/ai_agent_bridge/_gemini.py
+++ b/scripts/ai_agent_bridge/_gemini.py
@@ -38,6 +38,7 @@ from ._config import (
     GEMINI_FALLBACK_MODEL,
     PYTHON_CMD,
     REPO_ROOT,
+    agent_child_env,
 )
 from ._github import _post_review_to_github
 from ._messaging import (
@@ -295,7 +296,7 @@ def _launch_gemini_background(msg: dict, message_id: int, model: str, prompt: st
             stdout=lf,
             stderr=subprocess.STDOUT,
             cwd=str(REPO_ROOT),
-            env=_PARENT_ENV,
+            env=agent_child_env("gemini"),
             start_new_session=True
         )
         lf.close()

--- a/scripts/ai_agent_bridge/_github.py
+++ b/scripts/ai_agent_bridge/_github.py
@@ -4,6 +4,8 @@ import re
 import subprocess
 from datetime import UTC, datetime
 
+from agent_runtime.redact import redact_text
+
 from ._config import GH_CHAR_LIMIT
 
 
@@ -36,12 +38,13 @@ def _split_content(content: str, limit: int = GH_CHAR_LIMIT) -> list[str]:
 
 def _gh_comment(issue_num: int, body: str) -> bool:
     """Post a comment on a GitHub issue. Returns True on success."""
+    body = redact_text(body)
     result = subprocess.run(
         ["gh", "issue", "comment", str(issue_num), "-F", "-"],
         input=body, text=True, capture_output=True, timeout=15
     )
     if result.returncode != 0:
-        print(f"⚠️  GitHub comment failed: {result.stderr[:200]}")
+        print(f"⚠️  GitHub comment failed: {redact_text(result.stderr)[:200]}")
         return False
     return True
 
@@ -54,7 +57,7 @@ def _post_review_to_github(task_id: str, content: str, model: str) -> int | None
     try:
         from ._messaging import _extract_issue_number
         issue_num = _extract_issue_number(task_id)
-        chunks = _split_content(content)
+        chunks = _split_content(redact_text(content))
         total_parts = len(chunks)
 
         if issue_num:
@@ -104,11 +107,11 @@ def _post_as_new_issue(task_id: str, chunks: list[str], model: str, total_parts:
             input=first_body, text=True, capture_output=True, timeout=15
         )
     if result.returncode != 0:
-        print(f"⚠️  GitHub issue creation failed: {result.stderr[:200]}")
+        print(f"⚠️  GitHub issue creation failed: {redact_text(result.stderr)[:200]}")
         return None
 
     # Parse issue number from URL output
-    url = result.stdout.strip()
+    url = redact_text(result.stdout).strip()
     url_match = re.search(r'/issues/(\d+)', url)
     if not url_match:
         print(f"⚠️  Could not parse issue number from: {url}")

--- a/scripts/ai_agent_bridge/_messaging.py
+++ b/scripts/ai_agent_bridge/_messaging.py
@@ -7,6 +7,8 @@ import subprocess
 from datetime import UTC, datetime
 from pathlib import Path
 
+from agent_runtime.redact import redact_jsonable, redact_json_string, redact_text
+
 from ._db import get_db
 
 
@@ -32,7 +34,7 @@ def check_inbox(for_llm: str = "gemini"):
     print(f"📬 {len(rows)} unread message(s) for {for_llm}:\n")
     for row in rows:
         msg_id, from_llm, msg_type, preview, timestamp = row
-        preview = preview.replace('\n', ' ')
+        preview = redact_text(preview).replace('\n', ' ')
         if len(preview) >= 100:
             preview += "..."
         print(f"  [{msg_id}] From: {from_llm} | Type: {msg_type} | {timestamp}")
@@ -76,12 +78,12 @@ def read_message(message_id: int, quiet: bool = False):
         print(f"   Task: {msg['task_id'] or 'N/A'}")
         print(f"   Time: {msg['timestamp']}")
         print(f"\n{'='*60}\n")
-        print(msg['content'])
+        print(redact_text(msg['content']))
 
         if msg['data']:
             print(f"\n{'='*60}")
             print("📎 Attached Data:")
-            print(msg['data'])
+            print(redact_json_string(msg['data']))
 
     return msg
 
@@ -91,6 +93,9 @@ def send_message(content: str, task_id: str | None = None, msg_type: str = "resp
                  from_model: str | None = None, to_model: str | None = None,
                  quiet: bool = False):
     """Send a message between agents."""
+    content = redact_text(content)
+    data = redact_text(data) if data is not None else None
+
     conn = get_db()
     cursor = conn.cursor()
 
@@ -108,7 +113,7 @@ def send_message(content: str, task_id: str | None = None, msg_type: str = "resp
     if to_model:
         metadata["to_model"] = to_model
 
-    data_json = json.dumps(metadata) if metadata else None
+    data_json = json.dumps(redact_jsonable(metadata)) if metadata else None
 
     cursor.execute("""
         INSERT INTO messages (task_id, from_llm, to_llm, message_type, content, data, timestamp, status)
@@ -129,7 +134,7 @@ def send_message(content: str, task_id: str | None = None, msg_type: str = "resp
 
     # Trigger macOS notification to alert human
     try:
-        preview = content[:80].replace('"', '\\"').replace('\n', ' ')
+        preview = redact_text(content[:80]).replace('"', '\\"').replace('\n', ' ')
         notification = f'display notification "{preview}..." with title "{from_llm.title()} → {to_llm.title()}" subtitle "Check inbox"'
         subprocess.run(["osascript", "-e", notification], check=False, capture_output=True)
     except Exception:

--- a/scripts/ai_agent_bridge/_model.py
+++ b/scripts/ai_agent_bridge/_model.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 from pathlib import Path
 
-from ._config import _MODEL_CACHE, _MODEL_CACHE_TTL, _PARENT_ENV, GEMINI_CLI
+from ._config import _MODEL_CACHE, _MODEL_CACHE_TTL, GEMINI_CLI, agent_child_env
 
 
 def _force_gemini_subscription() -> bool:
@@ -12,10 +12,10 @@ def _force_gemini_subscription() -> bool:
 
 
 def _subscription_env() -> dict[str, str]:
-    env = _PARENT_ENV.copy()
-    env.pop("GEMINI_API_KEY", None)
-    env.pop("GOOGLE_API_KEY", None)
-    return env
+    return agent_child_env(
+        "gemini",
+        {"GEMINI_API_KEY": None, "GOOGLE_API_KEY": None},
+    )
 
 
 def _has_gemini_api_key(env: dict[str, str]) -> bool:
@@ -50,7 +50,7 @@ def check_model(model: str, timeout: int = 15, force: bool = False) -> bool:
             print(f"🔍 Model '{model}': {status} (cached {int(age)}s ago)")
             return available
 
-    env = _subscription_env() if _force_gemini_subscription() else _PARENT_ENV
+    env = _subscription_env() if _force_gemini_subscription() else agent_child_env("gemini")
     try:
         result = subprocess.run(
             [GEMINI_CLI, "-m", model, "-p", "Reply with exactly: MODEL_OK"],

--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -26,6 +26,8 @@ from pathlib import Path
 
 import psutil
 
+from agent_runtime.env_sanitize import build_agent_env
+from agent_runtime.redact import redact_text
 from ai_agent_bridge._prompts import build_review_message
 
 REPO_ROOT = Path(__file__).parent.parent
@@ -36,10 +38,22 @@ MCP_CONFIG = REPO_ROOT / ".mcp.json"
 GEMINI_CLI = shutil.which("gemini") or "gemini"
 CODEX_CLI = shutil.which("codex") or "codex"
 
-# Environment for subprocesses
-_ENV = os.environ.copy()
-_ENV["GEMINI_SESSION"] = "1"        # Disable hostile aliases (eza, bat, zoxide)
-_ENV["KUBEDOJO_PIPELINE"] = "1"     # Suppress inbox hooks during pipeline runs
+# Environment for subprocesses. Agent CLIs get sanitized snapshots so broad
+# shell credentials (GitHub/cloud/npm/etc.) are not inherited by model children.
+_AGENT_ENV_OVERRIDES = {
+    "GEMINI_SESSION": "1",        # Disable hostile aliases (eza, bat, zoxide).
+    "KUBEDOJO_PIPELINE": "1",     # Suppress inbox hooks during pipeline runs.
+}
+
+
+def _agent_env(provider: str, overrides: dict[str, str | None] | None = None) -> dict:
+    merged_overrides = {**_AGENT_ENV_OVERRIDES}
+    if overrides:
+        merged_overrides.update(overrides)
+    return build_agent_env(provider=provider, overrides=merged_overrides)
+
+
+_ENV = _agent_env("bridge")
 # Gemini auth: CLI prefers GEMINI_API_KEY when set; otherwise falls
 # through to OAuth/subscription creds in ~/.gemini/oauth_creds.json.
 #
@@ -58,11 +72,11 @@ def _gemini_env(use_subscription: bool) -> dict:
     """Return the child env for a Gemini dispatch. When use_subscription=True,
     strip the API keys so the CLI falls back to OAuth creds."""
     if not use_subscription:
-        return _ENV
-    env = {**_ENV}
-    env.pop("GEMINI_API_KEY", None)
-    env.pop("GOOGLE_API_KEY", None)
-    return env
+        return _agent_env("gemini")
+    return _agent_env(
+        "gemini",
+        {"GEMINI_API_KEY": None, "GOOGLE_API_KEY": None},
+    )
 
 # GitHub comment char limit (65,536 minus safety margin)
 GH_CHAR_LIMIT = 64000
@@ -288,9 +302,9 @@ def dispatch_gemini(prompt: str, model: str | None = None,
                 # Non-zero exit but got output — likely usable
                 _log("gemini", model, full_prompt, output, True, elapsed, stderr)
                 return True, output
-            print(f"Gemini error (exit {proc.returncode}): {stderr[:500]}", file=sys.stderr)
+            print(f"Gemini error (exit {proc.returncode}): {redact_text(stderr)[:500]}", file=sys.stderr)
             _log("gemini", model, full_prompt, output, False, elapsed, stderr)
-            return False, stderr
+            return False, redact_text(stderr)
 
         output = "".join(output_lines).strip()
         _log("gemini", model, full_prompt, output, True, elapsed)
@@ -441,18 +455,20 @@ def dispatch_claude(prompt: str, model: str = CLAUDE_DEFAULT_MODEL,
     t0 = time.time()
 
     try:
-        result = _run_with_process_group(cmd, prompt, timeout, str(REPO_ROOT), _ENV)
+        result = _run_with_process_group(
+            cmd, prompt, timeout, str(REPO_ROOT), _agent_env("claude")
+        )
         elapsed = time.time() - t0
         if result.returncode != 0:
-            print(f"Claude error (exit {result.returncode}): {result.stderr[:500]}", file=sys.stderr)
+            print(f"Claude error (exit {result.returncode}): {redact_text(result.stderr)[:500]}", file=sys.stderr)
             _log("claude", model, prompt, "", False, elapsed, result.stderr)
             # Escalate rate-limit / quota failures so the pipeline can pause
             # the module instead of treating it as a generic write failure.
             if _is_rate_limited(result.stderr) or _is_rate_limited(result.stdout):
                 raise ClaudeUnavailableError(
-                    f"Claude rate-limited or quota exhausted: {result.stderr[:200]}"
+                    f"Claude rate-limited or quota exhausted: {redact_text(result.stderr)[:200]}"
                 )
-            return False, result.stderr
+            return False, redact_text(result.stderr)
         output = result.stdout.strip()
         _claude_call_count += 1
         _log("claude", model, prompt, output, True, elapsed)
@@ -485,7 +501,9 @@ def dispatch_codex(prompt: str, model: str = CODEX_DEFAULT_MODEL,
 
     t0 = time.time()
     try:
-        result = _run_with_process_group(cmd, prompt, timeout, str(REPO_ROOT), _ENV)
+        result = _run_with_process_group(
+            cmd, prompt, timeout, str(REPO_ROOT), _agent_env("codex")
+        )
         elapsed = time.time() - t0
         output = result.stdout.strip()
         stderr = result.stderr or ""
@@ -493,10 +511,10 @@ def dispatch_codex(prompt: str, model: str = CODEX_DEFAULT_MODEL,
         if result.returncode != 0:
             # Check if it was a rate limit / quota issue so caller can degrade
             rate_limited = _is_rate_limited(output + "\n" + stderr)
-            tag = "RATE_LIMIT" if rate_limited else stderr[:500]
+            tag = "RATE_LIMIT" if rate_limited else redact_text(stderr)[:500]
             print(f"Codex error (exit {result.returncode}): {tag}", file=sys.stderr)
             _log("codex", model, prompt, output, False, elapsed, tag)
-            return False, output if output else stderr
+            return False, redact_text(output if output else stderr)
 
         _log("codex", model, prompt, output, True, elapsed)
         return True, output
@@ -528,17 +546,19 @@ def dispatch_codex_review(prompt: str, model: str = CODEX_REVIEW_DEFAULT_MODEL,
 
     t0 = time.time()
     try:
-        result = _run_with_process_group(cmd, prompt, timeout, str(REPO_ROOT), _ENV)
+        result = _run_with_process_group(
+            cmd, prompt, timeout, str(REPO_ROOT), _agent_env("codex")
+        )
         elapsed = time.time() - t0
         output = result.stdout.strip()
         stderr = result.stderr or ""
 
         if result.returncode != 0:
             rate_limited = _is_rate_limited(output + "\n" + stderr)
-            tag = "RATE_LIMIT" if rate_limited else stderr[:500]
+            tag = "RATE_LIMIT" if rate_limited else redact_text(stderr)[:500]
             print(f"Codex review error (exit {result.returncode}): {tag}", file=sys.stderr)
             _log("codex-review", model, prompt, output, False, elapsed, tag)
-            return False, output if output else stderr
+            return False, redact_text(output if output else stderr)
 
         _log("codex-review", model, prompt, output, True, elapsed)
         return True, output
@@ -567,17 +587,19 @@ def dispatch_codex_patch(prompt: str, model: str = CODEX_PATCH_DEFAULT_MODEL,
 
     t0 = time.time()
     try:
-        result = _run_with_process_group(cmd, prompt, timeout, str(REPO_ROOT), _ENV)
+        result = _run_with_process_group(
+            cmd, prompt, timeout, str(REPO_ROOT), _agent_env("codex")
+        )
         elapsed = time.time() - t0
         output = result.stdout.strip()
         stderr = result.stderr or ""
 
         if result.returncode != 0:
             rate_limited = _is_rate_limited(output + "\n" + stderr)
-            tag = "RATE_LIMIT" if rate_limited else stderr[:500]
+            tag = "RATE_LIMIT" if rate_limited else redact_text(stderr)[:500]
             print(f"Codex patch error (exit {result.returncode}): {tag}", file=sys.stderr)
             _log("codex-patch", model, prompt, output, False, elapsed, tag)
-            return False, output if output else stderr
+            return False, redact_text(output if output else stderr)
 
         _log("codex-patch", model, prompt, output, True, elapsed)
         return True, output
@@ -597,7 +619,7 @@ def post_to_github(issue_num: int, content: str, model: str) -> bool:
     if not content:
         return False
 
-    chunks = _split_content(content)
+    chunks = _split_content(redact_text(content))
     total = len(chunks)
 
     for i, chunk in enumerate(chunks, start=1):
@@ -609,10 +631,10 @@ def post_to_github(issue_num: int, content: str, model: str) -> bool:
         try:
             result = subprocess.run(
                 ["gh", "issue", "comment", str(issue_num), "-F", "-"],
-                input=body, text=True, capture_output=True, timeout=15,
+                input=redact_text(body), text=True, capture_output=True, timeout=15,
             )
             if result.returncode != 0:
-                print(f"GitHub comment failed: {result.stderr[:200]}", file=sys.stderr)
+                print(f"GitHub comment failed: {redact_text(result.stderr)[:200]}", file=sys.stderr)
                 return False
         except FileNotFoundError:
             print("gh CLI not found — skipping GitHub posting", file=sys.stderr)
@@ -645,11 +667,11 @@ def _log(agent: str, model: str, prompt: str, output: str, ok: bool,
         "duration_s": round(duration_s, 1),
         "prompt_chars": len(prompt),
         "output_chars": len(output),
-        "prompt": prompt[:5000] + ("..." if len(prompt) > 5000 else ""),
-        "output": output[:10000] + ("..." if len(output) > 10000 else ""),
+        "prompt": redact_text(prompt)[:5000] + ("..." if len(prompt) > 5000 else ""),
+        "output": redact_text(output)[:10000] + ("..." if len(output) > 10000 else ""),
     }
     if stderr:
-        entry["stderr"] = stderr[:2000]
+        entry["stderr"] = redact_text(stderr)[:2000]
 
     log_file.write_text(json.dumps(entry, indent=2, ensure_ascii=False))
     return log_file

--- a/tests/test_agent_env.py
+++ b/tests/test_agent_env.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from agent_runtime.env_sanitize import build_agent_env
+from ai_agent_bridge._config import agent_child_env
+
+
+def _base_env() -> dict[str, str]:
+    return {
+        "PATH": "/bin:/usr/bin",
+        "HOME": "/tmp/home",
+        "GITHUB_TOKEN": "github_pat_012345678901234567890123456789",
+        "GH_TOKEN": "ghp_012345678901234567890123456789012345",
+        "AWS_SECRET_ACCESS_KEY": "aws-secret",
+        "NPM_TOKEN": "npm_012345678901234567890123456789",
+        "OPENAI_API_KEY": "sk-012345678901234567890123456789",
+        "ANTHROPIC_API_KEY": "sk-ant-test-value",
+        "GEMINI_API_KEY": "AIza012345678901234567890123456789",
+        "GOOGLE_API_KEY": "google-api-key",
+        "KUBEDOJO_GEMINI_SUBSCRIPTION": "1",
+        "CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS": "20000",
+        "LEAKY_VALUE": "ghp_012345678901234567890123456789012345",
+        "NORMAL_SETTING": "enabled",
+    }
+
+
+def test_generic_agent_env_strips_token_shaped_names_and_values():
+    env = build_agent_env(base=_base_env())
+
+    assert env["PATH"] == "/bin:/usr/bin"
+    assert env["HOME"] == "/tmp/home"
+    assert env["NORMAL_SETTING"] == "enabled"
+    assert "GITHUB_TOKEN" not in env
+    assert "GH_TOKEN" not in env
+    assert "AWS_SECRET_ACCESS_KEY" not in env
+    assert "NPM_TOKEN" not in env
+    assert "LEAKY_VALUE" not in env
+    assert "OPENAI_API_KEY" not in env
+    assert "ANTHROPIC_API_KEY" not in env
+    assert "GEMINI_API_KEY" not in env
+    assert "GOOGLE_API_KEY" not in env
+
+
+def test_provider_env_keeps_only_matching_provider_secret():
+    codex_env = build_agent_env(provider="codex", base=_base_env())
+    claude_env = build_agent_env(provider="claude", base=_base_env())
+    gemini_env = build_agent_env(provider="gemini", base=_base_env())
+
+    assert codex_env["OPENAI_API_KEY"].startswith("sk-")
+    assert "ANTHROPIC_API_KEY" not in codex_env
+    assert "GEMINI_API_KEY" not in codex_env
+    assert "GITHUB_TOKEN" not in codex_env
+
+    assert claude_env["ANTHROPIC_API_KEY"] == "sk-ant-test-value"
+    assert "OPENAI_API_KEY" not in claude_env
+    assert "GEMINI_API_KEY" not in claude_env
+    assert "GH_TOKEN" not in claude_env
+
+    assert gemini_env["GEMINI_API_KEY"].startswith("AIza")
+    assert gemini_env["GOOGLE_API_KEY"] == "google-api-key"
+    assert "OPENAI_API_KEY" not in gemini_env
+    assert "ANTHROPIC_API_KEY" not in gemini_env
+    assert "AWS_SECRET_ACCESS_KEY" not in gemini_env
+
+
+def test_bridge_env_allows_llm_provider_keys_but_not_github_or_cloud_tokens():
+    env = build_agent_env(provider="bridge", base=_base_env())
+
+    assert "OPENAI_API_KEY" in env
+    assert "ANTHROPIC_API_KEY" in env
+    assert "GEMINI_API_KEY" in env
+    assert "GOOGLE_API_KEY" in env
+    assert "GITHUB_TOKEN" not in env
+    assert "AWS_SECRET_ACCESS_KEY" not in env
+
+
+def test_overrides_apply_before_sanitizing_and_none_removes_allowed_secret():
+    env = build_agent_env(
+        provider="gemini",
+        base=_base_env(),
+        overrides={
+            "GEMINI_API_KEY": None,
+            "GOOGLE_API_KEY": None,
+            "KUBEDOJO_PIPELINE": "1",
+            "GITHUB_TOKEN": "github_pat_999999999999999999999999999999",
+        },
+    )
+
+    assert env["KUBEDOJO_PIPELINE"] == "1"
+    assert "GEMINI_API_KEY" not in env
+    assert "GOOGLE_API_KEY" not in env
+    assert "GITHUB_TOKEN" not in env
+
+
+def test_fake_agent_subprocess_cannot_read_unrelated_token_env():
+    env = build_agent_env(provider="codex", base=_base_env())
+
+    result = subprocess.run(
+        [
+            "sh",
+            "-c",
+            'printf "%s" "${GITHUB_TOKEN-unset}|${OPENAI_API_KEY-unset}|${AWS_SECRET_ACCESS_KEY-unset}"',
+        ],
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=5,
+        check=True,
+    )
+
+    assert result.stdout == f"unset|{_base_env()['OPENAI_API_KEY']}|unset"
+
+
+def test_bridge_child_env_is_provider_scoped(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", _base_env()["OPENAI_API_KEY"])
+    monkeypatch.setenv("ANTHROPIC_API_KEY", _base_env()["ANTHROPIC_API_KEY"])
+    monkeypatch.setenv("GEMINI_API_KEY", _base_env()["GEMINI_API_KEY"])
+    monkeypatch.setenv("GITHUB_TOKEN", _base_env()["GITHUB_TOKEN"])
+
+    claude_env = agent_child_env("claude")
+    gemini_env = agent_child_env("gemini")
+    generic_env = agent_child_env()
+
+    assert claude_env["ANTHROPIC_API_KEY"] == _base_env()["ANTHROPIC_API_KEY"]
+    assert "OPENAI_API_KEY" not in claude_env
+    assert "GEMINI_API_KEY" not in claude_env
+    assert "GITHUB_TOKEN" not in claude_env
+
+    assert gemini_env["GEMINI_API_KEY"] == _base_env()["GEMINI_API_KEY"]
+    assert "OPENAI_API_KEY" not in gemini_env
+    assert "ANTHROPIC_API_KEY" not in gemini_env
+    assert "GITHUB_TOKEN" not in gemini_env
+
+    assert "OPENAI_API_KEY" not in generic_env
+    assert "ANTHROPIC_API_KEY" not in generic_env
+    assert "GEMINI_API_KEY" not in generic_env
+    assert "GITHUB_TOKEN" not in generic_env

--- a/tests/test_bridge_gemini_models.py
+++ b/tests/test_bridge_gemini_models.py
@@ -338,7 +338,7 @@ def test_model_check_falls_back_to_oauth_on_api_quota(monkeypatch):
             )
         return SimpleNamespace(returncode=0, stdout="MODEL_OK", stderr="")
 
-    monkeypatch.setattr(_model, "_PARENT_ENV", {"GEMINI_API_KEY": "api-key"})
+    monkeypatch.setenv("GEMINI_API_KEY", "api-key")
     monkeypatch.setattr(_model.subprocess, "run", fake_run)
     monkeypatch.delenv("KUBEDOJO_GEMINI_SUBSCRIPTION", raising=False)
     _model._MODEL_CACHE.clear()

--- a/tests/test_dispatch_gemini_timeout.py
+++ b/tests/test_dispatch_gemini_timeout.py
@@ -116,8 +116,8 @@ def test_gemini_quiet_mode_defaults_off_outside_pipeline(monkeypatch):
 
 
 def test_gemini_env_strips_api_keys_on_subscription(monkeypatch):
-    monkeypatch.setitem(dispatch._ENV, "GEMINI_API_KEY", "sk-test")
-    monkeypatch.setitem(dispatch._ENV, "GOOGLE_API_KEY", "gg-test")
+    monkeypatch.setenv("GEMINI_API_KEY", "sk-test")
+    monkeypatch.setenv("GOOGLE_API_KEY", "gg-test")
 
     api_env = dispatch._gemini_env(use_subscription=False)
     sub_env = dispatch._gemini_env(use_subscription=True)

--- a/tests/test_egress_redaction.py
+++ b/tests/test_egress_redaction.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import dispatch
+from agent_runtime.redact import REDACTION, redact_jsonable, redact_text
+from ai_agent_bridge import _channels, _db, _github, _messaging
+
+GH_PAT = "github_pat_012345678901234567890123456789"
+OPENAI_KEY = "sk-012345678901234567890123456789"
+GEMINI_KEY = "AIza012345678901234567890123456789"
+
+
+def test_redact_text_catches_token_values_and_assignments():
+    text = (
+        f"GITHUB_TOKEN={GH_PAT}\n"
+        f"OPENAI_API_KEY: {OPENAI_KEY}\n"
+        f"plain {GEMINI_KEY}"
+    )
+
+    redacted = redact_text(text)
+
+    assert GH_PAT not in redacted
+    assert OPENAI_KEY not in redacted
+    assert GEMINI_KEY not in redacted
+    assert redacted.count(REDACTION) >= 3
+
+
+def test_redact_text_catches_quoted_secret_assignments():
+    text = 'GITHUB_TOKEN="custom format secret" PASSWORD=\'another custom secret\''
+
+    redacted = redact_text(text)
+
+    assert "custom format secret" not in redacted
+    assert "another custom secret" not in redacted
+    assert redacted == f"GITHUB_TOKEN={REDACTION} PASSWORD={REDACTION}"
+
+
+def test_redact_jsonable_recurses_nested_payloads():
+    payload = {"outer": [{"token": GH_PAT}], "safe": "keep"}
+
+    redacted = redact_jsonable(payload)
+
+    assert redacted["outer"][0]["token"] == REDACTION
+    assert redacted["safe"] == "keep"
+
+
+def test_redact_jsonable_redacts_values_when_key_is_sensitive():
+    payload = {
+        "PASSWORD": "custom format secret",
+        "nested": {"client_secret": "not token shaped"},
+        "safe": "keep",
+    }
+
+    redacted = redact_jsonable(payload)
+
+    assert redacted["PASSWORD"] == REDACTION
+    assert redacted["nested"]["client_secret"] == REDACTION
+    assert redacted["safe"] == "keep"
+
+
+def test_github_comment_redacts_body_before_posting():
+    completed = subprocess.CompletedProcess(
+        ["gh"], 0, stdout="", stderr="",
+    )
+
+    with patch("ai_agent_bridge._github.subprocess.run", return_value=completed) as run:
+        assert _github._gh_comment(123, f"leak {GH_PAT}") is True
+
+    posted = run.call_args.kwargs["input"]
+    assert GH_PAT not in posted
+    assert REDACTION in posted
+
+
+def test_dispatch_github_post_redacts_body_before_commenting():
+    completed = subprocess.CompletedProcess(
+        ["gh"], 0, stdout="", stderr="",
+    )
+
+    with patch("dispatch.subprocess.run", return_value=completed) as run:
+        assert dispatch.post_to_github(123, f"leak {OPENAI_KEY}", "model") is True
+
+    posted = run.call_args.kwargs["input"]
+    assert OPENAI_KEY not in posted
+    assert REDACTION in posted
+
+
+def test_message_broker_redacts_content_and_data(tmp_path):
+    db_file = tmp_path / "messages.db"
+    with patch("ai_agent_bridge._config.DB_PATH", db_file), patch(
+        "ai_agent_bridge._db.DB_PATH", db_file,
+    ), patch("ai_agent_bridge._messaging.subprocess.run"):
+        _db.init_db()
+        msg_id = _messaging.send_message(
+            f"content {GH_PAT}",
+            data=json.dumps({"key": OPENAI_KEY}),
+            quiet=True,
+        )
+        msg = _messaging.read_message(msg_id, quiet=True)
+
+    assert GH_PAT not in msg["content"]
+    assert REDACTION in msg["content"]
+    assert OPENAI_KEY not in msg["data"]
+    assert REDACTION in msg["data"]
+
+
+def test_channel_post_redacts_body_attachments_and_monitor_snapshot(tmp_path):
+    db_file = tmp_path / "messages.db"
+    with patch("ai_agent_bridge._config.DB_PATH", db_file), patch(
+        "ai_agent_bridge._db.DB_PATH", db_file,
+    ):
+        _db.init_db()
+        _channels.create_channel("topic")
+        _channels.post(
+            "topic",
+            "gemini",
+            f"body {GH_PAT}",
+            attachments=[{"token": OPENAI_KEY}],
+            monitor_state_snapshot={"token": GEMINI_KEY},
+            auto_snapshot=False,
+        )
+        msg = _channels.read("topic")[0]
+
+    assert GH_PAT not in msg["body"]
+    assert msg["attachments"][0]["token"] == REDACTION
+    assert msg["monitor_state_snapshot"]["token"] == REDACTION
+
+
+def test_dispatch_log_redacts_prompt_output_and_stderr(tmp_path):
+    with patch("dispatch.LOG_DIR", tmp_path):
+        log_path = dispatch._log(
+            "codex",
+            "model",
+            f"prompt {GH_PAT}",
+            f"output {OPENAI_KEY}",
+            False,
+            1.0,
+            f"stderr {GEMINI_KEY}",
+        )
+
+    text = log_path.read_text()
+    assert GH_PAT not in text
+    assert OPENAI_KEY not in text
+    assert GEMINI_KEY not in text
+    assert text.count(REDACTION) == 3


### PR DESCRIPTION
## Summary\n- add sanitized child-agent environment construction so LLM subprocesses do not inherit unrelated GitHub/cloud/npm/HF tokens\n- add shared token-shaped egress redaction before GitHub posting, bridge messages, channel posts, dispatch logs, and runtime usage stderr excerpts\n- add regression tests for sanitizer behavior, fake child-process env visibility, and outbound redaction chokepoints\n\nCloses #770\n\n## Verification\n- ../../.venv/bin/ruff check scripts/agent_runtime/env_sanitize.py scripts/agent_runtime/redact.py scripts/agent_runtime/runner.py scripts/agent_runtime/adapters/base.py scripts/ai_agent_bridge/_config.py scripts/ai_agent_bridge/_github.py scripts/ai_agent_bridge/_messaging.py scripts/ai_agent_bridge/_channels.py scripts/dispatch.py tests/test_agent_env.py tests/test_dispatch_gemini_timeout.py tests/test_egress_redaction.py\n- ../../.venv/bin/python -m pytest tests/test_agent_env.py tests/test_egress_redaction.py tests/test_dispatch_gemini_timeout.py tests/test_dispatch_codex_routing.py tests/test_dispatch_zombie_kill.py tests/test_bridge_gemini_models.py tests/test_bridge_channels.py tests/test_bridge_inbox.py tests/test_bridge_inbox_cli.py -q (123 passed, 1 skipped)\n- ../../.venv/bin/python scripts/test_pipeline.py (166 passed)\n\nAstro build skipped: no src/content/docs/ or Astro config changes.