### PR TITLE
feat(338): rewrite Kubernetes for ML module (#338)

### DIFF
--- a/src/content/docs/ai-ml-engineering/mlops/module-1.4-kubernetes-for-ml.md
+++ b/src/content/docs/ai-ml-engineering/mlops/module-1.4-kubernetes-for-ml.md
@@ -5,189 +5,76 @@ sidebar:
   order: 605
 ---
 
-## The Cyber Monday Meltdown
+> **Complexity**: Intermediate
+>
+> **Time to Complete**: 90-120 minutes
+>
+> **Prerequisites**: [Module 1.1: MLOps Foundations](./module-1.1-ml-devops-foundations/), [Module 1.2: Docker for ML](./module-1.2-docker-for-ml/), [Module 1.3: CI/CD for ML](./module-1.3-cicd-for-ml/), basic YAML, container images, and command-line Kubernetes practice.
 
-A retailer can enter a peak sales event with an ML recommendation service pinned to a small, fixed set of servers and then discover that a sudden traffic spike exceeds what those machines can handle.
-
-A sudden traffic spike can overwhelm one inference node, push traffic onto the remaining nodes, and trigger a cascading failure if the service is running on a small fixed pool of servers.
-
-When recovery depends on manual provisioning and configuration, an ML service can stay down far too long during a peak event and cause serious business damage. The operational lesson is that dynamic workloads need automated scaling, traffic management, and failure recovery.
+---
 
 ## What You'll Be Able to Do
 
-By the end of this comprehensive module, you will be deeply equipped to:
-- **Design** highly scalable, resilient machine learning inference architectures using core Kubernetes primitives.
-- **Implement** robust, fault-tolerant deployment strategies that guarantee absolute zero-downtime model updates.
-- **Configure** precise, aggressive GPU scheduling and rigid resource management policies tailored specifically for deep learning workloads.
-- **Evaluate** and select between diverse autoscaling mechanisms to perfectly optimize performance while strictly controlling infrastructure costs.
-- **Diagnose** and permanently resolve complex, cascading production issues directly related to memory management, node exhaustion, and pod lifecycles.
-- **Compare** the operational mechanics of Horizontal and Vertical Pod Autoscalers based on the specific volatility of the target workload.
+- **Design** a Kubernetes-based inference architecture using Deployments, Services, probes, rollout strategy, and workload isolation.
+- **Configure** CPU, memory, GPU, storage, and scheduling controls for machine learning services and training jobs.
+- **Evaluate** Horizontal Pod Autoscaler, Vertical Pod Autoscaler, Cluster Autoscaler, and queue-based scaling choices for ML workloads.
+- **Diagnose** Pending Pods, OOMKilled containers, slow model startup, failed rollouts, and GPU placement failures from Kubernetes evidence.
+- **Implement** a runnable local inference mock with manifests, service exposure, rollout checks, autoscaling hooks, and cleanup steps.
 
-## The Scaling Challenge
+## Why This Module Matters
 
-Deploying a machine learning model to a local development environment or a single standalone server is relatively straightforward. You load the model weights into memory, expose a simple API endpoint, and process incoming requests. However, this simplistic approach rapidly crumbles under the rigorous demands of a true production environment.
+Most machine learning models do not fail in production because the model file suddenly forgets statistics. They fail because the system around the model cannot keep up with traffic, memory pressure, rollout timing, hardware scarcity, or ordinary operational change. A classifier that behaves correctly in a notebook may still become unavailable when every replica loads a two-gigabyte model at the same time. A batch training job may be written correctly and still sit Pending for hours because no node matches its GPU request. An inference API may pass unit tests and still return errors during every deployment because readiness probes mark Pods healthy before the model is actually loaded.
 
-When your application requires high availability, fault tolerance, and the ability to process tens of thousands of requests per second, a single server becomes a catastrophic single point of failure. You must distribute the workload across multiple physical or virtual machines, ensure traffic is evenly balanced across those machines, and maintain the operational capacity to dynamically adjust computational resources based on fluctuating user demand.
+Kubernetes is not a magic machine learning platform. It is a reconciliation system for running containerized workloads on shared infrastructure. That distinction matters because Kubernetes gives you durable primitives, not automatic judgment. Deployments keep replicas running, Services give stable network identities to changing Pods, probes tell traffic routers when a process is ready, resource requests help the scheduler place work, limits protect nodes from runaway processes, and autoscalers adjust capacity when metrics cross a policy boundary. A productive MLOps engineer learns how those primitives combine into a reliable serving or training workflow.
 
-This is the central orchestration challenge. Kubernetes provides a declarative, resilient framework to solve this. Instead of manually managing servers, you define the desired state of your application. Kubernetes continuously monitors the actual state of the system and automatically takes corrective action to ensure it matches your defined desired state.
+The ML-specific challenge is that model workloads put unusual stress on ordinary Kubernetes assumptions. Large model artifacts make startup slow, GPUs are scarce and expensive, training jobs can run for hours, inference traffic can spike quickly, and bad rollout behavior can create customer-visible errors even when the container process stays alive. The right design therefore starts from the workload question: is this stateless online inference, scheduled batch scoring, distributed training, feature generation, or asynchronous embedding work? The answer determines which Kubernetes objects are appropriate and which controls are dangerous distractions.
 
-```mermaid
-flowchart TD
-    subgraph Single Server
-        A[ML Model: 1 instance] -->|What happens when this dies?| B(Downtime)
-        A -->|Can't handle 10K req/sec| C(Bottleneck)
-        A -->|No GPU sharing| D(Inefficiency)
-    end
+This module treats Kubernetes as an engineering substrate for ML, not as a collection of YAML recipes. You will learn how to reason from workload behavior to objects, requests, probes, autoscaling metrics, rollout policy, and debugging commands. The examples assume Kubernetes 1.35 or newer. Before using short commands, define the standard alias with `alias k=kubectl`; all `k` examples in this module assume that alias exists.
 
-    subgraph Kubernetes Cluster Solution
-        LB[Load Balancer] --> AS[Autoscaler: scale based on CPU/GPU/queue]
-        AS --> P1[Pod 1 replica]
-        AS --> P2[Pod 2 replica]
-        AS --> P3[Pod 3 replica]
-        AS --> PN[Pod N replica]
-    end
-```
+## Did You Know
 
-> **Did You Know?** Kubernetes was originally open-sourced by Google on June 6, 2014, [heavily inspired by their internal Borg system](https://kubernetes.io/blog/2015/04/borg-predecessor-to-kubernetes/). [Kubernetes is widely used for production workloads, including machine learning systems](https://kubernetes.io/case-studies/).
+- Kubernetes does not schedule containers directly; it schedules Pods, and the Pod is the unit that receives an IP address, lifecycle state, volumes, resource requests, and placement decisions.
+- A Deployment is usually the right controller for stateless inference, while a Job is usually the right controller for finite training, migration, or batch scoring work that should run to completion.
+- GPU scheduling depends on advertised extended resources such as `nvidia.com/gpu`; Kubernetes will not infer GPU needs from a Python package, CUDA image tag, or model framework.
+- Readiness probes protect users from unfinished model startup, while liveness probes protect the cluster from processes that are stuck badly enough that restarting is better than waiting.
 
-> **Stop and think**: If a Pod represents a single instance of your model, what happens to ongoing user requests if the node hosting that Pod suddenly loses power? How does the system recover without manual intervention?
+## 1. Map ML Workloads to Kubernetes Objects
 
-### What Kubernetes Solves for ML
+The first design decision is not which YAML field to write. The first decision is what kind of workload you are operating. Online inference usually needs a Deployment because it should keep several interchangeable replicas alive behind a stable Service. Batch scoring often fits a Job because it should run until a finite dataset is processed. Scheduled retraining may fit a CronJob when the cadence is time-based. Distributed training may need a higher-level operator, but the underlying scheduling still depends on Pods, resource requests, volumes, and node placement. Treating every workload as a long-running Deployment creates systems that are harder to debug and easier to overprovision.
 
-Kubernetes fundamentally addresses the core operational complexities of deploying machine learning models at massive scale by abstracting the underlying hardware into a unified compute fabric:
+For ML serving, a Kubernetes Deployment gives you three important controls. The replica count defines how many interchangeable inference Pods should exist. The rollout strategy controls how old Pods are replaced by new Pods. The Pod template defines the runtime contract: image, ports, environment, probes, resource requests, limits, volumes, and security settings. If the model service is stateless and reads model artifacts from the image, object storage, or mounted volume, this controller is normally the simplest production starting point. If the service writes training state locally, a Deployment is probably the wrong abstraction.
+
+The Service object solves a different problem. Pods are intentionally replaceable, so their IP addresses cannot be treated as stable dependencies. A Service gives clients a durable name and load-balances traffic to Pods selected by labels. For internal feature services, a `ClusterIP` Service is often enough. For public inference APIs, a cloud load balancer or ingress controller may sit in front of the Service. The Service does not know whether the backend is an ML model, a cache, or a normal API. It only knows which Pods match the selector and which Pods are ready to receive traffic.
 
 ```mermaid
-flowchart TD
-    subgraph KUBERNETES BENEFITS FOR ML
-        direction TB
-        B1[1. SCALABILITY: Auto-scale from 1 to 100 replicas based on load. Handle traffic spikes without manual intervention.]
-        B2[2. HIGH AVAILABILITY: If a pod dies, Kubernetes restarts it automatically. Spread replicas across nodes for fault tolerance.]
-        B3[3. GPU MANAGEMENT: Schedule ML workloads on GPU nodes. Share GPUs across multiple pods.]
-        B4[4. RESOURCE EFFICIENCY: Pack multiple workloads on same hardware. Set limits to prevent noisy neighbors.]
-        B5[5. DEPLOYMENT FLEXIBILITY: Rolling updates, canary deployments. Rollback instantly if deployment fails.]
-    end
+flowchart LR
+    Client[Client or API gateway] --> Service[Service: stable DNS name]
+    Service --> PodA[Pod: model replica A]
+    Service --> PodB[Pod: model replica B]
+    Service --> PodC[Pod: model replica C]
+    Deployment[Deployment controller] --> PodA
+    Deployment --> PodB
+    Deployment --> PodC
 ```
 
-## Kubernetes Architecture
+The important operational lesson is that each object answers a separate question. A Deployment answers, "How many model-serving replicas should exist, and how should they roll forward?" A Service answers, "How do clients find whichever replicas are ready right now?" A Job answers, "How do I run this finite training or scoring task to completion?" A PersistentVolumeClaim answers, "How does this Pod receive storage without knowing the provider-specific disk identity?" Good Kubernetes design is mostly the discipline of matching the object to the workload instead of copying a generic manifest.
 
-Understanding the foundational architecture of Kubernetes is absolutely essential for effective debugging and system design. A Kubernetes cluster is structurally divided into two primary sections: the Control Plane and the Worker Nodes.
+## 2. Build a Minimal Inference Deployment
 
-### Core Components
-
-The Control Plane acts as the central nervous system of the cluster. It meticulously maintains the global state, schedules workloads to available nodes, and responds to various cluster events. The API Server acts as the primary interface, receiving and validating all REST requests. The Scheduler evaluates specific resource requirements and assigns incoming workloads to appropriate Worker Nodes. The Controller Manager runs continuous background reconciliation loops. Finally, etcd is a highly available key-value database that serves as the ultimate, uncorrupted source of truth for all configuration data.
-
-Worker Nodes execute your workloads. Each node runs a kubelet, a lightweight agent ensuring containers are running correctly within a Pod. The kube-proxy maintains the necessary network iptables or IPVS rules to facilitate communication. For ML, specialized GPU Nodes run additional components to safely expose hardware accelerators to the environment.
-
-```mermaid
-flowchart TD
-    subgraph Control Plane
-        API[API Server]
-        SCHED[Scheduler]
-        CTRL[Controller Manager]
-        ETCD[(etcd cluster state database)]
-        API --- SCHED
-        API --- CTRL
-        API --- ETCD
-    end
-
-    subgraph Worker Node 1
-        K1[kubelet]
-        KP1[kube-proxy]
-        CR1[Container Runtime]
-        P1[Pod]
-        P2[Pod]
-    end
-
-    subgraph Worker Node 2
-        K2[kubelet]
-        KP2[kube-proxy]
-        CR2[Container Runtime]
-        P3[Pod]
-        P4[Pod]
-    end
-
-    subgraph GPU Node
-        K3[kubelet]
-        KP3[kube-proxy]
-        NR[NVIDIA Runtime]
-        GPU[GPU Hardware]
-    end
-
-    API --> K1
-    API --> K2
-    API --> K3
-```
-
-### Key Concepts
-
-Kubernetes utilizes a highly specific set of abstractions to manage applications. These concepts form a clear operational hierarchy, starting from broad organizational boundaries down to the specific execution environments where your code runs.
-
-```mermaid
-graph TD
-    NS[Namespace: isolation boundary] --> DEP[Deployment: manages replicas]
-    DEP --> RS[ReplicaSet: ensures N pods running]
-    RS --> POD[Pod: runs containers]
-    POD --> CONT[Container: your app]
-```
-
-## Core Kubernetes Objects
-
-To successfully deploy a machine learning model, you must perfectly translate your precise infrastructure requirements into Kubernetes objects using declarative YAML manifests.
-
-### Pod
-
-The Pod is the smallest atomic unit of execution in Kubernetes. It encapsulates one or more containers, providing them with shared storage volumes and a unique network IP. For machine learning inference, a Pod typically contains a single container running a serving framework like Triton or FastAPI.
+A useful inference Deployment begins with a boring contract: immutable image, stable port, explicit resource requests, readiness probe, liveness probe, and labels that match a Service. The image should contain your server code and either the model artifact itself or the logic to fetch the artifact during startup. The request values should describe the resources needed for normal placement, while limits should describe the boundary beyond which the workload is allowed to be throttled or killed. This is not only about fairness; the scheduler cannot place a workload intelligently if the manifest hides the workload size.
 
 ```yaml
-# pod.yaml - Basic ML inference pod
-apiVersion: v1
-kind: Pod
-metadata:
-  name: ml-inference
-  labels:
-    app: sentiment-classifier
-spec:
-  containers:
-  - name: model
-    image: myregistry/sentiment:v2.0.0
-    ports:
-    - containerPort: 8000
-    resources:
-      requests:
-        memory: "1Gi"
-        cpu: "500m"
-      limits:
-        memory: "2Gi"
-        cpu: "1000m"
-    env:
-    - name: MODEL_PATH
-      value: "/models/sentiment.pt"
-    volumeMounts:
-    - name: model-storage
-      mountPath: /models
-  volumes:
-  - name: model-storage
-    persistentVolumeClaim:
-      claimName: model-pvc
-```
-
-### Deployment
-
-Managing individual Pods manually is highly dangerous. If a node fails, naked Pods are permanently lost. A Deployment acts as a rigorous supervisory controller. You declare the desired number of replicas, and [the Deployment continuously monitors the cluster to guarantee that exact number of Pods is running](https://kubernetes.io/docs/concepts/workloads/). It also facilitates sophisticated rollout strategies.
-
-```yaml
-# deployment.yaml - ML inference deployment
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: sentiment-classifier
+  name: sentiment-inference
   labels:
-    app: sentiment-classifier
+    app: sentiment-inference
 spec:
   replicas: 3
   selector:
     matchLabels:
-      app: sentiment-classifier
+      app: sentiment-inference
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -196,1851 +83,474 @@ spec:
   template:
     metadata:
       labels:
-        app: sentiment-classifier
+        app: sentiment-inference
     spec:
       containers:
-      - name: model
-        image: myregistry/sentiment:v2.0.0
-        ports:
-        - containerPort: 8000
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "500m"
-          limits:
-            memory: "2Gi"
-            cpu: "1000m"
-        readinessProbe:
-          httpGet:
-            path: /health
-            port: 8000
-          initialDelaySeconds: 30
-          periodSeconds: 10
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: 8000
-          initialDelaySeconds: 60
-          periodSeconds: 30
+        - name: model-server
+          image: registry.example.com/sentiment-inference:v2.1.0
+          ports:
+            - containerPort: 8000
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1Gi"
+            limits:
+              cpu: "1"
+              memory: "2Gi"
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+            initialDelaySeconds: 20
+            periodSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /live
+              port: 8000
+            initialDelaySeconds: 60
+            periodSeconds: 20
+            failureThreshold: 3
 ```
 
-### Service
+The readiness probe is the ML-specific guardrail in this manifest. A generic web service may be ready as soon as the process binds a port, but a model server is not ready until weights are loaded, any tokenizer or feature metadata is initialized, and the first prediction path can complete. If readiness returns success too early, Kubernetes may send real traffic to a Pod that can only return errors. If readiness is too strict, the rollout may stall even though the process could serve. Your readiness endpoint should reflect the real user-facing condition: this replica can answer inference requests now.
 
-Because Pods are inherently ephemeral, their internal IP addresses change constantly. The Service object completely resolves this issue by [providing a persistent, perfectly stable network endpoint that actively distributes incoming requests evenly across healthy Pods](https://kubernetes.io/docs/concepts/services-networking/service/).
+The rollout policy also deserves explicit attention. `maxUnavailable: 0` tells Kubernetes not to intentionally remove old ready replicas before a replacement is available, which is a sensible default for low-replica inference services. `maxSurge: 1` allows one extra Pod during the rollout so capacity does not dip while new replicas start. These values are not free. If each Pod requires a large GPU or several gigabytes of memory, surging may be impossible without spare cluster capacity. A rollout strategy is therefore a contract between availability and available infrastructure, not a universal recipe.
 
 ```yaml
-# service.yaml - Expose deployment internally
 apiVersion: v1
 kind: Service
 metadata:
-  name: sentiment-service
+  name: sentiment-inference
 spec:
+  type: ClusterIP
   selector:
-    app: sentiment-classifier
+    app: sentiment-inference
   ports:
-  - port: 80
-    targetPort: 8000
-  type: ClusterIP  # Internal only
+    - name: http
+      port: 80
+      targetPort: 8000
 ```
+
+The Service selector must match the Pod labels created by the Deployment. If labels drift during a refactor, the Service may have zero endpoints even though Pods exist and appear healthy. This is a common failure during rushed model releases because engineers update the Deployment name, image, and labels but forget that Services select labels, not controller names. When traffic fails, always check both the Service and its endpoints before assuming the model container is broken.
+
+## 3. Configure CPU, Memory, and Quality of Service
+
+Resource requests are scheduling promises. When you request `1Gi` of memory and `500m` of CPU, the scheduler looks for a node with that much unreserved capacity. Limits are runtime boundaries. CPU limits usually throttle the process when it exceeds the limit, while memory limits can terminate the container when the process exceeds the allowed memory. For ML workloads, memory limits need careful testing because model loading can have temporary peaks that are higher than steady-state inference. A service that appears right-sized after warmup may still be killed during startup.
+
+Kubernetes assigns each Pod a Quality of Service class based on its resource settings. Guaranteed Pods have requests equal to limits for every container and every relevant resource. Burstable Pods have at least one request but do not meet the strict Guaranteed rule. BestEffort Pods have no requests or limits. During node pressure, this class affects eviction decisions. Critical inference services should usually avoid BestEffort because they become the easiest workloads to evict when the node is unhealthy. That does not mean every ML workload must be Guaranteed; it means the choice should be deliberate.
 
 ```yaml
-# For external access
-apiVersion: v1
-kind: Service
-metadata:
-  name: sentiment-service-external
-spec:
-  selector:
-    app: sentiment-classifier
-  ports:
-  - port: 80
-    targetPort: 8000
-  type: LoadBalancer  # Gets external IP
-```
-
-### Service Types
-
-Different Service types strictly accommodate various internal and external network architecture patterns.
-
-```mermaid
-flowchart LR
-    subgraph ClusterIP
-        CIP[Internal IP: 10.96.0.1:80] -->|Only accessible within cluster| C_POD[Pod]
-    end
-    subgraph NodePort
-        NP[External: NodeIP:30000-32767] -->|Opens port on every node| NP_POD[Pod]
-    end
-    subgraph LoadBalancer
-        LB[Cloud Load Balancer] -->|Gets public IP from cloud| LB_POD[Pod]
-    end
-    subgraph Ingress
-        ING[HTTP/HTTPS routing] -->|/api| SVC_A[Service A]
-        ING -->|/ml| SVC_B[Service B]
-    end
-```
-
-## GPU Scheduling for ML
-
-Complex deep learning workloads fundamentally require immense hardware acceleration. Managing GPUs natively within Kubernetes requires robust drivers and strict scheduling enforcement.
-
-### NVIDIA GPU Operator
-
-The NVIDIA GPU Operator automatically installs all required device drivers, container toolkits, and critical device plugins across the cluster, seamlessly transforming a standard node into a fully accelerator-aware execution environment.
-
-```mermaid
-flowchart TD
-    subgraph GPU Node
-        subgraph GPU Operator
-            ND[NVIDIA Driver: Auto-install]
-            CT[Container Toolkit]
-            DP[Device Plugin]
-            DCGM[DCGM Exporter: Monitoring]
-            GFD[GPU Feature Discovery]
-        end
-        subgraph GPU Hardware
-            G0[GPU 0: A100 80GB]
-            G1[GPU 1: A100 80GB]
-        end
-    end
-```
-
-### Requesting GPUs
-
-You must proactively leverage node selectors and tolerations to explicitly instruct the scheduler to assign the Pod strictly to specialized accelerator nodes, preventing standard CPU workloads from consuming expensive GPU capacity.
-
-```yaml
-# gpu-pod.yaml - Request GPU resources
-apiVersion: v1
-kind: Pod
-metadata:
-  name: gpu-training
-spec:
-  containers:
-  - name: trainer
-    image: pytorch/pytorch:2.0.1-cuda11.8-cudnn8-runtime
-    resources:
-      limits:
-        nvidia.com/gpu: 1  # Request 1 GPU
-    command: ["python", "train.py"]
-  # Ensure scheduling on GPU node
-  nodeSelector:
-    accelerator: nvidia-tesla-a100
-  tolerations:
-  - key: nvidia.com/gpu
-    operator: Exists
-    effect: NoSchedule
-```
-
-### GPU Resource Types
-
-Modern accelerators offer incredibly sophisticated partitioning mechanisms.
-
-```yaml
-# Different GPU configurations
-resources:
-  limits:
-    # Whole GPU
-    nvidia.com/gpu: 1
-
-    # MIG (Multi-Instance GPU) - A100 only
-    nvidia.com/mig-1g.5gb: 1   # 1/7 of A100
-    nvidia.com/mig-2g.10gb: 1  # 2/7 of A100
-    nvidia.com/mig-3g.20gb: 1  # 3/7 of A100
-
-    # Time-slicing (shared GPU)
-    # Configured via GPU Operator config
-```
-
-> **Did You Know?** Multi-Instance GPU (MIG) technology enables a single high-end A100 accelerator to be physically partitioned into up to seven isolated hardware instances. This provides rigid, hardware-level isolation for parallel inference workloads, maximizing utilization while preventing performance degradation.
-
-### GPU Scheduling Strategy
-
-For intensive batch processes, strictly utilize the Kubernetes Job resource. A Job actively manages execution until successful completion.
-
-```yaml
-# Training job - needs dedicated GPU
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: model-training
-spec:
-  template:
-    spec:
-      containers:
-      - name: trainer
-        image: myregistry/trainer:v2.0.0
-        resources:
-          limits:
-            nvidia.com/gpu: 4  # 4 GPUs for distributed training
-            memory: "64Gi"
-            cpu: "16"
-      restartPolicy: Never
-      # Use GPU node pool
-      nodeSelector:
-        node-pool: gpu-training
-      tolerations:
-      - key: nvidia.com/gpu
-        operator: Exists
-        effect: NoSchedule
-```
-
-## Resource Management
-
-Effective resource management is absolutely critical for cluster stability. The scheduler must precisely understand computational demands to prevent catastrophic out-of-memory events.
-
-### Resource Requests vs Limits
-
-A request represents the guaranteed minimum allocation used for scheduling. A limit is the unbreakable maximum ceiling. [CPU is compressible (the process is merely throttled), but memory is incompressible. Exceeding a memory limit can lead to an OOM kill when the kernel detects memory pressure.](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
-
-```mermaid
-flowchart LR
-    A[0] -->|Guaranteed| B[requests.memory: 1Gi]
-    B -->|Burstable| C[limits.memory: 2Gi]
-    C -->|OOMKilled| D[Exceeds Limit]
-```
-
-### QoS Classes
-
-Kubernetes assigns strict Quality of Service classes based on these resource configurations, [dictating eviction priority during severe node pressure](https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/).
-
-```yaml
-# Guaranteed QoS (highest priority)
-# requests == limits for all containers
 resources:
   requests:
-    memory: "1Gi"
-    cpu: "500m"
+    cpu: "2"
+    memory: "4Gi"
   limits:
-    memory: "1Gi"
-    cpu: "500m"
-
-# Burstable QoS (medium priority)
-# requests < limits
-resources:
-  requests:
-    memory: "512Mi"
-    cpu: "250m"
-  limits:
-    memory: "1Gi"
-    cpu: "500m"
-
-# BestEffort QoS (lowest priority, evicted first)
-# No requests or limits specified
-resources: {}
+    cpu: "4"
+    memory: "8Gi"
 ```
 
-### Resource Quotas
+Right-sizing starts with measurement rather than guesses. Capture startup memory, warm inference memory, peak batch size memory, CPU during typical requests, and CPU during expensive requests. Then set requests near the stable amount needed for reliable placement and set limits high enough to tolerate normal bursts without hiding true leaks. If a model has a predictable memory footprint, tighter requests improve bin packing. If a workload has occasional large input outliers, pair memory limits with input validation so the API rejects unsafe payloads before the process is killed.
 
-To prevent a single team from exhausting cluster capacity, administrators enforce Resource Quotas.
+Namespaces and ResourceQuotas provide a second layer of control. In a shared ML platform, every team wants faster experiments, larger batch sizes, and more replicas. Without quotas, one experiment can consume the cluster capacity needed for production inference. A quota does not replace capacity planning, but it gives the platform team a clear boundary for each namespace. Pair quotas with LimitRanges so every Pod receives default requests and limits when a team forgets to specify them.
 
 ```yaml
-# Limit resources per namespace
 apiVersion: v1
 kind: ResourceQuota
 metadata:
   name: ml-team-quota
-  namespace: ml-team
+  namespace: ml-team-a
 spec:
   hard:
-    requests.cpu: "100"
-    requests.memory: "200Gi"
-    limits.cpu: "200"
-    limits.memory: "400Gi"
-    requests.nvidia.com/gpu: "8"
-    pods: "50"
-    persistentvolumeclaims: "20"
+    requests.cpu: "40"
+    requests.memory: 160Gi
+    limits.cpu: "80"
+    limits.memory: 320Gi
+    pods: "80"
 ```
 
-## Autoscaling for ML
+The operational habit is to read resource configuration as a scheduling story. A Pending Pod with a huge memory request may be perfectly valid, but the cluster may have no node large enough to place it. An OOMKilled Pod may have an application leak, an unexpectedly large payload, or a limit that ignores model startup behavior. A throttled CPU-bound model may meet availability targets but miss latency objectives. Kubernetes tells you what happened through Pod events, container state, and metrics; your job is to connect that evidence to model behavior.
 
-Autoscaling enables systems to react dynamically to unpredictable load, ensuring performance and strict economic efficiency.
+## 4. Schedule GPU Workloads Deliberately
 
-### Horizontal Pod Autoscaler (HPA)
-
-[The HPA periodically evaluates targeted metrics](https://kubernetes.io/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/). When thresholds are exceeded, it instructs the Deployment to systematically increase replica counts.
+GPU workloads require explicit scheduling controls because GPUs are scarce, expensive, and unevenly distributed across node pools. Kubernetes represents GPUs as extended resources advertised by a device plugin, commonly `nvidia.com/gpu`. A container requests GPUs under `resources.limits`; requests are not written separately for the same extended resource. If the cluster has no node with the requested GPU resource free, the Pod remains Pending. Kubernetes will not inspect your Python dependencies, CUDA libraries, or image name to decide that a GPU is needed.
 
 ```yaml
-# hpa.yaml - Scale based on CPU
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: sentiment-hpa
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: sentiment-classifier
-  minReplicas: 2
-  maxReplicas: 20
-  metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: 70
-  - type: Resource
-    resource:
-      name: memory
-      target:
-        type: Utilization
-        averageUtilization: 80
-  behavior:
-    scaleDown:
-      stabilizationWindowSeconds: 300  # Wait 5 min before scaling down
-      policies:
-      - type: Percent
-        value: 10
-        periodSeconds: 60
-    scaleUp:
-      stabilizationWindowSeconds: 0  # Scale up immediately
-      policies:
-      - type: Percent
-        value: 100
-        periodSeconds: 15
-```
-
-> **Pause and predict**: If you configure a Horizontal Pod Autoscaler to target high CPU load, but the underlying physical node has absolutely no free GPUs available, what operational state will the newly created Pods enter?
-
-### Custom Metrics for ML
-
-CPU utilization is often insufficient. Advanced configurations leverage custom metrics like inference queue depth.
-
-```yaml
-# Scale based on inference queue length
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: inference-hpa
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: inference-server
-  minReplicas: 1
-  maxReplicas: 50
-  metrics:
-  # Custom metric from Prometheus
-  - type: Pods
-    pods:
-      metric:
-        name: inference_queue_length
-      target:
-        type: AverageValue
-        averageValue: "10"  # Scale when queue > 10 per pod
-  # GPU utilization (requires DCGM)
-  - type: External
-    external:
-      metric:
-        name: dcgm_gpu_utilization
-      target:
-        type: AverageValue
-        averageValue: "80"
-```
-
-### Vertical Pod Autoscaler (VPA)
-
-While HPA aggressively adds Pods, [the VPA subtly adjusts core resource requests and limits of existing Pods](https://kubernetes.io/docs/concepts/workloads/autoscaling/vertical-pod-autoscale/). This is optimal for stateful workloads.
-
-```yaml
-# vpa.yaml - Auto-tune resources
-apiVersion: autoscaling.k8s.io/v1
-kind: VerticalPodAutoscaler
-metadata:
-  name: ml-inference-vpa
-spec:
-  targetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: ml-inference
-  updatePolicy:
-    updateMode: "Auto"  # Or "Off" for recommendations only
-  resourcePolicy:
-    containerPolicies:
-    - containerName: model
-      minAllowed:
-        cpu: "100m"
-        memory: "256Mi"
-      maxAllowed:
-        cpu: "4"
-        memory: "8Gi"
-```
-
-## Persistent Storage for ML
-
-Complex deep learning models are massive data artifacts. Embedding them directly into container images results in bloated artifacts. Kubernetes safely allows containers to dynamically mount external volumes.
-
-### Storage Architecture
-
-```mermaid
-flowchart TD
-    subgraph Pod
-        C[Container] -->|mounts /models| PVC
-    end
-    subgraph Storage
-        PVC[PersistentVolumeClaim: model-pvc 10Gi RWO] -->|binds to| PV
-        PV[PersistentVolume: model-pv NFS/EBS/GCS]
-    end
-```
-
-### PersistentVolumeClaim for Models
-
-By fully isolating storage requests, you strictly decouple application logic from the underlying cloud provider.
-
-```yaml
-# pvc.yaml - Request storage for models
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: model-storage
-spec:
-  accessModes:
-    - ReadWriteOnce  # RWO: Single node read-write
-  resources:
-    requests:
-      storage: 50Gi
-  storageClassName: fast-ssd  # SSD for fast model loading
-```
-
-```yaml
-# For shared model access (multiple pods)
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: shared-models
-spec:
-  accessModes:
-    - ReadOnlyMany  # ROX: Multiple nodes read-only
-  resources:
-    requests:
-      storage: 100Gi
-  storageClassName: nfs  # NFS for shared access
-```
-
-### Access Modes
-
-The specific method by which a volume is attached fundamentally alters its utility for parallel operations.
-
-```
-ACCESS MODES
-============
-
-ReadWriteOnce (RWO):
-- Single node can mount as read-write
-- Use for: Training checkpoints, single-replica inference
-
-ReadOnlyMany (ROX):
-- Multiple nodes can mount as read-only
-- Use for: Shared models across inference replicas
-
-ReadWriteMany (RWX):
-- Multiple nodes can mount as read-write
-- Use for: Distributed training, shared logs
-- Requires: NFS, CephFS, GlusterFS
-
-ReadWriteOncePod (RWOP):
-- Single pod can mount as read-write
-- Supported in K8s v1.35+
-```
-
-> **Did You Know?** [Use `ReadWriteOncePod` when you need to guarantee single-Pod write access to a volume across the cluster.](https://kubernetes.io/docs/tasks/administer-cluster/change-pv-access-mode-readwriteoncepod/)
-
-## ML Deployment Patterns
-
-### Pattern 1: Simple Inference Service
-
-This establishes a highly available API endpoint utilizing strict configuration maps to manage variables independently.
-
-```yaml
-# Complete inference deployment namespace and config
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: ml-inference
-```
-
-```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: model-config
-  namespace: ml-inference
-data:
-  MODEL_NAME: "sentiment-classifier"
-  MODEL_VERSION: "v2.0.0"
-  MAX_BATCH_SIZE: "32"
-```
-
-```yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: sentiment-api
-  namespace: ml-inference
-spec:
-  replicas: 3
-  selector:
-    matchLabels:
-      app: sentiment-api
-  template:
-    metadata:
-      labels:
-        app: sentiment-api
-    spec:
-      containers:
-      - name: api
-        image: myregistry/sentiment:v2.0.0
-        ports:
-        - containerPort: 8000
-        envFrom:
-        - configMapRef:
-            name: model-config
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "500m"
-          limits:
-            memory: "2Gi"
-            cpu: "1000m"
-        readinessProbe:
-          httpGet:
-            path: /health
-            port: 8000
-          initialDelaySeconds: 30
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: 8000
-          initialDelaySeconds: 60
-```
-
-```yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: sentiment-api
-  namespace: ml-inference
-spec:
-  selector:
-    app: sentiment-api
-  ports:
-  - port: 80
-    targetPort: 8000
-  type: LoadBalancer
-```
-
-### Pattern 2: GPU Training Job
-
-For heavy processing, the Job resource ensures the compute-intensive workload executes successfully to completion.
-
-```yaml
-# Training job with GPU
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: bert-finetuning
-  namespace: ml-training
+  name: embedding-trainer
 spec:
-  backoffLimit: 3
   template:
     spec:
+      restartPolicy: Never
       containers:
-      - name: trainer
-        image: myregistry/bert-trainer:v2.0.0
-        command: ["python", "train.py"]
-        args:
-          - "--epochs=10"
-          - "--batch-size=32"
-          - "--learning-rate=2e-5"
-        resources:
-          limits:
-            nvidia.com/gpu: 1
-            memory: "16Gi"
-            cpu: "4"
-        volumeMounts:
-        - name: data
-          mountPath: /data
-        - name: checkpoints
-          mountPath: /checkpoints
-      volumes:
-      - name: data
-        persistentVolumeClaim:
-          claimName: training-data
-      - name: checkpoints
-        persistentVolumeClaim:
-          claimName: checkpoints
-      restartPolicy: OnFailure
+        - name: trainer
+          image: registry.example.com/embedding-trainer:v1.8.0
+          command: ["python", "train.py"]
+          resources:
+            limits:
+              nvidia.com/gpu: 1
+              cpu: "8"
+              memory: "48Gi"
       nodeSelector:
-        accelerator: nvidia-tesla-v100
+        accelerator: nvidia-a100
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
 ```
 
-### Pattern 3: Model A/B Testing
+Node labels and taints create the placement boundary around accelerator nodes. Labels let GPU workloads select appropriate nodes, such as A100 nodes rather than T4 nodes. Taints repel ordinary workloads unless those workloads declare a matching toleration. This protects GPU capacity from accidental CPU-only Pods. A cluster that allows every preprocessing container onto GPU nodes will waste money even if the Pods never touch the accelerator. Good scheduling policy prevents expensive mistakes before a human has to notice a cloud bill.
 
-Deploying entirely new models carries immense risk. A service mesh facilitates canary deployments, securely shifting a controlled percentage of traffic to evaluate performance.
+GPU partitioning and sharing complicate the design. Some environments expose whole GPUs only. Others use Multi-Instance GPU profiles, time-slicing, or higher-level serving systems. Each option changes isolation and performance expectations. Whole GPUs are simpler and safer for training, while partitioned or shared GPUs can improve utilization for smaller inference models. Do not treat sharing as a free optimization. Measure latency, memory isolation, and noisy-neighbor behavior before putting multiple production models on the same physical accelerator.
+
+Observability is mandatory for GPU operations because standard CPU metrics do not describe accelerator saturation. Queue depth, GPU memory usage, GPU utilization, request latency, and batch size distribution often matter more than Pod CPU. If an HPA scales only on CPU while the real bottleneck is GPU memory, the autoscaler may add replicas that cannot be scheduled or may fail to add replicas while latency rises. A GPU-aware platform publishes the metrics that match the bottleneck and keeps scheduling policy aligned with those metrics.
+
+## 5. Choose the Right Autoscaling Mechanism
+
+The Horizontal Pod Autoscaler adjusts the number of replicas for scalable controllers such as Deployments. It is usually appropriate for stateless inference when additional replicas can independently serve more traffic. CPU utilization can be a starting metric for simple services, but ML inference often needs custom or external metrics. Request rate, queue depth, p95 latency, GPU utilization, or in-flight requests may better describe user pain. The best metric is not the most sophisticated metric; it is the metric that moves before the service violates its objective.
 
 ```yaml
-# Canary deployment with Istio
-apiVersion: networking.istio.io/v1beta1
-kind: VirtualService
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
 metadata:
-  name: sentiment-routing
+  name: sentiment-inference
 spec:
-  hosts:
-  - sentiment-api
-  http:
-  - match:
-    - headers:
-        x-model-version:
-          exact: "v2"
-    route:
-    - destination:
-        host: sentiment-api-v2
-  - route:
-    - destination:
-        host: sentiment-api-v1
-        weight: 90
-    - destination:
-        host: sentiment-api-v2
-        weight: 10  # 10% traffic to new model
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: sentiment-inference
+  minReplicas: 3
+  maxReplicas: 20
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 65
 ```
 
-## Networking Deep Dive for ML Services
+The Vertical Pod Autoscaler changes resource recommendations, and in some modes updates Pod requests. It is useful when teams do not know the right CPU or memory requests for a workload, or when a long-running service has stable traffic but poorly tuned resource settings. VPA is not a substitute for horizontal scaling of stateless inference under traffic spikes. If a service needs twice as much capacity during a promotion, adding replicas may be safer than trying to resize each existing Pod. VPA is best viewed as a right-sizing tool and HPA as a replica-count tool.
 
-### DNS Resolution: How Pods Find Each Other
+The Cluster Autoscaler changes the number of nodes when Pods cannot be scheduled because the cluster lacks capacity. This is a different layer from HPA. HPA may request more Pods, but those Pods still need somewhere to run. If the cluster autoscaler is not configured for the relevant node pool, additional inference replicas can remain Pending. For GPU workloads, the relationship is even more important because node provisioning may be slow and cloud providers may not have accelerator capacity available. Autoscaling policy should account for the time it takes to add nodes, pull images, and load models.
 
-Internal services discover one another using [built-in DNS](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/).
+Queue-based scaling is often better for asynchronous ML workloads than CPU-based scaling. Embedding generation, offline scoring, document processing, and feature computation frequently receive work through a queue. In those systems, queue length, oldest message age, or work completion rate can describe demand more directly than CPU. Kubernetes Event-driven Autoscaling and similar controllers can scale consumers from queue metrics, including scaling to zero when no work exists. The tradeoff is cold-start delay, which may be unacceptable for interactive inference but useful for batch and background jobs.
 
-```python
-# Inside your pod, use DNS names
-import requests
+## 6. Manage Model Artifacts and Storage
 
-# Same namespace - just use service name
-response = requests.get("http://127.0.0.1:8080/features")
-
-# Different namespace - use full DNS
-# Format: <service>.<namespace>.svc.cluster.local
-```
-
-### Network Policies for ML Security
-
-Network isolation is paramount for protecting proprietary model APIs.
+Model artifacts can be stored in images, mounted volumes, object storage, or a model registry pulled during startup. Embedding the model in the image makes deployments reproducible and avoids network startup dependencies, but it can create very large images and slow rollouts. Pulling from object storage keeps images smaller and lets teams update artifacts separately, but it moves failure risk into startup. Mounting a PersistentVolumeClaim can work for shared or cached artifacts, but the access mode must match the workload. Each option has a different failure mode, so choose it deliberately.
 
 ```yaml
-# Only allow traffic from the API gateway to inference pods
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: inference-isolation
-  namespace: ml-production
-spec:
-  podSelector:
-    matchLabels:
-      app: inference-service
-  policyTypes:
-  - Ingress
-  ingress:
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          name: api-gateway
-    - podSelector:
-        matchLabels:
-          role: gateway
-    ports:
-    - port: 8000
-      protocol: TCP
-```
-
-### Latency Optimization Strategies
-
-To aggressively shave milliseconds, configurations attempt to [tightly localize active traffic within the exact same availability zone](https://kubernetes.io/docs/concepts/services-networking/topology-aware-routing/).
-
-```yaml
-# Spread inference pods across zones for client proximity
-affinity:
-  podAntiAffinity:
-    preferredDuringSchedulingIgnoredDuringExecution:
-    - weight: 100
-      podAffinityTerm:
-        labelSelector:
-          matchLabels:
-            app: inference
-        topologyKey: topology.kubernetes.io/zone
-```
-
-```yaml
-# Route to pods in same zone first (reduces cross-zone latency)
 apiVersion: v1
-kind: Service
+kind: PersistentVolumeClaim
 metadata:
-  name: inference-local
+  name: model-cache
 spec:
-  selector:
-    app: inference
-  topologyKeys:
-  - "topology.kubernetes.io/zone"
-  - "*"  # Fall back to any pod if none in zone
+  accessModes:
+    - ReadOnlyMany
+  resources:
+    requests:
+      storage: 50Gi
 ```
 
-```python
-# In your inference service, configure HTTP keep-alive
-import httpx
+Access modes are especially important in ML because teams often confuse "many replicas need the model" with "many replicas need to write the same files." Inference replicas usually need read access to the same artifact, not concurrent write access. Training jobs may need write access for checkpoints, but a single-writer checkpoint volume is safer than a shared writable directory unless the framework is designed for it. If multiple Pods write arbitrary files to the same path without coordination, the storage system can become the hidden source of corruption, latency, or inconsistent results.
 
-# Create a client with connection pooling
-client = httpx.Client(
-    limits=httpx.Limits(
-        max_keepalive_connections=100,
-        max_connections=200,
-        keepalive_expiry=30.0
-    ),
-    timeout=10.0
-)
+Large artifacts also affect rollout behavior. If every new Pod downloads a model from remote storage at the same time, a rollout can overload the storage service or hit rate limits. Init containers, local node caches, image pre-pulling, and staggered rollouts can reduce that risk. Readiness probes should stay false until the artifact is present and validated. A common production mistake is treating a successful container start as proof that the model exists; a better server validates checksum, schema compatibility, and load success before reporting readiness.
 
-# Reuse connections across requests
-response = client.post("http://127.0.0.1:8080/features", json=data)
-```
+## 7. Debug Kubernetes Evidence for ML Failures
 
-## Essential kubectl Commands
-
-Complete mastery of the CLI is mandatory for efficient cluster operation.
+Kubernetes debugging starts with state, events, and logs. A failing model service may produce Python stack traces, but Kubernetes tells you whether the Pod was scheduled, whether containers started, whether probes failed, whether the container was killed, and whether the Service has endpoints. Start broad, then narrow. Check the Deployment rollout, list Pods, describe the suspicious Pod, inspect events, inspect previous container logs after restarts, and then inspect metrics. This workflow prevents the common mistake of staring at application logs when the scheduler already explained the problem.
 
 ```bash
-# CLUSTER INFO
-kubectl cluster-info
-kubectl get nodes
-kubectl get nodes -o wide  # With IPs
+alias k=kubectl
 
-# DEPLOYMENTS
-kubectl get deployments
-kubectl describe deployment <name>
-kubectl scale deployment <name> --replicas=5
-kubectl rollout status deployment <name>
-kubectl rollout history deployment <name>
-kubectl rollout undo deployment <name>
-
-# PODS
-kubectl get pods
-kubectl get pods -o wide  # With node info
-kubectl describe pod <name>
-kubectl logs <pod-name>
-kubectl logs <pod-name> -f  # Follow
-kubectl logs <pod-name> --previous  # Previous container
-kubectl exec -it <pod-name> -- bash  # Shell into pod
-
-# SERVICES
-kubectl get services
-kubectl describe service <name>
-kubectl port-forward service/<name> 8080:80  # Local access
-
-# GPU NODES
-kubectl get nodes -l accelerator=nvidia
-kubectl describe node <gpu-node> | grep -A5 "Allocated resources"
-
-# RESOURCES
-kubectl top nodes
-kubectl top pods
-kubectl get resourcequota
-
-# DEBUGGING
-kubectl get events --sort-by='.lastTimestamp'
-kubectl describe pod <pod-name>  # Check Events section
-kubectl logs <pod-name> --all-containers
+k get deploy sentiment-inference
+k rollout status deploy/sentiment-inference
+k get pods -l app=sentiment-inference -o wide
+k describe pod <pod-name>
+k logs <pod-name> --previous
+k get endpoints sentiment-inference
 ```
 
-## Production War Stories: Kubernetes Lessons Learned
+A Pending Pod is usually a scheduling problem rather than an application problem. `k describe pod` will often show events such as insufficient CPU, insufficient memory, untolerated taint, unmatched node selector, or unavailable GPU resources. For ML teams, this evidence is more useful than rerunning the training script. If the Pod requests `nvidia.com/gpu: 4` and every node has only one free GPU, the application cannot fix placement. The choices are to lower the request, change the node pool, wait for capacity, or redesign the distributed job.
 
-### The Pod That Wouldn't Die
+An OOMKilled container is a memory contract problem until proven otherwise. It may be a leak, an unexpectedly large payload, a batch size that grew beyond testing, a model artifact loaded twice, or a limit below startup peak. The event proves that the kernel killed the process after memory pressure; it does not prove why the process used that memory. Compare startup memory, steady-state memory, request size, and model version. If the problem appears only after a new model release, validate artifact size and runtime loading behavior before increasing limits blindly.
 
-A rollout can fail if an old Pod does not terminate cleanly and continues holding onto state or connections, leaving traffic on the previous version longer than expected.
+A failed rollout is often a readiness or capacity problem. If new Pods never become ready, inspect readiness endpoint logs and probe configuration. If new Pods stay Pending, inspect scheduling events. If old Pods terminate before new Pods can serve, inspect rollout strategy and PodDisruptionBudget. If the Service has no endpoints, inspect labels and selectors. This systematic evidence chain is what separates Kubernetes operations from random YAML editing. The goal is not to memorize every error message; the goal is to ask which controller made the decision and what evidence it recorded.
 
-```yaml
-# The fix: Add proper termination handling
-spec:
-  terminationGracePeriodSeconds: 30
-  containers:
-  - name: model
-    lifecycle:
-      preStop:
-        exec:
-          command: ["/bin/sh", "-c", "sleep 5"]  # Allow connections to drain
-```
+## 8. Production Design Pattern
 
-### The GPU Scheduling Disaster
+A production ML serving stack normally includes more than a Deployment and a Service. It includes immutable model versioning, CI/CD promotion gates, readiness that validates loaded artifacts, resource policy, autoscaling based on meaningful metrics, traffic management for gradual rollout, observability, and rollback. Kubernetes provides the substrate for many of those controls, while surrounding systems provide registry, monitoring, alerting, feature stores, and model evaluation. The platform design should make the safe path easy enough that product teams do not need to reinvent it for every model.
 
-Autoscaling can create additional Pods that remain Pending if the cluster has no spare GPU capacity, so scaling signals need to reflect the real bottleneck and available hardware.
-
-```yaml
-   # Cluster Autoscaler config
-   scaleDownEnabled: true
-   scaleDownDelayAfterAdd: 10m
-   scaleDownUnneededTime: 10m
-   expanderName: priority  # Prefer GPU nodes for GPU workloads
-```
-
-```yaml
-   - type: External
-     external:
-       metric:
-         name: gpu_nodes_available
-       target:
-         type: Value
-         value: "1"  # Only scale if GPUs are available
-```
-
-```yaml
-   apiVersion: policy/v1
-   kind: PodDisruptionBudget
-   spec:
-     minAvailable: 5  # Always keep at least 5 pods
-```
-
-### The Memory Leak That Killed Christmas
-
-A memory leak or unexpectedly large in-memory data structure can trigger OOM kills and cascading instability in a recommendation workload.
-
-```yaml
-   resources:
-     requests:
-       memory: "2Gi"
-     limits:
-       memory: "8Gi"  # Increased headroom
-```
-
-```yaml
-   - type: Resource
-     resource:
-       name: memory
-       target:
-         type: Utilization
-         averageUtilization: 60  # Scale before hitting limits
-   ```
-
-```python
-   @memory_guard(max_mb=4000)
-   def generate_recommendations(user_history):
-       if len(user_history) > 1000:
-           user_history = user_history[-1000:]  # Truncate
-       # ... process
-   ```
-
-## Economics of Kubernetes for ML
-
-Transitioning to heavily orchestrated infrastructure drastically alters deep operational economics. Dynamic provisioning entirely eliminates the staggering inefficiency of maintaining massive idle capacity.
-
-| Scenario | Manual Scaling | Kubernetes + HPA |
-|----------|----------------|------------------|
-| **Peak capacity provisioning** | | |
-| Servers for peak load | Fixed-capacity setups must provision for expected peak demand | Autoscaled setups can add capacity as load rises |
-| Monthly infrastructure cost | Often higher when capacity is fixed for peaks | Often lower when capacity can scale with demand, depending on workload and pricing |
-| Utilization rate | Often lower when infrastructure is overprovisioned for peaks | Often higher when capacity can be packed and scaled more dynamically |
-| **Operations** | | |
-| On-call incidents (monthly) | Incident volume depends on workload design and operational maturity | Incident volume can improve with better automation, but exact outcomes vary |
-| Engineer time responding | Manual operations can consume significant engineering time | Automation can reduce response effort, but the amount varies by team and system design |
-| Deployment time | Manual releases can be slow and error-prone | Automated rollouts can be much faster, depending on the application and release process |
-| **Annual Total** | | |
-| Infrastructure | Annual spend is typically higher when systems are provisioned for peak load all the time | Annual spend can be lower when capacity is scaled and utilized more efficiently |
-| Operations | Labor cost depends on staffing model, tooling, and incident volume | Automation can reduce operating effort, but exact labor savings vary widely |
-| **Total** | Higher overall spend is common with fixed overprovisioning | Lower overall spend is possible with better utilization and automation |
-| **Savings** | | Savings depend on workload shape, pricing, and operational maturity |
-
-| Strategy | Without K8s | With K8s | Savings |
-|----------|-------------|----------|---------|
-| **GPU Utilization** | | | |
-| Single-tenant VMs | Utilization is often lower when GPUs are dedicated to one workload | N/A | Baseline comparison |
-| Kubernetes scheduling | N/A | Shared scheduling can improve utilization when workloads fit the cluster well | GPU savings depend on workload mix and bin-packing efficiency |
-| **Spot/Preemptible** | | | |
-| On-demand GPUs | On-demand accelerator pricing varies by cloud, region, and instance type | N/A | Baseline comparison |
-| Spot or preemptible GPUs with interruption handling | N/A | Interruptible capacity can be much cheaper than on-demand capacity, but prices and availability vary | Savings depend on provider pricing and workload tolerance for interruption |
-| **Right-sizing** | | | |
-| Fixed instance types | Static sizing often leaves some workloads overprovisioned | VPA can help identify better-fit requests over time | Cost impact depends on workload behavior and how recommendations are applied |
-
-| Provider | On-Demand | Spot (70% workload) | Annual Cost |
-|----------|-----------|---------------------|-------------|
-| GKE | Pricing varies by region and machine choice | Spot capacity can reduce spend when interruptions are acceptable | Annual cost is workload-dependent |
-| EKS | Pricing varies by region and machine choice | Spot capacity can reduce spend when interruptions are acceptable | Annual cost is workload-dependent |
-| AKS | Pricing varies by region and machine choice | Spot capacity can reduce spend when interruptions are acceptable | Annual cost is workload-dependent |
-
-> **Did You Know?** Better scheduling and autoscaling can reduce wasted infrastructure spend, but the exact savings depend on workload shape, pricing, and operational maturity.
-
-## System Design Interview: ML Inference Platform
-
-**Prompt**: "Design a highly available machine learning inference platform capable of robustly serving multiple large-scale models to exactly 10,000 requests per second."
-
-**Cluster Architecture**:
 ```mermaid
 flowchart TD
-    CP[Control Plane: managed EKS/GKE/AKS]
-    CPUN[CPU Node Pool: c5.2xlarge x 10]
-    GPUN[GPU Node Pool: p4d.24xlarge x 8]
-    CA[Cluster Autoscaler]
-
-    CPUN -->|Hosts| GW[API gateways, load balancers, monitoring]
-    GPUN -->|Hosts| A100[A100 GPUs for inference]
-    GPUN -->|Hosts| SPOT[Spot instances with preemption handling]
-    CA -->|Scale 4-16 based on pending pods| GPUN
+    Registry[Model registry and image registry] --> Pipeline[CI/CD promotion gate]
+    Pipeline --> Deploy[Deployment with immutable image]
+    Deploy --> Ready[Readiness validates model load]
+    Ready --> Service[Service and ingress route traffic]
+    Service --> Metrics[Latency, errors, queue, GPU metrics]
+    Metrics --> HPA[Autoscaling policy]
+    Metrics --> Alert[Alerts and rollback decision]
 ```
 
-**Model Serving Layer**:
-```yaml
-# Per-model deployment
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: sentiment-model
-spec:
-  replicas: 4
-  selector:
-    matchLabels:
-      app: sentiment-model
-  template:
-    spec:
-      containers:
-      - name: model
-        image: registry/sentiment:v2.1.0
-        resources:
-          limits:
-            nvidia.com/gpu: 1
-            memory: "16Gi"
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 8000
-          initialDelaySeconds: 60
+The pattern changes for training. Training jobs often need stronger data access controls, checkpoint storage, accelerator scheduling, retry policy, and experiment tracking. A failed inference Pod should usually restart quickly, while a failed training job may need careful inspection before retrying because rerunning can waste expensive accelerator hours. Kubernetes Jobs give you completion semantics, but the surrounding ML platform still needs dataset identity, run metadata, artifact registration, and reproducibility. Kubernetes can run the process; it does not automatically make the experiment scientifically meaningful.
+
+The platform team should expose a small number of reviewed templates rather than letting every team assemble raw primitives from scratch. A standard inference template can require probes, resource requests, immutable image tags, labels, metrics annotations, and rollout settings. A standard training template can require explicit GPU requests, checkpoint volume policy, restart behavior, and namespace quota awareness. Templates do not eliminate engineering judgment, but they move repeated safety decisions into a shared baseline that reviewers and operators can understand.
+
+## 9. Operate the Release Lifecycle
+
+The release lifecycle for a Kubernetes-hosted model starts before the manifest is applied. A model image should be tied to a specific model artifact, training data lineage, dependency set, and evaluation record. If the image tag is mutable, rollback becomes guesswork because different nodes may pull different content at different times. If the manifest does not record the model version through labels, annotations, or environment variables, incident responders may not know which model is serving traffic. The platform should make release identity visible from both Kubernetes and the ML registry.
+
+Promotion should happen through environments that test different risks. A local or ephemeral namespace can prove that the manifests apply, Pods become Ready, and the Service routes to the correct endpoints. A staging environment can prove that the model loads real artifacts, handles realistic payloads, emits metrics, and respects resource limits. Production rollout should then prove that the new model behaves under live traffic without replacing every replica at once. Each stage answers a different question, so skipping stages usually moves uncertainty into the most expensive environment.
+
+Canary rollout is useful when model behavior and system behavior both carry risk. At the Kubernetes layer, a canary may be implemented with separate Deployments, labels, ingress routing, service mesh weights, or external traffic management. At the ML layer, the team also needs model-quality checks such as drift, prediction distribution, business metrics, or manual review. A rollout that is technically healthy can still be a model-quality failure. The Kubernetes operator should therefore expose deployment health while the ML owner validates prediction behavior from domain metrics.
+
+Rollback should be rehearsed, not merely promised. Kubernetes can roll a Deployment back to a previous ReplicaSet when rollout history is available, but that is only safe if the previous image tag and model artifact are still retrievable. If the old model was deleted from the registry, if the old image tag was overwritten, or if the feature schema changed incompatibly, a rollback may restart Pods that cannot serve. The reliable pattern is to retain release artifacts, version feature contracts, and keep backward-compatible serving paths until the team has evidence that the new version is stable.
+
+```bash
+k rollout history deployment/sentiment-inference
+k rollout undo deployment/sentiment-inference
+k rollout status deployment/sentiment-inference
 ```
 
-**Traffic Management**:
-```mermaid
-flowchart TD
-    ING[Ingress: NGINX or Istio] -->|/models/sentiment| S1[sentiment-service]
-    ING -->|/models/classification| S2[classification-service]
-    ING -->|/models/embedding| S3[embedding-service]
-```
+The release checklist should include Kubernetes evidence and ML evidence. Kubernetes evidence includes successful rollout, expected replica count, ready endpoints, stable restart count, acceptable probe behavior, and resource usage inside planned boundaries. ML evidence includes prediction latency, error rate, output distribution, feature freshness, and model-specific quality indicators. These signals should be reviewed together because either side can invalidate the release. A model can be accurate but unavailable, and a perfectly available service can return harmful or low-quality predictions.
 
-**Capacity Planning**:
-```text
-Per GPU: ~1,500 req/s (depends on model)
-10K req/s ÷ 1,500 = ~7 GPUs active
-With 70% utilization target: 10 GPUs
-With headroom for spikes: 12-16 GPUs available
+## 10. Separate Online Inference from Batch and Training
 
-Node pool: 8 × p4d.24xlarge = 64 A100s total
-Active pods: 12-16 (normal), up to 40 (peak)
-```
+Online inference is usually latency-sensitive and customer-facing. It benefits from multiple small replicas, fast readiness, conservative rollout, stable Services, and autoscaling that reacts before user-facing latency violates an objective. Batch scoring is usually throughput-sensitive and often reads from queues, object storage, or scheduled datasets. It benefits from Jobs, queue-based scaling, resumable work units, and idempotent output writes. Training is often accelerator-sensitive and expensive, so it benefits from deliberate GPU placement, checkpointing, retry control, and strong experiment metadata.
 
-**Observability Hierarchy**:
-```text
-Prometheus + Grafana
-├── GPU utilization (DCGM exporter)
-├── Request latency (p50, p95, p99)
-├── Queue depth
-└── Error rates
+When teams collapse these workload types into one generic template, the template becomes unsafe for at least one of them. A Deployment template with aggressive liveness restarts can be harmful for a training job that needs time to checkpoint. A Job template without readiness probes is inadequate for an inference API. A queue worker that scales to zero may be efficient for embedding backfills but unacceptable for a low-latency user request path. The platform should expose different defaults because the controller semantics, failure tolerance, and cost profile are genuinely different.
 
-Alerts:
-- GPU utilization > 85% for 5 min
-- Latency p99 > 500ms
-- Error rate > 1%
-- Pods in Pending > 2 min
-```
+Batch and training workloads also need stronger idempotency thinking. If a Job retries after a node failure, it may process the same input shard twice unless the application writes outputs with stable identifiers or commit markers. If a training process restarts from the beginning after every interruption, cheap spot capacity may become more expensive than reliable on-demand capacity. Kubernetes can retry a Pod, but it cannot infer whether the workload is safe to retry. The ML code and the storage contract must make retry behavior explicit.
 
-```mermaid
-graph TD
-    PG[Prometheus + Grafana] --> GPU[GPU utilization DCGM exporter]
-    PG --> LAT[Request latency p50, p95, p99]
-    PG --> QD[Queue depth]
-    PG --> ER[Error rates]
-    PG --> AL[Alerts: Utilization > 85%, Latency > 500ms]
-```
+For distributed training, Kubernetes placement becomes a coordination problem rather than a single-Pod problem. The job may need several Pods to start together, communicate over fast networking, and access shared or sharded data. Plain Jobs can handle simple single-Pod training, but distributed frameworks often need operators that understand worker roles, chief Pods, rendezvous, and failure policy. Even when an operator manages the framework-specific lifecycle, the underlying issues remain Kubernetes issues: resources, node pools, volumes, events, logs, and quotas.
 
-**Deployment Strategy**:
-```yaml
-strategy:
-  type: RollingUpdate
-  rollingUpdate:
-    maxSurge: 1
-    maxUnavailable: 0
-```
+## 11. Design Observability Around User Pain
 
-```python
-@app.get("/ready")
-def ready():
-    if not model_loaded:
-        raise HTTPException(503)
-    # Optional: run a warmup inference
-    _ = model.predict(warmup_input)
-    return {"ready": True}
-```
+A model-serving dashboard that only shows Pod count is not an operations dashboard. The service may have the correct number of replicas while every request times out because the model is waiting on a feature service. It may have low CPU while the GPU is saturated. It may have no restarts while readiness flaps under load. Observability should start from user pain: latency, error rate, availability, saturation, and prediction-path success. Kubernetes metrics explain infrastructure behavior, while application and model metrics explain serving behavior.
+
+For online inference, useful metrics include request rate, p50 and p95 latency, error rate, in-flight requests, queue depth if batching is used, model load duration, cold-start count, and prediction payload size. For GPU inference, add GPU utilization, GPU memory, batch occupancy, and time waiting for accelerator work. For batch jobs, track items processed, oldest queued item, retry count, output failures, and completion lag. These metrics are not decoration. They determine autoscaling policy, alert thresholds, and whether a rollout is improving or damaging the system.
+
+Logs should include model version, request identifier, important validation failures, and downstream dependency errors, but they should not leak sensitive input data. ML services often handle text, images, user behavior, or business records that are more sensitive than normal operational metadata. A Kubernetes log pipeline can centralize logs quickly, so application teams must decide what belongs in logs before an incident forces everyone to search them. The best debugging log is specific enough to explain the failure and restrained enough to avoid becoming a data-governance problem.
+
+Tracing is valuable when inference depends on multiple services. A request may pass through an API gateway, feature service, model server, vector database, cache, and post-processing service. Kubernetes can tell you which Pod ran each component, but distributed tracing can show which hop consumed the time. This distinction matters during incidents because scaling the model Deployment will not fix a slow feature lookup. Trace attributes should include model version and safe workload identifiers so performance regressions can be tied to releases without exposing raw user data.
+
+Alerts should be tied to action. An alert for "Pod restarted once" may create noise if the service has enough replicas and the restart was harmless. An alert for sustained error rate, empty Service endpoints, unavailable ready replicas, or queue age beyond an objective usually deserves attention. For ML systems, also alert when model load fails, when prediction latency changes sharply after rollout, or when resource saturation prevents scale-out. The alert should tell the operator where to look first: rollout, scheduler, probes, resource pressure, dependency, or model behavior.
+
+## 12. Review Security and Multi-Tenancy
+
+ML workloads often run in shared clusters because GPUs and data platforms are expensive. Shared infrastructure requires strict boundaries. Namespaces provide a naming and policy boundary, but they are not enough by themselves. Service accounts, role-based access control, NetworkPolicies, image provenance, secret handling, Pod security settings, and quotas all contribute to isolation. A model-serving Pod rarely needs broad cluster permissions. If it only serves HTTP and reads a model artifact, its service account should not be able to list secrets or modify Deployments.
+
+NetworkPolicy is especially useful for feature and model systems. An inference service may need to receive traffic from an API gateway and call a feature service, but it probably should not accept traffic from every namespace or call the Kubernetes API server. Training jobs may need access to object storage or metadata services, but not to production inference backends. Default-allow networking is convenient during early experiments and dangerous in shared production clusters. A reviewed template should make required network paths explicit.
+
+Secrets deserve careful design because ML services often need registry credentials, object-store credentials, database passwords, or API tokens. Kubernetes Secrets are not a license to spread credentials through every namespace. Prefer short-lived identity mechanisms from the cloud or platform when available, mount only the secrets required by the workload, and avoid printing secret-derived values in logs. If a model server pulls artifacts at startup, failure messages should identify the missing permission without revealing credentials or signed URLs.
+
+Image and dependency control also matter. A model server image may include Python packages, native libraries, CUDA components, and serving frameworks. The platform should scan images, pin base images, and promote images through CI/CD rather than allowing ad hoc builds from laptops. Kubernetes will run the image you ask it to run; it will not decide whether the dependency tree is safe. MLOps teams need the same supply-chain discipline as application teams, with extra attention to native packages and accelerator runtime compatibility.
+
+## 13. Capacity Planning and Cost Control
+
+Autoscaling reduces manual work, but it does not remove the need for capacity planning. A service with a five-minute model startup time cannot react instantly to a sudden traffic surge, even if HPA detects the surge quickly. A GPU node pool may take several minutes to provision, and the cloud provider may have limited regional capacity. A large image may take time to pull on every new node. Capacity planning therefore includes warm replicas, spare node capacity, image pre-pulling, artifact caching, and realistic load tests, not only autoscaler configuration.
+
+Cost control should be evaluated per workload type. Online inference usually pays for low latency and availability, so keeping a minimum number of replicas warm is often justified. Batch jobs can use cheaper interruptible capacity if they checkpoint and resume safely. Training may justify dedicated accelerator reservations when failed or delayed jobs cost more than idle time. Queue workers may scale to zero when latency is not user-facing. The same Kubernetes cluster can host all of these patterns, but the cost policy should not pretend they have the same business priority.
+
+Resource efficiency comes from measuring both utilization and outcomes. A GPU at high utilization is not necessarily efficient if the model is serving low-value traffic, retrying failed work, or waiting on slow data access. A CPU service at low utilization may be deliberately overprovisioned to meet latency objectives. The platform team should report cost alongside workload owner, namespace, model version, request volume, and business purpose. Kubernetes labels and annotations make that accounting easier when teams use them consistently.
+
+The final capacity question is operational maturity. A small team may prefer a simpler design with fewer moving parts even if it costs more, because the team cannot safely operate custom metrics, service mesh routing, and complex GPU sharing yet. A mature platform team may invest in those capabilities because the savings and reliability gains justify the complexity. Kubernetes gives you the mechanisms; engineering judgment decides when each mechanism is worth its operational burden.
 
 ## Common Mistakes
 
-| Mistake | Why it Occurs | Correct Implementation |
-|---------|--------------|------------------------|
-| **Missing Limits** | Neglecting to firmly define strict resource constraints places the Pod in the lowest BestEffort QoS tier, maximizing the probability of sudden, unceremonious eviction during routine operations. | See snippet below. Always explicitly specify boundaries. |
-| **Using Latest Tag** | The `latest` image tag is highly mutable. Attempting a rapid rollback may completely fail to revert to the desired state, and disparate nodes may cache deeply conflicting artifacts. | See snippet below. Utilize rigidly immutable version identifiers. |
-| **Omitted Probes** | Without readiness probes, the overarching control plane cannot discern if a massive model is successfully loaded into active memory or if the process has entirely deadlocked. | See snippet below. Configure both liveness and readiness checks. |
-| **No PDB** | Routine node maintenance or automated infrastructure updates can simultaneously evict all instances of an application if strict minimum availability thresholds are utterly undeclared. | See snippet below. Formally define a secure PodDisruptionBudget. |
-| **Wrong Service Type** | Utilizing an expensive LoadBalancer type for strictly internal microservices generates unnecessary cloud infrastructure costs and heavily suboptimal routing paths. | See snippet below. Utilize ClusterIP strictly for internal communications. |
-| **Ignoring Grace** | Applications abruptly terminated by the kernel blindly drop active connections, resulting in massive client-side errors and extremely poor user experience. | Define `terminationGracePeriodSeconds` properly. |
-| **Blind Autoscaling** | Scaling solely based on general CPU usage when the specific workload is entirely bottlenecked by specialized hardware (GPUs) results in massive arrays of pending, unusable Pods. | Implement complex custom metrics targeting actual hardware availability. |
-
-```yaml
-# Mistake 1 Fix
-containers:
-- name: model
-  image: mymodel:v2.0.0
-  resources:
-    requests:
-      memory: "1Gi"
-      cpu: "500m"
-    limits:
-      memory: "2Gi"
-      cpu: "1000m"
-```
-
-```yaml
-# Mistake 2 Fix
-image: mymodel:v2.0.0-abc123
-imagePullPolicy: IfNotPresent
-```
-
-```yaml
-# Mistake 3 Fix
-containers:
-- name: model
-  readinessProbe:
-    httpGet:
-      path: /ready
-      port: 8000
-    initialDelaySeconds: 30
-    periodSeconds: 10
-  livenessProbe:
-    httpGet:
-      path: /live
-      port: 8000
-    initialDelaySeconds: 60
-    periodSeconds: 30
-    failureThreshold: 3
-```
-
-```yaml
-# Mistake 4 Fix
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: ml-inference-pdb
-spec:
-  minAvailable: 2  # Always keep at least 2 pods
-  selector:
-    matchLabels:
-      app: ml-inference
-```
-
-```yaml
-# Mistake 5 Fix
-# For internal services
-spec:
-  type: ClusterIP
-```
-
-```yaml
-# Mistake 5 Fix Continued
-# For external APIs
-spec:
-  type: LoadBalancer
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-internal: "true"  # Internal LB
-```
+| Mistake | Why It Happens | What To Do Instead |
+|---|---|---|
+| Treating a Pod as a durable server | Teams familiar with virtual machines expect a Pod IP and local filesystem to survive replacement. | Put replicas behind a Service, store durable artifacts outside the Pod, and let controllers recreate Pods. |
+| Reporting readiness too early | The process binds a port before model weights, tokenizers, or feature metadata are loaded. | Make readiness validate the actual inference path or a strong local model-load condition. |
+| Scaling on CPU when the bottleneck is GPU or queue depth | CPU metrics are easy to collect, but they may not represent accelerator saturation or user wait time. | Use metrics that match the bottleneck, such as queue age, p95 latency, GPU utilization, or in-flight requests. |
+| Forgetting resource requests | A container works in development, so the manifest omits scheduling information. | Set measured CPU and memory requests so the scheduler can place Pods predictably. |
+| Using GPU nodes for ordinary CPU work | GPU node pools are not tainted, or CPU workloads tolerate too much by default. | Taint accelerator nodes and require explicit tolerations plus selectors for GPU workloads. |
+| Rolling out large models without spare capacity | Surging new replicas requires memory, CPU, storage bandwidth, and sometimes GPUs that may not exist. | Match rollout settings to real capacity and pre-warm artifacts when startup is expensive. |
+| Debugging only application logs | Engineers jump to Python errors even when Kubernetes events already show scheduling, probe, or OOM evidence. | Read rollout status, Pod events, container state, previous logs, metrics, and Service endpoints in order. |
 
 ## Knowledge Check
 
 <details>
-<summary>1. A machine learning inference Deployment is currently running, but live clients report highly intermittent 502 errors exclusively during rolling updates. Diagnose the probable root configuration deficiency.</summary>
+<summary>1. Design a Kubernetes inference architecture for a stateless model API that must survive Pod replacement without changing the client endpoint.</summary>
 
-**Answer**: The deployment is almost certainly missing a properly configured readinessProbe. Without it, the control plane can route high-volume traffic to the newly created Pods before the large model weights have fully initialized in memory. By implementing a strict readiness check that exclusively returns a success code only after the entire model is fully loaded, the load balancer will correctly wait before actively distributing requests to the new instance.
+Use a Deployment to manage interchangeable model-serving replicas and a Service to provide a stable DNS name and load-balancing target. The Deployment should include immutable image tags, resource requests, readiness probes that wait for model load, liveness probes for stuck processes, and a rolling update strategy. The Service should select Pods by stable labels rather than by controller name, because Pods will be replaced during rollout and node failure.
 </details>
 
 <details>
-<summary>2. You urgently need to provision a heavily distributed training job that absolutely requires simultaneous access to a vast, shared dataset directory. Evaluate exactly which storage access mode must be utilized.</summary>
+<summary>2. Configure the core controls needed for a GPU training Job that should run only on accelerator nodes.</summary>
 
-**Answer**: You must strictly utilize the `ReadWriteMany` (RWX) access mode. Distributed model training fundamentally necessitates that multiple discrete Pods, often scheduled far apart across disparate physical nodes, concurrently read and write to the exact same shared volume. While `ReadWriteOnce` is sufficient for isolated checkpoints, it explicitly prohibits the concurrent multi-node attachment demanded by this complex architecture.
+Use a Job rather than a Deployment because the training process should run to completion. Request the GPU as an extended resource such as `nvidia.com/gpu` under container limits, add a node selector for the accelerator node pool, and add a toleration that matches the GPU node taint. Also define CPU and memory limits, checkpoint storage, and a restart policy that matches the cost of retrying the training process.
 </details>
 
 <details>
-<summary>3. During extreme peak hours, a configured autoscaler successfully requests more Pods, yet they persistently remain trapped in a Pending status. Compare this scenario with potential infrastructural root causes.</summary>
+<summary>3. Evaluate whether HPA, VPA, Cluster Autoscaler, or queue-based scaling best fits three different ML workloads.</summary>
 
-**Answer**: The cluster has entirely exhausted its available physical resources. The Horizontal Pod Autoscaler correctly detected massively increased load and forcefully instructed the Deployment to expand, but the Scheduler simply cannot locate a single node possessing the requisite unreserved CPU, memory, or specialized GPU capacity. Resolution mandates either manually provisioning additional worker nodes or verifying that the Cluster Autoscaler is correctly configured to expand the underlying infrastructure pool dynamically.
+For stateless online inference, HPA is usually the first fit because adding replicas increases request capacity. For poorly sized long-running services, VPA can recommend better CPU and memory requests, but it should not be treated as traffic scaling. For Pending Pods caused by insufficient nodes, Cluster Autoscaler addresses the infrastructure layer. For asynchronous embedding or batch scoring work, queue-based scaling often gives the clearest demand signal.
 </details>
 
 <details>
-<summary>4. Design a robust operational strategy to firmly prioritize mission-critical inference Pods, guaranteeing they are the absolute last workloads to be forcibly evicted during severe cluster resource pressure.</summary>
+<summary>4. Diagnose a Deployment where the rollout hangs and new Pods never become ready after a model version update.</summary>
 
-**Answer**: The optimal, fail-safe strategy demands establishing a Guaranteed Quality of Service (QoS) class. This is typically achieved by ensuring that each container within the active Pod explicitly defines resource requests that match its resource limits. Kubernetes heavily prioritizes Guaranteed workloads, usually evicting BestEffort and Burstable Pods first to preserve the stability of highly critical inference processes.
+Start with `k rollout status`, then inspect new Pods with `k describe pod` and read readiness probe failures. If Pods are Running but not Ready, validate that the model artifact downloads successfully, the server loads the new model schema, and the readiness endpoint reflects load completion. If Pods are Pending, inspect scheduling events for insufficient memory, unavailable GPUs, node selectors, or taints.
 </details>
 
 <details>
-<summary>5. Scenario: Your stateful model training workload requires gradually increasing memory over a 48-hour epoch, while your stateless inference API receives unpredictable massive daily traffic spikes. Evaluate and justify the autoscaling strategy required for each, explaining the fundamental operational difference between the mechanisms chosen.</summary>
+<summary>5. Diagnose an OOMKilled inference container that only fails after larger request payloads arrive.</summary>
 
-**Answer**: The Horizontal Pod Autoscaler aggressively adjusts overall capacity by actively modifying the precise quantity of running Pod replicas to efficiently distribute massive load across a much broader cluster footprint. Conversely, the Vertical Pod Autoscaler directly modifies the highly specific resource allocations (such as CPU and memory requests and limits) actively assigned to individual running Pods. While horizontal scaling is vastly preferred for stateless inference APIs, vertical scaling is highly effective for stateful workloads or when meticulously optimizing baseline resource consumption over extended time periods.
+An OOMKilled state means the process exceeded its memory limit and was killed under memory pressure. Compare request size, batch size, model version, startup peak, and steady-state memory. The fix may involve input limits, smaller batch sizes, streaming, model optimization, or a higher memory limit. Raising the limit alone can hide a leak or move the failure to the node level.
 </details>
 
 <details>
-<summary>6. How do you definitively instruct the central scheduler to guarantee that a heavily CPU-bound data preprocessing Pod is absolutely never accidentally placed onto a highly expensive GPU-accelerated node?</summary>
+<summary>6. Implement a safe local test workflow before promoting a Kubernetes model-serving manifest to a shared cluster.</summary>
 
-**Answer**: You efficiently employ a powerful combination of node taints and precise tolerations. The core infrastructure team must firmly apply a specific, highly restrictive taint to the GPU nodes (e.g., `accelerator=gpu:NoSchedule`). Subsequently, only workloads that explicitly declare a perfectly matching toleration within their YAML Pod manifest will be permitted execution on those specialized nodes, effectively and permanently repelling the standard CPU-bound processes.
+Use a mock or lightweight model server locally, apply manifests in a disposable namespace, verify Pods, check Service endpoints, run a simple request, inspect rollout status, and delete the namespace afterward. The goal is not to prove the model is accurate; it is to prove the Kubernetes contract works before adding real model artifacts, cloud load balancers, and shared infrastructure constraints.
 </details>
 
-## Hands-On Exercise: Runnable End-to-End Inference Mock
-
-In this revised, fully executable lab, we will construct a simulated machine learning inference workload utilizing a lightweight NGINX server firmly configured to actively return a mock JSON prediction. This strategy guarantees you can safely practice complex deployment, service exposure, and autoscaling locally without encountering debilitating `ImagePullBackOff` errors associated with private enterprise registries.
-
-**Task 1: Deploy the Simulated Inference Service**
-We will create a specific ConfigMap to hold our mock inference response and deeply integrate it into our standard deployment container.
-
 <details>
-<summary>Solution: ConfigMap and Deployment</summary>
+<summary>7. Explain why a Service can have no endpoints even when Pods exist in the namespace.</summary>
+
+A Service routes only to Pods matching its selector and only to Pods considered ready. Label drift, selector mistakes, readiness failures, or Pods in a different namespace can all produce an empty endpoint list. The debugging path is to compare `k get pods --show-labels`, `k describe service`, and `k get endpoints` before changing application code.
+</details>
+
+## Hands-On Exercise: Deploy a Local Inference Mock
+
+This exercise uses a lightweight HTTP container so you can practice Kubernetes operations without downloading a large model. The mock server returns static JSON, but the Kubernetes contract is the same one used by real inference services: a Deployment creates replicas, probes protect traffic, a Service exposes the replicas, and commands verify rollout behavior. Use a local cluster such as kind, minikube, Docker Desktop, or another disposable Kubernetes environment before applying similar manifests to shared infrastructure.
+
+- [ ] Create a namespace and define `alias k=kubectl` for the remaining commands.
+- [ ] Apply the ConfigMap, Deployment, Service, and optional HPA manifest.
+- [ ] Verify Pods, readiness, Service endpoints, and rollout status from Kubernetes evidence.
+- [ ] Send a request from inside the cluster and confirm the mock prediction response.
+- [ ] Delete the namespace so no local resources remain after the exercise.
+
+```bash
+alias k=kubectl
+k create namespace ml-k8s-lab
+```
 
 ```yaml
-# 1-mock-config.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ml-mock-config
+  name: mock-model-config
+  namespace: ml-k8s-lab
 data:
   default.conf: |
     server {
-        listen 8000;
-        location /predict {
-            default_type application/json;
-            return 200 '{"status": "success", "prediction": [0.92, 0.08]}';
-        }
-        location /health {
-            return 200 'OK';
-        }
-        location /ready {
-            return 200 'OK';
-        }
+      listen 8000;
+      location /ready {
+        return 200 "ready\n";
+      }
+      location /live {
+        return 200 "live\n";
+      }
+      location /predict {
+        default_type application/json;
+        return 200 '{"label":"positive","score":0.91}';
+      }
     }
 ---
-# 2-mock-deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ml-inference-mock
-  labels:
-    app: ml-inference-mock
+  name: mock-inference
+  namespace: ml-k8s-lab
 spec:
   replicas: 2
   selector:
     matchLabels:
-      app: ml-inference-mock
+      app: mock-inference
   template:
     metadata:
       labels:
-        app: ml-inference-mock
+        app: mock-inference
     spec:
       containers:
-      - name: inference
-        image: nginx:1.27.0-alpine
-        ports:
-        - containerPort: 8000
-        volumeMounts:
-        - name: config-volume
-          mountPath: /etc/nginx/conf.d
-        resources:
-          requests:
-            cpu: "100m"
-            memory: "128Mi"
-          limits:
-            cpu: "250m"
-            memory: "256Mi"
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 8000
-          initialDelaySeconds: 2
-          periodSeconds: 5
+        - name: server
+          image: nginx:1.27-alpine
+          ports:
+            - containerPort: 8000
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nginx/conf.d
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "64Mi"
+            limits:
+              cpu: "250m"
+              memory: "128Mi"
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8000
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /live
+              port: 8000
+            periodSeconds: 10
       volumes:
-      - name: config-volume
-        configMap:
-          name: ml-mock-config
-```
-
-Execute the application:
-```bash
-kubectl apply -f 1-mock-config.yaml
-kubectl apply -f 2-mock-deployment.yaml
-kubectl get pods -w -l app=ml-inference-mock
-```
-</details>
-
-**Task 2: Expose the Service for Load Generation**
-<details>
-<summary>Solution: Internal ClusterIP Service</summary>
-
-For local load generation within the cluster framework, we utilize a strictly internal ClusterIP.
-
-```yaml
-# 3-mock-service.yaml
+        - name: config
+          configMap:
+            name: mock-model-config
+---
 apiVersion: v1
 kind: Service
 metadata:
-  name: ml-inference-svc
+  name: mock-inference
+  namespace: ml-k8s-lab
 spec:
   type: ClusterIP
   selector:
-    app: ml-inference-mock
+    app: mock-inference
   ports:
-  - port: 8000
-    targetPort: 8000
-```
-
-Execute the exposure:
-```bash
-kubectl apply -f 3-mock-service.yaml
-kubectl get svc ml-inference-svc
-```
-</details>
-
-**Task 3: Provision Persistent Storage for Mock Training**
-<details>
-<summary>Solution: Local PersistentVolumeClaims</summary>
-
-```yaml
-# 4-mock-pvc.yaml
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: mock-training-data-pvc
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 1Gi
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: mock-checkpoint-pvc
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 1Gi
-```
-
-Execute storage binding:
-```bash
-kubectl apply -f 4-mock-pvc.yaml
-```
-</details>
-
-**Task 4: Execute a Mock Training Job**
-<details>
-<summary>Solution: Mock Job Execution</summary>
-
-```yaml
-# 5-mock-job.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: mock-training-job
-spec:
-  backoffLimit: 1
-  template:
-    spec:
-      restartPolicy: OnFailure
-      containers:
-      - name: trainer
-        image: python:3.12-slim
-        command: ["/bin/sh", "-c"]
-        args:
-        - "echo 'Starting training...' && sleep 10 && echo 'Weights saved to /checkpoints/model.pt' > /checkpoints/model.pt && echo 'Done!'"
-        volumeMounts:
-        - name: training-data
-          mountPath: /data
-        - name: checkpoints
-          mountPath: /checkpoints
-      volumes:
-      - name: training-data
-        persistentVolumeClaim:
-          claimName: mock-training-data-pvc
-      - name: checkpoints
-        persistentVolumeClaim:
-          claimName: mock-checkpoint-pvc
-```
-
-Execute and observe completion:
-```bash
-kubectl apply -f 5-mock-job.yaml
-kubectl logs -f job/mock-training-job
-```
-</details>
-
-**Task 5: Trigger Expansion via Horizontal Pod Autoscaler**
-<details>
-<summary>Solution: HPA Application and Target Load Test</summary>
-
-```yaml
-# 6-mock-hpa.yaml
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: ml-inference-hpa
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: ml-inference-mock
-  minReplicas: 2
-  maxReplicas: 8
-  metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: 50
-```
-
-Deploy the HPA and instantly trigger massive simulated load using the correct DNS endpoint:
-```bash
-kubectl apply -f 6-mock-hpa.yaml
-kubectl get hpa ml-inference-hpa -w &
-
-# Open a secondary terminal to generate active traffic directly to the service DNS
-kubectl run -it --rm load-test --image=busybox -- /bin/sh -c "while true; do wget -q -O- http://ml-inference-svc:8000/predict; done"
-```
-
-Verify Pod replica expansion:
-```bash
-kubectl get pods -l app=ml-inference-mock -w
-```
-</details>
-
-### Success Checklist
-- [ ] Mock deployment running steadily without debilitating `ImagePullBackOff` interruptions.
-- [ ] ConfigMap successfully mounted and correctly returning JSON payloads on `/predict`.
-- [ ] PVCs structurally bound and the mock training job successfully executed to completion.
-- [ ] Load test correctly targeting the `ml-inference-svc` endpoint and successfully triggering HPA cluster expansion.
-
-## Production Reference Templates (Historical Archive)
-
-The fully executable lab above prioritizes lightweight, widely available assets. However, in live production environments actively utilizing heavily guarded cloud registries, your manifests reflect significantly greater complexity. The structural templates below serve strictly as a reference for advanced implementation architecture.
-
-```yaml
-# inference-deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: ml-inference
-  labels:
-    app: ml-inference
-spec:
-  replicas: 3
-  selector:
-    matchLabels:
-      app: ml-inference
-  template:
-    metadata:
-      labels:
-        app: ml-inference
-    spec:
-      containers:
-      - name: inference
-        image: your-registry/ml-model:v2.0.0
-        ports:
-        - containerPort: 8000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1000m"
-          limits:
-            memory: "4Gi"
-            cpu: "2000m"
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: 8000
-          initialDelaySeconds: 30
-          periodSeconds: 10
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 8000
-          initialDelaySeconds: 5
-          periodSeconds: 5
-        env:
-        - name: MODEL_PATH
-          value: "/models/latest"
-        - name: WORKERS
-          value: "4"
-```
-
-```yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: ml-inference-lb
-spec:
-  type: LoadBalancer
-  selector:
-    app: ml-inference
-  ports:
-  - port: 80
-    targetPort: 8000
+    - port: 80
+      targetPort: 8000
 ```
 
 ```bash
-# Apply the deployment
-kubectl apply -f inference-deployment.yaml
-
-# Watch pods come up
-kubectl get pods -w -l app=ml-inference
-
-# Check service external IP
-kubectl get svc ml-inference-lb
-
-# Test the endpoint
-curl http://203.0.113.50/predict -d '{"input": [1,2,3]}'
-```
-
-```yaml
-# training-job.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: model-training-job
-spec:
-  backoffLimit: 3  # Retry up to 3 times on failure
-  template:
-    spec:
-      restartPolicy: OnFailure
-      containers:
-      - name: trainer
-        image: your-registry/trainer:v2.0.0
-        command: ["python", "train.py"]
-        args:
-        - "--epochs=100"
-        - "--batch-size=32"
-        - "--checkpoint-dir=/checkpoints"
-        resources:
-          limits:
-            nvidia.com/gpu: 1
-            memory: "16Gi"
-            cpu: "4000m"
-        volumeMounts:
-        - name: training-data
-          mountPath: /data
-        - name: checkpoints
-          mountPath: /checkpoints
-        env:
-        - name: CUDA_VISIBLE_DEVICES
-          value: "0"
-        - name: WANDB_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: wandb-secret
-              key: api-key
-      volumes:
-      - name: training-data
-        persistentVolumeClaim:
-          claimName: training-data-pvc
-      - name: checkpoints
-        persistentVolumeClaim:
-          claimName: checkpoint-pvc
-      nodeSelector:
-        gpu: "true"
-      tolerations:
-      - key: "nvidia.com/gpu"
-        operator: "Exists"
-        effect: "NoSchedule"
+k apply -f mock-inference.yaml
+k rollout status deployment/mock-inference -n ml-k8s-lab
+k get pods -n ml-k8s-lab -l app=mock-inference -o wide
+k get endpoints mock-inference -n ml-k8s-lab
 ```
 
 ```bash
-# Watch job progress
-kubectl get jobs -w
-
-# View training logs
-kubectl logs -f job/model-training-job
-
-# Check GPU utilization (if nvidia-smi available)
-kubectl exec -it $(kubectl get pod -l job-name=model-training-job -o name) -- nvidia-smi
+k run curl-test \
+  -n ml-k8s-lab \
+  --rm -it \
+  --image=curlimages/curl:8.10.1 \
+  --restart=Never \
+  -- http://mock-inference/predict
 ```
 
-```yaml
-# hpa.yaml
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: ml-inference-hpa
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: ml-inference
-  minReplicas: 2
-  maxReplicas: 10
-  metrics:
-  # CPU-based scaling
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: 70
-  # Memory-based scaling
-  - type: Resource
-    resource:
-      name: memory
-      target:
-        type: Utilization
-        averageUtilization: 80
-  behavior:
-    scaleDown:
-      stabilizationWindowSeconds: 300  # Wait 5 min before scaling down
-      policies:
-      - type: Percent
-        value: 50
-        periodSeconds: 60  # Scale down at most 50% per minute
-    scaleUp:
-      stabilizationWindowSeconds: 0  # Scale up immediately
-      policies:
-      - type: Percent
-        value: 100
-        periodSeconds: 15  # Can double every 15 seconds
-      - type: Pods
-        value: 4
-        periodSeconds: 15  # Or add 4 pods every 15 seconds
-```
+If the request fails, debug from the Kubernetes layer before changing the mock server. Check whether Pods are Ready, whether the Service has endpoints, whether the selector matches Pod labels, and whether the container logs show NGINX configuration errors. That habit transfers directly to real model-serving failures because many incidents are caused by rollout, readiness, routing, and resource contracts rather than by model code.
 
 ```bash
-# Apply HPA
-kubectl apply -f hpa.yaml
-
-# Watch HPA decisions
-kubectl get hpa ml-inference-hpa -w
-
-# Generate load for testing
-kubectl run -it --rm load-test --image=busybox -- \
-  /bin/sh -c "while true; do wget -q -O- http://127.0.0.1:8000/predict; done"
-
-# Watch pods scale
-kubectl get pods -l app=ml-inference -w
+k describe pod -n ml-k8s-lab -l app=mock-inference
+k logs -n ml-k8s-lab -l app=mock-inference
+k describe service mock-inference -n ml-k8s-lab
+k delete namespace ml-k8s-lab
 ```
 
-<details>
-<summary>View the deployment configuration</summary>
+## Next Module
 
-```yaml
-# inference-deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: ml-inference
-  labels:
-    app: ml-inference
-spec:
-  replicas: 3
-  selector:
-    matchLabels:
-      app: ml-inference
-  template:
-    metadata:
-      labels:
-        app: ml-inference
-    spec:
-      containers:
-      - name: inference
-        image: your-registry/ml-model:v2.0.0
-        ports:
-        - containerPort: 8000
-        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1000m"
-          limits:
-            memory: "4Gi"
-            cpu: "2000m"
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: 8000
-          initialDelaySeconds: 30
-          periodSeconds: 10
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 8000
-          initialDelaySeconds: 5
-          periodSeconds: 5
-        env:
-        - name: MODEL_PATH
-          value: "/models/latest"
-        - name: WORKERS
-          value: "4"
-```
-</details>
-
-<details>
-<summary>View the service configuration</summary>
-
-```yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: ml-inference-lb
-spec:
-  type: LoadBalancer
-  selector:
-    app: ml-inference
-  ports:
-  - port: 80
-    targetPort: 8000
-```
-</details>
-
-<details>
-<summary>View the execution commands</summary>
-
-```bash
-# Apply the deployment
-kubectl apply -f inference-deployment.yaml
-
-# Watch pods come up
-kubectl get pods -w -l app=ml-inference
-
-# Check service external IP
-kubectl get svc ml-inference-lb
-
-# Test the endpoint
-curl http://203.0.113.50/predict -d '{"input": [1,2,3]}'
-```
-</details>
-
-<details>
-<summary>View the job configuration</summary>
-
-```yaml
-# training-job.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: model-training-job
-spec:
-  backoffLimit: 3  # Retry up to 3 times on failure
-  template:
-    spec:
-      restartPolicy: OnFailure
-      containers:
-      - name: trainer
-        image: your-registry/trainer:v2.0.0
-        command: ["python", "train.py"]
-        args:
-        - "--epochs=100"
-        - "--batch-size=32"
-        - "--checkpoint-dir=/checkpoints"
-        resources:
-          limits:
-            nvidia.com/gpu: 1
-            memory: "16Gi"
-            cpu: "4000m"
-        volumeMounts:
-        - name: training-data
-          mountPath: /data
-        - name: checkpoints
-          mountPath: /checkpoints
-        env:
-        - name: CUDA_VISIBLE_DEVICES
-          value: "0"
-        - name: WANDB_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: wandb-secret
-              key: api-key
-      volumes:
-      - name: training-data
-        persistentVolumeClaim:
-          claimName: training-data-pvc
-      - name: checkpoints
-        persistentVolumeClaim:
-          claimName: checkpoint-pvc
-      nodeSelector:
-        gpu: "true"
-      tolerations:
-      - key: "nvidia.com/gpu"
-        operator: "Exists"
-        effect: "NoSchedule"
-```
-
-```bash
-# Watch job progress
-kubectl get jobs -w
-
-# View training logs
-kubectl logs -f job/model-training-job
-
-# Check GPU utilization (if nvidia-smi available)
-kubectl exec -it $(kubectl get pod -l job-name=model-training-job -o name) -- nvidia-smi
-```
-</details>
-
-<details>
-<summary>View the autoscaler configuration</summary>
-
-```yaml
-# hpa.yaml
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: ml-inference-hpa
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: ml-inference
-  minReplicas: 2
-  maxReplicas: 10
-  metrics:
-  # CPU-based scaling
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: 70
-  # Memory-based scaling
-  - type: Resource
-    resource:
-      name: memory
-      target:
-        type: Utilization
-        averageUtilization: 80
-  behavior:
-    scaleDown:
-      stabilizationWindowSeconds: 300  # Wait 5 min before scaling down
-      policies:
-      - type: Percent
-        value: 50
-        periodSeconds: 60  # Scale down at most 50% per minute
-    scaleUp:
-      stabilizationWindowSeconds: 0  # Scale up immediately
-      policies:
-      - type: Percent
-        value: 100
-        periodSeconds: 15  # Can double every 15 seconds
-      - type: Pods
-        value: 4
-        periodSeconds: 15  # Or add 4 pods every 15 seconds
-```
-
-```bash
-# Apply HPA
-kubectl apply -f hpa.yaml
-
-# Watch HPA decisions
-kubectl get hpa ml-inference-hpa -w
-
-# Generate load for testing
-kubectl run -it --rm load-test --image=busybox -- \
-  /bin/sh -c "while true; do wget -q -O- http://127.0.0.1:8000/predict; done"
-
-# Watch pods scale
-kubectl get pods -l app=ml-inference -w
-```
-</details>
-
-## Debugging and Troubleshooting
-
-When serious incidents absolutely inevitably arise in your machine learning infrastructure, swift, precise diagnosis utilizing core primitives is paramount.
-
-### Scenario 1: Pod Stuck in Pending
-
-```bash
-# Check pod status
-kubectl describe pod <pod-name>
-
-# Look for these messages:
-# "0/3 nodes are available: 3 Insufficient nvidia.com/gpu"
-# "0/3 nodes are available: 3 Insufficient memory"
-
-# Solutions:
-# 1. Check cluster capacity
-kubectl describe nodes | grep -A5 "Allocated resources"
-
-# 2. Check GPU availability
-kubectl describe nodes | grep -A3 "nvidia.com/gpu"
-
-# 3. Reduce resource requests or add nodes
-```
-
-### Scenario 2: OOMKilled - The Memory Assassin
-
-```bash
-# Check if pod was killed for memory
-kubectl get pod <pod-name> -o jsonpath='{.status.containerStatuses[0].lastState}'
-
-# If OOMKilled, increase limits:
-# resources:
-#   limits:
-#     memory: "8Gi"  # Was 4Gi, model needs more
-
-# Pro tip: Set memory request = limit for ML workloads
-# This prevents overcommitment and makes OOM behavior predictable
-```
-
-### Scenario 3: Slow Model Loading
-
-```yaml
-# Increase initialDelaySeconds for probes
-# livenessProbe:
-#   initialDelaySeconds: 120  # Give model 2 min to load
-#   periodSeconds: 30
-# 
-# readinessProbe:
-#   initialDelaySeconds: 60
-#   periodSeconds: 10
-#   failureThreshold: 6  # Try 6 times before giving up
-```
-
-### The Kubernetes Debugging Cheat Sheet
-
-```bash
-# Pod won't start?
-kubectl describe pod <name>
-kubectl get events --sort-by='.lastTimestamp'
-
-# Pod keeps restarting?
-kubectl logs <pod> --previous  # Logs from crashed container
-
-# Service not reachable?
-kubectl get endpoints <service-name>  # Should show pod IPs
-
-# Everything looks fine but still broken?
-kubectl exec -it <pod> -- /bin/sh  # Get a shell and investigate
-```
-
-## ⏭️ Next Steps
-
-You have now rigorously mastered the incredibly complex art of securely managing highly dynamic machine learning environments utilizing the foundational orchestration power of Kubernetes. By orchestrating heavily robust deployments, firmly enforcing meticulous hardware resource policies, and actively monitoring overall cluster health, your deep learning infrastructure is completely fortified for extreme scale.
-
-**Up Next**: [Module 1.5 - Advanced Kubernetes](./module-1.5-advanced-kubernetes)
+Next, continue to [Module 1.5: Advanced Kubernetes](./module-1.5-advanced-kubernetes/) to connect these workload primitives to deeper cluster operations, production policies, and advanced deployment patterns.
 
 ## Sources
 
-## Sources
-
-- [Borg: The Predecessor to Kubernetes](https://kubernetes.io/blog/2015/04/borg-predecessor-to-kubernetes/) — Explains how Borg influenced the design and operational model of Kubernetes.
-- [Kubernetes Case Studies](https://kubernetes.io/case-studies/) — Shows real production uses of Kubernetes across industries, including data and ML-adjacent platforms.
-- [Workloads](https://kubernetes.io/docs/concepts/workloads/) — Describes Pods and higher-level workload controllers such as Deployments and Jobs.
-- [Service](https://kubernetes.io/docs/concepts/services-networking/service/) — Defines how Services provide stable access to changing sets of backend Pods.
-- [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) — Covers requests, limits, CPU throttling behavior, and memory-related OOM outcomes.
-- [Pod Quality of Service Classes](https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/) — Explains Guaranteed, Burstable, and BestEffort QoS and how they affect eviction behavior.
-- [Horizontal Pod Autoscaling](https://kubernetes.io/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/) — Explains how HPA adjusts replica counts from observed metrics and is useful follow-on reading for the autoscaling examples.
-- [Vertical Pod Autoscaling](https://kubernetes.io/docs/concepts/workloads/autoscaling/vertical-pod-autoscale/) — Describes how VPA recommends or updates Pod resource settings over time.
-- [Change the Access Mode of a PersistentVolume to ReadWriteOncePod](https://kubernetes.io/docs/tasks/administer-cluster/change-pv-access-mode-readwriteoncepod/) — Explains the single-Pod write-access semantics of ReadWriteOncePod.
-- [DNS for Services and Pods](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/) — Documents built-in DNS naming patterns such as `service.namespace.svc.cluster.local`.
-- [Topology Aware Routing](https://kubernetes.io/docs/concepts/services-networking/topology-aware-routing/) — Explains same-zone routing preferences and when they improve performance, reliability, or cost.
-- [Kubernetes Components](https://kubernetes.io/docs/concepts/overview/components/) — Best upstream overview of control plane and node components referenced throughout the module.
-- [Schedule GPUs](https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/) — Covers the official Kubernetes model for requesting GPUs and scheduling workloads onto accelerator nodes.
-- [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) — Explains persistent storage concepts and access modes referenced in the storage section.
+- [Kubernetes: Pods](https://kubernetes.io/docs/concepts/workloads/pods/) — Defines the Pod abstraction, lifecycle context, networking model, and why Pods are the schedulable unit for containers.
+- [Kubernetes: Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) — Documents rollout behavior, replica management, selectors, and Deployment status used for inference services.
+- [Kubernetes: Services](https://kubernetes.io/docs/concepts/services-networking/service/) — Explains stable networking and Service selectors for changing sets of Pods.
+- [Kubernetes: Configure Liveness, Readiness, and Startup Probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) — Covers probe semantics used to protect model startup and traffic routing.
+- [Kubernetes: Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) — Describes requests, limits, CPU throttling, memory behavior, and scheduling implications.
+- [Kubernetes: Pod Quality of Service Classes](https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/) — Explains Guaranteed, Burstable, and BestEffort classes and their relationship to eviction.
+- [Kubernetes: Horizontal Pod Autoscaling](https://kubernetes.io/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/) — Documents HPA behavior and metrics-driven replica scaling.
+- [Kubernetes: Schedule GPUs](https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/) — Describes the official GPU scheduling model and extended resource requests.
+- [Kubernetes: Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) — Explains how node taints and Pod tolerations shape placement decisions.
+- [Kubernetes: Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) — Covers PersistentVolumes, PersistentVolumeClaims, and access modes for model artifacts and checkpoints.
+- [Kubernetes: Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/job/) — Defines finite task execution semantics for training, batch scoring, and migration-style workloads.
+- [KEDA Documentation: Concepts](https://keda.sh/docs/latest/concepts/) — Provides background on event-driven autoscaling patterns for queue-backed workloads.


### PR DESCRIPTION
## Summary

- Rewrites the AI/ML Engineering MLOps Kubernetes for ML module to the #388 verifier structure.
- Adds standard metadata, Why This Module Matters, 4 Did You Know items, 7 common mistakes, 7 detailed quiz items, hands-on local inference mock, Next Module link, and 12 reachable sources.
- Replaces the historical archive-style long YAML dump with denser teaching prose and focused runnable examples.

## Verification

- [x] `.venv/bin/python scripts/quality/verify_module.py --glob src/content/docs/ai-ml-engineering/mlops/module-1.4-kubernetes-for-ml.md --summary --quiet` -> T0, all gates pass
- [x] `git diff --check`
- [ ] `npm run build` from primary checkout before merge
- [ ] Gemini cross-family review

Addresses part of #338 / #388. Does not close #338 because the AI/ML Engineering epic still has more modules.