### PR TITLE
feat(388): rewrite module-4-undo-recovery (#388 pilot)

### DIFF
--- a/src/content/docs/prerequisites/git-deep-dive/module-4-undo-recovery.md
+++ b/src/content/docs/prerequisites/git-deep-dive/module-4-undo-recovery.md
@@ -2,6 +2,7 @@
 title: "Module 4: The Safety Net — Undo and Recovery"
 sidebar:
   order: 4
+revision_pending: false
 ---
 
 # Module 4: The Safety Net — Undo and Recovery
@@ -13,35 +14,36 @@ sidebar:
 ## Learning Outcomes
 
 - Implement `git reset` with `--soft`, `--mixed`, and `--hard` flags to intentionally manipulate the working directory, staging area, and commit history in order to correct architectural mistakes.
-- Diagnose and recover from catastrophic Git mistakes (like a botched interactive rebase or an accidental hard reset) using `git reflog` to trace and restore orphaned commits.
+- Diagnose and recover from catastrophic Git mistakes, including botched rebases and accidental hard resets, using `git reflog` to trace and restore orphaned commits.
 - Evaluate when to use `git revert` versus `git reset` based on branch protection rules, collaboration constraints, and the need to preserve an immutable audit trail.
 - Execute surgical file-level recovery operations using `git restore` and `git checkout` to retrieve specific file states from past commits without disrupting the overall branch history.
 - Transplant specific commits across branches using `git cherry-pick` to resolve misaligned feature branches and backport critical security patches.
 
 ## Why This Module Matters
 
-It was 2:00 AM on a Friday, and the lead DevOps engineer at a major fintech startup was attempting to clean up the commit history on the `main` branch before a critical production release. The release included weeks of complex Kubernetes manifest updates—new ConfigMaps, ingress routing rules, and tightened NetworkPolicies designed to satisfy a new compliance audit. In an attempt to squash a few messy commits and make the history look pristine, the engineer ran an interactive rebase, got confused by a merge conflict involving the ingress controller, panicked, and ran `git reset --hard HEAD~5`. Instantly, five crucial commits representing three days of collective team effort vanished. The local working directory updated, wiping out the new manifests. The engineer broke out in a cold sweat, staring at a terminal that offered no immediate undo button.
+At 2:00 AM on a Friday, the lead DevOps engineer at a fintech company was trying to clean the commit history on a release branch before a compliance-driven production deployment. The release included weeks of Kubernetes manifest work: ConfigMaps for payment routing, ingress rules for a new API gateway, and NetworkPolicies that auditors expected to see before Monday. During an interactive rebase, a conflict appeared in the ingress manifest, the engineer misread the rebase state, and `git reset --hard HEAD~5` seemed like the fastest way to get unstuck. Five commits disappeared, the working directory snapped back to an older state, and the terminal gave no friendly undo button.
 
-This scenario plays out in engineering teams across the world every single day. Git is incredibly powerful, fundamentally designed as a distributed graph database for your code. However, its commands can feel like loaded weapons when you are under pressure. The fear of "breaking the repo" or permanently losing work is one of the most common anxieties among developers and platform engineers alike. When you do not deeply understand Git's recovery mechanisms, every destructive command feels permanent, leading to a culture of hesitation, overly defensive version control practices, and a reliance on copying folders as ".bak" backups.
+The production issue was not only lost text. The missing commits represented peer review, deployment sequencing, and operational promises that other teams had already planned around. A platform team that treats Git as a black box often responds to this moment with panic, copy-pasted backup folders, or a risky force push that makes the outage worse. A platform team that understands Git's recovery model can slow down, inspect where the branch pointer moved, identify whether the lost work had ever been committed, and choose a recovery command that matches the blast radius.
 
-In this module, we will strip away that fear completely. You will learn that in Git, almost nothing is truly lost unless you go out of your way to permanently delete it or wait months for the garbage collector. We will dive deep into the mechanics of undoing mistakes, from the nuanced differences between reset flags to the ultimate, hidden safety net: the reflog. By the end of this session, you will possess the precise mental models and practical command-line skills to confidently navigate and recover from even the most terrifying Git disasters. You will transform from hoping you do not break things to knowing exactly how to diagnose and fix them when you inevitably do.
+This module turns Git undo from superstition into engineering judgment. You will learn why `reset`, `restore`, `revert`, `reflog`, and `cherry-pick` are not interchangeable synonyms for "go back." Each command edits a different part of Git's state model, and each has a different collaboration contract. By the end, you should be able to look at a broken branch, decide whether you need to move a pointer, create an inverse commit, restore one file, or copy a patch across histories, and then explain that decision to a teammate under incident pressure.
+
+Before the commands begin, anchor the operational context. Kubernetes examples in this module target Kubernetes 1.35 or later, and when cluster validation appears we use the common shell alias `k` for `kubectl` after defining it once. The Git recovery workflow itself works without a cluster, but platform engineers usually recover code that will eventually become cluster state, so the lesson keeps the repository mechanics connected to deployment risk.
+
+```bash
+alias k=kubectl
+```
 
 ## 1. The Three Trees of Git and `git reset`
 
-To truly master the `git reset` command and use it predictably, you must first understand the "Three Trees" architecture that Git uses to manage the state of your files. Think of these trees as three distinct layers of state that your code passes through on its way into permanent history.
+`git reset` is frightening when it is treated as a single dangerous command, but it becomes predictable when you see the three pieces of repository state it can touch. Git keeps your current files in the working directory, the proposed next snapshot in the staging area, and the current branch tip in `HEAD`. Those three areas are often called Git's three trees, even though the working directory is normal files on disk and the staging area is Git's index. Reset moves `HEAD` first, then optionally rewrites the index and working directory to match that new point in history.
 
-1.  **The Working Directory**: This is the file system you see and edit in your IDE or terminal. It is your scratchpad. It represents the current state of the files on your disk.
-2.  **The Staging Area (Index)**: This is the loading dock. You selectively move files here (using `git add`) to prepare them for the next commit. It is a precise snapshot of what the next commit will look like.
-3.  **The HEAD (Commit History)**: This is the permanent record. It is a pointer to the last commit in your current branch. It represents the state of your repository the last time you ran `git commit`.
+Think of the working directory as the room where parts are scattered, the staging area as the loading dock where finished boxes are labeled for shipment, and `HEAD` as the truck already carrying the last accepted shipment. When you run `git add`, you are not saving work permanently; you are choosing which current file snapshots should go on the loading dock. When you run `git commit`, Git records the staged snapshot as a durable commit and moves the branch pointer to that new object. A reset command moves the truck label backward or sideways, then decides whether the loading dock and room should be left alone, unpacked, or overwritten.
 
-When you use `git reset`, you are explicitly telling Git to move the `HEAD` pointer to a different, usually older, commit. But the crucial part—and the source of most confusion—is what happens to the Staging Area and the Working Directory during this move. This behavior is controlled by the flags: `--soft`, `--mixed`, and `--hard`.
+1. **The Working Directory**: This is the file system you see and edit in your IDE or terminal. It is your scratchpad. It represents the current state of the files on your disk.
+2. **The Staging Area (Index)**: This is the loading dock. You selectively move files here, using `git add`, to prepare them for the next commit. It is a precise snapshot of what the next commit will look like.
+3. **The HEAD (Commit History)**: This is the permanent record. It is a pointer to the last commit in your current branch. It represents the state of your repository the last time you ran `git commit`.
 
-### The Mental Model
-
-Imagine you are packing boxes for a move to a new data center.
-- **HEAD**: The boxes already loaded and secured onto the moving truck.
-- **Staging Area**: The boxes taped up, labeled, and sitting on the loading dock, ready to be loaded.
-- **Working Directory**: The loose servers, cables, and components scattered around your staging room.
+The important lesson is that reset does not mean "delete my work" by default. It means "move my current branch reference to another commit, then reconcile some local state with that target." If you know which layers are rewritten, you can use reset to reshape local history without losing useful edits. If you guess, the same command can erase an uncommitted manifest rewrite that Git never had a chance to protect.
 
 ```mermaid
 graph LR
@@ -53,13 +55,9 @@ graph LR
     Soft["--soft moves this<br>(only moves HEAD)"] -.-> HEAD
 ```
 
-### `git reset --soft`
+`git reset --soft` only moves the branch tip. The index and working directory remain exactly as they were before the command, which means the changes from the commits you backed out are still staged and ready to be committed again. This is useful when the commit boundary was wrong but the staged content was mostly right. You might have committed a Deployment and Service together, then realized one environment variable belongs in the same logical change because reviewers need to inspect the application rollout as a single unit.
 
-A soft reset only moves `HEAD` to a previous commit. It completely ignores your Staging Area and your Working Directory.
-
-**Analogy**: You take boxes off the moving truck and put them back onto the loading dock. The items are still packed, taped, and ready to go. You haven't unpacked anything; you just decided they aren't ready to leave yet.
-
-**Use Case**: You made a commit containing a Kubernetes `Deployment` and a `Service`, but you realized you forgot to add a crucial environment variable to the container spec. You want to undo the commit, but you absolutely want to keep all the changes staged so you can quickly fix the file, re-add it, and commit again.
+The soft reset is a history-editing tool, not a file-editing tool. It is the Git equivalent of saying, "I want the last commit message and object hash to stop existing on this local branch, but I still want the exact proposed snapshot on the loading dock." Because the index remains populated, an immediate `git commit` after a soft reset recreates a commit with the same file state. The hash will differ because commit metadata changes, but the content snapshot can be identical.
 
 ```bash
 # View current log to see the commit we want to undo
@@ -80,16 +78,11 @@ git status
 #   new file:   service.yaml
 ```
 
-> **Pause and predict**: What do you think happens if you run `git commit -m "Same thing"` immediately after a `git reset --soft HEAD~1`?
-> *Prediction*: You would recreate the exact same commit you just undid, containing the exact same file states. Because `--soft` leaves the staging area untouched, the snapshot ready for the next commit is identical to one you just rolled back.
+Pause and predict: what do you think happens if you run `git commit -m "Same thing"` immediately after a `git reset --soft HEAD~1`? You would recreate the same file snapshot you just removed from the branch tip, because `--soft` leaves the staging area untouched. The new commit may have a different hash, author timestamp, or message, but the tree recorded by the commit will match unless you edit or restage something first. That is why `--soft` is excellent for fixing commit messages, adding one missed file, or combining the last local commit with an adjacent change before publication.
 
-### `git reset --mixed` (The Default)
+`git reset --mixed` is the default reset mode, so `git reset HEAD~1` behaves like `git reset --mixed HEAD~1`. It moves `HEAD` and rewrites the staging area to match the target commit, but it leaves the working directory files alone. In practical terms, the content from the removed commits becomes unstaged local modifications. You have not lost the YAML, scripts, or docs; you have only unpacked them from the index so you can sort them into better commits.
 
-A mixed reset (which is what runs if you simply type `git reset HEAD~1` without a flag) moves `HEAD` and also clears the Staging Area. However, it leaves your Working Directory completely untouched.
-
-**Analogy**: You take boxes off the truck, bring them all the way back into the staging room, and rip them open. The items are all still there on the floor, but they need to be sorted and packed into new boxes.
-
-**Use Case**: You committed a massive chunk of YAML files together—a `Deployment`, a `ConfigMap`, an `Ingress`, and a `Secret`. During code review, a senior engineer tells you these need to be logically separated into four atomic commits.
+Mixed reset is the safest everyday command for reshaping local commits because it gives you another chance to choose boundaries. Suppose a review points out that one commit changed a Deployment, ConfigMap, Ingress, and Secret all at once. That commit is difficult to review because each file carries a different operational risk. A mixed reset lets you take the combined patch back into the working directory, then restage one intent at a time so reviewers can validate the rollout plan, configuration surface, routing rule, and secret handling separately.
 
 ```bash
 # We have a monolithic commit we want to break apart into smaller pieces
@@ -112,13 +105,9 @@ git add configmap.yaml
 git commit -m "Add backend environment configuration"
 ```
 
-### `git reset --hard`
+`git reset --hard` moves `HEAD`, resets the index, and overwrites tracked files in the working directory to match the target commit. It is not evil, but it is absolute about tracked file state. If the only changes you care about are already committed somewhere, hard reset can be a fast way to return to a known clean state. If your valuable work is uncommitted, a hard reset can destroy it because Git has no commit object that records those file contents.
 
-A hard reset is the nuclear option. It moves `HEAD`, clears the Staging Area, and violently overwrites your Working Directory to make it exactly match the target commit. Any uncommitted changes in tracked files are permanently destroyed.
-
-**Analogy**: You back the truck into the staging room, dump everything out, and set the building on fire. Only what was originally packed in the truck remains. Everything else is ash.
-
-**Use Case**: You spent two hours experimenting with a highly complex Istio `VirtualService` configuration. It is completely broken, the syntax is a mess, routing is failing, and you just want to return to a known good clean slate.
+The word "tracked" matters here. A hard reset overwrites tracked files that Git knows about, but it does not remove untracked files by itself. That distinction sometimes misleads beginners into thinking the command is safer than it is, because a newly created untracked file may survive while a heavily edited tracked manifest is wiped clean. For a platform repository, that can mean a scratch note survives while the important Deployment patch disappears. Before using `--hard`, run `git status --short` and decide whether every tracked modification is truly disposable.
 
 ```bash
 # WARNING: This will destroy all uncommitted changes in tracked files
@@ -128,17 +117,15 @@ git reset --hard HEAD
 git reset --hard HEAD~1
 ```
 
-### War Story: The Accidental Nuke
+The war story behind this warning is painfully common. A junior platform engineer was asked to update CPU and memory resource requests across dozens of Kubernetes manifests. They wrote a shell script, saw a huge `git status`, became uncertain about one substitution, and ran `git reset --hard` because they thought it would merely unstage files. The command erased all tracked file edits, and because the edits had never been committed, the best remaining recovery options were IDE local history and shell scrollback. Git could recover the branch pointer, but it could not resurrect content it had never stored.
 
-A junior platform engineer was tasked with updating CPU and memory resource requests in all Kubernetes namespaces. They wrote a complex `sed` script that made sweeping changes across 50 different manifests. Before committing, they ran `git status` and saw a massive list of modifications. Overwhelmed, worried about a typo in their script, and unsure if the changes were safe, they typed `git reset --hard`, intending to just clear the staging area (which would have required `--mixed`). The `--hard` flag instantly obliterated all 50 uncommitted file changes. Because the changes were never committed, Git had no record of them. The engineer lost hours of careful script tuning and had to start from scratch.
+Use reset as a deliberate state operation. Ask which tree contains the work you want to preserve, then choose the reset mode that leaves that tree intact. If the valuable state is already committed, `--hard` may be acceptable. If it is staged, `--soft` preserves it. If it is in the working directory, `--mixed` generally keeps it available for reorganization. That decision process is slower than muscle memory, but it is much faster than explaining to a team why a production fix vanished.
 
 ## 2. `git reflog`: The Safety Net Under the Safety Net
 
-When you perform a destructive command like `git reset --hard HEAD~3`, it feels like those three commits are gone forever. If you type `git log`, they are nowhere to be seen. The history looks as if they never existed. But Git is inherently lazy and non-destructive behind the scenes. It rarely deletes data immediately. It just removes the pointers to that data.
+When a commit disappears from `git log`, it has usually disappeared from the visible branch path, not from Git's object database. Git stores commits as objects and uses references, such as branch names and tags, to decide which objects are easy to reach. A destructive-looking reset often just moves a reference away from a commit. The commit becomes orphaned from normal history, but the object remains present until Git's expiration and garbage collection rules eventually remove unreachable data.
 
-Enter the Reference Log, universally known as the `reflog`.
-
-The reflog is a chronologically ordered, hidden diary of every single time the tip of a branch (`HEAD`) was updated in your local repository. Every commit you make, every branch you check out, every reset you execute, every merge, and every rebase is recorded here, regardless of whether it shows up in `git log`.
+The reflog, short for reference log, is the local diary that records where references have pointed over time. Every commit, checkout, merge, rebase, and reset that updates `HEAD` can leave a reflog entry. This diary is local to one repository clone; it is not pushed to GitHub, GitLab, or a teammate's machine. That locality is both its strength and its limit. It can save you from your own mistake on your laptop, but it is not a substitute for pushing important work or maintaining backups.
 
 ```text
 HEAD@{0}: reset: moving to HEAD~2                           
@@ -148,9 +135,9 @@ HEAD@{3}: checkout: moving from feature-auth to main
 HEAD@{4}: pull origin main: Fast-forward                    
 ```
 
-### Recovering a Lost Commit
+Read reflog output as a timeline where `HEAD@{0}` is the latest recorded movement and larger numbers go backward in time. The commit hash at the left is the place `HEAD` ended up after that movement. If you reset away from useful commits, the entry immediately before the reset often points at the last good branch state. Recovery usually means selecting that hash or reflog selector and moving a branch reference back to it. The skill is not memorizing `HEAD@{1}`; the skill is reading the messages and confirming the target before moving anything.
 
-Let us simulate a terrifying disaster. You make a crucial commit containing sensitive infrastructure configurations, and then accidentally destroy it with a hard reset.
+Let us simulate a disaster with a committed file. The word "committed" is doing the heavy lifting here, because committed content has an object hash that the reflog can help you find. In a real infrastructure repository, the file might be a template for a Secret, a HorizontalPodAutoscaler, or a migration script that needs careful review before deployment. The exact content is less important than the fact that Git recorded it before the reset.
 
 ```bash
 # Create and commit the critical file
@@ -168,7 +155,7 @@ git log --oneline
 # 1d2e3f4 (HEAD -> main) Previous stable state
 ```
 
-At this point, most beginners panic. But as a KubeDojo engineer, you consult the diary.
+At this point, beginners often assume the commit is gone because `git log` cannot see it. That is a reasonable interpretation if you think `git log` shows everything Git knows, but it actually shows commits reachable from the current starting point. The reflog gives you another starting point. It tells you where `HEAD` used to be, so you can inspect or restore commits that are no longer reachable from the current branch tip.
 
 ```bash
 git reflog
@@ -177,7 +164,7 @@ git reflog
 # 1d2e3f4 HEAD@{2}: commit: Previous stable state
 ```
 
-Look closely at the output. You can see that `7a8b9c0` is the commit we lost. It still exists perfectly intact in Git's object database; it just lacks a branch pointer indicating where it belongs. To get it back, we simply reset our current branch to point at that orphaned hash.
+The lost commit hash is visible as `7a8b9c0`. You can recover by moving the current branch back to that hash with a hard reset, because in this scenario you want the branch, index, and working directory to exactly match the recovered commit. You could also create a branch at the lost hash first if you want a safer inspection step. In incident work, that temporary branch is often the calmer choice because it lets you examine the recovered state before changing the branch you are standing on.
 
 ```bash
 # Rescue the orphaned commit
@@ -185,20 +172,17 @@ git reset --hard 7a8b9c0
 # Output: HEAD is now at 7a8b9c0 Add critical database credentials template
 ```
 
-The commit, the `secret-config.yaml` file, and the entire history are fully restored. You have cheated death.
+Pause and predict: before running another command, what output do you expect if you run `git reflog` immediately after the recovery? The reflog will have a new entry at the top recording the recovery action, usually something like `reset: moving to 7a8b9c0`. Older entries will move down one position. The reflog appends movements instead of pretending the mistake never happened, which is exactly why it can function as an audit trail for local repair.
 
-> **Pause and predict**: Before running this, what output do you expect if you run `git reflog` again immediately after the recovery?
-> *Prediction*: The reflog will have a brand new entry at the very top (`HEAD@{0}`) recording the recovery action: `reset: moving to 7a8b9c0`. The older entries will be pushed down to `HEAD@{1}`, `HEAD@{2}`, etc. The reflog always appends; it never deletes its own history (until it expires).
+There is one subtle decision to make during reflog recovery: whether to reset the current branch, branch from the lost commit, or cherry-pick the lost commit onto the current branch. Reset is appropriate when the branch pointer itself went to the wrong place and you want to put it back. Creating a branch is appropriate when you are unsure what the recovered commit contains or you need to preserve the current branch state for comparison. Cherry-pick is appropriate when the current branch has legitimately moved on, but one lost changeset should be reapplied as a new commit.
+
+Reflog recovery has an expiration window. Default Git configuration keeps reflog entries for reachable commits longer than unreachable ones, and garbage collection eventually prunes unreachable objects after grace periods. The exact timing can be configured, so you should not rely on a vague promise that reflog can save anything forever. The operational habit is simple: when you realize a destructive command happened, stop making unnecessary moves, run `git reflog`, create a safety branch at the promising hash, and only then perform more invasive repair.
 
 ## 3. `git revert`: Safe Undos for Shared History
 
-`git reset` is an incredibly powerful tool for local history manipulation. It literally rewrites time, pretending the future never happened. This is perfectly fine, and even encouraged, for local feature branches that only exist on your laptop.
+`git reset` changes where a branch points. That is powerful on a private branch and dangerous on a shared branch because other people may already have based work on the commits you want to remove. If you rewrite a published branch, teammates can end up with histories that no longer agree with the remote. Their next pull may require confusing reconciliation, and their next push may be rejected or, worse, may reintroduce commits you thought you had removed.
 
-However, `git reset` is catastrophic for shared branches like `main`, `develop`, or `production`. If you reset a commit that your colleagues have already pulled down to their machines, their local histories will suddenly diverge from the remote repository. When they try to pull or push, they will face chaotic, confusing merge conflicts, and the team's continuous deployment pipeline will likely break.
-
-When a bad commit has already been pushed to a remote server and shared with others, you must never use `git reset`. You must use `git revert`.
-
-Instead of erasing a commit, `git revert` creates a *new* commit that introduces the exact opposite changes of the target commit. It is an "undo" that rolls forward, preserving the immutable audit trail of what happened.
+`git revert` solves a different problem. Instead of erasing a commit from history, it creates a new commit whose patch is the inverse of the target commit. The old commit remains visible, the new commit records the rollback, and collaborators can fast-forward normally. That makes revert the right command for production branches, protected branches, release branches, and any history that has been pulled by other people or automation. Revert does not make the original mistake disappear; it makes the repair explicit.
 
 ```mermaid
 graph LR
@@ -206,9 +190,7 @@ graph LR
     B --> C["Commit C<br>Revert of B"]
 ```
 
-### Reverting a Bad Configuration
-
-Imagine a developer merges a pull request that accidentally routes all production web traffic to the staging backend API. The site is down.
+The audit trail matters for platform work. If a bad ingress route sends production traffic to a staging backend, you do not want to hide the mistake by rewriting `main`. You want the incident timeline to show the bad change, the rollback, and the later corrected implementation. That record helps incident review, compliance review, and future debugging. It also protects every developer and deployment job that already saw the original commit, because their histories remain compatible with the remote branch.
 
 ```bash
 # Identify the bad commit hash causing the outage
@@ -218,46 +200,41 @@ git log --oneline
 # 1d2e3f4 Add new payment gateway service
 ```
 
-> **Pause and predict**: If you run `git revert 9a8b7c6` on the `main` branch, what will `git log --oneline` show immediately afterward?
-> *Prediction*: The log will show a new commit at the tip of the branch with a message like "Revert 'Update ingress routing rules'". The original bad commit `9a8b7c6` will remain completely intact in the history directly below it.
+Pause and predict: if you run `git revert 9a8b7c6` on `main`, what will `git log --oneline` show immediately afterward? You should expect a new commit at the tip with a message like `Revert "Update ingress routing rules"`, while the original bad commit remains below it. The branch moves forward, not backward. That distinction is the entire collaboration contract: everyone can pull the new rollback commit without being asked to pretend the old commit never existed.
 
 ```bash
 # Revert the specific bad commit to restore service
 git revert 9a8b7c6
 ```
 
-When you run this command, Git will calculate the inverse patch of commit `9a8b7c6`. If lines were added, it will delete them. If lines were deleted, it will restore them. Git will then open your default text editor to finalize the commit message (which defaults to "Revert 'Update ingress routing rules'"). Once saved, a new commit is added to the tip of `main`.
+Revert is not magic; it calculates an inverse patch using the current file context. If later commits have changed the same lines, Git may stop for conflicts, just as it would during a merge or cherry-pick. That conflict is not a reason to switch to reset on a shared branch. It is a signal that the rollback needs human judgment because the bad change and later changes are entangled. Resolve the conflict, stage the corrected files, and continue the revert so the public history remains honest.
 
-The history remains perfectly intact, the audit trail shows exactly who made the mistake and who fixed it, and the production system is safely restored to its previous state without disrupting anyone else's local repository.
+Merge commits require extra care because a merge has more than one parent. To revert a merge, Git needs to know which parent is the mainline that should be preserved. The common command is `git revert -m 1 <merge-commit>`, but you should not type it blindly. Parent one is usually the branch you merged into, yet workflows differ, and the wrong mainline can reverse the wrong side of the merge. Inspect the merge commit with `git show --summary <hash>` before deciding.
 
-### War Story: The Un-Revertable Merge
+The classic war story is the "un-revertable" merge. A team merged a large feature into `main`, discovered database lock problems, and reverted the merge with `git revert -m 1`. Production stabilized, but two weeks later Git reported "Already up to date" when the team tried to merge the fixed feature branch again. Git was technically correct: the original feature commits were already in `main`'s history, even though their effects had been counteracted by a revert commit. The team had to revert the revert, then apply new fixes on top.
 
-A team merged a massive, multi-month feature branch into `main`. Almost immediately after deployment, the feature caused cascading database locks in production, taking down the primary application. In a panic, the tech lead ran `git revert -m 1 <merge-commit-hash>`. The revert successfully worked, the bad code was removed, and production stabilized. 
-
-Two weeks later, the team painstakingly debugged and fixed the locking issue on their local branch. They tried to merge the feature branch into `main` again. To their horror, Git reported "Already up to date." No changes were merged. Why? Because the original commits were still technically in the history of `main` (they had just been counteracted by the revert commit). Git saw the commit hashes and thought, "I already have these." The team had to execute a highly confusing maneuver: they had to revert the revert commit to reintroduce the original broken code, and then apply their new fixes on top. 
+That story does not mean merge reverts are bad. It means rollback strategy should include a reintroduction plan. If you revert a feature merge, write down whether the future fix will revert the revert, rebuild the feature on a new branch with new commits, or cherry-pick a smaller corrected patch. Without that plan, the emergency rollback can become a confusing historical knot long after the incident is over.
 
 ## 4. File-Level Recovery: `git restore` and `git checkout`
 
-Often, you do not want to manipulate entire commits. You just want to discard local, messy changes to a single file, or you need to grab an old, working version of a file from a past commit because you accidentally deleted a crucial block of code.
+Many recovery tasks are smaller than a commit. You may have ruined one file while leaving five others in useful shape, or you may need an old version of a dashboard JSON without reverting the commit that also changed unrelated application code. File-level recovery exists for that reason. It lets you copy a file state from `HEAD`, from another commit, or from the index without moving the branch pointer or rewriting unrelated files.
 
-### Discarding Local Changes
+Historically, Git taught developers to use `git checkout` for both branch switching and file restoration. That overloading created a lot of accidental confusion, especially around the `--` separator. Modern Git provides `git restore` for file restoration and `git switch` for branch switching, which makes commands easier to read during stressful repair work. You can still understand legacy examples that use checkout, but for day-to-day file recovery, prefer `restore` when it fits.
 
-You have been hacking on a complex Kubernetes `statefulset.yaml` file for an hour, adding volume claim templates and affinity rules. You realize your architectural approach is entirely flawed. You want to throw away your work and revert the file to exactly how it looks in your last commit (`HEAD`).
+You have been hacking on a complex Kubernetes `statefulset.yaml` file for an hour, adding volume claim templates and affinity rules. The approach now looks wrong because the storage class differs across environments and your anti-affinity rules would strand pods during node maintenance. You do not want to rewrite branch history, and you do not want to disturb unrelated files. You only want this one tracked file to match the last commit.
 
-Historically, developers were taught to use `git checkout` for this:
 ```bash
 git checkout -- statefulset.yaml
 ```
 
-While this works, it is semantically confusing because `checkout` is also used for switching branches. To solve this, Git 2.23 introduced a clearer, dedicated command specifically for manipulating files: `git restore`. While initially labeled experimental in 2.23, `git restore` (along with `git switch`) is now a fully stable, standard command in modern Git.
+The checkout form works because the `--` tells Git that `statefulset.yaml` is a path, not a branch name. Without that separator, old command habits can become ambiguous when a branch and a file have similar names. `git restore statefulset.yaml` expresses the same intent more directly: restore this file in the working directory from the default source, which is `HEAD`. For a learner, the command name maps to the operation better than checkout does.
 
 ```bash
 # Discard all changes in the working directory for a specific file
 git restore statefulset.yaml
 ```
 
-> **Pause and predict**: If `statefulset.yaml` is currently modified and staged, what will `git status` show immediately after you run `git restore --staged statefulset.yaml`?
-> *Prediction*: The `git status` output will move `statefulset.yaml` from the "Changes to be committed" section down to the "Changes not staged for commit" section. The actual modifications in the file will remain untouched in your working directory.
+Pause and predict: if `statefulset.yaml` is currently modified and staged, what will `git status` show immediately after you run `git restore --staged statefulset.yaml`? The file will move out of the "Changes to be committed" section and into the unstaged section, while the actual file contents in your working directory remain modified. That command changes the index, not the working file. If you also want to discard the working directory changes, you need a separate restore without `--staged`.
 
 ```bash
 # What if you already added the file to the staging area?
@@ -265,9 +242,7 @@ git restore statefulset.yaml
 git restore --staged statefulset.yaml
 ```
 
-### Retrieving a File from the Past
-
-What if someone accidentally deleted a crucial Grafana dashboard JSON configuration three commits ago, and you need it back without reverting the entire commit and disrupting other changes? You can target that specific file at a specific point in time.
+File-level recovery also works in the other direction: retrieve an old version of a file and bring it into the current branch. Imagine someone deleted a Grafana dashboard JSON while cleaning a directory, and you need that file back without reverting the entire cleanup commit. Reverting the whole commit could restore unrelated files or undo useful cleanup. Pulling just the dashboard file from the last good commit is more precise.
 
 ```bash
 # First, find the commit where the file still existed and was working
@@ -280,15 +255,21 @@ git log --oneline -- dashboard.json
 git checkout a1b2c3d -- dashboard.json
 ```
 
-The `dashboard.json` file is now instantly placed in your working directory and automatically staged, ready to be committed back into the current history.
+After this command, `dashboard.json` appears in the working directory and is staged for commit. That staging behavior surprises some people, but it is useful because Git has copied a specific historical snapshot into the proposed next commit. Review it before committing, especially if the file contains environment-specific URLs, dashboard data source names, or alert thresholds. A recovered file can be syntactically correct and still operationally stale.
+
+For Kubernetes manifests, pair file recovery with validation. If a restored object will be applied to a cluster, run the repository's usual validation path before opening a pull request. At minimum, a platform engineer should be comfortable checking client-side syntax against the current Kubernetes command surface. With the alias defined earlier, a simple local validation command might look like this when a real cluster context and manifest are available.
+
+```bash
+k apply --dry-run=client -f deployment.yaml
+```
+
+File-level commands are safest when you name both the source and the target in your head. "Restore `statefulset.yaml` from `HEAD` into my working directory" is a clear operation. "Checkout something" is vague. During recovery, vague commands invite mistakes because Git has multiple places it can read from and multiple places it can write to. If you cannot say the source and destination out loud, inspect with `git status`, `git diff`, and `git diff --staged` before changing state.
 
 ## 5. `git cherry-pick`: Surgical Precision
 
-Sometimes you find yourself needing a specific commit from another branch, but you absolutely do not want to merge the entire branch. 
+`git cherry-pick` copies the changes introduced by an existing commit and applies them as a new commit on the current branch. It does not move the source branch, and it does not merge every commit from that branch. This makes it valuable when one changeset is ready but its surrounding branch is not. In platform work, that often happens when a security patch, resource limit correction, or deployment safety fix sits inside a broader feature branch that still contains unfinished experiments.
 
-Perhaps a colleague fixed a critical, zero-day security vulnerability on a sprawling, unstable feature branch. You need that security fix on the `main` branch immediately to deploy a hotfix, but the rest of their feature is broken and cannot be merged.
-
-`git cherry-pick` is the surgeon's scalpel of Git. It takes the exact changeset (the diff) from a specific commit on any branch and applies it as a brand new commit on your current branch.
+The key tradeoff is that cherry-pick duplicates the patch, not the identity of the commit. The new commit usually has a different hash because it has a different parent and possibly different metadata. That is fine when your goal is to move a fix across release lines, but it can complicate later merges if teams cherry-pick casually without tracking what moved. Use it deliberately, write clear commit messages, and prefer a normal merge when you actually want the whole branch relationship preserved.
 
 ```mermaid
 graph LR
@@ -305,7 +286,7 @@ graph LR
     C -. "cherry-pick C" .-> C_prime
 ```
 
-### Applying a Fix Across Branches
+Consider a colleague's feature branch that contains ten commits. One commit updates an image tag to a patched base image and adjusts the Deployment resource requests to avoid throttling. The rest of the branch changes a controller interface and is not ready for production. A merge would bring too much risk. A revert would require the bad change to already be on the target branch. A reset would rewrite local history. Cherry-pick is the command that matches the problem: copy this one patch here.
 
 ```bash
 # Ensure you are on the target branch
@@ -317,84 +298,152 @@ git branch
 git cherry-pick 8f9g0h1
 ```
 
-If the surrounding file context matches closely enough, Git will seamlessly create a new commit on `main` containing the changes. 
+If the surrounding file context is close enough, Git creates a new commit automatically. If the target branch has changed the same lines, Git stops with a conflict and asks you to reconcile the patch manually. That pause is helpful, not annoying. It means Git cannot safely infer whether the source branch's edit still makes sense in the target branch's current architecture. Resolve the conflict, run the relevant tests or manifest validation, stage the files, and continue with `git cherry-pick --continue`.
 
-However, if the context has diverged too much (for example, if the file was heavily refactored on `main` since `feature-x` diverged), Git will pause the cherry-pick and present you with a merge conflict. You must resolve the conflict manually in your editor, run `git add` to mark it resolved, and then run `git cherry-pick --continue` to finalize the operation.
+```bash
+# After resolving conflicts in your editor
+git status
+git add deployment.yaml
+git cherry-pick --continue
+```
 
-> **Stop and think**: Which approach would you choose here and why?
-> Scenario: You have 10 messy, experimental commits on a feature branch. You only want to keep 3 of them and bring them over to `main` for a clean pull request.
-> *Approach*: You should check out `main` and run `git cherry-pick <hash>` three times, sequentially, for each specific commit hash you want to keep. This is vastly cleaner, safer, and easier to comprehend than attempting a complex interactive rebase and dropping 7 commits.
+Before running this, what output do you expect from `git log --oneline -3` after a clean cherry-pick? You should expect the current branch tip to be a new commit with the cherry-picked message, followed by the previous commits from the target branch. You should not expect the source branch's earlier commits to appear. That absence is the point of the operation, and it is also why cherry-picking a stack of dependent commits must be done in dependency order.
+
+When several commits are required, apply the oldest necessary commit first. Later commits may depend on files, functions, or manifests introduced by earlier commits. Cherry-picking newest first can create avoidable conflicts or even produce a build that appears to pass while missing a prerequisite. If you need three commits from a messy branch, identify their hashes with `git log --oneline --reverse feature-x`, then apply the selected commits in the order they originally built on each other.
+
+Stop and think: which approach would you choose if you have ten messy experimental commits on a feature branch, but only three should become a clean pull request on `main`? Check out `main` or a new branch from `main`, then cherry-pick the three desired commit hashes in chronological order. That approach is usually easier to review than attempting a complicated interactive rebase that drops seven commits from the original branch, especially when the original branch still belongs to ongoing experimentation.
+
+Cherry-pick is also a common release maintenance tool. A fix may land on `main`, then need to be backported to a supported release branch without bringing the next version's features along. In that case, the destination branch's tests matter more than the source branch's tests. A patch that was correct on `main` can be incomplete on an older release because APIs, manifest layouts, or dependency versions differ. Treat every cherry-pick as a new integration event, not as a free copy.
+
+## Patterns & Anti-Patterns
+
+Experienced teams build recovery habits that reduce both data loss and social confusion. The first pattern is to classify the scope before choosing a command. Local, unpublished mistakes are candidates for reset, restore, and rebase because nobody else has built on them. Published mistakes are candidates for revert because the team needs a forward-moving public history. Cross-branch patches are candidates for cherry-pick when the target branch should receive only selected commits. This classification takes seconds and prevents most dangerous misuse.
+
+The second pattern is to create a temporary safety branch before invasive repair. If reflog shows a promising lost hash, `git branch rescue/<short-name> <hash>` gives that object a durable reference while you inspect it. You can delete the rescue branch later, but during recovery it prevents a second mistake from making the first one harder to diagnose. This pattern scales well in incident response because one engineer can preserve the state while another reviews the diff and tests the restored files.
+
+The third pattern is to inspect before and after every state-changing operation. `git status --short`, `git log --oneline --decorate -n 8`, `git diff`, and `git diff --staged` are not ceremony; they are instruments. Before a reset, they tell you where valuable work lives. After a revert or cherry-pick, they confirm whether Git stopped for conflicts or produced the commit you expected. Teams that normalize this inspection have fewer mystery fixes because every command is paired with evidence.
+
+| Pattern or Anti-Pattern | When It Appears | Better Operational Habit |
+| :--- | :--- | :--- |
+| Pattern: soft reset to amend local intent | The last local commit is almost right, but one file or message is missing. | Move `HEAD` back with `git reset --soft`, adjust the staged snapshot, then recommit before pushing. |
+| Pattern: rescue branch from reflog | A reset, rebase, or branch deletion hid useful committed work. | Create `rescue/<name>` at the reflog hash before doing further repair. |
+| Pattern: revert shared outages | A bad commit reached `main`, a release branch, or a protected branch. | Use `git revert` so collaborators receive a normal forward-moving commit. |
+| Anti-pattern: hard reset as cleanup | The working tree looks messy and the engineer wants a blank slate quickly. | Inspect tracked and untracked changes first; stash, commit, restore selected files, or reset only when disposable work is confirmed. |
+| Anti-pattern: cherry-pick without dependency order | A team grabs a later commit without the earlier commit it assumes exists. | Review the source branch graph and apply required commits oldest first. |
+| Anti-pattern: treating reflog as a backup service | Work remains local for days because the engineer assumes Git can always recover it. | Push important branches, create reviewable commits, and remember reflog is local and expires. |
+
+One anti-pattern deserves special attention: using reset to hide mistakes after a branch is shared. The temptation is understandable because the cleaned history looks simpler, but the simplification is local and deceptive. Everyone else now has a different version of history, and the team spends energy reconciling Git state instead of fixing the actual defect. If the branch has crossed a collaboration boundary, prefer a visible repair commit and explain it in the pull request or incident notes.
+
+Another anti-pattern is overusing cherry-pick as a substitute for small, coherent branches. If every release requires several hand-picked commits from a sprawling feature branch, the source workflow is carrying too much mixed intent. Cherry-pick can rescue you from schedule mismatch, but it should not become the normal way to assemble a release. A better long-term pattern is to keep fixes, refactors, and features in separate branches so ordinary merges carry understandable units of change.
+
+## Decision Framework
+
+The recovery decision starts with two questions: has the work been committed, and has the history been shared? If the work has never been committed, Git recovery commands have limited power because there may be no object to recover. If the work has been committed locally, reflog and reset can usually find it. If the work has been pushed or pulled by others, the social contract changes, and preserving shared history becomes more important than making the graph look tidy.
+
+Use `restore` when the branch is correct but one file or staged state is wrong. Use `reset --soft` when the last local commit boundary is wrong and the staged snapshot should remain ready. Use `reset --mixed` when local commits should be unpacked for restaging. Use `reset --hard` only when committed state elsewhere is the source of truth and tracked working changes are confirmed disposable. Use `revert` when the bad change is public. Use `cherry-pick` when a specific commit belongs on another branch without the rest of its source history.
+
+```text
+Need to undo or recover?
+|
++-- Is the problem one file or staging state?
+|   +-- Yes: use git restore or checkout with an explicit path
+|
++-- Is the bad change already shared?
+|   +-- Yes: use git revert, including -m for merge commits when needed
+|
++-- Did committed work disappear locally?
+|   +-- Yes: inspect git reflog, then branch, reset, or cherry-pick the lost hash
+|
++-- Is the last local commit shaped wrong?
+|   +-- Keep staged snapshot: git reset --soft
+|   +-- Keep working files only: git reset --mixed
+|   +-- Discard tracked file changes too: git reset --hard after inspection
+|
++-- Need one commit from another branch?
+    +-- Use git cherry-pick on the target branch, oldest dependency first
+```
+
+A decision framework is only useful if it includes the cost of being wrong. The cost of using `restore` too narrowly is low; you can inspect and repeat with another file. The cost of using `reset --hard` too broadly can be high if valuable tracked work is uncommitted. The cost of using `reset` on shared history is social and operational because teammates and automation must reconcile divergent graphs. The cost of using `revert` locally is usually clutter, not disaster. When uncertain, choose the command that preserves more evidence and creates fewer surprises for other people.
+
+For incident work, write down the chosen command before running it. A short note such as "public `main`, revert bad ingress commit, do not reset" forces the team to agree on the collaboration boundary. In a solo learning repository this may feel excessive, but production pressure changes behavior. Naming the intent turns recovery from reflex into reviewable action. It also gives the person at the keyboard permission to pause when a proposed command does not match the written plan.
 
 ## Did You Know?
 
-1.  **Reflogs Expire Automatically**: The `git reflog` is a safety net, but it is not permanent. By default, unreachable commits (those not part of any branch history, like the ones you dropped during a reset) expire and are deleted by the garbage collector after 30 days. Reachable commits expire after 90 days. Furthermore, `git gc` only prunes loose unreachable objects older than 2 weeks by default. You are not safe forever!
-2.  **Branches are Just Tiny Text Files**: In Git, a branch is not a folder or a complex structure. It is literally just a text file containing 40 characters—the SHA-1 hash of the commit it points to. When you delete a branch, you are only deleting that tiny text file, not the commits themselves.
-3.  **The Origin of Cherry-Pick**: The command name comes directly from the English idiom "cherry-picking," which means selecting only the best, most desirable items from a group, much like picking the ripest cherries from a tree while leaving the sour ones behind.
-4.  **Revert Can Target Merges**: `git revert` can undo merge commits, but you must specify the `-m` flag (mainline). A merge commit has two parent commits. You must tell Git which parent branch should be considered the "mainline" to keep (`-m 1`), and which branch's changes should be reversed.
-5.  **Dangling Object Recovery**: If your reflog has already expired, you might still have a chance. You can use the `git fsck --full` utility, which checks your database for integrity and shows all dangling or unreachable commit objects before they are permanently garbage-collected.
+1. **Reflogs Expire Automatically**: The `git reflog` is a safety net, but it is not permanent. By default, unreachable reflog entries expire sooner than reachable ones, and garbage collection eventually prunes unreachable objects after grace periods. You are not safe forever.
+2. **Branches are Tiny References**: In Git, a branch is a reference that points to a commit hash. Deleting a branch removes the reference, not necessarily the commits, which is why reflog-based recovery can recreate a branch after an accidental deletion.
+3. **Cherry-Pick Copies a Patch, Not a Hash**: A cherry-picked commit usually gets a new hash because its parent history differs on the target branch. The changes can be identical while the commit identity is different.
+4. **Revert Can Target Merges**: `git revert` can undo merge commits, but you must specify the mainline parent with `-m`. That flag tells Git which side of the merge should be treated as the history to keep.
 
 ## Common Mistakes
 
 | Mistake | Why It Happens | How to Fix It |
 | :--- | :--- | :--- |
-| Running `git reset --hard` on uncommitted work | Misunderstanding that `--hard` violently wipes the working directory, not just the staging area. | You cannot easily fix this using Git. Uncommitted, unstaged work is gone. Rely on IDE local history or file system backups if available. |
-| Reverting a commit instead of resetting locally | Thinking `revert` is the only way to undo, creating messy, cluttered histories on local, unshared feature branches. | Use `git reset` while the branch is local and unpushed. Only use `git revert` after pushing to a shared remote like GitHub. |
-| Losing a branch after accidental deletion | Deleting an unmerged branch with `git branch -D` and panicking because `git log` no longer shows the work. | Run `git reflog`, find the hash where the branch was last checked out, and recreate it with `git branch <name> <hash>`. |
-| Cherry-picking a commit multiple times | Running cherry-pick on a commit that was already merged, leading to empty commits or bizarre, confusing conflicts. | Use `git log --cherry-mark` to see which commits have already been applied, or check commit messages carefully before cherry-picking. |
-| Thinking the reflog is a remote backup | Assuming `git reflog` on GitHub or a coworker's machine will miraculously show your local mistakes. | Understand that the reflog is strictly local to your specific `.git` directory on your laptop. It never syncs over the network. |
-| Using `git checkout` for files, causing detached HEAD confusion | Forgetting the `--` separator when checking out files, sometimes accidentally checking out a similarly named branch and detaching HEAD. | Adopt the modern `git restore` command for all file-level manipulations to avoid overloading the checkout command. |
+| Running `git reset --hard` on uncommitted work | Misunderstanding that `--hard` wipes tracked working-directory changes, not just the staging area. | Stop and inspect `git status --short`; if the reset already happened, check IDE local history or backups because Git may not have stored unstaged content. |
+| Reverting a commit instead of resetting locally | Treating every undo as a public rollback, even when the branch has never left the laptop. | Use `git reset --soft` or `git reset --mixed` for local commit reshaping, then use `git revert` after publication. |
+| Losing a branch after accidental deletion | Deleting an unmerged branch with `git branch -D` and assuming the commits vanished with the name. | Run `git reflog`, find the last useful hash, and recreate the branch with `git branch <name> <hash>`. |
+| Cherry-picking a commit multiple times | Applying a patch that was already merged or previously backported, which creates empty picks or confusing conflicts. | Check the target history with `git log --cherry-mark` or compare pull request references before applying the patch again. |
+| Thinking the reflog is a remote backup | Assuming GitHub, GitLab, or a coworker's clone will show your local reflog entries. | Remember that reflog is local to one `.git` directory; push important branches and create durable references for valuable work. |
+| Using `git checkout` for files without the separator | Forgetting `--` and accidentally asking Git to switch branches or interpret an ambiguous name. | Prefer `git restore` for file recovery, or use `git checkout <commit> -- <path>` when reading older documentation. |
+| Reverting a merge without checking parents | Copying `git revert -m 1` from memory without confirming which parent is the mainline. | Inspect the merge with `git show --summary <hash>` and choose the parent that represents the history you intend to keep. |
 
 ## Quiz
 
 <details>
-<summary>Question 1: You just committed three YAML manifests, but realized you forgot to include a crucial ConfigMap in the same commit. You want to undo the commit, but keep all the previously committed changes exactly as they are in the staging area, so you can just add the ConfigMap and re-commit. Which reset flag should you use and why?</summary>
+<summary>Question 1: You just committed three YAML manifests, but realized you forgot to include a crucial ConfigMap in the same commit. You want to undo the commit, keep all previously committed changes staged, add the ConfigMap, and commit again. Which reset flag should you use and why?</summary>
 
-You should use `git reset --soft`. The crucial difference between the flags lies entirely in how they handle the Staging Area. `git reset --soft` moves the HEAD pointer backward but leaves the Staging Area completely intact, meaning all previously committed changes are now staged and ready to be committed again immediately. Conversely, `git reset --mixed` moves the HEAD pointer AND forcefully clears the Staging Area, placing those changes back into the Working Directory as unstaged modifications that you must manually `git add` again. Using the correct flag prevents accidental omission of files during a rapid rollback and re-commit cycle.
-
-</details>
-
-<details>
-<summary>Question 2: You are working on a massive `deployment.yaml` file. You make several changes over an hour, realize they are fundamentally wrong, and want to return the file to the exact state of your last commit. What command should you use?</summary>
-
-You should use `git restore deployment.yaml`. This command specifically targets the working directory and replaces the file with the pristine version from the current HEAD. Alternatively, `git checkout -- deployment.yaml` achieves the exact same result, but `restore` is the modern, preferred method specifically designed for file-level actions. Unlike `git reset --hard` which would wipe out all uncommitted changes across the entire repository, this command provides surgical precision. It ensures that only the target file is reverted while leaving any other experimental files you might be working on completely untouched.
+Use `git reset --soft HEAD~1`. The soft reset moves `HEAD` back but leaves the staging area exactly as the removed commit prepared it, so the Deployment, Service, and other manifest changes are still ready for the next commit. After adding the missing ConfigMap, the next commit records the corrected logical snapshot. A mixed reset would also preserve the file contents, but it would unstage everything and create unnecessary restaging work during a quick correction.
 
 </details>
 
 <details>
-<summary>Question 3: Your team just deployed a new release to production. Immediately, Datadog alerts start firing because a database migration script introduced in the last merge commit has a severe syntax error. The branch was heavily shared and other teams have pulled from it. What do you do?</summary>
+<summary>Question 2: You are working on a massive `deployment.yaml` file. After an hour, you realize the approach is wrong and want only that file to return to the exact state of your last commit while leaving other files alone. What command should you use?</summary>
 
-You must use `git revert -m 1 <commit-hash>`. Because the bad changes were introduced in a merge commit, you must specify the mainline parent using the `-m` flag to tell Git which history to preserve. Furthermore, because the commit has already been pushed to a shared remote and deployed to production, using `git reset` would rewrite history and cause synchronization chaos for the rest of the engineering team. `git revert` creates a safe, rolling-forward undo commit that counteracts the bug without rewriting history. This approach preserves an immutable audit trail, ensuring that when your colleagues pull the latest `main` branch, Git can seamlessly fast-forward their local histories without triggering complex merge conflicts.
-
-</details>
-
-<details>
-<summary>Question 4: You intended to clear your staging area with `git reset --mixed`, but your finger slipped and you accidentally typed `git reset --hard HEAD~2`. Two very important commits are now completely missing from your history. How do you recover them?</summary>
-
-You need to use the `git reflog`. First, run `git reflog` to view your local, chronological diary of HEAD movements. Locate the hash of the commit right before you executed the hard reset (it will likely be at index `HEAD@{1}` or `HEAD@{2}`). Then, execute `git reset --hard <that-hash>` to forcefully restore your branch pointer and working directory to that safe state. Git rarely deletes actual commit objects immediately, so the data is still safely stored within your local `.git` directory's object database. By resetting back to the orphaned hash found in the reflog, you effectively undo the disastrous hard reset and instantly bring your branch back to its pristine condition.
+Use `git restore deployment.yaml`. That command restores the working-directory copy of the named file from `HEAD` without moving the branch pointer or touching unrelated files. The older `git checkout -- deployment.yaml` form also works, but `restore` is clearer because it is dedicated to file-level state changes. Avoid `git reset --hard` for this scenario because it would discard tracked changes across the whole repository, not just the one mistaken file.
 
 </details>
 
 <details>
-<summary>Question 5: You have a long-running feature branch with 5 commits. You realize that commit number 3 actually contains a critical memory leak fix that needs to go to the `main` branch immediately, ahead of the rest of the unfinished feature. How do you isolate and move it?</summary>
+<summary>Question 3: Your team deployed a release from a shared branch, and alerts show that a merge commit introduced a broken database migration. Other teams have already pulled the branch. What should you do first, and why?</summary>
 
-You should use `git cherry-pick`. First, find the specific hash of commit number 3 using `git log` on the feature branch. Next, check out the `main` branch so it becomes your current active branch. Finally, run `git cherry-pick <hash>` to apply the fix. This command duplicates the exact changes from that specific commit onto `main` as a brand new commit, without bringing along the rest of the unstable feature branch. This technique isolates the emergency fix from unrelated, potentially broken feature code, allowing for a rapid and targeted hotfix deployment while the larger feature branch continues its normal development lifecycle independently.
+Use `git revert -m 1 <merge-commit-hash>` after confirming the merge parents. Because the branch is shared, reset would rewrite public history and force collaborators to reconcile divergent graphs during an incident. Revert creates a new commit that counteracts the bad merge while preserving the audit trail and allowing normal pulls. The `-m` flag is necessary for a merge commit because Git needs to know which parent represents the mainline history to keep.
 
 </details>
 
 <details>
-<summary>Question 6: You run `git branch -D feature-ingress` and instantly regret it because you had three days of unmerged Kubernetes manifests in there. Can `git reflog` save you? If so, exactly how?</summary>
+<summary>Question 4: You meant to clear your staging area with a mixed reset, but accidentally typed `git reset --hard HEAD~2`. Two important commits are missing from `git log`. How do you recover them?</summary>
 
-Yes, `git reflog` can easily save you. The reflog tracks where the HEAD pointer has been over time, completely independent of branch labels. Even though the branch label `feature-ingress` is deleted, the actual commits still exist in the Git database. You run `git reflog` to find the exact hash of the last commit you made while you were on that branch. Once you find the hash, you can recreate the branch pointing to that exact commit using the command `git branch feature-ingress <hash>`. Since a Git branch is fundamentally just a lightweight movable pointer to a specific commit, deleting a branch only destroys the pointer, not the underlying snapshot data. By recreating the branch label and attaching it to the recovered hash, you seamlessly restore your access to all the previously unreachable commits in that history.
+Run `git reflog` and identify the entry just before the hard reset moved `HEAD`. The lost commits are likely still present as objects because Git does not immediately delete them when a branch reference moves away. Once you find the last good hash, either create a rescue branch at that hash or reset the current branch back to it with `git reset --hard <hash>`. Creating the rescue branch first is safer if you want to inspect the recovered state before moving the current branch again.
+
+</details>
+
+<details>
+<summary>Question 5: A long-running feature branch has five commits, and the third commit contains a critical memory leak fix that must reach `main` immediately. The rest of the branch is unfinished. How do you isolate and move the fix?</summary>
+
+Check out `main` or a new branch from `main`, then run `git cherry-pick <hash-of-the-fix>`. Cherry-pick copies the patch from that one commit and creates a new commit on the target branch without merging the unfinished feature branch. After the pick, run the target branch's tests because the fix is now integrated with a different parent history. If the commit depends on earlier commits, cherry-pick those dependencies first in chronological order.
+
+</details>
+
+<details>
+<summary>Question 6: You deleted `feature-ingress` with `git branch -D` and then remembered it contained three days of unmerged Kubernetes manifests. Can reflog save you, and what exact recovery shape should you prefer?</summary>
+
+Yes, reflog can usually save committed branch work because deleting the branch removes a reference, not the underlying commit objects. Run `git reflog` and look for the last checkout or commit entry that points to the old branch tip. Prefer `git branch feature-ingress <hash>` to recreate the branch at that commit, because it restores the label without disturbing your current branch. After recreating it, inspect the log and manifests before continuing development or opening a pull request.
+
+</details>
+
+<details>
+<summary>Question 7: A teammate suggests using `git reset --hard` on `main` to remove a bad ingress commit because "the history will look cleaner." The commit has already been pushed and reviewed. How do you respond?</summary>
+
+Reject the reset and use `git revert <bad-hash>` instead. Clean-looking history is not worth breaking every clone, deployment job, and pull request that already knows about the pushed commit. A revert records the rollback as a new commit and keeps the branch fast-forwardable for everyone else. If the team later reintroduces the change, they can do so intentionally with a follow-up commit or by reverting the revert after the corrected fix is ready.
 
 </details>
 
 ## Hands-On Exercise
 
-In this exercise, we will simulate a catastrophic workflow error and use advanced Git recovery techniques to rescue the project from the brink of disaster.
+In this exercise, you will simulate a catastrophic workflow error and recover the project using the same decision framework you would use during a real platform incident. The repository is local, so you can practice destructive commands without risking shared history. The goal is not to memorize a happy path; it is to observe which Git state changes, inspect the evidence, and choose the repair command that matches that state.
 
 ### Step 1: Scenario Setup
 
-Let's build our environment, create some infrastructure code, and set up a simulated disaster.
+Create a fresh repository, add a stable Kubernetes-style manifest, and build a feature branch with three commits. The feature intentionally mixes one questionable Deployment change with two useful autoscaling changes so you can practice recovering a branch and then transplanting only the approved commits.
 
 ```bash
 # 1. Create a fresh repository
@@ -426,7 +475,7 @@ git log --oneline
 
 ### Step 2: The Disaster
 
-You meant to switch back to `main`, but you get distracted, confused, and accidentally perform a hard reset, violently wiping out the last three commits on your feature branch.
+You meant to switch back to `main`, but you get distracted and perform a hard reset on the feature branch. This is the important distinction from a purely staged mistake: the useful work had been committed, so the reflog has something to find. After the reset, inspect the log and directory so you can see what normal history no longer shows.
 
 ```bash
 # THE MISTAKE: You thought you were resetting a single file, but you nuked the branch history
@@ -439,7 +488,7 @@ ls -la
 
 ### Step 3: The Rescue Mission
 
-Your task is to find the lost commits and restore the branch to its correct, fully featured state.
+Your task is to find the lost commits and restore the branch to its correct, fully featured state. Do not guess at the hash. Read the reflog message, identify the commit that represents the last good state, and then choose the reset target deliberately.
 
 - [ ] Run the command that shows the hidden diary of HEAD movements.
 - [ ] Identify the exact commit hash associated with the message "Feature: Set HPA CPU threshold".
@@ -471,7 +520,7 @@ cat hpa.yaml
 
 ### Step 4: The Surgical Transplant
 
-Now that you recovered the branch, your tech lead messages you on Slack. The HPA manifests (`Feature: Add HPA manifest` and `Feature: Set HPA CPU threshold`) must be moved to `main` immediately to handle an incoming traffic spike, but the replica change (`Feature: Increase replicas to 3`) is buggy and not approved yet.
+Now that you recovered the branch, your tech lead messages you. The HPA manifests must move to `main` immediately to handle an incoming traffic spike, but the replica change is buggy and not approved yet. This is a cherry-pick problem because you want selected commits from the feature branch, not the entire branch history.
 
 - [ ] Check out the `main` branch.
 - [ ] View the log of the `feature-scaling` branch to get the hashes of the two specific HPA commits.
@@ -505,6 +554,28 @@ cat deployment.yaml # Should NOT contain the "replicas: 3" line
 
 </details>
 
+Success criteria:
+
+- [ ] The `feature-scaling` branch contains the recovered HPA commits again.
+- [ ] `main` contains the two HPA commits after cherry-pick.
+- [ ] `deployment.yaml` on `main` does not contain the unapproved `replicas: 3` line.
+- [ ] You can explain why reflog was appropriate for recovery and cherry-pick was appropriate for transplanting the approved changes.
+
 ## Next Module
 
 Now that you know how to reliably recover from disasters and manipulate history with surgical precision, it is time to master working on multiple features simultaneously without losing your mind in [Module 5: Multi-Tasking Mastery](../module-5-worktrees-stashing/).
+
+## Sources
+
+- [Git documentation: git-reset](https://git-scm.com/docs/git-reset)
+- [Git documentation: git-reflog](https://git-scm.com/docs/git-reflog)
+- [Git documentation: git-revert](https://git-scm.com/docs/git-revert)
+- [Git documentation: git-restore](https://git-scm.com/docs/git-restore)
+- [Git documentation: git-checkout](https://git-scm.com/docs/git-checkout)
+- [Git documentation: git-cherry-pick](https://git-scm.com/docs/git-cherry-pick)
+- [Git documentation: git-gc](https://git-scm.com/docs/git-gc)
+- [Git documentation: git-fsck](https://git-scm.com/docs/git-fsck)
+- [Pro Git book: Reset Demystified](https://git-scm.com/book/en/v2/Git-Tools-Reset-Demystified)
+- [Pro Git book: Revision Selection](https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection)
+- [Pro Git book: Git References](https://git-scm.com/book/en/v2/Git-Internals-Git-References)
+- [Kubernetes documentation: kubectl apply](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_apply/)


### PR DESCRIPTION
## Summary
- Rewrote `src/content/docs/prerequisites/git-deep-dive/module-4-undo-recovery.md` for #388 density, structure, alignment, and anti-leak gates.
- Cleared `revision_pending: false`.

## Verifier
- Verifier summary: tier T0; body_words=5143; mean_wpp=76.8; median_wpp=80; short_rate=0.03; max_run=1; mean_sentence_length=19.8.
- Source reachability: 12 URLs checked, 12 returned 200.

## Protected Assets
- Preserved protected assets with counts: code blocks 21 before / 25 after; Mermaid diagrams 3 before / 3 after; tables 1 before / 2 after; ASCII diagrams 0 before / 0 after.

## Validation
- `.venv/bin/python scripts/quality/verify_module.py --glob src/content/docs/prerequisites/git-deep-dive/module-4-undo-recovery.md --skip-source-check --summary --quiet` passed T0.
- `.venv/bin/python scripts/quality/verify_module.py --glob src/content/docs/prerequisites/git-deep-dive/module-4-undo-recovery.md --summary --quiet` passed T0 with live sources.
- `.venv/bin/python scripts/test_pipeline.py` passed: 166 tests.
- `git diff --check -- src/content/docs/prerequisites/git-deep-dive/module-4-undo-recovery.md` passed.
- `npm run build` passed in the worktree using a temporary node_modules symlink because the primary checkout had unrelated dirty state and could not be safely switched.

Commit SHA: ba2659d2982c9be224cf9425f299a760d0829fe8