### PR TITLE
feat(388): rewrite src/content/docs/k8s/cnpa/module-1.5-practice-questions-set-2.md

### DIFF
--- a/src/content/docs/k8s/cnpa/module-1.5-practice-questions-set-2.md
+++ b/src/content/docs/k8s/cnpa/module-1.5-practice-questions-set-2.md
@@ -1,104 +1,406 @@
 ---
-revision_pending: true
+revision_pending: false
 title: "CNPA Practice Questions Set 2"
 slug: k8s/cnpa/module-1.5-practice-questions-set-2
 sidebar:
   order: 105
 ---
 
-> **CNPA Track** | Practice questions | Set 2
+# CNPA Practice Questions Set 2
 
-## How To Use This Set
+> **CNPA Track** | Practice questions | Set 2 | Complexity: Medium | Time: 75 minutes | Prerequisites: CNPA modules 1.1 through 1.4, basic Kubernetes objects, and platform engineering vocabulary
 
-This second set is designed to expose comparison traps. Focus on the reason each distractor is wrong.
+This second practice set focuses on comparison traps: platform engineering versus traditional operations, reconciliation versus one-time deployment, guardrails versus unrestricted access, and measurement that proves the platform is useful rather than merely busy. Read the explanations as carefully as the answers, because the exam often rewards the learner who can explain why three plausible answers are still weaker than the best answer.
 
-## Questions
+## Learning Outcomes
 
-### 1. Which option best reflects platform engineering?
+- Evaluate platform engineering choices by comparing self-service, paved paths, and manual ticket workflows.
+- Diagnose reconciliation and drift scenarios by tracing desired state, actual state, and control-loop behavior.
+- Design guardrails that combine policy, limits, auditability, and developer autonomy.
+- Measure platform health using adoption, reliability, and time-to-value signals instead of activity alone.
+
+## Why This Module Matters
+
+Hypothetical scenario: a Kubernetes organization has grown from three application teams to twelve, and every team now owns a slightly different deployment script, namespace request process, and production checklist. The operations group is not failing because people are careless; it is failing because each team is solving the same platform problems alone, which multiplies review work, delays releases, and makes reliability depend on who remembers which private convention.
+
+The CNPA lens asks you to evaluate that situation as a platform product problem rather than as a pure tooling problem. A platform team should reduce duplicated decisions, expose safer self-service paths, and give developers enough autonomy to move without waiting for every infrastructure change to become a ticket. That does not mean every developer gets unlimited cluster access, and it does not mean the platform team disappears. It means the platform becomes the interface through which reliable delivery happens repeatedly.
+
+This practice set turns those ideas into exam-style decisions. You will compare platform models, diagnose reconciliation language, choose guardrails for self-service workflows, and measure whether the platform is helping its users. Before you answer each question, slow down and name the tradeoff in plain language; the best CNPA answer is usually the one that balances developer experience, operational control, and product thinking.
+
+## Reading CNPA Questions Like a Platform Engineer
+
+Practice questions in this part of the CNPA track often look deceptively simple because the wrong answers reuse familiar engineering words. A choice that mentions automation is not automatically platform engineering, and a choice that mentions control is not automatically mature governance. The exam expects you to notice whether the platform is designed as a reusable product, whether it gives users a paved path, and whether it creates feedback loops that make delivery safer over time.
+
+Think of an internal developer platform as a reliable train system rather than a pile of vehicles. The platform team designs routes, signals, stations, maintenance procedures, and passenger information so many travelers can move with less local planning. Application teams still choose where they need to go, but they do not rebuild the railway for each trip. That analogy matters because platform engineering is not the same as centralizing every decision; it is about making good decisions easy and repeatable.
+
+The first comparison trap is the difference between a platform team and a traditional operations queue. A manual queue may create consistency because one group approves every request, but it rarely creates speed or learning for developers. A platform product can still include review, policy, and escalation, yet its default path should let teams complete routine work without waiting for another human to translate their intent into infrastructure changes.
+
+The second comparison trap is tool worship. Backstage, Crossplane, Argo CD, Flux, Terraform, Kubernetes controllers, and policy engines can all participate in a platform, but no single tool makes the organization platform-oriented by itself. The platform story is stronger when the tools are arranged around user journeys: create a service, request an environment, deploy safely, observe behavior, and recover quickly when actual state diverges from desired state.
+
+Pause and predict: if a team creates a portal with impressive dashboards but every production namespace still requires a private chat message to one senior operator, would you call that self-service? The likely answer is no, because the visible interface does not remove the hidden dependency. The platform may have a user interface, but the operational model still relies on manual gatekeeping and personal knowledge.
+
+When you read the answer options, watch for words that turn a platform into a cost center. “Every team builds its own deployment tooling” sounds autonomous, but it usually means duplicated effort and uneven safety. “The ops team handles all provisioning requests manually” sounds controlled, but it keeps the organization dependent on queue capacity. “Developers may use any workflow, with no standards” sounds flexible, but it removes the paved path that makes repeatable delivery possible.
+
+Exam questions also test whether you can separate a platform principle from an implementation detail. A golden path might be implemented as a template, a portal workflow, a GitOps repository pattern, or an API that provisions namespaces and dependencies. The principle is that users receive a recommended, supported route with sensible defaults and clear escape hatches. If an option only names a tool without describing the user outcome, it may be less complete than the product-oriented answer.
+
+## Reconciliation, Desired State, and Drift
+
+Reconciliation is the control-loop idea that links Kubernetes thinking to platform engineering. In Kubernetes, controllers compare desired state declared through the API with actual state observed in the cluster, then act to reduce the difference. Platform systems borrow the same model when they keep environments, policies, access, or cloud resources aligned with declared intent rather than treating provisioning as a one-time script.
+
+Desired state is the instruction the system is trying to honor, and actual state is the world as it currently exists. Drift appears when those two pictures diverge, which can happen through manual changes, failed operations, partial rollouts, missing permissions, unavailable dependencies, or outdated configuration. A platform that reconciles drift gives teams a predictable way to recover because the system keeps comparing intent with reality instead of assuming the first deployment completed perfectly.
+
+The important exam distinction is that reconciliation is continuous, not ceremonial. A one-time deployment step can create a resource, but it does not keep checking whether the resource remains correct. A manual approval can control who changes something, but it does not guarantee the thing stays aligned after approval. A control loop gives the platform a memory of intent and a repeated opportunity to repair or report divergence.
+
+You can reason about reconciliation with a simple mental model. The platform receives desired state from a source such as Git, an API request, or a service catalog form. A controller or reconciler reads the current state from Kubernetes, cloud APIs, or platform inventory. The system then decides whether to create, update, delete, or alert, and it repeats that comparison on a regular schedule or after events.
+
+```text
++--------------------+       ++--------------------+
+| Desired state      |       | Actual state        |
+| Git, API, catalog  |       | Cluster, cloud, IAM |
++---------+----------+       ++----------+---------+
+          |                             ^
+          v                             |
++--------------------+       ++---------+----------+
+| Reconciler         | ----> | Change or report    |
+| compare and decide |       | until states align  |
++--------------------+       ++--------------------+
+```
+
+That diagram is intentionally small because the exam usually tests the concept rather than the machinery. The best answer often says the loop compares desired and actual state, then brings them together. Weaker answers describe reconciliation as a deployment phase, a manual meeting, or a way to hide drift. Hiding drift is especially wrong because mature platforms make drift visible and actionable; they do not pretend reality matches the document.
+
+Before running through a reconciliation question, ask what the system is comparing and what it does when the comparison fails. If no desired state is recorded, the platform has nothing stable to reconcile against. If actual state is never observed, the platform cannot detect drift. If the system detects drift but only logs it without giving owners a recovery route, the platform may be observable, but it is not fully managing the lifecycle.
+
+Reconciliation also changes how you design platform interfaces. A self-service form that directly creates resources can be useful, but it becomes stronger when the request is translated into durable desired state that another component reconciles. That approach makes retries, audits, rollbacks, and ownership clearer because the request is no longer trapped in a transient click or a one-off command. The system can show what was requested, what exists, and what is still waiting.
+
+The tradeoff is that reconciliation requires careful boundaries. A platform should not fight a team that has legitimate permission to change a setting through an approved workflow, and it should not endlessly revert emergency fixes without a way to record the new desired state. Good platforms define which fields are owned by the platform, which fields teams can tune, and how exceptions move from emergency action back into declared configuration.
+
+## Self-Service, Guardrails, and Developer Autonomy
+
+Self-service is not the same as “anything goes.” The phrase means users can complete common tasks without waiting for platform staff, while the platform encodes policy, limits, auditability, and sensible defaults around those tasks. In the CNPA context, self-service is valuable because it shortens feedback loops and reduces toil, but it remains mature only when the platform protects shared infrastructure and records important decisions.
+
+Guardrails are the difference between a safe road and an empty field. A team can move quickly on a paved road because lanes, signs, speed limits, and barriers make normal travel predictable. The same idea applies to Kubernetes platforms: namespaces can be created with ResourceQuotas, workloads can be checked against Pod Security Standards, access can be scoped with RBAC, and deployment changes can be visible through GitOps history or platform audit logs.
+
+The exam usually rewards answers that combine autonomy with constraints. If an answer says developers can do anything they want, it ignores the shared nature of clusters, cloud accounts, and production risk. If an answer says the platform team must approve every request manually, it defeats the point of self-service. The strongest answer gives developers a safe path where normal work is fast, repeatable, observable, and bounded.
+
+Which approach would you choose here and why: a platform workflow that lets teams create namespaces instantly with default quotas and policy checks, or a ticket process that waits for an operator to copy a namespace template by hand? The self-service workflow is usually better because it encodes the same controls into the platform and makes the safe path repeatable. The ticket process may feel safer, but it often depends on memory and queue capacity.
+
+Guardrails also need to be visible to users. A policy that rejects a deployment without explaining why creates frustration, and a platform that hides every rule behind an opaque approval queue teaches teams to avoid the platform. Better guardrails show the rule, the reason, the remediation path, and the owner who can grant an exception. That product detail is not cosmetic; it is what turns governance from a blocker into a learning system.
+
+Different guardrails solve different risks, so exam answers sometimes combine several concerns. RBAC limits who can perform actions, admission policy limits what can enter the cluster, resource quotas reduce noisy-neighbor problems, network policy shapes traffic, and audit logs help reconstruct who changed what. A mature platform does not choose one of these ideas as a universal answer. It layers controls so developers receive useful autonomy without inheriting cluster-wide blast radius.
+
+There is also a user-experience side to guardrails. If the platform exposes one golden path for a stateless service, another for a scheduled job, and another for a data-sensitive workload, users can choose the route that matches their intent. When every workload must start from blank YAML, the organization transfers platform complexity to application teams. The result may look flexible on paper, but it often creates support tickets, security exceptions, and uneven reliability.
+
+The best CNPA answers therefore talk about safe paths, policy, limits, and auditability together. The platform is not merely a permission system, and it is not merely a portal. It is a product that packages infrastructure capabilities behind interfaces developers can use repeatedly. When that product succeeds, teams spend less energy discovering how the organization deploys software and more energy improving the software itself.
+
+## Product Thinking and Platform Measurement
+
+Platform engineering is product work because the platform has users, journeys, adoption patterns, friction points, and measurable outcomes. A platform team can be busy while the platform itself is unhealthy, just as a support desk can close many tickets without removing the causes of support demand. CNPA questions about measurement usually test whether you can separate activity metrics from value metrics.
+
+Adoption is one signal, but it needs interpretation. High adoption can mean the platform is useful, or it can mean users have no alternative. Low adoption can mean the platform lacks value, or it can mean the platform is new, poorly documented, or aimed at a narrow class of workloads. The better exam answer pairs adoption with reliability, lead time, time-to-value, support demand, user satisfaction, and the health of golden paths.
+
+Time-to-value is especially important because platforms are supposed to reduce the distance between intent and a working environment. If a new service used to take two weeks of meetings and now takes an afternoon through a supported path, the platform has changed the delivery system. If the same service still requires many hidden approvals, the platform may have improved documentation without changing the operational bottleneck.
+
+Reliability signals matter because a platform that accelerates unsafe delivery is not mature. You might track successful deployments, failed reconciliations, policy rejection reasons, incident contribution, rollback frequency, and the percentage of workloads using supported templates. These measures are not about punishing application teams. They help the platform team learn where the paved path is strong, where users leave it, and where the interface needs clearer feedback.
+
+Measurement also protects the platform team from becoming a request factory. If success is defined as “the team is busy,” the platform will accumulate tickets, exceptions, and bespoke workflows. If success is defined as “teams can safely complete common work without us,” the platform team has a reason to automate repeated requests and improve documentation, templates, APIs, and controls. The exam tends to favor the second mindset because it reflects product ownership.
+
+Consider a scorecard that combines user and system signals. Adoption shows whether people use the platform. Reliability shows whether the platform path works under real load. Time-to-value shows whether the platform removes delay. Support demand shows where users get stuck. Together, those signals form a healthier picture than cost alone because they describe whether the platform changes delivery behavior.
+
+| Signal | What it tells you | Weak interpretation | Strong interpretation |
+|---|---|---|---|
+| Adoption | Whether teams use the platform path | More users always means success | Adoption is useful when paired with quality and fit |
+| Reliability | Whether the path works repeatedly | Failures belong only to app teams | Failures reveal where platform defaults need work |
+| Time-to-value | How quickly intent becomes usable capability | Fast creation is enough | Fast, safe, observable creation is the target |
+| Support demand | Where users need help | Tickets prove the platform team is valuable | Repeated tickets identify product improvements |
+| Policy outcomes | Which guardrails trigger | Rejections mean users are wrong | Rejections should teach users and improve defaults |
+
+Do not reduce platform measurement to cost reduction. Cost matters because platform work consumes people, infrastructure, and tooling, but a cheaper platform that slows every team is not a win. Likewise, a costly platform may be justified when it removes broad delivery risk and accelerates many teams. The exam answer should reflect balanced measurement rather than a single financial or activity metric.
+
+## Connecting the Original Comparison Traps
+
+The original five questions in this set were short, but they represented important CNPA comparison traps. The first trap asks whether platform engineering means every team builds alone, a dedicated group builds reusable internal products, operations handles everything manually, or standards disappear. The reusable-product answer is strongest because it combines specialization with leverage; one platform team improves the shared path so many application teams can move with less duplicated effort.
+
+The second trap asks whether reconciliation is one-time setup, a continuous desired-versus-actual loop, a manual approval process, or a way to hide drift. The continuous-loop answer is strongest because it reflects Kubernetes controller thinking and GitOps-style operations. Drift is not embarrassing noise to hide; it is evidence the system needs to correct, report, or ask for a new desired state.
+
+The third trap groups related concepts. Developer experience, golden paths, and internal developer platforms belong together because they describe the user-facing side of platform engineering. Ticket queues, tribal knowledge, ad hoc scripts, invisible drift, and one-off YAML may appear in real organizations, but they describe the problems platform engineering tries to reduce. When the exam asks for the natural combination, choose the set that forms a coherent operating model.
+
+The fourth trap asks how to measure platform success. Activity alone is a weak metric because a busy platform team may simply be absorbing friction that the platform should remove. Cost alone is also too narrow because the platform exists to improve delivery, safety, and user experience. Adoption, reliability, and time-to-value are stronger signals because they connect platform work to user behavior and operational outcomes.
+
+The fifth trap asks about self-service with guardrails. The best answer is not unlimited freedom and not complete separation between developers and infrastructure. It is autonomy within controlled boundaries, with policy, limits, and auditability built into the supported path. That phrase is worth remembering because it captures the practical balance the CNPA exam expects: developers move quickly, and the platform keeps shared risk visible and bounded.
+
+These traps reinforce one another. Reusable platform products need measurement to prove they help users. Reconciliation needs guardrails so controllers do not create unsafe resources. Self-service needs product thinking so the interface fits real developer journeys. Golden paths need feedback because a path nobody adopts is a document, not a platform.
+
+When you study, practice explaining the wrong answers without sounding dismissive. Manual approvals can be appropriate for exceptional risk, but they are not the default model for scalable self-service. Team-specific tooling can solve urgent local pain, but it should not become the organization’s long-term delivery strategy. Flexibility matters, yet flexibility without standards turns every deployment into a custom integration exercise.
+
+## Worked Review of a Platform Proposal
+
+Exercise scenario: a platform team proposes a service onboarding flow for Kubernetes 1.35 clusters. Developers open a catalog entry, choose a workload type, enter ownership metadata, and submit a request. The platform writes a small desired-state record into Git, a GitOps controller applies namespace and access resources, admission policy checks workload settings, and a dashboard reports whether the service reached the supported deployment path.
+
+Start the review with the user journey rather than with the tool list. The user is an application team that needs a service space, safe defaults, and enough visibility to recover when deployment fails. The repeated task is onboarding a service into a production-ready environment. The platform should make that task predictable by turning organizational rules into a supported workflow rather than leaving each team to discover namespace labels, quota expectations, and access conventions through private conversations.
+
+The first CNPA question you can ask is whether this proposal creates a reusable internal product. A catalog entry alone is not enough, because a catalog can become a directory of links that still depends on manual action behind the scenes. The proposal becomes platform engineering when the catalog starts a reliable workflow, records desired state, applies consistent defaults, and exposes status back to the team. That combination shows the platform is more than a page; it is an operational interface.
+
+The second question is whether the proposal uses reconciliation as a lifecycle model. If the desired-state record remains in Git and a controller continues comparing it to cluster state, then drift can be corrected or reported after the first request. If the record is used only to trigger a one-time script and then discarded, the workflow may be automated, but it is weaker as a platform foundation. Durable intent is what lets the platform explain what should exist tomorrow, not only what was created today.
+
+The third question is whether guardrails are encoded in a way developers can understand. Admission policy can reject unsafe configurations, but the platform should also return messages that explain the rule and the fix. Resource quotas can prevent a team from consuming shared capacity, but the platform should explain how to request a larger boundary when the workload legitimately needs it. RBAC can scope access, but users should know what role they received and which actions require an exception.
+
+The fourth question is whether measurement reflects user value. A dashboard that counts catalog clicks may be useful, but it does not prove the path works. A stronger dashboard shows how many services completed onboarding, how long onboarding took, how often reconciliation failed, which policies rejected requests, and how many support tickets came from the same workflow step. Those measures help the platform team improve the product instead of merely reporting activity.
+
+Now test the proposal against the original distractors. “Every team builds its own deployment tooling” would be a poor outcome because the proposed workflow should replace duplicated service onboarding scripts. “The ops team handles all provisioning requests manually” would also be weak because the routine path should be automated and reconciled. “Developers may use any workflow, with no standards” would conflict with the idea of a supported path, even if some exceptions remain possible for unusual workloads.
+
+The most subtle weakness would be a platform that looks self-service but secretly depends on manual approvals for ordinary work. A portal can collect a request while an operator still copies YAML later, and the user may not notice until work queues up. During review, ask whether the platform returns status automatically, whether it records why a request is waiting, and whether the normal request can complete without a private handoff. Those checks reveal whether the workflow truly reduces dependency on the platform team.
+
+Another subtle weakness is a platform that reconciles too aggressively. If a controller overwrites every field without respecting team-owned settings, developers may work around the platform because it fights legitimate changes. A mature design defines ownership boundaries, such as platform-owned labels, security settings, and quotas, while allowing teams to tune deployment replicas or environment variables through an approved path. Reconciliation should preserve intent, not erase all local agency.
+
+You can also evaluate the proposal through failure modes. If Git is unavailable, what status does the platform show? If policy rejects the request, where does the user learn the remediation? If the namespace exists but RBAC binding fails, does the platform expose partial progress? Exam answers rarely require this level of implementation detail, but practicing these questions sharpens your ability to distinguish real lifecycle management from optimistic automation.
+
+The same review can be applied to a smaller platform. A team may not have a full portal, but it can still use Git templates, pull request checks, Kubernetes admission policy, and a simple dashboard to create a paved path. Conversely, a large organization may have a polished portal and still lack reconciliation or useful measurement. CNPA thinking is therefore less about the size of the interface and more about whether the operating model helps users deliver safely.
+
+When a question offers a cost-only answer, compare it against this proposal. The platform may reduce toil and waste, but its deeper value is that teams can start from a supported route, receive consistent guardrails, and recover from drift. A pure cost metric would miss whether the service onboarding workflow is adopted, whether it succeeds reliably, and whether teams reach a working environment faster than before. Cost belongs in the scorecard, but it should not be the entire scorecard.
+
+When a question offers a happiness-only answer, use the same discipline. User sentiment can reveal pain that metrics miss, especially when policy messages are confusing or templates do not fit real workloads. However, happiness without operational signals may hide reliability issues, slow onboarding, or repeated manual intervention. Product thinking combines qualitative feedback with quantitative evidence so the platform team can make roadmap decisions grounded in behavior.
+
+The worked review also helps with the phrase “golden path.” A golden path is not a prison sentence for every workload; it is the route the platform team can support best. It should include documented assumptions, strong defaults, and an escape hatch for valid exceptions. If too many teams need exceptions, that is not proof users are difficult. It is product feedback that the current path may be too narrow or poorly matched to common workload shapes.
+
+Finally, use the proposal to practice explaining why the correct answer is best rather than simply naming it. “Reusable internal products and paved paths” is correct because it changes how many teams consume infrastructure capabilities. “A loop that compares desired state to actual state” is correct because it captures the ongoing nature of reconciliation. “Safe paths with policy, limits, and auditability” is correct because it balances autonomy with shared risk. “Adoption, reliability, and time-to-value” is correct because it connects platform work to user outcomes.
+
+## Patterns & Anti-Patterns
+
+Patterns and anti-patterns help you answer CNPA questions because they reveal the operating model behind the vocabulary. A platform pattern usually reduces repeated work, makes safe behavior easier, and gives users feedback. An anti-pattern usually hides work, fragments ownership, or makes success depend on individual memory rather than a reliable system.
+
+| Pattern | When to use it | Why it works | Scaling consideration |
+|---|---|---|---|
+| Golden path with escape hatch | Common workloads share most deployment needs | Teams start from a supported route while unusual cases remain possible | Review escape-hatch demand to decide what the next supported path should include |
+| Durable desired state | Environments, policies, or resources need ongoing alignment | Reconciliation can compare intent with reality after the first request | Define ownership so controllers do not fight legitimate changes |
+| Guarded self-service | Developers need autonomy on shared infrastructure | Policy, quotas, RBAC, and audit logs make routine work safe | Error messages and remediation guidance matter as much as enforcement |
+| Product scorecard | The platform team needs proof of value | Adoption, reliability, time-to-value, and support demand show user outcomes | Metrics should inform roadmap decisions rather than become vanity reporting |
+
+Anti-patterns often feel reasonable at first because they optimize for a local pressure. A ticket queue feels controlled when the cluster is small. A pile of team scripts feels fast when one team is under deadline. An unrestricted namespace feels empowering during experimentation. The problem appears later, when scale turns every local shortcut into shared operational load.
+
+| Anti-pattern | What goes wrong | Why teams fall into it | Better alternative |
+|---|---|---|---|
+| Portal-only platform | The interface looks modern, but hidden manual work remains | Teams equate a UI with self-service | Back the portal with APIs, reconciliation, and clear ownership |
+| Unlimited developer access | Small mistakes can affect shared infrastructure | Frustration with slow approvals leads to overcorrection | Provide scoped access through RBAC and policy-backed workflows |
+| Ticket queue as default path | Delivery speed depends on platform team capacity | Manual review feels safer than encoded controls | Automate routine requests and reserve review for exceptional risk |
+| Metrics based on busyness | The team celebrates demand instead of removing friction | Tickets are easy to count and report | Track time-to-value, adoption quality, and repeated support themes |
+
+The pattern table is not a checklist to memorize in isolation. Use it as a translation layer between exam wording and platform behavior. If an answer makes a user journey faster while preserving policy and visibility, it probably represents a platform pattern. If an answer moves work into a hidden queue or leaves every team to invent its own process, it is probably an anti-pattern.
+
+## Decision Framework
+
+Use a decision framework when two answers both sound partly correct. CNPA questions are rarely asking whether control matters or whether autonomy matters; they are asking which answer balances both in the platform context. The most reliable approach is to identify the user, the repeated task, the risk boundary, and the feedback loop.
+
+```text
+Question asks about a platform decision
+          |
+          v
+Is there a repeated developer journey?
+          |
+     +----+----+
+     |         |
+    Yes        No
+     |         |
+     v         v
+Can the safe path encode policy?    Use human review for exceptional cases
+     |
+ +---+---+
+ |       |
+Yes      No
+ |       |
+ v       v
+Prefer self-service with guardrails  Improve prerequisites before automation
+ |
+ v
+Measure adoption, reliability, and time-to-value
+```
+
+The framework starts with repetition because platform engineering gets leverage from common journeys. If a task happens once a year and carries unusual risk, a manual review may be sensible. If a task happens every week across many teams, the platform should probably encode the rules and expose a self-service path. That distinction prevents you from treating every approval as bad or every automation as good.
+
+Risk boundaries come next. A self-service namespace request can include quotas, labels, network defaults, ownership metadata, and RBAC. A production database deletion request may still need a separate review because the blast radius and reversibility are different. Good platform thinking does not erase judgment; it moves repeated judgment into reliable systems and leaves genuinely unusual decisions to humans with context.
+
+Feedback loops complete the decision. If users abandon the golden path, the platform team should ask why rather than blame users. If policy rejects deployments repeatedly for the same reason, the error message, template, or documentation may need improvement. If reconciliation continually reverts the same emergency change, the platform may need a better exception flow. A platform is a product, so observed behavior should shape the roadmap.
+
+| Decision point | Prefer this answer when | Be cautious when |
+|---|---|---|
+| Platform engineering model | The answer describes reusable internal products and paved paths | The answer centralizes every action in a manual queue |
+| Reconciliation model | The answer compares desired and actual state continuously | The answer treats deployment as a one-time event |
+| Guardrail model | The answer combines autonomy with policy, limits, and auditability | The answer chooses either unlimited access or total lockout |
+| Measurement model | The answer includes adoption, reliability, and time-to-value | The answer measures only cost, busyness, or vague happiness |
+
+Use the decision table to test your first instinct. If you are tempted by an answer because it sounds efficient, ask whether it is also safe and observable. If you are tempted by an answer because it sounds controlled, ask whether it lets developers complete routine work without queueing. The best answer usually preserves both sides of that tradeoff.
+
+## Final Exam Review Strategy
+
+The strongest way to use this set is to rehearse the reasoning pattern, not the exact wording. After you choose an answer, rewrite the question in operational terms: who is the user, what task is repeated, what risk needs a boundary, and what feedback tells the platform team whether the path works. That habit turns a short multiple-choice prompt into a platform design review, which is closer to how CNPA concepts appear in real decisions.
+
+When a question mentions developer experience, look for evidence that the platform reduces cognitive load for application teams. Cognitive load is not only the number of screens a developer opens; it includes hidden conventions, unclear ownership, unpredictable approvals, and unfamiliar Kubernetes details that every team must rediscover. A platform answer is stronger when it packages those decisions into a supported path and explains where users can safely customize.
+
+When a question mentions reliability, avoid answers that treat reliability as something separate from platform design. Platform reliability includes the health of the platform itself and the reliability of the workloads that consume it. A namespace template with quotas, policy, and ownership metadata can improve workload reliability because it gives teams a safer starting point. A reconciliation loop can improve platform reliability because it detects when reality no longer matches the recorded intent.
+
+When a question mentions governance, avoid the false choice between unlimited freedom and slow approval. Mature governance is often encoded as policy, review rules, role bindings, quotas, and audit trails that users encounter inside the normal path. The exam answer should not celebrate bureaucracy for its own sake, and it should not remove all constraints to make users happy. The platform goal is to make the right action the easiest action most of the time.
+
+When a question mentions a tool, ask what operating model the tool supports. A portal can support self-service, but it can also become a decorative front end for tickets. A GitOps controller can support reconciliation, but it still needs clear ownership and useful status. A policy engine can support guardrails, but it needs understandable feedback. The best answer usually explains the behavior and outcome, not only the tool name.
+
+When a question mentions metrics, classify each metric as activity, adoption, quality, speed, or learning. Activity metrics count effort, such as tickets closed or meetings held. Adoption metrics show whether people use the path. Quality metrics show whether the path succeeds safely. Speed metrics show whether teams reach value faster. Learning metrics, such as repeated rejection reasons, show where the platform roadmap should change.
+
+It also helps to build a short elimination checklist for distractors. Reject an answer if it makes every team rebuild common capability, hides drift, measures only busyness, removes all standards, or turns routine work into a manual queue. Be cautious with answers that sound absolute, because platform engineering usually deals with tradeoffs and boundaries. A complete answer tends to mention users, repeatability, safety, observability, and improvement over time.
+
+Finally, review your written explanations for balanced language. If your explanation says only “developers move faster,” add the guardrail that keeps shared infrastructure safe. If it says only “policy enforces standards,” add the user feedback that makes the policy usable. If it says only “the platform team owns it,” add how application teams consume the capability through a product interface. That balance is the practical center of this module.
+
+## Did You Know?
+
+- Kubernetes was announced in 2014 and joined the Cloud Native Computing Foundation as one of its earliest projects in 2015, which is why CNPA questions often connect platform thinking back to controller-style operations.
+- The Kubernetes documentation describes controllers as control loops, and that language is the conceptual bridge between reconciliation in clusters and reconciliation in platform products.
+- The Platform Engineering Maturity Model describes platform work as an evolution from scattered scripts toward product-managed internal platforms, which matches the CNPA focus on user journeys and adoption.
+- Kubernetes 1.35 continues the long-running pattern of declarative APIs, controllers, RBAC, admission controls, and resource policies that platform teams compose into safer paved paths.
+
+## Common Mistakes
+
+| Mistake | Why It Happens | How to Fix It |
+|---|---|---|
+| Treating a platform as only a portal | A visible interface is easier to recognize than the operating model behind it | Ask whether the portal triggers APIs, durable desired state, policy checks, and useful feedback |
+| Choosing unlimited freedom as self-service | Teams react against slow ticket queues and assume autonomy means no constraints | Look for autonomy within guardrails: scoped access, quotas, policy, and auditability |
+| Calling manual approvals “platform engineering” | Centralized approval feels controlled and familiar | Reserve manual review for exceptional risk and automate routine requests through supported paths |
+| Describing reconciliation as deployment | The first creation event is easier to picture than a continuing loop | Use desired state, actual state, compare, act, and repeat as your mental model |
+| Measuring platform health by team busyness | Tickets and meetings are visible measures of effort | Track adoption quality, reliability, time-to-value, repeated support themes, and user outcomes |
+| Ignoring why distractors are wrong | The correct option can feel obvious after reading the answer | Explain every distractor so you can recognize similar wording on the exam |
+| Equating golden paths with rigid lock-in | Standards can sound like lost flexibility | Remember that strong golden paths include clear extension points and exception handling |
+
+## Quiz
+
+### Question 1
 
 1. Every team builds its own deployment tooling.
 2. A dedicated team builds reusable internal products and paved paths.
 3. The ops team handles all provisioning requests manually.
 4. Developers may use any workflow, with no standards.
 
-<details>
-<summary>Answer</summary>
+<details><summary>Your organization has eight application teams, each with a different deployment script and namespace checklist. Which option best reflects platform engineering?</summary>
 
 **Correct answer: 2**
 
-Platform engineering reduces duplicated effort by building shared products. It is not a return to centralized ticket handling.
+Option 2 is correct because platform engineering reduces duplicated effort by treating shared delivery capabilities as reusable internal products. Option 1 is wrong because team-specific tooling spreads the same platform work across many groups. Option 3 is wrong because manual provisioning keeps routine delivery dependent on queue capacity. Option 4 is wrong because the absence of standards removes the paved path that makes delivery repeatable.
 </details>
 
-### 2. What is the best description of reconciliation in a platform context?
+### Question 2
 
 1. A one-time setup step that happens only during deployment.
 2. A loop that compares desired state to actual state and brings them together.
 3. A manual approval process for every change.
 4. A method of hiding drift from developers.
 
-<details>
-<summary>Answer</summary>
+<details><summary>A GitOps controller keeps reverting a manual change to a Deployment because the repository still declares the previous value. What is the best description of reconciliation in a platform context?</summary>
 
 **Correct answer: 2**
 
-Reconciliation is continuous, not one-time. It is the control-loop idea that underpins GitOps and many provisioning platforms.
+Option 2 is correct because reconciliation is continuous comparison followed by action or reporting. Option 1 is wrong because a one-time deployment cannot keep detecting drift after the first operation. Option 3 is wrong because approval may control a change, but it is not the same as a control loop. Option 4 is wrong because mature reconciliation exposes drift and either corrects it or makes it visible.
 </details>
 
-### 3. Which combination belongs most naturally together?
+### Question 3
 
 1. Developer experience, golden paths, internal developer platforms
 2. Ticket queues, tribal knowledge, ad hoc scripts
 3. Monitoring only, no policies, no metrics
 4. Manual approvals, one-off YAML, invisible drift
 
-<details>
-<summary>Answer</summary>
+<details><summary>A team is choosing words for a CNPA study card and wants one set that naturally belongs together. Which combination belongs most naturally together?</summary>
 
 **Correct answer: 1**
 
-Those three ideas form a coherent CNPA story: the platform exists to improve the developer journey.
+Option 1 is correct because developer experience, golden paths, and internal developer platforms describe a coherent product-oriented platform model. Option 2 is wrong because ticket queues, tribal knowledge, and ad hoc scripts are symptoms platform engineering tries to reduce. Option 3 is wrong because monitoring without policy or metrics is too narrow to describe platform work. Option 4 is wrong because manual approvals, one-off YAML, and invisible drift describe fragmented operations rather than a mature platform.
 </details>
 
-### 4. Which statement about measurement is most accurate?
+### Question 4
 
 1. Platform success is only measured by cost reduction.
 2. A platform should be measured with adoption, reliability, and time-to-value signals.
 3. If the platform team is busy, the platform is healthy.
 4. A platform needs no metrics if users are happy.
 
-<details>
-<summary>Answer</summary>
+<details><summary>A platform team reports that it closed many support tickets, but application teams still wait days for routine environments. Which statement about measurement is most accurate?</summary>
 
 **Correct answer: 2**
 
-Cost matters, but CNPA expects product thinking. Adoption and time-to-value are usually stronger indicators than activity.
+Option 2 is correct because product-oriented platform measurement combines whether teams use the platform, whether it works reliably, and whether it shortens the path to useful capability. Option 1 is wrong because cost reduction alone can miss delivery speed and safety. Option 3 is wrong because busyness may indicate unresolved friction. Option 4 is wrong because user sentiment helps, but it does not replace operational evidence.
 </details>
 
-### 5. Which is the best explanation of self-service with guardrails?
+### Question 5
 
 1. Developers can do anything they want.
 2. The platform exposes safe paths with policy, limits, and auditability.
 3. The platform team approves every request manually.
 4. Developers never interact with the platform at all.
 
-<details>
-<summary>Answer</summary>
+<details><summary>A developer portal lets teams request namespaces without waiting for a ticket, but each namespace receives default quotas, labels, RBAC, and audit logging. Which is the best explanation of self-service with guardrails?</summary>
 
 **Correct answer: 2**
 
-The essence is autonomy within controlled boundaries. That is the pattern the exam wants you to recognize.
+Option 2 is correct because guarded self-service gives developers autonomy inside controlled and observable boundaries. Option 1 is wrong because unlimited access ignores shared cluster risk. Option 3 is wrong because manual approval for every routine request removes the self-service benefit. Option 4 is wrong because platform engineering usually improves how developers interact with infrastructure rather than hiding every interaction from them.
 </details>
 
-## Readiness Check
+### Question 6
 
-If you can explain why answers 2 in questions 1, 2, 4, and 5 are correct without re-reading the module, you are in good shape for the conceptual part of CNPA.
+1. Remove all policy checks so deployments stop failing.
+2. Keep the policy, but add clear reasons, remediation guidance, and an exception path.
+3. Require the service team to open a ticket for every deployment.
+4. Stop measuring adoption because users are responsible for following standards.
 
-## Final Review Notes
+<details><summary>A service team avoids the official golden path because policy rejections say only “denied” and provide no owner or remediation. What should the platform team improve first?</summary>
 
-- Platform engineering is a delivery model, not just a tool stack.
-- A platform without adoption is a cost center.
-- Self-service without policy is not mature platform engineering.
+**Correct answer: 2**
+
+Option 2 is correct because guardrails should teach users how to succeed while preserving the safety boundary. Option 1 is wrong because removing all policy checks trades frustration for unmanaged risk. Option 3 is wrong because it turns a product feedback problem into a queue. Option 4 is wrong because adoption and abandonment are important signals that the platform team should use to improve the product.
+</details>
+
+### Question 7
+
+1. Pick the newest portal framework and announce that the platform is complete.
+2. Start with the developer journey, encode safe defaults, reconcile desired state, and measure time-to-value.
+3. Let each team design a separate workflow so the platform team has fewer decisions to make.
+4. Focus only on reducing cloud spend, because user adoption will follow automatically.
+
+<details><summary>A platform roadmap includes a new workflow for production service creation. Which choice best shows product thinking rather than tool-first implementation?</summary>
+
+**Correct answer: 2**
+
+Option 2 is correct because it begins with the user journey and connects interface design, guardrails, reconciliation, and measurement. Option 1 is wrong because a framework alone does not create a platform operating model. Option 3 is wrong because separate workflows recreate the duplication the platform should reduce. Option 4 is wrong because cost control matters, but it does not prove that developers can deliver safely and quickly.
+</details>
+
+## Hands-On Exercise
+
+Exercise scenario: you are reviewing a proposed internal developer platform before a CNPA study group meets. The platform has a portal, a GitOps repository, namespace templates, RBAC defaults, ResourceQuota templates, and a dashboard that shows deployment success rates. Your job is not to deploy anything; your job is to evaluate whether the design answers the same comparison traps covered in this practice set.
+
+Start by writing a one-page review in your notes. Describe the repeated developer journey, the desired state source, the actual state observed by the platform, and the guardrails applied before a team receives a production namespace. Then identify which metric would best prove that the platform improved delivery without creating hidden risk. This written exercise matters because the CNPA exam often gives you a scenario and asks for the most complete operating-model answer.
+
+- [ ] Evaluate platform engineering choices by naming the reusable internal product, the paved path, and the manual work it replaces.
+- [ ] Diagnose reconciliation and drift scenarios by identifying desired state, actual state, and the component that compares them.
+- [ ] Design guardrails by listing at least four controls, including policy, limits, auditability, and scoped developer autonomy.
+- [ ] Measure platform health with adoption, reliability, and time-to-value signals instead of team busyness alone.
+- [ ] Explain why each original comparison-trap distractor is wrong in one or two sentences.
+
+<details><summary>Solution guide</summary>
+
+A strong review says the reusable internal product is the platform workflow for creating and operating services or namespaces. The paved path might begin in the portal, create durable desired state in Git, and rely on a controller or GitOps reconciler to compare that desired state with actual cluster state. The design should mention guardrails such as RBAC, ResourceQuota, Pod Security Standards, admission policy, labels, ownership metadata, and audit logs. The strongest measurement answer combines adoption with reliability and time-to-value, then uses repeated support requests and policy rejections as product feedback.
+</details>
+
+<details><summary>Success criteria</summary>
+
+Your answer is ready when it avoids tool-only language, names the user journey, explains continuous reconciliation, balances self-service with guardrails, and chooses measurements that prove user value. It should also explain why manual ticket queues, team-specific scripts, unlimited workflows, cost-only reporting, and hidden drift are weaker CNPA answers.
+</details>
+
+## Sources
+
+- [Kubernetes documentation: Working with Kubernetes objects](https://kubernetes.io/docs/concepts/overview/working-with-objects/)
+- [Kubernetes documentation: Controllers](https://kubernetes.io/docs/concepts/architecture/controller/)
+- [Kubernetes documentation: Operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/)
+- [Kubernetes documentation: Role-based access control good practices](https://kubernetes.io/docs/concepts/security/rbac-good-practices/)
+- [Kubernetes documentation: Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
+- [Kubernetes documentation: Resource quotas](https://kubernetes.io/docs/concepts/policy/resource-quotas/)
+- [Kubernetes documentation: Limit ranges](https://kubernetes.io/docs/concepts/policy/limit-range/)
+- [Kubernetes documentation: Auditing](https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/)
+- [CNCF TAG App Delivery: Operator Whitepaper](https://tag-app-delivery.cncf.io/whitepapers/operator/)
+- [CNCF Platforms Working Group: Platform Engineering Maturity Model](https://tag-app-delivery.cncf.io/whitepapers/platform-eng-maturity-model/)
 
 ## Next Module
 
-Move to the CGOA track if you also want the GitOps associate exam path.
+Continue to the CGOA track if you want to practice the GitOps associate exam path next.

--- a/src/content/docs/k8s/cnpa/module-1.5-practice-questions-set-2.md
+++ b/src/content/docs/k8s/cnpa/module-1.5-practice-questions-set-2.md
@@ -270,12 +270,14 @@ Finally, review your written explanations for balanced language. If your explana
 
 ### Question 1
 
+Your organization has eight application teams, each with a different deployment script and namespace checklist. Which option best reflects platform engineering?
+
 1. Every team builds its own deployment tooling.
 2. A dedicated team builds reusable internal products and paved paths.
 3. The ops team handles all provisioning requests manually.
 4. Developers may use any workflow, with no standards.
 
-<details><summary>Your organization has eight application teams, each with a different deployment script and namespace checklist. Which option best reflects platform engineering?</summary>
+<details><summary>Show answer and explanation</summary>
 
 **Correct answer: 2**
 
@@ -284,12 +286,14 @@ Option 2 is correct because platform engineering reduces duplicated effort by tr
 
 ### Question 2
 
+A GitOps controller keeps reverting a manual change to a Deployment because the repository still declares the previous value. What is the best description of reconciliation in a platform context?
+
 1. A one-time setup step that happens only during deployment.
 2. A loop that compares desired state to actual state and brings them together.
 3. A manual approval process for every change.
 4. A method of hiding drift from developers.
 
-<details><summary>A GitOps controller keeps reverting a manual change to a Deployment because the repository still declares the previous value. What is the best description of reconciliation in a platform context?</summary>
+<details><summary>Show answer and explanation</summary>
 
 **Correct answer: 2**
 
@@ -298,12 +302,14 @@ Option 2 is correct because reconciliation is continuous comparison followed by 
 
 ### Question 3
 
+A team is choosing words for a CNPA study card and wants one set that naturally belongs together. Which combination belongs most naturally together?
+
 1. Developer experience, golden paths, internal developer platforms
 2. Ticket queues, tribal knowledge, ad hoc scripts
 3. Monitoring only, no policies, no metrics
 4. Manual approvals, one-off YAML, invisible drift
 
-<details><summary>A team is choosing words for a CNPA study card and wants one set that naturally belongs together. Which combination belongs most naturally together?</summary>
+<details><summary>Show answer and explanation</summary>
 
 **Correct answer: 1**
 
@@ -312,12 +318,14 @@ Option 1 is correct because developer experience, golden paths, and internal dev
 
 ### Question 4
 
+A platform team reports that it closed many support tickets, but application teams still wait days for routine environments. Which statement about measurement is most accurate?
+
 1. Platform success is only measured by cost reduction.
 2. A platform should be measured with adoption, reliability, and time-to-value signals.
 3. If the platform team is busy, the platform is healthy.
 4. A platform needs no metrics if users are happy.
 
-<details><summary>A platform team reports that it closed many support tickets, but application teams still wait days for routine environments. Which statement about measurement is most accurate?</summary>
+<details><summary>Show answer and explanation</summary>
 
 **Correct answer: 2**
 
@@ -326,12 +334,14 @@ Option 2 is correct because product-oriented platform measurement combines wheth
 
 ### Question 5
 
+A developer portal lets teams request namespaces without waiting for a ticket, but each namespace receives default quotas, labels, RBAC, and audit logging. Which is the best explanation of self-service with guardrails?
+
 1. Developers can do anything they want.
 2. The platform exposes safe paths with policy, limits, and auditability.
 3. The platform team approves every request manually.
 4. Developers never interact with the platform at all.
 
-<details><summary>A developer portal lets teams request namespaces without waiting for a ticket, but each namespace receives default quotas, labels, RBAC, and audit logging. Which is the best explanation of self-service with guardrails?</summary>
+<details><summary>Show answer and explanation</summary>
 
 **Correct answer: 2**
 
@@ -340,12 +350,14 @@ Option 2 is correct because guarded self-service gives developers autonomy insid
 
 ### Question 6
 
+A service team avoids the official golden path because policy rejections say only “denied” and provide no owner or remediation. What should the platform team improve first?
+
 1. Remove all policy checks so deployments stop failing.
 2. Keep the policy, but add clear reasons, remediation guidance, and an exception path.
 3. Require the service team to open a ticket for every deployment.
 4. Stop measuring adoption because users are responsible for following standards.
 
-<details><summary>A service team avoids the official golden path because policy rejections say only “denied” and provide no owner or remediation. What should the platform team improve first?</summary>
+<details><summary>Show answer and explanation</summary>
 
 **Correct answer: 2**
 
@@ -354,12 +366,14 @@ Option 2 is correct because guardrails should teach users how to succeed while p
 
 ### Question 7
 
+A platform roadmap includes a new workflow for production service creation. Which choice best shows product thinking rather than tool-first implementation?
+
 1. Pick the newest portal framework and announce that the platform is complete.
 2. Start with the developer journey, encode safe defaults, reconcile desired state, and measure time-to-value.
 3. Let each team design a separate workflow so the platform team has fewer decisions to make.
 4. Focus only on reducing cloud spend, because user adoption will follow automatically.
 
-<details><summary>A platform roadmap includes a new workflow for production service creation. Which choice best shows product thinking rather than tool-first implementation?</summary>
+<details><summary>Show answer and explanation</summary>
 
 **Correct answer: 2**
 
@@ -399,7 +413,7 @@ Your answer is ready when it avoids tool-only language, names the user journey, 
 - [Kubernetes documentation: Limit ranges](https://kubernetes.io/docs/concepts/policy/limit-range/)
 - [Kubernetes documentation: Auditing](https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/)
 - [CNCF TAG App Delivery: Operator Whitepaper](https://tag-app-delivery.cncf.io/whitepapers/operator/)
-- [CNCF Platforms Working Group: Platform Engineering Maturity Model](https://tag-app-delivery.cncf.io/whitepapers/platform-eng-maturity-model/)
+- [CNCF Platforms Working Group: Platform Engineering Maturity Model](https://tag-app-delivery.cncf.io/whitepapers/platforms/)
 
 ## Next Module
 


### PR DESCRIPTION
## Summary

#388 sweep — rewrite of `src/content/docs/k8s/cnpa/module-1.5-practice-questions-set-2.md` for rubric-critical score.

## Codex response excerpt

```
Rewrote and committed the module only: `c35e1ff2c867`.

Verifier is T0: `body_words=5148`, `mean_wpp=67.7`, `median_wpp=68.5`, `short_rate=0.013`, `max_run=1`. `scripts/test_pipeline.py` passed `166 tests, OK`. `npm run build` could not be completed: primary checkout was already on `pr925` with untracked user files, and the fallback worktree build hit the known Astro worktree symlink failure.

Branch pushed: `codex/388-pilot-module-1-5-practice-questions-set-2`.

I could not open the PR because `gh` is unauthenticated and no `GH_TOKEN`/`GITHUB_TOKEN` is present in this session.

https://github.com/kube-dojo/kube-dojo.github.io/pull/new/codex/388-pilot-module-1-5-practice-questions-set-2
```

## Test plan

- [ ] Cross-family review per `docs/review-protocol.md`
- [ ] Verify rubric score >=4.0 post-merge

PR opened by orchestrator (codex sandbox lacks GH_TOKEN by design).
