### PR TITLE
chore(878): set-based delta gate for incident-dedup (Phase 0)

### DIFF
--- a/.github/workflows/incident-dedup.yml
+++ b/.github/workflows/incident-dedup.yml
@@ -1,0 +1,52 @@
+name: Incident dedup delta gate
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  contents: read
+
+jobs:
+  incident-dedup-gate:
+    name: Incident dedup gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+
+      - name: Fetch origin/main
+        run: git fetch origin main --depth=1
+
+      - name: Run incident dedup delta gate
+        id: incident-dedup-gate
+        run: |
+          set -euo pipefail
+          if ! output="$(python scripts/quality/incident_dedup_gate.py --base origin/main 2>&1 | tee gate.log)"; then
+            echo "$output"
+            {
+              echo "## Incident dedup gate failed"
+              echo ""
+              echo "New incident triples introduced:"
+              cat gate.log
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          echo "$output"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: incident-dedup-gate
+        name: incident dedup delta gate
+        entry: .venv/bin/python scripts/quality/incident_dedup_gate.py --mode delta --base origin/main
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/docs/audits/2026-05-04-incident-canonicals.md
+++ b/docs/audits/2026-05-04-incident-canonicals.md
@@ -6,6 +6,8 @@
 
 ## Lock table
 
+**FROZEN until #878 closes. No canonical reassignments allowed. Adding new canonicals is allowed only when claiming a catalog replacement in a Phase 1+ sweep PR.**
+
 | # | Incident | Canonical module | Lesson it owns |
 |---|---|---|---|
 | 1 | Knight Capital 2012 | `prerequisites/modern-devops/module-1.1-infrastructure-as-code.md` | Fleet drift / partial deployment / "7 of 8 servers" |

--- a/scripts/quality/incident_dedup_gate.py
+++ b/scripts/quality/incident_dedup_gate.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Set-based gate for incident-duplication regressions.
+
+The checker enforces a monotonicity rule:
+
+* New violations may be introduced by base->branch diff **only if**
+  they are not in the base set.
+* Passing means ``after`` violations are a subset of ``before`` and count
+  has not increased.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+Triple = tuple[str, str, str]
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _python_executable(repo_root: Path) -> str:
+    venv_python = repo_root / ".venv" / "bin" / "python"
+    if venv_python.exists():
+        return str(venv_python)
+    return os.environ.get("KUBEDOJO_INCIDENT_GATE_PYTHON", "python3")
+
+
+def _run_git(cmd: list[str], repo_root: Path) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["git", *cmd],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        stderr = result.stderr.strip() or result.stdout.strip() or "git command failed"
+        raise RuntimeError(stderr)
+    return result
+
+
+def _run_check(repo_root: Path) -> list[dict]:
+    script = repo_root / "scripts" / "check_incident_reuse.py"
+    result = subprocess.run(
+        [_python_executable(repo_root), str(script), "--json"],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+    )
+
+    if result.returncode not in (0, 1):
+        err = result.stderr.strip() or result.stdout.strip() or "checker command failed"
+        raise RuntimeError(err)
+
+    payload = json.loads(result.stdout)
+    violations = payload.get("violations")
+    if not isinstance(violations, list):
+        raise RuntimeError("checker JSON missing violations list")
+    return violations
+
+
+def _to_triples(violations: list[dict]) -> set[Triple]:
+    triples: set[Triple] = set()
+    for violation in violations:
+        if not isinstance(violation, dict):
+            continue
+        kind = violation.get("kind")
+        incident = violation.get("incident")
+        file = violation.get("file")
+        if all(isinstance(value, str) for value in (kind, incident, file)):
+            triples.add((str(kind), str(incident), str(file)))
+    return triples
+
+
+def _run_in_base_worktree(repo_root: Path, base_ref: str) -> tuple[set[Triple], list[dict]]:
+    with tempfile.TemporaryDirectory(prefix="incident-dedup-base-") as worktree:
+        worktree_path = Path(worktree)
+        _run_git(["worktree", "add", "--detach", str(worktree_path), base_ref], repo_root)
+        try:
+            before_violations = _run_check(worktree_path)
+            return _to_triples(before_violations), before_violations
+        finally:
+            # Remove the linked worktree registration even if inspection fails.
+            _run_git(["worktree", "remove", "--force", str(worktree_path)], repo_root)
+
+
+def _sorted_triples(triples: set[Triple]) -> list[list[str]]:
+    return [list(item) for item in sorted(triples)]
+
+
+def run_delta_gate(repo_root: Path, base_ref: str) -> tuple[bool, dict]:
+    before_set, before_violations = _run_in_base_worktree(repo_root, base_ref)
+    after_violations = _run_check(repo_root)
+    after_set = _to_triples(after_violations)
+
+    added = after_set - before_set
+    removed = before_set - after_set
+    count_regressed = len(after_set) > len(before_set)
+
+    ok = len(added) == 0 and not count_regressed
+    return ok, {
+        "mode": "delta",
+        "base_ref": base_ref,
+        "status": "pass" if ok else "fail",
+        "added": _sorted_triples(added),
+        "removed": _sorted_triples(removed),
+        "before": _sorted_triples(before_set),
+        "after": _sorted_triples(after_set),
+        "before_count": len(before_set),
+        "after_count": len(after_set),
+        "added_count": len(added),
+        "removed_count": len(removed),
+        "count_regressed": count_regressed,
+        "before_violations": before_violations,
+        "after_violations": after_violations,
+    }
+
+
+def run_absolute_gate(repo_root: Path) -> tuple[bool, dict]:
+    after_violations = _run_check(repo_root)
+    after_set = _to_triples(after_violations)
+    ok = len(after_set) == 0
+    return ok, {
+        "mode": "absolute",
+        "status": "pass" if ok else "fail",
+        "after": _sorted_triples(after_set),
+        "after_count": len(after_set),
+        "violations": after_violations,
+    }
+
+
+def _print_human_report(result: dict, ok: bool, mode: str) -> None:
+    if mode == "delta":
+        print(f"incident_dedup_gate: {'PASS' if ok else 'FAIL'} (delta)")
+        print(
+            f"before violations: {result['before_count']} | after violations: {result['after_count']} "
+            f"| added: {result['added_count']} | removed: {result['removed_count']}"
+        )
+        if result["count_regressed"]:
+            print(
+                f"COUNT REGRESSION: after={result['after_count']} > before={result['before_count']}"
+            )
+        if result["added"]:
+            print("NEW triples introduced:")
+            for kind, incident, file in result["added"]:
+                print(f"  - kind={kind} | incident={incident} | file={file}")
+        if ok:
+            print("No new incident triples introduced.")
+        return
+
+    print(f"incident_dedup_gate: {'PASS' if ok else 'FAIL'} (absolute)")
+    if not ok:
+        print(f"Remaining violations: {result['after_count']}")
+        for kind, incident, file in result["after"]:
+            print(f"  - kind={kind} | incident={incident} | file={file}")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Gate incident reuse regressions by set difference",
+    )
+    parser.add_argument(
+        "--base",
+        default="origin/main",
+        help="Base git ref for delta comparison (default: origin/main)",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    parser.add_argument(
+        "--mode",
+        default="delta",
+        choices=("delta", "absolute"),
+        help="Gate mode (delta compares base->current, absolute fails if any violations exist)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    repo_root = REPO_ROOT
+
+    if args.mode == "delta":
+        ok, payload = run_delta_gate(repo_root, args.base)
+    else:
+        ok, payload = run_absolute_gate(repo_root)
+
+    if args.json:
+        json.dump(
+            payload,
+            sys.stdout,
+            indent=2,
+            sort_keys=True,
+        )
+        sys.stdout.write("\n")
+    else:
+        _print_human_report(payload, ok, args.mode)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_incident_dedup_gate.py
+++ b/tests/test_incident_dedup_gate.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GATE_SCRIPT = REPO_ROOT / "scripts/quality/incident_dedup_gate.py"
+PYTHON_BIN = shutil.which("python3") or shutil.which("python") or "python"
+
+
+def _git(repo: Path, args: list[str]) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+
+
+def _init_repo_with_scripts(repo: Path) -> None:
+    scripts_dir = repo / "scripts"
+    quality_dir = scripts_dir / "quality"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    quality_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy(REPO_ROOT / "scripts" / "check_incident_reuse.py", scripts_dir / "check_incident_reuse.py")
+    shutil.copy(REPO_ROOT / "scripts" / "audit_incident_reuse.py", scripts_dir / "audit_incident_reuse.py")
+    shutil.copy(GATE_SCRIPT, quality_dir / "incident_dedup_gate.py")
+
+    _git(repo, ["init", "-b", "main"])
+    _git(repo, ["config", "user.email", "test@example.com"])
+    _git(repo, ["config", "user.name", "test"])
+    _git(repo, ["add", "scripts"])
+    _git(repo, ["commit", "-m", "add incident scripts"])
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _commit(repo: Path, path: str, content: str, message: str) -> None:
+    target = repo / path
+    _write_text(target, content)
+    _git(repo, ["add", path])
+    _git(repo, ["commit", "-m", message])
+
+
+def _branch(repo: Path, name: str) -> None:
+    _git(repo, ["checkout", "-b", name])
+
+
+def _run_gate(repo: Path, *, base: str = "main", mode: str = "delta", emit_json: bool = True) -> subprocess.CompletedProcess[str]:
+    cmd = [PYTHON_BIN, str(repo / "scripts/quality/incident_dedup_gate.py"), "--base", base, "--mode", mode]
+    if emit_json:
+        cmd.append("--json")
+    return subprocess.run(
+        cmd,
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+
+
+VIOLATION_UBER = "Uber had a security event with MFA fatigue in 2022.\n"
+VIOLATION_TARGET = "Target had an HVAC-related incident around the 2013 breach.\n"
+VIOLATION_NONE = "This module contains only generic conceptual guidance.\n"
+
+
+def _parse_gate_payload(result: subprocess.CompletedProcess[str]) -> dict:
+    assert result.returncode in (0, 1)
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_delta_mode_pass_when_set_is_identical(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo_with_scripts(repo)
+    _commit(repo, "src/content/docs/module.md", VIOLATION_UBER, "seed base")
+    _branch(repo, "delta-identical")
+
+    result = _run_gate(repo, base="main", mode="delta", emit_json=False)
+    assert result.returncode == 0
+
+
+def test_delta_mode_fails_when_new_triple_added(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo_with_scripts(repo)
+    _commit(repo, "src/content/docs/module.md", VIOLATION_UBER, "seed base")
+    _branch(repo, "delta-new-triple")
+    _commit(repo, "src/content/docs/new/module.md", VIOLATION_TARGET, "add new triple")
+
+    result = _run_gate(repo, base="main", mode="delta", emit_json=True)
+    payload = _parse_gate_payload(result)
+    assert result.returncode == 1
+    assert payload["status"] == "fail"
+    assert payload["mode"] == "delta"
+    assert ["duplicate", "Target 2013 breach", "src/content/docs/new/module.md"] in payload["added"]
+
+
+def test_delta_mode_pass_when_old_triple_removed(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo_with_scripts(repo)
+    _commit(repo, "src/content/docs/module.md", VIOLATION_UBER, "seed base")
+    _branch(repo, "delta-removed")
+    _commit(repo, "src/content/docs/module.md", VIOLATION_NONE, "remove violation")
+
+    result = _run_gate(repo, base="main", mode="delta", emit_json=True)
+    payload = _parse_gate_payload(result)
+    assert result.returncode == 0
+    assert payload["status"] == "pass"
+    assert payload["added"] == []
+
+
+def test_delta_mode_fails_when_old_replaced_by_different_triple(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo_with_scripts(repo)
+    _commit(repo, "src/content/docs/module.md", VIOLATION_UBER, "seed base")
+    _branch(repo, "delta-replace")
+    _commit(repo, "src/content/docs/module.md", VIOLATION_NONE, "remove old violation")
+    _commit(repo, "src/content/docs/other/module.md", VIOLATION_TARGET, "add replacement violation")
+
+    result = _run_gate(repo, base="main", mode="delta", emit_json=True)
+    payload = _parse_gate_payload(result)
+    assert result.returncode == 1
+    assert payload["status"] == "fail"
+    assert ["duplicate", "Target 2013 breach", "src/content/docs/other/module.md"] in payload["added"]
+    assert ["duplicate", "Uber 2022 hardcoded credentials", "src/content/docs/module.md"] in payload["removed"]
+
+
+def test_absolute_mode_fails_when_any_after_violation_exists(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo_with_scripts(repo)
+    _commit(repo, "src/content/docs/module.md", VIOLATION_NONE, "seed base")
+    _branch(repo, "absolute-fails")
+    _commit(repo, "src/content/docs/new/module.md", VIOLATION_UBER, "add violation")
+
+    result = _run_gate(repo, base="main", mode="absolute", emit_json=True)
+    payload = _parse_gate_payload(result)
+    assert result.returncode == 1
+    assert payload["status"] == "fail"
+    assert payload["mode"] == "absolute"
+    assert payload["after_count"] == 1


### PR DESCRIPTION
## Summary

Phase 0 of #878 closure: install the guardrail BEFORE the rewrite sweeps so codex/claude/gemini cannot silently re-introduce incident duplicates during Phase 1+ work. Per architecture consult with codex (gpt-5.5).

## What lands

1. **`scripts/quality/incident_dedup_gate.py`** — new CLI gate. Diff-based, set keyed on `(kind, incident, file)` triples — NOT count-based. Pure count check has a hole: removing one old triple while adding a new one nets zero. The set check catches it. Belt-and-suspenders: also enforces `len(after) <= len(before)`.
   - `--base origin/main` (default), `--mode {delta,absolute}`, `--json`.
   - `delta` (default) is the Phase 1+ enforcement mode.
   - `absolute` is reserved for Phase 4 (after count = 0).

2. **`.pre-commit-config.yaml`** — local hook wires the gate to commit-time.

3. **`.github/workflows/incident-dedup.yml`** — required PR check on `pull_request` against `main`. Writes diff of NEW triples to `GITHUB_STEP_SUMMARY` on failure.

4. **`tests/test_incident_dedup_gate.py`** — 5 cases:
   - identical set → pass
   - new triple introduced → fail
   - remove old, add nothing → pass
   - **remove old + add different (count nets zero) → fail** (the case pure-count would miss)
   - absolute mode fails on any non-empty set

5. **`docs/audits/2026-05-04-incident-canonicals.md`** — adds a freeze paragraph: no canonical reassignments allowed during #878. Adding new canonicals is allowed only when claiming a catalog replacement in a Phase 1+ sweep PR.

## Verification

- `pytest tests/test_incident_dedup_gate.py -v` → 5 passed
- `ruff check` → clean
- Smoke pass against current main → PASS (no diff vs base, no violations introduced)
- Smoke fail with a seeded fake violation → FAIL with clear added-triple summary

## Why this PR first

Without this, every #338/#334/#388 module dispatch can quietly add new incident dups. The dedup sweep epic stays Sisyphean. Phase 0 is the gate; Phase 1+ ride on it.

## Context

- 2026-05-05 session 5 codex architecture consult: set-based diff (not count), freeze canonicals during #878, per-file directives in subsequent phases, split sweep PRs by risk/action under repo's <20-file rule.
- Issue #878 (incident-dedup epic, 4 of 7 sweeps already merged).
- Current count: 33 violations across 13 incidents in ~22 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)