### PR TITLE
feat(quality-board): split shipped_unreviewed out of needs_review

### DIFF
--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -3724,7 +3724,12 @@ def _quality_board_classify(
     """Apply the precedence ladder from issue #389.
 
     Order is mutually exclusive — first match wins:
-      in_flight > both > needs_review > needs_rewrite > done.
+      in_flight > both > needs_review > shipped_unreviewed > needs_rewrite > done.
+
+    ``shipped_unreviewed`` separates ad-hoc-shipped modules
+    (stage=UNAUDITED + score>=4 + no banner) from active mid-pipeline
+    review queue items so the operator can tell bookkeeping debt apart
+    from in-flight reviews.
     """
     score_val = float(score) if score is not None else 0.0
     needs_deferred_review = auto_approved and in_post_review_queue
@@ -5891,7 +5896,7 @@ def render_dashboard_html(*, issue_number: int = DEFAULT_FEEDBACK_ISSUE) -> str:
       qualityBoardData = data;
       const totals = data.totals || {{}};
       const total = totals.total || 0;
-      const needs = (totals.needs_rewrite || 0) + (totals.needs_review || 0) + (totals.both || 0);
+      const needs = (totals.needs_rewrite || 0) + (totals.needs_review || 0) + (totals.shipped_unreviewed || 0) + (totals.both || 0);
       badge.textContent = `${{totals.done || 0}} / ${{total}} done · ${{needs}} left`;
       badge.style.background = needs ? 'var(--amber-muted)' : 'var(--green-muted)';
       badge.style.color = needs ? 'var(--amber)' : 'var(--green)';

--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -3743,6 +3743,15 @@ def _quality_board_classify(
         and (latest_verdict is None or latest_verdict == "approve")
     ):
         return "done"
+    # Ad-hoc-shipped modules: passed the structural rubric (score >= 4.0)
+    # and merged on main, but the pipeline state machine never recorded
+    # an independent-family review. Distinct from `needs_review` (which
+    # is mid-pipeline/awaiting-reviewer) so the operator can tell
+    # "shipped without review" apart from "review in flight". Same
+    # actionable category — needs cross-family review — but separates
+    # the bookkeeping debt from the active review queue.
+    if score_val >= 4.0 and not revision_pending and stage == "UNAUDITED":
+        return "shipped_unreviewed"
     # Anything left over (e.g. score 3.0–3.9 with no banner, no review,
     # no auto-approve, no FAILED) is a soft "needs_review" — surface it
     # so the operator sees it instead of silently hiding modules from
@@ -3755,14 +3764,22 @@ def build_quality_board(repo_root: Path) -> dict[str, Any]:
     revision banners, the post-review queue, and review verdicts.
 
     Status precedence (first match wins): ``in_flight`` >
-    ``both`` > ``needs_review`` > ``needs_rewrite`` > ``done``.
+    ``both`` > ``needs_review`` > ``shipped_unreviewed`` >
+    ``needs_rewrite`` > ``done``.
     See issue #389 for the contract.
+
+    ``shipped_unreviewed`` is for modules that passed the structural
+    rubric (score >= 4.0) and merged on main but have stage=UNAUDITED —
+    i.e. ad-hoc shipments the pipeline state machine never tracked.
+    Same actionable category as ``needs_review`` (cross-family review
+    pending) but separated so the operator can distinguish bookkeeping
+    debt from active in-flight reviews.
     """
     docs_root = repo_root / "src" / "content" / "docs"
     if not docs_root.exists():
         return {
             "generated_at": int(time.time()),
-            "totals": {"done": 0, "needs_rewrite": 0, "needs_review": 0, "both": 0, "in_flight": 0, "total": 0},
+            "totals": {"done": 0, "needs_rewrite": 0, "needs_review": 0, "shipped_unreviewed": 0, "both": 0, "in_flight": 0, "total": 0},
             "tracks": [],
             "modules": [],
         }
@@ -3791,7 +3808,7 @@ def build_quality_board(repo_root: Path) -> dict[str, Any]:
 
     modules: list[dict[str, Any]] = []
     track_buckets: dict[str, dict[str, Any]] = {}
-    totals = {"done": 0, "needs_rewrite": 0, "needs_review": 0, "both": 0, "in_flight": 0, "total": 0}
+    totals = {"done": 0, "needs_rewrite": 0, "needs_review": 0, "shipped_unreviewed": 0, "both": 0, "in_flight": 0, "total": 0}
     source_counts = {
         "quality_pipeline_records": len(states),
         "committed_full_review": sum(
@@ -3872,6 +3889,7 @@ def build_quality_board(repo_root: Path) -> dict[str, Any]:
                 "done": 0,
                 "needs_rewrite": 0,
                 "needs_review": 0,
+                "shipped_unreviewed": 0,
                 "both": 0,
                 "in_flight": 0,
                 "total": 0,
@@ -4738,6 +4756,7 @@ def render_dashboard_html(*, issue_number: int = DEFAULT_FEEDBACK_ISSUE) -> str:
     .qb-done {{ background: var(--green); }}
     .qb-needs_rewrite {{ background: var(--red); }}
     .qb-needs_review {{ background: var(--amber); }}
+    .qb-shipped_unreviewed {{ background: #f97316; }}
     .qb-both {{ background: #c084fc; }}
     .qb-in_flight {{ background: var(--accent); }}
     .qb-legend {{
@@ -4848,6 +4867,7 @@ def render_dashboard_html(*, issue_number: int = DEFAULT_FEEDBACK_ISSUE) -> str:
     .qb-chip.done {{ background: var(--green-muted); color: var(--green); }}
     .qb-chip.needs_rewrite {{ background: var(--red-muted); color: var(--red); }}
     .qb-chip.needs_review {{ background: var(--amber-muted); color: var(--amber); }}
+    .qb-chip.shipped_unreviewed {{ background: rgba(249,115,22,0.14); color: #f97316; }}
     .qb-chip.both {{ background: rgba(192,132,252,0.14); color: #c084fc; }}
     .qb-chip.in_flight {{ background: var(--accent-muted); color: var(--accent); }}
     .qb-detail {{
@@ -5768,11 +5788,12 @@ def render_dashboard_html(*, issue_number: int = DEFAULT_FEEDBACK_ISSUE) -> str:
       }}).join('');
     }}
 
-    const QB_STATUS = ['done', 'needs_rewrite', 'needs_review', 'both', 'in_flight'];
+    const QB_STATUS = ['done', 'needs_rewrite', 'needs_review', 'shipped_unreviewed', 'both', 'in_flight'];
     const QB_LABEL = {{
       done: 'Done',
       needs_rewrite: 'Rewrite',
       needs_review: 'Review',
+      shipped_unreviewed: 'Shipped (unreviewed)',
       both: 'Both',
       in_flight: 'In flight',
     }};

--- a/tests/test_quality_board.py
+++ b/tests/test_quality_board.py
@@ -116,6 +116,7 @@ def test_quality_board_track_totals_sum_to_modules(tmp_path: Path) -> None:
         "done": 1,
         "needs_rewrite": 1,
         "needs_review": 1,
+        "shipped_unreviewed": 0,
         "both": 0,
         "in_flight": 1,
         "total": 4,


### PR DESCRIPTION
## Summary

The needs_review bucket conflated two very different populations:
- Mid-pipeline modules genuinely awaiting review (stage AUDITED/ROUTED) — 59
- Ad-hoc-shipped modules merged on main without ever entering the pipeline state machine (stage UNAUDITED + score >= 4.0) — 192

That conflation was 192 of 251 orange chips on the quality board — enough to bury actionable mid-pipeline reviews under bookkeeping debt. Operator could not tell "review in flight" from "shipped without review tracking."

This PR adds a new status \`shipped_unreviewed\` that fires for:

    score >= 4.0 AND not revision_pending AND stage == "UNAUDITED"

Wired through: classifier, totals, per-track buckets, dashboard QB_STATUS list, QB_LABEL map, two CSS rules (orange #f97316 vs amber #fbbf24).

## Counts

| status | before | after |
|---|---|---|
| done | 78 | 78 |
| needs_rewrite | 424 | 424 |
| needs_review | 251 | **59** |
| shipped_unreviewed | — | **192** |
| both | 1 | 1 |

## Test plan

- [x] ruff clean on scripts/local_api.py
- [x] Verified totals against primary's .pipeline state — counts match expectation
- [x] Live API restarted from worktree, dashboard renders new bucket distinctly
- [ ] Cross-family review by Gemini (Codex out this window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)