### PR TITLE
feat(388): rewrite module-1.1-first-cluster (#388 pilot)

### DIFF
--- a/src/content/docs/prerequisites/kubernetes-basics/module-1.1-first-cluster.md
+++ b/src/content/docs/prerequisites/kubernetes-basics/module-1.1-first-cluster.md
@@ -1,6 +1,7 @@
 ---
 title: "Module 1.1: Your First Cluster"
 slug: prerequisites/kubernetes-basics/module-1.1-first-cluster
+revision_pending: false
 sidebar:
   order: 2
 lab:
@@ -17,39 +18,39 @@ lab:
 **Time to Complete:** 45-60 minutes
 **Prerequisites:** Docker installed, Cloud Native 101 completed
 
+Throughout this module, `kubectl` is the official Kubernetes command-line client, and we will use the common short alias `k` after defining it once. The alias matters because Kubernetes work involves many repeated inspection commands, and the shorter form keeps examples readable without changing what is executed.
+
+```bash
+alias k=kubectl
+```
+
 ## Learning Outcomes
-- Construct a local Kubernetes cluster using `kind` to provide an isolated environment for workload experimentation.
-- Compare local Kubernetes provisioning tools (kind, minikube, k3d, Docker Desktop) to select the appropriate solution for specific development scenarios.
-- Diagnose common cluster initialization failures by interpreting system logs and container states.
-- Design a multi-node local cluster configuration to simulate realistic production topologies.
-- Evaluate the impact of control plane component failures on the overall cluster state.
-- Analyze and manipulate the `kubeconfig` file to seamlessly authenticate and switch contexts between multiple discrete clusters.
-- Formulate a strict local development strategy that mitigates the financial and operational risks associated with cloud-managed Kubernetes environments.
-- Deconstruct the monolithic architecture of a cluster into its distinct Control Plane and Data Plane components.
+
+- Construct and verify a Kubernetes 1.35+ local cluster with `kind`, Docker, and the `k` command-line workflow.
+- Compare local cluster tools and design a topology that matches the development or testing problem in front of you.
+- Diagnose local cluster startup, networking, kubeconfig, and control plane failures by reading concrete signals from Docker and Kubernetes.
+- Evaluate how control plane and worker node components cooperate, then predict how failures affect scheduling and access.
+- Implement a repeatable local development routine that keeps clusters disposable, version-pinned, and isolated from cloud cost risk.
 
 ## Why This Module Matters
 
-It is widely cited in industry case studies that in August 2012, Knight Capital Group deployed a software update to their production trading servers. They lacked a proper staging environment that precisely mirrored production, and they had no local sandboxes for developers to safely test the interaction between new code and legacy routing systems. When the flawed update went live, it resurrected a dormant testing subroutine that began buying high and selling low at a staggering volume. In just 45 minutes, Knight Capital lost 460 million dollars. They went bankrupt shortly after. 
+In August 2012, Knight Capital Group deployed a software update across production trading servers and accidentally reactivated old testing logic that should never have influenced live orders. The company lost 460 million dollars in about 45 minutes, then needed outside rescue financing almost immediately. The incident was not a Kubernetes story, but it was exactly the kind of engineering failure Kubernetes teams still create when they treat production or a shared staging cluster as the first realistic place to test behavior.
 
-While you might not be deploying high-frequency algorithmic trading software today, the foundational engineering principle remains identical: testing directly in production, or in shared staging environments where multiple teams are constantly mutating state, is a recipe for unpredictable and catastrophic failure. You need a safe, ephemeral, and accurate replica of your production orchestration system where you can experiment, break things, and rebuild them in seconds without financial or operational risk. Relying solely on cloud-managed clusters for initial learning and testing introduces unnecessary friction, high costs, and dangerous blast radii.
+A cluster is not just another command-line tool you install and forget. It is a distributed control system with authentication, desired state, schedulers, background controllers, network translation, container runtimes, and persistent state. When a team experiments directly in a shared environment, one mistaken manifest can block other engineers, consume scarce cloud resources, or hide a bug behind someone else's active changes. A local cluster gives you the opposite operating model: a private arena where failure is cheap, recovery is fast, and the blast radius stays on your laptop.
 
-Consider the reality of cloud computing costs. An Amazon EKS cluster incurs an hourly control plane fee simply for existing. Beyond that base tax, you pay for the EC2 worker nodes, the Elastic Block Store (EBS) volumes, the Elastic Load Balancers (ELB), and cross-Availability Zone data transfer. Leaving a simple "learning" cluster running over a long weekend can easily result in a $150 surprise bill. In a team of 10 developers, if everyone spins up their own cloud sandbox, the monthly burn rate skyrockets unnecessarily.
+Cloud-managed Kubernetes is the right answer for many production workloads, yet it is a poor first sandbox for learning. A managed control plane can take many minutes to provision, incurs a fee simply for existing, and often brings attached costs for nodes, disks, load balancers, and cross-zone traffic. A forgotten learning cluster can create a real invoice, while a local `kind` cluster can be deleted without leaving behind cloud infrastructure. This module teaches you to build that local arena, inspect its moving parts, and decide when a single-node cluster is enough versus when a multi-node topology is worth the extra resources.
 
-Furthermore, cloud provisioning is inherently slow. Bootstrapping a managed cluster via Terraform or a cloud console often takes 15 to 25 minutes as underlying virtual machines are allocated, networks are configured, and control plane software is bootstrapped by the provider. If you make a fundamental mistake in your configuration—such as applying a globally restrictive network policy that locks you out—and need to tear the cluster down to rebuild it, that feedback loop is painfully long. Local clusters, in contrast, can be provisioned from scratch and destroyed in mere seconds. The faster you fail, the faster you learn.
+The goal is not to memorize a cluster creation command. The goal is to develop an operational model: you should know what `kind` builds, where `k` sends requests, why kubeconfig controls your identity, which component schedules a Pod, why a local LoadBalancer stays pending, and how to recover when Docker, disk space, version skew, or the control plane fails. Once you can deliberately create, break, inspect, and delete your first cluster, later modules about workloads, services, storage, security, and automation become much less abstract.
 
-This module provides exactly the solution to that problem. You will learn to provision and manage a local Kubernetes cluster entirely on your workstation. This is the absolute foundational skill for everything that follows in your Kubernetes journey. By running a cluster locally, you isolate your learning environment, completely eliminate cloud costs, and gain the freedom to intentionally destroy and restore your infrastructure to deeply understand how it behaves under duress. You will transition from theoretical knowledge to practical, hands-on control of a distributed system.
-
-> **Stop and think**: Reflect on a time you or a colleague accidentally broke a shared staging environment. How much time was wasted coordinating with other developers who were blocked by your mistake? How would an isolated, local replica of the environment have changed the outcome?
+There is also a cultural lesson in this first module. Teams that are confident with disposable local clusters tend to write smaller experiments, reproduce bugs with fewer meetings, and describe failures with better evidence. Teams without that practice often treat every cluster problem as a shared emergency because nobody can quickly recreate the conditions alone. As you work through the module, keep asking which facts you can prove locally before involving a shared platform. That habit saves time, money, and credibility when the same diagnostic pattern later appears in a real environment.
 
 ## Section 1: Anatomy of a Kubernetes Cluster
 
-Before you can construct a cluster, you must possess a rigorous understanding of what you are actually building. A Kubernetes cluster is not a single monolithic application; it is a highly distributed system composed of multiple specialized, independent components working in concert through declarative APIs. At the highest architectural level, a cluster is rigidly divided into two distinct logical planes: the Control Plane and the Data Plane (commonly referred to as Worker Nodes).
+Before you construct a cluster, you need to know what is being assembled. Kubernetes is not a single process that "runs containers"; it is a collection of cooperating services that maintain desired state through an API. A useful first split is the control plane and the data plane. The control plane stores decisions and coordinates work, while the data plane runs the actual application containers on nodes. That separation is why a cluster can keep existing Pods running even when some management components are temporarily unhealthy, but it is also why new changes can freeze when the API or scheduler is unavailable.
 
-Consider a symphony orchestra as an analogy. The orchestra consists of dozens of highly skilled musicians (the worker nodes) who actually hold the instruments and produce the sound (run the application workloads). However, without a conductor (the control plane) interpreting the musical score (the desired state), keeping the tempo, and directing exactly when specific sections should play, the result would be uncoordinated noise. The conductor does not play an instrument, just as the control plane does not execute your business logic. It solely manages the state, maintains harmony, and orchestrates the workers based on a central plan.
+Think about an orchestra where the musicians are the worker nodes and the conductor is the control plane. The musicians create the sound, but the conductor decides timing, coordination, and interpretation of the score. In Kubernetes, your YAML manifests are the score: they describe what should exist, not every mechanical step required to create it. The control plane accepts that desired state, stores it, and continuously guides worker nodes toward it. If you remember that model, many confusing behaviors become predictable rather than mysterious.
 
-Alternatively, imagine a massive global shipping port. The container ships and the dockworkers physically moving cargo represent the Worker Nodes. But the Port Authority—the central office making decisions about which ship docks at which pier, tracking the ledger of all manifests, and monitoring the weather—represents the Control Plane. 
-
-Here is an architectural view mapping the components of a standard Kubernetes cluster:
+Another useful analogy is a shipping port. The cranes and dock workers move containers, but the port authority assigns berths, tracks manifests, checks credentials, and coordinates the overall flow. A worker node is like the machinery that physically moves cargo, while the control plane is the authority that decides what should move where. If the authority is temporarily unreachable, cargo already sitting on a dock does not vanish, but new instructions cannot be accepted cleanly. That is why a healthy cluster is more than "containers are still running"; it is the continued cooperation of state storage, API access, scheduling, and node execution.
 
 ```mermaid
 flowchart TD
@@ -84,9 +85,10 @@ flowchart TD
                 CE1 --- POD1A
                 CE1 --- POD1B
             end
-            
+
             subgraph NODE_2 [NODE 2]
                 direction TB
+
                 K2[Kubelet]
                 P2[Proxy]
                 CE2[Container Engine]
@@ -104,58 +106,23 @@ flowchart TD
     end
 ```
 
-### The Control Plane Components
+The API server is the front door of the cluster. Every external command, controller request, and internal status update flows through it, and it is the only component that talks directly to the backing datastore. When you run a command with `k`, the API server authenticates who you are, authorizes the action through RBAC, applies admission policies, validates the object, and then persists accepted state. If the API server is down, you may still have containers running on worker nodes, but you cannot reliably read or change cluster state through the Kubernetes API.
 
-The Control Plane consists of four critical, distinct daemons. Understanding their distinct responsibilities is the key to mastering Kubernetes.
+`etcd` is the cluster's memory. It is a strongly consistent key-value store that holds objects such as namespaces, Deployments, Secrets, Services, and Pod records. The scheduler does not keep an independent private database, and neither does the controller manager; they watch the API server and write their decisions back into persisted state. This design makes Kubernetes auditable and declarative, but it also means that `etcd` health is not optional. If the datastore cannot accept writes, the cluster cannot safely accept new desired state.
 
-#### 1. `kube-apiserver`
-This is the absolute front door of the cluster. It provides the REST API that all other components and external users (like you) interact with. Crucially, it is the *only* component permitted to communicate with the backend datastore (`etcd`). 
-When you execute a command, the API server performs three distinct, sequential steps before doing anything else:
-- **Authentication:** Proving who you are cryptographically.
-- **Authorization:** Proving you have Role-Based Access Control (RBAC) permissions to perform the action.
-- **Admission Control:** Executing plugins that can mutate your request or deny it based on complex organizational policy.
-If the API server is down, the entire cluster becomes a frozen, read-only system where no configuration can change.
+The scheduler is the matchmaker. It watches for Pods that exist in the API but do not yet have a node assignment, filters nodes that cannot run them, scores the remaining nodes, and writes the selected node name back onto the Pod object. It does not start containers itself. The kubelet on the chosen node later observes the assignment and works with the container runtime to make the Pod real. This distinction is important when debugging: a Pending Pod is often a scheduling problem, while a Pod assigned to a node but failing to start is usually a node, image, runtime, or configuration problem.
 
-#### 2. `etcd`
-The memory of the cluster. This is a highly available, strongly consistent key-value store utilizing the Raft consensus algorithm. It holds the entire state of the cluster—every configuration, every secret, every pod definition, every namespace. If the `etcd` quorum is lost, your cluster suffers complete amnesia. It favors consistency over availability; in a network partition, it will halt writes rather than risk diverging state (split-brain).
+The controller manager is the cluster's collection of reconciliation loops. A controller repeatedly compares observed state with desired state and takes small corrective actions. If a Deployment says three replicas should exist and one Pod disappears, the relevant controller creates another Pod object. If a node stops reporting, the node controller marks that condition. Kubernetes feels automatic because many controllers are constantly watching and nudging state toward the declarations you made. They are not magic; they are programs repeatedly asking, "What changed, and what needs to happen next?"
 
-#### 3. `kube-scheduler`
-The matchmaker. It constantly watches the API server for newly created workloads (Pods) that have no assigned node. It executes a complex two-step algorithm:
-- **Filtering:** Which nodes possess the required hardware (CPU/Memory) and fulfill the strict constraints (node selectors) to run this pod? If a node is out of memory, it is filtered out immediately.
-- **Scoring:** Of the eligible nodes, which is the absolute optimal choice based on current utilization and affinity rules? 
-Once decided, the scheduler simply writes the chosen node's name back to the Pod API object in etcd. It doesn't actually start the Pod.
+Worker nodes run the kubelet, kube-proxy, and a container engine such as `containerd`. The kubelet receives Pod specifications assigned to its node and ensures the required containers are running and reporting health. Kube-proxy manages network rules so Services can route traffic to changing Pod IPs. The container engine pulls images and asks the operating system kernel to create isolated processes using cgroups and namespaces. Kubernetes also delegates networking to CNI plugins and runtime integration to the CRI, which is why clusters can use different networking and runtime implementations while exposing the same Kubernetes API.
 
-#### 4. `kube-controller-manager`
-The thermostat. It runs numerous independent controller processes in continuous background loops. These controllers obsessively compare the current observed state of the cluster to your desired state (stored in etcd), taking immediate action to reconcile any deviations. If a node crashes, the Node Controller notices and triggers the ReplicaSet Controller to spin up replacement pods elsewhere.
+This component split also explains why Kubernetes debugging is usually a process of narrowing responsibility. If the API server rejects a manifest, you inspect schema, authentication, authorization, or admission. If a Pod stays Pending, you inspect scheduling constraints and node capacity. If a Pod is assigned but not running, you inspect kubelet events, image pulls, runtime errors, probes, and volumes. If traffic reaches a Service but not a backend, you inspect selectors, endpoints, kube-proxy behavior, and network policy. A local cluster gives you a place to practice that narrowing without waiting for a production incident to teach it under pressure.
 
-### The Worker Node Components
+Pause and predict: if the `kube-scheduler` process crashes but the API server and `etcd` remain healthy, what happens when you create a new Deployment? The request can still be accepted and stored, but the new Pods will remain Pending because nothing assigns them to nodes. Existing running Pods usually continue because kubelets already know about them. That prediction is the operational habit you are building: separate "the API accepted my desired state" from "a worker can actually execute it."
 
-The Worker Nodes are the heavy lifters where the actual computational execution occurs:
+## Section 2: Choosing a Local Kubernetes Tool
 
-#### 1. `kubelet`
-The captain of the ship. Each node runs a kubelet process directly on the operating system. It receives pod specifications from the API server and ensures the described containers are actually running and healthy on that specific node. It acts as the bridge between Kubernetes and the underlying container runtime via the Container Runtime Interface (CRI). It constantly reports the node's health back to the API Server. If the kubelet dies, the node becomes "NotReady".
-
-#### 2. `kube-proxy`
-The network dispatcher. It maintains complex network routing rules (often manipulating Linux `iptables` or `IPVS`) directly on the host operating system. When a request hits a Service IP (a virtual IP that doesn't actually exist on any network card), `kube-proxy`'s rules are responsible for transparently translating that virtual IP into the real, routable IP address of a backend Pod container.
-
-#### 3. Container Engine
-The low-level software (such as `containerd` or `CRI-O`) responsible for unpacking OCI (Open Container Initiative) images from a registry and interfacing with the Linux kernel (using cgroups and namespaces) to create isolated processes. It executes the literal start/stop commands on the containers.
-
-#### 4. Container Runtime Interface (CRI)
-While not a standalone daemon, the CRI is a critical architectural boundary. Originally, Kubernetes was hard-coded specifically to talk to Docker. As the ecosystem matured, the maintainers realized they needed to support other runtimes. They ripped out the hard-coded Docker logic and replaced it with the CRI, a standardized gRPC interface. Any software that implements the CRI can now act as a Kubernetes container engine.
-
-#### 5. Container Network Interface (CNI)
-Similar to the CRI, the CNI is a standardized interface, but specifically for network plugins. Kubernetes itself does not know how to assign IP addresses to Pods or route traffic between different physical nodes. It delegates this entirely to a CNI plugin (such as Calico, Flannel, or Cilium). When a Pod starts, the kubelet calls the CNI plugin to configure the virtual network interfaces and assign the IP.
-
-> **Pause and predict**: What do you think happens if the `kube-scheduler` process crashes, but all other components remain healthy? If you attempt to deploy a new application while the scheduler is down, what exact state will that application be stuck in?
-> <details>
-> <summary>Reveal Answer</summary>
-> The API Server will successfully authenticate your request and persist the pod definition into the `etcd` datastore. However, the pod will remain in a `Pending` state indefinitely. This occurs because the `kube-scheduler` is exclusively responsible for evaluating nodes and assigning the pod to a specific worker. Without that assignment, no `kubelet` will ever be instructed to launch the corresponding container.
-> </details>
-
-## Section 2: The Local Kubernetes Arena - Choosing Your Weapon
-
-The ecosystem recognizes the critical need for local development and provides several exceptional, mature tools for running local Kubernetes clusters. Each tool makes distinct architectural trade-offs to achieve its specific goals. Selecting the right tool requires understanding how they construct the illusion of a distributed system on a single physical machine.
+Local Kubernetes tools all answer the same high-level need, but they do not build the same kind of environment. Some tools create virtual machines, some run clusters inside containers, and some integrate with a desktop virtualization layer. The right choice depends on whether you care most about startup speed, distribution fidelity, resource limits, multi-node behavior, or convenience. For this curriculum, we use `kind` because it is fast, scriptable, upstream-oriented, and excellent for disposable clusters used in tests and exercises.
 
 | Tool | Underlying Architecture | Primary Use Case | Pros | Cons |
 |---|---|---|---|---|
@@ -164,15 +131,7 @@ The ecosystem recognizes the critical need for local development and provides se
 | **k3d** | Docker Containers running k3s | Edge computing simulation, IoT | Minimal memory footprint, extraordinarily fast startup. | Uses k3s (a stripped-down, modified Kubernetes distribution), which may lack 100% parity with cloud providers. |
 | **Docker Desktop / Colima** | Integrated Hypervisor / Lightweight VM | Quick validation for Mac/Windows users | Zero configuration, GUI integration, easy volume mounting. | Inflexible, limited strictly to a single monolithic node, tightly coupled to the virtualization engine. |
 
-For this curriculum, we strictly mandate the use of `kind`. 
-
-### The Magic of Docker-in-Docker (DinD)
-
-The name `kind` stands for Kubernetes IN Docker. It was originally built by the Kubernetes open-source project maintainers themselves. They needed a way to automatically test the Kubernetes codebase on GitHub Pull Requests without waiting 30 minutes for cloud resources to provision. They needed something fast, cheap, and entirely ephemeral.
-
-`kind` provisions Kubernetes nodes by running standard Docker containers, but these containers are specially privileged to run `systemd` (the Linux init system), container runtimes (like `containerd`), and all the native Kubernetes components *inside* themselves. This nested architecture is known as "Docker-in-Docker."
-
-When you ask `kind` for a 3-node cluster, it simply asks your host Docker daemon to spin up 3 large Docker containers. Inside each of those containers, a full Linux environment boots up, starts `kubelet`, and begins running Kubernetes pods (which are themselves containers nested inside the outer node container). This provides the exact API surface and distributed nature of a real cluster while keeping resource overhead drastically lower than booting three separate VirtualBox VMs.
+`kind` stands for Kubernetes IN Docker, and the name is literal. A `kind` node is a Docker container that is privileged enough to run Kubernetes node processes inside it. When you create a three-node `kind` cluster, Docker starts three node containers, and each node container runs its own kubelet and `containerd`. The cluster feels distributed to Kubernetes because each node has a separate identity and network address, even though all of those nodes are ultimately containers on your workstation. This is not the same as production hardware, but it is close enough to teach scheduling, kubeconfig, controller behavior, and many networking patterns.
 
 ```mermaid
 flowchart TD
@@ -214,29 +173,21 @@ flowchart TD
     Node2 -.-> PodA
 ```
 
-> **Pause and predict**: If a `kind` worker node is fundamentally just a Docker container running on your host machine, what happens if you restart the Docker daemon on your host? Will the Kubernetes cluster survive?
-> <details>
-> <summary>Reveal Answer</summary>
-> No, the Kubernetes cluster will not survive a Docker daemon restart. Because `kind` nodes are essentially just privileged Docker containers, restarting the host daemon forcibly stops and reconstructs the container environments. This terminates all active Kubernetes processes, including the API Server and `etcd`. Consequently, the active state of your local cluster is destroyed, requiring a complete recreation of the cluster to restore functionality.
-> </details>
+The hidden tradeoff is that a `kind` cluster depends on the host Docker daemon. If Docker stops, the node containers stop, and your cluster disappears with them. That makes `kind` a poor home for durable state and a strong home for learning, integration testing, and quick reproduction. A local cluster should be treated like a whiteboard, not a records archive. Build it, test the hypothesis, export logs if you need evidence, and delete it when the exercise is over.
 
-## Section 3: Demystifying Kubeconfig - The Passport to Your Cluster
+That tradeoff is exactly why `kind` fits the early Kubernetes learning path. You are not trying to preserve customer data, survive a zone outage, or prove a managed cloud integration. You are trying to learn the shape of the API, observe controllers, compare node topology, and build confidence with failure. The cheaper the environment is to recreate, the more willing you become to test dangerous questions: what if the scheduler is gone, what if an image is missing, what if the active context is wrong, or what if the host Docker daemon stops. Those experiments are valuable precisely because cleanup is quick.
 
-Before we bootstrap a cluster, we must rigorously understand how we will talk to it. Kubernetes is secure by default. You cannot simply send unauthenticated HTTP requests to the API Server. You require cryptographic credentials. 
+Before running commands, choose the smallest topology that can prove the behavior you care about. A single-node cluster is enough for basic API interaction, simple manifests, and most early workload tests. A multi-node cluster becomes valuable when you need scheduling spread, node selectors, taints, tolerations, DaemonSets, or realistic network paths between nodes. Which approach would you choose here and why: testing a basic ConfigMap mount, or testing whether two replicas land on different nodes? The first needs little topology; the second requires a cluster that can express placement.
 
-Enter the `kubeconfig` file. By default, the `kubectl` command-line tool looks for a file located at `~/.kube/config`. This file is the absolute source of truth for your identity and routing information. It tells `kubectl` *where* the cluster is, and *who* you are.
+## Section 3: Kubeconfig Is Your Passport
 
-Think of the `kubeconfig` file as a physical **Passport**.
+Kubernetes is secure by default, so `k` cannot simply send anonymous HTTP requests to a cluster and hope for the best. It needs an API server address, a trusted certificate authority, and credentials that identify you. That information lives in kubeconfig, usually at `~/.kube/config`. A kubeconfig file is not merely a convenience file; it is the passport that tells your client where to travel, which identity to present, and which cluster/user pairing is active right now.
 
-1.  **Clusters (The Country):** A cluster entry in the file defines the destination. It contains the URL of the API Server (e.g., `https://127.0.0.1:54321`) and the Certificate Authority (CA) data required to cryptographically verify that the server is legitimate and not a man-in-the-middle attacker. This is like knowing the geographical location of a country and trusting its government.
-2.  **Users (The Visa / Identity):** A user entry defines *you*. It might contain a client certificate and private key, a bearer token, or instructions to execute an external authentication plugin (like AWS IAM or Google Cloud Identity). This is your biometric data and visa paperwork proving who you are.
-3.  **Contexts (The Passport Stamp):** A context is the crucial glue. A context explicitly binds one specific User to one specific Cluster, and optionally defines a default namespace. When you "switch contexts," you are telling `kubectl`, "For my next commands, use the 'admin' user credentials to talk to the 'production-eu' cluster."
+The structure has three major pieces. A cluster entry defines the destination API server and the certificate authority data used to verify that server, much like knowing which country you are entering and trusting its passport control. A user entry defines the identity material, such as certificates, tokens, or an external login plugin. A context binds one user to one cluster, optionally with a default namespace. Switching context changes where future commands go and which credentials they use, which is why context mistakes can be dangerous.
 
-When you create a cluster with `kind`, or any other tool, the very last step of the provisioning process automatically writes a new Cluster, User, and Context entry into your `~/.kube/config` file, and sets that new context as the current active one.
+Kubeconfig becomes especially important once you have more than one cluster. A single file might contain a local `kind` context, a staging context, and a production context, all available to the same command-line tool. That convenience is powerful, but it means the active context is part of the safety model. Before applying anything that creates, deletes, or changes workloads, make it a habit to ask, "Which cluster will receive this request, which user will I be, and which namespace will be assumed?" Beginners often treat kubeconfig as plumbing; operators treat it as a control surface.
 
-### Anatomy of the YAML
-
-Here is a simplified example of what that file actually looks like. Pay close attention to how the context glues the user and cluster together:
+Here is a simplified kubeconfig. The certificate fields are shortened because real files contain long base64-encoded values, and those values are sensitive when they grant cluster access. Notice that the context does not contain a server URL or a private key itself; it references the named cluster and user. That indirection is what lets one kubeconfig file hold multiple clusters and multiple identities without duplicating every field.
 
 ```yaml
 apiVersion: v1
@@ -263,7 +214,7 @@ contexts:
   name: kind-dojo-basics
 ```
 
-You can inspect and manipulate your passport at any time using the `config` subcommand:
+You can inspect and manipulate your passport at any time. In production, you should avoid casually printing secrets to shared terminals, recordings, or logs, but on a private learning workstation these commands are useful for seeing how context selection works. The active context is the one with the star in `get-contexts`, and changing it changes the default destination for future commands in that shell.
 
 ```bash
 # View the raw YAML of your configuration (redacting actual secrets)
@@ -276,34 +227,24 @@ kubectl config get-contexts
 kubectl config use-context <context-name>
 ```
 
-### The KUBECONFIG Environment Variable
-
-Sometimes you do not want to modify your default `~/.kube/config` file. If a teammate sends you a configuration file for a temporary staging cluster, merging it manually is tedious and error-prone. Kubernetes solves this elegantly via the `KUBECONFIG` environment variable.
-
-If you set this variable, `kubectl` will completely ignore the default file and read exclusively from the path you specify:
+Sometimes you do not want to modify your default kubeconfig. A teammate might send a temporary staging config, or a CI job might generate a short-lived file for one deployment. The `KUBECONFIG` environment variable lets you point the client at a specific file for the current process environment. That is useful because it makes access explicit, temporary, and reversible instead of merging unknown credentials into your everyday configuration.
 
 ```bash
 export KUBECONFIG=/path/to/my/temporary/config.yaml
 kubectl get nodes # Operates against the temporary cluster
 ```
 
-You can even instruct `kubectl` to merge multiple files in memory simultaneously by separating paths with a colon. This is incredibly useful for CI/CD pipelines:
+You can also combine multiple kubeconfig files by separating paths with a colon on Unix-like systems. Kubernetes reads them as a merged view, which is helpful when your personal clusters, staging clusters, and generated CI credentials live in separate files. The merge behavior is powerful, but it also means names matter. Two contexts with the same name can create confusing collisions, so use clear cluster names when creating local environments.
 
 ```bash
 export KUBECONFIG=~/.kube/config:/path/to/another/config.yaml
 ```
 
-> **Pause and predict**: If you possess a `kubeconfig` file containing administrative credentials for a production cluster, what are the security implications of accidentally committing that file to a public GitHub repository?
-> <details>
-> <summary>Reveal Answer</summary>
-> It would result in an immediate and total cluster compromise. Automated bots continuously scan public repositories for exposed credentials and `kubeconfig` files. Once obtained, malicious actors can use the embedded certificates to bypass authentication and gain full administrative access to your API Server. They will instantly deploy malicious workloads, such as cryptominers, or exfiltrate highly sensitive secrets and customer data from your environment.
-> </details>
+Pause and predict: if a kubeconfig containing administrator credentials for a production cluster is committed to a public repository, what happens next? The practical answer is immediate incident response. Automated scanners look for exposed credentials, and an attacker with valid cluster credentials can read Secrets, create workloads, or run compute at your expense. Treat kubeconfig files like keys, not notes, and practice with local clusters so your muscle memory becomes careful before the stakes are high.
 
-> **Stop and think**: Run `kubectl config get-contexts` in your terminal. Examine the output and locate the context with a `*` next to it, which indicates your currently active cluster connection.
+## Section 4: Bootstrapping and Verifying the First Cluster
 
-## Section 4: Bootstrapping Your First Cluster with kind
-
-To begin, you must have Docker running on your system, as `kind` utilizes the Docker API to provision its node containers. `kind` itself is distributed as a single, statically compiled Go binary that you download and place in your system's executable path. 
+To create your first cluster, Docker must be installed and running because `kind` calls the Docker API to create node containers. The `kind` binary itself is a single executable. The exact install command varies by operating system and package manager, but the Linux AMD64 example shows the basic shape: download the binary, mark it executable, and place it somewhere on your `PATH`. Package managers such as Homebrew can perform the same job on macOS or Linux.
 
 ```bash
 # Example download for Linux AMD64 architecture
@@ -314,82 +255,51 @@ chmod +x ./kind
 sudo mv ./kind /usr/local/bin/kind
 ```
 
-Creating a default cluster is accomplished with a single declarative command. By default, `kind` provisions a single-node cluster architecture. In this specific configuration, the control plane components and the worker components (where your applications run) are collocated on the exact same node (container).
+A default `kind` cluster is created with one command. In that default topology, one container acts as both control plane and worker node. That is acceptable for first contact because it gives you the API server, `etcd`, scheduler, controller manager, kubelet, kube-proxy, CoreDNS, and a runtime in one compact environment. For deterministic exercises, pin the node image to a Kubernetes 1.35+ tag so everyone sees the same API behavior rather than whatever happens to be latest on the day they run the command.
 
 ```bash
 kind create cluster --name dojo-basics
 ```
 
-To explicitly pin the Kubernetes version, which is critical for deterministic testing, append the `--image` flag (e.g., `kind create cluster --name dojo-basics --image kindest/node:v1.35.0`).
+When this command runs, `kind` pulls the `kindest/node` image, starts a privileged node container, generates certificates, runs `kubeadm init`, starts control plane components, installs networking, and writes access details into kubeconfig. That final kubeconfig step is why your next `k` command knows where the new API server lives. The cluster is local, but it is not fake: you are talking to a real Kubernetes API server whose loopback port is mapped from your host into the node container.
 
-When you execute this seemingly simple command, `kind` performs a complex orchestration sequence behind the scenes:
-1.  **Image Pull:** It pulls a massive Docker image (`kindest/node`) pre-packaged with the Kubernetes binaries, systemd, and containerd.
-2.  **Node Provisioning:** It starts a privileged Docker container mapping random host ports to the container's internal port 6443.
-3.  **Cert Generation:** It generates cryptographic certificates for secure internal communication.
-4.  **Bootstrapping:** It executes `kubeadm init` inside the container to bootstrap the API server, etcd, scheduler, and controller-manager.
-5.  **Kubeconfig Injection:** It automatically extracts the generated admin credentials and merges them into your `~/.kube/config` file.
+This sequence is worth slowing down because every step leaves a different diagnostic trail. A pull failure points toward registry access or disk space. A node container failure points toward Docker health, permissions, or resource allocation. A `kubeadm init` failure points toward Kubernetes bootstrap logs inside the node. A kubeconfig failure points toward client access rather than cluster creation. When you read a `kind` error, do not collapse all of those stages into "cluster failed." Identify which stage failed, then choose the tool that can see that layer.
 
-To interact with the cluster, you will use `kubectl`, the official Kubernetes command-line interface. Because interacting with Kubernetes requires typing this command continuously throughout the day, the universal industry standard is to alias it to a single letter: `k`. You should append this to your `~/.bashrc` or `~/.zshrc` profile immediately:
-
-```bash
-alias k=kubectl
-```
-
-Let us empirically verify your cluster is fully operational. First, check the cluster endpoint metadata:
+To explicitly pin the Kubernetes version, append the `--image` flag, for example `kind create cluster --name dojo-basics --image kindest/node:v1.35.0`. Pinning matters when you are learning from written material because Kubernetes evolves. A command, API default, or warning can change between releases, and you want differences to be deliberate rather than accidental. In real teams, version pinning also makes bug reports reproducible because everyone can create the same local cluster shape before discussing the failure.
 
 ```bash
 k cluster-info
 ```
 
-You should see output indicating that the Kubernetes control plane is running at a local loopback address (e.g., `https://127.0.0.1:42315`) and that the CoreDNS service is operational. This proves your local `kubectl` binary can successfully authenticate and establish a secure connection to the API Server.
-
-Next, verify the state of the logical nodes:
+The `cluster-info` output should show the Kubernetes control plane running at a loopback address such as `https://127.0.0.1:42315`, plus system services such as CoreDNS. This confirms three things at once: kubeconfig points to the new cluster, your credentials authenticate successfully, and the API server can answer requests. If this command fails, do not jump straight to workload debugging. First prove whether the client can reach the control plane.
 
 ```bash
 k get nodes
 ```
 
-You will observe one node named `dojo-basics-control-plane` reporting a status of `Ready`. Notice that its designated role is `control-plane`. In a single-node setup, `kind` automatically removes the standard "NoSchedule" taint from this node, allowing your regular application workloads to be scheduled right alongside the critical control plane daemons.
-
-Finally, rigorously examine the system pods. Kubernetes natively runs its own control plane components as standard pods within an isolated, protected namespace called `kube-system`.
+You should see one node named `dojo-basics-control-plane` in the Ready state. In many production clusters, control plane nodes are tainted so normal workloads cannot run there. In a default single-node `kind` cluster, the tool makes that node schedulable so you can run application Pods without needing separate workers. That is convenient, but it is also a reminder that local clusters intentionally trade some production separation for speed and simplicity.
 
 ```bash
 k get pods --namespace kube-system
 ```
 
-You will see pods listed for `etcd`, `kube-apiserver`, `kube-controller-manager`, and `kube-scheduler`. If these pods are reporting a `Running` state, your cluster is mathematically healthy and ready to accept custom workloads.
+System Pods in `kube-system` show the cluster running itself as Kubernetes-managed workloads. You should see components such as `etcd`, `kube-apiserver`, `kube-controller-manager`, and `kube-scheduler`. This is a useful mental shift: Kubernetes does not hide every internal process from you. Many core components are visible as Pods, which means you can inspect their status, logs, and restarts using the same habits you will later use for your own workloads.
 
-> **Pause and predict**: Before running `docker ps` on your host machine, what exact output do you expect to see based on the architecture discussed? How many containers will the Docker daemon report are actively running to support this single-node cluster?
+Do not skip verification just because the create command ended successfully. A command can return after bootstrapping while some background components are still settling, image pulls are completing, or CoreDNS is restarting. The node list, system Pod list, and cluster-info output together give you a fast health snapshot from three angles: node readiness, control plane reachability, and add-on state. In professional workflows, those checks become preconditions for running tests. You want failures to point at the thing under test, not at a half-created cluster that was never ready.
 
-> **Stop and think**: Run `docker ps` on your host machine. Count the number of containers running for your `dojo-basics` cluster. You should see exactly one container running the `kindest/node` image, acting as your entire single-node cluster.
+Before running this, what output do you expect from `docker ps` on your host after creating a default `dojo-basics` cluster? You should expect one outer Docker container for the single `kind` node, not one Docker container per Kubernetes Pod visible inside the cluster. The Pods run through `containerd` inside the node container, so host Docker sees the node abstraction while Kubernetes sees the internal cluster abstraction. That layered view explains many early surprises when learners compare Docker and Kubernetes commands.
 
-## Section 5: Understanding kind Networking
+## Section 5: Local Networking and Multi-Node Design
 
-Before we build complex topologies, we need to understand how traffic flows into our isolated `kind` cluster. This is where many engineers stumble.
+Networking is where local clusters often stop feeling intuitive. Your Pods receive IP addresses from a cluster network, but your laptop does not automatically route to that Pod network. In a `kind` cluster, nodes sit on a Docker bridge network, and the API server is the one port mapped by default so `k` can communicate. If you deploy a web application, a Pod IP such as `10.244.0.5` is meaningful inside the cluster, but your browser has no native route to that address from the host.
 
-Because the cluster is running inside a Docker network bridge, it does not share an IP space with your host machine. Your laptop cannot natively "ping" a Pod IP address (e.g., `10.244.0.5`) because your laptop's routing table has no idea where that subnet exists.
+The quickest access pattern is port forwarding. A command like `k port-forward svc/my-web-app 8080:80` opens a local client-side tunnel through the API server to a Service or Pod. It is excellent for debugging because it requires no permanent cluster networking setup, but it ends when the foreground process ends. For more realistic local ingress, you can configure `kind` port mappings before cluster creation and run an ingress controller. For local LoadBalancer behavior, you need an implementation such as MetalLB because your laptop does not have a cloud load balancer controller.
 
-When you create a cluster, `kind` only exposes one port by default: the API Server port. This is mapped from a random localhost port (like `127.0.0.1:42315`) to the container's internal `6443`. This is why `kubectl` works.
+Pause and predict: if you start a port-forward, load the application in your browser, and then close the terminal window, what happens to the browser connection? The tunnel disappears immediately because the forwarding path is maintained by the local process. Kubernetes did not create a durable Service exposure on your host; it simply carried traffic through a live debugging connection. This distinction keeps you from mistaking a successful port-forward for a production networking design.
 
-If you deploy a web application and want to view it in your browser, you cannot simply use a Kubernetes `LoadBalancer` service, because your laptop is not AWS. It cannot provision a physical load balancer. You have three primary solutions:
+A single-node cluster is enough for many first exercises, but it cannot represent placement constraints. If every control plane process and every workload share one node, you cannot test whether replicas spread across nodes, whether a DaemonSet runs once per node, or whether a workload with a node selector lands only where intended. Multi-node `kind` clusters solve that by declaring multiple node containers in a configuration file. You still run locally, but Kubernetes now has a meaningful set of nodes to choose from.
 
-1. **Port Forwarding:** Use `kubectl port-forward svc/my-web-app 8080:80`. This creates a secure, temporary tunnel from your laptop's port 8080 directly to the Pod's port 80 over the API Server connection. It's excellent for quick debugging.
-2. **NodePorts with kind config:** You can pre-configure `kind` to map specific host ports directly to NodePorts during cluster creation.
-3. **Ingress Controllers:** You can deploy an NGINX Ingress controller and configure `kind` to map host port 80 and 443 to the Ingress controller pods.
-
-> **Pause and predict**: If you run `kubectl port-forward`, and then close your terminal window, what happens to the network tunnel?
-> <details>
-> <summary>Reveal Answer</summary>
-> The tunnel process is terminated immediately, and all access to the pod is completely severed. The `kubectl port-forward` command runs as a foreground process in your local terminal session to maintain the proxy connection. When you close the terminal, the operating system sends a termination signal to the process. Since the tunnel relies entirely on that active client-side process, closing the window destroys the routing path.
-> </details>
-
-## Section 6: Designing Multi-Node Topologies
-
-While a single-node cluster is entirely sufficient for basic API testing and validating simple pod manifests, it completely fails to replicate the complex, distributed nature of real-world production systems. In any production environment, you will have multiple distinct worker nodes, and your pods will be scheduled dynamically across them based on resource availability and constraints. 
-
-To effectively practice advanced concepts like node affinity (forcing a pod to run on a specific node), pod anti-affinity (ensuring two replicas never run on the same physical hardware), taints, tolerations, distributed network routing, and simulating network degradation (e.g., injecting latency between distinct worker nodes using the Linux `tc` traffic control utility), you strictly require a multi-node cluster.
-
-The brilliance of `kind` is that it allows you to declaratively define the physical architecture of your local cluster using a simple YAML configuration file, mirroring how you deploy applications. Let us design a cluster architecture containing one dedicated control plane node and two dedicated worker nodes.
+The multi-node step also prepares you for a key production reality: Kubernetes placement is an API decision, not a wish. You can request replicas, set affinity rules, add tolerations, label nodes, and constrain resources, but the scheduler still evaluates the current node set before binding each Pod. In a one-node cluster, many placement mistakes are invisible because there is nowhere else to go. In a multi-node cluster, those mistakes surface as Pending Pods, unexpected distribution, or workloads landing on nodes you did not intend. That feedback is exactly what a local training topology should reveal.
 
 Create a file named `multi-node-config.yaml` on your filesystem:
 
@@ -398,7 +308,7 @@ Create a file named `multi-node-config.yaml` on your filesystem:
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
-  # The control plane node (API server, etcd, etc.)
+  # The control plane node (API server, etc.)
   - role: control-plane
   # The first worker node (Application workloads)
   - role: worker
@@ -406,21 +316,19 @@ nodes:
   - role: worker
 ```
 
-Before applying this new desired state, you must decisively delete your existing cluster to free up local CPU and memory resources:
+Delete the first cluster before creating the next one unless you intentionally want multiple clusters running. Local clusters consume CPU, memory, disk, and ports, and the fastest way to create confusing test results is to forget which context is active. Treat the delete-and-recreate loop as normal, not destructive. Your local cluster should be easier to replace than to repair.
 
 ```bash
 kind delete cluster --name dojo-basics
 ```
 
-Now, construct the new, distributed topology by passing the declarative configuration file directly to the create command:
+Now create the multi-node topology. `kind` starts three Docker containers, initializes the first as the control plane, generates join material, and has the other two join as workers over the Docker bridge network. The command takes a little longer than the single-node cluster, but it gives you a topology that can teach scheduling decisions instead of merely API submission.
 
 ```bash
 kind create cluster --name dojo-multi --config multi-node-config.yaml
 ```
 
-This provisioning process will take slightly longer. `kind` is now explicitly starting three distinct Docker containers on your host daemon. It configures the first container as the master control plane, generates secure join tokens, and explicitly instructs the other two containerized nodes to execute `kubeadm join` to securely attach themselves to the cluster as standard workers over the virtual Docker bridge network.
-
-Verify the new architecture is fully realized:
+Verify the architecture through Kubernetes, not only through Docker. The Kubernetes node list is what the scheduler uses when it chooses placement, so it is the view that matters for later workload behavior. Worker nodes normally show `<none>` in the roles column unless you label them, which is expected and not an error.
 
 ```bash
 k get nodes
@@ -435,192 +343,173 @@ dojo-multi-worker           Ready    <none>          1m58s   v1.35.0
 dojo-multi-worker2          Ready    <none>          1m58s   v1.35.0
 ```
 
-Notice closely that the worker nodes do not have a defined role in the output column; this is standard, expected Kubernetes behavior. A missing role indicates they are standard nodes completely available for generic workload scheduling. You now possess a fully functional distributed orchestration system running entirely within the memory space of your local workstation.
+Run `k get nodes -o wide` and examine the internal IPs. Each node is really a Docker container, yet Kubernetes sees distinct node addresses and can schedule across them. That makes the topology valuable for practicing node labels, taints, tolerations, affinity, anti-affinity, and DaemonSets. If you later test a workload that must run one copy per node, the multi-node cluster is the first topology in this module that can prove the behavior rather than merely accept the manifest.
 
-> **Stop and think**: Which node approach would you choose when testing a DaemonSet configuration (a workload that must run exactly one replica on every node), and why? A single-node cluster or a multi-node cluster?
+Multi-node local clusters are still approximations, so use them honestly. They do not reproduce separate physical machines, independent power domains, real cloud routing, or storage hardware failure. They do reproduce enough of the Kubernetes control loop to teach scheduling, node identity, Pod placement, and many networking patterns. That boundary matters when reporting results. You can say, "This manifest schedules correctly across three `kind` nodes," but you should not claim it proves production availability. Good local testing answers the Kubernetes question first and leaves cloud-specific questions for environments that actually contain those cloud behaviors.
 
-> **Stop and think**: Run `kubectl get nodes -o wide` in your newly created `dojo-multi` cluster. Observe the `INTERNAL-IP` column. Notice how each node (which is actually a Docker container) has been assigned a distinct IP address on the virtual bridge network.
+## Section 6: Troubleshooting and Local Development Discipline
 
-## Section 7: Best Practices for Local Development
+Local cluster failures usually come from the host environment. Docker might be stopped, Docker might lack memory, the disk might be full, your client might be outside the supported Kubernetes version skew, or a port might already be bound by another process. These are not distractions from Kubernetes learning; they are the first diagnostic layer. Production debugging also starts by separating client, control plane, node, network, and storage signals. Local clusters simply make those layers visible and cheap to reproduce.
 
-To ensure your local environment mimics reality without crushing your laptop, adopt these core principles:
+The fastest troubleshooting loop starts with the error boundary. If `kind` cannot create a node container, Kubernetes is not ready for inspection yet. If the node exists but the API is unreachable, inspect control plane logs and kubeconfig. If the API is reachable but a workload is Pending, inspect events and scheduling constraints. If the workload is Running but inaccessible, inspect Services, endpoints, port-forwarding, and ingress mappings. Writing those branches down may feel mechanical, but it prevents a common beginner mistake: running random commands until one seems relevant.
 
-1. **Resource Limits:** Always configure resource limits (CPU/Memory) on your pods during local testing. If you don't, a memory leak in a pod will consume all memory inside the `kind` container, which will in turn consume all Docker memory, bringing your entire workstation to a halt.
-2. **Namespace Isolation:** Do not deploy everything into the `default` namespace. Practice creating namespaces for different components (e.g., `monitoring`, `database`, `frontend`). This habit is critical for production readiness.
-3. **Automate Bootstrap:** Write a simple `Makefile` or bash script to bootstrap your `kind` cluster and install core dependencies (like an Ingress Controller, Metrics Server, or local registry). This ensures you can destroy and rebuild your cluster in exactly the same state in under two minutes.
-
-## Section 8: When Things Go Sideways - Troubleshooting
-
-Infrastructure eventually fails. When operating a local cluster, failures diverge from cloud failures; they usually stem from host-level resource constraints, strict networking conflicts, or misconfigured container daemons. Learning to systematically diagnose these local failures builds the exact same analytical mental muscle memory required to debug catastrophic production outages.
-
-Below are five specific, common failure scenarios you will eventually encounter, and how to scientifically diagnose them.
-
-### Scenario 1: The OOMKilled Silence (Memory Exhaustion)
-**Symptom:** You execute `kind create cluster`. The terminal output hangs indefinitely at "Starting control-plane...". Eventually, it times out and crashes with an unhelpful generic error. 
-**Diagnosis:** `kind` relies entirely on Docker's stability. If Docker is starved for hardware resources, the heavy Kubernetes components inside the node container will fail to start. `kind` strictly requires at least 4GB of RAM (preferably 8GB for multi-node) allocated specifically to the Docker engine.
-**Action:** Inspect the node container logs directly bypassing `kubectl`: 
+If `kind create cluster` hangs at control-plane startup, inspect Docker first. A Kubernetes control plane needs memory, and the node image is not small. Docker Desktop users should allocate enough memory for the engine, especially for multi-node clusters, while Linux users should check host pressure and swapping. When the API is not available yet, `k` cannot help you, so you bypass Kubernetes and read the node container logs directly through Docker.
 
 ```bash
 docker logs <container-id>
 ```
 
-You will likely discover an `OOMKilled` (Out Of Memory) event injected by the Linux kernel. If using Docker Desktop, open the settings and increase the memory allocation limit. On Linux, ensure your host is not aggressively swapping using `free -h`.
+Port conflicts produce a different failure shape. The API server listens on port 6443 inside the node container, and `kind` maps a host port to reach it. If you explicitly configure host ports for ingress or reuse a port already taken by another local process, the new cluster cannot bind it. On macOS or Linux, commands such as `lsof -i :6443` or `netstat -tulpn | grep 6443` identify the owner. Prefer choosing a different configured port over killing unknown processes unless you are certain what owns the socket.
 
-### Scenario 2: The Port 6443 Conflict
-**Symptom:** `kind` fails immediately during control-plane initialization complaining about "port already in use" or "bind address".
-**Diagnosis:** The Kubernetes API server fundamentally listens on port 6443. `kind` attempts to map a host port to the container's internal 6443. If you are running multiple local development tools, an ingress controller on your host, or if an orphaned, crashed `kind` cluster left a binding zombie process open, the new cluster cannot bind the port.
-**Action:** Utilize `lsof -i :6443` or `netstat -tulpn | grep 6443` (on macOS or Linux) to definitively identify the conflicting process ID (PID). Terminate it (`kill -9 <PID>`) before retrying. Alternatively, you can use a `kind` config file to explicitly map to a different host port (like 8443).
+Version skew looks stranger because the cluster may be healthy while your client behaves incorrectly. Kubernetes supports a limited minor-version skew between `kubectl` and the API server. If your local client is too old for a Kubernetes 1.35 cluster, you can see errors such as missing resources, malformed output, or unsupported API behavior even though Docker shows the control plane container running. Check both client and server versions, then upgrade the client so it falls within the supported skew window.
 
-### Scenario 3: The API Negotiation Failure (Version Skew)
-**Symptom:** The cluster bootstraps perfectly. However, when you type `kubectl get pods`, you receive bizarre errors like `the server could not find the requested resource` or completely silent formatting failures.
-**Diagnosis:** You have a severe version skew between your `kubectl` client binary and the cluster's API Server version. Kubernetes officially supports a version skew of exactly +/- 1 minor version (e.g., client v1.34 can talk to server v1.33, v1.34, or v1.35). If your local client is v1.33 and `kind` just booted a v1.35 cluster, the API schemas are fundamentally incompatible.
-**Action:** Check your skew by running `kubectl version`. Utilize a strict version manager like `asdf`, `mise`, or `brew` to ensure your local `kubectl` binary is upgraded to match your cluster version.
-
-### Scenario 4: The Daemon Disconnect
-**Symptom:** You execute `kind create cluster`, but the command instantly fails with: 
+The most basic failure is a missing container runtime. `kind` cannot create nodes if Docker is not reachable, and the error often says exactly that:
 
 ```text
 failed to create cluster: failed to get docker info: Cannot connect to the Docker daemon at unix:///var/run/docker.sock.
 ```
 
-**Diagnosis:** `kind` is fundamentally incapable of working without a running container runtime. Either the Docker service has crashed, hasn't been started, or your current user account lacks the necessary file permissions to read and write to the Docker unix socket.
-**Action:** Verify Docker is running (`systemctl status docker` on Linux, or check the Docker Desktop UI). If it is running, verify your user is in the `docker` group (`sudo usermod -aG docker $USER`), log out, and log back in to apply the permission change.
+On Linux, verify the service and permissions. On desktop platforms, confirm the virtualization engine is running before retrying. If your user is not allowed to access the Docker socket, adding the user to the Docker group requires a new login session before the permission change applies. Do not debug Kubernetes scheduling when the node factory itself is unavailable.
 
-### Scenario 5: Silent Disk Space Exhaustion
-**Symptom:** The cluster creation succeeds, but when you attempt to deploy a simple NGINX pod, it gets stuck in `Pending` or `ImagePullBackOff` state. You notice system performance degrading rapidly.
-**Diagnosis:** Docker images utilized for `kind` nodes (`kindest/node`) are exceptionally large, often exceeding 1.5GB each. As you test different Kubernetes versions, these images accumulate silently. Furthermore, any files written by your pods are actually written to the underlying Docker container's filesystem, consuming your host's physical disk space. You have run out of disk space.
-**Action:** Execute the following command periodically to aggressively clear unused images, dangling volumes, and stopped containers, ensuring you maintain at least 20GB of free space for local development:
+```bash
+systemctl status docker
+sudo usermod -aG docker $USER
+```
+
+Disk pressure is another common local failure because node images, application images, writable container layers, and volumes accumulate quietly. A Pod stuck in `ImagePullBackOff` after a local build may be an image-loading mistake, but a failure to pull node images can be plain storage exhaustion. Maintain free space and prune deliberately when old test images are no longer needed. The command below is intentionally aggressive, so read its output and avoid using it when you still need stopped containers, volumes, or cached images.
 
 ```bash
 docker system prune -a --volumes
 ```
 
-**Pro Tip:** If a cluster fails and you need deep forensic data, `kind` provides a powerful utility command to extract all internal Kubernetes component logs (kubelet, containerd, API server, etcd) from the failed node containers onto your local filesystem for deep inspection:
+When a cluster fails in a way worth studying, export logs before deleting it. `kind` can collect kubelet, container runtime, API server, and other component logs from node containers into a local directory. This is the local version of preserving evidence during an incident. It lets you inspect after the cluster is gone and gives teammates concrete data instead of a vague report that "kind broke."
 
 ```bash
 kind export logs ./kind-troubleshooting-logs --name dojo-multi
 ```
 
-## Common Mistakes Deep Dive
+Strong local development discipline keeps these problems bounded. Pin Kubernetes versions, name clusters clearly, check the active context before applying manifests, load local images into the cluster when needed, and delete idle clusters when the test is complete. Avoid manually editing files inside node containers because that creates invisible state drift; put node-level changes into `kind` configuration and recreate the cluster. The point of local Kubernetes is not to preserve one perfect snowflake. The point is to make realistic environments disposable.
 
-Understanding how developers commonly misconfigure or misunderstand their local clusters is crucial for avoiding those exact traps. The local cluster can be an immense boon, but if misunderstood, it can cause deep frustration.
+A useful routine is to start each session with a named cluster, a clear version, and one written hypothesis. For example, "I am testing whether this Deployment schedules on workers labeled `workload=frontend` in Kubernetes 1.35." After the test, capture the commands, events, and final observation, then delete the cluster. That routine gives you reproducible evidence instead of a half-remembered terminal session. It also makes later automation obvious: once the manual sequence is clear, a script or Makefile can recreate it consistently for teammates and CI.
 
-### Mistake 1: Exhausting Host Disk Space
-**Symptom:** Your computer runs extremely slowly. `kind` suddenly fails to pull new node images. Your terminal warns "No space left on device."
-**Root Cause:** Docker node images are enormous. A single `kindest/node:v1.35.0` image can be upwards of 1.5GB. Over time, as you test different versions of Kubernetes to reproduce bugs, these massive images silently fill up your hard drive, leading to an eventual complete lack of space.
-**Resolution:** Run `docker system prune -a --volumes` periodically. This clears unused images, dangling volumes, and stopped containers. Ensure you always maintain at least 20GB of free space for local cloud native development.
+## Patterns & Anti-Patterns
 
-### Mistake 2: Forgetting to Delete Idle Clusters
-**Symptom:** Your workstation's fan is running constantly, and battery life is dropping rapidly, even when you aren't doing any active development. Your IDE starts to lag.
-**Root Cause:** Developers rapidly create clusters for quick testing and simply leave them running in the background. The `kubelet` and `API server` components are constantly polling and reconciling, consuming massive amounts of RAM and CPU cycles unnecessarily. A Kubernetes control plane is never truly "idle".
-**Resolution:** Always execute `kind get clusters` to audit your system and aggressively run `kind delete cluster --name <name>` when finished with a localized development session. Treat clusters as completely disposable entities. Do not grow attached to them.
+Reliable local Kubernetes work depends less on one clever command and more on repeatable habits. The patterns below are the habits worth building early because they scale into team workflows. The anti-patterns are tempting because they feel faster in the moment, but they create the exact hidden state, cost, and ambiguity that local clusters are supposed to remove.
 
-### Mistake 3: Modifying the Node Container Directly
-**Symptom:** You manually SSH/exec into a node to tweak a configuration file. It works perfectly today. But the next time you recreate the cluster to test again, the setting is gone and your application breaks in mysterious ways.
-**Root Cause:** Attempting to execute `docker exec -it <node-container> bash` into the node and change system configurations manually leads to untracked state drift. It explicitly breaks the core concept of reproducible environments. If it isn't documented in code, it never happened.
-**Resolution:** Treat the kind nodes strictly as immutable infrastructure. Make any required architectural changes via declarative YAML config files (like using `kind`'s `kubeadmConfigPatches`) and completely recreate the cluster from scratch to verify the configuration actually persists.
+| Pattern | When to Use It | Why It Works |
+|---|---|---|
+| Disposable named clusters | Any learning lab, reproduction case, or integration test | Names make kubeconfig contexts obvious, while deletion keeps resource use and state drift under control. |
+| Version-pinned node images | Curriculum, CI, operator testing, and bug reproduction | Pinning Kubernetes 1.35+ behavior makes test results deterministic and avoids accidental release drift. |
+| Declarative topology files | Multi-node tests, ingress port mappings, or kubeadm patches | A checked-in config can be reviewed, recreated, and shared instead of reconstructed from memory. |
+| Host-first diagnostics | Cluster creation failures, Docker errors, disk pressure, and port conflicts | Local clusters depend on the host runtime, so Docker and OS signals often explain failures before Kubernetes exists. |
 
-### Mistake 4: Assuming LoadBalancers Work Natively
-**Symptom:** You expose a deployment using a Service of type `LoadBalancer`. When you run `kubectl get svc`, the EXTERNAL-IP column is perpetually stuck in `<pending>`. You wait 20 minutes, and nothing changes.
-**Root Cause:** Local clusters completely lack a cloud provider controller (like AWS ELB, Azure LB, or Google Cloud Load Balancer) to dynamically provision external hardware load balancers. There is no physical infrastructure outside your laptop to fulfill the request to route traffic in.
-**Resolution:** Install a local load balancer implementation operator like MetalLB into your `kind` cluster, or simply utilize `kubectl port-forward` for direct, temporary local network testing without exposing an actual IP.
+| Anti-Pattern | What Goes Wrong | Better Alternative |
+|---|---|---|
+| Treating a local cluster as durable infrastructure | Manual changes disappear or become impossible to reproduce after deletion | Store manifests and `kind` configs, then recreate the cluster to prove repeatability. |
+| Applying manifests without checking context | Workloads land in the wrong cluster, sometimes a costly shared environment | Run `k config current-context` or inspect contexts before risky actions. |
+| Expecting LoadBalancer Services to work like cloud providers | `EXTERNAL-IP` remains pending because no cloud controller provisions hardware | Use port-forwarding, mapped ingress, or a local load balancer implementation. |
+| Leaving many clusters idle | CPU, memory, ports, and disk are consumed by environments no one is using | Audit with `kind get clusters` and delete clusters at the end of each session. |
 
-### Mistake 5: Encountering Port Binding Conflicts
-**Symptom:** You try to run two `kind` clusters simultaneously that both require an Ingress controller, and the second one fails to start with a networking error.
-**Root Cause:** You are attempting to start multiple independent kind clusters that are heavily mapping to the exact same host ports (like port 80 for HTTP and port 443 for HTTPS). A host operating system can only bind a port to a single process at a time. The first cluster took port 80, the second one crashed trying to steal it.
-**Resolution:** Specify explicit, mathematically unique host port mappings in the `kind` configuration YAML for each distinct cluster instance (e.g., mapping cluster A to 8080 and cluster B to 8081).
+## Decision Framework
 
-### Mistake 6: Forgetting to Load Local Docker Images
-**Symptom:** You build an image locally (`docker build -t my-app:v1 .`), and then apply a Deployment manifest. The Pod gets stuck in `ImagePullBackOff` state.
-**Root Cause:** The `kind` cluster is running *inside* Docker. It has its own isolated `containerd` runtime inside that container. It cannot see the images you just built on your host machine's Docker daemon. It attempts to pull them from Docker Hub, fails, and crashes.
-**Resolution:** You must explicitly load local images into the cluster's internal runtime using `kind load docker-image my-app:v1 --name <cluster-name>`.
+Use a local cluster when the learning or test question is about Kubernetes API behavior, scheduling, manifests, controllers, Services, or basic networking. Use a cloud-managed cluster when the question depends on cloud integrations such as managed load balancers, IAM identity, persistent disks, autoscaling groups, or production-grade failure domains. Use a single-node local cluster when the topology does not matter. Use a multi-node local cluster when placement, node-specific behavior, DaemonSets, or inter-node networking are part of the hypothesis.
+
+```text
+Start with the question you need to answer
+|
++-- Is the question about cloud-managed integrations?
+|   +-- Yes: use a real cloud cluster with strict cost controls.
+|   +-- No: continue locally.
+|
++-- Does the behavior depend on multiple nodes?
+|   +-- Yes: create a multi-node kind cluster from YAML.
+|   +-- No: create a single-node kind cluster.
+|
++-- Do you need deterministic version behavior?
+|   +-- Yes: pin kindest/node:v1.35.0 or the required test version.
+|   +-- No: still record the version so results are explainable.
+```
+
+The practical decision is usually about feedback speed and fidelity. Local clusters give rapid feedback and low risk, but they cannot prove every cloud behavior. Cloud clusters give high fidelity for provider integrations, but they cost money and take longer to rebuild. Good engineers do not pick one forever; they choose the cheapest environment that can honestly answer the question. For this module, the honest question is how Kubernetes itself behaves, so a local `kind` cluster is the right default.
 
 ## Did You Know?
 
-1. The name "Kubernetes" originates directly from ancient Greek, meaning helmsman, pilot, or governor. This is why the project's iconic logo is a ship's steering wheel consisting of exactly eight spokes.
-2. The initial, highly secretive internal project name for Kubernetes at Google was reportedly "Project Seven", a deliberate reference to the Star Trek Borg character Seven of Nine. This is why the spokes on the steering wheel logo number exactly eight: it was a subtle nod to the project name, plus one.
-3. The `kind` project was never originally intended or designed for end-users or developers. It was constructed strictly as an internal continuous integration mechanism for the Kubernetes project itself, allowing maintainers to run deep compliance tests on GitHub pull requests without waiting hours for cloud resources to provision. It just happened to be incredibly useful for developers, too.
-4. An `etcd` datastore node is generally understood to be hard-limited to 8GB of storage space by maximum configuration. While this sounds incredibly small for a modern database, because it only stores cluster state configuration (as compressed text YAML/JSON), this capacity can easily support massive enterprise clusters running tens of thousands of concurrent pods.
-5. The abbreviation `k8s` is a numeronym. It simply takes the word Kubernetes, keeps the first letter (k), the last letter (s), and replaces the 8 letters in between (`ubernete`) with the number 8. It's a standard linguistic compression technique, similar to `i18n` for internationalization.
-6. The original creators of Kubernetes (Joe Beda, Brendan Burns, and Craig McLuckie) reportedly originally pitched the idea to Google executives explicitly as a way to commoditize the cloud layer, preventing Amazon AWS from achieving total monopoly lock-in via proprietary APIs.
-7. `kubectl` is essentially just a very fancy `curl` wrapper. Every single command you execute with `kubectl` is translated into a standard HTTP REST API call (GET, POST, PUT, PATCH, DELETE) against the `kube-apiserver`. You can actually use raw `curl` with the right certificates to run a cluster.
+1. Kubernetes 1.35 is the version target for this curriculum, so pinning local node images prevents examples from drifting as upstream releases continue.
+2. The name "Kubernetes" comes from a Greek word associated with a helmsman or pilot, which matches the project's steering-wheel logo.
+3. `kind` began as infrastructure for testing Kubernetes itself, which explains why it is fast, disposable, and friendly to automation.
+4. The abbreviation `k8s` is a numeronym: it keeps the first and last letters of Kubernetes and replaces the eight letters between them with `8`.
+
+## Common Mistakes
+
+| Mistake | Why It Happens | How to Fix It |
+|---|---|---|
+| Building an image on the host and expecting a `kind` Pod to find it | The node container has its own internal `containerd`, separate from the host Docker image list. | Run `kind load docker-image my-app:v1 --name <cluster-name>` or push the image to a registry the cluster can reach. |
+| Forgetting which kubeconfig context is active | `kind` updates kubeconfig automatically, and multiple clusters can coexist in one file. | Inspect contexts before applying changes and use clear cluster names such as `kind-dojo-basics`. |
+| Assuming a local LoadBalancer Service provisions an external IP | There is no cloud provider controller on your laptop to create external load balancer infrastructure. | Use `k port-forward`, configured ingress port mappings, or a local implementation such as MetalLB. |
+| Leaving idle clusters running for days | Control plane loops, node containers, images, and volumes consume host resources even when you are not testing. | Audit with `kind get clusters` and delete clusters immediately after a lab or reproduction is complete. |
+| Editing a node container by hand | Manual `docker exec` changes are invisible to your cluster configuration and vanish on recreate. | Encode node behavior in `kind` config, manifests, or automation, then recreate the cluster to prove it persists. |
+| Ignoring Docker memory and disk limits | `kind` relies on Docker, so host resource pressure prevents Kubernetes components and images from starting. | Allocate enough Docker memory, keep free disk space, and inspect Docker logs when cluster creation fails. |
+| Using an old client against a newer API server | Kubernetes only supports limited client/server minor-version skew. | Upgrade the client or create a cluster version that falls within the supported skew policy. |
 
 ## Quiz
 
-<details>
-<summary><strong>[Tests LO8: Deconstruct the monolithic architecture]</strong> You successfully deploy a critical application to your local `kind` cluster. You wish to verify that the API Server has successfully persisted the declarative desired state of your application for fault tolerance. Which specific daemon component of the Control Plane must be fully operational for this state persistence to occur?</summary>
-The `etcd` datastore daemon must be fully operational and possess quorum. The API Server itself is entirely stateless; it acts solely as the RESTful interface and validation engine. When you submit a deployment request, the API Server validates the schema, checks authorization, and then writes that desired state configuration directly into the `etcd` key-value store. If `etcd` is unavailable, crashed, or locked in read-only mode, absolutely no new state can be persisted, and the cluster is mathematically incapable of accepting new workloads.
+<details><summary><strong>[Tests LO4]</strong> You create a Deployment while the API server and `etcd` are healthy, but the scheduler Pod has been deleted. What state do the new Pods enter, and why?</summary>
+The Pods will be accepted into the API and remain Pending. The API server can validate and persist the desired state because `etcd` is available, but the scheduler is the component that assigns unscheduled Pods to nodes. Without that assignment, no kubelet receives responsibility for starting the containers. This is why a Pending Pod is often evidence of a scheduling break rather than an image pull or application crash.
 </details>
 
-<details>
-<summary><strong>[Tests LO2: Compare local Kubernetes provisioning tools]</strong> Your team is building a new logging microservice that needs to write heavily to the local disk of the node it executes on. During local testing, a developer complains that when they test with `kind`, their laptop's entire hard drive fills up and crashes, but when using `minikube` (with VirtualBox), it does not. What fundamental architectural difference causes this behavior?</summary>
-Because `kind` leverages Docker containers to simulate entire physical nodes, any raw data written to the "node's" local disk by a pod is actually being written directly into the underlying Docker container's writable layer on your host filesystem. If the container grows indefinitely, it consumes the host's physical disk space. `minikube` traditionally utilizes a hardware Virtual Machine, which possesses a pre-allocated, fixed-size virtual disk block. The VM physically cannot consume more space on your host than its allocated block size, thus protecting the broader host operating system from catastrophic disk exhaustion.
+<details><summary><strong>[Tests LO2]</strong> Your team needs to test a DaemonSet that must run one Pod on every node. Should you use a single-node or multi-node `kind` cluster, and what would the single-node test fail to prove?</summary>
+Use a multi-node `kind` cluster because the behavior depends on node count and placement. A single-node cluster can prove that the DaemonSet object is accepted and that one Pod can run, but it cannot prove per-node scheduling across multiple workers. A multi-node topology lets you verify that each node receives exactly one Pod and that node-level conditions or labels affect the outcome as expected.
 </details>
 
-<details>
-<summary><strong>[Tests LO1: Construct a local Kubernetes cluster]</strong> You are strictly required to test a third-party custom operator that explicitly mandates Kubernetes version 1.34. Your currently running local `kind` cluster is operating on version 1.35. What is the safest, most deterministic, and fastest method to acquire a local 1.34 environment?</summary>
-You must completely bypass the upgrade or downgrade process and create an entirely new, parallel cluster by explicitly specifying the node image version tag during the creation command. You execute `kind create cluster --name test-134 --image kindest/node:v1.34.0`. Unlike attempting to upgrade or downgrade a complex production cluster in place (which is inherently risky and error-prone), local clusters are strictly ephemeral. It is fundamentally safer and significantly faster to provision a fresh cluster with the exact version required, execute your tests, and subsequently destroy the cluster when finished.
+<details><summary><strong>[Tests LO3]</strong> A developer builds `my-app:v1` with Docker, applies a Deployment, and gets `ImagePullBackOff` in `kind`. The image name is correct. What should they check and do?</summary>
+They should check whether the image was loaded into the `kind` cluster's internal runtime. Host Docker can know about an image while the node container's `containerd` cannot see it, so Kubernetes tries to pull the image from a registry and fails. The local fix is to run `kind load docker-image my-app:v1 --name <cluster-name>` before creating or restarting the Pod. In team workflows, pushing to a registry can be more repeatable.
 </details>
 
-<details>
-<summary><strong>[Tests LO4: Design a multi-node local cluster configuration]</strong> You are tasked with reproducing a complex production bug that only manifests when network latency between a web frontend pod and a backend database pod consistently exceeds 50ms. Which local cluster architecture would you design to test this hypothesis, and why?</summary>
-You must design and provision a multi-node cluster configuration utilizing `kind` with a minimum of two separate worker nodes. By explicitly scheduling the web application on worker node 1 and the database on worker node 2 using node selectors, you force the network traffic to traverse the virtualized network bridge between the distinct nodes. You can then utilize the Linux `tc` (traffic control) utility executing inside one of the worker node containers to artificially inject exactly 50ms of latency on its virtual network interface. This accurately and deterministically simulates the production network partition without requiring complex cloud infrastructure.
+<details><summary><strong>[Tests LO1]</strong> You are required to reproduce a bug on Kubernetes v1.35.0, but your default `kind` installation creates a different version. What is the safest local workflow?</summary>
+Create a fresh cluster with an explicit node image tag instead of mutating an existing cluster in place. A command such as `kind create cluster --name repro-135 --image kindest/node:v1.35.0` gives you a deterministic API server and node version for the test. Local clusters are disposable, so recreating them is usually safer and faster than treating them like long-lived infrastructure. Record the version in your notes so other engineers can reproduce the same environment.
 </details>
 
-<details>
-<summary><strong>[Tests LO5: Evaluate the impact of control plane component failures]</strong> During a routine chaos engineering exercise on your local `kind` multi-node cluster, you accidentally delete the `kube-scheduler` pod running in the `kube-system` namespace. Immediately after, you submit a new `Deployment` manifest for a critical frontend application. What exact state will the new frontend pods enter, and why?</summary>
-The newly created frontend pods will transition immediately into a `Pending` state and remain there indefinitely. The API Server will successfully authenticate the request, validate the manifest, and persist the desired state to `etcd`, meaning the pods exist as records in the datastore. However, because the `kube-scheduler` is responsible for evaluating node resources and assigning pods to specific worker nodes, its absence breaks the deployment chain. Without the scheduler's node assignment, the `kubelet` processes on the worker nodes will never be instructed to actually start the containers.
+<details><summary><strong>[Tests LO5]</strong> You receive a temporary kubeconfig for a staging cluster, but you do not want it merged into your default `~/.kube/config`. How should you use it?</summary>
+Set the `KUBECONFIG` environment variable for the shell session or command that needs access. That makes the client read the provided file instead of silently modifying or depending on your default configuration. After the session ends or the variable is unset, your normal contexts return. This reduces the chance of accidentally applying manifests to the wrong cluster later.
 </details>
 
-<details>
-<summary><strong>[Tests LO6: Analyze and manipulate the kubeconfig file]</strong> You are consulting for a team managing multiple Kubernetes environments. A developer provides you with a custom `kubeconfig` file containing administrative credentials for their staging cluster and asks you to debug a deployment. You do not want to risk permanently modifying your default `~/.kube/config` file. How do you securely interact with the staging cluster using their provided file without altering your existing global configuration?</summary>
-You must explicitly export the `KUBECONFIG` environment variable in your terminal session, pointing it directly to the absolute path of the provided file (e.g., `export KUBECONFIG=/path/to/staging-config.yaml`). When this variable is set, the `kubectl` binary completely bypasses the default `~/.kube/config` location and exclusively reads authentication and routing data from the specified path. This ensures perfect isolation for your debugging session. Once you close the terminal window or unset the variable, your `kubectl` tool will safely revert to utilizing your original, unmodified default configuration file.
+<details><summary><strong>[Tests LO3]</strong> `kind create cluster` fails before any Kubernetes objects are available, and the error says it cannot connect to the Docker daemon. Why is `k get pods` the wrong next diagnostic command?</summary>
+`k get pods` depends on a reachable Kubernetes API server, and the API server does not exist yet if `kind` cannot create node containers. The failure is below Kubernetes, at the host runtime layer. The right next checks are Docker service status, Docker Desktop state, socket permissions, and whether the current user can run Docker commands. Once Docker is reachable, `kind` can create the node container that hosts the control plane.
 </details>
 
-<details>
-<summary><strong>[Tests LO7: Formulate a strict local development strategy]</strong> You successfully provision a local `kind` cluster. You then run `kubectl port-forward svc/my-web-app 8080:80` to access a web server pod. You open a browser and the site loads perfectly. You then press `Ctrl+C` in your terminal to stop the command, and refresh the browser. What happens and why?</summary>
-The browser will immediately return a "Connection Refused" or "Site cannot be reached" error. `kubectl port-forward` creates an active, foreground proxy tunnel between your local workstation and the API Server, which then tunnels directly to the specific pod network namespace. When you terminate the process (`Ctrl+C`), the tunnel is immediately destroyed, completely severing the network path. It is not a permanent routing configuration or a load balancer; it is strictly an ephemeral debugging utility that relies on the foreground process remaining active.
-</details>
-
-<details>
-<summary><strong>[Tests LO3: Diagnose cluster failures]</strong> A junior engineer executes `kind create cluster`, but the command immediately fails, throwing an error stating "failed to pull image". The engineer verifies their internet connection is functioning perfectly. What is the most probable root cause, and how do you explicitly diagnose it?</summary>
-The most probable root cause is exhausted host disk space. Because `kind` node images are enormous (often exceeding 1.5GB), accumulated images can silently fill your hard drive, causing Docker to fail when attempting to pull new images. You diagnose this by checking your system's available storage or looking for a "No space left on device" warning in the terminal. You resolve it by aggressively clearing unused images and volumes using `docker system prune -a --volumes` to restore at least 20GB of free space.
-</details>
-
-<details>
-<summary><strong>[Tests LO3: Diagnose cluster failures]</strong> You recently joined a new project and are tasked with testing a deployment on a local `kind` cluster running Kubernetes v1.35. You run `kubectl get pods` on your workstation, and you immediately receive an error: `the server could not find the requested resource`. You check `docker ps` and see the control plane container is running perfectly. What is the likely mismatch occurring here, and how do you resolve it?</summary>
-This is the classic symptom of severe Version Skew between your client and the server. The `kubectl` binary you are using on your host machine is likely too far out of date (e.g., v1.33) compared to the Kubernetes version running inside the `kind` cluster API Server (v1.35). The API schemas and endpoints have fundamentally changed between those versions, and the client no longer knows how to correctly construct or parse the REST requests. To resolve this, you must upgrade your `kubectl` binary to ensure it is within the officially supported +/- 1 minor version window of the cluster.
+<details><summary><strong>[Tests LO3]</strong> A local Service of type `LoadBalancer` stays in `<pending>` for a long time. The Pods are healthy. What is missing from the local cluster?</summary>
+The cluster is missing a load balancer implementation that can satisfy the Service request. In cloud clusters, a provider controller creates external infrastructure and updates the Service status with an address. A plain local `kind` cluster has no such controller or external hardware, so the request remains pending. For local access, use port-forwarding, configured ingress mappings, or install a local load balancer implementation appropriate for the lab.
 </details>
 
 ## Hands-On Exercise
 
-In this comprehensive exercise, you will synthesize everything you've learned. You will provision multiple isolated Kubernetes environments, manipulate cluster topologies using declarative configuration, dive deeply into your `kubeconfig` file to extract secret certificates, and deterministically diagnose a deliberately broken state. 
+In this exercise, you will create multiple local clusters, inspect kubeconfig, pin Kubernetes versions, switch contexts, declare topology, and observe what happens when the control plane disappears. The work is intentionally progressive: first you prove basic creation, then you prove identity and version control, and only then do you simulate failure. Keep notes on what each command proves, because the diagnostic habit is more valuable than the specific cluster names.
 
 **Setup Requirements:**
-Ensure the Docker daemon is installed and actively running on your host machine. Ensure you have the `kind` CLI utility and `kubectl` downloaded, marked as executable, and available on your system path. Grab a coffee, because we are diving deep.
+Ensure the Docker daemon is installed and actively running on your host machine. Ensure you have the `kind` CLI utility and `kubectl` downloaded, marked as executable, and available on your system path. Use the `k` alias after defining it, and delete lab clusters when finished so your workstation returns to a clean state.
 
-**Tasks:**
+### Tasks
 
 1. **The Baseline Cluster Initialization:** Create a standard single-node cluster named `primary-dojo`. Verify the cluster is fully running, and utilize command-line tools to determine the exact IP address and port the control plane API server is bound to on your host machine's network interface.
-2. **The Kubeconfig Deep Dive:** Without using the `kubectl config view` command, directly open your `~/.kube/config` file utilizing a terminal text editor (like `cat`, `less`, or `vim`). Locate the precise Cluster, User, and Context blocks that `kind` just injected for your `primary-dojo` cluster.
-3. **Strict Version Pinning:** Create a second, completely simultaneous cluster named `legacy-dojo`. This cluster must rigidly enforce running an older version of Kubernetes, specifically v1.34.0 (utilizing the specific image tag `kindest/node:v1.34.0`).
+2. **The Kubeconfig Deep Dive:** Without using the `kubectl config view` command, directly open your `~/.kube/config` file utilizing a terminal text editor like `cat`, `less`, or `vim`. Locate the precise Cluster, User, and Context blocks that `kind` just injected for your `primary-dojo` cluster.
+3. **Strict Version Pinning:** Create a second, completely simultaneous cluster named `legacy-dojo`. This cluster must rigidly enforce running an older version of Kubernetes, specifically v1.34.0, utilizing the specific image tag `kindest/node:v1.34.0`.
 4. **Context Switching Mastery:** Utilize `kubectl` to seamlessly switch your authentication context back and forth between `primary-dojo` and `legacy-dojo`. Execute a version command against each to mathematically prove you are communicating with two distinctly different API Server versions.
-5. **Topology Engineering and Declaration:** Create a declarative YAML configuration file designed to deploy a third cluster named `ha-dojo`. This cluster must artificially simulate a highly available control plane architecture by provisioning exactly three control-plane nodes and zero worker nodes. 
-6. **Simulated Catastrophic Failure:** Delete all currently running clusters to reclaim resources. Create a fresh cluster named `broken-dojo`. Locate the underlying Docker container running the control plane daemon. Utilize a raw Docker command to forcibly terminate (kill) the container without graceful shutdown. Immediately observe and document how `kubectl` behaves when the control plane is suddenly annihilated.
+5. **Topology Engineering and Declaration:** Create a declarative YAML configuration file designed to deploy a third cluster named `ha-dojo`. This cluster must artificially simulate a highly available control plane architecture by provisioning exactly three control-plane nodes and zero worker nodes.
+6. **Simulated Catastrophic Failure:** Delete all currently running clusters to reclaim resources. Create a fresh cluster named `broken-dojo`. Locate the underlying Docker container running the control plane daemon. Utilize a raw Docker command to forcibly terminate the container without graceful shutdown. Immediately observe and document how `kubectl` behaves when the control plane is suddenly unreachable.
 
-**Solutions:**
+### Solutions
 
 <details>
 <summary>Solution for Task 1: Baseline Cluster Initialization</summary>
 
-First, we execute the standard creation command. We specify a custom name to override the default "kind" name.
+First, execute the standard creation command. The custom name makes the generated node container and kubeconfig context easier to identify later.
 
 ```bash
 # Provision the cluster
 kind create cluster --name primary-dojo
 ```
 
-Once the cluster indicates it has started successfully, we need to find out exactly where it is listening. `kind` maps a random high-numbered port on your host's localhost address to port 6443 inside the container.
+Once the cluster indicates it has started successfully, find out exactly where it is listening. `kind` maps a random high-numbered port on your host's localhost address to port 6443 inside the container.
 
 ```bash
 # Investigate the cluster connection metadata
@@ -634,36 +523,33 @@ docker port primary-dojo-control-plane
 <details>
 <summary>Solution for Task 2: The Kubeconfig Deep Dive</summary>
 
-The configuration file is a plain text YAML file. We can print it to the screen directly.
+The configuration file is plain text YAML, so you can print it to the screen directly in a private terminal.
 
 ```bash
 # Print the raw contents of the file
 cat ~/.kube/config
 ```
 
-You will see a large YAML structure. Scroll through it and locate the three distinct sections that bind your access together:
-1. `clusters:` -> look for `name: kind-primary-dojo`
-2. `users:` -> look for `name: kind-primary-dojo`
-3. `contexts:` -> look for `name: kind-primary-dojo`
-4. Notice that `current-context:` is set to `kind-primary-dojo`.
+Locate the three distinct sections that bind your access together: `clusters:` contains `name: kind-primary-dojo`, `users:` contains `name: kind-primary-dojo`, and `contexts:` contains `name: kind-primary-dojo`. Notice that `current-context:` is also set to `kind-primary-dojo` after creation.
 </details>
 
 <details>
 <summary>Solution for Task 3: Strict Version Pinning</summary>
 
-We can run multiple `kind` clusters simultaneously on the same machine, as long as our computer has enough RAM. By providing the `--image` flag, we override the default version and pull an older image.
+Run multiple `kind` clusters simultaneously only if your computer has enough memory. The `--image` flag overrides the default node image and pulls the requested Kubernetes version.
 
 ```bash
 # Provision the version-pinned cluster in parallel
 kind create cluster --name legacy-dojo --image kindest/node:v1.34.0
 ```
-This command will take a moment as it must download the 1.5GB+ Docker image for version 1.34.0.
+
+This command may take a moment if Docker must download the node image for version 1.34.0.
 </details>
 
 <details>
 <summary>Solution for Task 4: Context Switching Mastery</summary>
 
-Now that we have two clusters running, we need to instruct `kubectl` which one to talk to. We do this by changing the active context in our `kubeconfig` file.
+Now that two clusters are running, instruct the client which one to talk to by changing the active context in kubeconfig.
 
 ```bash
 # List all available contexts in your configuration file. 
@@ -687,7 +573,7 @@ kubectl version
 <details>
 <summary>Solution for Task 5: Topology Engineering and Declaration</summary>
 
-To build complex architectures, we use a configuration file instead of command line flags. Create a file named `ha-config.yaml`:
+To build complex architectures, use a configuration file instead of a long set of command-line flags. Create a file named `ha-config.yaml`:
 
 ```yaml
 kind: Cluster
@@ -698,7 +584,7 @@ nodes:
   - role: control-plane
 ```
 
-Now, instruct `kind` to read this file during cluster creation:
+Now instruct `kind` to read this file during cluster creation.
 
 ```bash
 # Provision the cluster using the configuration file
@@ -707,13 +593,14 @@ kind create cluster --name ha-dojo --config ha-config.yaml
 # Validate the topology
 kubectl get nodes 
 ```
-You should definitively see exactly three nodes listed, all explicitly marked with the control-plane role. Notice that the names are suffixed with `-1`, `-2`, etc.
+
+You should see exactly three nodes listed, all explicitly marked with the control-plane role. Notice how the generated names are suffixed to keep each node distinct.
 </details>
 
 <details>
 <summary>Solution for Task 6: Simulated Catastrophic Failure</summary>
 
-Finally, we practice cleaning up our environment and observing a raw failure.
+Finally, practice cleaning up the environment and observing a raw control plane failure.
 
 ```bash
 # Aggressively clean up the environment
@@ -731,10 +618,12 @@ docker kill <container-id>
 # Attempt to interact with the broken cluster state
 kubectl get nodes
 ```
-The connection will either hang indefinitely until timeout or immediately fail with a `TCP connection refused` error. This empirically demonstrates that without the API Server container operating, the entire cluster interface is dead. You cannot read state, nor can you alter it.
+
+The connection will either hang until timeout or immediately fail with a TCP connection refused error. This demonstrates that without the API server container operating, the cluster interface is unavailable. You cannot read state through Kubernetes, nor can you alter it, even if some previous workload process might have existed before the control plane disappeared.
 </details>
 
-**Success Criteria:**
+### Success Criteria
+
 - [ ] You successfully provisioned and ran multiple distinct, isolated Kubernetes clusters on your host machine simultaneously.
 - [ ] You identified and explained the structural components of the `kubeconfig` file.
 - [ ] You seamlessly and reliably switched authentication contexts between different clusters utilizing `kubectl`.
@@ -743,17 +632,20 @@ The connection will either hang indefinitely until timeout or immediately fail w
 - [ ] You practiced excellent infrastructure hygiene by successfully deleting all ephemeral clusters created during this exercise.
 
 ## Next Module
-[Module 1.2: kubectl Basics](/prerequisites/kubernetes-basics/module-1.2-kubectl-basics/) — Learn to fluidly talk to your cluster, navigate its resources, and bend it to your exact will.
 
-## Section 9: The Developer Setup Checklist
+[Module 1.2: kubectl Basics](/prerequisites/kubernetes-basics/module-1.2-kubectl-basics/) — Learn to navigate cluster resources, inspect objects, and turn API access into practical operational control.
 
-Before you conclude this module, ensure you have established these local tools for your ongoing journey:
-1. **Docker Desktop / Colima:** The engine running your clusters. Ensure memory limits are at least 8GB.
-2. **kind:** The cluster lifecycle tool.
-3. **kubectl:** The universal cluster client.
-4. **k9s (Optional but Recommended):** A powerful terminal UI that wraps `kubectl`, drastically speeding up navigation and debugging. It visualizes exactly what is happening in your cluster in real-time.
-5. **Helm (Upcoming):** The Kubernetes package manager, which you will need in later modules.
-6. **A robust terminal multiplexer:** Tools like `tmux`, `zellij`, or `iTerm2` are invaluable when you need to watch logs in one pane while executing commands in another.
-7. **Lens (Alternative):** A graphical IDE for Kubernetes. While `k9s` keeps you close to the terminal, Lens provides a full desktop experience for cluster management.
+## Sources
 
-> **Stop and think**: Install `k9s` today and run it against your `dojo-multi` cluster. How does the experience of navigating pods compare to typing raw `kubectl get pods` commands?
+- [Kubernetes Components](https://kubernetes.io/docs/concepts/overview/components/)
+- [Kubernetes Nodes](https://kubernetes.io/docs/concepts/architecture/nodes/)
+- [Organizing Cluster Access Using kubeconfig Files](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/)
+- [kubectl Reference](https://kubernetes.io/docs/reference/kubectl/)
+- [Kubernetes Version Skew Policy](https://kubernetes.io/releases/version-skew-policy/)
+- [Kubernetes Services](https://kubernetes.io/docs/concepts/services-networking/service/)
+- [Use Port Forwarding to Access Applications in a Cluster](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/)
+- [kind Project](https://kind.sigs.k8s.io/)
+- [kind Quick Start](https://kind.sigs.k8s.io/docs/user/quick-start/)
+- [kind Configuration](https://kind.sigs.k8s.io/docs/user/configuration/)
+- [kind Known Issues](https://kind.sigs.k8s.io/docs/user/known-issues/)
+- [etcd Learning Documentation](https://etcd.io/docs/)


### PR DESCRIPTION
## Summary
- Rewrote Module 1.1: Your First Cluster for #388 density, structure, alignment, and anti-leak gates.
- Cleared `revision_pending: false` in frontmatter.
- Preserved the original topic coverage while reorganizing into the required module-writer order.

## Verifier
- `.venv/bin/python scripts/quality/verify_module.py --glob src/content/docs/prerequisites/kubernetes-basics/module-1.1-first-cluster.md --skip-source-check --summary --quiet`
- Summary: tier T0; body_words=5207, mean_wpp=75.5, median_wpp=80, short_rate=0.043, max_run=1, mean_sentence_length=19.6, paragraph_count=69.
- Gates: density, structure, alignment, anti_leak, and sources_min_10 passed; sources_all_reachable skipped by requested `--skip-source-check`.

## Protected Assets
- Before: code_blocks=29, mermaid_diagrams=2, ascii_diagrams=3, tables=1.
- After: code_blocks=31, mermaid_diagrams=2, ascii_diagrams=3, tables=4.
- Original Mermaid diagrams, command/YAML examples, troubleshooting examples, hands-on command assets, table coverage, and existing source URLs were preserved or carried forward; added required Common Mistakes, Patterns, and Decision Framework tables plus Sources URLs.

## Additional Checks
- `git diff --check -- src/content/docs/prerequisites/kubernetes-basics/module-1.1-first-cluster.md` passed.
- Forbidden-token grep for standalone 47/TODO/FIXME/XXX/AI leakage passed with no matches.
- `npm run build` passed from the primary checkout.

Commit: 692efad43c3c