### PR TITLE
feat(388): rewrite module-8-scale (#388 pilot)

### DIFF
--- a/src/content/docs/prerequisites/git-deep-dive/module-8-scale.md
+++ b/src/content/docs/prerequisites/git-deep-dive/module-8-scale.md
@@ -1,6 +1,7 @@
 ---
 title: "Module 8: Efficiency at Scale — Sparse Checkout and LFS"
 description: "Master advanced Git techniques to handle massive monorepos, optimize CI/CD pipelines, and manage large binary assets."
+revision_pending: false
 sidebar:
   order: 8
 ---
@@ -15,37 +16,27 @@ sidebar:
 
 By the end of this module, you will be able to:
 
-*   **Implement** sparse checkouts using cone mode to isolate specific service directories within a massive Kubernetes monorepo, drastically reducing local disk usage.
-*   **Compare and contrast** shallow clones and partial clones to optimize CI/CD pipeline checkout times and network bandwidth.
-*   **Configure** Git Large File Storage (LFS) to manage large binary files, such as packaged Helm chart tarballs, without bloating the core repository history.
-*   **Evaluate** the operational trade-offs between Git Submodules and Git Subtrees when architecting shared configuration repositories.
-*   **Diagnose** local repository performance degradation and execute Git maintenance strategies, including garbage collection and commit graph optimization, to restore speed.
+* **Implement** sparse checkouts using cone mode to isolate specific service directories within a massive Kubernetes monorepo while preserving correct repository history.
+* **Compare** shallow clones and partial clones for CI/CD pipelines, choosing the strategy that matches network cost, history needs, and server workload.
+* **Configure** Git Large File Storage for large binary assets such as packaged Helm chart tarballs without bloating the core Git object database.
+* **Evaluate** the operational trade-offs between Git Submodules and Git Subtrees when designing shared configuration repositories.
+* **Diagnose** local repository performance degradation and apply Git maintenance strategies such as garbage collection, repacking, commit graphs, and scheduled maintenance.
 
 ## Why This Module Matters
 
-The platform engineering division at a rapidly expanding e-commerce provider decided to consolidate all their infrastructure configuration into a single repository. Initially, this monorepo was an operational dream: twenty microservices, all Kubernetes manifests in one place, and atomic commits that could deploy cross-service configuration changes synchronously. Everyone praised the visibility and simplicity.
+The platform engineering division at a rapidly expanding e-commerce provider decided to consolidate infrastructure configuration into a single repository. At first, the decision felt elegant: service manifests lived beside shared policies, cluster add-ons were visible to every team, and one pull request could update a Deployment, its NetworkPolicy, and the matching observability rule together. Two years later the same repository held more than 1,500 services, tens of thousands of Kubernetes manifests, and several gigabytes of proprietary Helm chart tarballs that security required to be versioned with the deployment code. A normal clone took more than ten minutes on a strong office connection, CI runners burned paid minutes before reaching the first test, and developers began avoiding routine rebases because `git status` made their laptops sound like build machines.
 
-Fast forward two years. The company acquired three competitors. The repository now contains configurations for over 1,500 distinct microservices, 50,000 raw Kubernetes manifests, and gigabytes of bundled, proprietary Helm chart tarballs that the security team requires to be stored alongside the deployment code. A simple `git clone` operation now takes twelve minutes on a gigabit connection. The CI/CD runners are timing out during the initial fetch phase before a single test or deployment step can even begin. Developers are complaining that their laptop fans spin up to maximum speed just by running `git status`, and their IDEs are freezing while trying to index the massive directory tree. 
+Nothing in that story is a Git bug. Git was built as a content-addressed database, and a large repository asks that database to move several different kinds of weight: commit history, directory structure, file content, working tree entries, and binary objects that may not compress well. When teams talk loosely about a repository being "too big," they often mix these costs together and reach for the wrong fix. Sparse checkout reduces working tree scope, shallow clones reduce history depth, partial clones defer object downloads, Git LFS moves binary payloads out of normal Git history, and maintenance commands rebuild the local database so common operations stay fast. Each tool solves a different pressure point.
 
-Engineering velocity ground to a halt. The code was not broken, the deployments were not failing due to bad YAML, but the version control system was choking on the sheer volume of data. The tool meant to accelerate collaboration became the primary bottleneck.
-
-This module teaches you how to rescue a team in exactly that scenario. You will learn how to tame massive repositories, optimize clone operations for CI pipelines, manage large binary assets without permanently bloating the Git history, and keep local developer performance snappy. You will move from treating Git as a simple file tracker to operating it as a high-performance database optimized for scale.
+This module teaches you how to reason about those pressure points instead of copying optimization flags into every clone command. You will work through sparse checkout for human developers, clone filters for CI, LFS for large artifacts, submodules and subtrees for shared dependencies, and local maintenance for repositories that have accumulated years of loose objects. Kubernetes examples use version 1.35+ assumptions, and when we need `kubectl` we will introduce the shell alias `alias k=kubectl` before using `k` in commands. The goal is not to make every repository tiny; the goal is to make large repositories predictable, explainable, and fast enough that Git stops being the bottleneck in the delivery path.
 
 ## Core Content: The Monorepo Problem and Sparse Checkout
 
-When you execute a standard `git clone`, Git performs two distinct, resource-intensive operations. First, it downloads the entire compressed history of every file that has ever existed in the repository into the `.git` directory. Second, it unpacks the latest commit into your working tree — the actual files you see and edit on your disk.
+When you execute a standard `git clone`, Git performs two expensive operations that are easy to confuse. First it downloads repository objects into the `.git` directory, including commits, trees, tags, and blobs that represent file contents. Second it checks out one commit into your working tree, which is the ordinary directory full of files that your editor, shell, search tools, and language servers inspect. In a monorepo, the working tree is often the pain a human feels first, because the developer touching `services/payment-gateway` still watches the editor index `services/inventory-api`, `services/user-auth`, and hundreds of unrelated directories.
 
-In a massive monorepo, both of these operations become problematic, but the working tree is often the most immediate pain point for developers. If a repository has 1,500 services, a developer working on the `payment-gateway` service does not need the files for the other 1,499 services cluttering their IDE, slowing down their searches, and consuming their local disk space.
+Sparse checkout addresses the working tree side of the problem. It tells Git to keep the repository database intact while only materializing selected paths on disk, so the user sees a smaller tree without creating a forked or incomplete history. That distinction matters operationally. If another team updates a hidden service and you fetch or merge `main`, Git still processes that change inside the repository database; the file simply does not appear in your working directory unless it is inside your sparse definition. Sparse checkout is therefore a visibility and performance tool, not a permission boundary and not a way to avoid integrating the rest of the repository.
 
-This is where **Sparse Checkout** comes in. Sparse checkout allows you to tell Git to only populate specific directories in your working tree while leaving the rest of the repository hidden.
-
-### Cone Mode vs. Non-Cone Mode
-
-Historically, sparse checkout used complex regular expressions to determine which files to include. This "non-cone" mode was extremely flexible but computationally expensive. Running `git status` required Git to evaluate those regular expressions against every file in the repository, which could take seconds in a large codebase.
-
-Modern Git introduced **Cone Mode**. Cone mode restricts the matching logic to exact directory paths (forming a "cone" of inclusion). It is exponentially faster because Git can use hash lookups instead of pattern matching.
-
-Let us visualize the difference in a standard Kubernetes platform repository:
+Historically, sparse checkout supported flexible pattern matching. You could write rules that looked like `.gitignore` patterns and include individual filenames anywhere in the repository. That flexibility had a hidden cost: commands such as `git status` had to evaluate pattern rules across the tracked tree, and those checks became noticeable as repositories grew. Modern Git strongly favors cone mode, which restricts sparse rules to directory cones and lets Git use faster path matching. The trade-off is intentional. You give up arbitrary wildcard selection so the common case, "I work in these service directories," remains cheap.
 
 ```mermaid
 graph TD
@@ -82,11 +73,7 @@ graph TD
     class CA,CAL,CERT,NS,DEF,KS,INV,UA hidden;
 ```
 
-In cone mode, if you specify `services/payment-gateway`, Git automatically includes the files directly in `platform-repo/` (like `README.md` or `.gitignore`), the files directly in `platform-repo/services/`, and everything recursively inside `platform-repo/services/payment-gateway/`.
-
-### Implementing Cone Mode
-
-To set up a sparse checkout for an existing repository, you use the `sparse-checkout` command.
+In cone mode, if you specify `services/payment-gateway`, Git automatically includes root-level files such as `README.md` and `.gitignore`, the immediate parent directories needed to reach the cone, and everything recursively inside `services/payment-gateway`. That behavior keeps the repository usable because root metadata and parent directories still exist, while unrelated service trees stay absent from disk. Think of it like checking out a map with only the roads you need highlighted, while the navigation system still knows the rest of the city exists.
 
 ```bash
 # First, enable sparse checkout in cone mode
@@ -101,48 +88,38 @@ git sparse-checkout set services/payment-gateway
 # Your working directory now contains the root files and the payment-gateway files.
 ```
 
-If you need to collaborate with another team temporarily, you can add their service to your cone:
+The sequence above is deliberately staged. Initializing sparse checkout in cone mode usually leaves you with only root files, which surprises people the first time because an apparently healthy repository suddenly looks empty. The next command defines the cone that should be populated. If your team rotates on-call across two services, you can widen the cone without restarting the clone, which is much cheaper than maintaining separate local copies of the monorepo.
 
 ```bash
 git sparse-checkout add services/user-auth
 ```
 
-To return to a normal, full working tree:
+Sparse checkout should also be easy to unwind. If you are about to perform a repository-wide refactor, migrate all manifests to a new Kubernetes 1.35+ field convention, or run a formatter across every service, temporarily disabling sparse checkout is clearer than trying to remember which paths are hidden. After the wide operation, you can re-enable the focused cone and return to your normal working set.
 
 ```bash
 git sparse-checkout disable
 ```
 
-> **Pause and predict**: If you have a sparse checkout configured to only show `services/payment-gateway`, and you run `git commit -a -m "update"`, will Git accidentally commit changes that someone else made to `services/inventory-api` that you recently pulled? 
+Pause and predict: if you have a sparse checkout configured to only show `services/payment-gateway`, and you run `git commit -a -m "update"`, will Git accidentally commit changes that someone else made to `services/inventory-api` after you pulled? The answer is no for ordinary pulled changes, because `git commit -a` records your staged or modified working tree changes, not every hidden path that changed upstream. The more important risk is the opposite: you may forget that a cross-service change requires paths outside your cone, so you should widen the cone before making repository-wide edits.
 
-**War Story: The Regex Trap**
-A platform team tried to optimize their workflow by writing a sparse checkout rule to include "any file named `deployment.yaml` anywhere in the repo." They used the legacy non-cone mode with a wildcard pattern `**/deployment.yaml`. As the repository grew to 30,000 files, every time a developer typed `git status`, Git had to execute a recursive pattern match across the entire virtual tree. `git status` began taking 8 seconds. Switching to cone mode and explicitly listing the required service directories dropped the execution time to 40 milliseconds.
+War story: a platform team tried to optimize daily work by writing a sparse checkout rule that included any file named `deployment.yaml` anywhere in the repository. The rule seemed clever because Kubernetes services usually had that filename, but it forced legacy non-cone matching across a rapidly growing tree. By the time the repository passed 30,000 tracked files, `git status` took several seconds because every path had to be tested against the pattern. Switching to cone mode and explicitly listing service directories reduced status latency to interactive speed because Git could reason about directory prefixes rather than arbitrary wildcard matches.
+
+Sparse checkout is also a social contract. If every team invents private path rules, support gets harder because build failures may reproduce only for the one person whose working tree is shaped differently. Strong platform teams publish common cones, such as "service developer," "cluster add-on maintainer," and "release engineer," and they document which tasks require widening the tree. That documentation prevents sparse checkout from becoming invisible local state that only the original author understands.
 
 ## Core Content: Starving the CI Pipeline: Shallow and Partial Clones
 
-While sparse checkout solves the working tree problem for human developers, it does not solve the network and disk problem for Continuous Integration (CI) pipelines. A sparse checkout still downloads the entire `.git` history; it just hides the files on the final checkout.
+Sparse checkout helps humans by shrinking the working tree, but it does not automatically shrink the object database. A CI runner that uses sparse checkout may still download most repository history before it hides unused files, which means the runner pays the network and storage cost before getting any benefit. CI optimization starts by asking a different question: what historical data does this job actually need? A lint job that checks current YAML has different needs from a release-note generator, and both differ from a security scanner that compares RBAC changes across months of history.
 
-CI pipelines usually do not care about the history. When a pipeline runs to apply Kubernetes manifests via `kubectl apply` (or using the alias `k apply` which we will use from now on), it only needs the exact state of the files at the specific commit that triggered the job.
-
-### Shallow Clones
-
-A **Shallow Clone** truncates the repository history. You tell Git to only download the last *N* commits.
+A shallow clone truncates history by asking Git for only the most recent commits. It is simple, widely supported, and often effective for jobs that only need the checked-out files at one revision. The cost is that many history-aware tools stop working or produce misleading output because the runner no longer has enough ancestry to answer questions about blame, merge bases, tags, or previous versions. Shallow clone is a time filter, and time filters are risky when a job quietly depends on context older than the selected depth.
 
 ```bash
 # Clone only the very latest commit of the default branch
 git clone --depth 1 https://git.example.com/platform-repo.git
 ```
 
-This drastically reduces the data transferred over the network. A 5GB repository might become a 20MB download. 
+The appeal of `--depth 1` is obvious: a multi-gigabyte repository can become a much smaller transfer for a simple current-state job. The operational drawback is less obvious until a tool fails in production CI. A code quality scanner may need blame information to distinguish new findings from old findings, a deployment script may compute the merge base against `main`, and a release process may search tags to derive a version. In those cases the checkout appears successful, but the job's reasoning is based on a deliberately incomplete history.
 
-However, shallow clones have severe limitations:
-1. You generally cannot push from a shallow clone.
-2. Tools that rely on history (like SonarQube for blame-based metrics, or release note generators) will fail.
-3. Fetching updates into a shallow clone can sometimes be computationally heavier on the server side than a normal fetch, as the server has to calculate exactly what is missing from your truncated history.
-
-### Partial Clones
-
-**Partial Clones** are the modern, superior alternative to shallow clones. Instead of truncating time (history), partial clones filter data types. The most common filters omit large file contents (blobs) or omit entire directory trees until they are explicitly needed.
+Partial clone solves a different problem by filtering object types instead of truncating time. A blobless clone downloads commits and tree objects while deferring file content blobs until they are needed. That means Git can still answer many history and ancestry questions without immediately downloading every historical version of every file. When a command later asks for an old diff, Git performs an on-demand fetch for the missing blobs. The result is often a better default for large monorepos because it preserves the shape of history while avoiding old file payloads until a workflow proves it needs them.
 
 ```mermaid
 graph TD
@@ -158,37 +135,33 @@ graph TD
     J -->|Triggers Fetch for| I
 ```
 
-A **blob-less** clone downloads all the commits and all the directory structures (trees), but omits the actual file contents (blobs) for historical commits. It only downloads the blobs required to populate your current working tree.
-
 ```bash
 # Clone the repository, but omit all historical file contents
 git clone --filter=blob:none https://git.example.com/platform-repo.git
 ```
 
-If you ever run a command that needs an old file (like `git log -p` to see the diffs, or `git checkout` to move to an old branch), Git will automatically and transparently reach out to the server and download just the specific blobs it needs in real-time.
+Pause and predict: you run `git clone --filter=blob:none`, then run `git diff HEAD~5` on a path that changed several commits ago. The local repository has the commit graph and tree information needed to locate the old path, but it may not have the old blob content needed to render the patch. Git will contact the remote, fetch the missing blobs for that diff, and then continue as though the data had always been local. This is usually good for interactive work, but it can surprise CI designers who expected a job to be fully offline after clone.
 
-> **Pause and predict**: You ran `git clone --filter=blob:none`. Now you run `git diff HEAD~5`. What network activity do you expect, and why?
-
-For CI pipelines that only need the latest commit, a **tree-less** clone is even faster:
+Treeless partial clones go further by omitting historical tree objects as well. They are useful for highly ephemeral CI jobs that need the current checkout and little else, because the runner avoids downloading old directory structures that it will never traverse. The trade-off is that history exploration becomes more dependent on on-demand network fetches. If your CI job runs in an isolated network after the checkout step, or if it performs many historical comparisons, treeless clones can move cost from the start of the job to the middle of the job, where failures are more frustrating.
 
 ```bash
 # Omit all historical file contents AND historical directory structures
 git clone --filter=tree:0 https://git.example.com/platform-repo.git
 ```
 
-> **Stop and think**: Which approach would you choose for a CI pipeline that runs a security scanner analyzing the evolution of RBAC permissions over the last six months, and why?
+Before applying Kubernetes manifests in CI, define the `kubectl` alias close to the first use so the log is explicit and shell steps are reproducible. The alias itself is not a Git optimization, but it keeps the module's Kubernetes commands consistent with the rest of KubeDojo. A shell setup line such as `alias k=kubectl` should appear before later commands like `k apply -f services/payment-gateway/manifests/`, and that small discipline prevents readers from wondering whether `k` is a custom wrapper, a local script, or the standard Kubernetes CLI shortcut.
+
+Combining partial clone and sparse checkout is often the winning move for current-state deployment jobs, but the order still matters. The clone filter decides what object data is available locally, while sparse checkout decides what paths appear in the working tree. If the job clones bloblessly and then sparsely checks out only one service, the runner avoids old file payloads and avoids materializing unrelated service directories. If the job only uses sparse checkout after a full clone, it may still transfer the very history it was trying to avoid. This is why checkout optimization belongs in the CI design, not in a late shell step copied from a developer laptop.
+
+Stop and think: which approach would you choose for a CI pipeline that runs a security scanner analyzing the evolution of RBAC permissions over the last six months, and why? A depth-one shallow clone is a poor fit because the scanner needs meaningful history. A blobless partial clone is usually a better starting point because it preserves commit and tree relationships while deferring file contents, though you should test whether the scanner repeatedly asks for old blobs and therefore needs a deeper or full checkout for stable runtime.
+
+Clone strategy should be owned like any other build architecture decision. Put the reasoning in CI configuration comments, measure checkout time separately from test time, and revisit the choice when jobs change. A pipeline that originally linted current YAML may later grow release note generation, provenance checks, or policy drift analysis. If the clone mode remains unchanged, the team may debug strange tool behavior for hours before noticing that the runner never had the history the tool assumed.
 
 ## Core Content: The Heavy Lifters: Git LFS for Binaries
 
-Git is exceptionally good at versioning plain text files like YAML manifests, Go source code, or Markdown documentation. It uses delta compression, storing only the specific lines that changed between commits.
+Git stores file contents as blobs and can compress text history extremely well because line-oriented changes often share structure. Kubernetes YAML, Markdown, Go source, and shell scripts usually produce efficient deltas. Compressed archives, virtual machine images, database dumps, media files, and packaged Helm chart tarballs behave differently. A one-byte change inside a compressed file can make the entire compressed output look unrelated to the previous version, so Git stores another large blob. After several updates, every clone drags years of obsolete binary payloads through the network even though most developers only need the latest one.
 
-Git is exceptionally terrible at versioning compiled binaries, database dumps, or compressed archives. If you change one byte in a 100MB Helm chart `.tgz` file and commit it, Git cannot compress the difference. It stores an entirely new 100MB object. Do this ten times, and your repository size increases by 1GB. Every developer who clones the repo has to download that entire gigabyte, even if they only want the latest version.
-
-**Git Large File Storage (LFS)** solves this by replacing the large files in your repository with tiny text pointers. The actual large files are stored on a separate LFS server.
-
-### The Anatomy of LFS
-
-When you commit a file tracked by LFS, the actual binary data is intercepted and uploaded to the LFS server via an HTTP API. Git only records a pointer file in the commit history.
+Git Large File Storage changes what Git records. Instead of committing the large binary payload directly into the normal object database, LFS stores a small pointer file in Git and uploads the real content to an LFS server. The pointer includes the LFS spec version, a content hash, and the size of the object. From Git's perspective, history contains tiny text files. From the developer's perspective, the LFS extension replaces those pointers with real files in the working tree when the relevant checkout is populated.
 
 ```mermaid
 flowchart TD
@@ -215,19 +188,13 @@ flowchart TD
     B2 -.->|LFS extension uploads binary| C2
 ```
 
-> **Stop and think**: If you run `git log -p` on a file tracked by LFS, what will you see in the diff — the binary content or the pointer file content? What if you have the LFS extension installed vs not installed?
-
-When another developer clones the repository, Git downloads the tiny pointer files. Then, the LFS extension reads those pointers and automatically downloads the correct 50MB binary from the LFS server to populate their working tree. They only download the binaries for the specific commit they have checked out, not the entire history.
-
-### Configuring LFS
-
-First, you must install the LFS extension and initialize it for your user account:
+The pointer model has two consequences that platform engineers must explain clearly. First, LFS does not make large files vanish; it moves their storage and transfer path to a service designed for large payloads. Second, everyone who needs real binary files must have LFS installed and must authenticate to the LFS endpoint. A clone without LFS support may leave pointer text where a Helm chart or dataset should be, and a CI runner with Git credentials but no LFS access can fail after the Git fetch succeeds.
 
 ```bash
 git lfs install
 ```
 
-Next, you tell LFS which files to track in your repository. This creates or updates a `.gitattributes` file.
+Installing the extension prepares the user's Git client to apply LFS filters, but it does not decide which repository paths belong in LFS. Tracking rules live in `.gitattributes`, and that file is part of the repository contract. Commit it before or with the first matching binary so every contributor and runner applies the same filters. If you add the tracking rule after binaries have already entered normal Git history, future commits may use LFS, but the old large objects remain in history until you perform a deliberate migration.
 
 ```bash
 # Track all tarball files
@@ -237,14 +204,12 @@ git lfs track "*.tgz"
 git lfs track "tests/data/seed-db.sql"
 ```
 
-You must commit the `.gitattributes` file so everyone else cloning the repository knows which files should be handled by LFS.
-
 ```bash
 git add .gitattributes
 git commit -m "chore: configure LFS tracking for tarballs and test DBs"
 ```
 
-Now, when you add a tarball, it is processed by LFS automatically:
+Once the rule is committed, adding a matching tarball should store a pointer in Git and upload the real object through LFS during push. Notice that the command sequence is ordinary Git from the user's perspective. That is the strength of LFS: it keeps day-to-day workflows familiar while changing the storage path behind the scenes. The team still needs quota monitoring, retention policy, and restore testing because the large objects now depend on the health of a second service.
 
 ```bash
 cp ~/Downloads/monitoring-chart-v2.tgz charts/
@@ -253,39 +218,31 @@ git commit -m "feat: add monitoring helm chart"
 git push origin main
 ```
 
-**War Story: The Accidental Dump**
-A junior engineer generated a 2GB PostgreSQL database dump locally to test a data migration script. They accidentally ran `git commit -a -m "WIP"` and pushed to the origin. Realizing the mistake, they immediately ran `git rm the-dump.sql`, committed the deletion, and pushed again. The file was gone from the working tree, but the 2GB object was permanently embedded in the Git history. Every subsequent `git clone` by every pipeline and developer took twenty minutes longer. The team had to coordinate a highly disruptive history rewrite using `git filter-repo` to scrub the binary out of the permanent record, forcing everyone to delete their local clones and start fresh. If LFS had been configured for `*.sql` files proactively, this disaster would have been averted.
+Stop and think: if you run `git log -p` on a file tracked by LFS, what will you see in the diff? Git history contains pointer file changes, so the textual patch describes pointer metadata rather than the binary payload itself. The LFS extension makes your working tree convenient, but it does not transform Git history into a binary diff viewer. For review workflows, that means teams often pair LFS with checksum checks, provenance metadata, or artifact promotion rules so reviewers know why a large binary changed.
+
+War story: a junior engineer generated a 2GB PostgreSQL database dump to test a migration and accidentally pushed it with a work-in-progress commit. Deleting the file in the next commit removed it from the current tree, but the large object stayed reachable in history and every new clone paid for it. The eventual fix required a coordinated history rewrite, temporary freeze, force push, and instructions for every developer to replace local clones or carefully repair their remotes. If the repository had tracked dump patterns through LFS before the incident, the payload would have gone through the large-object path rather than permanently inflating normal Git history.
+
+LFS is not a reason to store every artifact in Git. If a build can reproduce a chart from source, an artifact registry may be the better system of record, with Git storing only the source and version metadata. LFS is strongest when the binary is legitimately part of the reviewable repository state, must be checked out with the code, and cannot be rebuilt easily by the consumer. That boundary keeps Git useful as a collaboration tool instead of turning it into a general storage bucket.
+
+There is also a review culture dimension to LFS. A pull request that changes a pointer file may look tiny, but the actual payload can be large, opaque, and operationally important. Teams that use LFS well attach generated checksums, provenance notes, release references, or automated validation output to the review so a human can decide whether the binary belongs in the repository state. Without that habit, LFS can accidentally make large changes less visible because the diff becomes smaller. The goal is smaller Git history, not weaker review.
 
 ## Core Content: Dependency Hell: Submodules vs Subtrees
 
-In large platforms, you often want to share code between repositories. For example, you might have a dedicated repository for standard Kubernetes Custom Resource Definitions (CRDs) that needs to be included in multiple different service repositories. 
+Large platform repositories rarely live alone. A service repository may need shared Custom Resource Definitions, common Terraform modules, generated policy bundles, or an upstream Helm chart. Git offers two native inclusion models, submodules and subtrees, and the right choice depends less on elegance than on operational friction. Ask who updates the dependency, how often CI must fetch it, whether consumers need it after an ordinary clone, and how painful it would be if the dependency pointer referenced a commit that nobody else could fetch.
 
-Git provides two native ways to nest repositories inside other repositories: Submodules and Subtrees.
-
-### Git Submodules
-
-A submodule is essentially a pointer to a specific commit in another repository. 
-
-When you add a submodule:
+A submodule is a pointer from one Git repository to a specific commit in another repository. The parent repository records metadata in `.gitmodules` and stores a special entry for the nested path, but it does not copy the nested repository's file contents into the parent object database. This is clean when the dependency is large, independently versioned, and rarely edited by the parent team. It is also easy to misuse because a normal clone may leave the submodule directory empty until the user performs an additional initialization step.
 
 ```bash
 git submodule add https://git.example.com/shared-crds.git manifests/crds
 ```
 
-Git does not copy the files from `shared-crds` into your repository's database. Instead, it creates a special file called `.gitmodules` and records the exact commit hash of the `shared-crds` repository.
-
-**The pain of submodules:**
-When someone else clones your repository, the `manifests/crds` directory will be completely empty. They must explicitly run:
+When someone else clones a repository that uses submodules, they must either clone with submodule recursion enabled or initialize submodules afterward. CI systems need the same treatment, otherwise a job can fail with missing CRD files even though the parent repository checkout succeeded. The detached-head behavior inside a submodule is another source of mistakes: if a developer commits inside the submodule but only pushes the parent pointer update, the parent can reference an object that does not exist on the submodule remote visible to everyone else.
 
 ```bash
 git submodule update --init --recursive
 ```
 
-Furthermore, if you enter the `manifests/crds` directory, you will be in a "detached HEAD" state. If you make changes there, commit them, and push your main repository without first pushing the submodule repository, you will break the build for everyone else (your main repo points to a commit in the submodule that does not exist on the remote server).
-
-### Git Subtrees
-
-A subtree takes a different approach. It physically copies the files and the history from the external repository directly into your repository.
+A subtree makes the opposite trade-off. It brings external files into a directory of the parent repository, optionally squashing the imported history into a single commit so the parent history stays readable. A normal clone gets the files immediately because they are ordinary files in the parent tree. The cost is that synchronization with the upstream repository is more manual, and the parent repository now carries those files directly, which may be undesirable for very large or fast-moving dependencies.
 
 ```bash
 # Add a remote for the shared repo
@@ -295,10 +252,7 @@ git remote add shared-crds https://git.example.com/shared-crds.git
 git subtree add --prefix=manifests/crds shared-crds main --squash
 ```
 
-The `--squash` flag combines all the history of the external repository into a single commit in your repository, keeping your history clean.
-
-**The benefit of subtrees:**
-When another developer clones your repository, they get the `manifests/crds` directory immediately. No extra commands are needed. The CI pipeline does not need special configuration to fetch submodules. It behaves exactly like normal files.
+The comparison table is intentionally blunt because most submodule and subtree debates are really about developer experience. Submodules preserve separation but demand extra clone and push discipline. Subtrees simplify consumption but make the parent repository larger and place more responsibility on the parent maintainers to pull upstream changes intentionally. Neither tool replaces a package registry, chart repository, or artifact registry when those are the cleaner abstraction.
 
 | Feature | Submodules | Subtrees |
 | :--- | :--- | :--- |
@@ -308,17 +262,17 @@ When another developer clones your repository, they get the `manifests/crds` dir
 | **Making Upstream Changes** | Difficult (detached HEAD, push ordering) | Complex but manageable (`git subtree push`) |
 | **Best Used For** | Large external projects you rarely edit | Smaller shared libraries you update occasionally |
 
-> **Stop and think**: Your team maintains a shared Terraform modules repo (200 files, updated weekly) and a massive vendor CRD repo (5,000 files, updated quarterly). Which inclusion strategy would you use for each, and why?
+Stop and think: your team maintains a shared Terraform modules repository with 200 files updated weekly and a massive vendor CRD repository with 5,000 files updated quarterly. The Terraform modules may fit a subtree if you want ordinary clones and occasional parent-side edits, provided the parent can tolerate carrying those files. The vendor CRDs may fit a submodule if you rarely change them and want to avoid importing thousands of files, but only if your CI and onboarding documentation make recursive checkout mandatory. The decision is not about which feature is newer; it is about which failure mode your team can reliably operate.
+
+The strongest teams also define ownership around inclusion mechanisms. If a subtree is used, someone must own upstream pulls and conflict resolution. If a submodule is used, someone must own pointer updates, remote availability, and CI clone configuration. The lack of ownership is why shared dependency strategies become painful: the command works once, then the repository quietly accumulates stale pointers or copied code nobody feels responsible for maintaining.
+
+Submodules and subtrees also interact differently with incident response. During an outage, an empty submodule directory can consume precious time because responders must remember the recursive update step before they can inspect the missing manifests. A stale subtree creates a different failure mode: the files are present, so the incident team may not realize they are looking at an older copy of a shared policy bundle. Good runbooks call out these mechanics directly. They say how to refresh the dependency, how to verify the exact upstream revision, and who is allowed to move the pointer or subtree import during a live incident.
 
 ## Core Content: Under the Hood: Maintenance and Performance
 
-As you work with Git, adding, modifying, and deleting files, the local `.git` database accumulates "loose objects." Furthermore, Git's internal index of how commits relate to each other can become fragmented. Over time, operations like `git status` or `git log` will visibly slow down.
+Git repositories age. Every commit, rebase, fetch, merge, delete, and branch operation changes the shape of the local object database. Some objects are stored as loose files before they are packed, some packfiles become suboptimal as new history arrives, and history traversal may repeatedly parse commit relationships that could be cached. When a developer says a repository is slow, the right response is not always "clone it again." A fresh clone hides the symptom, but maintenance commands teach you what was wrong and help the whole team document a repeatable fix.
 
-Git includes internal tools to optimize its own database.
-
-### Garbage Collection and Repacking
-
-The `git gc` (garbage collection) command cleans up unnecessary files and optimizes the local repository. 
+Garbage collection is the familiar entry point. `git gc` prunes unreachable objects when safe, packs loose objects, and optimizes storage so the operating system opens fewer files during common operations. Aggressive garbage collection can spend more CPU looking for better deltas, which may reduce disk usage but can take much longer. That trade-off matters on laptops and shared CI runners: a normal garbage collection is often enough for routine cleanup, while aggressive repacking is better reserved for planned maintenance windows or local clones with serious bloat.
 
 ```bash
 # Run a standard garbage collection
@@ -328,96 +282,112 @@ git gc
 git gc --aggressive
 ```
 
-When you run `git gc`, Git performs a `repack`. It takes thousands of individual loose object files and compresses them into a single "packfile." Packfiles use delta compression to store objects incredibly efficiently. This reduces the number of file handles the operating system needs to open and saves disk space.
-
-### Commit Graphs
-
-In a repository with hundreds of thousands of commits, commands that traverse history (like figuring out if a branch is ahead or behind, or generating a log) have to read and parse thousands of individual commit objects. 
-
-Git can generate a **commit graph** file, which is a highly optimized binary cache of the commit history structure.
+Commit graphs target a different bottleneck. Many Git commands need to walk commit ancestry, answer reachability questions, determine whether a branch is ahead or behind, or render a graph. In a repository with hundreds of thousands of commits, repeatedly parsing individual commit objects adds latency. A commit graph file is a compact, optimized representation of commit relationships, and writing it can make history-heavy operations feel much more responsive without changing repository content.
 
 ```bash
 # Generate the commit graph
 git commit-graph write --reachable
 ```
 
-Writing the commit graph can make commands like `git log --graph` execute significantly faster.
+Pause and predict: a repository has 500,000 loose objects and no commit graph. Running `git gc` alone should improve operations that suffer from loose-object overhead, while adding `git commit-graph write --reachable` should especially help commands that traverse history, such as `git log --graph` or branch ahead-behind checks. The exact speedup depends on disk, filesystem, repository shape, and command mix, so the professional move is to measure before and after rather than promise a universal percentage.
 
-> **Pause and predict**: A repository has 500,000 loose objects and no commit graph. Estimate the relative speedup of running `git gc` alone vs `git gc` + `commit-graph write` for a `git log --graph` command.
-
-### Automated Maintenance
-
-Instead of remembering to run these commands manually, modern Git allows you to register a repository for automatic background maintenance.
+Modern Git also supports scheduled maintenance so users do not have to remember periodic cleanup commands. `git maintenance start` registers background tasks appropriate to the operating system, such as prefetching, loose-object cleanup, incremental repacking, and commit graph updates. This is useful for long-lived local clones of large repositories because maintenance runs while the developer is not actively waiting on Git. It is less useful for short-lived CI workspaces, where clone strategy and cache design usually dominate.
 
 ```bash
 git maintenance start
 ```
 
-This sets up background cron jobs (or systemd timers, depending on your OS) that will periodically run pre-fetch operations, loose object pruning, and commit graph updates while you are not actively using the repository. 
+Maintenance should be paired with diagnosis. Check whether slow operations are working-tree scans, history walks, network fetches, or LFS downloads. A slow `git status` in a huge tree may point to sparse checkout or filesystem monitoring; a slow `git log --graph` may point to commit graph maintenance; a slow CI checkout may point to clone filters; a slow first build after checkout may point to LFS payload size. Treat Git performance like any other production performance problem: identify the resource under pressure, choose the tool designed for that resource, and record the result so the team does not rediscover the fix next quarter.
+
+For a local diagnosis, ask the developer to describe the slow command rather than the vague feeling that "Git is slow." `git status`, `git fetch`, `git checkout`, `git log`, and the first build after checkout stress different parts of the system. The path from symptom to fix is much shorter when the team names the command, repository size, recent history, sparse configuration, LFS status, and whether background maintenance is enabled. That information also helps distinguish a repository problem from an endpoint protection tool, network proxy, or editor extension that is scanning the same files Git is trying to update.
+
+## Patterns & Anti-Patterns
+
+The best pattern for large repositories is scope-first checkout. Human developers should materialize the directories they actively edit, while retaining enough root metadata and shared configuration to run local checks. This pattern works because it reduces editor indexing, shell search noise, and working tree scans without creating a separate repository or hiding history from Git. It scales when platform owners publish recommended sparse cones and teach people when to widen them for cross-service changes.
+
+Another strong pattern is history-aware CI checkout. Rather than applying `--depth 1` everywhere, classify jobs by history needs. Current-state linters and manifest validators can use aggressive filters, while scanners, release-note builders, and provenance tools need enough history to reason correctly. This pattern works because it treats checkout as part of the job contract, not as a generic prelude copied between workflows. It scales when CI logs report checkout mode and timing as separate metrics.
+
+For large binary files, the durable pattern is policy before payload. Configure LFS rules, commit `.gitattributes`, verify runner authentication, and document size expectations before the first large chart, image, or dump enters the repository. The policy must also say when LFS is not appropriate and an artifact registry should be used instead. This pattern works because cleaning old large objects from Git history is disruptive, while preventing them from entering normal history is routine.
+
+The common anti-pattern is optimization by folklore. Someone remembers that shallow clones were fast in one project and applies them to every job, including tools that need blame history. Someone else hears that submodules are "clean" and adds one without teaching CI to recurse. A third engineer enables LFS after the binary damage is already in history and expects old clones to shrink. These mistakes happen because Git features are treated as magic flags instead of database design choices with explicit trade-offs.
+
+## Decision Framework
+
+Start with the pain you can measure. If developers see too many files and local commands crawl while history operations are acceptable, choose sparse checkout in cone mode. If CI spends most of its time downloading history for jobs that only inspect the current tree, evaluate partial clone filters and possibly shallow depth. If the repository grows because large binary artifacts change over time, introduce LFS or move the artifacts to a registry. If shared files must appear inside another repository, decide between submodules and subtrees based on consumption friction, update ownership, and repository size.
+
+Use this decision matrix as a practical guide, then verify the choice with a small experiment before rolling it across every team. A clone strategy that saves one minute in a lint job may break a release job, while an LFS rule that helps developers may require extra CI credentials. The point of a framework is not to replace judgment; it is to force the right questions before a flag becomes institutional habit.
+
+If the pressure is the working tree, start with sparse checkout because it reduces visible files while preserving the full repository model. If the pressure is CI network transfer for a current-state job, start with partial clone filters and test whether the job triggers on-demand fetches. If the pressure is history-aware CI, avoid depth-only fixes until you prove the tool can operate on truncated ancestry. If the pressure is binary growth, choose between LFS and an artifact registry based on whether the binary must be reviewed and checked out with source. If the pressure is shared dependency inclusion, use submodules when separation matters more than clone convenience, and subtrees when ordinary clones matter more than keeping the parent small. If the pressure is a slow long-lived local clone, run maintenance before asking everyone to reclone.
+
+The framework becomes more useful when teams write down negative decisions. "We are not using shallow clone for releases because release notes need merge bases" is the kind of sentence that prevents a future well-meaning optimization from breaking production. "We are not storing rebuilt charts in LFS because the registry is the source of truth" prevents repository storage from becoming an accidental artifact archive. These notes do not need to be long, but they should live beside the CI workflow or repository onboarding guide where the next person will look during a performance cleanup.
+
+For a Kubernetes platform repository, a realistic design often combines several tools. Developers use sparse checkout for their service cones, CI uses a blobless or treeless partial clone depending on job history needs, packaged Helm charts move to LFS only when they must be reviewed with the code, and shared CRDs use either subtrees or submodules based on ownership. The important habit is to explain each layer separately. When the next failure occurs, the team can identify whether the working tree, object transfer, binary storage, dependency inclusion, or local database is the constraint.
+
+A good rollout plan starts with one repository and one workflow rather than a site-wide flag day. Pick a painful service directory, publish the sparse checkout commands, measure local status time before and after, then repeat with one CI job whose history needs are understood. Only after those wins are stable should the team migrate binary policy or dependency inclusion patterns. This staged approach creates evidence, gives developers time to adjust their mental model, and avoids mixing unrelated changes into one difficult rollback.
 
 ## Did You Know?
 
-*   **The Linux Kernel Repo:** The Linux kernel repository contains over 1.2 million commits and 80,000 files, yet a properly optimized local clone can execute a `git status` in under 50 milliseconds.
-*   **Git LFS Origins:** Git LFS was originally created by GitHub in 2015 as an open-source extension, specifically because game developers and machine learning teams were abandoning Git due to its inability to handle large textures, models, and datasets.
-*   **The 2GB Limit:** Due to architectural decisions in how Git maps memory and processes files on 32-bit systems (which persist in some legacy underlying libraries), Git can catastrophicly fail or run out of memory if you attempt to track a single file larger than 2 Gigabytes without LFS.
-*   **Zero-Byte Commits:** You can create a commit that contains absolutely no changes to the working tree using `git commit --allow-empty`. This is frequently used by platform engineers to trigger CI/CD pipeline runs without having to push a fake "bump" change to a README.
+* **The Linux Kernel Repo:** The Linux kernel repository contains more than 1.2 million commits and roughly 80,000 tracked files, yet a properly optimized local clone can still make common status checks feel interactive on modern hardware.
+* **Git LFS Origins:** Git LFS was announced by GitHub in 2015 because teams working with games, media, and machine learning datasets needed Git workflows without storing every large binary revision in the normal object database.
+* **The 2GB Limit:** Very large single files have historically exposed memory and tooling limits in Git clients and surrounding libraries, which is one reason large payloads should move to LFS or an artifact system before they become routine.
+* **Zero-Byte Commits:** `git commit --allow-empty` creates a commit with no working tree changes, and platform engineers often use it to trigger CI/CD flows without inventing a meaningless file edit.
 
 ## Common Mistakes
 
 | Mistake | Why It Happens | How to Fix It |
 | :--- | :--- | :--- |
-| **Tracking already committed binaries with LFS** | A developer runs `git lfs track "*.tgz"` *after* the `.tgz` has already been pushed to the repo history. | Use `git lfs migrate import --include="*.tgz"` to rewrite local history and move the existing objects to LFS pointers, then force push. |
-| **Forgetting to push submodules** | A developer updates a submodule, commits the pointer change in the main repo, and pushes the main repo, but forgets to push the changes from inside the submodule directory. | Configure Git to push submodules automatically: `git config push.recurseSubmodules check` or `on-demand`. |
-| **Using shallow clones for SonarQube analysis** | The CI pipeline is optimized with `--depth 1`, but the static analysis tool needs the Git history to assign blame and track new vs. old code smells. | Switch the CI pipeline from a shallow clone to a partial clone: `git clone --filter=blob:none`. |
-| **Mixing cone and non-cone sparse checkouts** | Manually editing the `.git/info/sparse-checkout` file with complex regexes while cone mode is enabled. | Stick strictly to the `git sparse-checkout set` command; avoid manual edits to the underlying configuration files. |
-| **Running out of disk space during `git gc`** | Repacking requires creating the new packfile before deleting the old ones, temporarily doubling the required storage space. | Ensure you have at least as much free disk space as the size of your `.git/objects` directory before running an aggressive GC. |
-| **Committing the `.gitattributes` file late** | Setting up LFS tracking rules but forgetting to commit `.gitattributes`, causing other developers' clones to treat binaries as regular Git objects. | Always commit the `.gitattributes` file in the exact same commit (or earlier) as the first large binary file you add. |
+| **Tracking already committed binaries with LFS** | A developer runs `git lfs track "*.tgz"` *after* the `.tgz` has already been pushed to the repo history. | Use `git lfs migrate import --include="*.tgz"` to rewrite local history and move the existing objects to LFS pointers, then force push only with a coordinated migration plan. |
+| **Forgetting to push submodules** | A developer updates a submodule, commits the pointer change in the main repo, and pushes the main repo, but forgets to push the changes from inside the submodule directory. | Configure Git to push submodules automatically with `git config push.recurseSubmodules check` or `on-demand`, and document the parent-plus-submodule push order. |
+| **Using shallow clones for SonarQube analysis** | The CI pipeline is optimized with `--depth 1`, but the static analysis tool needs the Git history to assign blame and track new versus old code smells. | Switch the CI pipeline from a shallow clone to a partial clone such as `git clone --filter=blob:none`, then confirm the scanner can reach the history it needs. |
+| **Mixing cone and non-cone sparse checkouts** | Someone manually edits `.git/info/sparse-checkout` with complex patterns while cone mode is enabled, creating rules Git cannot optimize cleanly. | Stick to `git sparse-checkout set` and `git sparse-checkout add` for cone-mode directories, and reserve non-cone mode for rare cases with measured justification. |
+| **Running out of disk space during `git gc`** | Repacking creates new packfiles before deleting old ones, so cleanup can temporarily require much more free space than expected. | Check the size of `.git/objects` before aggressive maintenance and run cleanup on a machine with enough temporary disk headroom. |
+| **Committing the `.gitattributes` file late** | LFS tracking rules are configured locally but not committed before the first large binary, so other clones treat the file as a normal Git blob. | Commit `.gitattributes` in the same change as the policy setup, and add a review checklist item for new binary patterns. |
+| **Assuming sparse checkout is access control** | Hidden directories feel absent, so teams incorrectly treat sparse rules as a security boundary or ownership enforcement mechanism. | Use repository permissions, CODEOWNERS, and review rules for access and governance; use sparse checkout only for local working tree scope. |
 
 ## Quiz
 
-<details>
-<summary>Question 1: Your CI pipeline runs a bash script that lints all Kubernetes YAML files in the `manifests/` directory. It does not need to analyze history, and it does not need to build any binaries. The monorepo is 10GB. What is the most efficient clone strategy to implement in the CI configuration?</summary>
+<details><summary>Question 1: Your CI pipeline lints all Kubernetes YAML files under `manifests/`. It does not analyze history, derive versions from tags, or build binaries. The monorepo is several gigabytes. What clone strategy would you test first, and what risk would you watch for?</summary>
 
-You should use a treeless partial clone by executing `git clone --filter=tree:0 <url>`. Because the CI pipeline only needs to read the files at the current commit to lint them, it does not need historical file contents (blobs) or historical directory structures (trees). This approach drastically reduces the amount of data transferred over the network compared to a full clone, speeding up the pipeline execution. Furthermore, it is generally more robust and less computationally expensive for the Git server to process than a traditional shallow clone (`--depth 1`), which requires the server to calculate exactly what to omit.
+I would test a treeless partial clone such as `git clone --filter=tree:0 <url>` because the job needs the current checkout more than historical trees or blobs. This can reduce network transfer and startup time while keeping the checkout model compatible with normal Git commands. The risk is that a future version of the job may add a history-aware tool and trigger on-demand fetches or incorrect assumptions. I would record the clone mode in the CI configuration and measure checkout time separately so the trade-off remains visible.
 </details>
 
-<details>
-<summary>Question 2: You joined a new team and cloned their microservice repository. When you try to run `k apply -f vendor/shared-crds/base.yaml`, kubectl reports that the file does not exist. You look in the `vendor/shared-crds` directory and it is completely empty. What happened, and how do you fix it?</summary>
+<details><summary>Question 2: You joined a team and cloned its microservice repository. When you run `k apply -f vendor/shared-crds/base.yaml`, Kubernetes reports that the file does not exist, and the directory is empty. What happened, and how do you fix the immediate problem?</summary>
 
-The team is using Git Submodules to include the shared CRDs, and a standard `git clone` does not automatically fetch submodule contents. You need to initialize and update the submodules by running `git submodule update --init --recursive` in the root of the repository. Alternatively, you could have cloned the repository initially using `git clone --recurse-submodules`. This happens because Git only records a pointer to the submodule's commit in the parent repository, leaving the actual fetching of the nested repository's data as an explicit, secondary step for the developer.
+The repository is probably using a Git submodule for `vendor/shared-crds`, and a standard clone did not fetch the nested repository contents. The immediate fix is to run `git submodule update --init --recursive` from the parent repository root, or to reclone with submodule recursion enabled. The deeper lesson is that submodules require explicit clone and CI configuration because the parent stores a pointer, not the dependency files themselves. If the team wants ordinary clones to contain those files, it should evaluate a subtree or another distribution mechanism.
 </details>
 
-<details>
-<summary>Question 3: Your team lead asks you to configure sparse checkout so you only download the `services/billing` directory. You run `git sparse-checkout init --cone` and then `git sparse-checkout set services/billing`. Later, you run `git merge main` to get the latest updates. Will this merge process updates to the `services/auth` directory even though you cannot see it?</summary>
+<details><summary>Question 3: Your sparse checkout contains only `services/billing`. After fetching `main`, you merge a change that updated `services/auth`, which is outside your cone. Will Git ignore that hidden service, and what should you check before committing your own work?</summary>
 
-Yes, the merge operation will successfully process and record the updates to the `services/auth` directory. Sparse checkout is purely a working tree optimization; it only hides files from your local disk view to save space and index time. The underlying `.git` database still downloads and tracks the full history and state of the entire repository during fetch and merge operations. Therefore, your local repository remains perfectly in sync with the remote, and you will not inadvertently revert or ignore changes made by other teams in directories outside your sparse cone.
+Git will not ignore the hidden service during repository operations; sparse checkout controls what appears in your working tree, not what exists in the object database or merge result. The merge can record updates outside your cone even though those files remain hidden locally. Before committing your own work, check whether the change you are making is truly limited to `services/billing` or whether it should include shared manifests, policies, or other service directories. If the work is cross-cutting, widen the cone or disable sparse checkout temporarily.
 </details>
 
-<details>
-<summary>Question 4: You need to include an open-source Helm chart repository into your internal platform repository. You want other engineers to get the files automatically when they clone, without having to run any extra commands. Which tool should you use, Submodules or Subtrees, and why?</summary>
+<details><summary>Question 4: A packaged Helm chart was committed normally six months ago and updated several times. Today your team adds `git lfs track "*.tgz"`. Why does the repository stay large, and what kind of fix is required?</summary>
 
-You should use Git Subtrees for this scenario because it physically merges the external files into your repository's tree and history. When other engineers execute a standard `git clone`, they will receive all the Helm chart files immediately alongside your internal code. If you had chosen Submodules instead, they would pull down an empty directory and would be forced to run the `git submodule update` command to actually retrieve the chart data. Subtrees provide a much smoother developer experience when the goal is seamless, out-of-the-box consumption of shared dependencies.
+The new LFS tracking rule affects future additions and modifications, but it does not rewrite the existing Git history where the tarballs were stored as ordinary blobs. Those old objects remain reachable from previous commits, so fresh clones still download them. Fixing the old history requires a deliberate migration such as `git lfs migrate import --include="*.tgz"` followed by a coordinated force push and clone repair plan. Because that is disruptive, teams should define LFS policy before large binaries enter the repository.
 </details>
 
-<details>
-<summary>Question 5: A developer complains that their local repository is extremely sluggish. `git status` takes several seconds, and their IDE is freezing. They have never configured any advanced Git features. What two commands should you instruct them to run to optimize their local database?</summary>
+<details><summary>Question 5: A release job computes notes from tags and merge bases, then packages current manifests. A teammate proposes `--depth 1` because checkout is slow. How would you respond?</summary>
 
-You should instruct them to run `git gc` and `git commit-graph write --reachable`. The `git gc` command will garbage collect loose objects and compress them efficiently into packfiles, which reduces the number of file handles the OS needs to open and saves disk space. The `git commit-graph write --reachable` command generates an optimized binary cache of the commit history structure, drastically accelerating history traversal commands. Alternatively, they could enable background optimization by running `git maintenance start`, which schedules these critical maintenance tasks to run automatically without manual intervention.
+I would reject `--depth 1` as the first fix because the release job explicitly depends on history, tags, and ancestry. A depth-one checkout may make the clone faster while making version calculation wrong or brittle. I would test a blobless partial clone because it preserves commit and tree relationships while deferring old file contents until needed. If the release tooling still fetches many old blobs, the team should measure that behavior and choose a deeper or full fetch for this specific job.
 </details>
 
-<details>
-<summary>Question 6: You correctly configured Git LFS to track `*.iso` files, committed the `.gitattributes` file, and committed a 5GB Ubuntu image. When you push to your corporate Git server, it rejects the push with an HTTP 413 "Payload Too Large" error. What is the most likely architectural cause of this failure?</summary>
+<details><summary>Question 6: Developers report that `git log --graph` and branch ahead-behind checks are slow in a long-lived local clone, but current working tree size is reasonable. Which maintenance actions fit the symptom?</summary>
 
-The most likely cause is that a reverse proxy or load balancer (like Nginx or HAProxy) sitting in front of the Git LFS server is restricting the maximum client body size. Even though Git LFS is specifically designed to handle massive binary objects, the actual data transfer still occurs via standard HTTP API calls. These API requests must pass through the corporate network infrastructure, which often has default upload limits configured for standard web traffic. You will need to work with the infrastructure team to increase the `client_max_body_size` or equivalent setting on the proxy handling the LFS route.
+The symptom points at history traversal and local database shape more than working tree size, so I would start with `git gc` and `git commit-graph write --reachable`. Garbage collection packs loose objects and improves object access, while the commit graph gives Git an optimized cache for ancestry questions. If the repository is a long-lived daily workspace, `git maintenance start` can keep those optimizations fresh in the background. I would still measure before and after because filesystem performance and repository shape can change which command helps most.
+</details>
+
+<details><summary>Question 7: Your platform team maintains a small shared policy bundle used by every service repository. Developers complain whenever clone instructions require extra steps. Would you lean toward submodules or subtrees, and what ownership rule would you add?</summary>
+
+I would lean toward a subtree if the bundle is small enough for parent repositories to carry and the priority is that ordinary clones work immediately. Subtrees make the dependency files regular parent-tree content, which removes the empty-directory surprise that submodules create. The ownership rule is that one team must own upstream synchronization, conflict handling, and the cadence for pulling policy updates into each parent repository. Without that ownership, subtree copies become stale and the convenience turns into hidden drift.
 </details>
 
 ## Hands-On Exercise
 
-In this exercise, you will simulate working in a massive Kubernetes monorepo. You will initialize a local repository with a simulated structure of 20 services, configure a sparse checkout to isolate just your team's domains, and set up Git LFS to track compiled Helm charts.
+In this exercise, you will simulate working in a large Kubernetes monorepo. You will initialize a local repository with 20 services, configure sparse checkout to isolate your team's domains, and set up Git LFS to track packaged Helm charts. The exercise is intentionally local so you can inspect every file and undo the directory afterward without needing a remote Git server or a Kubernetes cluster.
 
 ### Prerequisites Setup
 
-First, let's generate a simulated monorepo structure. Execute this script in your terminal to create the environment:
+First, generate a simulated monorepo structure. Run this script in a disposable directory, and make sure your Git user name and email are configured before the first commit. The manifests are intentionally small because the lesson is about Git shape, not Kubernetes API depth, but they are recognizable enough for a platform workflow that targets Kubernetes 1.35+ clusters.
 
 ```bash
 mkdir k8s-monorepo-sim
@@ -442,57 +412,52 @@ git commit -m "Initial massive monorepo commit"
 
 ### Tasks
 
-1.  **Analyze the initial state:** Check how many directories are currently visible in the `services/` folder.
-2.  **Predict and Observe:** You are about to initialize sparse checkout. Predict what will happen to the `services` directory when you run `git sparse-checkout init --cone`. Run the command and observe your working directory. Explain why the files disappeared.
-3.  **Target your scope:** Your team is only responsible for `service-4` and `service-12`. Configure the sparse checkout to include these specific directories.
-4.  **Predict and Verify:** Before running `ls services/`, predict exactly what will be returned. Run the command to verify your prediction and confirm isolation.
-5.  **Configure LFS tracking:** Your team needs to store bundled Helm charts (`*.tgz` files) in the `services/service-4/charts/` directory. Configure Git LFS to track all `.tgz` files anywhere in the repository.
-6.  **Commit the configuration:** Ensure the LFS tracking configuration is permanently recorded in the repository.
+1. **Analyze the initial state:** Check how many directories are visible in the `services/` folder and explain why a developer assigned to two services would not want all of them in the editor.
+2. **Predict and Observe:** Before initializing sparse checkout, predict what will happen to the `services` directory when cone mode starts with only root files selected. Run the command and compare the result with your prediction.
+3. **Target your scope:** Configure sparse checkout so your working tree includes only `service-4` and `service-12`, then explain why Git can still merge changes for services you cannot see.
+4. **Predict and Verify:** Before running `ls services/`, predict exactly which names will be returned. Run the command, then record whether the output proves the cone is isolated.
+5. **Configure LFS tracking:** Your team needs to store bundled Helm charts (`*.tgz` files) under `services/service-4/charts/`. Configure Git LFS to track tarballs anywhere in the repository.
+6. **Commit the configuration:** Commit the LFS tracking policy and explain why `.gitattributes` must be reviewed like source code rather than treated as a private local setting.
 
 ### Solutions and Success Criteria
 
-<details>
-<summary>Task 1: Analyze the initial state</summary>
+<details><summary>Task 1: Analyze the initial state</summary>
 
 ```bash
 ls services/
 ```
 
-You should see `service-1` through `service-20`.
+You should see `service-1` through `service-20`. The point is not that 20 directories are hard to manage; it is that the same pattern becomes expensive when a real platform repository grows to hundreds or thousands of services. A developer assigned to two services benefits when search, editor indexing, and accidental file browsing focus on the paths they actually maintain.
 </details>
 
-<details>
-<summary>Task 2: Predict and Observe</summary>
+<details><summary>Task 2: Predict and Observe</summary>
 
 ```bash
 git sparse-checkout init --cone
 ```
 
-Immediately after running this, if you type `ls`, you will likely only see files at the root of the repository. The `services` directory will disappear from your working tree. This happens because initializing sparse checkout in cone mode defaults to only including the root directory files, hiding everything else until explicitly requested.
+Immediately after running this, `ls` will likely show only files at the repository root. The `services` directory disappears from your working tree because cone mode starts with the root selected and no service cone requested yet. The repository history is still present; Git has changed which tracked paths are materialized on disk.
 </details>
 
-<details>
-<summary>Task 3: Target your scope</summary>
+<details><summary>Task 3: Target your scope</summary>
 
 ```bash
 git sparse-checkout set services/service-4 services/service-12
 ```
 
-This tells Git to construct a cone that explicitly includes those two directories, signaling that you want them populated in your working tree.
+This command tells Git to populate exactly those service cones, along with the parent directories needed to reach them. Git can still merge changes outside those cones because sparse checkout does not delete history or remote tracking data. It only limits your working tree view.
 </details>
 
-<details>
-<summary>Task 4: Predict and Verify</summary>
+<details><summary>Task 4: Predict and Verify</summary>
 
 ```bash
 ls services/
 ```
 
-You should now ONLY see `service-4` and `service-12`. The other 18 service directories remain hidden from your local disk. This fulfills the prediction that sparse checkout isolates your view to exactly the cones you defined. As a result, you save local disk space and significantly reduce Git's index parsing time.
+You should now see only `service-4` and `service-12`. The other service directories remain hidden from your local disk, which confirms that your sparse definition is doing useful work. If additional services appear, inspect your sparse checkout list before assuming Git ignored the command.
 </details>
 
-<details>
-<summary>Task 5: Configure LFS tracking</summary>
+<details><summary>Task 5: Configure LFS tracking</summary>
 
 ```bash
 # Ensure LFS is installed for your user
@@ -502,11 +467,10 @@ git lfs install
 git lfs track "*.tgz"
 ```
 
-This command creates or updates a `.gitattributes` file in the root of your repository with the LFS tracking definition.
+This command creates or updates `.gitattributes` in the repository root. The rule says matching tarballs should pass through the LFS filter rather than becoming ordinary Git blobs. If `git lfs` is not installed, install it through your operating system package manager and rerun the command.
 </details>
 
-<details>
-<summary>Task 6: Commit the configuration</summary>
+<details><summary>Task 6: Commit the configuration</summary>
 
 ```bash
 # You must commit the .gitattributes file so others get the LFS rules
@@ -514,13 +478,30 @@ git add .gitattributes
 git commit -m "build: configure LFS tracking for helm chart tarballs"
 ```
 
+Committing `.gitattributes` makes the LFS policy part of the repository contract. Other developers and CI runners need that rule before they add or modify matching tarballs. Treat this commit as a policy change because it affects storage, authentication, and future migration work.
 </details>
 
 **Success Criteria:**
+
 - [ ] Running `ls services/` shows exactly two directories: `service-4` and `service-12`.
 - [ ] A `.gitattributes` file exists in the root of the repository containing the line `*.tgz filter=lfs diff=lfs merge=lfs -text`.
-- [ ] `git status` reports a clean working tree.
+- [ ] `git status` reports a clean working tree after the final commit.
+- [ ] You can explain why sparse checkout reduces working tree scope but does not remove hidden services from repository history.
+- [ ] You can explain why LFS must be configured before large tarballs are committed normally.
 
 ## Next Module
 
 Ready to stop doing things manually? Learn how to force compliance and automate conflict resolution in [Module 9: Automation and Customization](../module-9-hooks-rerere/).
+
+## Sources
+
+- [Git sparse-checkout documentation](https://git-scm.com/docs/git-sparse-checkout)
+- [Git partial clone design notes](https://git-scm.com/docs/partial-clone)
+- [Git clone documentation](https://git-scm.com/docs/git-clone)
+- [Git LFS documentation](https://git-lfs.com/)
+- [Git LFS specification](https://github.com/git-lfs/git-lfs/blob/main/docs/spec.md)
+- [Git submodule documentation](https://git-scm.com/docs/git-submodule)
+- [Git subtree documentation](https://git-scm.com/docs/git-subtree)
+- [Git garbage collection documentation](https://git-scm.com/docs/git-gc)
+- [Git commit-graph documentation](https://git-scm.com/docs/git-commit-graph)
+- [Git maintenance documentation](https://git-scm.com/docs/git-maintenance)


### PR DESCRIPTION
## Summary
- Rewrote `src/content/docs/prerequisites/git-deep-dive/module-8-scale.md` for #388 density, structure, alignment, and anti-leak gates.
- Cleared `revision_pending: false` in frontmatter.

## Verifier
- `.venv/bin/python scripts/quality/verify_module.py --glob src/content/docs/prerequisites/git-deep-dive/module-8-scale.md --skip-source-check --summary --quiet`: T0; body_words=5183, mean_wpp=83.6, median_wpp=87.0, short_rate=0.048, max_run=2.

## Protected Assets
- Preserved protected asset counts: code_blocks=26, ascii_diagrams=1, mermaid_diagrams=3, tables=2.
- Preserved original example source URLs and added a Sources section with 10 official/vendor URLs; live source reachability was skipped per command.

## Checks
- `git diff --check -- src/content/docs/prerequisites/git-deep-dive/module-8-scale.md`: passed.
- `.venv/bin/python scripts/test_pipeline.py`: passed, 166 tests.
- `npm run build`: attempted from worktree because primary checkout is dirty and not on main; failed with the documented worktree resolver issue for `../../node_modules/@astrojs/starlight/style/layers.css`.

Commit: ee9168606de4251219d26422e719b32ae2678996