### PR TITLE
feat(388): rewrite k8s/cgoa/module-1.1 exam strategy and blueprint review

### DIFF
--- a/src/content/docs/k8s/cgoa/module-1.1-exam-strategy-and-blueprint-review.md
+++ b/src/content/docs/k8s/cgoa/module-1.1-exam-strategy-and-blueprint-review.md
@@ -475,10 +475,6 @@ Declarative files in Git are necessary ingredients in many GitOps systems, but t
 
 ```bash
 mkdir -p cgoa-study
-if command -v kubectl >/dev/null 2>&1; then
-  alias k=kubectl
-  k version --client
-fi
 cat > cgoa-study/exam-decision-sheet.md <<'EOF'
 # CGOA Exam Decision Sheet
 

--- a/src/content/docs/k8s/cgoa/module-1.1-exam-strategy-and-blueprint-review.md
+++ b/src/content/docs/k8s/cgoa/module-1.1-exam-strategy-and-blueprint-review.md
@@ -1,6 +1,7 @@
 ---
 title: "CGOA Exam Strategy and Blueprint Review"
 slug: k8s/cgoa/module-1.1-exam-strategy-and-blueprint-review
+revision_pending: false
 sidebar:
   order: 101
 ---
@@ -11,15 +12,11 @@ sidebar:
 
 ## Learning Outcomes
 
-After completing this module, you will be able to evaluate a CGOA question by identifying which exam domain it belongs to, what GitOps principle it is testing, and which answer choice preserves the operating model.
-
-You will be able to compare GitOps with CI/CD, Infrastructure as Code, and configuration automation without collapsing those practices into one vague "automation" bucket.
-
-You will be able to design a study plan that gives more practice time to higher-weight blueprint areas while still covering tooling, patterns, and related practices with the right depth.
-
-You will be able to analyze multiple-choice distractors by tracing whether each option keeps Git as the source of truth, uses automated pull-based reconciliation, and maintains a feedback loop.
-
-You will be able to build and validate a personal exam strategy using scenario classification, answer elimination, and a timed practice review process.
+- **Evaluate CGOA scenario questions** by identifying the blueprint domain, the GitOps principle being tested, and the answer choice that preserves the operating model.
+- **Compare GitOps with CI/CD, Infrastructure as Code, and configuration automation** without collapsing those practices into one vague "automation" bucket.
+- **Design a blueprint-weighted study plan** that gives more practice time to higher-weight areas while still covering tooling, patterns, and related practices with the right depth.
+- **Analyze multiple-choice distractors** by tracing whether each option keeps Git as the source of truth, uses automated pull-based reconciliation, and maintains a feedback loop.
+- **Build and validate a personal exam strategy** using scenario classification, answer elimination, and a timed practice review process.
 
 ## Why This Module Matters
 
@@ -294,6 +291,90 @@ When reading the tooling modules, focus on capability boundaries. ArgoCD and Flu
 
 The path above is intentionally broader than a cram sheet. CGOA is an associate exam, but the strongest preparation is to understand why GitOps exists as an operating model. If you can explain the trade-off behind each pattern, you can handle unfamiliar wording because you are reasoning from first principles.
 
+## Patterns & Anti-Patterns
+
+The exam strategy that works best is the same strategy that works in a production design review: name the ownership boundary before you name the tool. In a healthy GitOps answer, the proposed change is represented as declarative desired state, the desired state is stored in a reviewed and versioned location, a software agent pulls that state, and the runtime system is checked continuously for convergence. This pattern prevents a question from turning into a guessing contest about whether the examiner prefers ArgoCD, Flux, Helm, Kustomize, or another implementation detail.
+
+The first strong pattern is **controller-owned convergence**. Use it when a question describes a cluster, an environment, or a fleet that should stay aligned with Git over time. The reason this pattern works is that the deployment authority remains with the reconciler rather than with a laptop, a one-shot CI job, or a dashboard button. It scales because every environment can have its own reconciliation scope, permissions, and health feedback while still using the same mental model for rollback and drift investigation.
+
+The second strong pattern is **reviewed promotion of immutable artifacts**. Use it when a question describes movement from development to staging or production, especially when the same tested image should move through multiple environments. The best answer usually changes an image digest, chart version, or overlay value in the next environment's desired state, then lets that environment's controller reconcile. This pattern keeps promotion auditable and prevents teams from copying live runtime objects forward with all their accidental mutations.
+
+The third strong pattern is **tool-neutral capability mapping**. Use it whenever an answer choice names a product, because product names are often distractors unless the role is clear. ArgoCD and Flux commonly reconcile desired state; Helm packages and renders applications; Kustomize composes bases and overlays; policy engines validate rules; secret tooling protects sensitive material while preserving declarative workflows. A candidate who maps capability before tool can answer unfamiliar product wording without abandoning the GitOps principles.
+
+The fourth strong pattern is **miss review by failure mode**. Use it during study after every timed practice set, because raw score alone does not tell you what to repair. Tag each miss as terminology confusion, principle break, related-practice boundary, pattern trade-off, tool-role confusion, or careless reading. After a few sets, the pattern of misses tells you whether to reread a domain, rebuild a diagram, or practice answer elimination, and that is more efficient than rereading every module with equal weight.
+
+The most dangerous anti-pattern is **Git as deployment paperwork**. Teams fall into it because they genuinely store manifests or values in Git, but the runtime change still happens somewhere else through a direct command, dashboard action, or pipeline push. It feels close to GitOps because Git is present, yet it breaks audit, rollback, and reconciliation because Git records intent after the fact rather than owning the desired state. On the exam, reject answers where Git is merely a record of what someone already did.
+
+Another common anti-pattern is **manual incident drift with delayed cleanup**. It happens because production incidents reward immediate action, and a direct edit may look like the fastest way to restore service. The trap is that the controller may later revert the edit, or future deployments may behave unpredictably because the desired state and actual state tell different stories. A better answer allows emergency action only inside a process that captures the fix in Git quickly, documents the reason, and returns convergence authority to the reconciler.
+
+A subtler anti-pattern is **blueprint silo studying**. Candidates see the domain weights and create separate piles of flashcards, then become surprised when a tooling question depends on a principle or a pattern question depends on terminology. The blueprint is layered, not isolated: terminology gives names, principles define the loop, related practices define boundaries, patterns show design choices, and tooling provides implementations. Study activities should cross those layers so each practice question builds judgment rather than isolated recall.
+
+| Pattern or anti-pattern | Use or avoid when | Why it matters for CGOA reasoning | Scaling concern |
+|---|---|---|---|
+| Controller-owned convergence | Use when runtime state must stay aligned with reviewed desired state | Preserves pull-based reconciliation and feedback | Scope controllers and permissions per environment or cluster |
+| Reviewed promotion of immutable artifacts | Use when moving tested releases through environments | Keeps promotion auditable and repeatable | Avoid mutable tags and unclear ownership of production state |
+| Tool-neutral capability mapping | Use when product names appear in choices | Prevents tool trivia from hiding principle violations | Keep a short role map for common tools instead of memorizing screens |
+| Miss review by failure mode | Use after every timed practice set | Converts wrong answers into a targeted study plan | Tag misses consistently or the data becomes noisy |
+| Git as deployment paperwork | Avoid when Git records changes after runtime action | Breaks source-of-truth reasoning | Audit trails become weak and rollback becomes guesswork |
+| Manual incident drift with delayed cleanup | Avoid when direct edits are not captured in Git | Creates conflict between actual state and desired state | Emergency paths need ownership, time limits, and review |
+| Blueprint silo studying | Avoid when preparing across domains | Produces brittle answers to mixed scenario questions | Review paths should connect terms, principles, patterns, and tools |
+
+## Decision Framework
+
+Use this framework whenever a CGOA question feels ambiguous, because ambiguity usually means the exam is asking you to compare operating consequences rather than recall a definition. First, find the scenario's decision point: a deployment path, a rollback, a drift response, an environment promotion, a tool choice, or a study-priority choice. Second, ask which blueprint domain is most visible and which lower-level principle supports it. Third, trace the GitOps loop and eliminate answer choices that make Git stale, make humans the steady-state deploy mechanism, remove continuous reconciliation, or hide feedback.
+
+The framework starts with desired state because desired state is the anchor for every other exam decision. If an answer does not say where the target state lives, who can review it, and how it changes, the answer is probably incomplete even if it mentions automation. Desired state also separates Kubernetes platform configuration from unrelated runtime data: a Deployment replica count, an ArgoCD Application, or a Kustomize overlay can be managed declaratively, while user transactions in a database are not normally promoted through GitOps as YAML. That boundary prevents overbroad answers that claim Git should contain every changing value in a system.
+
+After desired state, evaluate the execution path. In GitOps, a controller or software agent should pull approved state and reconcile the runtime environment; CI should usually build, test, scan, package, render, and propose changes rather than become the long-term cluster convergence mechanism. This distinction does not make CI less important. It makes the handoff cleaner: CI produces confidence and artifacts, Git records the desired operational target, and the reconciler applies and observes the target inside the environment where drift can occur.
+
+Next, evaluate feedback and recovery. A deployment that cannot report sync, health, drift, or reconciliation failure is not a complete operating model, because the team cannot tell whether intent became reality. A rollback that edits production by hand may be fast in the moment, but it leaves the next reconciliation cycle and the next audit review in doubt. Prefer answers where rollback is a desired-state change to a known good version, followed by convergence and observation, because that preserves both speed and governability.
+
+Finally, compare the remaining choices against the wording of the scenario rather than against personal preference. If the scenario emphasizes regulation, the best pattern may isolate production permissions even if a single repository is simpler. If the scenario emphasizes a small team learning GitOps, one repository with clear environment paths may be easier to reason about than a many-repository layout. If the scenario emphasizes Kubernetes 1.35 or newer platform behavior, assume current Kubernetes primitives and controller-based reconciliation rather than older manual cluster operation habits.
+
+Pause and predict: if a question says a team uses encrypted secrets in Git but disables the controller during every production change, which part of the GitOps loop is protected and which part is broken? The confidentiality problem is handled better than plaintext secrets, but the reconciliation model is still broken if the controller is not trusted to apply and observe desired state. This is why "best answer" questions often require choosing the option that preserves the most important operating properties together, not the option that fixes only one symptom.
+
+The same sequence works when the question mentions Kubernetes directly. For Kubernetes 1.35 and newer, assume that declarative API objects, controllers, server-side validation, and status reporting are normal parts of the platform, so a GitOps answer should use those strengths instead of bypassing them. If a prompt mentions `kubectl`, remember that the exam is usually testing whether the command belongs in an emergency investigation, a one-time bootstrap, or the steady-state deployment path; the `k` alias is convenient for practice, but it does not change the operating boundary.
+
+This distinction is useful because many realistic teams keep a small number of imperative commands for diagnosis, bootstrap, or recovery while still expecting normal delivery to flow through reviewed desired state. The exam is not asking you to pretend those commands never exist; it is asking you to decide whether they are temporary support actions or the regular mechanism that changes production. That difference often separates a merely plausible answer from the strongest GitOps answer.
+
+Before running a timed practice set, write the following decision sequence on scratch paper or in your notes. The sequence is short enough to use under exam pressure, but it still protects the reasoning path. If a question takes too long, stop rereading the same sentence and move through the sequence deliberately: problem, domain, principle, broken answer choices, best operational consequence.
+
+```ascii
++-------------------------+
+| 1. Name the problem     |
+| drift, promotion, tool, |
+| boundary, or study plan |
++-----------+-------------+
+            |
+            v
++-------------------------+
+| 2. Map the domain       |
+| terminology, principle, |
+| practice, pattern, tool |
++-----------+-------------+
+            |
+            v
++-------------------------+
+| 3. Trace the loop       |
+| desired, versioned,     |
+| pulled, reconciled      |
++-----------+-------------+
+            |
+            v
++-------------------------+
+| 4. Eliminate breaks     |
+| stale Git, manual push, |
+| missing feedback        |
++-----------+-------------+
+            |
+            v
++-------------------------+
+| 5. Pick consequence     |
+| safest for audit,       |
+| recovery, and scale     |
++-------------------------+
+```
+
 ## Did You Know?
 
 1. **GitOps is defined by an operating model, not by Git alone.** A repository gives version history, but the model also requires declarative desired state, automated pull-based application, continuous reconciliation, and feedback about convergence.
@@ -319,77 +400,61 @@ The path above is intentionally broader than a cram sheet. CGOA is an associate 
 
 ## Quiz
 
-1. **Your team stores Kubernetes manifests in Git, and a CI job applies them directly to production after tests pass. A practice question asks whether this is the strongest GitOps design. How should you evaluate the workflow?**
+<details>
+<summary>Your team stores Kubernetes manifests in Git, and a CI job applies them directly to production after tests pass. A CGOA scenario question asks whether this is the strongest GitOps design. How should you evaluate the workflow?</summary>
 
-   <details>
-   <summary>Answer</summary>
+The workflow has declarative and versioned pieces, but it is not the strongest GitOps design because deployment is push-based from CI and may not include continuous reconciliation. A better answer separates CI from reconciliation: CI builds, tests, scans, and proposes or updates desired state, while a GitOps controller pulls the approved state and keeps the cluster converged. The tested reasoning is the boundary between CI/CD and GitOps, not whether CI is useful. This evaluates the scenario by locating the blueprint domain first, then checking which GitOps principle is at risk.
 
-   The workflow has declarative and versioned pieces, but it is not the strongest GitOps design because deployment is push-based from CI and may not include continuous reconciliation. A better answer separates CI from reconciliation: CI builds, tests, scans, and proposes or updates desired state, while a GitOps controller pulls the approved state and keeps the cluster converged. The tested reasoning is the boundary between CI/CD and GitOps, not whether CI is useful.
+</details>
 
-   </details>
+<details>
+<summary>A production incident is fixed by editing a live Deployment in the cluster. The next morning the value changes back to the Git version, and the team is confused. Which concept should you apply first, and what process change would you recommend?</summary>
 
-2. **A production incident is fixed by editing a live Deployment in the cluster. The next morning the value changes back to the Git version, and the team is confused. Which concept should you apply first, and what process change would you recommend?**
+Apply the concepts of drift, desired state, and reconciliation. The live edit created a runtime difference from the desired state stored in Git, and the reconciler moved the cluster back toward the declared target. The better process is to capture the incident fix as a reviewed desired-state change in Git, then let the controller reconcile it, with an emergency path that still restores Git as the source of truth. That answer preserves auditability while explaining why the original runtime-only change did not last.
 
-   <details>
-   <summary>Answer</summary>
+</details>
 
-   Apply the concepts of drift, desired state, and reconciliation. The live edit created a runtime difference from the desired state stored in Git, and the reconciler moved the cluster back toward the declared target. The better process is to capture the incident fix as a reviewed desired-state change in Git, then let the controller reconcile it, with an emergency path that still restores Git as the source of truth.
+<details>
+<summary>A question describes a team choosing between separate production and staging repositories or one repository with environment directories. Which answer is most likely correct if production has stricter approval and audit requirements?</summary>
 
-   </details>
+The stronger answer is likely a design that enforces production-specific approval and access boundaries, which may mean a separate production repository or a strongly protected production path. The reasoning should mention governance, blast radius, and review requirements rather than claiming one repository pattern is always best. CGOA pattern questions usually reward matching the repository strategy to risk and ownership constraints. This is a design decision, so the best answer must explain the trade-off rather than simply choosing the most isolated layout.
 
-3. **A question describes a team choosing between separate production and staging repositories or one repository with environment directories. Which answer is most likely correct if production has stricter approval and audit requirements?**
+</details>
 
-   <details>
-   <summary>Answer</summary>
+<details>
+<summary>A team uses Helm charts to package an application and stores values files in Git. Deployments happen when an engineer runs Helm from a laptop. A question asks whether Helm makes the workflow GitOps. What should you answer?</summary>
 
-   The stronger answer is likely a design that enforces production-specific approval and access boundaries, which may mean a separate production repository or strongly protected production path. The reasoning should mention governance, blast radius, and review requirements rather than claiming one repository pattern is always best. CGOA pattern questions usually reward matching the repository strategy to risk and ownership constraints.
+Helm supports the workflow by rendering and packaging manifests, but Helm alone does not make it GitOps. The laptop-driven command is a manual push action, and the scenario does not describe continuous pull-based reconciliation or feedback. A more GitOps-aligned design would store the desired chart version and values in Git and have a controller reconcile that desired state into the cluster. This answer compares tool capability with the operating model instead of treating a familiar Kubernetes tool as proof of GitOps.
 
-   </details>
+</details>
 
-4. **A team uses Helm charts to package an application and stores values files in Git. Deployments happen when an engineer runs Helm from a laptop. A question asks whether Helm makes the workflow GitOps. What should you answer?**
+<details>
+<summary>A security team wants to store secrets in Git so that every environment can be fully recreated. One answer suggests committing plaintext Kubernetes Secret manifests because Git is the source of truth. Why is that answer weak, and what would be stronger?</summary>
 
-   <details>
-   <summary>Answer</summary>
+The answer is weak because it applies the source-of-truth idea while ignoring confidentiality. GitOps does not require exposing sensitive values in plaintext. A stronger answer uses a safer declarative secret pattern, such as encrypted secrets, sealed secrets, or external secret references, while preserving reviewable desired state and automated reconciliation. The reasoning matters because a secure GitOps answer must satisfy both governance and secrecy, not one at the expense of the other.
 
-   Helm supports the workflow by rendering and packaging manifests, but Helm alone does not make it GitOps. The laptop-driven command is a manual push action, and the scenario does not describe continuous pull-based reconciliation or feedback. A more GitOps-aligned design would store the desired chart version and values in Git and have a controller reconcile that desired state into the cluster.
+</details>
 
-   </details>
+<details>
+<summary>During a practice exam, two multiple-choice distractors both mention ArgoCD. One says ArgoCD should show sync and health status while reconciling from Git. The other says ArgoCD should be used as a dashboard after CI has already pushed changes into the cluster. How do you choose?</summary>
 
-5. **A security team wants to store secrets in Git so that every environment can be fully recreated. One answer suggests committing plaintext Kubernetes Secret manifests because Git is the source of truth. Why is that answer weak, and what would be stronger?**
+Choose the answer where ArgoCD reconciles from Git and reports sync and health status. That answer preserves the controller's role in the GitOps loop. The dashboard-only answer uses a tool name but assigns the deployment authority to CI, which weakens the pull-based reconciliation model and may turn Git into documentation after the fact. This is the distractor-analysis move: ignore the shared product name and trace which option keeps source of truth, reconciliation, and feedback intact.
 
-   <details>
-   <summary>Answer</summary>
+</details>
 
-   The answer is weak because it applies the source-of-truth idea while ignoring confidentiality. GitOps does not require exposing sensitive values in plaintext. A stronger answer uses a safer declarative secret pattern, such as encrypted secrets, sealed secrets, or external secret references, while preserving reviewable desired state and automated reconciliation.
+<details>
+<summary>A team wants faster promotion from staging to production. One proposal copies the live staging cluster objects into production. Another proposal promotes the same tested image digest by updating production desired state through a reviewed pull request. Which proposal is more GitOps-aligned, and why?</summary>
 
-   </details>
+Promoting the tested image digest through reviewed production desired state is more GitOps-aligned. It keeps production controlled by a versioned source of truth, preserves auditability, and lets the production reconciler apply the approved target. Copying live cluster objects can transfer accidental runtime state and bypass the reviewable desired-state model. The scenario is about promotion design, so the best answer should preserve artifact immutability and environment-specific approval rather than moving observed state by hand.
 
-6. **During a practice exam, two choices both mention ArgoCD. One says ArgoCD should show sync and health status while reconciling from Git. The other says ArgoCD should be used as a dashboard after CI has already pushed changes into the cluster. How do you choose?**
+</details>
 
-   <details>
-   <summary>Answer</summary>
+<details>
+<summary>A learner keeps missing questions that compare GitOps with Infrastructure as Code, CI/CD, and configuration automation. Their instinct is to answer that any declarative file in Git is GitOps. How would you correct their reasoning and adjust the study plan?</summary>
 
-   Choose the answer where ArgoCD reconciles from Git and reports sync and health status. That answer preserves the controller's role in the GitOps loop. The dashboard-only answer uses a tool name but assigns the deployment authority to CI, which weakens the pull-based reconciliation model and may turn Git into documentation after the fact.
+Declarative files in Git are necessary ingredients in many GitOps systems, but they are not the whole model. The learner should check whether the desired state is versioned and immutable, whether a software agent pulls it automatically, and whether actual state is continuously reconciled with feedback. IaC, CI/CD, and configuration automation can support GitOps, but they do not automatically supply the full control loop. The study plan should add boundary-comparison drills and missed-question tagging so the learner can validate progress instead of rereading the same definitions.
 
-   </details>
-
-7. **A team wants faster promotion from staging to production. One proposal copies the live staging cluster objects into production. Another proposal promotes the same tested image digest by updating production desired state through a reviewed pull request. Which proposal is more GitOps-aligned, and why?**
-
-   <details>
-   <summary>Answer</summary>
-
-   Promoting the tested image digest through reviewed production desired state is more GitOps-aligned. It keeps production controlled by a versioned source of truth, preserves auditability, and lets the production reconciler apply the approved target. Copying live cluster objects can transfer accidental runtime state and bypass the reviewable desired-state model.
-
-   </details>
-
-8. **A learner keeps missing questions that compare GitOps with Infrastructure as Code. Their instinct is to answer that any declarative Terraform or Kubernetes file in Git is GitOps. How would you correct their reasoning?**
-
-   <details>
-   <summary>Answer</summary>
-
-   Declarative files in Git are necessary ingredients in many GitOps systems, but they are not the whole model. The learner should check whether the desired state is versioned and immutable, whether a software agent pulls it automatically, and whether actual state is continuously reconciled with feedback. IaC can feed GitOps, but a manual apply workflow is not automatically GitOps.
-
-   </details>
+</details>
 
 ## Hands-On Exercise
 
@@ -410,6 +475,10 @@ The path above is intentionally broader than a cram sheet. CGOA is an associate 
 
 ```bash
 mkdir -p cgoa-study
+if command -v kubectl >/dev/null 2>&1; then
+  alias k=kubectl
+  k version --client
+fi
 cat > cgoa-study/exam-decision-sheet.md <<'EOF'
 # CGOA Exam Decision Sheet
 
@@ -456,6 +525,21 @@ EOF
 - [ ] You have identified one weakest domain for follow-up review and linked it to a module in the recommended KubeDojo path.
 
 **Reflection prompt:** After completing the worksheet, choose the scenario that felt most ambiguous and write a short explanation of what made it hard. Ambiguity is useful feedback. If the difficulty came from vocabulary, review terminology. If it came from two answers sounding correct, practice tracing the full control loop. If it came from tool names, rewrite the scenario in tool-neutral language and solve it again.
+
+## Sources
+
+- https://training.linuxfoundation.org/certification/certified-gitops-associate-cgoa/
+- https://www.cncf.io/training/certification/cgoa/
+- https://github.com/cncf/curriculum/blob/master/CGOA_Curriculum.pdf
+- https://opengitops.dev/
+- https://github.com/open-gitops/documents/blob/main/PRINCIPLES.md
+- https://argo-cd.readthedocs.io/en/stable/
+- https://fluxcd.io/flux/concepts/
+- https://helm.sh/docs/
+- https://kubectl.docs.kubernetes.io/references/kustomize/
+- https://kubernetes.io/docs/concepts/configuration/secret/
+- https://external-secrets.io/latest/
+- https://getsops.io/docs/
 
 ## Next Module
 


### PR DESCRIPTION
## Summary

#388 sweep — rewrite of `src/content/docs/k8s/cgoa/module-1.1-exam-strategy-and-blueprint-review.md` for rubric-critical score (1.5).

## Codex verifier metrics (T0)

- `body_words=5052`
- `mean_wpp=64.8`, `median_wpp=64.0` (target: median ≥28, mean ≥30)
- `short_rate=0.026` (target: ≤0.20)
- `max_run=1`
- Live sources: 12/12 reachable
- `git diff --check`: clean
- Forbidden-token grep: clean
- `npm run build`: passed
- Protected assets: 5 code blocks → 6, 8 tables → 9 (one new decision-framework diagram + one new table)

## Test plan

- [ ] Gemini cross-family review (PEDAGOGY / ACCURACY / DENSITY / PROTECTED ASSETS / SOURCES) per `docs/review-protocol.md`
- [ ] Verify rubric score ≥4.0 post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)