### PR TITLE
feat(388): rewrite module-1.3-cicd-pipelines (#388 pilot)

### DIFF
--- a/src/content/docs/prerequisites/modern-devops/module-1.3-cicd-pipelines.md
+++ b/src/content/docs/prerequisites/modern-devops/module-1.3-cicd-pipelines.md
@@ -1,109 +1,58 @@
 ---
 title: "Module 1.3: CI/CD Pipelines"
 slug: prerequisites/modern-devops/module-1.3-cicd-pipelines
+revision_pending: false
 sidebar:
   order: 4
 ---
 
 # Module 1.3: CI/CD Pipelines
 
-**Complexity:** [MEDIUM]  
-**Time to Complete:** 45-60 minutes  
-**Prerequisites:** [Module 1.1: Infrastructure as Code](/prerequisites/modern-devops/module-1.1-infrastructure-as-code/), basic Git knowledge  
+**Complexity:** [MEDIUM]<br>
+**Time to Complete:** 60-75 minutes<br>
+**Prerequisites:** [Module 1.1: Infrastructure as Code](/prerequisites/modern-devops/module-1.1-infrastructure-as-code/), basic Git knowledge
 
 ## Learning Outcomes
 
 By the end of this module, you will be able to:
-- Differentiate between Continuous Integration, Continuous Delivery, and Continuous Deployment by analyzing real-world deployment scenarios.
-- Architect a multi-stage container-native pipeline incorporating build, test, vulnerability scanning, and deployment stages.
-- Evaluate the architectural trade-offs between GitHub Actions, GitLab CI, Jenkins, and Tekton for Kubernetes-native workflows.
-- Compare and implement progressive deployment strategies (rolling updates, blue-green, canary, shadow) using pipeline orchestration.
-- Differentiate between traditional Push-based CD and modern Pull-based GitOps (ArgoCD/Flux).
-- Troubleshoot failed pipelines by diagnosing common anti-patterns such as ignored flaky tests, snowflake build agents, or hardcoded secrets.
-- Optimize pipeline performance using dependency caching and parallel job execution.
+
+- Differentiate Continuous Integration, Continuous Delivery, and Continuous Deployment by analyzing release scenarios and identifying where automation stops.
+- Architect a multi-stage container-native pipeline that builds, tests, scans, signs, stores, and deploys one immutable artifact.
+- Evaluate the trade-offs between GitHub Actions, GitLab CI, Jenkins, and Tekton for Kubernetes-native delivery workflows.
+- Compare Kubernetes deployment strategies and GitOps pull-based delivery against traditional push-based cluster deployment.
+- Diagnose pipeline failures and optimize delivery performance using caching, timeouts, immutable tags, and earlier security gates.
 
 ## Why This Module Matters
 
-### War Story: The 45-Minute Bankruptcy
-In 2012, Knight Capital Group deployed a new software update to their high-frequency trading servers. The deployment process was highly manual, poorly documented, and completely lacked automated testing or verification. An engineer simply forgot to copy the new code to one of the eight load-balanced servers. When the market opened, the outdated server began executing a dormant, flawed testing algorithm that bought high and sold low. In just 45 minutes, Knight Capital lost $460 million and was forced into bankruptcy. This incident remains the starkest, most terrifying reminder of why manual, undocumented deployments are a catastrophic risk at scale. Human beings are terrible at performing repetitive, precise tasks consistently. Machines excel at it.
+In 2012, Knight Capital Group deployed a software update to its high-frequency trading platform with a process that depended on manual server-by-server coordination. One of eight servers kept old code, the market opened, and a dormant testing path began sending live trading orders that bought high and sold low. In 45 minutes, the firm lost about $460 million and was forced into a rescue sale. The technical lesson was not merely that a bad algorithm existed; it was that the delivery system allowed inconsistent versions to reach production without an automated proof that every node was running the same validated artifact.
 
-### War Story: The Supply Chain Compromise
-In 2020, sophisticated attackers compromised the build environment of SolarWinds, injecting malicious code into the Orion software update before it was digitally signed and shipped to thousands of government and enterprise customers. This wasn't a vulnerability in the application code written by developers; it was a compromise of the *delivery mechanism itself*. It highlights why securing the pipeline (the software factory) is just as critical as securing the application. A pipeline must not only be automated, but cryptographically verifiable and locked down.
+In 2020, attackers compromised the SolarWinds Orion build environment and inserted malicious code into a signed software update that customers trusted. That incident widened the definition of deployment risk from "will our app crash?" to "can we prove where this artifact came from, who changed it, which dependencies are inside it, and whether anything touched it after the build?" A modern pipeline is therefore not a convenience script wrapped around Git. It is the software factory, the audit trail, the security checkpoint, the release controller, and the first place where weak engineering discipline becomes visible.
 
-### Analogy: The Automated Assembly Line
-In 1913, Henry Ford revolutionized manufacturing with the moving assembly line. Before this, cars were built one at a time by highly skilled craftsmen—a slow, error-prone, and unscalable process. Manual software deployment (SSHing into a server, pulling code, running build scripts by hand) is the digital equivalent of artisanal car manufacturing. CI/CD is the modern assembly line for code. Raw materials (source code) enter the factory, pass through automated quality checks, are assembled into parts (binaries/images), and roll off the line ready for the consumer.
+Think of CI/CD as the automated assembly line for software. Source code enters as raw material, moves through quality stations, becomes a container image, receives a label and signature, and is promoted only if each station records a clean result. A team can still choose when a release reaches users, but the release should never depend on someone remembering which commands to run on which host. Kubernetes 1.35+ assumes this world: applications arrive as versioned container images, rollout controllers converge toward desired state, and platform teams rely on repeatable automation rather than personal deployment folklore.
 
-Modern software delivery relies on these automated pipelines to remove human error, enforce strict quality gates, and exponentially accelerate feedback loops. A pipeline is not merely a script that runs commands; it is the codified, executable definition of your engineering culture. If your tests are flaky and ignored, your pipeline will be ignored. If your security scans are manual and happen right before release, your pipeline provides a false sense of security. 
+This module turns that assembly line into a design skill. You will separate CI from the two meanings of CD, model pipelines as stages and jobs, connect Infrastructure as Code to delivery gates, secure container artifacts with scans and provenance, compare common CI/CD tools, and choose rollout strategies that fit the risk of the change. When later Kubernetes modules use `k` as the kubectl alias, read it as `alias k=kubectl`; for example, a rollout check would be written as `k rollout status deployment/myapp` after the alias is configured in your shell.
 
-In a cloud-native ecosystem, CI/CD is the essential bridge between developers committing code and users experiencing value. Understanding how to build, secure, and operate these pipelines is non-negotiable for anyone working with Kubernetes, as the orchestrator itself assumes applications will be delivered automatically, consistently, and securely.
+## Core Concepts: CI, Delivery, and Deployment
 
-## Core Concepts: CI vs. CD vs. CD
+The phrase "CI/CD" hides three related but different promises, and confusing them leads to brittle release designs. Continuous Integration asks whether a change can merge safely with the shared codebase. Continuous Delivery asks whether the merged artifact is ready to be released on demand. Continuous Deployment asks whether every passing change should flow to production automatically without a final human approval. Those boundaries matter because each step requires more trust in automation, observability, rollback, and organizational discipline than the one before it.
 
-The acronym "CI/CD" is often used interchangeably, but it actually represents three distinct, progressive phases of software delivery maturity. Understanding the exact boundaries between them is crucial for designing effective, safe pipelines.
+Continuous Integration exists to prevent integration hell, the familiar late-project moment when several long-running branches finally collide and nobody knows which failure came from which change. In a mature CI workflow, developers merge small changes frequently, and every pull request or push triggers a fast feedback loop: checkout, compile, unit tests, linting, static analysis, secret scanning, and sometimes a lightweight integration test. The golden rule is that a red main branch stops normal feature work, because a broken main branch turns the pipeline from a signal into background noise.
 
-### Continuous Integration (CI)
+Continuous Delivery builds on that foundation by producing a validated, versioned, immutable artifact that could be released at any time. The important word is "could." The pipeline may deploy automatically to a staging environment, run end-to-end checks, publish reports, and wait at a production approval gate because the business wants to coordinate the release with customer support, compliance, or a maintenance window. The final action is still manual, but the manual action is a release decision, not a hand-built deployment procedure.
 
-Continuous Integration is the foundational practice of merging all developers' working copies to a shared mainline (branch) several times a day. Its primary goal is to prevent **"Integration Hell."** 
+Continuous Deployment removes that final human approval. If a change passes all automated gates, the system promotes it to production. This is powerful, but it is not a badge a team earns by deleting an approval button. It requires tests that catch real failures, feature flags that limit exposure, metrics that detect customer impact quickly, and rollback automation that can act faster than a meeting can be scheduled. Without those controls, Continuous Deployment simply accelerates mistakes.
 
-*Integration Hell* is the dreaded scenario where developers work in isolated feature branches for weeks or months, only to spend an entire weekend resolving massive, complex Git merge conflicts before a release. By the time the code is merged, nobody remembers exactly how it all works together, and bugs multiply exponentially.
+> **Pause and predict:** if a team moves from Continuous Delivery to Continuous Deployment, which system becomes more important than the deploy button: the test suite, the observability stack, or rollback automation? The practical answer is that all three become one safety system, because a fully automated release path needs automated evidence before, during, and after the rollout.
 
-When a developer pushes code to a branch or opens a Pull Request, the CI server automatically:
-1. Fetches the code from the repository.
-2. Compiles or builds the application (catching syntax errors immediately).
-3. Runs unit tests and integration tests to verify business logic.
-4. Performs static code analysis (linting) to enforce style guides.
-5. Runs security scans (SAST - Static Application Security Testing) to catch hardcoded secrets or known insecure coding patterns.
+Consider two release scenarios. In the first, a developer merges to `main`, the code compiles, tests run, and a Docker image is pushed to a registry, but the operations team later SSHes into a host and manually pulls the tag on Friday evening. That team has CI, not delivery, because the deployment path still depends on human memory. In the second, the pipeline builds the image, deploys it to QA, waits for a reviewer to approve the production environment, and then performs the deployment automatically. That is Continuous Delivery because the release decision is manual while the mechanics are automated.
 
-**The Golden Rule of CI:** If the build fails on the mainline branch, the team drops what they are doing to fix it. The mainline branch must always be in a deployable state. It relies on the "broken window theory" of software: if the build is allowed to stay broken, developers will lose trust in it, ignore the red X marks, and stop caring about test failures.
-
-### Continuous Delivery (CD)
-
-Continuous Delivery extends Continuous Integration by ensuring that the software can be released to production at any given time. It's about being technically *ready* to deploy on demand, even if the business chooses not to deploy immediately.
-
-In a Continuous Delivery workflow:
-1. The CI pipeline completes and produces a validated, versioned, immutable artifact (e.g., a tagged Docker image).
-2. The artifact is automatically deployed to a staging environment that identically mirrors the production environment.
-3. Acceptance tests, performance tests, and end-to-end tests are executed automatically against the live staging service.
-4. The final deployment to the production cluster is triggered by a **manual business decision** (a human clicking a "Deploy" or "Approve" button). This allows product managers, marketing, or compliance teams to control the exact release timing to align with press releases or maintenance windows.
-
-### Continuous Deployment (CD)
-
-Continuous Deployment is the ultimate automation goal. It removes the human element entirely from the release process.
-
-In a Continuous Deployment workflow:
-1. Every single code change that passes all stages of the CI and staging pipelines is automatically deployed directly to production.
-2. There are absolutely no manual approval gates. No "Release Managers" or "Change Advisory Boards."
-3. This requires immense, absolute trust in your automated testing suite, robust observability (monitoring and alerting), and rapid, automated rollback mechanisms. Companies like Netflix, Amazon, and Etsy deploy thousands of times a day using this model. A developer merges a pull request, goes to get a coffee, and by the time they return, their code is serving live customer traffic.
-
-> **Pause and predict**: If a team transitions from Continuous Delivery to Continuous Deployment, what is the absolute most critical automated system they must strengthen to prevent catastrophic outages?
-
-### Active Learning Prompt
-
-> **Scenario A:** A developer merges code to `main`. The code compiles, tests run, and a Docker image is built and pushed to a container registry. The pipeline stops. On Friday evening, the Ops team manually pulls that specific image tag and applies it to the Kubernetes cluster using `kubectl set image`.
->
-> **Scenario B:** A developer merges code. Tests run, an image is built, and the pipeline automatically deploys it to the QA environment. A QA engineer reviews the staging environment and clicks "Approve" in GitHub Actions. The pipeline then automatically continues, deploying the image to the Production cluster.
->
-> **Questions:**
-> 1. Which phase of CI/CD does Scenario A satisfy?
-> 2. Is Scenario B practicing Continuous Delivery or Continuous Deployment?
->
-> <details>
-> <summary>Click for the answers</summary>
-> 1. **Continuous Integration (CI) only.** The artifact is successfully built, tested, and integrated, but the deployment process is entirely manual and disjointed from the automated pipeline. Because the deployment requires an Ops team member to manually pull and apply the image on a Friday evening, it completely lacks the automated deployment mechanisms required for Continuous Delivery. The CI phase has done its job by producing a verifiable artifact, but the pipeline stops there.
-> 2. **Continuous Delivery.** The presence of the QA engineer's manual "Approve" click before the final production deployment distinguishes it from Continuous Deployment, which would flow all the way to production automatically without human intervention. This strategy ensures the code is always in a deployable state while retaining business control over the actual release moment. This manual gate is the defining characteristic of Continuous Delivery, allowing for human validation without sacrificing automated promotion through lower environments.
-> </details>
+The distinction also affects incident review. If production broke because a test missed a regression, the pipeline may need better coverage or a safer rollout strategy. If production broke because an engineer ran the wrong command, the problem is not only testing; the deployment procedure itself was outside the pipeline. A senior engineer reviewing a failed release asks where the artifact changed hands, where automation stopped, and whether the next change will travel through the same unreliable gap.
 
 ## Anatomy of a Pipeline
 
-Pipelines are structured hierarchically. While different tools (Jenkins, GitHub Actions, GitLab CI, CircleCI) use slightly different terminology, the underlying mental model remains identical across the industry.
+A pipeline is easiest to understand as a hierarchy of workflow, stages, jobs, steps, and artifacts. The workflow is the entire process triggered by an event such as a pull request, push, tag, schedule, or manual dispatch. Stages are ordered groups such as build, test, package, scan, and deploy. Jobs are independent units that run on runners or containers, often in parallel. Steps are the commands inside a job, and artifacts are the outputs passed forward, such as test reports, compiled binaries, SBOMs, signatures, or container image references.
 
-### Analogy: The Restaurant Kitchen
-Think of a pipeline like a high-end commercial kitchen during dinner service:
-- **Pipeline / Workflow:** The entire dinner service from open to close. The overarching process.
-- **Stage:** The course of the meal (Appetizers, Mains, Desserts). You cannot serve the Main stage until the Appetizer stage is fully complete and successful. Stages enforce order.
-- **Job:** Different stations in the kitchen. The Grill station and the Fry station can work on different parts of the Appetizer stage at the exact same time (Parallel execution). Jobs run on separate workers (runners) and are isolated.
-- **Step:** The specific actions a chef takes. Chop onions, season meat, sear in pan. These must happen in strict sequential order within a Job.
-- **Artifact:** The completed, plated dish passed to the waiter to be delivered to the customer (or passed to the next Stage).
+The restaurant kitchen analogy is useful because it shows why ordering and parallelism both matter. Dinner service is the workflow. Appetizers, mains, and desserts are stages because the kitchen should not plate dessert before the mains are ready. The grill and fry stations are jobs because they can work at the same time on separate equipment. Chopping, seasoning, and searing are steps because each one depends on the previous one inside the station. The plated dish is the artifact, and if the waiter receives a different dish than the one inspected by the chef, quality control has failed.
 
 ```mermaid
 flowchart LR
@@ -130,48 +79,51 @@ flowchart LR
     end
 ```
 
-1. **Pipeline/Workflow:** The overarching process triggered by an event (e.g., a push to the `main` branch, a pull request creation, or a nightly cron schedule).
-2. **Stages:** Logical groupings of jobs that run sequentially. The `Deploy` stage won't start until the `Test` stage succeeds.
-3. **Jobs:** A collection of steps that execute on the same runner (virtual machine or container). Jobs within the same stage can run in parallel (e.g., `JOB B` and `JOB C` above) to vastly speed up execution time.
-4. **Steps:** Individual tasks within a job. These are executed sequentially. A step can be a simple shell command (like `npm install`) or a complex, predefined, reusable action block.
-5. **Artifacts:** Files or data produced by a job that are saved and passed to subsequent jobs or stages (e.g., a compiled binary, a test coverage HTML report, or a Docker image tarball).
+This diagram shows a small but important design principle: build once, then fan out where possible. The compile job must succeed before testing and linting can evaluate the result, but the unit test and lint jobs can run at the same time because neither one needs the other. The Docker packaging stage waits for both checks, then produces the artifact used by the deployment job. When pipelines feel slow, the fix is often not more runners; it is recognizing which jobs are truly independent and which ones accidentally serialize work that could be parallel.
 
-### Pipeline-as-Code
+Pipeline-as-code makes that hierarchy reviewable. GitHub Actions stores workflow YAML under `.github/workflows/`, GitLab CI uses `.gitlab-ci.yml`, Jenkins commonly uses a `Jenkinsfile`, and Tekton represents pipelines as Kubernetes Custom Resources such as `Task`, `Pipeline`, `TaskRun`, and `PipelineRun`. Keeping the pipeline definition beside the application means the deployment process changes in the same pull request as the application code that needs it. A new service, a new test dependency, or a new scan rule should be reviewed with the code it affects, rather than patched later in a hidden CI dashboard.
 
-Modern pipelines are defined as code (usually YAML) and live directly alongside the application source code in the same Git repository. This practice ensures that the deployment process is version-controlled, auditable, and subject to the exact same Pull Request review process as the application logic. 
+The artifact boundary is the most important boundary in the whole pipeline. If you build one image for testing and a second image for production, you have not promoted evidence; you have produced a look-alike. Package managers, base images, and remote build steps can change between those builds, which means production may run dependencies that tests never saw. A mature pipeline builds a single immutable image, tags it with a commit SHA or release identifier, scans that exact image, signs that exact image, and promotes that exact image through staging and production.
 
-**Why does this matter?** If a developer introduces a new microservice that requires a new testing step, they update the pipeline YAML in the exact same Pull Request as the code itself. If you rollback your application code to a version from a month ago, you automatically rollback the pipeline definition to how it existed a month ago, ensuring it builds correctly.
+### Worked Example: Following One Commit Through the Line
 
-Common locations for pipeline definitions:
-- **GitHub Actions:** `.github/workflows/main.yml`
-- **GitLab CI:** `.gitlab-ci.yml`
-- **Jenkins:** `Jenkinsfile` (often written in Groovy)
-- **Tekton:** Kubernetes Custom Resource Definitions (CRDs) like `PipelineRun` and `TaskRun`
+Imagine a developer changes the login service to add stricter session expiration. The pull request should first answer whether the change fits with the existing codebase, so CI checks formatting, compiles the service, runs fast unit tests, and searches for leaked credentials or unsafe patterns. These checks are intentionally close to the developer because they catch mistakes while the change is still small. A failure here should feel like a normal part of editing, not like a release emergency.
 
-## Infrastructure as Code (IaC) Integration
+After the quick checks pass, the pipeline can build the container image. This is the point where the change stops being an abstract set of source files and becomes the artifact Kubernetes will eventually run. The image should receive a tag tied to the commit and, more importantly, a digest that identifies its exact content. Tags are convenient labels, but digests are the stronger identity because they change when any byte in the image changes.
 
-Pipelines aren't just for application code; they are also the primary mechanism for deploying Infrastructure as Code (IaC) tools like Terraform, Pulumi, or AWS CloudFormation. 
+The next stage tests the artifact rather than rebuilding it. Integration tests might start the login service with a database container, exercise the session expiration path, and publish a report for reviewers. If the test suite needs supporting services, the pipeline should create them from disposable infrastructure rather than relying on a shared environment with unknown state. Shared test environments often produce misleading failures because one team's cleanup job or fixture data can change another team's result.
 
-### The GitOps vs. traditional CI/CD divide for IaC
-When deploying infrastructure, you generally have two choices:
-1. **CI/CD Driven (Terraform inside GitHub Actions):** The pipeline runs `terraform plan` to show you what will change, and after manual approval, runs `terraform apply`. The CI server itself executes the infrastructure changes.
-2. **GitOps Driven (Crossplane or ACK):** The pipeline merely generates Kubernetes manifests that describe your desired AWS/GCP infrastructure, and GitOps tools (like ArgoCD) apply them to the cluster. The cluster itself provisions the external cloud resources.
+Security checks then inspect the same image from a different angle. A vulnerability scan asks whether the base operating system and language dependencies contain known issues. An SBOM records what is inside the image so the team can answer future vulnerability questions. A signature records that the approved pipeline produced the artifact. None of these checks proves the login logic is correct, but together they prove the artifact is known, inspected, and traceable.
 
-> **Pause and predict**: If a developer updates a Terraform file to add a new AWS S3 bucket, at what exact stage in the CI/CD pipeline should the cost estimation tool run to be most effective?
+At this stage, the pipeline has enough evidence to promote the image to a staging environment. In Continuous Delivery, staging deployment should still be automated because manual staging deploys are where drift quietly enters the system. If the staging namespace is missing a secret, has an outdated manifest, or depends on a different database migration state, the pipeline should expose that mismatch before production is involved. Staging is most valuable when it is similar enough to production to reveal deployment problems and isolated enough to be safely disposable.
 
-### IaC Pipeline Best Practices
-If you are running IaC like Terraform inside your pipelines, you must enforce specific quality gates:
-- **`terraform fmt -check`:** Automatically fail the build if the infrastructure code is not formatted correctly. This prevents messy pull requests.
-- **`terraform validate`:** Catch syntax errors immediately before wasting time attempting to plan against the cloud provider's API.
-- **`tflint`:** A static analysis tool that enforces best practices (e.g., ensuring you attached specific required tags to an AWS EC2 instance).
-- **Cost Estimation:** Tools like `Infracost` can be integrated directly into your Pull Request pipeline. When a developer adds a new database to the Terraform code, the pipeline automatically comments on the PR with a message like: *"This change will increase your AWS bill by $140/month."* This provides developers with immediate financial feedback before resources are ever provisioned.
-- **Security Scanning (tfsec):** Similar to scanning Docker images, tools like `tfsec` or `checkov` scan your Terraform code *before* it runs to ensure you aren't doing things like creating an S3 bucket that is completely open to the public internet.
+Production promotion should be boring because every interesting question was asked earlier. The approval gate, if one exists, should ask whether the business is ready for this release, not whether the engineer remembers the deployment command. The job after approval should update a GitOps repository, call a progressive delivery controller, or apply a reviewed manifest using tightly scoped credentials. The approver should see the image digest, test summary, scan result, and target environment, because approving a release without evidence is just a ritual.
 
-## Container-Native CI/CD & Security
+Observability closes the loop after the rollout begins. The pipeline can start the deployment, but service health must be measured from production signals such as error rate, latency, saturation, restart count, and domain-specific behavior like login success rate. A rollout controller can pause or rollback when those signals degrade. This is why mature delivery teams treat metrics and alerts as part of the release design rather than a separate operations concern that appears only after an outage.
 
-When deploying to Kubernetes, your CI/CD pipeline must be absolutely container-native. The ultimate artifact of your build process is no longer a `.jar` file, an `.exe`, or a static binary; it is a Docker container image. 
+When this commit later causes an incident, the same evidence chain helps the review stay factual. The team can identify the exact image digest, the workflow run that built it, the tests that passed, the vulnerabilities that were accepted or rejected, the approval that promoted it, and the metrics that changed after rollout. Without that chain, incident review turns into speculation about which server, which image, which dependency, or which manual command was involved. CI/CD is therefore also an investigation tool.
 
-A typical container-native pipeline integrates security tightly into the workflow, shifting security "left" (earlier) in the development process rather than treating it as an afterthought before release.
+The same chain also helps teams improve without blaming whoever happened to click the final approval. If the login regression escaped because no test covered expired sessions, the corrective action is a test and perhaps a canary metric. If it escaped because staging used a different configuration than production, the corrective action is environment parity and configuration review. If it escaped because the image tag moved after approval, the corrective action is digest pinning and immutable promotion. Good pipelines make the next improvement obvious, concrete, and repeatable.
+
+This worked example shows why a pipeline is not just a set of commands in YAML. It is a sequence of claims: this source merged cleanly, this artifact was built once, this artifact passed checks, this artifact was promoted intentionally, and this deployment behaved acceptably under real conditions. If any claim is missing, the pipeline may still be automated, but it is not yet trustworthy. The engineering task is to make those claims explicit and cheap enough that every change can carry them.
+
+> **Before running this in a real project, predict the failure mode:** what do you expect if an integration test uses one image digest, but the deployment manifest points to a tag that was rebuilt later? The likely result is a confusing incident where every pipeline check appears green while production behaves differently, because the tested artifact and deployed artifact are no longer the same object.
+
+## Infrastructure as Code in the Pipeline
+
+CI/CD is not only for application code. Terraform, Pulumi, CloudFormation, Kubernetes manifests, Helm charts, and Crossplane resources all need the same discipline because infrastructure changes can be more dangerous than application changes. A broken web route can produce errors; a broken network policy, IAM role, or database migration can take away the recovery path. The pipeline must therefore validate infrastructure code before it reaches an account, cluster, or production namespace.
+
+Traditional IaC delivery lets the CI server execute the infrastructure change. A pull request runs formatting, validation, linting, security scanning, cost estimation, and `terraform plan`; after approval, the pipeline runs `terraform apply` using credentials stored in the CI system. This model is direct and widely understood, but it also makes the CI platform a privileged actor. If its credentials are too broad, a compromised runner can mutate production infrastructure far beyond the intended change.
+
+GitOps changes the direction of control. Instead of letting the CI platform push directly into the cluster, the pipeline updates a Git repository that describes desired state, and an in-cluster reconciler such as Argo CD or Flux pulls those changes and applies them locally. For external cloud resources, teams may use Crossplane or provider controllers so Kubernetes Custom Resources represent cloud databases, buckets, and network objects. The tradeoff is more moving parts, but the security boundary is cleaner: the cluster watches Git, and CI does not need a standing admin token for the cluster.
+
+Cost estimation belongs early enough to change behavior. If a developer adds a managed database, the useful moment for financial feedback is the pull request, not the monthly invoice and not the final production gate. Tools such as Infracost can comment on a PR with estimated monthly impact, while policy tools can reject missing tags, public storage buckets, or overly broad security groups. The goal is not to embarrass the developer; it is to make cost and risk visible while the change is still small.
+
+Infrastructure checks should be layered from cheap to expensive. Formatting and syntax validation should run first because they fail quickly and provide precise feedback. Static policy checks and secret scanning should run next because they do not need cloud access. Plans, previews, and environment-specific checks can run after that because they may need remote state, provider credentials, or cluster access. This ordering keeps feedback fast and reduces the number of times privileged credentials enter the pipeline.
+
+## Container-Native CI/CD and Supply Chain Security
+
+Kubernetes delivery changes the artifact from "some files copied to a server" to "a container image referenced by a workload manifest." That sounds simple, but it expands the security surface. The image contains operating system packages, language dependencies, application code, build metadata, and sometimes misconfigured defaults inherited from the base image. A cloud-native pipeline must inspect that artifact before it reaches a registry and must leave enough evidence for operators to answer what is running later.
 
 ```mermaid
 graph LR
@@ -186,25 +138,11 @@ graph LR
     I --> J(Deploy to K8s)
 ```
 
-### The Software Supply Chain and SBOMs
+This flow places security before registry promotion because the registry should be a library of trusted artifacts, not a junk drawer of every experimental build. The pipeline builds an image, scans it, fails on policy violations, generates an SBOM, signs the artifact, and only then pushes or promotes it. In stricter systems, admission control in the cluster later verifies the signature before a Pod starts. That second check matters because it catches images that were modified, replaced, or pulled from an unapproved source after CI completed.
 
-In physical manufacturing, companies maintain a "Bill of Materials"—a comprehensive list of every nut, bolt, microchip, and wire that goes into a product. If a specific brand of airbag is recalled by a supplier, the car manufacturer can query their Bill of Materials and know exactly which car models contain the defective part.
+An SBOM, or Software Bill of Materials, is the dependency inventory for the image. Physical manufacturers use bills of materials to identify which products contain a recalled part; software teams use SBOMs to identify which services contain a vulnerable package after a disclosure. Tools such as Syft can generate SBOMs during CI, and vulnerability scanners such as Trivy or Grype can compare image contents against vulnerability databases. During a Log4j-style emergency, the team with SBOMs searches evidence, while the team without SBOMs searches guesses.
 
-Software has the exact same concept: the **SBOM (Software Bill of Materials)**. A modern, mature CI/CD pipeline generates an SBOM alongside the Docker image. It exhaustively lists every open-source library, operating system package, and transitive dependency included in your container. Tools like **Syft** can generate this in your pipeline in seconds. If a massive zero-day vulnerability (like Log4j) hits the news, you don't need to guess if your hundreds of microservices are vulnerable; you simply query your central repository of SBOMs to find out instantly.
-
-### SLSA Framework
-
-The industry standard for securing pipelines is **SLSA (Supply-chain Levels for Software Artifacts)**. It provides a maturity model to prevent tampering.
-- **Level 1:** You have a build process that is fully automated and generates provenance (data about how it was built).
-- **Level 2:** The build service must be hosted, and provenance must be authenticated.
-- **Level 3:** The build environment must be ephemeral (created fresh for each build) and isolated, preventing cross-contamination.
-- **Level 4:** Requires a two-person review for all changes, and a hermetic (completely isolated from the internet) build process.
-
-### Vulnerability Scanning
-
-Once unit and integration tests pass, the pipeline builds the container image. Before pushing this image to a container registry (like Docker Hub, Amazon ECR, or Google GCR), it is hyper-critical to scan it for known vulnerabilities (CVEs). 
-
-If a critical vulnerability is found in the base image (e.g., using an outdated, vulnerable version of Debian) or in the application dependencies (e.g., an old version of React with XSS flaws), the pipeline should fail immediately, returning a non-zero exit code. This prevents the insecure image from ever reaching the registry, let alone production.
+SLSA, the Supply-chain Levels for Software Artifacts framework, gives teams a maturity model for build integrity. At early levels, the build is automated and produces provenance describing how an artifact was made. At stronger levels, the build service is hosted, isolated, ephemeral, and protected against tampering. The practical takeaway for this module is that the pipeline should be able to answer who changed the code, which workflow built it, which source revision was used, which dependencies were present, and whether the resulting artifact was signed.
 
 | Security Tool | Primary Use Case | Open Source? | Notes |
 | :--- | :--- | :--- | :--- |
@@ -213,13 +151,13 @@ If a critical vulnerability is found in the base image (e.g., using an outdated,
 | **Snyk** | Developer-focused security platform | Freemium | Deep IDE integration, provides automated fix pull requests to developers before they even commit code. |
 | **Kube-linter** | IaC / Kubernetes Manifest scanning | Yes | Checks Kubernetes YAML manifests for security misconfigurations (e.g., running containers as root, missing resource limits) *before* deployment. |
 
-### Signing Images
+Security gates need thresholds, not vibes. Blocking on every low-severity finding can train developers to ignore the pipeline, especially when the fix is unavailable or unrelated to runtime risk. Blocking on critical exploitable vulnerabilities in the base image, leaked credentials, unsigned release images, or privileged Kubernetes manifests is much easier to defend. A strong platform team publishes the policy in plain language, runs the checks consistently, and gives developers a fast remediation path instead of a mysterious red mark.
 
-To ensure software supply chain security and prevent tampering, images should be cryptographically signed. Tools like **Cosign** (part of the Linux Foundation's Sigstore project) allow the pipeline to attach a digital signature to the image. When Kubernetes attempts to pull the image from the registry, an admission controller (like Kyverno or OPA Gatekeeper) verifying the signature intercepts the request. If the image was tampered with by a malicious actor after the pipeline built it, Kubernetes will aggressively reject it and refuse to run the Pod.
+Image signing closes the loop between CI and the cluster. Tools such as Cosign attach signatures to image digests, and admission controllers such as Kyverno or OPA Gatekeeper can reject unsigned or untrusted images before scheduling. The signature does not prove the application is bug-free, but it proves the artifact came from the expected pipeline and was not swapped on the way to production. That distinction is central to supply chain security because attackers often target the delivery path rather than the application repository.
 
 ## Tool Comparison Deep-Dive
 
-The CI/CD tooling landscape is vast, confusing, and highly competitive. Choosing the right tool depends heavily on your existing infrastructure, team expertise, security requirements, and whether you prefer managed SaaS or self-hosted control.
+CI/CD tools differ less in their vocabulary than in their operating model. GitHub Actions and GitLab CI are convenient when the source hosting platform is already central to team workflow. Jenkins remains valuable when organizations need unusual plugins, legacy build environments, or dedicated administrators who can maintain it responsibly. Tekton fits Kubernetes-heavy platform teams that want pipeline execution to be expressed as Kubernetes resources and scheduled as Pods. The best choice is not the newest tool; it is the tool whose failure modes your team can operate.
 
 | Feature | GitHub Actions | GitLab CI | Jenkins | Tekton |
 | :--- | :--- | :--- | :--- | :--- |
@@ -229,22 +167,15 @@ The CI/CD tooling landscape is vast, confusing, and highly competitive. Choosing
 | **Weaknesses** | Debugging complex workflows locally is difficult (requires community tools like `act`). | Best experience requires using GitLab as your Git repository host as well. | "Plugin hell", requires significant, painful ongoing maintenance, not inherently cloud-native. | Extremely steep learning curve, very verbose YAML, total overkill for simple static site projects. |
 | **Best For** | Open-source projects, teams already locked into the GitHub ecosystem. | Enterprises wanting a cohesive, single-pane-of-glass DevOps platform. | Complex legacy builds, large monoliths, teams with deep Groovy expertise and dedicated Jenkins admins. | Kubernetes-heavy platform engineering teams wanting infrastructure-as-code for CI. |
 
-### Active Learning Prompt
+GitHub Actions is often the fastest path for teams already using GitHub because the trigger model, permission model, marketplace, and pull request checks are integrated. The risk is that marketplace actions are code you execute in your pipeline, so pinning versions and reviewing permissions matter. GitLab CI gives a more integrated DevOps platform when repository hosting, container registry, environments, and deployment views all live together. Jenkins offers enormous flexibility, but that flexibility becomes an operational cost when plugins drift, agents become snowflakes, and Groovy logic grows beyond what reviewers can reason about.
 
-> **Scenario:** You are joining a rapidly growing AI startup that uses Kubernetes exclusively. They have no legacy applications (no mainframes or ancient VMs). They want their CI/CD pipelines to run directly inside their Kubernetes clusters, utilizing the cluster's native autoscaling capabilities to handle massive bursts of build jobs dynamically during the day, and scale to zero at night to save costs. They want everything, including the pipeline definitions, defined strictly as Kubernetes Custom Resources to integrate seamlessly with their GitOps tools (like ArgoCD).
->
-> **Question:** Which CI/CD tool from the table above would be the most architecturally aligned with these specific requirements, and why?
->
-> <details>
-> <summary>Click for the answer</summary>
-> **Tekton**. It is specifically designed from the ground up as a Kubernetes-native CI/CD framework. It uses Custom Resource Definitions (like Task, Pipeline, PipelineRun) to define workflows, and executes jobs natively as Kubernetes Pods. This perfectly leverages the cluster's autoscaling and ties directly into Kubernetes-native tooling, making it ideal for a strictly cloud-native startup. By storing pipeline definitions as standard Kubernetes manifests, the team can manage their entire CI/CD infrastructure using the exact same GitOps processes they use for their applications.
-> </details>
+Tekton changes the mental model by making pipeline definitions Kubernetes resources. A `PipelineRun` creates Pods for tasks, those Pods can use cluster scheduling and autoscaling, and GitOps tools can manage the pipeline resources like any other manifest. That is elegant for platform teams standardizing on Kubernetes, but it is verbose for a small static site or a simple library package. If your team cannot explain Kubernetes RBAC, Pod scheduling, storage workspaces, and controller reconciliation, Tekton may move complexity from the CI dashboard into the cluster without reducing it.
+
+> **Which approach would you choose here and why?** A startup runs every workload on Kubernetes, wants CI jobs to scale with cluster capacity, and already manages platform resources through GitOps. Tekton is architecturally aligned because it treats pipelines as Kubernetes objects, but GitHub Actions might still be the pragmatic first step if the team needs a working path this week and lacks platform engineering capacity.
 
 ## Deployment Strategies via Pipelines
 
-Once your image is securely in the registry, the pipeline must orchestrate its deployment to Kubernetes. Pushing a new version should rarely mean taking the system offline. Advanced deployment strategies minimize downtime and ruthlessly limit the "blast radius" if the new code contains a critical bug.
-
-### Deployment Strategies Quick Reference
+Once an image is built, scanned, signed, and stored, the pipeline still has to decide how users meet it. Kubernetes gives you a default rolling update, but a pipeline can coordinate richer strategies through manifests, deployment controllers, service mesh routing, progressive delivery tools, or GitOps reconciler changes. The strategy should match the risk of the change, not the seniority of the person pressing the deploy button. A CSS fix and a database-backed recommendation engine rewrite should not share the same release plan.
 
 | Strategy | Risk | Rollback Speed | Infrastructure Cost | Best Use Case |
 | :--- | :--- | :--- | :--- | :--- |
@@ -253,129 +184,130 @@ Once your image is securely in the registry, the pipeline must orchestrate its d
 | **Canary** | Very Low | Fast | Low | Testing new features on real users with minimal blast radius. |
 | **Shadow** | None | N/A | High | Testing backend refactors or load capacity without user impact. |
 
-### 1. Push vs. Pull (GitOps)
+Push-based deployment is the traditional pattern: the CI pipeline authenticates to the Kubernetes API and runs commands or applies manifests after the build. It is direct, simple to understand, and easy to demonstrate, but it places cluster credentials in the CI system. Pull-based GitOps reverses that trust relationship. The pipeline updates Git with the desired image tag or manifest change, and a controller inside the cluster pulls and reconciles that change. CI no longer needs direct production cluster access, and Git becomes the auditable source of desired state.
 
-Before discussing strategies, we must address how the deployment is triggered.
-- **Push-based CD (Traditional):** The CI pipeline (e.g., GitHub Actions) finishes building the image, authenticates to the Kubernetes cluster using an admin token, and runs `kubectl apply -f manifest.yaml`. This is a security risk, as the CI server holds the keys to the kingdom.
-- **Pull-based CD (GitOps):** The CI pipeline merely updates a Git repository with the new image tag. An agent *inside* the Kubernetes cluster (like ArgoCD or Flux) constantly watches that Git repository. When it sees a change, it pulls the new manifest and applies it locally. The CI server never touches the cluster directly.
+Rolling updates are the Kubernetes default for Deployments. The controller incrementally creates Pods for the new ReplicaSet and removes old Pods while respecting availability limits. This is efficient and often correct for stateless services, but it assumes old and new versions can run at the same time. If version two changes a database schema in a way version one cannot read, a rolling update can create a mixed-version failure. The pipeline should catch that risk before rollout, often by requiring expand-and-contract database migrations.
 
-### 2. Rolling Update
+Blue-green deployment keeps two complete environments: blue is live, green is idle or warming. The pipeline deploys the new version to green, runs checks there, and then switches routing. Rollback is fast because traffic can flip back to blue, but the cost is high because the team needs duplicate capacity and careful state management. This strategy fits high-value applications where the cost of idle resources is lower than the cost of a slow recovery.
 
-This is the default, built-in Kubernetes strategy. The pipeline (or GitOps tool) updates the Deployment manifest with the new image tag. Kubernetes incrementally scales down old Pods while simultaneously scaling up new Pods, ensuring a minimum number of Pods are always available to serve user traffic.
-*   **Analogy:** Replacing the engines on an airplane one by one while it's still flying at 30,000 feet, ensuring enough thrust remains to keep it airborne.
-*   **Pros:** Easy to implement natively, zero downtime.
-*   **Cons:** Rollback takes time. Since both v1 and v2 run concurrently during the rollout window, your database schema must be strictly backwards-compatible, or v1 will crash when v2 modifies the database.
+Canary deployment gradually exposes the new version to a small percentage of traffic, watches metrics, and increases exposure only if the signals stay healthy. A team once failed a canary because its load balancer routed the selected percentage to internal administrators running unusually heavy reporting queries, which made latency look worse than it was. The lesson is that canaries require thoughtful segmentation and meaningful metrics. A canary based only on Pod readiness can miss business failures, while a canary based on biased traffic can reject a healthy release.
 
-### 3. Blue-Green Deployment
+Shadow deployment, sometimes called dark launching, duplicates production traffic to the new version while returning only the old version's response to users. It is excellent for read-heavy services, search behavior, and performance testing under real load. It is dangerous for code paths that mutate state, send emails, charge cards, or write analytics events, because duplicated traffic can create duplicated side effects. A safe shadow pipeline needs strict controls that prevent the shadow service from writing to production systems.
 
-The pipeline maintains two completely identical environments: Blue (current live production) and Green (idle). The pipeline deploys the new version to Green and runs extensive automated integration tests against it in complete isolation. Once verified, the pipeline updates a Kubernetes Service or Ingress (the router) to switch 100% of the traffic from Blue to Green instantly.
-*   **Analogy:** Changing trains at a station. You prepare the second train (Green) entirely. People step off the platform onto it. If the engine won't start, they simply step back onto the first train (Blue) which is still waiting there perfectly functional.
-*   **Pros:** Instant, near-zero-time rollback (just flip the router back to Blue). Safe, realistic testing in a true production-like environment before users ever see it.
-*   **Cons:** Extremely expensive; requires double the infrastructure resources. Complex state management (databases must handle both active versions simultaneously, or data replication gets very tricky).
+> **Stop and think:** why might a team choose a slower canary deployment over a near-instant blue-green switch? The answer is evidence. Blue-green proves the new version can start and pass checks before traffic moves; canary proves the new version behaves acceptably under a controlled slice of real user behavior before everyone receives it.
 
-### 4. Canary Deployment
+## Patterns & Anti-Patterns
 
-The pipeline routes a very small percentage of live user traffic (e.g., 5%) to the new version (the "canary"). The pipeline then automatically monitors observability metrics (error rates, latency). If the pipeline metrics are healthy for a set time (e.g., 10 minutes), the pipeline automatically increases the traffic percentage (10%, 25%, 50%, 100%) until the new version serves everyone.
-*   **War Story: "The Poisonous Canary."** A team rolled out a canary to 1% of traffic. However, their load balancer routed traffic based on user ID hashes, and that specific 1% happened to accidentally include all the company's internal administrators doing heavy, slow database reporting queries, skewing the latency metrics and falsely failing the deployment. Canary rollouts require truly randomized or carefully, deliberately segmented traffic.
-*   **Pros:** Lowest risk of broad impact. Tests against real user traffic and real, unpredictable usage patterns. Automated rollback based on cold mathematical thresholds, not human intuition.
-*   **Cons:** Highly complex to set up. Requires advanced Ingress controllers or Service Meshes (like Istio or Linkerd) and extremely tight integration with a metrics system (like Prometheus). Results in a very slow deployment process.
+Healthy pipelines share a few patterns that make releases boring. They build once, promote the same artifact, fail early on cheap checks, isolate runners, keep credentials narrow, and make rollback a tested action rather than a document nobody has opened during an incident. These patterns are less glamorous than a complex dashboard, but they are what let teams deploy on ordinary workdays without changing their breathing.
 
-> **Stop and think**: Why might a team choose a slower Canary deployment over a near-instant Blue-Green deployment if both strategies aim to reduce deployment risk?
+| Pattern | When to Use It | Why It Works | Scaling Consideration |
+| :--- | :--- | :--- | :--- |
+| Build once, promote everywhere | Any containerized service moving through staging and production | The tested artifact is the deployed artifact, so evidence follows the image digest | Store image digests, SBOMs, signatures, and scan results together |
+| Fast checks before slow checks | Repositories with growing test suites or costly integration environments | Developers receive useful failures quickly and runners are not wasted | Split jobs by dependency boundaries and run independent jobs in parallel |
+| Ephemeral runners | Teams handling production credentials, secrets, or supply chain risk | Each build starts clean, reducing contamination from previous jobs | Provision runners through IaC or managed pools rather than manual setup |
+| GitOps promotion | Kubernetes platforms with multiple environments and audit needs | CI updates desired state while the cluster reconciles from inside the trust boundary | Use clear repository layout and review rules for environment changes |
 
-### 5. Shadow Deployment (Dark Launching)
-
-The new version is deployed alongside the old version. The network router duplicates incoming user traffic, sending it to both versions simultaneously. Only the response from the old version is actually returned to the user. The response from the new version is analyzed for errors and then silently discarded.
-*   **Pros:** Zero risk to the end user. Tests the new code under true, brutal production load to see if it crashes or leaks memory.
-*   **Cons:** Incredibly complex. The new version must absolutely not mutate data (no writing to the database, no sending emails, no charging credit cards), or you will double-charge customers or corrupt data. It is purely for testing read-heavy services, search algorithms, or major architectural refactors.
-
-## Pipeline Anti-Patterns
-
-A badly designed pipeline is often worse than having no pipeline at all, as it provides a false sense of security while actively slowing down developers and frustrating teams. Watch out for these common anti-patterns:
+A badly designed pipeline can be worse than no pipeline because it creates a false sense of safety. If developers learn that failures are random, approvals are ceremonial, or deployments still depend on a hidden shell script, they will route around the system. The anti-patterns below are not personality flaws; they are structural traps that appear when teams add automation without deciding what evidence the automation must produce.
 
 | Anti-Pattern | Description & Impact | The Fix (Best Practice) |
 | :--- | :--- | :--- |
-| **"Deploy on Friday" Phobia** | Fearing deployments at the end of the week implies your automated testing suite is inadequate and your CI/CD pipeline is fundamentally untrustworthy. | The goal of continuous delivery is boring, uneventful deployments. Build trust through exhaustive automated testing and robust rollback mechanisms so deploying at 4:55 PM on Friday is safe. |
+| **"Deploy on Friday" Phobia** | Fearing deployments at the end of the week implies your automated testing suite is inadequate and your CI/CD pipeline is fundamentally untrustworthy. | The goal of continuous delivery is boring, uneventful deployments. Build trust through exhaustive automated testing and robust rollback mechanisms so deploying late in the week is safe. |
 | **The Snowflake Build Agent** | Using a self-hosted CI runner that was manually configured years ago. If the hard drive dies, the company cannot deploy code for a week. | Build agents must be completely ephemeral, stateless, and provisioned dynamically via Infrastructure as Code. |
 | **Ignored Flaky Tests** | Tests that randomly fail 10% of the time destroy trust. Developers will ignore failures, assuming it's just the flaky test, masking real bugs. | Flaky tests must be deleted, disabled, or fixed immediately. They are pipeline poison. |
-| **Secrets in Code** | Hardcoding API keys or database passwords in the pipeline definition YAML file exposes them to anyone with repository read access. | Use native secret management (GitHub Secrets, HashiCorp Vault, Kubernetes External Secrets) and inject them purely at runtime. |
+| **Secrets in Code** | Hardcoding API keys or database passwords in the pipeline definition YAML file exposes them to anyone with repository read access. | Use native secret management, HashiCorp Vault, or Kubernetes External Secrets and inject values purely at runtime. |
 | **The "God" Script** | A pipeline consisting of a single unreadable, un-debuggable 800-line `deploy.sh` script that cannot utilize parallel execution. | Break scripts into discrete, logical CI/CD jobs and tightly scoped steps that can run concurrently. |
-| **Manual Gates Everywhere** | Requiring a human manager's manual approval for every single stage (QA, Security, Staging), creating massive bottlenecks. | Automate the quality gates based on strict thresholds. Reserve manual approvals only for the final business decision to release to production. |
-| **The Monolithic Pipeline** | A single pipeline that builds 50 different microservices sequentially, even if only one microservice changed, causing integration hell. | Pipelines should be scoped specifically to the codebase that changed using path-filtering or monorepo tools. |
-| **Orphaned Artifacts** | Building Docker images for failed deployments and never cleaning the registry, leading to massive cloud storage fees over time. | Container registries must have lifecycle policies configured to automatically delete untagged or old development images. |
-| **Pipeline as an Afterthought** | Writing 100,000 lines of application code and then building the CI/CD pipeline the week before launch. | The pipeline must be the *very first* piece of code written in a new project to establish the deployment path immediately. |
+| **Manual Gates Everywhere** | Requiring a human manager's manual approval for every single stage creates massive bottlenecks. | Automate the quality gates based on strict thresholds. Reserve manual approvals only for the final business decision to release to production. |
+| **The Monolithic Pipeline** | A single pipeline that builds many different microservices sequentially, even if only one microservice changed, recreates integration hell inside CI. | Scope pipelines to the codebase that changed using path filtering, affected-project detection, or monorepo tooling. |
+| **Orphaned Artifacts** | Building Docker images for failed deployments and never cleaning the registry leads to avoidable cloud storage costs over time. | Container registries must have lifecycle policies configured to delete untagged or old development images. |
+| **Pipeline as an Afterthought** | Writing application code for months and then building the CI/CD pipeline right before launch creates a fragile release path. | The pipeline should be one of the first pieces of project code so delivery constraints shape the service early. |
+
+## Decision Framework
+
+Pipeline design is a set of trade-offs, not a universal template. Start by asking what must be proven before merge, what must be proven before release, who is allowed to promote an artifact, and how the system recovers when the answer is wrong. A small internal tool may need fast tests, a vulnerability scan, and manual deployment. A payment service may need signed images, SBOM retention, canary analysis, environment approvals, and a GitOps controller enforcing production state.
+
+| Decision Point | Choose the Simpler Option When | Choose the Stronger Option When | Operational Tradeoff |
+| :--- | :--- | :--- | :--- |
+| CI only vs Continuous Delivery | The team is still creating reliable builds and tests | Staging and production deployments need repeatability | Delivery adds environment management and approval design |
+| Continuous Delivery vs Continuous Deployment | Releases need business timing or compliance approval | Tests, metrics, feature flags, and rollback are mature | Deployment removes waiting but raises automation requirements |
+| Push CD vs GitOps pull CD | The platform is small and CI credentials are tightly scoped | Kubernetes is central and production credentials need stronger boundaries | GitOps adds controllers and repository design decisions |
+| Rolling update vs canary | The service is stateless and the change is low risk | Real-user behavior is needed before broad exposure | Canary needs traffic splitting and meaningful metrics |
+| GitHub Actions vs Tekton | Source hosting integration and speed matter most | Pipelines should run as Kubernetes-native resources | Tekton fits platform teams but increases YAML and cluster complexity |
+
+Use this sequence as a practical review checklist. First, identify the artifact and make sure it is built once. Second, decide which checks must block merge and which checks must block promotion. Third, choose whether CI pushes to the cluster or updates Git for an in-cluster reconciler. Fourth, select a rollout strategy based on blast radius and rollback speed. Fifth, define the metrics that determine success. A pipeline without explicit success metrics is just a sequence of commands with optimism attached.
+
+When a pipeline fails, diagnose it by layer. If the build fails, inspect dependency changes, runner images, and cache keys. If tests fail, determine whether the failure is deterministic, flaky, or environment-specific. If image scanning fails, check the base image and dependency tree before suppressing the finding. If deployment fails, compare the manifest, image digest, namespace policy, and rollout events. If users report errors after a green rollout, review whether the deployment strategy monitored the right business and service-level indicators.
 
 ## Did You Know?
 
-- **300x Faster:** According to the highly respected DORA (DevOps Research and Assessment) report, high-performing DevOps teams utilizing robust CI/CD pipelines deploy code 300 times more frequently and recover from critical incidents 2,500 times faster than low-performing teams.
-- **50% Less Time:** Teams that integrate automated vulnerability scanning directly into their pipelines (Shift-Left Security) spend 50% less time remediating critical security issues compared to teams that scan right before release.
-- **The First CI Server:** The first widely used Continuous Integration tool was "CruiseControl," created by ThoughtWorks developers (including Martin Fowler) in 2001. It was written in Java and paved the way for Jenkins.
-- **10 Deploys a Day:** In 2009, engineers from Flickr famously presented a landmark talk titled "10+ Deploys per Day: Dev and Ops Cooperation at Flickr," which radically shifted the industry mindset. At the time, deploying software once a month was considered fast and risky.
+- **300x Faster:** The DORA research program has repeatedly found that high-performing software delivery organizations deploy far more frequently than low performers while also recovering faster from incidents.
+- **50% Less Time:** Teams that integrate automated vulnerability scanning early in the pipeline often spend far less time remediating critical security issues than teams that scan only before release.
+- **The First CI Server:** CruiseControl, one of the first widely used Continuous Integration tools, was created by ThoughtWorks developers in 2001 and helped popularize automated build feedback.
+- **10 Deploys a Day:** In 2009, Flickr engineers presented "10+ Deploys per Day," a talk that made frequent production deployment feel practical to many teams that still treated monthly releases as fast.
 
 ## Common Mistakes
 
 | Mistake | Why it happens | How to fix it |
 | :--- | :--- | :--- |
-| **Using `latest` image tags** | Developers use `image: myapp:latest` in Kubernetes deployment files out of sheer convenience when initially testing. | **Never use `:latest`.** Always use specific, immutable tags (e.g., the Git commit SHA like `:v1.2.3-a1b2c3d`). If a node restarts and pulls `:latest`, it might pull a completely different codebase than what was running 5 minutes ago, causing impossible-to-debug version drift across your cluster. |
-| **No timeout limits on jobs** | A process hangs indefinitely (e.g., waiting for an external third-party API that is down, or an infinite `while` loop in a unit test), keeping the CI runner occupied and running up massive cloud computing bills. | Define explicit, aggressive timeouts for every job and step (e.g., `timeout-minutes: 15` in GitHub Actions). Fail fast. |
-| **Building images multiple times** | Rebuilding the Docker image from scratch for the testing stage, again for the staging stage, and *again* for the final production stage. | **Build once, promote everywhere.** Build the image exactly once in the CI stage, test that exact image, push it to the registry, and promote that *exact immutable image artifact* through all subsequent environments. Rebuilding introduces the severe risk of pulling different underlying dependencies on the second build. |
-| **Running scans at the end** | Security scans are placed right before the deployment step, acting as a slow, painful bottleneck right when developers are trying to ship their feature. | **Shift-left.** Run linting, SAST, and image vulnerability scans in parallel with unit tests at the very beginning of the pipeline. Catch flaws within minutes of a commit. |
-| **No cache utilization** | Downloading the exact same 2GB of Node.js or Maven dependencies from the public internet on every single pipeline run, adding 10 minutes of completely wasted time to the build. | Use caching mechanisms provided by the CI tool to store and retrieve dependency folders (like `node_modules`) between runs, hashing the lockfile to know exactly when the cache actually needs updating. |
-| **Alert fatigue** | The pipeline sends an automated Slack message or email to the entire engineering channel for every successful step, causing developers to mute the channel entirely. | Only alert the team on **failures**, or when a previously failing pipeline recovers back to green. Silence is golden in CI/CD. |
+| **Using `latest` image tags** | Developers use `image: myapp:latest` in Kubernetes deployment files out of convenience during early testing. | **Never use `:latest`.** Use specific, immutable tags or image digests, such as a Git commit SHA, so a restarted node cannot pull a different artifact than the one tested. |
+| **No timeout limits on jobs** | A process hangs indefinitely while waiting for a slow API, an unavailable dependency, or an infinite loop inside a test. | Define explicit timeouts for every job and step, such as `timeout-minutes: 15` in GitHub Actions, so failed work releases the runner quickly. |
+| **Building images multiple times** | The team rebuilds the Docker image for testing, staging, and production because each environment owns its own pipeline stage. | Build once, scan once, sign once, and promote the exact immutable image artifact through every environment. |
+| **Running scans at the end** | Security checks are placed right before deployment, where they feel like a painful release bottleneck. | Shift scans left by running secret scanning, SAST, IaC checks, and image scanning as early as their inputs are available. |
+| **No cache utilization** | The pipeline downloads the same dependency archive on every run even when the lockfile has not changed. | Use dependency caching keyed from lockfiles, and invalidate the cache automatically when dependencies change. |
+| **Alert fatigue** | The pipeline sends a notification for every successful step, so developers mute the channel and miss real failures. | Notify only on failures, recovery from failure, and events that require human action, such as a production approval. |
 
 ## Quiz
 
 <details>
-<summary>1. Scenario: A startup has configured their pipeline so that every time a developer merges code to the main branch, the code is compiled, tested, built into a container, and automatically deployed to a staging cluster. Once verified in staging, a Product Manager must manually click an "Approve" button in the CI/CD dashboard to trigger the final deployment to the live production cluster. What specific CI/CD practice are they following, and why?</summary>
-They are following the practice of Continuous Delivery. The key differentiator is the presence of the manual, human-driven approval gate before the final production rollout. While the pipeline successfully automates the integration, testing, and delivery of the artifact to a production-ready staging environment, it stops short of fully automated production deployment. If the pipeline deployed to production automatically without that human intervention, it would be classified as Continuous Deployment. This deliberate pause allows for final business validation before releasing features to customers.
+<summary>1. Scenario: A team builds and tests a container image on every merge, then an operator manually deploys that image to production later in the week. Is this CI, Continuous Delivery, or Continuous Deployment?</summary>
+This is Continuous Integration only. The pipeline integrates the change, validates it, and produces an artifact, but the deployment process remains manual and separate from the automated workflow. Continuous Delivery would automate the deployment mechanics and leave only the release decision to a human approval. Continuous Deployment would remove that production approval and release every passing change automatically.
 </details>
 
 <details>
-<summary>2. Scenario: A junior engineer modifies a pipeline to speed up execution. Their new pipeline builds a Docker image to run integration tests. Once the tests pass, it rebuilds a fresh Docker image from the same source code and pushes that second image to the production registry. Why is this considered a dangerous anti-pattern?</summary>
-This approach violates the fundamental principle of artifact immutability because the image deployed to production is not the exact same image that was tested. When rebuilding the image a second time, the package manager might pull a newer, slightly different version of an underlying transitive dependency or a patched OS base layer. This introduces a severe risk where the production environment behaves differently than the tested environment, leading to impossible-to-track bugs. The correct approach is to build the image exactly once, verify that specific artifact, and promote it through all subsequent environments.
+<summary>2. Scenario: A pipeline builds one Docker image for integration tests, then rebuilds a second image from the same source for production. Why is this dangerous?</summary>
+The production image is not the same artifact that passed testing, so the team has broken the evidence chain. A package manager, base image, or transitive dependency could change between the two builds even if the application source is unchanged. The safer design is to build one immutable image, scan and sign that exact image, and promote it through staging and production. That makes failures easier to diagnose because every environment refers to the same digest.
 </details>
 
 <details>
-<summary>3. Scenario: A large retail application needs to deploy a major update to its recommendation engine during a busy shopping season. The engineering team is debating between a Rolling Update and a Canary deployment. Both offer zero downtime, but they ultimately choose Canary. What is the primary advantage of a Canary deployment over a Rolling Update in this high-risk situation?</summary>
-The primary advantage of a Canary deployment is its ability to strictly limit the "blast radius" of a potential failure by exposing the new code to only a tiny, controlled subset of real user traffic (e.g., 2%). It actively monitors application-level observability metrics (like error rates and latency) to ensure safety before automatically proceeding with the rollout. In contrast, a Rolling Update incrementally replaces pods and eventually exposes all users to the new code, but it doesn't natively pause or rollback based on custom business metrics if the application is technically running but functionally failing. By using a Canary, the team ensures that if the new engine is flawed, only a small fraction of users are impacted. This strategy provides empirical confidence in the new release without risking a total outage.
+<summary>3. Scenario: A retail service is releasing a new recommendation engine during a busy season. Why might the team choose canary deployment instead of a normal rolling update?</summary>
+A canary limits blast radius by exposing the new behavior to a small slice of real traffic before expanding the rollout. A rolling update can prove Pods are healthy, but it does not automatically prove the recommendation engine is producing acceptable business behavior. With canary analysis, the team can watch error rates, latency, conversion impact, and other service indicators before everyone receives the new version. The tradeoff is that canaries require routing control and meaningful metrics.
 </details>
 
 <details>
-<summary>4. Scenario: Your platform team wants pipeline definitions stored as Kubernetes Custom Resources so GitOps tools like ArgoCD can manage them seamlessly alongside your application manifests. They also need builds to execute as native Pods to leverage the cluster's existing autoscaling capabilities. Which CI/CD tool would you recommend, and what two specific CRD types would define the workflow?</summary>
-You should recommend Tekton for this cloud-native architecture. Tekton is fundamentally designed to be Kubernetes-native, meaning it doesn't just deploy to Kubernetes; it runs within and is orchestrated by Kubernetes itself. By utilizing Custom Resource Definitions (CRDs) like `PipelineRun` and `TaskRun`, pipeline definitions become standard Kubernetes manifests. This allows GitOps tools to manage your CI/CD infrastructure exactly the same way they manage your microservices, eliminating the need for a separate, external CI/CD orchestration engine. Furthermore, Tekton executes these pipeline steps as standard Pods, natively integrating with cluster autoscalers.
+<summary>4. Scenario: A platform team wants pipeline definitions managed as Kubernetes Custom Resources and wants build steps to execute as Pods. Which tool is the best fit, and why?</summary>
+Tekton is the best architectural fit because it defines CI/CD workflows through Kubernetes resources and executes tasks as Pods. That lets the team manage pipeline infrastructure with the same GitOps practices used for application manifests. It also allows pipeline workloads to use cluster scheduling and autoscaling behavior. The tradeoff is complexity, because Tekton requires comfort with Kubernetes controllers, RBAC, workspaces, and verbose YAML definitions.
 </details>
 
 <details>
-<summary>5. Scenario: You are reviewing a GitHub Actions workflow that takes 45 minutes to run. Upon investigation, you notice it downloads 2GB of NPM dependencies from the public internet every single time it triggers, even if no dependencies have changed. What architectural feature should you implement to fix this massive bottleneck, and how does it work?</summary>
-You should implement dependency caching within the pipeline to eliminate the redundant network downloads. The CI pipeline can be configured to cache the `node_modules` directory across runs, using the cryptographic hash of the `package-lock.json` file as the unique cache key. When the pipeline runs, it checks if the hash matches an existing cache; if it does, it instantly restores the dependencies from the local cache instead of downloading them. This drastically reduces the execution time and skips the network download entirely unless a developer actually modifies the dependencies. Reclaiming this wasted time optimizes CI/CD runner availability and speeds up developer feedback loops.
+<summary>5. Scenario: Security asks why the CI system should not hold a standing production cluster admin token. How does pull-based GitOps reduce that risk?</summary>
+Pull-based GitOps keeps the production reconciler inside the cluster and lets it pull desired state from Git. The CI system updates a repository or image tag reference rather than directly applying manifests to the Kubernetes API. This reduces the blast radius of a compromised CI runner because it no longer needs broad production cluster credentials. It also makes Git the auditable record of what the cluster should be running.
 </details>
 
 <details>
-<summary>6. Scenario: A pipeline successfully builds code, passes all unit tests, builds a Docker image, and deploys it directly to the cluster. Two days later, a critical zero-day vulnerability is discovered and exploited in the application's base operating system image, leading to a cluster breach. What critical security stage was completely missing from this CI pipeline?</summary>
-The pipeline was missing a vulnerability scanning (or Container Image scanning) stage before the deployment phase. Tools like Trivy or Grype should have been integrated to automatically scan the built image immediately after the build step. If configured correctly, this scan would detect critical CVEs in the base OS layer and forcefully fail the pipeline, returning a non-zero exit code. This "shift-left" security approach prevents the insecure image from ever being pushed to the container registry or deployed to the production cluster. By catching the vulnerability earlier, the team avoids deploying compromised infrastructure.
+<summary>6. Scenario: A GitHub Actions workflow takes 45 minutes because it downloads the same npm dependencies on every run. What should you change, and what should key the cache?</summary>
+Add dependency caching and key the cache from the lockfile, such as `package-lock.json`, so the cache changes only when dependencies change. That avoids repeated downloads while preserving correctness when the dependency graph is updated. The cache should speed up feedback without hiding dependency changes from the build. If the lockfile changes, the pipeline should create or restore a different cache entry rather than reusing stale packages.
 </details>
 
 <details>
-<summary>7. Scenario: Your organization recently suffered a data breach because a developer accidentally committed an AWS access key into the `main` branch. The key was valid and exploited within minutes. To prevent this, your security team wants to block such commits from ever being integrated. Where is the most effective place in the CI/CD workflow to implement this control, and why?</summary>
-You should implement static code analysis and secret scanning during the Continuous Integration (CI) phase, specifically triggered on Pull Requests before they are merged. By shifting security left, the pipeline acts as an automated gatekeeper that stops sensitive data before it reaches the main repository. If the CI job detects a secret pattern (like an AWS key signature), it immediately fails the build and blocks the PR from merging into the main branch. This approach prevents the exposed secret from ever becoming part of the shared codebase, ensuring it never reaches the deployment phase or gets permanently written into the Git history. It enforces a secure-by-default posture for all incoming code changes.
+<summary>7. Scenario: A signed image passes CI, but Kubernetes rejects the Pod at admission time. What should you inspect first?</summary>
+Start by comparing the image reference in the manifest with the digest that CI signed. Admission controllers usually verify a specific digest or trusted identity, so a mutable tag, wrong registry path, or unsigned rebuild can cause rejection. Then inspect the policy rule to confirm which issuer, repository, or signature identity it expects. This failure is useful because it means the cluster is enforcing the artifact trust contract instead of running an unverified image.
 </details>
 
 <details>
-<summary>8. Scenario: You are tasked with designing the deployment strategy for a massive, highly complex database schema migration for an e-commerce platform. The migration will completely restructure how user profiles are stored. Can you safely use a standard Rolling Update strategy for the application deployment simultaneously with this database migration? Why or why not?</summary>
-No, you cannot safely use a standard Rolling Update for this scenario without extreme caution. During a Rolling Update, both the old version (v1) and the new version (v2) of your application Pods will be running and serving live traffic concurrently. If the database schema is suddenly restructured by v2, the v1 Pods will immediately crash or corrupt data when they attempt to read or write using the old schema expectations. For complex structural changes, the schema must be strictly backwards-compatible, or you must decouple the database migration from the application deployment rollout. Alternatively, a more advanced deployment strategy or the expand-and-contract database migration pattern must be employed to guarantee zero downtime.
+<summary>8. Scenario: A service needs a database schema migration that old Pods cannot read. Why is a basic rolling update risky, and what should the team do instead?</summary>
+A rolling update temporarily runs old and new Pods together, so incompatible schema changes can break one version while the other is still serving traffic. The team should decouple the database migration from the application rollout or use an expand-and-contract migration pattern that keeps both versions compatible during the transition. They may also choose a safer rollout strategy with explicit checks and rollback planning. The key is to preserve compatibility until no old Pods need the old schema.
 </details>
 
 ## Hands-On Exercise
 
-In this comprehensive exercise, you will create a GitHub Actions workflow that not only builds a container image, but utilizes caching to massively speed up builds, scans for critical vulnerabilities using Trivy, and simulates a Continuous Delivery deployment with a manual approval gate.
-
-We will intentionally introduce a severe vulnerability to see the pipeline fail, and then we will remediate it.
+In this exercise, you will create a GitHub Actions workflow that builds a container image, uses caching to speed up dependency installation, scans the image with Trivy, simulates a Continuous Delivery approval gate, and adds a timeout so a stuck job fails quickly. The application is intentionally small because the goal is to study the pipeline mechanics, not to build a production web service. You will first create an insecure image and watch the security gate fail, then remediate the base image and let the pipeline pass.
 
 ### Task 1: Create the Application and Dockerfile
 
-Create a simple Node.js application that deliberately uses an outdated, highly vulnerable base image to demonstrate pipeline security gates in action.
+Create a simple Node.js application that deliberately uses an outdated, vulnerable base image to demonstrate pipeline security gates in action. This mirrors real incidents where the application code is harmless, but the inherited operating system layer carries critical vulnerabilities into production. The point is to see that the pipeline must evaluate the whole artifact, not just the lines written by the application developer.
 
 1. Create a new directory and initialize a git repository.
 2. Create a file named `app.js`:
+
 ```javascript
 const http = require('http');
 const server = http.createServer((req, res) => {
@@ -387,7 +319,9 @@ server.listen(8080, () => {
     console.log('Server is listening on port 8080');
 });
 ```
-3. Create a `package.json` to simulate real-world dependencies (even though we don't strictly need them for this simple app, it allows us to test caching later):
+
+3. Create a `package.json` to simulate real-world dependencies:
+
 ```json
 {
   "name": "kubedojo-pipeline-app",
@@ -397,10 +331,12 @@ server.listen(8080, () => {
   }
 }
 ```
-4. Create a `Dockerfile`. **Notice we are using a severely outdated, vulnerable base image.**
+
+4. Create a `Dockerfile`. Notice that this base image is intentionally outdated for the lab:
+
 ```dockerfile
 # INSECURE BASE IMAGE FOR TESTING PIPELINE GATES
-FROM node:14.16.0-alpine 
+FROM node:14.16.0-alpine
 WORKDIR /app
 COPY package*.json ./
 RUN npm install
@@ -453,17 +389,13 @@ EOF
 
 ### Task 2: Define the CI Pipeline with Caching
 
-Create a GitHub Actions workflow file that sets up Node.js, caches npm dependencies to speed up future runs, and builds the Docker image.
+Create a GitHub Actions workflow file that sets up Node.js, caches npm dependencies to speed up future runs, and builds the Docker image. Caching is safe here because the cache is tied to the dependency definition rather than reused blindly. If the dependency lockfile changes, the cache key changes, and the workflow naturally refreshes the dependency set.
 
 1. Create the workflow directory structure: `.github/workflows/`
 2. Create a file named `ci-cd.yml` in that directory.
 3. Configure it to trigger on `push` events to the `main` branch.
 4. Add a job named `build-and-test` that runs on `ubuntu-latest`.
-5. Add steps to:
-   - Checkout the code using `actions/checkout@v4`.
-   - Setup Node.js using `actions/setup-node@v4` and configure it to cache `npm` dependencies.
-   - Run `npm install`.
-   - Build the Docker image (tag it `kubedojo-app:test`).
+5. Add steps to checkout code, set up Node.js, install dependencies, and build the Docker image as `kubedojo-app:test`.
 
 <details>
 <summary>Solution</summary>
@@ -498,15 +430,15 @@ jobs:
 ```
 </details>
 
-### Task 3: Add Vulnerability Scanning (Trivy)
+### Task 3: Add Vulnerability Scanning
 
-Extend the `build-and-test` job to scan the built image. We want the pipeline to strictly halt immediately if CRITICAL CVEs are detected.
+Extend the `build-and-test` job to scan the built image. The scan belongs after the image build because it needs the completed artifact, but before deployment because the registry and cluster should not receive an artifact that violates policy. For this lab, the policy blocks critical vulnerabilities so the failure is obvious and tied to the intentionally outdated base image.
 
 1. Edit `.github/workflows/ci-cd.yml`.
-2. At the end of the `build-and-test` job, add a step using the official Trivy action (`aquasecurity/trivy-action`).
+2. At the end of the `build-and-test` job, add a step using the official Trivy action.
 3. Configure it to scan the `kubedojo-app:test` image.
-4. Set `exit-code: '1'` so the pipeline forcefully fails on finding vulnerabilities.
-5. Set `severity: 'CRITICAL'` to only block on the highest risk issues.
+4. Set `exit-code: '1'` so the pipeline fails on matching vulnerabilities.
+5. Set `severity: 'CRITICAL'` to block only the highest risk issues in this lab.
 
 <details>
 <summary>Solution</summary>
@@ -528,13 +460,11 @@ Append this step to your `build-and-test` job:
 
 ### Task 4: Execute and Observe the Security Failure
 
-If you pushed this to GitHub, the pipeline would run and immediately fail. For this local exercise, we will simulate the pipeline security step by running Trivy locally via Docker against our built image.
+If you pushed this to GitHub, the workflow would run and fail when Trivy reports critical vulnerabilities in the old base image. For a local simulation, build the image and run Trivy with Docker against the local image. The important learning moment is the non-zero exit code: CI/CD tools do not need to understand every vulnerability detail as long as the scanning step produces a clear pass or fail result.
 
 1. Build the image locally to test: `docker build -t kubedojo-app:test .`
-2. Run Trivy locally using Docker (simulating the GitHub Action step):
-   `docker run --rm -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy image --severity CRITICAL --exit-code 1 kubedojo-app:test`
-
-Observe the massive amount of red output. Trivy will find multiple critical CVEs in the outdated `node:14.16.0-alpine` base image (such as `apk-tools` vulnerabilities) and return an exit code of `1`. In a real CI environment, this exit code halts the pipeline, preventing deployment of insecure code.
+2. Run Trivy locally using Docker: `docker run --rm -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy image --severity CRITICAL --exit-code 1 kubedojo-app:test`
+3. Observe that the scanner returns exit code `1`, which would halt the pipeline before deployment.
 
 <details>
 <summary>Solution output snippet</summary>
@@ -553,19 +483,20 @@ Total: 3 (CRITICAL: 3)
 ```
 </details>
 
-### Task 5: Fix the Vulnerability (Remediation)
+### Task 5: Fix the Vulnerability
 
-To get our pipeline to pass, we must fix the root cause: the insecure base image.
+To make the pipeline pass, fix the root cause rather than suppressing the finding. In this case, the root cause is the unsupported base image. Updating to a current base image changes the operating system package set and lets the same scan policy succeed without weakening the gate.
 
 1. Open your `Dockerfile`.
-2. Change the `FROM` line to use a modern, secure, actively supported base image: `node:22-alpine`.
-3. Re-run the local docker build: `docker build -t kubedojo-app:test .`
-4. Re-run the local Trivy scan. It should now pass with 0 critical vulnerabilities and an exit code of `0`.
+2. Change the `FROM` line to use `node:22-alpine`.
+3. Re-run the local Docker build: `docker build -t kubedojo-app:test .`
+4. Re-run the local Trivy scan and confirm it exits successfully.
 
 <details>
 <summary>Solution</summary>
 
 **Updated Dockerfile:**
+
 ```dockerfile
 FROM node:22-alpine
 WORKDIR /app
@@ -578,15 +509,15 @@ CMD ["node", "app.js"]
 When you re-run Trivy, the output should end with `Total: 0 (CRITICAL: 0)`, and the process will exit successfully. The pipeline gate is now unblocked.
 </details>
 
-### Task 6: Implement Continuous Delivery (Manual Approval Gate)
+### Task 6: Implement Continuous Delivery
 
-Now that the image is secure and building correctly, let's simulate a Continuous Delivery workflow by adding a deployment job that requires manual human approval before executing.
+Now that the image is secure and building correctly, simulate a Continuous Delivery workflow by adding a deployment job that requires manual human approval before executing. In a real repository, the `environment: production` setting can require reviewers before the job starts. That keeps the deployment mechanics automated while preserving a deliberate release decision.
 
 1. Edit `.github/workflows/ci-cd.yml`.
 2. Add a new job named `deploy-to-production`.
-3. Ensure this job absolutely only runs if the first job succeeds by using `needs: build-and-test`.
-4. Add an `environment: production` key to this job. (In a real GitHub repository, you would configure the "production" environment in repository settings to require specific code reviewers).
-5. Add a simple mock step that echoes "Deploying to Kubernetes...".
+3. Ensure this job only runs if the first job succeeds by using `needs: build-and-test`.
+4. Add an `environment: production` key to this job.
+5. Add a mock step that echoes deployment activity.
 
 <details>
 <summary>Solution</summary>
@@ -647,13 +578,13 @@ jobs:
 ```
 </details>
 
-### Task 7: Configure a Pipeline Timeout (Fail Fast)
+### Task 7: Configure a Pipeline Timeout
 
-One of the most common and expensive mistakes in CI/CD is allowing a pipeline to hang indefinitely (e.g., waiting for an external API that is down, or stuck in an infinite `while` loop inside a unit test). This burns through your monthly CI/CD minutes and locks up valuable runners. Let's add a global timeout to our pipeline to ensure it fails fast.
+One common and expensive CI/CD mistake is allowing a pipeline to hang indefinitely while waiting for an external service or a broken test. A timeout is not just a cost control; it is a diagnostic boundary. When a job times out consistently, the team can investigate a specific stage instead of discovering hours later that a runner has been occupied by work that was never going to complete.
 
 1. Edit your `.github/workflows/ci-cd.yml` file one last time.
-2. At the root level of your jobs, or on specific individual steps, you can add a `timeout-minutes` configuration.
-3. For this exercise, add a strict 15-minute timeout to the `build-and-test` job to ensure it doesn't run forever.
+2. Add a `timeout-minutes` configuration to the `build-and-test` job.
+3. Use a strict 15-minute timeout for this lab.
 
 <details>
 <summary>Solution</summary>
@@ -672,13 +603,34 @@ jobs:
       # ...rest of steps...
 ```
 
-If any single step within this job (like a slow `npm install` or a hung Trivy container scan) takes longer than 15 minutes, GitHub Actions will automatically cancel the job, fail the pipeline with a clear error, and instantly free up the runner. This is a critical cost-saving and resource-management best practice.
+If a slow install, hung test, or stalled scan takes longer than 15 minutes, GitHub Actions cancels the job, fails the pipeline with a clear error, and frees the runner for other work.
 </details>
+
+### Success Criteria
+
+- [ ] The workflow builds one container image and uses that same image reference for scanning and deployment simulation.
+- [ ] The first Trivy run fails because the intentionally outdated base image contains critical vulnerabilities.
+- [ ] Updating the Dockerfile to `node:22-alpine` allows the critical vulnerability gate to pass.
+- [ ] The deployment job depends on the build job and uses a production environment gate to model Continuous Delivery.
+- [ ] The build job includes a timeout so a stuck pipeline does not consume runner capacity indefinitely.
+
+## Sources
+
+- [GitHub Actions workflow syntax](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions)
+- [GitHub Actions dependency caching](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)
+- [GitLab CI/CD YAML syntax reference](https://docs.gitlab.com/ci/yaml/)
+- [Jenkins Pipeline documentation](https://www.jenkins.io/doc/book/pipeline/)
+- [Tekton Pipelines documentation](https://tekton.dev/docs/pipelines/)
+- [Kubernetes Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)
+- [Argo CD documentation](https://argo-cd.readthedocs.io/en/stable/)
+- [Flux documentation](https://fluxcd.io/flux/)
+- [Trivy documentation](https://aquasecurity.github.io/trivy/)
+- [Syft SBOM tool documentation](https://github.com/anchore/syft)
+- [Sigstore Cosign documentation](https://docs.sigstore.dev/cosign/overview/)
+- [SLSA specification](https://slsa.dev/spec/v1.0/)
 
 ## Next Module
 
-Now that you know exactly how code gets packaged, continuously tested, securely scanned, and deployed automatically, how do you know if it's *actually* working once it's running in production? A green pipeline doesn't necessarily mean your users aren't experiencing errors. 
-
-In the next module, we will explore the three pillars of tracing, metrics, and logs to ensure your applications remain healthy post-deployment.
+A green pipeline proves that the artifact passed the checks you designed, but it does not prove that users are happy after the rollout. The next module moves from delivery to production feedback by examining metrics, logs, and traces as the evidence system for running services.
 
 [Proceed to Module 1.4: Observability](/prerequisites/modern-devops/module-1.4-observability/)


### PR DESCRIPTION
Summary:
- Rewrote src/content/docs/prerequisites/modern-devops/module-1.3-cicd-pipelines.md for #388 density, structure, alignment, and anti-leak gates.
- Cleared revision_pending: false.

Verifier:
- T0; body_words=5000, mean_wpp=75.8, median_wpp=80.5, short_rate=0.045, max_run=2, mean_sentence_length=20.7.
- Command run with primary checkout venv because this worktree has no .venv/bin/python: /Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/quality/verify_module.py --glob src/content/docs/prerequisites/modern-devops/module-1.3-cicd-pipelines.md --skip-source-check --summary --quiet

Protected assets:
- Preserved code blocks: 12 before / 12 after.
- Preserved mermaid diagrams: 2 before / 2 after.
- Preserved ASCII diagrams: 0 before / 0 after.
- Preserved original markdown tables: 5 before / 7 after, with the original comparison/reference tables retained and two instructional tables added.

Additional checks:
- git diff --check clean on the changed module.
- Forbidden token / no-number-47 grep clean.
- Sources check intentionally skipped per dispatch; 12 source URLs included and counted by verifier.
- npm run build not run because the primary checkout is dirty with unrelated local changes and this task constrained edits to the module file only.

Commit: 32c4d3631168eb810a60be7ec0e8c4cd8f61ef66