### PR TITLE
fix(gemini): fallback model on rate-limit-exhausted

### DIFF
--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -469,7 +469,16 @@ def dispatch_gemini_with_retry(prompt: str, model: str = GEMINI_DEFAULT_MODEL,
                       file=sys.stderr)
                 time.sleep(delay)
                 continue
-            # All retries exhausted.
+            # All retries exhausted on the primary model — last-ditch try the
+            # fallback model on subscription. If gemini-3.1-pro-preview is
+            # capacity-out, gemini-3-flash-preview / auto often still answers.
+            if model != GEMINI_FALLBACK_MODEL:
+                print(f"Rate-limit retries exhausted on {model} — last-ditch on fallback model {GEMINI_FALLBACK_MODEL} (subscription)",
+                      file=sys.stderr)
+                ok, output = dispatch_gemini(prompt, GEMINI_FALLBACK_MODEL, review, timeout, mcp,
+                                             use_subscription=True)
+                if ok:
+                    return True, output
             return False, output
 
         # Timeout — don't retry, just fail (Gemini is slow, not broken)

--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -494,10 +494,13 @@ def dispatch_gemini_with_retry(prompt: str, model: str = GEMINI_DEFAULT_MODEL,
         if output == "TIMEOUT":
             return False, output
 
-        # Non-rate-limit, non-timeout failure — try fallback model once
-        if model != GEMINI_FALLBACK_MODEL:
-            print(f"Retrying with fallback model: {GEMINI_FALLBACK_MODEL}", file=sys.stderr)
-            return dispatch_gemini(prompt, GEMINI_FALLBACK_MODEL, review, timeout, mcp,
+        # Non-rate-limit, non-timeout failure — try fallback model once.
+        # Reviews use the explicit GEMINI_REVIEW_FALLBACK_MODEL pin to avoid
+        # silently routing verdicts through "auto" (which can pick 2.5-flash).
+        nrl_fallback = GEMINI_REVIEW_FALLBACK_MODEL if review else GEMINI_FALLBACK_MODEL
+        if model != nrl_fallback:
+            print(f"Retrying with fallback model: {nrl_fallback}", file=sys.stderr)
+            return dispatch_gemini(prompt, nrl_fallback, review, timeout, mcp,
                                    use_subscription=use_subscription)
 
         return False, output

--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -91,6 +91,12 @@ GEMINI_WRITER_MODEL = "gemini-3.1-pro-preview"
 GEMINI_DEFAULT_MODEL = "gemini-3-flash-preview"
 GEMINI_REVIEW_MODEL = "gemini-3.1-pro-preview"  # Pro for reviews — hallucinations on Flash cost real iteration time
 GEMINI_FALLBACK_MODEL = "auto"
+# Last-ditch fallback when the review model is rate-limited on every tier.
+# Pinned to gemini-3-flash-preview rather than "auto" because auto can pick
+# gemini-2.5-flash which hallucinates on review tasks (per memory
+# feedback_gemini_models.md). Flash-3 misses some Pro nuance but is the agreed
+# "good enough to publish a verdict" floor when Pro is capacity-out.
+GEMINI_REVIEW_FALLBACK_MODEL = "gemini-3-flash-preview"
 CLAUDE_DEFAULT_MODEL = "claude-sonnet-4-6"
 CODEX_DEFAULT_MODEL = "codex"  # lets codex CLI pick the default model
 CODEX_REVIEW_DEFAULT_MODEL = "codex"
@@ -471,11 +477,14 @@ def dispatch_gemini_with_retry(prompt: str, model: str = GEMINI_DEFAULT_MODEL,
                 continue
             # All retries exhausted on the primary model — last-ditch try the
             # fallback model on subscription. If gemini-3.1-pro-preview is
-            # capacity-out, gemini-3-flash-preview / auto often still answers.
-            if model != GEMINI_FALLBACK_MODEL:
-                print(f"Rate-limit retries exhausted on {model} — last-ditch on fallback model {GEMINI_FALLBACK_MODEL} (subscription)",
+            # capacity-out, gemini-3-flash-preview often still answers.
+            # Reviews use GEMINI_REVIEW_FALLBACK_MODEL (explicit, never "auto")
+            # to avoid silently picking gemini-2.5-flash for verdicts.
+            fallback = GEMINI_REVIEW_FALLBACK_MODEL if review else GEMINI_FALLBACK_MODEL
+            if model != fallback:
+                print(f"Rate-limit retries exhausted on {model} — last-ditch on fallback model {fallback} (subscription)",
                       file=sys.stderr)
-                ok, output = dispatch_gemini(prompt, GEMINI_FALLBACK_MODEL, review, timeout, mcp,
+                ok, output = dispatch_gemini(prompt, fallback, review, timeout, mcp,
                                              use_subscription=True)
                 if ok:
                     return True, output

--- a/tests/test_dispatch_gemini_timeout.py
+++ b/tests/test_dispatch_gemini_timeout.py
@@ -221,3 +221,95 @@ def test_gemini_with_retry_double_429_falls_back_to_subscription_backoff():
     # backoff sleep → subscription (success)
     assert [c["use_subscription"] for c in calls] == [False, True, True]
     sleep_mock.assert_called_once()  # exactly one backoff between the two subscription attempts
+
+
+def test_gemini_with_retry_falls_back_to_review_fallback_model_on_exhaust():
+    """When every retry on the primary review model returns rate-limit, the
+    last-ditch dispatch must hit GEMINI_REVIEW_FALLBACK_MODEL on subscription
+    once before giving up. This covers the gemini-3.1-pro-preview capacity-out
+    case from PR #891 / #892 (2026-05-05)."""
+    calls: list[dict] = []
+
+    def fake_dispatch(prompt, model, review, timeout, mcp, use_subscription=None):
+        calls.append({"model": model, "review": review,
+                      "use_subscription": use_subscription})
+        # Every primary-model attempt rate-limits; the fallback model succeeds.
+        if model == dispatch.GEMINI_REVIEW_FALLBACK_MODEL:
+            return True, "fallback-model verdict"
+        return False, "429 rate limit"
+
+    with patch("dispatch.dispatch_gemini", side_effect=fake_dispatch), \
+         patch("dispatch.dispatch_gemini_rest", return_value=(False, "REST not used in this test")), \
+         patch("dispatch.time.sleep"), \
+         patch.object(dispatch, "_FORCE_GEMINI_SUBSCRIPTION", False):
+        ok, output = dispatch.dispatch_gemini_with_retry(
+            "review this", model=dispatch.GEMINI_REVIEW_MODEL,
+            review=True, max_retries=2,
+        )
+
+    assert ok is True
+    assert output == "fallback-model verdict"
+    # Final call must be the review fallback model on subscription.
+    assert calls[-1]["model"] == dispatch.GEMINI_REVIEW_FALLBACK_MODEL
+    assert calls[-1]["use_subscription"] is True
+    assert calls[-1]["review"] is True
+
+
+def test_gemini_with_retry_no_fallback_when_already_on_fallback_model():
+    """Recursion guard: if the caller already passed the fallback model and
+    every retry rate-limits, we must NOT re-dispatch on the same model — that
+    would double the burn for nothing. Just return the failure.
+
+    Uses review=False so dispatch.py:423's auto-promote-to-Pro doesn't fire
+    (that branch only triggers when model == GEMINI_DEFAULT_MODEL).
+    """
+    calls: list[dict] = []
+
+    def fake_dispatch(prompt, model, review, timeout, mcp, use_subscription=None):
+        calls.append({"model": model, "use_subscription": use_subscription})
+        return False, "429 rate limit"
+
+    with patch("dispatch.dispatch_gemini", side_effect=fake_dispatch), \
+         patch("dispatch.dispatch_gemini_rest", return_value=(False, "REST not used in this test")), \
+         patch("dispatch.time.sleep"), \
+         patch.object(dispatch, "_FORCE_GEMINI_SUBSCRIPTION", False):
+        ok, output = dispatch.dispatch_gemini_with_retry(
+            "draft this", model=dispatch.GEMINI_FALLBACK_MODEL,
+            review=False, max_retries=2,
+        )
+
+    assert ok is False
+    assert "429" in output
+    # No dispatch call should be on a different model — recursion guard works.
+    assert all(c["model"] == dispatch.GEMINI_FALLBACK_MODEL for c in calls)
+
+
+def test_gemini_with_retry_non_review_uses_auto_fallback():
+    """Non-review (writer) calls use GEMINI_FALLBACK_MODEL ("auto"), not the
+    review-specific pin. This keeps the auto-pick latitude for cheap writer
+    work while reserving the explicit pin for verdict-publishing reviews."""
+    calls: list[dict] = []
+
+    def fake_dispatch(prompt, model, review, timeout, mcp, use_subscription=None):
+        calls.append({"model": model, "review": review})
+        if model == dispatch.GEMINI_FALLBACK_MODEL:
+            return True, "auto verdict"
+        return False, "429 rate limit"
+
+    # Use a non-default writer model so dispatch.py:423 auto-promote doesn't
+    # silently swap us to GEMINI_REVIEW_MODEL.
+    primary = "gemini-3-flash-preview-experimental"
+
+    with patch("dispatch.dispatch_gemini", side_effect=fake_dispatch), \
+         patch("dispatch.dispatch_gemini_rest", return_value=(False, "REST not used in this test")), \
+         patch("dispatch.time.sleep"), \
+         patch.object(dispatch, "_FORCE_GEMINI_SUBSCRIPTION", False):
+        ok, output = dispatch.dispatch_gemini_with_retry(
+            "draft this", model=primary,
+            review=False, max_retries=2,
+        )
+
+    assert ok is True
+    # Final call must be auto fallback (not the review-specific one).
+    assert calls[-1]["model"] == dispatch.GEMINI_FALLBACK_MODEL
+    assert calls[-1]["review"] is False

--- a/tests/test_dispatch_gemini_timeout.py
+++ b/tests/test_dispatch_gemini_timeout.py
@@ -284,6 +284,43 @@ def test_gemini_with_retry_no_fallback_when_already_on_fallback_model():
     assert all(c["model"] == dispatch.GEMINI_FALLBACK_MODEL for c in calls)
 
 
+def test_gemini_with_retry_no_fallback_when_review_already_on_review_fallback():
+    """Recursion guard, review variant: if a review caller is already on
+    GEMINI_REVIEW_FALLBACK_MODEL and every retry rate-limits, no extra
+    dispatch must fire. Mirrors the writer-side guard test but on the
+    review path so the explicit-pin branch is also exercised.
+
+    Patches GEMINI_DEFAULT_MODEL to a synthetic value so dispatch.py:423's
+    auto-promote-to-Pro doesn't silently swap our test model: the real
+    GEMINI_DEFAULT_MODEL and GEMINI_REVIEW_FALLBACK_MODEL are both
+    "gemini-3-flash-preview", so passing the latter as the explicit
+    starting model would otherwise trigger the auto-promote branch.
+    """
+    calls: list[dict] = []
+
+    def fake_dispatch(prompt, model, review, timeout, mcp, use_subscription=None):
+        calls.append({"model": model, "review": review,
+                      "use_subscription": use_subscription})
+        return False, "429 rate limit"
+
+    with patch("dispatch.dispatch_gemini", side_effect=fake_dispatch), \
+         patch("dispatch.dispatch_gemini_rest", return_value=(False, "REST not used in this test")), \
+         patch("dispatch.time.sleep"), \
+         patch.object(dispatch, "_FORCE_GEMINI_SUBSCRIPTION", False), \
+         patch.object(dispatch, "GEMINI_DEFAULT_MODEL", "_synthetic-default-not-real"):
+        ok, output = dispatch.dispatch_gemini_with_retry(
+            "review this", model=dispatch.GEMINI_REVIEW_FALLBACK_MODEL,
+            review=True, max_retries=2,
+        )
+
+    assert ok is False
+    assert "429" in output
+    # Every dispatch call stays on the review fallback model — no double-burn
+    # on a different model after exhausting retries.
+    assert all(c["model"] == dispatch.GEMINI_REVIEW_FALLBACK_MODEL for c in calls)
+    assert all(c["review"] is True for c in calls)
+
+
 def test_gemini_with_retry_non_review_uses_auto_fallback():
     """Non-review (writer) calls use GEMINI_FALLBACK_MODEL ("auto"), not the
     review-specific pin. This keeps the auto-pick latitude for cheap writer


### PR DESCRIPTION
## Summary
- When `gemini-3.1-pro-preview` (review default) is server-side capacity-out, both the API key and OAuth tiers return "No capacity available" 429s on every retry. Backoff doesn't help — the model itself is congested.
- Previously: after exhausting `max_retries` on subscription, dispatch returned `(False, output)` and the caller had to be re-dispatched manually.
- Now: when retries exhaust on the primary model with rate-limit errors, last-ditch dispatch on `GEMINI_FALLBACK_MODEL` (`"auto"` → CLI picks gemini-3-flash-preview / gemini-2.5-flash) on the subscription path. Guarded by `model != GEMINI_FALLBACK_MODEL` to prevent infinite recursion if fallback also rate-limits.

API → OAuth fallback was already working as designed (lines 427-461). The gap was only at the end of the rate-limit retry loop.

## Trigger

PR #891 + #892 review timeouts on 2026-05-05: `gemini-3.1-pro-preview` out-of-capacity. REST 503 → CLI API-key 429 → OAuth 429 → backoff 429 → timeout (no fallback model attempt). With this fix, the chain ends with one shot at `auto` on subscription before giving up.

## Test plan
- [x] `.venv/bin/ruff check scripts/dispatch.py` — clean
- [x] `.venv/bin/pytest tests/test_dispatch_gemini_timeout.py tests/test_quality_dispatchers.py` — 28/28 pass
- [x] End-to-end smoke: `echo "what is 2+2? answer in 1 word" | dispatch.py gemini --review --timeout 60 -` → REST timed out, fell back to OAuth CLI, returned `Four`
- [ ] Codex cross-family review per `docs/review-protocol.md` (claude-authored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)