### PR TITLE
fix(dispatch): codex writer needs --search; reviewer needs WebFetch+WebSearch

### DIFF
--- a/scripts/agent_runtime/adapters/codex.py
+++ b/scripts/agent_runtime/adapters/codex.py
@@ -26,6 +26,7 @@ Issue: #1184
 """
 from __future__ import annotations
 
+import os
 import re
 import shutil
 import tempfile
@@ -170,15 +171,27 @@ class CodexAdapter:
         ) as output_fd:
             output_path = Path(output_fd.name)
 
-        cmd: list[str] = [
-            codex_bin,
+        # ``--search`` enables Codex's live web tool. It is a TOP-LEVEL
+        # codex flag (codex --search exec ...), not an exec subflag — putting
+        # it after ``exec`` silently drops it. Opt-in via env var so the book
+        # chapter dispatch path (which routes through this adapter) can verify
+        # cited URLs and version-specific facts at draft time, without
+        # changing behavior for callers that only need text reasoning.
+        # Mirrors the same env var honored by ``scripts/dispatch.py``
+        # ``dispatch_codex`` / ``dispatch_codex_patch`` (PR #888).
+        use_search = os.environ.get("KUBEDOJO_CODEX_SEARCH", "0") == "1"
+
+        cmd: list[str] = [codex_bin]
+        if use_search:
+            cmd.append("--search")
+        cmd.extend([
             "exec",
             "--skip-git-repo-check",
             "-C", str(cwd),
             "--color", "never",
             "-o", str(output_path),
             "-m", model or self.default_model,
-        ]
+        ])
         cmd.extend(self._mode_flags(mode))
         cmd.append("-")  # Read prompt from stdin.
 

--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -488,7 +488,7 @@ def dispatch_gemini_with_retry(prompt: str, model: str = GEMINI_DEFAULT_MODEL,
 
 
 _CLAUDE_TEXT_ONLY_DISALLOWED = (
-    "Bash,Edit,Write,NotebookEdit,WebFetch,WebSearch,Skill,Agent,Task,ExitPlanMode"
+    "Bash,Edit,Write,NotebookEdit,Skill,Agent,Task,ExitPlanMode"
 )
 """Tool list passed to ``--disallowedTools`` when ``tools_disabled=True``.
 
@@ -504,6 +504,13 @@ delegated rewrites to a subagent that wrote to a separate context, then
 summarized in stdout (observed twice on
 ai-ai-building-module-1.2-models-apis-context-structured-output: 8 min
 of internal work, ~1 KB summary out, classic "the module above" prose).
+
+``WebFetch`` and ``WebSearch`` STAY ENABLED (removed from this list
+2026-05-05). Original blanket ban was collateral damage — it stopped
+agentic file mutation but also blinded the reviewer to fact errors
+(hallucinated CIS recs, fake kube-bench flags, dead Sources URLs).
+The v2 reviewer needs web access to do its job; without it, factual
+hallucinations from the writer pass through every cross-family review.
 
 Read-only tools (Read, Glob, Grep, TodoWrite) stay enabled —
 empirically Claude needs them to plan output without hanging. With ALL
@@ -596,11 +603,30 @@ def dispatch_codex(prompt: str, model: str = CODEX_DEFAULT_MODEL,
                    timeout: int = 900) -> tuple[bool, str]:
     """Call Codex CLI directly via `codex exec`. Returns (success, output).
 
-    Reads prompt from stdin, runs in read-only sandbox, skips git repo check.
+    Reads prompt from stdin, skips git repo check.
+
+    Environment overrides (default off — preserves prior read-only / no-search
+    behavior for callers that only need text reasoning):
+
+    - ``KUBEDOJO_CODEX_SEARCH=1`` enables ``--search`` (live web). Required for
+      writer dispatches that produce factual content (#388 module rewrites,
+      anything quoting CLI flags or version-specific behavior).
+    - ``KUBEDOJO_CODEX_SANDBOX`` overrides the sandbox mode. Valid values:
+      ``read-only`` (default), ``workspace-write``, ``danger-full-access``.
+      Use ``danger-full-access`` for dispatches that commit + push inside the
+      codex run (workspace-write blocks ``.git/worktrees/.../index.lock`` and
+      ``api.github.com``; see ``feedback_codex_danger_for_git_gh.md``).
+
     On rate-limit or quota errors, returns (False, stderr) so the caller can
     react (see run_module review branch, which degrades gracefully).
     """
-    cmd = [CODEX_CLI, "exec", "--skip-git-repo-check", "--sandbox", "read-only"]
+    sandbox = os.environ.get("KUBEDOJO_CODEX_SANDBOX", "read-only")
+    use_search = os.environ.get("KUBEDOJO_CODEX_SEARCH", "0") == "1"
+
+    cmd = [CODEX_CLI]
+    if use_search:
+        cmd.append("--search")
+    cmd.extend(["exec", "--skip-git-repo-check", "--sandbox", sandbox])
     # Allow caller to pin a model (e.g. "codex-gpt-5"); "codex" alone means default.
     if model and model != "codex":
         cmd.extend(["-m", model])

--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -707,13 +707,30 @@ def dispatch_codex_review(prompt: str, model: str = CODEX_REVIEW_DEFAULT_MODEL,
 
 def dispatch_codex_patch(prompt: str, model: str = CODEX_PATCH_DEFAULT_MODEL,
                          timeout: int = 1200) -> tuple[bool, str]:
-    """Call Codex patch via `codex exec --sandbox read-only`.
+    """Call Codex patch via `codex exec`.
 
     Codex returns a JSON edit list. `patch_worker.py` applies the edits in
     Python (`apply_review_edits` → `_atomic_write_text`), so Codex itself
-    needs no write or exec capability.
+    needs no write capability — read-only sandbox is the right default.
+
+    Environment overrides (default off — preserves prior read-only / no-search
+    behavior for callers that don't need to verify cited URLs or version-gated
+    behavior while applying review edits):
+
+    - ``KUBEDOJO_CODEX_SEARCH=1`` enables ``--search`` (live web). Useful when
+      the review verdict cites URLs or version-specific facts the patcher
+      needs to confirm before rewriting prose around them.
+    - ``KUBEDOJO_CODEX_SANDBOX`` overrides the sandbox mode. Same valid values
+      and rationale as ``dispatch_codex``; default ``read-only`` is correct
+      for the patcher because edits are applied in Python downstream.
     """
-    cmd = [CODEX_CLI, "exec", "--skip-git-repo-check", "--sandbox", "read-only"]
+    sandbox = os.environ.get("KUBEDOJO_CODEX_SANDBOX", "read-only")
+    use_search = os.environ.get("KUBEDOJO_CODEX_SEARCH", "0") == "1"
+
+    cmd = [CODEX_CLI]
+    if use_search:
+        cmd.append("--search")
+    cmd.extend(["exec", "--skip-git-repo-check", "--sandbox", sandbox])
     if model:
         cmd.extend(["-m", model])
 


### PR DESCRIPTION
## Summary

Two corrupting defaults made the v2 quality pipeline produce and ship factually unverifiable content for the entire #388 program — and a third path (the AI-history book chapter dispatch) was just as blind. This patch fixes all three.

### Bug 1: codex writer had no web access

`scripts/dispatch.py:603` (`dispatch_codex`) hardcoded `--sandbox read-only` with no `--search`. Every codex writer dispatch — including the **153 #388 modules already shipped** — was training-data-only. Codex had no way to verify CIS recommendation IDs, CLI flags, version-specific behavior, or Sources URLs.

### Bug 2: claude reviewer had no web access either

`scripts/dispatch.py:491` (`_CLAUDE_TEXT_ONLY_DISALLOWED`) banned `WebFetch` and `WebSearch` alongside the agentic file-mutation tools. Original justification (block `Edit/Write/Bash/Task` to keep writer/reviewer stdout clean — see the `k8s-capa-module-1.2-argo-events` autopsy referenced in the docstring) was valid; web tools were collateral damage. The net effect: **both writer and reviewer were blind to factual hallucinations** across the entire pipeline. Cross-family review caught structural issues but couldn't fact-check anything.

### Bug 3: codex book-chapter path + codex patcher had no `--search` either

`scripts/agent_runtime/adapters/codex.py` (used by `scripts/dispatch_chapter_research.py` → `agent_runtime.runner.invoke` for AI-history book chapter drafting) had no `--search` plumbing at all. `scripts/dispatch.py` `dispatch_codex_patch` (used by `patch_worker.py` to apply review-driven edits) likewise hardcoded `read-only` with no search. **The book chapter draft path was therefore as blind as the #388 module path.** Same bug class, two more code paths.

## Fix

- `dispatch_codex` reads `KUBEDOJO_CODEX_SEARCH=1` and `KUBEDOJO_CODEX_SANDBOX=<read-only|workspace-write|danger-full-access>`. Defaults preserve prior behavior for non-writer callers (planners, code-review-only paths). #388 batches and other writer dispatches must opt in. `--search` lands BEFORE `exec` on the codex CLI (top-level flag, not an exec subflag).
- `dispatch_codex_patch` honors the same two env vars; default still `read-only` because edits are applied in Python downstream, but the patcher can now verify URLs / version specifics in cited reviewer evidence.
- `CodexAdapter.build_invocation` (agent_runtime book path) honors `KUBEDOJO_CODEX_SEARCH=1` with the same top-level-flag ordering. Sandbox stays a first-class adapter parameter (`mode`); the runner already passes it explicitly so no env override there.
- `_CLAUDE_TEXT_ONLY_DISALLOWED` no longer blocks `WebFetch`/`WebSearch`. The agentic mutation tools stay blocked (original autopsy logic preserved). Reviewer can now resolve URLs and search docs to validate factual claims.

## Validation

Empirically confirmed on the CKS pilot redo (PR #887, content-side):

- T0 verifier: all gates pass (body_words=5016, mean_wpp=66, median_wpp=72.5, short_rate=6.6%, max_run=2)
- 4/4 sampled Sources URLs resolve (CIS, kube-bench GitHub, etcd v3.6 path, Docker Hub)
- The Docker Hub namespace asymmetry — `aquasecurity/kube-bench` on GitHub but `aquasec/kube-bench` on Docker Hub — was rendered correctly. The alt namespace `aquasecurity/kube-bench` on Docker Hub returns 404, confirming codex did look this up rather than guess from training data
- BOGUS-VALUE smoke test rejected by codex CLI confirms env var threading on the `dispatch_codex` path
- 4-case smoke on `CodexAdapter.build_invocation` confirms `--search` lands at index 1 (before `exec`) under env=1 in both `read-only` and `danger` modes; absent under env=0 / no env

## Systemic risk

The 153 already-shipped #388 modules AND the in-flight AI-history book chapters all went through the broken defaults. They need a fact-check audit pass before being trusted. The book audit pilot (Phase D, ch-33 Deep Blue) is in flight as of this PR's r2 commit, gated on the patched `_CLAUDE_TEXT_ONLY_DISALLOWED` (so the cross-family auditor can fetch + search). Phase E (back-catalog batch) is gated on Phase D metrics.

## Test plan

- [x] BOGUS sandbox smoke-test rejected by codex CLI (env-var threading proven on dispatch.py side)
- [x] CKS pilot redo (PR #887) drafted, pushed, T0 verifier passed
- [x] Sample URLs from pilot Sources section resolve
- [x] 4-case adapter threading smoke on `CodexAdapter.build_invocation` (no env / env=1 / env=0 / env=1 + danger)
- [ ] Cross-family review (codex with `--use-search` — codex didn't author this code)
- [ ] Decide: do we promote one of the env-var defaults? (recommend: keep defaults conservative; require explicit opt-in for writer/book batches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)