### PR TITLE
feat(388): rewrite module-1.8-yaml-kubernetes (#388 pilot)

### DIFF
--- a/src/content/docs/prerequisites/kubernetes-basics/module-1.8-yaml-kubernetes.md
+++ b/src/content/docs/prerequisites/kubernetes-basics/module-1.8-yaml-kubernetes.md
@@ -3,46 +3,41 @@ title: "Module 1.8: YAML for Kubernetes"
 slug: prerequisites/kubernetes-basics/module-1.8-yaml-kubernetes
 sidebar:
   order: 9
+revision_pending: false
 ---
 
 # Module 1.8: YAML for Kubernetes
 
 **Complexity:** [MEDIUM]  
-**Time to Complete:** 45-60 minutes  
-**Prerequisites:** Modules 1.1-1.7 (familiarity with K8s resources)
+**Time to Complete:** 60-75 minutes
+**Prerequisites:** Modules 1.1-1.7, including basic Kubernetes resources, pods, services, deployments, labels, and the `kubectl` workflow
+**Command convention:** This module uses the short alias `k` for `kubectl`; set it once with `alias k=kubectl` before running the examples.
 
 ## Learning Outcomes
 
-By the end of this comprehensive module, you will be able to:
+By the end of this module, you will be able to:
 
-1. **Construct** structurally sound Kubernetes manifests using fundamental YAML syntax, including scalars, sequences, mappings, and complex multi-line strings.
-2. **Deconstruct** the four mandatory fields of every Kubernetes resource (`apiVersion`, `kind`, `metadata`, `spec`) to evaluate their distinct roles in declarative state management.
-3. **Diagnose** structural, schema, and type validation errors in YAML files by interpreting output from `kubectl apply --dry-run` and traversing the cluster's OpenAPI schema using `kubectl explain`.
-4. **Design** complex, multi-resource deployment configurations utilizing advanced YAML patterns like document separators, environment variable injections, and persistent volume mounts.
-5. **Compare** client-side and server-side validation strategies to implement safe, reliable continuous deployment pipelines for Kubernetes applications.
+1. **Construct** structurally sound Kubernetes manifests using YAML scalars, mappings, sequences, multi-line strings, and multi-document files.
+2. **Deconstruct** the required Kubernetes manifest fields `apiVersion`, `kind`, `metadata`, and `spec` so you can explain how they route declarative state through the API server.
+3. **Diagnose** YAML syntax, schema, and type validation failures by combining dry-run output, `k explain`, and targeted inspection of nested manifest paths.
+4. **Design** multi-resource application manifests that connect Deployments, Services, ConfigMaps, environment variables, labels, selectors, and volume mounts.
+5. **Compare** client-side validation, server-side validation, and diff workflows to choose the safest verification step before applying a production change.
 
 ## Why This Module Matters
 
-In 2021, a highly publicized production incident struck a rapidly growing fintech platform during a period of peak transaction volume. While attempting to scale their backend processing services to handle a massive influx of user traffic, a platform engineer deployed an updated Kubernetes manifest. The deployment was intended to increase pod replicas and adjust resource limits safely. However, a single, misplaced space in the YAML file shifted a critical container argument from a sequence item into a nested dictionary key. The Kubernetes API server accepted the technically valid YAML, but the container runtime failed to parse the execution arguments, causing the transaction pods to fall into a continuous CrashLoopBackOff state. This tiny syntactical error resulted in a 45-minute outage during a critical trading window, costing the company an estimated $2.5 million in lost revenue and causing significant reputational damage.
+In 2021, a fast-growing fintech platform entered a trading window with customer traffic already above its normal peak. A platform engineer pushed what looked like a routine Kubernetes manifest update: raise the replica count, adjust container arguments, and increase memory limits for the backend processors. One extra indentation level moved a command-line argument out of the container argument list and into a nested mapping. The YAML parser accepted the document, the review looked visually plausible, and the deployment moved forward, but the containers crashed as soon as the runtime tried to start them. The outage lasted 45 minutes, interrupted live transaction processing, and produced an estimated $2.5 million business impact before the team traced the failure back to a small structural mistake.
 
-**War Story: The Folded Certificate Catastrophe**
-In another infamous incident at a major European banking institution in 2019, an infrastructure engineer updated a TLS certificate stored as a Secret in their production Kubernetes cluster. Instead of using the literal block scalar (`|`) to precisely preserve the certificate's strict newlines, they accidentally used the folded block scalar (`>`). When Kubernetes mounted this Secret into the Ingress controller, the entire certificate was parsed as a single, massive string separated by spaces instead of the required newlines. The Ingress controller, completely unable to parse the malformed PEM data, crashed repeatedly. Because this was the primary ingress for the entire banking API, it caused a two-hour total global outage, preventing millions of users from accessing their funds. A single character difference (`>` vs `|`) completely bypassed basic YAML syntax checks because the YAML itself was structurally valid—it just silently corrupted the application data.
+That kind of incident feels unfair until you remember what YAML does in Kubernetes. YAML is not just a convenient file format for humans; it is the front door to the API server's declarative contract. A manifest is converted into structured data, validated against an OpenAPI schema, admitted through policy, persisted as desired state, and then reconciled by controllers. If the structure says the wrong thing, Kubernetes will faithfully pursue the wrong instruction or reject the request at the point where it can no longer interpret your intent. The discipline you build here is the discipline that keeps routine configuration work from becoming a production event.
 
-YAML (YAML Ain't Markup Language) is the undisputed lingua franca of Kubernetes. It is the exclusive language you use to communicate your precise desired state to the control plane. While the Kubernetes API server can technically consume JSON payloads, YAML is the human-readable standard embraced by the entire cloud-native ecosystem. However, its heavy reliance on significant whitespace and subtle syntactical rules makes it a dangerous minefield for the uninitiated. Mastering YAML is not just about learning a configuration language; it is about learning how to safely, precisely, and predictably interface with the Kubernetes API. This module will transform YAML from a source of endless frustration into a powerful, predictable tool for declarative infrastructure management.
+There is another class of failure that is even quieter. In 2019, a European financial institution rotated a TLS certificate through a Kubernetes Secret and used YAML's folded block scalar by mistake. The file was valid YAML, the Secret was created, and the rollout continued, but the folded scalar replaced certificate newlines with spaces. The ingress controller received a malformed PEM payload, failed to load its certificate, and repeatedly restarted while external banking APIs were unavailable. A single character, `>` instead of `|`, did not break YAML syntax; it changed the application data that YAML carried.
+
+This module teaches YAML as an operational interface, not as decorative syntax. You will learn the three YAML shapes that appear in every manifest, the four root fields Kubernetes uses to route objects, the schema tools that prevent guessing, and the validation workflow that turns manifest review into an engineering practice. The goal is not memorizing every field in Kubernetes 1.35; the goal is knowing how to reason from structure to schema to controller behavior when the cluster is about to act on your file.
 
 ## 1. YAML Fundamentals for Infrastructure
 
-Before diving into the complex, nested schemas specific to Kubernetes, you must first master the core data structures of the YAML specification. YAML is a data serialization language explicitly designed to be directly readable by humans while mapping effortlessly to native data structures in modern programming languages (such as dictionaries, lists, and strings). It removes the visual clutter of brackets and braces found in JSON, replacing them with strict indentation rules. This makes it heavily preferred over XML or raw JSON for infrastructure-as-code tasks where human readability and support for inline comments are paramount.
+YAML exists because infrastructure configuration has to be both machine-readable and reviewable by humans under time pressure. JSON is explicit, but large JSON manifests are visually noisy because every nested object needs braces, quotes, and commas. YAML removes much of that punctuation and lets indentation carry the hierarchy, which makes ordinary review easier but also makes whitespace part of the data model. A Kubernetes manifest is therefore closer to a carefully folded map than a casual note: the shape of each line tells the parser what belongs to what.
 
-### Scalars, Mappings, and Sequences
-
-At its absolute lowest level, every YAML file is constructed from exactly three primitive data structures. By combining and nesting these structures, you can represent incredibly complex architectural states.
-
-1. **Scalars:** These are single, irreducible values. They represent strings of text, integers, floating-point numbers, or booleans. They are the leaves of the data tree, holding the actual configuration values (like port numbers or replica counts).
-2. **Mappings (Dictionaries/Hashes):** These are collections of key-value pairs. They define the properties and attributes of an object. In Kubernetes, you will use mappings constantly to define metadata, labels, and specifications. Every key in a mapping must be unique within that specific indentation block.
-3. **Sequences (Lists/Arrays):** These are ordered collections of items. You use sequences whenever a configuration field expects multiple values, such as a list of containers inside a pod, a list of environment variables, or a list of ports exposed by a service. Sequence items are always denoted by a leading hyphen (`-`).
-
-These foundational structures can be infinitely nested to represent the complex systems required by modern microservices architectures:
+At the lowest level, YAML gives you three building blocks. A scalar is a single value such as `nginx:1.27`, `8080`, `true`, or `"production"`. A mapping is a collection of unique keys and values, the same idea as a dictionary or hash map in a programming language. A sequence is an ordered list, and every item in that list begins with a hyphen at the correct indentation level. Kubernetes resources combine these three shapes again and again until they describe a complete workload.
 
 ```yaml
 # This is a Mapping at the root level
@@ -68,21 +63,17 @@ users:
       - read
 ```
 
-**Crucial Rule:** YAML relies entirely on spaces for indentation to denote hierarchy and structure. **Tabs are strictly, unequivocally forbidden.** A standard and unbreakable convention in the Kubernetes ecosystem is to use exactly **two spaces** per indentation level. A single misaligned space will fundamentally change the entire data structure, often leading to schema validation failures or, worse, unexpected runtime behavior. When collaborating in enterprise environments, it is imperative to configure your IDE (like VSCode or IntelliJ) to strictly enforce space-based indentation.
+Read that example as a tree rather than as text. The root contains three mapping keys, `server`, `port`, and `is_active`, followed by two larger keys whose values contain nested structures. `allowed_origins` is a sequence of scalar strings, while `users` is a sequence of mappings, and each user mapping contains another sequence under `permissions`. Kubernetes uses exactly this nesting style for fields like `containers`, `env`, `ports`, `volumeMounts`, and `rules`, so the ability to identify the expected shape is more valuable than memorizing a particular manifest.
 
-> **Pause and predict**: 
-> Look at the `users` block above. How many items are in the `users` sequence? What type of data does the `permissions` key hold?
-> <details>
-> <summary>Reveal Answer</summary>
-> The `users` sequence has 2 items (mappings for alice and bob). The `permissions` key holds a Sequence (list) of string scalars.
-> </details>
+The most important rule is also the easiest to underestimate: YAML indentation uses spaces, not tabs, and the Kubernetes convention is two spaces per level. Tabs are not a stylistic disagreement in YAML; they are invalid indentation. A one-space drift can also change meaning without looking dramatic in a pull request, especially when a nested sequence item is visually close to the field above it. Configure your editor to render whitespace, convert tabs to spaces, and format YAML with two-space indentation before you rely on visual review.
+
+Pause and predict: in the `users` block above, how many items are in the `users` sequence, and what type of data does `permissions` hold? There are two user items, and each item is a mapping. The `permissions` value is a sequence of scalar strings. If you answered by counting hyphens at the same indentation level, you used the same structural habit you need when reviewing Kubernetes `containers`, `ports`, and `env` blocks.
 
 ### Multi-Line Strings: The `|` and `>` Operators
 
-When passing complex configuration files, bash scripts, or cryptographic certificates into Kubernetes ConfigMaps or Secrets, you will frequently need to embed multi-line strings directly into your YAML manifests. Handling multi-line text cleanly is one of YAML's greatest strengths over JSON, but it requires precise operator selection. YAML provides two distinct block scalar indicators for managing multi-line text:
+YAML becomes especially useful in Kubernetes when you need to carry text that already has internal structure. ConfigMaps often contain application configuration files, shell scripts, or web server snippets. Secrets can contain certificate material, private key text, or configuration fragments that must keep exact line boundaries after decoding. JSON can represent that data, but it forces escaped newline characters into a single string, while YAML can embed the text in a readable block.
 
-*   **Literal Block Scalar (`|`):** This operator preserves all newlines and exact formatting precisely as written. This is what you must use 99% of the time for embedded scripts, configuration files (like `nginx.conf`), or PEM-encoded TLS certificates. It instructs the parser to treat the exact text block as a literal string.
-*   **Folded Block Scalar (`>`):** This operator folds consecutive newlines into spaces, creating a single long string, unless it encounters a completely blank line. This is primarily useful for writing long, readable descriptions that should be treated as a single continuous paragraph by the application, preventing horizontal scrolling in your code editor.
+YAML has two block scalar operators that look similar and behave very differently. The literal block scalar, `|`, preserves newlines and indentation inside the block. The folded block scalar, `>`, folds ordinary line breaks into spaces while preserving paragraph breaks around blank lines. That makes `>` useful for long descriptions and almost always wrong for scripts, certificates, kubeconfig fragments, and any data where the receiving program treats newlines as syntax.
 
 ```yaml
 # Literal (|) - Preserves structure perfectly for a script
@@ -100,20 +91,13 @@ description: >
   continuous string of text.
 ```
 
-Understanding the distinct behavior of these two operators is critical for preventing the kind of catastrophic data corruption detailed in the war story at the beginning of this module. A misapplied folded scalar will silently mangle structured data.
+The operational consequence is simple: choose the scalar based on what the application expects, not on what is easier to read in your editor. A shell script mounted from a ConfigMap needs `|` because the shell reads one command line after another. A TLS certificate needs `|` because PEM boundaries and base64 line breaks are meaningful to many parsers. A human-readable annotation that an external dashboard displays as a paragraph can use `>` because the consumer wants one flowing string.
 
-> **Stop and think**: 
-> If you are embedding a `.pem` certificate key into a Kubernetes Secret, which multi-line operator MUST you use and why?
-> <details>
-> <summary>Reveal Answer</summary>
-> You MUST use the literal block scalar (`|`). Certificates rely on strict newline boundaries (e.g., `-----BEGIN CERTIFICATE-----` followed by a newline). If you use `>`, it will fold the certificate into one invalid line.
-> </details>
+Stop and think: if you are embedding a `.pem` certificate key into a Kubernetes Secret, which operator must you use and why? Use the literal block scalar, `|`, because a certificate is structured text with newline boundaries that must survive serialization. If you use `>`, the manifest may pass YAML parsing and still deliver corrupt application data, which is more dangerous than a syntax error because the failure appears later in the rollout.
 
 ### Advanced YAML: Anchors (`&`) and Aliases (`*`)
 
-While less common in standard, vanilla Kubernetes manifests due to the heavy industry preference for external templating tools like Helm or Kustomize, native YAML explicitly supports DRY (Don't Repeat Yourself) principles through the use of anchors and aliases. This native capability can drastically reduce redundancy when writing large manifests by hand.
-
-An anchor (denoted by `&`) defines a reusable chunk of YAML, assigning it a name. An alias (denoted by `*`) injects that exact chunk of YAML elsewhere in the document. When combined with the merge key (`<<`), you can powerfully compose and inherit configurations without duplicating lines of code. This is particularly useful for applying a common set of foundational labels across dozens of discrete resources within a single file.
+YAML also includes anchors and aliases, a native reuse feature that lets one part of a document refer to another part. An anchor, marked with `&`, names a reusable mapping or value. An alias, marked with `*`, expands that anchored value elsewhere. Combined with the merge key `<<`, anchors can reduce repeated labels or configuration fragments in hand-authored YAML, although many Kubernetes teams prefer Kustomize, Helm, or another purpose-built tool for larger reuse patterns.
 
 ```yaml
 # Define an anchor named 'common_labels'
@@ -134,7 +118,7 @@ backend_pod:
     name: node-api
 ```
 
-When the YAML parser processes this document, it resolves the alias and expands the data structure dynamically in memory. The resulting output, if converted to JSON for API consumption, demonstrates how the inherited labels are successfully merged alongside the unique `name` field, maintaining a perfectly flat dictionary structure:
+When a YAML parser resolves that document, it expands the alias before Kubernetes receives the object. The API server does not store an anchor as a special Kubernetes feature; it receives the resulting mapping. That distinction matters when debugging because an error from the API server refers to the expanded object shape, not to your reuse shortcut. Anchors can be useful in a small local exercise, but in shared production repositories they can make review harder if teammates are not expecting implicit expansion.
 
 ```json
 {
@@ -145,25 +129,11 @@ When the YAML parser processes this document, it resolves the alias and expands 
 }
 ```
 
-> **Pause and predict**: 
-> Look at the `frontend_pod` structure above. If you were to convert that YAML into JSON, what would the resulting JSON object look like for `frontend_pod.metadata`?
-> <details>
-> <summary>Reveal Answer</summary>
-> 
-> ```json
-> {
->   "app": "web-tier",
->   "environment": "production",
->   "managed-by": "platform-team",
->   "name": "react-frontend"
-> }
-> ```
-> The merge key expands the dictionary inline.
-> </details>
+Pause and predict: after expansion, what does `frontend_pod.metadata` contain? It contains the three shared labels from `common_labels` plus the explicit `name: react-frontend` key. The merge keeps the mapping flat, which is why the JSON representation above has four sibling keys rather than a nested `base_labels` object.
 
 ## 2. The Anatomy of a Kubernetes Manifest
 
-Every single resource you create, modify, or delete in Kubernetes—from a simple stateless Pod to a massively complex CustomResourceDefinition (CRD) managing a globally distributed database cluster—requires exactly four root-level fields. These fields form the absolute baseline contract between your infrastructure-as-code repository and the cluster control plane. If any one of these four fields is missing or malformed, the Kubernetes API server will reject the payload immediately, failing fast before any deeper structural validation occurs. Understanding these four foundational pillars is the master key to declarative state management.
+Once YAML gives you a data tree, Kubernetes needs to know what that tree represents. Every ordinary Kubernetes object starts with a small root-level contract: `apiVersion`, `kind`, `metadata`, and usually `spec`. Those fields are not decoration. They tell the API server which schema to use, which object type to route to, how to identify the object, and what desired state the controllers should reconcile. If the root contract is missing or contradictory, the cluster cannot safely interpret the manifest.
 
 ```mermaid
 flowchart LR
@@ -182,64 +152,41 @@ flowchart LR
     style D text-align:left
 ```
 
-Let us meticulously deconstruct each of these four mandatory fields to thoroughly understand their role in the Kubernetes asynchronous reconciliation loop:
+The `apiVersion` field selects the API group and version that define the resource schema. Core resources such as Pods, Services, ConfigMaps, and Secrets use `v1` because they belong to the core API group. Deployments use `apps/v1`, Ingresses use `networking.k8s.io/v1`, and many operators add custom API groups for their own resources. The slash in `apps/v1` is not a path separator in a file system; it separates the group from the version so Kubernetes can choose the correct schema and storage strategy.
 
-### 1. `apiVersion`
-This field explicitly tells the Kubernetes API server which exact version of the schema it must use to validate the payload. The Kubernetes APIs are constantly evolving and iterating. A new experimental resource type might be introduced in `v1alpha1`, graduate after extensive field testing to `v1beta1`, and finally stabilize as `v1`. The `apiVersion` dictates exactly what fields are fundamentally allowed in the rest of the manifest. API Group names are also included here to prevent naming collisions (for example, `apps/v1` for Deployments, or `networking.k8s.io/v1` for Ingresses). If there is no slash present, the resource belongs to the legacy "core" group (e.g., just `v1` for Pods, Services, and ConfigMaps).
+The `kind` field names the type of object inside that API version. `Deployment`, `Service`, `Pod`, `Job`, `StatefulSet`, and `Ingress` are different kinds, and each one has its own expected `spec` structure. A common beginner error is pairing a valid kind with the wrong API version, such as `kind: Deployment` under `apiVersion: v1`. That is not a small typo; it asks the core API group to recognize an object it does not own, so the server returns a "no matches for kind" error.
 
-*Worked Example:* As of Kubernetes v1.35, the standard `Deployment` resource is firmly rooted in `apps/v1`. If you attempt to create a `Deployment` object but incorrectly specify `apiVersion: v1`, the API server will reject it outright because Deployments are strictly governed by the `apps/v1` schema, not the core API group.
+The `metadata` field gives the object identity and the metadata that other controllers and tools use to find it. The `name` must be unique for that resource kind within a namespace. The `namespace` scopes names and policies, and omitting it means the object lands in the current or default namespace, depending on the command context. Labels are structured key-value pairs used by selectors, while annotations hold non-identifying metadata for tools, controllers, and humans. Treat labels as routing and grouping inputs, and treat annotations as descriptive or integration metadata unless a specific controller documents otherwise.
 
-### 2. `kind`
-This field declares the specific type of object you are attempting to create (e.g., `Pod`, `Service`, `Deployment`, `StatefulSet`, `Ingress`, `Job`). It is always formatted in PascalCase (capitalized camel case). The `kind` fundamentally tells the API server which specific backend controller should take ownership of this resource and begin managing its lifecycle.
+The `spec` field declares desired state, which is the central idea behind Kubernetes. A Deployment `spec` says how many replicas should exist, which pods it should manage, and what container template it should roll out. A Service `spec` says which ports to expose and which pod labels to select. A Pod `spec` says which containers, volumes, probes, and scheduling constraints should exist. Some data-centric resources, such as ConfigMaps and Secrets, use `data`, `binaryData`, or `stringData` instead of a traditional `spec`, but they still follow the same object identity and API routing model.
 
-### 3. `metadata`
-This field contains the critical data that uniquely identifies the object and allows the cluster to organize, track, and dynamically route network traffic to it.
-*   **`name`**: This must be completely unique within the namespace for that specific `kind` of object. You cannot have two Deployments named `web-app` co-existing in the same exact namespace.
-*   **`namespace`**: The virtual cluster partition the object belongs to. It defaults to the `default` namespace if omitted. If you forget to specify this explicitly in your manifest, you might accidentally deploy staging workloads directly into a production environment!
-*   **`labels`**: These are strictly constrained key-value pairs used for organizing and selecting subsets of objects (e.g., `tier: frontend`, `env: production`). Labels are highly functional and absolutely critical for internal cluster routing. Services and Deployments use label selectors to dynamically discover the pods they should manage.
-*   **`annotations`**: These are unconstrained, non-identifying metadata key-value pairs used by external tools, operators, or controllers (e.g., `build-commit: 4a2b9c`, `nginx.ingress.kubernetes.io/rewrite-target: /`). They are descriptive and usually do not directly affect standard Kubernetes internal routing, but are essential for third-party toolchains and CI/CD pipelines.
+Worked example: in Kubernetes 1.35, a Deployment belongs to `apps/v1`, and the pod template inside its `spec` contains the eventual container list. If you place `image: nginx:1.27` directly under `Deployment.spec`, the YAML may still be valid, but the schema is wrong because the image field belongs under `spec.template.spec.containers[]`. This is the difference between YAML validity and Kubernetes validity. YAML only proves the text can become data; Kubernetes validation proves the data matches the chosen API schema.
 
-### 4. `spec` (Specification)
-This is the true functional heart of the manifest. The `spec` declares your **desired state**. Every different `kind` of object has a drastically different, highly specific `spec` schema tailored to its purpose. A Pod's `spec` defines the exact container images, hardware resource limits, and persistent volumes. A Service's `spec` defines the exposed network ports and the label selectors used to discover backend pods. The entire Kubernetes control plane is essentially a massive collection of infinite control loops that continuously read your declared `spec` and work tirelessly to make the actual physical state of the cluster infrastructure match the desired state you declared here.
+Pause and predict: you are creating a ConfigMap, so which standard root field is replaced and what is the replacement called? A ConfigMap does not use a workload-style `spec`; it stores key-value content under `data` and optionally `binaryData`. You still need `apiVersion`, `kind`, and `metadata`, because the API server must know what object is being created and how to identify it.
 
-*(Note: A few specific data-centric objects designed for configuration delivery, such as `ConfigMap` and `Secret`, use a `data` or `stringData` field instead of a traditional `spec`, but the underlying declarative principle of communicating state remains exactly the same).*
+## 3. Exploring the Schema with `k explain`
 
-> **Pause and predict**: 
-> You are creating a `ConfigMap`. Which of the 4 standard root fields will be replaced, and what is its name?
-> <details>
-> <summary>Reveal Answer</summary>
-> The `spec` field is replaced by `data` (or `binaryData`). ConfigMaps and Secrets don't have a "specification" of desired state; they just hold raw data.
-> </details>
+You should not try to memorize the full Kubernetes API. Even the built-in resources have deeply nested fields, and production clusters often add CustomResourceDefinitions for ingress controllers, certificate managers, policy engines, database operators, service meshes, and delivery systems. Kubernetes gives you a better approach: query the OpenAPI schema through `kubectl explain`, or through `k explain` once you have set the alias. This turns the cluster itself into the version-matched reference for the fields it accepts.
 
-## 3. Exploring the Schema (Mastering `kubectl explain`)
-
-You cannot, and absolutely should not try to, memorize the entire Kubernetes API schema. There are thousands of nested fields, and the widespread introduction of Custom Resource Definitions (CRDs) adds thousands more unique fields to every modern enterprise cluster. When you need to know exactly how to configure a readiness probe, mount a persistent volume claim, or set complex pod anti-affinity rules, you do not need to blindly search the web or rely on outdated blog posts from three years ago. You have the official, exact, version-matched documentation built directly into your terminal via the powerful `kubectl explain` command.
-
-`kubectl explain` directly queries the OpenAPI schema hosted by your specific cluster's API server. This means it is always 100% accurate for your exact running cluster version (e.g., v1.35).
-
-### Traversing the Data Structure
-
-Want to know exactly what fields are available at the top level of a Pod's `spec` block?
+The basic habit is to traverse from a kind to the field you want to inspect. If you need to know what belongs directly under a Pod `spec`, ask for that exact path. The output includes a description and field list, and the type hints tell you whether the field expects a scalar, a mapping, or a sequence. Those hints map directly back to YAML structure: `<string>` means a scalar, `<Object>` means a mapping, `<[]Object>` means a sequence of mappings, and `<map[string]string>` means a mapping from string keys to string values.
 
 ```bash
 # General syntax: kubectl explain <kind>.<field>.<field>
 kubectl explain pod.spec
 ```
 
-The output of this command provides a high-level description of the `spec` block and lists all available fields immediately within it, strictly defining their expected programmatic data types (such as `<string>`, `<[]Object>`, `<map[string]string>`).
-*   `<string>`: Indicates the parser expects a simple scalar string (e.g., `restartPolicy: Always`).
-*   `<[]Object>`: The `[]` explicitly means it expects a Sequence (list). In YAML, this dictates that you must use hyphens to denote items within this block (e.g., `containers:`).
-*   `<map[string]string>`: Indicates it expects a Mapping (dictionary) of strings mapped to strings. You must provide distinct key-value pairs (e.g., `nodeSelector:`).
+When you run the aliased form in your terminal, use the same field path. The command below asks the same schema question while keeping the shorter `k` command style used in the rest of this module. The important habit is not the spelling of the binary; it is using the schema instead of guessing from memory or copying a stale example from an old blog post.
 
-### Drilling Deeply into the API
+```bash
+k explain pod.spec
+```
 
-You can chain fields together with dots to traverse deeply into the schema hierarchy, peeling back the layers of the API. Let's find out exactly how to configure the specifics of a liveness probe for a container.
+A liveness probe is a good example because it has several nested options, and only some combinations make sense. You can ask for the probe field first to see the available probe mechanisms, then drill into the HTTP action to inspect the path and port fields. That workflow scales from built-in resources to CRDs as long as the CRD publishes a usable OpenAPI schema.
 
 ```bash
 kubectl explain pod.spec.containers.livenessProbe
 ```
 
-**Output snippet:**
 ```text
 KIND:       Pod
 VERSION:    v1
@@ -265,34 +212,29 @@ You can continue drilling down even further to see the exact parameters required
 kubectl explain pod.spec.containers.livenessProbe.httpGet
 ```
 
-### The `--recursive` Flag
-
-If you want to quickly see the entire structural skeleton of a complex object all at once without the verbose descriptive text clogging up your terminal, use the `--recursive` flag. This is incredibly useful for visually grasping the deeply nested hierarchy of highly complex objects like Deployments or StatefulSets before you begin writing your YAML file.
+The `--recursive` flag is useful when you want the structural outline without reading a long description for every field. It is not a replacement for targeted field lookup, because a full recursive dump can be large, but it is excellent when you are trying to see the rough shape of a resource before authoring a manifest. For a Deployment, the recursive view quickly reminds you that the container list is inside `spec.template.spec`, not directly under the Deployment root.
 
 ```bash
 kubectl explain deployment --recursive
 ```
 
-> **Stop and think**: 
-> Use your terminal (or imagine using it). You need to add a "node selector" to ensure a Pod only runs on nodes with SSDs. What exact `kubectl explain` command would you run to find the documentation for the node selector field inside a Pod?
-> <details>
-> <summary>Reveal Answer</summary>
-> 
-> ```bash
-> kubectl explain pod.spec.nodeSelector
-> ```
-> This will show you that `nodeSelector` expects a `<map[string]string>`, meaning you provide key-value pairs representing node labels.
-> </details>
+```bash
+k explain deployment --recursive
+```
 
-By mastering `kubectl explain`, you achieve true technical independence as a Kubernetes engineer. You can reliably author manifests in completely air-gapped environments without any internet access, confidently relying on the cluster's own OpenAPI specifications as your ultimate and undeniable source of truth.
+Before running this, what output do you expect if you ask for `k explain pod.spec.nodeSelector`? You should expect a field description and a type that behaves like a mapping from string keys to string values. That means the YAML shape is not a list of selector objects; it is a mapping such as `disktype: ssd`, where each key and value correspond to node labels.
+
+```bash
+kubectl explain pod.spec.nodeSelector
+```
+
+This schema-first workflow is especially valuable in air-gapped environments. If your production cluster has no internet access, the API server still knows its own schema, including installed CRDs and admission-time expectations that generic web examples cannot cover. A senior Kubernetes engineer does not memorize every field; they know how to ask the cluster precise questions, then translate the returned types into YAML shapes that the API server can validate.
 
 ## 4. Common YAML Patterns in Kubernetes
 
-Let us meticulously examine how the fundamental YAML data structures we learned earlier directly map to everyday Kubernetes operational configurations. Misunderstanding these specific structures is the number one cause of broken CI/CD pipelines and highly frustrating schema validation errors.
+The same small set of YAML structures appears repeatedly in real manifests, but the consequences differ by field. A list under `containers` creates one or more container definitions. A mapping under `selector` controls which pods receive traffic. A two-part relationship between `volumes` and `volumeMounts` decides whether a pod can start at all. Once you train yourself to identify those shapes, error messages become clues instead of noise.
 
-### Environment Variables (Sequences of Mappings)
-
-Defining environment variables for a container runtime is a classic area where beginners stumble repeatedly. In the Kubernetes schema, the `env` field explicitly expects a Sequence (list) of Mappings (dictionaries). Each dictionary item in this list must have at least a `name` key and a corresponding `value` key. Furthermore, you can dynamically inject sensitive values from existing ConfigMaps or Secrets using the more complex `valueFrom` structural block.
+Environment variables show the most common nested pattern: a sequence of mappings. The `env` field under a container does not accept a single mapping of names to values. It accepts a list, and each list item is a mapping with a `name` field plus either a direct `value` or a `valueFrom` reference. This design lets each environment variable carry additional structure, such as references to ConfigMaps, Secrets, fields, or resource values.
 
 ```yaml
 apiVersion: v1
@@ -315,11 +257,9 @@ spec:
             key: api-key
 ```
 
-Notice exactly how every discrete item under `env:` securely begins with a hyphen. If you accidentally omit the hyphen, you are creating a single mapping instead of a required sequence, and the API server will immediately reject your manifest with a harsh type mismatch error during application.
+Notice that every environment variable starts with a hyphen at the same indentation level. If you remove one of those hyphens, you are no longer providing a sequence item, even if the text looks close to correct. Kubernetes will reject the manifest with a type mismatch because the OpenAPI schema expects a list of `EnvVar` objects. That is why `k explain pod.spec.containers.env` is more useful than visual guessing when you are unsure.
 
-### Volume Mounts (Connecting the Pieces)
-
-Attaching persistent storage to an ephemeral pod involves a strict two-step declarative process in YAML, requiring significant precision. First, you must explicitly define the source volume at the broader Pod level within the `spec.volumes` sequence. Second, you must mount that established volume into specific individual containers within the `spec.containers[].volumeMounts` sequence. Both of these are sequences, and the arbitrary `name` identifiers must match perfectly across both blocks.
+Volumes demonstrate a different source of mistakes because the configuration is split across two parts of the pod. The pod-level `spec.volumes` sequence declares volume sources, such as ConfigMaps, Secrets, empty directories, projected volumes, or persistent volume claims. Each container-level `volumeMounts` sequence decides where a named volume appears inside that container's filesystem. The link between those blocks is the volume name, so the names must match exactly.
 
 ```yaml
 apiVersion: v1
@@ -341,11 +281,9 @@ spec:
       name: my-app-config
 ```
 
-If the `name: config-store` declared in the `volumeMounts` section does not perfectly match the `name: config-store` provisioned in the `volumes` section, the pod will catastrophically fail to start, continually throwing a `MountVolume.SetUp failed` event visible in the cluster logs.
+The split design is intentional. One pod can define several volumes, and different containers can mount different subsets of those volumes at different paths. The tradeoff is that a typo in the shared name is not a YAML error and may not be caught by client-side validation. The pod is syntactically valid but cannot mount what it references, so you diagnose the problem by reading pod events with `k describe pod <name>` after creation or by reviewing the two name fields together before deployment.
 
-### Labels and Selectors (Mappings)
-
-Labels are simple key-value mappings used for robust identification. Selectors are utilized by higher-level resources, like Services and Deployments, to dynamically discover other resources based purely on those exact labels. For advanced matching capabilities, Deployments utilize standard `matchLabels` or highly expressive `matchExpressions` that allow for logical operators.
+Labels and selectors are mappings that connect resources without hard-coding pod names. A Service does not send traffic to a specific pod identity; it watches for pods whose labels match its selector. That indirection is what lets Kubernetes replace pods during rollouts while the Service remains stable. It also means a one-character label mismatch can create a healthy-looking Service with no endpoints.
 
 ```yaml
 # A Service looking for specific pods
@@ -361,13 +299,15 @@ spec:
   - port: 80
 ```
 
-The Kubernetes Service defined above will automatically and dynamically load-balance incoming network traffic to any pod in the namespace that simultaneously possesses BOTH the `app: frontend` label AND the `tier: web` label. If a pod only possesses one of those labels, it will be completely ignored by the Service's endpoint slice. This decoupled label-selector mechanism is the fundamental architectural bedrock of Kubernetes' dynamic service discovery and routing capabilities.
+The selector above is an AND relationship across mapping keys. A pod must have both `app: frontend` and `tier: web` to receive traffic. This is why Deployment pod-template labels and Service selectors deserve careful review together. If the Deployment creates pods with `tier: frontend` while the Service selects `tier: web`, both resources can be valid and still fail as a system because the intended relationship is broken.
+
+Which approach would you choose here and why: hard-code pod names into a client configuration file, or use a Service selector that matches stable labels? Use selectors for normal Kubernetes networking because pods are disposable and labels are the stable contract. Hard-coded pod names turn routine rollouts into configuration churn, while selectors let controllers replace pods without forcing clients to learn new identities.
 
 ## 5. Multi-Resource Files and CI/CD
 
-In modern production environments, a full application is rarely deployed as just a single, isolated resource. A highly functional microservice typically requires a Deployment to govern the compute layer, a Service for internal cluster networking, a ConfigMap for passing environment variables, and an Ingress object to broker external web access. 
+A production application rarely consists of one Kubernetes object. Even a small web service may need a ConfigMap for configuration, a Deployment for compute, a Service for stable networking, an Ingress for external routing, and perhaps a ServiceAccount or Secret. Keeping each object in a separate file can be clear for large repositories, but for a compact teaching example or a small application unit, a multi-document YAML file keeps related resources together while still preserving separate Kubernetes objects.
 
-Instead of painstakingly managing a dozen separate, fragile YAML files within a repository, you can elegantly combine multiple distinct Kubernetes resources into a single, unified YAML file stream. You achieve this cohesion by utilizing the official YAML document separator: `---` (three consecutive hyphens placed on a completely blank line).
+YAML uses `---` as the document separator. Three hyphens on a line by themselves end one YAML document and begin the next document in the same stream. `kubectl apply -f combined.yaml` reads that stream, splits it into individual objects, and submits them in order. Each object still has its own `apiVersion`, `kind`, `metadata`, and object-specific state. The separator does not merge objects; it lets one file carry several independent objects.
 
 ```text
 apiVersion: v1
@@ -393,150 +333,218 @@ spec:
   # ... service details ...
 ```
 
-When you execute a command like `kubectl apply -f combined.yaml`, the Kubernetes API server client reads the entire input stream, splits the text payload at every `---` separator, and processes all distinct documents sequentially in a single batch transaction. This is an absolutely critical pattern for integrating with Continuous Integration and Continuous Deployment (CI/CD) pipelines (like ArgoCD or Flux), ensuring that all interdependent components of an application are deployed together cleanly.
+Order matters less than beginners often fear, but it still matters for clean rollouts and readable logs. `kubectl` sends documents in file order, while controllers reconcile asynchronously after the objects exist. If a Deployment appears before the ConfigMap it references, the Deployment object can be accepted and the first pods may fail until the ConfigMap is created. Kubernetes will often recover once the dependency exists, but a pipeline that creates avoidable crash-loop events is harder to monitor and harder to trust.
 
-> **Stop and think**: 
-> Does the order of documents separated by `---` matter when you run `kubectl apply -f combined.yaml`?
-> <details>
-> <summary>Reveal Answer</summary>
-> Technically, `kubectl apply` processes them in the order they appear. However, because Kubernetes reconciles state continuously, if a Deployment is created before the ConfigMap it depends on, the Pods will simply fail to start and crash-loop until the ConfigMap is created moments later. It eventually resolves itself, but it is best practice to put dependencies (ConfigMaps, Secrets, PVCs) at the top of the file!
-> </details>
+For that reason, put foundational dependencies first: Namespaces, ServiceAccounts, ConfigMaps, Secrets, PersistentVolumeClaims, then workload controllers, then Services and ingress-facing resources as appropriate for your delivery system. GitOps tools such as Argo CD and Flux add their own ordering and health concepts, but they still consume manifests that must be valid Kubernetes objects. Multi-document files are not a substitute for dependency design; they are a packaging format for related desired state.
 
-It is crucial to deeply understand that while `kubectl` sends the parsed resources to the API server strictly in the order they appear in the file, the actual control plane operates entirely asynchronously. If your Deployment pods manage to start faster than the required ConfigMap is created, they may crash initially. However, the Kubernetes continuous reconciliation loop will tirelessly retry the operation until the ConfigMap eventually exists, ultimately bringing the entire system into the desired operational state. Regardless of this safety net, robust engineering best practice dictates placing foundational dependencies (Namespaces, ConfigMaps, Secrets, PersistentVolumeClaims) at the absolute top of the multi-document file to prevent noisy crash-loop logs during initial deployment.
+Stop and think: does document order matter when you run `k apply -f combined.yaml`? The client processes documents in order, but the cluster reconciles them over time. A missing dependency may cause a temporary pod failure even if the later document creates the dependency moments afterward, so order your file to reduce noisy transitional failures and make first-apply behavior easier to reason about.
+
+CI/CD validation should treat multi-resource files as a single deployment unit but inspect each object separately. A syntax error near the top can prevent the entire file from parsing. A schema error in one resource can fail the apply even if other resources are valid. A selector mismatch can pass validation entirely because it is a semantic relationship between objects rather than a local schema violation. This is why mature pipelines combine YAML parsing, server-side dry runs, and sometimes policy checks or integration tests.
 
 ## 6. Validating YAML and Real Debugging
 
-Writing basic YAML manifests is relatively easy; deeply debugging complex, 1000-line enterprise Kubernetes manifests is notoriously difficult. The Kubernetes API server is incredibly strict in its enforcement. You must rigorously validate your configuration files before attempting to apply them to a live cluster environment, especially in highly sensitive production scenarios.
+Debugging manifests becomes manageable when you separate four failure layers. The first layer is YAML syntax: can the text be parsed into data at all? The second layer is Kubernetes schema: does the data match the `apiVersion` and `kind` you declared? The third layer is cluster admission: do namespaces, CRDs, permissions, and policies allow the request? The fourth layer is runtime behavior: do controllers and workloads actually reach the desired state after the object is accepted?
 
-### Client-Side Validation
-
-The absolute fastest way to check your fundamental YAML syntax and structural schema correctness without impacting the remote cluster state in any way is to utilize the client-side dry run feature. This validation executes entirely locally on your machine, leveraging the `kubectl` binary's built-in schema definitions.
+Client-side dry run is the fastest first pass. It catches many syntax and schema mistakes without contacting the API server, so it is useful while authoring a file locally. It is also limited by the client version and by what the client can know without the live cluster. Use it as a quick edit loop, not as the final production gate.
 
 ```bash
 kubectl apply -f my-pod.yaml --dry-run=client
 ```
 
-If the execution is successful, the terminal will cleanly output `pod/my-pod created (dry run)`. If it fails due to a structural error or schema violation, `kubectl` will usually point you directly to the exact line number containing the indentation fault or unknown key.
+```bash
+k apply -f my-pod.yaml --dry-run=client
+```
 
-### Server-Side Validation
-
-Client-side validation is exceptionally fast, but it is dangerously incomplete. It has absolutely zero knowledge of the actual running cluster state. It does not know if a specific Custom Resource Definition (CRD) actually exists on the remote cluster, if the target namespace is missing, or if a dynamic admission webhook (like an OPA Gatekeeper security policy or Kyverno validation rule) will ultimately intercept and reject your mutation. 
-
-Server-side dry-run perfectly solves this severe limitation by transmitting the entire payload across the network to the active API server for exhaustive, complete validation. It runs the payload through all authorization checks and admission controllers, but deliberately stops just short of actually persisting the new object into the backend etcd database.
+Server-side dry run asks the actual API server to process the request through authentication, authorization, schema validation, defaulting, and admission control, but it stops before persisting the object. That makes it the better preflight for shared clusters, CRDs, and policy-heavy environments. If your CI system has cluster access, server-side dry run gives you confidence that the real control plane can accept the manifest under current conditions.
 
 ```bash
 kubectl apply -f my-pod.yaml --dry-run=server
 ```
 
-Server-side validation represents the gold standard for CI/CD pipeline verification. If a manifest successfully passes a rigorous server-side dry run, you can be highly confident it will deploy successfully in reality.
+```bash
+k apply -f my-pod.yaml --dry-run=server
+```
 
-### The `kubectl diff` Command
-
-Before applying potentially sweeping changes to a live, existing production resource, you must ALWAYS leverage the `kubectl diff` command. This powerful operational tool shows you exactly what fields will change in the live cluster state, outputting a standard, readable patch format (using `+` for additions and `-` for deletions). This simple verification step prevents accidental, catastrophic destructive updates, such as modifying a critical label selector that might suddenly orphan thousands of active production pods and sever their network routing.
+The `diff` command answers a different question: what would change compared with live state? This is vital for updates because a valid manifest can still make an unsafe change. For example, changing a Deployment selector can orphan existing ReplicaSets, and changing Service selector labels can remove endpoints from a traffic path. A dry run tells you whether the server accepts the request; a diff helps you judge whether the accepted change is the one you intended.
 
 ```bash
 kubectl diff -f my-updated-deployment.yaml
 ```
 
-### Decoding Error Messages
+```bash
+k diff -f my-updated-deployment.yaml
+```
 
-When validation inevitably fails, Kubernetes error messages can initially seem incredibly cryptic and overwhelming. Let us methodically decode the most common operational errors encountered by platform engineers:
+The best debugging workflow is deliberate. Start with the exact error message and decide which layer it belongs to. If the parser says it cannot convert YAML to JSON, inspect indentation, colons, tabs, and missing hyphens around the reported line and the lines immediately above it. If Kubernetes reports an invalid field or type, use `k explain` to inspect the expected path. If server-side dry run fails after client-side dry run succeeds, look for cluster-specific causes such as a missing namespace, CRD version, RBAC denial, or admission policy.
 
-**Error 1: The Indentation Trap**
+Treat each verifier result as evidence about where the manifest failed, not as a personal judgment about the author. A parser error says the text did not become a data tree, so editing the `apiVersion` will not help until the indentation or scalar syntax is repaired. A schema error says the data tree exists but does not match the object contract, so adding more document separators will not fix a misplaced `image` field. An admission error says the object is valid Kubernetes data but violates something true about the target cluster, such as a policy requiring ownership labels or a namespace quota limiting resource requests. This separation prevents frantic trial-and-error edits and makes review conversations more precise.
+
 ```text
 error: error parsing deployment.yaml: error converting YAML to JSON: yaml: line 15: mapping values are not allowed in this context
 ```
-*   **Diagnosis:** This message almost universally means you have an indentation error. Specifically, you likely missed a required hyphen for a list item, or you have incorrect spacing around a colon. The YAML parser hit a structural wall and aborted. Check line 15 and the lines immediately preceding it very carefully.
 
-**Error 2: The Type Mismatch**
+This usually means the YAML parser hit a structural contradiction before Kubernetes validation even began. The line number is a clue, not a verdict, because the actual mistake is often on the previous line. Missing hyphens under sequences, inconsistent indentation, or an unquoted colon inside a string can make the parser expect a key where it finds something else.
+
 ```text
 The Deployment "my-app" is invalid: spec.replicas: Invalid value: "3": spec.replicas must be an integer
 ```
-*   **Diagnosis:** You explicitly provided a quoted string `"3"` where the strict OpenAPI schema demanded a numerical integer `3`. In YAML, quotes definitively force a string data type evaluation. You must remove the quotes to satisfy the schema requirement.
 
-**Error 3: The Missing Schema**
+This is a schema type mismatch. YAML accepted `"3"` as a string, but the Deployment schema requires an integer for `spec.replicas`. The fix is not to silence validation; it is to represent the value with the type the schema expects, which means `replicas: 3` without quotes.
+
 ```text
 error: unable to recognize "pod.yaml": no matches for kind "Pod" in version "apps/v1"
 ```
-*   **Diagnosis:** You declared the completely wrong `apiVersion` for the specified `kind`. Pods intrinsically belong to the fundamental core `v1` API group, not `apps/v1` (which is strictly reserved for higher-level controllers managing replica sets like Deployments and StatefulSets).
 
-**Error 4: The Duplicate Key**
+This points to the root contract. Pods are core resources under `apiVersion: v1`, while `apps/v1` owns higher-level workload controllers such as Deployments, ReplicaSets, StatefulSets, and DaemonSets. When `apiVersion` and `kind` do not belong together, the server cannot choose a schema.
+
 ```text
 error: error parsing config.yaml: error converting YAML to JSON: yaml: unmarshal errors:
   line 12: mapping key "port" already defined at line 10
 ```
-*   **Diagnosis:** Mappings (dictionaries) require strictly unique keys at the exact same indentation level. You cannot define `port: 80` and then subsequently define `port: 443` in the exact same mapping block. The parser will rightfully reject it outright to prevent dangerous silent overwrites of critical data.
 
-**Error 5: Unknown Field Validation**
+Mappings require unique keys at the same indentation level. Duplicate keys are dangerous because some parsers historically allowed later values to overwrite earlier ones. Modern Kubernetes tooling rejects duplicates to prevent silent configuration loss, so the correct fix is to use a sequence when you need multiple ports or to remove the duplicate key when only one value is valid.
+
 ```text
 error: error validating "deployment.yaml": error validating data: ValidationError(Deployment.spec.template.spec): unknown field "image" in io.k8s.api.core.v1.PodSpec;
 ```
-*   **Diagnosis:** This is a classic schema structural mapping mismatch. You likely placed the `image` field directly under `spec`, but the OpenAPI schema heavily dictates that `image` must belong deeply nested inside the `containers` list (`spec.containers[0].image`). Use `kubectl explain` to trace and verify the exact required path.
+
+Unknown field errors usually mean the field is real but misplaced, or the field belongs to a different API version. In this example, `image` belongs inside a container object under `spec.template.spec.containers[]`, not directly under the pod spec. Follow the path in the error message, then use `k explain deployment.spec.template.spec.containers` to confirm the valid structure.
+
+War story: one platform team added a new `podLabels` field copied from a Helm chart values file directly into a rendered Deployment manifest. The field made sense in the chart input, but it was not part of the Kubernetes Deployment schema. Client-side checks on one developer laptop missed it because the script skipped validation for generated files, while server-side dry run in CI rejected it before production. The team fixed the chart template instead of weakening validation, and that decision prevented a bad habit from entering their release process.
+
+## Patterns & Anti-Patterns
+
+Strong Kubernetes YAML practice is less about memorizing snippets and more about creating reviewable patterns. A good pattern makes the intended data shape obvious, gives controllers stable relationships to reconcile, and lets validation fail early when the file does not match the schema. A bad pattern may still produce valid YAML, but it hides meaning, depends on accidental ordering, or lets a semantic mismatch escape into runtime behavior.
+
+| Pattern | When to Use It | Why It Works | Scaling Considerations |
+| :--- | :--- | :--- | :--- |
+| Schema-first authoring | Any time you add an unfamiliar field or nested structure | `k explain` tells you the expected Kubernetes type before you write YAML | Works for built-ins and well-defined CRDs; supplement with vendor docs when CRD schemas are sparse |
+| Dependency-first multi-document files | Small app bundles with ConfigMaps, Secrets, workloads, and Services | Foundational resources exist before pods reference them, reducing noisy initial failures | Larger systems may move ordering into GitOps waves or separate Kustomize bases |
+| Stable label contracts | Services, Deployments, NetworkPolicies, and observability selection | Labels provide durable relationships while pods remain disposable | Define label conventions centrally so teams do not invent incompatible keys |
+| Server-side dry run in CI | Shared clusters, CRDs, namespaces, RBAC, and admission policies | The real API server validates the request without persisting it | Requires safe CI credentials and representative target clusters |
+
+| Anti-Pattern | What Goes Wrong | Why Teams Fall Into It | Better Alternative |
+| :--- | :--- | :--- | :--- |
+| Guessing list versus mapping shape | The file is valid YAML but fails schema validation or creates the wrong object shape | Examples look visually similar, especially around `containers`, `env`, and `ports` | Read the schema type and map `<[]Object>` to hyphenated sequence items |
+| Copying chart values into manifests | Fields that belong to a templating tool are rejected by the Kubernetes API | The chart input and rendered output both use YAML, so the boundary feels blurry | Render the chart, inspect the output, and validate the actual Kubernetes manifest |
+| Quoting every scalar defensively | Integers and booleans become strings where the schema requires native types | Teams try to avoid YAML type surprises by treating everything as text | Quote ambiguous strings, but leave numeric fields unquoted when the schema expects numbers |
+| Treating client dry run as final proof | Cluster-specific policy, RBAC, CRDs, and admission failures appear later | Client validation is fast and available without cluster access | Use client dry run for editing and server-side dry run before merge or release |
+
+The most reliable pattern is to keep the intended object relationships near each other during review. If a Service selects `app: web`, reviewers should be able to see the pod template labels that satisfy that selector. If a container mounts `config-store`, reviewers should be able to see the pod-level volume named `config-store`. If an environment variable references `app-config`, reviewers should be able to see whether that ConfigMap is created by the same release unit or by a documented external dependency.
+
+## Decision Framework
+
+Choosing the right YAML and validation approach depends on the risk of the change, the cluster features involved, and the feedback speed you need. A local edit loop should be fast because you are shaping the document. A release gate should be authoritative because it represents a change the cluster may actually run. A production update should be inspectable because accepted changes can still be operationally dangerous.
+
+```text
+Start with a manifest change
+        |
+        v
+Is the field path unfamiliar?
+        |
+        +-- yes --> Run k explain for the exact path, then edit the YAML shape
+        |
+        +-- no ----+
+                  |
+                  v
+Does the file parse and match local schema?
+                  |
+                  +-- no --> Run k apply --dry-run=client and fix syntax or type errors
+                  |
+                  +-- yes ---+
+                             |
+                             v
+Does the target cluster have CRDs, RBAC, or admission policy involved?
+                             |
+                             +-- yes --> Run k apply --dry-run=server against that cluster
+                             |
+                             +-- no ----+
+                                       |
+                                       v
+Are you updating existing live resources?
+                                       |
+                                       +-- yes --> Run k diff -f <file> and review the patch
+                                       |
+                                       +-- no ---> Apply through the normal release workflow
+```
+
+Use client-side dry run when you are still editing and want immediate feedback on obvious syntax or schema problems. Use server-side dry run when the live cluster's view matters, which includes CRDs, namespaces, RBAC, admission controllers, defaulting, and version-specific validation. Use diff when the object already exists and the important question is not "is this valid?" but "what exactly will change?" A healthy pipeline often uses all three because they answer different questions.
+
+| Situation | Preferred Tool | Reason |
+| :--- | :--- | :--- |
+| You cannot remember where `readOnly` belongs for a volume mount | `k explain pod.spec.containers.volumeMounts` | The schema shows the exact nested field path and expected type |
+| You are editing a local Pod example and want fast feedback | `k apply --dry-run=client -f pod.yaml` | The client catches YAML and basic schema mistakes without waiting on the cluster |
+| You are validating an operator CRD before merge | `k apply --dry-run=server -f resource.yaml` | The API server validates the installed CRD version and admission policy |
+| You are changing selectors on a live Deployment or Service | `k diff -f service.yaml` | The diff exposes destructive relationship changes before they are applied |
+
+The framework also tells you when YAML is not the real problem. If server-side dry run accepts a Service but traffic still fails, inspect endpoints and labels rather than rewriting indentation. If a ConfigMap is valid but the application ignores it, inspect how the pod consumes it through environment variables or mounted files. YAML is the delivery format for desired state, but runtime debugging still requires following the controller and workload behavior after the API accepts the object.
 
 ## Did You Know?
 
-*   **YAML Versioning Nuances:** Kubernetes primarily utilizes the YAML version 1.2 specification, though many older client parsers in the ecosystem relied heavily on version 1.1. In YAML 1.1, the unquoted string `NO` natively evaluates to a boolean `False`. This actually caused massive, widespread configuration issues for users deploying resources in Norway (country code `NO`), strictly requiring them to quote country codes in their Kubernetes manifests.
-*   **The Etcd Size Limit:** The absolute physical maximum size of a single object you can store in etcd (and thus successfully submit via a YAML manifest) is exactly **1.5 Megabytes**. If your ConfigMap payload exceeds this hard database limit, you must fundamentally rethink your architecture and utilize external volume storage mechanisms.
-*   **The JSON Equivalence Reality:** Because the YAML specification is officially and deliberately designed as a strict superset of JSON, any properly formatted JSON document is automatically and inherently a perfectly valid YAML document. You can confidently execute `kubectl apply -f manifest.json` directly, and the API server will process it natively without any intermediate conversion required.
-*   **The Y2K of YAML 1.1:** The unquoted string `22:22` in YAML 1.1 actually resolves to an integer representing a base-60 format (similar to a sexagesimal clock), evaluating unexpectedly to `1342`. In YAML 1.2, it is safely evaluated as a standard string. To avoid unexpected runtime evaluation surprises, always strictly quote your timestamps and numerical version tags!
+* **YAML version differences caused real surprises:** YAML 1.1 treated several unquoted words, including `NO`, as booleans. That surprised teams using country codes and other short identifiers, which is why quoting ambiguous strings remains a practical habit even when modern tooling follows YAML 1.2 more closely.
+* **Kubernetes stores object state through etcd limits:** Large ConfigMaps and Secrets are constrained by the API server and etcd storage path, and Kubernetes documents a 1 MiB limit for individual ConfigMap data. If configuration approaches that size, use mounted files, object storage, or another delivery pattern instead of forcing everything into one manifest.
+* **JSON is valid YAML:** YAML is designed so JSON documents are also valid YAML documents. `kubectl` can apply JSON files directly, which is useful for generated payloads and API integrations where human editing is not the main goal.
+* **The API server cares about structure, not formatting taste:** Two manifests can look similar in a review while producing different data trees. A missing sequence hyphen under `containers` changes the data type, and the API server validates the data tree after parsing, not your visual intention.
 
 ## Common Mistakes
 
 | Mistake | Why It Happens | How to Fix It |
 | :--- | :--- | :--- |
-| **Using Tabs for Indentation** | Copy-pasting from web browsers or using misconfigured editors. YAML parsers will violently reject tabs. | Configure your IDE to convert tabs to spaces. Use exactly 2 spaces per indentation level. |
-| **Wrong `apiVersion`** | Guessing the API group instead of checking. Deployments are `apps/v1`, Ingress might be `networking.k8s.io/v1`. | Always verify with `kubectl api-resources \| grep <Kind>` to see the correct API group. |
-| **Hyphen vs No Hyphen** | Confusing sequences (lists) with mappings (dictionaries). For example, `containers:` requires a list `- name:`, but `metadata:` does not. | Read the schema. If `kubectl explain` says `<[]Object>`, use a hyphen. If it says `<Object>`, don't. |
-| **String/Integer Confusion** | Port numbers in Services must be integers. Annotations must strictly be strings. `port: "80"` (string) will fail if an integer is expected. | Remove quotes for integers (`80`). Force strings with quotes if YAML might misinterpret them (`"true"` vs `true`). |
-| **Forgetting `---` separator** | Putting multiple resources in one file without the document separator causes parsing to halt or overwrite data. | Always insert `---` on a blank line between distinct Kubernetes objects in a single file. |
-| **Mismatched Selectors** | A Service `selector` doesn't exactly match the Deployment Pod `labels`. | Triple-check that the key and value in the Service selector are identical to the labels applied in the Pod template. |
+| **Using tabs for indentation** | Copying from chat tools, browsers, or editors that insert tabs makes YAML invalid before Kubernetes sees it. | Configure the editor to insert two spaces for YAML files and show whitespace during review. |
+| **Pairing the wrong `apiVersion` with a `kind`** | Engineers guess from nearby examples, such as using `v1` for a Deployment because Pods use `v1`. | Run `k api-resources` or `k explain <kind>` and verify the API group before writing the manifest. |
+| **Missing hyphens for sequences** | Fields like `containers`, `env`, `ports`, and `volumeMounts` look like nested mappings until you inspect their schema. | If `k explain` shows `<[]Object>`, write a hyphenated list item at the correct indentation level. |
+| **Quoting values with the wrong type** | Teams quote every value to avoid YAML surprises, then fields like `replicas` or `port` become strings. | Quote ambiguous strings, but leave numeric schema fields unquoted when Kubernetes expects integers. |
+| **Forgetting `---` between resources** | Multiple resources are pasted into one file and the parser treats them as one broken or overwritten document. | Place `---` on a line by itself between complete Kubernetes objects in a multi-document file. |
+| **Mismatching Service selectors and pod labels** | Each resource validates locally, but the relationship between them is semantic and easy to miss. | Review Service selectors beside Deployment pod-template labels and confirm endpoints after apply. |
+| **Using `>` for structured multi-line data** | Folded scalars are readable, but they replace ordinary line breaks with spaces. | Use `|` for scripts, certificates, kubeconfig fragments, and any data where newlines are syntax. |
+| **Treating client dry run as production proof** | Client validation is fast, so teams promote it to the only gate even when clusters use CRDs and policies. | Keep client dry run for authoring, then run server-side dry run against the target cluster before release. |
 
 ## Quiz
 
-<details>
-<summary>1. Scenario: A colleague asks you to review a Pull Request where a Kubernetes Secret containing a private TLS certificate is failing to parse correctly in the Ingress controller. You notice the certificate data is defined using the `>` YAML operator. Why is this causing the Ingress controller to fail, and how do you fix it?</summary>
+<details><summary>1. Scenario: A colleague asks you to review a pull request where a Kubernetes Secret containing a private TLS certificate fails to parse in the ingress controller. You notice the certificate data is defined with the `>` YAML operator. Why is this causing the failure, and how do you fix it?</summary>
 
-**Answer:** The folded block scalar (`>`) collapses newlines into spaces, which destroys the strict formatting required by PEM-encoded TLS certificates. Certificates rely on precise newline boundaries to separate different sections, such as isolating the header `-----BEGIN CERTIFICATE-----` from the base64-encoded payload. By converting the multi-line certificate into a single continuous string, the Ingress controller receives an invalid certificate structure and crashes upon parsing it. To fix this configuration, you must use the literal block scalar (`|`). This instructs the YAML parser to preserve all original newlines exactly as they appear in the source file, maintaining the required certificate format.
+**Answer:** The folded block scalar `>` converts ordinary line breaks into spaces, which corrupts PEM certificate structure even though the YAML document can still parse successfully. The ingress controller receives a single malformed certificate string instead of line-preserved certificate data, so it cannot load the credential. Use the literal block scalar `|` for certificate material because it preserves newlines exactly. This answer tests the outcome about constructing manifests with the correct multi-line string form and diagnosing failures where valid YAML carries invalid application data.
 </details>
 
-<details>
-<summary>2. Scenario: During a critical production incident, a junior engineer attempts to apply a hotfix via `kubectl apply -f hotfix.yaml` but receives the error `error converting YAML to JSON: yaml: line 22: did not find expected key`. They are confused because line 22 simply contains `image: nginx:alpine`. What is structurally wrong with the manifest around this line?</summary>
+<details><summary>2. Scenario: During a production hotfix, an engineer runs `k apply -f hotfix.yaml` and receives `error converting YAML to JSON: yaml: line 22: did not find expected key`. Line 22 contains `image: nginx:alpine`, which looks harmless. What should they inspect first?</summary>
 
-**Answer:** This error occurs because the YAML parser is attempting to process a dictionary (mapping) but encountered data that breaks the expected `key: value` indentation structure. In Kubernetes manifests, strict spacing dictates the data hierarchy and relationship between fields. The most common cause for this specific error is a missing hyphen in a sequence (like under the `containers:` list) or an extra space before the key, which shifts the indentation level and confuses the parser. To resolve the issue, the engineer must ensure exactly two spaces are used per level and verify that sequence items properly start with hyphens to denote a list element. Using a linter or IDE with YAML support can easily catch these structural indentation faults before deployment.
+**Answer:** They should inspect the indentation and sequence structure around the `containers` block, including the lines immediately before line 22. YAML parser errors often point to the line where parsing became impossible, not necessarily the line where the mistake began. A missing hyphen before a container item or an incorrectly indented `name` field can make `image` appear where the parser expected a different key. This maps to the diagnostic outcome because the fix comes from reasoning about YAML structure before assuming the image value is wrong.
 </details>
 
-<details>
-<summary>3. Scenario: You are working in a secure, air-gapped environment with no internet access. You need to attach a PersistentVolumeClaim to a Pod but cannot remember if the field `readOnly` belongs inside the Pod's `volumes` block or the `volumeMounts` block. How can you definitively determine the correct placement without leaving your terminal?</summary>
+<details><summary>3. Scenario: You are in an air-gapped cluster and need to mount a PersistentVolumeClaim, but you cannot remember whether `readOnly` belongs under `volumes` or `volumeMounts`. How do you find the correct field path without web access?</summary>
 
-**Answer:** You can determine the correct placement by utilizing the `kubectl explain` command to query the cluster's OpenAPI schema directly. By running `kubectl explain pod.spec.volumes.persistentVolumeClaim` and `kubectl explain pod.spec.containers.volumeMounts`, you can traverse the nested structure of the Pod object to see the valid keys for each section. This offline tool provides authoritative documentation, including expected data types and descriptions for every field, straight from the cluster's API server. It completely removes the need for web-based documentation and allows you to confidently structure your manifest. You can even use the `--recursive` flag to see the entire resource skeleton if you need broader context.
+**Answer:** Use `k explain` to query the cluster's OpenAPI schema for the relevant nested fields. Compare `k explain pod.spec.volumes.persistentVolumeClaim` with `k explain pod.spec.containers.volumeMounts` and read the field descriptions and types. The cluster's schema is authoritative for that Kubernetes version and installed resources, so it is safer than memory or old examples. This evaluates the ability to diagnose and design manifests by traversing schema paths rather than guessing.
 </details>
 
-<details>
-<summary>4. Scenario: You submit a newly authored Custom Resource to the API server, but it is immediately rejected before any schema validation even occurs. The error simply states it cannot parse the object. You verify your syntax is perfectly valid YAML and all indentation is correct. What fundamental structural requirement of the Kubernetes declarative model have you likely violated?</summary>
+<details><summary>4. Scenario: A Custom Resource manifest is rejected immediately, and the error says the object cannot be recognized. The YAML syntax is valid and indentation is clean. Which root-level Kubernetes contract should you verify?</summary>
 
-**Answer:** You have likely omitted one of the four mandatory root-level fields required by the Kubernetes API: `apiVersion`, `kind`, `metadata`, or `spec` (or `data`). The API server relies on `apiVersion` and `kind` to route the payload to the correct internal handler, while `metadata` provides essential routing and identification information like the unique name. Without this foundational structure, the control plane cannot even begin to evaluate your desired state or apply validation rules. Even for Custom Resources, this strict contract must be upheld for the server to accept the payload. If any of these fields are missing, the parser immediately rejects the manifest as fundamentally malformed.
+**Answer:** Verify `apiVersion` and `kind` first, then confirm `metadata.name` exists and the resource uses the expected object body such as `spec`. The API server uses `apiVersion` and `kind` to locate the schema and handler for the object, so a typo or wrong version prevents deeper validation. For CRDs, the installed version in the cluster must match the manifest version. This tests deconstruction of the root manifest fields and their role in API routing.
 </details>
 
-<details>
-<summary>5. Scenario: Your team has generated a massive 500-line YAML file containing a complex StatefulSet and associated services. You run `kubectl apply -f app.yaml --dry-run=client` and it reports no errors. However, when you remove the dry-run flag, the API server rejects the manifest due to a Custom Resource Definition mismatch. Why did the client-side dry run fail to catch this, and how should you validate it in the future?</summary>
+<details><summary>5. Scenario: A 500-line application bundle passes `k apply --dry-run=client -f app.yaml`, but the real apply is rejected by an admission policy for a required label. Why did client-side validation miss it, and what should the pipeline do?</summary>
 
-**Answer:** The client-side dry run failed to catch the error because it only verifies basic YAML syntax and local schema correctness without communicating with the server's admission controllers or checking the cluster's actual state. It is entirely unaware of cluster-specific constraints, missing namespaces, or Custom Resource Definitions that reside on the control plane. To safely and accurately validate complex manifests against the actual cluster configuration without creating the objects, you must use `--dry-run=server`. This sends the entire payload to the API server for comprehensive validation without persisting the data to etcd. Utilizing server-side dry runs is a critical best practice for preventing deployment failures caused by cluster-state mismatches.
+**Answer:** Client-side validation does not contact the API server, so it cannot evaluate live admission controllers, RBAC, namespace state, or cluster-specific CRD behavior. The required-label policy exists in the target cluster, not in the local syntax check. The pipeline should run `k apply --dry-run=server -f app.yaml` against a representative cluster before applying the change. This question compares validation strategies and explains why server-side dry run is the safer release gate.
 </details>
 
-<details>
-<summary>6. Scenario: A legacy deployment script automatically generates Kubernetes configuration payloads in strict JSON format. A new engineer insists that the pipeline must be rewritten to convert these files into YAML because "Kubernetes only uses YAML". Why is the engineer incorrect, and how does the API server handle the legacy JSON files?</summary>
+<details><summary>6. Scenario: A Service is valid and a Deployment is valid, but the Service has no endpoints after deployment. The Service selector is `app: frontend` and `tier: web`, while the pod template labels are `app: frontend` and `tier: ui`. What is wrong?</summary>
 
-**Answer:** The engineer is incorrect because the YAML specification is officially designed as a strict superset of JSON. This means any properly formatted JSON document is inherently a valid YAML document without any modifications. When `kubectl apply -f payload.json` is executed, the underlying parser natively understands and processes the JSON data structure without requiring any conversion utility. The Kubernetes API server itself natively consumes both formats, making it perfectly acceptable and efficient to submit JSON directly in automated pipelines. There is no technical benefit to rewriting the pipeline merely to change the serialization format.
+**Answer:** The YAML and schemas can both be valid while the semantic relationship is broken. A Service selector is an AND match across all selector keys, so pods must have both `app: frontend` and `tier: web` to become endpoints. Since the pods have `tier: ui`, the Service selects nothing. Fix either the Service selector or the pod template labels so the intended label contract matches, then confirm endpoints with `k get endpoints` or EndpointSlice inspection.
+</details>
+
+<details><summary>7. Scenario: A release file contains a ConfigMap, a Deployment that consumes it as an environment variable, and a Service. A teammate wants the Deployment first because it is the "main" resource. How would you evaluate that choice?</summary>
+
+**Answer:** Kubernetes may eventually reconcile the application either way, but dependency-first ordering produces cleaner rollout behavior and easier diagnostics. If pods start before the ConfigMap exists, they can fail temporarily, generate noisy events, and obscure real problems. Put the ConfigMap before the Deployment, then put the Service where it best fits the review flow. This tests the design outcome around multi-resource manifests and the operational tradeoff between eventual reconciliation and clean first-apply behavior.
 </details>
 
 ## Hands-On Exercise
 
-In this comprehensive exercise, you will build a complex multi-resource application from scratch. You will deliberately introduce specific errors, and then utilize the debugging techniques discussed in this module to methodically diagnose and fix them. 
+In this exercise, you will build a small multi-resource application manifest, intentionally encounter structural failures, and use the module's debugging workflow to repair them. The exercise assumes access to a Kubernetes 1.35-compatible cluster such as kind, minikube, or a shared development namespace. If you do not have a cluster, you can still read the dry-run commands and compare the expected diagnostics, but the server-side validation step requires an API server.
 
-**Prerequisites:** Ensure you have access to a running Kubernetes cluster (such as minikube, kind, or a cloud provider) and have your `kubectl` CLI configured properly.
+Use a scratch directory outside your source repository for the lab file so you do not accidentally commit exercise artifacts. Define the alias before you start, then create a file named `dojo-app.yaml`. The first version is intentionally broken in several ways: the API version is wrong for a Deployment, a numeric field is quoted as a string, and the container list is missing its sequence structure.
 
 ### Task 1: The Broken Foundation
-Create a local file named `dojo-app.yaml`. Paste the following intentionally broken YAML payload into it. Attempt to apply it to your cluster using `kubectl apply -f dojo-app.yaml --dry-run=client`.
+
+Create `dojo-app.yaml` with this payload, then run `k apply -f dojo-app.yaml --dry-run=client` and read the first error carefully.
 
 ```yaml
 apiVersion: v1
@@ -558,43 +566,42 @@ spec:
       image: nginx:1.27
 ```
 
-<details>
-<summary>Solution & Diagnosis 1</summary>
+<details><summary>Solution & Diagnosis 1</summary>
 
-You should see an error similar to: `no matches for kind "Deployment" in version "v1"`.
-**Fix:** Change `apiVersion: v1` to `apiVersion: apps/v1`. Deployments do not live in the core API group.
+You should see an error similar to `no matches for kind "Deployment" in version "v1"`. Change `apiVersion: v1` to `apiVersion: apps/v1` because Deployments belong to the `apps` API group, not the core group. This repair addresses the Kubernetes root contract before you debug deeper structure.
 </details>
 
 ### Task 2: The Type and Structure Failures
-Apply the file again using the client dry-run. You will hit several more errors. Fix them one by one, carefully reading the error messages. Use `kubectl explain deployment.spec` if you get stuck on the expected structure.
 
-<details>
-<summary>Solution & Diagnosis 2</summary>
+Run the client dry run again. Fix the next errors one at a time instead of trying to rewrite the whole file from memory. Use `k explain deployment.spec.replicas` and `k explain deployment.spec.template.spec.containers` if you want to confirm both the integer field and the sequence shape.
 
-1.  **Error:** `Invalid value: "2": spec.replicas must be an integer`.
-    **Fix:** Change `replicas: "2"` to `replicas: 2` (remove quotes).
-2.  **Error:** `error converting YAML to JSON: yaml: line 15: mapping values are not allowed in this context` (or similar depending on parser). Look at the `containers` block.
-    **Fix:** `containers` expects a sequence (list) of objects, not a direct mapping. You are missing the hyphen.
-    Change:
-    ```yaml
-      containers:
-      name: nginx
-    ```
-    To:
-    ```yaml
-      containers:
-      - name: nginx
-        image: nginx:1.27
-    ```
+<details><summary>Solution & Diagnosis 2</summary>
+
+First, change `replicas: "2"` to `replicas: 2` because the Deployment schema expects an integer, not a string. Second, repair the container list because `containers` expects a sequence of container objects.
+
+```yaml
+  containers:
+  name: nginx
+```
+
+should become:
+
+```yaml
+  containers:
+  - name: nginx
+    image: nginx:1.27
+```
+
+The exact line number in the parser error may vary, but the structural issue is the missing sequence item under `containers`.
 </details>
 
 ### Task 3: Adding a Service Safely
-Now that the Deployment schema validates successfully, append a Service object to the *bottom* of the same `dojo-app.yaml` file. The Service should expose port 80 and route traffic to your existing Pods. **Ensure you use the correct YAML document separator.**
 
-<details>
-<summary>Solution 3</summary>
+After the Deployment validates, append a Service object to the bottom of the same file. The Service should expose port 80 and route to pods with `app: web`. Use the YAML document separator so the Service is a separate Kubernetes object rather than a malformed continuation of the Deployment.
 
-Add `---` at the end of the file, then append the Service definition:
+<details><summary>Solution 3</summary>
+
+Add `---` at the end of the Deployment document, then append the Service definition:
 
 ```text
 ---
@@ -612,10 +619,10 @@ spec:
 </details>
 
 ### Task 4: Adding a ConfigMap Dependency
-Next, add a third critical resource at the **very top** of the file (before the Deployment): a ConfigMap named `app-config` containing a single key `welcome-message` and the value `"Hello KubeDojo!"`.
 
-<details>
-<summary>Solution 4</summary>
+Add a third resource at the very top of the file, before the Deployment. The ConfigMap should be named `app-config` and should contain one key, `welcome-message`, with the value `"Hello KubeDojo!"`. Keep a separator between the ConfigMap and the Deployment so each object remains independent.
+
+<details><summary>Solution 4</summary>
 
 Add this to the very top of `dojo-app.yaml` and separate it from the Deployment with `---`.
 
@@ -631,16 +638,20 @@ data:
 </details>
 
 ### Task 5: Connecting the Pieces
-Modify the Deployment from Task 2 so that the `nginx` container dynamically mounts the ConfigMap from Task 4 as an environment variable explicitly named `GREETING`. Then, execute a comprehensive server-side dry run to validate the entire application stack.
+
+Modify the Deployment so the `nginx` container reads the ConfigMap key as an environment variable named `GREETING`. Then run a server-side dry run to validate the complete application stack against the live API server and any admission policy in the cluster.
 
 ```bash
 kubectl apply -f dojo-app.yaml --dry-run=server
 ```
 
-<details>
-<summary>Solution 5</summary>
+```bash
+k apply -f dojo-app.yaml --dry-run=server
+```
 
-Your final, valid `dojo-app.yaml` should look exactly like this:
+<details><summary>Solution 5</summary>
+
+Your final, valid `dojo-app.yaml` should look like this:
 
 ```text
 apiVersion: v1
@@ -686,24 +697,41 @@ spec:
     targetPort: 80
 ```
 
-When you run `kubectl apply -f dojo-app.yaml --dry-run=server`, you should see output confirming all three resources:
+When you run `k apply -f dojo-app.yaml --dry-run=server`, you should see output confirming all three resources:
+
 ```text
 configmap/app-config created (server dry run)
 deployment.apps/web-app created (server dry run)
 service/web-app-svc created (server dry run)
 ```
-If you see this, your complex multi-resource YAML file is structurally sound and schema-compliant. You can remove `--dry-run=server` to actually deploy it!
+
+If you see this, your multi-resource YAML file is structurally sound, schema-compliant, and acceptable to the target API server. Remove `--dry-run=server` only when you intend to create or update the objects in the selected namespace.
 </details>
 
 ### Exercise Success Checklist
-- [x] Successfully triggered an API group error and resolved it by switching `v1` to `apps/v1`.
-- [x] Successfully identified and fixed a YAML sequence indentation error by correctly implementing hyphens.
-- [x] Appended a Service object using the `---` multi-document separator.
-- [x] Prepended a ConfigMap and successfully referenced it in the Deployment spec.
-- [x] Executed a server-side dry run resulting in three successful "created" confirmations.
+
+- [ ] You triggered an API group error and fixed it by changing the Deployment from `v1` to `apps/v1`.
+- [ ] You identified a quoted integer problem and changed `replicas: "2"` to `replicas: 2`.
+- [ ] You repaired a sequence indentation problem by adding the missing container hyphen.
+- [ ] You appended a Service as a separate YAML document using `---`.
+- [ ] You prepended a ConfigMap dependency and referenced it from the Deployment environment.
+- [ ] You ran a server-side dry run and saw dry-run confirmations for the ConfigMap, Deployment, and Service.
+
+## Sources
+
+* [Kubernetes API overview](https://kubernetes.io/docs/concepts/overview/kubernetes-api/)
+* [Kubernetes objects](https://kubernetes.io/docs/concepts/overview/working-with-objects/)
+* [Kubernetes object management](https://kubernetes.io/docs/concepts/overview/working-with-objects/object-management/)
+* [Kubernetes labels and selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
+* [Kubernetes annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
+* [Kubernetes ConfigMaps](https://kubernetes.io/docs/concepts/configuration/configmap/)
+* [Kubernetes Secrets](https://kubernetes.io/docs/concepts/configuration/secret/)
+* [Kubernetes volumes](https://kubernetes.io/docs/concepts/storage/volumes/)
+* [kubectl explain reference](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_explain/)
+* [kubectl apply reference](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_apply/)
+* [kubectl diff reference](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_diff/)
+* [YAML 1.2.2 specification](https://yaml.org/spec/1.2.2/)
 
 ## Next Module
 
-You have now mastered the complex language of Kubernetes (YAML) and deeply understand how to construct, validate, and debug the declarative resources that run your critical enterprise workloads. But *why* is Kubernetes architected this way? Why enforce declarative YAML state definitions instead of simple imperative bash commands?
-
-Continue your journey in [Philosophy and Design](/prerequisites/philosophy-design/module-1.1-why-kubernetes-won/) to deeply understand the broader architectural picture: the autonomous control loops, the asynchronous reconciliation architecture, and the fundamental reasons why Kubernetes ultimately won the container orchestration war.
+You have now practiced YAML as the language of Kubernetes desired state: structure first, schema second, validation before mutation. Continue to [Philosophy and Design](/prerequisites/philosophy-design/module-1.1-why-kubernetes-won/) to see why Kubernetes is built around declarative APIs, asynchronous reconciliation, and controllers that continuously move actual state toward the state you declare.


### PR DESCRIPTION
## Summary
- Rewrites `src/content/docs/prerequisites/kubernetes-basics/module-1.8-yaml-kubernetes.md` to clear the #388 density, structure, alignment, anti-leak, and source-count verifier gates.
- Clears `revision_pending: false`.
- Preserves the original YAML/Kubernetes topic coverage and protected asset categories while expanding the teaching flow and adding sources.

## Verifier
- `verify_module.py --skip-source-check`: tier T0, passed=true; body_words=5038, mean_wpp=70.0, median_wpp=71.0, short_rate=0.014, max_run=1.

## Protected Assets
- Before: code_blocks=32, mermaid_diagrams=1, ascii_diagrams=0, tables=1.
- After: code_blocks=38, mermaid_diagrams=1, ascii_diagrams=0, tables=4.
- Original protected asset categories were preserved; additional validation and decision tables/code examples were added for #388 structure.

## Commit
- f8a7b68ca5117173b22f5b5dcf43b6d150e536eb

## Checks
- PASS: `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/quality/verify_module.py --glob src/content/docs/prerequisites/kubernetes-basics/module-1.8-yaml-kubernetes.md --skip-source-check --summary --quiet`
- PASS: `git diff --check -- src/content/docs/prerequisites/kubernetes-basics/module-1.8-yaml-kubernetes.md`
- NOT RUN: `npm run build`; primary checkout is dirty/behind with unrelated local changes, so I did not switch it or build there.
