### PR TITLE
feat(388): rewrite module-4.1-kernel-hardening (#388 pilot)

### DIFF
--- a/src/content/docs/linux/security/hardening/module-4.1-kernel-hardening.md
+++ b/src/content/docs/linux/security/hardening/module-4.1-kernel-hardening.md
@@ -1,5 +1,5 @@
 ---
-revision_pending: true
+revision_pending: false
 title: "Module 4.1: Kernel Hardening & sysctl"
 slug: linux/security/hardening/module-4.1-kernel-hardening
 sidebar:
@@ -11,65 +11,44 @@ lab:
   difficulty: "advanced"
   environment: "ubuntu"
 ---
-> **Linux Security** | Complexity: `[MEDIUM]` | Time: 25-30 min
+# Module 4.1: Kernel Hardening & sysctl
+
+> **Linux Security** | Complexity: `[MEDIUM]` | Time: 25-30 min, focused on practical kernel controls for production Linux and Kubernetes nodes.
 
 ## Prerequisites
 
-Before starting this module:
+Before starting this module, make sure you can already inspect Linux processes, reason about basic packet flow, and explain why security controls must match the role of the host:
 - **Required**: [Module 1.1: Kernel & Architecture](/linux/foundations/system-essentials/module-1.1-kernel-architecture/)
 - **Required**: [Module 3.1: TCP/IP Essentials](/linux/foundations/networking/module-3.1-tcp-ip-essentials/)
 - **Helpful**: Understanding of basic security concepts
 
----
+## Learning Outcomes
 
-## What You'll Be Able to Do
-
-After this module, you will be able to:
-- **Configure** sysctl parameters to harden a Kubernetes node against network attacks
-- **Evaluate** CIS benchmark recommendations and decide which to apply
-- **Explain** how ASLR, stack protector, and SYN cookies protect against specific attack types
-- **Audit** a running system's kernel security posture using sysctl and /proc
-
----
+After this module, you will be able to make and defend kernel-hardening decisions using live evidence from the host rather than relying on memorized benchmark lines:
+- **Implement** a persistent sysctl baseline that hardens network, memory, and filesystem behavior without breaking required services.
+- **Evaluate** CIS benchmark recommendations against real node roles, especially when a rule conflicts with Kubernetes networking requirements.
+- **Diagnose** Kubernetes node communication failures caused by kernel hardening settings such as IP forwarding, bridge netfilter, and reverse path filtering.
+- **Audit** a running system's kernel security posture with sysctl, `/proc`, AIDE, and package verification evidence.
 
 ## Why This Module Matters
 
-The Linux kernel has hundreds of tunable parameters that affect security. Many are insecure by default for compatibility reasons. Proper hardening reduces attack surface and prevents common exploits.
+On October 21, 2016, Dyn's managed DNS platform was hit by the Mirai botnet, and the outage rippled into major websites because a network control plane dependency was suddenly unreachable. That incident was not solved by a single sysctl flag, but it is the kind of event that makes kernel hardening practical rather than academic. When hosts accept spoofed routes, answer broadcast probes, keep weak TCP defaults, or expose kernel internals to untrusted processes, they become easier to abuse during the first minutes of an incident, when responders have the least time and the worst visibility.
 
-Understanding kernel hardening helps you:
+A Kubernetes platform team sees the same lesson at a smaller scale. A worker node is not just a Linux server running containers; it is also a packet forwarder, a bridge participant, a conntrack consumer, a process scheduler, and a shared memory boundary for workloads from different teams. If a hardening script blindly disables IP forwarding, pods lose cross-node traffic. If the team leaves pointer exposure and unrestricted tracing enabled, a compromised workload gains better reconnaissance inside the node. The financial impact usually shows up as missed SLOs, wasted incident hours, emergency consulting, SLA credits, and delayed releases, even when no public breach headline appears.
 
-- **Secure Kubernetes nodes** — CIS benchmarks require specific sysctl settings
-- **Pass CKS exam** — Kernel hardening is directly tested
-- **Prevent network attacks** — Disable IP forwarding, ICMP redirects
-- **Protect against memory exploits** — ASLR, exec-shield, etc.
+This module teaches you to treat sysctl as an operating decision system, not a bag of magic numbers. You will learn why a setting exists, what attack or failure mode it changes, where Kubernetes 1.35+ needs exceptions, and how to verify the result without trusting a compliance scanner blindly. The goal is not to memorize every Linux tunable; the goal is to build the judgment to harden a node, explain the tradeoff, and diagnose the fallout when a kernel-level control changes production behavior.
 
-When a security scanner flags sysctl settings or a CIS benchmark fails, you need to understand these parameters.
-
----
-
-## Did You Know?
-
-- **The Linux kernel has over 1,000 sysctl parameters** — Most are safe defaults, but dozens are security-critical. The CIS Benchmark for Linux covers about 50 of them.
-
-- **ASLR (Address Space Layout Randomization) has been default since 2005** — It randomizes where programs load in memory, making exploits much harder. Disabling it (`kernel.randomize_va_space=0`) is a major security mistake.
-
-- **IP forwarding disabled by default is intentional** — A workstation shouldn't route packets. Enabling it without proper firewall rules turns your machine into an open router.
-
-- **sysctl changes are not persistent by default** — Running `sysctl -w` changes only last until reboot. Files in `/etc/sysctl.d/` make them permanent.
-
----
+The practical discipline is to connect three questions every time you touch the kernel: what risk is reduced, what legitimate behavior might change, and what evidence proves the final state. That discipline prevents two common extremes. One team leaves permissive defaults because it fears outages, while another team pastes every benchmark recommendation into production and creates outages in the name of security. Kernel hardening works best in the middle, where controls are strict, exceptions are narrow, and verification is routine.
 
 ## sysctl Basics
 
 ### The Fortress Control Room
 
-Think of the Linux kernel as a massive fortress, and `sysctl` as the master control room where you dictate the behavior of its gates, drawbridges, and guards. By default, this fortress is designed to be highly accommodating—it happily forwards messages between different courtyards (IP forwarding) and politely gives directions to lost travelers (ICMP redirects). 
+Think of the Linux kernel as a large fortress, and `sysctl` as the control room where you set standing orders for gates, roads, watchtowers, and storage rooms. The default Linux posture is intentionally general purpose because the same kernel might run a laptop, a router, a database server, or a Kubernetes node. Compatibility is useful, but compatibility also means the kernel may accept routing hints, expose diagnostics, or allow runtime behaviors that are convenient during troubleshooting and risky on a hostile network.
 
-While this makes for a friendly, compatible operating system out of the box, it's a massive liability in a hostile network environment. Using `sysctl`, we are going to lock down the fortress. We will issue standing orders to stop trusting external routing directions, refuse to forward unauthorized traffic, and even randomize where the commander sleeps every night (ASLR) so assassins can't find him. Instead of viewing these settings as a disjointed dictionary of variables, think of them as specific security postures you are commanding your system to adopt.
+Hardening starts by separating a setting from the reason behind it. Setting `net.ipv4.conf.all.accept_redirects = 0` is not a charm against attackers; it tells the host to stop accepting ICMP messages that claim a better route exists through another gateway. Setting `kernel.randomize_va_space = 2` does not fix memory corruption bugs; it makes exploit reliability worse by changing where memory regions appear. A mature operator can read a benchmark recommendation and explain both the protection and the operational cost.
 
-### What is sysctl?
-
-**sysctl** modifies kernel parameters at runtime. These parameters live in `/proc/sys/` as virtual files.
+The kernel presents many tunables through `/proc/sys`, and `sysctl` is the friendly front door into that tree. A dotted key such as `net.ipv4.ip_forward` maps to a virtual file at `/proc/sys/net/ipv4/ip_forward`, so the command-line tool and the filesystem view are two ways to inspect the same live kernel state. That dual view matters during incidents because some tools call `sysctl`, while others read `/proc` directly, and you need to recognize that they are reporting one underlying value.
 
 ```mermaid
 graph LR
@@ -95,7 +74,9 @@ graph LR
     FS --> FSdots["..."]
 ```
 
-### Using sysctl
+The diagram is deliberately broad because hardening is not limited to the `kernel.*` namespace. Network controls live under `net.*`, filesystem protections live under `fs.*`, memory pressure controls live under `vm.*`, and some container-relevant bridge behavior appears under `net.bridge.*` after the right kernel module is loaded. A hardened baseline is usually a small, reviewed subset from this enormous surface, not the output of `sysctl -a` pasted into a file.
+
+`sysctl -w` is useful for experiments and emergency mitigation because it updates the running kernel immediately. The cost is that the change is volatile, so it disappears at the next reboot unless a configuration file under `/etc/sysctl.d/` or another loaded path declares the same value. That distinction is one of the most common operational failures in hardening work: the team fixes the live incident, reboots during patching, and silently returns to the vulnerable default.
 
 ```bash
 # View a parameter
@@ -117,13 +98,19 @@ sudo sysctl -p /etc/sysctl.d/99-security.conf
 sudo sysctl --system
 ```
 
----
+Pause and predict: if you run `sudo sysctl -w net.ipv4.tcp_syncookies=1` during an attack and later find no matching line in `/etc/sysctl.d/`, what will a reboot do to your mitigation, and how would you prove the change is now persistent rather than just active in memory?
+
+Use the command sequence as a diagnostic pattern, not just as a setup recipe. First read the current value, then decide whether the running value is wrong for the host role, then change it temporarily only if you understand the blast radius, and finally persist it in a named file that future operators can audit. That order leaves a trail of evidence and avoids the false confidence that comes from applying a command without checking whether the kernel accepted it.
 
 ## Network Hardening
 
 ### IP Forwarding
 
-> **Stop and think**: If you apply a strict CIS baseline that sets `net.ipv4.ip_forward = 0` to a Kubernetes worker node, what specific cluster network traffic will break immediately?
+Network hardening is where sysctl work most often collides with platform reality. A conventional server should not route packets between interfaces because that behavior can turn a compromised host into a pivot point. A Kubernetes worker, however, routinely handles packets that originate in pods and leave through host interfaces, so a blanket rule that disables forwarding can break the very traffic the node exists to carry.
+
+The right question is not whether IP forwarding is good or bad. The right question is whether this host is intentionally acting as a router, and whether firewall policy, CNI behavior, and observability match that role. A hardened laptop and a hardened Kubernetes worker can have different values for `net.ipv4.ip_forward`, and both can be correct when the decision is documented and verified.
+
+> **Stop and think**: If you apply a strict CIS baseline that sets `net.ipv4.ip_forward = 0` to a Kubernetes worker node, what specific cluster network traffic will break immediately, and which team would notice first?
 
 ```bash
 # Should be 0 on non-routers (1 needed for containers/K8s)
@@ -137,7 +124,13 @@ net.ipv6.conf.all.forwarding = 0
 # But should be combined with proper firewall rules
 ```
 
+For a non-router, forwarding disabled means packets not destined for the host are dropped instead of being relayed onward. That closes an entire class of accidental routing problems and makes network segmentation easier to reason about. For a Kubernetes node, the same drop can isolate pods because the host participates in pod-to-service, pod-to-pod, overlay, bridge, or routed traffic paths depending on the CNI plugin.
+
+The practical review is role-based. A bastion host, CI runner, database server, and developer workstation normally keep forwarding disabled unless a documented network design says otherwise. A Kubernetes worker normally keeps IPv4 forwarding enabled, and then relies on CNI policy, host firewall rules, kube-proxy or replacement dataplanes, and route controls to make that forwarding safe. You are not weakening hardening when you make a justified exception; you are hardening the actual system instead of an imaginary one.
+
 ### ICMP Hardening
+
+ICMP is valuable for diagnostics, path discovery, and network control messages, but some ICMP behaviors were designed for friendlier networks than the ones production hosts now inhabit. Broadcast echo handling can help amplification attacks. Redirect acceptance can let a nearby attacker influence routing. Redirect sending can cause a server to participate in route advice it should never provide.
 
 ```bash
 # Ignore ICMP broadcasts (prevent Smurf attacks)
@@ -157,7 +150,13 @@ net.ipv4.conf.all.send_redirects = 0
 net.ipv4.conf.default.send_redirects = 0
 ```
 
+The `all` and `default` keys are easy to misread. The `all` value applies across existing interfaces in a combined way, while `default` influences settings inherited by interfaces created later. Container hosts create and destroy interfaces during normal operation, so setting only a current interface can leave future interfaces with weaker behavior. A baseline should usually configure both the aggregate and the default path, then verify the live per-interface values after the network stack has settled.
+
+Redirects deserve special caution because their legitimate use is narrow on managed hosts. In a simple LAN, a router can tell a client that another router is a better next hop. In a production server subnet, the host should usually learn routes from controlled configuration, DHCP, routing daemons, or cloud metadata, not from unsolicited packet advice. Disabling redirect acceptance makes that trust boundary explicit.
+
 ### Source Routing & Spoofing
+
+Source routing lets a sender request a path through the network, which is rarely something a hardened server should honor. Reverse path filtering checks whether the return path for a packet's source address makes sense through the interface where the packet arrived. Together, source route rejection, reverse path filtering, and martian logging reduce the chance that spoofed or strangely routed packets pass unnoticed.
 
 ```bash
 # Disable source routing (attacker-controlled routing)
@@ -175,7 +174,15 @@ net.ipv4.conf.all.log_martians = 1
 net.ipv4.conf.default.log_martians = 1
 ```
 
+Reverse path filtering is powerful, but it is not free. Strict filtering can break asymmetric routing, multi-homed servers, certain overlay networks, and environments where packets legitimately enter through one interface and leave through another. That is why a Kubernetes team should validate `rp_filter` against its CNI plugin and routing model rather than blindly copying a workstation rule into a worker-node image.
+
+Before running this in a cluster image pipeline, what output do you expect from each current interface under `/proc/sys/net/ipv4/conf/*/rp_filter`, and how would a multi-homed node change your decision? Thinking through that answer before changing the setting helps you catch designs where strict anti-spoofing is correct on one interface and harmful on another.
+
+Martian logging is a visibility control as much as a prevention control. It can reveal spoofed source addresses, impossible routes, or misconfigured upstream devices, but it can also generate noise under attack or during a network migration. Enable it where logs are collected and reviewed, then make sure the team knows what a normal volume looks like so that a real anomaly is not lost in routine chatter.
+
 ### TCP SYN Protection
+
+TCP uses a handshake before a connection is established, and that handshake requires the server to remember half-open state after receiving a SYN. A SYN flood abuses that memory by sending many SYN packets without completing the final ACK. SYN cookies let the server encode enough state into the SYN-ACK sequence number that it can avoid storing every half-open connection during pressure.
 
 ```bash
 # Enable SYN cookies (prevent SYN flood attacks)
@@ -191,11 +198,17 @@ net.ipv4.tcp_fin_timeout = 15
 net.netfilter.nf_conntrack_max = 1000000
 ```
 
----
+SYN cookies are not a complete DDoS strategy because bandwidth, application capacity, load balancer behavior, and upstream filtering still matter. They are a kernel-level guardrail that keeps one specific resource exhaustion path from being trivially reliable. The setting is especially relevant on internet-facing hosts and load balancer nodes, but Kubernetes workers can still benefit because node-local services, ingress components, and host networking workloads can be exposed in ways that surprise the platform team.
 
-## Memory Protection
+Connection tracking limits deserve the same capacity-minded review. A high value such as `net.netfilter.nf_conntrack_max = 1000000` can be appropriate for a busy node with enough memory, but it is not a universal trophy number. If the table is too small, legitimate traffic fails under load. If it is too large for the node, memory pressure becomes its own reliability risk. Hardening and sizing meet at this point, so you should pair sysctl review with observed traffic patterns.
+
+## Memory and Filesystem Protection
 
 ### ASLR (Address Space Layout Randomization)
+
+Memory protections reduce exploit reliability after a vulnerability already exists. That framing matters because operators sometimes expect ASLR, stack protector, pointer restrictions, or `ptrace` policy to make vulnerable software safe. They do not. They add uncertainty, boundaries, and information hiding so an attacker has fewer stable assumptions while trying to turn a bug into code execution or data theft.
+
+ASLR changes where process memory regions appear, including stacks, heaps, libraries, and memory mappings. If an attacker knows a buffer overflow exists but cannot predict the address of useful code or data, the exploit becomes harder to automate. Full randomization is not magic, but disabling it gives attackers a simpler target and makes older exploit techniques more reliable.
 
 > **Pause and predict**: An attacker discovers a buffer overflow vulnerability in a containerized web server. If `kernel.randomize_va_space` is set to `2`, how does this setting specifically frustrate their attempt to execute a return-to-libc attack?
 
@@ -212,7 +225,13 @@ sysctl kernel.randomize_va_space
 kernel.randomize_va_space = 2
 ```
 
+Stack protector is related, but it is not a sysctl setting. It is usually a compiler hardening feature that places a canary value near sensitive stack data and checks whether the value changed before returning from a function. That means you audit it differently: sysctl can show ASLR state, while stack protector evidence comes from build flags, binary inspection, distribution defaults, and package provenance.
+
+The operational lesson is to avoid mixing controls into one vague phrase such as "memory hardening is on." ASLR is a runtime kernel behavior. Stack protector is a compile-time binary property. Non-executable memory, control-flow protections, seccomp, and mandatory access control are additional layers with different evidence. A good hardening report names each control, its source of truth, and the failure mode it reduces.
+
 ### Memory Protections
+
+`ptrace` is a legitimate debugging mechanism and a dangerous cross-process inspection primitive. Debuggers, tracers, and profilers use it to observe or manipulate another process, but the same capability can reveal secrets in memory or alter execution. In shared environments, the question becomes whether one workload should ever be able to inspect another workload's process state just because the Linux permission model would otherwise allow it.
 
 ```bash
 # Restrict ptrace (prevent debugging other processes)
@@ -235,7 +254,15 @@ kernel.dmesg_restrict = 1
 kernel.perf_event_paranoid = 3
 ```
 
+The tradeoff is troubleshooting friction. A developer who is used to attaching `strace` to a live process may suddenly see "Operation not permitted" after `kernel.yama.ptrace_scope` is raised. That failure is not automatically a bug in the node; it may be the hardening control doing exactly what it was designed to do. Production teams need a documented break-glass workflow for debugging without leaving broad tracing enabled all the time.
+
+Kernel pointer restriction and dmesg restriction are information-disclosure controls. Kernel addresses can help bypass address randomization, and unrestricted kernel logs can reveal device details, memory addresses, or security-relevant errors to users who do not need them. The best analogy is a building directory: it is not the same as a door key, but it helps an intruder plan where to go next.
+
+Performance event restrictions create another tension. Profiling tools are valuable for latency and CPU analysis, especially on Kubernetes nodes where noisy workloads can hurt neighbors. At the same time, low-level performance events can leak information across boundaries on some systems. Treat `kernel.perf_event_paranoid` as a policy decision that should be paired with approved profiling workflows, not as a random number copied from a benchmark.
+
 ### Disable Magic SysRq
+
+Magic SysRq exists for recovery and debugging. It can sync disks, remount filesystems, dump state, or trigger kernel actions from a keyboard sequence or proc interface, depending on configuration. On a lab machine, that can be useful. On a production server with physical or console access concerns, broad SysRq access can become an emergency control path that bypasses normal operational checks.
 
 ```bash
 # SysRq key allows keyboard-triggered kernel commands
@@ -246,9 +273,11 @@ kernel.sysrq = 0
 # See Documentation/admin-guide/sysrq.rst for bitmask values
 ```
 
----
+Disabling SysRq is straightforward when the team has other recovery options, such as out-of-band management, serial console access with audit trails, rescue images, and tested reboot procedures. If a specialized environment depends on particular SysRq functions, use the documented bitmask rather than enabling every function casually. The important part is to make the recovery path intentional, reviewed, and visible to operators.
 
-## Filesystem Security
+### Filesystem Security
+
+Shared writable directories create classic link attacks. A malicious user can place a symlink or hardlink in a sticky directory such as `/tmp` and hope that a privileged process follows it while writing, changing ownership, or truncating data. Filesystem protected link controls make those attacks harder by adding ownership and directory checks before the kernel allows risky link traversal.
 
 > **Stop and think**: In a shared temporary directory like `/tmp`, how do `fs.protected_symlinks` and `fs.protected_hardlinks` prevent a malicious user from tricking a privileged process into overwriting critical system files?
 
@@ -265,15 +294,19 @@ fs.protected_regular = 2
 fs.file-max = 2097152
 ```
 
----
+These filesystem controls are usually low-friction on modern distributions because they target behavior that well-written applications should not depend on. The exceptions tend to be older scripts, unusual package installers, or software that performs unsafe temporary-file handling. If a legacy workload breaks after enabling the protections, the fix should usually be to repair the workload's file handling rather than to remove the kernel guard for the whole host.
+
+`fs.file-max` is different because it is primarily a capacity limit. Raising it can prevent file descriptor exhaustion on busy nodes, but it does not automatically harden the system. Include it in the same review only when the node's workload profile justifies the setting, and remember that per-process limits, service manager limits, and application pooling behavior can still cap effective file usage even when the kernel-wide maximum is high.
 
 ## System Integrity Verification
+
+Runtime kernel settings are only part of the story. A node can have excellent sysctl values and still be compromised if important binaries, configuration files, or package-owned paths have changed unexpectedly. Integrity verification tools give you a second line of evidence: not "what does the kernel allow right now," but "does the filesystem still match a known-good baseline or package database?"
 
 Beyond runtime kernel settings, you need to verify that system files haven't been tampered with. AIDE (Advanced Intrusion Detection Environment) and `rpm -V` detect unauthorized changes to critical files.
 
 ### AIDE (Advanced Intrusion Detection Environment)
 
-AIDE creates a database of file checksums, permissions, and timestamps, then compares the current state against that baseline.
+AIDE creates a database of file checksums, permissions, and timestamps, then compares the current state against that baseline. The baseline is only meaningful if you create it when the system is trusted, store it carefully, and update it after legitimate changes through a controlled process. If you initialize AIDE after an attacker has modified the system, you have merely taught the tool to trust the wrong state.
 
 ```bash
 # Install AIDE
@@ -297,9 +330,11 @@ sudo aide --update
 sudo cp /var/lib/aide/aide.db.new /var/lib/aide/aide.db
 ```
 
+AIDE output requires judgment because not every change is malicious. Package updates, certificate rotations, log policy changes, and administrator edits can all produce differences. The operational pattern is to compare AIDE findings with change records, package manager history, deployment logs, and incident timelines. A suspicious binary change with no corresponding package update is very different from an expected configuration change during a planned maintenance window.
+
 ### Package Verification with rpm -V
 
-On RPM-based systems (RHEL, Rocky, Fedora), you can verify installed packages against their original checksums:
+On RPM-based systems (RHEL, Rocky, Fedora), you can verify installed packages against their original checksums. This is especially useful when you suspect a package-owned binary or library changed, because the package database gives you a quick comparison point. It is not a full incident-response platform, but it can help you decide whether to isolate a host, reinstall a package, or collect deeper forensic evidence.
 
 ```bash
 # Verify a specific package
@@ -321,11 +356,15 @@ rpm -Va
 
 > **Exam tip**: AIDE questions on the LFCS typically involve initializing a baseline and running a check. Remember the workflow: `aide --init`, move the database, then `aide --check`. On RPM systems, `rpm -V` is a quick way to verify individual packages.
 
----
+The strongest hardening programs connect these checks to response playbooks. If AIDE reports a modified SSH binary and `rpm -V` confirms a checksum mismatch, the team should not merely restore a file and move on. They should preserve evidence, rotate relevant credentials, inspect lateral movement paths, and rebuild the node from trusted artifacts when compromise cannot be ruled out. Kernel hardening reduces attack paths; integrity verification helps you notice when a path may already have been used.
 
 ## Kubernetes Node Hardening
 
 ### Required for Kubernetes
+
+Kubernetes changes the hardening conversation because the Linux host is part of the cluster dataplane. A worker node forwards pod traffic, handles bridge or virtual interface behavior, participates in service routing, and consumes conntrack entries under load. A baseline that is correct for a standalone server can be wrong for a node, so you must evaluate each control against the node role before treating a scanner failure as a defect.
+
+When you use Kubernetes commands in this curriculum, define the shortcut once with `alias k=kubectl`; the examples in this module focus on host-level Linux controls, but the project convention matters when you later validate Kubernetes 1.35+ node behavior with `k`. The alias is not a security feature. It is an operational habit that keeps exam and lab commands concise while making it clear that Kubernetes validation is separate from sysctl inspection.
 
 ```bash
 # These MUST be enabled for Kubernetes to work
@@ -341,7 +380,11 @@ net.bridge.bridge-nf-call-ip6tables = 1
 modprobe br_netfilter
 ```
 
+Bridge netfilter settings are a good example of dependency order. If the `br_netfilter` module is not loaded, the corresponding sysctl keys may not exist yet, and a configuration reload can appear to fail or skip the setting. A node bootstrap process should load required modules before applying the sysctl file, then verify that the expected keys exist and hold the intended values.
+
 ### Recommended for Kubernetes Nodes
+
+The best Kubernetes baseline is conservative where the node does not need legacy trust and explicit where the node does need routing behavior. Disable redirects and source routing, enable SYN cookies, protect filesystem links, restrict kernel information exposure, and keep the pod-network requirements that the CNI expects. That combination is more useful than simply labeling a benchmark as passed or failed.
 
 ```bash
 # /etc/sysctl.d/99-kubernetes-hardening.conf
@@ -368,7 +411,11 @@ fs.protected_symlinks = 1
 net.netfilter.nf_conntrack_max = 1000000
 ```
 
+Notice that `kernel.kptr_restrict = 1` appears here rather than the stricter value shown earlier. That can be a defensible Kubernetes choice when privileged node diagnostics need root-only visibility while ordinary users and workloads remain restricted. The point is not that one value is universally better; the point is that production hardening often uses a stricter default for general servers and a carefully justified exception for platform operations.
+
 ### CIS Benchmark Compliance
+
+CIS benchmark rules are valuable because they make common hardening expectations explicit, measurable, and reviewable. They are not a substitute for architecture knowledge. Some rules include phrases such as "unless routing is required," and a Kubernetes worker is exactly the kind of host where routing may be required. Your job is to document that exception, keep compensating controls in place, and verify the final risk posture.
 
 ```bash
 # Key CIS Benchmark sysctl requirements:
@@ -387,11 +434,15 @@ net.netfilter.nf_conntrack_max = 1000000
 grep -r "." /proc/sys/net/ipv4/conf/*/accept_redirects
 ```
 
----
+Which approach would you choose here and why: forcing every CIS value exactly as written, or creating a node-role exception file that preserves Kubernetes forwarding while enforcing redirect, source-routing, SYN, memory, and filesystem protections? A senior reviewer will expect you to defend the choice with traffic flow evidence, not with a vague statement that Kubernetes is special.
+
+Compliance review should end with a machine-readable baseline and a human-readable rationale. The machine-readable baseline gives automation a source of truth. The rationale explains why a node violates a generic rule, which compensating controls exist, and how the team will detect drift. That is the difference between hardening as a one-time script and hardening as an operating practice.
 
 ## Applying sysctl Settings
 
 ### Persistent Configuration
+
+Persistent configuration is where hardening becomes reproducible. A running value proves only that the current kernel has a setting at this moment. A file under `/etc/sysctl.d/` proves that the team has declared an intended value that boot and reload processes can apply again. The file name should communicate ownership and precedence, such as `99-hardening.conf` for a late security baseline that overrides distribution defaults.
 
 ```bash
 # Create configuration file
@@ -423,7 +474,11 @@ sudo sysctl --system
 sysctl kernel.randomize_va_space
 ```
 
+The apply step should be paired with verification because configuration files can contain unknown keys, module-dependent keys, syntax errors, or values overwritten later by another file. Treat `sudo sysctl --system` as a reload request, not as proof of final state. The proof is the value read back from the running kernel and, ideally, an automated audit that checks every setting your baseline claims to manage.
+
 ### Loading Order
+
+Loading order explains why two correct-looking files can produce a surprising final value. Later files override earlier files, and distribution-provided paths can interact with local administrator paths. If a baseline works during manual testing but changes after package updates or image rebuilds, inspect the full set of sysctl files and verify which declaration wins.
 
 ```
 /run/sysctl.d/*.conf
@@ -436,84 +491,110 @@ sysctl kernel.randomize_va_space
 (Later files override earlier ones)
 ```
 
----
+The safest operational pattern is to keep your security baseline small, named, version-controlled, and reviewed. Avoid scattering related settings across many files because that makes precedence and ownership harder to understand. If a platform team needs a Kubernetes exception, place it deliberately in the same baseline or in a clearly named node-role file, then test the final state after all configuration layers have loaded.
+
+## Patterns & Anti-Patterns
+
+Pattern one is role-based baselining. Start with a small set of controls that apply to every Linux host, then layer exceptions for routers, Kubernetes workers, load balancers, and specialized appliances. This works because sysctl settings express kernel behavior, and kernel behavior must match the job the host performs. It also scales well because reviewers can ask "which role owns this exception?" instead of arguing about every host from scratch.
+
+Pattern two is verify-after-apply automation. Every baseline should have a companion audit that reads live values from `sysctl` or `/proc`, reports pass or fail, and can be run after boot, image build, patching, and incident mitigation. This works because many sysctl mistakes are silent until a reboot or interface creation event changes the state. The scaling concern is noise, so the audit should check the settings the team actually owns rather than dumping thousands of kernel parameters.
+
+Pattern three is exception documentation tied to compensating controls. Kubernetes nodes may need IP forwarding, high conntrack capacity, and bridge netfilter behavior, while ordinary servers should not. A documented exception should name the reason, the owner, the validation command, and the control that limits the added risk. That turns "we failed CIS" into "we intentionally diverged from a generic rule because this node routes pod traffic, and here is how we constrain it."
+
+Anti-pattern one is compliance-copy hardening. Teams fall into it because scanner output feels objective and scripts are easy to run. The failure appears later when a node loses pod networking, a debugging workflow breaks during an outage, or a setting never survived reboot. The better alternative is to treat benchmarks as review inputs, then produce a role-specific baseline with verification evidence.
+
+Anti-pattern two is emergency-only sysctl work. During an attack, an operator changes a live value with `sysctl -w`, the immediate symptom improves, and the team forgets to persist the fix. The next reboot quietly removes the mitigation. The better alternative is to pair every emergency runtime change with a follow-up file change, a reload, a read-back check, and an incident note explaining why the value changed.
+
+Anti-pattern three is broad diagnostic exposure for convenience. Leaving unrestricted `ptrace`, kernel pointer visibility, or dmesg access makes troubleshooting easier for trusted administrators, but it also gives compromised workloads more information. The better alternative is to restrict the default posture and maintain an approved break-glass path for deeper debugging. That path can include temporary access, audit logging, and restoration checks after the diagnostic window closes.
+
+## Decision Framework
+
+Start each sysctl decision with the host role. If the host is a workstation, database server, CI runner, or application server, assume it should not forward packets, accept redirects, accept source routes, or expose kernel diagnostics broadly. If the host is a Kubernetes 1.35+ worker, load balancer, router, or network appliance, identify the traffic path that requires different behavior before changing a value. Role first prevents both under-hardening and accidental outages.
+
+Next, identify the failure mode the setting addresses. Redirect controls address route manipulation. SYN cookies address half-open TCP state exhaustion. ASLR and pointer restrictions address exploit reliability and information disclosure. Filesystem link protections address unsafe shared-directory behavior. If you cannot describe the failure mode in one or two sentences, you are not ready to declare the setting mandatory.
+
+Then check compatibility and evidence. Some values can be applied broadly with little risk, such as protected symlinks on modern systems. Others interact with routing topology, CNI plugins, debugging workflows, or kernel modules. Evidence can include `/proc` reads, CNI documentation, node traffic tests, package verification, and audit output. The decision should be supported by observed behavior, not just by a benchmark line.
+
+After compatibility, choose persistence and ownership. Temporary `sysctl -w` changes belong in incident notes and should be converted into configuration files if they remain necessary. Persistent files should live in a path and naming scheme that the team understands. Ownership matters because someone must review future changes, update exceptions, and explain why a node role differs from a generic security profile.
+
+Finally, validate the result after a reboot or node replacement. Hardening that works only on a single hand-tuned host does not protect a fleet. For Kubernetes, validate both the Linux values and the cluster behavior that depends on them: pod-to-pod traffic, service routing, ingress behavior, node logs, and expected debugging workflows. A correct sysctl baseline is one that survives lifecycle events and still lets the platform do its job.
+
+A useful review question is whether the decision would still make sense to someone reading the host image six months later. If the answer depends on tribal memory, improve the baseline name, add a comment, or write a short exception note. Hardening decisions age badly when they are invisible, especially in fleets where image rebuilds, kernel updates, CNI upgrades, and new workload patterns change the assumptions under old settings.
+
+## Did You Know?
+
+- **The Linux kernel exposes over 1,000 sysctl parameters** - most are safe defaults for ordinary use, but a much smaller set controls security-sensitive network, memory, filesystem, and diagnostic behavior.
+- **ASLR has been enabled by default in mainstream Linux distributions since the mid-2000s** - disabling it with `kernel.randomize_va_space=0` removes an important exploit-reliability barrier.
+- **IP forwarding is intentionally disabled on many non-router systems** - enabling it without a routing design and firewall policy can turn a normal server into an unexpected transit point.
+- **`sysctl -w` changes runtime state only** - files under `/etc/sysctl.d/` or related systemd-sysctl paths are what make a setting return after reboot.
 
 ## Common Mistakes
 
-| Mistake | Problem | Solution |
-|---------|---------|----------|
-| Disabling ASLR | Makes exploits easier | Keep randomize_va_space=2 |
-| IP forwarding on workstation | Acts as open router | Disable unless needed |
-| Changes not persistent | Lost at reboot | Use /etc/sysctl.d/ |
-| Hardening breaks K8s | Networking fails | Keep required K8s settings |
-| Not verifying changes | Settings not applied | Use `sysctl -a | grep` |
-| Hardening without testing | Production breakage | Test in staging first |
-
----
+| Mistake | Why It Happens | How to Fix It |
+|---------|----------------|---------------|
+| Disabling ASLR | A legacy-compatibility fear gets repeated without evidence, or a troubleshooting change is left behind | Keep `kernel.randomize_va_space=2`, test the specific legacy application, and document any narrow exception |
+| Enabling IP forwarding on a workstation | The host inherited a router or Kubernetes baseline even though it does not intentionally route traffic | Set forwarding to `0` on non-routers and review firewall rules for any host that must forward |
+| Forgetting persistence | `sysctl -w` fixed the immediate incident, so nobody added the setting to `/etc/sysctl.d/` | Write the value to a named config file, reload with `sysctl --system`, and read the value back |
+| Breaking Kubernetes networking | A strict benchmark script disabled forwarding or bridge netfilter behavior required by the CNI | Keep required Kubernetes settings, document the exception, and validate pod-to-pod and service traffic |
+| Verifying only one interface | The audit checked `all` but missed `default` or per-interface values created later | Check aggregate, default, and live interface paths under `/proc/sys/net/ipv4/conf/` |
+| Treating scanner output as design | The team assumes every benchmark line applies equally to every host role | Evaluate the rule, identify role-specific exceptions, and record compensating controls |
+| Leaving diagnostics wide open | Debugging convenience wins over least privilege after an outage | Restrict ptrace, dmesg, perf, and pointer visibility by default, then use a temporary break-glass workflow |
 
 ## Quiz
 
-### Question 1
-A security scanner flags a node because `kernel.randomize_va_space` is set to 0. A junior admin argues that changing it might break legacy applications. What is the actual risk of leaving it at 0, and what exactly does changing it to 2 do to protect the system?
+<details><summary>Your team applies a strict CIS script to a Kubernetes worker, and pods on that node can no longer reach pods on other nodes. What do you check first, and why?</summary>
 
-<details>
-<summary>Show Answer</summary>
-
-Leaving `kernel.randomize_va_space` at 0 completely disables Address Space Layout Randomization (ASLR), meaning the kernel loads memory segments like the stack, heap, and libraries at predictable, static addresses every time a program runs. This predictability allows attackers to craft reliable buffer overflow exploits, as they know exactly where their malicious payload or standard system functions (like libc) reside in memory. Changing the value to 2 enables full randomization, which mathematically shifts these memory areas to random locations on every execution. Consequently, the attacker's hardcoded memory jumps will fail, usually resulting in a harmless application crash rather than a successful system compromise.
+Start with `net.ipv4.ip_forward` because Kubernetes workers commonly need the host kernel to forward pod traffic between virtual and physical network paths. A generic server baseline may set it to `0`, which is sensible for non-routers but harmful for a node that intentionally routes pod traffic. You should also check bridge netfilter settings and whether `br_netfilter` is loaded, because service and policy behavior can depend on bridged traffic passing through netfilter hooks. The reasoning is role-based: the same control can be correct on a workstation and wrong on a Kubernetes worker.
 
 </details>
 
-### Question 2
-You applied a strict CIS benchmark script to a new Kubernetes worker node. Suddenly, pods on this node cannot communicate with pods on any other node, though they can reach the internet. Which sysctl parameter was likely altered by the script, and why is this parameter mandatory for Kubernetes but discouraged for regular servers?
+<details><summary>A scanner flags `kernel.randomize_va_space=0`, and an application owner says ASLR is optional because containers isolate the workload. How do you evaluate that claim?</summary>
 
-<details>
-<summary>Show Answer</summary>
-
-The script likely set `net.ipv4.ip_forward` to 0, which entirely disables the Linux kernel's ability to route packets between different network interfaces. In a Kubernetes environment, the host system acts as a router for the pod network, moving traffic from the physical network interface (like eth0) to the virtual bridge interfaces used by the pods. If this forwarding is disabled, the host drops any packets not explicitly destined for its own IP address, instantly breaking pod-to-pod communication across the cluster. While mandatory for Kubernetes, this setting is heavily discouraged on standard servers because it can inadvertently turn a misconfigured machine into an open router, allowing attackers to pivot traffic through it to bypass network segmentation.
+Containers do not remove the need for process memory hardening because a vulnerable process can still be exploited inside its own container boundary. ASLR makes return-oriented and return-to-libc style exploitation less reliable by moving memory regions away from predictable addresses. You should set `kernel.randomize_va_space=2` unless there is a specific, tested legacy failure, and that exception should be narrow and documented. The key point is that ASLR reduces exploit reliability after a software bug exists; it is not replaced by container packaging.
 
 </details>
 
-### Question 3
-During a suspected DDoS attack, your web server's CPU spikes, and legitimate users report connection timeouts. A tcpdump shows thousands of incoming TCP segments with the SYN flag set, but no completing ACKs from the clients. Which sysctl setting should you verify is active, and how does it mathematically solve this state exhaustion problem?
+<details><summary>During a SYN flood, you see many incoming SYN packets and few completed handshakes. Which setting do you verify, and what does it change about server state?</summary>
 
-<details>
-<summary>Show Answer</summary>
-
-You need to verify that `net.ipv4.tcp_syncookies` is set to 1. In a standard TCP handshake, the server allocates memory for a half-open connection upon receiving a SYN packet, which an attacker can exploit by sending millions of spoofed SYNs to exhaust the server's memory queue (a SYN flood). When SYN cookies are enabled, the server stops allocating this memory queue under heavy load. Instead, it mathematically hashes the connection details into the sequence number of its SYN-ACK response and "forgets" the connection. When a legitimate client responds with the final ACK, the server reconstructs the connection state from the acknowledged sequence number, effectively dropping the spoofed traffic without exhausting local resources.
+Verify `net.ipv4.tcp_syncookies=1`. Without SYN cookies, the server can allocate state for many half-open connections and exhaust queues or memory while waiting for ACKs that never arrive. With SYN cookies under pressure, the server encodes enough information in the SYN-ACK sequence number to reconstruct state only when a legitimate client completes the handshake. This does not solve upstream bandwidth exhaustion, but it reduces one kernel-level state exhaustion path.
 
 </details>
 
-### Question 4
-You successfully mitigated an attack by running `sudo sysctl -w net.ipv4.tcp_syncookies=1` at 2:00 AM. A week later, the server is rebooted for patching, and the attack succeeds again. Why did the mitigation fail after the reboot, and what is the proper operational procedure to ensure the setting survives a restart?
+<details><summary>A developer cannot attach `strace` to a production process after a hardening rollout. Which control is likely involved, and how should the team respond?</summary>
 
-<details>
-<summary>Show Answer</summary>
-
-The mitigation failed because the `sysctl -w` command only modifies the kernel parameter in the running memory, making it a temporary, ephemeral change. When the system was rebooted for patching, the kernel reloaded its default parameters or read from its configuration files, dropping your emergency mitigation. To ensure a sysctl configuration survives a system restart, you must write the parameter into a configuration file, typically located in the `/etc/sysctl.d/` directory. For example, saving `net.ipv4.tcp_syncookies = 1` into `/etc/sysctl.d/99-security.conf` guarantees that the system initialization process will apply the hardening rule every time the operating system boots.
+The likely control is `kernel.yama.ptrace_scope`, which restricts which processes can trace other processes. That restriction is valuable because unrestricted tracing can expose secrets in memory or allow process manipulation across workload boundaries. The response should not be to disable the control permanently; the team should use a documented break-glass workflow with temporary access, logging, and restoration checks. This preserves production security while still allowing deeper diagnostics when they are justified.
 
 </details>
 
-### Question 5
-A developer is troubleshooting a crashing pod on a production node and tries to use `strace` to attach to the running process. The command fails with "Operation not permitted", even though they have the necessary RBAC permissions to exec into the container. Which kernel parameter is blocking this action, and why is this restriction considered a critical security control in shared environments?
+<details><summary>An incident responder runs `sudo sysctl -w net.ipv4.tcp_syncookies=1`, but the same weakness returns after the next patch reboot. What failed operationally?</summary>
 
-<details>
-<summary>Show Answer</summary>
-
-The developer is being blocked by `kernel.yama.ptrace_scope`, which is likely set to 1 or higher. The `ptrace` system call allows one process to inspect and manipulate the internal memory and execution state of another process, which is how debuggers like `strace` or `gdb` function. While useful for debugging, unrestricted ptrace access is a massive security risk in a shared environment like Kubernetes, because a compromised process could attach to another process to steal cryptographic keys, read sensitive memory, or inject malicious code. Setting this parameter to 1 restricts tracing so that a process can only be debugged by its direct parent, effectively neutralizing cross-process memory harvesting attacks while still allowing basic system stability.
+The responder changed only the live kernel value and did not persist the setting in a sysctl configuration file. Runtime changes made with `sysctl -w` disappear when the kernel boots again and reloads configuration from disk. The correct procedure is to add the value to a reviewed file such as `/etc/sysctl.d/99-hardening.conf`, run `sudo sysctl --system`, and read the value back. The incident record should also explain why the setting changed so future reviewers understand the intent.
 
 </details>
 
----
+<details><summary>A RHEL node shows `..5....T. /usr/bin/ssh` from `rpm -V`, while AIDE reports the same binary changed. What conclusion is reasonable, and what should happen next?</summary>
+
+That evidence suggests a package-owned binary no longer matches the package database and the integrity baseline, which is suspicious unless a documented package update or approved replacement explains it. The team should treat the host as potentially compromised, preserve evidence, and compare the finding with package manager logs and change records. Reinstalling the package may restore the file, but it does not answer how the change happened. For a high-risk binary such as SSH, rebuilding the node from trusted artifacts is often safer than trying to clean it in place.
+
+</details>
+
+<details><summary>You are asked to evaluate a benchmark rule that disables reverse path filtering exceptions on every interface. What makes this a design decision instead of a simple pass or fail?</summary>
+
+Reverse path filtering blocks packets whose source address does not make sense for the interface where they arrived, which is useful against spoofing. The complication is that asymmetric routing, multi-homed hosts, and some overlay networks can have legitimate traffic patterns that strict filtering rejects. You should inspect the node role, routing table, CNI behavior, and per-interface values before deciding. The final answer should document whether strict filtering is safe everywhere, safe only on selected interfaces, or replaced by another anti-spoofing control.
+
+</details>
 
 ## Hands-On Exercise
 
-### Kernel Hardening
+This exercise has you audit a Linux host, apply a persistent hardening file, test visible effects, and compare your result with a small CIS-style audit. Run it on a disposable lab machine, not on a production node, because network and tracing controls can affect connectivity and debugging. If you adapt the commands for Kubernetes, keep the node-role exceptions from this module in mind before changing forwarding or bridge behavior.
 
-**Objective**: Audit and harden kernel parameters.
+### Setup
 
-**Environment**: Linux system with root access
+You need a Linux system with root access and permission to change sysctl values. A throwaway VM, lab instance, or Killercoda environment is ideal because you can reboot, reload, and inspect without risking shared workloads. Record the original values before changing anything so that you can explain what the hardening file actually changed.
 
-#### Part 1: Audit Current Settings
+### Task 1: Audit Current Settings
+
+Read the current kernel values and classify each one as acceptable, suspicious, or role-dependent. Your goal is not to pass a script yet; your goal is to build a small evidence set that explains the host's current posture.
 
 ```bash
 # 1. Check ASLR
@@ -541,7 +622,15 @@ sysctl fs.protected_hardlinks
 sysctl fs.protected_symlinks
 ```
 
-#### Part 2: Create Hardening Config
+<details><summary>Solution guidance for Task 1</summary>
+
+Expected secure values include ASLR set to `2`, redirects and source routing disabled, SYN cookies enabled, and filesystem link protections enabled. IP forwarding depends on the host role: it should usually be `0` on a normal server and `1` on a Kubernetes worker or another intentional router. If a key is missing, check kernel module dependencies or distribution support rather than assuming the system is safe.
+
+</details>
+
+### Task 2: Create Hardening Config
+
+Create a persistent configuration file and apply it with the system loader. Read the output carefully, because unknown keys or module-dependent settings can appear during reload.
 
 ```bash
 # 1. Create hardening file
@@ -590,7 +679,15 @@ sysctl kernel.randomize_va_space
 sysctl net.ipv4.tcp_syncookies
 ```
 
-#### Part 3: Test Impact
+<details><summary>Solution guidance for Task 2</summary>
+
+The reload should apply the values from `/etc/sysctl.d/99-security-hardening.conf`, and the read-back commands should show ASLR at `2` and SYN cookies at `1`. If your environment is a Kubernetes worker, review IP forwarding separately before adding any forwarding rule to this file. A clean implementation includes the file, the reload output, and the final read-back evidence.
+
+</details>
+
+### Task 3: Test Impact
+
+Run a few visible checks that connect the settings to behavior. These tests are intentionally simple; they help you see that hardening changes can affect process layout, kernel logs, and debugging permissions.
 
 ```bash
 # 1. Test ASLR (run multiple times)
@@ -605,7 +702,15 @@ strace -p 1 2>&1 | head -3
 # Should fail with permission error
 ```
 
-#### Part 4: Compare with CIS Benchmark
+<details><summary>Solution guidance for Task 3</summary>
+
+The stack mapping should vary between runs when ASLR is active, although exact formatting differs by distribution. Martian logs may be empty on a quiet lab system, which is not a failure by itself. The `strace` test should fail for an unprivileged user when ptrace restrictions are active, and that failure is useful evidence that the control is affecting cross-process debugging.
+
+</details>
+
+### Task 4: Compare with CIS Benchmark
+
+Create a small audit script that checks representative settings and reports pass or fail. This is not a complete CIS scanner, but it demonstrates how to turn a baseline into repeatable evidence.
 
 ```bash
 # Create a simple audit script
@@ -635,39 +740,45 @@ chmod +x /tmp/audit-sysctl.sh
 /tmp/audit-sysctl.sh
 ```
 
+<details><summary>Solution guidance for Task 4</summary>
+
+Each expected value should report pass if the hardening file loaded correctly. If a value fails, read it directly with `sysctl`, inspect other sysctl files for overrides, and confirm whether the value is role-dependent. Do not force a Kubernetes exception into a generic audit without noting why the exception exists.
+
+</details>
+
+### Task 5: Write the Operational Decision
+
+Summarize your baseline in a short note that another operator could review during an incident. Include the host role, the values you changed, any role-dependent exception, and the commands you used to verify the final state. The skill you are practicing is not only applying settings; it is making kernel hardening explainable.
+
+<details><summary>Solution guidance for Task 5</summary>
+
+A good note states whether the host is a normal server or Kubernetes node, names the sysctl file you created, lists the settings that changed, and explains any forwarding decision. It should also include read-back evidence from `sysctl` and the output of the audit script. If the host is a Kubernetes worker, the note should explicitly say why IP forwarding remains enabled and which controls reduce the added risk.
+
+</details>
+
 ### Success Criteria
 
-- [ ] Audited current kernel parameters
-- [ ] Created persistent hardening configuration
-- [ ] Verified settings were applied
-- [ ] Understand the purpose of key parameters
-- [ ] Ran basic CIS compliance check
+- [ ] Audited current kernel parameters and recorded the original values.
+- [ ] Created persistent hardening configuration in `/etc/sysctl.d/`.
+- [ ] Verified settings were applied with read-back commands.
+- [ ] Explained the purpose and tradeoff of key network, memory, and filesystem parameters.
+- [ ] Ran a basic CIS-style compliance check and interpreted any failure.
+- [ ] Documented whether Kubernetes node-role exceptions are needed.
 
----
+## Next Module
 
-## Key Takeaways
+Next up: [Module 4.2: AppArmor Profiles](/linux/security/hardening/module-4.2-apparmor-profiles/) shows how mandatory access control constrains what applications can do after the kernel and node baseline are in place.
 
-1. **sysctl controls kernel behavior** — Hundreds of tunable parameters
-
-2. **Network hardening is critical** — Disable redirects, source routing, enable SYN cookies
-
-3. **Memory protection matters** — ASLR, ptrace restrictions, pointer hiding
-
-4. **Persistence requires files** — Use /etc/sysctl.d/ for permanent changes
-
-5. **Kubernetes needs some "insecure" settings** — IP forwarding, bridge netfilter
-
----
-
-## What's Next?
-
-In **Module 4.2: AppArmor Profiles**, you'll learn mandatory access control for applications—constraining what programs can do beyond traditional permissions.
-
----
-
-## Further Reading
+## Sources
 
 - [Linux Kernel sysctl Documentation](https://www.kernel.org/doc/Documentation/admin-guide/sysctl/)
 - [CIS Benchmark for Linux](https://www.cisecurity.org/benchmark/distribution_independent_linux)
 - [NSA Linux Hardening Guide](https://media.defense.gov/2020/Aug/18/2002479461/-1/-1/0/HARDENING_YOUR_SYSTEMS.PDF)
 - [Red Hat Security Hardening](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/)
+- [Linux kernel IP sysctl documentation](https://docs.kernel.org/networking/ip-sysctl.html)
+- [Linux kernel Magic SysRq documentation](https://docs.kernel.org/admin-guide/sysrq.html)
+- [Linux kernel sysctl admin guide](https://docs.kernel.org/admin-guide/sysctl/index.html)
+- [Kubernetes install tools: Linux sysctl bridge prerequisites](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/)
+- [Kubernetes networking concepts](https://kubernetes.io/docs/concepts/cluster-administration/networking/)
+- [AIDE manual](https://aide.github.io/doc/)
+- [Red Hat rpm verify documentation](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/managing_software_with_the_dnf_tool/verifying-installed-packages_using-appstream)


### PR DESCRIPTION
## Summary
- Rewrote `src/content/docs/linux/security/hardening/module-4.1-kernel-hardening.md` for the #388 density, structure, alignment, and anti-leak gates.
- Cleared `revision_pending: false`.

## Verifier
- T0; body_words=5061, mean_wpp=61.0, median_wpp=64, short_rate=0.0, max_run=0, mean_sentence_length=20.2.
- Gates passed: density, structure, alignment, anti_leak, sources_min_10. Source reachability was skipped per dispatch command.

## Protected Assets
- Preserved protected assets: code blocks 21 before / 21 after; mermaid diagrams 1 before / 1 after; ASCII diagrams 0 before / 0 after; tables 1 before / 1 after.
- Preserved the original 4 source URLs and expanded Sources to 11 URLs total.

## Checks
- `../../.venv/bin/python scripts/quality/verify_module.py --glob src/content/docs/linux/security/hardening/module-4.1-kernel-hardening.md --skip-source-check --summary --quiet` - pass, T0.
- `../../.venv/bin/python scripts/test_pipeline.py` - pass, 166 tests OK.
- `git diff --check -- src/content/docs/linux/security/hardening/module-4.1-kernel-hardening.md` - clean.
- `npm run build` - not run: primary checkout is currently on `pr804` with unrelated dirty files, so I did not alter it or build from this worktree against repo instructions.

Commit SHA: 8724cd345ceee03f5e6c7aa99a961bc486500a3b