### PR TITLE
chore(388): writer prompts require ## Sources + bucket-builder skips active remote branches

### DIFF
--- a/scripts/prompts/module-rewriter-388.md
+++ b/scripts/prompts/module-rewriter-388.md
@@ -54,9 +54,13 @@ All must pass before commit. The deterministic verifier (`scripts/quality/verify
 7. >= 2 inline active-learning prompts in core content (not just in the final hands-on)
 8. Each Learning Outcome maps to >= 1 core section AND >= 1 quiz item OR lab task
 9. Quiz answers explain reasoning (not just name the fix)
-10. Sources >= 10, all reaching primary/vendor docs (not marketing fluff or dead redirects), URL uniqueness preserved
+10. `## Sources` is required as the last section before `## Next Module`, with at least 3 citations.
+   Acceptable citation formats are bare URLs (`- https://...`) or markdown links (`- [title](https://...)`).
+11. Sources >= 10, all reaching primary/vendor docs (not marketing fluff or dead redirects), URL uniqueness preserved
 
 Plus the structural gates from `module-writer.md`: section presence + order, exactly 4 DYK, 6-8 Common Mistakes rows, 6-8 scenario quiz with `<details>`, Hands-On with `- [ ]` checkboxes, no emojis, no number 47, kubectl alias `k`, K8s 1.35+, no anti-leak tokens.
+
+The deterministic verifier counts links inside the Sources section only — citations elsewhere don't count.
 
 ## TIER ROUTING
 

--- a/scripts/prompts/module-rewriter-388.md
+++ b/scripts/prompts/module-rewriter-388.md
@@ -54,9 +54,7 @@ All must pass before commit. The deterministic verifier (`scripts/quality/verify
 7. >= 2 inline active-learning prompts in core content (not just in the final hands-on)
 8. Each Learning Outcome maps to >= 1 core section AND >= 1 quiz item OR lab task
 9. Quiz answers explain reasoning (not just name the fix)
-10. `## Sources` is required as the last section before `## Next Module`, with at least 3 citations.
-   Acceptable citation formats are bare URLs (`- https://...`) or markdown links (`- [title](https://...)`).
-11. Sources >= 10, all reaching primary/vendor docs (not marketing fluff or dead redirects), URL uniqueness preserved
+10. `## Sources` is required as the **last H2** section before `## Next Module`. It must contain at least **10** unique URLs, each in either bare form (`- https://...`) or markdown form (`- [title](https://...)`), and all links must point to primary/vendor docs (not marketing fluff or dead redirects). Verifier counting applies only to links under `## Sources` (it does not count citations elsewhere).
 
 Plus the structural gates from `module-writer.md`: section presence + order, exactly 4 DYK, 6-8 Common Mistakes rows, 6-8 scenario quiz with `<details>`, Hands-On with `- [ ]` checkboxes, no emojis, no number 47, kubectl alias `k`, K8s 1.35+, no anti-leak tokens.
 

--- a/scripts/prompts/module-writer.md
+++ b/scripts/prompts/module-writer.md
@@ -59,7 +59,11 @@ TASK: Write a complete KubeDojo educational module.
     - 4-6 progressive tasks (easy → challenging)
     - Solutions in `<details>` tags
     - Clear success criteria checklist using `- [ ]` format
-11. **Next Module** — Link to the next module with a one-line teaser
+11. **Sources** — Required final module section before `## Next Module`, with at least 3 citations to primary/vendor docs.
+    - Each citation is either a bare URL (`- https://...`) or `[title](url)` markdown link.
+    - At least 3 entries are required.
+    - The deterministic verifier counts links inside the Sources section only — citations elsewhere don't count.
+12. **Next Module** — Link to the next module with a one-line teaser
 
 **TONE**:
 - Conversational but authoritative — like a senior engineer mentoring you

--- a/scripts/quality/run_388_batch.py
+++ b/scripts/quality/run_388_batch.py
@@ -50,6 +50,7 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import json
+import subprocess
 import sys
 import urllib.request
 from pathlib import Path
@@ -105,6 +106,42 @@ def fetch_active_leases() -> set[str]:
     return paths
 
 
+def fetch_active_pilot_branches() -> dict[str, str]:
+    """Read active remote `codex/388-pilot-*` and `claude/388-pilot-*` branches once."""
+    cmd = [
+        "git",
+        "-C",
+        str(REPO),
+        "ls-remote",
+        "--heads",
+        "origin",
+        "codex/388-pilot-*",
+        "claude/388-pilot-*",
+    ]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    except subprocess.CalledProcessError:
+        return {}
+    active: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        ref = parts[1]
+        if not ref.startswith("refs/heads/"):
+            continue
+        branch = ref.removeprefix("refs/heads/")
+        if branch.startswith("codex/388-pilot-"):
+            slug = branch.removeprefix("codex/388-pilot-")
+            if slug and slug not in active:
+                active[slug] = branch
+        elif branch.startswith("claude/388-pilot-"):
+            slug = branch.removeprefix("claude/388-pilot-")
+            if slug and slug not in active:
+                active[slug] = branch
+    return active
+
+
 def list_tracks(plan: dict) -> None:
     print(f"Total critical (<{CRITICAL_THRESHOLD}) modules: {plan.get('needs_upgrade_count', '?')}")
     print()
@@ -130,7 +167,13 @@ def list_tracks(plan: dict) -> None:
         print(f"  {alias:24s} → {' + '.join(prefixes)}")
 
 
-def select_modules(track_arg: str, plan: dict, board: dict, leases: set[str]) -> tuple[list[str], list[str]]:
+def select_modules(
+    track_arg: str,
+    plan: dict,
+    board: dict,
+    leases: set[str],
+    active_pilot_branches: dict[str, str] | None = None,
+) -> tuple[list[str], list[str]]:
     """Resolve --track to a filtered list of repo-relative paths.
 
     Returns (selected_paths, skip_reasons) — selected_paths are
@@ -167,9 +210,16 @@ def select_modules(track_arg: str, plan: dict, board: dict, leases: set[str]) ->
     # Filter: skip modules that the board says are already done OR currently leased
     selected: list[str] = []
     reasons: list[str] = []
+    pilot_map = active_pilot_branches or {}
     for m in candidates:
         api_path = m["path"]
         repo_path = f"src/content/docs/{api_path}"
+        slug = Path(api_path).name
+        if slug in pilot_map:
+            reason = f"[skip] {slug}: active remote branch {pilot_map[slug]}"
+            reasons.append(reason)
+            print(reason)
+            continue
         b = board.get(api_path, {})
         if b.get("status") == "done" or b.get("revision_pending") is False and (b.get("score", 0) or 0) >= 4.0:
             reasons.append(f"  skip [done]      {api_path}")
@@ -295,6 +345,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p.add_argument("--dry", action="store_true", help="Print the plan; do not dispatch or clean up.")
     p.add_argument("--no-cleanup", action="store_true", help="Skip the post-dispatch cleanup step.")
     p.add_argument("--max", "-n", type=int, default=0, help="Stop after N modules (passed through to dispatcher).")
+    p.add_argument(
+        "--no-skip-active-branches",
+        action="store_true",
+        help="Do not skip modules with active codex/claude 388-pilot remote branches.",
+    )
     return p.parse_args(argv)
 
 
@@ -317,9 +372,10 @@ def main(argv: list[str] | None = None) -> int:
         plan = fetch_upgrade_plan()
         board = fetch_quality_board()
         leases = fetch_active_leases()
+        active_branches = {} if args.no_skip_active_branches else fetch_active_pilot_branches()
         if leases:
             print(f"[batch] {len(leases)} active pipeline lease(s) — those modules will be skipped")
-        queue, _ = select_modules(args.track, plan, board, leases)
+        queue, _ = select_modules(args.track, plan, board, leases, active_branches)
         if not queue:
             print("❌ no modules to dispatch (all filtered out).", file=sys.stderr)
             return 1

--- a/scripts/quality/run_388_batch.py
+++ b/scripts/quality/run_388_batch.py
@@ -62,6 +62,7 @@ API_BASE = "http://127.0.0.1:8768"
 CRITICAL_THRESHOLD = 2.0  # rubric score below this = critical (mirrors API definition)
 
 sys.path.insert(0, str(REPO / "scripts"))
+from quality.dispatch_388_pilot import slugify  # noqa: E402
 
 
 # Top-level aliases → list of filesystem prefixes the alias covers.
@@ -120,7 +121,15 @@ def fetch_active_pilot_branches() -> dict[str, str]:
     ]
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, check=True)
-    except subprocess.CalledProcessError:
+    except subprocess.CalledProcessError as exc:
+        print("[batch] WARNING: failed to fetch remote pilot branches; skip-by-branch is disabled this run", file=sys.stderr)
+        print(f"[batch] WARNING:   error: {exc}", file=sys.stderr)
+        print("[batch] WARNING:   to skip duplicate codex burn, abort and re-run when network is healthy", file=sys.stderr)
+        return {}
+    except Exception as exc:
+        print("[batch] WARNING: failed to fetch remote pilot branches; skip-by-branch is disabled this run", file=sys.stderr)
+        print(f"[batch] WARNING:   error: {exc}", file=sys.stderr)
+        print("[batch] WARNING:   to skip duplicate codex burn, abort and re-run when network is healthy", file=sys.stderr)
         return {}
     active: dict[str, str] = {}
     for line in result.stdout.splitlines():
@@ -214,15 +223,17 @@ def select_modules(
     for m in candidates:
         api_path = m["path"]
         repo_path = f"src/content/docs/{api_path}"
-        slug = Path(api_path).name
+        b = board.get(api_path, {})
+        if b.get("status") == "done" or (
+            b.get("revision_pending") is False and (b.get("score", 0) or 0) >= 4.0
+        ):
+            reasons.append(f"  skip [done]      {api_path}")
+            continue
+        slug = slugify(api_path)
         if slug in pilot_map:
             reason = f"[skip] {slug}: active remote branch {pilot_map[slug]}"
             reasons.append(reason)
             print(reason)
-            continue
-        b = board.get(api_path, {})
-        if b.get("status") == "done" or b.get("revision_pending") is False and (b.get("score", 0) or 0) >= 4.0:
-            reasons.append(f"  skip [done]      {api_path}")
             continue
         if api_path in leases or repo_path in leases:
             reasons.append(f"  skip [leased]    {api_path}")

--- a/tests/test_run_388_batch.py
+++ b/tests/test_run_388_batch.py
@@ -14,8 +14,8 @@ def _build_plan() -> dict:
             {
                 "track": "platform",
                 "modules": [
-                    {"path": "platform/module-1.9-foo"},
-                    {"path": "platform/module-1.9-bar"},
+                    {"path": "platform/module-1.9-foo.md"},
+                    {"path": "platform/module-1.9-bar.md"},
                 ],
             }
         ]
@@ -28,16 +28,44 @@ def test_select_modules_skips_matching_remote_pilot_branches() -> None:
         _build_plan(),
         {},
         set(),
-        {"module-1.9-foo": "codex/388-pilot-module-1.9-foo"},
+        {"module-1-9-foo": "codex/388-pilot-module-1-9-foo"},
     )
-    assert selected == ["src/content/docs/platform/module-1.9-bar"]
-    assert any("[skip] module-1.9-foo: active remote branch codex/388-pilot-module-1.9-foo" in r for r in reasons)
+    assert selected == ["src/content/docs/platform/module-1.9-bar.md"]
+    assert any(
+        "[skip] module-1-9-foo: active remote branch codex/388-pilot-module-1-9-foo" in r
+        for r in reasons
+    )
 
 
 def test_select_modules_keeps_module_without_matching_remote_branch() -> None:
     selected, reasons = run_388_batch.select_modules("platform", _build_plan(), {}, set(), {})
     assert len(selected) == 2
+    assert selected == [
+        "src/content/docs/platform/module-1.9-foo.md",
+        "src/content/docs/platform/module-1.9-bar.md",
+    ]
     assert not reasons
+
+
+def test_select_modules_skips_done_before_active_pilot_branch() -> None:
+    board = {
+        "platform/module-1.9-foo.md": {
+            "status": "done",
+            "revision_pending": False,
+            "score": 4.7,
+        }
+    }
+    selected, reasons = run_388_batch.select_modules(
+        "platform",
+        _build_plan(),
+        board,
+        set(),
+        {"module-1-9-foo": "codex/388-pilot-module-1-9-foo"},
+    )
+
+    assert selected == ["src/content/docs/platform/module-1.9-bar.md"]
+    assert any("  skip [done]      platform/module-1.9-foo.md" in r for r in reasons)
+    assert not any("[skip] module-1-9-foo" in r for r in reasons)
 
 
 def test_main_no_skip_active_branches_overrides_bucket_skip(
@@ -50,15 +78,15 @@ def test_main_no_skip_active_branches_overrides_bucket_skip(
     monkeypatch.setattr(
         run_388_batch,
         "fetch_active_pilot_branches",
-        lambda: {"module-1.9-foo": "codex/388-pilot-module-1.9-foo"},
+        lambda: {"module-1-9-foo": "codex/388-pilot-module-1-9-foo"},
     )
 
     rc = run_388_batch.main(["--track", "platform", "--dry", "--no-skip-active-branches"])
     out = capsys.readouterr().out
 
     assert rc == 0
-    assert "[skip] module-1.9-foo: active remote branch" not in out
-    assert "platform/module-1.9-foo" in out
+    assert "[skip] module-1-9-foo: active remote branch" not in out
+    assert "platform/module-1.9-foo.md" in out
 
 
 def test_main_skips_module_with_active_pilot_branch_by_default(
@@ -71,13 +99,12 @@ def test_main_skips_module_with_active_pilot_branch_by_default(
     monkeypatch.setattr(
         run_388_batch,
         "fetch_active_pilot_branches",
-        lambda: {"module-1.9-foo": "codex/388-pilot-module-1.9-foo"},
+        lambda: {"module-1-9-foo": "codex/388-pilot-module-1-9-foo"},
     )
 
     rc = run_388_batch.main(["--track", "platform", "--dry"])
     out = capsys.readouterr().out
 
     assert rc == 0
-    assert "[skip] module-1.9-foo: active remote branch codex/388-pilot-module-1.9-foo" in out
-    assert "platform/module-1.9-bar" in out
-
+    assert "[skip] module-1-9-foo: active remote branch codex/388-pilot-module-1-9-foo" in out
+    assert "platform/module-1.9-bar.md" in out

--- a/tests/test_run_388_batch.py
+++ b/tests/test_run_388_batch.py
@@ -1,0 +1,83 @@
+"""Unit tests for #388 batch remote-branch skip behavior."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.quality import run_388_batch
+
+
+def _build_plan() -> dict:
+    return {
+        "tracks": [
+            {
+                "track": "platform",
+                "modules": [
+                    {"path": "platform/module-1.9-foo"},
+                    {"path": "platform/module-1.9-bar"},
+                ],
+            }
+        ]
+    }
+
+
+def test_select_modules_skips_matching_remote_pilot_branches() -> None:
+    selected, reasons = run_388_batch.select_modules(
+        "platform",
+        _build_plan(),
+        {},
+        set(),
+        {"module-1.9-foo": "codex/388-pilot-module-1.9-foo"},
+    )
+    assert selected == ["src/content/docs/platform/module-1.9-bar"]
+    assert any("[skip] module-1.9-foo: active remote branch codex/388-pilot-module-1.9-foo" in r for r in reasons)
+
+
+def test_select_modules_keeps_module_without_matching_remote_branch() -> None:
+    selected, reasons = run_388_batch.select_modules("platform", _build_plan(), {}, set(), {})
+    assert len(selected) == 2
+    assert not reasons
+
+
+def test_main_no_skip_active_branches_overrides_bucket_skip(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    monkeypatch.setattr(run_388_batch, "fetch_upgrade_plan", _build_plan)
+    monkeypatch.setattr(run_388_batch, "fetch_quality_board", lambda: {})
+    monkeypatch.setattr(run_388_batch, "fetch_active_leases", lambda: set())
+    monkeypatch.setattr(
+        run_388_batch,
+        "fetch_active_pilot_branches",
+        lambda: {"module-1.9-foo": "codex/388-pilot-module-1.9-foo"},
+    )
+
+    rc = run_388_batch.main(["--track", "platform", "--dry", "--no-skip-active-branches"])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "[skip] module-1.9-foo: active remote branch" not in out
+    assert "platform/module-1.9-foo" in out
+
+
+def test_main_skips_module_with_active_pilot_branch_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    monkeypatch.setattr(run_388_batch, "fetch_upgrade_plan", _build_plan)
+    monkeypatch.setattr(run_388_batch, "fetch_quality_board", lambda: {})
+    monkeypatch.setattr(run_388_batch, "fetch_active_leases", lambda: set())
+    monkeypatch.setattr(
+        run_388_batch,
+        "fetch_active_pilot_branches",
+        lambda: {"module-1.9-foo": "codex/388-pilot-module-1.9-foo"},
+    )
+
+    rc = run_388_batch.main(["--track", "platform", "--dry"])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "[skip] module-1.9-foo: active remote branch codex/388-pilot-module-1.9-foo" in out
+    assert "platform/module-1.9-bar" in out
+


### PR DESCRIPTION
## Summary

Two small #388-prep changes bundled into one PR. Both gate the next #388 ai-ml-engineering batch.

### 1) Writer prompts now require a `## Sources` heading

Files: `scripts/prompts/module-rewriter-388.md`, `scripts/prompts/module-writer.md`.

Per the 2026-05-05 stuck-investigation: 12 of 19 #388-rewritten ai-ml-engineering modules shipped without a `## Sources` heading. Scorer reads them as no-citations and caps at 1.5. Root cause: the writer prompts didn't make the section mandatory.

- Hard structural requirement: `## Sources` is the last H2 before `## Next Module`.
- `module-rewriter-388.md` (#388 sweeps): >= 10 unique URLs to primary/vendor docs (existing standard preserved).
- `module-writer.md` (greenfield): >= 3 citations.
- Accepted formats: bare URL (`- https://...`) or `[title](url)` markdown link — both scored as citations after PR #894.

### 2) Bucket-builder skips modules with active remote pilot branches

File: `scripts/quality/run_388_batch.py` (+ `tests/test_run_388_batch.py`).

Without this, every #388 batch rerun wastes ~30 min of codex on modules with in-flight pilot branches.

- New `fetch_active_pilot_branches()` reads remote heads once: `git ls-remote --heads origin 'codex/388-pilot-*' 'claude/388-pilot-*'`.
- `select_modules()` now uses the dispatcher's `slugify` (imported from `dispatch_388_pilot.py`) as single source of truth — fixes a slug-mismatch bug caught in gemini round 1.
- Skip happens AFTER the existing `done` check (so already-done modules log `[done]`, not active-branch).
- On `git ls-remote` failure: prints prominent stderr warnings and continues with skip disabled (round-1 review fix).
- New `--no-skip-active-branches` flag for forced reruns.
- 5 unit tests covering real `.md` paths + hyphenated slugs.

## Verification

- `PYTHONPATH=. .venv/bin/pytest tests/test_run_388_batch.py -v` → 5 passed
- `.venv/bin/ruff check scripts/quality/run_388_batch.py` → clean
- `npm run build` (primary tree) → 2,015 pages built

## Review history

- **Gemini round 1**: NEEDS CHANGES on (a) slug-derivation mismatch, (b) tests using artificial paths, (c) rewriter rules 10+11 contradiction, (d) silent fail on git error, (e) skip-order nit.
- **Round 2 commit `7dd63fbe`**: addresses all 5.
- **Gemini round 2**: APPROVE — all findings ADDRESSED, no new defects.

## Context

- 2026-05-05 session 4 handoff: `docs/session-state/2026-05-05-4-phase-e-complete-388-pilots-gemini-fallback.md`
- PR #894 (scorer fix): bare URLs in `## Sources` now count as citations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)