### PR TITLE
chore(agents): enable economical multi-agent workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,40 @@ Post the review as a PR comment (not `gh pr review --approve` — fails when the
 
 ---
 
+## Economical Multi-Agent Delegation
+
+When Codex multi-agent support is enabled, the user explicitly authorizes the main Codex agent to use lower-cost routine subagents for bounded work that can run in parallel without lowering quality. The main agent stays responsible for planning, integration, final review, PR creation, Gemini review routing, and merge decisions.
+
+Prefer `explorer` subagents for read-only investigation and validation. Use `worker` subagents only for mechanical edits with a clearly owned file set and no ambiguity.
+
+Routine subagent model routing:
+
+- Use `gpt-5.4-mini` for general repo search, small summaries, docs/index checks, simple validation, and straightforward documentation edits.
+- Use `gpt-5.3-codex-spark` for narrow code-heavy routine tasks where code fluency matters: mechanical Python/TypeScript edits, focused test-failure triage, small refactors with clear ownership, diff review, and targeted validation. This model has a separate usage/limit counter, so prefer it over the main model for bounded coding chores when it can run independently.
+
+Use routine subagents for:
+
+- finding where a feature, config, route, test, or workflow is defined
+- summarizing a small file set before the main agent edits it
+- checking whether docs, indexes, tests, or scripts reference a changed file
+- running simple validation such as `bash -n`, YAML/JSON parsing, `git diff --check`, or targeted tests
+- making mechanical edits in a clearly owned file set
+- updating straightforward documentation or generated indexes when explicitly in scope
+- verifying a narrow behavior while the main agent keeps implementing elsewhere
+
+Do not use routine subagents for architecture decisions, security-sensitive judgment, ambiguous debugging, broad refactors, PR creation, Gemini review routing, merges, destructive actions, or work that blocks the main agent's next immediate step. Give each subagent a narrow task, a clear file ownership boundary when edits are allowed, and instructions not to revert unrelated changes. The main agent must review every routine-subagent diff before finalizing or presenting the work as complete.
+
+Cost controls:
+
+- Use local deterministic tools before model calls: `rg`, `git diff --check`, `bash -n`, `.venv/bin/ruff`, targeted tests, JSON/YAML parsers, and local API endpoints.
+- Escalate routine model work in this order when quality allows: `gpt-5.4-mini` for general routine work, `gpt-5.3-codex-spark` for bounded code-heavy routine work, then the main model for judgment/integration.
+- Do not spawn a subagent for work the main agent can finish faster than delegation overhead.
+- Keep routine delegation to one to three subagents at a time unless the user explicitly asks for a larger sweep.
+- Do not let subagents read secrets, source `.envrc`, call `gh`, request reviews, or merge PRs.
+- Do not delegate the independent-family review requirement. Gemini review is still mandatory before merge.
+
+---
+
 ## Project Architecture
 
 KubeDojo is a cloud-native curriculum site built with **Astro/Starlight**. It is NOT an MkDocs project (the migration happened weeks ago — any AGENTS.md/CLAUDE.md guidance mentioning MkDocs is historical).

--- a/start-codex.sh
+++ b/start-codex.sh
@@ -17,9 +17,28 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$SCRIPT_DIR"
 CODEX_TARGET="${CODEX_TARGET:-worktree}"
 CODEX_ARGS=()
+CODEX_FLAGS=(--dangerously-bypass-approvals-and-sandbox)
+
+if [ "${CODEX_ENABLE_MULTI_AGENT:-1}" != "0" ]; then
+    CODEX_FLAGS+=(--enable multi_agent)
+fi
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
+        --help-wrapper)
+            cat <<'EOF'
+Usage: ./start-codex.sh [--main|--worktree] [codex args...]
+
+KubeDojo Codex launcher:
+  - runs Codex in .worktrees/codex-interactive by default
+  - use --main only when intentionally running in the primary checkout
+  - always adds --dangerously-bypass-approvals-and-sandbox
+  - enables Codex multi-agent support by default
+  - set CODEX_ENABLE_MULTI_AGENT=0 to disable multi-agent support
+  - forwards all other arguments to codex unchanged
+EOF
+            exit 0
+            ;;
         --main)
             CODEX_TARGET="main"
             shift
@@ -146,8 +165,13 @@ fi
 echo ""
 echo "   Handoff doc: .pipeline/codex-handoff.md"
 echo "   First command: cat .pipeline/codex-handoff.md"
+if [ "${CODEX_ENABLE_MULTI_AGENT:-1}" != "0" ]; then
+    echo "   Multi-agent: enabled"
+else
+    echo "   Multi-agent: disabled"
+fi
 echo ""
 
 echo "Launching Codex in $CODEX_TARGET checkout..."
 export CODEX_SESSION=1
-codex --dangerously-bypass-approvals-and-sandbox -C "$TARGET_DIR" "${CODEX_ARGS[@]}"
+codex "${CODEX_FLAGS[@]}" -C "$TARGET_DIR" "${CODEX_ARGS[@]}"


### PR DESCRIPTION
## Summary
- enable Codex multi-agent mode in `start-codex.sh` by default
- document cost-aware routine subagent routing in `AGENTS.md`
- route routine work to local tools first, then `gpt-5.4-mini`, then `gpt-5.3-codex-spark` for bounded code-heavy chores, keeping main models for judgment/integration
- preserve mandatory Gemini independent review before merge

## Validation
- `bash -n start-codex.sh`
- `./start-codex.sh --help-wrapper`
- `git diff --check`

No content/build changes; `npm run build` not required.