### PR TITLE
chore(388): orchestrator-driven PR fallback + Claude review fallback

### DIFF
--- a/scripts/quality/dispatch_388_pilot.py
+++ b/scripts/quality/dispatch_388_pilot.py
@@ -134,6 +134,54 @@ def find_pr_number(text: str) -> int | None:
     return int(m.group(1)) if m else None
 
 
+def orchestrator_open_pr(slug: str, module_path: str, codex_response: str) -> int | None:
+    """Fallback: orchestrator opens PR when codex sandbox lacked GH_TOKEN.
+
+    Codex's response (when ok=True) typically includes the branch name,
+    word counts, and verifier metrics. We construct a minimal PR body
+    from the last N chars of the response; the cross-family review
+    will look at the actual diff anyway.
+    """
+    branch = f"codex/388-pilot-{slug}"
+    # Verify the branch is on origin (codex pushes before responding)
+    ls = subprocess.run(
+        ["git", "ls-remote", "origin", branch],
+        cwd=REPO, capture_output=True, text=True, check=False,
+    )
+    if ls.returncode != 0 or not ls.stdout.strip():
+        log({"event": "orchestrator_pr_branch_missing", "slug": slug, "branch": branch})
+        return None
+    title = f"feat(388): rewrite {module_path}"
+    body = (
+        f"## Summary\n\n"
+        f"#388 sweep — rewrite of `{module_path}` for rubric-critical score.\n\n"
+        f"## Codex response excerpt\n\n"
+        f"```\n{(codex_response or '')[-1500:]}\n```\n\n"
+        f"## Test plan\n\n"
+        f"- [ ] Cross-family review per `docs/review-protocol.md`\n"
+        f"- [ ] Verify rubric score >=4.0 post-merge\n\n"
+        f"PR opened by orchestrator (codex sandbox lacks GH_TOKEN by design).\n"
+    )
+    create = subprocess.run(
+        ["gh", "pr", "create", "--base", "main", "--head", branch,
+         "--title", title, "--body", body],
+        cwd=REPO, capture_output=True, text=True, check=False,
+    )
+    if create.returncode != 0:
+        log({
+            "event": "orchestrator_pr_create_failed",
+            "slug": slug, "branch": branch,
+            "stderr": create.stderr[-500:],
+        })
+        return None
+    pr_num = find_pr_number(create.stdout or "")
+    if pr_num is None:
+        log({"event": "orchestrator_pr_no_url", "slug": slug, "stdout": create.stdout[-500:]})
+        return None
+    log({"event": "orchestrator_pr_opened", "slug": slug, "pr": pr_num, "branch": branch})
+    return pr_num
+
+
 def gemini_review_prompt(pr_num: int, module_path: str) -> str:
     return f"""Adversary cross-family review of PR #{pr_num} on KubeDojo.
 
@@ -175,6 +223,28 @@ def dispatch_gemini_review(pr_num: int, module_path: str, slug: str):
         return None, "ERROR"
     text = result.response or ""
     log({"event": "gemini_done", "pr": pr_num, "ok": result.ok, "response_excerpt": text[-2000:]})
+    return text, classify_verdict(text)
+
+
+def dispatch_claude_review(pr_num: int, module_path: str, slug: str):
+    """Fallback when Gemini fails. Headless Claude (sonnet) cross-family review."""
+    log({"event": "claude_review_start", "pr": pr_num, "module": module_path})
+    try:
+        result = invoke(
+            agent_name="claude",
+            prompt=gemini_review_prompt(pr_num, module_path),  # reuse same prompt
+            mode="read-only",
+            cwd=REPO,
+            model="claude-sonnet-4-6",
+            task_id=f"388-pilot-review-claude-{slug}",
+            entrypoint="dispatch",
+            hard_timeout=300,
+        )
+    except Exception as e:  # noqa: BLE001
+        log({"event": "claude_review_error", "pr": pr_num, "error": repr(e)})
+        return None, "ERROR"
+    text = result.response or ""
+    log({"event": "claude_review_done", "pr": pr_num, "ok": result.ok, "response_excerpt": text[-2000:]})
     return text, classify_verdict(text)
 
 
@@ -260,9 +330,16 @@ def main(argv: list[str] | None = None) -> int:
             continue
         pr_num = find_pr_number(codex_result.response or "")
         if pr_num is None:
-            log({"event": "module_skip", "module": module_path, "reason": "no_pr_in_response"})
-            continue
+            # Codex sandbox lacks GH_TOKEN by design — fall back to orchestrator.
+            pr_num = orchestrator_open_pr(slug, module_path, codex_result.response or "")
+            if pr_num is None:
+                log({"event": "module_skip", "module": module_path, "reason": "pr_creation_failed"})
+                continue
         review_text, verdict = dispatch_gemini_review(pr_num, module_path, slug)
+        if verdict in ("ERROR", "UNCLEAR"):
+            # Gemini hung or returned ambiguous output — fall back to Claude.
+            log({"event": "review_fallback_to_claude", "pr": pr_num, "module": module_path})
+            review_text, verdict = dispatch_claude_review(pr_num, module_path, slug)
         if review_text:
             post_review_comment(pr_num, review_text)
         if verdict == "APPROVE":

--- a/tests/test_dispatch_388_pilot_pr_fallback.py
+++ b/tests/test_dispatch_388_pilot_pr_fallback.py
@@ -1,0 +1,175 @@
+"""Tests for orchestrator-driven PR fallback in dispatch_388_pilot.py.
+
+Covers:
+  - orchestrator_open_pr happy path
+  - branch missing on origin
+  - gh pr create failure
+  - classify_verdict works on Claude-style responses
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.quality.dispatch_388_pilot import (
+    classify_verdict,
+    find_pr_number,
+    orchestrator_open_pr,
+)
+
+
+# ---------------------------------------------------------------------------
+# orchestrator_open_pr — happy path
+# ---------------------------------------------------------------------------
+
+def _make_run(returncode: int, stdout: str = "", stderr: str = ""):
+    m = MagicMock()
+    m.returncode = returncode
+    m.stdout = stdout
+    m.stderr = stderr
+    return m
+
+
+def test_orchestrator_open_pr_happy_path():
+    ls_result = _make_run(0, stdout="abc123\trefs/heads/codex/388-pilot-my-module\n")
+    create_result = _make_run(0, stdout="https://github.com/kube-dojo/kube-dojo.github.io/pull/917\n")
+
+    with patch("scripts.quality.dispatch_388_pilot.subprocess.run", side_effect=[ls_result, create_result]), \
+         patch("scripts.quality.dispatch_388_pilot.log") as mock_log:
+        result = orchestrator_open_pr(
+            slug="my-module",
+            module_path="src/content/docs/k8s/cka/module-1.1.md",
+            codex_response="Verifier: T0 | body_words=5800 | PR opened",
+        )
+
+    assert result == 917
+    events = [c.args[0]["event"] for c in mock_log.call_args_list]
+    assert "orchestrator_pr_opened" in events
+
+
+# ---------------------------------------------------------------------------
+# orchestrator_open_pr — branch missing on origin
+# ---------------------------------------------------------------------------
+
+def test_orchestrator_open_pr_branch_missing():
+    ls_result = _make_run(0, stdout="")  # empty stdout = branch not found
+
+    with patch("scripts.quality.dispatch_388_pilot.subprocess.run", return_value=ls_result), \
+         patch("scripts.quality.dispatch_388_pilot.log") as mock_log:
+        result = orchestrator_open_pr(
+            slug="missing-module",
+            module_path="src/content/docs/k8s/cka/module-1.2.md",
+            codex_response="",
+        )
+
+    assert result is None
+    events = [c.args[0]["event"] for c in mock_log.call_args_list]
+    assert "orchestrator_pr_branch_missing" in events
+
+
+def test_orchestrator_open_pr_branch_missing_nonzero_returncode():
+    ls_result = _make_run(128, stdout="", stderr="fatal: unable to connect")
+
+    with patch("scripts.quality.dispatch_388_pilot.subprocess.run", return_value=ls_result), \
+         patch("scripts.quality.dispatch_388_pilot.log") as mock_log:
+        result = orchestrator_open_pr(
+            slug="error-module",
+            module_path="src/content/docs/k8s/cka/module-1.3.md",
+            codex_response="",
+        )
+
+    assert result is None
+    events = [c.args[0]["event"] for c in mock_log.call_args_list]
+    assert "orchestrator_pr_branch_missing" in events
+
+
+# ---------------------------------------------------------------------------
+# orchestrator_open_pr — gh pr create failure
+# ---------------------------------------------------------------------------
+
+def test_orchestrator_open_pr_create_failure():
+    ls_result = _make_run(0, stdout="abc123\trefs/heads/codex/388-pilot-fail-module\n")
+    create_result = _make_run(1, stdout="", stderr="GraphQL: already exists")
+
+    with patch("scripts.quality.dispatch_388_pilot.subprocess.run", side_effect=[ls_result, create_result]), \
+         patch("scripts.quality.dispatch_388_pilot.log") as mock_log:
+        result = orchestrator_open_pr(
+            slug="fail-module",
+            module_path="src/content/docs/k8s/cka/module-1.4.md",
+            codex_response="some codex output",
+        )
+
+    assert result is None
+    events = [c.args[0]["event"] for c in mock_log.call_args_list]
+    assert "orchestrator_pr_create_failed" in events
+
+
+# ---------------------------------------------------------------------------
+# classify_verdict — agent-agnostic (works on Claude-style responses)
+# ---------------------------------------------------------------------------
+
+def test_classify_verdict_approve():
+    text = "The module teaches well. VERDICT: APPROVE"
+    assert classify_verdict(text) == "APPROVE"
+
+
+def test_classify_verdict_approve_with_nits():
+    text = "Minor issues found.\nVERDICT: APPROVE WITH NITS"
+    assert classify_verdict(text) == "APPROVE_WITH_NITS"
+
+
+def test_classify_verdict_needs_changes():
+    text = "Several errors detected.\nVERDICT: NEEDS CHANGES"
+    assert classify_verdict(text) == "NEEDS CHANGES"
+
+
+def test_classify_verdict_unclear():
+    text = "I reviewed the PR and found it mostly fine."
+    assert classify_verdict(text) == "UNCLEAR"
+
+
+def test_classify_verdict_approve_with_nits_wins_over_approve():
+    # Regression: "APPROVE WITH NITS" must not be classified as plain APPROVE
+    text = "VERDICT: APPROVE WITH NITS — fix the kubectl alias usage."
+    assert classify_verdict(text) == "APPROVE_WITH_NITS"
+
+
+def test_classify_verdict_claude_style_response():
+    # Claude tends to use structured markdown — verify the parser is robust
+    claude_response = """
+## Cross-family Review — PR #917
+
+### Pedagogy
+The module scaffolds concepts well from L1 to L3+ Bloom's.
+
+### Accuracy
+All commands verified against K8s 1.35 docs. No hallucinated flags.
+
+### Density vs Teaching
+Prose is genuinely explanatory, not padded.
+
+### Protected Assets
+3 code blocks, 1 ASCII diagram, 2 tables — all preserved per PR body.
+
+### Sources
+All 10 sources reach primary vendor documentation.
+
+**VERDICT: APPROVE**
+"""
+    assert classify_verdict(claude_response) == "APPROVE"
+
+
+# ---------------------------------------------------------------------------
+# find_pr_number — sanity check (used by orchestrator_open_pr)
+# ---------------------------------------------------------------------------
+
+def test_find_pr_number_extracts_from_gh_output():
+    stdout = "https://github.com/kube-dojo/kube-dojo.github.io/pull/917\n"
+    assert find_pr_number(stdout) == 917
+
+
+def test_find_pr_number_returns_none_on_no_match():
+    assert find_pr_number("branch pushed but no PR URL") is None


### PR DESCRIPTION
## Summary

`GH_TOKEN` does not propagate to the codex sandbox by design (intentional `_agent_env` restriction). Result: codex's `gh pr create` intermittently fails with `You are not logged into any GitHub hosts.` — every affected module ships with `module_skip: no_pr_in_response`, requiring the orchestrator to open all PRs manually (~3 min/module overhead).

This session: **PR #917 succeeded, PR #918's predecessor failed** — confirmed intermittent. Need a deterministic fallback before the autonomous chain processes 30+ more modules.

## Changes

- **`orchestrator_open_pr(slug, module_path, codex_response)`** — fallback PR creation in parent process where `GH_TOKEN` is available. Verifies branch exists on origin via `git ls-remote` before attempting create. Distinct log events per failure path (`orchestrator_pr_branch_missing`, `orchestrator_pr_create_failed`, `orchestrator_pr_no_url`, `orchestrator_pr_opened`).
- **`dispatch_claude_review(pr_num, module_path, slug)`** — fallback when Gemini hangs or returns `UNCLEAR`. Per `feedback_headless_claude_gemini_fallback.md`, Claude review is 25-65s vs Gemini 240s+ during rate-limit windows. Cross-family rule still satisfied (codex authored, Claude reviews).
- **`main()` flow** — PR fallback replaces the `continue` on `no_pr_in_response`; Gemini→Claude fallback inserted between review dispatch and `post_review_comment`.

## Tests

- 42 tests pass (12 new + 30 existing verify_module tests)
- ruff clean
- New tests cover: orchestrator_open_pr happy path, branch-missing, gh create failure, classify_verdict agent-agnostic

## Effect

Autonomous chain becomes truly end-to-end. K8S Cgoa required ~15 min orchestrator overhead for 5 modules; this drops to ~0 absent codex/gemini failures.

## Test plan

- [ ] Cross-family review (codex or gemini)
- [ ] After merge: next batch in autonomous chain validates orchestrator-PR fallback works in live pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)