### PR TITLE
feat(translation): detect_uk_divergence.py + summary cache (PR 3/3)

### DIFF
--- a/scripts/detect_uk_divergence.py
+++ b/scripts/detect_uk_divergence.py
@@ -41,6 +41,9 @@ def detect_uk_divergence(*, repo_root: Path, threshold: int = 5, dry_run: bool =
     missing_en_commit = []
     enqueued = []
     cp = None
+    # When --limit is hit we stop enqueuing but keep iterating so stale/missing_en_commit
+    # counts reflect the full scan rather than a truncated view.
+    enqueue_cap_reached = False
 
     for uk_path in uk_files:
         commit = uk_sync._get_uk_synced_commit(uk_path.read_text(encoding="utf-8"))
@@ -58,7 +61,7 @@ def detect_uk_divergence(*, repo_root: Path, threshold: int = 5, dry_run: bool =
             continue
 
         stale.append({"module_key": module_key, "en_commit_uk": commit[:8], "en_head": uk_sync._get_en_file_commit(en_path)[:8], "drift_lines": drift_lines})
-        if dry_run or translation_v2._has_pending_or_leased_job(db_path, module_key):
+        if dry_run or enqueue_cap_reached or translation_v2._has_pending_or_leased_job(db_path, module_key):
             continue
 
         if cp is None:
@@ -66,7 +69,7 @@ def detect_uk_divergence(*, repo_root: Path, threshold: int = 5, dry_run: bool =
         cp.enqueue(module_key, phase="write", model=translation_v2.TRANSLATE_MODEL, requested_calls=1, estimated_usd=translation_v2.TRANSLATE_ESTIMATED_USD, priority=100 + len(enqueued))
         enqueued.append(module_key)
         if limit is not None and len(enqueued) >= limit:
-            break
+            enqueue_cap_reached = True
 
     summary = {"scanned_at": datetime.now(timezone.utc).isoformat(), "total_uk_files": len(uk_files), "stale": stale, "missing_en_commit": missing_en_commit, "enqueued": enqueued}
     out = repo_root / ".pipeline/translation_divergence.json"

--- a/scripts/detect_uk_divergence.py
+++ b/scripts/detect_uk_divergence.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+SCRIPTS_ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPTS_ROOT))
+
+from pipeline_v2.control_plane import ControlPlane
+import translation_v2
+import uk_sync
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_DB_PATH = REPO_ROOT / ".pipeline" / "translation_v2.db"
+
+
+def _drift(repo_root: Path, en_commit: str, en_path: Path) -> int:
+    out = subprocess.run(["git", "diff", "--numstat", f"{en_commit}..HEAD", "--", str(en_path)], cwd=repo_root, capture_output=True, text=True, check=False).stdout.splitlines()
+    if not out:
+        return 0
+    p = out[0].split("\t", 2)
+    if len(p) < 2:
+        return 0
+    try:
+        return (0 if p[0] == "-" else int(p[0])) + (0 if p[1] == "-" else int(p[1]))
+    except ValueError:
+        return 0
+
+
+def detect_uk_divergence(*, repo_root: Path, threshold: int = 5, dry_run: bool = False, limit: int | None = None, db_path: Path = DEFAULT_DB_PATH) -> dict:
+    uk_root = repo_root / "src/content/docs/uk"
+    en_root = repo_root / "src/content/docs"
+    uk_files = uk_sync._find_content_files(uk_root, uk=True)
+    stale: list[dict] = []
+    missing_en_commit = []
+    enqueued = []
+    cp = None
+
+    for uk_path in uk_files:
+        commit = uk_sync._get_uk_synced_commit(uk_path.read_text(encoding="utf-8"))
+        if not commit:
+            missing_en_commit.append({"module_key": str(uk_path.relative_to(uk_root).with_suffix("")), "uk_path": str(uk_path.relative_to(repo_root))})
+            continue
+
+        en_path = en_root / uk_path.relative_to(uk_root)
+        if not en_path.exists():
+            continue
+
+        module_key = translation_v2._module_key_for_en_path(repo_root, en_path)
+        drift_lines = _drift(repo_root, commit, en_path)
+        if drift_lines <= threshold:
+            continue
+
+        stale.append({"module_key": module_key, "en_commit_uk": commit[:8], "en_head": uk_sync._get_en_file_commit(en_path)[:8], "drift_lines": drift_lines})
+        if dry_run or translation_v2._has_pending_or_leased_job(db_path, module_key):
+            continue
+
+        if cp is None:
+            cp = ControlPlane(repo_root=repo_root, db_path=db_path)
+        cp.enqueue(module_key, phase="write", model=translation_v2.TRANSLATE_MODEL, requested_calls=1, estimated_usd=translation_v2.TRANSLATE_ESTIMATED_USD, priority=100 + len(enqueued))
+        enqueued.append(module_key)
+        if limit is not None and len(enqueued) >= limit:
+            break
+
+    summary = {"scanned_at": datetime.now(timezone.utc).isoformat(), "total_uk_files": len(uk_files), "stale": stale, "missing_en_commit": missing_en_commit, "enqueued": enqueued}
+    out = repo_root / ".pipeline/translation_divergence.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8")
+    return summary
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--threshold", type=int, default=5)
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument("--limit", type=int, default=None)
+    p.add_argument("--json", action="store_true")
+    p.add_argument("--db", type=Path, default=DEFAULT_DB_PATH)
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    a = parse_args(argv)
+    s = detect_uk_divergence(repo_root=REPO_ROOT, threshold=a.threshold, dry_run=a.dry_run, limit=a.limit, db_path=a.db)
+    if a.json:
+        print(json.dumps(s, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_detect_uk_divergence.py
+++ b/tests/test_detect_uk_divergence.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+import detect_uk_divergence as detect
+
+
+def _run(repo: Path, *args: str) -> str:
+    return subprocess.run(["git", *args], cwd=repo, check=True, text=True, capture_output=True).stdout.strip()
+
+
+def _init_repo(repo: Path) -> None:
+    _run(repo, "init")
+    _run(repo, "config", "user.email", "test@example.com")
+    _run(repo, "config", "user.name", "Test User")
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _en(repo: Path, key: str, body: str = "English body") -> tuple[Path, str]:
+    path = repo / "src/content/docs" / f"{key}.md"
+    _write(path, "\n".join(["---", 'title: English', "---", "", "## Body", "", body]))
+    _run(repo, "add", str(path)); _run(repo, "commit", "-m", "en")
+    return path, _run(repo, "log", "-1", "--format=%H", "--", str(path))
+
+
+def _uk(path: Path, commit: str | None, en_file: Path) -> None:
+    lines = ["---", 'title: Українська']
+    if commit:
+        lines.append(f'en_commit: "{commit}"')
+    _write(path, "\n".join(lines + [f'en_file: "{en_file}"', "---", "", "## Тіло", "", "Переклад"]))
+
+
+def test_matching_commits_are_not_flagged(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    en_path, en_commit = _en(tmp_path, "prerequisites/zero-to-terminal/module-0.1-alpha")
+    _uk(tmp_path / "src/content/docs/uk/prerequisites/zero-to-terminal/module-0.1-alpha.md", en_commit, en_path.relative_to(tmp_path))
+    _run(tmp_path, "add", "."); _run(tmp_path, "commit", "-m", "uk")
+
+    summary = detect.detect_uk_divergence(repo_root=tmp_path, dry_run=True)
+    assert not summary["stale"]
+    assert not summary["missing_en_commit"]
+
+
+def test_drift_above_threshold(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    en_path, en_commit = _en(tmp_path, "prerequisites/zero-to-terminal/module-0.2-beta", "old")
+    _uk(tmp_path / "src/content/docs/uk/prerequisites/zero-to-terminal/module-0.2-beta.md", en_commit, en_path.relative_to(tmp_path))
+    _run(tmp_path, "add", "."); _run(tmp_path, "commit", "-m", "uk")
+
+    _write(en_path, "\n".join(["---", 'title: English', "---", "", "## Body", "", "changed", *[f"x{i}" for i in range(8)]]))
+    _run(tmp_path, "add", str(en_path)); _run(tmp_path, "commit", "-m", "en update")
+
+    db = tmp_path / ".pipeline/translation_v2.db"
+    summary = detect.detect_uk_divergence(repo_root=tmp_path, threshold=5, db_path=db)
+    assert summary["stale"][0]["module_key"] == "prerequisites/zero-to-terminal/module-0.2-beta"
+    assert summary["enqueued"] == ["prerequisites/zero-to-terminal/module-0.2-beta"]
+    assert detect.detect_uk_divergence(repo_root=tmp_path, threshold=5, dry_run=True)["enqueued"] == []
+
+
+def test_missing_en_commit_reported(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    en_path, _ = _en(tmp_path, "prerequisites/zero-to-terminal/module-0.3-gamma")
+    _uk(tmp_path / "src/content/docs/uk/prerequisites/zero-to-terminal/module-0.3-gamma.md", None, en_path.relative_to(tmp_path))
+    _run(tmp_path, "add", "."); _run(tmp_path, "commit", "-m", "uk")
+
+    summary = detect.detect_uk_divergence(repo_root=tmp_path, dry_run=True)
+    assert summary["missing_en_commit"][0]["module_key"] == "prerequisites/zero-to-terminal/module-0.3-gamma"
+    assert summary["stale"] == []

--- a/tests/test_detect_uk_divergence.py
+++ b/tests/test_detect_uk_divergence.py
@@ -73,3 +73,24 @@ def test_missing_en_commit_reported(tmp_path: Path) -> None:
     summary = detect.detect_uk_divergence(repo_root=tmp_path, dry_run=True)
     assert summary["missing_en_commit"][0]["module_key"] == "prerequisites/zero-to-terminal/module-0.3-gamma"
     assert summary["stale"] == []
+
+
+def test_idempotent_enqueue(tmp_path: Path) -> None:
+    # A second identical call must not re-enqueue the same module.
+    # After the first call, _has_pending_or_leased_job returns True for the module,
+    # so the enqueue branch is skipped and summary["enqueued"] == [] on the second run.
+    # Uses a real ControlPlane against a tempdir SQLite db (no mocks).
+    _init_repo(tmp_path)
+    en_path, en_commit = _en(tmp_path, "prerequisites/zero-to-terminal/module-0.4-delta", "old")
+    _uk(tmp_path / "src/content/docs/uk/prerequisites/zero-to-terminal/module-0.4-delta.md", en_commit, en_path.relative_to(tmp_path))
+    _run(tmp_path, "add", "."); _run(tmp_path, "commit", "-m", "uk")
+
+    _write(en_path, "\n".join(["---", 'title: English', "---", "", "## Body", "", "changed", *[f"x{i}" for i in range(8)]]))
+    _run(tmp_path, "add", str(en_path)); _run(tmp_path, "commit", "-m", "en update")
+
+    db = tmp_path / ".pipeline/translation_v2.db"
+    summary1 = detect.detect_uk_divergence(repo_root=tmp_path, threshold=5, db_path=db)
+    assert summary1["enqueued"] == ["prerequisites/zero-to-terminal/module-0.4-delta"]
+
+    summary2 = detect.detect_uk_divergence(repo_root=tmp_path, threshold=5, db_path=db)
+    assert summary2["enqueued"] == []


### PR DESCRIPTION
## Summary

Final PR in the UK translation pipeline trio (PR 1: #956 enqueue endpoint + russicism CI; PR 2: #958 worker --max-calls). Adds a nightly cron-friendly script that finds Ukrainian translations whose source EN file has drifted significantly since translation, and re-enqueues them for re-translation.

- Reuses existing `en_commit:` frontmatter (already injected by `uk_sync.translate_new_module`) — no new frontmatter field.
- Drift heuristic: `git diff --numstat <translated-en-commit>..HEAD -- <en_path>`; threshold default 5 lines (configurable via `--threshold`).
- Writes `.pipeline/translation_divergence.json` summary for dashboard visibility.
- Enqueues via `ControlPlane.enqueue(phase="write")` with idempotency check (skips already-pending/leased).
- CLI flags: `--threshold`, `--dry-run`, `--limit`, `--json`, `--db`.
- 3 new pytest tests covering matching commits, drift > threshold, missing en_commit.

## Test plan

- [x] `python3 -m pytest tests/test_detect_uk_divergence.py -v` (3/3 pass)
- [x] AST parse + `--help` smoketest
- [x] `--dry-run --json` real-repo smoketest

🤖 Generated with [Claude Code](https://claude.com/claude-code)