### PR TITLE
feat(safety): refuse --mode danger without --worktree + SessionStart HEAD-on-main check

### DIFF
--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -7,6 +7,15 @@ if [ -n "$CLAUDE_NON_INTERACTIVE" ] || [ -n "$KUBEDOJO_PIPELINE" ] || [ -n "$GEM
   exit 0
 fi
 
+REPO_HINT="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+REPO_ROOT=$(git -C "$REPO_HINT" rev-parse --show-toplevel)
+PRIMARY_WORKTREE=$(git -C "$REPO_ROOT" worktree list --porcelain | awk '/^worktree / {print $2; exit}')
+PRIMARY_BRANCH=$(git -C "$PRIMARY_WORKTREE" rev-parse --abbrev-ref HEAD)
+if [ "$PRIMARY_BRANCH" != "main" ]; then
+  printf '%b\n' "\033[31m[session-setup] PRIMARY TREE NOT ON main (currently '${PRIMARY_BRANCH}') — fix with: git -C ${PRIMARY_WORKTREE} checkout main\033[0m" >&2
+  exit 1
+fi
+
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
 ISSUES=()
 INFO=()

--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -8,8 +8,10 @@ if [ -n "$CLAUDE_NON_INTERACTIVE" ] || [ -n "$KUBEDOJO_PIPELINE" ] || [ -n "$GEM
 fi
 
 REPO_HINT="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
-REPO_ROOT=$(git -C "$REPO_HINT" rev-parse --show-toplevel)
-PRIMARY_WORKTREE=$(git -C "$REPO_ROOT" worktree list --porcelain | awk '/^worktree / {print $2; exit}')
+if ! REPO_ROOT=$(git -C "$REPO_HINT" rev-parse --show-toplevel 2>/dev/null); then
+  exit 0
+fi
+PRIMARY_WORKTREE=$(git -C "$REPO_ROOT" worktree list --porcelain | awk '/^worktree / {sub(/^worktree /, ""); print; exit}')
 PRIMARY_BRANCH=$(git -C "$PRIMARY_WORKTREE" rev-parse --abbrev-ref HEAD)
 if [ "$PRIMARY_BRANCH" != "main" ]; then
   printf '%b\n' "\033[31m[session-setup] PRIMARY TREE NOT ON main (currently '${PRIMARY_BRANCH}') — fix with: git -C ${PRIMARY_WORKTREE} checkout main\033[0m" >&2

--- a/scripts/dispatch_smart.py
+++ b/scripts/dispatch_smart.py
@@ -254,13 +254,14 @@ def main() -> int:
         sys.stderr.write("[smart] prompt is empty\n")
         return 2
 
+    if mode == "danger" and not args.worktree:
+        p.error("--mode danger requires --worktree (no override)")
+
     worktree: Path | None = None
     if args.worktree:
         worktree = Path(args.worktree)
         if not worktree.is_absolute():
             worktree = REPO / worktree
-        if mode != "read-only":
-            ensure_worktree(worktree, args.new_branch)
     elif mode != "read-only":
         sys.stderr.write(
             f"[smart] mode={mode} requires --worktree to avoid trampling "
@@ -275,6 +276,9 @@ def main() -> int:
         print(f"[dry-run] task_id={task_id}")
         print(f"[dry-run] prompt_chars={len(prompt)}")
         return 0
+
+    if worktree and mode != "read-only":
+        ensure_worktree(worktree, args.new_branch)
 
     return fire(
         agent=args.agent,

--- a/scripts/quality/test_session_setup_head_check.sh
+++ b/scripts/quality/test_session_setup_head_check.sh
@@ -6,9 +6,13 @@ set -o pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 HOOK_SOURCE="$SCRIPT_DIR/../../.claude/hooks/session-setup.sh"
 WORKROOT=$(mktemp -d)
+WORKROOT_OK=""
 STDERR_FILE=$(mktemp)
 cleanup() {
   rm -rf "$WORKROOT"
+  if [ -n "$WORKROOT_OK" ]; then
+    rm -rf "$WORKROOT_OK"
+  fi
   rm -f "$STDERR_FILE"
 }
 trap cleanup EXIT
@@ -43,3 +47,21 @@ grep -q "currently 'feature'" "$STDERR_FILE" || {
 }
 
 echo "[session-setup-test] PASS"
+
+# happy path: main branch should not error
+WORKROOT_OK=$(mktemp -d)
+mkdir -p "$WORKROOT_OK/.claude/hooks"
+cp "$HOOK_SOURCE" "$WORKROOT_OK/.claude/hooks/session-setup.sh"
+chmod +x "$WORKROOT_OK/.claude/hooks/session-setup.sh"
+
+git -C "$WORKROOT_OK" init -q -b main
+git -C "$WORKROOT_OK" config user.email "ci@example.com"
+git -C "$WORKROOT_OK" config user.name "CI"
+git -C "$WORKROOT_OK" commit --allow-empty -qm init
+
+if ! bash "$WORKROOT_OK/.claude/hooks/session-setup.sh" >/dev/null 2>&1; then
+  echo "[session-setup-test] hook errored on primary=main"
+  exit 1
+fi
+
+echo "[session-setup-test] PASS (main)"

--- a/scripts/quality/test_session_setup_head_check.sh
+++ b/scripts/quality/test_session_setup_head_check.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK_SOURCE="$SCRIPT_DIR/../../.claude/hooks/session-setup.sh"
+WORKROOT=$(mktemp -d)
+STDERR_FILE=$(mktemp)
+cleanup() {
+  rm -rf "$WORKROOT"
+  rm -f "$STDERR_FILE"
+}
+trap cleanup EXIT
+
+mkdir -p "$WORKROOT/.claude/hooks"
+cp "$HOOK_SOURCE" "$WORKROOT/.claude/hooks/session-setup.sh"
+chmod +x "$WORKROOT/.claude/hooks/session-setup.sh"
+
+git -C "$WORKROOT" init -q
+git -C "$WORKROOT" config user.email "ci@example.com"
+git -C "$WORKROOT" config user.name "CI"
+echo "bootstrap" > "$WORKROOT/file.txt"
+git -C "$WORKROOT" add file.txt
+git -C "$WORKROOT" commit -q -m "session-setup test seed"
+git -C "$WORKROOT" checkout -b feature
+
+if bash "$WORKROOT/.claude/hooks/session-setup.sh" >/dev/null 2>"$STDERR_FILE"; then
+  echo "[session-setup-test] expected guard to fail on non-main branch"
+  exit 1
+fi
+
+grep -q "PRIMARY TREE NOT ON main" "$STDERR_FILE" || {
+  echo "[session-setup-test] missing primary branch guard message"
+  cat "$STDERR_FILE"
+  exit 1
+}
+
+grep -q "currently 'feature'" "$STDERR_FILE" || {
+  echo "[session-setup-test] missing branch detail in guard message"
+  cat "$STDERR_FILE"
+  exit 1
+}
+
+echo "[session-setup-test] PASS"

--- a/tests/test_dispatch_smart.py
+++ b/tests/test_dispatch_smart.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "dispatch_smart.py"
+
+
+def _run_dispatch_smart(args: list[str]) -> subprocess.CompletedProcess:
+    cmd = [sys.executable, str(SCRIPT)] + args
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+
+def test_dispatch_smart_danger_requires_worktree() -> None:
+    """Dispatching danger mode without --worktree should hard-fail."""
+    result = _run_dispatch_smart(["edit", "--mode", "danger", "x"])
+
+    assert result.returncode != 0
+    merged_output = (result.stdout + result.stderr).lower()
+    assert "danger" in merged_output
+    assert "worktree" in merged_output
+
+
+def test_dispatch_smart_danger_allows_dry_run_with_worktree() -> None:
+    """Dry-run should not touch missing worktrees and should still resolve mode checks."""
+    result = _run_dispatch_smart(
+        ["edit", "--mode", "danger", "--worktree", ".worktrees/foo", "--dry-run", "x"]
+    )
+
+    assert result.returncode == 0
+    assert "mode=danger" in result.stdout
+    assert "[dry-run] task_id=" in result.stdout


### PR DESCRIPTION
## Summary

Two enforcement guards to prevent agents (codex/gemini/claude dispatches) from mutating the primary working tree's HEAD. Per user-quoted root cause:

> The worktree rule is enforced by prompt convention only, not by tooling. […] Two small changes eliminate the \"I forgot\" failure mode permanently.

### Guard 1 — \`dispatch_smart.py\` refuses \`--mode danger\` without \`--worktree\`

Hard parser-level error. No env-var override, no flag override.

### Guard 2 — SessionStart hook aborts if primary tree HEAD != \`main\`

\`.claude/hooks/session-setup.sh\` resolves the primary worktree (via \`git worktree list --porcelain\`), reads its HEAD, and exits 1 with a loud stderr error if it's not on \`main\`. Catches violations the moment a session starts.

## Tests

- \`tests/test_dispatch_smart.py\` — danger-without-worktree → exit non-zero with diagnostic; \`--dry-run\` still works with worktree.
- \`scripts/quality/test_session_setup_head_check.sh\` — temp repo on non-main → hook exit 1 with primary-HEAD error.

Both pass locally.

## Why no override flag

User explicitly said: \"Hard error. No override flag.\" The whole point is enforcement; an escape hatch defeats it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)