### PR TITLE
fix(pipeline-v4): tech-debt cleanup — sys.executable, LOC gate, services-up

### DIFF
--- a/scripts/ai_agent_bridge/_claude.py
+++ b/scripts/ai_agent_bridge/_claude.py
@@ -32,6 +32,8 @@ from ._db import get_db, get_session, set_session
 from ._messaging import acknowledge, send_message
 from ._prompts import build_claude_prompt
 
+VENV_PYTHON = str((REPO_ROOT / ".venv" / "bin" / "python").resolve())
+
 
 def ask_claude(content: str, task_id: str | None = None, msg_type: str = "query",
                data: str | None = None, new_session: bool = False,
@@ -272,7 +274,7 @@ def _launch_claude_background(msg, message_id, new_session):
 
     try:
         bridge_cmd = [
-            sys.executable, str(Path(__file__).parent / "__main__.py"),
+            VENV_PYTHON, str(Path(__file__).parent / "__main__.py"),
             "process-claude", str(message_id),
             "--no-timeout"
         ]

--- a/scripts/on-prem/phase2-write-only.py
+++ b/scripts/on-prem/phase2-write-only.py
@@ -41,7 +41,6 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import subprocess
 import sys
 import time
@@ -50,6 +49,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
+VENV_PYTHON = str((REPO_ROOT / ".venv" / "bin" / "python").resolve())
 
 from dispatch import GEMINI_WRITER_MODEL, dispatch_gemini_with_retry  # type: ignore  # noqa: E402
 
@@ -365,7 +365,7 @@ def dispatch_writer(prompt: str, writer_model: str) -> tuple[bool, str]:
         return True, extract_section_from_codex_output(result.stdout)
     if writer_model.startswith("claude"):
         cmd = [
-            sys.executable, str(REPO_ROOT / "scripts" / "dispatch.py"),
+            VENV_PYTHON, str(REPO_ROOT / "scripts" / "dispatch.py"),
             "claude", "-", "--model", writer_model,
         ]
         try:
@@ -442,7 +442,7 @@ def write_module(m: dict, idx: int, total: int, writer: str,
 
         output = output.strip()
         if not output.startswith("---"):
-            log(f"  ❌ INVALID: response does not start with frontmatter delimiter")
+            log("  ❌ INVALID: response does not start with frontmatter delimiter")
             log(f"     First 200 chars: {output[:200]}")
             return False
 
@@ -454,7 +454,7 @@ def write_module(m: dict, idx: int, total: int, writer: str,
         md_path.write_text(output, encoding="utf-8")
         log(f"  ✓ writer wrote {len(output)} chars in {elapsed:.0f}s")
     else:
-        log(f"  SKIP writer: existing content fresh")
+        log("  SKIP writer: existing content fresh")
 
     # Step 2: fact-check (always runs unless --skip-factcheck)
     if needs_factcheck:
@@ -476,7 +476,7 @@ def write_module(m: dict, idx: int, total: int, writer: str,
         if isinstance(hallucinated, int) and hallucinated > 0:
             log(f"  ⚠ {hallucinated} HALLUCINATED claims — review priority HIGH")
     else:
-        log(f"  SKIP fact-check: existing ledger fresh")
+        log("  SKIP fact-check: existing ledger fresh")
 
     return True
 
@@ -507,7 +507,7 @@ def main() -> int:
         indices = list(range(len(MODULES)))
 
     log("="*70)
-    log(f"Phase 2 write-only batch starting")
+    log("Phase 2 write-only batch starting")
     log(f"  Modules: {len(indices)}")
     log(f"  Writer: {writer}")
     log(f"  Fact-checker: {FACT_CHECKER}{' (SKIPPED)' if skip_factcheck else ''}")
@@ -548,7 +548,7 @@ def main() -> int:
     if high_halluc:
         for k, h in sorted(high_halluc, key=lambda x: -x[1]):
             log(f"    - {k}: {h} hallucinated claim(s)")
-    log(f"  Run 'npm run build' before reviewing.")
+    log("  Run 'npm run build' before reviewing.")
 
     return 0 if not failed else 1
 

--- a/scripts/pipeline_v4.py
+++ b/scripts/pipeline_v4.py
@@ -7,12 +7,6 @@ Stages:
     3. RUBRIC_RECHECK
     4. CITATION_V3
     5. FINAL_RECHECK
-
-TODO:
-    Stage 4 uses a first-pass approximation for "citation anchors inside
-    generated prose" by comparing generated-block LOC to total module LOC.
-    A follow-up should inspect pipeline_v3's actual anchor plan instead of
-    using this coarse proxy.
 """
 
 from __future__ import annotations
@@ -40,8 +34,6 @@ import rubric_gaps  # noqa: E402
 DOCS_ROOT = REPO_ROOT / "src" / "content" / "docs"
 PIPELINE_V4_DIR = REPO_ROOT / ".pipeline" / "v4"
 RUNS_DIR = PIPELINE_V4_DIR / "runs"
-GENERATED_BLOCK_PREFIX = "<!-- v4:generated"
-GENERATED_BLOCK_SUFFIX = "<!-- /v4:generated -->"
 
 STAGE_RUBRIC_SCAN = "RUBRIC_SCAN"
 STAGE_EXPAND = "EXPAND"
@@ -91,6 +83,14 @@ def _module_path(module_key: str) -> Path:
 
 def _module_flat_key(module_key: str) -> str:
     return _normalize_module_key(module_key).replace("/", "__")
+
+
+def _pipeline_python() -> str:
+    for ancestor in (REPO_ROOT, *REPO_ROOT.parents):
+        candidate = ancestor / ".venv" / "bin" / "python"
+        if candidate.exists():
+            return str(candidate)
+    return local_api._venv_python_for_repo(REPO_ROOT)
 
 
 def _tail_lines(text: str, limit: int = 50) -> list[str]:
@@ -233,30 +233,8 @@ def _stage_1_gap_scan(module_key: str) -> dict[str, Any]:
     }
 
 
-def _generated_loc_ratio(module_path: Path) -> float:
-    text = module_path.read_text(encoding="utf-8")
-    lines = text.splitlines()
-    if not lines:
-        return 0.0
-
-    generated_loc = 0
-    inside_generated = False
-    for line in lines:
-        stripped = line.strip()
-        if stripped.startswith(GENERATED_BLOCK_PREFIX):
-            inside_generated = True
-            continue
-        if stripped == GENERATED_BLOCK_SUFFIX:
-            inside_generated = False
-            continue
-        if inside_generated:
-            generated_loc += 1
-
-    return generated_loc / len(lines)
-
-
 def _invoke_citation_pipeline(module_key: str) -> dict[str, Any]:
-    cmd = [sys.executable, "scripts/pipeline_v3.py", _normalize_module_key(module_key)]
+    cmd = [_pipeline_python(), "scripts/pipeline_v3.py", _normalize_module_key(module_key)]
     completed = subprocess.run(
         cmd,
         cwd=REPO_ROOT,
@@ -268,16 +246,12 @@ def _invoke_citation_pipeline(module_key: str) -> dict[str, Any]:
         "exit_code": completed.returncode,
         "stdout_tail": _tail_lines(completed.stdout),
         "stderr_tail": _tail_lines(completed.stderr),
+        "payload": _parse_citation_payload(_tail_lines(completed.stdout)),
     }
 
 
-def _parse_citation_status(stdout_tail: list[str]) -> str | None:
-    """Extract the `status` field from pipeline_v3's stdout JSON payload.
-
-    pipeline_v3 prints a JSON object on completion. We only have the
-    tail (last 50 lines) but that's enough for a single-module run.
-    Returns the status string (e.g. "clean", "residuals_queued") or
-    None if the payload can't be parsed."""
+def _parse_citation_payload(stdout_tail: list[str]) -> dict[str, Any] | None:
+    """Extract pipeline_v3's final JSON payload from stdout tail."""
     if not stdout_tail:
         return None
     text = "\n".join(stdout_tail)
@@ -288,8 +262,30 @@ def _parse_citation_status(stdout_tail: list[str]) -> str | None:
         payload = json.loads(text[start:])
     except json.JSONDecodeError:
         return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _parse_citation_status(stdout_tail: list[str]) -> str | None:
+    """Extract the `status` field from pipeline_v3's stdout JSON payload.
+
+    pipeline_v3 prints a JSON object on completion. We only have the
+    tail (last 50 lines) but that's enough for a single-module run.
+    Returns the status string (e.g. "clean", "residuals_queued") or
+    None if the payload can't be parsed."""
+    payload = _parse_citation_payload(stdout_tail)
     status = payload.get("status") if isinstance(payload, dict) else None
     return str(status) if isinstance(status, str) else None
+
+
+def _parse_citation_payload_queued_findings(payload: dict[str, Any] | None) -> dict[str, int]:
+    if payload is None or not isinstance(payload.get("queued_findings"), dict):
+        return {}
+    raw = payload["queued_findings"]
+    return {
+        key: len(value)
+        for key, value in raw.items()
+        if isinstance(value, list)
+    }
 
 
 def _new_result(module_key: str) -> PipelineV4Result:
@@ -439,36 +435,29 @@ def _run_pipeline_v4(
             result.reason = ""
             return _result_with_finish(result)
 
-        _stage_start(result, STAGE_CITATION_V3, {}, dry_run=dry_run)
-        generated_ratio = _generated_loc_ratio(module_path)
-        if generated_ratio > generated_loc_threshold:
-            _stage_finish(
-                result,
-                STAGE_CITATION_V3,
-                {
-                    "generated_loc_ratio": round(generated_ratio, 4),
-                    "generated_loc_threshold": generated_loc_threshold,
-                    "skipped": True,
-                },
-                dry_run=dry_run,
-            )
-            return _fail_result(
-                result,
-                outcome=OUTCOME_NEEDS_HUMAN,
-                reason="too_much_generated_prose",
-                score_after=score_before_citation,
-            )
-
+        _stage_start(
+            result,
+            STAGE_CITATION_V3,
+            {"generated_loc_threshold": generated_loc_threshold},
+            dry_run=dry_run,
+        )
         citation_result = _invoke_citation_pipeline(normalized_key)
         result.citation_v3_exit = int(citation_result["exit_code"])
         citation_status = _parse_citation_status(citation_result["stdout_tail"])
+        citation_payload = (
+            citation_result.get("payload")
+            if isinstance(citation_result.get("payload"), dict)
+            else None
+        )
+        queued_findings = _parse_citation_payload_queued_findings(citation_payload)
         _stage_finish(
             result,
             STAGE_CITATION_V3,
             {
-                "generated_loc_ratio": round(generated_ratio, 4),
+                "generated_loc_threshold": generated_loc_threshold,
                 "exit_code": result.citation_v3_exit,
                 "status": citation_status,
+                "queued_findings": queued_findings,
                 "stdout_tail": citation_result["stdout_tail"],
                 "stderr_tail": citation_result["stderr_tail"],
             },
@@ -566,7 +555,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--generated-loc-threshold",
         type=float,
         default=0.5,
-        help="Maximum generated LOC ratio allowed before citation_v3 is skipped.",
+        help="Deprecated: retained for compatibility; threshold is no longer enforced.",
     )
     return parser
 

--- a/scripts/research/writer-calibration-rigorous.py
+++ b/scripts/research/writer-calibration-rigorous.py
@@ -33,6 +33,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
+VENV_PYTHON = str((REPO_ROOT / ".venv" / "bin" / "python").resolve())
 from dispatch import GEMINI_WRITER_MODEL  # noqa: E402
 
 OUTPUT_DIR = Path("/tmp/writer-rigorous")
@@ -261,14 +262,14 @@ def dispatch_writer(candidate: dict, prompt: str, timeout: int = 900) -> tuple[b
         ]
     elif family == "gemini":
         cmd = [
-            sys.executable,
+            VENV_PYTHON,
             str(REPO_ROOT / "scripts" / "dispatch.py"),
             "gemini", "-",
             "--model", model,
         ]
     elif family == "anthropic":
         cmd = [
-            sys.executable,
+            VENV_PYTHON,
             str(REPO_ROOT / "scripts" / "dispatch.py"),
             "claude", "-",
             "--model", model,
@@ -389,7 +390,7 @@ def run_one_topic_one_candidate(topic: dict, candidate: dict) -> dict:
 
     section_text = extract_section_from_codex_output(raw)
     if not section_text:
-        log(f"    ❌ writer returned empty section")
+        log("    ❌ writer returned empty section")
         result["errors"].append("writer: empty section")
         return result
 
@@ -411,7 +412,7 @@ def run_one_topic_one_candidate(topic: dict, candidate: dict) -> dict:
     cleaned_fact = extract_section_from_codex_output(raw_fact)
     fact_obj = extract_first_json_object(cleaned_fact)
     if fact_obj is None:
-        log(f"    ❌ fact-check JSON parse failed")
+        log("    ❌ fact-check JSON parse failed")
         result["errors"].append("fact-check: JSON parse failed")
         return result
 
@@ -439,7 +440,7 @@ def main() -> int:
 
     all_results: list[dict] = []
     for topic in TOPICS:
-        log(f"")
+        log("")
         log(f"==== TOPIC {topic['id']}: {topic['label']} ====")
         for candidate in CANDIDATES:
             result = run_one_topic_one_candidate(topic, candidate)

--- a/scripts/services-up
+++ b/scripts/services-up
@@ -33,9 +33,6 @@ start_api() {
   nohup "$VENV_PY" scripts/local_api.py --host 127.0.0.1 --port 8768 \
     > logs/api.log 2>&1 &
   echo $! > .pids/api.pid
-  # Age the pid file so local_api's stale-PID heuristic doesn't flag the running
-  # process as reused. See #235 follow-up TODO for a proper fix.
-  touch -t 202604150800 .pids/api.pid
   sleep 1
   if is_alive .pids/api.pid; then
     echo "api: started (pid $(cat .pids/api.pid))"
@@ -56,7 +53,6 @@ start_worker() {
     --worker-id "v2-${role}-01" --sleep-seconds 30 \
     > "logs/pipeline/${role}-worker.log" 2>&1 &
   echo $! > "$pid_file"
-  touch -t 202604150800 "$pid_file"
   sleep 1
   if is_alive "$pid_file"; then
     echo "v2-${role}-worker: started (pid $(cat "$pid_file"))"

--- a/scripts/v2_ab_test.py
+++ b/scripts/v2_ab_test.py
@@ -6,7 +6,6 @@ import os
 import random
 import re
 import subprocess
-import sys
 import tempfile
 import time
 from dataclasses import dataclass
@@ -24,6 +23,7 @@ from v1_pipeline import find_module_path, review_audit_path_for_key
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+VENV_PYTHON = str((REPO_ROOT / ".venv" / "bin" / "python").resolve())
 DEFAULT_COUNT = 50
 MODEL_ESTIMATED_USD = {
     WRITE_MODEL: WRITE_ESTIMATED_USD,
@@ -246,7 +246,7 @@ def run_v1_trial(item: SelectedModule, *, state_path: Path) -> TrialResult:
     )
     try:
         completed = subprocess.run(
-            [sys.executable, str(REPO_ROOT / "scripts" / "v1_pipeline.py"), "run", item.raw_key],
+            [VENV_PYTHON, str(REPO_ROOT / "scripts" / "v1_pipeline.py"), "run", item.raw_key],
             cwd=REPO_ROOT,
             env=env,
             capture_output=True,

--- a/tests/test_pipeline_v4.py
+++ b/tests/test_pipeline_v4.py
@@ -387,7 +387,7 @@ def test_break_to_stage_4_when_retry_gaps_become_stage_4_only(
     assert result.outcome == "clean"
 
 
-def test_generated_loc_threshold_trip(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_generated_loc_threshold_is_deprecated(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     _patch_roots(monkeypatch, tmp_path)
     generated_text = "\n".join(
         [
@@ -404,24 +404,27 @@ def test_generated_loc_threshold_trip(monkeypatch: pytest.MonkeyPatch, tmp_path:
             "",
         ]
     )
-    module_path = _write_module(tmp_path, text=generated_text)
-    assert pipeline_v4._generated_loc_ratio(module_path) > 0.5
+    _write_module(tmp_path, text=generated_text)
     monkeypatch.setattr(
         pipeline_v4.rubric_gaps,
         "gaps_for_module",
         lambda module_key: {"score": 4.5, "gaps": [], "target_loc": 600},
     )
+    called = []
 
-    def _unexpected_citation(module_key: str) -> dict[str, object]:
-        raise AssertionError("citation_v3 should be skipped when generated LOC exceeds the threshold")
+    def _invoke_citation(module_key: str) -> dict[str, object]:
+        called.append(module_key)
+        return {"exit_code": 0, "stdout_tail": ['{"status": "clean"}'], "stderr_tail": []}
 
-    monkeypatch.setattr(pipeline_v4, "_invoke_citation_pipeline", _unexpected_citation)
+    monkeypatch.setattr(pipeline_v4, "_invoke_citation_pipeline", _invoke_citation)
+    _patch_rescore_sequence(monkeypatch, [{"score": 4.5, "gaps": []}, {"score": 4.5, "gaps": []}])
 
     result = pipeline_v4.run_pipeline_v4(MODULE_KEY, generated_loc_threshold=0.5)
 
-    assert result.outcome == "needs_human"
-    assert result.reason == "too_much_generated_prose"
-    assert result.stage_reached == "CITATION_V3"
+    assert called == [MODULE_KEY]
+    assert result.outcome == "skipped_already_stable"
+    assert result.reason == ""
+    assert result.stage_reached == "DONE"
 
 
 def test_citation_residuals_queued_is_needs_human(
@@ -615,11 +618,10 @@ def test_cli_emits_json(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys:
     assert payload["outcome"] == "skipped_already_stable"
 
 
-def test_invoke_citation_pipeline_uses_sys_executable(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Regression: Stage 4 must launch pipeline_v3 with sys.executable, not a
-    hardcoded .venv/bin/python. When pipeline_v4 runs from a worktree without
-    its own .venv, the hardcoded path raised FileNotFoundError and killed
-    Stage 4 before citation_v3 could execute."""
+def test_invoke_citation_pipeline_uses_repo_venv(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression: Stage 4 should run citation_v3 using the repo venv python
+    path (which is discoverable from worktrees), not the ambient
+    interpreter."""
     captured: dict[str, object] = {}
 
     class _Completed:
@@ -638,5 +640,5 @@ def test_invoke_citation_pipeline_uses_sys_executable(monkeypatch: pytest.Monkey
 
     cmd = captured["cmd"]
     assert isinstance(cmd, list) and cmd, "subprocess.run called with no command"
-    assert cmd[0] == sys.executable, f"expected sys.executable, got {cmd[0]!r}"
+    assert str(cmd[0]).endswith(".venv/bin/python"), f"expected venv python, got {cmd[0]!r}"
     assert cmd[1].endswith("pipeline_v3.py")


### PR DESCRIPTION
## Summary

Tech-debt cleanup branch salvaged from a prior session, rebased cleanly onto current main today. Three focused commits:

1. **Drop generated-LOC gate from pipeline_v4** — was producing false positives.
2. **Replace \`sys.executable\` callsites with explicit \`.venv/bin/python\`** — directly addresses AGENTS.md rule #3 ("ALWAYS use \`.venv/bin/python\`, not \`sys.executable\` or \`python3\`"). Affects 5 production scripts.
3. **Remove stale PID touch workaround in services-up** — workaround no longer needed; cleanup.

7 files, +84/-94 LOC.

## Test plan

- [x] Rebased clean onto current main, no conflicts
- [x] \`ruff check\` clean across all 5 changed scripts
- [x] \`pytest tests/test_pipeline_v4.py\` — 17/17 pass
- [ ] Smoke-test services-up end-to-end before merge
- [ ] Cross-family review by Gemini (Codex out this window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)