### PR TITLE
fix(deliberation): block round-1 short-circuit + restructure per-round directive

### DIFF
--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -807,9 +807,15 @@ def _handle_discuss(args) -> int:
          it off to every agent in parallel through
          ``agent_runtime.runner.invoke``. Each response lands back in
          the channel as a reply with ``parent_id`` set to the root.
-      3. If all agents end their response with ``[AGREE]``, treat the
-         round as converged and stop early. Otherwise continue until
-         ``max_rounds`` is hit (capped at 4 regardless of caller).
+      3. From round 2 onward, if all agents end their response with
+         ``[AGREE]``, treat the round as converged and stop early.
+         Round 1 is parallel fan-out — agents have not seen each
+         other's replies — so round-1 ``[AGREE]`` cannot mean cross-
+         agent assent and is explicitly ignored for convergence (the
+         protocol always runs at least 2 rounds; ``--max-rounds`` is
+         clamped to a minimum of 2 for the same reason). Otherwise
+         continue until ``max_rounds`` is hit (capped at 4 regardless
+         of caller).
       4. Print a one-line transcript summary at the end so the user
          can tail the thread for the full conversation.
 
@@ -858,12 +864,26 @@ def _handle_discuss(args) -> int:
         )
         return 1
 
+    # Round 1 is parallel fan-out (agents haven't seen each other yet),
+    # so the convergence guard at line ~1115 disallows round-1 short-
+    # circuit. Setting `max_rounds = 1` would let the loop exit before
+    # round 2 ever runs — agents would print "Forcing round 2" and then
+    # immediately hit the `round_idx == max_rounds` break. Clamp the
+    # floor to 2 so the round-1-cannot-converge invariant is actually
+    # enforceable. Caught by codex review of PR #889.
     MAX_ROUNDS_CAP = 4
-    max_rounds = min(max(1, args.max_rounds), MAX_ROUNDS_CAP)
+    MAX_ROUNDS_FLOOR = 2
+    max_rounds = min(max(MAX_ROUNDS_FLOOR, args.max_rounds), MAX_ROUNDS_CAP)
     if args.max_rounds > MAX_ROUNDS_CAP:
         print(
             f"ℹ️  clamping --max-rounds {args.max_rounds} to {MAX_ROUNDS_CAP} "
             f"(hard cap — escalate to a human if 4 rounds don't converge)"
+        )
+    elif args.max_rounds < MAX_ROUNDS_FLOOR:
+        print(
+            f"ℹ️  clamping --max-rounds {args.max_rounds} to {MAX_ROUNDS_FLOOR} "
+            f"(round 1 is parallel fan-out and cannot converge by design — "
+            f"see _handle_discuss docstring)"
         )
 
     if _channels.get_channel(args.channel) is None:

--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -944,19 +944,69 @@ def _handle_discuss(args) -> int:
         # Every agent sees the full channel history (pinned context +
         # monitor state + recent posts including the root). The per-
         # round directive tells them what to produce.
-        directive = (
-            f"You are participating in a bounded multi-agent discussion "
-            f"on #{args.channel}. This is round {round_idx} of at most "
-            f"{max_rounds}. Read the history above, then respond with "
-            f"your position on the root question.\n\n"
-            f"- Be concise but substantive. Cite file:line when relevant.\n"
-            f"- Push back on any other agent's claim you disagree with.\n"
-            f"- End your response with one of:\n"
-            f"    [AGREE]     — you are satisfied with the current direction\n"
-            f"    [DISAGREE]  — you still have open objections\n"
-            f"- If every agent ends with [AGREE], the discussion "
-            f"short-circuits and stops before round {max_rounds}."
-        )
+        #
+        # Round-1 vs round-2+ semantics differ structurally:
+        #
+        # - Round 1 is parallel fan-out — every agent answers the root
+        #   question independently, NONE of them have seen any other
+        #   agent's reply yet. So `[AGREE]` in round 1 cannot mean
+        #   "I agree with the other agents" (no replies to agree with).
+        #   It can only mean "I'm satisfied with my own first take."
+        #   The convergence check below explicitly disallows round-1
+        #   short-circuit because of this — see comment there.
+        #
+        # - Round 2+ is where agents see each other's round-1 (and
+        #   later) replies via the channel history, and `[AGREE]` /
+        #   `[DISAGREE]` becomes meaningful as cross-agent assent or
+        #   pushback.
+        #
+        # This was originally a single uniform directive; that produced
+        # false convergence in the собака-gender deliberation 2026-05-05
+        # in the learn-ukrainian project (3 agents disagreed substantively
+        # but all signed [AGREE] in round 1, short-circuiting before any
+        # agent saw the disagreements). Ported to kubedojo from learn-
+        # ukrainian commit 872d8376b0.
+        if round_idx == 1:
+            directive = (
+                f"You are participating in a bounded multi-agent discussion "
+                f"on #{args.channel}. This is round 1 of at most "
+                f"{max_rounds}. The other participants are answering this "
+                f"same root question in parallel right now — you have NOT "
+                f"seen their replies. Produce your independent first take.\n\n"
+                f"- Be concise but substantive. Cite file:line when relevant.\n"
+                f"- Quote authoritative sources with specific entries; do "
+                f"not paraphrase from memory.\n"
+                f"- End your response with one of:\n"
+                f"    [DISAGREE]  — your default in round 1; you have a "
+                f"substantive position and want round 2 to compare it "
+                f"against the other agents' first takes.\n"
+                f"    [AGREE]     — only if your reading of the channel "
+                f"context (pinned rules) makes the question trivially "
+                f"resolved before any cross-agent comparison is needed. "
+                f"Rare; default is [DISAGREE] in round 1.\n"
+                f"- Even if all agents sign [AGREE] in round 1, the "
+                f"protocol will NOT short-circuit until round 2+ — round 2 "
+                f"is where you read each other and either confirm or push back."
+            )
+        else:
+            directive = (
+                f"You are participating in a bounded multi-agent discussion "
+                f"on #{args.channel}. This is round {round_idx} of at most "
+                f"{max_rounds}. Read the prior-round replies in the history "
+                f"above (they are posted as replies to the root). Compare "
+                f"them to your own prior position and decide.\n\n"
+                f"- Be concise but substantive. Cite file:line when relevant.\n"
+                f"- Push back on any other agent's claim you disagree with — "
+                f"name the agent, quote the claim, give the counter-evidence.\n"
+                f"- End your response with one of:\n"
+                f"    [AGREE]     — you have read the other agents' prior "
+                f"replies and you accept the converging position (or yours "
+                f"is unchanged and the others now match it).\n"
+                f"    [DISAGREE]  — you still have open substantive objections "
+                f"after reading the others.\n"
+                f"- If every agent ends with [AGREE], the discussion "
+                f"short-circuits and stops before round {max_rounds}."
+            )
 
         # history_tail must be big enough to preserve the root
         # question across every round. `tail` truncates from the
@@ -1044,14 +1094,35 @@ def _handle_discuss(args) -> int:
         # response with the literal `[AGREE]` token at the tail.
         # Strict endswith() — substring match would false-positive on
         # "I don't [AGREE] with that. [DISAGREE]".
+        #
+        # CRITICAL: round 1 cannot short-circuit, even if every agent
+        # signs [AGREE]. Round 1 is parallel fan-out — no agent has
+        # seen any other agent's reply yet, so [AGREE] in round 1 is
+        # an "I'm done with my own answer" signal, not cross-agent
+        # assent. Forcing round 2 ensures at least one pass where
+        # agents read each other's first takes and can surface
+        # disagreement. Discovered 2026-05-05 in the собака-gender
+        # deliberation in learn-ukrainian: Gemini hallucinated a
+        # claim, Claude and Codex contradicted it, but all three
+        # signed [AGREE] in round 1 and the protocol short-circuited
+        # without any cross-agent comparison. Hallucination would have
+        # shipped to curriculum if the transcript were taken at face
+        # value. Ported from learn-ukrainian commit 872d8376b0.
         all_ok = all(ok for (_, ok) in responses.values())
         all_agreed = all_ok and all(
             text.strip().endswith("[AGREE]") for (text, _) in responses.values()
         )
-        if all_agreed:
+        if all_agreed and round_idx >= 2:
             print()
             print(f"✅ converged at round {round_idx} — all agents signed off [AGREE]")
             break
+        elif all_agreed and round_idx == 1:
+            print()
+            print(
+                "ℹ️  all agents signed [AGREE] in round 1, but round 1 cannot "
+                "short-circuit (parallel fan-out — agents have not seen each "
+                "other's replies). Forcing round 2 for cross-agent comparison."
+            )
 
         if round_idx == max_rounds:
             # Tell the caller WHY we stopped so escalation is obvious.

--- a/tests/test_bridge_inbox_cli.py
+++ b/tests/test_bridge_inbox_cli.py
@@ -184,6 +184,49 @@ def test_discuss_replies_create_delivered_reply_deliveries(mock_invoke, monkeypa
     assert all(row["parent_id"] is not None for row in reply_deliveries)
 
 
+@patch("agent_runtime.runner.invoke")
+def test_discuss_max_rounds_one_clamps_to_two(mock_invoke, monkeypatch, capsys):
+    """`--max-rounds 1` is meaningless under the round-1-cannot-converge
+    invariant — round 1 would print "Forcing round 2" and then immediately
+    exit at the `round_idx == max_rounds` break. The CLI must clamp the
+    floor to 2 so the protocol actually runs round 2.
+
+    Caught by codex review of PR #889 (round-1 short-circuit port).
+    """
+    _channels.create_channel("shared")
+    monkeypatch.setattr(_channels, "fetch_monitor_state", lambda: None)
+
+    def _discuss_result(agent: str, *_args, **_kwargs) -> Result:
+        return Result(
+            ok=True,
+            agent=agent,
+            model="test-model",
+            mode="read-only",
+            response=f"{agent} discuss reply [AGREE]",
+            stderr_excerpt=None,
+            duration_s=0.1,
+            session_id=None,
+            rate_limited=False,
+            stalled=False,
+            returncode=0,
+            usage_record={},
+        )
+
+    mock_invoke.side_effect = _discuss_result
+
+    exit_code = _run_cli(
+        ["discuss", "shared", "topic", "--with", "claude,codex", "--max-rounds", "1"]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    # Clamp message must be visible.
+    assert "clamping --max-rounds 1 to 2" in captured.out
+    # Convergence must happen at round 2, not round 1.
+    assert "✅ converged at round 2" in captured.out
+    assert "✅ converged at round 1" not in captured.out
+
+
 def test_inbox_show_with_pending_and_failed(capsys):
     _channels.create_channel("topic")
     first = _channels.post("topic", "user", "first pending", to_agents=["claude"], auto_snapshot=False)

--- a/tests/test_bridge_inbox_cli.py
+++ b/tests/test_bridge_inbox_cli.py
@@ -153,16 +153,26 @@ def test_discuss_replies_create_delivered_reply_deliveries(mock_invoke, monkeypa
 
     mock_invoke.side_effect = _discuss_result
 
+    # Round 1 cannot short-circuit (round 1 is parallel fan-out, agents
+    # haven't seen each other's replies yet, so [AGREE] in round 1 means
+    # "I'm done with my answer" not cross-agent assent). Convergence
+    # requires ≥ round 2, so use --max-rounds 2 here. Pre-protocol-fix
+    # this test passed with --max-rounds 1; updated to match the round-1
+    # short-circuit block ported from learn-ukrainian commit 872d8376b0.
     exit_code = _run_cli(
-        ["discuss", "shared", "topic", "--with", "claude,codex", "--max-rounds", "1"]
+        ["discuss", "shared", "topic", "--with", "claude,codex", "--max-rounds", "2"]
     )
 
     assert exit_code == 0
     captured = capsys.readouterr()
-    assert "✅ converged at round 1" in captured.out
+    assert "✅ converged at round 2" in captured.out
 
+    # Each round produces N*(N-1) reply deliveries (each agent's reply is
+    # delivered to every OTHER agent). With 2 agents × 2 rounds = 4 deliveries.
     reply_deliveries = _reply_deliveries()
-    assert len(reply_deliveries) == 2
+    assert len(reply_deliveries) == 4
+    # Set collapses duplicates across rounds — still just 2 distinct
+    # (from, to, status) tuples for the 2-agent case.
     assert {
         (row["from_agent"], row["to_agent"], row["status"])
         for row in reply_deliveries


### PR DESCRIPTION
## Summary

- Port learn-ukrainian commits `872d8376b0` (round-1 short-circuit fix) + `4185c0a33c` (test alignment) to kubedojo. KubeDojo's bridge was forked from learn-ukrainian before the fix landed there, so the same false-converge bug ships in `ab discuss` here.
- Round 1 of `ab discuss` is parallel fan-out — agents have not seen each other's replies yet — so [AGREE] in round 1 cannot mean cross-agent assent. The pre-fix protocol short-circuited anyway, allowing a hallucinated claim from one agent to ship as "3-agent consensus."
- This patch (1) blocks convergence until `round_idx >= 2` and (2) splits the per-round directive: round 1 explicitly tells agents "[DISAGREE] is your default, the others are answering in parallel," round 2+ tells them "read the prior-round replies, name the agent, quote the claim, give counter-evidence."

## Why this matters for kubedojo

`ab discuss` is the canonical mechanism for high-leverage decisions per `.claude/rules/decision-card.md`. A protocol-level false-converge bug can ship a hallucination into a Decision Card without being caught. The собака-gender autopsy in learn-ukrainian is the empirical proof point.

## Test plan

- [x] 73/73 bridge tests pass locally (`tests/test_bridge_channels.py` + `tests/test_bridge_inbox_cli.py`)
- [x] `test_discuss_replies_create_delivered_reply_deliveries` updated for new protocol (max-rounds 2 + 4 deliveries)
- [ ] CI green
- [ ] Cross-family review (codex per `docs/review-protocol.md` — claude-authored)

## Notes

- This is **PR 1 of a planned 3-PR bridge sync** to bring kubedojo's bridge back in line with learn-ukrainian. PR 2 will port `_citation_check.py` (`c36d159a26`, ~1.3K LOC). PR 3 will port the bridge plumbing (watch --follow, --model/--deadline, deliveries-table routing, helpers) once kubedojo workflow signals demand.
- Inline comments name the empirical incident + reference the upstream commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)