### PR TITLE
fix(channels): D1.5 — watcher-independent rollup + ab post emits message_posted (#993)

### DIFF
--- a/scripts/ai_agent_bridge/_channels.py
+++ b/scripts/ai_agent_bridge/_channels.py
@@ -806,6 +806,28 @@ def post(
             ),
         )
 
+        conn.execute(
+            """
+            INSERT INTO channel_events (delivery_id, thread_id, event, payload_json, ts)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                None,
+                thread_id,
+                "message_posted",
+                json.dumps(
+                    {
+                        "message_id": message_id,
+                        "from_agent": from_agent,
+                        "round_index": round_index,
+                    },
+                    ensure_ascii=False,
+                    sort_keys=True,
+                ),
+                created_at,
+            ),
+        )
+
         delivery_ids = []
         for agent in to_agents or []:
             dlv_id = _new_id()
@@ -849,6 +871,82 @@ def post(
         # from the now-inside-transaction channel/parent checks.
         # Previously this was sqlite3.Error only, which left an orphan
         # lock when a ValueError escaped inside the transaction.
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def backfill_message_posted_events() -> int:
+    """Insert missing ``message_posted`` events for existing channel messages.
+
+    The durable transcript is ``channel_messages``. ``channel_events`` is a
+    supplementary progress stream, so older messages may lack corresponding
+    event rows. Match by payload ``message_id`` to keep this idempotent even
+    when several messages share one thread.
+    """
+    conn = get_db()
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        message_rows = conn.execute(
+            """
+            SELECT message_id, thread_id, from_agent, round_index, created_at
+            FROM channel_messages
+            ORDER BY created_at ASC, rowid ASC
+            """
+        ).fetchall()
+        event_rows = conn.execute(
+            """
+            SELECT payload_json
+            FROM channel_events
+            WHERE event = 'message_posted'
+            """
+        ).fetchall()
+
+        represented_message_ids: set[str] = set()
+        for row in event_rows:
+            payload_raw = row["payload_json"]
+            if not payload_raw:
+                continue
+            try:
+                payload = json.loads(payload_raw)
+            except json.JSONDecodeError:
+                continue
+            message_id = payload.get("message_id")
+            if isinstance(message_id, str):
+                represented_message_ids.add(message_id)
+
+        inserted = 0
+        for row in message_rows:
+            message_id = row["message_id"]
+            if message_id in represented_message_ids:
+                continue
+            conn.execute(
+                """
+                INSERT INTO channel_events (delivery_id, thread_id, event, payload_json, ts)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    None,
+                    row["thread_id"],
+                    "message_posted",
+                    json.dumps(
+                        {
+                            "message_id": message_id,
+                            "from_agent": row["from_agent"],
+                            "round_index": row["round_index"],
+                        },
+                        ensure_ascii=False,
+                        sort_keys=True,
+                    ),
+                    row["created_at"],
+                ),
+            )
+            inserted += 1
+
+        conn.commit()
+        return inserted
+    except Exception:
         conn.rollback()
         raise
     finally:

--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -15,6 +15,7 @@ ab channel info <name>
 ab channel context <name> [--edit] [--show]
 ab channel tail <name> [--n N] [--thread TID]
 ab channel watch <thread_id> [--follow] [--event-stream]
+ab channel backfill-events
 
 ab post <channel> <body> [--to A,...] [--parent ID] [--corr ID]
 ab p <channel> <agent> <body>                    # shorthand
@@ -143,6 +144,11 @@ def register_channel_commands(subparsers: Any) -> None:
         "--event-stream",
         action="store_true",
         help="Emit JSONL rows for machine readers",
+    )
+
+    channel_sub.add_parser(
+        "backfill-events",
+        help="Backfill missing message_posted events from channel_messages",
     )
 
     # ── top-level: post ───────────────────────────────────────────
@@ -323,6 +329,8 @@ def _dispatch_channel_group(args) -> int:
         return _handle_channel_tail(args)
     if sub == "watch":
         return _handle_channel_watch(args)
+    if sub == "backfill-events":
+        return _handle_channel_backfill_events(args)
     print(f"unknown subcommand: channel {sub}", file=sys.stderr)
     return 2
 
@@ -708,6 +716,16 @@ def _handle_channel_watch(args) -> int:
     except ValueError as exc:
         print(f"❌ {exc}", file=sys.stderr)
         return 1
+
+
+def _handle_channel_backfill_events(args) -> int:
+    try:
+        inserted = _channels.backfill_message_posted_events()
+    except Exception as exc:
+        print(f"❌ backfill failed: {exc}", file=sys.stderr)
+        return 1
+    print(f"backfill-events: inserted {inserted} message_posted event(s)")
+    return 0
 
 
 def _handle_post(args) -> int:

--- a/scripts/local_api/routes/channels.py
+++ b/scripts/local_api/routes/channels.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import html as _html
 import json as _json
+import re as _re
 from pathlib import Path
 from typing import Any, Callable
 from urllib.parse import unquote
@@ -17,7 +18,11 @@ def build_channel_threads_index(
     resolve_bridge_db_path_fn: Callable[[Path], Path],
     query_sqlite_rows_fn: Callable[..., list[dict[str, Any]]],
 ) -> dict[str, Any]:
-    """Build thread rollups for deliberation channels from ``channel_events``."""
+    """Build deliberation thread rollups from ``channel_messages``.
+
+    ``channel_messages`` is the transcript source of truth. ``channel_events``
+    is optional metadata for progress state and visualization hints.
+    """
     db_path = resolve_bridge_db_path_fn(repo_root)
     channels_raw = list_channels_fn()
 
@@ -36,57 +41,136 @@ def build_channel_threads_index(
         """
         SELECT
           cm.channel AS channel,
-          ce.thread_id AS thread_id,
-          MIN(ce.ts) AS first_event_ts,
-          MAX(ce.ts) AS last_event_ts,
-          COUNT(ce.event_id) AS event_count
-        FROM channel_events ce
-        INNER JOIN channel_messages cm
-          ON cm.thread_id = ce.thread_id
-        GROUP BY cm.channel, ce.thread_id
-        ORDER BY cm.channel, ce.thread_id
+          cm.thread_id AS thread_id,
+          MIN(cm.created_at) AS thread_started_at,
+          MAX(cm.created_at) AS thread_last_at,
+          COUNT(*) AS message_count,
+          (
+            SELECT substr(cm2.body, 1, 80)
+            FROM channel_messages cm2
+            WHERE cm2.channel = cm.channel
+              AND cm2.thread_id = cm.thread_id
+            ORDER BY cm2.rowid ASC
+            LIMIT 1
+          ) AS subject
+        FROM channel_messages cm
+        GROUP BY cm.channel, cm.thread_id
+        ORDER BY cm.channel ASC, MAX(cm.created_at) DESC
         """,
     )
 
-    if thread_rows:
-        for row in thread_rows:
-            channel = row.get("channel")
-            if not isinstance(channel, str):
+    thread_index: dict[tuple[str, str], dict[str, Any]] = {}
+    thread_keys_by_id: dict[str, list[tuple[str, str]]] = {}
+    for row in thread_rows:
+        channel = row.get("channel")
+        thread_id = row.get("thread_id")
+        if not isinstance(channel, str) or not isinstance(thread_id, str):
+            continue
+        thread_started_at = row.get("thread_started_at")
+        thread_last_at = row.get("thread_last_at")
+        thread_entry = {
+            "thread_id": thread_id,
+            "subject": (row.get("subject") or "").strip(),
+            "thread_started_at": thread_started_at,
+            "thread_last_at": thread_last_at,
+            "message_count": int(row.get("message_count") or 0),
+            "first_event_ts": None,
+            "last_event_ts": thread_last_at,
+            "event_count": 0,
+            "agents": [],
+            "model_cascades": [],
+            "reply_state": None,
+            "vote_counts": {
+                "agree": 0,
+                "defer": 0,
+                "options": {},
+            },
+        }
+        thread_key = (channel, thread_id)
+        thread_index[thread_key] = thread_entry
+        thread_keys_by_id.setdefault(thread_id, []).append(thread_key)
+        entry = channels.setdefault(
+            channel,
+            {"name": channel, "created_at": None, "threads": []},
+        )
+        entry["threads"].append(thread_entry)
+
+    if thread_index:
+        event_rows = query_sqlite_rows_fn(
+            db_path,
+            """
+            SELECT event_id, thread_id, event, payload_json, ts
+            FROM channel_events
+            ORDER BY event_id ASC
+            """,
+            limit=10000,
+        )
+        agents_by_thread: dict[str, set[str]] = {}
+        latest_reply_state: dict[str, tuple[int, dict[str, Any]]] = {}
+        for event_row in event_rows:
+            thread_id = event_row.get("thread_id")
+            if not isinstance(thread_id, str) or thread_id not in thread_keys_by_id:
                 continue
+            entries = [
+                thread_index[thread_key]
+                for thread_key in thread_keys_by_id[thread_id]
+            ]
+            ts = event_row.get("ts")
+            for entry in entries:
+                entry["first_event_ts"] = entry["first_event_ts"] or ts
+                entry["last_event_ts"] = ts or entry["last_event_ts"]
+                entry["event_count"] += 1
 
-            thread_id = row.get("thread_id")
-            if not isinstance(thread_id, str):
-                continue
+            payload_raw = event_row.get("payload_json")
+            try:
+                payload = _json.loads(payload_raw) if payload_raw else {}
+            except _json.JSONDecodeError:
+                payload = {}
+            event = event_row.get("event")
+            event_id = int(event_row.get("event_id") or 0)
 
-            thread_entry = {
-                "thread_id": thread_id,
-                "first_event_ts": row.get("first_event_ts"),
-                "last_event_ts": row.get("last_event_ts"),
-                "event_count": int(row.get("event_count") or 0),
-                "agents": [
-                    agent_row["agent"]
-                    for agent_row in query_sqlite_rows_fn(
-                        db_path,
-                        """
-                        SELECT DISTINCT json_extract(payload_json, '$.agent') AS agent
-                        FROM channel_events
-                        WHERE thread_id = ?
-                          AND event = 'reply_started'
-                          AND json_extract(payload_json, '$.agent') IS NOT NULL
-                        ORDER BY agent ASC
-                        """,
-                        (thread_id,),
-                    )
-                    if isinstance(agent_row.get("agent"), str)
-                ],
-            }
+            if event == "reply_started":
+                agent = payload.get("agent")
+                if isinstance(agent, str):
+                    agents_by_thread.setdefault(thread_id, set()).add(agent)
+                latest_reply_state[thread_id] = (
+                    event_id,
+                    {"event": event, "ts": ts, **payload},
+                )
+            elif event == "reply_complete":
+                agent = payload.get("agent")
+                if isinstance(agent, str):
+                    agents_by_thread.setdefault(thread_id, set()).add(agent)
+                latest_reply_state[thread_id] = (
+                    event_id,
+                    {"event": event, "ts": ts, **payload},
+                )
+                body = payload.get("body")
+                if isinstance(body, str):
+                    for entry in entries:
+                        entry["vote_counts"]["agree"] += len(
+                            _re.findall(r"\[AGREE\]", body)
+                        )
+                        entry["vote_counts"]["defer"] += len(
+                            _re.findall(r"\[DEFER\]", body)
+                        )
+                        options = entry["vote_counts"]["options"]
+                        for match in _re.findall(r"\[OPTION ([A-Z0-9]+)\]", body):
+                            options[match] = int(options.get(match, 0)) + 1
+            elif event == "model_cascade":
+                for entry in entries:
+                    entry["model_cascades"].append({"ts": ts, **payload})
 
-            entry = channels.setdefault(channel, {"name": channel, "created_at": None, "threads": []})
-            entry["threads"].append(thread_entry)
-
+        for thread_id, agents in agents_by_thread.items():
+            for thread_key in thread_keys_by_id.get(thread_id, []):
+                thread_index[thread_key]["agents"] = sorted(agents)
+        for thread_id, (_, state) in latest_reply_state.items():
+            for thread_key in thread_keys_by_id.get(thread_id, []):
+                thread_index[thread_key]["reply_state"] = state
         return {"channels": list(channels.values())}
 
-    # TODO: per-channel grouping when channels↔threads link is added
+    # Legacy fallback for event-only databases created before channel_messages
+    # existed. New rollups never depend on this path.
     fallback_threads = query_sqlite_rows_fn(
         db_path,
         """

--- a/tests/test_ab_post_writes_message_posted_event.py
+++ b/tests/test_ab_post_writes_message_posted_event.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from ai_agent_bridge import _channels, _cli, _db
+
+
+@pytest.fixture(autouse=True)
+def isolate_db(tmp_path):
+    db_file = tmp_path / "messages.db"
+    with patch("ai_agent_bridge._config.DB_PATH", db_file), \
+         patch("ai_agent_bridge._db.DB_PATH", db_file):
+        _db.init_db().close()
+        yield db_file
+
+
+def _run_cli(argv: list[str]) -> int:
+    with patch.object(sys, "argv", ["ab", *argv]):
+        try:
+            _cli.main()
+        except SystemExit as exc:
+            return exc.code if isinstance(exc.code, int) else 0
+    return 0
+
+
+def test_ab_post_writes_message_posted_event(isolate_db: Path, capsys) -> None:
+    _channels.create_channel("pipeline")
+
+    exit_code = _run_cli(
+        ["post", "pipeline", "hello from ab post", "--no-snapshot"]
+    )
+
+    assert exit_code == 0
+    assert "posted to #pipeline" in capsys.readouterr().out
+
+    conn = sqlite3.connect(isolate_db)
+    conn.row_factory = sqlite3.Row
+    try:
+        message = conn.execute(
+            """
+            SELECT message_id, thread_id, from_agent, round_index
+            FROM channel_messages
+            WHERE channel = 'pipeline'
+            """
+        ).fetchone()
+        assert message is not None
+        events = conn.execute(
+            """
+            SELECT thread_id, event, payload_json, ts
+            FROM channel_events
+            WHERE thread_id = ? AND event = 'message_posted'
+            """,
+            (message["thread_id"],),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    assert len(events) == 1
+    event = events[0]
+    assert event["thread_id"] == message["thread_id"]
+    payload = json.loads(event["payload_json"])
+    assert payload == {
+        "message_id": message["message_id"],
+        "from_agent": message["from_agent"],
+        "round_index": message["round_index"],
+    }
+
+
+def test_channel_backfill_events_is_idempotent(isolate_db: Path, capsys) -> None:
+    _channels.create_channel("pipeline")
+    conn = sqlite3.connect(isolate_db)
+    try:
+        conn.execute(
+            """
+            INSERT INTO channel_messages (
+                message_id, channel, thread_id, round_index, from_agent, kind, body, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "legacy-message",
+                "pipeline",
+                "legacy-thread",
+                0,
+                "user",
+                "post",
+                "historical post",
+                "2026-05-07T12:00:00+00:00",
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    assert _run_cli(["channel", "backfill-events"]) == 0
+    assert "inserted 1 message_posted" in capsys.readouterr().out
+    assert _run_cli(["channel", "backfill-events"]) == 0
+    assert "inserted 0 message_posted" in capsys.readouterr().out
+
+    conn = sqlite3.connect(isolate_db)
+    try:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM channel_events WHERE event = 'message_posted'"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+    assert count == 1

--- a/tests/test_ai_agent_bridge_channel_watch.py
+++ b/tests/test_ai_agent_bridge_channel_watch.py
@@ -64,10 +64,15 @@ def test_channel_watch_event_stream_replays_history_and_exits(capsys):
     captured = capsys.readouterr()
     assert captured.err == ""
     events = [json.loads(line) for line in captured.out.strip().splitlines()]
-    assert [event["event"] for event in events] == ["reply_started", "reply_complete"]
+    assert [event["event"] for event in events] == [
+        "message_posted",
+        "reply_started",
+        "reply_complete",
+    ]
     assert all(event["thread_id"] == thread_id for event in events)
-    assert events[0]["agent"] == "codex"
-    assert events[1]["chars"] == 42
+    assert events[0]["from_agent"] == "user"
+    assert events[1]["agent"] == "codex"
+    assert events[2]["chars"] == 42
 
 
 def test_channel_watch_follow_streams_new_rows():
@@ -84,7 +89,7 @@ def test_channel_watch_follow_streams_new_rows():
             "event_stream": True,
             "poll_interval_s": 0.01,
             "out": stream,
-            "max_events": 2,
+            "max_events": 3,
         },
         daemon=True,
     )
@@ -96,10 +101,11 @@ def test_channel_watch_follow_streams_new_rows():
     assert not watcher.is_alive()
     events = [json.loads(line) for line in stream.getvalue().strip().splitlines()]
     assert [event["event"] for event in events] == [
+        "message_posted",
         "reply_started",
         "delivery_delivered",
     ]
-    assert events[1]["delivery_id"] == thread["delivery_ids"][0]
+    assert events[2]["delivery_id"] == thread["delivery_ids"][0]
 
 
 def test_channel_watch_auto_migrates_missing_table():
@@ -115,5 +121,8 @@ def test_channel_watch_auto_migrates_missing_table():
     emit_reply_started(thread_id, agent="claude", model="test-model")
 
     events = read_channel_events(thread_id)
-    assert len(events) == 1
-    assert events[0]["event"] == "reply_started"
+    assert len(events) == 2
+    assert [event["event"] for event in events] == [
+        "message_posted",
+        "reply_started",
+    ]

--- a/tests/test_channel_rollup_works_without_events.py
+++ b/tests/test_channel_rollup_works_without_events.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+
+def _load_local_api():
+    module_path = Path(__file__).resolve().parent.parent / "scripts" / "local_api.py"
+    spec = importlib.util.spec_from_file_location(
+        "local_api_channel_rollup_without_events",
+        module_path,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+local_api = _load_local_api()
+
+
+def test_channel_rollup_works_without_events(tmp_path: Path, monkeypatch) -> None:
+    import ai_agent_bridge._db as bridge_db
+
+    db_path = tmp_path / "messages.db"
+    monkeypatch.setenv("AB_DB_PATH", str(db_path))
+    monkeypatch.setattr(bridge_db, "DB_PATH", db_path)
+    bridge_db.init_db().close()
+
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            INSERT INTO channels (name, created_at, description)
+            VALUES ('pipeline', '2026-05-07T12:00:00+00:00', 'Pipeline')
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO channel_messages (
+                message_id, channel, thread_id, round_index, from_agent, kind, body, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "m-root",
+                "pipeline",
+                "thread-1",
+                0,
+                "user",
+                "post",
+                "This is the thread subject that should be exposed without events.",
+                "2026-05-07T12:01:00+00:00",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO channel_messages (
+                message_id, channel, thread_id, parent_id, round_index,
+                from_agent, kind, body, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "m-reply",
+                "pipeline",
+                "thread-1",
+                "m-root",
+                1,
+                "codex",
+                "reply",
+                "Reply body",
+                "2026-05-07T12:03:00+00:00",
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    status_code, payload, _ = local_api.route_request(tmp_path, "/api/channels")
+
+    assert status_code == 200
+    channels = {channel["name"]: channel for channel in payload["channels"]}
+    assert len(channels["pipeline"]["threads"]) == 1
+    thread = channels["pipeline"]["threads"][0]
+    assert thread["thread_id"] == "thread-1"
+    assert thread["subject"] == (
+        "This is the thread subject that should be exposed without events."
+    )
+    assert thread["thread_started_at"] == "2026-05-07T12:01:00+00:00"
+    assert thread["thread_last_at"] == "2026-05-07T12:03:00+00:00"
+    assert thread["message_count"] == 2
+    assert thread["event_count"] == 0


### PR DESCRIPTION
## Summary
- rewrites `/api/channels` thread rollups to use `channel_messages` as the source of truth and layer optional `channel_events` metadata
- emits `message_posted` inside the `channel_messages` write transaction for `ab post`/`ab discuss` paths
- adds `ab channel backfill-events` for idempotent historical `message_posted` event backfill

Closes #993

## Verification
- `.venv/bin/ruff check scripts/local_api.py scripts/ai_agent_bridge/_channels.py scripts/ai_agent_bridge/_channels_cli.py tests/test_ai_agent_bridge_channel_watch.py tests/test_channel_rollup_works_without_events.py tests/test_ab_post_writes_message_posted_event.py`
- `.venv/bin/python -m pytest tests/test_ai_agent_bridge_channel_watch.py tests/test_bridge_channels.py tests/test_channels_d0.py tests/test_local_api_channels.py tests/test_local_api_channels_ui.py tests/test_channel_rollup_works_without_events.py tests/test_ab_post_writes_message_posted_event.py`
- `.venv/bin/python scripts/test_pipeline.py`
- live `AB_DB_PATH=../../.bridge/messages.db` API check on `127.0.0.1:8770`: non-empty threads for pipeline, architecture, ops, ai-history-book-consult, day3-388, deliberation-ui-roadmap, persistent-agent-listeners; content currently has 0 live messages
- live backfill via `PYTHONPATH=scripts AB_DB_PATH=../../.bridge/messages.db .venv/bin/python -m ai_agent_bridge channel backfill-events`: inserted 43, second run inserted 0

## Diff
- 6 files changed
- no generated artifacts staged
- Astro build skipped: no `src/content/docs/` or Astro config changes