### PR TITLE
fix(channels): D0 contract bugfixes (closes #963)

### DIFF
--- a/scripts/ai_agent_bridge/_channels_watch.py
+++ b/scripts/ai_agent_bridge/_channels_watch.py
@@ -11,6 +11,7 @@ from typing import Any, TextIO
 from ._db import get_db
 
 VALID_CHANNEL_EVENTS = (
+    "message_posted",
     "reply_started",
     "heartbeat",
     "model_cascade",
@@ -124,14 +125,18 @@ def emit_reply_complete(
     *,
     agent: str,
     chars: int,
+    body: str | None = None,
 ) -> None:
+    payload: dict[str, Any] = {
+        "agent": agent,
+        "chars": chars,
+    }
+    if body is not None:
+        payload["body"] = body
     append_channel_event(
         "reply_complete",
         thread_id=thread_id,
-        payload={
-            "agent": agent,
-            "chars": chars,
-        },
+        payload=payload,
     )
 
 

--- a/scripts/ai_agent_bridge/_config.py
+++ b/scripts/ai_agent_bridge/_config.py
@@ -14,13 +14,20 @@ REPO_ROOT = Path(
     os.environ.get("AB_REPO_ROOT", str(Path(__file__).parent.parent.parent))
 )
 
-# Database path (same as MCP server uses)
-DB_PATH = Path(
-    os.environ.get(
-        "AB_DB_PATH",
-        str(REPO_ROOT / ".mcp" / "servers" / "message-broker" / "messages.db"),
-    )
-)
+def _resolve_db_path() -> Path:
+    explicit = os.environ.get("AB_DB_PATH")
+    if explicit:
+        return Path(explicit)
+
+    bridge_path = REPO_ROOT / ".bridge" / "messages.db"
+    mcp_path = REPO_ROOT / ".mcp" / "servers" / "message-broker" / "messages.db"
+    for path in (bridge_path, mcp_path):
+        if path.exists():
+            return path
+    return bridge_path
+
+
+DB_PATH = _resolve_db_path()
 PID_DIR = Path(
     os.environ.get(
         "AB_PID_DIR",

--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -7297,7 +7297,7 @@ function render(data){
   if(!total){document.getElementById("grid").innerHTML='<p class="empty">No deliberation threads yet.<br>Start one with <code>ab discuss &lt;channel&gt;</code>.</p>';return;}
   const cards=channels.flatMap(c=>c.threads.map(t=>{
     const agents=(t.agents||[]).map(agentBadge).join("");
-    return`<a class="card" href="/channels/${encodeURIComponent(t.thread_id)}"><div class="card-ch">${esc(c.channel)}</div><div class="card-tid" title="${esc(t.thread_id)}">${esc(t.thread_id)}</div><div class="card-meta"><span class="badge bc">${esc(t.event_count)} events</span>${agents}</div><div class="card-ts">last activity: ${timeAgo(t.last_ts)}</div></a>`;
+    return`<a class="card" href="/channels/${encodeURIComponent(t.thread_id)}"><div class="card-ch">${esc(c.name)}</div><div class="card-tid" title="${esc(t.thread_id)}">${esc(t.thread_id)}</div><div class="card-meta"><span class="badge bc">${esc(t.event_count)} events</span>${agents}</div><div class="card-ts">last activity: ${timeAgo(t.last_event_ts)}</div></a>`;
   }));
   document.getElementById("grid").innerHTML=cards.join("");
 }

--- a/tests/test_channels_d0.py
+++ b/tests/test_channels_d0.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+
+def _load_local_api():
+    module_path = Path(__file__).resolve().parent.parent / "scripts" / "local_api.py"
+    spec = importlib.util.spec_from_file_location("local_api_channels_d0", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+local_api = _load_local_api()
+
+
+def _reload_bridge_modules():
+    import ai_agent_bridge._channels as bridge_channels
+    import ai_agent_bridge._channels_watch as channels_watch
+    import ai_agent_bridge._config as bridge_config
+    import ai_agent_bridge._db as bridge_db
+
+    importlib.reload(bridge_config)
+    importlib.reload(bridge_db)
+    importlib.reload(bridge_channels)
+    importlib.reload(channels_watch)
+    return bridge_db, bridge_channels, channels_watch
+
+
+def _init_bridge_schema(db_path: Path, bridge_db) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(bridge_db._LEGACY_SCHEMA)
+        conn.executescript(bridge_db._CHANNELS_SCHEMA)
+        conn.executescript(bridge_db._CHANNEL_EVENTS_SCHEMA)
+        conn.execute(
+            """
+            INSERT INTO channels (name, created_at, description)
+            VALUES ('ops', '2026-05-07T12:00:00+00:00', 'Operations')
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_api_channels_reads_bridge_db_without_ab_db_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    try:
+        with monkeypatch.context() as m:
+            m.setenv("AB_REPO_ROOT", str(tmp_path))
+            m.delenv("AB_DB_PATH", raising=False)
+            bridge_db, _, _ = _reload_bridge_modules()
+            _init_bridge_schema(tmp_path / ".bridge" / "messages.db", bridge_db)
+
+            status_code, payload, _ = local_api.route_request(tmp_path, "/api/channels")
+
+            assert status_code == 200
+            assert [channel["name"] for channel in payload["channels"]] == ["ops"]
+    finally:
+        _reload_bridge_modules()
+
+
+def test_message_posted_event_round_trips_body(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    try:
+        with monkeypatch.context() as m:
+            m.setenv("AB_REPO_ROOT", str(tmp_path))
+            m.setenv("AB_DB_PATH", str(tmp_path / "messages.db"))
+            bridge_db, _, channels_watch = _reload_bridge_modules()
+            bridge_db.init_db()
+
+            channels_watch.append_channel_event(
+                "message_posted",
+                thread_id="thread-d0",
+                payload={"agent": "user", "body": "please review this"},
+            )
+
+            events = channels_watch.read_channel_events("thread-d0")
+            assert events == [
+                {
+                    "event": "message_posted",
+                    "agent": "user",
+                    "body": "please review this",
+                    "thread_id": "thread-d0",
+                    "ts": events[0]["ts"],
+                    "_event_id": 1,
+                }
+            ]
+    finally:
+        _reload_bridge_modules()


### PR DESCRIPTION
## Summary

Fixes the four contract drifts in PR #961 + #962 that made `/channels` UI render `{}` against real `.bridge/messages.db` data. **Closes #963.** Per ADR `docs/decisions/2026-05-07-deliberation-ui-roadmap.md` this is the D0 gate before any further `/channels` UI work.

## Changes

| File | Change |
|------|--------|
| `scripts/local_api.py` | Renderer reads `c.name` / `t.last_event_ts` (was `c.channel` / `t.last_ts`). +1/-1 |
| `scripts/ai_agent_bridge/_channels_watch.py` | Adds `message_posted` to `VALID_CHANNEL_EVENTS`; `emit_reply_complete` now accepts optional `body` and writes it into `payload_json`. +9/-4 |
| `scripts/ai_agent_bridge/_config.py` | `_resolve_db_path()` prefers `.bridge/messages.db` then falls back to `.mcp/servers/message-broker/messages.db`. Honors `AB_DB_PATH` override unconditionally. +14/-7 |
| `tests/test_channels_d0.py` | 2 regression tests: `/api/channels` reads `.bridge/...` end-to-end without `AB_DB_PATH`; `message_posted` round-trips with body. +106/-0 |

## Verification

- `pytest -k "channel or local_api"` — 11 passed in 0.25s
- Pipeline gate — 166 tests OK in 84s
- Ruff — clean on changed Python files

## Reviewer

Cross-family review dispatched to **gemini-3.1-pro-preview** (codex authored). Per `docs/review-protocol.md` and memory `feedback_review_policy.md`. Fallback to headless claude per `feedback_headless_claude_gemini_fallback.md` if gemini 503.

## Author

Codex (gpt-5.5, danger sandbox, reasoning=high) on worktree `.worktrees/codex-d0-channels-contract`.