### PR TITLE
feat(translation): worker --max-calls + structured logging (PR 2/3)

### DIFF
--- a/scripts/translation_v2.py
+++ b/scripts/translation_v2.py
@@ -7,6 +7,7 @@ import re
 import sqlite3
 import sys
 import time
+from datetime import datetime, timezone
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
@@ -731,9 +732,11 @@ def build_parser() -> argparse.ArgumentParser:
     worker_run = worker_sub.add_parser("run", help="Translate one queued module")
     worker_run.add_argument("--worker-id", default="translation-worker")
     worker_run.add_argument("--json", action="store_true")
+    worker_run.add_argument("--max-calls", type=int)
     worker_loop = worker_sub.add_parser("loop", help="Run translation worker loop")
     worker_loop.add_argument("--worker-id", default="translation-worker")
     worker_loop.add_argument("--sleep-seconds", type=float, default=5.0)
+    worker_loop.add_argument("--max-calls", type=int)
 
     verify_worker = subparsers.add_parser("verify-worker", help="Run translation verify worker")
     verify_sub = verify_worker.add_subparsers(dest="verify_worker_command", required=True)
@@ -754,6 +757,24 @@ def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
     control_plane = ControlPlane(repo_root=args.repo_root, db_path=args.db, budgets_path=args.budgets)
+
+    def _worker_log_outcome(outcome: TranslationRunOutcome) -> None:
+        attempts = None
+        if outcome.details:
+            attempts = outcome.details.get("attempts")
+        payload = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "module_key": outcome.module_key,
+            "status": outcome.status,
+            "lease_id": outcome.lease_id,
+            "attempts": attempts,
+        }
+        print(f"[worker] {json.dumps(payload, sort_keys=True)}")
+
+    def _worker_summary(successful_calls: int, max_calls: int | None) -> None:
+        if max_calls is None:
+            return
+        print(f"worker summary: max_calls={max_calls} successful_calls={successful_calls}")
 
     if args.command == "status":
         report = build_status(args.repo_root, db_path=args.db, section=args.section)
@@ -785,15 +806,28 @@ def main(argv: list[str] | None = None) -> int:
         worker = TranslationWorker(control_plane, worker_id=args.worker_id)
         if args.worker_command == "run":
             outcome = worker.run_once()
+            successful_calls = 1 if outcome.status == "queued_for_verify" else 0
             if args.json:
                 print(json.dumps(outcome.__dict__, indent=2, sort_keys=True))
             else:
                 print(outcome.status)
                 if outcome.module_key:
                     print(outcome.module_key)
+                if args.max_calls is not None and successful_calls >= args.max_calls:
+                    _worker_summary(successful_calls, args.max_calls)
             return 0
         if args.worker_command == "loop":
-            worker.loop_forever(sleep_seconds=args.sleep_seconds)
+            successful_calls = 0
+            while True:
+                outcome = worker.run_once()
+                _worker_log_outcome(outcome)
+                if outcome.status == "queued_for_verify":
+                    successful_calls += 1
+                    if args.max_calls is not None and successful_calls >= args.max_calls:
+                        _worker_summary(successful_calls, args.max_calls)
+                        return 0
+                if outcome.status == "idle":
+                    time.sleep(args.sleep_seconds)
             return 0
 
     if args.command == "verify-worker":

--- a/tests/test_translation_v2.py
+++ b/tests/test_translation_v2.py
@@ -284,6 +284,53 @@ def test_translation_worker_completes_missing_module(tmp_path: Path) -> None:
     assert report["queue"]["counts"]["done"] == 1
 
 
+def test_worker_loop_respects_max_calls(tmp_path: Path, monkeypatch, capsys) -> None:
+    db_path = tmp_path / ".pipeline" / "translation_v2.db"
+
+    class FakeWorker:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def run_once(self) -> translation_v2.TranslationRunOutcome:
+            self.calls += 1
+            return translation_v2.TranslationRunOutcome(
+                status="queued_for_verify",
+                module_key=f"module-{self.calls}",
+                lease_id=f"lease-{self.calls}",
+                details={"attempts": self.calls},
+            )
+
+    worker = FakeWorker()
+    monkeypatch.setattr(translation_v2, "TranslationWorker", lambda *_args, **_kwargs: worker)
+
+    exit_code = translation_v2.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--db",
+            str(db_path),
+            "worker",
+            "loop",
+            "--max-calls",
+            "2",
+            "--sleep-seconds",
+            "0",
+        ]
+    )
+    output = capsys.readouterr().out.splitlines()
+
+    assert exit_code == 0
+    assert worker.calls == 2
+    worker_lines = [line for line in output if line.startswith("[worker]")]
+    assert len(worker_lines) == 2
+    first_payload = json.loads(worker_lines[0].split("] ", 1)[1])
+    assert first_payload["status"] == "queued_for_verify"
+    assert first_payload["module_key"] == "module-1"
+    assert first_payload["lease_id"] == "lease-1"
+    assert first_payload["attempts"] == 1
+    assert output[-1] == "worker summary: max_calls=2 successful_calls=2"
+
+
 def test_verify_worker_requeues_write_on_quality_failure(tmp_path: Path) -> None:
     repo_root = tmp_path
     _init_repo(repo_root)


### PR DESCRIPTION
## Summary

PR 2 of the UK translation pipeline (PR 1 was #956). Discovered during scope review that `scripts/translation_v2.py` already has the full `TranslationWorker` class + `worker run` / `worker loop` CLI subcommands wired through `dispatch_gemini_with_retry(mcp=True)` — so the original spec's "create new file" was over-scoped. Actual remaining work was operational guards.

- **`--max-calls N` budget cap** on both `worker run` and `worker loop` — prevents Gemini OAuth quota blowout when the queue holds 100+ candidate modules. Counts only successful (`queued_for_verify`) outcomes; exits cleanly with summary line at cap.
- **Per-iteration structured log line** in `worker loop` — one `[worker] <json>` line per `run_once` outcome (timestamp, module_key, status, lease_id, attempts). Operationally greppable.
- New test `test_worker_loop_respects_max_calls` covers the cap + summary line + log emission.

## Test plan

- [x] `python3 -m pytest tests/test_translation_v2.py -k max_calls -v` — passes
- [x] AST parse: `python3 -c "import ast; ast.parse(open('scripts/translation_v2.py').read())"`
- [x] `python3 scripts/translation_v2.py worker {run,loop} --help` — `--max-calls` visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)