### PR TITLE
chore(878): flip gate to absolute + bundle meta-phrasing regression fix + close #878 (Phase 4)

### DIFF
--- a/.github/workflows/incident-dedup.yml
+++ b/.github/workflows/incident-dedup.yml
@@ -39,7 +39,7 @@ jobs:
         id: incident-dedup-gate
         run: |
           set -euo pipefail
-          if ! output="$(python scripts/quality/incident_dedup_gate.py --base origin/main 2>&1 | tee gate.log)"; then
+          if ! output="$(python scripts/quality/incident_dedup_gate.py --mode absolute --base origin/main 2>&1 | tee gate.log)"; then
             echo "$output"
             {
               echo "## Incident dedup gate failed"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     hooks:
       - id: incident-dedup-gate
         name: incident dedup delta gate
-        entry: .venv/bin/python scripts/quality/incident_dedup_gate.py --mode delta --base origin/main
+        entry: .venv/bin/python scripts/quality/incident_dedup_gate.py --mode absolute --base origin/main
         language: system
         pass_filenames: false
         always_run: true

--- a/docs/audits/2026-05-04-incident-canonicals.md
+++ b/docs/audits/2026-05-04-incident-canonicals.md
@@ -6,7 +6,7 @@
 
 ## Lock table
 
-**FROZEN until #878 closes. No canonical reassignments allowed. Adding new canonicals is allowed only when claiming a catalog replacement in a Phase 1+ sweep PR.**
+**#878 closed 2026-05-06.** All 33 incident-reuse violations have been resolved. The gate (`scripts/quality/incident_dedup_gate.py`) now runs in `absolute` mode by default and is required on every PR via `.github/workflows/incident-dedup.yml`. New canonical assignments are allowed; new incident additions must be claimed in this doc as part of the introducing PR.
 
 | # | Incident | Canonical module | Lesson it owns |
 |---|---|---|---|

--- a/scripts/quality/incident_dedup_gate.py
+++ b/scripts/quality/incident_dedup_gate.py
@@ -173,9 +173,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
     parser.add_argument(
         "--mode",
-        default="delta",
+        # Keep delta as an explicit legacy mode for the #878 sweep PRs.
+        default="absolute",
         choices=("delta", "absolute"),
-        help="Gate mode (delta compares base->current, absolute fails if any violations exist)",
+        help=(
+            "Gate mode (absolute is default and fails if any violations exist). "
+            "Use delta only when you need legacy behavior for historical sweeps."
+        ),
     )
     return parser.parse_args(argv)
 

--- a/src/content/docs/cloud/advanced-operations/module-8.7-stateful-migration.md
+++ b/src/content/docs/cloud/advanced-operations/module-8.7-stateful-migration.md
@@ -24,7 +24,7 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-Stateful migration exposes a design fault line: if control planes diverge during topology shifts, consistency and write guarantees can become unreliable in minutes. The same lesson is developed in [Advanced Merging](../../prerequisites/git-deep-dive/module-2-advanced-merging/) and is where the canonical incident framing belongs.
+Stateful migration exposes a design fault line: if control planes diverge during topology shifts, consistency and write guarantees can become unreliable in minutes. This concept is further explored in [Advanced Merging](../../prerequisites/git-deep-dive/module-2-advanced-merging/).
 <!-- incident-xref: github-2018-10-split-brain -->
 <!-- incident-xref: github-2018-split-brain -->
 

--- a/src/content/docs/cloud/advanced-operations/module-8.7-stateful-migration.md
+++ b/src/content/docs/cloud/advanced-operations/module-8.7-stateful-migration.md
@@ -24,7 +24,7 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-Stateful migration exposes a design fault line: if control planes diverge during topology shifts, consistency and write guarantees can become unreliable in minutes. The same lesson is developed in Advanced Merging and is where the canonical incident framing belongs.
+Stateful migration exposes a design fault line: if control planes diverge during topology shifts, consistency and write guarantees can become unreliable in minutes. The same lesson is developed in [Advanced Merging](../../prerequisites/git-deep-dive/module-2-advanced-merging/) and is where the canonical incident framing belongs.
 <!-- incident-xref: github-2018-10-split-brain -->
 <!-- incident-xref: github-2018-split-brain -->
 

--- a/src/content/docs/cloud/aws-essentials/module-1.1-iam.md
+++ b/src/content/docs/cloud/aws-essentials/module-1.1-iam.md
@@ -219,7 +219,7 @@ ARNs (Amazon Resource Names) are how AWS uniquely identifies every resource. Und
 arn:partition:service:region:account-id:resource-type/resource-id
 ```
 
-Rather than repeat a real-world outage, treat this section as pure technical grounding and point incident learners to the canonical Reliability case study. The same conceptual lesson appears in [Failure Modes and Effects](../../platform/foundations/reliability-engineering/module-2.2-failure-modes-and-effects/).
+For an analysis of how identity failures cascade in distributed systems, see [Failure Modes and Effects](../../platform/foundations/reliability-engineering/module-2.2-failure-modes-and-effects/).
 <!-- incident-xref: aws-s3-2017-us-east-1 -->
 <!-- incident-xref: aws-s3-useast1-2017 -->
 

--- a/src/content/docs/linux/foundations/everyday-use/module-0.5-networking-tools.md
+++ b/src/content/docs/linux/foundations/everyday-use/module-0.5-networking-tools.md
@@ -280,7 +280,7 @@ echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check
 # Expected output: kubectl: OK
 ```
 
-The security and reliability implications of artifact trust are further analyzed in Modern DevOps 1.6 (*DevSecOps*). For the implementation details and narrative context, refer to that module.
+The security and reliability implications of artifact trust are further analyzed in Modern DevOps 1.6 (*DevSecOps*).
 <!-- incident-xref: codecov-2021-bash-uploader -->
 <!-- incident-xref: codecov-2021 -->
 

--- a/src/content/docs/linux/foundations/everyday-use/module-0.5-networking-tools.md
+++ b/src/content/docs/linux/foundations/everyday-use/module-0.5-networking-tools.md
@@ -280,7 +280,7 @@ echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check
 # Expected output: kubectl: OK
 ```
 
-The Security and reliability implications of artifact trust are treated in Modern DevOps 1.6 (*DevSecOps*). Use the same checksum-first workflow here, and keep the implementation lesson there in Modern DevOps for context.
+The security and reliability implications of artifact trust are further analyzed in Modern DevOps 1.6 (*DevSecOps*). For the implementation details and narrative context, refer to that module.
 <!-- incident-xref: codecov-2021-bash-uploader -->
 <!-- incident-xref: codecov-2021 -->
 

--- a/src/content/docs/linux/foundations/everyday-use/module-0.5-networking-tools.md
+++ b/src/content/docs/linux/foundations/everyday-use/module-0.5-networking-tools.md
@@ -280,7 +280,7 @@ echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check
 # Expected output: kubectl: OK
 ```
 
-The Security and reliability implications of artifact trust are treated in Modern DevOps 1.6 (*DevSecOps*). Use the same checksum-first workflow here, and keep the implementation lesson anchored there for narrative context.
+The Security and reliability implications of artifact trust are treated in Modern DevOps 1.6 (*DevSecOps*). Use the same checksum-first workflow here, and keep the implementation lesson there in Modern DevOps for context.
 <!-- incident-xref: codecov-2021-bash-uploader -->
 <!-- incident-xref: codecov-2021 -->
 

--- a/src/content/docs/linux/operations/module-8.3-package-user-management.md
+++ b/src/content/docs/linux/operations/module-8.3-package-user-management.md
@@ -39,7 +39,7 @@ After this module, you will be able to perform these operational tasks in a way 
 ## Why This Module Matters
 
 This module is the package-and-account hygiene playbook for emergency response: package inventory, patch posture, and least-privilege operations become operationally critical when incidents arrive.
-For the named incident framing and full narrative context, use the canonical lesson in [Docker Fundamentals](../../prerequisites/cloud-native-101/module-1.2-docker-fundamentals/).
+For a real-world analysis of these failure modes, see [Docker Fundamentals](../../prerequisites/cloud-native-101/module-1.2-docker-fundamentals/).
 <!-- incident-xref: equifax-2017 -->
 
 A similar pattern appears in smaller incidents that never make headlines. A team inherits an Ubuntu host where `nginx` was installed from a vendor repository, a contractor still has password login months after leaving, and the only deployment user has broad passwordless sudo because nobody wanted to debug a narrow rule. Nothing looks broken during normal operations, but the first security advisory or failed deploy reveals that the server has no clear owner, no reversible change trail, and no dependable way to explain what changed.

--- a/src/content/docs/on-premises/provisioning/module-2.1-datacenter-fundamentals.md
+++ b/src/content/docs/on-premises/provisioning/module-2.1-datacenter-fundamentals.md
@@ -442,7 +442,7 @@ For a production Kubernetes platform, set hard gates before any price comparison
 
 When negotiating the contract, push on these items explicitly because the standard boilerplate will paper over all of them. A "99.99% uptime" promise on the front page is meaningless if the credits are capped at one month of fees and the response times for remote hands are buried in an appendix as "commercially reasonable efforts."
 These clauses keep procurement accountable: power continuity commitments, cooling outage coverage, emergency response guarantees, maintenance notice windows, cross-connect delivery timelines, outage communication cadence, and expansion or exit terms.
-The concrete incident context for this section is covered in [Defense in Depth](../../platform/foundations/security-principles/module-4.2-defense-in-depth/).
+For real-world examples of physical security failures, see [Defense in Depth](../../platform/foundations/security-principles/module-4.2-defense-in-depth/).
 <!-- incident-xref: target-2013 -->
 
 ### Practical Negotiation Rule

--- a/tests/test_incident_dedup_gate.py
+++ b/tests/test_incident_dedup_gate.py
@@ -46,8 +46,16 @@ def _branch(repo: Path, name: str) -> None:
     _git(repo, ["checkout", "-b", name])
 
 
-def _run_gate(repo: Path, *, base: str = "main", mode: str = "delta", emit_json: bool = True) -> subprocess.CompletedProcess[str]:
-    cmd = [PYTHON_BIN, str(repo / "scripts/quality/incident_dedup_gate.py"), "--base", base, "--mode", mode]
+def _run_gate(
+    repo: Path,
+    *,
+    base: str = "main",
+    mode: str | None = None,
+    emit_json: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    cmd = [PYTHON_BIN, str(repo / "scripts/quality/incident_dedup_gate.py"), "--base", base]
+    if mode is not None:
+        cmd.extend(["--mode", mode])
     if emit_json:
         cmd.append("--json")
     return subprocess.run(
@@ -133,6 +141,21 @@ def test_absolute_mode_fails_when_any_after_violation_exists(tmp_path: Path) -> 
     _commit(repo, "src/content/docs/new/module.md", VIOLATION_UBER, "add violation")
 
     result = _run_gate(repo, base="main", mode="absolute", emit_json=True)
+    payload = _parse_gate_payload(result)
+    assert result.returncode == 1
+    assert payload["status"] == "fail"
+    assert payload["mode"] == "absolute"
+    assert payload["after_count"] == 1
+
+
+def test_default_mode_is_absolute(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo_with_scripts(repo)
+    _commit(repo, "src/content/docs/module.md", VIOLATION_NONE, "seed base")
+    _branch(repo, "default-absolute")
+    _commit(repo, "src/content/docs/new/module.md", VIOLATION_UBER, "add violation")
+
+    result = _run_gate(repo, base="main", emit_json=True)
     payload = _parse_gate_payload(result)
     assert result.returncode == 1
     assert payload["status"] == "fail"


### PR DESCRIPTION
Closes #878.

## Summary

Final PR of the #878 epic. Three bundled changes:

1. **Flip gate to absolute mode.** `scripts/quality/incident_dedup_gate.py` now defaults to `--mode absolute` (fail on ANY violation). Workflow + pre-commit hook updated. Delta mode still available for callers that pass `--mode delta` explicitly.
2. **Lift the canonicals freeze.** `docs/audits/2026-05-04-incident-canonicals.md` freeze paragraph replaced with a closing-status paragraph noting #878 is closed and the gate is now CI-required.
3. **Regression fix.** PR #906's squash-merge captured Phase 3 round 1, dropping round-2 commit `c0c8511c` from main. 4 meta-phrasing prompt-leaks landed on main as a result. This PR re-applies the missing fixes in the affected files (`module-8.7-stateful-migration.md`, `module-8.3-package-user-management.md`, `module-2.1-datacenter-fundamentals.md`, `module-1.1-iam.md`) using gemini round-1's exact rewrites.

## Verification

- `pytest tests/test_incident_dedup_gate.py -v` → 6 passed (incl. new `test_default_mode_is_absolute`)
- `ruff check` → clean
- `incident_dedup_gate.py --mode absolute` → PASS (absolute)
- `check_incident_reuse.py` → "OK — no incident-reuse violations." (count = 0)
- 7-file forbidden-vocabulary regex sweep (the Phase 3 set) → empty
- Marker count: 88 (unchanged)
- Build (primary tree): 2015 pages, clean

## Out of scope (followup, not this PR)

The full-repo forbidden-vocabulary scan finds residual matches in OTHER modules outside the 7 Phase-3 files — these are pre-existing and unrelated to #878 dedup. Optional polish for a future small PR.

## Context

- Phase 0 (#903): set-based delta gate
- Phase 1 (#904): Knight Capital ×14 sweep
- Phase 2 (#905): 4 multi-occurrence + 2 forbidden tropes
- Phase 3 (#906): 6 singletons + 1 fabricated trope
- Phase 4 (this PR): flip gate to absolute + regression fix + close epic
- Architecture consult with codex (gpt-5.5)

After merge, `check_incident_reuse.py` is enforced on every PR via `.github/workflows/incident-dedup.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)