### PR TITLE
feat(388): rewrite module-1.6-configmaps-secrets (#388 pilot)

### DIFF
--- a/src/content/docs/prerequisites/kubernetes-basics/module-1.6-configmaps-secrets.md
+++ b/src/content/docs/prerequisites/kubernetes-basics/module-1.6-configmaps-secrets.md
@@ -1,9 +1,12 @@
 ---
 title: "Module 1.6: ConfigMaps and Secrets"
 slug: prerequisites/kubernetes-basics/module-1.6-configmaps-secrets
+revision_pending: false
 sidebar:
   order: 7
 ---
+
+# Module 1.6: ConfigMaps and Secrets
 
 > **Complexity**: `[MEDIUM]` - Essential configuration management
 >
@@ -11,36 +14,39 @@ sidebar:
 >
 > **Prerequisites**: Module 1.3 (Pods)
 
-In late 2016, a catastrophic failure in secret management cost rideshare giant Uber a staggering $148 million in regulatory fines, alongside immeasurable reputational damage. The breach did not stem from a sophisticated zero-day exploit or a nation-state hacking syndicate. Instead, attackers compromised a private GitHub repository used by Uber's engineering team. Inside the repository's source code, the attackers discovered hardcoded AWS credentials—plaintext keys that granted broad access to the company's cloud infrastructure. With these credentials, the intruders accessed an Amazon S3 datastore containing the personal information of 57 million riders and drivers.
+Throughout this module, commands use the short alias `k` for `kubectl`. If your shell does not already define it, run `alias k=kubectl` before starting the hands-on work. The examples target Kubernetes 1.35 and focus on behavior that matters when configuration, credentials, and rollout operations meet in a real cluster.
 
-This devastating incident highlights a fundamental rule of modern software engineering: sensitive configuration must never be embedded within application code or container images. Hardcoding credentials not only exposes them to anyone with read access to the version control system but also guarantees that rotating a compromised password requires a full recompilation and redeployment of the application. In a cloud-native environment, configuration and code must evolve independently, allowing operators to rotate keys instantly without touching the underlying deployment artifacts.
-
-Kubernetes solves this problem through two core API resources: ConfigMaps and Secrets. These objects allow you to decouple configuration artifacts from container image content, ensuring your applications remain portable, configurable, and secure. However, as many organizations have discovered the hard way, simply moving a password into a Kubernetes Secret does not magically secure it. In this module, we will explore the internal mechanics of these resources, how they interact with the kubelet, and the critical security boundaries you must enforce to prevent your cluster from becoming the next headline.
-
-## What You'll Be Able to Do
+## Learning Outcomes
 
 After completing this module, you will be able to:
-- **Design** decoupled deployment architectures by extracting hardcoded environment variables and configuration files into externalized Kubernetes API objects.
-- **Implement** dynamic configuration updates for running pods by leveraging volume mounts and understanding the kubelet's synchronization delays.
-- **Diagnose** common failure modes related to secret consumption, including base64 encoding errors, namespace boundary violations, and static Pod limitations.
-- **Compare** the security postures of various encryption-at-rest providers, evaluating the transition from legacy KMS v1 to the modern KMS v2 architecture.
-- **Evaluate** the performance benefits of immutable ConfigMaps and Secrets in large-scale, high-churn Kubernetes clusters.
 
-## The Core Concept: Separation of Configuration and Code
+- **Design** decoupled deployment architectures that move environment-specific settings out of container images and into ConfigMaps or Secrets.
+- **Implement** runtime configuration delivery with environment variables, mounted files, and projected volumes while predicting which changes require a Pod restart.
+- **Diagnose** failed configuration and credential rollouts caused by base64 mistakes, namespace boundaries, missing keys, static Pod limits, or `subPath` mounts.
+- **Compare** ConfigMap and Secret security boundaries, including RBAC exposure, etcd encryption at rest, and the KMS v2 provider available in modern Kubernetes.
+- **Evaluate** when immutable ConfigMaps and Secrets reduce control-plane load and when versioned replacement objects create safer production rollouts.
 
-The Third Factor of the influential "Twelve-Factor App" methodology states: *Store config in the environment*. Configuration is defined as everything that is likely to vary between deployments (staging, production, developer environments). This includes database URIs, external API credentials, and application-specific toggle flags.
+## Why This Module Matters
 
-When you package an application into a Docker container, the filesystem is baked into an immutable image. If you hardcode a database connection string into a configuration file inside that image, you must build a distinct image for your staging environment and another for production. This violates the principle of artifact promotion, where the exact same binary or image should traverse the entire CI/CD pipeline untouched.
+In late 2016, a catastrophic failure in secret management cost rideshare giant Uber a staggering $148 million in regulatory fines, alongside immeasurable reputational damage. The breach did not stem from a sophisticated zero-day exploit or a nation-state hacking syndicate. Instead, attackers compromised a private GitHub repository used by Uber's engineering team. Inside the repository's source code, the attackers discovered hardcoded AWS credentials that granted broad access to the company's cloud infrastructure. With these credentials, the intruders accessed an Amazon S3 datastore containing the personal information of 57 million riders and drivers.
 
-Kubernetes ConfigMaps and Secrets provide a mechanism to inject this variable configuration into an immutable container at runtime. The application remains unaware of Kubernetes; it simply reads environment variables or files from its local filesystem, exactly as it would if running on a traditional Linux server. Both ConfigMap and Secret are core `v1` API resources, meaning they are foundational to the cluster's architecture and universally supported.
+That incident is remembered because the failure mode was painfully ordinary: a credential that should have been operational data became part of the application artifact. Once a password, token, certificate, database URI, or endpoint gets baked into a container image or committed into source control, rotation becomes slow and risky. The team cannot simply change a value; they must find every copy, invalidate every leaked credential, rebuild artifacts, retest deployments, and hope no old image is still running in a forgotten environment.
 
-To fully grasp the implications of this decoupling, imagine a scenario where a database password is leaked. If the password is baked into an image, your incident response team must wait for a full CI/CD pipeline run to build, test, and deploy a new image. During an active breach, every minute counts. If the password is externalized into a Kubernetes Secret, the team can update the Secret object in seconds, gracefully roll the deployment, and immediately sever the attacker's access without rebuilding a single binary.
+Kubernetes gives you two built-in resources for avoiding that trap: ConfigMaps for non-sensitive configuration and Secrets for sensitive data. They let the same container image run in development, staging, and production while the cluster supplies the values that vary between those environments. That design is powerful, but it also creates a new responsibility: you must know exactly how those resources are stored, delivered, refreshed, and protected, because moving a password into a Secret does not automatically make the surrounding workflow secure.
 
-## Architecture of ConfigMaps and Secrets
+## Separation of Configuration and Code
 
-Before diving into the syntax, we must understand the boundaries and structure of these objects. Both ConfigMaps and Secrets operate at the core API group and share foundational mechanics.
+The core idea behind ConfigMaps and Secrets is separation of concerns. Container images should contain application code, dependencies, and default behavior that is safe to promote unchanged through a pipeline. Deployment-specific values should be supplied at runtime, because they change for reasons that are independent of the application release cycle. A logging level changes during an incident, a database endpoint changes during a migration, a feature flag changes during a gradual launch, and a credential changes when it is rotated or compromised.
 
-Think of ConfigMaps as a restaurant's public menu: it changes occasionally, anyone can read it, and it tells the staff what to cook. Secrets are the locked safe containing the secret sauce recipe: you only give access to the specific chefs who actually need it.
+The Third Factor of the influential "Twelve-Factor App" methodology states: store config in the environment. In Kubernetes, that principle becomes more flexible than plain shell variables, because the platform can deliver configuration as environment variables, files, command arguments, or API objects. The application still reads ordinary process environment values or local filesystem paths; it does not need to know that a kubelet placed those values there. The operational benefit is that you can change a Deployment manifest, a ConfigMap, or a Secret without rebuilding the image.
+
+Think about artifact promotion as a chain of custody. If a web application image is built once and promoted unchanged from a developer namespace to staging and then production, every environment is testing the same executable payload. If the production database URL is hardcoded into the image, the chain breaks, because production now needs a different build. That difference makes debugging harder because a staging success no longer proves that the production artifact behaves the same way.
+
+ConfigMaps and Secrets are both core `v1` Kubernetes API resources, but they are not interchangeable. A ConfigMap is appropriate for non-sensitive values such as log levels, feature flags, application properties, Nginx snippets, or JSON configuration files. A Secret is appropriate for passwords, private keys, API tokens, TLS private material, and image pull credentials. The difference is not that Secrets are magically invisible; the difference is that Kubernetes applies different intent, access patterns, optional encryption support, and specialized types around data that should be treated as confidential.
+
+Pause and predict: if a team changes only a ConfigMap key used by a Deployment, should the container image digest change? If your answer is yes, the configuration is still coupled to the artifact somewhere. If your answer is no, you are describing the design Kubernetes is trying to support: the image stays fixed while the runtime object changes.
+
+There is also a practical incident-response reason to separate configuration from code. If a leaked database password is baked into an image, the response path includes a new build, a registry push, a Deployment update, and cleanup of any Pods still running the old image. If the password is externalized into a Secret, the team can rotate the credential, update the Secret object, and restart the consuming Pods without changing the application binary. That difference does not remove the need for disciplined rollout automation, but it shortens the path between detection and containment.
 
 ```mermaid
 graph TD
@@ -65,43 +71,29 @@ graph TD
     SEC -.-> N
 ```
 
-### Shared Constraints and API Details
+This diagram captures the first decision boundary, but it is only the beginning. The same value can be operationally sensitive in one environment and harmless in another, so classification is contextual. A log level is usually safe in a ConfigMap, but an internal endpoint that reveals private topology may deserve tighter handling. A TLS certificate file may be public material, while its matching private key must be treated as a Secret. The safest habit is to classify by consequence: if disclosure would create a security, compliance, or customer-impacting problem, use a Secret and restrict the surrounding access path.
 
-ConfigMap and Secret objects share several underlying constraints due to how Kubernetes stores data in its distributed key-value store, `etcd`:
+## Object Anatomy and API Boundaries
 
-1. **Size Limits**: Both ConfigMap and Secret individual object sizes are strictly limited to **1 MiB** (mebibyte) per object. This hard limit is designed to discourage users from storing massive datasets or binary blobs in the cluster state. Exceeding this limit would rapidly exhaust API server and kubelet memory, bloat the `etcd` database, and severely degrade cluster performance.
-2. **Namespace Isolation**: A pod must reside in the exact same namespace as the ConfigMap or Secret it references when using environment variables or volume mounts. You cannot mount a ConfigMap from the `backend` namespace into a pod running in the `frontend` namespace. Only direct API access (via custom controllers) allows cross-namespace reads, and this is heavily restricted by Role-Based Access Control (RBAC).
+ConfigMaps and Secrets are namespaced objects. A Pod can reference only a ConfigMap or Secret in its own namespace through ordinary environment variable or volume configuration. That boundary is deliberate because namespace-scoped RBAC, resource quotas, and application ownership often line up with team or environment boundaries. If a frontend Pod in the `web` namespace could mount a Secret from the `payments` namespace by accident, a small YAML mistake could become a cross-team credential leak.
 
-> **Pause and predict**: You have a TLS certificate (a `.pem` file) and an Nginx configuration file (`nginx.conf`). Both are plain text files. Which Kubernetes objects should you use to store them, and what makes their storage requirements different?
+Both object types are also limited to 1 MiB per object. That limit exists because these resources live in the Kubernetes API and are stored in etcd, which is designed for cluster state rather than bulk payload delivery. Large blobs force the API server, kubelet, watch caches, and etcd to move data that should have been served by an image layer, object store, persistent volume, or initialization workflow. When a configuration file grows beyond that limit, the right answer is usually to change the delivery mechanism, not to split the file into dozens of fragile keys.
 
-### ConfigMap Data Structures
+A ConfigMap has two payload fields. The `data` field stores UTF-8 strings, which is what you use for normal application settings and text configuration files. The `binaryData` field stores base64-encoded binary payloads for non-UTF-8 bytes. Kubernetes rejects a ConfigMap when the same key appears in both fields, because a consuming volume cannot safely decide which payload should become the file with that name.
 
-A ConfigMap does not provide secrecy or encryption and should absolutely never be used for sensitive or confidential data. It exposes two distinct data-bearing fields:
+A Secret has a similar `data` field, but every value in that field must be base64-encoded. This is a serialization requirement, not encryption. Anyone who can read the Secret object can decode those bytes. Kubernetes also offers `stringData`, a write-only convenience field that accepts plaintext values during create or update and stores them under `data` after encoding. When you read the Secret back, `stringData` is gone, which is why GitOps tools and server-side apply workflows sometimes need careful handling around field ownership.
 
-- `data`: This field holds standard UTF-8 string values. It is ideal for application properties, JSON configuration files, and standard text variables.
-- `binaryData`: This field holds binary data represented as base64-encoded strings. If you need to store a binary payload (like a compressed `.gz` file or a non-UTF-8 payload), you must place it here. 
+The built-in Secret types add validation and intent. The default `Opaque` type is a generic key-value container, while specialized types represent service account tokens, Docker registry credentials, basic authentication credentials, SSH keys, TLS certificate pairs, and bootstrap tokens. Those types do not replace access control; they tell Kubernetes and operators what shape of credential the object is supposed to hold. For example, a TLS Secret has conventional `tls.crt` and `tls.key` keys, making it easier for Ingress controllers and other components to consume it consistently.
 
-Crucially, keys must not overlap between the `data` and `binaryData` fields. If a key named `config.json` exists in both, the API server will reject the object.
+Static Pods are the exception that reveals why the API boundary matters. A static Pod is defined directly on a node and managed by the kubelet rather than created through the normal API server workflow. Because that path bypasses the normal Secret retrieval and authorization process, Secrets cannot be used with static Pods. If a node-level component needs sensitive material, the design must use a different secure delivery mechanism and should be reviewed as node administration, not as an ordinary Pod configuration pattern.
 
-### Secret Data Structures and Types
+Optional references are another boundary worth designing deliberately. Kubernetes lets you mark some ConfigMap or Secret references as optional, which can be helpful during phased rollouts when a value may not exist in every environment yet. The risk is that optional references can hide a real deployment error until application startup, where the symptom looks like a confusing missing file or empty variable. Use optional references for planned compatibility windows, not as a way to silence manifest validation.
 
-Secrets are designed to handle confidential data, but they carry a massive caveat: the `data` values are merely base64-encoded byte strings, not encrypted. Base64 is an encoding mechanism, providing zero cryptographic confidentiality. 
+Before running this, what output do you expect from a Secret created with `stringData`? The important prediction is that a later `k get secret -o yaml` will not show `stringData`; it will show base64 values under `data`. If that surprises you, pause before putting Secrets into review workflows, because reviewers may see encoded text and incorrectly assume it is protected from disclosure.
 
-To make secret creation easier, Kubernetes offers the `stringData` field as a write-only convenience field. The `stringData` field on a Secret accepts plaintext values; upon creation or update, Kubernetes automatically base64-encodes them and stores the result in the standard `data` field. When you read the object back via the API, the `stringData` field vanishes, and only the base64-encoded `data` is returned.
+## Creating ConfigMaps and Secrets
 
-While you will mostly use generic secrets, there are actually eight built-in Secret types native to the cluster:
-1. `Opaque` (The default for generic data when no type is specified)
-2. `kubernetes.io/service-account-token` (Used for ServiceAccount tokens)
-3. `kubernetes.io/dockercfg` (Legacy Docker credentials)
-4. `kubernetes.io/dockerconfigjson` (Modern Docker credentials for pulling images)
-5. `kubernetes.io/basic-auth` (Credentials for basic authentication)
-6. `kubernetes.io/ssh-auth` (SSH keys)
-7. `kubernetes.io/tls` (TLS certificates and private keys)
-8. `bootstrap.kubernetes.io/token` (Node bootstrap tokens)
-
-## Creating and Consuming ConfigMaps
-
-Let's look at how to construct ConfigMaps practically. You can generate them imperatively via the command line or declaratively via YAML manifests. The imperative approach is excellent for quickly bootstrapping data, especially from existing files on your workstation.
+Kubernetes supports both imperative creation and declarative manifests. Imperative commands are useful for learning, quick experiments, and generating initial YAML from local files. Declarative manifests are better for repeatable environments because they can be reviewed, versioned, diffed, and applied through the same delivery pipeline as the rest of the application. The professional habit is to understand both, then use declarative workflow for anything you expect to recreate.
 
 ```bash
 # From literal values
@@ -119,7 +111,7 @@ kubectl create configmap configs --from-file=./config-dir/
 kubectl get configmap app-config -o yaml
 ```
 
-The resulting YAML representation places your variables cleanly into the `data` block. Notice how multi-line strings, like `config.json`, use the YAML pipe `|` character to preserve formatting.
+The commands above are preserved because they show the basic creation modes exactly: literal keys, a single file, an entire directory, and a YAML inspection step. In day-to-day module work, run the same operations with `k` after defining the alias. A generated ConfigMap from a directory maps every file name to a key, which is convenient for configuration directories but dangerous if the directory contains editor backups, local overrides, or files that were never meant to leave your workstation.
 
 ```yaml
 apiVersion: v1
@@ -136,74 +128,7 @@ data:
     }
 ```
 
-### The Four Consumption Methods
-
-ConfigMaps and Secrets can be consumed by pods via four distinct methods:
-1. Container command and arguments (interpolating variables into the pod spec).
-2. Environment variables.
-3. Read-only volume mounts.
-4. Direct Kubernetes API access via custom application code.
-
-Only the direct API method supports reactive or subscribed updates directly from the control plane. The other three methods are either set statically at pod creation or refreshed asynchronously by the kubelet on the node.
-
-#### Injection via Environment Variables
-
-When you map a ConfigMap to environment variables, the variables are injected at pod startup.
-
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: app
-spec:
-  containers:
-  - name: app
-    image: myapp
-    env:
-    - name: LOG_LEVEL
-      valueFrom:
-        configMapKeyRef:
-          name: app-config
-          key: LOG_LEVEL
-    # Or all keys at once:
-    envFrom:
-    - configMapRef:
-        name: app-config
-```
-
-**Critical Limitation**: Environment variable values injected from a ConfigMap are NOT updated in a running container when the ConfigMap changes. They remain static for the container's entire lifetime. To force an application to pick up new environment variables, the Pod must be manually deleted and recreated, or rolled via a Deployment controller.
-
-#### Injection via Volume Mounts
-
-Volume mounts treat the ConfigMap keys as filenames and the values as file contents, placing them directly into the container's filesystem.
-
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: app
-spec:
-  containers:
-  - name: app
-    image: nginx
-    volumeMounts:
-    - name: config
-      mountPath: /etc/nginx/conf.d
-  volumes:
-  - name: config
-    configMap:
-      name: nginx-config
-```
-
-**The Update Advantage**: ConfigMap data mounted as a volume is updated automatically in running pods when the ConfigMap changes. The kubelet periodically syncs these mounts. However, the update is eventually consistent. The total propagation delay can take up to the sum of the kubelet sync period and the cache TTL (both defaulting to roughly 1 minute each, meaning up to ~2 minutes total delay). Applications that natively watch their configuration files for changes (like Prometheus or Nginx) can reload themselves without ever terminating the pod.
-
-**The SubPath Trap**: There is a major exception to the automatic update rule. Volumes mounted using the `subPath` directive (often used to inject a single file into a directory without overwriting the existing contents) do NOT receive automatic updates when the underlying ConfigMap or Secret changes. A `subPath` mount creates a static bind mount at the OS level, breaking the symbolic link rotation the kubelet uses to seamlessly swap in new data.
-
-> **Stop and think**: Your application takes 5 minutes to start up. If you need to change its log level from 'info' to 'debug' temporarily to troubleshoot an issue, would you prefer the log level to be injected as an environment variable or a mounted file? Explain your reasoning.
-
-## Creating and Consuming Secrets
-
-Secrets follow the same structural paradigm but require more caution regarding data formatting. Base64 encoding is mandatory for the `data` field, which often trips up beginners.
+The YAML representation shows why ConfigMaps are often used for application files, not just small variables. The `config.json` key becomes a file when mounted as a volume, and the pipe character preserves multiline formatting. That is useful for Nginx snippets, application properties, JSON, YAML, or INI files, but it also means normal configuration review rules apply. If a multiline block contains a password, it is still visible ConfigMap data and should be moved into a Secret.
 
 ```bash
 # From literal values
@@ -223,7 +148,7 @@ kubectl get secret db-creds -o yaml
 kubectl get secret db-creds -o jsonpath='{.data.password}' | base64 -d
 ```
 
-When writing declarative YAML, you must choose between pre-encoding your data in the `data` field, or leveraging the `stringData` field to let the API server handle the encoding.
+The Secret example demonstrates the workflow that causes many early mistakes. The CLI accepts literal values and stores encoded bytes, so the YAML view looks different from what the application will receive. Decoding with `base64 -d` is a debugging technique, not an authorization boundary. If a user, service account, or process can run that get command successfully, it can recover the original value.
 
 ```yaml
 apiVersion: v1
@@ -248,7 +173,60 @@ stringData:               # Plain text, auto-encoded
   password: secret123
 ```
 
-Consumption mirrors ConfigMaps perfectly, merely substituting `configMapRef` with `secretKeyRef` or `secretName`.
+The two Secret manifests produce the same practical result for a consuming Pod, but they create different review experiences. With `data`, the author must encode values correctly and avoid accidental newline characters from commands such as plain `echo`. With `stringData`, the author writes readable plaintext and lets the API server encode it. Neither style is safe to commit to a public repository, and neither style replaces a proper external secret workflow when Git is part of the delivery path.
+
+A useful review trick is to read a manifest from the perspective of the future operator who gets paged. Can they tell which values are safe to print in a ticket, which values require rotation if exposed, and which values need a rollout to take effect? If the answer is no, the manifest may be technically valid while still being operationally unclear. Names like `app-settings`, `app-secrets`, and stable keys such as `DB_PASSWORD` are simple, but they teach the reader where to look during an outage.
+
+## Consuming Values in Pods
+
+A Pod can consume ConfigMaps and Secrets through command arguments, individual environment variables, `envFrom`, read-only volumes, projected volumes, or direct API access from application code. The choice should follow how the application expects to read configuration and how often the value needs to change. Environment variables are simple and familiar, but they are captured when the container starts. Files are a better fit for structured config and can be refreshed by the kubelet for normal ConfigMap and Secret volumes.
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app
+spec:
+  containers:
+  - name: app
+    image: myapp
+    env:
+    - name: LOG_LEVEL
+      valueFrom:
+        configMapKeyRef:
+          name: app-config
+          key: LOG_LEVEL
+    # Or all keys at once:
+    envFrom:
+    - configMapRef:
+        name: app-config
+```
+
+This environment variable pattern is easy to read and works well for values that are naturally scalar, such as `LOG_LEVEL`, `ENVIRONMENT`, or a feature flag. Its limitation is just as important: changing the ConfigMap later does not mutate the environment of a running process. Linux processes receive their environment at start time, and Kubernetes does not rewrite it under the process. To pick up a new value, you delete the Pod, trigger a Deployment rollout, or use a controller pattern that changes a Pod template annotation when config changes.
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app
+spec:
+  containers:
+  - name: app
+    image: nginx
+    volumeMounts:
+    - name: config
+      mountPath: /etc/nginx/conf.d
+  volumes:
+  - name: config
+    configMap:
+      name: nginx-config
+```
+
+Mounted ConfigMaps and Secrets behave differently because the kubelet manages files on the node. When the API object changes, the kubelet eventually updates the projected files for regular volume mounts. The delay is not instantaneous; it can be as high as the kubelet sync period plus the cache propagation delay, which is commonly described as roughly two minutes under default behavior. Applications that watch files or reload on signal can use this path for dynamic configuration, while applications that read files only at startup still need a restart.
+
+The `subPath` option is the major exception. Teams often use `subPath` to mount a single ConfigMap key into a directory without hiding the rest of the directory contents. That convenience creates a static bind mount and breaks the kubelet's normal symlink rotation mechanism, so updates to the ConfigMap or Secret do not appear in the running container. If dynamic refresh matters, mount a directory without `subPath` and arrange the application path accordingly.
+
+Pause and predict: your application takes five minutes to start and you need to temporarily change logging from `info` to `debug` during an incident. If the application can reload a file but cannot reload environment variables, the mounted-file design is operationally better. If the application reads configuration only once at startup, both delivery methods still require a restart, so the deciding factor becomes readability, leak risk, and application convention.
 
 ```yaml
 apiVersion: v1
@@ -272,7 +250,7 @@ spec:
           key: password
 ```
 
-If you wish to mount Secrets as files, the pattern is identical to ConfigMap volumes:
+Secret environment variables are common but deserve extra caution. Many crash reporters, debug endpoints, support bundles, and process-inspection tools include environment variables by default. If a password appears in the environment, it may leak into logs or diagnostics even when RBAC around the Secret object is correct. Mounting a Secret as a file narrows that accidental exposure path because tooling usually does not read arbitrary credential files unless configured to do so.
 
 ```yaml
 apiVersion: v1
@@ -293,7 +271,7 @@ spec:
       secretName: db-creds
 ```
 
-The underlying mechanics of delivery are virtually identical. The kubelet handles the extraction of the payload and provisions it to the container runtime via either standard Linux environment variables or transient, memory-backed `tmpfs` volumes for file mounts. One extremely important restriction exists: Secrets cannot be used with static Pods. Because static Pods bypass the API server entirely, they cannot securely fetch the confidential payloads that the API server guards.
+When mounted as files, Secret payloads are delivered on the node through memory-backed storage rather than written as ordinary image-layer files. That implementation detail reduces the chance of accidental disk persistence on the node, but it does not protect the data from the running container. If an attacker gets a shell inside the application container, the Secret is available through the same filesystem path the application uses. Secrets protect against some storage and API exposure paths; they do not protect against a compromised workload that legitimately needs the credential.
 
 ```mermaid
 graph TD
@@ -316,15 +294,15 @@ graph TD
     VOL --- N2
 ```
 
+This flow explains why a rollout plan must include both the Kubernetes delivery mechanism and the application reload mechanism. Kubernetes can update a file, but it cannot force arbitrary application code to reread that file. Kubernetes can create an environment variable, but it cannot change a process environment after startup. The best production designs make that behavior explicit by using versioned object names, checksums in Pod template annotations, reload sidecars, or application-native reload endpoints depending on the reliability requirements.
+
+Controllers often automate the restart side of this problem by changing the Pod template whenever a referenced ConfigMap or Secret changes. Helm charts commonly add a checksum annotation derived from rendered configuration, and some operators watch objects directly and trigger rollouts. That pattern is powerful because it converts an invisible dependency into a visible Deployment change. The tradeoff is that every configuration edit can now restart workloads, so teams should decide whether the value is safe for live reload, restart-based rollout, or a manual maintenance window.
+
 ## Worked Example: Refactoring Hardcoded Config
 
-Let's walk through how to refactor an application that has hardcoded settings.
+Imagine a small web service that was originally built for a single developer laptop. It connects to a database at `localhost:5432`, uses a cache time-to-live of `3600`, and reads a password from a checked-in file. That design might work for a demo, but it fails the moment the same image needs to run in separate namespaces or clusters. The database location changes by environment, the cache policy may change during troubleshooting, and the password must rotate without producing a new application image.
 
-**1. Identify the configuration points**: The application connects to a database at `localhost:5432` with a password `supersecret`, and uses a caching TTL of `3600`.
-
-**2. Separate by sensitivity**: The cache TTL is not sensitive, so it belongs in a ConfigMap. The database password is highly sensitive, so it must go into a Secret.
-
-**3. Create the objects**:
+The first step is to classify the values by sensitivity and update behavior. The cache TTL is not confidential, so it belongs in a ConfigMap. The database password is confidential, so it belongs in a Secret. A database host might be non-sensitive in a small lab but sensitive in a production environment where topology disclosure matters; this module keeps the example simple, but production teams should classify that value deliberately rather than by habit.
 
 ```yaml
 # ConfigMap
@@ -346,7 +324,7 @@ stringData:
   DB_PASSWORD: "supersecret"
 ```
 
-**4. Mount them into the Pod**:
+These two objects decouple the release artifact from the runtime environment. The ConfigMap can be reviewed by application owners, and the Secret can be managed by a narrower operational path. In a GitOps setup, you would normally avoid committing plaintext Secret manifests and instead use a sealed, encrypted, or externally synchronized representation. The conceptual separation still matters because the Pod spec should communicate which values are configuration and which values are credentials.
 
 ```yaml
 # Pod using both
@@ -369,128 +347,202 @@ spec:
           key: DB_PASSWORD
 ```
 
-By decoupling these values, the exact same container image can be promoted from a local developer laptop all the way to a high-compliance production cluster simply by pointing the Pod spec at different ConfigMaps and Secrets in the respective namespaces. Furthermore, if you need to merge multiple configurations into a single path, ConfigMaps and Secrets can be combined into a single projected volume, allowing your application to read from a unified directory.
+This Pod keeps the original application interface simple: the process receives the cache setting and password as environment variables. That is acceptable for many beginner labs, but a production review should ask whether the password could appear in crash output, thread dumps, or debugging bundles. If the application supports reading a credential file, a mounted Secret is often preferable. If the application can reload configuration files, a mounted ConfigMap may reduce restart pressure during incident response.
 
-## The Reality of Secret Security
+The operational win is that the image `myapp:v1` can move through environments without being rebuilt. A staging namespace can provide one ConfigMap and Secret, while production provides different objects with the same keys. If the production password rotates, the Secret changes and the workload rolls; the application image remains the same. That is the difference between configuration as an operational input and configuration as a hidden dependency inside a release artifact.
 
-As emphasized repeatedly, Secrets are stored unencrypted (in plaintext) in `etcd` by default. If an attacker gains read access to the underlying `etcd` node, or steals a backup of the database, every secret in the cluster is compromised instantly. 
+When an application expects several files in one directory, projected volumes prevent awkward directory juggling. A projected volume can combine ConfigMaps, Secrets, service account tokens, and downward API data into a single mounted path. The application sees one directory, while Kubernetes preserves the separate ownership and sensitivity of each source object. That is especially useful for older software that expects `/opt/app/config` to contain a config file, a certificate, and a password file side by side.
 
-### Encryption at Rest
+## Security Reality: Secrets Are a Boundary, Not a Vault
 
-To combat this, cluster administrators must explicitly configure encryption at rest via the `--encryption-provider-config` flag on the API server. This configuration dictates how data is encrypted before being flushed to disk.
+The most important sentence in this module is simple: base64 is not encryption. Kubernetes uses base64 in Secret `data` fields so arbitrary bytes can fit cleanly into JSON and YAML API payloads. Base64 does not hide data from anyone who can read the object, list Secrets in the namespace, create a Pod that mounts the Secret, or compromise a running container that already has the Secret mounted. Treat a Secret as a Kubernetes access-controlled object, not as a complete secret-management system by itself.
 
-Encryption at rest supports multiple providers:
-- `identity`: This is a no-op provider. It means no encryption is taking place. It is typically the default first provider.
-- `aesgcm`: High-performance, highly secure AES encryption.
-- `aescbc`: An older AES block cipher implementation.
-- `secretbox`: Uses the XSalsa20 and Poly1305 cryptographic primitives.
-- `kms`: Delegates the encryption keys to an external Key Management Service (like AWS KMS, Azure Key Vault, or HashiCorp Vault).
+Encryption at rest addresses a different threat: the exposure of stored API data in etcd or backups. Cluster administrators can configure the API server with `--encryption-provider-config`, causing selected resource data such as Secrets to be encrypted before being written to disk. Providers include `identity`, which performs no encryption; local encryption providers such as `aescbc`, `aesgcm`, and `secretbox`; and KMS providers that integrate with an external key-management system.
 
-The KMS integration has seen significant architectural evolution. KMS v1 was deprecated in Kubernetes v1.28 and is actively disabled by default since v1.29. It suffered from performance issues because it forced a remote network call to the KMS provider for every single encryption operation, introducing tremendous latency to API server responses.
+The KMS story matters for Kubernetes 1.35 because older KMS v1 behavior had serious performance drawbacks. KMS v1 was deprecated in Kubernetes v1.28 and disabled by default beginning in v1.29 because it required remote provider interaction in ways that could add latency and fragility to API server operations. KMS v2 reached stable status in Kubernetes v1.29 and is the modern path for external key management because it improves performance while keeping the root of trust outside the cluster.
 
-To solve this, the modern KMS v2 encryption provider graduated to stable (GA) in Kubernetes v1.29. KMS v2 utilizes key derivation functions to generate single-use Data Encryption Keys (DEKs) locally from a primary seed, practically eliminating the network bottleneck and drastically improving cluster performance while maintaining a rigorous security posture.
+Encryption at rest does not protect plaintext manifests before they reach the API server. If a team commits a Secret YAML with `stringData` into a public repository, KMS v2 cannot help; the leak happened in Git, not in etcd. If a developer sends a Secret manifest through an unprotected chat channel, the cluster storage provider never gets a chance to reduce that exposure. The security boundary begins only after the API server receives and persists the object.
 
-### RBAC and Lateral Movement
+RBAC is the second major boundary, and it is easy to underestimate. Granting `get` on a named Secret allows direct retrieval of that Secret. Granting `list` on Secrets in a namespace is broader because list responses include full object payloads, not just names. Granting a user permission to create Pods in a namespace can also become indirect Secret access, because the user can create a Pod that mounts a Secret and then read it from inside the container.
 
-Beyond disk encryption, you must respect the access control boundaries within the cluster. Granting `list` access to Secrets implicitly allows a user to read all Secret values in the namespace, because a list operation returns the full object payload, not just the metadata.
+That last point changes how you should review access requests. A role that cannot read Secrets directly may still be too powerful if it can run arbitrary workloads in the same namespace as valuable credentials. Admission policies, namespace design, service account scoping, and workload identity all help narrow that blast radius. In production, the question is not merely "who can read Secret objects?" but also "who can cause a workload to run with access to those Secret objects?"
 
-Furthermore, an attacker does not need direct read access to Secrets if they can run workloads. A user with Pod-creation permissions in a namespace can indirectly read all Secrets accessible to those pods in that namespace. They simply create a dummy pod that mounts the desired Secret and executes a command to read the file and transmit it over the network. Therefore, Pod-creation privileges are functionally equivalent to Secret-reading privileges.
+Stop and think: an attacker has a shell inside your application container, and the application reads its database password from `/etc/secrets/password`. Will the attacker be stopped because the value came from a Secret rather than a ConfigMap? No. Once the workload is compromised, the credential is available through the same path the workload uses, so the stronger controls are runtime hardening, least privilege, short-lived credentials, network policy, and rapid rotation.
 
-> **Stop and think**: An attacker manages to execute a shell inside your application's container. They want to steal the database password. Will they be stopped by the fact that the password is stored in a Kubernetes Secret rather than a ConfigMap? Why or why not?
+This is why Secret design should be paired with credential design. A long-lived database password mounted into every replica creates a larger blast radius than a short-lived token scoped to one service account and rotated automatically. Kubernetes can deliver either value, but it cannot decide whether the credential itself is overpowered. Good teams review the consumer, the namespace, the service account, the network path, the database permissions, and the rotation mechanism as one system.
 
-## Projected Volumes and Immutability
+## Projected Volumes, Immutability, and Rollout Strategy
 
-As clusters grow, managing dozens of configurations becomes tedious. What if an application expects a configuration file, a TLS certificate, and a database password all to reside in the same `/opt/app/config` directory? 
+Configuration delivery becomes more interesting as clusters grow. A single namespace might contain many Deployments that share common settings, and a large platform might have thousands of Pods watching the same stable object. If every kubelet is watching mutable ConfigMaps and Secrets that almost never change, the control plane spends resources maintaining update paths that the application does not need. Kubernetes supports immutable ConfigMaps and Secrets to reduce that ongoing watch and polling pressure.
 
-Kubernetes solves this with **Projected Volumes**. A projected volume takes multiple sources and maps them into a unified directory structure, ensuring the application sees a contiguous set of files regardless of where the data originated.
+Setting `immutable: true` on a ConfigMap or Secret tells Kubernetes that the object data cannot be changed after creation. The kubelet can stop watching for updates to that object, which reduces load in high-churn clusters. The tradeoff is deliberate: a change now requires creating a new object and updating the workload to reference the new name. That pattern looks slightly more verbose, but it creates a safer rollout history because each versioned object represents a specific configuration snapshot.
 
-### The Power of Immutable Configuration
+Immutable ConfigMaps and Secrets became stable in Kubernetes v1.21 after earlier alpha and beta stages. The original enhancement planning documents included earlier target dates, but release announcements and current documentation are the source of truth for operational decisions. In Kubernetes 1.35, immutability is normal production behavior, not an experimental trick. It is especially useful for global constants, application defaults, certificate bundles, and config that should change only through a controlled rollout.
 
-In massive, high-churn clusters with tens of thousands of pods, the kubelet spends a massive amount of CPU cycles constantly polling the API server to watch for changes to ConfigMaps and Secrets. This constant polling can create immense load on the control plane.
+Versioned names are the practical companion to immutability. Instead of editing `app-config`, create `app-config-2026-05-03` or another release-specific name, update the Deployment, and let the rollout controller replace Pods gradually. The old object can stay in place while old Pods drain, and cleanup can happen after the rollout is complete. This makes rollback easier because the previous object still exists and has not been overwritten.
 
-To optimize this, Kubernetes introduced the concept of immutability. Marking a ConfigMap or Secret as immutable (by adding `immutable: true` to the object spec) causes the kubelet to completely stop watching or polling it for updates. This drastically reduces API server load and ensures that a rogue script cannot accidentally modify a critical configuration in production. If a configuration change is required, you must create a brand new object and update the Deployment to point to the new name, enforcing a safer rollout pattern.
+There is a tradeoff between dynamic update behavior and rollout clarity. A mutable mounted ConfigMap can update files in running Pods, which is useful for software that safely reloads configuration. A versioned immutable ConfigMap forces a rollout, which is more predictable when a bad configuration could break every replica at once. Senior operators choose based on blast radius: dynamic reload is convenient for low-risk toggles, while versioned rollouts are safer for settings that change connection pools, authorization behavior, or startup assumptions.
 
-Immutable ConfigMaps and Secrets were introduced as alpha in v1.18 and promoted to beta in v1.19. The feature officially graduated to GA (stable) in Kubernetes v1.21. However, if you read the original Kubernetes Enhancement Proposal (KEP sig-storage/1412) documentation, it erroneously slated it for v1.20. The official merged PR and release blog confirmed the v1.21 timeline. Always rely on the official release announcements rather than enhancement planning documents for definitive timelines.
+Use this decision as a small design review habit. If a value changes frequently and the application can validate and reload it safely, a mounted mutable ConfigMap may be right. If a value defines startup behavior, authentication, or critical routing, favor a versioned object and a Deployment rollout. If a value is sensitive, start with a Secret and then decide whether file or environment delivery creates fewer accidental leak paths for that specific application.
+
+Rollout history also matters after the incident is over. If a mutable object was edited in place several times during troubleshooting, reconstructing which Pods saw which value becomes difficult unless audit logs and deployment events are complete. Versioned objects leave a clearer trail because the object name appears in the Pod template. That extra clarity can be the difference between a quick post-incident review and hours spent guessing which configuration was active during a customer-impacting window.
+
+## Patterns & Anti-Patterns
+
+The strongest pattern is to make configuration ownership explicit. Application teams can own non-sensitive ConfigMaps that describe behavior, while platform or security teams own Secret creation, synchronization, and rotation. This does not mean every team needs a separate tool, but it does mean review paths should reflect consequence. A typo in a feature flag is not the same class of problem as a leaked database credential, and the workflow should not pretend they are equal.
+
+Another reliable pattern is to use stable keys with versioned object names. Applications should not need to change from `DB_PASSWORD` to `DATABASE_PASSWORD_V2` during ordinary rotation; the key contract should stay stable. The object name can change to represent a new version, and the Deployment rollout can point at that new object. Stable keys reduce application churn, while versioned names give operators a clean rollback surface.
+
+A third pattern is to prefer file mounts for complex structured configuration. JSON, YAML, certificates, and multi-line properties are easier to validate as files than as long environment variables. File mounts also allow applications or sidecars to watch for changes when dynamic reload is safe. Environment variables remain useful for small scalar values, but they become awkward when values contain whitespace, nested structure, or sensitive data that crash tooling might expose.
+
+The most common anti-pattern is treating Secrets as a complete vault. Kubernetes Secrets are API objects protected by Kubernetes controls; they are not a replacement for credential lifecycle management, short-lived tokens, access review, or external key management. Another anti-pattern is granting broad namespace permissions because a CI job or developer "just needs to deploy." If that role can create Pods, it may be able to extract Secrets indirectly. The better alternative is scoped service accounts, admission constraints, and separate namespaces for workloads with different credential sensitivity.
+
+These patterns scale because they reduce ambiguity. A new engineer can inspect a Deployment and infer whether a value is safe configuration, sensitive credential material, dynamically refreshed file data, or versioned rollout input. That readability is not cosmetic; it lowers operational risk. During an outage, teams make fewer mistakes when the YAML expresses intent clearly enough that the next action is obvious.
+
+| Pattern or Anti-Pattern | When It Appears | Operational Consequence | Better Practice |
+|---|---|---|---|
+| Pattern: stable keys with versioned object names | Teams rotate credentials or config while keeping application code stable. | Rollbacks are simpler because old Pods can keep using the old object until they drain. | Keep key names consistent and change object names during controlled rollouts. |
+| Pattern: file mounts for structured config | Applications read JSON, YAML, certificates, or multiline settings. | Validation and reload behavior are clearer than long environment variables. | Mount a directory and avoid `subPath` when updates must appear in running Pods. |
+| Pattern: immutable shared config | Many Pods consume a value that rarely changes. | Kubelet and API server watch pressure decreases in large clusters. | Set `immutable: true` and replace the object with a new version when needed. |
+| Anti-pattern: plaintext Secrets in Git | Teams want declarative manifests but skip secret-specific tooling. | Repository access becomes credential access, and history keeps old leaked values. | Use sealed, external, or operator-synchronized secret workflows. |
+| Anti-pattern: broad Pod creation rights | A user or job needs deployment convenience in a shared namespace. | Pod creation can become indirect access to mounted Secrets. | Scope RBAC, separate namespaces, and enforce admission policies. |
+| Anti-pattern: `subPath` for live config | A team wants one file mounted into an existing directory. | The file stops receiving kubelet refreshes after the initial bind mount. | Mount the whole directory or roll Pods intentionally after updates. |
+
+## Decision Framework
+
+Choosing between a ConfigMap, Secret, environment variable, mounted file, projected volume, or immutable object should be a design decision, not a reflex. Start by asking what happens if the value is disclosed. If disclosure is harmful, use a Secret and design the surrounding RBAC and delivery path carefully. If disclosure is harmless but incorrect values could break production, use a ConfigMap with the same rollout discipline you would apply to code.
+
+Next, ask how the application reads the value. If it expects process environment variables and reads them only at startup, environment injection is simple, but every change means a Pod restart. If it expects files or can be adapted to files, volume mounts often produce cleaner behavior for structured data and reduce accidental logging of sensitive values. If it expects a single directory that mixes several sources, projected volumes let Kubernetes compose that directory while keeping source objects separate.
+
+Finally, ask how often the value changes and how dangerous a bad change would be. High-risk changes deserve versioned objects and controlled rollouts even if Kubernetes could update a mounted file automatically. Low-risk toggles may benefit from dynamic file refresh if the application validates them safely. Rarely changing shared values are good candidates for immutability because they reduce platform overhead and prevent accidental edits.
+
+```text
++-----------------------------+
+| Is disclosure harmful?      |
++--------------+--------------+
+               |
+        yes    |    no
+               |
+      Secret   |   ConfigMap
+               |
+               v
++-----------------------------+
+| Does the app need a file?   |
++--------------+--------------+
+        yes    |    no
+               |
+  volume mount | environment
+               |
+               v
++-----------------------------+
+| Should updates be dynamic?  |
++--------------+--------------+
+        yes    |    no
+               |
+ avoid subPath | version name
++-----------------------------+
+```
+
+| Choice | Use It When | Avoid It When | Main Tradeoff |
+|---|---|---|---|
+| ConfigMap environment variable | The value is non-sensitive, scalar, and read only at startup. | The value must update in running Pods. | Simple startup injection in exchange for restart-based updates. |
+| ConfigMap volume | The value is structured text or a file the app can reload. | The application cannot tolerate eventual refresh timing. | Better file semantics with asynchronous propagation. |
+| Secret environment variable | The application only supports env-based credentials and logs are controlled. | Crash dumps or diagnostics expose environment values. | Compatibility in exchange for higher accidental leak risk. |
+| Secret volume | The application can read credential files. | A legacy app cannot be configured for file paths. | Lower accidental environment exposure with filesystem access inside the Pod. |
+| Projected volume | Multiple sources must appear in one directory. | Ownership boundaries would become confusing to operators. | Unified app view while preserving source object separation. |
+| Immutable object | Values rarely change or require controlled versioned rollout. | You need live mutation of the same object name. | Lower control-plane overhead and safer history in exchange for replacement workflow. |
 
 ## Did You Know?
 
 - **1 MiB Payload Limit**: ConfigMap and Secret individual object sizes are strictly limited to exactly 1 MiB to protect the etcd datastore from bloated memory consumption and unresponsive queries.
-- **KMS v2 GA Date**: The modern KMS v2 encryption provider achieved General Availability in Kubernetes v1.29, finally deprecating the slow, network-heavy KMS v1 architecture which is disabled by default.
-- **Immutability GA Timeline**: Immutable ConfigMaps and Secrets reached stable status in Kubernetes v1.21, though early KEP documentation erroneously slated it for v1.20.
-- **2-Minute Propagation Delay**: When mounting ConfigMaps as volumes, it can take up to roughly 2 minutes for changes to propagate into running pods due to the combined delay of the kubelet sync period and cache TTL.
+- **KMS v2 GA Date**: The modern KMS v2 encryption provider achieved General Availability in Kubernetes v1.29, finally replacing the slow, network-heavy KMS v1 architecture that is disabled by default.
+- **Immutability GA Timeline**: Immutable ConfigMaps and Secrets reached stable status in Kubernetes v1.21, though early enhancement planning materials targeted an earlier release.
+- **Two-Minute Propagation Window**: When mounting ConfigMaps as volumes, changes can take roughly two minutes to appear because kubelet sync timing and cache propagation both matter.
 
 ## Common Mistakes
 
-| Mistake | Why | Fix |
-|---------|-----|-----|
-| Committing secrets to Git | Exposes plain text or base64 credentials permanently in version history, resulting in a 100% compromise requiring immediate rotation. | Use tools like sealed-secrets or External Secrets Operator to manage references, not raw data. |
-| Thinking base64 = encrypted | Base64 is merely an encoding scheme. Anyone with read access can decode it instantly. It provides a false sense of security. | Enable encryption at rest in etcd using a secure provider like `aesgcm` or `kms`. |
-| Not using stringData | Manually encoding values to base64 frequently leads to errors, such as accidentally encoding trailing newline characters (`echo` vs `echo -n`). | Use the `stringData` field for plain text, letting the API server handle the encoding safely. |
-| Hardcoding in images | Changing a single variable requires a complete image rebuild and pipeline run, causing multi-minute deployment delays during an outage. | Externalize all variables into ConfigMaps and Secrets, ensuring the image remains immutable. |
-| Mounting with subPath | The `subPath` directive breaks the symbolic link rotation the kubelet relies on. The mounted file becomes completely static. | Mount the entire directory, or accept that changes will require manual pod restarts. |
-| Relying on `list` access | Granting a service account `list` permissions for Secrets allows it to read the full contents of every Secret in the namespace. | Scope RBAC permissions strictly. Prefer `get` on specific resource names instead of a blanket `list`. |
+| Mistake | Why It Happens | How to Fix It |
+|---|---|---|
+| Committing secrets to Git | Teams want declarative delivery and forget that base64 or `stringData` values remain recoverable from repository history. | Use sealed, external, or operator-managed secret workflows and rotate any credential that was committed. |
+| Thinking base64 means encrypted | Secret YAML displays encoded values, which looks unfamiliar enough to feel protected. | Treat base64 as serialization only, restrict Secret RBAC, and enable encryption at rest for stored API data. |
+| Encoding newline characters | Plain `echo` adds a newline, so the decoded password does not match what the application expects. | Prefer `stringData` for hand-written manifests or use `echo -n` when you intentionally prepare `data` values. |
+| Hardcoding config in images | A value starts as a demo default and becomes a hidden deployment dependency. | Move environment-specific values into ConfigMaps or Secrets and promote the same image across environments. |
+| Mounting live config with `subPath` | A team wants one file in an existing directory without masking other files. | Mount the whole directory when dynamic refresh matters, or accept that a Pod restart is required. |
+| Granting broad Secret `list` access | Operators think listing is safer than reading individual objects. | Remember that list responses include payload data and grant named `get` access only where practical. |
+| Ignoring Pod creation as Secret access | A role cannot read Secrets directly, so it appears harmless. | Treat arbitrary Pod creation in a namespace as potential indirect access to Secrets mounted in that namespace. |
 
 ## Quiz
 
-1. **A developer updates a ConfigMap that is injected into a running Pod as an environment variable, but the application isn't picking up the new value. Why?**
-   <details>
-   <summary>Answer</summary>
-   Environment variables are only read by the container runtime when the container initially starts up. Updating a ConfigMap in the API server does not automatically signal the kubelet to restart the Pod or inject new variables into the running process. To pick up the new environment variable, the Pod must be manually deleted and recreated, or restarted gracefully via a Deployment rollout. If the ConfigMap was mounted as a volume instead, the file contents would update dynamically on the filesystem without requiring a Pod restart.
-   </details>
+<details><summary>Your team updates a ConfigMap key used as an environment variable, but the running application still reports the old value. What should you check first?</summary>
 
-2. **You are reviewing a colleague's Kubernetes YAML and notice they have stored a production API key in a ConfigMap. Why is this a problem, and how should it be fixed?**
-   <details>
-   <summary>Answer</summary>
-   ConfigMaps are meant strictly for non-sensitive data and are often broadly accessible to anyone with read access within a namespace. Exposing the API key in a ConfigMap allows unauthorized internal users or compromised workloads to easily view the credential. To resolve this, the configuration should be moved to a Secret, and access to Secrets should be tightly restricted using Role-Based Access Control (RBAC). Additionally, for comprehensive security, the cluster itself should be configured with encryption at rest for Secrets so they are protected in the underlying etcd datastore.
-   </details>
+Environment variables are captured when the container starts, so the first check is whether the value was delivered through `env`, `envFrom`, or a file mount. If it was an environment variable, the behavior is expected and the Pod must be recreated or rolled by a controller. If the team expected dynamic updates, the design should move the setting to a mounted file and ensure the application actually reloads that file. This diagnoses the delivery mechanism instead of blaming the ConfigMap object itself.
 
-3. **Your security team runs a vulnerability scan and finds that if your application crashes, the database password is being printed in the crash logs. How can you change how the Secret is provided to fix this?**
-   <details>
-   <summary>Answer</summary>
-   The application is likely receiving the Secret as an environment variable, which crash dumpers and application frameworks often log by default during a fatal error. The most effective mitigation strategy is to mount the Secret as a read-only volume (a file) instead of injecting it as an environment variable. The application can then be configured to read the file into memory at startup to retrieve the password. Because crash reporters dump the environment state but do not automatically read and log the contents of arbitrary mounted files, this approach prevents the credential from leaking into your observability stack.
-   </details>
+</details>
 
-4. **You are attempting to deploy the following Secret YAML to your cluster to store a database password, but the application is failing to authenticate. What is the major problem with this configuration?**
-   ```yaml
-   apiVersion: v1
-   kind: Secret
-   metadata:
-     name: db-creds
-   data:
-     password: mysecretpassword
-   ```
-   <details>
-   <summary>Answer</summary>
-   The YAML uses the `data` field but provides the plaintext value directly instead of the required encoding. In Kubernetes, the `data` field strictly expects all values to be base64 encoded byte strings, not raw text. Because it is not encoded, the application will receive a corrupted or improperly decoded value when it attempts to read the Secret from the volume or environment variable. To fix this issue, the developer should either manually base64 encode the password before placing it in the `data` field, or change the key from `data` to `stringData` to allow Kubernetes to handle the encoding automatically upon creation.
-   </details>
+<details><summary>A developer stores a production API token in a ConfigMap because it is "only internal." How do you evaluate and correct the design?</summary>
 
-5. **Your engineering team is deploying a legacy application that requires an incredibly large, 5 MiB configuration file. Can this file be stored in a standard ConfigMap?**
-   <details>
-   <summary>Answer</summary>
-   No, a standard ConfigMap cannot accommodate a 5 MiB file because both ConfigMaps and Secrets have a strict 1 MiB size limit per object. This constraint exists to prevent massive objects from exhausting the memory of the API server and the kubelet, and to protect the underlying `etcd` datastore from becoming bloated and unresponsive. To handle a 5 MiB configuration file, you must explore alternative delivery mechanisms designed for larger payloads. Options include baking the file directly into the container image, downloading it at startup via an init container, or mounting a persistent volume that contains the necessary data.
-   </details>
+The value belongs in a Secret because disclosure would create a security incident regardless of whether the cluster is internal. Moving it to a Secret is only the first correction; RBAC must also restrict who can read it, list it, or create Pods that mount it. If the manifest is stored in Git, the team should use an encrypted or external secret workflow rather than committing plaintext `stringData`. The better design classifies by consequence, not by the network location of the cluster.
 
-6. **You have successfully configured KMS v2 encryption at rest on your API server. Does this mean your developers can now safely commit plaintext Secret YAML files into the company's public GitHub repository?**
-   <details>
-   <summary>Answer</summary>
-   Absolutely not; configuring KMS v2 encryption at rest only protects the data once it is written to the `etcd` database on the cluster's backend. The YAML manifests you construct locally on your workstation and commit to version control remain entirely unencrypted plain text. If you commit these plaintext Secrets to a GitHub repository, anyone with read access to the codebase can immediately view and compromise your credentials. To securely manage Secrets in version control, you must employ GitOps-friendly tools like Sealed Secrets or the External Secrets Operator, which encrypt the manifests before they are committed.
-   </details>
+</details>
 
-7. **A junior developer successfully mounts a Secret using the `subPath` directive to place a specific key into an existing directory. Later, they update the Secret in the API server, but complain that the mounted file in the Pod never updates. What is occurring?**
-   <details>
-   <summary>Answer</summary>
-   Volumes mounted using `subPath` do not receive automatic updates when the underlying ConfigMap or Secret changes in the API server. The `subPath` implementation relies on standard operating system bind mounts, which fundamentally break the symlink-rotation strategy the kubelet uses to seamlessly refresh mounted data. To force the application to see the new value, the Pod must be manually deleted and recreated. A better approach, if dynamic updates are required, is to mount the entire directory without using `subPath` and have the application watch the directory for changes.
-   </details>
+<details><summary>A Secret mounted with `subPath` does not update after rotation, and the application keeps using the old credential. What is happening?</summary>
 
-8. **You need to optimize your production cluster. A specific ConfigMap containing a list of global constants is read by 5,000 pods across the cluster, causing high kubelet polling load on the API server. How can you mitigate this without removing the ConfigMap?**
-   <details>
-   <summary>Answer</summary>
-   You should mark the ConfigMap as immutable by setting `immutable: true` in its specification. Marking a ConfigMap or Secret as immutable causes the kubelet to completely stop watching or polling it for updates. This dramatically reduces the burden on the API server, improving overall cluster performance and stability while guaranteeing the configuration cannot be accidentally altered in production. If the configuration ever needs to change in the future, you would simply create a new ConfigMap with a different name and update your Deployment to reference the new object.
-   </details>
+`subPath` creates a bind mount for a specific file, which bypasses the kubelet's normal symlink rotation for ConfigMap and Secret volumes. The Secret object may be updated correctly in the API server, but the mounted file inside the existing container remains static. The immediate fix is to restart or roll the Pod. The longer-term fix is to mount a directory without `subPath` when live refresh is required, or to use versioned Secrets with intentional rollouts.
+
+</details>
+
+<details><summary>A review finds this manifest, and the application cannot authenticate. What is the likely configuration error?</summary>
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: db-creds
+data:
+  password: mysecretpassword
+```
+
+The manifest uses the `data` field but provides raw plaintext instead of a base64-encoded value. Kubernetes Secret `data` values must be encoded byte strings, so the application will not receive the intended password. The safer hand-written version uses `stringData`, which lets the API server perform the encoding. If `data` is required, encode the exact value without an accidental trailing newline.
+
+</details>
+
+<details><summary>Your security team enables KMS v2 encryption at rest. Can developers now commit plaintext Secret YAML to a public repository?</summary>
+
+No. KMS v2 protects selected API data after the API server persists it to storage; it does not protect files before they enter the cluster. A plaintext Secret committed to a public repository is already leaked, even if the cluster later stores it encrypted in etcd. The correct workflow keeps plaintext credentials out of Git by using sealed secrets, external synchronization, or another approved secret-management process. Encryption at rest is an important layer, not permission to weaken source-control hygiene.
+
+</details>
+
+<details><summary>A platform team sees heavy API server load from thousands of Pods consuming a shared ConfigMap that almost never changes. What design change should they evaluate?</summary>
+
+They should evaluate marking the ConfigMap as immutable and moving to a versioned replacement workflow. Immutability lets kubelets stop watching or polling for updates to that object, reducing control-plane load in large clusters. When the value needs to change, the team creates a new ConfigMap and updates the workload reference, which triggers a controlled rollout. This fits stable shared configuration better than repeatedly editing one mutable object.
+
+</details>
+
+<details><summary>A user cannot read Secrets directly but can create Pods in the same namespace as a database credential. Why might this still be a security concern?</summary>
+
+Pod creation can become indirect Secret access. The user can create a Pod that references the Secret as an environment variable or mounted file, then read the credential from inside that Pod. RBAC reviews should therefore consider workload creation rights alongside direct Secret permissions. Stronger namespace boundaries, scoped service accounts, and admission controls reduce that lateral movement path.
+
+</details>
+
+<details><summary>A legacy application needs a 5 MiB configuration file. Should you store it in a standard ConfigMap?</summary>
+
+No. ConfigMaps and Secrets have a 1 MiB object size limit, and pushing multi-mebibyte payloads through the Kubernetes API harms the wrong components. A better design uses an image layer, persistent volume, object-store download, init container, or another delivery mechanism built for larger artifacts. The deciding factor is whether the file is code-like, data-like, environment-specific, or sensitive. ConfigMaps are for configuration state, not bulk file distribution.
+
+</details>
 
 ## Hands-On Exercise
 
-**Task**: Create and use ConfigMaps and Secrets.
+This exercise uses a disposable namespace so you can inspect ConfigMaps and Secrets without touching other work. You will create non-sensitive application settings, create a Secret, run a Pod that consumes both, and then modify the design to practice file-based delivery. The goal is not just to make the YAML apply; it is to predict which values are visible where and which changes require a new Pod.
+
+Before you begin, define the alias expected throughout the module:
+
+```bash
+alias k=kubectl
+```
+
+### Task 1: Create the configuration objects
+
+Use the original quick path to create a ConfigMap and Secret, then inspect them with the alias. The literal Secret value is intentionally a lab placeholder, not a production credential pattern.
 
 ```bash
 # 1. Create ConfigMap
@@ -531,25 +583,120 @@ kubectl wait --for=condition=Ready pod/config-test --timeout=60s
 kubectl logs config-test | grep -E "LOG_LEVEL|APP_NAME|DB_PASSWORD"
 ```
 
-**Success criteria**: 
-- [ ] ConfigMap `app-config` created successfully.
-- [ ] Secret `app-secret` created successfully without base64 errors.
-- [ ] Pod `config-test` transitions to the Running state.
-- [ ] Pod logs output all three environment variables populated with the correct plaintext values.
+<details><summary>Solution notes for Task 1</summary>
 
-### Graduated Mini-Challenge
+The original commands create one ConfigMap, one Secret, and one Pod. If you are following the module convention, the equivalent inspection commands are `k get configmap app-config -o yaml`, `k get secret app-secret -o yaml`, and `k logs config-test`. Notice that the Pod logs show plaintext environment values because the process received them at startup. That visibility is useful for a lab and risky for real credentials in production logs.
 
-Instead of injecting the ConfigMap as an environment variable using `envFrom`, modify the `config-test` Pod YAML to mount `app-config` as a volume at `/etc/app-config`. 
+</details>
 
-Once the Pod is running, verify the files exist by running:
-`kubectl exec config-test -- ls -l /etc/app-config`
+### Task 2: Inspect the Secret encoding boundary
 
-Then clean up your resources:
+Read the stored Secret and decode the single value so you can see exactly where base64 applies. This step builds the habit of distinguishing Kubernetes serialization from actual confidentiality.
+
+```bash
+k get secret app-secret -o yaml
+k get secret app-secret -o jsonpath='{.data.DB_PASS}' | base64 -d
+```
+
+<details><summary>Solution notes for Task 2</summary>
+
+The YAML view shows encoded data under `.data.DB_PASS`, while the decode command prints the original lab value. That proves base64 is reversible by anyone with read access. In a production review, this is the point where you verify RBAC, encryption at rest, and whether the Secret manifest itself was ever committed in plaintext.
+
+</details>
+
+### Task 3: Prove environment variables are static
+
+Update the ConfigMap after the Pod is running, then compare the API object with the Pod logs. You should see the new value in the ConfigMap and the old value inside the already-started container.
+
+```bash
+k create configmap app-config \
+  --from-literal=LOG_LEVEL=info \
+  --from-literal=APP_NAME=myapp \
+  --dry-run=client -o yaml | k apply -f -
+k get configmap app-config -o jsonpath='{.data.LOG_LEVEL}'
+k logs config-test | grep LOG_LEVEL
+```
+
+<details><summary>Solution notes for Task 3</summary>
+
+The ConfigMap object changes, but the environment in the existing container does not. This is expected because the container runtime does not rewrite process environments after startup. A Deployment rollout, Pod deletion, or file-based configuration design is required when the running application must observe a changed value.
+
+</details>
+
+### Task 4: Rework the Pod to mount the ConfigMap as files
+
+Delete the original Pod and recreate it with the ConfigMap mounted at `/etc/app-config`. Then inspect the directory to see how keys become files.
+
+```bash
+k delete pod config-test
+cat << 'EOF' | k apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: config-test
+spec:
+  containers:
+  - name: test
+    image: busybox
+    command: ['sh', '-c', 'ls -l /etc/app-config && cat /etc/app-config/LOG_LEVEL && sleep 3600']
+    volumeMounts:
+    - name: app-config
+      mountPath: /etc/app-config
+  volumes:
+  - name: app-config
+    configMap:
+      name: app-config
+EOF
+k wait --for=condition=Ready pod/config-test --timeout=60s
+k exec config-test -- ls -l /etc/app-config
+k exec config-test -- cat /etc/app-config/LOG_LEVEL
+```
+
+<details><summary>Solution notes for Task 4</summary>
+
+Each ConfigMap key appears as a file under `/etc/app-config`. This layout is better for applications that read configuration files or can reload them. If you update the ConfigMap, the file may refresh after kubelet propagation delay, but the application must still reread the file to act on the new value.
+
+</details>
+
+### Task 5: Clean up and record success criteria
+
+Remove the disposable resources after you have confirmed both environment and file delivery behavior. Cleanup matters because stale Secrets and ConfigMaps make later debugging harder.
+
 ```bash
 kubectl delete pod config-test
 kubectl delete configmap app-config
 kubectl delete secret app-secret
 ```
+
+<details><summary>Solution notes for Task 5</summary>
+
+The cleanup commands remove only the resources created in this exercise. If a delete command reports that a resource is not found, confirm you are in the expected namespace before assuming the resource never existed. In a shared cluster, explicit namespaces are safer than relying on the current context.
+
+</details>
+
+Success criteria:
+
+- [ ] ConfigMap `app-config` was created and inspected successfully.
+- [ ] Secret `app-secret` was created and decoded without confusing base64 for encryption.
+- [ ] Pod `config-test` reached the Running state and displayed the expected environment values.
+- [ ] Updating the ConfigMap did not change the already-running environment variable.
+- [ ] The ConfigMap was mounted as files under `/etc/app-config`.
+- [ ] All lab resources were deleted after verification.
+
+## Sources
+
+- [Kubernetes documentation: ConfigMaps](https://kubernetes.io/docs/concepts/configuration/configmap/)
+- [Kubernetes documentation: Secrets](https://kubernetes.io/docs/concepts/configuration/secret/)
+- [Kubernetes task: Configure a Pod to use a ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/)
+- [Kubernetes task: Distribute credentials securely using Secrets](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/)
+- [Kubernetes task: Encrypt data at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/)
+- [Kubernetes documentation: RBAC authorization](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
+- [Kubernetes documentation: Projected volumes](https://kubernetes.io/docs/concepts/storage/projected-volumes/)
+- [Kubernetes API reference: ConfigMap v1](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/config-map-v1/)
+- [Kubernetes API reference: Secret v1](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/secret-v1/)
+- [Kubernetes documentation: Managing Secrets using kubectl](https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl/)
+- [Kubernetes documentation: Immutable Secrets](https://kubernetes.io/docs/concepts/configuration/secret/#immutable-secrets)
+- [Kubernetes documentation: ConfigMap object details](https://kubernetes.io/docs/concepts/configuration/configmap/#configmap-object)
 
 ## Next Module
 


### PR DESCRIPTION
Verifier: tier T0; body_words=5103, mean_wpp=69.0, median_wpp=75.0, short_rate=0.054, max_run=1; all density, structure, alignment, anti_leak, and source gates passed.\n\nProtected assets preserved: before code_blocks=17, mermaid_diagrams=2, ascii_diagrams=1, tables=1; after code_blocks=22, mermaid_diagrams=2, ascii_diagrams=1, tables=3. Original code examples and Mermaid diagrams were retained, with additional lab/source-supporting assets added.\n\nSources: 12 unique source URLs, live check 12x 200.\n\nChecks: git diff --check clean; deterministic verifier passed with and without --skip-source-check using ../../.venv/bin/python because this worktree has no local .venv.\n\nCommit: f483144636217e67bde20fa1fb937f46c3ba8d9a