### PR TITLE
feat(388): rewrite module-7-remotes-prs (#388 pilot)

### DIFF
--- a/src/content/docs/prerequisites/git-deep-dive/module-7-remotes-prs.md
+++ b/src/content/docs/prerequisites/git-deep-dive/module-7-remotes-prs.md
@@ -1,38 +1,38 @@
 ---
-title: "Module 7: Professional Collaboration — Remotes and PRs"
+title: "Module 7: Professional Collaboration - Remotes and PRs"
 description: "Master remote tracking branches, fork workflows, and pull request lifecycles."
+revision_pending: false
 sidebar:
   order: 7
 ---
 
-# Module 7: Professional Collaboration — Remotes and PRs
+# Module 7: Professional Collaboration - Remotes and PRs
 
-**Complexity**: [MEDIUM]  
-**Time to Complete**: 75 minutes  
-**Prerequisites**: Module 6 of Git Deep Dive  
+**Complexity**: [MEDIUM]. **Time to Complete**: 90 minutes. **Prerequisites**: Module 6 of Git Deep Dive, comfort with branches, and basic Kubernetes manifest editing. This module uses Kubernetes 1.35+ examples and introduces the standard `alias k=kubectl` convention before using short `k apply` commands in review workflows.
 
 ## Learning Outcomes
 
-Upon completing this module, you will be able to:
+Upon completing this module, you will be able to perform the following review and synchronization tasks in realistic collaboration workflows:
+
 1. **Diagnose** discrepancies between local, remote-tracking, and remote branches to resolve synchronization issues without data loss.
 2. **Implement** a strict fork-and-pull workflow using multiple remotes (`origin` and `upstream`) for secure enterprise collaboration.
 3. **Evaluate** the safety of branch updates by choosing between `--force` and `--force-with-lease` based on shared branch states.
-4. **Design** atomic commits that isolate infrastructure changes (e.g., separating Kubernetes ConfigMap updates from Deployment scaling) to streamline Pull Request reviews.
+4. **Design** atomic commits that isolate infrastructure changes, such as separating Kubernetes ConfigMap updates from Deployment scaling, to streamline Pull Request reviews.
 5. **Implement** conventional commit specifications and SSH/GPG signing to construct automated, verifiable project changelogs.
 
 ## Why This Module Matters
 
-A junior platform engineer at a mid-sized logistics company merged a pull request containing a misconfigured Kubernetes Ingress manifest. Because the commits were tangled, massive, and lacked clear messages, the senior reviewer skimmed the 2,500-line diff, missed a crucial host routing rule, and approved the merge. The resulting deployment took down the primary shipping API for two hours, costing the company hundreds of thousands of dollars in lost transaction volume. The post-mortem revealed that the engineer had squashed multiple unrelated configuration changes—database migrations, service meshes, and the ingress rules—into a single monolithic commit with the vague message "update k8s manifests".
+A junior platform engineer at a mid-sized logistics company merged a pull request containing a misconfigured Kubernetes Ingress manifest. Because the commits were tangled, massive, and labeled with a vague message, the senior reviewer skimmed a 2,500-line diff, missed a critical host routing rule, and approved the change during a release window. The resulting deployment sent shipping API traffic to the wrong backend for two hours, interrupting order creation and costing the company hundreds of thousands of dollars in lost transaction volume and customer credits.
 
-When infrastructure is defined as code, version control is the final safety net before production. Professional collaboration in Git is not merely about memorizing commands to move code from your laptop to a server; it is about communicating intent, minimizing blast radius, and ensuring that every proposed change is independently verifiable. If you cannot structure your commits logically and navigate remote branches with absolute confidence, you introduce systemic risk to your team's deployment pipeline.
+The post-incident review found no exotic Git bug, no broken CI runner, and no mysterious platform outage. The failure came from ordinary collaboration habits: stale local branches, a branch pushed from the wrong remote, unrelated Kubernetes ConfigMap and Deployment edits packed into one commit, and a pull request that asked reviewers to trust intent instead of verifying it. The team had used Git as a file transport mechanism, but production needed Git to behave like an audit trail, a safety boundary, and a shared reasoning system.
 
-In this module, you will transition from using Git as a personal save button to wielding it as a collaborative engineering instrument. You will master the mechanics of remote tracking, the nuances of push strategies, and the discipline required to construct pull requests that your peers can actually review effectively.
+When infrastructure is defined as code, version control is the final safety net before production. Professional collaboration in Git is not merely about memorizing commands to move code from a laptop to a server; it is about communicating intent, minimizing blast radius, and ensuring that every proposed change is independently reviewable. In this module, you will move from using Git as a personal save button to using it as a collaborative engineering instrument, with special attention to remote state, fork boundaries, safe history rewriting, atomic pull requests, and verifiable commits.
 
-## 1. The Anatomy of a Remote and Tracking Branches
+## 1. Remote State Is a Local Cache, Not a Live Window
 
-Many engineers mistakenly believe that when they reference `origin/main`, they are querying the remote server in real-time over the network. This is a dangerous misconception. Git is fundamentally decentralized. The branch `origin/main` is entirely local to your machine; it is a cached bookmark of what the remote branch looked like the last time your local repository communicated with the server.
+Many engineers mistakenly believe that `origin/main` is a live view of the remote server. That misunderstanding creates real operational risk, because it encourages people to make safety decisions from stale evidence. Git is distributed by design, so most names you inspect locally are just references in your `.git` directory. A remote-tracking branch such as `origin/main` is a local bookmark that records what the remote branch looked like the last time your repository communicated with that server.
 
-To understand collaboration, you must visualize the three distinct layers of repository state:
+Think of remote-tracking branches like a printed train schedule on your desk. The schedule may have been accurate when you printed it, and it is useful for planning, but it does not prove that the train has not been delayed since then. `git fetch` is how you print a fresh schedule. Until you fetch, comparisons between `main` and `origin/main` are comparisons between your local branch and your last known copy of the remote branch, not a conversation with GitHub, GitLab, or another server.
 
 ```mermaid
 flowchart TD
@@ -60,11 +60,9 @@ flowchart TD
     RemoteRepo -- "git fetch" --> TrackingBranches
 ```
 
-When you work offline, you can checkout `main` and compare it against `origin/main` because `origin/main` is just a file on your hard drive (located in `.git/refs/remotes/origin/main`). It acts as a proxy.
+This diagram matters because each layer has a different owner and a different update rule. Local branches move when you commit, merge, rebase, reset, or check out a new position. Remote-tracking branches move when you fetch, pull, or push in ways that update your local knowledge. Remote branches move when someone successfully pushes to the server. Confusing those layers is how engineers accidentally rebase stale work, push to the wrong destination, or assume a teammate has not changed a branch when the only thing that is stale is their own cache.
 
-### The Magic of the Refspec
-
-How does Git actually know what `origin` means? The configuration is stored plainly in your `.git/config` file. If you run `cat .git/config`, you will see something like this:
+The mapping from remote server branches into local remote-tracking branches is not magical. It is configured by a refspec in `.git/config`, which tells Git where to fetch from and where to store the result locally. Reading this configuration once removes a lot of superstition from remote work, because it shows that `origin` is just a named remote with a URL and a mapping rule.
 
 ```ini
 [remote "origin"]
@@ -72,42 +70,32 @@ How does Git actually know what `origin` means? The configuration is stored plai
     fetch = +refs/heads/*:refs/remotes/origin/*
 ```
 
-The `fetch` line is called a **Refspec**. It explicitly tells Git how to map the branches on the server to the branches on your local machine. 
-- `refs/heads/*` is the source (the branches on the server).
-- `refs/remotes/origin/*` is the destination (your local tracking branches).
-- The `+` sign tells Git to forcefully update these tracking branches even if it results in a non-fast-forward update, ensuring your local cache is an exact mirror of the server.
+The source side, `refs/heads/*`, means "all branch heads on the remote server." The destination side, `refs/remotes/origin/*`, means "store those remote branch positions under my local remote-tracking namespace." The leading plus sign allows Git to update the tracking reference even when the remote branch moved in a non-fast-forward way, because the tracking reference is supposed to mirror the server rather than protect local work. Your local branch is protected separately by merge, rebase, and push rules.
 
-### Inspecting Your Remotes
-
-To view the remotes configured for your local repository without opening the config file, use the verbose flag:
+You can inspect remotes without opening the config file, and you should do this whenever a repository has more than one collaboration path. A surprising number of production mistakes start with a developer assuming `origin` points to the central repository when it actually points to a personal fork, a stale mirror, or a temporary migration remote.
 
 ```bash
 git remote -v
 ```
 
-Output:
+The output should show separate fetch and push URLs for the same remote, which is the simplest healthy configuration for a single-remote repository:
+
 ```text
 origin  git@github.com:kubedojo/core-platform.git (fetch)
 origin  git@github.com:kubedojo/core-platform.git (push)
 ```
 
-> **Pause and predict**: What do you think happens if you run `git commit` while on your local `main` branch? Does `origin/main` move?
+Pause and predict: if you run `git commit` while checked out on local `main`, what do you think happens to `origin/main`? The important answer is that only your local `main` branch pointer moves forward. `origin/main` stays exactly where it was, because it represents your last fetched knowledge of the server, not your current local work and not a live server query.
 
-*Prediction outcome:* Only your local `main` branch pointer moves forward. `origin/main` remains exactly where it was, representing the last known state of the server. They are now diverged.
+This distinction is the foundation for diagnosing remote discrepancies. When `git status` says your branch is ahead, behind, or diverged, Git is comparing your local branch to its configured upstream tracking branch. That comparison is only as current as your most recent fetch. A disciplined engineer therefore treats `git fetch --all --prune` as reconnaissance, not as a risky operation, and uses it before making decisions about rebasing, force pushing, or reviewing whether a branch is safe to delete.
 
-## 2. Fetch vs Pull: The Hidden Danger
+One useful diagnostic habit is to name the branch layer out loud before acting. "My local `main` is ahead of `origin/main`" is a different statement from "the remote server is ahead of my local `main`," and both are different from "my fork is behind upstream." That precision slows people down just enough to prevent destructive guesses. In team channels and incident notes, precise branch language also helps another engineer reproduce your state without sitting at your keyboard.
 
-Because `origin/main` is merely a local cache, it goes stale the moment a teammate pushes new code to the remote server. To update your cache, you must synchronize.
+## 2. Fetch, Pull, and the Shape of History
 
-This is where the distinction between `git fetch` and `git pull` becomes critical.
+Because remote-tracking branches are local cache entries, synchronization has two separate concerns: updating your knowledge of the remote and integrating that knowledge into your current work. `git fetch` handles the first concern and stops there. It connects to the remote, downloads objects you do not yet have, and updates `origin/*` or another remote-tracking namespace. It does not rewrite your working tree, change staged files, or move your local branch.
 
-### `git fetch`: The Safe Reconnaissance
-Running `git fetch origin` simply connects to the remote, downloads any new commits, and updates your Remote Tracking Branches (`origin/*`). It does **not** touch your local branches or your working directory. It is completely safe. You can fetch a dozen times a day without impacting your ongoing work.
-
-### `git pull`: The Aggressive Updater
-Running `git pull` is a compound operation. Under the hood, it executes:
-1. `git fetch origin`
-2. `git merge origin/main` (assuming you are on the `main` branch)
+`git pull` handles both concerns in one command, which is why it feels convenient and occasionally dangerous. A pull first fetches from the remote, then integrates the fetched tracking branch into your current branch by merge or rebase depending on configuration and flags. The danger is not that pull is broken; the danger is that it hides two decisions inside one word. In calm conditions that shortcut is fine, but during review repair, incident response, or branch recovery, you usually want to inspect before you integrate.
 
 ```mermaid
 sequenceDiagram
@@ -123,8 +111,7 @@ sequenceDiagram
     Local Branch-->>Working Tree: Update files on disk
 ```
 
-### The Merge Commit Menace
-If you have made local commits on `main`, and the remote `main` has also received new commits, `git pull` will automatically create a "Merge commit" to reconcile the two diverged histories.
+The hidden integration step is where teams accidentally create noisy merge commits. If your local branch has commits that the remote branch does not have, and the remote branch has commits that your local branch does not have, a merge-based pull must create a new merge commit to connect the histories. That merge commit may be technically valid, but it often adds no useful design information to a feature branch and makes later review harder.
 
 ```mermaid
 flowchart LR
@@ -143,27 +130,28 @@ flowchart LR
     end
 ```
 
-This clutters the project history with unnecessary branch diamonds. To maintain a clean, linear history, modern engineering teams prefer rebasing over merging when pulling updates.
+Modern review-oriented teams often prefer a linear feature history because it lets reviewers read the branch as a sequence of decisions. Rebasing local commits on top of the latest remote state preserves that shape by replaying your work after the commits that already exist upstream. The tradeoff is that rebasing rewrites commit hashes, so it is appropriate for your own unpublished or review-branch work but should be handled carefully on shared branches.
 
 ```bash
 # Fetch and rebase your local commits on top of the remote updates
 git pull --rebase origin main
 ```
 
-You can make this frequent behavior the default for your machine:
+You can make this frequent behavior the default for your machine, which reduces accidental merge commits when you pull updates into local feature branches:
+
 ```bash
 git config --global pull.rebase true
 ```
 
-## 3. The Fork and Pull Model (Upstream vs Origin)
+Before running a pull during real work, pause and ask a better diagnostic question: "Do I want to update my knowledge, or do I want to modify my current branch right now?" If you only need knowledge, fetch. If you are ready to integrate and have reviewed the incoming branch position, pull with the integration mode your team expects. That small pause prevents the common panic where an engineer thinks Git destroyed their work when it actually performed the merge they requested without realizing the branch had diverged.
 
-In enterprise environments and open-source projects, you rarely have direct write access to the central repository. Instead, you use the "Fork and Pull" model, often referred to as the **Triangle Workflow**.
+A practical Kubernetes example makes the decision concrete. Suppose you are editing `deployment.yaml` for a backend rollout and a teammate has just changed `configmap.yaml` on `origin/main`. Running `git fetch origin` lets you inspect the teammate's commit before your local files move. You can compare the branch tips, read the diff, and decide whether to rebase now or finish your local commit first. If you have defined `alias k=kubectl`, you can later validate the integrated manifest with `k apply --dry-run=server -f deployment.yaml` after the history is intentionally updated rather than accidentally blended.
 
-1. **Upstream**: The central, authoritative repository (e.g., `kubedojo/core-platform`).
-2. **Origin**: Your personal copy of the repository under your own account (e.g., `yourname/core-platform`).
-3. **Local**: Your laptop.
+## 3. Fork-and-Pull Workflows Create a Deliberate Security Boundary
 
-You clone your fork to your laptop, meaning `origin` points to your personal copy. To stay synchronized with the rest of the team, you must manually add the central repository as a second remote called `upstream`.
+In enterprise environments and open-source projects, you often should not have direct write access to the central repository even if you are a trusted contributor. The fork-and-pull model creates a deliberate buffer between personal work and authoritative history. Your fork is the place where you can push branches freely, experiment with rebases, and update pull requests. The upstream repository is the controlled integration point where branch protection, required reviews, signed commits, and CI checks decide what becomes official.
+
+This model is often called the triangle workflow because your local repository talks to two server-side repositories. `origin` usually points to your writable fork, while `upstream` points to the canonical project. That naming is convention rather than law, but it is so common that following it reduces cognitive load for every reviewer and teammate who helps you debug a remote problem.
 
 ```bash
 # Add the central repository as a remote
@@ -173,7 +161,8 @@ git remote add upstream git@github.com:kubedojo/core-platform.git
 git remote -v
 ```
 
-Expected output:
+The expected output makes the fork boundary visible by showing your writable `origin` separately from the authoritative `upstream` project:
+
 ```text
 origin    git@github.com:yourname/core-platform.git (fetch)
 origin    git@github.com:yourname/core-platform.git (push)
@@ -181,8 +170,7 @@ upstream  git@github.com:kubedojo/core-platform.git (fetch)
 upstream  git@github.com:kubedojo/core-platform.git (push)
 ```
 
-### Synchronizing a Fork (The Triangle Workflow)
-To bring your local `main` branch up to date with the team's central repository, you pull from one point of the triangle and push to another.
+The operational habit is simple: fetch from the authority, branch locally, push your proposal to your fork, then open a pull request against upstream. This is not bureaucracy for its own sake. It ensures that the same code path handles contributions from employees, contractors, and external maintainers, and it prevents a single mistaken `git push` from bypassing the review system that protects production.
 
 ```bash
 # 1. Fetch all updates from the central repository
@@ -198,64 +186,52 @@ git rebase upstream/main
 git push origin main
 ```
 
-> **Pause and predict**: If you accidentally run `git push upstream main`, what output do you expect?
+Pause and predict: if you accidentally run `git push upstream main` from a repository where you lack direct write permissions, what output do you expect and why? The expected result is a permission rejection from the hosting platform, often an HTTP 403 or SSH authorization error. That rejection is not a nuisance; it is the security boundary doing its job by forcing changes through pull requests instead of direct mutation.
 
-*Prediction outcome:* The server will reject the push with an HTTP 403 Forbidden error, because you do not have direct write permissions to the upstream repository. This is the exact security boundary the fork model is designed to enforce.
+The fork workflow also gives you a cleaner diagnostic vocabulary. If your branch is missing a teammate's merged work, ask whether you fetched from `upstream`, not whether "GitHub is behind." If your pull request does not update after a push, ask whether you pushed to `origin` and whether the PR source branch points to that fork. If your local `main` differs from both `origin/main` and `upstream/main`, ask which one represents your personal mirror and which one represents the project authority.
 
-## 4. Force Pushing Safely: The Lease Mechanism
+There is one subtle tradeoff: maintaining two remotes means you can create two kinds of staleness. Your local repository can be stale relative to upstream, and your fork can be stale relative to both upstream and your local work. The synchronization loop above closes that gap by updating local `main` from upstream and then pushing the synchronized `main` back to origin. In professional review flows, that extra push is useful because it keeps future feature branches and web-based comparisons from being based on an old fork state.
 
-When you rebase a branch or amend a commit, you rewrite Git history. You are essentially creating entirely new commits that happen to have the same file contents. If you have already pushed the old version of that branch to a remote, your local history and the remote history now conflict. A standard `git push` will be rejected.
+Teams that skip the fork synchronization step often discover the cost later, when a contributor opens a pull request whose base comparison includes months of unrelated upstream history. The code may be correct, but the review becomes noisy because the hosting platform is comparing from a stale fork branch. Keeping `origin/main` aligned with `upstream/main` is therefore not only housekeeping. It protects reviewer attention, keeps conflict resolution close to the author, and makes the eventual pull request show only the intended branch delta.
 
-You must force the remote to accept your rewritten history.
+## 4. Safe History Rewriting Depends on Leases
 
-### The Danger of `--force`
-Running `git push --force` tells the remote server: "Overwrite whatever you have with my local state, no questions asked."
+Rebasing, squashing, and amending are normal parts of preparing a clean pull request. They are not dishonest when used on a review branch; they are editing the proposed story before it becomes project history. The danger appears when a rewritten branch has already been pushed, because the old commit hashes still exist on the remote while your local branch now contains replacement commits. A normal push is rejected because the remote cannot fast-forward from the old history to your rewritten history.
 
-**War Story:** A platform engineer named Alex was working on a shared feature branch (`feature/helm-migration`). Alex rebased the branch locally to clean up commit messages, then typed `git push --force`. Meanwhile, a teammate, Sarah, had pushed three new commits to that exact remote branch an hour earlier. Alex's `--force` push completely eradicated Sarah's commits from the remote server. Git did exactly what it was told: it overwrote the server's history with Alex's local history.
+The blunt tool is `--force`, which tells the remote to accept your local branch position regardless of what currently exists on the server. That command is sometimes described as dangerous in a vague way, but the concrete danger is data loss for teammates. If another engineer pushed commits to the same branch after your last fetch, an unconditional force push can remove their commits from the branch tip even though you never saw them locally.
 
-### The Solution: `--force-with-lease`
-Instead of unconditional destruction, use a lease.
+**War Story:** A platform engineer named Alex was working on a shared feature branch called `feature/helm-migration`. Alex rebased the branch locally to clean up commit messages, then typed `git push --force`. Meanwhile, a teammate, Sarah, had pushed three new commits to that exact remote branch earlier that morning. Alex's push completely replaced the server's branch with the local rewritten branch, and Git did exactly what it was instructed to do.
+
+The safer tool is `--force-with-lease`, which turns the push into a conditional update. The lease says, in effect, "rewrite the remote branch only if it still points to the commit that my local remote-tracking branch says it points to." If the server has moved since your last fetch, the lease fails and the push is rejected. That rejection is a feature, because it tells you your local mental model is stale before you overwrite someone else's work.
 
 ```bash
 git push --force-with-lease origin feature/helm-migration
 ```
 
-> **Stop and think**: Why is `--force-with-lease` safer than `--force`? What specific check does it perform before rewriting history?
+Stop and think: why does the lease check use your remote-tracking branch instead of trusting your memory of the branch? The reason is that Git can compare object IDs precisely, while human memory collapses branch state into vague phrases like "I fetched recently." A lease converts "recently" into a specific expected commit. If the server does not match that expected commit, Git refuses to proceed until you fetch and inspect the new state.
 
-When you use `--force-with-lease`, Git performs a safety check. It compares your local tracking branch (`origin/feature/helm-migration`) with the actual branch on the remote server. 
-- If they match, it means nobody else has pushed new commits since your last fetch. The force push succeeds.
-- If they do not match, it means someone (like Sarah) has pushed new work. The push is instantly rejected, saving your teammate's data.
+When a lease is rejected, the correct response is not to fall back to `--force`. Fetch the remote, inspect the new commits, and decide how to incorporate them. A typical repair loop is `git fetch origin`, `git log origin/feature/helm-migration`, and then a rebase or merge that deliberately includes the teammate's work. Only after your local branch is based on the updated remote state should you try `--force-with-lease` again.
 
-**What to do when your lease is rejected?**
-If `--force-with-lease` is rejected, do not panic and do not fall back to `--force`.
-1. Run `git fetch origin` to update your tracking branches.
-2. Run `git log origin/feature/helm-migration` to see what your teammate pushed.
-3. Incorporate their changes into your work (usually via `git rebase origin/feature/helm-migration`).
-4. Attempt the `--force-with-lease` push again.
+The lease mechanism is also a useful social signal. If a branch rejects your push, Git is telling you that your assumption of sole ownership is no longer guaranteed. That does not always mean a teammate intentionally collaborated on your branch; automation might have updated it, a maintainer might have pushed a fix, or a previous local machine might have moved the same branch. In all cases, the safe next step is investigation, because the cost of one extra fetch is tiny compared with reconstructing lost review work.
 
-Always use `--force-with-lease`. Never use `--force`.
+This habit matters during pull request review because review branches are often rewritten in response to feedback. You might amend a Kubernetes Deployment commit after a reviewer asks for a resource limit, squash a noisy "fix typo" commit into the original documentation change, or rebase on a newly merged security patch. Those are reasonable operations when you own the review branch. They become risky only when the branch is shared and the push command ignores whether the server changed while you were editing.
 
-## 5. Pull Request Lifecycles and Atomic Commits
+## 5. Pull Requests Are Reviewable Stories, Not File Dumps
 
-A Pull Request (PR) is a request to merge your branch into the upstream main branch. The quality of a PR is determined entirely by the commits it contains.
+A pull request is not merely a request to merge files. It is a structured argument that says, "Here is the problem, here is the smallest coherent change that solves it, here is how I tested it, and here is the evidence reviewers need to trust it." The quality of that argument is determined largely by the commits it contains. If each commit does one logical thing and leaves the repository in a working state, reviewers can evaluate design decisions rather than untangling the author's afternoon.
 
-An **Atomic Commit** is a commit that does exactly one logical thing, and leaves the repository in a fully functional state. It should compile, tests should pass, and the infrastructure should deploy successfully at every single commit in the history.
+An atomic commit is a commit that does exactly one logical thing and keeps the repository functional. In infrastructure code, that often means separating a ConfigMap data change from a Deployment wiring change, or separating a Service port change from an application code change. The point is not aesthetic purity. The point is operational reversibility. During an incident, `git revert` is only surgical if the original commit was surgical.
 
-Consider you need to update a Kubernetes Deployment to use a new ConfigMap.
+Consider a change that updates a Kubernetes Deployment to consume a new ConfigMap. A monolithic approach modifies `deployment.yaml`, `configmap.yaml`, `service.yaml`, and a Python helper script, then commits everything as `fix: update environment setup`. If the rollout fails because the ConfigMap contains an invalid key, the team must either revert unrelated valid work or manually craft a forward fix while production is degraded. The commit has made the rollback decision harder than the original configuration problem.
 
-**Bad Practice (The Monolithic Commit):**
-You modify `deployment.yaml`, `configmap.yaml`, `service.yaml`, and update a Python script, then commit them all together with the message: `fix: update environment setup`.
-
-If the deployment fails, the team must revert the entire commit, removing the valid Python script and Service changes along with the broken ConfigMap.
-
-**Good Practice (Atomic Commits):**
-You break the changes down logically using Git's interactive staging tool: `git add -p`.
+The better approach is to stage the work by intent. Use `git add -p` when one file contains multiple unrelated hunks, and use explicit file paths when files naturally map to separate logical changes. This is a review skill as much as a Git skill. You are shaping the evidence so reviewers can verify one claim at a time.
 
 ```bash
 git add -p deployment.yaml
 ```
 
-Git will present you with "hunks" of code and ask what you want to do:
+Git will present you with "hunks" of code and ask what you want to do, which turns one messy file edit into a set of intentional review decisions:
+
 ```text
 diff --git a/deployment.yaml b/deployment.yaml
 @@ -14,6 +14,9 @@
@@ -270,9 +246,10 @@ diff --git a/deployment.yaml b/deployment.yaml
 Stage this hunk [y,n,q,a,d,s,e,?]? 
 ```
 
-You can press `y` to stage it, `n` to skip it, or `s` to split it into smaller pieces. This allows you to construct precise, logical commits out of a messy working directory.
+You can press `y` to stage the hunk, `n` to skip it, or `s` to split it into smaller pieces when Git can divide the patch safely. That interaction may feel slow at first, but it is faster than asking three reviewers to reverse-engineer which lines belong together. It also lets you build a branch where each commit can be checked out, tested, and reverted independently.
 
-Commit 1: Add the new ConfigMap variables.
+Commit 1 adds only the new ConfigMap variables, so reviewers can evaluate configuration data without also reasoning about Deployment wiring:
+
 ```yaml
 # configmap.yaml
 apiVersion: v1
@@ -284,7 +261,8 @@ data:
   CACHE_TIMEOUT_SECONDS: "300"
 ```
 
-Commit 2: Mount the ConfigMap in the Deployment.
+Commit 2 mounts the ConfigMap in the Deployment, which is a separate runtime integration decision with a different rollback profile:
+
 ```yaml
 # deployment.yaml
 apiVersion: apps/v1
@@ -308,17 +286,19 @@ spec:
         image: internal.registry.com/finance/payment:v1.2.4
 ```
 
-Commit 3: Update the Python script logic.
+Commit 3 updates the Python script logic, keeping application behavior separate from Kubernetes resource definition changes in the review history.
 
-*Note: The manifest examples in this module assume Kubernetes 1.35+ compatibility, ensuring we are using the latest stable API behaviors.*
+The manifest examples in this module assume Kubernetes 1.35+ compatibility, so the API versions shown here are stable for modern clusters. If you have `alias k=kubectl` defined in your shell, validate the manifest shape with a server-side dry run such as `k apply --dry-run=server -f deployment.yaml` after the branch contains the intended commits. Validation does not replace review, but it gives reviewers stronger evidence that the proposed history is not merely tidy; it is also deployable.
 
-When you open a PR containing these three atomic commits, the reviewer can step through the logic sequentially. If the Deployment configuration is wrong, they can request changes specifically to Commit 2.
+Before opening a pull request, read your branch with the reviewer in mind. Does the first commit establish a prerequisite? Does the second commit use it? Does the final commit update tests, documentation, or automation in a way that follows from the earlier changes? If the branch reads like a sequence of clean engineering decisions, reviewers can focus on architecture, security, resilience, and observability instead of asking the author to split the work after the fact.
 
-## 6. Conventional Commits and Signed Commits
+This is where atomic commits become a mentoring tool rather than a private preference. A reviewer can leave a focused comment on the Deployment commit, approve the ConfigMap commit, and ask for a test adjustment in the script commit without mixing concerns. The author receives clearer feedback, and the team builds a shared vocabulary for change size. Over time, those habits reduce review latency because small, well-labeled commits make it easier to distinguish real risk from ordinary implementation detail.
 
-To further professionalize collaboration, teams use **Conventional Commits** to standardize commit messages, allowing automated tools to generate changelogs and determine semantic version bumps automatically.
+## 6. Conventional and Signed Commits Turn History into Automation Evidence
 
-### Conventional Commit Format
+Commit messages are part of the product interface for future maintainers. A vague message like `updates` forces every later reader to open the diff and infer intent. A conventional message gives automation and humans a compact summary of the kind of change being made, the area affected, and whether the change should influence release notes or version numbers. This is especially valuable in platform repositories where infrastructure, application code, policy, and documentation often live together.
+
+Conventional Commits provide a lightweight grammar. The type communicates intent, the optional scope points to the affected subsystem, the description names the behavior change, and the body or footer explains context that does not fit on one line. The format is simple enough to write by hand but structured enough for changelog generators and release pipelines.
 
 ```text
 <type>[optional scope]: <description>
@@ -328,7 +308,8 @@ To further professionalize collaboration, teams use **Conventional Commits** to 
 [optional footer(s)]
 ```
 
-Common types and their semantic versioning implications:
+Common types and their semantic versioning implications give both humans and automation a shared vocabulary for deciding release impact:
+
 - `fix:` A bug fix. (Triggers a PATCH release, e.g., `v1.0.1`)
 - `feat:` A new feature or capability. (Triggers a MINOR release, e.g., `v1.1.0`)
 - `docs:` Documentation only changes. (No release)
@@ -336,7 +317,8 @@ Common types and their semantic versioning implications:
 - `refactor:` Code changes that neither fix a bug nor add a feature. (No release)
 - `BREAKING CHANGE:` anywhere in the footer or a `!` after the type (Triggers a MAJOR release, e.g., `v2.0.0`)
 
-Example:
+This example shows how a concise subject, explanatory body, and issue reference combine into a commit message that supports review and later auditing:
+
 ```text
 feat(ingress): add TLS termination for backend services
 
@@ -346,10 +328,9 @@ to automate Let's Encrypt certificate provisioning.
 Resolves: #812
 ```
 
-### Commit Signing
-To verify that a commit actually came from you (and not an attacker spoofing your email address), you should cryptographically sign your commits.
+Signed commits answer a different question: not "what kind of change is this?" but "can we verify who created this commit?" Git commit metadata includes a name and email address, but those values are easy to configure locally and are not proof of identity. Cryptographic signing ties the commit to a private key, allowing hosting platforms and CI policies to detect spoofed authorship or unsigned changes in protected branches.
 
-Historically, this required complex GPG key management. As of Git 2.34, you can use standard SSH keys instead.
+Historically, many teams avoided signing because GPG key management felt heavy. As of Git 2.34, standard SSH keys can be used for commit signing, which fits the authentication material many engineers already maintain. The setup is still security-sensitive, but it is no longer an exotic workflow reserved for release managers.
 
 ```bash
 # Configure Git to use SSH for signing
@@ -362,32 +343,73 @@ git config --global user.signingkey ~/.ssh/id_ed25519.pub
 git config --global commit.gpgsign true
 ```
 
-Now, every time you commit, Git will use your SSH key to sign the objects, and platforms like GitHub/GitLab will display a trusted "Verified" badge next to your work.
+Now every commit can carry verifiable authorship, and platforms such as GitHub and GitLab can display a trusted verification badge when the signature matches a registered public key. That badge is not a substitute for code review, but it removes one class of impersonation from the reviewer's threat model. In regulated or high-change infrastructure repositories, signed commits also make audit trails easier to defend because the commit graph records both the content and a verifiable identity signal.
 
-## 7. Reviewing Code: The Human Element
+## 7. Reviewing Pull Requests as a Production Control
 
-Submitting a Pull Request is only half the battle; reviewing your peers' code is the other. Effective code review is a high-level skill that separates junior engineers from seniors.
+Submitting a pull request is only half the collaboration loop; reviewing someone else's work is the other half. Effective review is a high-leverage engineering practice because it catches design mismatches, unclear rollback paths, and missing operational evidence before they reach production. The best reviewers are not trying to prove they are clever. They are trying to decide whether the change is understandable, safe, observable, and maintainable.
 
-**What to Ignore:**
-- Formatting, spacing, and styling. (These should be handled automatically by linters and formatters like `Prettier` or `gofmt`).
-- Missing semicolons or trivial syntax issues.
+Low-value review comments usually belong to automation. Formatting, spacing, generated files, import sorting, missing semicolons, and simple style consistency should be handled by linters, formatters, and CI checks. Human attention is expensive, so use it on architecture, security, resilience, observability, migration safety, and whether the pull request tells a coherent story. If a Kubernetes Deployment gains a new container without resource limits, if a Secret-like value appears in a ConfigMap, or if a rollback would remove unrelated work, those are human review findings.
 
-**What to Focus On:**
-- **Architecture**: Does this change fit the overall design of the system?
-- **Security**: Are credentials hardcoded? Are Kubernetes security contexts overly permissive (e.g., `runAsRoot: true`)?
-- **Resilience**: Are there resource limits on the containers? What happens if the downstream service is unavailable?
-- **Observability**: Did the developer add necessary logging or metrics for the new feature?
-
-When reviewing, be kind but rigorous. Instead of saying, "This is wrong, use a Secret instead of a ConfigMap," say, "Since this contains an API key, we should consider moving this to a Kubernetes Secret to prevent exposing it in plaintext logs. What do you think?"
-
-### Code Review Anti-Patterns
+Tone matters because review is a technical control performed by humans who must keep working together. Instead of saying, "This is wrong, use a Secret instead of a ConfigMap," say, "Since this value behaves like a credential, we should move it to a Kubernetes Secret so it is not exposed through ConfigMap reads or plaintext logs. Can you split that into its own commit?" The second version is still rigorous, but it explains the risk and gives the author a concrete path to repair.
 
 | Anti-Pattern | Description | How to Fix It |
 |--------------|-------------|---------------|
 | **The Rubber Stamp** | Approving a PR purely based on trust or because "it's just a config change." | Actually pull the branch locally and test it. Read every line. |
 | **The Syntax Sniper** | Focusing entirely on tabs vs spaces, variable names, or other linting errors. | Configure an automated CI pipeline with a linter so humans don't have to check syntax. |
-| **The Ghost Reviewer** | Leaving comments on a PR but never returning to approve it after the author makes the requested changes. | Set clear SLAs for re-reviewing code (e.g., within 24 hours of an update). |
+| **The Ghost Reviewer** | Leaving comments on a PR but never returning to approve it after the author makes the requested changes. | Set clear SLAs for re-reviewing code, such as within 24 hours of an update. |
 | **The Monolith Approver** | Reviewing a 3,000-line PR and giving up halfway through, just approving it to get it out of the queue. | Reject the PR and ask the author to split it into multiple, smaller, atomic PRs. |
+
+Reviewers should also know when to test locally. A documentation-only change might be safe to read in the web diff, but a Kubernetes manifest update deserves at least schema validation and often a dry run against an appropriate cluster context. The goal is not to create ceremony around every pull request. The goal is to match verification effort to blast radius and to make sure the branch structure gives reviewers enough evidence to do that work efficiently.
+
+## Patterns & Anti-Patterns
+
+Professional Git collaboration becomes repeatable when teams standardize patterns around branch ownership, synchronization, review size, and history rewriting. The patterns below are not rigid law; they are defaults that reduce ambiguity under pressure. When a team intentionally deviates from them, the deviation should be documented in the pull request or repository contribution guide so the next engineer understands the rule being applied.
+
+| Pattern | When to Use It | Why It Works | Scaling Consideration |
+|---------|----------------|--------------|-----------------------|
+| Fetch-before-decide | Before rebasing, force pushing, deleting branches, or diagnosing divergence. | It refreshes remote-tracking branches so decisions use current server state. | Make it part of review-branch repair playbooks and incident checklists. |
+| Fork-and-pull triangle | When contributors should not push directly to the authoritative repository. | It separates personal write access from protected integration history. | Keep `origin` and `upstream` names consistent across onboarding docs. |
+| Atomic PR commits | When a change touches multiple manifests, services, scripts, or docs. | It lets reviewers validate and revert one logical decision at a time. | Enforce smaller PRs socially before adding heavy policy gates. |
+| Lease-based rewriting | When amending, squashing, or rebasing a branch that has been pushed. | It prevents stale local state from overwriting newer remote commits. | Teach `--force-with-lease` as the default rewrite push, not as an advanced option. |
+
+Anti-patterns usually appear when speed is mistaken for simplicity. A monolithic pull request may feel fast for the author because it postpones organization, but it transfers complexity to reviewers and incident responders. A direct push to protected history may feel efficient until it bypasses the evidence trail that explains why the change was accepted. A raw force push may feel like the quickest way through a rejection, but it removes Git's chance to warn you that the server changed.
+
+| Anti-Pattern | What Goes Wrong | Better Alternative |
+|--------------|-----------------|--------------------|
+| Treating `origin/main` as live truth | You rebase or compare against stale tracking data. | Run `git fetch` before synchronization decisions and inspect the updated refs. |
+| Using `git pull` as a reflex | You merge or rebase before understanding incoming changes. | Fetch first when risk is high, then choose merge or rebase deliberately. |
+| Sharing one mutable feature branch broadly | Multiple people rewrite or push to the same branch and create ownership confusion. | Use separate contributor branches, or agree explicitly when a shared branch is required. |
+| Squashing unrelated work before review | Reviewers cannot isolate risk, and rollback becomes imprecise. | Use `git add -p` and explicit paths to create atomic commits before opening the PR. |
+
+## Decision Framework
+
+The most useful Git decision is often not "which command can do this?" but "what state am I protecting?" If you are protecting uncommitted working-tree changes, avoid commands that modify files until you have committed, stashed, or inspected. If you are protecting teammate commits, avoid unconditional force pushes. If you are protecting production history, avoid direct pushes and require review, signatures, and CI.
+
+```mermaid
+flowchart TD
+    A["Need remote information?"] -->|Yes| B["git fetch remote"]
+    A -->|No| C["Need to integrate remote commits?"]
+    B --> C
+    C -->|Clean local branch| D["Fast-forward or rebase"]
+    C -->|Local commits exist| E["Review divergence first"]
+    E --> F["git pull --rebase or manual rebase"]
+    F --> G["Need to update pushed rewritten branch?"]
+    G -->|Yes| H["git push --force-with-lease"]
+    G -->|No| I["git push origin branch"]
+    H --> J["Open or update PR"]
+    I --> J
+```
+
+| Situation | Prefer | Avoid | Reason |
+|-----------|--------|-------|--------|
+| You want to see whether teammates pushed new work | `git fetch origin` | `git pull` as a reflex | Fetch updates knowledge without touching your branch or working tree. |
+| Your feature branch has local commits and upstream moved | `git pull --rebase` or explicit `git rebase upstream/main` | Merge commits that add no design meaning | A linear review branch is easier to read and bisect. |
+| You amended a pushed review commit | `git push --force-with-lease origin branch` | `git push --force` | The lease protects teammate commits that appeared after your last fetch. |
+| You need a reviewer to understand Kubernetes manifest risk | Atomic commits plus validation notes | One huge commit with unrelated YAML and code | Reviewers can test and revert one operational decision at a time. |
+| You are contributing through a fork | Push to `origin`, open PR to `upstream` | Direct push to upstream main | The fork boundary preserves protected integration history. |
+
+Which approach would you choose here and why: a reviewer asks for a one-line label fix in the last commit of your PR, while another teammate has just commented that they are testing your branch locally? The safe answer depends on branch ownership. If you are the only pusher and the teammate is only reading, amend and push with a lease. If the teammate might push changes to the same branch, coordinate first or ask them to open a separate branch, because Git cannot infer team intent from a branch name.
 
 ## Did You Know?
 
@@ -400,75 +422,74 @@ When reviewing, be kind but rigorous. Instead of saying, "This is wrong, use a S
 
 | Mistake | Why It Happens | How to Fix It |
 |---------|----------------|---------------|
-| Running `git pull` on a diverged branch | Git defaults to merging the remote tracking branch into the local branch, creating an unnecessary merge commit. | Configure Git to rebase on pull by default: `git config --global pull.rebase true`. |
+| Running `git pull` on a diverged branch | Git defaults to merging the remote tracking branch into the local branch, creating an unnecessary merge commit. | Configure Git to rebase on pull by default: `git config --global pull.rebase true`, and fetch first when the branch state matters. |
 | Pushing with `git push --force` | You rebased locally and the remote rejected the standard push, so you forced it blindly. | Always use `git push --force-with-lease` to protect teammates' pushed commits. |
-| Committing secrets to a branch | Forgetting to add `.env` files or credentials to `.gitignore` before running `git add .`. | Use `git rm --cached <file>` immediately, and consider using tools like `git-filter-repo` if it has already been pushed. |
-| Vague commit messages | Treating the commit message as a chore rather than a communication tool (e.g., "updates"). | Adopt the Conventional Commits specification and describe *why* the change was made, not just *what* changed. |
+| Committing secrets to a branch | Forgetting to add `.env` files or credentials to `.gitignore` before running `git add .`. | Use `git rm --cached <file>` immediately, rotate exposed credentials, and use history-rewrite tools only with an agreed recovery plan. |
+| Vague commit messages | Treating the commit message as a chore rather than a communication tool, such as writing only "updates." | Adopt the Conventional Commits specification and describe why the change was made, not just what changed. |
 | Pushing directly to upstream `main` | Having write permissions to the central repo and bypassing the PR review process. | Protect the `main` branch in repository settings so it strictly requires verified Pull Requests to modify. |
 | Squashing unrelated changes | Laziness; wanting to group an afternoon's worth of disparate work into one save point. | Use `git add -p` to interactively stage specific chunks of files into separate, atomic commits. |
-| Panicking when a lease is rejected | You used `--force-with-lease` and it failed, so you switch to `--force`. | Stop. Fetch the remote, inspect the new commits, rebase them into your work, and try the lease again. |
+| Panicking when a lease is rejected | You used `--force-with-lease` and it failed, so you switch to `--force`. | Stop, fetch the remote, inspect the new commits, rebase them into your work, and try the lease again. |
+| Reviewing only the web diff for high-risk manifests | The browser makes it easy to skim YAML without testing server-side validation or rollout assumptions. | Pull the branch when risk warrants it, run the relevant tests, and validate Kubernetes manifests with `k apply --dry-run=server` where appropriate. |
 
 ## Quiz
 
 <details>
-<summary>Question 1: You are ready to start work on a new feature. You know the upstream `main` branch has received updates since yesterday. What sequence of commands ensures your local `main` is perfectly synced before you branch off?</summary>
-Answer: First, `git fetch upstream` to update your tracking branches. Then, `git checkout main` to ensure you are on the correct local branch. Finally, `git rebase upstream/main` to fast-forward your local branch to match the remote state. Using `git pull --rebase upstream main` achieves the exact same result in a single, more efficient step. This multi-step process is crucial because it cleanly updates your local state without creating unnecessary merge commits. Ensuring your new feature branch starts from a pristine, linear history prevents complicated conflicts later in the PR lifecycle.
+<summary>Question 1: You are ready to start work on a feature, and you know `upstream/main` changed overnight. What sequence gives you a clean starting point, and what are you diagnosing before creating your branch?</summary>
+
+Answer: First fetch from `upstream` so your remote-tracking branch reflects the current authoritative repository. Then check out local `main` and rebase it onto `upstream/main`, or use an equivalent pull-rebase command if your team permits that shortcut. This diagnoses whether your local branch was stale, ahead, or diverged before new feature work begins. Starting from a current upstream base reduces conflicts later and keeps the pull request focused on your change rather than yesterday's synchronization drift.
 </details>
 
 <details>
-<summary>Question 2: You just spent an hour rebasing your local feature branch to squash some messy commits. You run `git push origin my-feature` and it is rejected. Why did this happen, and what is the safest way to proceed?</summary>
-Answer: It was rejected because rebasing rewrites commit hashes, causing your local history to diverge from the remote history. The server sees this as a conflict. The safest way to proceed is `git push --force-with-lease origin my-feature`. This is crucial because it forces the update but includes a safety check that aborts if a teammate has pushed new commits to the remote in the meantime. If the lease fails, you will know immediately that you must fetch and integrate their changes before attempting to push again, preventing you from accidentally overwriting their work.
+<summary>Question 2: You rebased your review branch to clean up commits, but `git push origin my-feature` is rejected. How do you evaluate whether `--force-with-lease` is safe, and what should you do if the lease fails?</summary>
+
+Answer: A rejected normal push is expected after a rebase because the commit hashes no longer fast-forward from the remote branch. `--force-with-lease` is safe when you own the branch and your local remote-tracking reference still matches the server's current branch tip. If the lease fails, do not use raw `--force`; fetch the remote, inspect the new commits, and integrate them deliberately. The lease failure is evidence that someone or something moved the branch after your last known state.
 </details>
 
 <details>
-<summary>Question 3: Your team requires atomic commits. You have added a new Redis deployment manifest, updated the backend Service manifest to expose a new port, and fixed a typo in the README. How should you commit these?</summary>
-Answer: You should create three separate commits using `git add -p` or by specifying the files individually: one commit for the Redis deployment, one for the Service port update, and one for the README typo. This separation is necessary because it isolates changes by their logical purpose, allowing reviewers to verify them independently. Furthermore, atomic commits enable safe, precise rollbacks if one specific component fails without taking down unrelated changes. If you grouped them together, a rollback of the Redis deployment would needlessly revert the typo fix as well.
+<summary>Question 3: Your team requires atomic commits, and your working tree contains a new Redis Deployment, a Service port change, and a README typo. How should you design the commits so the pull request remains reviewable?</summary>
+
+Answer: Create separate commits for each logical purpose: one for the Redis Deployment, one for the Service port change, and one for the README typo. Use explicit file staging or `git add -p` if the changes are mixed within a file. This design lets reviewers evaluate operational risk independently and lets incident responders revert only the failing component if needed. A single commit would hide unrelated risk behind one approval decision.
 </details>
 
 <details>
-<summary>Question 4: You have uncommitted changes in your working directory and your teammate just pushed a breaking change to `origin/main`. You run `git fetch origin`. What is the state of your working directory and local `main` branch afterward?</summary>
-Answer: Your working directory and local `main` branch remain completely unchanged. `git fetch` is a safe operation that only downloads the new objects from the remote server and updates your hidden Remote Tracking Branches (like `origin/main`). You must explicitly merge or rebase to integrate those breaking changes into your local files. This behavior ensures your uncommitted work remains safe from being unexpectedly overwritten during routine synchronization. It gives you the opportunity to review the remote changes before applying them locally.
+<summary>Question 4: You have uncommitted local edits and your teammate just pushed a breaking change to `origin/main`. You run `git fetch origin`. What changes locally, and why is this the right first diagnostic step?</summary>
+
+Answer: Your working directory and local branch do not change; Git only downloads objects and updates remote-tracking references such as `origin/main`. That makes fetch the safe first step when you need current information but are not ready to integrate it. You can inspect the incoming diff, commit or stash your own edits, and then choose a merge or rebase deliberately. This preserves your local work while replacing stale remote knowledge with current evidence.
 </details>
 
 <details>
-<summary>Question 5: You are contributing to an open-source Kubernetes controller using the Fork and Pull model. You clone your personal fork to your laptop. A maintainer merges a major feature into the central repository. Which remote should you fetch from to get these changes, and why is this separation of remotes necessary?</summary>
-Answer: You should fetch from the `upstream` remote, which points to the central, authoritative repository. This separation is necessary for security and access control, as you do not have direct write permissions to the `upstream` server. By maintaining both an `origin` (your writable fork) and an `upstream` (the read-only central repo), you can pull the latest community changes safely. This workflow allows you to push your own proposals to your fork without risking the integrity of the main project's history. It acts as a deliberate buffer between your local experiments and the central codebase.
+<summary>Question 5: You cloned your personal fork of an open-source Kubernetes controller, and a maintainer merged a major feature into the central repository. Which remote do you fetch from, which remote do you push to, and why does that separation matter?</summary>
+
+Answer: Fetch from `upstream`, because it represents the central authoritative repository, and push your branch or synchronized fork state to `origin`, because that is your writable fork. This separation preserves the security boundary that prevents contributors from mutating protected history directly. It also clarifies troubleshooting: missing maintainer work means you need upstream synchronization, while a pull request that does not update usually means you pushed to the wrong fork or branch. The fork-and-pull model turns access control into a visible workflow.
 </details>
 
 <details>
-<summary>Question 6: A teammate reviews your Pull Request and asks you to change a label in your Kubernetes Deployment manifest. You make the change locally. How do you update the PR without adding a messy "fix label" commit to the history?</summary>
-Answer: You stage the change with `git add deployment.yaml`, then run `git commit --amend --no-edit` to fold the change into your previous commit. Finally, you run `git push --force-with-lease origin branch-name` to update the Pull Request on the server. This workflow is important because it maintains a clean, atomic commit history that reflects the final intended state of the feature. By amending instead of adding new commits, you avoid polluting the project log with incremental trial-and-error corrections. Reviewers will see a single, cohesive commit rather than a chaotic trail of fixes.
+<summary>Question 6: A reviewer asks you to change a label in a Kubernetes Deployment manifest that belongs in your previous commit. How do you update the pull request without creating a noisy "fix label" commit, and what safety command protects collaborators?</summary>
+
+Answer: Stage the label change, amend the previous commit with `git commit --amend --no-edit`, and update the remote review branch with `git push --force-with-lease origin branch-name`. Amending keeps the commit history aligned with the final intended change rather than preserving every review iteration as noise. The lease matters because the branch has already been pushed and might have changed on the server. If another contributor pushed to the same branch, the lease fails before their work is overwritten.
 </details>
 
 <details>
-<summary>Question 7: Your CI pipeline uses commit prefixes to decide whether to trigger a deployment. A teammate pushes a commit with the message `chore(deps): bump helm to 3.16`. Should the pipeline trigger a production deployment? Why or why not?</summary>
-Answer: The pipeline should not trigger a production deployment. According to the Conventional Commits specification, the `chore` type indicates routine maintenance that does not modify application logic or add features. Specifically, `chore(deps)` means a dependency was updated. Triggering a deployment for non-functional or non-user-facing changes introduces unnecessary risk and deployment churn, which is why CI pipelines typically ignore these commits. By reserving deployments for `feat` or `fix` commits, the team ensures that releases are stable and purpose-driven.
+<summary>Question 7: Your CI pipeline uses commit prefixes to decide release behavior, and a teammate pushes `chore(deps): bump helm to 3.16`. Should that commit trigger a production feature release, and what would change the answer?</summary>
+
+Answer: It should not trigger a feature release by itself because `chore` indicates maintenance rather than a user-visible feature or bug fix. Conventional Commits let automation distinguish dependency housekeeping from release-worthy behavior changes. The answer would change if the commit used `feat`, `fix`, or an explicit breaking-change marker because those types communicate different release implications. The pipeline should follow the structured intent, while reviewers still verify whether the chosen type is honest.
 </details>
 
 <details>
-<summary>Question 8: A malicious actor gains access to your organization's internal network and attempts to push a backdoor to a deployment script, configuring their Git client to use your name and email. How does cryptographically signing commits prevent this code from being trusted?</summary>
-Answer: While anyone can configure their local `user.name` and `user.email` to impersonate another developer, they cannot forge a cryptographic signature without possessing your private SSH or GPG key. When commits are signed, CI pipelines and code review platforms verify the signature against your public key. The malicious actor's commit would fail verification and lack the "Verified" badge. This missing badge immediately flags the spoofing attempt to reviewers and prevents the unauthorized backdoor from being merged. Enforcing signed commits thus acts as a critical security boundary for enterprise repositories.
-</details>
+<summary>Question 8: A suspicious commit appears with your name and email on a deployment script, but the hosting platform does not mark it verified. How do signed commits help reviewers evaluate the risk?</summary>
 
-<details>
-<summary>Question 9: You are reviewing a Pull Request that introduces a new microservice. The PR contains a single commit with a 2,500-line diff modifying Kubernetes Deployment, Service, ConfigMap, Ingress, and application source code simultaneously. Why should you reject this PR, and what should you instruct the author to do?</summary>
-Answer: You should reject the PR because the commit is monolithic, making it impossible to review effectively or revert safely if a specific component fails. The blast radius is simply too large for a single approval. You should instruct the author to use `git add -p` to break the changes into smaller, atomic commits. This approach allows isolating the ConfigMap update, the application code changes, and the Ingress routing into independent, logically separated commits that can be reviewed thoroughly. Doing so ensures each change can be individually tested, verified, and safely rolled back if necessary.
-</details>
-
-<details>
-<summary>Question 10: During an incident response, you need to revert a recent update to a Kubernetes ConfigMap that broke production. The commit history shows that the ConfigMap change was bundled in the same commit as a critical security patch for the application image. What is the consequence of this non-atomic commit, and how does it complicate the rollback?</summary>
-Answer: Because the changes were bundled non-atomically, you cannot use a simple `git revert` to undo the ConfigMap update without also removing the critical security patch. This forces the team to manually extract the ConfigMap change, write a new commit to fix it, and push it forward while the system is degraded. If the commit had been atomic (one commit for the ConfigMap, one for the security patch), you could have instantly reverted only the configuration error. This scenario highlights exactly why atomic commits are a fundamental requirement for reliable incident response. It minimizes downtime by allowing surgical rollbacks instead of messy manual interventions.
+Answer: Git names and emails are local configuration values and can be spoofed, but a valid cryptographic signature requires access to the private key associated with your registered public key. If the commit is unsigned or signed by an untrusted key, reviewers should not treat the author metadata as proof of identity. Signed commits therefore add an identity verification signal to the review process. They do not prove the code is correct, but they help detect impersonation and support stronger branch protection policies.
 </details>
 
 ## Hands-On Exercise
 
-In this exercise, you will simulate a professional fork-and-pull workflow by creating atomic commits and navigating a PR review loop. 
+In this exercise, you will simulate a professional fork-and-pull workflow by creating atomic commits and navigating a pull request review loop. The lab uses local bare repositories instead of GitHub so you can practice the remote mechanics without network access, permissions, or cleanup risk. Treat `upstream.git` as the protected central project, `origin.git` as your personal fork, and `k8s-pr-lab` as the working repository on your laptop.
 
-**Setup Instructions:**
-We will simulate the `upstream` and `origin` remotes using local folders instead of GitHub to keep the exercise self-contained.
+**Setup Instructions:** We will simulate the `upstream` and `origin` remotes using local folders instead of GitHub to keep the exercise self-contained. Run the commands from a scratch directory, not from an existing production repository. The goal is to see branch movement clearly, so avoid adding extra files beyond the manifests requested in the tasks.
 
 ### Task 1: Setup the Simulated Remotes
-Execute the following commands to create a workspace, the "server" repositories, and your local repository.
+
+Execute the following commands to create a workspace, the "server" repositories, and your local repository. The bare repositories behave like remote servers because they contain Git object data and references but no editable working tree. This mirrors the part of a hosting platform that receives pushes and serves fetches.
 
 ```bash
 # Create a workspace directory
@@ -488,7 +509,7 @@ git init --bare
 cd ..
 ```
 
-Now, create and link your working repository to these remotes.
+Now, create and link your working repository to these remotes. Notice that your local repository can push to both remotes in the lab, even though a real upstream repository would usually be protected by permissions and branch rules.
 
 ```bash
 # Initialize working repository
@@ -510,16 +531,19 @@ git push upstream main
 ```
 
 ### Task 2: Create a Feature Branch
-As a Kubernetes practitioner, you should configure the standard alias for kubectl if you haven't already: `alias k=kubectl`. We are defining infrastructure, so create a new feature branch for adding an NGINX deployment.
+
+As a Kubernetes practitioner, configure the standard alias for kubectl if you have not already: `alias k=kubectl`. You are defining infrastructure, so create a new feature branch for adding an NGINX deployment rather than committing directly on `main`. That branch boundary is the local version of a future pull request.
 
 ```bash
 git checkout -b feat/nginx-deployment
 ```
 
 ### Task 3: Make Atomic Commits
-Create the Kubernetes manifests using two distinct, atomic commits with conventional commit messages.
 
-First, create the namespace manifest:
+Create the Kubernetes manifests using two distinct, atomic commits with conventional commit messages. The namespace establishes the destination for later resources, and the Deployment consumes that namespace in a separate commit. Keeping those changes separate lets a reviewer verify the dependency order and revert one layer without rewriting the other.
+
+First, create the namespace manifest, because the Deployment should not be reviewed as though its target namespace appears from nowhere:
+
 ```yaml
 # namespace.yaml
 apiVersion: v1
@@ -527,13 +551,16 @@ kind: Namespace
 metadata:
   name: web-tier
 ```
-Commit this file isolated:
+
+Commit this file in isolation so the first atomic commit creates only the Kubernetes namespace prerequisite:
+
 ```bash
 git add namespace.yaml
 git commit -m "feat(k8s): add web-tier namespace"
 ```
 
-Next, create the deployment manifest:
+Next, create the deployment manifest, which should depend on the namespace but remain an independent review unit:
+
 ```yaml
 # deployment.yaml
 apiVersion: apps/v1
@@ -555,22 +582,27 @@ spec:
       - name: nginx
         image: nginx:1.27-alpine
 ```
-Commit this file isolated:
+
+Commit this file in isolation so the second atomic commit introduces only the workload that will run inside the namespace:
+
 ```bash
 git add deployment.yaml
 git commit -m "feat(k8s): add nginx deployment"
 ```
 
 ### Task 4: Push to Your Fork
-Push your feature branch to your personal `origin` repository.
+
+Push your feature branch to your personal `origin` repository. In a hosted workflow, this branch would become the source branch for a pull request into the upstream project. The branch name and commit messages should make the review intent obvious before anyone opens a diff.
+
 ```bash
 git push origin feat/nginx-deployment
 ```
 
 ### Task 5: Respond to Review Feedback
-Imagine a reviewer requested that you increase the `replicas` to `3`. Instead of making a new "fix replicas" commit, you will amend your previous work to keep the history clean.
 
-Modify `deployment.yaml` and change `replicas: 2` to `replicas: 3`.
+Imagine a reviewer requested that you increase the `replicas` value to `3`. Instead of making a new "fix replicas" commit, you will amend your previous work to keep the history clean. This is appropriate because the branch is still under review and the change belongs to the existing Deployment commit rather than a new design decision.
+
+Modify `deployment.yaml` and change `replicas: 2` to `replicas: 3`, treating the edit as a refinement of the Deployment commit rather than a new feature.
 
 ```bash
 sed -i.bak 's/replicas: 2/replicas: 3/' deployment.yaml
@@ -587,21 +619,25 @@ git push --force-with-lease origin feat/nginx-deployment
 ```
 
 ### Task 6: Review and Merge via Squash
-In the real world, you would open a PR on GitHub. Here, we will simulate the repository maintainer reviewing and merging your code using a squash merge. A squash merge takes all the commits from your feature branch, squashes them into a single new commit, and places it on the `main` branch. This keeps the `main` branch history pristine.
 
-Checkout the `main` branch and merge the feature branch using the squash flag:
+In the real world, you would open a PR on GitHub. Here, you will simulate the repository maintainer reviewing and merging your code using a squash merge. A squash merge takes all commits from your feature branch, squashes them into a single new commit, and places it on the `main` branch, which keeps the main branch history concise while preserving review discussion in the pull request record.
+
+Checkout the `main` branch and merge the feature branch using the squash flag, which prepares the combined content without immediately creating the final integration commit:
+
 ```bash
 git checkout main
 git merge --squash feat/nginx-deployment
 ```
 
-At this point, Git has prepared the merge but has *not* created a commit. Check your status:
+At this point, Git has prepared the merge but has not created a commit, so checking status confirms exactly what will enter the squashed result:
+
 ```bash
 git status
 ```
 
-Commit the squashed changes with a new conventional commit message that summarizes the entire PR:
-```bash
+Commit the squashed changes with a new conventional commit message that summarizes the entire PR rather than repeating the lower-level branch commits:
+
+```text
 git commit -m "feat(web): introduce nginx deployment and namespace
 
 This adds the core web-tier namespace and the nginx deployment 
@@ -611,17 +647,21 @@ Resolves PR #1"
 ```
 
 ### Task 7: Cleanup
-Push the newly squashed commit to upstream (simulating the maintainer hitting "Merge PR").
+
+Push the newly squashed commit to upstream, simulating the maintainer hitting "Merge PR." Then delete your local feature branch to keep your workspace clear and complete the triangle synchronization loop so your fork's `main` follows the central project again.
+
 ```bash
 git push upstream main
 ```
 
-Now, delete your local feature branch to keep your workspace clean:
+Now, delete your local feature branch to keep your workspace clean after the integration branch contains the accepted change:
+
 ```bash
 git branch -d feat/nginx-deployment
 ```
 
-And finally, fetch from upstream and sync your origin to complete the triangle:
+Finally, fetch from upstream and sync your origin to complete the triangle, proving that local main, upstream main, and fork main converge again:
+
 ```bash
 git fetch upstream
 git rebase upstream/main
@@ -629,17 +669,20 @@ git push origin main
 ```
 
 ### Success Criteria Checklist
+
 - [ ] You have two remote repositories configured (`origin` and `upstream`).
-- [ ] Your feature branch contains exactly two new commits (one for namespace, one for deployment).
+- [ ] Your feature branch contains exactly two new commits, one for namespace and one for deployment.
 - [ ] The deployment commit message strictly follows the conventional commit format.
 - [ ] You successfully utilized `--force-with-lease` to update a remote branch after an amend operation.
 - [ ] You successfully squashed the feature branch into the `main` branch, resulting in a single clean commit.
 
 ### Solutions
+
 <details>
 <summary>View the commands to verify your repository state</summary>
 
 Run `git remote -v` to check remotes:
+
 ```text
 origin    ../origin.git (fetch)
 origin    ../origin.git (push)
@@ -648,6 +691,7 @@ upstream  ../upstream.git (push)
 ```
 
 Run `git log --oneline` to verify the atomic commits before squashing:
+
 ```text
 a1b2c3d (HEAD -> feat/nginx-deployment, origin/feat/nginx-deployment) feat(k8s): add nginx deployment
 e4f5g6h feat(k8s): add web-tier namespace
@@ -655,13 +699,28 @@ i7j8k9l (upstream/main, origin/main, main) chore: initial project setup
 ```
 
 Run `git log --oneline main` to verify the squashed state:
+
 ```text
 m0n1o2p (HEAD -> main, upstream/main, origin/main) feat(web): introduce nginx deployment and namespace
 i7j8k9l chore: initial project setup
 ```
+
 *(Your commit hashes will differ)*
 </details>
 
+## Sources
+
+- [Git documentation: git-fetch](https://git-scm.com/docs/git-fetch)
+- [Git documentation: git-pull](https://git-scm.com/docs/git-pull)
+- [Git documentation: git-push](https://git-scm.com/docs/git-push)
+- [Git documentation: git-config](https://git-scm.com/docs/git-config)
+- [Git documentation: git-add](https://git-scm.com/docs/git-add)
+- [Git documentation: git-commit](https://git-scm.com/docs/git-commit)
+- [Pro Git: Remote Branches](https://git-scm.com/book/en/v2/Git-Branching-Remote-Branches)
+- [GitHub Docs: Collaborating with pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests)
+- [GitHub Docs: Telling Git about your signing key](https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key)
+- [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
+
 ## Next Module
 
-Ready to apply these concepts to massive, monorepo environments? Move on to [Module 8: Efficiency at Scale](../module-8-scale/).
+Ready to apply these collaboration habits to large repositories with expensive test suites and many moving parts? Move on to [Module 8: Efficiency at Scale](../module-8-scale/) and learn how to keep Git fast and reviewable when the repository itself becomes part of the challenge.

--- a/src/content/docs/prerequisites/git-deep-dive/module-7-remotes-prs.md
+++ b/src/content/docs/prerequisites/git-deep-dive/module-7-remotes-prs.md
@@ -542,7 +542,7 @@ git checkout -b feat/nginx-deployment
 
 Create the Kubernetes manifests using two distinct, atomic commits with conventional commit messages. The namespace establishes the destination for later resources, and the Deployment consumes that namespace in a separate commit. Keeping those changes separate lets a reviewer verify the dependency order and revert one layer without rewriting the other.
 
-First, create the namespace manifest, because the Deployment should not be reviewed as though its target namespace appears from nowhere:
+Create the namespace manifest first. Keeping the namespace in its own file lets reviewers verify the target scope before they inspect workload settings that depend on it:
 
 ```yaml
 # namespace.yaml
@@ -552,14 +552,14 @@ metadata:
   name: web-tier
 ```
 
-Commit this file in isolation so the first atomic commit creates only the Kubernetes namespace prerequisite:
+Commit only the namespace prerequisite. This makes the first commit a small, reversible change with one clear purpose:
 
 ```bash
 git add namespace.yaml
 git commit -m "feat(k8s): add web-tier namespace"
 ```
 
-Next, create the deployment manifest, which should depend on the namespace but remain an independent review unit:
+Create the deployment manifest as a separate review unit. Its diff should show the workload, replica count, labels, and image without mixing in namespace setup:
 
 ```yaml
 # deployment.yaml
@@ -583,7 +583,7 @@ spec:
         image: nginx:1.27-alpine
 ```
 
-Commit this file in isolation so the second atomic commit introduces only the workload that will run inside the namespace:
+Commit only the workload. The second commit now tells reviewers exactly when application runtime configuration entered the branch:
 
 ```bash
 git add deployment.yaml
@@ -622,14 +622,14 @@ git push --force-with-lease origin feat/nginx-deployment
 
 In the real world, you would open a PR on GitHub. Here, you will simulate the repository maintainer reviewing and merging your code using a squash merge. A squash merge takes all commits from your feature branch, squashes them into a single new commit, and places it on the `main` branch, which keeps the main branch history concise while preserving review discussion in the pull request record.
 
-Checkout the `main` branch and merge the feature branch using the squash flag, which prepares the combined content without immediately creating the final integration commit:
+Checkout `main` and prepare a squash merge. The index will contain the combined branch result, but Git will not create the final integration commit yet:
 
 ```bash
 git checkout main
 git merge --squash feat/nginx-deployment
 ```
 
-At this point, Git has prepared the merge but has not created a commit, so checking status confirms exactly what will enter the squashed result:
+Check the prepared squashed result before committing. This is the maintainer's last local chance to confirm that only the reviewed namespace and Deployment files are staged:
 
 ```bash
 git status
@@ -637,7 +637,7 @@ git status
 
 Commit the squashed changes with a new conventional commit message that summarizes the entire PR rather than repeating the lower-level branch commits:
 
-```text
+```bash
 git commit -m "feat(web): introduce nginx deployment and namespace
 
 This adds the core web-tier namespace and the nginx deployment 
@@ -660,7 +660,7 @@ Now, delete your local feature branch to keep your workspace clean after the int
 git branch -d feat/nginx-deployment
 ```
 
-Finally, fetch from upstream and sync your origin to complete the triangle, proving that local main, upstream main, and fork main converge again:
+Fetch from upstream and sync your fork's `main`. The final rebase makes your fork reflect the accepted upstream history instead of leaving a stale local integration state:
 
 ```bash
 git fetch upstream


### PR DESCRIPTION
## Summary

Rewrote src/content/docs/prerequisites/git-deep-dive/module-7-remotes-prs.md for the #388 density and structure verifier gates, preserving the original remote/PR topic coverage while expanding the lesson into a denser instructional chapter.

## Verifier

T0 pass with --skip-source-check: body_words=5084, mean_wpp=59.1, median_wpp=66.5, short_rate=0.023, max_run=2, mean_sentence_length=23.8. Failure gates: none. Sources live reachability intentionally skipped per dispatch.

## Protected assets

Preserved protected assets from the original module: code blocks 37 before / 38 after, Mermaid diagrams 3 before / 4 after, ASCII diagrams 0 before / 0 after, markdown tables 2 before / 5 after, source URLs 0 before / 10 after.

## Commit

c69f5d0d6fdd47fee86227b7197e8a130a83bcf2