### PR TITLE
fix(ai-history): honor Part 6 review coverage ownership (#559)

### DIFF
--- a/docs/research/ai-history/chapters/ch-32-the-darpa-sur-program/status.yaml
+++ b/docs/research/ai-history/chapters/ch-32-the-darpa-sur-program/status.yaml
@@ -116,7 +116,7 @@ reader_aids: landed                                        # none | pr_open | la
 lifecycle_updated: 2026-04-30
 review_coverage:
   research:
-    claude_anchor: pending
+    claude_anchor: n/a
     gemini_gap: done
     codex_anchor: done
   prose:
@@ -124,8 +124,8 @@ review_coverage:
     gemini_prose_quality: done
     codex_prose_quality: n/a
   cross_family_satisfied:
-    research: false
+    research: true
     prose: true
-    overall: false
-  backfill_pending: true
-  last_audited: 2026-05-01
+    overall: true
+  backfill_pending: false
+  last_audited: 2026-05-05

--- a/docs/research/ai-history/chapters/ch-33-deep-blue/status.yaml
+++ b/docs/research/ai-history/chapters/ch-33-deep-blue/status.yaml
@@ -80,7 +80,7 @@ reader_aids: landed                                        # none | pr_open | la
 lifecycle_updated: 2026-04-30
 review_coverage:
   research:
-    claude_anchor: pending
+    claude_anchor: n/a
     gemini_gap: done
     codex_anchor: done
   prose:
@@ -88,8 +88,8 @@ review_coverage:
     gemini_prose_quality: done
     codex_prose_quality: n/a
   cross_family_satisfied:
-    research: false
+    research: true
     prose: true
-    overall: false
-  backfill_pending: true
-  last_audited: 2026-05-01
+    overall: true
+  backfill_pending: false
+  last_audited: 2026-05-05

--- a/docs/research/ai-history/chapters/ch-34-the-accidental-corpus/status.yaml
+++ b/docs/research/ai-history/chapters/ch-34-the-accidental-corpus/status.yaml
@@ -51,7 +51,7 @@ reader_aids: landed                                        # none | pr_open | la
 lifecycle_updated: 2026-04-30
 review_coverage:
   research:
-    claude_anchor: pending
+    claude_anchor: n/a
     gemini_gap: done
     codex_anchor: done
   prose:
@@ -59,8 +59,8 @@ review_coverage:
     gemini_prose_quality: done
     codex_prose_quality: n/a
   cross_family_satisfied:
-    research: false
+    research: true
     prose: true
-    overall: false
-  backfill_pending: true
-  last_audited: 2026-05-01
+    overall: true
+  backfill_pending: false
+  last_audited: 2026-05-05

--- a/docs/research/ai-history/chapters/ch-35-indexing-the-mind/status.yaml
+++ b/docs/research/ai-history/chapters/ch-35-indexing-the-mind/status.yaml
@@ -106,7 +106,7 @@ reader_aids: landed                                        # none | pr_open | la
 lifecycle_updated: 2026-04-30
 review_coverage:
   research:
-    claude_anchor: pending
+    claude_anchor: n/a
     gemini_gap: done
     codex_anchor: done
   prose:
@@ -114,8 +114,8 @@ review_coverage:
     gemini_prose_quality: done
     codex_prose_quality: n/a
   cross_family_satisfied:
-    research: false
+    research: true
     prose: true
-    overall: false
-  backfill_pending: true
-  last_audited: 2026-05-01
+    overall: true
+  backfill_pending: false
+  last_audited: 2026-05-05

--- a/docs/research/ai-history/chapters/ch-36-the-multicore-wall/status.yaml
+++ b/docs/research/ai-history/chapters/ch-36-the-multicore-wall/status.yaml
@@ -54,7 +54,7 @@ reader_aids: landed                                        # none | pr_open | la
 lifecycle_updated: 2026-04-30
 review_coverage:
   research:
-    claude_anchor: pending
+    claude_anchor: n/a
     gemini_gap: done
     codex_anchor: done
   prose:
@@ -62,8 +62,8 @@ review_coverage:
     gemini_prose_quality: done
     codex_prose_quality: n/a
   cross_family_satisfied:
-    research: false
+    research: true
     prose: true
-    overall: false
-  backfill_pending: true
-  last_audited: 2026-05-01
+    overall: true
+  backfill_pending: false
+  last_audited: 2026-05-05

--- a/docs/research/ai-history/chapters/ch-37-distributing-the-compute/status.yaml
+++ b/docs/research/ai-history/chapters/ch-37-distributing-the-compute/status.yaml
@@ -138,7 +138,7 @@ reader_aids: landed                                        # none | pr_open | la
 lifecycle_updated: 2026-04-30
 review_coverage:
   research:
-    claude_anchor: pending
+    claude_anchor: n/a
     gemini_gap: done
     codex_anchor: done
   prose:
@@ -146,8 +146,8 @@ review_coverage:
     gemini_prose_quality: done
     codex_prose_quality: n/a
   cross_family_satisfied:
-    research: false
+    research: true
     prose: true
-    overall: false
-  backfill_pending: true
-  last_audited: 2026-05-01
+    overall: true
+  backfill_pending: false
+  last_audited: 2026-05-05

--- a/scripts/audit_review_coverage.py
+++ b/scripts/audit_review_coverage.py
@@ -72,10 +72,13 @@ def _lane_from_title(title: str) -> str | None:
     return None
 
 
-def _author_family(chapter_num: int) -> str:
-    # Issue #559 ownership model: Parts 1-2 and Part 3 through Ch15 are
-    # Claude-authored; Ch16 and Parts 4-9 are Codex-authored.
-    if chapter_num <= 15:
+def _research_author_family(chapter_num: int) -> str:
+    # Issue #559 ownership model plus the later Part 6 split:
+    # Parts 1-2 and Part 3 through Ch15 were Claude-authored; Ch32-Ch37
+    # were also Claude-authored research contracts after the 2026-04-28
+    # role split. Other research contracts in this audit use Codex as the
+    # author family.
+    if chapter_num <= 15 or 32 <= chapter_num <= 37:
         return "claude"
     return "codex"
 
@@ -94,7 +97,7 @@ def _expected_lane_fields(chapter_num: int, lane: str) -> set[str]:
     Ch10-Ch15 were reviewed by Claude+Gemini (pre-#421). Both patterns are valid
     cross-family coverage.
     """
-    author = _author_family(chapter_num)
+    author = _research_author_family(chapter_num)
     if lane == "research":
         if author == "claude":
             return {"gemini_gap", "codex_anchor"}

--- a/tests/test_audit_review_coverage.py
+++ b/tests/test_audit_review_coverage.py
@@ -1,0 +1,21 @@
+from scripts.audit_review_coverage import _expected_lane_fields, _lane_satisfied
+
+
+def test_part6_claude_research_requires_codex_and_gemini_reviews():
+    assert _expected_lane_fields(32, "research") == {"codex_anchor", "gemini_gap"}
+    assert _expected_lane_fields(37, "research") == {"codex_anchor", "gemini_gap"}
+
+
+def test_part6_exception_does_not_apply_after_ch37():
+    assert _expected_lane_fields(38, "research") == {"claude_anchor", "gemini_gap"}
+
+
+def test_part6_codex_gemini_research_markers_satisfy_cross_family_rule():
+    values = {
+        "claude_anchor": "n/a",
+        "gemini_gap": "done",
+        "codex_anchor": "done",
+    }
+
+    assert _lane_satisfied(values, 32, "research") is True
+


### PR DESCRIPTION
## Summary

Repairs the AI History review-coverage audit after the premature-closure sweep reopened #421 and #559. Ch32-Ch37 were Claude-authored Part 6 research contracts with existing Codex anchor verification + Gemini gap-audit comments. The audit was incorrectly treating them as Codex-authored and waiting for `claude_anchor`, which would be self-review.

Changes:
- adds the Ch32-Ch37 Part 6 research ownership exception in `scripts/audit_review_coverage.py`
- adds focused unit coverage for the Ch37/Ch38 boundary
- updates the six stale chapter `review_coverage` status blocks to match the strict GitHub audit result

## Verification

- `.venv/bin/python -m pytest tests/test_audit_review_coverage.py` — PASS
- `.venv/bin/ruff check scripts/audit_review_coverage.py tests/test_audit_review_coverage.py` — PASS
- `git diff --check` — PASS
- `.venv/bin/python scripts/audit_review_coverage.py --strict-gh` — PASS, `backfill_pending_count: 0`
- `.venv/bin/python scripts/test_pipeline.py` — PASS, 166 tests

## Issue State

Addresses the AI History review-backfill part of the reopened premature closures: #421 and #559. Does not close the broader quality backlog issues reopened in the same audit; those still have hundreds of modules pending and must remain open.