### PR TITLE
feat(388): rewrite linux-8.3-package-user-management (#388 pilot)

### DIFF
--- a/src/content/docs/linux/operations/module-8.3-package-user-management.md
+++ b/src/content/docs/linux/operations/module-8.3-package-user-management.md
@@ -1,6 +1,7 @@
 ---
 title: "Module 8.3: Package Management & User Administration"
 slug: linux/operations/module-8.3-package-user-management
+revision_pending: false
 sidebar:
   order: 3
 lab:
@@ -11,59 +12,43 @@ lab:
   environment: ubuntu
 ---
 
-> **Operations — LFCS** | Complexity: `[MEDIUM]` | Time: 40-50 min
+# Module 8.3: Package Management & User Administration
+
+> **Operations - LFCS** | Complexity: `[MEDIUM]` | Time: 40-50 min for administrators who need package state, user identity, and sudo delegation to be explainable under pressure.
 
 ## Prerequisites
 
-Before starting this module:
+Before starting this module, make sure you can already read Linux file ownership, recognize systemd service state, and explain why security context changes how much privilege an account should receive:
+
 - **Required**: [Module 1.4: Users & Permissions](/linux/foundations/system-essentials/module-1.4-users-permissions/) for UID/GID fundamentals and file ownership
 - **Required**: [Module 1.2: Processes & systemd](/linux/foundations/system-essentials/module-1.2-processes-systemd/) for understanding services and system state
 - **Helpful**: [Module 4.1: Kernel Hardening](/linux/security/hardening/module-4.1-kernel-hardening/) for security context
 
----
+For later KubeDojo labs that touch clusters, assume Kubernetes 1.35+ and define the standard shortcut with `alias k=kubectl` before running any `kubectl` command. This module itself stays on Linux host administration, because a reliable cluster node starts with boring, disciplined package and account management before any workload ever lands on it.
 
-## What You'll Be Able to Do
+## Learning Outcomes
 
-After this module, you will be able to:
-- **Manage** packages using apt/dnf (install, update, pin, hold) and resolve dependency conflicts
-- **Administer** users and groups with proper access controls and password policies
-- **Configure** sudo access with fine-grained permissions for different admin roles
-- **Audit** installed packages for security vulnerabilities and unnecessary software
+After this module, you will be able to perform these operational tasks in a way that can be verified by command output, reviewed by another administrator, and repeated safely in automation:
 
----
+- **Diagnose** package dependency, repository, and ownership problems with `apt`, `dnf`, `dpkg`, and `rpm`.
+- **Implement** safe package lifecycle controls for installs, upgrades, removals, holds, and signature verification.
+- **Administer** users, groups, password aging, skeleton files, and service accounts with least-privilege defaults.
+- **Configure** sudo delegation through validated drop-in files that grant only the commands an operator needs.
+- **Evaluate** whether a server's package and account state is auditable, supportable, and ready for automation.
 
 ## Why This Module Matters
 
-Two things happen on every Linux server, every day: software gets installed and people need access. Package management and user administration are the bread and butter of system administration — the skills you will use more often than anything else in your career.
+In 2017, Equifax disclosed a breach that exposed personal information for roughly 145 million people after attackers exploited an Apache Struts vulnerability that already had a public patch. The incident is usually remembered as an application security failure, but it is also a system administration lesson: somebody had to know what was installed, whether the vulnerable package was present, which systems needed updates, and whether access controls allowed the right people to remediate quickly. When package state and user authority are vague, an emergency becomes a treasure hunt.
 
-Understanding these skills helps you:
+A similar pattern appears in smaller incidents that never make headlines. A team inherits an Ubuntu host where `nginx` was installed from a vendor repository, a contractor still has password login months after leaving, and the only deployment user has broad passwordless sudo because nobody wanted to debug a narrow rule. Nothing looks broken during normal operations, but the first security advisory or failed deploy reveals that the server has no clear owner, no reversible change trail, and no dependable way to explain what changed.
 
-- **Keep systems patched** — Unpatched software is the number one attack vector in production
-- **Control access** — The principle of least privilege starts with user accounts and sudo
-- **Automate provisioning** — Every Ansible playbook, Dockerfile, and cloud-init script uses package and user commands
-- **Pass the LFCS exam** — User management and package management are tested directly
+Package management and user administration are the daily control plane of a Linux server. Packages decide what code is trusted to run, which files belong to which vendor, and how updates move through the machine. Accounts decide who can log in, what identity a process runs as, and which human action appears in the audit log. Mastering these skills is not clerical work; it is how you turn a server from a collection of hopeful commands into an environment that can be patched, delegated, rebuilt, and defended.
 
-If you have ever SSH'd into a server and typed `apt install` or `useradd`, you have already started. This module makes sure you really understand what those commands do under the hood.
+This module treats `apt install` and `useradd` as the beginning of the story, not the whole story. You will see how package managers build a local catalog, why low-level tools still matter during investigations, where account data actually lives, and how sudo policies fail when they are edited casually. The examples use Ubuntu and RHEL-family commands side by side because real operations teams often support both, even when the lab environment is Debian-based.
 
----
+## Package Managers as the Server's Inventory System
 
-## Did You Know?
-
-- **Debian's package archive contains over 60,000 packages** — making it one of the largest curated software collections in the world. Every single one is maintained by a volunteer. The `apt` tool manages the dependency graph between all of them automatically.
-
-- **The `/etc/shadow` file was invented because `/etc/passwd` was world-readable.** In the early days of Unix, password hashes lived in `/etc/passwd` where any user could read (and crack) them. Shadow passwords moved the hashes to a root-only file — a simple fix that dramatically improved security.
-
-- **`visudo` exists because of real disasters.** A single syntax error in `/etc/sudoers` can lock every user out of sudo, including root. `visudo` validates the file before saving. There is no undo if you edit it with a regular editor and make a mistake.
-
-- **RPM was created by Red Hat in 1997** and stands for "Red Hat Package Manager" (later backronymed to "RPM Package Manager," making it a recursive acronym like GNU). The `.rpm` format is still used by RHEL, Fedora, SUSE, and Amazon Linux.
-
----
-
-## Part 1: Package Management
-
-### What Is a Package?
-
-A package is a compressed archive containing:
+A package is not just a compressed file with software inside. It is a contract between the distribution, the package maintainer, and your machine that says which files will be installed, which other packages must exist first, which scripts run during installation or removal, and which signatures prove the payload came from a trusted source. Without that contract, every server becomes a hand-built artifact that can only be understood by remembering who copied which binary into which directory.
 
 ```mermaid
 graph LR
@@ -75,30 +60,22 @@ graph LR
   pkg --> script["Scripts (pre-install, post-install, pre-remove, post-remove)"]
 ```
 
-Without packages, you would compile every piece of software from source, manually track files, and resolve dependency conflicts by hand. Package managers handle all of this automatically.
+The diagram is the reason package managers feel almost invisible when they work well. Installing `nginx` is not just placing `/usr/sbin/nginx` on disk; it is also registering metadata, preserving configuration policy, recording dependencies, and running maintainer scripts in a defined order. When an incident responder asks whether a suspicious binary came from a package, the answer comes from that recorded inventory, not from the filename or from guesswork.
 
-### The Two Layers
-
-Every Linux distribution has two layers of package management:
+Every mainstream Linux distribution separates package handling into two layers. The low-level layer knows how to install or query an individual package file that is already present on disk. The high-level layer knows how to contact repositories, calculate dependencies, choose versions, and download every package needed to satisfy the requested change. Good administrators understand both layers because routine work belongs to the high-level tool, while investigation and repair often require the low-level database.
 
 | Layer | Debian/Ubuntu | RHEL/Fedora | Purpose |
 |-------|--------------|-------------|---------|
 | **Low-level** | `dpkg` | `rpm` | Install/remove individual package files |
 | **High-level** | `apt` | `dnf` | Resolve dependencies, download from repositories |
 
-Think of it like this: `dpkg`/`rpm` are like manually installing an app from a downloaded file. `apt`/`dnf` are like an app store that finds, downloads, and installs everything you need automatically.
+Think of `apt` and `dnf` like a pharmacy system that checks whether a prescription conflicts with what the patient already takes. Think of `dpkg` and `rpm` like the label on the bottle and the inventory record on the shelf. The high-level tool prevents bad combinations when it can, but the low-level record tells you exactly what is on the machine after the fact.
 
----
-
-### Debian/Ubuntu: apt and dpkg
-
-> **Stop and think**: If a package manager automatically resolves dependencies for you, where does it get the knowledge of which packages depend on which? Think about what happens when you run `apt update` before reading the next section.
-
-#### Updating Package Lists
+The first operational habit is refreshing metadata before you make decisions. `apt update` does not upgrade software; it downloads the current repository indexes so your machine knows what versions and dependencies are available. If you skip this step, the package manager may report stale versions, fail to find a newly published security fix, or try to install a dependency set that no longer matches the repository.
 
 ```bash
 # Refresh the list of available packages from repositories
-# This does NOT upgrade anything — it just downloads the latest catalog
+# This does NOT upgrade anything - it just downloads the latest catalog
 sudo apt update
 
 # Output shows which repositories were fetched:
@@ -107,9 +84,9 @@ sudo apt update
 # Fetched 2,345 kB in 3s (782 kB/s)
 ```
 
-Always run `apt update` before installing or upgrading. Without it, you are working from a stale catalog and may install outdated versions.
+Pause and predict: if a server has not refreshed package metadata for several weeks, what failure would you expect when a security team asks you to install a specific fixed version by name? The important answer is not simply "the command might fail." The deeper risk is that the administrator may conclude the fix is unavailable, when the local machine is only looking at an outdated catalog.
 
-#### Installing Packages
+Installing packages is intentionally simple because the hard work happens in dependency resolution. When you ask for `nginx`, the package manager checks the current repository metadata, compares dependencies against installed packages, downloads missing pieces, verifies signatures, unpacks files, and runs package scripts. That convenience is powerful, but it also means you should read the transaction summary before confirming changes on important hosts.
 
 ```bash
 # Install a single package
@@ -125,7 +102,9 @@ sudo apt install -y nginx
 sudo apt install nginx=1.24.0-1ubuntu1
 ```
 
-#### Searching and Inspecting
+The `-y` flag is useful in automation, but it removes a moment where a human would normally notice surprise removals or unexpected repositories. In scripts, compensate by making the package list explicit, pinning versions when needed, and testing on disposable systems before touching production. A package command should be repeatable enough that the next operator can rerun it without needing to remember the conversation that created it.
+
+Searching and inspecting packages is how you convert a vague request into a controlled change. A ticket that says "install a web server" should lead you to compare available packages, inspect dependencies, and confirm the package name, not to guess. `apt show` gives the maintainer, version, dependency list, and description; `apt list --installed` tells you what is already on the host.
 
 ```bash
 # Search for packages by name or description
@@ -145,9 +124,9 @@ apt list --installed
 apt list --installed 2>/dev/null | grep nginx
 ```
 
-> **Pause and predict**: If you use `apt remove` on a web server package, what happens to the configuration files you spent hours modifying? 
+Before running this on a real machine, ask what output would convince you that `nginx` is installed from the expected distribution repository rather than from a third-party source. The package name alone is not enough because repositories can provide packages with the same name. Version strings, repository policy, and package metadata together give you a much stronger operational picture.
 
-#### Removing Packages
+Removal is where many administrators first learn that package managers distinguish application files from configuration. `apt remove` deletes package-managed binaries and related files, but it deliberately leaves configuration under `/etc` so a reinstall can preserve local policy. That behavior is friendly during accidental removals and frustrating when you are trying to recover from a broken configuration, so choose the removal mode based on intent.
 
 ```bash
 # Remove the package but keep configuration files
@@ -163,12 +142,12 @@ sudo apt autoremove
 sudo apt purge -y nginx && sudo apt autoremove -y
 ```
 
-The difference between `remove` and `purge` matters. If you `remove` nginx and reinstall it later, your old configuration files are still there. If you `purge`, you start fresh.
+Use `purge` when the configuration itself is the problem or when decommissioning a service so it cannot be accidentally revived with old settings. Use `remove` when you are temporarily uninstalling software and expect to keep local configuration. The key is to document which intention you chose, because a later operator cannot infer your reason from the absence of the binary alone.
 
-#### Upgrading
+Upgrades need the same discipline. `apt upgrade` tries to move installed packages to newer versions without removing packages, while `apt full-upgrade` may remove packages to satisfy dependency changes. That difference matters during distribution upgrades, kernel transitions, and repository changes where a package split or replacement can cause legitimate removals. On production machines, preview the change set and confirm that the planned removals match the maintenance objective.
 
 ```bash
-# Upgrade all packages to their latest versions (safe — never removes packages)
+# Upgrade all packages to their latest versions (safe - never removes packages)
 sudo apt upgrade
 
 # Upgrade all packages, allowing removal of packages if needed for dependency resolution
@@ -178,9 +157,7 @@ sudo apt full-upgrade
 apt list --upgradable
 ```
 
-#### dpkg: Working with .deb Files Directly
-
-Sometimes you download a `.deb` file directly (like from a vendor's website). That is when `dpkg` comes in:
+The low-level `dpkg` tool appears when you have a package file in hand or when you need to interrogate the installed package database directly. If `dpkg -i` fails because dependencies are missing, the package may be partially unpacked, and `apt install -f` asks the high-level resolver to repair the dependency graph. This is a common pattern after downloading a vendor `.deb` file instead of installing through a repository.
 
 ```bash
 # Install a .deb file
@@ -203,7 +180,9 @@ dpkg -S /usr/sbin/nginx
 dpkg -L nginx-core
 ```
 
-#### Adding Repositories
+File ownership queries are one of the most valuable troubleshooting skills in this module. If a binary is owned by a package, you can inspect its version, verify its files, reinstall it, or trace it to a repository. If no package owns it, you are dealing with a manual install, a generated file, a copied artifact, or something more suspicious. That distinction changes the investigation immediately.
+
+Third-party repositories solve a real problem: distributions cannot ship every vendor's latest release on every schedule. They also expand your trust boundary, because you are allowing another signing key and repository policy into the system's update path. Modern Debian-family practice is to store a repository-specific keyring and reference it with `signed-by`, instead of using a global key that can authenticate unrelated packages.
 
 ```bash
 # Add a PPA (Ubuntu-specific shortcut)
@@ -222,11 +201,9 @@ sudo apt update
 sudo apt install example-package
 ```
 
-Repository definitions live in `/etc/apt/sources.list` and `/etc/apt/sources.list.d/`. Use the `.d/` directory for third-party repos — it keeps things organized and easy to remove.
+Repository definitions live in `/etc/apt/sources.list` and `/etc/apt/sources.list.d/`, and the `.d` directory is easier to audit because each vendor can have its own file. During incident response, that layout lets you quickly answer which external sources can influence package selection. During cleanup, it lets you remove one repository without editing a shared file and accidentally damaging the base distribution configuration.
 
-#### Holding Packages
-
-Sometimes you need to prevent a package from being upgraded — for example, if a newer kernel breaks your hardware:
+Package holds are a controlled exception to the normal upgrade story. You may hold a kernel while investigating a driver regression, pin a database package until an application compatibility test completes, or freeze a vendor package while waiting for a maintenance window. Holds should be visible and temporary, because a forgotten hold silently blocks future security fixes and becomes technical debt with root privileges.
 
 ```bash
 # Prevent a package from being upgraded
@@ -239,11 +216,11 @@ apt-mark showhold
 sudo apt-mark unhold linux-image-generic
 ```
 
----
+A useful review question is "who will remove this hold, and what evidence will tell them it is safe?" If the answer is not written down, the hold is not a control; it is a memory test. Good operations teams pair holds with tickets, expiry reviews, or configuration management so the exception remains visible after the person who created it moves on.
 
-### RHEL/Fedora: dnf and rpm
+## RHEL-Family Package Workflows and Cross-Distro Reasoning
 
-#### Installing and Removing
+RHEL, Fedora, CentOS Stream, Amazon Linux, and related systems use `dnf` as the high-level package manager and `rpm` as the low-level package database. The commands differ from Debian-family systems, but the mental model is the same: use the high-level tool for dependency-aware transactions and the low-level tool for package-file installation, ownership queries, verification, and detailed inventory work.
 
 ```bash
 # Install a package
@@ -259,7 +236,7 @@ sudo dnf remove nginx
 sudo dnf install ./package-1.0.0.x86_64.rpm
 ```
 
-#### Searching and Inspecting
+The practical difference is that `dnf install ./package.rpm` usually beats `rpm -i package.rpm` for routine local installs because `dnf` can still resolve dependencies from configured repositories. Use plain `rpm` when you need a precise query or verification action, not because it feels more direct. Direct tools are sharp; high-level tools add guardrails without hiding the package database.
 
 ```bash
 # Search for packages
@@ -277,7 +254,7 @@ dnf provides /usr/sbin/nginx
 dnf provides */bin/traceroute
 ```
 
-#### Updating
+The `dnf provides` command is especially useful when you know the command or file path but not the package name. New administrators often search the web and copy package names from a different distribution, then wonder why the install fails. Querying the repository metadata directly lets the distribution tell you which package owns the command in that ecosystem.
 
 ```bash
 # Update all packages
@@ -290,7 +267,7 @@ sudo dnf update nginx
 dnf check-update
 ```
 
-#### rpm: Working with .rpm Files Directly
+RHEL-family updates are usually described as `update`, while Debian-family documentation often says `upgrade`, but both words describe changing installed packages to newer repository versions. The operational questions are still the same: which repositories are enabled, which packages will change, which services need restarts, and what rollback path exists if a critical dependency behaves differently after the update.
 
 ```bash
 # Query all installed packages
@@ -312,10 +289,10 @@ rpm -qf /usr/sbin/nginx
 # Verify installed package (checks file integrity)
 rpm -V nginx
 # S.5....T.  c /etc/nginx/nginx.conf
-# (S=size, 5=md5, T=time changed — the config was modified)
+# (S=size, 5=md5, T=time changed - the config was modified)
 ```
 
-#### Adding Repositories
+`rpm -V` is a compact way to compare installed files against the package database. It will not tell you whether a configuration change was approved, but it will tell you that a package-managed file no longer matches the recorded metadata. That distinction is perfect for audits: the tool identifies drift, then humans and change records decide whether the drift is legitimate.
 
 ```bash
 # Add a repository from a URL
@@ -331,9 +308,7 @@ dnf repolist all
 sudo dnf config-manager --set-enabled powertools
 ```
 
----
-
-### Comparison Table: apt vs dnf
+Cross-distro fluency is less about memorizing command pairs and more about translating intent. If the task is "which package owns this file," you reach for `dpkg -S` on Debian and `rpm -qf` on RHEL. If the task is "which package would provide this missing command," you use repository search through `apt-file` when installed or `dnf provides` on RHEL-family systems. The names change, but the investigation shape stays stable.
 
 | Task | Debian/Ubuntu (apt) | RHEL/Fedora (dnf) |
 |------|--------------------|--------------------|
@@ -350,11 +325,11 @@ sudo dnf config-manager --set-enabled powertools
 | Hold/exclude from upgrade | `apt-mark hold pkg` | `dnf versionlock add pkg` |
 | Clean cache | `apt clean` | `dnf clean all` |
 
----
+Use the table as a translation map, not as a memorization exercise. The exam and real incidents both reward the ability to decide what question you are asking: install, remove, inspect, own, verify, or constrain. Once the question is clear, the command family follows naturally from the distribution.
 
-### Package Security: Verifying Signatures
+## Trust, Signatures, and Package Security
 
-Packages are cryptographically signed by their maintainers. Your system verifies these signatures automatically — but you should understand what is happening:
+Package signing exists because repositories are part of your software supply chain. When a package manager downloads metadata and packages, it checks cryptographic signatures against trusted keys so a mirror, proxy, or network attacker cannot silently substitute arbitrary software. The mechanism is automatic during normal installs, but an administrator must still understand key scope, signature warnings, and the danger of bypass flags.
 
 ```bash
 # --- Debian/Ubuntu ---
@@ -377,32 +352,28 @@ rpm --checksig package.rpm
 rpm -qa gpg-pubkey*
 ```
 
-If you ever see a warning like "The following signatures couldn't be verified," stop and investigate. Never blindly add `--nogpgcheck` — that defeats the purpose of signed packages and opens you to supply chain attacks.
+Never treat a signature warning as a cosmetic problem. It may mean the repository rotated keys, your local keyring is stale, a proxy is interfering, or the package is not from the source you think it is. The correct response is to verify the vendor's documented key path and repository configuration, not to add `--nogpgcheck` because the deployment window is closing.
 
----
+Security auditing also includes knowing what is unnecessary. Every installed package can add files, services, dependencies, and vulnerability surface, so production hosts should not accumulate tools just because someone needed them once. A build host may need compilers and debuggers; a runtime host usually should not. Package inventory gives you the evidence to make that distinction without relying on memory.
 
-## Part 2: User & Group Administration
+A war story from a platform team makes the point. Their image build job installed `curl`, `jq`, and a debugging shell tool into every server image during a migration. Months later, a vulnerability scanner flagged the debugging tool across hundreds of instances even though no application used it. The fix was not heroic security engineering; it was disciplined package ownership, a smaller base image, and a rule that temporary diagnostic packages must be removed before publishing an image.
 
-Module 1.4 introduced the concepts of UIDs, GIDs, and file permissions. This section covers the practical administration: creating users, managing groups, configuring sudo access, and understanding the critical files involved.
+When evaluating a package change, ask three questions before typing the command. First, which repository and signing key authorize this package? Second, which files and services will the package add or change? Third, how will you prove later that the installed state matches your intent? Those questions turn a one-line install into an auditable operational decision.
 
-### The Three Files That Matter
+## User and Group Databases: Identity as Data
 
-#### /etc/passwd — User Account Database
+Linux access control starts with identity records stored in plain text databases. Module 1.4 introduced UIDs, GIDs, and file permissions; this module focuses on administration, which means creating accounts intentionally, changing memberships without losing access, aging passwords, and separating human users from service identities. The commands are simple, but the consequences of a wrong UID, group, or shell can last for years in backups and file ownership.
 
-Every user account is a single line in `/etc/passwd`:
+Every user account has a line in `/etc/passwd`. The file is world-readable because many programs need to translate numeric UIDs into names, discover home directories, and identify login shells. The password field is normally just `x`, which means the actual password hash lives elsewhere. That split lets routine tools read account metadata without exposing password hashes to every local user.
 
-```
+```text
 username:x:UID:GID:comment:home_directory:login_shell
 ```
-
-Real example:
 
 ```bash
 grep "deploy" /etc/passwd
 # deploy:x:1001:1001:Deploy User:/home/deploy:/bin/bash
 ```
-
-Breaking it down:
 
 | Field | Value | Meaning |
 |-------|-------|---------|
@@ -414,8 +385,10 @@ Breaking it down:
 | `home` | /home/deploy | Home directory path |
 | `shell` | /bin/bash | Login shell |
 
+The UID is what the kernel really uses for ownership checks, and the name is the human-friendly label layered on top. If you delete a user and later reuse the same UID for a different person, old files may appear to belong to the new user. That is why careful environments reserve UID ranges, avoid casual reuse, and treat identity lifecycle as part of data governance rather than just login convenience.
+
 ```bash
-# View the file (it is world-readable — no passwords here)
+# View the file (it is world-readable - no passwords here)
 cat /etc/passwd
 
 # Count total users
@@ -425,17 +398,13 @@ wc -l /etc/passwd
 awk -F: '$3 >= 1000 && $3 < 65534 {print $1, $3}' /etc/passwd
 ```
 
-> **Stop and think**: Why is `/etc/passwd` globally readable, while `/etc/shadow` is tightly locked down? Consider what typical system commands might need to map UIDs to human-readable names.
+Pause and predict: why would a command like `ls -l` need `/etc/passwd` to be readable by normal users? The file permission makes sense once you remember that many tools show owner names instead of raw UIDs. They need identity metadata, but they do not need password hashes.
 
-#### /etc/shadow — Password Hashes
+Password hashes live in `/etc/shadow`, which is readable only by privileged users. Each line stores the username, password hash or lock marker, password aging fields, and optional account expiration. A locked account often has `!` or `*` where a usable hash would be, which prevents password login without necessarily deleting the account or changing file ownership.
 
-This is the sensitive file. Only root can read it:
-
-```
+```text
 username:$hashed_password:last_changed:min:max:warn:inactive:expire:reserved
 ```
-
-Real example:
 
 ```bash
 sudo grep "deploy" /etc/shadow
@@ -453,19 +422,19 @@ sudo grep "deploy" /etc/shadow
 | `inactive` | (empty) | Days after expiry before account is disabled |
 | `expire` | (empty) | Date account expires (days since epoch) |
 
-Password hash prefixes tell you the algorithm:
+Hash prefixes are useful during audits because they reveal whether the system is using an outdated password hashing scheme. You do not need to know the password to see that `$1$` means MD5 and should be retired. You also need to remember that changing the system default does not magically rehash existing passwords; users generally need to change passwords after the policy is updated.
 
 | Prefix | Algorithm | Status |
 |--------|-----------|--------|
-| `$1$` | MD5 | Weak — do not use |
+| `$1$` | MD5 | Weak - do not use |
 | `$5$` | SHA-256 | Acceptable |
 | `$6$` | SHA-512 | Current default on most distros |
 | `$y$` | yescrypt | Modern default on Debian 12+, Fedora 38+ |
 | `!` or `*` | (none) | Account is locked / no password login |
 
-#### /etc/group — Group Database
+Groups provide a scalable way to grant access without editing every file or sudo rule for every person. A primary group is recorded in `/etc/passwd`, while supplementary memberships live in `/etc/group`. The trap is that group membership changes often require a new login session before processes see the updated group list, so successful administration includes both changing the file and verifying the user's effective identity.
 
-```
+```text
 groupname:x:GID:member_list
 ```
 
@@ -482,11 +451,11 @@ id deploy
 # uid=1001(deploy) gid=1001(deploy) groups=1001(deploy),999(docker),27(sudo)
 ```
 
----
+Group-driven access works best when the group name describes a durable role rather than a temporary request. `webteam` or `deployers` can be reviewed later; `alice-temp` usually cannot. If you cannot explain why a group exists, which files or sudo rules depend on it, and who approves membership, the group is drifting from access control into folklore.
 
-### Creating and Managing Users
+## Creating Accounts, Service Identities, and Home Defaults
 
-#### useradd — Create User Accounts
+Creating a user is easy; creating a user that matches policy is the real skill. A good account record has a clear purpose, predictable UID or UID range when required, an appropriate shell, a home directory only when needed, group memberships that match the role, and an expiration date for temporary access. The `useradd` command exposes all of those choices, so do not rely blindly on distribution defaults.
 
 ```bash
 # Create a user with defaults
@@ -513,10 +482,12 @@ sudo useradd -u 2000 -m -s /bin/bash bob
 sudo useradd -m -s /bin/bash -e 2026-12-31 contractor
 ```
 
-#### usermod — Modify Existing Users
+The safest habit is to decide whether the account is for a human, automation, or a daemon before choosing flags. Humans usually need a home directory, an interactive shell, and password or SSH policy tied to an identity provider. Automation users may need a home directory for SSH keys but should have narrow sudo. Daemon accounts usually should not have interactive login at all.
+
+Modifying accounts is where a small flag can cause a large outage. `usermod -G` replaces the supplementary group list unless combined with `-a`, so a well-meaning administrator can accidentally remove a user from `sudo`, `docker`, or a shared project group while adding a new membership. Always verify the before and after state with `id username`, especially when changing access for someone who is currently on call.
 
 ```bash
-# Add user to a supplementary group (APPEND — critical flag!)
+# Add user to a supplementary group (APPEND - critical flag!)
 sudo usermod -aG docker alice
 #   -a   Append to group list (without -a, it REPLACES all groups!)
 #   -G   Supplementary group
@@ -537,9 +508,7 @@ sudo usermod -d /home/newalice -m alice
 sudo usermod -l newalice alice
 ```
 
-The `-aG` flag is so important it deserves its own warning: `usermod -G docker alice` (without `-a`) removes alice from every other supplementary group. This has locked people out of sudo access more times than anyone cares to count.
-
-#### userdel — Remove Users
+When removing users, decide whether the home directory and mail spool are records to preserve or risks to clean up. A departing employee's home directory may contain evidence, handoff material, or data that belongs in a project directory instead. `userdel -r` is convenient for lab cleanup, but production offboarding often requires archiving or transferring files before deletion.
 
 ```bash
 # Remove user but keep home directory
@@ -549,7 +518,7 @@ sudo userdel alice
 sudo userdel -r alice
 ```
 
-#### passwd — Manage Passwords
+Password tooling controls both authentication and lifecycle pressure. `passwd` changes or locks credentials, `chage` manages aging policy, and `chpasswd` is useful in scripts when fed from a protected input source. Avoid putting real passwords in shell history, ticket comments, or command-line arguments; examples here use temporary lab values, but production automation should integrate with a secret manager or identity system.
 
 ```bash
 # Set or change a user's password (interactive)
@@ -574,9 +543,7 @@ sudo chage -M 90 alice
 sudo chage -E 2026-12-31 contractor
 ```
 
----
-
-### Creating and Managing Groups
+Group commands complete the identity toolkit. `groupadd` creates shared access targets, `gpasswd -d` removes a member safely, and `groupmod` lets you rename a group when the organization changes. Like user deletion, group deletion should be preceded by a search for files, sudo rules, service configs, or automation that reference the group name or GID.
 
 ```bash
 # Create a new group
@@ -588,7 +555,7 @@ sudo groupadd -g 3000 devops
 # Add existing user to the group
 sudo usermod -aG developers alice
 
-# Remove a user from a group (no direct command — use gpasswd)
+# Remove a user from a group (no direct command - use gpasswd)
 sudo gpasswd -d alice developers
 
 # Delete a group
@@ -598,9 +565,7 @@ sudo groupdel developers
 sudo groupmod -n dev-team developers
 ```
 
----
-
-### System Accounts vs Regular Accounts
+System accounts deserve different defaults from human accounts. A daemon account exists so a process can run with limited file and network permissions, not so a person can log in. Give it a system UID, a clear comment, a service-specific home only when needed, and `/usr/sbin/nologin` or `/bin/false` as the shell. That way, even if a password is accidentally set, interactive login remains blocked.
 
 | Characteristic | System Account | Regular Account |
 |---------------|----------------|-----------------|
@@ -622,11 +587,7 @@ sudo su - myapp
 # This account is currently not available.
 ```
 
----
-
-### Home Directory Management: /etc/skel
-
-When `useradd -m` creates a home directory, it copies everything from `/etc/skel`:
+Home directory defaults live in `/etc/skel`, the skeleton directory copied when `useradd -m` creates a new home. This is a simple but powerful standardization point for shell profiles, SSH directory structure, onboarding notes, and local tool configuration. Use it carefully, because changes apply only to future homes and because secrets or personal keys do not belong in a global skeleton.
 
 ```bash
 # See what's in the skeleton directory
@@ -649,50 +610,27 @@ ls -la /home/newuser/
 # -rw-r--r-- .bashrc  (your customized version)
 ```
 
-This is how organizations standardize user environments across servers. Put your standard shell configuration, SSH directory structure, and any other defaults into `/etc/skel`.
+A worked example ties these pieces together. Suppose a contractor needs access until the end of the year, must read deployment logs, and must not keep shell access afterward. You would create the account with an expiration date, add only the needed group, force a password change or install approved SSH keys, and document the expiration in the access request. The commands are routine, but the policy thinking is what prevents old accounts from becoming permanent attack paths.
 
----
+## Sudo Delegation Without Root Sprawl
 
-### sudo and the sudoers File
+`sudo` exists because logging in as root hides accountability and grants more power than most tasks require. With sudo, an administrator can run a command as another user, usually root, while the system records who requested it. The important design goal is not "make this person an administrator"; it is "grant this role the narrow command set needed to operate the service, with logs that identify the human who acted."
 
-#### Why sudo Exists
+Running all commands through full root shells feels convenient during emergencies, but it destroys useful audit detail. A log that says `alice` ran `systemctl restart nginx` is actionable. A log that says several people shared a root session is much weaker. Sudo cannot solve every privileged access problem, but it gives local Linux administration a language for command-level delegation.
 
-Running commands as root is dangerous. `sudo` provides:
-
-- **Auditing** — Every sudo command is logged (`/var/log/auth.log` or `journalctl`)
-- **Granularity** — Grant specific commands, not full root access
-- **Accountability** — You know *who* ran the command, not just "root did something"
-- **Time limits** — sudo credentials expire (default 15 minutes)
-
-#### The War Story: Never Edit sudoers with vim
-
-> **Pause and predict**: What would happen if two administrators tried to edit `/etc/sudoers` at the exact same time using a standard text editor? How might the system prevent this race condition?
-
-Here is a story that has happened at countless companies. A junior admin needs to give a developer sudo access. They know the sudoers file is at `/etc/sudoers`, so they do what seems logical:
+The classic failure mode is editing `/etc/sudoers` with a normal editor. A single syntax error can prevent sudo from parsing any valid policy, and if root login is disabled, the server may require recovery console access or disk mounting to repair. The failure is painful because the change is tiny and the blast radius is immediate.
 
 ```bash
 sudo vim /etc/sudoers      # DO NOT DO THIS
 ```
 
-They add a line, but make a tiny typo — maybe a missing comma or an extra space in the wrong place. They save and quit. Vim does not validate sudoers syntax.
-
-Now `sudo` is broken. Every `sudo` command returns:
-
-```
+```text
 >>> /etc/sudoers: syntax error near line 42 <<<
 sudo: parse error in /etc/sudoers near line 42
 sudo: no valid sudoers sources found, quitting
 ```
 
-Nobody can use sudo. Including root (if root login is disabled, which it often is on cloud servers). The only ways to fix this:
-
-1. Boot into single-user/recovery mode (if you have physical/console access)
-2. Mount the disk from another instance (in the cloud)
-3. Use `pkexec` if PolicyKit is installed (rare lifeline)
-
-The fix was always simple: use `visudo`.
-
-#### visudo — The Only Safe Way
+The safe tool is `visudo`, which locks the file and validates syntax before writing. It also works with drop-in files through `-f`, which lets you keep team or service rules separate from the main policy. Separation matters because it makes review easier, lets packages and configuration management own their own files, and reduces the chance that one unrelated edit damages every sudo rule.
 
 ```bash
 # Edit the sudoers file safely
@@ -700,20 +638,18 @@ sudo visudo
 
 # visudo does two critical things:
 # 1. Locks the file so two admins can't edit simultaneously
-# 2. Validates syntax before saving — rejects invalid changes
+# 2. Validates syntax before saving - rejects invalid changes
 
 # Edit a specific sudoers drop-in file
 sudo visudo -f /etc/sudoers.d/developers
 ```
 
-If you make a syntax error, `visudo` tells you and asks what to do:
-
-```
+```text
 >>> /etc/sudoers: syntax error near line 25 <<<
 What now? (e)dit, (x)exit without saving, (Q)quit without saving
 ```
 
-#### sudoers Syntax
+Before you write a sudo rule, describe the operational task in one sentence. "Developers need root" is not a task. "Members of `webteam` need to check and restart `nginx` during deploys" is a task, and it points to specific commands. That discipline is how sudo remains delegation instead of becoming a second path to unrestricted root access.
 
 ```bash
 # Basic format:
@@ -733,8 +669,6 @@ bob     ALL=(ALL:ALL) NOPASSWD: ALL
 deploy  ALL=(root) NOPASSWD: /usr/bin/rsync, /usr/bin/systemctl restart myapp
 ```
 
-Breaking down `alice ALL=(ALL:ALL) ALL`:
-
 | Part | Meaning |
 |------|---------|
 | `alice` | This rule applies to user alice |
@@ -742,11 +676,9 @@ Breaking down `alice ALL=(ALL:ALL) ALL`:
 | `(ALL:ALL)` | Can run as any user:any group |
 | Last `ALL` | Can run any command |
 
-> **Stop and think**: Why might a system administrator prefer to use modular drop-in files in `/etc/sudoers.d/` rather than appending rules directly into the main `/etc/sudoers` file?
+The fully open `alice ALL=(ALL:ALL) ALL` rule is useful for understanding syntax, not for casual delegation. Groups are usually better than per-user rules because membership can be reviewed separately from command policy. Absolute command paths are better than bare names because sudo evaluates the command path, and a writable directory earlier in a user's `PATH` should not influence privileged execution.
 
-#### /etc/sudoers.d/ — Drop-in Files
-
-Instead of editing the main sudoers file, use drop-in files. This is the modern, recommended approach:
+Drop-in files under `/etc/sudoers.d/` are the modern way to keep policies modular. File names must avoid dots and tildes, permissions must be restrictive, and the main sudoers file must include the directory. These details sound picky until you troubleshoot a perfectly valid rule that never loaded because the file was named `web.devs` and silently ignored.
 
 ```bash
 # Create a file for the developers team
@@ -762,98 +694,102 @@ sudo visudo -f /etc/sudoers.d/deploy
 # deploy ALL=(root) NOPASSWD: /usr/bin/systemctl restart myapp, /usr/bin/rsync
 ```
 
-Rules for drop-in files:
-- File names must NOT contain `.` or `~` (they will be silently ignored)
-- Files must be owned by root with permissions `0440`
-- Always create them with `visudo -f`, which sets correct permissions
-- The main `/etc/sudoers` must include: `@includedir /etc/sudoers.d` (or `#includedir` on older systems — the `#` is NOT a comment here)
+Which approach would you choose here and why: a single `deploy` user with passwordless access to every command, or a `deploy` user limited to `rsync` and `systemctl restart myapp`? The narrow rule takes more thought, but it turns a leaked deployment key from total host compromise into a smaller service-specific problem. Sudo design is security engineering in miniature.
 
----
+Always test sudo from the target identity, not from your own assumptions. `sudo -l -U username` can show allowed commands, and a controlled test confirms the exact path and arguments work. If the rule grants `systemctl restart nginx` but the service is actually `nginx.service`, or if a wrapper script lives outside the allowed path, the policy may be syntactically valid and operationally useless.
+
+## Patterns & Anti-Patterns
+
+A strong package pattern is "repository first, local file second, manual copy last." Prefer distribution or vendor repositories because they provide metadata, updates, signatures, and ownership records. Use a local `.deb` or `.rpm` when a vendor does not provide a repository, and immediately record where it came from. Manual copies into `/usr/local` are sometimes legitimate, but they should be documented because the package manager cannot update or verify them.
+
+A second pattern is "make exceptions visible." Package holds, third-party repositories, passwordless sudo rules, and contractor expiration dates are all exceptions to the default flow. They are not bad by themselves, but they become dangerous when nobody can list them. Use package queries, `/etc/sudoers.d/`, `chage`, and group reviews to turn exceptions into reviewable objects.
+
+A third pattern is "separate human and service identity." Human accounts should map to people or identity-provider users so audit logs stay meaningful. Service accounts should run daemons with no interactive shell and only the filesystem access the service needs. Deployment users sit between those worlds, so they need especially careful sudo rules and credential rotation.
+
+An anti-pattern is "installing your way out of troubleshooting." When a command is missing, administrators sometimes install broad tool bundles until the immediate error disappears. That leaves production hosts with compilers, network scanners, or debugging utilities that were never needed at runtime. A better approach is to identify the package that provides the command, install the narrow tool if justified, and remove temporary diagnostics after the investigation.
+
+Another anti-pattern is "using groups as a dumping ground." Adding every operator to `sudo`, `docker`, and multiple project groups may unblock work, but it makes access reviews meaningless. The better alternative is to create role-based groups tied to concrete files, services, or sudo rules, then remove memberships when the role ends. If a group has no owner, it should not grant meaningful access.
+
+The most damaging sudo anti-pattern is "NOPASSWD because automation was hard." Passwordless sudo may be appropriate for a tightly scoped deployment command, but it is dangerous when combined with `ALL`. If a non-interactive job needs privilege, give it the smallest command set, use absolute paths, protect the credential that triggers the job, and test failure behavior so operators do not widen the rule during an outage.
+
+## Decision Framework
+
+Start package decisions by naming the source of truth. If the software is available from the distribution repository at an acceptable version, use that repository because updates, signatures, and dependency policy are already integrated. If the vendor repository is required, isolate its signing key with `signed-by` or the RHEL-family equivalent and document why the distribution package is insufficient. If only a local package file exists, install it with the high-level tool when possible and record ownership.
+
+For removals, decide whether you are undoing an install, resetting configuration, or decommissioning a service. Use `remove` when you want to keep configuration for a later reinstall, `purge` when configuration is part of the fault or the service is being retired, and `autoremove` after reviewing dependencies that became unused. The right command depends on whether preserving state is a feature or a liability.
+
+For account work, begin with the actor type. Human users need traceable identity, appropriate groups, and lifecycle dates for temporary access. Service accounts need non-login shells and the minimum home directory required by the daemon. Shared deployment users should be rare, narrowly scoped, and backed by logs that identify which pipeline or person triggered privileged actions.
+
+For sudo, choose the smallest stable role that can complete the task. If the role needs many unrelated commands, it may really be an administrator role and should be reviewed as such. If the role needs one service restart and one status check, write those exact commands in a drop-in file, validate with `visudo -f`, test with `sudo -l`, and keep the file name free of dots so sudo actually reads it.
+
+Evaluate the final state with an audit question: "Could another administrator explain this server tomorrow without asking me?" If the answer is yes, the packages have known sources, the accounts have clear purposes, the sudo rules map to real operational tasks, and exceptions are visible. If the answer is no, slow down and improve the record before automating the same ambiguity across more machines.
+
+## Did You Know?
+
+- **Debian's package archive contains over 60,000 packages** - making it one of the largest curated software collections in the world. Every single one is maintained through a formal process, and `apt` relies on repository metadata to manage the dependency graph automatically.
+- **The `/etc/shadow` file exists because `/etc/passwd` was historically world-readable.** Early Unix systems stored password hashes in a file that normal users could read, which made offline cracking far easier. Moving hashes into a root-only database dramatically improved the security model while preserving readable account metadata.
+- **`visudo` protects against two failure classes at once.** It validates sudoers syntax before saving, and it locks the policy file so two administrators do not race each other with overlapping edits. That is why it is still the standard tool even though the file is plain text.
+- **RPM was created by Red Hat in 1997** and originally stood for "Red Hat Package Manager." The format and tooling still underpin RHEL, Fedora, SUSE-family systems, and many enterprise package workflows.
 
 ## Common Mistakes
 
-| Mistake | What Happens | Fix |
-|---------|-------------|-----|
-| `apt install` without `apt update` first | Install outdated or missing package versions | Always run `sudo apt update` before installing |
-| `usermod -G` without `-a` | User is removed from ALL other supplementary groups | Always use `usermod -aG group user` |
-| Editing `/etc/sudoers` with vim/nano | Syntax error locks out all sudo access | Always use `visudo` |
-| Using `apt-key add` for GPG keys | Deprecated; keys trusted for ALL repositories | Use `signed-by` with keyring files in `/usr/share/keyrings/` |
-| Deleting a user without `-r` | Orphaned home directory wastes disk and is a security risk | Use `userdel -r` or manually clean up `/home/username` |
-| Setting password via command line argument | Password visible in shell history and process list | Use `passwd` interactively or pipe through `chpasswd` |
-| Forgetting `nologin` shell for service accounts | Service accounts can be used for interactive login | Create with `useradd -r -s /usr/sbin/nologin` |
-| Adding `--nogpgcheck` to silence warnings | Disables cryptographic verification of packages | Import the correct GPG key instead |
-| Sudoers drop-in file with `.` in name | File is silently ignored — rule never applies | Name files without dots or tildes (e.g., `developers` not `developers.conf`) |
-| Running `apt full-upgrade` without checking | May remove packages to resolve dependencies | Run `apt list --upgradable` first to review changes |
-
----
+| Mistake | Why It Happens | How to Fix It |
+|---------|----------------|---------------|
+| Running `apt install` against stale metadata | The command is familiar, and `apt update` feels like an optional pre-step | Run `sudo apt update` before install or upgrade work, then review the transaction summary |
+| Using `usermod -G` without `-a` | The option name reads like "add to groups," but it replaces supplementary groups | Use `sudo usermod -aG group user`, then verify with `id user` |
+| Editing `/etc/sudoers` with vim or nano | Sudoers looks like a normal text file until a syntax error breaks privilege escalation | Use `sudo visudo` or `sudo visudo -f /etc/sudoers.d/name` for every sudo policy edit |
+| Trusting a repository key globally | Older tutorials used `apt-key add`, which made keys trusted across repositories | Store vendor keys in a dedicated keyring and reference them with `signed-by` |
+| Deleting a user before handling their files | Account cleanup is treated as a login problem rather than a data ownership problem | Review and archive home directories, project files, cron jobs, and mail spools before deletion |
+| Giving service accounts interactive shells | The account is created quickly with human defaults copied from previous examples | Create daemon users with `useradd -r -s /usr/sbin/nologin` and a service-specific home only if needed |
+| Silencing package signature errors | The deployment is urgent, and the warning looks like a repository annoyance | Verify the documented vendor key and repository configuration instead of bypassing signature checks |
+| Naming sudoers drop-ins with dots | People use `.conf` out of habit from other config directories | Use names like `webteam` or `deploy`, keep ownership as root, and permissions at `0440` |
 
 ## Quiz
 
-**Q1: You are troubleshooting an Nginx server that is failing to start due to a corrupted configuration file you accidentally modified. You decide to reinstall it, so you run `sudo apt remove nginx` followed by `sudo apt install nginx`. However, the server still fails to start with the exact same configuration error. Why did this happen, and what command should you have used instead?**
+<details><summary>Your team reinstalls `nginx` after a bad configuration edit, but the service fails with the same syntax error. What do you check first, and what package action should have been used if the goal was a clean configuration?</summary>
 
-<details>
-<summary>Show Answer</summary>
-
-When you use `apt remove`, the package manager uninstalls the binary files but intentionally leaves all configuration files intact on the disk. This is a safety feature designed to prevent accidental data loss if you briefly uninstall and reinstall a package. Because the corrupted configuration file was left behind, the new installation simply reused it, leading to the same startup error. To completely wipe both the application binaries and its configuration files, you must use the `apt purge` command instead. After purging, a fresh installation will generate the default, uncorrupted configuration files.
+`apt remove` leaves configuration files in place, so a reinstall can reuse the same broken file under `/etc/nginx`. First confirm whether the failed file is package-managed configuration and whether it survived removal. If the goal is to reset package configuration, use `apt purge nginx` before reinstalling, then restore only the known-good configuration. The reasoning matters because preserving configuration is normally protective, but it is the wrong behavior when configuration is the fault.
 </details>
 
-**Q2: You have just inherited a legacy Debian server and found a mysterious custom script that relies on a tool located at `/opt/custom/bin/data-parser`. You want to know if this tool was installed via the package manager or compiled from source by the previous administrator. How can you determine if a package owns this specific file, and why is this method definitive?**
+<details><summary>A legacy server has `/opt/custom/bin/data-parser`, and nobody knows whether it came from a package. How do you diagnose ownership, and how does the answer shape the next step?</summary>
 
-<details>
-<summary>Show Answer</summary>
-
-You can determine the file's origin by running `dpkg -S /opt/custom/bin/data-parser`. When a package is installed, the package manager records every single file it extracts into a local database. The `dpkg -S` (or search) command queries this exact database to see if any known package claims ownership of the given path. If the command returns a package name, you know it was installed via `apt` or `dpkg`. If it returns 'no path found', the tool was likely compiled manually, copied directly to the server, or installed via an unmanaged method like a tarball.
+On a Debian-family host, run `dpkg -S /opt/custom/bin/data-parser`; on a RHEL-family host, use `rpm -qf /opt/custom/bin/data-parser`. A package owner means you can inspect version, repository, installed file list, and verification state through the package database. No owner means the file was likely copied, compiled, extracted from an archive, or generated by another tool. That result changes the investigation from package maintenance to artifact provenance and local change history.
 </details>
 
-**Q3: During a security audit of your company's Linux servers, you notice that all user password hashes in `/etc/shadow` begin with the `$1$` prefix. Your security compliance tool flags this as a critical vulnerability. What does this prefix indicate about how the passwords are stored, and why is the security tool raising an alarm?**
+<details><summary>An audit finds password hashes in `/etc/shadow` beginning with `$1$`. Why is this a serious finding, and what operational work remains after changing the default hash policy?</summary>
 
-<details>
-<summary>Show Answer</summary>
-
-The `$1$` prefix in the `/etc/shadow` file indicates that the user passwords have been hashed using the MD5 algorithm. This is considered a critical vulnerability because MD5 is an outdated and cryptographically weak algorithm that is highly susceptible to brute-force and dictionary attacks using modern hardware. Attackers can crack MD5 hashes significantly faster than those generated by modern algorithms. To secure the system, you must migrate to a stronger hashing standard, such as SHA-512 (indicated by `$6$`) or yescrypt (indicated by `$y$`), by updating the system's password configuration and forcing users to reset their passwords.
+The `$1$` prefix indicates MD5-based password hashes, which are weak against modern cracking hardware compared with SHA-512 or yescrypt. Updating the system default prevents future password changes from using the old scheme, but existing hashes do not automatically change. Users must reset passwords, or administrators must force password changes through policy. The audit should verify both the configured default and the actual hash prefixes that remain in `/etc/shadow`.
 </details>
 
-**Q4: Alice, a developer, submitted a ticket requesting access to run Docker commands on the staging server. A junior administrator ran the command `sudo usermod -G docker alice` to grant her access. Shortly after, Alice reports that while she can now run Docker, she has completely lost her ability to use `sudo` and access the `developers` shared group. What exactly caused this issue, and how should the command have been structured?**
+<details><summary>A junior admin runs `sudo usermod -G docker alice`, and Alice loses sudo access while gaining Docker access. What exactly happened, and how do you repair the process?</summary>
 
-<details>
-<summary>Show Answer</summary>
-
-The issue occurred because the `-G` flag, when used without the append modifier, completely replaces the user's existing supplementary group memberships with the new list provided. By running `usermod -G docker alice`, the administrator inadvertently removed Alice from her essential groups, like `sudo` and `developers`, and set her supplementary group solely to `docker`. To safely add a user to a new group without affecting their current memberships, the command must include the `-a` (append) flag. The correct command would have been `sudo usermod -aG docker alice`, which appends the new group to her existing profile.
+Without `-a`, `usermod -G` replaces the user's supplementary group list with the groups named on the command line. Alice was removed from groups such as `sudo` and `developers` because the command set her supplementary groups to only `docker`. The correct pattern is `sudo usermod -aG docker alice`, followed by `id alice` to verify membership. The repair process should also restore the missing groups from records or backups rather than guessing.
 </details>
 
-**Q5: To grant the web development team access to restart the Nginx service, your colleague used `visudo -f /etc/sudoers.d/web.devs` to create a new configuration file. The syntax inside the file is perfectly valid, but the developers still receive a "permission denied" error when trying to run the command. What is preventing the system from reading this file, and why does this restriction exist?**
+<details><summary>A sudoers drop-in created as `/etc/sudoers.d/web.devs` has valid syntax, but the team still cannot restart `nginx`. What should you suspect, and why is the restriction useful?</summary>
 
-<details>
-<summary>Show Answer</summary>
-
-The problem stems from the filename `/etc/sudoers.d/web.devs`, which contains a dot character. By design, the `sudo` configuration parser silently ignores any files in the `/etc/sudoers.d/` directory that contain a dot or end with a tilde. This strict naming convention is a safety mechanism implemented to prevent the system from accidentally parsing backup files, package manager artifacts (like `.dpkg-old`), or hidden files that might contain broken or outdated configurations. To resolve the issue, you simply need to rename the file to something without a dot, such as `web-devs`, ensuring the parser reads and applies the rules.
+Sudo ignores drop-in files with dots or tildes in their names, so the valid rule may never be parsed. The restriction prevents backup files, package-manager leftovers, and editor artifacts from becoming active policy by accident. Rename the file to something like `/etc/sudoers.d/webdevs`, validate it with `visudo -f`, and confirm the rule appears with `sudo -l`. This is a good example of a syntactically correct policy failing because the surrounding operational convention was wrong.
 </details>
 
-**Q6: Your production environment relies on a specific, older version of the `postgresql` package due to compatibility issues with a legacy database application. You want to run `sudo apt upgrade` to apply security patches to the rest of the system, but you must guarantee that `postgresql` is absolutely not touched during this process. How can you enforce this restriction, and how does the system track it?**
+<details><summary>A database package must stay on its current version during a security patch window for the rest of the host. How do you control the package dependency risk without making the exception invisible?</summary>
 
-<details>
-<summary>Show Answer</summary>
-
-You can enforce this restriction by placing a 'hold' on the package using the command `sudo apt-mark hold postgresql`. When you issue this command, the package manager flags the package state in its internal database, instructing `apt` to ignore any available updates for it during standard upgrade operations. This ensures your legacy application remains stable while the rest of the system receives critical security patches. When the compatibility issues are finally resolved and you are ready to update the database, you can simply run `sudo apt-mark unhold postgresql` to remove the flag and allow normal upgrades to resume.
+On Debian-family systems, use `sudo apt-mark hold postgresql` and verify it with `apt-mark showhold`. The hold tells `apt` not to upgrade that package during normal upgrade operations, which protects the compatibility constraint while allowing other packages to move. The exception should be tied to a ticket, owner, and review date because forgotten holds block future fixes. When compatibility testing passes, remove it with `sudo apt-mark unhold postgresql`.
 </details>
 
-**Q7: Your company has hired twenty new engineers who all need accounts on the primary development server. Security policy mandates that every new user must have a specific, pre-configured `.ssh/config` file and a customized `.bashrc` loaded with company aliases the moment their account is created. How can you automate this process so you don't have to manually copy these files for each of the twenty new users?**
+<details><summary>A new deployment role needs to copy files and restart one service, but a teammate proposes full passwordless sudo for speed. How would you design the safer sudo rule?</summary>
 
-<details>
-<summary>Show Answer</summary>
-
-You can automate this process by utilizing the `/etc/skel` (skeleton) directory. When you create a new user account using the `useradd -m` command, the system automatically copies all contents from the `/etc/skel` directory directly into the newly created home directory. By placing the required `.ssh/config` file and the custom `.bashrc` into `/etc/skel` beforehand, you ensure that these files are automatically distributed to every new user upon creation. This guarantees a consistent, policy-compliant environment across the server without requiring any manual post-creation setup.
+Create or reuse a deployment identity, then grant only the absolute command paths required for the workflow, such as `rsync` and `systemctl restart myapp`. Put the rule in a dedicated `/etc/sudoers.d/deploy` file through `visudo -f`, avoid dots in the filename, and test from the target identity with `sudo -l`. Full `NOPASSWD: ALL` turns any credential leak into total host control. A narrow rule still supports automation while reducing the damage of a compromised key or pipeline.
 </details>
-
----
 
 ## Hands-On Exercise: User and Package Administration
 
-**Objective**: Practice the full lifecycle of user management and package operations on a Linux system.
+**Objective**: Practice the full lifecycle of package inspection, user management, sudo delegation, and home-directory defaults on a disposable Linux system.
 
-**Environment**: Any Ubuntu/Debian VM, container, or WSL instance with root access.
+**Environment**: Any Ubuntu/Debian VM, container, or WSL instance with root access. Do not run this on a shared production host because the exercise intentionally creates users, groups, sudoers files, and package state that you will later remove.
 
 ### Task 1: Package Management
+
+This task builds the package-management loop you will use during real maintenance: refresh metadata, install narrow tools, prove package ownership, inspect installed files, hold a package, then cleanly remove lab packages. Read the output after each command instead of treating success as silent; the point is to learn what evidence each tool gives you.
 
 ```bash
 # Update package lists
@@ -888,7 +824,14 @@ sudo apt purge -y tree
 sudo apt autoremove -y
 ```
 
+<details><summary>Solution notes for Task 1</summary>
+
+Successful output should show both commands on your `PATH`, `dpkg -S` should identify the package that owns the `jq` binary, and `apt-mark showhold` should list `jq` only while the hold is active. If removal leaves dependencies behind, `apt autoremove` should propose cleanup. The important reasoning is that every step produces evidence: availability from the shell, ownership from the package database, metadata from `apt show`, and policy state from `apt-mark`.
+</details>
+
 ### Task 2: User and Group Management
+
+This task creates two human-style lab users and a shared group, then verifies the identity data from multiple angles. Notice that the commands do not only create accounts; they also check `/etc/passwd`, `/etc/shadow`, and `/etc/group` so you can connect command behavior to the files that define Linux identity.
 
 ```bash
 # Create a group
@@ -926,7 +869,14 @@ grep webteam /etc/group
 # webteam:x:3000:testdev,testops
 ```
 
+<details><summary>Solution notes for Task 2</summary>
+
+The `id` output should show `testdev` with UID `2000` and membership in `webteam`, while `/etc/passwd` should show the shell, home directory, and comment field you selected. The shadow query should reveal that a password record exists without printing the full hash, and `chage -l` should show that the user must change the password. The second user proves why `usermod -aG` matters: it appends the group rather than replacing existing memberships.
+</details>
+
 ### Task 3: sudoers Configuration
+
+This task grants a role the ability to inspect and restart one service without granting full root. The lab uses `nginx` in the rule because it is a familiar service name, but the key lesson is sudo policy design: use a group, use absolute command paths, keep the drop-in modular, and validate through `visudo`.
 
 ```bash
 # Create a sudoers drop-in file for the webteam group
@@ -944,7 +894,14 @@ sudo -u testdev sudo -l
 # (root) /usr/bin/systemctl restart nginx, /usr/bin/systemctl status nginx
 ```
 
+<details><summary>Solution notes for Task 3</summary>
+
+`visudo -f` should reject syntax errors before saving, and the resulting file should be owned by root with restrictive permissions. `sudo -l` should show only the service commands granted to the `webteam` group, not full root access. If the rule does not appear, check that the filename has no dot or tilde and that the main sudoers configuration includes the drop-in directory.
+</details>
+
 ### Task 4: Skeleton Directory Customization
+
+This task demonstrates how `/etc/skel` standardizes future home directories. You will add a harmless onboarding file, create a user, and verify that the file was copied during home creation. Existing users will not receive the file automatically, which is an important limitation when planning real migrations.
 
 ```bash
 # Add a custom file to /etc/skel
@@ -957,7 +914,14 @@ cat /home/skeltest/WELCOME.txt
 # Welcome to the team! Read /wiki for onboarding docs.
 ```
 
+<details><summary>Solution notes for Task 4</summary>
+
+The `WELCOME.txt` file should appear in `/home/skeltest` because `useradd -m` copied the skeleton directory at account creation time. If the file is missing, confirm that you created it in `/etc/skel` before creating the user and that the command actually created a home directory. In real environments, keep skeleton content generic and never place shared secrets or personal SSH private keys there.
+</details>
+
 ### Cleanup
+
+Cleanup is part of the exercise, not an optional courtesy. Removing the lab users, group, sudoers file, and skeleton customization proves that you can reverse your own administrative changes and leave the system in a known state.
 
 ```bash
 # Remove users
@@ -975,18 +939,36 @@ sudo rm /etc/sudoers.d/webteam
 sudo rm /etc/skel/WELCOME.txt
 ```
 
+<details><summary>Cleanup verification</summary>
+
+After cleanup, `id testdev`, `id testops`, and `id skeltest` should fail because the users no longer exist. `getent group webteam` should return no group, and `ls /etc/sudoers.d/webteam` should report that the file is absent. If `groupdel webteam` fails, check whether a remaining user still has it as a primary group, then remove or modify that user before retrying.
+</details>
+
 ### Success Criteria
 
-- [ ] Installed and removed packages using `apt`, verified with `dpkg -S`
-- [ ] Held and unheld a package with `apt-mark`
-- [ ] Created users with specific UID, shell, groups, and home directory
-- [ ] Set passwords and configured password aging with `chage`
-- [ ] Created a sudoers drop-in file using `visudo -f`
-- [ ] Customized `/etc/skel` and verified it works for new users
-- [ ] Cleaned up all test users, groups, and files
-
----
+- [ ] Diagnosed package ownership and dependency metadata with `apt`, `dpkg -S`, and `dpkg -L`
+- [ ] Implemented package lifecycle controls by installing, holding, unholding, removing, purging, and cleaning packages
+- [ ] Administered users with specific UID, shell, group membership, home directory, password, and password aging settings
+- [ ] Configured group-based sudo delegation through a validated `/etc/sudoers.d/webteam` drop-in
+- [ ] Evaluated account and package state through `id`, `/etc/passwd`, `/etc/shadow`, `/etc/group`, and package queries
+- [ ] Customized `/etc/skel` and verified the default file appears only for newly created users
+- [ ] Cleaned up all lab users, groups, sudoers files, package holds, and skeleton changes
 
 ## Next Module
 
-Continue with [Module 8.4: Service Configuration & Scheduling](../module-8.4-scheduling-backups/) to learn about systemd unit files, cron jobs, and timers — the tools that keep Linux services running and tasks executing on schedule.
+Continue with [Module 8.4: Service Configuration & Scheduling](../module-8.4-scheduling-backups/) to learn about systemd unit files, cron jobs, and timers - the tools that keep Linux services running and tasks executing on schedule.
+
+## Sources
+
+- [Debian Administrator's Handbook: Package Management](https://www.debian.org/doc/manuals/debian-handbook/sect.apt-get.en.html)
+- [Debian manpage: apt](https://manpages.debian.org/bookworm/apt/apt.8.en.html)
+- [Debian manpage: dpkg](https://manpages.debian.org/bookworm/dpkg/dpkg.1.en.html)
+- [Debian manpage: sources.list](https://manpages.debian.org/bookworm/apt/sources.list.5.en.html)
+- [Fedora Docs: DNF Command Reference](https://docs.fedoraproject.org/en-US/quick-docs/dnf/)
+- [RPM documentation](https://rpm.org/documentation.html)
+- [Linux man-pages: passwd file format](https://man7.org/linux/man-pages/man5/passwd.5.html)
+- [Linux man-pages: shadow file format](https://man7.org/linux/man-pages/man5/shadow.5.html)
+- [Linux man-pages: group file format](https://man7.org/linux/man-pages/man5/group.5.html)
+- [Linux man-pages: useradd](https://man7.org/linux/man-pages/man8/useradd.8.html)
+- [Sudo manual: sudoers](https://www.sudo.ws/docs/man/sudoers.man/)
+- [Sudo manual: visudo](https://www.sudo.ws/docs/man/visudo.man/)


### PR DESCRIPTION
## Summary
- Rewrote src/content/docs/linux/operations/module-8.3-package-user-management.md for #388 density, structure, alignment, and anti-leak gates.
- Cleared revision_pending: false and preserved the module's package, user, sudo, lab, and source coverage while adding primary/vendor references.

## Verifier
- Tiers: T0=1; failure_gates={}; body_words=5054; mean_wpp=60.2; median_wpp=61.5; short_rate=0.0; max_run=0; mean_sentence_length=22.2; paragraph_count=84.
- Protected assets preserved: code_blocks 40 before / 40 after; mermaid_diagrams 1 before / 1 after; tables 8 before / 8 after; ascii_diagrams 0 before / 0 after.
- Sources: 12 URLs; reachability check returned 12x 200, 0 redirects, 0 404, 0 fetch_failed.
- Commit: 55aca58ac53d.

## Checks
- .venv/bin/python scripts/quality/verify_module.py --glob <worktree module path> --skip-source-check --summary --quiet: T0 pass.
- scripts/quality/verify_module.py without skip-source-check: T0 pass, 12/12 sources reachable.
- git diff --check: pass.
- /Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/test_pipeline.py: 166 tests OK.
- npm run build: pass in worktree after ignored node_modules symlink workaround for the known Astro worktree resolution issue; 2015 pages built.
