### PR TITLE
fix(api): harden review path lookup for CodeQL

### DIFF
--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -1785,7 +1785,24 @@ def build_pipeline_stuck(
 
 _REVIEW_AUDIT_DIR = Path(".pipeline") / "reviews"
 _VALID_FACT_CHECK_STATUSES = {"verified", "unverified", "failed", "none"}
-_SAFE_REVIEW_FILENAME_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*(?:__[a-z0-9][a-z0-9._-]*)*\.md$")
+
+def _is_safe_review_filename(filename: str) -> bool:
+    """Validate review filename format without using user-driven regexes."""
+    if "/" in filename or "\\" in filename:
+        return False
+    if not filename.endswith(".md") or filename == ".md":
+        return False
+    stem = filename[:-3]
+    for segment in stem.split("__"):
+        if not segment:
+            return False
+        if segment[0] not in "abcdefghijklmnopqrstuvwxyz0123456789":
+            return False
+        for ch in segment:
+            if ch in "abcdefghijklmnopqrstuvwxyz0123456789._-":
+                continue
+            return False
+    return True
 _LATEST_REVIEW_RE = re.compile(r"^## .*?— `REVIEW`.*?(?=^## |\Z)", re.MULTILINE | re.DOTALL)
 _FAILED_FACT_CHECK_RE = re.compile(r"^- \*\*FACT_CHECK\*\*:\s*(.+)$", re.MULTILINE)
 _UNVERIFIED_CLAIM_RE = re.compile(r"unverified:\s*(.+)", re.IGNORECASE)
@@ -1814,16 +1831,20 @@ def _safe_review_path_for_module_key(repo_root: Path, module_key: str) -> Path |
     except OSError:
         return None
     filename = _module_key_to_review_filename(normalized)
-    if "/" in filename or "\\" in filename:
+    if not _is_safe_review_filename(filename):
         return None
-    if not _SAFE_REVIEW_FILENAME_RE.fullmatch(filename):
+    if not reviews_dir.is_dir():
         return None
-    try:
-        path = (reviews_dir / filename).resolve()
-        path.relative_to(reviews_dir)
-    except (OSError, RuntimeError, ValueError):
-        return None
-    return path
+    for candidate in reviews_dir.glob("*.md"):
+        if candidate.name != filename:
+            continue
+        try:
+            path = candidate.resolve()
+            path.relative_to(reviews_dir)
+        except (OSError, RuntimeError, ValueError):
+            return None
+        return path
+    return None
 
 
 def _fact_check_summary(review_body: str) -> dict[str, Any]:

--- a/tests/test_local_api.py
+++ b/tests/test_local_api.py
@@ -1679,6 +1679,29 @@ def test_reviews_index_and_single(tmp_path: Path) -> None:
     assert trunc["body_size"] == 1000
 
 
+def test_reviews_route_rejects_invalid_module_param(tmp_path: Path) -> None:
+    tmp_path.joinpath(".pipeline", "reviews").mkdir(parents=True)
+    status_code, payload, _ = local_api.route_request(
+        tmp_path,
+        "/api/reviews?module=../../etc/passwd",
+    )
+    assert status_code == 400
+    assert payload["error"] == "invalid_module_key"
+
+
+def test_safe_review_filename_validation() -> None:
+    assert local_api._is_safe_review_filename(
+        "prerequisites__zero-to-terminal__module-0.1-alpha.md"
+    ) is True
+    assert local_api._is_safe_review_filename("bad__name/with__slash.md") is False
+    assert local_api._is_safe_review_filename("bad__name_with__slash.md") is True
+    assert local_api._is_safe_review_filename("UPPER__x.md") is False
+    assert local_api._is_safe_review_filename("bad__name__") is False
+    assert (
+        local_api._is_safe_review_filename("0__0__0__0__0.md") is True
+    )
+
+
 def test_reviews_route_filter_module_state_diag_and_briefing_unverified(tmp_path: Path) -> None:
     module_key, _ = _setup_repo(tmp_path)
     _write(


### PR DESCRIPTION
## Summary
- fixes the 3 open CodeQL alerts in `scripts/local_api.py` around review artifact lookup
- replaces the ambiguous review filename regex with bounded segment validation
- avoids constructing review file paths directly from request-derived filenames by matching existing files under `.pipeline/reviews`
- adds regression coverage for invalid review module input and review filename validation

## Code scanning alerts addressed
- #25 `py/path-injection`
- #24 `py/redos`
- #23 `py/polynomial-redos`

## Validation
- `../../.venv/bin/ruff check scripts/local_api.py tests/test_local_api.py tests/test_local_api_security.py`
- `../../.venv/bin/python -m pytest tests/test_local_api.py -k "reviews_route_rejects_invalid_module_param or safe_review_filename_validation or test_reviews_index_and_single" tests/test_local_api_security.py -q`
- with worktree `.venv` symlink for local_api venv discovery: `.venv/bin/python -m pytest tests/test_local_api.py tests/test_local_api_security.py -q` (122 passed)
- with worktree `.venv` symlink for local_api venv discovery: `.venv/bin/python scripts/test_pipeline.py` (166 passed)

No Astro/content changes; `npm run build` not required.