### PR TITLE
feat(388): rewrite module-1.1-what-are-containers (#388 pilot)

### DIFF
--- a/src/content/docs/prerequisites/cloud-native-101/module-1.1-what-are-containers.md
+++ b/src/content/docs/prerequisites/cloud-native-101/module-1.1-what-are-containers.md
@@ -1,39 +1,35 @@
 ---
-revision_pending: true
+revision_pending: false
 title: "Module 1.1: What Are Containers?"
 slug: prerequisites/cloud-native-101/module-1.1-what-are-containers
 sidebar:
   order: 2
 ---
-> **Complexity**: `[QUICK]` - Foundational concepts
->
-> **Time to Complete**: 30-35 minutes
->
-> **Prerequisites**: None
+# Module 1.1: What Are Containers?
 
----
+**Complexity**: `[QUICK]` - Foundational concepts. **Time to Complete**: 30-35 minutes. **Prerequisites**: none beyond a terminal for the optional Docker lab and curiosity about why deployment environments drift.
 
 ## What You'll Be Able to Do
 
-After this module, you will be able to:
-- **Explain** what containers are and the specific problem ("works on my machine") they solve
-- **Compare** containers to virtual machines and explain when you'd use each
-- **Describe** how containers use Linux kernel features (namespaces, cgroups) to isolate applications
-- **Predict** what happens when a container is stopped and restarted (what persists, what doesn't)
+After this module, you will be able to make practical decisions about packaging, isolation, repeatability, and state instead of treating containers as a vague deployment buzzword.
 
----
+- **Debug** an environment drift failure by separating application code, dependencies, configuration, and host assumptions.
+- **Compare** containers with virtual machines and choose the safer packaging model for a given workload.
+- **Diagnose** how namespaces, cgroups, and layered filesystems shape container behavior during runtime failures.
+- **Evaluate** container image names, registries, and tags for repeatable deployment risk.
+- **Design** a simple persistence plan that avoids losing state when a container is replaced.
 
 ## Why This Module Matters
 
-Containers are the building blocks of modern application deployment. Before you can understand Kubernetes (a container orchestrator), you need to understand what containers are and what problems they solve.
+At a payments company preparing for a holiday launch, a small Node.js service passed every test on developer laptops and failed only after the release train reached production. The application needed a native library that was present on one engineer's workstation, missing from the production host, and quietly different on the staging machine. The outage window was measured in hours, refunds had to be issued manually, and the postmortem did not blame a single bad line of business logic. It blamed an invisible gap between the application the team thought it had shipped and the environment that actually ran it.
 
-This isn't about memorizing technical details—it's about understanding the "why" that makes everything else make sense.
+That failure is the reason containers matter before Kubernetes matters. Kubernetes is an orchestrator, which means it schedules, restarts, connects, and scales running containers, but it does not magically make a vague application package precise. If a team cannot explain what is inside a container image, what is borrowed from the host kernel, what disappears when a container is replaced, and what must be pinned for repeatability, Kubernetes turns those misunderstandings into faster-moving production incidents.
 
----
+This module builds the mental model you will use throughout the cloud native track. You will treat a container as an isolated Linux process with a packaged filesystem, not as a tiny virtual machine or a persistent server. That distinction seems simple, but it explains why containers start quickly, why the same image can run on a laptop and in a cluster, why memory limits matter, why `latest` tags cause surprises, and why storage must be designed deliberately. Later Kubernetes examples assume version 1.35 or newer, and when kubectl appears in those labs you will see the standard shorthand introduced as `alias k=kubectl` before commands use `k`.
 
-## The Problem Containers Solve
+## The Problem Containers Solve: Environment Drift
 
-### The Classic Deployment Problem
+Every useful application depends on more than its source code. It depends on a runtime, system libraries, file paths, environment variables, certificates, startup commands, and small operating-system details that are easy to forget because they sit outside the Git repository. When a developer says, "it works on my machine," they are usually telling the truth, but the statement is incomplete. The application works inside one assembled environment, while production is a different assembled environment with different history.
 
 ```text
 Developer: "It works on my machine!"
@@ -43,19 +39,8 @@ Operations: "Production has Python 3.7, different libraries, different paths..."
 Everyone: [Frustrated sigh]
 ```
 
-This is the **environment consistency problem**. Applications depend on:
-- Operating system version
-- Runtime versions (Python, Node, Java)
-- Library versions
-- Configuration files
-- Environment variables
-- File paths
+The classic response was documentation. A careful team wrote a README that listed every installation step, every package manager command, every environment variable, and every manual tweak needed to prepare a server. That was better than tribal knowledge, but it still relied on humans replaying mutable instructions perfectly against machines that were already drifting. Documentation describes an environment; it does not freeze one.
 
-When any of these differ between development and production, things break.
-
-### Traditional Solutions (That Didn't Scale)
-
-**Solution 1: Detailed Documentation**
 ```text
 README.md:
 1. Install Python 3.9.7
@@ -65,7 +50,8 @@ README.md:
 (Nobody reads this. When they do, it's outdated.)
 ```
 
-**Solution 2: Virtual Machines**
+Virtual machines solved a larger slice of the problem by packaging an entire guest operating system with the application. That gave teams a repeatable server image, strong isolation, and a way to carry custom OS assumptions forward. The tradeoff was weight. A VM image can be large, slow to start, and expensive to multiply across many small services, especially when each service needs only a process, a runtime, and a few libraries rather than a whole independent operating system.
+
 ```text
 Ship the entire operating system:
 - Works consistently
@@ -75,7 +61,7 @@ Ship the entire operating system:
 - Hard to manage at scale
 ```
 
-### The Container Solution
+Containers were the practical middle path. Instead of shipping the whole computer, a container image packages the application and the user-space pieces it needs, then runs that package as an isolated process on a shared host kernel. The host still provides the Linux kernel, device access, and low-level scheduling, but the application sees its own filesystem, process tree, network view, and resource boundaries. The result is lighter than a VM and more precise than a README.
 
 ```text
 What if we could package:
@@ -89,9 +75,19 @@ Into a lightweight, portable unit that runs the same everywhere?
 That's a container.
 ```
 
----
+The practical difference is ownership. Without containers, production often owns the runtime environment and application teams negotiate against it. With containers, the application package declares its own runtime, dependencies, and startup command, while the platform provides a compatible kernel and runtime. That boundary does not remove operational responsibility, but it gives both sides a clearer contract: the image says what to run, and the platform decides where and under what limits it can run.
+
+Pause and predict: if a Python service uses a native library installed on the developer laptop but not on the production host, what should change when the service is packaged as a container image? The correct expectation is not that the host suddenly becomes cleaner. The important change is that the service now carries the needed user-space dependency inside the image, so the host's missing package is no longer part of the runtime contract.
+
+This contract is especially useful for teams that deploy many small services. A platform team cannot safely hand-tune every server for every application version, and an application team cannot debug every production host by memory. Containers make the application artifact more complete, which lets automation do repeatable work. A scheduler can pull an image, start a process, enforce limits, restart a failed instance, and repeat the same action across hundreds of machines without reinterpreting a setup guide.
+
+Another way to say this is that containers move deployment knowledge from a human checklist into a machine-readable artifact. The difference is not merely convenience. A checklist can be skipped, interpreted differently, or applied to a server that already has old packages installed. An image records the filesystem and startup metadata that the runtime will use, so the deployment system has a concrete object to fetch, verify, cache, and run.
+
+That machine-readable artifact also changes how teams investigate failures. Instead of asking whether the staging host had the same Python patch level as production, the team can ask which image digest was running in each environment. Instead of comparing manual setup histories, they compare artifacts and runtime settings. This does not make all failures easy, but it removes a whole class of guesswork from the first hour of incident response.
 
 ## Containers vs. Virtual Machines
+
+The shortest useful comparison is this: a virtual machine virtualizes hardware and runs its own operating-system kernel, while a container isolates processes that share the host kernel. That difference explains nearly every operational tradeoff. VMs are heavier but can carry a different kernel and provide hardware-level isolation. Containers are lighter but assume kernel compatibility with the host. Neither is universally better; each solves a different packaging and isolation problem.
 
 ```mermaid
 flowchart BT
@@ -117,7 +113,7 @@ flowchart BT
     end
 ```
 
-### Key Differences
+The diagram shows why startup time and density differ. A VM boots a guest OS before the application can run, so it carries kernel initialization, device models, background services, and a larger image. A container runtime starts a process with isolation already provided by the host kernel, so startup can feel close to launching any other Linux process. That speed matters when a scheduler replaces failed instances or adds capacity during a traffic spike.
 
 | Aspect | Virtual Machine | Container |
 |--------|-----------------|-----------|
@@ -128,24 +124,23 @@ flowchart BT
 | Portability | VM image formats vary | Universal container images |
 | Density | ~10-20 VMs per server | ~100s of containers per server |
 
-### When to Use Which
+The table should not be read as a scoreboard where every smaller number wins. Hardware virtualization is the right tool when a workload requires a different operating system kernel, custom kernel modules, or a stronger isolation boundary between tenants. A legacy Windows Server application does not become Linux-compatible because it is packaged in a Linux container. If it needs Windows kernel behavior, it needs a Windows environment, usually a VM or a Windows container on a Windows host.
 
-- **Use Virtual Machines when**: You need strict, hardware-level isolation, require a completely different operating system (e.g., Windows on a Linux host), or need a specific, custom kernel.
-- **Use Containers when**: You want to maximize server density, require fast startup times, and are deploying modern applications that can share the host OS.
+Containers fit modern services that can share the host kernel and benefit from rapid replacement. A stateless API, background worker, queue consumer, or web frontend usually needs a predictable runtime more than it needs its own guest OS. That is why containers became the default unit for Kubernetes: the cluster can treat applications as disposable, repeatable processes instead of long-lived pets that must be patched and tuned in place.
 
-> **Stop and think**: You are tasked with migrating a 15-year-old monolithic application that requires a custom, heavily modified version of the Linux kernel to run properly. Would you choose to containerize this application or run it in a Virtual Machine? (Hint: Think about what containers share vs. what VMs provide).
+There is still a security tradeoff. A VM boundary is not invulnerable, but it is a different boundary from a container namespace and cgroup boundary. If a container breakout vulnerability appears in the kernel or runtime, multiple containers on the same host may be in scope. Sensible teams respond by combining controls: minimal images, non-root users, read-only filesystems where possible, runtime profiles, frequent patching, and separate nodes for workloads with different trust levels.
 
----
+Which approach would you choose here and why: a 15-year-old monolith requires a custom Linux kernel patch, while a new Go API only needs a CA bundle and a configuration file? The monolith is a VM candidate because the kernel assumption is part of the workload. The Go API is a container candidate because its dependencies live comfortably in user space and it benefits from fast, repeatable replacement.
 
-## How Containers Work
+A useful operational test is to ask where the workload's weirdness lives. If the weirdness is in kernel behavior, device access, or a proprietary operating-system dependency, a VM may be the honest package. If the weirdness is in user-space libraries, language runtimes, files, and environment variables, a container is usually a cleaner package. Teams get into trouble when they choose containers because they are fashionable rather than because the workload's assumptions fit the container boundary.
 
-> **Stop and think**: If containers aren't virtual machines, how do they isolate applications? A VM creates a completely separate operating system. Containers share the host's OS kernel but trick each process into thinking it has its own filesystem, network, and process tree. The trick is in Linux itself — two kernel features called namespaces (for isolation) and cgroups (for resource limits).
+Cost also needs a precise definition. Containers can improve density because many isolated processes share one kernel, but the platform still needs CPU, memory, storage, network bandwidth, logging, monitoring, and patching. A node packed with containers is still a node that can fail. Container density is valuable only when the team also designs limits, health checks, rollout strategy, and failure isolation around that density.
 
-Containers use Linux kernel features to create isolated environments:
+## How Containers Work: Isolation, Limits, and Layers
 
-### 1. Namespaces (Isolation)
+A container feels like a small machine because the process inside it sees a filtered view of the system. That feeling is useful, but it is also where many beginner mistakes begin. The container is not booting a private Linux kernel. It is a normal process, or a small group of processes, launched with kernel features that give it private names for things like process IDs, network interfaces, mounts, hostnames, and users.
 
-Namespaces make a process think it has its own system:
+Namespaces provide that private view. A process namespace can make a containerized process appear to be PID 1 inside the container even though the host sees it as a regular process with a regular host PID. A network namespace gives the container its own interfaces, routes, and port space. A mount namespace gives it a filesystem view assembled from image layers and runtime mounts. The application is not alone on the machine, but it is given a convincing local view.
 
 ```mermaid
 flowchart LR
@@ -162,11 +157,11 @@ flowchart LR
     Namespaces --> Result
 ```
 
-> **Pause and predict**: Imagine the `NET` (Network) namespace isolation completely failed, but all other namespaces kept working. What specific disaster would happen if you tried to run three separate web server containers on the same host, all configured to listen on port 80?
+The network namespace example makes the idea concrete. Three containers can each run a web server listening on port 8080 because each container has its own network namespace. Inside each namespace, the port is available. The host or orchestrator then decides which container ports are published, proxied, or connected to a service network. If every process shared the host network namespace by default, the second web server would collide with the first.
 
-### 2. Control Groups (Resource Limits)
+Pause and predict: imagine the `NET` namespace isolation failed while the other namespaces kept working. Three web server containers all try to listen on the same port, and only one can bind successfully on the shared host network stack. The failure would look like an ordinary "port already in use" error, but the root cause would be that the platform lost the network illusion containers rely on.
 
-cgroups limit how much resource a container can use:
+Resource limits come from control groups, usually called cgroups. Namespaces decide what a process can see. Cgroups decide how much CPU, memory, and other resources the process group can consume. This matters because isolation without limits is only a partial defense. A runaway memory leak in one application should not be allowed to starve the database, the node agent, or unrelated containers on the same host.
 
 ```mermaid
 flowchart LR
@@ -178,9 +173,9 @@ flowchart LR
     style Host fill:#f9f,stroke:#333,stroke-width:2px
 ```
 
-### 3. Union Filesystems (Layered Images)
+Cgroups also explain why Kubernetes resource requests and limits are more than scheduling decoration. A memory limit becomes an enforcement boundary, and a container that exceeds it can be killed rather than taking down the node. A CPU limit affects scheduling and throttling behavior. The exact mechanics differ by runtime and cgroup version, but the operational lesson is stable: a container is not inherently polite. You must give the platform enough information to protect neighboring workloads.
 
-Container images are built in layers:
+The third major idea is the layered filesystem. A container image is built from layers, and each layer records filesystem changes from a build step. Layers can be cached, shared, downloaded once, and reused by many images. When a container starts, the runtime gives it a writable layer on top of the read-only image layers. That writable layer belongs to the container instance, not to the image blueprint.
 
 ```mermaid
 flowchart BT
@@ -199,30 +194,19 @@ flowchart BT
     style L4 fill:#bfb,stroke:#333,stroke-width:2px
 ```
 
-Benefits:
-- Layers are shared between images
-- Only changed layers need rebuilding
-- Efficient storage and transfer
+Layering is why image build order affects performance. If the dependency installation layer changes rarely, it can be reused while small application code changes rebuild only the top layer. If a Dockerfile copies the entire source tree before installing dependencies, a one-line code change may invalidate expensive dependency layers. Even before writing Dockerfiles in the next module, you should recognize layers as a storage, transfer, and build-cache mechanism rather than as a decorative implementation detail.
 
----
+A useful war story ties these three ideas together. A Java service with a memory leak looked stable in staging because staging had little traffic and no memory limit. In production, the same leak expanded until the host began reclaiming memory aggressively and unrelated services slowed down. After the service was run with a real memory limit, it failed faster and more visibly, but the node survived. That was progress: a contained failure is easier to diagnose than a host-wide brownout.
 
-## Container Images and Registries
+The container runtime is the component that applies these kernel features and starts the process. Docker made the workflow famous, but the broader ecosystem includes containerd, CRI-O, and OCI specifications that define image and runtime expectations. Kubernetes talks to container runtimes through the Container Runtime Interface, which is why you can learn the container model once and then apply it across different cluster implementations. The names change, but the image, process, namespace, cgroup, and filesystem ideas remain the foundation.
 
-### What's a Container Image?
+This is also why container debugging often begins by translating a symptom back to ordinary Linux behavior. A permission error may be a user ID, mount, or read-only filesystem issue. A connectivity problem may be a namespace, route, DNS, or port-publishing issue. A sudden restart may be an out-of-memory kill caused by a cgroup limit. Containers add packaging and isolation, but they do not repeal the operating-system rules underneath.
 
-A container image is a read-only template containing:
-- A minimal operating system (often Alpine Linux, ~5MB)
-- Your application code
-- Dependencies (libraries, runtimes)
-- Configuration
+One more detail matters before Kubernetes enters the story: container replacement is normal, not exceptional. The platform is expected to stop old instances and start new ones during rollouts, scaling events, node maintenance, and failure recovery. If the process can only survive by keeping hidden state in its writable layer, the container model will punish that design. If the process can reconstruct itself from image, configuration, and durable services, replacement becomes a routine operation.
 
-Think of it like a **class** in programming—it's the blueprint.
+## Images, Containers, Registries, and Tags
 
-### What's a Container?
-
-A container is a **running instance** of an image.
-
-Think of it like an **object**—it's the instantiation.
+A container image is a read-only template that contains the filesystem and metadata needed to start a container. It usually includes application code, a runtime, libraries, certificates, default environment values, and a command. A container is a running instance created from that template. The programming analogy is not perfect, but it is useful: an image is like a class or blueprint, while a container is like an object or constructed building.
 
 ```text
 Image → Container
@@ -231,9 +215,9 @@ Image → Container
 (Recipe → Meal)
 ```
 
-### Container Registries
+The distinction matters during scaling. If an ecommerce site needs more cart service capacity, the orchestrator does not build new images for each new instance. It starts more containers from an existing image. Building is a supply-chain activity, usually done by CI. Running is a scheduling activity, usually done by a runtime or orchestrator. Confusing those stages leads to slow deployments, unreproducible rollbacks, and mystery differences between instances.
 
-Images are stored in registries:
+Registries are where images are stored and discovered. Public registries such as Docker Hub are convenient for base images and open-source software. Cloud registries such as ECR, Artifact Registry, and Azure Container Registry are common for private application images near the compute platform. GitHub Container Registry and Quay are also common in open-source and enterprise workflows. The registry is not the runtime; it is the distribution point.
 
 ```mermaid
 flowchart LR
@@ -252,17 +236,14 @@ flowchart LR
     end
 ```
 
-Usage examples:
+Pulling an image downloads the referenced layers and metadata to a machine that can run containers. These examples are intentionally simple because the next module goes deeper into Docker commands. The important idea is that a pull resolves an image reference, downloads missing content, and prepares the runtime to create containers from that content. A successful pull does not mean the application is healthy; it means the image artifact was retrieved.
+
 ```bash
 docker pull nginx              # From Docker Hub
 docker pull gcr.io/project/app # From Google
 ```
 
----
-
-## Image Naming
-
-Container images have a specific naming format:
+Image references carry a specific structure. The registry portion is optional because Docker Hub is the default in many tools. A namespace or organization may be present. The repository identifies the image name, and the tag identifies a named version or channel. The danger is that tags are not guaranteed to be immutable unless your registry policy enforces it. A tag is a pointer, and pointers can move.
 
 ```text
 [registry/][namespace/]repository[:tag]
@@ -275,7 +256,7 @@ gcr.io/myproject/myapp:latest  # Google Container Registry
 ghcr.io/username/app:sha-abc123 # GitHub Container Registry
 ```
 
-### Tags Are Important
+Production deployments should avoid mutable tags like `latest` because they hide change. Running the same script on Monday and Thursday can produce different software if the tag was retargeted between runs. A version tag is better, and an image digest is stronger because the digest identifies content rather than a human-readable label. As you advance, you will see Kubernetes manifests that pin images carefully so a rollout can be audited and repeated.
 
 ```text
 nginx:latest     # Whatever is newest (unpredictable!)
@@ -285,38 +266,17 @@ nginx:1.25.3     # Exact version (best for production)
 Rule: Never use :latest in production
 ```
 
-> **War Story**: A startup deployed their database container using `postgres:latest`. It worked flawlessly for six months. One night, the server rebooted, pulling the new `:latest` image—which happened to be a major version upgrade with incompatible file formats. The database refused to start, resulting in 12 hours of downtime while they scrambled to downgrade and recover data. Pin your tags!
+A startup learned this the painful way after running `postgres:latest` for months. The container started cleanly after each routine restart until a host reboot pulled a newer major image with incompatible expectations for the data directory. The database refused to start, recovery required downgrading and careful data handling, and the team lost most of a night to a deployment choice that had looked harmless. Pinning tags is not bureaucracy; it is how you make time behave.
 
----
+Before running this in your own environment, what output would you expect if you pulled `nginx:1.25` twice in a row? The second pull should reuse layers already present locally unless the registry metadata has changed. That small observation previews a major operational benefit: layered images make repeated deployments cheaper because unchanged content does not need to move again.
 
-## Did You Know?
+Image naming also becomes a supply-chain control. A registry path can tell you who owns the artifact, a tag can tell you the intended release channel, and a digest can tell you the exact content. Mature teams use all three pieces deliberately. They avoid ambiguous image names, restrict who can push production repositories, scan images before promotion, and record the image reference used in each deployment so an incident can be traced to a precise artifact.
 
-- **Containers aren't new.** Unix had chroot in 1979. FreeBSD Jails came in 2000. Linux Containers (LXC) in 2008. Docker just made it accessible (2013).
+There is a social benefit too. When application teams and platform teams argue about a deployment, an image reference gives them a shared object to inspect. The application team can reproduce the artifact locally, while the platform team can inspect pull events, runtime settings, and node placement. Without that shared object, conversations drift back toward assumptions about which branch, package cache, or server setup was involved. Containers are not just technology; they are a coordination tool.
 
-- **Most containers use Alpine Linux** as their base. It's only 5MB. Compare to Ubuntu (~70MB) or a full VM (gigabytes).
+## The Shipping-Container Analogy and Ephemeral State
 
-- **Container images are immutable.** Once built, they never change. This is key to reproducibility.
-
-- **The Docker whale** is named Moby Dock. The whale carries containers (shipping containers) on its back.
-
----
-
-## Common Misconceptions & Costly Mistakes
-
-| Misconception / Mistake | Reality / Correction |
-|-------------------------|----------------------|
-| "Containers are lightweight VMs" | Containers share the host kernel. VMs have their own kernel. They are fundamentally different technologies. |
-| Treating containers like VMs | SSHing into containers to install updates or tweak configs is an anti-pattern. Containers should be immutable—if you need a change, build a new image. |
-| Storing data inside the container | Container filesystems are ephemeral by default. When the container dies, data dies. Always use external volumes for persistent data. |
-| "Containers are less secure" | Different threat model, not worse. Properly configured containers are very secure, but running everything as `root` inside a container is a common, dangerous mistake. |
-
----
-
-## The Analogy: Shipping Containers
-
-> **Pause and predict**: If you write data inside a running container — say, a log file or a database entry — and then the container crashes and restarts, do you think that data survives? This is one of the most important things to understand about containers, and getting it wrong has caused real data loss in production. Containers are *ephemeral* by default — their filesystem is temporary. Anything not stored in a volume disappears when the container dies.
-
-The name "container" comes from shipping containers:
+The word "container" comes from shipping containers because the software idea borrows the same standardization story. Before standardized cargo containers, freight handling was slow, fragile, and custom. Different goods needed different packing, ports needed specialized labor, and moving cargo between ship, rail, and truck involved repeated manual handling. Standard containers did not make cargo simple, but they made the interface around cargo predictable.
 
 ```text
 Before Shipping Containers (1950s):
@@ -341,154 +301,229 @@ Software Containers:
 - Fast, portable, reliable
 ```
 
----
+The analogy is powerful only if you keep its limits in mind. A shipping container standardizes the outside shape and handling equipment, not the value or fragility of what is inside. A software container standardizes packaging and runtime assumptions, not application correctness, schema design, or security posture. You can ship a broken application inside a flawless image just as easily as you can ship damaged goods in a strong steel box.
+
+The most important limit for beginners is persistence. A running container usually has a writable layer, but that layer belongs to that particular container instance. If the instance is removed and replaced, data written only to that layer is gone. This behavior is not a bug; it is what makes containers replaceable. The image remains clean, and a new container starts from the same known template.
+
+Pause and predict: if you write a log file or uploaded profile picture inside a running container and then remove the container, should the data survive? The safest answer is no unless you deliberately wrote it to external storage or a mounted volume. The container's internal filesystem is convenient scratch space, not a persistence plan. Many real outages begin with someone treating it like a small durable server disk.
+
+This is where the container mental model becomes operational rather than philosophical. Stateless processes are easy to replace because their important state lives elsewhere, such as in a database, queue, object store, or mounted volume. Stateful systems can run in containers, but they need explicit storage design, backup strategy, and careful lifecycle management. Kubernetes does not change that law; it gives you primitives such as volumes and StatefulSets, which still require correct design.
+
+A practical engineering habit is to ask, "What must survive replacement?" before choosing where data goes. Application binaries, libraries, and default configuration belong in the image. Temporary cache files may belong in the container filesystem if they can be rebuilt. User uploads, database files, message queues, and audit logs need external persistence. Once you sort data by replacement tolerance, the container lifecycle becomes much less mysterious.
+
+Designing persistence is not the same as refusing containers for stateful workloads. Databases and queues can run in containers when their storage, identity, backup, and recovery rules are designed carefully. The beginner mistake is running stateful software as if the container's writable layer were a durable disk. The professional approach is to separate the process package from the data lifecycle, then decide which platform primitives are responsible for each part.
+
+This separation also helps during local development. A developer may destroy and recreate an application container many times while keeping a local database volume for test data, or they may deliberately remove the volume to reset the environment. Both choices are valid when they are explicit. The danger is not ephemerality itself; the danger is accidental ephemerality where important data disappears because nobody named the boundary.
+
+## Patterns & Anti-Patterns
+
+Good container practice begins with treating images as immutable release artifacts. Build an image once in CI, scan it, tag it clearly, and promote that same artifact across environments. Do not rebuild "the same version" separately for dev, staging, and production because those builds may capture different base images or dependency versions. Promotion should move a known artifact forward, not recreate it and hope it matches.
+
+A second pattern is keeping containers focused on one primary process. This does not mean a container can never have helper processes, but it should have one clear responsibility, one lifecycle, and one health model. When a container behaves like a small general-purpose server with several unrelated daemons, restart behavior becomes confusing. A clean container should be easy to start, stop, observe, and replace.
+
+A third pattern is making state explicit. If data matters, put it in a volume, managed database, object store, or another durable system with a recovery plan. If data does not matter, allow it to disappear and document that expectation. Ambiguity is the risky middle ground, because engineers may assume a file is durable simply because it was visible during a shell session inside a running container.
+
+The common anti-pattern is treating containers like VMs. Teams SSH or exec into a running container, install packages by hand, edit configuration files, and then feel surprised when replacement erases the changes. That habit is understandable because many engineers learned operations on long-lived servers. In container operations, the better response is to modify the image build or deployment configuration, then roll out a new container instance.
+
+Another anti-pattern is trusting defaults as if they were production policy. Default tags, root users, unbounded resources, broad filesystem write access, and missing health checks may all work during a demo. Production turns those defaults into risk because the container is now part of a larger scheduling and failure-recovery system. Defaults are starting points for learning, not proof that a workload is ready.
+
+The final anti-pattern is pretending containers remove the need to understand Linux. Containers hide many details, but the failure modes still come from processes, filesystems, networking, permissions, and kernel resource enforcement. When a container cannot bind a port, cannot write a file, gets killed for memory, or cannot resolve a name, the diagnosis is often a Linux diagnosis through a container lens.
+
+Patterns also become more important as teams move from Docker on one laptop to Kubernetes across many nodes. A weak local habit can become a fleet-wide incident when automation repeats it quickly. Mutable tags, missing limits, root containers, and hidden writable state may all seem harmless in one manual test. In a scheduler, those choices are multiplied across rollouts, restarts, and scale events, so the cost of ambiguity rises sharply.
+
+## When You'd Use This vs Alternatives
+
+Use a container when the workload can share the host kernel, starts from a repeatable user-space package, and benefits from fast replacement. This is the default for most web APIs, workers, scheduled jobs, sidecars, and development environments. The stronger the need for automated rollout and horizontal scaling, the more valuable the container packaging model becomes.
+
+Use a virtual machine when the workload needs a different operating-system kernel, specialized kernel behavior, or a stronger isolation boundary than process isolation provides. VMs also remain useful when a team must run old software with server-level assumptions that would be expensive to untangle immediately. A VM can be a pragmatic bridge while the application is modernized gradually.
+
+Use direct host installation when the software is part of the host itself or when containerizing it would obscure more than it helps. Low-level agents, storage drivers, node bootstrapping tools, and some hardware integrations may need direct host access. Even then, teams often package the surrounding management plane in containers while leaving the host component installed by the operating system or configuration management.
+
+For a quick decision, ask four questions in order. Does the workload require a different kernel? If yes, prefer a VM. Does its important data survive process replacement somewhere explicit? If no, design storage before containerizing. Does it need fast repeatable rollout across environments? If yes, containers fit well. Does it require direct host control? If yes, containerize only the parts that can tolerate the boundary.
+
+The decision is rarely permanent. A team may start by putting a legacy application in a VM, extract a stateless API into containers, and later redesign storage so more components can move into Kubernetes. That staged approach is healthier than forcing every workload through the same packaging model at once. The goal is not to maximize container count; the goal is to make each workload's assumptions visible enough that operations can be automated safely.
+
+When you apply this framework in a real design review, listen for hidden lifecycle words. "Install," "patch," "tune," and "log in to fix" often describe server thinking, while "build," "promote," "replace," and "roll back" describe artifact thinking. Neither vocabulary is morally superior, but mixing them without noticing creates confusion. If the team says it wants containers yet also expects manual changes inside running instances, pause the design and clarify which parts belong in the image, which parts belong in configuration, and which parts belong in persistent services. That conversation is cheaper before the first deployment than during an incident.
+
+The same vocabulary check helps during reviews of learning labs. A command that creates a disposable process should be safe to repeat, while a command that creates durable data should name where that data lives. Beginners build confidence faster when the exercise makes that boundary visible instead of hiding it behind successful output.
+
+## Did You Know?
+
+- **Containers are older than Docker.** Unix had chroot in 1979, FreeBSD Jails arrived in 2000, Linux Containers appeared in 2008, and Docker made the workflow approachable in 2013.
+- **Alpine Linux is tiny by design.** A minimal Alpine base image is commonly only a few megabytes, while a general Ubuntu base is much larger and a full VM image can be measured in gigabytes.
+- **Container images are intended to be immutable release artifacts.** Once an image is built and identified by digest, changing behavior should mean building a new image rather than editing a running container by hand.
+- **The Docker whale is named Moby Dock.** The mascot works because the metaphor connects software containers to standardized shipping containers carried across different transport systems.
+
+## Common Mistakes
+
+| Mistake | Why It Happens | How to Fix It |
+|---------|----------------|---------------|
+| Calling containers "lightweight VMs" | The container shell feels like a small server, so beginners assume there is a private kernel inside. | Teach the shared-kernel model explicitly and reserve VMs for workloads that need a separate operating system. |
+| Treating running containers like pets | Engineers are used to SSHing into servers, installing packages, and preserving manual fixes. | Rebuild the image or change deployment configuration, then replace the container instead of mutating it. |
+| Storing durable data inside the container filesystem | Files appear to persist during one running instance, which hides the replacement boundary. | Mount a volume or use an external durable service for data that must survive container removal. |
+| Deploying `:latest` in production | The tag is convenient during demos and local experiments, but it is a moving pointer. | Pin a version tag or digest, and promote the same image artifact through environments. |
+| Running everything as root | Many base images default to root because it avoids early permission friction. | Create a non-root user where practical and grant only the filesystem and network privileges the process needs. |
+| Skipping resource limits | Small tests do not reveal what happens when traffic, leaks, or batch jobs consume the node. | Set memory and CPU boundaries appropriate to the workload, then observe throttling and kill behavior under load. |
+| Assuming containers are automatically secure | The packaging boundary feels strong, but vulnerable images, broad permissions, and old kernels still matter. | Patch base images, scan dependencies, reduce privileges, and keep the host runtime updated. |
 
 ## Quiz
 
-1. **Scenario**: A developer's Node.js application works perfectly on their MacOS laptop but crashes on the Ubuntu production server because of a missing C++ compilation library.
-   **Question**: How exactly does a container solve this specific issue?
+<details>
+<summary>Your team's Node.js application works on a macOS laptop but fails on Ubuntu because a native C++ library is missing. What should containerization change, and what should it not promise?</summary>
 
-   <details>
-   <summary>Answer</summary>
-   The container image packages not just the Node.js application code, but also the exact operating system runtime environment (e.g., a specific Debian base) and all system-level dependencies (like the C++ library). Because the container runs the exact same packaged environment on the laptop and the server, the missing library on the host Ubuntu server no longer matters. The application uses the packaged library inside the container, completely ignoring what is installed on the host. This guarantees that if it works on the developer's machine, it will work exactly the same way in production.
-   </details>
+A correct container image should package the application with the needed user-space runtime and library so the production host no longer needs that exact library installed globally. The container does not make macOS and Linux kernels interchangeable, and it does not remove the need to build for the target architecture and operating-system family. The win is that the runtime contract becomes part of the image artifact instead of a manual server setup assumption. If the image works in one compatible runtime, the same image should behave consistently in another compatible runtime.
+</details>
 
-2. **Scenario**: Your company has merged with another firm and inherited a critical legacy application that only runs on Windows Server 2012. Your infrastructure is entirely Linux-based.
-   **Question**: Can you package this Windows application in a standard container and run it on your Linux servers? Why or why not?
+<details>
+<summary>A legacy accounting application requires Windows Server kernel APIs, but your servers run Linux. Should you choose a standard Linux container or a VM?</summary>
 
-   <details>
-   <summary>Answer</summary>
-   No, you cannot. Containers are not full virtual machines; they inherently share the underlying host operating system's kernel to function. A standard container running on a Linux host relies entirely on the Linux kernel to execute its processes. A Windows application requires a Windows kernel and its specific APIs. To run this legacy application, you would need to either provision a Virtual Machine running a full Windows guest OS, or set up a dedicated Windows server capable of running Windows containers natively.
-   </details>
+Choose a VM, or another environment that provides the Windows kernel APIs the application requires. A Linux container shares the Linux host kernel, so it cannot satisfy a workload whose core assumption is a Windows kernel. This is the practical boundary between containers and VMs: containers package user space around a shared kernel, while VMs can carry a different guest operating system. Containerizing the application without addressing the kernel requirement would only move the failure into a different package.
+</details>
 
-3. **Scenario**: You launch three different web application containers on a single host server. All three applications are hardcoded to listen on port 8080.
-   **Question**: Why doesn't the host server throw a "Port already in use" error when the second and third containers start?
+<details>
+<summary>Three web containers each listen on port 8080, and all start successfully on the same host. What isolation feature explains that result?</summary>
 
-   <details>
-   <summary>Answer</summary>
-   This is due to the Linux `NET` (Network) namespace isolation feature. Each container is provisioned with its own completely isolated network stack, which includes its own virtual IP address and its own independent set of ports. From the perspective of each container, it is the only process running and using port 8080 on its specific isolated network interface. The host machine handles the complexity of routing incoming external traffic to the correct container's internal virtual IP and port, avoiding any conflicts on the host itself.
-   </details>
+Network namespaces explain why the containers can each use the same internal port without colliding. Each container has its own view of network interfaces, routes, and port bindings, so port 8080 inside one namespace is distinct from port 8080 inside another. The host or orchestrator can then map, proxy, or route external traffic to the intended container. If the containers all shared the host network namespace by default, only the first bind would succeed.
+</details>
 
-4. **Scenario**: A newly deployed Java application has a severe memory leak. Within minutes, it attempts to allocate 64GB of RAM, which is the entire capacity of the host server.
-   **Question**: If this application is running in a properly configured container, what prevents it from crashing the host server, and what Linux feature is responsible?
+<details>
+<summary>A Java service leaks memory until it tries to consume the whole host. What container mechanism limits the blast radius, and what failure should you expect?</summary>
 
-   <details>
-   <summary>Answer</summary>
-   The container will be forcefully terminated (OOMKilled - Out Of Memory) by the system before it can consume enough resources to crash the entire host. This protection relies on a Linux kernel feature called `cgroups` (Control Groups). Administrators use cgroups to enforce strict, hard limits on the maximum amount of CPU and memory a specific process or container can consume. By fencing in the memory usage, `cgroups` ensures that a runaway process is killed off, successfully protecting the host operating system and all other containers from resource starvation.
-   </details>
+Cgroups limit the memory available to the container's process group when a memory limit is configured. If the process exceeds that boundary, the runtime or kernel can terminate it instead of allowing it to starve the entire host. In Kubernetes, this often appears as an out-of-memory kill for the container, followed by restart behavior depending on the pod policy. That is still a service failure, but it is a contained service failure rather than a node-wide collapse.
+</details>
 
-5. **Scenario**: An e-commerce site experiences a massive spike in traffic during a flash sale. The single shopping cart container is overwhelmed, and the orchestrator needs to scale up to 10 instances immediately.
-   **Question**: Does the system need to build 9 new container images, or launch 9 new containers? Explain the difference.
+<details>
+<summary>During a flash sale, an orchestrator scales one cart service to ten running instances. Does it need nine new images or nine new containers?</summary>
 
-   <details>
-   <summary>Answer</summary>
-   The system will instantly launch 9 new containers from the 1 existing container image. A container image serves as a static, immutable, and read-only template or blueprint for your application. A container is simply the running, instantiated object created from that blueprint. Because the underlying image is an immutable template, the container orchestrator can rapidly stamp out as many identical running containers as your underlying hardware can support without needing to rebuild or download the application code again. This rapid instantiation is what makes containers so powerful for dynamic scaling.
-   </details>
+It needs nine new containers from the existing image, assuming the image is already built and available. The image is the immutable template produced by the build pipeline, while containers are running instances created from that template. This separation is why containers are useful for rapid scaling: the platform can stamp out more identical processes without rebuilding the application. If each scale event required a new image build, deployment speed and repeatability would collapse.
+</details>
 
-6. **Scenario**: A junior developer configures a containerized blogging platform to save uploaded user profile pictures directly to the `/var/www/uploads` directory inside the running container. Later that night, the container crashes and is automatically restarted.
-   **Question**: What happens to the users' profile pictures, and why?
+<details>
+<summary>A blogging platform saves uploaded profile photos under `/var/www/uploads` inside the running container, then the container is removed and recreated. What happened to the photos?</summary>
 
-   <details>
-   <summary>Answer</summary>
-   The uploaded profile pictures are permanently lost the moment the container crashes. By default, containers are completely ephemeral, meaning any data written to a container's internal, writable filesystem layer only exists for the lifecycle of that specific container instance. When the system restarts the container, a fresh, clean instance is created directly from the original read-only image, discarding all previous state. To ensure data persists across restarts, developers must explicitly configure external storage volumes and mount them into the container's filesystem.
-   </details>
+The photos are gone unless that path was backed by a mounted volume or another external storage system. The container's writable layer belongs to the specific container instance, and removing the instance discards that layer. A newly created container starts from the image again, which contains only what was built into the image. Durable user uploads must be stored outside the disposable container filesystem.
+</details>
 
-7. **Scenario**: You write a deployment script that pulls and runs `my-api:latest`. It works fine on Tuesday. On Thursday, you run the exact same script on a new server, and the application fails to start due to a database schema mismatch.
-   **Question**: Assuming the database hasn't changed, what is the most likely cause of this failure?
+<details>
+<summary>A deployment script pulls `my-api:latest` on Tuesday and succeeds, then pulls the same reference on Thursday and fails with a schema mismatch. What is the most likely packaging problem?</summary>
 
-   <details>
-   <summary>Answer</summary>
-   The `latest` tag is merely a mutable pointer, and it was highly likely updated to point to a new version of the image by the developers between Tuesday and Thursday. When the script ran on Thursday, it pulled this completely different, newer version of the application code that expected an updated database schema. This scenario directly violates the principle of predictable, repeatable deployments. You should always pin your deployments to specific, immutable version tags (such as `my-api:v1.2.4`) in production environments to mathematically guarantee the exact same code runs every single time.
-   </details>
-
----
+The `latest` tag probably moved to a different image between Tuesday and Thursday. Tags are human-readable pointers, and unless the registry enforces immutability, they can be retargeted to new content. The script looked repeatable because the text was the same, but the artifact behind the text changed. Pinning a version tag or digest gives the deployment a stable reference that can be audited and rolled back.
+</details>
 
 ## Hands-On Exercise: The Illusion of Isolation
 
-**Task**: Prove that a container is just an isolated process running on your host, not a magical separate machine. 
+This lab proves that a container is an isolated process, not a magical separate machine. You will start a long-running Alpine container, inspect its process view from inside, compare that with the host view, and then destroy data written only to the container filesystem. The exercise is intentionally small because the goal is not Docker fluency yet. The goal is to make the core mental model visible.
 
-**Requirements**: A terminal with Docker installed.
+Requirements: use a terminal with Docker installed. On a native Linux host, the process comparison is direct. On macOS or Windows with Docker Desktop, Docker runs a hidden Linux VM, so the host-process observation happens inside that VM rather than on the native desktop operating system. That difference is itself a useful reminder that containers share a compatible kernel somewhere.
 
-**Step 1: Start a long-running container process**
-Run a simple Alpine container that sleeps for an hour. Notice we run it in the background (`-d`).
+**Task 1: Start a long-running container process.** Run a simple Alpine container that sleeps for an hour. The `-d` flag starts it in the background so your terminal returns immediately while the process keeps running.
+
 ```bash
 docker run -d --name isolation-test alpine sleep 3600
 ```
 
-Verify the container is running:
+Verify the container is running by checking the container list for the name you just assigned to this specific lab process.
+
 ```bash
 docker ps | grep isolation-test
 ```
 
-**Step 2: View the process from inside the container**
-Execute a shell command inside the container to list processes.
+<details>
+<summary>Solution notes for Task 1</summary>
+
+You should see a running container named `isolation-test`. If Docker reports that the name is already in use, remove the old container with the cleanup command at the end of the lab and run the task again. At this point you have not created a VM manually; you have asked the container runtime to start one isolated process from the Alpine image.
+</details>
+
+**Task 2: View the process from inside the container.** Execute a shell command inside the container to list processes. The key observation is that the sleep process appears to be PID 1 from inside the container's process namespace.
+
 ```bash
 docker exec isolation-test ps aux
 ```
-*Observe: The `sleep 3600` process likely has PID (Process ID) 1. It thinks it is the very first process on the entire system.*
 
-**Step 3: Break the illusion (View from the host)**
-Now, look for that exact same `sleep 3600` process on your actual host machine.
+<details>
+<summary>Solution notes for Task 2</summary>
+
+The process list should be very small, and `sleep 3600` will likely appear as PID 1. That does not mean it is the first process on the physical host. It means the PID namespace presents a private numbering view to the containerized process, which is exactly the isolation concept from the core lesson.
+</details>
+
+**Task 3: Break the illusion from the host view.** Now look for the same sleep process on the host. On native Linux, the host will show the process with a different PID because the host is seeing through the namespace boundary.
+
 ```bash
 ps aux | grep "sleep 3600"
 ```
-*Observe: The process exists on your host! But its PID is NOT 1. It will be a normal, large PID number assigned by your host operating system.*
 
-> **Note for Mac/Windows Users**: If you are using Docker Desktop, Docker runs a hidden Linux virtual machine in the background. You won't see this process on your native Mac/Windows host system because it is running inside that Linux VM. This step assumes a native Linux host.
+<details>
+<summary>Solution notes for Task 3</summary>
 
-**Step 4: Prove Ephemerality (The Disappearing Data)**
-Create a file inside the running container:
+On native Linux, the process should exist on the host with a normal host PID rather than PID 1. On Docker Desktop, you may not see it from the macOS or Windows host because the compatible Linux kernel is inside Docker's managed VM. In either case, the result supports the same lesson: containers require a Linux process environment, and the apparent machine boundary is built from isolation features.
+</details>
+
+**Task 4: Prove ephemerality by losing disposable data.** Create a file inside the running container, verify it exists, then remove and recreate the container with the same name. You are deliberately writing to the container's own filesystem, not to a mounted volume.
+
 ```bash
 docker exec isolation-test sh -c "echo 'Important Data' > /secret.txt"
 ```
-Verify it exists:
+
+Verify it exists before removing the container so you can separate successful file creation from the later replacement behavior.
+
 ```bash
 docker exec isolation-test cat /secret.txt
 ```
-Now, stop and remove the container, then start a new one with the exact same name:
+
+Now stop and remove the container, then start a new one with the exact same name so the replacement boundary is impossible to miss.
+
 ```bash
 docker rm -f isolation-test
 docker run -d --name isolation-test alpine sleep 3600
 ```
-Try to read your file again:
+
+Try to read your file again from the new instance, and connect the expected failure back to the writable container layer.
+
 ```bash
 docker exec isolation-test cat /secret.txt
 ```
-*Observe: The file is gone. The new container started fresh from the read-only image.*
 
-**Step 5: Clean up**
+<details>
+<summary>Solution notes for Task 4</summary>
+
+The final read should fail because the new container started from the original Alpine image and did not inherit the removed container's writable layer. This is the same reason uploaded user files, database files, and manual package installs disappear when they live only inside a disposable container instance. If the data matters, it needs a volume or an external durable service.
+</details>
+
+**Task 5: Clean up.** Remove the lab container after the evidence is collected so the next experiment starts from a known state instead of inheriting a leftover name.
+
 ```bash
 docker rm -f isolation-test
 ```
 
+<details>
+<summary>Solution notes for Task 5</summary>
+
+The cleanup command is safe to run even if the container is already stopped because `-f` asks Docker to remove it forcefully. A clean lab environment matters because repeated experiments become confusing when old containers, names, or filesystem layers remain. The habit is the same one you will use later with Kubernetes resources: create deliberately, inspect deliberately, and clean up deliberately.
+</details>
+
 ### Success Criteria
-- [ ] You verified that the container process believes it is PID 1 (Namespace isolation).
-- [ ] You located the exact same process running on your host OS with a different PID (proving it shares the host kernel).
-- [ ] You experienced data loss by destroying a container, proving their ephemeral nature.
 
----
+- [ ] You verified that the container process believes it is PID 1 because of namespace isolation.
+- [ ] You located the same process from the host or explained why Docker Desktop hides it inside a Linux VM.
+- [ ] You removed a container and observed that data written only inside it disappeared.
+- [ ] You can explain the difference between an image, a container, and a writable container layer.
+- [ ] You designed a simple persistence plan for data that must avoid losing state when a container is replaced.
 
-## Summary
+## Sources
 
-Containers solve the environment consistency problem by packaging:
-- Application code
-- Dependencies
-- Configuration
-- Everything needed to run
-
-They achieve this through:
-- **Namespaces**: Process isolation
-- **Control groups**: Resource limits
-- **Union filesystems**: Efficient layered images
-
-Containers are:
-- **Lightweight**: Megabytes, not gigabytes
-- **Fast**: Seconds to start, not minutes
-- **Portable**: Run anywhere containers run
-- **Immutable**: Built once, unchanged
-
----
+- [Docker Docs: What is a container?](https://docs.docker.com/get-started/docker-concepts/the-basics/what-is-a-container/)
+- [Docker Docs: Understanding image layers](https://docs.docker.com/get-started/docker-concepts/building-images/understanding-image-layers/)
+- [Docker CLI: docker container run](https://docs.docker.com/reference/cli/docker/container/run/)
+- [Docker CLI: docker container exec](https://docs.docker.com/reference/cli/docker/container/exec/)
+- [Docker CLI: docker image pull](https://docs.docker.com/reference/cli/docker/image/pull/)
+- [Open Container Initiative](https://opencontainers.org/)
+- [OCI Image Format Specification](https://github.com/opencontainers/image-spec)
+- [OCI Runtime Specification](https://github.com/opencontainers/runtime-spec)
+- [Kubernetes Docs: Containers](https://kubernetes.io/docs/concepts/containers/)
+- [Kubernetes Docs: Resource management for pods and containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+- [Linux man-pages: namespaces](https://man7.org/linux/man-pages/man7/namespaces.7.html)
+- [Linux Kernel Docs: Control Group v2](https://docs.kernel.org/admin-guide/cgroup-v2.html)
 
 ## Next Module
 
-[Module 1.2: Docker Fundamentals](../module-1.2-docker-fundamentals/) - Hands-on with building and running containers.
+[Module 1.2: Docker Fundamentals](../module-1.2-docker-fundamentals/) - Next you will build and run containers directly so the image, container, layer, and tag concepts become commands you can inspect.


### PR DESCRIPTION
## Summary
- Rewrote `src/content/docs/prerequisites/cloud-native-101/module-1.1-what-are-containers.md` for #388 density, structure, alignment, and anti-leak gates.
- Cleared `revision_pending: false`.
- Preserved the original topic coverage and protected teaching assets while expanding prose depth and assessment alignment.

## Verifier
- `.venv/bin/python scripts/quality/verify_module.py --glob src/content/docs/prerequisites/cloud-native-101/module-1.1-what-are-containers.md --skip-source-check --summary --quiet` equivalent run with the primary checkout venv because this worktree has no local `.venv/bin/python`.
- Result: T0, passed=true; body_words=5037, mean_wpp=64.6, median_wpp=68.5, short_rate=0.0, max_run=0, mean_sentence_length=17.7.

## Protected assets
- Before: code_blocks=23, mermaid_diagrams=5, ascii_diagrams=1, tables=2, source_urls=0.
- After: code_blocks=23, mermaid_diagrams=5, ascii_diagrams=1, tables=2, source_urls=12.
- Original Docker examples, Mermaid diagrams, comparison table, image naming examples, tag examples, shipping-container analogy block, and hands-on lab commands are retained.

## Checks
- Verifier: T0.
- `git diff --check`: clean.
- Forbidden-token scan: clean for number 47, TODO/FIXME/XXX, AI refusal phrases, and sampled emoji tokens.
- `npm run build`: not run because the primary checkout is currently on `pr804` with unrelated dirty files, and AGENTS.md forbids building from `.worktrees/*`.

Commit: a2bc476c151c6c7e96045752a2629ecb0e4c2b01