### PR TITLE
feat(388): rewrite module-1.3-pods (#388 pilot)

### DIFF
--- a/src/content/docs/prerequisites/kubernetes-basics/module-1.3-pods.md
+++ b/src/content/docs/prerequisites/kubernetes-basics/module-1.3-pods.md
@@ -1,6 +1,7 @@
 ---
 title: "Module 1.3: Pods - The Atomic Unit"
 slug: prerequisites/kubernetes-basics/module-1.3-pods
+revision_pending: false
 sidebar:
   order: 4
 lab:
@@ -14,71 +15,26 @@ lab:
 # Module 1.3: Pods - The Atomic Unit
 **Complexity**: [MEDIUM]
 **Time to Complete**: 60-75 minutes
-**Prerequisites**: Module 1.2 (kubectl Basics)
+**Prerequisites**: Module 1.2 (kubectl Basics; define `alias k=kubectl` before using shorthand)
 
 ## Learning Outcomes
-- Diagnose complex Pod initialization and runtime failures (such as `CrashLoopBackOff`, `ImagePullBackOff`, `CreateContainerConfigError`, `CreateContainerError`, and `OOMKilled`) using native Kubernetes inspection tools and an intimate understanding of Linux exit codes.
-- Design advanced multi-container Pod architectures implementing the sidecar, ambassador, adapter, and init container patterns to solve real-world logging, proxying, and bootstrapping challenges without modifying legacy application code.
-- Evaluate the impact of resource requests and limits on Pod scheduling algorithms, node stability, and the Linux kernel's Completely Fair Scheduler (CFS) and Out Of Memory (OOM) killer mechanisms.
-- Categorize Pods into their respective Quality of Service (QoS) classes (Guaranteed, Burstable, BestEffort) and predict how the Kubelet will prioritize them during node resource starvation and eviction events.
-- Compare imperative command-line creation versus declarative YAML manifest management, justifying the industry preference for declarative workflows in GitOps-driven CI/CD pipelines.
-- Implement shared storage (via `emptyDir` and `hostPath`) and low-latency intra-pod network communication strategies between multiple coupled containers residing within the same network and IPC namespaces.
-- Configure, tune, and evaluate Readiness, Liveness, and Startup probes to govern a Pod's condition transitions, prevent premature termination of slow-starting legacy apps, and guarantee zero-downtime production traffic routing.
-- Formulate secure pod architectures utilizing the `securityContext` to enforce least-privilege principles, drop Linux kernel capabilities, mandate read-only root filesystems, and mitigate potential container escape vulnerabilities.
+- Diagnose Pod lifecycle failures, including `Pending`, `ImagePullBackOff`, `CreateContainerConfigError`, `CrashLoopBackOff`, and `OOMKilled`, by combining events, logs, exit codes, and native `k` inspection commands.
+- Design multi-container Pods that use sidecar, ambassador, adapter, init container, ephemeral container, shared `emptyDir`, and `localhost` communication patterns without turning the Pod into a small virtual machine.
+- Evaluate requests, limits, Quality of Service classes, CFS throttling, OOM killer behavior, taints, tolerations, affinity, and anti-affinity when predicting how Pods schedule and survive resource pressure.
+- Implement declarative Pod manifests with labels, annotations, volumes, probes, `securityContext`, service accounts, and Kubernetes 1.35-compatible fields that make runtime behavior explicit and reviewable.
+- Compare naked Pods and imperative commands with controller-managed, Git-backed declarative workflows, and justify when a temporary Pod is useful versus when a Deployment or Job is required.
 
 ## Why This Module Matters
-In late 2021, a scaling e-commerce platform—let's call them "GlobalTradeX"—attempted to modernize their infrastructure by migrating their monolithic inventory management system to Kubernetes ahead of the Black Friday shopping season. Eager to lift-and-shift their architecture with minimal code refactoring, the team misunderstood a fundamental Kubernetes concept: they treated Kubernetes Pods like traditional Virtual Machines. 
+In late 2021, a scaling e-commerce platform, anonymized here as GlobalTradeX, migrated its inventory system to Kubernetes before a holiday traffic surge. The team had strong application engineers and a reasonable cluster, but they carried a virtual-machine mental model into a scheduler designed around Pods. They packed a web frontend, Java API, cache, worker, log forwarder, metrics exporter, and timed job into one Pod because those processes had once lived together on one server. When the API needed more CPU, the Horizontal Pod Autoscaler could only duplicate the whole Pod, which multiplied every helper process and exhausted node memory. The outage lasted several hours and cost an estimated $2.4 million in missed orders, not because Kubernetes was mysterious, but because the team misunderstood the unit Kubernetes can actually place, restart, scale, and evict.
 
-Instead of decoupling their architecture into discrete microservices, they created a single Pod specification containing seven different application containers. Inside this Pod lived the Next.js web frontend, the Java Spring Boot backend API, an in-memory Redis cache, a Celery background worker, a Fluentd logging agent, a Prometheus metrics exporter, and a cron job process. They believed they were being efficient by keeping everything together just as it had been on their legacy physical servers.
+A Pod is not a miniature server, and it is not a convenient folder for everything that happens to support an application. It is the smallest scheduling and lifecycle unit in Kubernetes: the control plane places the entire Pod on one node, the kubelet starts and watches the containers together, and higher-level controllers replace the Pod rather than repairing it in place. This matters because every design choice flows from that boundary. If two processes must share a local file and loopback network, they may belong together; if they scale, fail, upgrade, or store data independently, putting them in the same Pod creates a hidden coupling that production traffic will eventually expose.
 
-When the Black Friday traffic spike hit, the Java backend API container started consuming heavy CPU to process the incoming database transactions. Because all seven software components were locked inside the same Pod abstraction, Kubernetes could not scale the Java API independently of the other components. 
+This module turns the Pod from a vocabulary word into an operational model. You will see why Kubernetes wraps containers in a shared sandbox, how the pause container anchors networking, why `Pending` differs from `CrashLoopBackOff`, how probes change traffic routing, and how resource settings influence scheduling and eviction. We will use the shorthand alias `k` for `kubectl`; if your shell does not already define it, run `alias k=kubectl` before practicing the commands. The examples target Kubernetes 1.35 or later and focus on decisions you will make repeatedly: when to use one container, when to add a sidecar, how to write a manifest that survives review, and how to debug a Pod without guessing.
 
-To handle the CPU load, the Horizontal Pod Autoscaler (HPA) was forced to duplicate the entire Pod as a single unit. It began spinning up unnecessary copies of the Redis cache, the frontend web server, and the background workers just to get more capacity for the Java API. This rapid scaling quickly exhausted the cluster's physical memory capacity. 
+## From Containers to Pods: The Sandbox Boundary
+Containerization is built from Linux primitives rather than magic. Namespaces decide what a process can see, and control groups decide what a process can consume. A network namespace gives a process its own interfaces, routing table, and port space; a mount namespace gives it a filesystem view; a PID namespace gives it a process tree; and cgroups account for CPU, memory, and other resource use. Docker made these pieces approachable for developers, but Kubernetes needed a higher-level abstraction because production applications often need a tiny group of tightly coupled processes to share the same placement, IP address, and scratch storage.
 
-Within an hour, the EC2 worker nodes began crashing due to system-level resource starvation and Out Of Memory panics. The inventory system went dark. The external database connections were exhausted by the duplicated background workers. The company lost an estimated $2.4 million over a four-hour outage, and the engineering team spent the weekend manually rolling back the deployment to their legacy Virtual Machine infrastructure.
-
-This architectural failure stemmed from a misunderstanding of what a Pod is and what it is not. A Pod is not a virtual machine. It is not a dumping ground for disparate application components. A Pod is the smallest, atomic, indivisible unit of execution and scheduling in the Kubernetes ecosystem. 
-
-By mastering Pods, you gain the ability to predictably schedule workloads, isolate failures, and design microservices that scale precisely when and how they need to. You will learn how to forensically debug failures when a container refuses to start, how to couple helper processes without compromising application modularity, and how to speak the declarative YAML language the Kubernetes control plane expects. You will transition from seeing Kubernetes as a black box to understanding it as an orchestrator of Linux primitives.
-
-## A Brief History: From Chroot to Pods
-Before we dive into the Linux mechanisms that power a Kubernetes Pod, we must establish the historical context that necessitated its invention. The evolution of the Pod did not occur in a vacuum; it was the result of decades of trial and error in isolated computing.
-
-In 1979, the concept of process isolation was born with the introduction of the `chroot` system call in Unix Version 7. `chroot` allowed a system administrator to permanently change the apparent root directory for a specific running process and its children. This was revolutionary because a process could no longer physically traverse the filesystem to access other directories, providing a rudimentary form of isolation.
-
-Fast forward to 2000, and the introduction of FreeBSD Jails brought the concept of `chroot` to its logical extreme. Jails isolated not only the filesystem but also the network stack and the process view, creating "virtual machines" that shared a single kernel. This was followed by Solaris Zones in 2004, which brought advanced resource control to these environments. 
-
-In 2008, the Linux community merged Linux Control Groups (cgroups) into the mainline kernel. Developed by engineers at Google, cgroups provided the accounting required to limit how much CPU, Memory, Disk I/O, and Network bandwidth a specific group of processes could consume. When combined with Linux Namespaces, the foundational building blocks for modern Linux containers were complete.
-
-In 2013, Docker democratized this Linux technology. Docker took the difficult-to-configure low-level primitives and wrapped them in an elegant Command Line Interface (CLI) and image packaging format. Suddenly, any developer could build an isolated Linux container in seconds.
-
-However, as companies scaled Docker into production data centers, a complex new problem arose: orchestration. Managing tens of thousands of individual Docker containers scattered across physical servers was a logistical nightmare. Google, having run containerized workloads internally for a decade, knew that managing single containers was structurally flawed.
-
-Google engineers understood that in distributed systems, applications almost never exist in perfect isolation. A web server needs a log forwarder. A cache needs a metrics scraper. A proxy needs an encryption layer. If you orchestrate single containers, you force these components to communicate over the routed public network, introducing latency and security risks.
-
-To solve this, when Google open-sourced Kubernetes in 2014, they introduced their most brilliant architectural decision: The Pod. They rejected the idea of scheduling raw containers. Instead, they invented the Pod—a logical sandbox designed to house a cohesive group of interdependent containers that must run on the same host machine, sharing the same IP address and local disk volume.
-
-## What a Pod Actually Is (A Deep Dive into Linux Primitives)
-When you first learn about containerization, you are taught that a container is an isolated process running on a shared host Linux machine. It has its own dedicated filesystem, isolated network stack, and restricted access to underlying CPU and memory. So, why doesn't Kubernetes manage containers directly? Why did the engineers create this abstraction layer called a "Pod"?
-
-To understand this design decision, we must look at how the Linux kernel achieves container isolation. A "container" is not a physical construct; it is an illusion created by a combination of Linux Kernel Namespaces and Control Groups (cgroups).
-
-**Namespaces** limit what a specific process can *see*. They provide the illusion that a process has the operating system to itself.
-- **PID (Process ID) Namespace:** Ensures that processes inside one container cannot see or send signals to processes in another container. To a containerized application, its main process always appears as Process ID (PID) 1.
-- **Network Namespace:** Provides an isolated network stack, including its own virtual network interfaces, unique IP address, routing tables, and full port space (0-65535).
-- **Mount Namespace:** Gives the container its own isolated filesystem hierarchy, distinct from the host machine's `/` directory.
-- **UTS (UNIX Time-Sharing) Namespace:** Allows the isolated container to have its own independent hostname and domain name.
-- **IPC (Inter-Process Communication) Namespace:** Isolates shared memory segments and Inter-Process Communication mechanisms, preventing cross-container memory snooping.
-- **User Namespace:** Allows a process to have root privileges *inside* the container, while remaining an unprivileged user on the host system.
-
-**Control Groups (cgroups)** limit what a process can *use*. They act as the accountants of the Linux kernel.
-- They ensure a container cannot consume more than its allotted CPU time slice or physical RAM. If a container exceeds its memory cgroup limit, the kernel terminates it to protect the host.
-
-If Kubernetes only managed individual containers, low-latency collaboration between processes would be difficult, inefficient, and insecure. Imagine a main application container that needs a helper process to compress its log files, or a proxy container to encrypt outbound network traffic. 
-
-If these were separate containers managed directly by Kubernetes, they would have different IP addresses, isolated file systems, and no high-performance way to communicate over local inter-process communication (IPC) or shared memory without traversing the physical network stack.
-
-A Pod solves this architectural problem by creating a shared environment. A Pod is a logical enclosure that wraps one or more physical containers. Containers within the same Pod share specific namespaces while keeping others isolated.
+The Pod is that abstraction. When the scheduler binds a Pod to a node, the kubelet asks the container runtime to create a Pod sandbox before it starts your application containers. The sandbox owns the shared network, IPC, and UTS namespaces, while each application container keeps its own image and mount namespace. That arrangement lets two containers talk over `localhost` and share an `emptyDir` volume without forcing them to share every binary, library, or filesystem path. It is the same reason two roommates can share a kitchen and front door while keeping separate bedrooms; shared space is useful only when the occupants truly need it.
 
 ```mermaid
 flowchart TD
@@ -102,81 +58,13 @@ flowchart TD
     end
 ```
 
-Specifically, containers within the same Pod share:
-1. **The Network Namespace:** They share the same IP address and port space. They can communicate with each other using the `localhost` loopback interface. 
-2. **The IPC Namespace:** They can utilize SystemV IPC or POSIX message queues to communicate directly in shared memory, bypassing the TCP/IP network stack.
-3. **The UTS Namespace:** They share the same internal hostname.
-4. **Storage Volumes:** They can mount the same physical or virtual storage volumes to read and write shared files simultaneously.
+The pause container is the quiet anchor that makes this model stable. It starts first, claims the Pod's shared namespaces, and then sleeps by calling a small process that does essentially nothing. Your application containers join those namespaces after the sandbox exists. If the app crashes ten times, the Pod IP does not have to disappear ten times, because the pause container still holds the network namespace open. That stability is why Services can keep routing to a Pod while an individual container restarts, and why container restarts are not the same thing as Pod replacement.
 
-However, they do *not* automatically share the PID namespace or the Mount namespace. Each container retains its own isolated filesystem containing its specific application binaries, preventing dependency hell.
+Pause and predict: if one container in a Pod binds port 8080 and a second container in the same Pod tries to bind port 8080, what should you expect? The second process fails with an address-in-use error because both containers share the same network namespace and port table. The containers have different filesystems, but the kernel sees only one loopback interface for that Pod. This is a frequent beginner mistake when teams add a metrics exporter, debug proxy, or admin endpoint and forget that ports must be unique across the whole Pod, not merely inside each container stanza.
 
-### The Secret "Pause" Container: The Unsung Hero of Kubernetes
-To hold these shared Linux namespaces together without relying on the application containers themselves, Kubernetes does something clever. When the Kubernetes Scheduler assigns a Pod to a worker node, the node's Kubelet instructs the Container Runtime Interface (CRI) to build the Pod sandbox. It doesn't just start your application container directly. 
+The Pod model also explains why Kubernetes does not scale containers independently inside the same Pod. A ReplicaSet, Deployment, Job, or StatefulSet creates and replaces whole Pods. If your API container needs ten replicas but its cache helper needs one, those processes should not be in one Pod. Multi-container Pods are for colocated helpers that share fate with the main process: a log tailer reading a local file, a proxy encrypting local traffic, an adapter normalizing metrics, or an init container preparing files before the app starts. The shared fate is the feature and the cost.
 
-Instead, the first action the runtime takes is to start a tiny, invisible container known as the `pause` container (or "infrastructure container"). 
-
-The `pause` container's only job is to request and claim the network, IPC, and UTS namespaces from the Linux kernel, and then go to sleep by executing the `pause()` system call. Your actual application containers are then launched and joined to the `pause` container's already-existing namespaces. 
-
-Imagine if your Pod only had one application container responsible for holding the network namespace. If that application crashed, the Linux namespace repair would be destroyed, the IP address released, and when the application restarted, it would be assigned a completely new IP address. This constant churn would destroy cluster networking. 
-
-Because the `pause` container literally does nothing but sleep, it never crashes. It holds the network namespace open indefinitely, acting as an anchor. This means that if your application container crashes and restarts a hundred times, the Pod's IP address never changes.
-
-> **Pause and predict**: If Container A in a multi-container Pod starts a web server bound to port 8080, and Container B in the same Pod attempts to start and bind to port 8080 to serve metrics, what will happen and why?
-> *(Because both containers share the same network namespace, loopback interface, and IP address provided by the `pause` container, Container B will crash with an `Address already in use` error. In a multi-container Pod, port numbers must be unique across all containers, just as they must be unique on a single developer laptop.)*
-
-## The PLEG (Pod Lifecycle Event Generator) and the Kubelet Sync Loop
-To comprehend how Pods operate, we must look at the Kubelet daemon running on every worker node. The Kubelet is a state machine manager. Its mandate is to compare the "desired state" of the Pods assigned to its node against the actual reality of the containers running via the local CRI runtime. 
-
-If the API Server desires a Pod with two running containers, but the CRI reports only one container is running because it crashed, the Kubelet intervenes to reconcile the physical reality back to the desired state.
-
-Historically, the Kubelet would actively poll the underlying Docker daemon every second, asking, "Is container X running?" In a cluster with thousands of pods per node, this polling volume destroyed node CPU performance.
-
-To solve this scalability bottleneck, Kubernetes architects introduced the **Pod Lifecycle Event Generator (PLEG)**. 
-
-The PLEG is an embedded subsystem within the Kubelet's binary. Instead of polling every container directly, the PLEG leverages low-level Linux Kernel features to subscribe to an asynchronous stream of system events originating from the CRI runtime. 
-
-When a container crashes, the CRI fires a low-latency event directly to the PLEG. The PLEG registers the state change, translates the event into a Pod Lifecycle Event, and pushes it onto the Kubelet's primary sync loop queue. The Kubelet wakes up, reads the event, evaluates the Pod's `restartPolicy`, and commands the CRI to rebuild and restart the container process.
-
-This event-driven architecture ensures that the Kubelet reacts to pod failures in milliseconds with zero polling overhead. Understanding the PLEG is crucial for administrators. If the PLEG becomes starved for CPU or overwhelmed by a storm of container crash events, it will log `PLEG is not healthy` errors. When the PLEG fails, the Kubelet goes blind; it stops reporting pod statuses back to the control plane, causing node failures.
-
-## Why Do Pods Even Exist? Advanced Architectural Patterns
-If statistical telemetry shows that over 90% of the time a Pod only contains a single application container, why mandate this abstraction? The answer lies in the remaining 10% of critical edge cases where coupled processes are architecturally necessary to solve complex distributed systems problems.
-
-### 1. The Sidecar Pattern (Augmentation without Modification)
-The Sidecar pattern is widely utilized. Imagine you are tasked with modernizing a legacy application written in C++. It hardcodes its operational logs to be written to a local file at `/var/log/legacy-app/audit-trail.log`. However, your Kubernetes observability stack uses Fluent-bit to scrape logs exclusively from standard output (`stdout`) and route them to a centralized Datadog cluster.
-
-Instead of painfully rewriting the legacy application's C++ source code, you can deploy a **Sidecar Container** alongside it in the same Pod sandbox.
-
-The main container runs the legacy C++ application and writes its logs to a shared `emptyDir` volume mount. The sidecar container mounts that same volume and runs a simple shell script: `tail -f /shared-logs/audit-trail.log`. Because the sidecar outputs the results of the `tail` command directly to its own isolated `stdout` stream, the cluster's logging daemon can capture the legacy logs perfectly. 
-
-### 2. The Ambassador Pattern (Network Proxying)
-The Ambassador pattern utilizes a secondary container to route and secure network traffic to and from the main application container. Imagine your main application needs to connect to an external database, and the connection requires mutual TLS (mTLS) certificate exchange and connection pooling.
-
-Rather than building this complex networking logic directly into your application code, you deploy an Ambassador container (like Envoy proxy) inside the Pod. 
-
-Your application makes a plain-text, unencrypted local HTTP request directly to `localhost:5432`. The Ambassador container, actively listening on that loopback port, intercepts the traffic, encrypts it on the fly with mTLS, manages the connection pool, and forwards the payload securely to the external database. This pattern is the bedrock upon which modern Service Meshes are built.
-
-### 3. The Adapter Pattern (Data Normalization)
-The Adapter pattern is used to standardize and normalize the varied output of multiple applications. Suppose you operate ten different microservices. They all expose performance metrics, but in conflicting formats (JSON, XML, and text). You want to monitor them all using a modern Prometheus stack, which expects a standard text-based format.
-
-Instead of a company-wide rewrite, you deploy an Adapter container in each application's Pod. The Adapter container polls the main application's metrics endpoint via `localhost`, translates the format on the fly, and exposes a new endpoint on a new port that Prometheus can seamlessly scrape.
-
-### 4. Init Containers (Strict Bootstrapping)
-Sometimes, an application requires a specific environment to be prepared before it can safely boot. Perhaps a database schema must be migrated, or the application must wait until an external API is confirmed to be online.
-
-**Init Containers** are specialized containers that run *before* the main application containers are allowed to start. They are executed sequentially. Init Container 1 must complete successfully (exit code of 0) before Init Container 2 begins. Only when all Init Containers have completed will the Kubelet authorize the start of the main application containers.
-
-If an Init Container fails, Kubernetes will repeatedly restart the Pod until the Init Container succeeds. This provides a robust mechanism to delay application startup until dependencies are satisfied. Init Containers can also contain powerful tools (like the `aws-cli` or database migration binaries) that you do not want to package inside your main application container image.
-
-### 5. Ephemeral Containers (Live Production Debugging)
-A powerful feature in Kubernetes is the **Ephemeral Container**. Historically, if a production Pod was crashing and the image was built securely without a shell (e.g., distroless images), you could not use `kubectl exec` to debug it.
-
-Ephemeral Containers solve this. They allow an administrator to attach a temporary container to a Pod *that is already running*. You can attach a debugging image (like `busybox` or `netshoot`) to a running distroless production Pod. Because the Ephemeral Container joins the existing Pod's shared network and IPC namespaces, you can run `tcpdump` inside the ephemeral container to sniff the live network traffic of your application container in real-time.
-
-## Pod Networking: The CNI and IP Allocation
-Unlike Docker running on your laptop, where networking is relatively straightforward, Kubernetes operates across distributed clusters of physical servers. How does a Pod get a unique IP address that can communicate with any other Pod located on any other node?
-
-This magic is facilitated by the **Container Network Interface (CNI)**. Kubernetes itself does not handle IP address allocation or physical routing. Instead, Kubernetes strictly defines a programmatic interface (the CNI specification) and relies on third-party plugin providers (like Calico, Cilium, Flannel, or AWS VPC CNI) to execute network manipulation.
+That shared-fate rule is also why Pod design belongs early in architecture conversations, not at the end of deployment work. A team might say that a report generator and an API "belong together" because they are released from the same repository, but release origin is not the same as runtime coupling. If the report generator spikes CPU once an hour while the API needs steady low latency, a shared Pod forces the scheduler, probes, and resource limits to treat very different behaviors as one unit. Separating them lets the API scale for traffic and the report worker scale for batch load, even if the source code lives side by side.
 
 ```mermaid
 flowchart TD
@@ -186,96 +74,14 @@ flowchart TD
     CNI -->|1. Allocates IP from IPAM<br/>2. Creates veth pair<br/>3. Configures iptables/routes| NetNS["Pod Net Namespace<br/>(IP Assigned to eth0)"]
 ```
 
-When the Kubernetes Scheduler assigns your Pod to a worker node, the following sequence occurs:
-1. The Kubelet commands the local CRI runtime to establish the Pod Sandbox via the `pause` container.
-2. Before the Kubelet allows any application containers to boot, it physically calls the configured CNI plugin binary executable residing on the node.
-3. The CNI plugin evaluates its configuration and securely allocates a unique IP address from the cluster's CIDR block designated for that node.
-4. The CNI plugin executes Linux networking commands to dynamically create a virtual ethernet interface pair (a `veth` pair). It inserts one end of the `veth` pair inside the Pod's network namespace (assigning it the requested IP address as `eth0`) and binds the opposing end to the host machine's network bridge.
-5. The CNI plugin programs the host node's `iptables` rules or eBPF maps to guarantee that network packets destined for that IP address are routed from the physical ethernet card directly into the Pod's interface.
-6. The CNI successfully returns the IP address back to the waiting Kubelet. The Kubelet records this IP in the Pod's API Status object and authorizes the CRI to commence booting the primary application containers.
+Networking adds another layer to the same idea. Kubernetes defines the Container Network Interface contract, but the installed CNI plugin performs the node-level work: allocate an IP address, create a virtual ethernet pair, place one end in the Pod namespace, and program routes, iptables rules, or eBPF maps so other Pods can reach that address. If the CNI plugin is missing or broken on a node, the kubelet cannot finish the sandbox, so the application containers do not safely start. The symptom often looks like `ContainerCreating`, `NetworkPluginNotReady`, or a stream of network setup events rather than an application crash.
 
-> **Stop and think**: If the CNI plugin binary is missing or misconfigured on a worker node, what happens when the Scheduler assigns a new Pod to that node? Will the containers start?
-> *(The Kubelet will fail to configure the network namespace because it cannot execute the CNI plugin to allocate an IP address or configure the routing. The Pod will remain in a `ContainerCreating` or `NetworkPluginNotReady` state, and the application containers will not be permitted to boot until the network is established.)*
+Before running a manifest, ask yourself which boundaries the process actually needs. If it needs a separate release cadence, independent scaling, independent failure handling, or a different security profile, make it a separate Pod behind a Service. If it needs local disk sharing, loopback communication, strict startup ordering, or namespace-level troubleshooting next to the main process, a multi-container Pod may be justified. That decision is architectural, not decorative, and it should be visible in code review before the scheduler ever sees the YAML.
 
-## Advanced Pod Scheduling: Taints, Tolerations, and Affinity
-The Kubernetes Scheduler is a powerful algorithmic engine. By default, it attempts to distribute your Pods evenly across the cluster to maximize resource utilization. However, you frequently require precise control over where your atomic units are placed. You might possess specialized nodes featuring expensive GPUs, NVMe drives, or nodes mandated for compliance zones.
+## Lifecycle, Conditions, and Health Signals
+A Pod has a lifecycle, but the high-level phase is only the first clue. `Pending` means the API server accepted the object but at least one container has not been created; the cause may be unsatisfied scheduling, image pull trouble, missing networking, or container setup delay. `Running` means the Pod is bound to a node and at least one container is running or starting, but it does not guarantee the application is ready for traffic. `Succeeded` and `Failed` describe terminal Pods, usually batch or one-off work, and `Unknown` means the control plane cannot reliably hear from the kubelet.
 
-### 1. Node Taints and Pod Tolerations (Repelling Workloads)
-Imagine you possess worker nodes equipped with GPUs intended exclusively for machine learning inference. By default, the Scheduler will haphazardly schedule mundane web servers directly onto these nodes, wasting computational resources.
-
-To solve this, you apply a **Taint** to the physical Node object. A Taint repels Pods. If you apply the taint `accelerator=nvidia-gpu:NoSchedule` to the node, the Scheduler will refuse to place any standard Pod on that host.
-
-To allow a machine learning Pod to schedule onto that node, you configure a **Toleration** inside the Pod's YAML. The Toleration mathematically declares, "I tolerate the `accelerator=nvidia-gpu` taint." When the Scheduler evaluates the node, it recognizes the valid Toleration and permits the Pod to land.
-
-### 2. Node Affinity (Attracting Workloads)
-While Taints repel workloads, **Node Affinity** allows you to attract Pods to specific nodes based on logical expressions. It represents an architectural upgrade over the rudimentary `nodeSelector` parameter.
-
-Node Affinity features two primary operational modes:
-- `requiredDuringSchedulingIgnoredDuringExecution`: This is a hard rule. If you mandate that a Pod MUST be scheduled on a node with the label `zone=us-east-1a`, and no nodes with that label have sufficient CPU resources available, the Pod will remain permanently trapped in the `Pending` state.
-- `preferredDuringSchedulingIgnoredDuringExecution`: This is a flexible, "soft" preference. You can instruct the Scheduler, "I prefer this Pod to land on a node with `disk-type=nvme`, but if none are available, gracefully schedule it onto standard nodes."
-
-### 3. Pod Affinity and Anti-Affinity (Spreading for High Availability)
-The pinnacle of scheduling control lies in **Pod Affinity** and **Pod Anti-Affinity**. Instead of calculating placement based on node labels, these rules calculate placement based strictly on the labels of the *other Pods* actively running on the node.
-
-- **Pod Anti-Affinity (Spreading):** This is crucial for extreme high availability. If you are deploying three replicas of your `payment-gateway` web application, you do not want the Scheduler to place all three Pods onto the same physical worker node. By configuring `podAntiAffinity` against the label `app=payment-gateway` with a topology key of `kubernetes.io/hostname`, you force the Scheduler to spread the three Pods across different physical servers.
-- **Pod Affinity (Colocation):** Conversely, if you have a web application Pod that makes ten thousand micro-requests per second to a caching Pod, you want those two separate Pods placed on the same physical node. By configuring `podAffinity`, the Scheduler ensures they dynamically land together, communicating securely over the local loopback interface.
-
-| Feature | Target | Action | Use Case |
-|---|---|---|---|
-| Taints & Tolerations | Nodes (Taint), Pods (Tolerate) | Repels pods from nodes | Dedicate nodes to specific workloads (e.g., GPUs) |
-| Node Affinity | Pods | Attracts pods to specific nodes | Ensure pods run in specific zones or on specific hardware |
-| Pod Affinity | Pods | Attracts pods to other pods | Co-locate tightly coupled services to reduce latency |
-| Pod Anti-Affinity | Pods | Repels pods from other pods | Spread replicas across hosts/zones for high availability |
-
-## Pod Security: Hardening the Atomic Unit
-The power of containerization inherently comes with security risks. Because containers share the underlying host Linux kernel, a severe vulnerability could allow an attacker who compromises a web application Pod to break out, gain root access to the physical worker node, and pivot laterally to compromise the entire cluster.
-
-To mitigate this, Kubernetes provides the **Security Context**, a set of deeply embedded Linux kernel configurations applied directly to the Pod or container YAML spec.
-
-A hardened Security Context includes:
-- `runAsNonRoot: true`: This setting forbids the container runtime from executing the application process as the `root` user (UID 0). If the Dockerfile entrypoint incorrectly attempts to run as root, the Kubelet will refuse to start the container.
-- `readOnlyRootFilesystem: true`: A critical security control. It forcefully mounts the container filesystem layer as completely read-only. If an attacker successfully exploits a remote code execution (RCE) vulnerability, they will be unable to download a malicious payload or modify binary scripts. (Note: You must thoughtfully mount an `emptyDir` volume specifically at `/tmp` if your application requires a scratch space).
-- `allowPrivilegeEscalation: false`: This setting modifies the `no_new_privs` bit. It ensures that no child process created by the container can acquire greater privileges than its parent process, rendering malicious `setuid` binaries useless.
-- `capabilities: drop: ["ALL"]`: By default, Linux containers retain a subset of root privileges grouped into "capabilities" (like `CAP_NET_RAW`). A hardened production application rarely requires these capabilities. By explicitly dropping all capabilities, you drastically shrink the viable attack surface area.
-
-> **Pause and predict**: You configure `runAsNonRoot: true` in your Pod manifest. However, the Dockerfile used to build the image ends with `USER root`. What will happen when Kubernetes attempts to start this Pod?
-> *(The Kubelet will inspect the image metadata and see that the process intends to run as UID 0 (root). Because the Pod specification explicitly forbids this via `runAsNonRoot: true`, the Kubelet will refuse to start the container, throwing a `CreateContainerConfigError` and keeping the Pod from running.)*
-
-## Storage in Pods: Volumes and Persistence
-Pods are inherently ephemeral, meaning any file written directly to the container's root filesystem is lost the moment the container crashes or the Pod is evicted. To preserve state or share data between containers within the same Pod, Kubernetes introduces the concept of **Volumes**.
-
-A Volume is essentially a directory accessible to the containers in a Pod. The medium backing that directory depends entirely on the specific Volume Type you configure.
-
-### 1. emptyDir (Ephemeral Scratch Space)
-An `emptyDir` volume is created the exact moment a Pod is assigned to a Node. It is initially empty. All containers within the Pod can read and write identically to the same files in the `emptyDir` volume. When a Pod is removed from a node, the data in the `emptyDir` is permanently deleted. It is perfect for scratch space or sidecar log sharing.
-
-### 2. hostPath (Dangerous Node Access)
-A `hostPath` volume fiercely mounts a file or directory from the underlying physical host node's filesystem into your Pod. This is dangerous. If you mount `/var/run/docker.sock` into a Pod, that Pod now has total root control over the entire node. `hostPath` is rarely used in secure production environments except by highly privileged system daemons that require raw access to node-level logs.
-
-### 3. PersistentVolumes (Stateful Durability)
-For true data persistence (like a PostgreSQL database file), you must use **PersistentVolumeClaims (PVCs)**. A PVC is an explicit request for permanent storage. When a Pod claims a PVC, Kubernetes provisions an external block storage device (like an AWS EBS volume) and attaches it to the worker node. Even if the Pod is destroyed, the physical cloud disk remains intact. When the Pod is rescheduled to a completely different node, Kubernetes seamlessly reattaches it to the new node, preserving the data indefinitely.
-
-## The Pod Lifecycle, State Machine, and Probes
-A Pod is an inherently ephemeral entity. It is born, it lives, it performs its configured duty, and it dies. Once a Pod is dead, it is finalized; it is never resurrected. If a worker node suffers a kernel panic, the Pods currently running on that specific node are lost forever. Kubernetes controllers (like Deployments) must step in to create entirely *new* Pods to replace the dead ones.
-
-To truly understand what a Pod is currently doing at a system level, you must understand its rigid lifecycle phases:
-
-1. **Pending**: The Pod specification has been formally accepted by the Kubernetes API server and written to the `etcd` database. However, one or more of its containers has not been created by the runtime yet. This phase encompasses the time spent waiting for the Scheduler to execute its bin-packing algorithms, and the time spent downloading the container images. If a Pod is stuck in Pending for hours, it is a scheduling constraint issue or an image pull authorization error.
-2. **Running**: The Pod has been bound to a specific Node. The `pause` container has secured the network sandbox. All containers have been successfully initialized. At least one container is still actively running, or is in the process of starting up. 
-3. **Succeeded**: All containers in the Pod have successfully terminated gracefully (returning a Linux exit code of precisely 0), and the Pod's restart policy dictates that they will not be restarted. This phase is common for one-off tasks, cron jobs, or batch processing workflows.
-4. **Failed**: All containers in the Pod have terminated, and at least one container has terminated in failure (returning an exit code other than zero, or was forcefully terminated by the OOM killer). 
-5. **Unknown**: The true state of the Pod could not be reliably obtained by the Kubernetes control plane. This is almost universally due to a network communication failure between the API server and the specific Kubelet daemon on the node.
-
-### Pod Conditions and Probes: The True Measure of Readiness
-While the high-level `Phase` provides a broad summary of the Pod's existence, Kubernetes also rigorously tracks highly specific **Conditions** that give a deep view of the Pod's readiness to serve live traffic:
-- `PodScheduled`: Has the Pod been assigned to a worker node by the Scheduler?
-- `Initialized`: Have all sequential Init Containers completed their tasks with an exit code 0?
-- `ContainersReady`: Are all the primary application containers fully booted?
-- `Ready`: Is the Pod officially ready to be added to the load balancer and serve HTTP requests?
-
-It is entirely possible for a Pod to be in the `Running` phase, but have a `Ready` condition stuck at `False`. This happens if the application inside the container is actively running as a Linux process, but takes 60 seconds to boot its Spring Boot context and establish connection pools.
-
-To manage this orchestration, Kubernetes utilizes **Probes**—active health checks executed systematically by the Kubelet against your containers:
+Conditions provide the detail that phases omit. `PodScheduled` tells you whether the scheduler found a node. `Initialized` tells you whether all init containers completed successfully. `ContainersReady` tells you whether the ordinary containers are ready. `Ready` tells Services and load balancers whether this Pod should receive user requests. A Pod can be `Running` while `Ready` remains false because the process exists but the application has not warmed caches, opened database pools, or passed its readiness endpoint. That distinction is one of the most important operational lessons in Kubernetes.
 
 ```mermaid
 flowchart TD
@@ -288,20 +94,20 @@ flowchart TD
     Readiness -- Succeeds --> Add["Add to Load Balancer"]
 ```
 
-1. **Liveness Probes**: "Is the application deadlocked or frozen?" The Kubelet checks if the application is healthy. If the Liveness Probe fails repeatedly, the Kubelet restarts the container process to attempt to clear the deadlock and restore service.
-2. **Readiness Probes**: "Is the application fully ready to receive user traffic?" The Kubelet checks if the app has finished booting. If a Readiness Probe fails, the container is *not* restarted. Instead, the Pod's `Ready` condition is set to `False`, and the Pod's IP address is removed from all Kubernetes Services and cloud load balancers. Traffic is routed away to healthy pods until the probe succeeds again.
-3. **Startup Probes**: "Has the slow application finished its initial boot sequence?" This probe disables all Liveness and Readiness checks until it passes. This prevents the Kubelet from prematurely killing a slow-starting legacy application because its Liveness probe timed out before it even had a fair chance to finish loading.
+Probes turn vague health expectations into kubelet decisions. A startup probe protects slow applications by giving them a separate boot window before other probes begin. A liveness probe asks whether the process is so broken that it should be restarted, such as a deadlocked server that still has a PID but no longer handles requests. A readiness probe asks whether the Pod should receive traffic right now, and failure removes the Pod from Service endpoints without restarting the container. Mixing those meanings is a common cause of self-inflicted outages, especially when teams use an aggressive liveness probe for an endpoint that really describes dependency readiness.
 
-These probes are configured with specific mathematical parameters:
-- `initialDelaySeconds`: How long to wait after the container starts before launching the first probe.
-- `periodSeconds`: How often to execute the probe.
-- `failureThreshold`: How many consecutive times the probe must fail before Kubernetes takes action.
-- `successThreshold`: How many consecutive times a failed probe must succeed to be marked healthy again.
+Probe timing is simple arithmetic with real consequences. `initialDelaySeconds` controls when checking begins, `periodSeconds` controls how often the kubelet checks, `failureThreshold` controls how many failures trigger action, and `successThreshold` controls how many successful readiness checks are needed after failure. If a Java service usually takes 70 seconds to load but the liveness probe begins at 20 seconds and fails after three quick checks, Kubernetes will kill the app before it has a fair chance to start. The fix is not to remove health checks; the fix is to model startup, liveness, and readiness as different questions.
 
-## Anatomy of a Pod Specification: The Master Manifest
-In Kubernetes, you define exactly what you want the cluster architecture to look like using structured YAML manifests. A Pod manifest has four critical top-level sections: `apiVersion`, `kind`, `metadata`, and `spec`. 
+The kubelet enforces this lifecycle through a sync loop. It watches the Pod objects assigned to the node, asks the container runtime about actual containers, and reconciles differences. Internally, the Pod Lifecycle Event Generator helps the kubelet react to container changes without relying on expensive constant polling. If the runtime reports that a container exited, the kubelet records the state, evaluates the Pod's restart policy, and starts the next attempt when appropriate. When a node logs that PLEG is unhealthy, the node may stop reporting accurate container state, so Pods can appear stale even though the control plane itself is still alive.
 
-Let's dissect an enterprise-grade production Pod specification:
+Pause and predict: a web Pod is `Running`, its liveness probe succeeds, and its readiness probe fails for two minutes during a database migration. Should the kubelet restart the container? It should not restart the container solely because readiness fails. Instead, the Pod should be removed from Service endpoints until the readiness probe passes again. This lets rolling updates and dependency disruptions drain traffic without turning a temporary dependency problem into a restart storm.
+
+Lifecycle also clarifies why naked Pods are fragile. When a node dies, the Pod object may remain visible for a while, but the processes on that node are gone. A Deployment, StatefulSet, DaemonSet, or Job is the controller that creates replacement Pods; the Pod itself does not travel to a new node like a live virtual machine. For temporary experiments, a naked Pod is useful because it is easy to inspect. For an application that must recover, the absence of a controller is a design defect.
+
+## Writing Declarative Pod Manifests
+Declarative manifests are the operational contract between your team and the cluster. An imperative command says, "do this now," which is excellent for learning, probing, or generating a draft. A YAML manifest says, "this is the desired state," which can be reviewed, versioned, rolled back, audited, and reapplied. In production, the difference matters because the cluster will recreate Pods after failures, and it can only recreate what your source of truth describes. If a manual command changed a live Pod but Git never changed, the next replacement returns to the old behavior.
+
+The core Pod shape has four top-level parts: `apiVersion`, `kind`, `metadata`, and `spec`. Metadata names and labels the object so controllers, Services, metrics systems, and humans can select it. The spec describes the containers, volumes, security posture, resource constraints, node placement, service account, probes, and restart behavior. Treat the spec as a review document, not just a blob of YAML. A reviewer should be able to answer where the Pod may run, what identity it uses, how it proves readiness, how much memory it can consume, and what happens if it fails.
 
 ```yaml
 apiVersion: v1
@@ -394,22 +200,18 @@ spec:
           memory: "512Mi"
 ```
 
-### Breaking Down the Complex Master Spec
-1. **Metadata**: The `name` uniquely identifies the Pod within its `namespace`. `labels` are crucial to the Kubernetes architecture. They are key-value pairs used to organize and select resources. Without accurate labels, Kubernetes Services would have no mathematical way to dynamically select which Pods they are routing traffic to. `annotations` are similar to labels but are used for non-identifying metadata, often read by external infrastructure tools.
-2. **nodeSelector and Tolerations**: This instructs the Scheduler. The `nodeSelector` demands the Pod *only* be placed on worker nodes that possess the exact matching labels. The `tolerations` block allows this Pod to bypass a node's "Taint". 
-3. **affinity**: This `podAntiAffinity` block forces the Scheduler to ensure that no two `payment-gateway` pods are *ever* scheduled on the exact same physical host machine. This guarantees high availability.
-4. **serviceAccountName**: Explicitly grants the Pod a specific cryptographic identity, allowing it to dynamically authenticate against the Kubernetes API or major cloud providers without hardcoding static credentials inside the container image.
-5. **securityContext**: This block hardens the container at the Linux kernel level. It forces the application to run as an unprivileged user, forbids the process from running as the `root` user, drops ALL Linux kernel capabilities, and mounts the entire container filesystem as Read-Only to guarantee attackers cannot download malicious payloads.
-6. **Volumes**: We define an `emptyDir` volume with a strict 1Gi size limit. This is a scratch directory dynamically created when the Pod is assigned to a node. It exists only as long as the Pod exists on that node and is shared securely among all containers.
-7. **Resource Requests and Limits**: This is the most important section for cluster stability and preventing cascading node failures.
+This example is intentionally rich because production Pods usually encode more than an image name. Labels such as `app`, `tier`, and `security-zone` give Services, NetworkPolicies, metrics, and policy engines a stable way to select the Pod. Annotations provide non-identifying hints for tools, such as a Prometheus scraper. The service account gives the Pod an identity, which is much safer than baking static cloud credentials into an image. The `securityContext` forces least privilege, and the probes separate boot, health, and traffic readiness from whether the Linux process exists.
 
-## The Importance of Requests and Limits
-When you ask Kubernetes to schedule a Pod, the Scheduler's bin-packing algorithm needs to mathematically prove if a Node has enough physical room to accommodate it.
+Volumes also express runtime intent. An `emptyDir` is created when the Pod lands on a node and disappears when the Pod leaves that node, so it is useful for scratch space and container-to-container handoff. A `hostPath` mounts a node path into the Pod and should be treated as privileged access because it ties the Pod to node internals. A PersistentVolumeClaim is the normal path for durable data, because the storage object outlives the Pod and can be reattached according to the storage class rules. The manifest should make those durability choices obvious rather than hiding them inside application code.
 
-- **Requests (The Guarantee)**: This is exactly what the container is guaranteed to get by the cluster. If a container requests `256Mi` of memory, the Scheduler will exclusively place this Pod on a Node that has at least `256Mi` of unallocated memory. It is used *exclusively* for scheduling calculations.
-- **Limits (The Hard Ceiling)**: This is the maximum threshold the container is permitted to use by the Linux kernel's cgroups. 
-    - **CPU Limits:** If a container attempts to consume more CPU than its limit, the kernel's Completely Fair Scheduler (CFS) actively throttles (slows down) the application. The container will not crash, but it will suffer severe latency. 
-    - **Memory Limits:** If a container attempts to allocate more physical memory than its limit, the host Linux kernel immediately terminates the main application process via the OOM (Out Of Memory) Killer, resulting in a container crash and an exit code of `137`.
+Before running this, what output do you expect from a dry review of the manifest? A scheduler will only consider nodes matching the `nodeSelector`, permitted by the toleration, and compatible with the anti-affinity rule. The init container must complete before the main container starts, and the main container will refuse to run as root. Once the process starts, readiness controls traffic and liveness controls restarts. If you cannot describe those consequences from the YAML, the manifest is not yet reviewable enough for production.
+
+Imperative commands still have a place when used deliberately. For a quick connectivity test, `k run` can create a disposable Pod, and `--dry-run=client -o yaml` can help you draft a manifest. The danger appears when an emergency manual change becomes the only record of truth. A news organization once fixed a cache image during a live event with a direct command and restored service, but the change never reached Git. When a node failed later, the replacement Pod came from the old manifest and reintroduced the bug. The rule is blunt because incidents are blunt: if the desired state is not in version control, the cluster cannot be trusted to preserve it.
+
+## Scheduling, Resources, and Quality of Service
+Scheduling is a constraint-solving problem. The scheduler does not place a Pod on a node because the image looks small or because the cluster has total free capacity somewhere. It evaluates the Pod's requested resources, placement rules, taints, tolerations, affinity, anti-affinity, and current node allocations. A Pod requesting more memory than any single node can provide will stay `Pending` even if the cluster has plenty of memory in aggregate. This is why requests are not documentation; they are part of the scheduling equation.
+
+Requests are guarantees used for placement, while limits are enforcement boundaries applied by the kernel. A CPU request reserves scheduling capacity and influences fair sharing under contention. A CPU limit can cause throttling through the Completely Fair Scheduler when a container tries to use more than its quota; the process slows down but usually does not die. A memory limit is harsher. When the process exceeds the cgroup memory ceiling, the Linux OOM killer can terminate it, and Kubernetes records the familiar `OOMKilled` reason with exit code 137. Latency problems often come from CPU throttling, while sudden restarts without application logs often point toward memory pressure.
 
 ```mermaid
 flowchart TD
@@ -431,80 +233,76 @@ flowchart TD
     Q3 -- NO --> BestEffort
 ```
 
-Based on how you configure these two values, Kubernetes categorizes your Pod into one of three **Quality of Service (QoS)** classes:
-1. **Guaranteed**: The Pod sets both Requests and Limits for both CPU and Memory, and they are exactly equal. These are the highest priority pods. They will be the last to be killed if the node runs out of memory.
-2. **Burstable**: The Pod has Requests defined that are strictly lower than its Limits. It is guaranteed a baseline, but can "burst" up to its limit if the node has spare resources. If the node runs out of memory, Burstable pods that are exceeding their requests are killed before Guaranteed pods.
-3. **BestEffort**: The Pod has zero Requests and zero Limits defined. It is allowed to use whatever resources are freely available, but if the node experiences the slightest memory pressure, BestEffort pods are terminated immediately to protect the system.
+Quality of Service classes summarize how completely resources are specified. A `Guaranteed` Pod sets CPU and memory requests equal to limits for every container, making it the last class Kubernetes prefers to evict during node pressure. A `Burstable` Pod has some requests or has requests lower than limits, so it can use spare capacity but may be evicted before Guaranteed workloads if it exceeds its request. A `BestEffort` Pod has no requests or limits and is easiest to evict when the node needs protection. The class does not replace good sizing, but it helps you predict survival during resource starvation.
 
-> **Pause and predict**: Look at the following specification: CPU Request: 250m, CPU Limit: 500m, Memory Request: 512Mi, Memory Limit: 512Mi. What QoS class will Kubernetes assign to this Pod?
-> *(Kubernetes will assign the `Burstable` QoS class. Even though the memory request and limit are equal, the CPU request is strictly less than the CPU limit. For a Pod to be classified as `Guaranteed`, both CPU and memory must have requests perfectly equal to limits.)*
+Placement rules shape where the scheduler may solve the resource problem. A taint repels ordinary Pods from a node, and a toleration lets selected Pods accept that taint, which is useful for dedicated hardware or isolation zones. Node affinity attracts Pods to nodes with labels such as storage type, region, or compliance boundary. Pod anti-affinity spreads replicas away from each other so a single node failure does not remove every copy of a service. Pod affinity colocates related Pods when locality matters, although colocating independent services can create shared failure risk if overused.
 
-## Imperative vs. Declarative Management
-There are two distinct, philosophically opposed ways to instruct Kubernetes to manage a Pod.
+| Feature | Target | Action | Use Case |
+|---|---|---|---|
+| Taints & Tolerations | Nodes (Taint), Pods (Tolerate) | Repels pods from nodes | Dedicate nodes to specific workloads (e.g., GPUs) |
+| Node Affinity | Pods | Attracts pods to specific nodes | Ensure pods run in specific zones or on specific hardware |
+| Pod Affinity | Pods | Attracts pods to other pods | Co-locate tightly coupled services to reduce latency |
+| Pod Anti-Affinity | Pods | Repels pods from other pods | Spread replicas across hosts/zones for high availability |
 
-**Imperative Management** involves typing commands directly into your terminal, explicitly telling the Kubernetes API *what specific action to perform right now*.
-`kubectl run my-nginx-test --image=nginx:1.27-alpine --port=80 --labels=env=dev`
-This approach is fast and excellent for rapidly generating YAML templates via dry-runs. However, it is an anti-pattern for production environments. If a junior engineer accidentally deletes the Pod, there is zero historical record of how it was created. It is not version-controlled, auditable, or repeatable in a disaster recovery scenario.
+The practical workflow is to start with resource requests that match observed baseline usage, then set memory limits carefully enough to protect the node without creating predictable OOM kills. CPU limits deserve extra caution on latency-sensitive services because throttling can look like random slowness even when the Pod never restarts. For placement, prefer simple labels and anti-affinity for availability, then add taints or hard node affinity only when you have a clear isolation or hardware requirement. Strong constraints improve control but reduce scheduling flexibility, so every hard rule should have a reason a reviewer can defend.
 
-**Declarative Management** involves writing a detailed YAML file defining *the exact state you desire*, and asking Kubernetes to autonomously make physical reality match your file.
-`kubectl apply -f pod-manifest.yaml`
-This is the universally accepted industry standard. The YAML file is securely committed to a Git repository (a practice known as GitOps). Any changes to the infrastructure must go through a formal pull request and peer code review. If the entire data center burns to the ground, you simply re-apply the repository of YAML files to a new cluster, and your architecture is restored autonomously.
+Resource decisions also affect neighbors that your team may never meet. In a shared cluster, an oversized request can strand capacity by reserving space the process rarely uses, while a missing request can make the scheduler overpack a node and invite eviction pressure later. Limits have their own failure modes: a limit that is too low creates predictable restarts, but no limit allows a runaway process to threaten unrelated workloads on the same node. The point is not to find perfect numbers on the first day. The point is to start with honest estimates, observe real usage, and treat resource changes as part of application tuning rather than as a one-time platform chore.
 
-### War Story: The Ephemeral Ghost in the Machine
-At a major international news agency during a breaking news event, a site reliability engineer manually updated the container image of a critical caching Pod using a fast imperative command (`kubectl set image pod/cache-pod cache=redis:7.2-alpine`). They fixed the bug instantly, restored service, and went home for the weekend. 
+Which approach would you choose here and why: a payment API with three replicas must survive a node failure, while a fraud-scoring model needs GPU nodes and has one replica during a test? The payment API should use anti-affinity or topology spread through a controller so replicas do not pile onto one host. The model should tolerate a GPU taint and request the appropriate accelerator resources, accepting that scheduling may be slower because eligible nodes are scarce. Both are Pods, but the scheduling intent is different, and the manifest should make that difference explicit.
 
-However, on Sunday morning, a node hardware failure caused the imperative caching Pod to be automatically evicted and forcefully rescheduled onto a healthy node. Because the engineer's imperative change was completely ephemeral and was never saved to the declarative YAML manifests, the cluster automatically pulled the *old*, buggy image definition directly from the Git repository to recreate the new Pod instance. The application broke again, the entire website went down, and the platform team learned a hard lesson: **If it isn't defined in Git, it simply does not exist.** Never use imperative commands to alter production state.
+## Multi-Container Patterns, Storage, and Security
+Most Pods contain one application container, and that is healthy. A single-container Pod is simple to scale, simple to reason about, and easy for controllers to replace. Multi-container Pods become valuable only when two processes need shared fate and node-local collaboration. The sidecar pattern augments an application without changing it, such as tailing a legacy log file from a shared `emptyDir` and writing it to stdout. The ambassador pattern proxies local traffic, often to add TLS, connection pooling, or policy. The adapter pattern translates application-specific output into a standard format that the platform already understands.
 
-## Diagnosing Pod Failures: The Deep Detective Work
-When a Pod fails to start, crashes repeatedly, or mysteriously goes offline, Kubernetes provides a wealth of forensic clues. Your job is to interpret them using the `kubectl` toolset.
+Init containers solve a different problem: finite setup that must finish before the app starts. They run sequentially, and each must exit successfully before the next init container or main container begins. This is appropriate for preparing a schema, downloading a model file, waiting for a dependency contract, or rendering configuration into a shared volume. It is not appropriate for continuous polling, background synchronization, or log forwarding, because an init container that never exits blocks the main application forever. Kubernetes 1.35 also supports native sidecar-style behavior through init container semantics, but the design question remains whether the helper should run before, beside, or outside the main app.
 
-### 1. The `Pending` State (Scheduling and Pull Errors)
-If you apply a Pod manifest and it fails to ever reach the `Running` phase, the very first command you must execute is:
-`kubectl describe pod <pod-name>`
-Do not look at the YAML output; scroll directly to the bottom to the **Events** section. This is the chronological log of what the Control Plane and the Scheduler attempted to do.
+Ephemeral containers are for live debugging rather than steady architecture. They let an operator attach a temporary debugging image to an existing Pod, which is especially useful when the production image is distroless and intentionally lacks a shell. Because the debug container can join the Pod's namespaces, it can inspect network behavior next to the app without rebuilding the app image. That power should be controlled through RBAC and audit logs, because the ability to attach debugging tools to production Pods can expose sensitive runtime information if granted casually.
 
-- **Insufficient Resources**: If the event says `0/50 nodes are available: 50 Insufficient memory`, your Pod mathematically requested more guaranteed memory than any single node in your cluster can provide. You must lower your CPU/Memory requests, delete other pods to free up space, or add larger nodes to the cluster.
-- **Taint / Affinity Mismatch**: If it says `0/50 nodes are available: 50 node(s) had taint {dedicated: database}, that the pod didn't tolerate`, the scheduler is refusing to place your web pod on a node reserved exclusively for databases.
-- **ImagePullBackOff / ErrImagePull**: If the event says `Failed to pull image "my-company/backend:v99": rpc error: code = NotFound`, the Kubelet cannot download the image. Kubernetes is desperately trying to pull the image and exponentially backing off before trying again. 
-  - **The Fix:** Rigorously check for typos in the image name, verify the image tag exists in the remote registry, and ensure the cluster has the correct authentication secrets (`imagePullSecrets`) to securely access private registries.
+Security context settings turn least privilege into runtime policy. `runAsNonRoot` blocks images that try to start as UID 0, `allowPrivilegeEscalation: false` prevents child processes from gaining more privilege than their parent, `readOnlyRootFilesystem` makes the image layer immutable at runtime, and dropping Linux capabilities removes kernel privileges that most web applications never need. These settings can break poorly prepared images, which is a feature during review rather than a nuisance during an incident. If an app needs scratch space with a read-only root filesystem, mount an `emptyDir` at `/tmp` or another explicit path instead of leaving the whole image writable.
 
-### 2. The `CreateContainerConfigError` and `CreateContainerError`
-Sometimes the image pulls successfully, but the container refuses to begin executing.
-If you see these errors in the Events, you have asked the Kubelet to do something logically impossible.
-- **Root Cause:** You defined an environment variable that references a Kubernetes Secret or ConfigMap that literally does not exist in the namespace. The Kubelet refuses to start the container because it cannot fulfill the configuration contract.
-- **The Fix:** Verify that your ConfigMaps and Secrets are created *before* you deploy the Pod that depends on them.
+Storage choices should match data meaning. Files written directly to a container filesystem are disposable because a restarted container gets a fresh writable layer. `emptyDir` keeps data for the lifetime of the Pod on the node, so it is excellent for shared logs, generated static content, temporary model downloads, or handoff between init and main containers. `hostPath` reaches into the node and should be limited to privileged infrastructure agents with a clear reason. PersistentVolumeClaims are for data that must outlive Pod replacement, such as database files, but stateful workloads also need higher-level controllers and storage-aware rollout plans.
 
-### 3. The `CrashLoopBackOff`
-This is arguably the most common error for Kubernetes beginners. The Pod reaches the `Running` state, meaning scheduling, networking, and image pulling were all executed perfectly. However, the application inside the container crashes (it exits with a non-zero Linux exit code like 1, 2, or 255). 
+A useful mental test is whether deleting the Pod should delete the data or only stop the process. If deleting the Pod should delete the data, an `emptyDir` may be correct. If deleting the Pod must not delete the data, use a persistent volume and design recovery deliberately. If the Pod needs node internals, pause and ask whether you are building a node agent, a security exception, or an accidental privilege escalation. The storage stanza is not just plumbing; it is a durability and trust statement.
 
-The Kubelet restarts the container process. It crashes again immediately. The Kubelet restarts it again. To prevent the node from burning 100% of its CPU cycles restarting a broken app, Kubernetes introduces an exponential backoff delay. It waits 10 seconds, then 20 seconds, then 40, up to a strict maximum limit of exactly 5 minutes between restarts. This cycle is known as `CrashLoopBackOff`.
+## Diagnosing Pod Failures Without Guessing
+Debugging Pods is easier when you follow the lifecycle instead of jumping straight to logs. If the Pod is `Pending`, the application may never have started, so logs are often irrelevant. Start with `k describe pod <pod-name>` and read the Events section from bottom to top. Events such as insufficient CPU, untolerated taints, node affinity mismatch, or volume attach failure point to scheduling and setup. Events such as `ErrImagePull` or `ImagePullBackOff` point to registry access, wrong image names, missing tags, or private registry authentication. The kubelet is telling you which step failed; your job is to look at the step that actually ran.
 
-**How to systematically diagnose:** Do *not* use `describe` here. The container actually started successfully, so the scheduling events are totally fine. You need to see exactly what the application process printed to the console standard output mere milliseconds before it died.
-`kubectl logs <pod-name> --previous` (The `--previous` flag shows the logs of the *last* crashed container instance).
-If the logs state `FATAL: Unable to connect to database - Connection Refused` or `SyntaxError: Unexpected token`, you have successfully found your root cause. It is an application code bug, a missing environment variable, or a networking error, and not a Kubernetes scheduling error.
+`CreateContainerConfigError` usually means the kubelet cannot assemble the container configuration from the Pod spec. A missing ConfigMap key, missing Secret, invalid environment reference, or impossible security setting can block startup even after the image pulls successfully. `CreateContainerError` means the runtime encountered a lower-level creation problem, such as a bad command, missing executable, mount failure, or permission issue. In both cases, the container may not have produced application logs because the process did not reach normal execution. Events and state blocks are more useful than staring at an empty log stream.
 
-### 4. The Silent Killer: `OOMKilled` (Exit Code 137)
-If a poorly written application leaks memory over time, it will eventually hit the hard memory limit defined in its `resources.limits.memory` specification. When this threshold is crossed, the Linux kernel aggressively terminates the offending process to protect the rest of the node's stability.
+`CrashLoopBackOff` means the container did start and then exited repeatedly. Kubernetes restarts it according to policy, but backs off to avoid burning node CPU on a process that immediately fails. Here, logs are usually the primary signal, and the `--previous` flag matters because the current container instance may be new and empty. Use `k logs <pod-name> --previous` when the last crashed instance printed the useful stack trace, failed database connection, syntax error, or missing file message just before exiting. If there are multiple containers, add `-c <container-name>` so you are reading the right process.
 
-If an application Pod restarts unexpectedly without a single error log being printed to standard output, you must check the system exit code immediately. 
-`kubectl describe pod <pod-name>`
-Look closely at the `Last State` block of the specific container. If you see `Reason: OOMKilled` and `Exit Code: 137`, your application ran completely out of its permitted memory and was assassinated by the kernel.
-**The Fix:** You must fix the architectural memory leak in the application's source code, or edit the Pod YAML to significantly increase the physical memory limit (e.g., from `512Mi` to `1024Mi`).
+`OOMKilled` is different because the application may not have a chance to print anything. The kernel terminates the process after it exceeds its memory cgroup limit, and Kubernetes records `Reason: OOMKilled` with exit code 137 in the container's last state. The short-term fix may be increasing the memory limit, but the durable fix is to compare actual memory growth, request sizing, limit sizing, and application behavior. A memory leak hidden behind repeated restarts can look like a flaky cluster until you connect restart count, last state, and metrics.
 
-### 5. Interactive Debugging with `exec` and `port-forward`
-Sometimes simply reading static logs isn't enough to solve a highly complex, intermittent networking issue. You need to get physically inside the container's isolated network and filesystem namespace to see exactly what it sees.
-`kubectl exec -it <pod-name> -- /bin/sh`
-This command drops you directly into an interactive shell *inside* the live, running container process. From here, you can execute `nslookup` to test internal cluster DNS resolution, `ping` remote databases to verify routing, or read local configuration files physically mounted on the container disk.
+Interactive tools are useful after you know what layer you are investigating. `k exec -it <pod-name> -- /bin/sh` drops into a running container if the image includes a shell, which lets you inspect mounted files, environment variables, DNS, and local network behavior. `k port-forward pod/<pod-name> 8080:80` tunnels traffic through the API server to the Pod, which is helpful before you create a Service or Ingress. Ephemeral containers help when the image lacks a shell, but they should support diagnosis, not become a substitute for fixing the manifest or image.
 
-Furthermore, if you need to test a web application running inside a Pod but you haven't set up complex public routing (Services, Ingresses) yet, you can tunnel traffic directly from your local laptop into the Pod's network namespace over the encrypted API server connection:
-`kubectl port-forward pod/<pod-name> 8080:80`
-Now, opening `http://localhost:8080` in your local web browser will route the HTTP request through the encrypted Kubernetes API server tunnel and directly into port 80 of your deeply isolated Pod.
+The debugging order is simple enough to memorize. First, identify the phase and conditions with `k get pod` and `k describe`. Second, read Events for scheduling, image, network, volume, and configuration failures. Third, read logs, using `--previous` for repeated crashes and `-c` for multi-container Pods. Fourth, inspect resource state for OOM kills and throttling. Fifth, use exec, port-forward, or ephemeral containers to test what the process can see from inside the namespace. Skipping the first two steps is how teams waste an hour debugging application code that never started.
+
+A good incident note records the same sequence because it separates evidence from guesses. Instead of writing "Kubernetes killed the app," record that the Pod was scheduled to a specific node, the container previously terminated with exit code 137, memory usage rose above the configured limit, and the kubelet restarted the container according to policy. Instead of writing "networking is broken," record that the Pod remained in `ContainerCreating`, the Events stream showed CNI setup failure, and no application container had started. These details matter during review because they point to different owners, different fixes, and different prevention work.
+
+The same discipline helps when several symptoms appear together. A Pod can have an image pull warning from an older attempt, a readiness failure from the current instance, and a restart count from a previous crash. Events are chronological, container state is per container, and logs are per container instance. Reading them as one flat error message creates false conclusions. During an outage, name the container, the attempt, the timestamp, and the lifecycle step before proposing a fix. That habit makes your diagnosis slower for the first minute and much faster for the next thirty.
+
+## Patterns & Anti-Patterns
+Use a single application container per Pod when the process can scale, fail, and deploy independently. This is the default pattern because it keeps controller behavior clean and lets Services route to one application boundary. Use a sidecar when a helper must share a local volume or loopback interface with the main process and should be replaced whenever the main Pod is replaced. Use an init container when setup must finish before the application starts, and keep the init image separate if it needs tools you do not want in the production runtime image.
+
+Use declarative manifests for anything that should be repeatable. A manifest reviewed in Git captures labels, probes, resources, security context, volumes, and placement rules in one place. Use naked imperative Pods for temporary experiments, connectivity tests, or quick reproductions, then delete them. Use controllers for durable workloads because controllers create replacement Pods when nodes fail, roll out new versions, and maintain replica counts. A Pod is the thing being managed; it is not usually the manager.
+
+The strongest anti-pattern is the "server in a Pod" design, where teams place unrelated processes together because they once shared a host. It feels familiar but destroys independent scaling and failure isolation. Another anti-pattern is the probe-as-hammer design, where every health endpoint becomes a liveness probe and temporary dependency failures trigger restarts. A third anti-pattern is resource optimism, where teams omit requests and limits until a shared node becomes unstable. These mistakes share one cause: treating the Pod spec as a deployment afterthought rather than the operating contract.
+
+When a multi-container Pod is justified, keep the relationship narrow and documented. The helper should have a clear reason to share the Pod sandbox, and its failure mode should make sense alongside the main container. A log sidecar dying may mean observability is broken even if the app still serves traffic; a proxy sidecar dying may make the app effectively unavailable; an adapter failing may break scraping but not user traffic. The Pod can express these differences only if probes, resources, and container responsibilities are configured intentionally.
+
+## Decision Framework
+Start with the question, "What is the smallest unit that should be scheduled and replaced together?" If the answer is one process, use one container in one Pod and put replication, rollout, and recovery in a controller. If a helper must share `localhost` or an `emptyDir` with the main process, consider a sidecar or adapter. If a task must complete before the main process starts, use an init container. If the work is a finite batch task, use a Job rather than a long-running Pod. If the workload needs stable identity and durable storage across replacements, study StatefulSets after you understand basic controllers.
+
+Next, ask, "What must be true before this Pod receives traffic?" Put startup assumptions into startup probes, serving assumptions into readiness probes, and deadlock recovery into liveness probes. Then ask, "What can this Pod consume without harming the node?" Put baseline needs into requests and hard safety boundaries into limits, remembering that CPU limits throttle and memory limits can kill. Finally, ask, "Where is this Pod allowed to run?" Use labels and soft preferences first, then hard affinity, taints, and tolerations when hardware, compliance, or isolation requires them.
+
+The decision is rarely about a single field. A secure payment Pod may need a service account, non-root user, read-only root filesystem, memory limit, readiness probe, anti-affinity, and a controller above it. A disposable network test Pod may need only an image, a command, and a fast deletion path. Both are valid when their manifests match their purpose. The danger is using the disposable shape for a production service or using the production shape as a cargo-cult template without understanding the tradeoffs.
+
+When you are unsure, write down the recovery story in one paragraph before choosing the object. If a node disappears, who creates the replacement Pod and what state must move with it? If a rollout fails, what signal stops traffic and what signal triggers rollback? If the process leaks memory, will the node survive and will the evidence remain visible long enough to debug? These questions often reveal whether you are missing a controller, a probe, a resource boundary, or durable storage. The right Pod spec is the one whose failure behavior you can explain before the failure happens.
 
 ## Did You Know?
-1. The foundational concept and terminology of the "Pod" was inspired by the biological term for a tight-knit group of whales, fitting perfectly with Docker's iconic whale logo and Kubernetes' broader nautical and maritime theme.
-2. The `pause` container image, which quietly holds the vital network namespace open for every Pod across your entire global cluster, is incredibly tiny and optimized—compiled purely from low-level C, the resulting binary is typically far less than 700 kilobytes.
-3. In Kubernetes 1.28+, native support for true "Sidecar Containers" was finally introduced as a core built-in feature, fundamentally changing how init containers can be powerfully configured. They can now be formally instructed to run indefinitely alongside main workloads without blocking the startup sequence, solving an architectural headache for Service Meshes.
-4. If a container process unexpectedly exits with the exact code `137`, it mathematically means it received a highly fatal `SIGKILL` (signal 9) from the host Linux operating system. In a Kubernetes context, this undeniably guarantees the process was abruptly terminated by the node's OOM (Out Of Memory) Killer mechanism.
+1. Kubernetes introduced Pods in 2014 as a deliberate abstraction above individual containers, reflecting lessons from Google's earlier large-scale container orchestration systems.
+2. The pause container is tiny because its job is only to hold shared namespaces open, which makes Pod networking stable while ordinary containers restart.
+3. Native sidecar container behavior reached stable status in recent Kubernetes releases, including the Kubernetes 1.35 era targeted by this curriculum, after years of teams modeling long-running helpers with ordinary containers.
+4. Exit code 137 is conventionally 128 plus signal 9, which is why it strongly suggests a SIGKILL event such as the kernel OOM killer terminating a container.
 
 ## Common Mistakes
 
@@ -522,65 +320,55 @@ Now, opening `http://localhost:8080` in your local web browser will route the HT
 ## Quiz
 
 <details>
-<summary>1. Scenario: You have an entrenched legacy application that hardcodes its critical audit logs to a local file `/var/log/app.log`. Your organization's strict monitoring standard requires all logs to be streamed to standard output (`stdout`) for Fluentd collection. How should you architect the Pod to meet this requirement without rewriting a single line of the legacy application's C++ source code?</summary>
+<summary>1. Scenario: Your team deploys a Pod that stays `Pending` for 20 minutes. `k describe pod api` shows insufficient CPU and a node affinity mismatch. What layer failed, and what should you change first?</summary>
 
-**Answer:** Implement the Sidecar architectural pattern to solve this without modifying the legacy code. Deploy a multi-container Pod where the legacy application writes its logs to a shared `emptyDir` volume mount. Next, deploy a second sidecar container within the same Pod that mounts this shared volume and runs a continuous command like `tail -f /var/log/app.log`. Because the sidecar reads the file and outputs the data to its own `stdout` stream, the cluster's logging daemon can scrape it seamlessly. This approach successfully isolates the legacy codebase from modern infrastructure requirements.
+**Answer:** The failure is at scheduling time, not inside the application container. The scheduler cannot find a node that satisfies both the requested CPU and the placement rule, so logs will not help because the container may never have started. First review whether the CPU request reflects measured need and whether the hard affinity is truly required. If both are correct, add suitable node capacity or adjust node labels so the scheduler has a valid target.
 </details>
 
 <details>
-<summary>2. Scenario: Your new microservice Pod has been stuck in a `Pending` state for over 15 minutes. You run `kubectl describe pod my-microservice` and see the event: `0/50 nodes are available: 50 Insufficient cpu`. What is the root cause, and what are your two architectural options to resolve it?</summary>
+<summary>2. Scenario: A legacy application writes audit logs only to `/var/log/app.log`, but the platform collects stdout. How should you design the Pod without changing the application code?</summary>
 
-**Answer:** The root cause is that the Pod's requested CPU is higher than the available, unallocated CPU capacity on any single worker node across the cluster. The Scheduler evaluates these constraints mathematically and cannot find a node with enough space to accommodate it. To resolve this, you can decrease the CPU `requests` in the Pod's YAML specification if the application does not actually need that much compute. Alternatively, you can add a larger worker node to the cluster or trigger an autoscaling event to provide enough physical capacity. Both options ensure the Scheduler's resource equation can be satisfied.
+**Answer:** Use a sidecar pattern with a shared `emptyDir` volume. The legacy container writes the file into the shared mount, while the sidecar tails that file and writes each line to its own stdout. This design is appropriate because the helper needs local file sharing and should be replaced with the main application. It would be overkill to create a separate Service for a process whose only job is local log translation.
 </details>
 
 <details>
-<summary>3. Scenario: You are designing a Pod that needs to download a 500MB machine learning model from an S3 bucket before the main Python inference application starts serving traffic. What Kubernetes feature should you implement to guarantee the file is downloaded before the web server boots?</summary>
+<summary>3. Scenario: A Pod is `Running`, but users still receive errors during rollout because the application needs time to build caches and open database pools. Which probe should control traffic, and why?</summary>
 
-**Answer:** You should use an Init Container for this strict bootstrapping requirement. Define an Init Container with the `aws-cli` tool and mount an `emptyDir` volume shared with the main Python application. The Init Container runs the S3 download command into the shared volume and exits with a code of 0. Kubernetes guarantees the main container will not start until the Init Container successfully finishes, preventing the application from booting without its required data. By sharing the volume, the downloaded model is immediately available to the main container once it begins initialization.
+**Answer:** A readiness probe should control whether the Pod receives traffic. The process can be alive while still unable to serve correctly, and readiness failure removes the Pod from Service endpoints without restarting it. A liveness probe would be too aggressive for this dependency and could cause restart loops during normal warmup. If boot itself is slow, pair readiness with a startup probe so liveness checks do not begin too early.
 </details>
 
 <details>
-<summary>4. Scenario: A developer complains that their Node.js application restarts randomly under load. You inspect the Pod and see a Restart Count of 14, with the Last State indicating `Reason: OOMKilled` and `Exit Code: 137`. What kernel subsystem terminated the container, and what modification is required?</summary>
+<summary>4. Scenario: A container restarts repeatedly with no useful application logs. The last state shows `Reason: OOMKilled` and `Exit Code: 137`. What happened, and how do requests and limits influence the fix?</summary>
 
-**Answer:** The Linux kernel's Out Of Memory (OOM) Killer terminated the container. This occurred because the Node.js process attempted to allocate more RAM than permitted by the container's cgroup hard limit. To fix this permanently, you must edit the Pod's declarative YAML manifest and increase the `resources.limits.memory` value. However, you should also ensure the application is not suffering from a continuous memory leak before simply raising the limit. Addressing the underlying memory usage is just as important as adjusting the cgroup boundary.
+**Answer:** The process exceeded its memory cgroup limit and the kernel killed it with SIGKILL, which Kubernetes recorded as exit code 137. Raising the memory limit may stop the immediate restarts, but it should be based on observed memory behavior rather than guesswork. The memory request affects scheduling capacity, while the memory limit defines the hard ceiling. A good fix reviews the application memory pattern, adjusts request and limit values, and checks for a leak.
 </details>
 
 <details>
-<summary>5. Scenario: Two separate containers are defined in the same Pod. Container A runs an Nginx web server on port 80. Container B runs a Prometheus metrics exporter that needs to scrape the status page from Container A. What hostname and port should Container B use in its HTTP request to connect to Container A?</summary>
+<summary>5. Scenario: A security review rejects a Pod because the image starts as root and has a writable filesystem. What manifest fields reduce the risk, and what side effect should you plan for?</summary>
 
-**Answer:** Container B should make its HTTP request directly to `http://localhost:80`. This is perfectly possible because all containers within a single Pod share the same network namespace provided by the `pause` container. They can communicate with each other over the loopback interface just as if they were isolated processes running on the exact same physical server. There is no need to use complex external service names or external cluster IPs. This shared networking model significantly simplifies intra-Pod architecture and reduces communication latency.
+**Answer:** Add a `securityContext` that sets `runAsNonRoot: true`, disables privilege escalation, drops unnecessary capabilities, and makes the root filesystem read-only. These settings reduce the blast radius if the application is compromised because the process has fewer kernel privileges and cannot freely write into the image layer. The side effect is that applications needing scratch space must receive an explicit writable volume such as `emptyDir` mounted at `/tmp` or another known path. The image may also need a non-root user configured before the Pod can start.
 </details>
 
 <details>
-<summary>6. Scenario: You notice a production Pod is stuck in `CrashLoopBackOff`. You run `kubectl logs my-failing-pod`, but the terminal output is completely blank. Why might the logs be empty, and how can you determine why the container failed to start?</summary>
+<summary>6. Scenario: Two containers in one Pod need to communicate. One serves HTTP on port 80, and the other scrapes it every few seconds. What address should the scraper use, and what mistake must it avoid?</summary>
 
-**Answer:** The logs might be blank because the application crashed before it could initialize and write any data to standard output. This often happens if the container image is physically missing the entrypoint executable or if a file permission error prevents the process from launching. To investigate, you should use `kubectl describe pod my-failing-pod` and look deeply at the State and Events sections. These sections will reveal the raw exit code or any underlying container runtime errors that definitively explain the failure. Diagnosing these early failures is critical because application-level logs simply cannot be generated if the process fails to start.
+**Answer:** The scraper can use `http://localhost:80` because containers in the same Pod share the network namespace. That shared namespace is provided by the Pod sandbox, so loopback traffic stays inside the Pod and does not require a Service. The mistake to avoid is binding the scraper itself to the same port, because port numbers are unique across the whole Pod. If both containers need listeners, assign distinct ports.
 </details>
 
 <details>
-<summary>7. Scenario: You used the imperative command `kubectl run test-pod --image=nginx` to test network connectivity. Ten minutes later, the worker node your Pod was scheduled on suffers a hardware failure and loses power. What will happen to your `test-pod`?</summary>
+<summary>7. Scenario: An engineer hotfixes a naked Pod with an imperative command during an incident, but the change never reaches Git. A node failure happens later. What should you expect, and what workflow prevents it?</summary>
 
-**Answer:** Your `test-pod` will be permanently lost and will not recover on its own. Because the Pod was created imperatively as a naked, unmanaged resource, it is not monitored or governed by a higher-level autonomous controller like a Deployment or ReplicaSet. The control plane will eventually notice the node is dead and mark the Pod's state as `Terminating`. It will not automatically recreate or reschedule the Pod onto a healthy node. This demonstrates exactly why declarative management and controllers are strictly required for production workloads.
-</details>
-
-<details>
-<summary>8. Scenario: A security audit reveals that an attacker escaped an application container and executed a remote code payload because the container was running as the root user. What YAML configuration must you add to the Pod manifest to prevent this?</summary>
-
-**Answer:** You must add a `securityContext` block to the Pod or container specification to implement least privilege. Specifically, add `runAsNonRoot: true` to mandate that the container runtime executes the process as an unprivileged user. Additionally, setting `readOnlyRootFilesystem: true` forcefully prevents an attacker from downloading destructive payload binaries directly onto the container disk. These settings drastically reduce the viable attack surface area by constraining what the compromised process can physically do. Properly applying these context rules hardens the overall cluster against dangerous lateral movement.
+**Answer:** The original naked Pod will not be recreated by itself when the node is lost, and any replacement created from old manifests will lose the manual hotfix. Imperative state is temporary unless it is captured in the declarative source of truth. The correct workflow is to update the manifest, review it, apply it through the normal delivery path, and let a controller manage replacement Pods. Temporary imperative commands are acceptable for diagnosis, but they should not become production configuration.
 </details>
 
 ## Hands-On Exercise: The Ultimate Multi-Container Debugging Challenge
 
-In this hands-on exercise, you will create a multi-container Pod, physically inspect its shared namespaces using native tools, intentionally introduce a fatal configuration error, and systematically use native diagnostic commands to uncover the deep root cause of the failure.
+In this hands-on exercise, you will create a multi-container Pod, inspect its shared namespace behavior, trigger an intentional memory failure, and practice the diagnostic sequence used during real incidents. Work in a disposable namespace or local training cluster, and keep using the `k` alias so your commands match the rest of the Kubernetes basics track.
 
 <details>
 <summary>Task 1: Declarative Multi-Container Creation</summary>
 
-Write a declarative YAML manifest named `multi-pod.yaml` that creates a single Pod containing two communicating containers. 
-- The Pod name should be `web-logger`.
-- Container 1: Name it `nginx-server`, use the `nginx:1.27-alpine` public image, and mount a shared volume named `html-dir` at the path `/usr/share/nginx/html`.
-- Container 2: Name it `content-writer`, use the `busybox:1.36.1` public image. It must mount the same `html-dir` volume at the path `/data`. Its primary command should be a continuous shell loop that writes the current date and time to `/data/index.html` every 5 seconds. *(Hint for the command array: `["/bin/sh", "-c", "while true; do date > /data/index.html; sleep 5; done"]`)*
-- The shared volume must be of type `emptyDir: {}`.
+Write a declarative YAML manifest named `multi-pod.yaml` that creates a single Pod containing two communicating containers. The Pod name should be `web-logger`. The first container should be named `nginx-server`, use the `nginx:1.27-alpine` public image, and mount a shared volume named `html-dir` at `/usr/share/nginx/html`. The second container should be named `content-writer`, use the `busybox:1.36.1` public image, mount the same volume at `/data`, and continuously write the current date to `/data/index.html` every 5 seconds. The shared volume must be an `emptyDir`.
 
 **Solution:**
 ```yaml
@@ -610,29 +398,29 @@ spec:
 <details>
 <summary>Task 2: Apply and Verify the Architecture</summary>
 
-Apply the declarative manifest to your local cluster. Verify that the Pod systematically transitions through the `Pending` phase into the `Running` state and that *both* containers are reported as ready. Finally, use port-forwarding to dynamically create a secure tunnel and continuously view the generated webpage on your local browser.
+Apply the declarative manifest to your local cluster. Verify that the Pod transitions through `Pending` into `Running`, confirm both containers become ready, and then use port-forwarding to view the generated page through the API server tunnel.
 
 **Solution:**
 ```bash
 # Apply the declarative manifest to the API Server
-kubectl apply -f multi-pod.yaml
+k apply -f multi-pod.yaml
 
 # Wait for the pod to become fully ready
-kubectl wait --for=condition=Ready pod/web-logger --timeout=60s
+k wait --for=condition=Ready pod/web-logger --timeout=60s
 ```
 
 Open a new terminal window, or background the port-forward process to test it:
 
 ```bash
 # Establish a secure port-forward tunnel to the Pod in the background
-kubectl port-forward pod/web-logger 8080:80 &
+k port-forward pod/web-logger 8080:80 &
 
 # Wait a moment for the tunnel to establish
 sleep 2
 
 # Curl the local port to verify
 curl http://localhost:8080
-# You should see the current date and time printed, updating every 5 seconds!
+# You should see the current date and time printed, updating every 5 seconds.
 
 # Terminate the background port-forward process
 kill %1
@@ -642,33 +430,33 @@ kill %1
 <details>
 <summary>Task 3: Interactive Namespace Exploration</summary>
 
-The `content-writer` container is continuously overwriting the physical file on the shared disk. Use `kubectl exec` to securely drop into an interactive root shell inside the `nginx-server` container. Once inside, manually install the `curl` utility and make a local HTTP request perfectly to `localhost:80`. Why does this miraculously work across container boundaries?
+The `content-writer` container continuously overwrites the physical file on the shared volume. Use `k exec` to open an interactive shell inside the `nginx-server` container. Once inside, install `curl` and make a local HTTP request to `localhost:80`. Explain why this works across container boundaries.
 
 **Solution:**
 ```bash
 # Execute an interactive shell inside the specific container
-kubectl exec -it web-logger -c nginx-server -- /bin/sh
+k exec -it web-logger -c nginx-server -- /bin/sh
 ```
 
 Once inside the container's interactive shell, execute the following:
 
 ```bash
-# Inside the container's isolated mount namespace, quickly install curl
+# Inside the container's isolated mount namespace, install curl
 apk add --no-cache curl
 
-# Curl the incredibly local network interface
+# Curl the local network interface shared by the Pod
 curl http://localhost:80
 
 # Exit the container gracefully
 exit
 ```
-*Exactly why it works: Even though we executed directly into the `nginx-server` container's specific filesystem namespace, it is actively listening on port 80 of the overall Pod's shared network namespace. The fast local loopback interface (`localhost`) is shared equally among all active containers residing within the Pod thanks to the foundational `pause` container architecture.*
+Even though you entered the `nginx-server` container's filesystem namespace, Nginx listens on port 80 of the Pod's shared network namespace. The loopback interface is shared by all containers in the Pod, while the mounted volume lets one container write the file another container serves.
 </details>
 
 <details>
 <summary>Task 4: Intentionally Triggering an OOMKilled Event</summary>
 
-Let's intentionally break a new Pod to intimately observe harsh kernel behavior. Create a completely new file called `oom-pod.yaml`. Define a Pod that runs the `polinux/stress` image to generate load. Give it a strict memory limit of `50Mi`. Set the container command explicitly to `["stress", "--vm", "1", "--vm-bytes", "150M", "--vm-hang", "1"]`. Apply the file and watch its lifecycle status.
+Create a new file named `oom-pod.yaml`. Define a Pod that runs the `polinux/stress` image, give it a strict memory limit of `50Mi`, and set the command to allocate more memory than the cgroup permits. Apply the file and watch its lifecycle status.
 
 **Solution:**
 ```yaml
@@ -688,41 +476,60 @@ spec:
 ```
 ```bash
 # Apply the doomed pod to the cluster
-kubectl apply -f oom-pod.yaml
+k apply -f oom-pod.yaml
 
-# Watch the carnage unfold (wait a few seconds for the crash)
+# Watch the failure unfold after the process asks for too much memory
 sleep 5
-kubectl get pod memory-hog
+k get pod memory-hog
 ```
-*You will briefly see it change to `Running`, and then almost immediately transition permanently to `OOMKilled`, followed by the frustrating `CrashLoopBackOff` cycle. The container software explicitly asked the Linux kernel to allocate precisely 150 Megabytes of RAM, but Kubernetes configured the cgroup hard limit to exactly 50 Megabytes. The kernel instantly terminated the rogue process.*
+You should briefly see the Pod run and then observe a restart cycle. The process asks the kernel for substantially more memory than the configured cgroup permits, so the kernel terminates it to protect the node.
 </details>
 
 <details>
 <summary>Task 5: Forensically Diagnosing the Death</summary>
 
-Use the incredibly detailed `kubectl describe` command to forensically prove exactly *why* the `memory-hog` Pod died. Find the exact mathematical Exit Code and String Reason to present to your senior engineering team.
+Use `k describe` to prove why the `memory-hog` Pod died. Find the exact reason and exit code in the container's last state, and connect that result back to the memory limit in the manifest.
 
 **Solution:**
 ```bash
 # Extract the forensic log of the dead pod
-kubectl describe pod memory-hog
+k describe pod memory-hog
 ```
-*Scroll down to the `Containers:` section, carefully locate the `stress-test` container definition, and look intimately at the `Last State:` data block. You will clearly see `Reason: OOMKilled` directly alongside `Exit Code: 137`. This is the exact smoking gun you desperately look for in massive production outages.*
+Scroll to the `Containers:` section, locate the `stress-test` container, and inspect the `Last State:` block. The important evidence is `Reason: OOMKilled` alongside `Exit Code: 137`, which shows that the kernel killed the process after it exceeded the configured memory limit.
 </details>
 
 <details>
 <summary>Task 6: Systematic Clean Up</summary>
 
-Cleanly delete both completely broken Pods created during this exercise to immediately free up valuable cluster resources for your colleagues.
+Cleanly delete both Pods created during this exercise to free cluster resources and leave the training environment ready for the next module.
 
 **Solution:**
 ```bash
 # Delete the pods, returning the cluster to a clean state
-kubectl delete pod web-logger memory-hog --force --grace-period=0
+k delete pod web-logger memory-hog --force --grace-period=0
 ```
 </details>
 
-## Next Module
-Now that you comprehensively understand the absolute atomic unit of execution in the Kubernetes ecosystem, you might be legitimately wondering: "If Pods are ephemeral and die when underlying nodes fail, how do I reliably keep my enterprise application running smoothly? How do I effortlessly scale from exactly 1 Pod to 1,000 Pods without ever writing 1,000 separate YAML files?" 
+Success criteria:
+- [ ] You created a declarative multi-container Pod that uses a shared `emptyDir` volume.
+- [ ] You verified both containers became ready and served changing content through `localhost` and port-forwarding.
+- [ ] You explained why Pod containers can share loopback networking while keeping separate filesystems.
+- [ ] You triggered and diagnosed an `OOMKilled` restart using `k describe` and exit code 137.
+- [ ] You cleaned up both disposable Pods without leaving training resources behind.
 
-The profound, architectural answer lies purely in higher-level, highly autonomous control loops. In **[Module 1.4: Deployments](/prerequisites/kubernetes-basics/module-1.4-deployments/)**, we will formally and deeply introduce the immensely powerful Kubernetes Deployment object—the algorithmic engine that tirelessly watches over your Pods, resurrects them when they inevitably die, and seamlessly enables zero-downtime rolling updates to your entire fleet.
+## Sources
+- [Kubernetes Pods](https://kubernetes.io/docs/concepts/workloads/pods/)
+- [Pod Lifecycle](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/)
+- [Init Containers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/)
+- [Sidecar Containers](https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/)
+- [Ephemeral Containers](https://kubernetes.io/docs/concepts/workloads/pods/ephemeral-containers/)
+- [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+- [Pod Quality of Service Classes](https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/)
+- [Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+- [Configure Liveness, Readiness, and Startup Probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
+- [Volumes](https://kubernetes.io/docs/concepts/storage/volumes/)
+- [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
+- [Assign Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/)
+
+## Next Module
+Now that you can reason about the Pod as the atomic unit, the next question is how production systems keep enough Pods alive through failures, updates, and scale changes. In **[Module 1.4: Deployments](/prerequisites/kubernetes-basics/module-1.4-deployments/)**, you will learn how Deployment controllers create, replace, and roll out Pods without treating individual Pods as permanent pets.


### PR DESCRIPTION
## Summary
- Rewrote `src/content/docs/prerequisites/kubernetes-basics/module-1.3-pods.md` for #388 density, structure, alignment, and anti-leak gates.
- Cleared `revision_pending: false` in frontmatter.

## Verifier
- `T0`; body_words=5205, mean_wpp=91.3, median_wpp=95, short_rate=0.018, max_run=1, mean_sentence_length=21.5.
- Density, structure, alignment, anti_leak, and sources_min_10 gates pass; source reachability was skipped per command.

## Protected Assets
- Preserved counts before -> after: code blocks 14 -> 14, Mermaid diagrams 4 -> 4, markdown tables 2 -> 2, ASCII diagram groups 2 -> 2.
- Original lab URL retained; Sources section now includes 12 Kubernetes primary documentation URLs.

## Checks
- `../../.venv/bin/python scripts/quality/verify_module.py --glob src/content/docs/prerequisites/kubernetes-basics/module-1.3-pods.md --skip-source-check --summary --quiet` passed T0.
- `git diff --check -- src/content/docs/prerequisites/kubernetes-basics/module-1.3-pods.md` clean.
- Forbidden-token/number scan clean.
- `../../.venv/bin/python scripts/test_pipeline.py` passed: 166 tests OK.
- `npm run build` not run: the primary checkout is already dirty with unrelated local changes and cannot be safely switched for the branch build without touching user work.

Commit: 3fbfd071