### PR TITLE
fix(388): normalize fundamentals module headers

### DIFF
--- a/.claude/rules/module-quality.md
+++ b/.claude/rules/module-quality.md
@@ -46,6 +46,9 @@ paths:
 - NEVER remove or simplify existing visual aids during rewrites — they are protected assets
 
 ## Content Rules
+- Do NOT add a Markdown `# Module ...` heading after frontmatter. Starlight renders the page H1 from `title:` frontmatter, so a source H1 creates a duplicate visible title.
+- The top-of-module metadata must be a blockquote immediately after frontmatter:
+  `> **Complexity**: ...`, blank quoted line, `> **Time to Complete**: ...`, blank quoted line, `> **Prerequisites**: ...`, then `---`, then `## What You'll Be Able to Do`.
 - 600-800+ lines of CONTENT minimum (250+ for KCNA theory modules). Visual aids (ASCII diagrams, code blocks for illustration) do NOT count toward the minimum — they supplement teaching, not substitute for it.
 - Explain "why" before "what"
 - All code must be runnable (not pseudocode)

--- a/scripts/quality/prompts.py
+++ b/scripts/quality/prompts.py
@@ -94,6 +94,8 @@ Produce a complete, replacement module that teaches the topic from beginner to s
 
 Mandatory:
 - Preserve the `title:` and `sidebar.order:` from existing frontmatter.
+- Do NOT add a Markdown `# Module ...` heading after frontmatter. Starlight renders the visible page H1 from `title:` frontmatter, so a source H1 creates a duplicate title in the rendered page.
+- Put top metadata immediately after frontmatter as blockquote lines: `> **Complexity**: ...`, `> **Time to Complete**: ...`, and `> **Prerequisites**: ...`; then add `---`; then use `## What You'll Be Able to Do` for the learning outcomes section.
 - Do NOT preserve `revision_pending:` if present in input frontmatter — drop it from output. The banner is a queue marker that the merge step removes; carrying it through into a fresh rewrite would leave a "queued for revision" banner on a freshly-shipped module.
 - **Visual-aid preservation is COUNT-BASED, not "best-effort"**: count the input's ` ```mermaid ` fenced blocks, ` ```ascii ` blocks, and `|---|` table rows. Your output MUST contain AT LEAST as many of each. Dropping any is a hard fail that bounces the module back to you.
 - **NEVER replace an ` ```ascii ` or ` ```text ` block with a Markdown table.** If a table reads better in your judgment, **add the table next to the ASCII block** — do not remove the ASCII. The same applies to Mermaid: never replace ASCII with Mermaid; keep both. The visual-aid count is checked PER TYPE (mermaid count, ascii count, table count) — substituting one type for another is detected and rejected.
@@ -232,6 +234,7 @@ Rules:
 - Ignore the `## Sources` section for scoring — citation insertion runs in a SEPARATE downstream stage (`scripts/citation_backfill.py`), so neither the rubric's "Citation Gate" nor the absence of a Sources section should reduce the score here. The writer was instructed to preserve any pre-existing Sources verbatim and not add a new one; verify that instruction was honored (do not flag absence as a must-fix).
 - For track=structural: verify existing content was PRESERVED verbatim (zero edits to pre-existing lines). If any existing line was modified, verdict must be changes_requested.
 - For track=rewrite: verify narrative flow (not a bullet list), worked examples present before learner is asked to solve similar, at least 2 inline active-learning prompts.
+- Verify the top-of-module format: no source-level `# Module ...` heading after frontmatter, blockquote metadata for complexity/time/prerequisites, separator, then `## What You'll Be Able to Do`. Flag duplicate H1 or inline metadata as a must-fix.
 - Preserved visual aids (ASCII, Mermaid, tables): must be present and not removed.
 
 Return the JSON object at the END of your response. Nothing after it.

--- a/scripts/quality/test_verify_module.py
+++ b/scripts/quality/test_verify_module.py
@@ -63,6 +63,92 @@ Hidden prose should not appear.
     ]
 
 
+def test_body_prose_extraction_skips_top_metadata_blockquote() -> None:
+    text = """---
+title: Demo
+---
+> **Complexity**: [MEDIUM]
+>
+> **Time to Complete**: 45-60 minutes
+>
+> **Prerequisites**: Prior module
+
+---
+
+## What You'll Be Able to Do
+
+This teaching paragraph remains with enough words to count as prose after the metadata block.
+"""
+    assert verify_module.extract_body_paragraphs(text) == [
+        "This teaching paragraph remains with enough words to count as prose after the metadata block."
+    ]
+
+
+def test_body_prose_extraction_skips_horizontal_rules() -> None:
+    text = """---
+title: Demo
+---
+## What You'll Be Able to Do
+
+This first teaching paragraph has enough words to count as prose before the separator.
+
+---
+
+This second teaching paragraph also remains after the separator without counting the rule itself.
+"""
+    assert verify_module.extract_body_paragraphs(text) == [
+        "This first teaching paragraph has enough words to count as prose before the separator.",
+        "This second teaching paragraph also remains after the separator without counting the rule itself.",
+    ]
+
+
+def test_anti_leak_ignores_top_metadata_for_kubectl_alias_order() -> None:
+    text = """---
+title: Demo
+---
+> **Prerequisites**: Have a `kubectl` binary installed.
+
+---
+
+Set the alias before using shorthand commands:
+
+```bash
+alias k=kubectl
+k get pods
+```
+"""
+    assert verify_module.anti_leak_metrics(text)["kubectl_alias_introduced"] is True
+
+
+def test_anti_leak_allows_longform_kubectl_before_alias() -> None:
+    text = """---
+title: Demo
+---
+Use `kubectl` in full while explaining the API client.
+
+Define the shorthand before the first shorthand command:
+
+```bash
+alias k=kubectl
+k get pods
+```
+"""
+    assert verify_module.anti_leak_metrics(text)["kubectl_alias_introduced"] is True
+
+
+def test_anti_leak_rejects_shorthand_before_alias() -> None:
+    text = """---
+title: Demo
+---
+Run `k get pods` before defining the alias.
+
+```bash
+alias k=kubectl
+```
+"""
+    assert verify_module.anti_leak_metrics(text)["kubectl_alias_introduced"] is False
+
+
 def test_density_metrics_on_synthetic_short_module_fail() -> None:
     metrics = verify_module.density_metrics("Tiny.\n\nShort too.\n")
     gates = verify_module.gate_results(

--- a/scripts/quality/verify_module.py
+++ b/scripts/quality/verify_module.py
@@ -180,6 +180,7 @@ def extract_body_paragraphs(text: str) -> list[str]:
     in_sources = False
     in_list = False
     in_table = False
+    seen_heading = False
 
     for idx, line in enumerate(lines):
         stripped = line.strip()
@@ -194,12 +195,17 @@ def extract_body_paragraphs(text: str) -> list[str]:
             continue
 
         heading = re.match(r"^(#{1,6})\s+(.+?)\s*$", stripped)
+        if heading:
+            seen_heading = True
         if heading and len(heading.group(1)) <= 2:
             in_sources = _heading_matches(heading.group(2), SOURCES_HEADINGS)
         if in_sources:
             kept.append("")
             continue
 
+        if not seen_heading and stripped.startswith(">"):
+            kept.append("")
+            continue
         if in_html:
             if f"</{in_html}" in lower:
                 in_html = None
@@ -216,6 +222,9 @@ def extract_body_paragraphs(text: str) -> list[str]:
         if not stripped:
             in_list = False
             in_table = False
+            kept.append("")
+            continue
+        if re.fullmatch(r"-{3,}", stripped):
             kept.append("")
             continue
 
@@ -549,27 +558,41 @@ def anti_leak_metrics(text: str) -> dict[str, object]:
     lowered = body_no_code.lower()
     forbidden = [token for token in FORBIDDEN_TOKENS if token.lower() in lowered]
     has_k_shortcut = bool(KUBECTL_COMMAND_RE.search(body_no_code))
-    first_kubectl = re.search(r"\bkubectl\b", body_no_code, re.IGNORECASE)
     if not has_k_shortcut:
         kubectl_alias_introduced = True
-    elif first_kubectl:
-        # Search the original body (with code blocks) — `alias k=kubectl` is
-        # almost always defined inside a fenced bash snippet, so stripping
-        # code first would miss legitimate aliases. Anchor the proximity
-        # window on the same `kubectl` mention located in `body`.
-        first_kubectl_in_body = re.search(r"\bkubectl\b", body, re.IGNORECASE)
-        anchor = first_kubectl_in_body or first_kubectl
-        start = max(0, anchor.start() - 1000)
-        end = min(len(body), anchor.end() + 1000)
-        kubectl_alias_introduced = bool(ALIAS_RE.search(body[start:end]))
     else:
-        kubectl_alias_introduced = False
+        # Search the original body because alias definitions normally live
+        # inside fenced bash snippets. The alias only needs to appear before
+        # the first shorthand command, not before every long-form kubectl
+        # mention in explanatory prose.
+        first_shortcut = KUBECTL_COMMAND_RE.search(body)
+        alias = ALIAS_RE.search(body)
+        kubectl_alias_introduced = bool(
+            first_shortcut and alias and alias.start() < first_shortcut.start()
+        )
     return {
         "forbidden_tokens": forbidden,
         "has_emoji": bool(EMOJI_RE.search(body_no_code)),
         "has_47": bool(re.search(r"(?<!\d)47(?!\d)", body_no_code)),
         "kubectl_alias_introduced": kubectl_alias_introduced,
     }
+
+
+def _strip_top_metadata(body: str) -> str:
+    """Drop canonical metadata blockquotes before prose checks."""
+    lines = body.splitlines()
+    start = 0
+    while start < len(lines) and not lines[start].strip():
+        start += 1
+    while start < len(lines) and lines[start].strip().startswith(">"):
+        start += 1
+    while start < len(lines) and not lines[start].strip():
+        start += 1
+    if start < len(lines) and re.fullmatch(r"-{3,}", lines[start].strip()):
+        start += 1
+    while start < len(lines) and not lines[start].strip():
+        start += 1
+    return "\n".join(lines[start:])
 
 
 def protected_assets(text: str) -> dict[str, int]:

--- a/src/content/docs/prerequisites/cloud-native-101/module-1.1-what-are-containers.md
+++ b/src/content/docs/prerequisites/cloud-native-101/module-1.1-what-are-containers.md
@@ -5,9 +5,13 @@ slug: prerequisites/cloud-native-101/module-1.1-what-are-containers
 sidebar:
   order: 2
 ---
-# Module 1.1: What Are Containers?
+> **Complexity**: `[QUICK]` - Foundational concepts.
+>
+> **Time to Complete**: 30-35 minutes.
+>
+> **Prerequisites**: none beyond a terminal for the optional Docker lab and curiosity about why deployment environments drift.
 
-**Complexity**: `[QUICK]` - Foundational concepts. **Time to Complete**: 30-35 minutes. **Prerequisites**: none beyond a terminal for the optional Docker lab and curiosity about why deployment environments drift.
+---
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/prerequisites/cloud-native-101/module-1.2-docker-fundamentals.md
+++ b/src/content/docs/prerequisites/cloud-native-101/module-1.2-docker-fundamentals.md
@@ -5,9 +5,6 @@ slug: prerequisites/cloud-native-101/module-1.2-docker-fundamentals
 sidebar:
   order: 3
 ---
-
-# Module 1.2: Docker Fundamentals
-
 > **Complexity**: `[MEDIUM]` - Hands-on practice required
 >
 > **Time to Complete**: 50-60 minutes
@@ -15,6 +12,8 @@ sidebar:
 > **Prerequisites**: Module 1.1: What Are Containers?
 >
 > **Environment**: A workstation with Docker Engine or Docker Desktop, a terminal, and permission to run local containers.
+
+---
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/prerequisites/cloud-native-101/module-1.3-what-is-kubernetes.md
+++ b/src/content/docs/prerequisites/cloud-native-101/module-1.3-what-is-kubernetes.md
@@ -5,14 +5,13 @@ slug: prerequisites/cloud-native-101/module-1.3-what-is-kubernetes
 sidebar:
   order: 4
 ---
-
-# Module 1.3: What Is Kubernetes?
-
 > **Complexity**: `[QUICK]` - High-level overview
 >
 > **Time to Complete**: 30-35 minutes
 >
 > **Prerequisites**: Module 1 (Containers), Module 2 (Docker). This lesson assumes you can explain why teams package applications as containers and can recognize a basic Docker image or container command, but it does not assume previous Kubernetes experience.
+
+---
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/prerequisites/cloud-native-101/module-1.4-cloud-native-ecosystem.md
+++ b/src/content/docs/prerequisites/cloud-native-101/module-1.4-cloud-native-ecosystem.md
@@ -5,17 +5,17 @@ slug: prerequisites/cloud-native-101/module-1.4-cloud-native-ecosystem
 sidebar:
   order: 5
 ---
+> **Complexity**: `[QUICK]` - Orientation, not deep dives
+>
+> **Time to Complete**: 40-55 minutes
+>
+> **Prerequisites**: Module 1.3 (What Is Kubernetes?)
+>
+> **Kubernetes target**: 1.35+
 
-# Module 1.4: The Cloud Native Ecosystem
+---
 
-| Metadata | Value |
-|---|---|
-| Complexity | `[QUICK]` - Orientation, not deep dives |
-| Time to Complete | 40-55 minutes |
-| Prerequisites | Module 1.3 (What Is Kubernetes?) |
-| Kubernetes target | 1.35+ |
-
-## Learning Outcomes
+## What You'll Be Able to Do
 
 After this module, you will be able to:
 

--- a/src/content/docs/prerequisites/cloud-native-101/module-1.5-monolith-to-microservices.md
+++ b/src/content/docs/prerequisites/cloud-native-101/module-1.5-monolith-to-microservices.md
@@ -5,17 +5,17 @@ slug: prerequisites/cloud-native-101/module-1.5-monolith-to-microservices
 sidebar:
   order: 6
 ---
+> **Complexity**: `[QUICK]` - Architectural concepts
+>
+> **Time to Complete**: 40-55 minutes
+>
+> **Prerequisites**: Module 1.3 (What Is Kubernetes?)
+>
+> **Kubernetes target**: 1.35+
 
-# Module 1.5: From Monolith to Microservices
+---
 
-| Metadata | Value |
-|---|---|
-| Complexity | `[QUICK]` - Architectural concepts |
-| Time to Complete | 40-55 minutes |
-| Prerequisites | Module 1.3 (What Is Kubernetes?) |
-| Kubernetes target | 1.35+ |
-
-## Learning Outcomes
+## What You'll Be Able to Do
 
 After this module, you will be able to:
 

--- a/src/content/docs/prerequisites/kubernetes-basics/module-1.1-first-cluster.md
+++ b/src/content/docs/prerequisites/kubernetes-basics/module-1.1-first-cluster.md
@@ -11,12 +11,13 @@ lab:
   difficulty: "beginner"
   environment: "kubernetes"
 ---
+> **Complexity**: [MEDIUM]
+>
+> **Time to Complete**: 45-60 minutes
+>
+> **Prerequisites**: Docker installed, Cloud Native 101 completed
 
-# Module 1.1: Your First Cluster
-
-**Complexity:** [MEDIUM]
-**Time to Complete:** 45-60 minutes
-**Prerequisites:** Docker installed, Cloud Native 101 completed
+---
 
 Throughout this module, `kubectl` is the official Kubernetes command-line client, and we will use the common short alias `k` after defining it once. The alias matters because Kubernetes work involves many repeated inspection commands, and the shorter form keeps examples readable without changing what is executed.
 
@@ -24,7 +25,7 @@ Throughout this module, `kubectl` is the official Kubernetes command-line client
 alias k=kubectl
 ```
 
-## Learning Outcomes
+## What You'll Be Able to Do
 
 - Construct and verify a Kubernetes 1.35+ local cluster with `kind`, Docker, and the `k` command-line workflow.
 - Compare local cluster tools and design a topology that matches the development or testing problem in front of you.

--- a/src/content/docs/prerequisites/kubernetes-basics/module-1.2-kubectl-basics.md
+++ b/src/content/docs/prerequisites/kubernetes-basics/module-1.2-kubectl-basics.md
@@ -11,17 +11,15 @@ lab:
   difficulty: "beginner"
   environment: "kubernetes"
 ---
-# Module 1.2: kubectl Basics
-
-> **Complexity**: `[MEDIUM]` - Essential commands to master
+> **Complexity**: `[MEDIUM]` - Essential commands to master.
 >
-> **Time to Complete**: 60-75 minutes
+> **Time to Complete**: 60-75 minutes.
 >
 > **Prerequisites**: Module 1.1 (a working kind or minikube cluster), basic familiarity with the Linux shell, and a `kubectl` binary on your `$PATH` matching your Kubernetes 1.35+ cluster within one minor version.
 
-This module uses `kubectl` in full until the productivity section installs `alias k=kubectl`; after that point, `k get pods` and similar short commands mean exactly the same API calls with less typing.
+---
 
-## Learning Outcomes
+## What You'll Be Able to Do
 
 After completing this module, you will be able to debug, compare, design, evaluate, and implement `kubectl` workflows against a Kubernetes 1.35+ cluster:
 
@@ -30,6 +28,8 @@ After completing this module, you will be able to debug, compare, design, evalua
 - **Design** a safe context-management workflow that prevents the cross-cluster destruction described above, including current-context checks, named contexts per environment, and `--dry-run=server` previews.
 - **Evaluate** the output of `kubectl get -o jsonpath` and `kubectl get -o custom-columns` to extract precisely the data needed for automation, monitoring scripts, or certification exam tasks.
 - **Implement** a productivity-boosting shell environment with the `k` alias, autocomplete, and a small library of inspection one-liners that you can reproduce on any new machine in under five minutes.
+
+This module uses `kubectl` in full until the productivity section installs `alias k=kubectl`; after that point, `k get pods` and similar short commands mean exactly the same API calls with less typing.
 
 ## Why This Module Matters
 

--- a/src/content/docs/prerequisites/kubernetes-basics/module-1.3-pods.md
+++ b/src/content/docs/prerequisites/kubernetes-basics/module-1.3-pods.md
@@ -11,13 +11,15 @@ lab:
   difficulty: "beginner"
   environment: "kubernetes"
 ---
+> **Complexity**: [MEDIUM]
+>
+> **Time to Complete**: 60-75 minutes
+>
+> **Prerequisites**: Module 1.2 (kubectl Basics; define `alias k=kubectl` before using shorthand)
 
-# Module 1.3: Pods - The Atomic Unit
-**Complexity**: [MEDIUM]
-**Time to Complete**: 60-75 minutes
-**Prerequisites**: Module 1.2 (kubectl Basics; define `alias k=kubectl` before using shorthand)
+---
 
-## Learning Outcomes
+## What You'll Be Able to Do
 - Diagnose Pod lifecycle failures, including `Pending`, `ImagePullBackOff`, `CreateContainerConfigError`, `CrashLoopBackOff`, and `OOMKilled`, by combining events, logs, exit codes, and native `k` inspection commands.
 - Design multi-container Pods that use sidecar, ambassador, adapter, init container, ephemeral container, shared `emptyDir`, and `localhost` communication patterns without turning the Pod into a small virtual machine.
 - Evaluate requests, limits, Quality of Service classes, CFS throttling, OOM killer behavior, taints, tolerations, affinity, and anti-affinity when predicting how Pods schedule and survive resource pressure.

--- a/src/content/docs/prerequisites/kubernetes-basics/module-1.4-deployments.md
+++ b/src/content/docs/prerequisites/kubernetes-basics/module-1.4-deployments.md
@@ -11,12 +11,15 @@ lab:
   difficulty: "beginner"
   environment: "kubernetes"
 ---
+> **Complexity**: `[MEDIUM]` - Core workload management.
+>
+> **Time to Complete**: 40-45 minutes.
+>
+> **Prerequisites**: Module 3, Pods. This module assumes a Kubernetes 1.35 or newer cluster and a working shell. To keep commands short during practice, set `alias k=kubectl` before you begin, then read `k` as the same client command you already used in earlier modules.
 
-# Module 1.4: Deployments - Managing Applications
+---
 
-**Complexity**: `[MEDIUM]` - Core workload management. **Time to Complete**: 40-45 minutes. **Prerequisites**: Module 3, Pods. This module assumes a Kubernetes 1.35 or newer cluster and a working shell. To keep commands short during practice, set `alias k=kubectl` before you begin, then read `k` as the same client command you already used in earlier modules.
-
-## Learning Outcomes
+## What You'll Be Able to Do
 
 After completing this module, you will be able to:
 

--- a/src/content/docs/prerequisites/kubernetes-basics/module-1.5-services.md
+++ b/src/content/docs/prerequisites/kubernetes-basics/module-1.5-services.md
@@ -11,18 +11,17 @@ lab:
   difficulty: "beginner"
   environment: "kubernetes"
 ---
-
-# Module 1.5: Services - Stable Networking
-
 > **Complexity**: `[MEDIUM]` - Essential networking concept for every application that runs behind a controller
 >
 > **Time to Complete**: 35-40 minutes of reading and lab work, with extra practice time if you intentionally break selectors
 >
 > **Prerequisites**: Module 4 (Deployments), especially labels, replicas, rollout behavior, and why pods are replaceable
 
+---
+
 This module uses the common shell alias `alias k=kubectl` so the examples stay readable once the commands become repetitive. Run that alias in your terminal before the hands-on section, and read commands such as `k get svc` as normal Kubernetes CLI calls through `kubectl`. The examples target Kubernetes 1.35 and focus on the built-in Service API rather than higher-level routing systems such as Ingress or Gateway API.
 
-## Learning Outcomes
+## What You'll Be Able to Do
 
 After this module, you will be able to perform the work below in a real cluster rather than only define the vocabulary. Each outcome is reflected again in the troubleshooting narrative, quiz scenarios, and lab checks, because Services are best learned by following traffic from a stable name to the selected pods behind it.
 

--- a/src/content/docs/prerequisites/kubernetes-basics/module-1.6-configmaps-secrets.md
+++ b/src/content/docs/prerequisites/kubernetes-basics/module-1.6-configmaps-secrets.md
@@ -5,18 +5,17 @@ revision_pending: false
 sidebar:
   order: 7
 ---
-
-# Module 1.6: ConfigMaps and Secrets
-
 > **Complexity**: `[MEDIUM]` - Essential configuration management
 >
 > **Time to Complete**: 35-40 minutes
 >
 > **Prerequisites**: Module 1.3 (Pods)
 
+---
+
 Throughout this module, commands use the short alias `k` for `kubectl`. If your shell does not already define it, run `alias k=kubectl` before starting the hands-on work. The examples target Kubernetes 1.35 and focus on behavior that matters when configuration, credentials, and rollout operations meet in a real cluster.
 
-## Learning Outcomes
+## What You'll Be Able to Do
 
 After completing this module, you will be able to:
 

--- a/src/content/docs/prerequisites/kubernetes-basics/module-1.7-namespaces-labels.md
+++ b/src/content/docs/prerequisites/kubernetes-basics/module-1.7-namespaces-labels.md
@@ -5,14 +5,15 @@ revision_pending: false
 sidebar:
   order: 8
 ---
+> **Complexity**: [MEDIUM]
+>
+> **Time to Complete**: 50-60 minutes
+>
+> **Prerequisites**: [Module 1.4: Deployments](/prerequisites/kubernetes-basics/module-1.4-deployments/), [Module 1.5: Services](/prerequisites/kubernetes-basics/module-1.5-services/)
 
-# Module 1.7: Namespaces and Labels
+---
 
-**Complexity:** [MEDIUM]
-**Time to Complete:** 50-60 minutes
-**Prerequisites:** [Module 1.4: Deployments](/prerequisites/kubernetes-basics/module-1.4-deployments/), [Module 1.5: Services](/prerequisites/kubernetes-basics/module-1.5-services/)
-
-## Learning Outcomes
+## What You'll Be Able to Do
 
 After completing this module, you will be able to:
 
@@ -28,7 +29,7 @@ At 2:00 AM on a Friday, a platform engineer at a busy online retailer is paged b
 
 The outage is not really about one careless command. It is about a cluster that has grown past the point where memory, discipline, and naming conventions can protect it. A single physical Kubernetes cluster is attractive because it centralizes capacity, networking, observability, and operational skill, but that same centralization creates a shared fate unless the cluster is divided into understandable operating zones. Without namespaces, teams collide over names and permissions; without labels, controllers and humans cannot reliably find the objects they mean to affect; without quotas and defaults, one tenant can unintentionally starve another.
 
-This module teaches the two organizational primitives that make Kubernetes usable beyond toy demos. Namespaces divide the API into logical rooms, while labels attach structured identity to the objects inside those rooms. You will learn what those boundaries actually isolate, what they absolutely do not isolate, how selectors allow decoupled controllers to cooperate, and how namespace-level policy turns a shared cluster into a platform that can survive normal human mistakes.
+This module teaches the two organizational primitives that make Kubernetes usable beyond toy demos. Namespaces divide the API into logical rooms, while labels attach structured identity to the objects inside those rooms. You will learn what those boundaries actually isolate, what they absolutely do not isolate, how selectors allow decoupled controllers to cooperate, and how namespace-level policy turns a shared cluster into a platform that can survive normal human mistakes. That shared vocabulary also makes incident review faster because ownership, blast radius, and cleanup scope become visible in ordinary commands.
 
 Throughout the commands, this module uses `k` as the local alias for `kubectl`; if your shell does not already define it, run `alias k=kubectl` before practicing. The Kubernetes examples target version 1.35 or newer behavior, and the concepts are stable across modern clusters even when individual cloud distributions add their own admission policies or default labels.
 

--- a/src/content/docs/prerequisites/kubernetes-basics/module-1.8-yaml-kubernetes.md
+++ b/src/content/docs/prerequisites/kubernetes-basics/module-1.8-yaml-kubernetes.md
@@ -5,15 +5,17 @@ sidebar:
   order: 9
 revision_pending: false
 ---
+> **Complexity**: [MEDIUM]
+>
+> **Time to Complete**: 60-75 minutes
+>
+> **Prerequisites**: Modules 1.1-1.7, including basic Kubernetes resources, pods, services, deployments, labels, and the `kubectl` workflow
+>
+> **Command convention**: This module uses the short alias `k` for `kubectl`; set it once with `alias k=kubectl` before running the examples.
 
-# Module 1.8: YAML for Kubernetes
+---
 
-**Complexity:** [MEDIUM]  
-**Time to Complete:** 60-75 minutes
-**Prerequisites:** Modules 1.1-1.7, including basic Kubernetes resources, pods, services, deployments, labels, and the `kubectl` workflow
-**Command convention:** This module uses the short alias `k` for `kubectl`; set it once with `alias k=kubectl` before running the examples.
-
-## Learning Outcomes
+## What You'll Be Able to Do
 
 By the end of this module, you will be able to:
 
@@ -31,7 +33,7 @@ That kind of incident feels unfair until you remember what YAML does in Kubernet
 
 There is another class of failure that is even quieter. In 2019, a European financial institution rotated a TLS certificate through a Kubernetes Secret and used YAML's folded block scalar by mistake. The file was valid YAML, the Secret was created, and the rollout continued, but the folded scalar replaced certificate newlines with spaces. The ingress controller received a malformed PEM payload, failed to load its certificate, and repeatedly restarted while external banking APIs were unavailable. A single character, `>` instead of `|`, did not break YAML syntax; it changed the application data that YAML carried.
 
-This module teaches YAML as an operational interface, not as decorative syntax. You will learn the three YAML shapes that appear in every manifest, the four root fields Kubernetes uses to route objects, the schema tools that prevent guessing, and the validation workflow that turns manifest review into an engineering practice. The goal is not memorizing every field in Kubernetes 1.35; the goal is knowing how to reason from structure to schema to controller behavior when the cluster is about to act on your file.
+This module teaches YAML as an operational interface, not as decorative syntax. You will learn the three YAML shapes that appear in every manifest, the four root fields Kubernetes uses to route objects, the schema tools that prevent guessing, and the validation workflow that turns manifest review into an engineering practice. The goal is not memorizing every field in Kubernetes 1.35; the goal is knowing how to reason from structure to schema to controller behavior when the cluster is about to act on your file. That reasoning gives reviewers something better than visual confidence: a repeatable path from text to API behavior.
 
 ## 1. YAML Fundamentals for Infrastructure
 


### PR DESCRIPTION
## Summary

Normalizes the top-of-module pattern for the active Fundamentals rewrite surface:

- removes source-level `# Module ...` headings that render as duplicate H1s in Starlight
- converts inline/table/plain metadata to the canonical blockquote metadata block
- normalizes the first learning section to `## What You'll Be Able to Do`
- updates rewrite/review instructions so future agent rewrites do not reintroduce duplicate H1s
- teaches `verify_module.py` to ignore top metadata blockquotes/horizontal rules for prose density

Scope is intentionally limited to `cloud-native-101` and `kubernetes-basics` to stay below the repo file-count rule. Git Deep Dive / Linux / KCNA / KCSA should be separate follow-up cleanup PRs.

## Verification

- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/ruff check scripts/quality/prompts.py scripts/quality/verify_module.py scripts/quality/test_verify_module.py`
- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python -m pytest scripts/quality/test_verify_module.py -q` → 14 passed
- targeted `verify_module.py --skip-source-check --summary --quiet` on all 12 touched modules → all T0
- `git diff --check` clean

`npm run build` not run here because the primary checkout is currently dirty and far behind `origin/main`; per repo rule, builds should run from primary rather than `.worktrees/*`.

Refs #388
