### PR TITLE
feat(api): /api/channels + /api/channel/<thread>/events for deliberation UI

### DIFF
--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -2053,6 +2053,161 @@ def build_bridge_messages(
     }
 
 
+def _build_channel_threads_index(
+    repo_root: Path,
+    *,
+    list_channels_fn,
+) -> dict[str, Any]:
+    """Build thread rollups for deliberation channels from ``channel_events``."""
+    db_path = _resolve_bridge_db_path(repo_root)
+    channels_raw = list_channels_fn()
+
+    channels: dict[str, dict[str, Any]] = {
+        channel["name"]: {
+            "name": channel["name"],
+            "created_at": channel.get("created_at"),
+            "threads": [],
+        }
+        for channel in channels_raw
+        if isinstance(channel, dict)
+    }
+
+    thread_rows = _query_sqlite_rows(
+        db_path,
+        """
+        SELECT
+          cm.channel AS channel,
+          ce.thread_id AS thread_id,
+          MIN(ce.ts) AS first_event_ts,
+          MAX(ce.ts) AS last_event_ts,
+          COUNT(ce.event_id) AS event_count
+        FROM channel_events ce
+        INNER JOIN channel_messages cm
+          ON cm.thread_id = ce.thread_id
+        GROUP BY cm.channel, ce.thread_id
+        ORDER BY cm.channel, ce.thread_id
+        """,
+    )
+
+    if thread_rows:
+        for row in thread_rows:
+            channel = row.get("channel")
+            if not isinstance(channel, str):
+                continue
+
+            thread_id = row.get("thread_id")
+            if not isinstance(thread_id, str):
+                continue
+
+            thread_entry = {
+                "thread_id": thread_id,
+                "first_event_ts": row.get("first_event_ts"),
+                "last_event_ts": row.get("last_event_ts"),
+                "event_count": int(row.get("event_count") or 0),
+                "agents": [
+                    agent_row["agent"]
+                    for agent_row in _query_sqlite_rows(
+                        db_path,
+                        """
+                        SELECT DISTINCT json_extract(payload_json, '$.agent') AS agent
+                        FROM channel_events
+                        WHERE thread_id = ?
+                          AND event = 'reply_started'
+                          AND json_extract(payload_json, '$.agent') IS NOT NULL
+                        ORDER BY agent ASC
+                        """,
+                        (thread_id,),
+                    )
+                    if isinstance(agent_row.get("agent"), str)
+                ],
+            }
+
+            entry = channels.setdefault(channel, {"name": channel, "created_at": None, "threads": []})
+            entry["threads"].append(thread_entry)
+
+        return {"channels": list(channels.values())}
+
+    # TODO: per-channel grouping when channels↔threads link is added
+    fallback_threads = _query_sqlite_rows(
+        db_path,
+        """
+        SELECT
+          thread_id,
+          MIN(ts) AS first_event_ts,
+          MAX(ts) AS last_event_ts,
+          COUNT(event_id) AS event_count
+        FROM channel_events
+        GROUP BY thread_id
+        ORDER BY thread_id
+        """,
+    )
+    if not fallback_threads:
+        return {"channels": list(channels.values())}
+
+    threads: list[dict[str, Any]] = []
+    for row in fallback_threads:
+        thread_id = row.get("thread_id")
+        if not isinstance(thread_id, str):
+            continue
+        threads.append({
+            "thread_id": thread_id,
+            "first_event_ts": row.get("first_event_ts"),
+            "last_event_ts": row.get("last_event_ts"),
+            "event_count": int(row.get("event_count") or 0),
+            "agents": [
+                agent_row["agent"]
+                for agent_row in _query_sqlite_rows(
+                    db_path,
+                    """
+                    SELECT DISTINCT json_extract(payload_json, '$.agent') AS agent
+                    FROM channel_events
+                    WHERE thread_id = ?
+                      AND event = 'reply_started'
+                      AND json_extract(payload_json, '$.agent') IS NOT NULL
+                    ORDER BY agent ASC
+                    """,
+                    (thread_id,),
+                )
+                if isinstance(agent_row.get("agent"), str)
+            ],
+        })
+
+    return {
+        "channels": [
+            {
+                "name": "all-threads",
+                "created_at": None,
+                "threads": threads,
+            }
+        ]
+    }
+
+
+def _build_channel_events_payload(
+    thread_id: str,
+    read_channel_events_fn,
+    since_event_id: int = 0,
+) -> dict[str, Any]:
+    events_raw = read_channel_events_fn(thread_id, after_event_id=since_event_id)
+    events: list[dict[str, Any]] = []
+    next_since_event_id = since_event_id
+
+    for event in events_raw:
+        event_id = int(event.get("_event_id", 0))
+        payload = dict(event)
+        payload.pop("_event_id", None)
+        payload.pop("thread_id", None)
+        payload["event_id"] = event_id
+        events.append(payload)
+        next_since_event_id = max(next_since_event_id, event_id)
+
+    return {
+        "thread_id": thread_id,
+        "events": events,
+        "next_since_event_id": next_since_event_id,
+    }
+
+
 # ---- #388 dispatcher batch progress ----
 #
 # scripts/quality/dispatch_388_pilot.py writes a JSONL event log per batch
@@ -7057,6 +7212,12 @@ def build_api_schema() -> dict[str, Any]:
                 "desc": ".bridge/messages.db tail",
                 "query": ["since=<ISO-8601>", "limit=... (max 500)"],
             },
+            {"path": "/api/channels", "desc": "List deliberation channels with thread event rollups"},
+            {
+                "path": "/api/channel/{thread_id}/events",
+                "desc": "Channel thread event timeline",
+                "query": ["since_event_id=..."],
+            },
             {"path": "/api/quality/scores", "desc": "Live heuristic rubric scores from current English module files"},
             {
                 "path": "/api/quality/board",
@@ -7368,6 +7529,35 @@ def route_request(repo_root: Path, raw_path: str) -> tuple[int, Any, str]:
         except (TypeError, ValueError):
             limit = 100
         return 200, build_bridge_messages(repo_root, since, limit), "application/json; charset=utf-8"
+    if path == "/api/channels":
+        from ai_agent_bridge._channels import list_channels
+        return (
+            200,
+            _build_channel_threads_index(repo_root, list_channels_fn=list_channels),
+            "application/json; charset=utf-8",
+        )
+    if path.startswith("/api/channel/") and path.endswith("/events"):
+        raw_thread_id = path[len("/api/channel/") : -len("/events")]
+        thread_id = unquote(raw_thread_id).strip("/")
+        if not thread_id:
+            return 400, {"error": "missing_thread_id"}, "application/json; charset=utf-8"
+        try:
+            since_raw = query.get("since_event_id", ["0"])[0]
+            if since_raw is None:
+                raise TypeError
+            since_event_id = int(since_raw)
+        except (TypeError, ValueError):
+            return 400, {"error": "invalid_since_event_id"}, "application/json; charset=utf-8"
+        from ai_agent_bridge._channels_watch import read_channel_events
+        return (
+            200,
+            _build_channel_events_payload(
+                thread_id,
+                read_channel_events_fn=read_channel_events,
+                since_event_id=since_event_id,
+            ),
+            "application/json; charset=utf-8",
+        )
     if path == "/api/quality/scores":
         return 200, build_quality_scores(repo_root), "application/json; charset=utf-8"
     if path == "/api/quality/board":

--- a/tests/test_local_api_channels.py
+++ b/tests/test_local_api_channels.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import sys
+
+
+def _load_local_api():
+    module_path = Path(__file__).resolve().parent.parent / "scripts" / "local_api.py"
+    spec = importlib.util.spec_from_file_location("local_api_channels", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+local_api = _load_local_api()
+
+
+def _init_channel_events_db(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS channel_events (
+              event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+              delivery_id TEXT,
+              thread_id TEXT NOT NULL,
+              event TEXT NOT NULL,
+              payload_json TEXT,
+              ts TEXT NOT NULL
+            );
+            """
+        )
+    finally:
+        conn.commit()
+        conn.close()
+
+
+def _seed_channel_events(db_path: Path, events: list[dict[str, Any]], *, thread_id: str) -> None:
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executemany(
+            """
+            INSERT INTO channel_events (delivery_id, thread_id, event, payload_json, ts)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    event.get("delivery_id"),
+                    thread_id,
+                    event["event"],
+                    json.dumps(event["payload"]),
+                    event["ts"],
+                )
+                for event in events
+            ],
+        )
+    finally:
+        conn.commit()
+        conn.close()
+
+
+def _use_bridge_db(monkeypatch, db_path: Path) -> None:
+    import importlib
+
+    bridge_db = importlib.import_module("ai_agent_bridge._db")
+    monkeypatch.setenv("AB_DB_PATH", str(db_path))
+    monkeypatch.setattr(bridge_db, "DB_PATH", db_path)
+
+
+def test_api_channels_returns_empty_shape(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "messages.db"
+    _use_bridge_db(monkeypatch, db_path)
+    status_code, payload, _ = local_api.route_request(tmp_path, "/api/channels")
+    assert status_code == 200
+    assert payload == {"channels": []}
+
+
+def test_api_channel_events_returns_events_in_order(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "messages.db"
+    _use_bridge_db(monkeypatch, db_path)
+    _init_channel_events_db(db_path)
+    thread_id = "thread-123"
+    _seed_channel_events(
+        db_path,
+        [
+            {
+                "event": "reply_started",
+                "payload": {"agent": "codex", "model": "gpt-5.5"},
+                "ts": "2026-05-07T15:00:00+00:00",
+            },
+            {
+                "event": "heartbeat",
+                "payload": {"delivery_id": "d-1", "elapsed_s": 30},
+                "ts": "2026-05-07T15:00:30+00:00",
+            },
+            {
+                "event": "model_cascade",
+                "payload": {"agent": "gemini", "model": "gpt-5.5"},
+                "ts": "2026-05-07T15:01:00+00:00",
+            },
+        ],
+        thread_id=thread_id,
+    )
+    status_code, payload, _ = local_api.route_request(tmp_path, f"/api/channel/{thread_id}/events")
+    assert status_code == 200
+    assert payload["thread_id"] == thread_id
+    assert payload["events"] == [
+        {
+            "event_id": 1,
+            "event": "reply_started",
+            "ts": "2026-05-07T15:00:00+00:00",
+            "agent": "codex",
+            "model": "gpt-5.5",
+        },
+        {
+            "event_id": 2,
+            "event": "heartbeat",
+            "ts": "2026-05-07T15:00:30+00:00",
+            "delivery_id": "d-1",
+            "elapsed_s": 30,
+        },
+        {
+            "event_id": 3,
+            "event": "model_cascade",
+            "ts": "2026-05-07T15:01:00+00:00",
+            "agent": "gemini",
+            "model": "gpt-5.5",
+        },
+    ]
+    assert payload["next_since_event_id"] == 3
+
+
+def test_api_channel_events_since_event_id_filters(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "messages.db"
+    _use_bridge_db(monkeypatch, db_path)
+    _init_channel_events_db(db_path)
+    thread_id = "thread-123"
+    _seed_channel_events(
+        db_path,
+        [
+            {
+                "event": "reply_started",
+                "payload": {"agent": "codex"},
+                "ts": "2026-05-07T15:00:00+00:00",
+            },
+            {
+                "event": "heartbeat",
+                "payload": {"delivery_id": "d-1"},
+                "ts": "2026-05-07T15:00:30+00:00",
+            },
+            {
+                "event": "reply_complete",
+                "payload": {"agent": "gemini"},
+                "ts": "2026-05-07T15:01:00+00:00",
+            },
+        ],
+        thread_id=thread_id,
+    )
+    status_code, payload, _ = local_api.route_request(
+        tmp_path,
+        f"/api/channel/{thread_id}/events?since_event_id=2",
+    )
+    assert status_code == 200
+    assert payload["events"] == [
+        {
+            "event_id": 3,
+            "event": "reply_complete",
+            "ts": "2026-05-07T15:01:00+00:00",
+            "agent": "gemini",
+        }
+    ]
+    assert payload["next_since_event_id"] == 3


### PR DESCRIPTION
## Summary

Foundation for the upcoming web UI to follow live agent deliberations (`ab discuss --with claude,codex,gemini`). Two new HTTP endpoints expose the existing `channel_events` SQLite data:

- `GET /api/channels` — list channels with their threads (event_count, agents, first/last event timestamps). Falls back to a synthetic `all-threads` channel with a TODO comment if the channels↔threads mapping isn't available yet.
- `GET /api/channel/<thread_id>/events?since_event_id=N` — paginated events for one thread; response includes `next_since_event_id` for incremental polling.

Both endpoints use lazy imports of `ai_agent_bridge._channels.list_channels` and `ai_agent_bridge._channels_watch.read_channel_events` so we don't bloat the local_api module load. Schema index updated.

## Test plan

- [x] `python3 -m pytest tests/test_local_api_channels.py -v` — 3/3 pass (empty-shape, events-in-order, since_event_id filter)
- [x] AST parse: `python3 -c "import ast; ast.parse(open('scripts/local_api.py').read())"`
- [x] Live smoketest: `curl -s http://127.0.0.1:8768/api/channels | python3 -m json.tool` returns valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)