### PR TITLE
feat(388): rewrite module-0.2-environment-permissions (#388 pilot)

### DIFF
--- a/src/content/docs/linux/foundations/everyday-use/module-0.2-environment-permissions.md
+++ b/src/content/docs/linux/foundations/everyday-use/module-0.2-environment-permissions.md
@@ -1,6 +1,7 @@
 ---
 title: "Module 0.2: Environment & Permissions (Who You Are & Where You Are)"
 slug: linux/foundations/everyday-use/module-0.2-environment-permissions
+revision_pending: false
 sidebar:
   order: 3
 lab:
@@ -10,68 +11,51 @@ lab:
   difficulty: "intermediate"
   environment: "ubuntu"
 ---
-> **Everyday Use** | Complexity: `[QUICK]` | Time: 45 min
+
+# Module 0.2: Environment & Permissions (Who You Are & Where You Are)
+
+> **Everyday Use** | Complexity: `[QUICK]` | Time: 45 min | This practical lesson focuses on diagnosing the identity, lookup, inheritance, and permission failures that make everyday Linux work feel unpredictable.
 
 ## Prerequisites
 
-Before starting this module:
+Before starting this module, make sure you can move around the filesystem, run simple commands, and edit a user-owned text file without using elevated privileges.
+
 - **Required**: [Module 0.1: The CLI Power User](../module-0.1-cli-power-user/)
-- **Environment**: Any Linux system (VM, WSL, or native)
+- **Environment**: Any Linux system, including a VM, WSL, or native install
+- **Helpful**: Basic comfort with `cd`, `ls`, command history, and editing a text file
 
----
+## Learning Outcomes
 
-## What You'll Be Able to Do
+After this module, you will be able to perform these troubleshooting tasks in a terminal session and explain the reasoning behind each repair.
 
-After this module, you will be able to:
-- **Configure** shell environment variables (PATH, HOME, PS1) and explain how they're inherited
-- **Debug** "command not found" errors by tracing the PATH variable
-- **Use** sudo safely and explain why running as root is dangerous
-- **Manage** file ownership and permissions across users and groups
-
----
+- **Configure** shell environment variables such as `PATH`, `HOME`, `PS1`, `EDITOR`, and `KUBECONFIG` so child commands inherit the settings you intend.
+- **Debug** command lookup failures by tracing how the shell searches `PATH`, resolves aliases, and treats explicit paths such as `./deploy.sh`.
+- **Evaluate** file permission strings and numeric modes so you can choose least-privilege settings for scripts, directories, SSH material, and shared project files.
+- **Diagnose** ownership and privilege problems with `ls -l`, `chmod`, `chown`, `chgrp`, and targeted `sudo` commands without turning a small fix into a root-owned mess.
 
 ## Why This Module Matters
 
-Picture this. You download a script from a tutorial. You type `./deploy.sh`. The terminal spits back:
+In 2024, a small platform team lost most of a release window because a deployment helper existed on disk, passed code review, and still refused to run on the production jump host. The engineer on call tried `deploy.sh` and got one error, tried `./deploy.sh` and got another, then escalated to a root shell because the clock was moving and the rollback window was closing. The immediate outage cost was measured in delayed customer migrations rather than a public headline, but the internal post-incident review found a familiar chain: unclear `PATH`, missing execute permission, a file edited with `sudo`, and a service account that could no longer read its own configuration.
 
-```
+```text
 bash: ./deploy.sh: Permission denied
 ```
 
-So you try again with `deploy.sh` (without the `./`). Now you get:
-
-```
+```text
 bash: deploy.sh: command not found
 ```
 
-You stare at the screen. The file is *right there*. You can see it with `ls`. Why does Linux pretend it does not exist? And why, when you point directly at it, does Linux refuse to run it?
+Those symptoms feel unrelated when you are new to Linux. "Command not found" sounds like a missing file, "Permission denied" sounds like a hostile operating system, and `sudo` feels like a universal escape hatch. In reality, all three are usually signs that Linux is doing exactly what it was designed to do: separating identity, location, inheritance, and authority. The shell needs a search path before it can find a command by name, the kernel needs an execute bit before it can run a file as a program, and privileged operations need an accountable way to borrow root power.
 
-These two errors — "Permission denied" and "command not found" — are probably the most common frustrations for Linux beginners. They feel random and unfair. But they are not random at all. They come from two systems that are working exactly as designed:
+The same mental model follows you into Kubernetes 1.35 and newer. A container still runs as a user, a mounted Secret still has file modes, a ServiceAccount still needs scoped authority, and a command launched with a broken environment still behaves like any other child process. This module gives you a practical way to reason about those failures before the pressure is high. You will learn to ask who is running, where the command is found, which variables are inherited, which permission bit is missing, and whether `sudo` is solving the actual problem or hiding it.
 
-1. **The Environment** — a collection of settings that tells your shell where to find programs, who you are, and how to behave
-2. **Permissions** — a security system that controls who can read, write, and execute every single file on the system
+## 1. The Environment Is a Contract Between Parent and Child
 
-Once you understand these two systems, those cryptic errors transform from brick walls into helpful signposts. You will know *exactly* what is wrong and *exactly* how to fix it. More importantly, when you start working with Kubernetes, you will understand why containers run as non-root, why ServiceAccounts exist, and why RBAC matters — because they are all built on these same permission concepts.
+Environment variables are not magic shell decorations. They are name-value pairs that a process carries around and optionally passes to the processes it starts. Your terminal shell has an environment, every command you run receives an environment, and each child process gets a copy rather than a live connection back to the parent. That copy-on-start behavior is why environment bugs can be confusing: a value may look correct in your current prompt while a script, editor, daemon, or test process sees something different.
 
----
+Think of the environment like the settings sheet handed to a contractor at the start of a job. It says where home base is, which editor to open, what language to use, where commands are searched, and which cluster configuration should be read. If the sheet is wrong or never handed over, the contractor does not know your intentions. Linux will not guess that a deployment script needs your unexported variable, and it will not search your Downloads folder just because you recently saved a binary there.
 
-## Did You Know?
-
-1. The `$PATH` variable was introduced in Unix Version 7 in 1979. Before that, you had to type the full path to every single command — imagine typing `/usr/bin/ls` every time you wanted to list files.
-
-2. The numeric permission system (like `chmod 755`) is based on **octal** (base-8) numbers. Each digit represents three binary bits — one for read, one for write, one for execute. It is literally binary math you can do in your head.
-
-3. The `sudo` command logs every single invocation to `/var/log/auth.log` (or `/var/log/secure` on RHEL-based systems). Your sysadmin can see exactly what you ran and when. There are no secrets with `sudo`.
-
-4. On most Linux distributions, the root user's home directory is `/root`, not `/home/root`. Root is so special it does not even live in the same neighborhood as regular users.
-
----
-
-## 1. Environment Variables: Your Terminal's Settings Panel
-
-Think of environment variables like the **Settings app on your phone**. Your phone stores your language preference, your default browser, your wallpaper choice — all so that every app knows how to behave without asking you each time. Environment variables do the same thing for your terminal and every program that runs inside it.
-
-An environment variable is simply a **name=value pair** stored in memory. By convention, the names use ALL_CAPS with underscores:
+The basic inspection commands are deliberately simple. `env` and `printenv` show exported environment variables, while `echo $NAME` asks the shell to expand a specific variable before the command runs. The dollar sign matters because it tells the shell, not the program, to substitute the variable's value. That distinction becomes important later when you debug scripts that behave differently from the commands you type by hand.
 
 ```bash
 # See ALL your environment variables (there are a lot!)
@@ -80,12 +64,12 @@ env
 # Or use printenv for the same thing
 printenv
 
-# See just one specific variable — the $ says "give me the value"
+# See just one specific variable - the $ says "give me the value"
 echo $USER
 echo $HOME
 ```
 
-### The Essential Variables You Should Know
+The most useful variables are not useful because they are exotic; they are useful because so many tools quietly depend on them. `$HOME` tells programs where to store user-level configuration, `$SHELL` explains which shell was assigned to your account, `$PWD` tracks the current working directory, and `$PATH` determines how command names become executable files. `$EDITOR` and `$KUBECONFIG` are especially common in operations work because tools need to know which editor to launch and which Kubernetes cluster configuration to read.
 
 | Variable | What It Stores | Example Value |
 | :--- | :--- | :--- |
@@ -97,9 +81,9 @@ echo $HOME
 | `$LANG` | Your language and encoding | `en_US.UTF-8` |
 | `$HOSTNAME` | The name of this machine | `web-server-01` |
 | `$TERM` | Your terminal type | `xterm-256color` |
-| `$PATH` | Where to find commands | (see next section) |
+| `$PATH` | Where to find commands | A colon-separated directory list |
 
-Try them right now:
+Run a few checks on your own machine and read the output as a status report, not as trivia. If `$HOME` is unexpected, tools may write config in a surprising place. If `$SHELL` is not the shell whose startup file you edited, your aliases may never load. If `$PWD` is not where you think you are, relative paths will point to the wrong files. These checks are small, but they build the habit of confirming assumptions before reaching for broader fixes.
 
 ```bash
 echo "Hello, $USER! You are on $HOSTNAME."
@@ -107,23 +91,64 @@ echo "Your home is $HOME and your shell is $SHELL."
 echo "You are currently in $PWD."
 ```
 
----
+Pause and predict: if a script prints an empty value for `$PROJECT_NAME` but your prompt prints the expected value, what process boundary should you investigate first? The right answer is usually not "the script is broken." It is usually "the variable exists in the parent shell but was never exported to the child process," or "the command was launched from a different shell that never loaded the same configuration."
 
-## 2. $PATH — The Most Important Variable You Will Ever Meet
+`PS1` deserves special mention because it proves that environment and shell settings overlap but are not identical. `PS1` controls the interactive prompt in shells such as Bash, and changing it can help you display the current directory, cluster name, or user. However, prompt changes are a convenience for humans, not a permission control. A prompt that says `prod` does not prove your commands target production, and a prompt that says `dev` does not protect you from a dangerous `KUBECONFIG`.
 
-When you type `ls` and press Enter, how does your shell know where the `ls` program lives? It does not search the entire hard drive — that would take forever. Instead, it checks a specific list of directories, in order, and runs the first match it finds. That list is your `$PATH`.
+When you set a variable in the current shell without `export`, the shell can expand it, but child processes do not automatically receive it. When you export a variable, you mark it for inheritance so future child processes receive a copy at startup. The distinction is easy to demonstrate and worth practicing until it becomes instinctive, because many deployment failures are caused by a local value that never left the parent shell.
+
+```bash
+# Setting a variable WITHOUT export
+GREETING="Hello from parent"
+echo $GREETING        # Works! Prints: Hello from parent
+bash                  # Start a child shell (a new process)
+echo $GREETING        # Nothing! Empty! The child does not know about it
+exit                  # Return to parent shell
+
+# Setting a variable WITH export
+export GREETING="Hello from parent"
+echo $GREETING        # Works! Prints: Hello from parent
+bash                  # Start a child shell
+echo $GREETING        # Works! Prints: Hello from parent
+exit                  # Return to parent shell
+```
+
+Use unexported variables for values that only your current shell needs, such as a temporary file name used in one interactive sequence. Use exported variables for values that programs need to read after they start. Kubernetes work commonly uses exported `KUBECONFIG`, editor tooling commonly uses exported `EDITOR`, and language toolchains often use exported variables such as `JAVA_HOME`. The rule is not about importance; it is about whether a child process must see the value.
+
+```bash
+# Common exports you will see in Kubernetes work
+export KUBECONFIG=~/.kube/config
+export EDITOR=vim
+export JAVA_HOME=/usr/lib/jvm/java-17
+
+# Quick throwaway - no export needed
+BACKUP_DATE=$(date +%Y-%m-%d)
+echo "Backing up for $BACKUP_DATE"
+```
+
+If a value should no longer exist, remove it instead of setting it to a blank value and hoping every tool interprets that blank the same way. `unset` deletes the variable from the current shell, and future children will not inherit it unless you set it again. This is especially useful when you stop using a temporary cluster config or a one-off build flag and want to return to normal behavior.
+
+```bash
+# Remove a variable entirely
+unset GREETING
+echo $GREETING    # Nothing - it is gone
+```
+
+## 2. PATH Turns Command Names Into Files
+
+When you type `ls`, the shell does not search your entire disk. It walks through the directories listed in `$PATH`, from left to right, and runs the first executable file with the matching name. This is a performance decision and a security decision. It keeps command lookup predictable, and it prevents arbitrary files in random directories from being treated as commands just because they happen to share a name with something you typed.
 
 ```bash
 echo $PATH
 ```
 
-You will see something like this (directories separated by colons):
+You will usually see a colon-separated list. Each directory is a place the shell is allowed to search by command name. The order matters because the first match wins, which is why putting a custom directory before `/usr/bin` can intentionally override a system command, while putting it after `/usr/bin` keeps the system command as the default.
 
-```
+```text
 /usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/home/alice/bin
 ```
 
-Here is how the shell uses it when you type a command:
+Here is the lookup process when you type a command such as `kubectl`. In KubeDojo labs we define the standard shortcut with `alias k=kubectl` or the quoted form `alias k='kubectl'`, and after that point you can use commands such as `k get pods` when the module asks you to inspect Kubernetes resources. The alias is a shell shortcut, but the underlying lookup still depends on an executable named `kubectl` being found in `PATH`.
 
 ```mermaid
 flowchart TD
@@ -138,35 +163,31 @@ flowchart TD
     H -- "NO" --> J["bash: kubectl: command not found"]
 ```
 
-> **Pause and predict**: If you type `kubectl` and the shell searches through all directories in your `$PATH` but doesn't find it, what exact error message will it print?
-
-This is why `./deploy.sh` works but `deploy.sh` does not. The current directory (`.`) is **not** in your `$PATH` by default. When you type `deploy.sh`, the shell looks through every `$PATH` directory, never finds it, and gives up. When you type `./deploy.sh`, you are giving an explicit path — you are saying "run the file right here" — so the shell does not need `$PATH` at all.
-
-### Finding Where Commands Live
+This explains why `./deploy.sh` and `deploy.sh` can fail differently while referring to the same file. `deploy.sh` is only a command name, so the shell searches `PATH` and does not automatically include the current directory. `./deploy.sh` is an explicit relative path, so the shell skips `PATH` lookup and asks the kernel to run the file at that location. If the file exists but lacks execute permission, the problem has moved from command lookup to file mode.
 
 ```bash
-# which — shows the full path of a command
+# which - shows the full path of a command
 which ls
 # Output: /usr/bin/ls
 
 which python3
 # Output: /usr/bin/python3
 
-# type — shows what the shell thinks a command is
+# type - shows what the shell thinks a command is
 type ls
 # Output: ls is aliased to 'ls --color=auto'   (if aliased)
-# Output: ls is /usr/bin/ls                      (if not)
+# Output: ls is /usr/bin/ls                    (if not)
 
 type cd
-# Output: cd is a shell builtin                  (built into bash itself)
+# Output: cd is a shell builtin                (built into bash itself)
 ```
 
-### Adding a Directory to $PATH
+`which` is useful, but `type` is often better during shell debugging because it can reveal aliases, functions, and builtins. If `type k` says the command is an alias, the shell expands it before normal lookup continues. If `type cd` says the command is a builtin, there is no external executable to find. This layered resolution model is why "command not found" is only one possible failure among several, and why the first diagnostic step should be identifying what the shell believes the word means.
 
-Say you put custom scripts in `~/bin`. You need to add that directory to your `$PATH`:
+Adding a personal script directory to `PATH` is normal, but the placement is a deliberate choice. Put your directory at the front when you intentionally want your tool to win over a system tool with the same name. Put it at the end when you want system tools to keep priority. In either case, use an absolute or home-relative directory, and make the change permanent only after you have tested the temporary export in the current shell.
 
 ```bash
-# Temporary — lasts until you close the terminal
+# Temporary - lasts until you close the terminal
 export PATH="$HOME/bin:$PATH"
 
 # Verify it worked
@@ -174,97 +195,32 @@ echo $PATH
 # Now /home/alice/bin appears at the front
 ```
 
-Putting your directory at the **front** means your custom scripts get found first, before system commands with the same name. Putting it at the **end** means system commands take priority.
+Do not add the current directory, `.`, to the beginning of `PATH`. The convenience looks harmless until you stand in a directory controlled by someone else. A malicious executable named `ls`, `ssh`, or `kubectl` can then win command lookup simply because the shell checks the current directory first. Saving two characters with `./` is not worth allowing untrusted directories to become command sources.
 
-To make it permanent, add the `export PATH=...` line to your shell config file (covered in Section 4).
+War Story: a team inherited an old build host where root's `PATH` began with `.` because an administrator wanted local helper scripts to feel convenient. During an incident, a temporary directory contained a file named `ls` from a failed tool extraction. A root shell entered that directory and ran `ls`, which executed the local file instead of `/usr/bin/ls`. The compromise was contained quickly, but the root cause was not an advanced exploit; it was command lookup order combined with unnecessary root authority.
 
-### Trade-off: Convenience vs. Security in $PATH
+Before running this, what output do you expect from `type deploy.sh` when `deploy.sh` exists in the current directory but no directory in `PATH` contains that name? If you expect "command not found," you are tracking the shell's perspective correctly. Existence in the current directory is not enough for name-based lookup, and the shell does not treat visible files as commands unless the path rules say it should.
 
-It might be tempting to add the current directory (`.`) to your `$PATH` like this: `export PATH=".:$PATH"`. This way, you could just type `deploy.sh` instead of `./deploy.sh`.
+## 3. Startup Files Make Settings Persistent
 
-**War Story**: A sysadmin once added `.` to the *beginning* of their root user's `$PATH` for convenience. An attacker created a malicious script named `ls` and placed it in a world-writable directory like `/tmp`. When the sysadmin `cd`'d into `/tmp` and typed `ls`, the shell searched `.` first, found the malicious script, and executed it as root. The server was instantly compromised. The trade-off is clear: saving two keystrokes (`./`) is never worth giving an attacker an easy execution vector. Always keep `.` out of your `$PATH` and use explicit paths for local files.
-
----
-
-## 3. Setting Variables: `export` vs No `export`
-
-This distinction trips up almost everyone. 
-
-> **Stop and think**: If you set `API_KEY="12345"` in your terminal without `export`, and then run a deployment script that needs to read `$API_KEY`, will the script succeed? Why or why not?
-
-Watch carefully:
-
-```bash
-# Setting a variable WITHOUT export
-GREETING="Hello from parent"
-echo $GREETING        # Works! Prints: Hello from parent
-bash                   # Start a child shell (a new process)
-echo $GREETING        # Nothing! Empty! The child does not know about it
-exit                   # Return to parent shell
-
-# Setting a variable WITH export
-export GREETING="Hello from parent"
-echo $GREETING        # Works! Prints: Hello from parent
-bash                   # Start a child shell
-echo $GREETING        # Works! Prints: Hello from parent
-exit                   # Return to parent shell
-```
-
-Why does this matter? Because every command you run is a **child process** of your shell. When you run a Python script, a Docker command, or kubectl, they are all child processes. If you set a variable without `export`, those programs cannot see it.
-
-The rule is simple:
-
-- **No `export`**: Variable exists only in your current shell session. Use this for quick throwaway values.
-- **With `export`**: Variable is inherited by every child process. Use this for settings that programs need to see (like `$KUBECONFIG`, `$EDITOR`, `$JAVA_HOME`).
-
-```bash
-# Common exports you will see in Kubernetes work
-export KUBECONFIG=~/.kube/config
-export EDITOR=vim
-export JAVA_HOME=/usr/lib/jvm/java-17
-
-# Quick throwaway — no export needed
-BACKUP_DATE=$(date +%Y-%m-%d)
-echo "Backing up for $BACKUP_DATE"
-```
-
-### Unsetting Variables
-
-```bash
-# Remove a variable entirely
-unset GREETING
-echo $GREETING    # Nothing — it is gone
-```
-
----
-
-## 4. Shell Config Files: Making Changes Permanent
-
-Every change you make in the terminal is **temporary** — it vanishes when you close the window. To make environment variables, aliases, and `$PATH` changes permanent, you need to add them to a **shell config file** that runs automatically when a new shell starts.
-
-But which file? This is where it gets confusing, because there are several and they run at different times.
-
-### When Each File Runs
+Interactive shell changes disappear when the shell exits because they live in process memory. To keep aliases, exports, prompt settings, and `PATH` additions across new terminals, you place them in startup files that your shell reads when it begins. The confusing part is that "a new shell" does not always mean the same kind of shell. SSH sessions, graphical terminal tabs, login shells, and non-login interactive shells can read different files depending on the shell program and operating system defaults.
 
 ```mermaid
 flowchart TD
     subgraph Login ["LOGIN SHELL (SSH session, first terminal on Linux)"]
-        L1["Runs: /etc/profile<br/>→ then the FIRST one found of:<br/>~/.bash_profile<br/>~/.bash_login<br/>~/.profile"]
-        L2>Think: 'Welcome! Let me set up your entire session.']
+        L1["Runs: /etc/profile<br/>then the FIRST one found of:<br/>~/.bash_profile<br/>~/.bash_login<br/>~/.profile"]
+        L2>Think: "Welcome! Let me set up your entire session."]
         L1 --> L2
     end
 
     subgraph NonLogin ["INTERACTIVE NON-LOGIN SHELL (new terminal tab/window on desktop)"]
         N1["Runs: ~/.bashrc"]
-        N2>Think: 'Just another shell, here are your shortcuts.']
+        N2>Think: "Just another shell, here are your shortcuts."]
         N1 --> N2
     end
 ```
 
-In practice, most people want their settings in **every** shell. The standard trick is:
-
-1. Put all your settings in `~/.bashrc`
-2. Have `~/.bash_profile` source it:
+For Bash users, the common operational pattern is to keep interactive settings in `~/.bashrc` and make `~/.bash_profile` source it. That way, login shells and non-login interactive shells converge on the same practical configuration. For Zsh users, especially on macOS, `~/.zshrc` is the usual place for interactive aliases and exports. The exact file matters less than verifying which shell you use and which startup path it actually reads.
 
 ```bash
 # Contents of ~/.bash_profile
@@ -273,13 +229,7 @@ if [ -f ~/.bashrc ]; then
 fi
 ```
 
-This way, login shells load `.bashrc` too, and you only maintain one file.
-
-**For Zsh users** (default on macOS): The equivalent is `~/.zshrc`. Zsh reads it for every interactive shell, login or not — much simpler.
-
-### Reloading After Changes
-
-After editing your config file, you do NOT need to close and reopen the terminal:
+Reloading matters because editing a startup file does not change the environment of the already-running shell. A shell reads its startup files at startup, then continues with its in-memory state. If you add `export PATH="$HOME/bin:$PATH"` to `~/.bashrc`, the current prompt will not notice until you source the file or start a new interactive shell. This detail explains many "I edited the file but nothing changed" reports.
 
 ```bash
 # Reload .bashrc immediately
@@ -289,11 +239,7 @@ source ~/.bashrc
 . ~/.bashrc
 ```
 
----
-
-## 5. Aliases: Your Custom Shortcut Commands
-
-An alias is a custom shortcut that expands into a longer command. They save you keystrokes every single day.
+Aliases are expanded by the interactive shell before the command is executed. They are excellent for repeatable shortcuts, but they are not a replacement for scripts when logic becomes conditional or multi-line. In this module, the important alias is `k='kubectl'`, which is the short form used throughout KubeDojo after the alias has been defined. If a lab says `k get pods`, it means the shell expands `k` to `kubectl` before command execution, and Kubernetes 1.35 command behavior comes from the real CLI.
 
 ```bash
 # Create an alias
@@ -305,10 +251,10 @@ alias ports='ss -tulnp'
 alias myip='curl -s ifconfig.me'
 ```
 
-### Practical Aliases for DevOps and Kubernetes
+These aliases are typical because they shorten commands people run constantly, but they also show the boundary of alias usefulness. `ll` is a harmless display preference, while `rm='rm -i'` changes safety behavior and deserves a team convention. Aliases are personal shell features, so they should never be required for automation unless the script defines its own behavior explicitly. A CI job should call the real command or a committed wrapper script, not depend on someone's private `.bashrc`.
 
 ```bash
-# Kubernetes — the k alias is used throughout KubeDojo
+# Kubernetes - the k alias is used throughout KubeDojo
 alias k='kubectl'
 alias kgp='kubectl get pods'
 alias kgs='kubectl get svc'
@@ -322,7 +268,7 @@ alias dps='docker ps'
 alias dimg='docker images'
 alias dex='docker exec -it'
 
-# Safety nets — ask before overwriting
+# Safety nets - ask before overwriting
 alias cp='cp -i'
 alias mv='mv -i'
 alias rm='rm -i'
@@ -333,7 +279,7 @@ alias diskinfo='df -h'
 alias cpuinfo='lscpu'
 ```
 
-To make aliases permanent, add them to your `~/.bashrc`:
+Make aliases permanent by placing them in your startup file, then reload the file in the current shell. If an alias works immediately after you type it but disappears tomorrow, persistence is the issue. If an alias still does not work after sourcing the file, inspect the shell type, the startup file path, and whether a later line redefines or removes it.
 
 ```bash
 # Open your .bashrc and add aliases at the bottom
@@ -343,7 +289,7 @@ nano ~/.bashrc
 source ~/.bashrc
 ```
 
-### Checking and Removing Aliases
+You also need to know how to inspect and bypass aliases, because they can hide the real command during debugging. A backslash before a command disables alias expansion for that invocation, while `command ls` asks the shell to run the command without shell functions. This is useful when a safety alias or display alias makes output differ from a script, another user's terminal, or a production host.
 
 ```bash
 # See all your current aliases
@@ -354,20 +300,20 @@ alias ll
 # Output: alias ll='ls -la'
 
 # Temporarily bypass an alias (use the real command)
-\ls          # The backslash skips the alias
-command ls   # Another way to skip
+\ls
+command ls
 
 # Remove an alias for this session
 unalias ll
 ```
 
+Which approach would you choose here and why: add `~/downloads` to `PATH`, move one trusted binary into `~/bin`, or run it by explicit path from `~/downloads`? For a one-time tool, explicit path is usually clearest. For a trusted personal tool you use every week, `~/bin` is reasonable. Adding a general downloads directory to `PATH` is weak because downloads are often unreviewed and cluttered.
+
 ---
 
-## 6. File Permissions: The rwx System
+## 4. Permissions Decide What Identity Can Do
 
-Linux is a **multi-user** operating system. Even if you are the only human using the machine, there are dozens of system users (like `www-data` for your web server, `postgres` for your database). Permissions ensure that your web server cannot read your SSH keys and your database cannot modify your application code.
-
-Run `ls -l` in any directory:
+Linux permissions exist because Linux is a multi-user operating system even when only one human logs in. System services run as separate users such as `www-data`, `postgres`, or `systemd-network`, and those identities limit damage when one process is compromised. A web server should not read your SSH private key, a database should not rewrite your shell startup file, and a deployment script should not become editable by every account on the machine.
 
 ```bash
 ls -l /etc/passwd /bin/ls /home
@@ -378,7 +324,7 @@ ls -l /etc/passwd /bin/ls /home
 # drwxr-xr-x 3 root root    4096 Mar 10 14:22 /home
 ```
 
-Let us decode that first column character by character:
+The first column in `ls -l` is a compact permission report. The first character tells you the file type, and the next nine characters are grouped into owner, group, and others. Each group has read, write, and execute positions. That string is not just display text; it is the fastest way to decide whether the user running a command has the authority needed for the action being attempted.
 
 ```mermaid
 flowchart LR
@@ -388,41 +334,27 @@ flowchart LR
     P --> O["r-x : OTHERS"]
 ```
 
-### What r, w, x Actually Mean
+File and directory permissions use the same letters, but the directory meanings are different enough to cause real bugs. Read on a directory lets you list names. Execute on a directory lets you traverse into it and access known names. Write on a directory lets you create, delete, and rename entries inside it. That means a file can be writable while the containing directory blocks deletion, or a directory can be enterable while its contents cannot be listed.
 
 | Permission | On a File | On a Directory |
 | :--- | :--- | :--- |
-| `r` (read) | View the file contents (`cat`, `less`) | List the directory contents (`ls`) |
+| `r` (read) | View the file contents with `cat` or `less` | List the directory contents with `ls` |
 | `w` (write) | Modify or overwrite the file | Create, rename, or delete files inside it |
-| `x` (execute) | Run the file as a program | Enter the directory (`cd`) |
+| `x` (execute) | Run the file as a program | Enter the directory with `cd` |
 | `-` (none) | Cannot do the action | Cannot do the action |
 
-The directory permissions catch people off guard. A directory without `x` is like a room with a locked door — you cannot walk in, even if you know what is inside. A directory without `r` but with `x` is like a dark room — you can walk in and grab files if you know their names, but you cannot turn on the lights to see what is there.
-
-### Reading Permission Strings — Practice
+The directory distinction is why `Permission denied` can appear even when a file itself looks readable. If you cannot traverse one parent directory on the path, Linux cannot reach the file on your behalf. A directory without execute permission is like a locked hallway. A directory with execute but without read is like a hallway you can walk through only if you already know the exact door name.
 
 | String | Owner | Group | Others | Meaning |
 | :--- | :--- | :--- | :--- | :--- |
-| `-rwxr-xr-x` | rwx | r-x | r-x | Typical program — everyone can run it, only owner can edit |
-| `-rw-r--r--` | rw- | r-- | r-- | Typical config file — everyone can read, only owner can edit |
-| `-rw-------` | rw- | --- | --- | Private file — only owner can read and write |
-| `-rwx------` | rwx | --- | --- | Private script — only owner can run it |
-| `drwxr-xr-x` | rwx | r-x | r-x | Typical directory — everyone can enter and list, only owner can modify |
-| `drwx------` | rwx | --- | --- | Private directory — only owner can enter |
+| `-rwxr-xr-x` | rwx | r-x | r-x | Typical program: everyone can run it, only owner can edit |
+| `-rw-r--r--` | rw- | r-- | r-- | Typical config file: everyone can read, only owner can edit |
+| `-rw-------` | rw- | --- | --- | Private file: only owner can read and write |
+| `-rwx------` | rwx | --- | --- | Private script: only owner can run it |
+| `drwxr-xr-x` | rwx | r-x | r-x | Typical directory: everyone can enter and list, only owner can modify |
+| `drwx------` | rwx | --- | --- | Private directory: only owner can enter |
 
----
-
-## 7. Changing Permissions with `chmod`
-
-`chmod` (change mode) modifies permissions. You can use it in two ways.
-
-### Symbolic Mode — Human-Readable
-
-Format: `chmod [who][operator][permission] file`
-
-- **Who**: `u` (user/owner), `g` (group), `o` (others), `a` (all three)
-- **Operator**: `+` (add), `-` (remove), `=` (set exactly)
-- **Permission**: `r`, `w`, `x`
+`chmod` changes the mode, which is the permission bit pattern. Symbolic mode is readable and minimizes mistakes when you only need one adjustment, such as adding execute permission for the owner. Numeric mode is compact and precise when you want to set the full owner, group, and others pattern in one operation. Both are valid; the operational skill is choosing the one that makes the intended change obvious.
 
 ```bash
 # Make a script executable for the owner
@@ -434,7 +366,7 @@ chmod go-w config.yaml
 # Give everyone read permission
 chmod a+r README.md
 
-# Set exact permissions — owner gets rwx, everyone else gets nothing
+# Set exact permissions - owner gets rwx, everyone else gets nothing
 chmod u=rwx,go= secret-script.sh
 
 # Add execute for everyone
@@ -444,11 +376,9 @@ chmod +x run-tests.sh        # Without specifying who, + applies to all
 chmod o= private-notes.txt   # = with nothing after it means "set to nothing"
 ```
 
-### Numeric Mode — Fast and Precise
+Numeric mode comes from adding read as 4, write as 2, and execute as 1 for each of owner, group, and others. A 7 means all three bits, a 6 means read plus write, a 5 means read plus execute, and a 0 means no permission. Once you see the bits, values such as `755`, `644`, `600`, and `700` become descriptions rather than memorized magic numbers.
 
-Each permission has a number: **read = 4, write = 2, execute = 1**. Add them up for each position (owner, group, others).
-
-```
+```text
 Permission  Binary  Decimal
 ---------   -----   -------
   ---        000       0     (no permissions)
@@ -461,71 +391,67 @@ Permission  Binary  Decimal
   rwx        111       7     (read + write + execute)
 ```
 
-You specify three digits: owner, group, others.
-
 ```bash
-# 755 — owner: rwx (7), group: r-x (5), others: r-x (5)
+# 755 - owner: rwx (7), group: r-x (5), others: r-x (5)
 # Standard for scripts and programs
 chmod 755 deploy.sh
 
-# 644 — owner: rw- (6), group: r-- (4), others: r-- (4)
+# 644 - owner: rw- (6), group: r-- (4), others: r-- (4)
 # Standard for regular files
 chmod 644 config.yaml
 
-# 600 — owner: rw- (6), group: --- (0), others: --- (0)
+# 600 - owner: rw- (6), group: --- (0), others: --- (0)
 # Private files (SSH keys, passwords)
 chmod 600 ~/.ssh/id_rsa
 
-# 700 — owner: rwx (7), group: --- (0), others: --- (0)
+# 700 - owner: rwx (7), group: --- (0), others: --- (0)
 # Private directories, private scripts
 chmod 700 ~/.ssh
 
-# 444 — owner: r-- (4), group: r-- (4), others: r-- (4)
-# Read-only for everyone (like a museum exhibit — look but do not touch)
+# 444 - owner: r-- (4), group: r-- (4), others: r-- (4)
+# Read-only for everyone
 chmod 444 important-record.txt
 ```
 
-> **Pause and predict**: You have a directory. You want users to be able to `cd` into it and `ls` its contents, but NOT be able to create or delete files. What is the numeric `chmod` value for this exact set of permissions?
-
-### The Most Common Permission Patterns
+Pause and predict: you have a directory where users should be able to enter and list files but must not create or delete anything. Which bits are required on the directory, and which bit must be absent? Read plus execute are required for listing and traversal, while write must be absent. For owner-only access that pattern is `500`; for a typical shared read-only directory it may appear as `755` when the owner still needs write permission.
 
 | Pattern | Numeric | Use Case |
 | :--- | :--- | :--- |
 | `rwxr-xr-x` | `755` | Programs, scripts, directories |
 | `rw-r--r--` | `644` | Regular files, config files |
-| `rw-------` | `600` | SSH private keys, secrets |
+| `rw-------` | `600` | SSH private keys, secret-like local files |
 | `rwx------` | `700` | SSH directory, private scripts |
 | `rwxrwxr-x` | `775` | Shared project directories |
 | `rw-rw-r--` | `664` | Shared project files |
 
----
+The wrong reflex is `chmod 777` because it appears to fix everything at once. It does, but by granting every user read, write, and execute access. On a shared host, that means another account can replace your script before you run it. In a container image, it can turn a minor application compromise into persistent tampering. Least privilege is not ceremony; it is the discipline of granting the missing bit to the identity that actually needs it.
 
-## 8. Ownership with `chown` and `chgrp`
+## 5. Ownership, Groups, and Sudo Connect Identity to Authority
 
-Every file has two ownership attributes: a **user** (owner) and a **group**.
+Every file has an owner and a group, and permissions are evaluated against the identity of the process trying to act. If the process user is the owner, owner bits apply. If the process is not the owner but belongs to the file's group, group bits apply. If neither condition matches, the others bits apply. This is why changing ownership can be more secure than widening "others" permissions for everyone on the system.
 
 ```bash
 # Check ownership
 ls -l myfile.txt
 # -rw-r--r-- 1 alice developers 1024 Mar 10 14:22 myfile.txt
 #               ^^^^^  ^^^^^^^^^^
-#               owner    group
+#               owner  group
 ```
 
-### Changing Ownership
+Changing a file's owner usually requires root authority because ownership affects disk quotas, accountability, and access control. If any user could give large files to someone else, they could evade quotas or frame another account for storage usage. Group changes are sometimes allowed without `sudo` when you own the file and belong to the target group, but ownership changes should still be treated as security decisions rather than routine cleanup.
 
 ```bash
 # Change owner (requires sudo because you are giving away a file)
 sudo chown bob myfile.txt
 ```
 
-> **Stop and think**: Why does Linux require you to use `sudo` to give a file you own to another user? What malicious thing could you do if you could arbitrarily assign ownership of large files to other users?
+When a team shares project files, the group is often the cleanest unit of access. You can keep the owner as the human or service that manages the file, then set the group to `developers`, `webteam`, or another role-specific group. The file mode can grant the group read or write permission without opening access to every other account. This pattern maps well to services because system accounts can be placed in narrow groups rather than being given broad world-readable access.
 
 ```bash
 # Change group only
 sudo chgrp developers myfile.txt
 
-# Change both at once — user:group
+# Change both at once - user:group
 sudo chown bob:developers myfile.txt
 
 # Change ownership of a directory and EVERYTHING inside it (-R = recursive)
@@ -535,29 +461,9 @@ sudo chown -R alice:webteam /var/www/mysite
 chgrp devops deployment.yaml     # No sudo needed if you belong to "devops"
 ```
 
-### Why Ownership Matters for Kubernetes
+Recursive ownership changes deserve extra caution because they turn one command into hundreds or thousands of file changes. If the target path is wrong, `-R` spreads the mistake quickly. Before using `sudo chown -R`, run `ls -ld` on the directory, confirm the path, and consider whether only one subdirectory actually needs the change. When a service cannot read a file, the better first question is "which identity is the service using?" rather than "how do I make everything writable?"
 
-When a container runs, it runs as a specific user (often root by default, which is a security risk). Kubernetes `securityContext` lets you set `runAsUser` and `runAsGroup` — the exact same user/group ownership concept you are learning here, just applied inside a container.
-
----
-
-## 9. The Root User and `sudo`
-
-### Root: The All-Powerful Superuser
-
-Linux has one special user called `root` (UID 0). Root can:
-
-- Read, write, and execute any file regardless of permissions
-- Kill any process
-- Modify any system configuration
-- Bind to privileged ports (below 1024)
-- Format disks, mount filesystems, do absolutely anything
-
-This is why running as root is **dangerous**. A typo like `rm -rf /` (instead of `rm -rf ./`) would wipe the entire system. There is no "Are you sure?" prompt, no recycle bin, no undo.
-
-### sudo: Borrow Root Power Safely
-
-`sudo` stands for "superuser do." It lets an authorized regular user run a single command with root privileges:
+Linux has one special user named `root`, with user ID 0. Root can override normal permissions, manage services, install packages, bind privileged ports, and change system configuration. That power is necessary for administration, but it is also why routine work as root is dangerous. A typo that merely fails as a normal user can destroy important files as root, and a root-owned file accidentally created in your home directory can break applications that later run under your normal account.
 
 ```bash
 # Install a package (requires root)
@@ -575,25 +481,18 @@ sudo whoami
 # Output: root
 ```
 
-When you run `sudo`, it asks for **your** password (not root's password). This confirms that the person at the keyboard is actually you and not someone who walked up to your unlocked laptop.
-
-### The sudoers File
-
-Not everyone can use `sudo`. The file `/etc/sudoers` controls who is allowed. You should **never** edit it directly — always use the special `visudo` command, which checks for syntax errors before saving (a broken sudoers file can lock you out of root access entirely).
+`sudo` is the preferred way to borrow root authority for a specific command because it leaves an audit trail and keeps the privileged action narrow. It asks for your password because it is verifying the authorized user at the keyboard, not because it knows or needs the root password. A targeted `sudo systemctl restart nginx` is much safer than starting a long-lived root shell and then forgetting which prompt is privileged.
 
 ```bash
 # See your sudo privileges
 sudo -l
 
 # Common output shows something like:
-# (ALL : ALL) ALL         — you can do anything as any user
-# (ALL) NOPASSWD: ALL     — you can do anything without a password (common on cloud VMs)
+# (ALL : ALL) ALL         - you can do anything as any user
+# (ALL) NOPASSWD: ALL     - you can do anything without a password (common on cloud VMs)
 ```
 
-On most systems, you get sudo access by being in a specific group:
-
-- **Ubuntu/Debian**: The `sudo` group
-- **RHEL/CentOS/Fedora**: The `wheel` group
+The `/etc/sudoers` policy controls who may use `sudo`, and it should be edited with `visudo` rather than a normal editor. `visudo` checks syntax before saving because a broken sudoers file can lock administrators out of privileged access. On Debian and Ubuntu systems, membership in the `sudo` group usually grants sudo access. On RHEL, CentOS, and Fedora families, the equivalent group is often `wheel`.
 
 ```bash
 # Check what groups you belong to
@@ -603,99 +502,128 @@ groups
 # If "sudo" or "wheel" is in the list, you can use sudo
 ```
 
-### Best Practices with sudo
+Safe sudo usage starts by asking whether privilege is actually required. Reading your own file, editing your own notes, and running a script in your home directory should not need root. If you use `sudo vim notes.txt`, the file may be created or saved as root-owned, leaving your normal account unable to edit it later. This is one of the most common self-inflicted permission problems on development machines.
 
 ```bash
 # DO: Use sudo for specific commands that need it
 sudo systemctl restart nginx
 
 # DO NOT: Start a root shell and work in it
-sudo -i        # Avoid this — you lose the safety net of per-command authorization
-sudo su -      # Avoid this too — same problem
+sudo -i        # Avoid this - you lose the safety net of per-command authorization
+sudo su -      # Avoid this too - same problem
 
 # DO NOT: Use sudo for things that do not need it
 sudo cat myfile.txt    # If you own the file, just use cat!
-sudo vim notes.txt     # The file will end up owned by root — now YOU cannot edit it
+sudo vim notes.txt     # The file will end up owned by root - now YOU cannot edit it
 ```
 
-**War Story**: A junior engineer once ran `sudo vim` to edit a config file in their home directory. The file's ownership changed to root. Later, the application that needed to read that config file (running as a normal user) got "Permission denied" and crashed in production. The fix was a simple `chown`, but finding the cause took hours of debugging. The lesson: only use `sudo` when you actually need root privileges.
+War Story: a junior engineer once ran `sudo vim` to edit a config file in their home directory because they had recently used sudo for a system service and stayed in the habit. The file became owned by root. Hours later, an application running as the normal user crashed with `Permission denied` while reading that config, and the team investigated application code before noticing ownership. The fix was one `chown`, but the lesson was sharper: use privilege for the command that needs it, then put it down.
 
----
+There is one more sudo trap worth knowing early. Shell redirection happens in your current shell before `sudo` runs the command, so `sudo echo "line" >> /etc/hosts` still asks the unprivileged shell to open `/etc/hosts` for appending. Use `sudo tee -a /etc/hosts` instead when the privileged operation is the write itself. That pattern keeps the privilege narrow while moving it to the process that opens the protected file.
+
+## Patterns & Anti-Patterns
+
+The healthy pattern across environment and permissions work is to diagnose in the same layer where the failure occurs. If a command name fails, inspect `type`, `which`, and `PATH` before changing permissions. If an explicit path fails, inspect `ls -l` and parent directory traversal before using `sudo`. If a service cannot read a file, inspect the service user and group before broadening access for everyone. This layered approach avoids the common habit of applying root authority to every unknown error.
+
+For personal shell setup, prefer small, reviewable startup file changes. Add `~/bin` to `PATH` only when it contains tools you trust and maintain. Keep aliases in one startup file, source it intentionally, and use `type` to confirm what the shell will execute. If a shortcut becomes part of a team workflow, move it into documentation or a committed script so the behavior does not depend on one person's terminal history.
+
+For file permissions, prefer symbolic changes when the current mode is mostly right and numeric modes when the target state must be exact. `chmod u+x script.sh` communicates "make this executable for the owner" without disturbing group and others bits. `chmod 600 ~/.ssh/id_rsa` communicates "set this private key to owner read-write only" and avoids accidental leftover access. Both are precise because they say what problem they solve.
+
+For shared access, prefer groups over world permissions. A project directory owned by `alice:developers` with group write can support collaboration without giving every local account the same authority. If the group approach becomes hard to reason about, write down the intended identities: who edits, who reads, who executes, and who only traverses. Permissions are easier when they reflect a real role model instead of a sequence of emergency chmod commands.
+
+The major anti-pattern is treating `sudo` as a debugging tool rather than an authority boundary. `sudo` can make a command succeed by bypassing permission checks, but that does not prove the original user had the right access, and it can leave root-owned files behind. Another anti-pattern is widening permissions until the error disappears, especially with `777`. The error disappearing is not the same as the system being correct; it may mean the system is now too open to notice the original mistake.
+
+Another anti-pattern is hiding security-sensitive assumptions in shell startup files. A `.bashrc` that silently changes `KUBECONFIG`, prepends untrusted directories to `PATH`, or aliases destructive commands to unexpected behavior can make one terminal behave differently from another. Keep important context visible, confirm it before sensitive actions, and remember that scripts and non-interactive shells often do not read the same files as your interactive prompt.
+
+## Decision Framework
+
+Start with the error boundary. If the shell says `command not found`, ask whether you typed a command name or a path. For command names, run `type name`, inspect `PATH`, and decide whether the tool belongs in an existing searched directory, a trusted personal directory, or should be run by explicit path. Do not use `chmod` to fix a lookup problem, because execute permission is irrelevant until the shell has resolved the file to execute.
+
+If the shell found the file but the kernel says `Permission denied`, inspect `ls -l file` and `ls -ld` on the parent directories. Add execute permission only when the file should be runnable, and add directory execute permission only when users should traverse that directory. If the file is owned by the wrong user or group, correct ownership instead of granting broad access. If the operation touches system paths, use a targeted `sudo` command rather than opening a root shell.
+
+For persistence questions, separate "works now" from "loads later." A command typed at the prompt changes only the current shell unless it edits a startup file. A startup file change affects future shells only after startup or an explicit `source`. If a child process cannot see a variable, check `export`. If a new terminal cannot see an alias, check which shell started and which startup file it read. This framework keeps fixes small and reversible.
+
+Use the following mental flow during incidents: first identify the actor, then identify the path, then identify the permission bit, then identify whether privilege is necessary. The actor is the process user, not necessarily you. The path may be explicit or found through `PATH`. The bit may belong to a file or a directory. Privilege is the last step, not the first, because root can hide the evidence you need to make the lasting fix.
+
+When the failure involves Kubernetes tooling, keep the same sequence instead of treating the cluster as a different universe. If `k get pods` fails before contacting the API server, the problem may be the local alias, the `kubectl` binary lookup, or the exported `KUBECONFIG` value. If a pod starts but cannot read a mounted file, inspect the container user, `runAsUser`, `runAsGroup`, filesystem mode, and directory traversal bits before changing application code. If an operation reaches the API server and returns an authorization error, you have moved beyond Unix file permissions into ServiceAccount and RBAC policy, but the diagnostic habit is still the same: name the actor, name the resource, then inspect the rule that connects them.
+
+During reviews, ask for the smallest command that proves the theory. `type command` proves lookup. `env | grep NAME` proves exported process environment better than a shell-only echo. `ls -ld parent child` proves directory traversal and file bits together. `id` proves user and group membership. `sudo -l` proves privilege policy without changing any files. These checks are boring in the best possible way, because they narrow the problem before anyone changes ownership, widens mode bits, or starts a privileged shell.
+
+If you are unsure which branch of the framework applies, reproduce the failure with the most explicit command you can write. Replace a command name with an absolute path, replace a shell-only variable check with an exported child-process check, and replace a broad permission change with a read-only inspection command. Each substitution removes one possible explanation without mutating the system. That discipline is what separates controlled troubleshooting from accidental configuration drift. Keep a short incident note beside each command.
+
+## Did You Know?
+
+- The `$PATH` variable became a standard part of Unix practice early in Unix history, and Unix Version 7 from 1979 is a common reference point for the environment model many modern shells still resemble. Before command search paths became normal, users had to type more full paths or rely on a smaller set of built-in conventions.
+- Numeric permissions such as `755` are octal, which means each digit represents three binary bits. Read, write, and execute are simply `4`, `2`, and `1`, so `7` is not a mysterious privilege level; it is the sum of all three allowed actions.
+- `sudo` normally logs invocations through the system logging stack, commonly into authentication logs such as `/var/log/auth.log` on Debian and Ubuntu or `/var/log/secure` on RHEL-family systems. The command is designed for accountable privilege, not invisible privilege.
+- The root user's home directory is normally `/root`, not `/home/root`. That path difference is a practical reminder that root is a special administrative identity, not just another regular user with a higher number of permissions.
 
 ## Common Mistakes
 
 | Mistake | Why It Happens | How to Fix It |
 | :--- | :--- | :--- |
-| "command not found" for a script in the current directory | The current directory `.` is not in `$PATH`. Typing `script.sh` makes the shell search `$PATH` only. | Run it with `./script.sh` (explicit path) or add its directory to `$PATH`. |
-| "Permission denied" when running a script | The file does not have execute (`x`) permission. Linux requires it explicitly. | Run `chmod u+x script.sh` then try again. |
-| Alias disappears after closing the terminal | You defined it in the shell but not in `~/.bashrc`. Shell settings do not persist automatically. | Add the `alias` line to `~/.bashrc` and run `source ~/.bashrc`. |
-| `export` in `.bashrc` does not take effect | You edited the file but did not reload it. The running shell does not watch for file changes. | Run `source ~/.bashrc` or open a new terminal. |
-| Using `sudo vim` to edit files you own | Creates the file as root-owned. Now your normal user cannot modify it. | Use `vim` without `sudo`. If already owned by root, run `sudo chown $USER file`. |
-| Running as root all the time (`sudo su -`) | Feels convenient but removes all safety nets. One wrong `rm` can destroy everything. | Use `sudo` per command. Exit root shells immediately when done. |
-| `chmod 777` on everything to "fix" permission errors | Gives everyone full access — a massive security hole. | Figure out which specific permission is missing and grant only that. Usually `chmod 755` or `644` is correct. |
-| Forgetting the `-R` flag with `chown` or `chmod` | Only changes the directory itself, not the files inside it. | Use `-R` for recursive: `sudo chown -R alice:devs /project`. |
+| "command not found" for a script in the current directory | The current directory `.` is not in `$PATH`, so typing `script.sh` makes the shell search only configured directories. | Run it with `./script.sh` for an explicit path, or move a trusted reusable script into a directory already listed in `$PATH`. |
+| "Permission denied" when running a script | The file exists, but it does not have execute permission for the user, group, or others category that applies to your process. | Run `ls -l script.sh`, then use `chmod u+x script.sh` or a precise numeric mode such as `755` when that matches the intended sharing model. |
+| Alias disappears after closing the terminal | The alias was defined only in the running shell process, so the next shell starts without it. | Add the `alias` line to the correct startup file such as `~/.bashrc` or `~/.zshrc`, then run `source ~/.bashrc` or open a new terminal. |
+| Exported value does not reach a program | The value was assigned without `export`, or the program was launched from a different shell that never received the value. | Use `export NAME=value` before starting the child process, or pass a one-command environment assignment such as `NAME=value command`. |
+| Using `sudo vim` to edit files you own | The editor runs as root and can create or save files with root ownership in your working tree or home directory. | Edit files you own without `sudo`; if damage already happened, inspect with `ls -l` and repair ownership with a targeted `sudo chown $USER file`. |
+| Running as root all the time with `sudo -i` or `sudo su -` | A root shell feels convenient because it avoids repeated prompts, but it removes the per-command pause that catches mistakes. | Use `sudo` for the specific command that needs privilege, then return to normal user operations immediately. |
+| Applying `chmod 777` to "fix" permissions | It removes the error by granting everyone full access, including users who should never edit or execute the file. | Determine the missing bit and the affected identity, then grant the narrowest useful mode such as `u+x`, `644`, `755`, `600`, or a group-specific setting. |
+| Forgetting directory permissions during file debugging | The file mode looks correct, but one parent directory lacks execute permission or the containing directory blocks creation and deletion. | Check each relevant directory with `ls -ld`, remember that directory write controls create/delete, and adjust the directory mode rather than the file mode when appropriate. |
 
----
+## Quiz
 
-## Quiz (Testing Your Outcomes)
+<details><summary><strong>Q1 [Outcome: Debug command lookup]</strong>: A junior developer downloads a binary named <code>kubens</code> into <code>~/downloads</code>. They type <code>kubens</code> and get "command not found", even though <code>ls ~/downloads</code> shows the file. What do you check, and what fix would you choose?</summary>
 
-**Test yourself.** Try to answer before revealing the solution.
-
-<details>
-<summary><strong>Q1 [Outcome: Debug "command not found"]</strong>: You are helping a junior developer. They downloaded a binary called <code>kubens</code> into <code>~/downloads</code> and typed <code>kubens</code>. The terminal returns "command not found". They prove the file is there by running <code>ls ~/downloads</code> and seeing <code>kubens</code> listed. Why did this happen and how do they fix it?</summary>
-
-The shell only looks for commands in the directories listed in the `$PATH` environment variable. By default, `~/downloads` is not in `$PATH`, and the current directory (`.`) is also not checked automatically for security reasons. Because of this, the shell cannot resolve the command name to the actual file location on disk. To fix this, the developer must either provide the explicit relative or absolute path (e.g., `./kubens` or `~/downloads/kubens`) or move the binary to a directory that is already in `$PATH`, like `/usr/local/bin`.
+The shell is searching `PATH`, not every directory where files happen to exist, and `~/downloads` is normally not in `PATH`. First run `type kubens` or inspect `echo $PATH` to confirm the lookup failure. For one-time use, run the binary by explicit path such as `~/downloads/kubens`; for a trusted tool used regularly, move it into `~/bin` or another searched directory. Adding a general downloads directory to `PATH` is weaker because downloads often contain unreviewed files.
 </details>
 
-<details>
-<summary><strong>Q2 [Outcome: Configure environment]</strong>: You set a database password using <code>DB_PASS=secret</code> in your terminal. You then run a Python script <code>python3 connect.py</code> that reads the <code>DB_PASS</code> environment variable, but the script crashes complaining that the variable is missing. You type <code>echo $DB_PASS</code> and see "secret". What is happening?</summary>
+<details><summary><strong>Q2 [Outcome: Configure inherited environment]</strong>: You set <code>PROJECT_NAME=kubedojo-lab</code>, confirm that <code>echo $PROJECT_NAME</code> works, and then a child script prints an empty value. Why can both observations be true?</summary>
 
-The variable was set locally in the current shell, but it was not exported to the environment. When you run a script or program, it spawns as a child process of your current shell. Child processes only inherit environment variables that have been explicitly flagged with the `export` command. Because it was missing, the Python script spawned with an environment that did not contain `DB_PASS`. To fix this, you need to run `export DB_PASS=secret` before running the Python script, or pass it inline like `DB_PASS=secret python3 connect.py`.
+The current shell can expand a variable that exists only in its own shell state, but child processes inherit only exported variables. The script starts as a separate process, so it receives a copy of the exported environment at launch time. If `PROJECT_NAME` was not exported, the script has no value to read even though the parent prompt can still echo it. Use `export PROJECT_NAME=kubedojo-lab` before starting the script when the child process must see it.
 </details>
 
-<details>
-<summary><strong>Q3 [Outcome: Manage permissions]</strong>: A web server running as the user <code>www-data</code> needs to read a configuration file <code>app.conf</code>. The file is currently owned by <code>alice:developers</code> with permissions <code>-rw-r-----</code>. The <code>www-data</code> user is not part of the <code>developers</code> group. What is the most secure way to grant the web server read access without exposing the file to every user on the system?</summary>
+<details><summary><strong>Q3 [Outcome: Evaluate permissions]</strong>: A script has mode <code>-rw-r--r--</code>. Running <code>script.sh</code> returns "command not found", while running <code>./script.sh</code> returns "Permission denied". Explain both failures and the smallest likely fix.</summary>
 
-The most secure approach is to change the group ownership of the file to a group that `www-data` already belongs to, or change the owner directly to `www-data`. You should avoid using broad permissions like `chmod 777` or `chmod o+r` (which results in `644`), as these would allow any other user on the system to read the potentially sensitive configuration. By using a command like `chown alice:www-data app.conf` (assuming `www-data` acts as a group), the group permissions (`r--`) will apply exclusively to the web server. This keeps the "others" permissions at zero (`---`), ensuring the principle of least privilege is maintained.
+The first command uses name-based lookup, so the shell searches `PATH` and does not automatically search the current directory. The second command provides an explicit relative path, so lookup succeeds, but the kernel refuses to execute the file because no execute bit is set. The smallest likely fix is `chmod u+x script.sh` if only the owner should run it, followed by `./script.sh`. Moving the file into `PATH` is a separate decision and should be reserved for trusted reusable commands.
 </details>
 
-<details>
-<summary><strong>Q4 [Outcome: Manage permissions]</strong>: You have a directory <code>/opt/scripts/</code> with permissions <code>drwxr-x---</code> owned by <code>root:devops</code>. You are logged in as <code>bob</code>, who is a member of the <code>devops</code> group. You try to create a new script inside this directory using <code>touch /opt/scripts/new.sh</code>, but you receive a "Permission denied" error. Why?</summary>
+<details><summary><strong>Q4 [Outcome: Diagnose directory permission]</strong>: A directory is <code>drwxr-x---</code> and owned by <code>root:devops</code>. Bob belongs to <code>devops</code> and can list the directory, but <code>touch /opt/scripts/new.sh</code> fails. Which bit is missing?</summary>
 
-File creation within a Linux directory is governed by the write (`w`) permission of the directory itself, not the permissions of the files inside it. As a member of the `devops` group, the directory's group permissions `r-x` apply to your user. The `r` (read) allows you to list the directory contents, and the `x` (execute) allows you to enter the directory using the `cd` command. However, since the group lacks the `w` (write) permission, you are forbidden from modifying the directory's inventory, which means you cannot create, delete, or rename files within it.
+Bob is using the group permission triplet because he is a member of `devops`, and that triplet is `r-x`. Read lets him list names, and execute lets him traverse into the directory, but write is required to create, delete, or rename entries inside the directory. The missing bit is group write on the directory, not on a file that does not exist yet. A fix such as `sudo chmod g+w /opt/scripts` may be appropriate only if the group should truly manage entries there.
 </details>
 
-<details>
-<summary><strong>Q5 [Outcome: Use sudo safely]</strong>: You need to append a new line to a protected system file <code>/etc/hosts</code>. You try running <code>sudo echo "10.0.0.5 myserver" >> /etc/hosts</code>, but you get a "Permission denied" error, even though you used <code>sudo</code>. Why did this fail, and how do you fix it?</summary>
+<details><summary><strong>Q5 [Outcome: Use sudo narrowly]</strong>: You need to append one line to <code>/etc/hosts</code>. Why does <code>sudo echo "10.0.0.5 myserver" >> /etc/hosts</code> still fail, and what should you run instead?</summary>
 
-The failure happens because the shell handles output redirection (`>>`) before `sudo` ever executes the command. As a result, `sudo` only applies to the `echo` command itself, while your current, unprivileged shell attempts to open `/etc/hosts` for writing, which it lacks the permissions to do. To fix this safely without switching entirely to a root shell, you can use the `tee` command combined with `sudo`. Running `echo "10.0.0.5 myserver" | sudo tee -a /etc/hosts` executes `tee` with root privileges, allowing it to successfully append the text to the protected file.
+The shell performs `>> /etc/hosts` before `sudo` starts `echo`, so the unprivileged shell is the process trying to open the protected file for writing. `sudo` only applies to `echo`, which is not the operation being denied. A safer fix is `echo "10.0.0.5 myserver" | sudo tee -a /etc/hosts`, because `tee` runs with privilege and performs the append. This keeps the privileged operation narrow without opening a full root shell.
 </details>
 
-<details>
-<summary><strong>Q6 [Outcome: Use sudo safely]</strong>: An application running on your server is crashing, and the logs are in <code>/var/log/app/error.log</code>, which is owned by <code>root:root</code> with <code>-rw-------</code> permissions. You type <code>sudo vim /var/log/app/error.log</code> to investigate. Why is this a bad practice, and what should you do instead?</summary>
+<details><summary><strong>Q6 [Outcome: Diagnose ownership]</strong>: After editing a project config with <code>sudo vim</code>, your normal application process can no longer update the file. <code>ls -l</code> shows the owner is <code>root</code>. What happened, and how do you recover without making the file world-writable?</summary>
 
-Using an interactive editor like `vim` with `sudo` simply to view a file is highly dangerous because it runs the entire editor program with root privileges. If you accidentally bump the keyboard, you might unintentionally modify critical system logs or configuration files. Furthermore, if the editor contains vulnerabilities or automatically executes macros, those actions will execute with full system-level authority. Instead, you should always use commands specifically designed for read-only viewing, such as `sudo less`, `sudo cat`, or `sudo tail`, which eliminate the risk of accidental modification or privilege escalation.
+The editor ran as root and saved the file with root ownership, so the normal application user no longer matches the owner permissions. Making the file world-writable would hide the symptom while granting unnecessary authority to every local account. Inspect the intended owner and group, then use a targeted command such as `sudo chown alice:developers config.yaml` or the appropriate service identity. After ownership is correct, set a narrow mode such as `640`, `644`, or `660` depending on who should read and write it.
 </details>
 
-<details>
-<summary><strong>Q7 [Outcome: Manage permissions]</strong>: You downloaded a bash script <code>setup.sh</code> that automates a complex installation. When you run <code>./setup.sh</code>, the system says "Permission denied". You run <code>ls -l</code> and see <code>-rw-r--r--</code>. You are tempted to run <code>chmod 777 setup.sh</code> to get it working quickly. What is the numeric permission you should actually use, and why is <code>777</code> a bad idea?</summary>
+<details><summary><strong>Q7 [Outcome: Choose least privilege]</strong>: A web service running as <code>www-data</code> needs to read <code>app.conf</code>, currently owned by <code>alice:developers</code> with mode <code>-rw-r-----</code>. The service is not in <code>developers</code>. What is better than <code>chmod o+r app.conf</code>?</summary>
 
-The correct numeric permission for a script you want to run is `755` (or simply `chmod u+x` if only the owner needs to execute it). Using `chmod 777` is a massive security risk because it grants read, write, and execute permissions to every single user on the entire system. This means any other user could maliciously modify the script to inject harmful commands, which you would unknowingly execute the next time you ran it. By using `755` (`-rwxr-xr-x`), you ensure that only the owner can modify the file, while everyone else is restricted to merely reading and executing it.
+`chmod o+r` would let every local user read the file, which may be too broad for configuration that contains internal details. A better fix is to align ownership or group membership with the service identity. For example, set the group to one that includes `www-data`, or use `sudo chown alice:www-data app.conf` if that group model is appropriate, while keeping the group read bit and leaving others at zero. The key is to grant read access to the service role, not to the entire machine.
 </details>
 
-<details>
-<summary><strong>Q8 [Outcome: Configure environment]</strong>: You want to override the system's version of <code>python3</code> (located in <code>/usr/bin/python3</code>) with a newer version you compiled yourself and placed in <code>/opt/custom/bin/python3</code>. However, when you type <code>python3 --version</code>, it still shows the old system version. How do you modify your environment to fix this?</summary>
+<details><summary><strong>Q8 [Outcome: Configure PATH precedence]</strong>: You compiled a newer <code>python3</code> in <code>/opt/custom/bin</code>, but <code>python3 --version</code> still reports the system version from <code>/usr/bin</code>. How do you debug and correct the environment?</summary>
 
-The shell searches through the directories listed in your `$PATH` variable from left to right and immediately stops at the first matching executable it finds. Because `/usr/bin` is already present in your default `$PATH` and your custom directory is not (or is placed at the very end), the shell discovers the system version first. To override this behavior, you must prepend your custom directory to the absolute front of the `$PATH` by adding a line like `export PATH="/opt/custom/bin:$PATH"` to your `~/.bashrc`. This guarantees that the shell evaluates `/opt/custom/bin` prior to `/usr/bin`, allowing your custom compiled version to take precedence.
+Run `type python3` to see what the shell resolves first, then inspect the order of directories in `echo $PATH`. The shell stops at the first matching executable, so `/usr/bin` winning means your custom directory is absent or appears later. To intentionally prefer the custom build in interactive shells, add `export PATH="/opt/custom/bin:$PATH"` to the correct startup file and source it. Be careful with this kind of override because system tools may expect the distribution-provided interpreter.
 </details>
-
----
 
 ## Hands-On Exercise: Environment and Permissions Boot Camp
 
-**Scenario**: You are setting up a development environment on a new server. You need to configure your shell, create a project with proper permissions, and set up scripts that your team can use.
+You are setting up a development environment on a new server. The goal is not to memorize commands; it is to practice identifying which layer owns each failure. You will inspect inherited environment values, make a shell shortcut persistent, create a script that fails for a real permission reason, repair it narrowly, and secure a local config file without using `sudo` for files you own.
 
-### Part 1: Environment Variables
+### Setup
+
+Use a regular user account in a disposable VM, WSL session, or lab environment. Do not run this exercise from a root shell. If you already have a heavily customized `~/.bashrc`, read the commands first and adapt the alias block so you do not overwrite personal settings. The commands append a clearly marked section that you can remove after the lab.
+
+### Task 1: Inspect and Export Environment State
+
+Run the commands, then explain why the first child process cannot see `PROJECT_NAME` and the second child process can. This confirms the parent-child inheritance model from the core lesson.
 
 ```bash
 # 1. Display your current username, home directory, and shell
@@ -706,17 +634,24 @@ echo "Shell: $SHELL"
 # 2. See your entire $PATH, one directory per line (easier to read)
 echo $PATH | tr ':' '\n'
 
-# 3. Set a variable WITHOUT export — verify it does not reach child processes
+# 3. Set a variable WITHOUT export - verify it does not reach child processes
 PROJECT_NAME="kubedojo-lab"
-echo $PROJECT_NAME         # Should print: kubedojo-lab
-bash -c 'echo $PROJECT_NAME'   # Should print nothing (empty)
+echo $PROJECT_NAME
+bash -c 'echo $PROJECT_NAME'
 
 # 4. Now export it and verify the child process CAN see it
 export PROJECT_NAME="kubedojo-lab"
-bash -c 'echo $PROJECT_NAME'   # Should print: kubedojo-lab
+bash -c 'echo $PROJECT_NAME'
 ```
 
-### Part 2: Shell Configuration
+<details><summary>Solution notes for Task 1</summary>
+
+The unexported value exists only in the current shell, so `echo $PROJECT_NAME` works before the child starts. `bash -c 'echo $PROJECT_NAME'` starts a child shell, and that child receives only exported environment variables. After `export PROJECT_NAME="kubedojo-lab"`, the child shell receives a copy and prints the expected value. This is the same reason deployment tools, test runners, and Kubernetes helpers may miss variables that look correct in your prompt.
+</details>
+
+### Task 2: Persist Aliases Safely
+
+Append a small alias block to `~/.bashrc`, reload it, and verify the shell expands your shortcut. The `k` alias is included because KubeDojo uses it after explaining that it expands to `kubectl`.
 
 ```bash
 # 5. Add useful aliases to your .bashrc
@@ -731,10 +666,18 @@ EOF
 
 # 6. Reload your config and test
 source ~/.bashrc
-ll       # Should show detailed listing with hidden files
+ll
+type k
 ```
 
-### Part 3: Permissions
+<details><summary>Solution notes for Task 2</summary>
+
+`source ~/.bashrc` runs the file in the current shell, so you do not need to close the terminal. `ll` should expand to `ls -la`, and `type k` should report that `k` is aliased to `kubectl` if no later line overrides it. If `type k` does not show the alias, confirm you are using Bash and confirm that the alias block was appended to the file you sourced. In a Zsh shell, place the same alias in `~/.zshrc` instead.
+</details>
+
+### Task 3: Create and Repair a Script Permission Failure
+
+Create a project script, attempt to run it, inspect the failure, and add only the permission bit required for the owner to execute it. The point is to distinguish "file exists" from "file is executable."
 
 ```bash
 # 7. Create a project directory structure
@@ -747,7 +690,7 @@ echo "Deploying $PROJECT_NAME..."
 echo "Deploy complete at $(date)"
 EOF
 
-# 9. Try to run it — observe the error
+# 9. Try to run it - observe the error
 ~/lab-project/scripts/deploy.sh
 # Expected: Permission denied
 
@@ -767,13 +710,20 @@ ls -l ~/lab-project/scripts/deploy.sh
 # Expected: "Deploying kubedojo-lab..." and timestamp
 ```
 
-### Part 4: Securing Files
+<details><summary>Solution notes for Task 3</summary>
+
+The file exists and the path is explicit, so `PATH` is not the failure layer in this task. The failure happens because the file mode lacks execute permission, and the kernel refuses to run it as a program. `chmod u+x` adds execute only for the owner and leaves group and others unchanged, which is narrower than `chmod 777`. If the script still prints an empty project name, return to Task 1 and confirm that `PROJECT_NAME` is exported in the same shell.
+</details>
+
+### Task 4: Secure Local Files Without Sudo
+
+Create a local file that represents sensitive configuration and lock it down with owner-only file and directory modes. This is not a real credential, but the permission pattern is the same one you will use for SSH keys and local secret-like development files.
 
 ```bash
-# 14. Create a "secret" config file
-echo "DB_PASSWORD=supersecret123" > ~/lab-project/secrets/db.env
+# 14. Create a local config file
+echo "DB_PASSWORD=example-password" > ~/lab-project/secrets/db.env
 
-# 15. Lock it down — only you can read and write (numeric mode)
+# 15. Lock it down - only you can read and write (numeric mode)
 chmod 600 ~/lab-project/secrets/db.env
 
 # 16. Verify
@@ -789,24 +739,41 @@ ls -la ~/lab-project/scripts/
 ls -la ~/lab-project/secrets/
 ```
 
+<details><summary>Solution notes for Task 4</summary>
+
+The file mode `600` gives the owner read and write while giving group and others no access. The directory mode `700` lets only the owner list, create, delete, and traverse entries in that directory. No `sudo` is required because you created these files under your own home directory and already own them. If you accidentally used `sudo` and the files became root-owned, repair the ownership with a targeted `sudo chown -R "$USER":"$(id -gn)" ~/lab-project`.
+</details>
+
 ### Success Criteria
 
-You have completed this exercise successfully if you can demonstrate the following module outcomes:
-
-- [ ] **[Outcome: Debug "command not found"]** You can explain what `$PATH` does and why `./script.sh` works but `script.sh` does not.
-- [ ] **[Outcome: Configure environment]** Your aliases and environment variables are saved in `~/.bashrc` and persist after running `source ~/.bashrc`.
-- [ ] **[Outcome: Manage permissions]** `deploy.sh` has execute permission for the owner (`-rwxr--r--` or similar).
-- [ ] **[Outcome: Manage permissions]** `db.env` is locked down to owner-only access (`-rw-------` / `600`) and the `secrets/` directory is locked to owner-only (`drwx------` / `700`).
-- [ ] **[Outcome: Use sudo safely]** You did not use `sudo` for anything in this exercise, proving you understand it is not needed for files you own.
+- [ ] **[Outcome: Debug command lookup]** You can explain what `PATH` does and why `./script.sh` works differently from `script.sh`.
+- [ ] **[Outcome: Configure inherited environment]** You can show that exported `PROJECT_NAME` reaches a child shell while an unexported value does not.
+- [ ] **[Outcome: Evaluate permissions]** `deploy.sh` has execute permission for the owner and you can justify why `chmod u+x` was narrower than `chmod 777`.
+- [ ] **[Outcome: Diagnose ownership and sudo]** You completed the lab without using `sudo` for files you own, and you can explain when a targeted sudo command would be appropriate.
+- [ ] **[Outcome: Secure local files]** `db.env` is locked down to owner-only access with `600`, and the `secrets/` directory is locked to owner-only traversal with `700`.
 
 ### Cleanup
 
+Remove the lab directory when you are finished. If you do not want to keep the aliases, open your startup file, remove the marked KubeDojo block, and run `source ~/.bashrc` again. If you use Zsh, make the equivalent cleanup in `~/.zshrc`.
+
 ```bash
-# When you are done experimenting
 rm -rf ~/lab-project
-# Optionally remove the aliases from ~/.bashrc if you do not want them
 ```
 
----
+## Sources
 
-**Next Up:** [Module 0.3: Process & Resource Survival Guide](../module-0.3-processes-resources/) — Learn how to find running processes, monitor system resources, and stop runaway programs before they cause trouble.
+- [GNU Bash Manual: Shell Variables](https://www.gnu.org/software/bash/manual/bash.html#Shell-Variables)
+- [GNU Bash Manual: Bash Startup Files](https://www.gnu.org/software/bash/manual/bash.html#Bash-Startup-Files)
+- [GNU Bash Manual: Aliases](https://www.gnu.org/software/bash/manual/bash.html#Aliases)
+- [Linux man-pages: environ(7)](https://man7.org/linux/man-pages/man7/environ.7.html)
+- [Linux man-pages: chmod(1)](https://man7.org/linux/man-pages/man1/chmod.1.html)
+- [Linux man-pages: chown(1)](https://man7.org/linux/man-pages/man1/chown.1.html)
+- [Linux man-pages: sudo(8)](https://man7.org/linux/man-pages/man8/sudo.8.html)
+- [sudo project documentation](https://www.sudo.ws/docs/)
+- [Kubernetes documentation: Configure a Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+- [Kubernetes documentation: ServiceAccounts](https://kubernetes.io/docs/concepts/security/service-accounts/)
+- [Kubernetes documentation: RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
+
+## Next Module
+
+[Module 0.3: Process & Resource Survival Guide](../module-0.3-processes-resources/) teaches you how to inspect running processes, monitor resource pressure, and stop runaway work before it damages a Linux host or Kubernetes node.


### PR DESCRIPTION
## Summary
Rewrite `src/content/docs/linux/foundations/everyday-use/module-0.2-environment-permissions.md` for the #388 density and structure verifier while clearing `revision_pending: false`.

## Verification
- Verifier: T0; body_words=5005, mean_wpp=68.6, median_wpp=72, short_rate=0.014, max_run=1, mean_sentence_length=21.3.
- Protected assets preserved by count: code blocks 36 -> 36, Mermaid diagrams 3 -> 3, markdown tables 5 -> 5, ASCII diagrams 0 -> 0; original Killercoda lab URL preserved.
- Sources: 11 URLs present; live source check intentionally skipped per dispatch command.
- Build: `npm run build` passed from an isolated archive of the pushed branch after local `npm ci`.
- Commit: a4925d9dcb674eab6f6e3d99c64c6ee66e3900d6.