### PR TITLE
feat(388): rewrite module-1.1-why-kubernetes-won (#388 pilot)

### DIFF
--- a/src/content/docs/prerequisites/philosophy-design/module-1.1-why-kubernetes-won.md
+++ b/src/content/docs/prerequisites/philosophy-design/module-1.1-why-kubernetes-won.md
@@ -3,61 +3,60 @@ title: "Module 1.1: Why Kubernetes Won"
 slug: prerequisites/philosophy-design/module-1.1-why-kubernetes-won
 sidebar:
   order: 2
+revision_pending: false
 ---
-> **Complexity**: `[QUICK]` - Conceptual understanding, no hands-on
+> **Complexity**: `[QUICK]` - Conceptual foundation with a practical evaluation exercise
 >
-> **Time to Complete**: 25-30 minutes
+> **Time to Complete**: 45-55 minutes
 >
 > **Prerequisites**: None - this is where everyone starts
 
 ---
 
-## What You'll Be Able to Do
+# Module 1.1: Why Kubernetes Won
+
+## Learning Outcomes
 
 After this module, you will be able to:
-- **Explain** why Kubernetes won over Docker Swarm, Mesos, and Nomad with specific technical and ecosystem reasons
-- **Identify** the patterns that make a technology "win" (community, extensibility, cloud provider adoption)
-- **Evaluate** new technology claims by asking "does this have the ecosystem markers that Kubernetes had?"
-- **Describe** the timeline from Borg to Kubernetes and why Google open-sourced it
+
+- **Compare** Kubernetes with Docker Swarm, Apache Mesos plus Marathon, and HashiCorp Nomad using concrete technical and ecosystem tradeoffs.
+- **Evaluate** infrastructure technology claims by testing whether the project has declarative operation, extensibility, neutral governance, and broad provider adoption.
+- **Diagnose** why manually managed or proprietary orchestration approaches fail as workloads, teams, and failure modes scale.
+- **Design** a short adoption argument that explains when Kubernetes is the right platform choice and when a simpler alternative is more appropriate.
 
 ---
 
 ## Why This Module Matters
 
-It was 3 AM on Black Friday 2014. A developer at a fast-growing e-commerce startup stared at 35 terminal windows, each SSH'd into a different server. Their flash sale had gone viral — 10x the expected traffic. Docker containers were crashing faster than he could restart them. "Scale up server 23... no wait, 23 is full, try 31... 31 is down, when did that happen?" By 4 AM, the site was offline. By Monday, the CEO was asking why they'd lost $340,000 in sales.
+It was 3 AM on Black Friday 2014, and a developer at a fast-growing e-commerce company was staring at terminal windows across a fleet of Linux servers. Their flash sale had gone far beyond the forecast, containers were crashing as traffic shifted between overloaded hosts, and every attempted manual restart created another question about capacity, ports, logs, and whether the replacement process had landed on a healthy machine. By sunrise the incident review was already forming: the company had lost hundreds of thousands of dollars in orders, but the deeper failure was that the team had tried to operate a distributed system as if it were a collection of pets.
 
-That developer's nightmare is exactly why Kubernetes exists. Not as an academic exercise, not as a Google vanity project — but because **manually managing containers at scale is a problem that will eat you alive.**
+That kind of incident is why the orchestration wars mattered. Docker made containers approachable, but approachability did not answer the harder operational questions: where should each container run, what happens when a machine disappears, how does a rollout happen without downtime, and who remembers the intended shape of the system after several emergency commands have changed production? Kubernetes won because it turned those questions into a persistent control problem rather than a heroic shell session, and that difference still shapes every Kubernetes task you will practice in this curriculum.
 
-As of 2026, roughly 85% of organizations run Kubernetes in production (up from 66% in 2023). Kubernetes didn't win by accident. Understanding the orchestration wars helps you appreciate why certain patterns exist and why alternatives failed.
+This module is not a nostalgia tour through old infrastructure brands. It is a decision-making lesson about why some platforms become durable standards while others become historical footnotes, respectable niches, or maintenance burdens. As you move into Kubernetes 1.35 and later modules, you will see controllers, manifests, labels, Deployments, Services, Custom Resource Definitions, and managed clusters; the history explains why those pieces exist and why they are arranged around an API-driven, declarative control loop instead of a pile of remote commands.
 
----
-
-## The Problem: Container Orchestration
-
-By 2014, containers had proven their value. Docker made them accessible. But a new problem emerged:
-
-**How do you run thousands of containers across hundreds of machines?**
-
-> **Stop and think**: How would you update 100 running containers to a new version without causing any downtime for your users if you had to do it manually? 
-
-Manual management doesn't scale. You need:
-- Automated scheduling (where should this container run?)
-- Self-healing (what happens when a container dies?)
-- Scaling (how do I handle more traffic?)
-- Networking (how do containers find each other?)
-- Updates (how do I deploy without downtime?)
-
-This is **container orchestration**.
+Before we go further, set the command-language expectation for the rest of the path. In hands-on Kubernetes modules, KubeDojo uses the shell alias `alias k=kubectl`, so a phrase such as `k get pods` means the normal Kubernetes CLI with a shorter name. This particular module is mostly conceptual, but introducing the alias here prevents a small syntax detail from becoming a distraction when the next module begins using commands for real.
 
 ---
 
-## The Contenders
+## The Problem: Containers Solved Packaging, Not Operations
 
-### Docker Swarm
+Docker's breakthrough was not that Linux suddenly gained isolation primitives in 2013; namespaces, cgroups, and related kernel mechanisms already existed. Docker's breakthrough was that it made container packaging, image distribution, and local execution understandable to ordinary application teams. A developer could build an image, run it on a laptop, push it to a registry, and reasonably expect the same filesystem and process environment to appear on a server. That was a major improvement over long setup documents and hand-tuned machines, but it moved the bottleneck from "how do I package this app?" to "how do I keep thousands of those packages alive?"
 
-**The Simple Choice**
+The first operational trap was placement. If ten services each need memory, CPU, storage, ports, and low-latency network paths to dependencies, someone has to decide where each replica belongs. On one host, that decision is easy enough to make by looking at `docker ps`, but across a large fleet it becomes a scheduling problem with constraints, competing priorities, and constant change. A system that places containers once and then forgets about them will slowly decay as machines fill up, workloads spike, disks fail, or teams deploy new versions with different resource profiles.
 
-Docker Inc.'s answer to orchestration. Built into Docker itself.
+The second trap was failure recovery. Containers made processes cheap to replace, but cheap replacement is only useful when the platform can notice failure, choose a safe destination, restart the workload, and reconnect traffic without waiting for a person to read a dashboard. A human operator can restart one container after one crash; a platform has to handle node failure, image pull errors, bad releases, partial network outages, and noisy neighbor effects while preserving the intended service shape. That is why orchestration is not just a convenience layer over containers; it is the difference between "we can run a container" and "the service keeps running after reality changes."
+
+The third trap was coordination between teams. Once container adoption spread, application developers, security engineers, network teams, storage teams, and operations teams all needed a shared contract. Without a common API, every team invented its own deployment scripts, environment conventions, service discovery habits, and emergency procedures. Those local conventions work until teams need to share tooling or move workloads between environments, and then every hidden assumption becomes a migration cost.
+
+Pause and predict: if you had to update one hundred running containers by hand with zero downtime, which part would fail first: choosing hosts, routing traffic, rolling back a bad version, or proving afterward what actually happened? Most teams discover that the hardest part is not starting the first replacement container. The hard part is preserving intent while many small actions happen under pressure, because imperative actions leave the operator responsible for remembering the desired final state.
+
+That pressure produced a category called container orchestration. A container orchestrator schedules work, monitors health, restarts failed containers, scales replicas, connects services, coordinates rollouts, and gives the organization a vocabulary for how production should look. The contenders of the mid-2010s agreed that orchestration was necessary, but they made different bets about simplicity, scope, extensibility, and governance. Kubernetes won because those bets lined up with how infrastructure standards actually survive.
+
+---
+
+## The Contenders and Their Tradeoffs
+
+Docker Swarm was the most obvious answer for teams that already loved Docker. It promised a gentle path from local Docker commands to clustered container management, and that mattered because the early container audience did not want to become distributed systems specialists overnight. Its best feature was familiarity: if a small team had Docker Compose files and a modest deployment footprint, Swarm felt like the shortest distance between local containers and production scheduling.
 
 ```text
 Pros:
@@ -73,13 +72,9 @@ Cons:
 - Scaling limitations
 ```
 
-**What Happened**: Docker Inc. bet everything on Swarm. When Kubernetes won, Docker Inc. eventually pivoted (acquired by Mirantis in 2019). Swarm Mode is now in a maintenance-only status—while Mirantis has committed to supporting it until at least 2030, there is no active development of new features.
+The same familiarity that made Swarm attractive also limited its strategic reach. Enterprises were not only asking for a nicer way to start containers; they needed a platform that could become the meeting point for networking, storage, observability, policy, security, release automation, and cloud-provider services. Swarm did not build enough gravity around extension points and neutral governance to make competitors comfortable investing heavily in it. When Docker later added Kubernetes support and Mirantis acquired Docker Enterprise in 2019, the market signal was clear: Swarm remained useful for some small or established deployments, but it was no longer the center of container-platform innovation.
 
-### Apache Mesos + Marathon
-
-**The Enterprise Choice**
-
-Born at UC Berkeley, used by Twitter and Airbnb. Marathon provided the container orchestration layer on top of Mesos.
+Apache Mesos plus Marathon represented the opposite end of the spectrum. Mesos was powerful, proven, and designed as a broad datacenter resource manager rather than a container-only product. It had real credibility because large engineering organizations such as Twitter had run it at significant scale, and its two-level scheduling model could support many workload types beyond containers. If Swarm's risk was that it was too narrow, Mesos's risk was that ordinary application teams had to understand too much machinery before they could ship confidently.
 
 ```text
 Pros:
@@ -95,13 +90,9 @@ Cons:
 - Required separate components (Marathon, Chronos)
 ```
 
-**What Happened**: Twitter deprecated Mesos in 2020, moving to Kubernetes. Mesosphere (the company) pivoted to become D2iQ and now sells Kubernetes. Apache Mesos was formally retired and moved to the Apache Attic in August 2025 due to inactivity. Marathon is abandoned.
+Mesos teaches an important lesson about platform competition: excellent technology can still lose if the adoption path is too heavy and the ecosystem becomes fragmented. Marathon, Chronos, DC/OS, framework choices, and operational complexity created a surface area that rewarded specialist teams but intimidated many mainstream adopters. Kubernetes did not have a trivial learning curve, but it offered a clearer container-first story, a standard API shape, and a fast-growing ecosystem that made new integrations feel like investments in the industry default. Apache formally retired Mesos to the Attic in 2025, which turned that market outcome into project history.
 
-### HashiCorp Nomad
-
-**The Pragmatic Choice**
-
-HashiCorp's orchestrator, released in 2015. Designed as a single binary that handles both containers and non-containerized workloads.
+HashiCorp Nomad is the most interesting comparison because it did not disappear. Nomad chose a pragmatic design: a single binary, a smaller conceptual surface, and first-class support for mixed workloads such as containers, Java services, batch jobs, and ordinary binaries. It fits organizations that value operational simplicity and already use Consul, Vault, or Terraform. That makes Nomad less like a defeated rival and more like a disciplined alternative for teams that do not need the full Kubernetes ecosystem.
 
 ```text
 Pros:
@@ -115,13 +106,9 @@ Cons:
 - Less momentum for pure container-first architectures
 ```
 
-**What Happened**: Nomad didn't "lose" in the same way Swarm or Mesos did. It survived by carving out a strong, profitable niche for organizations that prioritize simplicity or need to orchestrate mixed workloads without the immense complexity of Kubernetes.
+Nomad's survival matters because it prevents a lazy conclusion. Kubernetes did not win because every other orchestrator was useless, and it is not automatically the best answer for every workload. Kubernetes won the broad industry standard role because it matched the needs of cloud-native container platforms, vendor ecosystems, and extensible APIs better than the alternatives. Nomad continues to make sense where the problem is mixed workload scheduling with lower platform overhead, especially when an organization can accept a smaller third-party integration universe.
 
-### Kubernetes
-
-**The Google Choice**
-
-Google's internal system "Borg" had orchestrated containers for over a decade. Kubernetes was Borg's open-source successor, donated to the newly-formed CNCF.
+Kubernetes entered the contest with a different kind of credibility. Google had operated Borg and then explored Omega, giving the founding team hard-won experience with scheduling, reconciliation, service management, and failure at enormous scale. Kubernetes was not a direct open-source dump of Borg, but it carried lessons from a decade of internal container management into a project that outside teams could run, inspect, extend, and govern together. The project also arrived at the right time: Docker had popularized containers, cloud providers were competing for portable workloads, and enterprises wanted a standard that no single vendor could take away.
 
 ```text
 Pros:
@@ -137,15 +124,13 @@ Cons:
 - "Too much" for simple deployments
 ```
 
-**What Happened**: It won. Decisively.
+The honest version of the Kubernetes story includes that last disadvantage. Kubernetes is complex, and the complexity is not imaginary; a cluster brings API servers, etcd, controllers, schedulers, networking plugins, storage integrations, certificates, RBAC, admission control, node lifecycle, and upgrade planning. The reason the industry accepted that complexity is that many organizations already had the underlying distributed-systems problems, and Kubernetes gave them a shared control plane instead of countless custom scripts. Complexity did not vanish; it moved into a standard platform where the ecosystem could amortize the learning.
 
 ---
 
-## Why Kubernetes Won
+## The Declarative Model Changed the Job
 
-### 1. The Declarative Model
-
-Kubernetes introduced a fundamentally different approach:
+The deepest difference between Kubernetes and many early approaches is the move from imperative commands to declarative desired state. Imperative operation tells the system exactly which steps to perform: start this container here, restart that process there, add two more replicas when traffic grows, and run this rollback command if a release fails. Declarative operation records the intended final condition and lets controllers continuously compare that intent with the actual cluster. This is the mental model behind Deployments, Services, ConfigMaps, Secrets, custom resources, and almost every advanced Kubernetes pattern you will meet later.
 
 ```text
 Imperative (Swarm/Traditional):
@@ -158,73 +143,55 @@ Declarative (Kubernetes):
 (Kubernetes figures out the rest)
 ```
 
-> **Pause and predict**: If you define the state as "3 replicas" and someone manually logs into a server and deletes 2 of them, what will the declarative system do? 
-> *(Answer: It immediately detects the state mismatch and spins up 2 new replicas to restore the desired state.)*
+The phrase "Kubernetes figures out the rest" should not be read as magic. It means the API server stores desired state, controllers watch that state, the scheduler selects nodes, kubelets run workloads, and status flows back into the control plane. Each controller owns a narrow reconciliation loop: observe reality, compare it with the desired object, and take the next safe step toward convergence. If a pod disappears but the Deployment still declares three replicas, the system does not need a human to remember that the missing pod was supposed to exist.
 
-This shift is profound. You describe *what you want*, not *how to get there*. Kubernetes continuously reconciles reality with your desired state.
+Pause and predict: if a Deployment declares three replicas and someone manually deletes two matching pods, what should a declarative system do after it observes the mismatch? The correct answer is that it creates replacements until the observed state matches the desired state again, subject to scheduling capacity and policy. That behavior feels obvious once you know Kubernetes, but it was a profound shift from treating deployment as a one-time command sequence.
 
-### 2. Google's Experience
+Declarative design also changes accountability. In an imperative system, the record of production may be a shell history, a runbook, and a set of people who remember what was done during an incident. In a declarative system, the intended configuration can live in version-controlled manifests, reviewed changes, and auditable API objects. That does not eliminate mistakes, but it gives teams a stable source of truth to inspect when something drifts.
 
-Google had run containers at scale for over a decade with Borg. Kubernetes embodied lessons learned from:
-- Billions of container deployments per week
-- Failures at every possible level
-- What actually works at scale
+The tradeoff is that declarative systems require learners to become comfortable with indirect action. When you change a Deployment, you are not personally starting each replacement pod; you are changing the desired object and letting controllers execute the rollout. Beginners sometimes interpret that indirection as unnecessary YAML ceremony, especially when a direct `docker run` command feels faster. The platform's value appears when the third replica fails at midnight, a node drains during maintenance, or a rollout needs to pause, resume, and report status without inventing custom control logic.
 
-This wasn't a startup's first attempt—it was Google's third-generation system. Google chose to open-source it to commoditize the container orchestration layer, preventing competitors like AWS from locking developers into proprietary infrastructure and ensuring workloads could more easily migrate to Google Cloud.
-
-### 3. The Ecosystem Effect & The Spotify Case Study
-
-Kubernetes made smart architectural decisions:
-- **Extensible**: Custom Resource Definitions (CRDs) let anyone extend K8s
-- **Pluggable**: Container runtimes, networking, storage all pluggable
-- **API-first**: Everything is an API, enabling tooling
-
-**The Spotify Case Study:**
-Consider Spotify's migration in 2018. They had built their own open-source orchestrator called Helios. Why did they abandon it for Kubernetes? Because while Helios deployed containers, Kubernetes offered an entire ecosystem. Spotify wanted to use industry-standard tools for logging, monitoring (Prometheus), and service mesh, all of which natively integrated with Kubernetes. 
-
-> **Pause and predict**: If a company builds a proprietary orchestration tool, how likely are their competitors to build integrations for it compared to a CNCF-governed open-source project?
-
-By 2019, Kubernetes held over 75% of the container orchestration market share, making homegrown solutions impossible to justify. *(Note: While some secondary sources today claim Kubernetes holds roughly 92% market share, this specific figure is unverified by primary analysts. However, the 2025 CNCF Annual Survey definitively confirms that 93% of organizations are now using or evaluating Kubernetes.)*
-
-### 4. Cloud Provider Adoption
-
-By 2017, all major cloud providers offered managed Kubernetes:
-- Google Kubernetes Engine (GKE)
-- Amazon Elastic Kubernetes Service (EKS)
-- Azure Kubernetes Service (AKS)
-
-> **Stop and think**: Why would AWS want to offer a managed service based on a tool originally created by Google? 
-
-This was unprecedented. Competitors usually don't adopt each other's technology. But Kubernetes was:
-- Open source (no single vendor owns it)
-- Governed by CNCF (neutral foundation)
-- Becoming the standard (couldn't ignore it)
-
-### 5. Community & Governance
-
-The CNCF (Cloud Native Computing Foundation) provided:
-- Neutral governance (not controlled by Google)
-- Vendor-neutral certification
-- Clear contribution guidelines
-- Trademark protection
-
-This meant companies could invest in Kubernetes without fearing vendor lock-in.
+This is why Kubernetes concepts can feel oddly philosophical at first. A Deployment is not merely a file format, and a Service is not merely a network rule. They are API contracts that let independent controllers and tools coordinate around desired state. The same pattern later powers GitOps, operators, autoscaling, policy controllers, and service meshes, because each extension can work with the Kubernetes API rather than inventing a separate platform from scratch.
 
 ---
 
-## Applying the Framework: The Orchestrator Survival Checklist
+## Experience Became an Open Platform
 
-When evaluating any new foundational infrastructure technology today (like WebAssembly platforms or AI orchestrators), apply the "Kubernetes Framework" to predict its survival. Does it have:
+Google's role mattered, but not in the simplistic sense that "Google built it, so everyone followed." The stronger point is that Kubernetes encoded production lessons from Borg and Omega while deliberately avoiding the trap of remaining a Google-only platform. The Borg, Omega, and Kubernetes paper describes lessons from three generations of container management systems, and those lessons show up in Kubernetes as control loops, labels, service abstraction, desired state, and API machinery. That background gave Kubernetes credibility before most companies had enough container history to know which failures were waiting for them.
 
-- [ ] **Declarative State Management**: Does it rely on continuous reconciliation rather than imperative commands?
-- [ ] **Extensible Architecture**: Can users add their own custom resources without modifying the core codebase?
-- [ ] **Neutral Governance**: Is it hosted by a foundation (like CNCF) rather than controlled by a single vendor?
-- [ ] **Pluggable Interfaces**: Can the networking, storage, and runtimes be easily swapped out?
-- [ ] **Cloud Provider Buy-in**: Are multiple competing cloud providers offering it as a managed service?
+The first Kubernetes commit landed in June 2014, the public announcement followed at DockerCon, and version 1.0 arrived in July 2015 alongside donation to the newly formed Cloud Native Computing Foundation. Those dates matter because the project moved from a vendor-originated idea into a neutral foundation before cloud providers had to decide whether adopting it meant endorsing a competitor's proprietary product. That governance move was not administrative decoration; it was one of the reasons AWS, Azure, Google Cloud, Red Hat, VMware, and many others could build businesses around the same API.
+
+Consider the strategic choice from Google's point of view. If Google had kept Kubernetes as a tightly controlled Google Cloud feature, it might have gained a temporary product advantage, but the broader industry would have remained fragmented across cloud-specific orchestrators. By open-sourcing the project and placing it under neutral governance, Google helped commoditize the orchestration layer and made workload portability a more realistic expectation. That made Google Cloud more credible for teams that did not want to bet everything on a single provider, even though it also allowed competitors to offer managed Kubernetes services.
+
+The cloud providers' adoption created a feedback loop. Once Google Kubernetes Engine, Azure Kubernetes Service, Amazon Elastic Kubernetes Service, and other managed offerings existed, many organizations could use Kubernetes without building every control-plane component themselves. Managed services lowered the entry barrier, which brought more users, which attracted more vendors, which produced more integrations, which made the platform even harder to ignore. Kubernetes did not become simple; it became the standard complexity that cloud providers were willing to operate on behalf of customers.
+
+Which approach would you choose here and why: a proprietary orchestrator that is technically elegant but tied to one vendor, or a rougher open platform with multiple providers competing to host it? For foundational infrastructure, the second option often wins because buyers are not only purchasing features. They are purchasing exit options, hiring pools, training materials, third-party integrations, and confidence that the platform will outlive a single product roadmap.
+
+The CNCF also changed how related projects formed. Prometheus, Envoy, Fluentd, containerd, Helm, OpenTelemetry, and many other cloud-native tools could integrate with Kubernetes while living in a broader foundation ecosystem. Some of those projects predated or evolved independently from Kubernetes, but Kubernetes gave them a common operating environment. That is the ecosystem effect: the platform becomes more valuable because other projects can assume its API, labels, service discovery patterns, and operational vocabulary.
+
+The Spotify migration from Helios to Kubernetes illustrates the point at an organizational scale learners can understand. Spotify had a homegrown orchestration system that solved real problems for its environment, but feature parity with a fast-moving open ecosystem became expensive. Moving toward Kubernetes meant Spotify could benefit from shared tooling, community knowledge, and industry-standard integrations instead of carrying every platform improvement alone. The lesson is not that internal platforms are always wrong; the lesson is that internal platforms must justify the compounding cost of being outside the ecosystem.
 
 ---
 
-## The Timeline
+## Extensibility Turned Kubernetes into a Platform for Platforms
+
+Kubernetes won partly because it did not try to hard-code every future infrastructure idea into the core project. Instead, it exposed an API model that could be extended through Custom Resource Definitions, controllers, admission webhooks, storage interfaces, networking interfaces, and standard metadata. That design let the ecosystem build platform features around Kubernetes without requiring every feature to become part of Kubernetes itself. A smaller core with strong extension points is easier to evolve than a monolith that must bless every workflow centrally.
+
+Custom Resource Definitions are the clearest example. A CRD lets a team define a new API type that the Kubernetes API server can store and serve, such as a certificate request, database cluster, backup policy, rollout strategy, or machine-learning inference service. A controller can then watch those custom objects and reconcile real infrastructure to match them. This pattern is why Kubernetes became a substrate for operators and platform engineering rather than only a place to run stateless web containers.
+
+Extensibility also explains why Kubernetes could absorb disagreement. Teams disagreed about networking approaches, storage backends, ingress behavior, runtime choices, packaging methods, and deployment workflows. A less extensible platform would have forced one answer early, alienating users whose environments needed another approach. Kubernetes instead defined enough common ground for interoperability while leaving room for Container Network Interface plugins, Container Storage Interface drivers, ingress controllers, service meshes, GitOps tools, and policy engines.
+
+That flexibility has a cost. A new learner can reasonably ask why there are so many ways to expose traffic, install applications, collect metrics, manage certificates, or run policy checks. The answer is that Kubernetes became a marketplace of operational approaches, and marketplaces produce choice overload. The cure is not to memorize every ecosystem project at the beginning; it is to understand the core control model well enough to evaluate whether an extension follows Kubernetes patterns or fights them.
+
+The API-first approach made automation durable. Tools do not need to scrape a dashboard or SSH into nodes to understand intent; they can read and write Kubernetes objects through the API. A deployment tool can update a manifest, an autoscaler can change replica counts, an admission controller can reject unsafe specs, and an observability system can label metrics with Kubernetes metadata. When many tools share the same API grammar, integration becomes less fragile.
+
+The same extensibility is why Kubernetes can feel "too much" for tiny applications. A two-container hobby project may not need CRDs, admission control, autoscaling, storage classes, multi-zone scheduling, or service meshes. For that project, Docker Compose, a small platform-as-a-service, or a managed container app service may be the better engineering decision. Kubernetes wins when its ecosystem and control loops solve problems the team actually has, not when the team wants a fashionable architecture diagram.
+
+---
+
+## Timeline and Market Outcome
+
+The orchestration wars happened quickly because container adoption compressed years of infrastructure debate into a few crowded release cycles. Docker arrived as the developer-friendly packaging layer, Swarm tried to extend that familiarity into clustering, Mesos brought proven resource-management ideas from large-scale datacenters, Nomad offered a lean scheduler for mixed workloads, and Kubernetes combined container-first abstractions with neutral governance and extensibility. By the end of the decade, the question in many companies had changed from "which orchestrator should we choose?" to "how do we operate Kubernetes responsibly?"
 
 ```mermaid
 timeline
@@ -247,9 +214,11 @@ timeline
     2025 : Apache Mesos formally retired
 ```
 
----
+Timelines can make victory look inevitable, but engineers living through those years did not have that luxury. Docker had the developer mindshare, Mesos had scale credentials, Nomad had operational elegance, and Kubernetes had a steep learning curve. The decisive factor was not one feature; it was the way several forces compounded. Declarative controllers made operations more resilient, Google's experience made the design credible, CNCF governance made vendors comfortable, cloud-provider support made adoption practical, and extensibility made the ecosystem self-reinforcing.
 
-## Visualization
+The Pokemon Go launch in 2016 became an unusually visible proof point because traffic reportedly surged far beyond expectations and Google Cloud discussed how Kubernetes and GKE helped handle the load. Case studies should never be treated as universal proof that one platform solves every scaling problem, but they matter because enterprises often need public evidence before trusting a young infrastructure project. Kubernetes gained a story that was easy to retell: real consumer traffic, extreme demand, and an orchestration platform that could scale under pressure.
+
+The Gantt view below is a simplified market map rather than a precise maintenance calendar. Its value is that it shows the different endings: Swarm remained available but no longer defined the market, Mesos moved from proven enterprise technology to retirement, and Kubernetes moved from rapid growth into default-platform status. Nomad is not shown in this preserved diagram, but you should remember it as the niche survivor rather than a failed clone.
 
 ```mermaid
 gantt
@@ -270,25 +239,31 @@ gantt
     De Facto Standard  :active, 2018, 2026
 ```
 
----
+Adoption data reinforces the outcome, but it should be read carefully. CNCF survey numbers describe respondent populations and usage categories, not every server in the world, so they are better evidence of momentum than a perfect census. The more important pattern is that Kubernetes moved from experimentation into production infrastructure across industries, while managed Kubernetes services made the API available even to teams that did not want to operate the full control plane themselves.
 
-## Did You Know?
+By 2026, the discussion had shifted again. Kubernetes was no longer only the web-service orchestrator from the container boom; it had become a control-plane pattern for platform teams, security policy, data infrastructure, and AI workloads. That expansion creates both opportunity and risk. The opportunity is that a stable API substrate can support many kinds of automation; the risk is that teams will treat Kubernetes as a universal answer and ignore simpler deployment models that would meet their needs with less operational burden.
 
-- **Kubernetes means "helmsman" or "pilot" in Ancient Greek.** It is also the etymological root of "cybernetics". The abbreviation **K8s** results from counting the 8 letters between the "K" and the "s".
+Another way to read the market outcome is through hiring and training. A company choosing Kubernetes can recruit engineers who have seen similar objects, failure modes, and operational patterns elsewhere, even if the surrounding cloud provider and tooling differ. A company choosing a private orchestrator must teach every new engineer its local model from scratch, and every vendor integration becomes a translation project. That does not make the private choice impossible, but it raises the long-term cost of being unique.
 
-- **The logo is a ship's wheel, but the 7 spokes are a sci-fi reference.** They are a homage to the Star Trek character "Seven of Nine", reflecting the project's original internal codename at Google: *Project Seven of Nine* (a nod to Borg).
-
-- **Kubernetes was created by Craig McLuckie, Joe Beda, and Brendan Burns at Google.** It was publicly announced at the first DockerCon on June 10, 2014, with the first GitHub commit containing just 250 files.
-
-- **Borg was named after Star Trek.** Google's internal predecessor to Kubernetes. Another Google project followed: Omega. The *Borg, Omega, and Kubernetes* paper (2016) details how these systems inspired K8s.
-
-- **Pokemon Go's launch was a K8s milestone.** When it launched in 2016, traffic was 50x expected. Kubernetes scaled the backend automatically. This was the "proof point" that convinced many enterprises.
-
-- **Docker tried to buy Kubernetes.** Before Kubernetes was open-sourced, Docker approached Google about acquiring it. Google declined and donated it to CNCF instead.
+The same shared vocabulary helps during incidents. When an engineer says a rollout is stuck, a pod is pending, a Service has no endpoints, or a controller is reconciling slowly, other Kubernetes practitioners can form useful hypotheses quickly because the abstractions are standard. In a custom platform, the team may first need to rediscover what the local terms mean and which component owns the next action. Standards matter most when the room is tired, production is noisy, and precision saves time.
 
 ---
 
-## Common Misconceptions
+## Patterns & Anti-Patterns
+
+The first durable pattern is to separate the platform decision from the packaging decision. Containers answer how an application artifact is built and run; orchestration answers how many copies should exist, where they should run, how they recover, how they receive traffic, and how teams coordinate changes. Kubernetes won because it treated orchestration as a persistent platform responsibility. A team evaluating a new technology should ask whether the tool only improves packaging convenience or whether it also owns the control-loop problems that appear during real production failure.
+
+The second pattern is to prefer APIs over hidden procedures. Kubernetes resources are not perfect documentation, but they are inspectable objects with metadata, status, ownership relationships, and declarative specs. That makes the system legible to controllers and humans at the same time. When teams build platform workflows around scripts that mutate servers directly, they often lose that shared record; when they build around API objects, other tools can observe, validate, and extend the workflow.
+
+The third pattern is to value neutral ecosystems for foundational layers. A developer tool can sometimes thrive as a single-vendor product because the switching cost is low and the integration surface is narrow. A production orchestration layer touches networking, storage, identity, deployment, monitoring, cloud contracts, and team training. For that kind of layer, neutral governance and multiple provider implementations reduce adoption fear because organizations can invest without assuming one vendor will always make decisions in their favor.
+
+The most common anti-pattern is the heroic internal orchestrator. A team starts with a reasonable script that restarts a few containers, then adds placement rules, then health checks, then blue-green deployments, then service discovery, then secrets handling, then logs, then rollback behavior, then audit requirements. At each step the script seems cheaper than adopting a platform, but after enough incidents the team owns a partial orchestrator with fewer tests, fewer contributors, and fewer integrations than the standard tool it avoided.
+
+Another anti-pattern is Kubernetes maximalism. Some teams hear that Kubernetes won and conclude that every workload should move there immediately. That is historically illiterate in the opposite direction from ignoring Kubernetes: the lesson is not that the biggest platform always wins locally, but that ecosystem fit and operational needs matter. If a team has one small service, no autoscaling need, no multi-team platform contract, and no reason to standardize around Kubernetes APIs, a simpler service may be a better first move.
+
+The final anti-pattern is ecosystem shopping without core understanding. New learners sometimes collect Helm charts, service meshes, dashboards, and policy engines before they can explain why a Deployment recreates a pod or how a Service selects endpoints. That reverses the learning order. Kubernetes won because its core abstractions created a stable base for extensions, so a team that does not understand the base will misconfigure the extensions and blame the ecosystem for confusion it introduced itself.
+
+The preserved misconception table below captures three useful corrections. Keep it nearby when you hear simplified origin stories, because each row warns against reducing a complex platform outcome to a single cause.
 
 | Misconception | Reality |
 |---------------|---------|
@@ -298,116 +273,149 @@ gantt
 
 ---
 
+## Decision Framework
+
+Use Kubernetes when the operational problem has grown beyond simple container startup. Good signals include multiple services, multiple teams, rolling updates, self-healing requirements, horizontal scaling, service discovery, policy enforcement, and a need for shared tooling across environments. The platform starts to pay for itself when the same API can support deployment, observability, security, and automation workflows that would otherwise be rebuilt separately. In that world, Kubernetes is not merely running containers; it is giving the organization a common contract for production change.
+
+Use a simpler alternative when the workload is small, the team is early, or the operational surface does not justify a cluster. Docker Compose, a managed platform-as-a-service, a serverless container service, or Nomad may be the more responsible choice when the business needs speed with fewer moving parts. Choosing something simpler is not a failure to appreciate Kubernetes. It is applying the same historical lesson correctly: platform choices should fit the coordination and failure problems you actually face.
+
+Use Nomad or another lean scheduler when mixed workloads and operational simplicity matter more than Kubernetes-native ecosystem depth. This is common in organizations with long-running non-container workloads, batch jobs, existing HashiCorp tooling, and a platform team that wants a small scheduling core. The tradeoff is that the team accepts fewer Kubernetes-native integrations and a smaller hiring and training market. That can be an excellent trade when it is explicit and matched to real constraints.
+
+Avoid proprietary orchestration as a foundational bet unless the integration boundary is intentionally narrow. A cloud-specific scheduler can be valuable if your organization has already made a strong provider commitment and the service reduces toil dramatically. It becomes risky when teams need portability, independent tooling, multi-cloud leverage, or long-lived platform knowledge that survives vendor roadmap changes. Kubernetes won partly because it made competitors comfortable enough to support the same model, so a new technology that lacks that property should face harder questions.
+
+When evaluating a new foundational infrastructure technology today, apply this survival checklist. It is not a guarantee, but it forces the right conversation before a team mistakes a polished demo for a durable platform.
+
+- [ ] **Declarative State Management**: Does it rely on continuous reconciliation rather than imperative commands?
+- [ ] **Extensible Architecture**: Can users add their own custom resources without modifying the core codebase?
+- [ ] **Neutral Governance**: Is it hosted by a foundation (like CNCF) rather than controlled by a single vendor?
+- [ ] **Pluggable Interfaces**: Can the networking, storage, and runtimes be easily swapped out?
+- [ ] **Cloud Provider Buy-in**: Are multiple competing cloud providers offering it as a managed service?
+
+Before running this decision framework in a real team meeting, write down the strongest argument against your preferred answer. If you prefer Kubernetes, describe the operational burden honestly. If you prefer a simpler platform, describe the migration trigger that would make Kubernetes worth revisiting. Good platform decisions include their own expiration conditions.
+
+---
+
+## Did You Know?
+
+- **Kubernetes means "helmsman" or "pilot" in Ancient Greek.** It is also the etymological root of "cybernetics", and the abbreviation **K8s** counts the 8 letters between the "K" and the "s".
+
+- **Kubernetes was publicly announced at DockerCon on June 10, 2014.** The project had begun days earlier with an initial GitHub commit that included 250 files, then reached version 1.0 in July 2015.
+
+- **The logo is a ship's wheel, and the 7 spokes are a Star Trek reference.** They nod to the project's early internal codename, *Project Seven of Nine*, which itself referenced Borg.
+
+- **Apache Mesos became an Apache top-level project in June 2013 and retired to the Apache Attic in 2025.** That history is a useful reminder that serious, proven infrastructure can still lose platform momentum.
+
+---
+
 ## Common Mistakes
 
 When learning about container orchestration history and applying its lessons, beginners often make these conceptual errors:
 
-| Mistake | Why It's a Mistake | Better Approach |
-|---------|-------------------|-----------------|
-| Treating K8s as just "Docker Swarm but bigger" | It fundamentally changes the paradigm from imperative commands to declarative reconciliation loops. | Understand K8s as a state-matching engine, not a script runner. |
-| Choosing K8s for a simple 2-container app | The operational overhead of managing a cluster often outweighs the benefits for trivial workloads. | Start with Docker Compose or PaaS (like Heroku/Render) until you need K8s' scale. |
-| Believing vendor-locked orchestrators are safer | History shows tools owned by a single company (like Docker Swarm) struggle to gain broad ecosystem support. | Prioritize CNCF-backed or open-governance tools for long-term infrastructure. |
-| Ignoring the CNCF ecosystem | Trying to build custom logging or monitoring instead of using standard K8s integrations wastes the platform's main advantage. | Leverage ecosystem tools like Prometheus and Fluentd that integrate natively. |
-| Focusing only on Google's role | While Google started it, the neutral CNCF governance was the actual catalyst for AWS and Azure adoption. | Recognize the importance of open foundations in enterprise tech adoption. |
-| Assuming Kubernetes replaces Docker | K8s orchestrates containers, but it still needs a container runtime (like containerd) to run them. | Differentiate between the container image/runtime and the orchestrator. |
-| Trying to learn K8s without understanding the "Why" | Jumping straight into YAML without understanding the problems K8s solves leads to rote memorization. | Learn the history and the declarative philosophy first. |
-
----
-
-## Why This History Matters for Learning
-
-Understanding why Kubernetes won helps you:
-
-1. **Appreciate declarative design**: The reconciliation loop isn't arbitrary—it's the core innovation.
-2. **Understand the ecosystem**: Knowing why CRDs exist helps you use them effectively.
-3. **Avoid dead ends**: You won't waste time on deprecated approaches.
-4. **Speak the language**: In interviews and work, this context demonstrates deeper understanding.
+| Mistake | Why It Happens | How to Fix It |
+|---------|----------------|---------------|
+| Treating K8s as just "Docker Swarm but bigger" | It is tempting to compare only the visible container-starting behavior and miss the shift from commands to reconciliation loops. | Understand K8s as a state-matching engine with controllers, not as a larger script runner. |
+| Choosing K8s for a simple 2-container app | Teams confuse the industry-standard platform with the right local answer for every small workload. | Start with Docker Compose, a managed app platform, or another simpler option until orchestration requirements are real. |
+| Believing vendor-locked orchestrators are safer | A polished single-vendor service can feel safer than a broad open ecosystem when the first demo is smooth. | Prioritize open governance and exit options for foundational infrastructure that will shape hiring, tooling, and architecture. |
+| Ignoring the CNCF ecosystem | Beginners sometimes rebuild logging, monitoring, policy, and delivery workflows without noticing that standard integrations already exist. | Evaluate mature ecosystem tools before creating custom platform components that your team must maintain alone. |
+| Focusing only on Google's role | The origin story is memorable, so it can overshadow the governance and provider-adoption choices that made adoption safe for competitors. | Explain Kubernetes as Google experience plus CNCF neutrality plus multi-provider adoption, not as a Google product story. |
+| Assuming Kubernetes replaces Docker | Container images, runtimes, and orchestrators solve different parts of the system and are often discussed together loosely. | Differentiate image building, runtime execution, and orchestration so each tool's responsibility stays clear. |
+| Trying to learn K8s without understanding the "Why" | Jumping straight into YAML can make Kubernetes feel like arbitrary ceremony rather than a control-system design. | Learn the history and declarative philosophy first, then connect each object to the operational problem it solves. |
 
 ---
 
 ## Quiz
 
-1. **Scenario**: Your startup is migrating from a single server to a multi-node architecture. The lead developer suggests writing a Python script that SSHes into servers to start Docker containers, checks if they are running every 5 minutes, and restarts them if they fail. Based on the history of orchestration, why is this approach risky?
-   <details>
-   <summary>Answer</summary>
+<details><summary>1. Your startup is moving from one server to several nodes, and the lead developer proposes a Python script that SSHes into hosts, starts Docker containers, checks them every few minutes, and restarts failed processes. Based on orchestration history, what risk should you diagnose first?</summary>
 
-   This approach represents a primitive imperative system, similar to early attempts before Docker Swarm. It is risky because building a reliable reconciliation loop (monitoring state, handling network partitions, managing server failures) is incredibly difficult. Kubernetes already solves this with a robust declarative model based on a decade of Google's experience. Rebuilding it from scratch will lead to edge-case failures, massive technical debt, and a system that requires constant human intervention to maintain uptime during unexpected outages.
-   </details>
+The first risk is that the team is accidentally building an imperative orchestrator without the engineering budget of a real platform. The script may handle the happy path, but it must eventually learn placement, health checks, rollout safety, node failure behavior, logging, auditability, and conflict handling. Kubernetes won because it made desired state durable and delegated reconciliation to controllers instead of relying on a person or script to remember every corrective action. The safer argument is not "never automate"; it is "do not hide a growing control plane inside one-off automation."
 
-2. **Scenario**: A major tech company releases a new, proprietary container orchestrator that boasts faster scheduling than Kubernetes. They offer it for free, but it only runs on their specific cloud platform. Based on why Kubernetes won, why is this new tool likely to fail in the broader market?
-   <details>
-   <summary>Answer</summary>
+</details>
 
-   The new tool lacks neutral governance and broad cloud provider adoption, which were critical to Kubernetes' success under the CNCF. Enterprises avoid vendor lock-in for foundational infrastructure, meaning a tool tied to a single cloud will struggle to gain widespread trust. Without an open, extensible ecosystem where competitors can also contribute, the proprietary tool will struggle to build the massive community and tooling ecosystem that made Kubernetes the industry standard. Furthermore, relying on a single cloud provider restricts hybrid and multi-cloud strategies, which many modern organizations require for resilience and compliance.
-   </details>
+<details><summary>2. A cloud vendor releases a proprietary orchestrator that benchmarks faster than Kubernetes but only runs on that vendor's platform. How should you evaluate the claim using the Kubernetes survival checklist?</summary>
 
-3. **Scenario**: Your team is debating between Docker Swarm and Kubernetes for a new enterprise application that will eventually span across AWS and on-premises servers. An engineer argues for Swarm because "it's simpler to set up." What historical context should you provide to counter this?
-   <details>
-   <summary>Answer</summary>
+You should separate technical speed from platform survivability. A faster scheduler may matter for some workloads, but a foundational orchestrator also needs neutral governance, extension points, multi-provider confidence, and an ecosystem that outside vendors will support. Kubernetes won because competitors could adopt and extend it without surrendering control to Google. A proprietary single-cloud tool might be useful inside that cloud, but it is a weaker broad standard unless your organization has intentionally accepted the lock-in.
 
-   While Swarm is indeed simpler initially, it is in a maintenance-only status with no new features being actively developed by Mirantis. It struggled in the orchestration wars specifically because it could not handle complex, multi-cloud enterprise use cases as well as its competitors. Kubernetes won because its extensible, declarative architecture handles complex networking, storage scaling, and hybrid deployments far better out of the box. Choosing a technology that lacks an active, growing ecosystem for a new enterprise project introduces severe long-term support and integration risks that outweigh the initial ease of setup.
-   </details>
+</details>
 
-4. **Scenario**: During an interview, you are asked: "If you have a container crashing repeatedly, how does a declarative orchestrator handle it differently than a sysadmin writing an imperative script?" How do you respond?
-   <details>
-   <summary>Answer</summary>
+<details><summary>3. Your team is comparing Docker Swarm and Kubernetes for an enterprise application that may run across AWS and on-premises servers. One engineer argues for Swarm because setup is simpler. What historical context changes the decision?</summary>
 
-   An imperative script executes a series of rigid steps (e.g., "start container, check status, restart if down") and can easily fail if an unexpected state occurs, like the underlying server running out of disk space or memory. A declarative orchestrator, like Kubernetes, constantly compares the current actual state of the cluster to the desired state (e.g., "always have 3 replicas running"). It continuously works to reconcile the two, utilizing built-in intelligence to reschedule the container on a healthier node without manual intervention. This continuous reconciliation loop is far more resilient than one-off imperative commands because it handles the "how" dynamically based on real-time cluster conditions.
-   </details>
+The engineer is correct that Swarm can be simpler at the start, so the response should not dismiss the concern. The historical issue is that Swarm did not build the same extensible, vendor-neutral, multi-cloud ecosystem that Kubernetes built, and it no longer represents the main direction of container-platform development. For a small deployment, simplicity may win; for an enterprise system expected to span environments and integrate with modern tooling, Kubernetes offers a more durable API and ecosystem. The decision turns on future coordination costs, not only day-one installation effort.
 
-5. **Scenario**: Your company uses Kubernetes, but a developer complains that writing YAML files is tedious and wants to go back to manually starting containers using `docker run`. What fundamental feature of Kubernetes' design are they failing to leverage?
-   <details>
-   <summary>Answer</summary>
+</details>
 
-   The developer is missing the power of the declarative model, which is the foundational innovation of Kubernetes. While writing YAML can be tedious, it serves as version-controlled, executable documentation of the desired state that the orchestration system can read and enforce. By using `docker run`, they are reverting to a fragile imperative approach that cannot be easily scaled, audited, or self-healed by the orchestrator during node failures. The YAML files allow Kubernetes to automatically maintain the system's health and scalability dynamically, effectively acting as the source of truth that outlives any single container or manual command.
-   </details>
+<details><summary>4. During an incident review, someone says the Deployment YAML is "just documentation" because operators can always run commands directly. How do you explain the declarative model?</summary>
 
-6. **Scenario**: You are evaluating a new observability tool for your cluster. Tool A is a standalone product built by a small startup. Tool B is a CNCF-incubating project built specifically using Kubernetes Custom Resource Definitions (CRDs). Why might Tool B be the safer long-term choice based on orchestration history?
-   <details>
-   <summary>Answer</summary>
+The YAML is not merely documentation; it is the desired state consumed by the Kubernetes API and controllers. Direct commands can be useful during investigation, but they do not automatically create a durable record of what production should converge toward. A Deployment spec tells the system how many replicas should exist and gives controllers a target to restore after drift or failure. That is why declarative configuration is central to Kubernetes rather than a stylistic preference.
 
-   Tool B leverages Kubernetes' extensible architecture (CRDs) and is part of the CNCF ecosystem, similar to the pattern of how Kubernetes itself succeeded. The CNCF backing ensures neutral governance and community-driven development, significantly reducing the risk of the project being abruptly abandoned or locked behind a restrictive paywall. Its native integration with the Kubernetes API means it will likely work seamlessly with other standard ecosystem tools, avoiding friction during upgrades or expansions. Adopting ecosystem-aligned tools ensures your team benefits from the collective troubleshooting and operational experience of the broader community rather than fighting isolated bugs.
-   </details>
+</details>
 
-7. **Scenario**: A CTO looks at a diagram of Apache Mesos and Kubernetes. They note that Mesos was successfully used by Twitter at massive scale, yet it lost to Kubernetes. They ask you why the "best technology" doesn't always win. How do you explain the outcome?
-   <details>
-   <summary>Answer</summary>
+<details><summary>5. A platform team wants to build an internal orchestrator because Kubernetes feels complex. Which lesson from Spotify's Helios migration should shape your response?</summary>
 
-   Technology doesn't exist in a vacuum; ecosystem, extensibility, and usability are just as critical for long-term platform survival. Mesos was incredibly powerful and proven at scale, but possessed a steep learning curve and was difficult to operate out of the box, often requiring separate components like Marathon just to run containers. Kubernetes struck the right balance by offering Google-grade orchestration concepts while cultivating an unmatched, open ecosystem that invited massive community contribution. The neutral CNCF governance encouraged every major cloud provider to adopt it as a managed service, creating a snowball effect of accessibility that Mesos couldn't match. Ultimately, an accessible platform with standard API abstractions and massive community momentum will outcompete a technically superior but fragmented or complex alternative.
-   </details>
+Spotify's experience shows that a homegrown orchestrator can solve real local problems and still become expensive when the broader ecosystem moves faster. The team must maintain features, integrations, training, and operational knowledge that the Kubernetes community and vendors are already sharing. That does not prove every internal platform is wrong, but it raises the bar for building one. The response should compare total ecosystem cost, not just the discomfort of learning Kubernetes.
+
+</details>
+
+<details><summary>6. A CTO notes that Mesos was proven at massive scale and asks why the "best technology" did not win. How should you answer?</summary>
+
+The answer is that platform outcomes depend on adoption path, ecosystem, governance, and usability as well as raw technical capability. Mesos was powerful and credible, but its operational model and surrounding components were harder for mainstream container teams to adopt. Kubernetes offered a clearer container-first API, strong extension points, and neutral governance that encouraged cloud-provider support. The "best" platform for industry adoption is often the one that enough teams can learn, extend, and trust together.
+
+</details>
+
+<details><summary>7. Your organization is evaluating a new Kubernetes operator that defines several CRDs. What should you check before treating it as an ecosystem-aligned choice?</summary>
+
+You should check whether the operator follows Kubernetes patterns rather than merely installing custom complexity into the cluster. Look for clear CRD schemas, controller behavior that reconciles status predictably, RBAC scoped to the required resources, upgrade guidance, and compatibility with your Kubernetes version. CRDs are powerful because they extend the API model, but they also add new operational responsibilities. The safe choice is not "anything with a CRD"; it is a tool whose extension points are understandable and maintainable.
+
+</details>
 
 ---
 
 ## Hands-On Exercise: Orchestration Architecture Reflection
 
-While this module is conceptual, applying the historical lessons to a modern scenario solidifies your understanding. 
+This module is conceptual, but the learning should still produce an artifact you can use in an engineering conversation. Imagine your company's CTO wants to build a proprietary internal orchestration system for microservices because Kubernetes "feels too complex." Your task is to prepare a short technical argument that uses the orchestration wars as evidence without pretending Kubernetes is free of tradeoffs.
 
-**Scenario:** Your company's CTO wants to build a proprietary, internal orchestration system for your microservices because Kubernetes "feels too complex." You need to prepare a counter-argument based on the Orchestration Wars.
+Start by writing three sentences that define the operational problem, not the preferred tool. Your argument should mention placement, failure recovery, rollout safety, and shared APIs because those are the problems that appear after basic container packaging succeeds. Then write two sentences explaining why an imperative script or proprietary scheduler becomes expensive as teams and failure modes grow. This forces you to diagnose the control-plane problem before recommending the control-plane product.
 
-**Task:** Draft a brief (3-4 point) technical argument against building a custom orchestrator, referencing specific historical lessons from Docker Swarm and Mesos.
+Next, compare at least two historical contenders. Use Docker Swarm to discuss the difference between day-one simplicity and long-term ecosystem gravity, and use Mesos to discuss the difference between proven scale and mainstream adoption. If you include Nomad, treat it fairly as a living niche alternative rather than as a failed Kubernetes clone. The goal is to show judgment, not brand loyalty.
+
+Then make the Kubernetes case with both strengths and limits. Mention declarative reconciliation, extensibility through the API, CNCF governance, managed cloud-provider adoption, and the availability of standard integrations. Also include one sentence describing when Kubernetes would be too much for the current workload. A persuasive platform argument is stronger when it admits the boundary where a simpler option would be better.
+
+Finally, turn your notes into a brief recommendation. It should be short enough for an architecture review comment, specific enough to survive follow-up questions, and grounded enough that another engineer can see the historical evidence behind it. Treat this as practice for the platform conversations you will have later when choosing between native Kubernetes, managed services, operators, GitOps tools, and simpler deployment systems.
 
 ### Success Criteria
 
-- [ ] You have identified at least one risk related to building a custom ecosystem (referencing the CNCF or K8s ecosystem).
-- [ ] You have explained the difference between imperative and declarative models in your argument.
-- [ ] You have referenced the maintenance burden, citing Google's decade of experience with Borg.
-- [ ] You have provided a concrete example of a company (like Docker or Twitter) that abandoned their own orchestrator.
+- [ ] You identified at least one ecosystem risk related to building a custom orchestrator, referencing CNCF governance or Kubernetes integrations.
+- [ ] You explained the difference between imperative commands and declarative reconciliation in your argument.
+- [ ] You referenced the maintenance burden implied by Google's decade of Borg and Omega experience.
+- [ ] You provided a concrete example of a company or project that moved away from its earlier orchestration approach.
+- [ ] You stated one condition where Kubernetes would be the wrong first choice for a small workload.
+
+<details><summary>Solution notes</summary>
+
+A strong answer says that the team should avoid building a proprietary orchestrator unless it can justify owning scheduling, reconciliation, rollout behavior, service discovery, security integration, observability hooks, and ecosystem maintenance. It uses Swarm as the warning about day-one simplicity without broad ecosystem gravity, Mesos as the warning that proven scale does not guarantee mainstream adoption, and Spotify's Helios migration as a warning about internal feature parity costs. It recommends Kubernetes when the organization needs a shared API and ecosystem, while admitting that Docker Compose, a managed app platform, or Nomad may fit smaller or mixed-workload cases better.
+
+</details>
 
 ---
 
-## Summary
+## Sources
 
-Kubernetes won the orchestration wars because:
-- **Declarative model**: Define desired state, let K8s handle the rest
-- **Google's experience**: Decade of production learnings from Borg
-- **Ecosystem**: Extensible architecture enabled massive tooling ecosystem
-- **Governance**: CNCF neutrality enabled industry-wide adoption
-- **Cloud adoption**: All major providers offering managed K8s
-
-The alternatives didn't fail because they were bad—they failed because Kubernetes was better positioned for industry-wide adoption.
+- [Kubernetes Blog: 10 Years of Kubernetes](https://kubernetes.io/blog/2024/06/06/10-years-of-kubernetes/)
+- [Kubernetes Blog: 4 Years of K8s](https://kubernetes.io/blog/2018/06/06/4-years-of-k8s/)
+- [Google Research: Borg, Omega, and Kubernetes](https://research.google/pubs/borg-omega-and-kubernetes/)
+- [Kubernetes Documentation: Components](https://kubernetes.io/docs/concepts/overview/components/)
+- [Kubernetes Documentation: Controllers](https://kubernetes.io/docs/concepts/architecture/controller/)
+- [Kubernetes Documentation: Custom Resources](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
+- [Kubernetes Documentation: Declarative Management of Objects](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/declarative-config/)
+- [Docker Docs: Swarm Mode](https://docs.docker.com/engine/swarm/)
+- [Apache Attic: Apache Mesos](https://attic.apache.org/projects/mesos.html)
+- [Apache Mesos Project Site](https://mesos.apache.org/)
+- [CNCF Announcement: 2025 Annual Cloud Native Survey](https://www.cncf.io/announcements/2026/01/20/kubernetes-established-as-the-de-facto-operating-system-for-ai-as-production-use-hits-82-in-2025-cncf-annual-cloud-native-survey/)
+- [Google Cloud Blog: Bringing Pokemon Go to Life on Google Cloud](https://cloud.google.com/blog/products/containers-kubernetes/bringing-pokemon-go-to-life-on-google-cloud)
+- [CNCF Blog: Spotify Capacity Planning with Kubernetes](https://www.cncf.io/blog/2019/06/27/with-kubernetes-spotifys-capacity-planning-went-from-almost-an-hour-to-seconds-or-minutes-2/)
+- [HashiCorp Nomad Documentation](https://developer.hashicorp.com/nomad/docs)
 
 ---
 
 ## Next Module
 
-[Module 1.2: Declarative vs Imperative](../module-1.2-declarative-vs-imperative/) - The philosophy that makes Kubernetes different.
+[Module 1.2: Declarative vs Imperative](../module-1.2-declarative-vs-imperative/) - The next module turns the philosophy from this lesson into hands-on Kubernetes behavior, showing how desired state changes what you do at the command line.


### PR DESCRIPTION
Rewrites src/content/docs/prerequisites/philosophy-design/module-1.1-why-kubernetes-won.md for the #388 verifier pilot.\n\nVerifier: T0; body_words=5022, mean_wpp=76.1, median_wpp=79.0, short_rate=0.03, max_run=1, mean_sentence_length=22.1.\n\nProtected assets preserved: code blocks 7 before / 7 after, Mermaid diagrams 2 before / 2 after, markdown tables 2 before / 2 after, ASCII diagrams 0 before / 0 after, source URLs 0 before / 14 after.\n\nChecks run:\n- /Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/quality/verify_module.py --glob src/content/docs/prerequisites/philosophy-design/module-1.1-why-kubernetes-won.md --skip-source-check --summary --quiet\n- git diff --check -- src/content/docs/prerequisites/philosophy-design/module-1.1-why-kubernetes-won.md\n- rg --pcre2 forbidden-token scan: no matches\n- /Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/test_pipeline.py: 166 tests OK\n- npm run build: passed using worktree-local temporary node_modules symlink to primary checkout because primary main had unrelated dirty files\n\nCommit: 0cd77c597874c22af608cd4accb536eb65daad86