### PR TITLE
feat(388): rewrite module-5.2-cpu-scheduling (#388 pilot)

### DIFF
--- a/src/content/docs/linux/operations/performance/module-5.2-cpu-scheduling.md
+++ b/src/content/docs/linux/operations/performance/module-5.2-cpu-scheduling.md
@@ -1,6 +1,7 @@
 ---
 title: "Module 5.2: CPU & Scheduling"
 slug: linux/operations/performance/module-5.2-cpu-scheduling
+revision_pending: false
 sidebar:
   order: 3
 lab:
@@ -10,43 +11,44 @@ lab:
   difficulty: advanced
   environment: ubuntu
 ---
-> **Linux Performance** | Complexity: `[MEDIUM]` | Time: 30-35 min
+# Module 5.2: CPU & Scheduling
+
+> **Linux Performance** | Complexity: `[MEDIUM]` | Time: 30-35 min, with practical Linux and Kubernetes CPU scheduling diagnostics throughout the lesson.
 
 ## Prerequisites
 
-Before starting this module:
+Before starting this module, make sure you can already read basic Linux process output and recognize how containers are mapped onto cgroups.
 - **Required**: [Module 5.1: USE Method](../module-5.1-use-method/)
 - **Required**: [Module 2.2: cgroups](/linux/foundations/container-primitives/module-2.2-cgroups/)
 - **Helpful**: Understanding of processes and threads
 
----
 
 ## Learning Outcomes
 
-After completing this module, you will be able to:
+After completing this module, you will be able to connect Linux scheduler evidence to Kubernetes resource policy decisions during realistic production incidents.
 - **Diagnose** CPU contention and bottlenecks using standard Linux utilities like `top`, `mpstat`, and `vmstat`.
 - **Evaluate** the impact of Kubernetes CPU requests and limits on application performance and throttling.
 - **Implement** strategies to optimize CPU resource allocation for containerized workloads in Kubernetes.
 - **Compare** the roles of the Completely Fair Scheduler (CFS) and cgroups in managing CPU resources.
 - **Troubleshoot** high load averages and unexpected application latency stemming from CPU scheduling issues.
 
----
 
 ## Why This Module Matters: The Hidden Cost of CPU Throttling
 
-Imagine a major e-commerce platform, let's call it "MegaMart," preparing for its biggest sales event of the year. Their site reliably handles millions of requests per day, and their monitoring dashboards show average CPU utilization well within acceptable limits—never exceeding 30% on most application servers. Yet, when the sales event goes live, customers report slow page loads, transactions time out, and carts mysteriously empty. MegaMart's engineers scramble, checking everything from network latency to database performance, but find no obvious culprits. The CPUs *look* idle on average. What went wrong?
+Imagine a major e-commerce platform, anonymized here as MegaMart, preparing for its largest sale of the year. Its service owners have dashboards showing average CPU utilization below 30% across most application nodes, and the autoscaler has already added capacity. When the event begins, customers still see checkout timeouts, search requests pile up, and carts disappear after retries. The incident review later estimates millions of dollars in lost revenue, even though the first dashboard everyone opened made the servers look relaxed.
 
-This scenario, tragically common in cloud-native environments, is often caused by an insidious performance killer: **CPU throttling**. Despite seemingly low average utilization, poorly configured CPU limits in Kubernetes can introduce micro-pauses for your applications, turning smooth execution into a stop-and-go crawl. These tiny, forced delays accumulate, dramatically increasing latency for user-facing requests and causing cascading failures across microservices. MegaMart's seemingly "idle" CPUs were actually forcing critical application processes to wait, even when ample capacity was available, leading to a disastrous customer experience and millions in lost revenue. Understanding CPU scheduling isn't just an academic exercise; it's a critical skill for preventing such catastrophes and ensuring your applications perform reliably under pressure.
+The root cause was not an absent CPU. The root cause was time that the application was not allowed to use. Several latency-sensitive containers had CPU limits that converted short bursts of request handling into forced pauses, so a request that needed a small amount of compute could still wait for the next cgroup enforcement period before continuing. Average utilization stayed low because averages smear out the exact moments when users were waiting, and the service team spent precious minutes chasing network, cache, and database theories before checking throttling.
 
----
+This module gives you the operating model needed to avoid that kind of mistake. You will diagnose CPU contention with `top`, `mpstat`, `vmstat`, load averages, context switch counters, cgroup files, and Kubernetes metrics, then connect those observations to scheduler behavior and resource configuration. For Kubernetes examples, define the standard alias `alias k=kubectl`; after that, commands such as `k top pod` are the preferred form, and the target cluster behavior in this module assumes Kubernetes 1.35 or newer.
 
-## CPU Fundamentals: Understanding How Linux Sees Your Processor
+The deeper lesson is that CPU performance is about permission to make progress, not only about silicon being present. Linux decides which runnable task executes next, cgroups decide how much CPU a group of tasks may consume, and Kubernetes decides where pods land and what constraints the kubelet applies. When those layers agree with the workload's shape, applications feel smooth under load; when they conflict, dashboards can look calm while users wait.
 
-Before diving into how the CPU is scheduled, it's crucial to understand how Linux perceives and measures its utilization. This section covers the basic tools and concepts for monitoring CPU activity.
 
-### CPU Time Categories
+## CPU Fundamentals: Reading What Linux Is Really Saying
 
-The operating system categorizes CPU time into various states, providing a granular view of where your processor's cycles are being spent. Understanding these categories is the first step in diagnosing CPU-related performance issues.
+Linux performance work starts by separating three ideas that people often collapse into one word: utilization, saturation, and delay. Utilization tells you how busy CPUs were during a measurement interval, saturation tells you whether runnable work was waiting for a CPU, and delay tells you what users or upstream systems actually felt. A host can have moderate utilization with painful delay if a single core is saturated, a cgroup quota is throttling bursts, or runnable work is constantly preempted by higher priority activity.
+
+The first discipline is to treat CPU state as a set of categories rather than one percentage. User time means application code is executing, system time means kernel code is executing on behalf of workloads, idle time means no runnable task needed the CPU, and iowait means the CPU could have done work but the task was blocked on I/O. Interrupt time, soft interrupt time, and steal time each tell a different story about hardware, networking, timers, and virtualized infrastructure, so a responsible diagnosis reads the category mix before naming a bottleneck.
 
 ```bash
 # View CPU time categories
@@ -67,11 +69,9 @@ top -bn1 | grep "Cpu(s)"
 | `si` | Software IRQ - Soft interrupts | Network/timer handling |
 | `st` | Steal - VM overhead | Hypervisor stealing time |
 
-A high `%us` means your applications are working hard. A high `%sy` might indicate an issue with system calls or device drivers. Crucially, a high `%wa` signals an I/O bottleneck, meaning the CPU is waiting for data from disk or network, not that the CPU itself is the limiting factor.
+A high `%us` value usually means application code is consuming processor time, but it does not automatically mean the system is unhealthy. A high `%sy` value points you toward kernel paths such as packet handling, filesystem work, memory management, or very frequent system calls. A high `%wa` value is especially important because it can raise load while CPUs are not actually computing, which is why the USE method from the previous module insists on checking saturation and errors rather than reading one utilization line in isolation.
 
-### Understanding Load Average
-
-The load average is a metric that gives you a sense of how many processes are either currently running or waiting to run (including those waiting for disk I/O) over 1, 5, and 15-minute intervals. It's often misunderstood, as it doesn't directly represent CPU utilization.
+Load average is the second metric that deserves careful handling. It reports the average number of tasks that were runnable or in uninterruptible sleep over one, five, and fifteen minute windows. That means load includes tasks waiting to run on a CPU and tasks stuck waiting for resources such as disk I/O, so it is closer to a queue length signal than a CPU usage signal. When you compare load to the number of logical CPUs, you get a first approximation of whether runnable demand is exceeding available execution slots.
 
 ```bash
 # Show load average
@@ -84,7 +84,7 @@ cat /proc/loadavg
 # load averages   running/total  last PID
 ```
 
-The load average of `2.15, 1.87, 1.42` means that over the last minute, 2.15 processes were either running or waiting. On a system with `N` CPU cores, a load average equal to `N` indicates perfect utilization without queuing. Anything significantly above `N` indicates that processes are contending for CPU resources, or waiting on I/O.
+On a four CPU system, a load near four can mean the machine is busy but not necessarily falling behind. A load near eight means that, on average, four tasks are running while several more are waiting or blocked, and the next question is whether those waiters are runnable CPU work or I/O sleepers. The trend matters too: a one minute load above the five and fifteen minute values indicates a recent spike, while a fifteen minute value above the short windows suggests the pressure has been slowly clearing.
 
 ```mermaid
 graph TD
@@ -131,16 +131,9 @@ graph TD
     end
 ```
 
-> **Pause and predict**: You have a 16-core system with a load average of 24. What does this tell you about your system's performance and workload?
+Pause and predict: you have a sixteen CPU system with a load average of twenty-four, but `top` reports substantial iowait and low user time. What conclusion would you avoid, and what would you check next? The conclusion to avoid is "we simply need more CPU," because blocked I/O tasks can inflate load without consuming processor cycles. The next check is `vmstat 1`, especially the `r` and `b` columns, because they separate runnable pressure from tasks blocked in uninterruptible sleep.
 
-<details>
-<summary>Show Answer</summary>
-A load average of 24 on a 16-core system indicates that the system is significantly overloaded. On average, 16 processes are actively utilizing the CPU, and an additional 8 processes are waiting in the run queue for CPU time. This suggests severe CPU contention, where processes are delayed due to a lack of available processing power, leading to reduced application responsiveness and overall system performance degradation.
-</details>
-
-### CPU Count and Topology
-
-Understanding the physical and logical CPU count on your system helps interpret metrics like load average and `mpstat`. Modern CPUs often have multiple cores, and each core can have multiple hardware threads (hyperthreading), which appear as separate logical CPUs to the operating system.
+CPU count and topology make the load comparison meaningful. `nproc` tells you how many logical CPUs Linux can schedule onto, while `lscpu` shows whether those logical CPUs are spread across sockets, cores, and hardware threads. Hyperthreads are useful scheduling targets, but they are not equivalent to independent physical cores for all workloads, so a latency-sensitive service pinned against one busy hardware thread can still struggle while a dashboard claims the machine has spare logical CPU.
 
 ```bash
 # Number of CPUs
@@ -158,15 +151,16 @@ lscpu
 cat /proc/cpuinfo | grep "processor\|model name" | head -8
 ```
 
----
+There is a useful mental model for these first measurements: utilization is the speedometer, load is the line at the counter, and topology is the number of counters that can actually serve customers. If the line is long because every counter is busy, CPU is saturated. If the line is long because customers are waiting for payment authorization, more cashiers will not fix the problem. If one counter has a long line while the rest are empty, the aggregate average is hiding a distribution problem.
 
-## The Linux Scheduler: Orchestrating Processor Time
+That model also explains why the first few minutes of an incident should be deliberately boring. You want to establish CPU count, load trend, CPU state categories, and per-core shape before making a change. A premature restart or a random limit increase can erase the evidence you need, while a measured baseline lets you prove whether the next action actually reduced runnable pressure, I/O wait, or throttling delay.
 
-The Linux kernel is responsible for deciding which process runs on which CPU at any given moment. This complex task is handled by the scheduler, with the Completely Fair Scheduler (CFS) being the default for general-purpose workloads.
 
-### Completely Fair Scheduler (CFS)
+## The Linux Scheduler: Fairness, Priority, and Preemption
 
-Since Linux kernel version 2.6.23 (released in 2007), the Completely Fair Scheduler (CFS) has been the default process scheduler. It replaced older, more complex schedulers by introducing a simpler, elegant approach focused on fairness. CFS aims to give every process a "fair" share of CPU time by tracking a metric called **virtual runtime (vruntime)**.
+The Linux kernel scheduler answers a question that appears simple but is operationally difficult: when many tasks can run, which task gets which CPU right now? General purpose Linux systems use the Completely Fair Scheduler for normal workloads, and CFS is designed around fairness rather than fixed time slices. Instead of giving every task identical wall clock slices, it tracks how much processor service each runnable task has effectively received, then tries to run the task that is furthest behind its fair share.
+
+Since Linux kernel 2.6.23 in 2007, CFS has used virtual runtime as its central accounting idea. A task that runs accumulates `vruntime`; a task that sleeps or waits stops accumulating it; a task with higher priority accumulates it more slowly. The scheduler keeps runnable tasks in an ordered data structure, traditionally described as a red-black tree, and chooses the task with the smallest virtual runtime. That mechanism favors tasks that have received less CPU service while still allowing priorities to affect the rate at which tasks fall behind or catch up.
 
 ```mermaid
 graph TD
@@ -189,11 +183,9 @@ graph TD
     F --> G(Higher priority = vruntime increases slower)
 ```
 
-CFS maintains a red-black tree (a self-balancing binary search tree) where each leaf node represents a runnable task. The key for each node is its `vruntime`. The scheduler always picks the leftmost node (the one with the smallest `vruntime`) to run next. As a process consumes CPU time, its `vruntime` increases. When a process yields the CPU (e.g., waiting for I/O) or is preempted, its `vruntime` stops increasing, allowing other processes to "catch up." This mechanism naturally prioritizes processes that have received less CPU time, ensuring fairness.
+The fairness goal is not the same as a latency guarantee. CFS can make sensible decisions among runnable tasks, but it cannot make a single-threaded program use several cores at once, it cannot make an I/O blocked task proceed before storage responds, and it cannot ignore a cgroup quota that says a container has exhausted its allowed CPU time. The scheduler is one layer in a stack that includes process behavior, kernel work, interrupt handling, cgroup policy, and Kubernetes placement.
 
-### Nice Values and Process Priority
-
-While CFS strives for fairness, sometimes you need to explicitly tell the scheduler that certain processes are more important than others. This is where "nice values" come in. A nice value (or "niceness") is a user-space priority hint to the CFS.
+Nice values are the everyday interface for adjusting priority among normal CFS tasks. A lower nice value means higher priority, so a task at `-10` receives more favorable scheduling than a task at `10` when both are runnable. This is a hint within the CFS policy, not a hard reservation, and it is most visible when tasks contend for the same CPU. If the machine is mostly idle, a low priority task can still run freely because there is no other runnable work competing for the processor.
 
 ```bash
 # View process nice values
@@ -216,18 +208,11 @@ renice 10 -p 1234
 sudo nice -n -10 ./critical-process
 ```
 
-The `ni` column in `ps` output shows the nice value. A lower nice value means a higher priority. A process with a nice value of `-20` is the highest priority, while `19` is the lowest. The default nice value is `0`. The effect of nice values on `vruntime` is inverse: processes with lower nice values (higher priority) have their `vruntime` increased at a slower rate, effectively making them run more often.
+The practical value of `nice` is that it lets you express intent without rewriting the application. A backup checksum job can be made nice so it yields more readily to interactive or request-serving work, while an emergency maintenance script can be given a higher priority by an operator with the required privileges. The limitation is just as important: in Kubernetes, the container's cgroup CPU weight and quota are usually the stronger controls, so process nice values inside a container cannot compensate for a pod-level CPU limit that is too low.
 
-> **Stop and think**: You're running a critical real-time data processing service and a low-priority batch job on the same machine. How would you use `nice` and `renice` commands to prioritize the real-time service? What's a key limitation to consider?
+Stop and think: you run a critical data ingestion process and a weekly reporting job on the same VM, and both are CPU bound during a backfill. Which process would you start with a higher nice value, and what would prove the change worked? The reporting job should receive the higher nice value because higher nice means lower priority, and the proof is a comparison of CPU allocation and nonvoluntary context switches while both jobs are runnable under load.
 
-<details>
-<summary>Show Answer</summary>
-To prioritize the real-time data processing service, you would use `sudo nice -n -10 ./real-time-service` to start it with a higher priority (lower nice value). For the batch job, you could use `nice -n 10 ./batch-job` to assign it a lower priority (higher nice value). If the batch job is already running, you'd use `renice 10 -p <batch_job_pid>`. A key limitation is that only the root user can set negative nice values, meaning that without root privileges, you can only *lower* a process's priority, not raise it above the default of 0. Also, nice values only apply to the CFS; real-time schedulers (`SCHED_FIFO`, `SCHED_RR`) have their own priority mechanisms.
-</details>
-
-### Real-Time Scheduling Policies
-
-For highly time-sensitive applications where even small delays are unacceptable (e.g., industrial control systems, audio/video processing), Linux offers real-time scheduling policies that bypass the CFS fairness mechanisms. These policies ensure that a real-time process will run as soon as it's ready, preempting any non-real-time processes.
+Real-time scheduling policies are a separate mechanism for workloads that cannot tolerate normal fairness behavior. `SCHED_FIFO` and `SCHED_RR` can preempt ordinary CFS tasks, which makes them useful for specialized domains such as audio, industrial control, or carefully isolated low-latency services. They are also dangerous because a badly behaved real-time task can starve important system work, so they should not be used as a casual fix for application latency in general purpose clusters.
 
 ```bash
 # Check scheduling policy
@@ -246,17 +231,16 @@ chrt -p 1234
 sudo chrt -f -p 50 1234
 ```
 
-Using real-time policies requires extreme caution. A misbehaving real-time process can monopolize the CPU, leading to system unresponsiveness or crashes, as it will prevent even critical kernel tasks from running.
+A useful war story comes from a media processing team that moved an encoder helper into a real-time policy to remove audio glitches during peak ingest. The change helped in a single host test, but in production one helper process entered a tight loop and starved node agents long enough to cause health checks and restarts. The durable fix was not "make everything real-time"; it was isolating the workload, bounding concurrency, measuring scheduling delay, and reserving real-time policy for the smallest component that truly needed it.
 
----
+The scheduler's fairness also interacts with application design. A process that spawns hundreds of runnable worker threads on a small host can create pressure even when each thread individually seems harmless, because the scheduler must rotate among all runnable tasks and the application may spend more time contending for locks than doing useful work. When you see high context switches and poor throughput together, ask whether the program has too much runnable concurrency for the CPU it actually owns.
 
-## CPU Metrics Deep Dive: Going Beyond Averages
+For containerized services, this is where local process tuning meets platform policy. Reducing thread pool size can lower run queue pressure inside a pod, but it will not remove throttling caused by a tight CPU limit. Raising the pod request can improve fair share during node contention, but it will not make a single thread use multiple cores. Good CPU work keeps these layers separate until the evidence shows which one is limiting progress.
 
-While `top` and `uptime` give you a good overview, diagnosing complex CPU issues requires a deeper look into per-CPU statistics, context switches, and the run queue.
 
-### Per-CPU Statistics
+## CPU Metrics Deep Dive: Seeing Contention Instead of Averages
 
-Aggregate CPU utilization can hide problems. One CPU core might be saturated while others are idle, leading to performance bottlenecks for applications tied to the busy core, even if the overall CPU usage looks low. Tools like `mpstat` provide per-CPU breakdowns.
+Aggregate CPU utilization is a convenient starting point and a frequent source of false comfort. If an eight CPU node shows 12.5% total CPU usage, one logical CPU may still be fully saturated while seven are idle. That pattern appears with single-threaded runtimes, interrupt affinity problems, thread pools with poor work distribution, and workloads constrained to a CPU set. Per-CPU metrics turn the vague question "is the machine busy?" into the useful question "where is runnable work actually landing?"
 
 ```bash
 # Per-CPU utilization
@@ -269,18 +253,11 @@ mpstat -P ALL 1
 # 10:30:02    3    13.0    2.0   83.0     2.0
 ```
 
-The output of `mpstat -P ALL 1` shows the utilization for each individual CPU core (`CPU 0`, `CPU 1`, etc.) as well as the average across all CPUs (`all`). This is invaluable for identifying "hot" cores that might be causing bottlenecks.
+When `mpstat -P ALL 1` shows one CPU doing most of the system and soft interrupt work, the next investigation is often interrupt handling rather than application code. Network drivers, storage controllers, and kernel packet processing can concentrate work on a small number of CPUs if affinity or queue configuration is poor. That explains the frustrating case where a web service cannot keep up with traffic even though the host has many idle cores: the application might be waiting behind a kernel path that is pinned to one hot CPU.
 
-> **Stop and think**: You notice that `CPU 0` is consistently at 100% usage (mostly `%sy` and `%si`), while `CPU 1` through `CPU 7` are 99% idle. What kind of system configuration might cause this specific core imbalance?
+Pause and predict: `CPU 0` is consistently near 100% in `%sy` and `%si`, while `CPU 1` through `CPU 7` are almost idle. What kind of configuration problem would you suspect first? The first suspect is interrupt or soft interrupt concentration, often from network receive processing or storage interrupts landing on one CPU. The fix might involve driver queue configuration, receive packet steering, IRQ affinity, or moving the workload, but the diagnosis starts with proving that the hot core is kernel work rather than balanced user code.
 
-<details>
-<summary>Show Answer</summary>
-A consistently maxed-out `CPU 0` with high system (`%sy`) and software interrupt (`%si`) time often points to hardware interrupt affinity issues. By default, many network interface cards (NICs) or storage controllers might route all their hardware interrupts to the first CPU core. If network traffic is extremely high, `CPU 0` spends all its time processing these interrupts, creating a bottleneck while other cores sit idle.
-</details>
-
-### Context Switches
-
-A context switch occurs when the CPU scheduler stops one process from running and starts another. This involves saving the state of the current process and loading the state of the new one, which incurs a performance overhead. A high rate of context switches can indicate that the system is spending a lot of time managing processes rather than doing useful work.
+Context switches add another lens. A context switch happens when the scheduler stops running one task and starts another, which requires saving and restoring execution state. Some context switching is normal and healthy because programs block on I/O, sleep, wait for locks, or yield cooperatively. Excessive switching, especially nonvoluntary switching for a CPU-bound process, can indicate that the process wants to run but is repeatedly preempted before making enough progress.
 
 ```bash
 # System-wide context switches
@@ -300,11 +277,9 @@ cat /proc/1234/status | grep ctxt
 # Nonvoluntary = Preempted by scheduler
 ```
 
-`vmstat` provides system-wide context switch rates (`cs`). For a specific process, `/proc/<PID>/status` shows `voluntary_ctxt_switches` (the process willingly gave up the CPU, e.g., for I/O or sleeping) and `nonvoluntary_ctxt_switches` (the scheduler preempted the process because its time slice expired or a higher-priority process became runnable). A high number of non-voluntary context switches often indicates CPU contention.
+The difference between voluntary and nonvoluntary context switches is operationally useful. Voluntary switches suggest the task is waiting by choice, such as sleeping, waiting on a socket, or blocking on disk. Nonvoluntary switches suggest the scheduler removed the task while it was runnable, commonly because the task exhausted its slice or another runnable task had stronger scheduling priority. If a latency-sensitive process shows a rapidly increasing nonvoluntary counter during an incident, you have evidence of CPU contention even before installing a profiler.
 
-### Run Queue Depth
-
-The run queue (or runnable queue) is where processes wait for their turn to be scheduled on a CPU. Its length indicates the immediate demand for CPU resources.
+The run queue is the most direct saturation signal in the basic toolkit. In `vmstat`, the `r` column shows tasks that are runnable or currently running, while the `b` column shows tasks blocked in uninterruptible sleep. A run queue persistently above the number of logical CPUs means runnable work is waiting for CPU service. A high blocked column with moderate runnable pressure tells you that load is being driven by I/O waits, lock waits in kernel paths, or other non-CPU stalls.
 
 ```bash
 # Processes in run queue
@@ -321,17 +296,18 @@ cat /proc/loadavg
 #                 └── 2 currently running / 150 total
 ```
 
-In `vmstat`, the `r` column shows the number of runnable processes (those waiting for or currently using a CPU). A persistently high `r` value (greater than the number of CPU cores) signifies CPU saturation and contention.
+A worked example makes the sequence concrete. Suppose users report intermittent latency on a VM, while the host-level CPU chart sits around 55%. You check `vmstat 1` and see `r` fluctuating between ten and fourteen on an eight CPU host, with `b` near zero, so runnable work is queuing for CPU. Then `ps aux --sort=-%cpu` reveals a backup compression process and the application competing heavily, while `/proc/<PID>/status` shows the application accumulating nonvoluntary context switches quickly. That evidence supports lowering the backup priority, moving the job, or adding capacity, rather than tuning database timeouts.
 
----
+The same sequence also prevents a common misdiagnosis. If the one minute load average is high but `vmstat` shows `r` near one and `b` near eight, the bottleneck is not raw CPU service. You would pivot to storage latency, network filesystems, disk saturation, or kernel paths holding tasks in uninterruptible sleep. CPU scheduling still appears in the investigation, but it is no longer the primary suspect, and that distinction saves time during production incidents.
+
+You should also preserve the time relationship between metrics. A screenshot of high load without the matching `vmstat`, application latency, and cgroup counters is weak evidence because the workload may have already changed. During a live incident, collect several consecutive samples at a short interval and annotate what was happening at the same time. That habit turns scattered command output into a timeline that can survive review after the immediate pressure has passed.
+
+Another useful habit is to compare symptoms at different scopes. Host metrics tell you whether the node is saturated, process metrics tell you whether a particular program is being preempted, and cgroup metrics tell you whether a container group is being capped. When those scopes disagree, the disagreement is often the diagnosis. A quiet node with a throttled pod points to quota; a busy node with many runnable pods points to capacity or requests; a quiet node with one hot CPU points to imbalance.
+
 
 ## Kubernetes CPU Management: Requests, Limits, and Throttling
 
-Kubernetes, leveraging Linux cgroups, provides powerful mechanisms to manage CPU resources for pods and containers. However, these mechanisms, particularly CPU limits, come with nuances that are critical to understand for optimal performance. Note that modern Kubernetes environments (v1.30+) exclusively utilize **cgroups v2** (the unified hierarchy), replacing the legacy v1 paths. 
-
-### How CPU Requests and Limits Work
-
-In Kubernetes, you define CPU resources using `requests` and `limits` in your pod specifications. These translate directly into Linux cgroup parameters on the underlying node.
+Kubernetes does not invent CPU control from scratch. It uses Linux cgroups to express scheduling weight and hard quota, then relies on the node kernel to enforce those controls. In Kubernetes 1.35, the operational model you should use is the cgroups v2 model: CPU requests influence relative weight during contention, while CPU limits translate into `cpu.max`, a quota and period that cap execution even when the node has spare CPU. That distinction is the center of modern CPU tuning.
 
 ```yaml
 resources:
@@ -341,8 +317,7 @@ resources:
     cpu: "500m"     # Maximum allowed
 ```
 
--   **CPU Requests (`cpu: "100m"`)**: This is a *guaranteed minimum* amount of CPU that the scheduler uses to place your pod on a node. It translates to `cpu.weight` in modern cgroups v2 (or `cpu.shares` in older v1 systems). `cpu.weight` is a relative priority; it determines the proportion of CPU your container gets *when there is contention* for CPU resources.
--   **CPU Limits (`cpu: "500m"`)**: This is a *hard maximum* amount of CPU your container can consume. It translates to `cpu.max` in cgroups v2 (which replaced `cpu.cfs_quota_us` and `cpu.cfs_period_us`). This mechanism *always* enforces a cap, even if the node has abundant idle CPU.
+A CPU request is primarily a scheduling and fairness signal. The Kubernetes scheduler uses requests to decide whether a pod fits on a node, and the kubelet maps the request into a cgroup weight so the container has a proportional claim when CPU is contested. A CPU limit is a hard cap. When the container consumes its quota for the current period, the kernel throttles it until the next period, and that pause happens even if other CPUs are idle.
 
 ```mermaid
 graph LR
@@ -366,16 +341,7 @@ graph LR
     K8s_2CPU --> CG_quota200k
 ```
 
-> **Stop and think**: If CPU limits cause throttling and latency, why might a platform engineering team still choose to enforce them across a multi-tenant cluster?
-
-<details>
-<summary>Show Answer</summary>
-A platform engineering team might enforce CPU limits to ensure strict resource isolation and predictable billing in a multi-tenant environment. Without limits, a poorly optimized application in one namespace could burst and consume all available CPU, causing performance degradation for other tenants sharing the same physical node. Limits act as a safeguard to prevent noisy neighbor scenarios, prioritizing cluster-wide stability over the burst performance of individual pods.
-</details>
-
-### The Problem with CPU Throttling
-
-CPU limits, while seemingly beneficial for resource isolation, can introduce significant and often subtle performance problems through **throttling**. When a container reaches its CPU limit, the kernel temporarily pauses its execution until the next scheduling period begins.
+The word "millicore" can hide the physical behavior. A limit of `500m` does not mean the container gets a smooth half CPU every millisecond. It usually means the cgroup can consume a total budget of 50 milliseconds of CPU time per 100 millisecond period, and the budget may be consumed quickly by parallel threads. A multi-threaded service, a garbage collector, or a TLS-heavy request burst can burn the period budget early, then sit idle by force while user-facing latency grows.
 
 ```bash
 # Check container throttling (cgroups v2 example)
@@ -391,15 +357,9 @@ cat /sys/fs/cgroup/system.slice/container-id.scope/cpu.stat
 # 30,000,000 microseconds = 30 seconds throttled
 ```
 
--   `nr_periods`: The number of 100ms enforcement periods that have elapsed.
--   `nr_throttled`: The number of periods where the container was throttled.
--   `throttled_usec`: The total time (in microseconds) that the container was throttled.
+`nr_periods` tells you how many enforcement periods elapsed, `nr_throttled` tells you in how many periods the cgroup hit the cap, and `throttled_usec` tells you total time spent throttled. These counters are better evidence than average CPU usage when investigating latency under limits. A service can average far below its limit over a minute while still suffering frequent short pauses during the hottest milliseconds of request handling.
 
-A high `nr_throttled` count or `throttled_usec` indicates that your application is frequently being paused, leading to latency spikes and degraded performance, even if average CPU utilization appears low.
-
-### CPU Requests vs. Quotas: A Critical Distinction
-
-It's vital to understand the different implications of CPU requests (which lead to `cpu.weight`) and CPU limits (which lead to `cpu.max`).
+The request versus limit distinction is easiest to remember through idle capacity. Requests shape who wins under contention, so a pod with only a request can burst above that request when nobody else needs the CPU. Limits enforce a maximum whether or not anyone else needs the CPU, so a pod with a low limit can be paused on an otherwise quiet node. This is why many platform teams avoid CPU limits for latency-sensitive services while still requiring realistic CPU requests.
 
 | Mechanism | Effect | When Applied |
 |-----------|--------|--------------|
@@ -434,17 +394,18 @@ graph TD
     end
 ```
 
-**CPU requests** provide a proportional guarantee. If two pods on a node have requests of `100m` and `200m` respectively, and the node is saturated, they will get roughly 1/3 and 2/3 of the available CPU time. However, if one pod is idle, the other can burst and use 100% of the CPU if needed. **CPU limits** impose a strict ceiling. A container with a `500m` limit will *never* use more than 50% of a single CPU core, regardless of how much idle capacity is available on the node. This hard cap is what causes throttling.
-
-### Viewing Container CPU Metrics
-
-Monitoring tools are essential for understanding how your containers are utilizing CPU and whether they are being throttled.
+There are legitimate reasons to keep CPU limits. A hard multi-tenant cluster may need limits to protect tenants from noisy neighbors, support chargeback expectations, or prevent unbounded batch jobs from harming control plane agents and system daemons. The tradeoff is that strict isolation can convert bursty compute into tail latency. A strong platform standard states which workload classes may run without CPU limits, what requests they must set, which namespaces require caps, and what alerts prove throttling is actually happening.
 
 ```bash
 # Pod CPU usage
-kubectl top pod
+alias k=kubectl
+k top pod
 
 # Detailed metrics (if metrics-server installed)
+k get --raw /apis/metrics.k8s.io/v1beta1/pods
+
+# Equivalent full kubectl forms kept for comparison:
+kubectl top pod
 kubectl get --raw /apis/metrics.k8s.io/v1beta1/pods
 
 # Viewing direct cgroup v2 stats for a container via the filesystem
@@ -452,17 +413,18 @@ kubectl get --raw /apis/metrics.k8s.io/v1beta1/pods
 find /sys/fs/cgroup -name cpu.stat -exec awk '/nr_throttled/ {if ($2 > 0) print FILENAME ": " $2}' {} +
 ```
 
-`kubectl top pod` provides a quick overview of current CPU and memory usage. For more detailed insights, especially into throttling, directly inspecting the cgroup `cpu.stat` file for a specific container is the most accurate method.
+Metrics Server gives a useful current usage view, but it does not replace cgroup throttling counters. For a Kubernetes 1.35 workload, the operational path is to correlate application latency with pod CPU usage, node CPU saturation, and cgroup `cpu.stat` growth. If latency spikes line up with `nr_throttled` and `throttled_usec` increases while node CPU is not saturated, the limit is a likely cause. If node CPU is saturated and many pods are runnable, the request and placement strategy may be the stronger lever.
 
----
+Which approach would you choose here and why: a payment API with strict p99 latency gets realistic CPU requests, no CPU limit, horizontal autoscaling, and node capacity alerts; a best-effort image resize queue gets a request and a conservative limit. That split is often healthier than one cluster-wide rule because the payment API is harmed by short forced pauses, while the batch queue can tolerate slower completion in exchange for stronger isolation.
+
+The request value should come from measurement rather than guesswork. A common policy is to start from recent production CPU usage, choose a percentile that reflects steady demand, add headroom for normal bursts, and revisit the number after large releases. If every service requests the minimum because teams fear lower bin packing, the scheduler's fairness signal becomes fiction, and the cluster will eventually reveal that fiction during contention.
+
+The limit value, when present, should have an even clearer reason. It might protect a shared tenant node from runaway batch work, or it might enforce a cost boundary for a namespace that accepts slower jobs. If nobody can name the failure the limit is preventing, the limit is a candidate for removal from latency-sensitive services. The review is not ideological; it is a tradeoff between isolation and the delay caused by quota enforcement.
+
 
 ## Troubleshooting CPU Performance Issues
 
-Diagnosing and resolving CPU-related performance bottlenecks requires a systematic approach, combining observation of high-level metrics with deep dives into kernel-level statistics.
-
-### Diagnosing High Load Average
-
-When your system's load average is consistently high, it's a clear signal of contention. The first step is to determine if the bottleneck is truly CPU or if processes are waiting on other resources, primarily I/O.
+A reliable CPU investigation moves from broad symptoms to narrow evidence. Start with the user-visible symptom, such as p95 latency, queue lag, request timeouts, or missed cron deadlines. Then determine whether host-level saturation, per-core imbalance, process contention, cgroup throttling, or I/O blocking explains the symptom. The order matters because jumping straight to one tool often confirms the theory you already had, while a structured path protects you from mistaking load, utilization, and quota delay for one another.
 
 ```bash
 # Diagnosis steps:
@@ -477,26 +439,11 @@ top -bn1 | head -15
 ps aux --sort=-%cpu | head -10
 ```
 
--   **`vmstat`**: Observe the `r` (run queue) and `b` (blocked for I/O) columns. A high `r` indicates CPU contention, while a high `b` points to I/O bottlenecks.
--   **`top`/`ps`**: Identify the specific processes consuming the most CPU. This helps pinpoint the problematic applications.
--   **cgroup `cpu.stat`**: For containerized workloads, always check for throttling, as it can be a primary cause of perceived CPU issues even when overall utilization is low.
+The first branch is CPU-bound versus I/O-bound pressure. A high `r` value with low `b` means runnable tasks are waiting for CPU, so you inspect the heaviest processes, per-CPU distribution, and context switches. A high `b` value means tasks are blocked in the kernel, so disk latency, network filesystems, or storage controllers become stronger suspects. If both are high, you may have a feedback loop, such as CPU-heavy compression making storage writes slower while blocked writers accumulate.
 
-### Debugging CPU Throttling in Kubernetes
+For containerized workloads, add cgroup checks early instead of treating Kubernetes as a separate world. A pod can be throttled by `cpu.max` while the node has idle CPU, and that finding changes the remedy from "add nodes" to "adjust or remove the limit for this workload class." Conversely, a pod without a limit can burst freely, but if the node is saturated and requests are too low, the pod may lose scheduling share to other workloads under contention. Requests and limits solve different problems, so the fix has to match the evidence.
 
-If your containerized applications are experiencing unexplained latency or degraded performance, especially under moderate load, CPU throttling is a prime suspect.
-
-The immediate solutions for CPU throttling are to either increase the CPU `limit` for the affected pod or, in some cases, remove the CPU `limit` entirely to allow the pod to burst freely. Many organizations have moved towards removing CPU limits entirely for latency-sensitive workloads, relying instead on horizontal pod autoscaling and node autoscaling to manage demand, arguing that throttling causes more problems than it solves.
-
-> **Pause and predict**: If you completely remove CPU limits for a latency-sensitive pod, what new risks do you introduce to the node and other workloads?
-
-<details>
-<summary>Show Answer</summary>
-Removing CPU limits allows the pod to burst and use all available idle CPU on the node, eliminating throttling latency. However, it introduces the risk of CPU starvation for other workloads if the node becomes fully saturated. Without limits, a runaway process could monopolize the CPU, potentially degrading the performance of system daemons or other tenant applications unless they are protected by appropriately sized CPU requests.
-</details>
-
-### Visualizing Throttling Latency
-
-The impact of throttling on application latency can be counter-intuitive. Even if a container needs only a small amount of CPU, if its limit is set too low, it will be forced to wait.
+The throttling latency pattern is counterintuitive because the wall clock delay can be much larger than the CPU time the application needed. A container limited to `100m` can use only about ten milliseconds of CPU in a typical 100 millisecond period. If a request needs twenty milliseconds of CPU and arrives just after the quota is consumed, the request can be split across periods and wait far longer than its actual compute requirement. This is why low average CPU usage can coexist with sharp tail latency.
 
 ```mermaid
 sequenceDiagram
@@ -512,96 +459,151 @@ sequenceDiagram
     Note over App: This is why low CPU% can still cause latency issues!
 ```
 
-This diagram illustrates how a container, limited to `100m` (10ms of CPU per 100ms period), experiences significant latency even if its actual processing time is only 20ms. Once its 10ms quota is exhausted, it's forcibly paused, waiting for the next 100ms period to begin, dramatically increasing the total response time. This is the "hidden cost" of CPU limits.
+A practical Kubernetes playbook has four checks. First, compare application latency with pod CPU usage and node CPU saturation so you know whether the symptom follows demand. Second, inspect throttling counters for the affected cgroup or container. Third, compare CPU requests to observed steady-state demand, because an unrealistically low request can make the pod a weak competitor during node contention. Fourth, examine whether the workload is bursty, multi-threaded, garbage-collector-heavy, or single-threaded, because each shape reacts differently to limits and per-core saturation.
 
----
+Removing CPU limits is not a universal cure. It can eliminate quota throttling for a latency-sensitive pod, but it also allows that pod to consume idle CPU and potentially starve other workloads when the node becomes saturated. The safer pattern is to remove limits only for classes that need burst behavior, set requests from measured demand plus headroom, use pod and node autoscaling, and keep noisy batch or tenant workloads constrained. Platform policy should also reserve CPU for system components so node agents are not pushed out by application bursts.
+
+One worked example ties the layers together. A Java API reports p99 latency spikes after a deployment, and `k top pod` shows average CPU below the configured two CPU limit. The team checks cgroup `cpu.stat` and sees `nr_throttled` growing during latency spikes, while the node has idle CPU. The application changed garbage collection behavior and now performs short parallel bursts that consume quota quickly. Raising or removing the CPU limit for that service, while keeping a realistic request and autoscaling policy, addresses the actual scheduler delay rather than hiding it behind more replicas.
+
+Another example points the other way. A single-threaded Node.js consumer falls behind on an eight CPU VM, and dashboards show overall CPU near 12.5%. `mpstat -P ALL 1` reveals one core at or near full user time while the others are mostly idle. There is no cgroup throttling problem, and adding a pod CPU limit change would not help. The fix is to shard the queue, run more worker processes, adjust runtime concurrency, or redesign the workload so it can use multiple cores.
+
+When the diagnosis leads to a configuration change, verify the result with the same evidence that justified the change. If you remove a CPU limit, `nr_throttled` should stop increasing during the same traffic pattern, but node saturation and neighbor workloads must remain healthy. If you raise a request, the pod should receive a better share under contention, but scheduling density may drop. If you change thread count, context switches and run queue depth should move in the expected direction.
+
+Avoid treating autoscaling as a substitute for scheduler understanding. Horizontal Pod Autoscaling can add replicas when demand rises, but it reacts to metrics over time and may not fix per-request quota pauses inside each replica. Node autoscaling can add capacity, but it cannot make a low CPU limit stop throttling a single pod on an idle node. Autoscaling is powerful when resource policy is truthful; it is confusing when requests and limits hide the workload's real shape.
+
+
+## Patterns & Anti-Patterns
+
+Good CPU operations are less about memorizing one command and more about choosing a pattern that matches the workload. Latency-sensitive services need room for short bursts, realistic requests, and alerts that catch throttling before users report it. Batch jobs need fairness, bounded concurrency, and often lower priority. Shared clusters need tenant isolation without silently punishing the workloads that are most sensitive to short scheduler pauses.
+
+| Pattern | When to Use | Why It Works | Scaling Considerations |
+|---------|-------------|--------------|------------------------|
+| Requests based on measured steady load plus headroom | Long-running services with stable traffic patterns | Gives the scheduler and cgroup weight a truthful baseline during contention | Revisit after major releases, traffic changes, or runtime upgrades |
+| No CPU limit for latency-sensitive services | APIs, gateways, and control loops where p99 delay matters | Allows short bursts to use idle node CPU without quota pauses | Requires node saturation alerts, HPA, and protection for system daemons |
+| Conservative limits for tolerant batch work | Rendering, indexing, reports, and queue jobs with flexible deadlines | Prevents noisy jobs from consuming all shared CPU | Pair with queue depth alerts and concurrency controls |
+| Per-core inspection during imbalance | Single-threaded services, IRQ-heavy nodes, and pinned workloads | Reveals hot CPUs hidden by aggregate utilization | Combine with thread model, affinity, and runtime concurrency review |
+
+These patterns scale when teams document the reason behind each resource policy. A service manifest that says "no CPU limit because p99 latency is quota-sensitive; request set from seven day p95 CPU plus headroom" is much easier to operate than a manifest that simply omits the limit. The comment is not decoration; it tells the next engineer what evidence would justify changing the policy.
+
+| Anti-Pattern | What Goes Wrong | Better Alternative |
+|--------------|-----------------|--------------------|
+| Setting tiny CPU limits on every pod by default | Bursty services are throttled even on idle nodes | Require requests everywhere, use limits only where isolation matters |
+| Treating load average as CPU utilization | I/O-blocked tasks are mistaken for CPU starvation | Compare load with `vmstat` `r` and `b` before deciding |
+| Looking only at aggregate CPU | Hot-core bottlenecks disappear into the average | Use `mpstat -P ALL 1` and runtime-specific concurrency checks |
+| Raising real-time priority to fix ordinary latency | A runaway task can starve system and application work | Use capacity, isolation, profiling, and bounded concurrency first |
+
+The common thread is that CPU policy should describe a tradeoff explicitly. A limit buys isolation at the cost of possible latency. A missing limit buys burst capacity at the cost of stronger noisy-neighbor risk. A high request buys fair share and placement confidence at the cost of lower packing density. The right answer depends on the service's failure mode, and the evidence should come from the same measurements you use during incidents.
+
+Teams that do this well usually make CPU review part of normal service ownership rather than emergency tuning. They record the reason for each request and limit, alert on throttling where it matters, and compare resource settings after major runtime or traffic changes. The payoff is not only better latency. It is faster incident response because the team already knows which workloads are allowed to burst, which are intentionally capped, and which metrics prove the policy is working.
+
+
+## Decision Framework
+
+Use this framework when a workload shows CPU-related symptoms or when you are reviewing a Kubernetes resource policy. Begin with the symptom, not the manifest. If the symptom is tail latency or queue lag, verify whether runnable work is waiting, whether one CPU is hot, whether the cgroup is throttled, and whether I/O wait is inflating load. Only then choose between changing requests, changing limits, changing concurrency, adding replicas, or moving the workload.
+
+| Observation | Strongest Next Check | Likely Action |
+|-------------|----------------------|---------------|
+| High load and high `r` in `vmstat` | `top`, `ps`, per-process context switches | Reduce CPU demand, add capacity, tune priority, or move jobs |
+| High load and high `b` in `vmstat` | Storage, filesystem, and network I/O metrics | Investigate I/O instead of buying CPU first |
+| Low average CPU but high p99 latency in a limited pod | cgroup `cpu.stat` throttling counters | Raise or remove CPU limit, then protect with requests and autoscaling |
+| One CPU saturated while others are idle | `mpstat -P ALL 1`, runtime thread model, IRQ affinity | Shard, add worker processes, tune affinity, or rebalance interrupts |
+| Node saturated with many pods contending | Requests versus actual CPU demand | Resize requests, spread workloads, add nodes, or adjust scheduling |
+
+```mermaid
+flowchart TD
+    A[Symptom: latency, queue lag, or high load] --> B{vmstat r above CPU count?}
+    B -- yes --> C[CPU runnable pressure]
+    B -- no --> D{vmstat b high or iowait high?}
+    D -- yes --> E[Investigate I/O path first]
+    D -- no --> F[Check per-core and cgroup signals]
+    C --> G{One CPU much hotter?}
+    G -- yes --> H[Investigate single-threading or IRQ affinity]
+    G -- no --> I{Kubernetes pod limited?}
+    I -- yes --> J[Check cpu.stat throttling]
+    I -- no --> K[Review demand, requests, and capacity]
+    J --> L{Throttling grows during symptom?}
+    L -- yes --> M[Raise or remove limit for this workload class]
+    L -- no --> K
+```
+
+When the framework points to a CPU limit, make the smallest policy change that matches the workload class. For an API, that may mean removing the limit, setting a request based on observed demand, and confirming HPA or node autoscaling behavior. For a tenant batch job, that may mean raising the limit enough to avoid pathological throttling while keeping a cap that protects the rest of the node. For a single-threaded application, the decision may have nothing to do with limits because one thread cannot use a larger quota across many cores.
+
+The framework is also useful during design reviews. Before approving a new workload, ask what happens when it receives a burst, what happens when the node is saturated, and what evidence would show the chosen policy is wrong. Those questions connect the manifest to operations. They also keep teams from copying resource settings across services with completely different latency tolerance, concurrency models, and tenant risk.
+
 
 ## Did You Know?
 
--   **Linux uses the Completely Fair Scheduler (CFS) since 2007** — It replaced the O(1) scheduler and uses red-black trees to ensure every process gets a fair share of CPU time, revolutionizing Linux's ability to handle diverse workloads efficiently.
--   **CPU "millicores" are a Kubernetes abstraction** — Linux doesn't natively understand `100m`. Kubernetes translates this into cgroup limits demonstrating the sophisticated layer of resource management Kubernetes builds on top of Linux primitives.
--   **Throttling happens in 100ms periods by default** — The cgroup quota period defaults to 100,000 microseconds (100ms). This means that a container's CPU quota is enforced over these 100ms intervals, leading to the discrete "pauses" that define throttling.
--   **Nice values range from -20 (highest priority) to 19 (lowest priority)** — While the default is 0, only processes running as root can set negative nice values, giving them elevated priority. A difference of one nice unit can correspond to approximately a 10% change in CPU allocation during contention.
+- **Linux has used CFS for normal tasks since 2007** - Kernel 2.6.23 replaced the older O(1) scheduler with a design based on virtual runtime and fair service.
+- **Kubernetes CPU `100m` is a control-plane abstraction** - The node kernel enforces weights and quotas through cgroups; it does not schedule a native unit called a millicore.
+- **The common cgroup quota period is 100,000 microseconds** - A `100m` limit can therefore behave like ten milliseconds of CPU budget per 100 millisecond period.
+- **Nice values run from -20 to 19** - Lower values are higher priority, and unprivileged users can usually make their own tasks nicer but not more favored than default.
 
----
 
-## Common Mistakes and How to Avoid Them
+## Common Mistakes
 
-| Mistake | Problem | Solution |
-|---------|---------|----------|
-| Setting CPU limits too low | Throttling causes latency, even with low average CPU utilization. | Test under realistic load, consider removing CPU limits, especially for latency-sensitive services. |
-| Confusing requests and limits | Leads to either overcommitment (no limits, high contention) or wasted resources (high limits, underutilized) or unnecessary throttling. | Use requests for guaranteed baseline and scheduling. Use limits for safety nets, or remove them for burstable workloads. |
-| Ignoring `iowait` (`wa%`) in `top` | Blaming CPU for performance issues when the true bottleneck is disk or network I/O. | Always check `wa%` in `top` or `vmstat`. A high value indicates I/O is the problem, not CPU saturation. |
-| Not checking per-CPU statistics | Average CPU utilization can hide a single saturated core, leading to bottlenecks for single-threaded applications. | Use `mpstat -P ALL` to inspect individual CPU core utilization. |
-| Assuming `nice` values matter in containers | `nice` values are overridden or irrelevant when cgroups are actively managing CPU resources. | In Kubernetes, rely on CPU requests (which map to `cpu.weight`) for relative priority among containers. |
-| High context switches without clear cause | Excessive context switching indicates processes are frequently yielding or being preempted, potentially due to too many active threads or CPU contention. | Analyze `voluntary` vs. `nonvoluntary` context switches via `/proc/<PID>/status`. Reduce thread count if necessary or investigate CPU contention. |
+| Mistake | Why It Happens | How to Fix It |
+|---------|----------------|---------------|
+| Setting CPU limits too low on latency-sensitive pods | Teams want isolation and copy a default limit without testing burst behavior | Use realistic requests, inspect throttling, and remove or raise limits where p99 latency is quota-sensitive |
+| Confusing requests and limits | Both appear under `resources`, but one is a scheduling weight and the other is a hard cap | Teach requests as fair-share baseline and limits as quota enforcement, then review each workload class |
+| Ignoring `iowait` (`wa%`) in `top` | High load feels like CPU trouble during an incident | Check `vmstat` `r` and `b`; pivot to storage or network I/O when blocked tasks dominate |
+| Trusting aggregate CPU on multi-core hosts | Dashboards average away hot-core and single-threaded bottlenecks | Use `mpstat -P ALL 1` and inspect runtime concurrency before adding CPU quota |
+| Assuming `nice` values override container policy | Process priority is visible inside the container, but cgroup controls still govern CPU share and quota | Tune Kubernetes requests and limits first, then use nice values only for local process priorities |
+| Ignoring nonvoluntary context switches | CPU contention is harder to see than a high usage graph | Inspect `/proc/<PID>/status` and compare voluntary versus nonvoluntary switch growth under load |
+| Removing every CPU limit without guardrails | Avoiding throttling can create noisy-neighbor risk on saturated nodes | Pair limit-free services with measured requests, autoscaling, node alerts, and separate treatment for batch work |
 
----
 
 ## Quiz
 
-### Question 1: Scenario-Based
-A Kubernetes pod is configured with `cpu: "200m"` for requests and `cpu: "500m"` for limits. On a node with 4 CPU cores, this pod occasionally experiences performance degradation and high latency, even when the overall node CPU utilization is only 40%.
-Explain why this might be happening and what metric you would check first to confirm your hypothesis.
+<details><summary>Question 1: A Kubernetes API pod has a `200m` request and a `500m` limit. Users report latency spikes while node CPU utilization sits near 40%. What do you check first, and why?</summary>
 
-<details>
-<summary>Show Answer</summary>
-This scenario strongly suggests the application is suffering from CPU throttling. Even though the node's overall CPU utilization is relatively low at 40%, the pod's `500m` CPU limit imposes a strict quota, preventing it from using more than 50% of a single CPU core. If the application handles requests with bursty CPU requirements, it will rapidly exhaust this hard quota and be forcibly paused by the Linux kernel until the next cgroup accounting period begins. This forced waiting introduces significant artificial latency, making the application feel extremely slow to end users despite the abundance of available node resources. To definitively confirm this, you should check the `cpu.stat` file within the container's cgroup specifically looking at `nr_throttled` and `throttled_time` (or `throttled_usec`).
+Check the pod or container cgroup `cpu.stat` counters, especially `nr_throttled` and `throttled_usec`, during the latency window. The `500m` limit is a hard quota, so the container can be paused after consuming its period budget even when the node has idle CPU. Average node utilization cannot reveal those short forced waits. If throttling grows with latency, the limit is a stronger suspect than node capacity.
+
 </details>
 
-### Question 2: Scenario-Based
-You observe a Linux server with an 8-core CPU reporting a 1-minute load average of 10.0, a 5-minute load average of 8.0, and a 15-minute load average of 6.0.
-Describe the current state of the system and its trend, and what you would look for next using `vmstat`.
+<details><summary>Question 2: An eight CPU server shows load averages of 10.0, 8.0, and 6.0. What does the trend suggest, and how would `vmstat` guide your next step?</summary>
 
-<details>
-<summary>Show Answer</summary>
-The system is currently overloaded, which is evident because the 1-minute load average of 10.0 exceeds the total number of available CPU cores (8). This metric indicates that, on average, two active processes are stuck waiting in the run queue for CPU time they cannot immediately get. However, the historical trend (from 10.0 down to 8.0 and then 6.0 over 15 minutes) suggests that the intense load spiked recently but is actively decreasing, slowly returning the system to a state of full utilization or slight underutilization. To diagnose the root cause, you should use `vmstat` to examine the `r` (run queue) and `b` (blocked for I/O) columns. A high `r` value would confirm pure CPU contention, while a spike in the `b` column would indicate that the processes are actually bottlenecked by disk or network I/O rather than raw compute availability.
+The system is currently above its CPU count and the short window is higher than the longer windows, so pressure increased recently. `vmstat 1` tells you whether that pressure is runnable CPU demand or blocked I/O demand. A high `r` value points toward CPU contention, while a high `b` value points toward tasks stuck in uninterruptible waits. That distinction determines whether you inspect processes and priorities or pivot to storage and I/O paths.
+
 </details>
 
-### Question 3: Scenario-Based
-A legacy Java application is deployed in a Kubernetes cluster. Developers report that setting CPU limits below 2 CPUs for this application consistently leads to severe performance degradation and increased garbage collection pauses, even though `kubectl top pod` shows its average CPU usage rarely exceeds 1.5 CPUs.
-Based on your understanding of CPU limits and Java applications, what is a likely explanation for this behavior?
+<details><summary>Question 3: A Java service slows down whenever its CPU limit is below two CPUs, but `k top pod` shows average CPU around one and a half CPUs. What is a likely explanation?</summary>
 
-<details>
-<summary>Show Answer</summary>
-The most likely explanation is that the Java application is highly sensitive to CPU throttling due to its internal garbage collection (GC) mechanisms. Modern Java Virtual Machines (JVMs) attempt to optimize GC by performing bursty, highly concurrent, and CPU-intensive work during collection phases. If the CPU limit is set too low (e.g., restricted to 1.5 CPUs), these aggressive GC bursts will quickly hit the cgroup quota and be severely throttled by the kernel. Because the GC process is artificially stretched out over multiple enforcement periods, the application experiences prolonged "stop-the-world" pauses. This directly impacts application latency and throughput, proving that average CPU usage often masks the brief, high-intensity compute spikes required by runtime environments like the JVM.
+The service may need short parallel bursts, especially during garbage collection, JIT activity, TLS work, or request fanout. Averages can stay below the limit while the process still exhausts quota during brief hot periods. Once the quota is consumed, the kernel throttles the cgroup and stretches application pauses across scheduling periods. Checking `cpu.stat` during the slow windows would confirm whether throttling aligns with the degradation.
+
 </details>
 
-### Question 4: Scenario-Based
-You are tasked with deploying a batch processing workload and a web server on a shared Kubernetes node that frequently has ample idle CPU. You configure the batch workload with requests only, and the web server with both requests and strict limits. During an off-peak period where the node is 80% idle, the web server experiences a sudden traffic spike. How will the Linux scheduler treat the CPU allocation for these two pods differently under these idle conditions, and why?
+<details><summary>Question 4: A batch worker has only CPU requests, while a web server has requests and a strict CPU limit. During an off-peak web traffic spike, the node is mostly idle. How will the scheduler treat them differently?</summary>
 
-<details>
-<summary>Show Answer</summary>
-Under these idle conditions, the Linux scheduler will treat the two pods very differently due to how requests and limits are implemented at the cgroup level. The batch workload, relying only on CPU requests, has no upper bound and can freely burst to consume all available idle CPU cycles on the node to finish its tasks faster. Conversely, the web server, which has strict CPU limits, is bound by a hard execution cap regardless of the node's 80% idle state. If the web server's traffic spike requires more compute than its defined limit, the kernel will forcefully throttle its containers, introducing latency despite the abundance of free resources. This illustrates that limits enforce a strict ceiling at all times, whereas requests simply guarantee a proportional minimum during times of active contention.
+The batch worker can burst above its request because a request is a relative weight that matters during contention. The web server is still capped by its CPU limit because the limit maps to quota enforcement. If the web server needs more CPU than its limit during the spike, it can be throttled even though idle node CPU exists. This is why limits and requests should not be described as two versions of the same guarantee.
+
 </details>
 
-### Question 5: Scenario-Based
-Users are complaining about intermittent latency in a monolithic backend service running directly on a VM. Upon initial investigation, the overall CPU usage appears moderate, but you suspect the specific application process (PID 54321) is suffering from severe CPU contention with a noisy neighbor process. To prove this hypothesis without installing external profiling tools, which specific system file and metric would you inspect for this process, and how would you interpret the findings?
+<details><summary>Question 5: A VM-hosted backend has moderate total CPU usage, but you suspect one process is being preempted by noisy neighbors. Which local evidence would support that hypothesis?</summary>
 
-<details>
-<summary>Show Answer</summary>
-To prove that the specific process is suffering from CPU contention, you should inspect the `/proc/54321/status` file and look specifically at the `nonvoluntary_ctxt_switches` metric. This counter tracks how many times the Linux scheduler forcibly preempted the process because its time slice expired or a higher-priority task became runnable. A rapidly increasing or unusually high value for this metric strongly indicates that the application is competing heavily for processor time and losing out to other processes. If the value of `voluntary_ctxt_switches` is low while `nonvoluntary_ctxt_switches` is high, it definitively confirms the process wants to compute but is being starved of CPU cycles by the noisy neighbor. Checking these metrics provides concrete evidence of CPU starvation without requiring external tools.
+Inspect `/proc/<PID>/status` for `voluntary_ctxt_switches` and `nonvoluntary_ctxt_switches`, then watch how they grow during the symptom. A rapidly increasing nonvoluntary counter means the process wanted to run but the scheduler removed it. If voluntary switches are not growing at the same pace, the process is less likely to be merely sleeping or waiting on I/O. That evidence supports CPU contention before you install heavier profiling tools.
+
 </details>
 
-### Question 6: Scenario-Based
-A critical single-threaded Node.js application is failing to process its message queue quickly enough, causing a severe backlog. When the operations team checks the monitoring dashboard for the 8-core host machine, they see a comfortable overall CPU utilization of just 12.5%. They are confused why the application is bottlenecking when the system appears mostly idle. What specific tool and flag should they use to uncover the true nature of this performance issue, and what are they likely to find?
+<details><summary>Question 6: A single-threaded Node.js consumer falls behind on an eight CPU host showing only 12.5% total CPU usage. What tool exposes the likely bottleneck?</summary>
 
-<details>
-<summary>Show Answer</summary>
-The operations team should immediately use the `mpstat -P ALL` command (or press '1' while inside the `top` utility) to break down the CPU utilization on a per-core basis. Overall CPU averages can easily mask extreme uneven load distribution across multiple cores, which is especially problematic for single-threaded applications. Because a single-threaded Node.js process can only execute on one CPU core at a time, it will max out its assigned core (reaching 100% utilization for that specific core) while the other seven cores remain completely idle. This creates a severe performance bottleneck for the application, even though the aggregate system load mathematically averages out to a seemingly safe 12.5%. This illustrates why checking per-core statistics is mandatory when debugging CPU performance.
+Use `mpstat -P ALL 1` or an equivalent per-CPU view. A single-threaded process can fully occupy one logical CPU while the other seven sit mostly idle, and the aggregate average will hide that shape. If one CPU is hot in user time, increasing a pod limit or buying a larger node may not solve the queue lag. The likely fixes are sharding, more worker processes, or changing the concurrency model.
+
 </details>
 
----
 
 ## Hands-On Exercise: Exploring CPU Scheduling Dynamics
 
 **Objective**: Gain practical experience observing CPU scheduling, priority, and throttling behavior using common Linux tools and container runtimes.
 
-**Environment**: A Linux system (VM, cloud instance, or local machine) running a modern distribution with `stress` and `docker` (or `podman`) installed. Root access may be required for some steps.
+**Environment**: A Linux system, VM, cloud instance, or local machine running a modern distribution with `stress` and `docker` or `podman` installed. Root access may be required for cgroup steps, and Kubernetes checks assume a Kubernetes 1.35 or newer cluster when you use `alias k=kubectl` and commands such as `k top pod`.
+
+This exercise intentionally moves from observation to controlled pressure. First you record CPU topology and current load so every later number has context. Then you create competing CPU-bound work, inspect scheduling behavior, and finally apply cgroup quotas directly before observing the same concept through a container runtime. The goal is not to memorize one output format, but to build the habit of connecting each metric to the scheduler behavior that produced it.
+
+Before you begin, decide what result would surprise you. For example, if the machine has many CPUs, a small `stress --cpu 4` run may not overload it, and the interesting observation might be per-core distribution rather than a high run queue. If your container runtime uses a slightly different cgroup path, the lesson is to follow the runtime's mapping carefully rather than assume every host arranges cgroup files the same way.
 
 ### Part 1: Initial CPU System Metrics
 
-Begin by establishing a baseline understanding of your system's CPU characteristics and current load.
+Begin by establishing a baseline understanding of your system's CPU characteristics and current load. Write down the number of logical CPUs before interpreting load average, because a load of four means something very different on a two CPU laptop than on a sixteen CPU build host.
 
 ```bash
 # 1. Check CPU info: Identify the number of logical CPUs, cores, and sockets.
@@ -623,19 +625,15 @@ top -bn1 | head -8
 mpstat -P ALL 1 3
 ```
 
-<details>
-<summary>Expected Output and Analysis</summary>
-After running these commands, you should see:
-- `nproc` will output the number of logical CPUs (e.g., `4`).
-- `lscpu` will provide detailed CPU topology, confirming cores and threads.
-- `uptime` and `cat /proc/loadavg` will show the current load averages. Compare these to your `nproc` output to understand if your system is under, perfectly, or over-loaded.
-- `top` will show the `%Cpu(s)` line with various categories. Pay attention to `us`, `sy`, `id`, and `wa`.
-- `mpstat` will display utilization for each CPU (`CPU 0`, `CPU 1`, etc.) and an `all` average. If one core is consistently much higher than others, it suggests uneven workload distribution.
+<details><summary>Expected Output and Analysis</summary>
+
+You should see `nproc` print the number of logical CPUs, `lscpu` describe threads, cores, and sockets, and `uptime` show the one, five, and fifteen minute load averages. Compare those load values to the CPU count instead of judging them in isolation. `top` should show CPU time categories such as user, system, idle, and iowait, while `mpstat` should show whether one CPU is doing far more work than the others. If a single CPU is much hotter than the average, keep that observation for later troubleshooting.
+
 </details>
 
 ### Part 2: Observing Nice Values in Action
 
-This section demonstrates how `nice` values influence CPU allocation between competing processes.
+This section demonstrates how `nice` values influence CPU allocation between competing processes. The commands use two infinite hashing jobs so there is clear contention; do not run them on a production host, and clean them up promptly.
 
 ```bash
 # 1. Start two CPU-intensive processes with different nice values.
@@ -659,14 +657,15 @@ ps -o pid,ni,%cpu,comm -p $PID1,$PID2
 kill $PID1 $PID2
 ```
 
-<details>
-<summary>Expected Output and Analysis</summary>
-You should observe that `PID2` (nice value 0) consistently gets a higher percentage of CPU time compared to `PID1` (nice value 19). This demonstrates how `nice` values, as hints to the CFS, can effectively prioritize one CPU-bound workload over another when CPU resources are contended. The difference won't be perfectly proportional to `19` vs `0` due to other system processes and scheduling complexities, but the trend will be clear.
+<details><summary>Expected Output and Analysis</summary>
+
+The `nice 0` process should usually receive more CPU time than the `nice 19` process while both are CPU bound. The split will not be perfectly stable because other system work also runs, but the direction should be clear. This demonstrates that nice values influence fair-share scheduling under contention rather than imposing an absolute CPU cap. If both processes run on an otherwise idle multi-core machine, you may need to start more competing workers or constrain affinity to make the difference obvious.
+
 </details>
 
 ### Part 3: System-Wide Scheduling Behavior
 
-Explore how context switches and the run queue behave under increasing system load.
+Explore how context switches and the run queue behave under increasing system load. Keep the `vmstat` output visible while you start load, because the transition is more educational than a static snapshot after the system has already settled.
 
 ```bash
 # 1. Monitor system-wide context switches and run queue depth.
@@ -686,15 +685,15 @@ stress --cpu 4 --timeout 30 &
 watch -n 1 uptime
 ```
 
-<details>
-<summary>Expected Output and Analysis</summary>
-- When `stress` starts, you'll see the `r` column in `vmstat` increase, indicating more processes are runnable and waiting for CPU. The `cs` column might also increase as the scheduler works harder to manage the increased contention.
-- In `watch -n 1 uptime`, the 1-minute load average will rise, potentially exceeding your CPU count, signaling CPU saturation. This demonstrates that load average reflects both running and waiting processes.
+<details><summary>Expected Output and Analysis</summary>
+
+When `stress` starts, the `r` column should increase because more processes are runnable and competing for CPU service. The `cs` column may also rise as the scheduler switches among active tasks. The one minute load average will climb gradually rather than instantly because load averages are smoothed over time. Compare the load to your `nproc` result so you can decide whether the system is merely busy or actually queuing runnable work.
+
 </details>
 
 ### Part 4: Investigating cgroup CPU Quotas (Native Linux)
 
-This part uses the modern cgroups v2 unified hierarchy to demonstrate CPU quotas directly on a Linux system. This is the exact mechanism Kubernetes uses under the hood.
+This part uses the modern cgroups v2 unified hierarchy to demonstrate CPU quotas directly on a Linux system. This is the same family of kernel mechanism Kubernetes uses under the hood, so the lesson transfers directly to pod CPU limits.
 
 ```bash
 # 1. Create a new CPU cgroup (cgroups v2).
@@ -724,14 +723,15 @@ echo $$ | sudo tee /sys/fs/cgroup/cgroup.procs # Move shell back to root cgroup
 sudo rmdir /sys/fs/cgroup/test
 ```
 
-<details>
-<summary>Expected Output and Analysis</summary>
-After a few seconds of `sha256sum` running, `cat /sys/fs/cgroup/test/cpu.stat` will show `nr_throttled` and `throttled_usec` values greater than zero. This directly demonstrates that the process, despite being CPU-bound, is being actively throttled to adhere to the 10% CPU quota imposed by the cgroup. This is the underlying mechanism for Kubernetes CPU limits.
+<details><summary>Expected Output and Analysis</summary>
+
+After a few seconds of `sha256sum` running, `cpu.stat` should show `nr_throttled` and `throttled_usec` greater than zero. That proves the process is runnable and wants CPU, but the cgroup quota prevents it from consuming more than the configured share during each period. If cleanup fails because the shell is still inside the test cgroup or a child process remains, move the shell back to the root cgroup and make sure the hashing process is stopped before removing the directory.
+
 </details>
 
 ### Part 5: Container CPU Limits and Throttling (Docker/Podman)
 
-This section extends the cgroup understanding to container runtimes, showing how `docker` (or `podman`) applies CPU limits and how to observe their effect via modern cgroups v2.
+This section extends the cgroup understanding to container runtimes, showing how `docker` or `podman` applies CPU limits and how to observe their effect via modern cgroups v2. The important connection is that a friendly container flag becomes a kernel quota file, and the kernel is what enforces the pause.
 
 ```bash
 # 1. Run a container with a CPU limit (e.g., 0.5 CPUs).
@@ -755,45 +755,38 @@ docker exec cpu-test cat /sys/fs/cgroup/cpu.stat
 docker rm -f cpu-test
 ```
 
-<details>
-<summary>Expected Output and Analysis</summary>
-- The `cpu.max` output inside the container should be `50000 100000`.
-- After running `sha256sum` inside the container for a minute, `docker exec cpu-test cat /sys/fs/cgroup/cpu.stat` will show non-zero (and likely growing) values for `nr_throttled` and `throttled_usec`. This confirms that Docker, using cgroups, is actively throttling the container's CPU usage according to the `--cpus` limit. This is directly analogous to how Kubernetes CPU limits work.
+<details><summary>Expected Output and Analysis</summary>
+
+The `cpu.max` output inside the container should show a quota and period consistent with half a CPU, commonly `50000 100000`. After the hashing workload runs, `cpu.stat` should show nonzero throttling counters. This is directly analogous to Kubernetes CPU limits, except Kubernetes writes the cgroup settings through the kubelet and container runtime. If you repeat the experiment without the CPU limit, the throttling counters should stop growing under the same local load.
+
 </details>
 
-### Success Checklist
+### Success Criteria Checklist
 
-- [ ] I can explain the difference between `us`, `sy`, `id`, `wa`, `st` CPU time categories.
-- [ ] I can interpret load average values relative to the number of CPU cores.
+- [ ] I can explain the difference between `us`, `sy`, `id`, `wa`, and `st` CPU time categories.
+- [ ] I can interpret load average values relative to the number of logical CPUs.
 - [ ] I have observed how `nice` values impact CPU allocation among competing processes.
 - [ ] I have monitored context switches and run queue depth under load.
-- [ ] I understand how cgroups v2 `cpu.max` implement CPU limits natively.
+- [ ] I understand how cgroups v2 `cpu.max` implements CPU limits natively.
 - [ ] I have seen evidence of CPU throttling both in native cgroups and within a container.
 
----
 
-## Key Takeaways
+## Next Module
 
-1.  **Load average ≠ CPU utilization**: Load average includes processes waiting for I/O, while CPU utilization only measures active processing. A high load average can indicate either CPU contention or I/O bottlenecks.
-2.  **CFS ensures fairness**: The Completely Fair Scheduler balances CPU time among runnable processes using `vruntime`, prioritizing those that have received less CPU time.
-3.  **Requests = weight, Limits = max caps**: In Kubernetes, CPU requests translate to cgroup weights (relative priority during contention), while CPU limits translate to hard maximums.
-4.  **Throttling causes latency**: Kubernetes CPU limits, enforced via cgroup quotas, can introduce significant latency spikes by pausing container execution, even if average CPU usage is low.
-5.  **Check per-CPU stats**: Aggregate CPU metrics can hide performance bottlenecks caused by a single saturated core. Use `mpstat -P ALL` for a granular view.
-6.  **I/O wait is critical**: Don't confuse high `iowait` (`wa%`) with CPU starvation; it indicates processes are waiting for disk or network I/O, shifting the troubleshooting focus.
+Continue to [Module 5.3: Memory Management](./module-5.3-memory-management/) to compare CPU throttling with memory pressure, OOM behavior, RSS, cache, swap, and the very different failure mode of Kubernetes memory limits.
 
----
-
-## What's Next?
-
-CPU is only one piece of the performance puzzle. In **Module 5.3: Memory Management**, you'll learn how Linux handles memory, the implications of OOM events, and how Kubernetes memory limits differ fundamentally from CPU limits. Prepare to dive into RSS, VSS, swap, and the dreaded OOM Killer!
-
----
 
 ## Further Reading
 
--   [Module 5.1: USE Method](../module-5.1-use-method/)
--   [Module 2.2: cgroups](/linux/foundations/container-primitives/module-2.2-cgroups/)
--   [CFS Scheduler Documentation](https://www.kernel.org/doc/Documentation/scheduler/sched-design-CFS.txt)
--   [CPU Bandwidth Control](https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt)
--   [Kubernetes CPU Management](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/)
--   [For the Love of God, Stop Using CPU Limits](https://home.robusta.dev/blog/stop-using-cpu-limits)
+- [Module 5.1: USE Method](../module-5.1-use-method/)
+- [Module 2.2: cgroups](/linux/foundations/container-primitives/module-2.2-cgroups/)
+- [CFS Scheduler Documentation](https://www.kernel.org/doc/Documentation/scheduler/sched-design-CFS.txt)
+- [CPU Bandwidth Control](https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt)
+- [CFS Scheduler Design](https://www.kernel.org/doc/html/latest/scheduler/sched-design-CFS.html)
+- [Cgroup v2 CPU Controller](https://docs.kernel.org/admin-guide/cgroup-v2.html#cpu)
+- [Proc Filesystem Load Average](https://docs.kernel.org/filesystems/proc.html)
+- [Kubernetes Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+- [Kubernetes CPU Management Policies](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/)
+- [Kubernetes Metrics Server](https://kubernetes.io/docs/tasks/debug/debug-cluster/resource-metrics-pipeline/)
+- [Kubernetes Node Allocatable](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/)
+- [For the Love of God, Stop Using CPU Limits](https://home.robusta.dev/blog/stop-using-cpu-limits)


### PR DESCRIPTION
## Summary
- Rewrote `src/content/docs/linux/operations/performance/module-5.2-cpu-scheduling.md` for #388 density, structure, alignment, and anti-leak gates.
- Cleared `revision_pending` to `false`.

## Verifier
- `verify_module.py --skip-source-check`: tier T0; body_words=5317, mean_wpp=72.8, median_wpp=79, short_rate=0.0, max_run=0, mean_sentence_length=22.2; all density+structure+alignment+anti_leak+protected source-count gates pass; source reachability skipped per dispatch.

## Protected Assets
- Preserved/increased protected assets: code blocks 22 -> 23, mermaid diagrams 5 -> 6, ASCII diagrams 0 -> 0, tables 3 -> 6.
- Source URLs preserved and expanded: 4 -> 10 unique URLs.

## Validation
- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/quality/verify_module.py --glob src/content/docs/linux/operations/performance/module-5.2-cpu-scheduling.md --skip-source-check --summary --quiet` passed T0.
- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/test_pipeline.py` passed: 166 tests OK.
- `npm run build` passed in a temp copy with physical `node_modules` copied from the primary checkout. Direct worktree build hit the known `../../node_modules` Astro resolution failure; the primary checkout was not on main and had unrelated dirty files, so it was not modified.
- `git diff --check -- src/content/docs/linux/operations/performance/module-5.2-cpu-scheduling.md` passed.

Commit: b60810b6