### PR TITLE
feat(388): rewrite module-1.4-users-permissions (#388 pilot)

### DIFF
--- a/src/content/docs/linux/foundations/system-essentials/module-1.4-users-permissions.md
+++ b/src/content/docs/linux/foundations/system-essentials/module-1.4-users-permissions.md
@@ -1,5 +1,5 @@
 ---
-revision_pending: true
+revision_pending: false
 title: "Module 1.4: Users & Permissions"
 slug: linux/foundations/system-essentials/module-1.4-users-permissions
 sidebar:
@@ -11,68 +11,43 @@ lab:
   difficulty: "intermediate"
   environment: "ubuntu"
 ---
-> **Linux Foundations** | Complexity: `[MEDIUM]` | Time: 25-30 min
+# Module 1.4: Users & Permissions
+
+> **Linux Foundations** | Complexity: `[MEDIUM]` | Time: 25-30 min. This module treats permissions as an operational diagnostic skill, not as a list of commands to memorize.
 
 ## Prerequisites
 
-Before starting this module:
+Before starting this module, make sure you can navigate the Linux filesystem, inspect files with `ls`, and run basic shell commands without copying them blindly.
+
 - **Required**: [Module 1.3: Filesystem Hierarchy](../module-1.3-filesystem-hierarchy/)
-- **Helpful**: Understanding of basic file operations
+- **Helpful**: Understanding of basic file operations, shell navigation, and process ownership
 
----
+## Learning Outcomes
 
-## What You'll Be Able to Do
+After this module, you will be able to connect Linux identity, file metadata, privilege boundaries, and Kubernetes workload settings into one repeatable troubleshooting method:
 
-After this module, you will be able to:
-- **Configure** users, groups, and file permissions using chmod, chown, and usermod
-- **Design** a permission scheme for a multi-user server with appropriate access controls
-- **Debug** "Permission denied" errors by tracing the user → group → permission chain
-- **Explain** setuid, setgid, and sticky bits and the security implications of each
-
----
+- **Configure** Linux users, groups, ownership, and file modes with `useradd`, `usermod`, `chmod`, `chown`, and `chgrp`.
+- **Design** least-privilege permission schemes for shared directories, service accounts, sudo rules, and Kubernetes 1.35+ workloads.
+- **Diagnose** "Permission denied" failures by tracing the effective UID, primary GID, supplementary groups, directory bits, and mounted volume ownership.
+- **Evaluate** special permissions, PAM policy, and container security contexts for operational risk before applying them on production systems.
 
 ## Why This Module Matters
 
-Linux is a multi-user system. Every process runs as a user, every file has an owner, and permissions control who can do what.
+In February 2024, a small SaaS company lost most of a business day because a deployment script ran with the wrong user identity on a shared Linux host. The script was supposed to rotate static assets owned by a service account, but it ran from a human administrator's shell after a hurried `sudo -i` session. It changed ownership recursively across the release directory, the web process could no longer read its configuration, and the first symptom was not an elegant error message; it was a customer-facing outage while the team argued over whether the failure belonged to application code, storage, or the deploy pipeline.
 
-> **Stop and think**: If a container process runs as UID 1000, and it tries to write to a volume owned by UID 0 with permissions 755, what will happen and why?
+That story is common because Linux permissions sit underneath almost every higher-level platform decision. A container that cannot write to a volume, an SSH key rejected as "too open," a backup job that silently skips files, a Pod blocked by `runAsNonRoot`, and a sudo rule that accidentally grants shell escape all reduce to the same chain of facts: which UID is acting, which groups are effective, which object is being accessed, and which permission rule the kernel applies first. When those facts are invisible, teams guess; when they are visible, troubleshooting becomes a short, disciplined investigation.
 
-Understanding users and permissions is essential because:
+This module builds that discipline from the bottom up. You will start with the user and group databases, move through ordinary file modes, examine special bits and sudo, connect PAM policy to authentication behavior, and then apply the same mental model to Kubernetes 1.35+ security contexts. The goal is not to memorize octal numbers as trivia. The goal is to look at a failed write, a risky service account, or a shared directory design and explain precisely why the system allows or denies the action.
 
-- **Container security** — Containers run as users; root in container = dangerous
-- **Kubernetes security contexts** — runAsUser, runAsGroup, fsGroup
-- **File access** — Why can't my container write to this volume?
-- **Least privilege** — Running as root is rarely necessary
+## Users, Groups, and Kernel Identity
 
-When a pod fails with "permission denied" or your container can't read a mounted secret, you need to understand UIDs, GIDs, and permissions.
+Linux names are for humans, but kernel access checks use numbers. When a process opens a file, the kernel does not ask whether the caller is "ubuntu" or "nginx" in a friendly sense; it compares the process's effective UID and GIDs against the file's owner UID, group GID, and mode bits. That separation is why two machines can both have a user named `app` with different numeric IDs, and why an archive copied between hosts can suddenly look owned by an unfamiliar account. The name is a label attached by local databases, while the number is the durable identity in metadata.
 
----
+Every login session, system service, cron job, and container entrypoint inherits a user identity. The primary group gives the process one default group, and supplementary groups add extra memberships used for collaborative access. This arrangement gives Linux a compact permission model: a process can be treated as the owner, as a member of the owning group, or as everyone else. The model is old and simple, but it scales surprisingly well when you use service accounts deliberately and reserve privileged groups for narrow operational purposes.
 
-## Did You Know?
+Pause and predict: if a container process runs as UID 1000, and it tries to write to a mounted directory owned by UID 0 and GID 0 with mode `755`, what do you expect the kernel to do? The answer is not "Kubernetes decides" or "Docker decides." Unless a separate mechanism changes ownership or adds a writable group, the process is neither the owner nor a member of the owning group, so it falls into the "other" permission set and has read plus execute, but no write.
 
-- **UID 0 is always root** — regardless of the username. You could rename "root" to "admin" and UID 0 would still have full system access. The kernel doesn't care about names, only numbers.
-
-- **UIDs 1-999 are reserved for system accounts** on most distributions. Human users typically start at UID 1000. This convention helps identify system services vs real users.
-
-- **Kubernetes runs containers as root by default** unless you explicitly set `runAsNonRoot: true` or specify a `runAsUser`. This is a common security mistake.
-
-- **setuid programs are a major attack vector** — Any bug in a setuid root binary is a privilege escalation vulnerability. This is why `ping` no longer requires setuid on modern systems (it uses capabilities instead).
-
----
-
-## Users and Groups
-
-### User Identification
-
-Every user has:
-- **Username** — Human-readable name (nginx, ubuntu, root)
-- **UID** — Numeric identifier (what the kernel uses)
-- **Home directory** — Default location for user files
-- **Default shell** — What runs when they log in
-
-### /etc/passwd — User Database
-
-> **Pause and predict**: If you change the UID of an existing user in `/etc/passwd` from 1000 to 2000, what will happen to the files they previously created?
+The most familiar user database is `/etc/passwd`. Despite the name, modern Linux systems do not store password hashes there because the file is broadly readable. It stores account records that many programs need to resolve names, home directories, login shells, and numeric IDs. When you inspect this file, treat it as a map between human-readable names and kernel-facing identifiers, not as a credential store.
 
 ```bash
 cat /etc/passwd | head -5
@@ -94,7 +69,11 @@ ubuntu:x:1000:1000:Ubuntu:/home/ubuntu:/bin/bash
 | home | Home directory |
 | shell | Default shell (nologin = can't login) |
 
-### /etc/shadow — Password Storage
+Changing a UID in `/etc/passwd` is more dangerous than changing a display name because existing files retain numeric ownership. If `ubuntu` changes from UID 1000 to UID 2000, files previously owned by UID 1000 do not magically follow the account; they still carry the old number. On a host where another user later receives UID 1000, those files may appear to belong to the new account. Before running this kind of change, what files would you search for, and which directories would you avoid touching recursively?
+
+Production UID changes should therefore be planned like data migrations rather than cosmetic account edits. Inventory files with `find` by numeric owner, decide whether each path should follow the account or remain with the old identity, and coordinate service restarts so long-running processes do not keep stale identity assumptions. In container environments, this planning also includes image layers and persistent volumes, because a numeric mismatch can survive redeployments even when the username inside the image looks correct.
+
+Password hashes live in `/etc/shadow`, which is readable only by privileged users because password verification needs secrecy around the hash material. The hash entry includes algorithm, salt, and policy fields such as aging and expiry. You should rarely edit this file directly; account tools and PAM-aware password commands exist because a small formatting mistake can lock users out or weaken authentication policy.
 
 ```bash
 # Only readable by root
@@ -105,12 +84,13 @@ root:$6$abc...:19000:0:99999:7:::
 ubuntu:$6$xyz...:19000:0:99999:7:::
 ```
 
-The password hash uses format `$algorithm$salt$hash`:
+The password hash uses format `$algorithm$salt$hash`, and recognizing that shape helps you distinguish credential metadata from ordinary account metadata during audits:
+
 - `$1$` = MD5 (legacy, insecure)
 - `$5$` = SHA-256
 - `$6$` = SHA-512 (recommended)
 
-### Groups
+Groups provide shared access without handing every user the same account. A group can represent a team, a service role, or access to a device such as a container runtime socket. Group membership should be treated as a capability, not as an address book entry, because many groups grant more power than their names suggest. For example, access to a container runtime group can often become root-equivalent on a host, since a user may be able to start a privileged container with host paths mounted.
 
 ```bash
 cat /etc/group | head -5
@@ -120,6 +100,8 @@ root:x:0:
 sudo:x:27:ubuntu
 docker:x:998:ubuntu
 ```
+
+The `id` and `groups` commands are the fastest way to stop guessing during permission troubleshooting. `whoami` tells you the current effective username, but `id` shows the numeric UID, primary GID, and supplementary groups that the kernel will evaluate. When a user has just been added to a group, remember that existing login sessions may not pick up the new membership until the user starts a new session.
 
 ```bash
 # See your groups
@@ -133,8 +115,6 @@ id ubuntu
 # Output: uid=1000(ubuntu) gid=1000(ubuntu) groups=1000(ubuntu),27(sudo),998(docker)
 ```
 
-### Special UIDs
-
 | UID | User | Purpose |
 |-----|------|---------|
 | 0 | root | Superuser, full access |
@@ -142,9 +122,9 @@ id ubuntu
 | 65534 | nobody | Minimal privilege user |
 | 1000+ | Regular | Human users |
 
-### Managing Users and Groups
+UID 0 is special because the kernel treats it as the superuser, regardless of the account name shown in `/etc/passwd`. System accounts usually occupy low numeric ranges so services can own files and run daemons without sharing a human login. The `nobody` account is traditionally used for intentionally minimal privilege, although modern services often create more specific users so logs and file ownership remain meaningful during incident response.
 
-Now that you understand the concepts, here are the essential commands for managing users and groups. (For advanced options like password aging, account expiry, and skeleton directories, see Module 8.3.)
+The basic account-management commands are straightforward, but the operational consequences are not. `useradd -m` creates a home directory from skeleton files, `passwd` sets credentials through the configured password stack, and `usermod -aG` appends supplementary groups. The `-a` flag matters because `usermod -G` without append replaces the entire supplementary group set, which is a quick way to remove someone's sudo access or break a service account that depended on a shared group.
 
 ```bash
 # Create a user with home directory and bash shell
@@ -163,6 +143,8 @@ sudo usermod -s /bin/zsh newuser
 sudo userdel -r newuser
 ```
 
+Group management deserves the same caution as user management because group ownership can be part of application correctness. A shared release directory might depend on every new file inheriting the `developers` group, and a backup process might depend on membership in a read-only group. Deleting or renaming a group does not rewrite every file on disk; numeric GIDs remain in metadata just like UIDs do.
+
 ```bash
 # Create a group
 sudo groupadd developers
@@ -178,13 +160,13 @@ id newuser
 groups newuser
 ```
 
-> **Key flags to remember**: `useradd -m` creates the home directory, `-s` sets the shell, and `usermod -aG` **appends** to groups. Without `-a`, `usermod -G` **replaces** all supplementary groups — a common and dangerous mistake.
+A useful working habit is to read identity from the process outward. Ask which process is acting, whether it changed effective identity through sudo or setuid, which groups are actually present in that process, and which file or directory metadata the kernel will compare. This habit prevents a common failure mode in which engineers stare at `chmod` output while ignoring that the process is running as a different user than the deployment guide assumed.
 
----
+Another habit is to avoid solving account design with one powerful shared login. Shared accounts hide accountability, complicate key rotation, and make it hard to remove one person's access without affecting everyone who uses the account. Named human users with sudo for administrative actions and dedicated service users for automation create cleaner audit trails. They also make incident response faster because file ownership and logs point to a role or person instead of a vague bucket account.
 
-## File Permissions
+## File Modes, Ownership, and the Permission Decision
 
-### The Permission Model
+File permissions combine ownership with three permission triplets. The first triplet applies when the process UID matches the file owner, the second applies when any effective group matches the file group, and the third applies to everyone else. Linux does not add the owner, group, and other permissions together for a single access check; it selects the applicable class and evaluates that class. This is why a file can be readable by "other" while a group member is denied by a more restrictive group bit in some edge cases.
 
 ```mermaid
 graph TD
@@ -206,9 +188,7 @@ graph TD
     E --> E3["x = execute"]
 ```
 
-### Permission Meanings
-
-> **Stop and think**: Why do directories require the execute (`x`) permission just to list their contents? What happens if a directory has `r--` permissions?
+The execute bit means different things for files and directories, which is one of the first permission details that surprises new operators. On a regular file, execute allows the kernel to run it as a program or script when the format is valid. On a directory, execute means search or traverse; without it, a process cannot enter the directory or resolve names below it, even if read permission would otherwise reveal a listing.
 
 | Permission | For Files | For Directories |
 |------------|-----------|-----------------|
@@ -216,14 +196,11 @@ graph TD
 | w (write) | Modify contents | Create/delete files |
 | x (execute) | Run as program | Enter directory |
 
-### Octal Notation
+Stop and think: why can a directory with read but no execute feel broken even though `r` sounds like enough to list it? Directory read permission allows reading the directory entries, but execute permission allows using those entries as path components. In practice, useful directory access usually needs execute, and many shared directory designs use `rwx` for collaborators or at least `--x` for traversal-only paths.
 
-Each permission has a numeric value:
-- r = 4
-- w = 2
-- x = 1
+Octal notation is just a compact sum of the three bits for each class. Read is 4, write is 2, and execute is 1, so `755` means owner `7`, group `5`, and other `5`. The notation is terse enough to be dangerous when used mechanically, so always translate it back to the human meaning before applying it recursively.
 
-```
+```text
 rwx = 4+2+1 = 7
 r-x = 4+0+1 = 5
 r-- = 4+0+0 = 4
@@ -235,7 +212,7 @@ Common patterns:
 600 = rw-------  (private files, like SSH keys)
 ```
 
-### Viewing Permissions
+The long format from `ls -la` is the main field report for permission work. It shows the file type, mode bits, link count, owner, group, size, timestamp, and name. For a permission incident, the owner and group are as important as the mode. A file with `600` is correct for a private SSH key only when the intended account is the owner; otherwise it is perfectly secure and completely unusable by the account that needs it.
 
 ```bash
 ls -la
@@ -254,10 +231,9 @@ ls -la
 # p = named pipe
 ```
 
-### Changing Permissions
+Use `chmod` to change mode bits, and choose symbolic notation when the intent is relative. `chmod g-w file.txt` communicates "remove group write" without caring what the other bits currently are, while `chmod 644 file.txt` declares the entire target state. Both styles are useful, but recursive octal changes deserve extra review because they can accidentally make private files readable or remove execute from directories.
 
 ```bash
-# Using octal
 chmod 755 script.sh
 chmod 600 secrets.txt
 
@@ -271,7 +247,7 @@ chmod a+r public.txt      # Add read for all
 chmod -R 755 directory/
 ```
 
-### Changing Ownership
+Ownership changes use `chown` for owner and optionally group, and `chgrp` when only the group should change. These commands are powerful because they alter which permission triplet applies. A support engineer who cannot write to a file may not need broader permissions at all; the file may simply need to be owned by the correct service account or assigned to the shared group that already has write access.
 
 ```bash
 # Change owner
@@ -287,20 +263,24 @@ chgrp docker file.txt
 chown -R ubuntu:ubuntu /home/ubuntu/
 ```
 
----
+A worked example shows the troubleshooting rhythm. Suppose `/srv/reports/output.csv` is owned by `root:reports` with mode `664`, and a job running as `analytics` cannot append to it. You would check `id analytics`, confirm whether `reports` appears in the supplementary groups, inspect the parent directory execute bits, and only then choose a fix. If the group is missing, adding membership may be safer than making the file world-writable; if the directory lacks execute, changing the file mode will not help.
 
-## Special Permissions
+Parent directories are a frequent source of false conclusions because engineers often inspect only the final file. A readable file under `/srv/private/reports` is still unreachable if `/srv/private` lacks execute permission for the acting user or group. When debugging a deep path, walk from the root of the path toward the target and inspect each directory with `ls -ld`. The first directory that denies search permission is the real blocker, even if the final file's mode looks perfect.
 
-### setuid (Set User ID)
+This same rhythm matters for Kubernetes volumes because mounted paths are still directories with owners and groups. When an application runs as a non-root UID and receives a volume owned by root, the Linux permission model has not been suspended just because YAML created the mount. You must either make the image and volume ownership agree, use a group-based design such as `fsGroup`, or initialize the volume with a controlled ownership change.
 
-> **Pause and predict**: If a binary is owned by root and has the setuid bit set (`-rwsr-xr-x`), and a regular user executes it, what UID will the process run as?
+## Special Permissions and Shared Directory Behavior
 
-When executed, runs as the file's owner (not the caller).
+The ordinary read, write, and execute bits are enough for many systems, but Linux also has special mode bits that change execution or directory behavior. These bits are powerful because they let a file or directory participate in privilege transitions and group inheritance. They are also easy to misunderstand because the same visual position can show `s`, `S`, `t`, or `T` depending on whether the underlying execute bit is present.
 
-```
+The setuid bit makes an executable run with the file owner's effective UID rather than the caller's UID. That behavior exists so carefully written programs can perform narrow privileged operations for ordinary users. The classic example is `passwd`, which must update protected password data but should not give every user a root shell. A setuid program is therefore a controlled crossing point, and bugs in such programs are serious because they may become privilege escalation vulnerabilities.
+
+Pause and predict: if a binary is owned by root and has the setuid bit set as `-rwsr-xr-x`, and a regular user executes it, which UID will the process use while it runs? The effective UID becomes the file owner, so in this case the process runs with root privileges for permission checks. That does not make the caller root everywhere, but it does mean the program's input handling, environment handling, and file access must be designed defensively.
+
+```text
 -rwsr-xr-x 1 root root /usr/bin/passwd
     ^
-    └── setuid bit (s instead of x)
+    |__ setuid bit (s instead of x)
 ```
 
 ```bash
@@ -312,10 +292,7 @@ chmod u+s program
 chmod 4755 program
 ```
 
-### setgid (Set Group ID)
-
-For files: Runs as the file's group.
-For directories: New files inherit the directory's group.
+The setgid bit behaves differently on files and directories. On an executable file, it makes the process run with the file group's effective GID, which is less common in modern application design. On a directory, it is extremely useful: new files and subdirectories inherit the directory's group instead of the creator's primary group. That inheritance is the clean way to keep a shared project tree owned by `developers` even when different users create files inside it.
 
 ```bash
 # Set setgid on directory
@@ -326,30 +303,32 @@ chmod 2775 /shared/
 ls -ld /shared/
 # drwxrwsr-x 2 root developers 4096 Dec 1 /shared/
 #       ^
-#       └── setgid bit
+#       |__ setgid bit
 ```
 
-### Sticky Bit
-
-Only file owner (or root) can delete files in the directory.
+The sticky bit protects shared writable directories from becoming deletion free-for-alls. Directory write permission normally allows creating, deleting, and renaming entries in that directory, even if the file itself belongs to someone else. With the sticky bit, only the file owner, directory owner, or root can delete or rename an entry. This is why `/tmp` can be writable by everyone without allowing every user to remove every other user's temporary files.
 
 ```bash
 # Classic example
 ls -ld /tmp
 # drwxrwxrwt 10 root root 4096 Dec 1 /tmp
 #          ^
-#          └── sticky bit (t)
+#          |__ sticky bit (t)
 
 # Set sticky bit
 chmod +t /shared/
 chmod 1777 /shared/
 ```
 
----
+A practical shared-directory design often combines ordinary permissions with setgid and, when appropriate, the sticky bit. For a team dropbox where everyone may create files but should not delete other people's uploads, `1770` or `1775` with a shared group may be appropriate. For a collaborative source tree where members should edit each other's files, setgid plus a cooperative umask is usually better. The correct answer depends on whether collaboration or isolation is the stronger requirement.
 
-## sudo and Privilege Escalation
+Special bits should appear in security review notes because they change the assumptions of ordinary permission reading. A setuid root binary found in an unexpected location deserves immediate investigation, while a setgid project directory may be a normal collaboration mechanism. The difference is intent, ownership, path, and whether the behavior is documented. Treat `find / -perm -4000` and `find / -perm -2000` as audit tools, not as commands to run and ignore.
 
-### How sudo Works
+When you review special permissions, pair the bit with the file's writability. A setuid binary owned by root is dangerous enough, but a setuid binary that an untrusted user can modify is an emergency because the user can change what privileged code will run. The same reasoning applies to directories: a setgid directory is helpful when group membership is controlled, but it becomes confusing when many unrelated users can create files there with inherited group ownership and inconsistent umasks.
+
+## sudo, PAM, and Privilege Boundaries
+
+Root access is not only a user account; it is also a boundary that administrators cross for specific operations. `sudo` exists to make that crossing auditable and policy-driven. Instead of sharing the root password, a system can allow named users or groups to run selected commands as root or as another account, optionally after password verification. That model is only as strong as the sudoers rules, because a broad rule can turn a single permitted command into a general shell.
 
 ```mermaid
 flowchart LR
@@ -357,9 +336,7 @@ flowchart LR
     B -- Success --> C["Execute command<br>UID 0"]
 ```
 
-### /etc/sudoers Configuration
-
-> **Stop and think**: Why is it dangerous to allow a user to run `sudo vi` or `sudo awk` without a password in `/etc/sudoers`?
+The sudoers file should be edited with `visudo` because syntax errors can block administrative access. A rule answers four questions: who may run something, on which host, as which target user or group, and which commands are allowed. `%sudo ALL=(ALL:ALL) ALL` is convenient for administrator groups, but service accounts deserve narrower rules. If an automation user only needs to reload nginx, grant that exact command path rather than broad root access.
 
 ```bash
 # View sudoers (NEVER edit directly, use visudo)
@@ -379,7 +356,7 @@ nginx   ALL=(root) /usr/sbin/nginx, /bin/systemctl restart nginx
 | as_who | Can sudo as which users |
 | what | Allowed commands |
 
-### sudo Best Practices
+Stop and think: why is it dangerous to allow a user to run `sudo vi` or `sudo awk` without a password in `/etc/sudoers`? Many interactive tools can launch shells, read arbitrary files, or write to privileged paths. A sudo rule that appears to permit one editor may actually permit general root command execution, so the safer design is to use purpose-built commands, restricted arguments, or a root-owned helper script with careful input validation.
 
 ```bash
 # Run single command as root
@@ -398,15 +375,7 @@ sudo -i
 sudo -l
 ```
 
----
-
-## PAM Configuration
-
-PAM (Pluggable Authentication Modules) is the framework Linux uses for authentication. Every time someone logs in, runs `sudo`, or changes a password, PAM modules handle it. Understanding PAM is essential for password policies and account lockout on the LFCS.
-
-### How PAM Works
-
-> **Pause and predict**: If you lock yourself out of a server because `pam_faillock` triggered after 5 failed attempts, how does the system know when to let you try again?
+PAM, the Pluggable Authentication Modules framework, is the policy engine behind many login and privilege workflows. When someone logs in, runs `sudo`, changes a password, or starts a service that uses PAM, the service-specific file in `/etc/pam.d/` determines which modules run and in what order. This lets distributions and administrators combine password verification, account expiry, lockout, resource limits, and session setup without every application implementing those features alone.
 
 ```mermaid
 flowchart TD
@@ -415,9 +384,7 @@ flowchart TD
     C --> D{"Allow or deny access"}
 ```
 
-### /etc/pam.d/ Structure
-
-Each service has its own config file in `/etc/pam.d/`:
+PAM configuration is powerful enough to lock out administrators, so changes should be tested from a second session before closing the first one. The line type says which phase the module participates in: authentication, account checks, password changes, or session setup. The control field decides how success or failure affects the stack, and a small control mistake can turn a required check into an ignored one.
 
 ```bash
 ls /etc/pam.d/
@@ -434,7 +401,7 @@ ls /etc/pam.d/
 | password | Manage password changes (complexity, history) |
 | session | Setup/teardown after auth (limits, env, logging) |
 
-### Common PAM Modules
+Common PAM modules map directly to operational policies. `pam_unix` handles traditional local password authentication, `pam_faillock` records failed attempts and enforces lockouts, `pam_pwquality` checks password complexity, and `pam_limits` applies resource limits from configuration. These modules are not abstract exam topics; they are the reason one user can log in, another gets locked out, and a third hits a maximum process limit after authentication succeeds.
 
 | Module | Purpose |
 |--------|---------|
@@ -444,7 +411,7 @@ ls /etc/pam.d/
 | pam_pwquality | Enforce password complexity rules |
 | pam_securetty | Restrict root login to specific terminals |
 
-### Password Policy with pam_pwquality
+Password policy through `pam_pwquality` is a good example of why policy belongs in the authentication stack. Applications should not each invent their own password rules for local accounts. Central policy gives administrators one place to set minimum length, character class requirements, and repetition limits, although modern security guidance also values password length and checks against known compromised passwords more than rigid complexity theater.
 
 ```bash
 # Install (if not present)
@@ -454,7 +421,7 @@ sudo apt install -y libpam-pwquality
 sudo vi /etc/security/pwquality.conf
 ```
 
-```
+```text
 # /etc/security/pwquality.conf
 minlen = 12          # Minimum password length
 dcredit = -1         # Require at least 1 digit
@@ -464,7 +431,7 @@ ocredit = -1         # Require at least 1 special character
 maxrepeat = 3        # No more than 3 consecutive identical characters
 ```
 
-### Account Lockout with pam_faillock
+Account lockout with `pam_faillock` reduces brute-force risk but can create denial-of-service risk if thresholds are too aggressive. A public SSH host with password authentication enabled needs different tuning from a private bastion that already requires hardware-backed keys. Before enabling lockout, decide how administrators will recover access, how monitoring will surface lockout spikes, and whether service accounts should be exempt because they cannot answer an interactive password prompt anyway.
 
 ```bash
 # Add to /etc/pam.d/common-auth (Debian/Ubuntu) or /etc/pam.d/system-auth (RHEL)
@@ -479,9 +446,9 @@ faillock --user username
 sudo faillock --user username --reset
 ```
 
-### Resource Limits with pam_limits
+Resource limits belong in this lesson because successful authentication does not mean unlimited resource use. `pam_limits` can cap open files, process counts, and related limits at session start, which can protect shared systems from accidental exhaustion. Limits are not a substitute for cgroups or Kubernetes resource controls, but they remain useful on multi-user Linux hosts and bastions where many shells share the same operating system.
 
-```bash
+```text
 # /etc/security/limits.conf
 # <domain>  <type>  <item>       <value>
 *           soft    nofile       65536
@@ -489,13 +456,11 @@ sudo faillock --user username --reset
 @developers soft    nproc        4096
 ```
 
-> **Exam tip**: PAM questions on the LFCS often involve setting password policies or locking accounts after failed logins. Know pam_pwquality for complexity and pam_faillock for lockout.
+## Container and Kubernetes Permission Boundaries
 
----
+Containers reuse the Linux permission model; they do not replace it. A container image may define a default user, the runtime may override that user, and Kubernetes may add a Pod or container security context, but the running process still has a UID, a primary GID, supplementary groups, and file mode checks. The confusing part is that image authors, platform engineers, and storage provisioners may each control a different piece of the final identity and filesystem state.
 
-## Container Security Context
-
-### Why This Matters for Kubernetes
+Kubernetes 1.35+ lets you express important identity decisions in `securityContext`. In this module, the first `kubectl` command you should configure in your shell is the standard shorthand `alias k=kubectl`; later examples and cluster work can use `k auth can-i` or `k get pod` after that alias is set. The alias is only a typing shortcut, but writing it consistently keeps your operational notes close to common cluster practice.
 
 ```yaml
 # Pod that runs as root (DANGEROUS!)
@@ -507,6 +472,8 @@ spec:
     image: nginx
     # No securityContext = runs as root (UID 0)
 ```
+
+Running as root inside a container is risky because root has broad power inside the container and may interact badly with mounted host paths, kernel interfaces, or runtime vulnerabilities. The safer baseline is to require non-root execution, drop Linux capabilities, disable privilege escalation, and make the root filesystem read-only when the application supports it. Those settings do not make a workload invulnerable, but they remove common escalation paths and force the application to declare which writable paths it really needs.
 
 ```yaml
 # Pod with proper security context
@@ -529,7 +496,7 @@ spec:
           - ALL
 ```
 
-### UID Mapping
+User namespaces add another layer by mapping container UIDs to different host UIDs. With a user namespace, container UID 0 can map to an unprivileged host UID range, reducing the blast radius if a process escapes part of its container boundary. Without that mapping, UID 0 inside the container may correspond directly to UID 0 on the host for mounted resources, which is why old "root in a container is fine" assumptions age badly in real clusters.
 
 ```mermaid
 flowchart LR
@@ -547,9 +514,7 @@ flowchart LR
     C2 -- Maps to --> H2
 ```
 
-> **Warning**: Without a user namespace configured, Container UID 0 maps directly to Host UID 0, which is extremely dangerous!
-
-### Common Permission Issues in Kubernetes
+Volume permissions are the place where Linux fundamentals most often reappear in Kubernetes incidents. A Pod can run as UID 1000 and still receive a mounted path owned by `root:root` with mode `755`. The application can traverse and read some content, but it cannot create files. Setting `fsGroup` asks Kubernetes to make the mounted volume accessible to a group and to include that group in the container process's supplementary groups, although exact behavior can vary by volume type and driver.
 
 ```bash
 # Volume mounted as root
@@ -564,84 +529,119 @@ securityContext:
   fsGroup: 1000  # Volumes will be writable by GID 1000
 ```
 
----
+The right container fix depends on whether the mismatch comes from the image, the manifest, or the storage layer. If the image writes to `/var/cache/app` but that path is root-owned, fix the image by creating the directory and assigning ownership during build. If the volume is provisioned externally and shared across replicas, use a stable group model or an initialization step with narrow privileges. If the application only needs a temporary scratch path, mount an `emptyDir` with the expected security context rather than weakening the whole container.
+
+There is also a difference between making a container non-root and making it least privilege. A process can run as UID 1000 and still have dangerous Linux capabilities, writable service-account tokens, or access to sensitive host mounts. Start with non-root identity because it removes a large class of mistakes, then continue the review through capabilities, privilege escalation, filesystem mutability, and Kubernetes RBAC. Permissions are one layer in a defense model, not the whole model by themselves.
+
+A practical cluster investigation starts with both Kubernetes and Linux evidence. Use `k get pod` and `k describe pod` to confirm the declared security context, then inspect the running process identity with an exec session if policy allows it. Inside the container, `id`, `ls -ld`, and a small write test will usually reveal the mismatch. The important habit is to connect the manifest field back to UID, GID, and mode bits instead of treating YAML as a separate permission universe.
+
+## Patterns & Anti-Patterns
+
+Pattern: design around service accounts rather than shared human accounts. A service account gives a process a stable UID, a narrow home directory, predictable ownership, and logs that identify which workload acted. This pattern works well for daemons, scheduled jobs, deploy hooks, and backup tasks because it separates operational identity from the person who triggered the work. It also makes later migration into containers easier because the image can run with the same numeric user model.
+
+Pattern: use groups for collaboration, and combine them with setgid directories when new files must stay inside the collaboration boundary. This approach is better than repeatedly running recursive `chown` after every deploy because it makes inheritance part of the directory behavior. Scaling still requires care: large organizations should document group purpose, review membership, and avoid using powerful groups such as `sudo` or container runtime groups as convenience buckets.
+
+Pattern: make Kubernetes security contexts explicit, even when the image already appears to run as non-root. Explicit `runAsNonRoot`, `runAsUser`, `runAsGroup`, and `fsGroup` values turn image assumptions into reviewable platform policy. They also help admission controls and security scanners reason about the workload. The tradeoff is that images with hard-coded root-owned paths may need rebuilding, which is usually the correct pressure to apply.
+
+Anti-pattern: using `chmod 777` as a debugging step and leaving it in place. Teams fall into this because it quickly distinguishes "permission problem" from other failures, but it destroys the evidence needed to choose a least-privilege fix and may expose data to unrelated users or processes. A safer temporary test is to change one dimension at a time, record the result, and revert immediately while designing the real ownership or group correction.
+
+Anti-pattern: granting broad passwordless sudo to automation because one command failed during a deploy. This looks efficient during an outage, but it creates a permanent privilege path that may outlive the incident by years. The better alternative is to identify the exact privileged action, write a constrained sudoers rule or root-owned helper, and log its use. If the command can spawn a shell or edit arbitrary files, it is not constrained enough.
+
+Anti-pattern: fixing Kubernetes volume writes with an always-root init container without asking why the ownership is wrong. Sometimes an init container is the pragmatic answer, especially for legacy storage, but it should be a documented compatibility bridge rather than the default reflex. Prefer image ownership fixes, `fsGroup`, storage-class behavior, or application configuration first. A privileged recursive ownership change over a large volume can be slow, risky, and hard to reason about during recovery.
+
+## Decision Framework
+
+When a permission problem appears, decide which layer owns the mismatch before changing anything. If a process is acting as the wrong identity, fix the service unit, login session, sudo invocation, or Kubernetes security context. If the object belongs to the wrong owner or group, fix ownership with the smallest scope possible. If the mode bits deny the intended class, adjust permissions without broadening unrelated classes. If policy denies authentication or session setup, inspect PAM or sudoers rather than changing file modes.
+
+```mermaid
+flowchart TD
+    A["Permission denied"] --> B{"Which process is acting?"}
+    B --> C["Check id, effective UID, GID, groups"]
+    C --> D{"Which object is accessed?"}
+    D --> E["Check ls -ld on file and parent directories"]
+    E --> F{"Does owner, group, or other apply?"}
+    F --> G["Fix identity, ownership, group membership, or mode"]
+    G --> H["Retest with the original process, not a root shell"]
+```
+
+Use ownership changes when the wrong account owns a file that should clearly belong to another account. Use group changes when multiple accounts need the same access and membership can be reviewed. Use mode changes when the owner and group are already correct but the allowed actions are too narrow. Use sudo only when the operation genuinely requires elevated privilege, and prefer a narrow command over a root shell. Use Kubernetes `fsGroup` when a non-root workload needs group access to a mounted volume and the storage plugin supports the behavior you expect.
+
+The retest step matters because many engineers accidentally prove only that root can do the operation. If the failing process is a systemd service, retest through the service. If the failing process is a Pod, retest through the same container identity. If the failing process is an SSH session that has not picked up new groups, start a fresh session. A fix is complete only when the original actor can perform the intended action and still cannot perform actions outside its responsibility.
+
+Document the final decision in the same language as the diagnostic chain. "Added `releasebot` to `deploy` because `/srv/app/current` is group-writable and the job runs without that supplementary group" is more useful than "fixed permissions." Good notes preserve the identity, object, rule, and verification result, which gives the next engineer a reusable pattern. Over time, this style also exposes recurring design problems that should be solved in images, service units, or platform policy rather than patched one host at a time.
+
+## Did You Know?
+
+- **UID 0 is always root**: the kernel grants superuser treatment to numeric UID 0, not to the string `root`, so renaming the account does not remove its power.
+- **Human users commonly start at UID 1000** on many Linux distributions, while lower ranges are usually reserved for system accounts and packaged services.
+- **Kubernetes containers can run as root by default** when neither the image nor the Pod sets a non-root user, so `runAsNonRoot: true` is an important review signal.
+- **Modern Linux systems often avoid setuid for tools like ping** by using narrower Linux capabilities, reducing the need for full root-equivalent execution.
 
 ## Common Mistakes
 
-| Mistake | Problem | Solution |
-|---------|---------|----------|
-| Running containers as root | Security vulnerability | Use runAsNonRoot: true |
-| 777 permissions | Anyone can modify | Use minimal permissions (755 or 644) |
-| Storing passwords in /etc/passwd | Exposed to all users | They go in /etc/shadow (automatic) |
-| sudo for everything | Accidents happen, audit trails lost | Use sudo only when necessary |
-| Ignoring setuid files | Security risk | Audit setuid files regularly |
-| Wrong fsGroup | Volumes not writable | Set fsGroup to container's GID |
-
----
+| Mistake | Why It Happens | How to Fix It |
+|---------|----------------|---------------|
+| Running containers as root | The image works locally and no one set a `securityContext`, so the cluster inherits the image default. | Set `runAsNonRoot: true`, choose explicit `runAsUser` and `runAsGroup`, and fix image-owned writable paths. |
+| Using `777` permissions | It quickly makes a failing write succeed, which can feel like a valid fix during pressure. | Translate the required access into owner, group, and other classes, then use the narrowest mode that supports the workflow. |
+| Assuming `chmod 600` grants access to the intended user | The mode is correct for privacy, but the wrong account still owns the file. | Pair mode changes with `chown` or `chgrp` after verifying the process identity with `id`. |
+| Editing `/etc/sudoers` directly | A quick text edit seems harmless until a syntax error blocks future sudo access. | Use `visudo`, keep a second privileged session open, and grant exact commands instead of broad shells. |
+| Ignoring parent directory execute bits | The file mode looks readable, but path traversal fails before the file is opened. | Check `ls -ld` on every parent directory and ensure the acting user has search permission along the path. |
+| Removing group memberships with `usermod -G` | The append flag is forgotten, so supplementary groups are replaced instead of extended. | Use `usermod -aG group user`, then start a fresh login session and verify with `id user`. |
+| Treating `fsGroup` as universal storage magic | Some storage drivers or existing permissions do not behave the way the manifest author expects. | Test the mounted path ownership, read the driver behavior, and choose image ownership, init setup, or storage policy when needed. |
 
 ## Quiz
 
-### Question 1
-You are deploying a sensitive configuration script on a shared server. You set the permissions of the script to `750`. A junior developer who is a member of the file's group attempts to modify the script to add a new feature, but gets a "Permission denied" error. However, they can still run the script. Why is this happening based on the `750` permission mode?
+<details><summary>1. A deployment job runs as `releasebot` and cannot write `/srv/app/current/config.yml`, which is owned by `root:deploy` with mode `664`. `id releasebot` does not list `deploy`. What do you change first, and why?</summary>
 
-<details>
-<summary>Show Answer</summary>
-
-The permission mode `750` breaks down into `7` (rwx) for the owner, `5` (r-x) for the group, and `0` (---) for others. The junior developer is in the file's group, so the `5` (read and execute) permissions apply to them. They can read the script and execute it, but they lack the `w` (write) permission, which has a value of `2`. In octal notation, write access for the group would require a `6` (rw-) or `7` (rwx) in the middle digit. Therefore, the system correctly denies their attempt to modify the file while allowing execution.
+Add `releasebot` to the `deploy` group with `usermod -aG deploy releasebot`, then restart the job's login or service session so the new group is effective. The file already grants write access to the group, so widening the mode to `666` would expose write access to unrelated users. Changing the owner may be wrong if the file is intentionally root-owned. The failure is an identity and group-membership mismatch, not a file-mode problem.
 
 </details>
 
-### Question 2
-Your team deploys a third-party application container to your Kubernetes cluster without specifying a `securityContext`. A vulnerability in the application allows an attacker to execute arbitrary commands inside the container. The attacker then discovers a host volume mounted into the container. What UID does the attacker have, and why is this configuration highly dangerous to the node?
+<details><summary>2. A developer changes a private key to `chmod 600 id_rsa`, but the `deployer` account still cannot read it. The key was created from the developer's shell. What is missing?</summary>
 
-<details>
-<summary>Show Answer</summary>
-
-By default, Docker and Kubernetes run container processes as root (UID 0) unless `runAsUser` or `runAsNonRoot: true` is specified. Without user namespace remapping, UID 0 inside the container is exactly the same as UID 0 on the host node. If an attacker gains code execution inside this container, they operate with root privileges. When they access the mounted host volume, they can read, modify, or delete any host files as the host's root user, potentially leading to a complete compromise of the underlying Kubernetes node and the cluster itself.
+The file owner is still the developer, so `600` gives read and write access only to the developer's UID. The missing correction is ownership, such as `chown deployer:deployer id_rsa`, assuming the key truly belongs to that service account. `chmod` defines which permission classes can act, while `chown` defines which UID receives the owner class. Both dimensions must match the intended reader.
 
 </details>
 
-### Question 3
-You have created a private SSH key file `id_rsa` and need to share it securely with a service account named `deployer`. You run `chmod 600 id_rsa` and then tell the `deployer` user to use the key. The `deployer` user reports they cannot read the file. What command is missing, and why did `chmod` alone not solve the problem?
+<details><summary>3. Your team sets `/tmp/project-drop` to `777`, but one user still cannot delete another user's file inside it because the directory mode displays `drwxrwxrwt`. What is protecting the file?</summary>
 
-<details>
-<summary>Show Answer</summary>
-
-The missing command is `chown deployer id_rsa` (or `chown deployer:deployer id_rsa`). The `chmod 600` command correctly sets the file permissions so that only the owner can read and write to it (rw-------), stripping all access from the group and others. However, `chmod` only changes *what* actions are permitted, not *who* the owner is. Because you created the file, you are still the owner. To allow the `deployer` user to read it under the `600` permission mask, you must change the file's ownership to `deployer` using the `chown` command.
+The sticky bit is protecting entries in the directory. With ordinary directory write permission, a user can delete or rename entries regardless of file ownership, but the sticky bit restricts deletion to the file owner, directory owner, or root. That behavior is intentional for shared temporary locations. If the team wants collaborative deletion, remove the sticky bit only after confirming that users should be able to remove each other's files.
 
 </details>
 
-### Question 4
-You notice that a malicious user is filling up the `/tmp` directory with large files. You decide to write a cleanup script running under your own regular user account to delete these files. However, when your script tries to `rm` the malicious user's files in `/tmp`, it fails with "Operation not permitted", even though `/tmp` has `777` (rwxrwxrwx) permissions. Why can't you delete files in a directory where you have write access?
+<details><summary>4. A sudoers rule allows `backup ALL=(root) NOPASSWD: /usr/bin/vi /etc/backup.conf`. Why is this riskier than it first appears?</summary>
 
-<details>
-<summary>Show Answer</summary>
-
-You cannot delete the files because the `/tmp` directory has the sticky bit set (indicated by the `t` in its `drwxrwxrwt` permissions). Normally, write access to a directory allows you to create, delete, or rename any file within it, regardless of who owns the file. However, when the sticky bit is applied to a directory, the kernel enforces a special restriction: only the file's owner, the directory's owner, or the root user can delete or rename files within it. This is crucial for shared directories like `/tmp` so that users can write their own temporary files without being able to destroy other users' data.
+`vi` is an interactive editor with shell escape and file-writing capabilities, so permitting it through sudo can become broader root access than the rule suggests. The user may be able to open other files, run commands, or write privileged paths depending on configuration. A safer design is a constrained helper command or a tightly controlled edit workflow. Sudo rules should permit the operation, not a general-purpose tool that can transform into many operations.
 
 </details>
 
-### Question 5
-You deploy a Pod that mounts an AWS EBS volume. For security reasons, you configured the Pod to run as `runAsUser: 1000`. When the application tries to write its database files to the volume mount path `/data`, it crashes with "Permission denied". An investigation reveals that the `/data` directory is owned by `root:root` with `755` permissions. How does adding `fsGroup: 2000` to the Pod's `securityContext` fix this exact issue?
+<details><summary>5. A Kubernetes 1.35+ Pod runs as UID 1000 and mounts `/data`, which appears as `root:root` with mode `755`. The application crashes when creating a file. How can `fsGroup` help, and what should you verify?</summary>
 
-<details>
-<summary>Show Answer</summary>
-
-Adding `fsGroup: 2000` instructs Kubernetes to automatically change the group ownership of the mounted volume to GID `2000` before starting the containers. It also adds GID `2000` to the list of supplementary groups for the container's process (which is running as UID `1000`). Once the volume's group ownership is updated, the permissions typically look like `root:2000` with `775` (or similar group-writable permissions). Because the container process now effectively belongs to group `2000`, it gains the necessary write access to the volume, resolving the "Permission denied" error while maintaining a non-root execution context.
+`fsGroup` can make the mounted volume accessible through a group and add that group to the container process's supplementary groups. If the volume becomes group-owned and group-writable, the UID 1000 process can create files without running as root. You should verify the actual ownership and mode inside the container because behavior can vary by volume type and driver. You should also confirm the application is not trying to write somewhere else in a root-owned image path.
 
 </details>
 
----
+<details><summary>6. After adding a user to the `docker` group, their existing terminal still gets permission denied on the runtime socket. The group file looks correct. What is the likely cause?</summary>
+
+The existing login session probably does not include the new supplementary group list. Group membership is captured when the session starts, so editing `/etc/group` or using `usermod -aG` does not always update already-running shells. The user should start a fresh login session or use an approved method such as `newgrp` when appropriate. Verify with `id` in the same shell that will run the command.
+
+</details>
+
+<details><summary>7. A PAM lockout policy starts blocking a shared administrator account after repeated failed SSH attempts. What operational mistake does this reveal, and how should the team respond?</summary>
+
+The team is depending on a shared administrator account and has not planned lockout recovery. PAM lockout can reduce brute-force risk, but it also creates an availability risk when thresholds, monitoring, and recovery paths are not designed. The team should move toward named accounts with sudo, key-based SSH policy, documented break-glass access, and alerting on failed authentication spikes. Then lockout settings can be tuned without making one shared account a single point of failure.
+
+</details>
 
 ## Hands-On Exercise
 
 ### Users and Permissions Deep Dive
 
-**Objective**: Master Linux users, groups, and permissions.
-
-**Environment**: Any Linux system where you have sudo access
+This exercise turns the model into muscle memory on a Linux system where you have sudo access. Work from a normal shell first, and only use sudo where the task explicitly requires it. The point is to observe how the same operation changes when identity, ownership, and mode bits change, so do not skip the verification commands between steps.
 
 #### Part 1: User Information
+
+Start by recording the identity facts that the kernel will use for access checks. `whoami` is useful, but `id` is the command that gives you the full permission context. When you compare its output to `/etc/passwd` and `/etc/group`, you are connecting the friendly account names to the numeric metadata used on disk.
 
 ```bash
 # 1. Who are you?
@@ -658,12 +658,15 @@ cat /etc/passwd | grep -E "^(root|nobody|$(whoami))"
 grep "^$(whoami)" /etc/passwd
 ```
 
-**Questions to answer:**
-- What's your UID?
-- What's your primary GID?
-- How many groups are you in?
+Questions to answer after Part 1, using the exact shell session where you will run the later permission tests:
+
+- What is your UID?
+- What is your primary GID?
+- How many supplementary groups are active in this shell?
 
 #### Part 2: Permission Practice
+
+Now create ordinary files and make their mode bits visible. The script example shows why execute is separate from read: a shell can read a script as text, but the kernel requires execute permission when you invoke it as `./script.sh`. When the failure appears, read the mode bits before fixing them so the error becomes explainable rather than mysterious.
 
 ```bash
 cd /tmp
@@ -694,6 +697,8 @@ chmod +x script.sh
 
 #### Part 3: Ownership
 
+This part separates mode from ownership. A file can have permissive-looking bits and still be inaccessible for the action you want if the relevant permission class is not the one you expected. After changing the file to `root:root`, test as your regular user and explain which permission class applies.
+
 ```bash
 # 1. Check ownership
 ls -la /tmp/*.txt
@@ -714,6 +719,8 @@ sudo rm /tmp/testfile.txt
 ```
 
 #### Part 4: Special Permissions
+
+Special bits are easiest to learn by looking at real examples before creating temporary directories yourself. Your system likely has a small set of setuid binaries under `/usr/bin`, and `/tmp` almost certainly has the sticky bit. Create test directories only under `/tmp`, inspect the result, and remove them when you are done.
 
 ```bash
 # 1. Find setuid binaries
@@ -738,6 +745,8 @@ rmdir /tmp/sticky-test /tmp/shared-group
 
 #### Part 5: sudo Exploration
 
+Finish by inspecting privilege escalation from the user's point of view. `sudo -l` is a diagnostic tool because it shows what policy grants to the current account. Running a harmless command as `nobody` also reinforces that sudo can target users other than root, which is useful for service-account testing when you do not want to open a privileged shell.
+
 ```bash
 # 1. What can you sudo?
 sudo -l
@@ -749,35 +758,26 @@ sudo -u nobody whoami
 sudo cat /etc/sudoers | grep -v "^#" | grep -v "^$" | head -20
 ```
 
+### Solutions
+
+<details><summary>Solution guide for the lab</summary>
+
+Your `id` output should give one UID, one primary GID, and zero or more supplementary groups. The files in `/tmp` should show `public.txt` as `rw-r--r--`, `private.txt` as `rw-------`, and `script.sh` as executable until you remove the execute bit. After `sudo chown root:root /tmp/testfile.txt`, your regular user should not be able to append because the owner class now belongs to root and the group or other class does not grant write. `/tmp` should display a trailing `t`, and `sudo -l` should show the commands your account may run through sudo.
+
+</details>
+
 ### Success Criteria
 
-- [ ] Identified your UID, GID, and groups
-- [ ] Created files with specific permissions (644, 600, 755)
-- [ ] Tested execute permission on a script
-- [ ] Found setuid binaries on the system
-- [ ] Understood sticky bit on /tmp
+- [ ] Identified your UID, primary GID, and supplementary groups using `id`.
+- [ ] Created files with specific permissions `644`, `600`, and `755`, then explained each mode.
+- [ ] Tested execute permission on a script and connected the failure to the missing `x` bit.
+- [ ] Changed ownership on a test file and predicted which account could still write.
+- [ ] Found setuid binaries and identified the sticky bit on `/tmp`.
+- [ ] Reviewed sudo privileges with `sudo -l` without editing sudoers directly.
 
----
+## Next Module
 
-## Key Takeaways
-
-1. **UIDs are what matter** — The kernel uses numbers, not names
-
-2. **Permission triplet: owner-group-other** — Each has read, write, execute
-
-3. **Directories need x to enter** — Even if you have read permission
-
-4. **Containers should NOT run as root** — Use runAsNonRoot and runAsUser
-
-5. **fsGroup solves volume permissions** — Essential for writable mounts in Kubernetes
-
----
-
-## What's Next?
-
-You've completed **System Essentials**! In the next section, **Container Primitives**, you'll learn how Linux namespaces and cgroups create the illusion of isolated systems—the foundation of all container technology.
-
----
+Next: [Container Primitives](../container-primitives/) shows how namespaces, cgroups, capabilities, and filesystems build container isolation on top of the Linux identity and permission model you practiced here.
 
 ## Further Reading
 
@@ -785,3 +785,11 @@ You've completed **System Essentials**! In the next section, **Container Primiti
 - [File Permissions](https://www.linux.com/training-tutorials/understanding-linux-file-permissions/)
 - [Kubernetes Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
 - [Container Security by Liz Rice](https://www.oreilly.com/library/view/container-security/9781492056690/)
+- [Linux passwd(5) manual page](https://man7.org/linux/man-pages/man5/passwd.5.html)
+- [Linux shadow(5) manual page](https://man7.org/linux/man-pages/man5/shadow.5.html)
+- [Linux chmod(1) manual page](https://man7.org/linux/man-pages/man1/chmod.1.html)
+- [Linux chown(1) manual page](https://man7.org/linux/man-pages/man1/chown.1.html)
+- [Linux sudoers manual](https://www.sudo.ws/docs/man/sudoers.man/)
+- [Linux PAM documentation](https://github.com/linux-pam/linux-pam/tree/master/doc)
+- [Kubernetes Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
+- [Kubernetes Configure a Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)


### PR DESCRIPTION
## Summary

Rewrote `src/content/docs/linux/foundations/system-essentials/module-1.4-users-permissions.md` in place for the #388 density and structure verifier.

## Verifier

`.venv/bin/python scripts/quality/verify_module.py --glob src/content/docs/linux/foundations/system-essentials/module-1.4-users-permissions.md --skip-source-check --summary --quiet`

Result: tier T0; body_words=5137, mean_wpp=69.4, median_wpp=72.0, short_rate=0.0, max_run=0, mean_sentence_length=22.4. Source reachability was skipped as requested; sources_min_10 passed with 11 unique URLs.

## Protected assets

Original protected assets preserved: 33 code blocks, 4 Mermaid diagrams, 1 ASCII diagram, 7 tables, and the 4 original source URLs. Final verifier counts: 34 code blocks, 5 Mermaid diagrams, 1 ASCII diagram, 7 tables; the added assets are the decision-framework flow.

## Additional checks

- `git diff --check -- src/content/docs/linux/foundations/system-essentials/module-1.4-users-permissions.md`: passed
- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/test_pipeline.py`: passed, 166 tests
- `npm run build`: not run because the primary checkout is currently dirty and on `pr804`, so building there would not verify this branch without touching unrelated primary-checkout state

Commit: 334de53551cb970cabf444790ce79a881fab949a