### PR TITLE
fix(388): delete meta-commentary paragraph in anomaly-detection module (#892 follow-up)

### DIFF
--- a/src/content/docs/ai-ml-engineering/machine-learning/module-1.9-anomaly-detection-and-novelty-detection.md
+++ b/src/content/docs/ai-ml-engineering/machine-learning/module-1.9-anomaly-detection-and-novelty-detection.md
@@ -41,12 +41,6 @@ Choosing a detector is inseparable from deciding what training data
 means, what score semantics mean, what threshold means, and what kinds
 of errors the surrounding workflow can tolerate.
 
-This module builds directly on the prerequisite ideas without simply
-restating them with a new vocabulary. The worked examples are Python
-and scikit-learn focused. When this scoring logic is later deployed on
-Kubernetes 1.35 or newer, this curriculum uses `k` as the kubectl alias
-after `alias k=kubectl`, but this module does not require cluster access.
-
 Anomaly detection introduces a harder epistemic problem:
 the detector can always produce a ranking, but the ranking is not the
 same thing as verified abnormality.


### PR DESCRIPTION
## Summary

Follow-up to PR #892 (already merged as `ca1a9b2b`). Gemini round-2 review caught that the previous fix RELOCATED the prerequisites meta-commentary paragraph into `## Why This Module Matters` instead of DELETING it. The original NEEDS CHANGES verdict explicitly said: "Delete this entire paragraph (lines 44-48)."

## Fix

Single-paragraph deletion in `src/content/docs/ai-ml-engineering/machine-learning/module-1.9-anomaly-detection-and-novelty-detection.md`:

```
- This module builds directly on the prerequisite ideas without simply
- restating them with a new vocabulary. The worked examples are Python
- and scikit-learn focused. When this scoring logic is later deployed on
- Kubernetes 1.35 or newer, this curriculum uses `k` as the kubectl alias
- after `alias k=kubectl`, but this module does not require cluster access.
```

## Verification

- [x] `npm run build` — 2015 pages, 0 errors
- [x] `grep "kubectl alias\|builds directly on the prerequisite"` — 0 matches
- [ ] Gemini cross-family re-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)