### PR TITLE
feat(local-api): D2 — chat shell + post form (#965)

### DIFF
--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -7486,10 +7486,24 @@ def route_request(repo_root: Path, raw_path: str) -> tuple[int, Any, str]:
     return 404, {"error": "not_found", "path": path}, "application/json; charset=utf-8"
 
 
-def route_post_request(repo_root: Path, raw_path: str) -> tuple[int, Any, str]:
+def route_post_request(
+    repo_root: Path,
+    raw_path: str,
+    *,
+    body_bytes: bytes | None = None,
+    content_type: str = "",
+) -> tuple[int, Any, str]:
     path = urlsplit(raw_path).path.rstrip("/") or "/"
     if path == "/api/build/run":
         return start_build_job(repo_root)
+    channel_post = _CHANNEL_ROUTES.route_channel_post_request(
+        path,
+        body_bytes=body_bytes,
+        content_type=content_type,
+        bridge_db_path=_resolve_bridge_db_path(repo_root),
+    )
+    if channel_post is not None:
+        return channel_post
     return 404, {"error": "not_found", "path": path}, "application/json; charset=utf-8"
 
 
@@ -7709,7 +7723,23 @@ def make_handler(repo_root: Path) -> type[BaseHTTPRequestHandler]:
 
         def do_POST(self) -> None:  # noqa: N802
             try:
-                status_code, payload, content_type = route_post_request(repo_root, self.path)
+                content_length = int(self.headers.get("Content-Length", "0") or "0")
+                body_bytes = self.rfile.read(max(0, content_length))
+                request_content_type = self.headers.get("Content-Type", "")
+                try:
+                    status_code, payload, content_type = route_post_request(
+                        repo_root,
+                        self.path,
+                        body_bytes=body_bytes,
+                        content_type=request_content_type,
+                    )
+                except TypeError as exc:
+                    if "unexpected keyword argument" not in str(exc):
+                        raise
+                    status_code, payload, content_type = route_post_request(
+                        repo_root,
+                        self.path,
+                    )
             except Exception as exc:  # noqa: BLE001 - surface all write failures as JSON
                 status_code = 500
                 payload = {

--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -7726,20 +7726,12 @@ def make_handler(repo_root: Path) -> type[BaseHTTPRequestHandler]:
                 content_length = int(self.headers.get("Content-Length", "0") or "0")
                 body_bytes = self.rfile.read(max(0, content_length))
                 request_content_type = self.headers.get("Content-Type", "")
-                try:
-                    status_code, payload, content_type = route_post_request(
-                        repo_root,
-                        self.path,
-                        body_bytes=body_bytes,
-                        content_type=request_content_type,
-                    )
-                except TypeError as exc:
-                    if "unexpected keyword argument" not in str(exc):
-                        raise
-                    status_code, payload, content_type = route_post_request(
-                        repo_root,
-                        self.path,
-                    )
+                status_code, payload, content_type = route_post_request(
+                    repo_root,
+                    self.path,
+                    body_bytes=body_bytes,
+                    content_type=request_content_type,
+                )
             except Exception as exc:  # noqa: BLE001 - surface all write failures as JSON
                 status_code = 500
                 payload = {

--- a/scripts/local_api/routes/channels.py
+++ b/scripts/local_api/routes/channels.py
@@ -3,12 +3,68 @@ from __future__ import annotations
 import html as _html
 import json as _json
 import re as _re
+import threading as _threading
 from pathlib import Path
 from typing import Any, Callable
-from urllib.parse import unquote
+from urllib.parse import parse_qs, unquote
 
 
 RouteResponse = tuple[int, Any, str]
+_POST_DB_LOCK = _threading.Lock()
+
+
+def _json_response(status: int, payload: dict[str, Any]) -> RouteResponse:
+    return status, payload, "application/json; charset=utf-8"
+
+
+def _safe_json_for_script(value: Any) -> str:
+    return (
+        _json.dumps(value)
+        .replace("&", "\\u0026")
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+    )
+
+
+def _channel_event_sort_key(channel: dict[str, Any]) -> str:
+    value = channel.get("last_event_ts") or channel.get("created_at") or ""
+    return str(value)
+
+
+def _finalize_channel_rollup(
+    channels: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    for channel in channels.values():
+        threads = channel.get("threads")
+        if not isinstance(threads, list):
+            threads = []
+            channel["threads"] = threads
+        channel["thread_count"] = len(threads)
+        channel["message_count"] = sum(
+            int(thread.get("message_count") or 0)
+            for thread in threads
+            if isinstance(thread, dict)
+        )
+        channel["event_count"] = sum(
+            int(thread.get("event_count") or 0)
+            for thread in threads
+            if isinstance(thread, dict)
+        )
+        channel["last_event_ts"] = max(
+            (
+                str(thread.get("last_event_ts") or "")
+                for thread in threads
+                if isinstance(thread, dict)
+            ),
+            default=channel.get("created_at") or "",
+        )
+    return {
+        "channels": sorted(
+            channels.values(),
+            key=_channel_event_sort_key,
+            reverse=True,
+        )
+    }
 
 
 def build_channel_threads_index(
@@ -167,7 +223,7 @@ def build_channel_threads_index(
         for thread_id, (_, state) in latest_reply_state.items():
             for thread_key in thread_keys_by_id.get(thread_id, []):
                 thread_index[thread_key]["reply_state"] = state
-        return {"channels": list(channels.values())}
+        return _finalize_channel_rollup(channels)
 
     # Legacy fallback for event-only databases created before channel_messages
     # existed. New rollups never depend on this path.
@@ -185,7 +241,7 @@ def build_channel_threads_index(
         """,
     )
     if not fallback_threads:
-        return {"channels": list(channels.values())}
+        return _finalize_channel_rollup(channels)
 
     threads: list[dict[str, Any]] = []
     for row in fallback_threads:
@@ -215,15 +271,15 @@ def build_channel_threads_index(
             ],
         })
 
-    return {
-        "channels": [
-            {
+    return _finalize_channel_rollup(
+        {
+            "all-threads": {
                 "name": "all-threads",
                 "created_at": None,
                 "threads": threads,
             }
-        ]
-    }
+        }
+    )
 
 
 def build_channel_events_payload(
@@ -251,175 +307,373 @@ def build_channel_events_payload(
     }
 
 
-def render_channels_index_html(*, top_nav_css: str, render_top_nav_fn: Callable[[str], str]) -> str:
-    return """<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Agent Deliberations</title>
-  <style>
-    :root{--bg:#0a0f1a;--surface-0:#111827;--surface-1:#1a2332;--surface-2:#1f2b3d;--text:#e5e7eb;--text-dim:#6b7280;--accent:#38bdf8;--green:#4ade80;--border:rgba(255,255,255,0.06);--radius:12px;--radius-sm:8px}
-    *{box-sizing:border-box;margin:0}
-    body{font-family:-apple-system,BlinkMacSystemFont,'Inter','Segoe UI',sans-serif;background:var(--bg);color:var(--text);line-height:1.5;-webkit-font-smoothing:antialiased}
-""" + top_nav_css + """
-    .hdr{background:linear-gradient(180deg,rgba(17,24,39,.95),rgba(10,15,26,.98));border-bottom:1px solid var(--border);padding:20px 24px;display:flex;align-items:center;justify-content:space-between;position:sticky;top:var(--topnav-h, 45px);z-index:50;backdrop-filter:blur(12px)}
-    .hdr h1{font-size:18px;font-weight:700;letter-spacing:-.02em}
-    .hdr p{font-size:12px;color:var(--text-dim);margin-top:2px}
-    .btn{background:var(--surface-1);color:var(--text);border:1px solid var(--border);padding:6px 14px;border-radius:var(--radius-sm);font-size:13px;font-weight:500;cursor:pointer;transition:background .15s}
-    .btn:hover{background:var(--surface-2)}
-    .main{max-width:1200px;margin:0 auto;padding:24px}
-    .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:16px}
-    a.card{background:var(--surface-0);border:1px solid var(--border);border-radius:var(--radius);padding:20px;text-decoration:none;color:var(--text);display:block;transition:border-color .15s,background .15s}
-    a.card:hover{border-color:var(--accent);background:var(--surface-1)}
-    .card-ch{font-size:11px;color:var(--accent);text-transform:uppercase;letter-spacing:.06em;font-weight:600;margin-bottom:6px}
-    .card-tid{font-size:12px;color:var(--text-dim);font-family:monospace;margin-bottom:12px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-    .card-meta{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
-    .badge{display:inline-flex;padding:2px 8px;border-radius:20px;font-size:11px;font-weight:600}
-    .bc{background:rgba(56,189,248,.1);color:#38bdf8}.bcl{background:rgba(56,189,248,.15);color:#38bdf8}
-    .bco{background:rgba(74,222,128,.15);color:#4ade80}.bg{background:rgba(167,139,250,.15);color:#a78bfa}
-    .bu{background:rgba(251,191,36,.15);color:#fbbf24}
-    .card-ts{font-size:11px;color:var(--text-dim);margin-top:8px}
-    .empty{text-align:center;color:var(--text-dim);padding:60px 0;font-size:14px}
-    .dot{width:6px;height:6px;border-radius:50%;background:var(--green);display:inline-block;animation:pulse 2s ease-in-out infinite}
-    @keyframes pulse{0%,100%{opacity:1}50%{opacity:.4}}
-    .status{display:flex;align-items:center;gap:8px;font-size:12px;color:var(--text-dim)}
-  </style>
-</head>
-<body>
-""" + render_top_nav_fn("channels") + """
-<div class="hdr">
-  <div><h1>Agent Deliberations</h1><p>ab discuss live transcripts &#8212; claude / codex / gemini</p></div>
-  <div style="display:flex;align-items:center;gap:12px">
-    <span class="status"><span class="dot"></span>&nbsp;<span id="st">Loading&#8230;</span></span>
-    <button class="btn" onclick="load()">Refresh</button>
-  </div>
-</div>
-<div class="main"><div id="grid" class="grid"></div></div>
-<script>
-const BADGE = {claude:"bcl",codex:"bco",gemini:"bg",user:"bu"};
-function esc(s){return String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;");}
-function timeAgo(iso){if(!iso)return"";const d=Math.floor((Date.now()-new Date(iso))/1000);if(d<60)return d+"s ago";if(d<3600)return Math.floor(d/60)+"m ago";if(d<86400)return Math.floor(d/3600)+"h ago";return Math.floor(d/86400)+"d ago";}
-function agentBadge(a){const c=BADGE[a]||"bc";return`<span class="badge ${c}">${esc(a)}</span>`;}
-function render(data){
-  const channels=data.channels||[];
-  const total=channels.reduce((n,c)=>n+c.threads.length,0);
-  document.getElementById("st").textContent=total+" thread"+(total===1?"":"s");
-  if(!total){document.getElementById("grid").innerHTML='<p class="empty">No deliberation threads yet.<br>Start one with <code>ab discuss &lt;channel&gt;</code>.</p>';return;}
-  const cards=channels.flatMap(c=>c.threads.map(t=>{
-    const agents=(t.agents||[]).map(agentBadge).join("");
-    return`<a class="card" href="/channels/${encodeURIComponent(t.thread_id)}"><div class="card-ch">${esc(c.name)}</div><div class="card-tid" title="${esc(t.thread_id)}">${esc(t.thread_id)}</div><div class="card-meta"><span class="badge bc">${esc(t.event_count)} events</span>${agents}</div><div class="card-ts">last activity: ${timeAgo(t.last_event_ts)}</div></a>`;
-  }));
-  document.getElementById("grid").innerHTML=cards.join("");
-}
-function load(){fetch("/api/channels").then(r=>r.json()).then(render).catch(()=>{document.getElementById("st").textContent="API unavailable";});}
-load();setInterval(load,30000);
-</script>
-</body></html>"""
+def build_channel_timeline_payload(
+    repo_root: Path,
+    channel_name: str,
+    *,
+    resolve_bridge_db_path_fn: Callable[[Path], Path],
+    query_sqlite_rows_fn: Callable[..., list[dict[str, Any]]],
+    since_event_id: int = 0,
+    since_ts: str | None = None,
+) -> dict[str, Any]:
+    """Return channel events enriched with posted message bodies.
+
+    ``channel_events`` stores event metadata while ``channel_messages`` stores
+    prose. The browser timeline needs both, but writes must still flow through
+    the bridge primitive, so this read path joins them at render time.
+    """
+    db_path = resolve_bridge_db_path_fn(repo_root)
+    params: list[Any] = [channel_name, since_event_id]
+    since_clause = ""
+    if since_ts:
+        since_clause = "AND ce.ts > ?"
+        params.append(since_ts)
+
+    rows = query_sqlite_rows_fn(
+        db_path,
+        f"""
+        SELECT
+          ce.event_id,
+          ce.delivery_id,
+          ce.thread_id,
+          ce.event,
+          ce.payload_json,
+          ce.ts,
+          posted.message_id AS message_id,
+          posted.from_agent AS message_from_agent,
+          posted.from_model AS message_from_model,
+          posted.kind AS message_kind,
+          posted.body AS message_body,
+          posted.created_at AS message_created_at
+        FROM channel_events ce
+        LEFT JOIN channel_messages posted
+          ON posted.message_id = json_extract(ce.payload_json, '$.message_id')
+        WHERE EXISTS (
+          SELECT 1
+          FROM channel_messages cm
+          WHERE cm.channel = ?
+            AND cm.thread_id = ce.thread_id
+        )
+          AND ce.event_id > ?
+          {since_clause}
+        ORDER BY ce.event_id ASC
+        """,
+        tuple(params),
+        limit=10000,
+    )
+
+    events: list[dict[str, Any]] = []
+    next_since_event_id = since_event_id
+    for row in rows:
+        event_id = int(row.get("event_id") or 0)
+        payload_raw = row.get("payload_json")
+        try:
+            payload = _json.loads(payload_raw) if payload_raw else {}
+        except _json.JSONDecodeError:
+            payload = {}
+        if not isinstance(payload, dict):
+            payload = {}
+
+        event = {
+            "event_id": event_id,
+            "delivery_id": row.get("delivery_id"),
+            "thread_id": row.get("thread_id"),
+            "event": row.get("event"),
+            "ts": row.get("ts"),
+            **payload,
+        }
+        if row.get("message_id"):
+            event.update(
+                {
+                    "message_id": row.get("message_id"),
+                    "from_agent": row.get("message_from_agent"),
+                    "from_model": row.get("message_from_model"),
+                    "kind": row.get("message_kind"),
+                    "body": row.get("message_body"),
+                    "created_at": row.get("message_created_at"),
+                }
+            )
+        events.append(event)
+        next_since_event_id = max(next_since_event_id, event_id)
+
+    return {
+        "channel": channel_name,
+        "events": events,
+        "count": len(events),
+        "next_since_event_id": next_since_event_id,
+    }
 
 
-def render_channel_thread_html(
-    thread_id: str,
+def channel_exists_in_db(
+    repo_root: Path,
+    channel_name: str,
+    *,
+    resolve_bridge_db_path_fn: Callable[[Path], Path],
+    query_sqlite_rows_fn: Callable[..., list[dict[str, Any]]],
+) -> bool:
+    rows = query_sqlite_rows_fn(
+        resolve_bridge_db_path_fn(repo_root),
+        "SELECT 1 AS found FROM channels WHERE name = ? LIMIT 1",
+        (channel_name,),
+    )
+    return bool(rows)
+
+
+def render_channels_chat_html(
+    selected_channel: str | None,
     *,
     top_nav_css: str,
     render_top_nav_fn: Callable[[str], str],
 ) -> str:
-    tid_js = _json.dumps(thread_id)
-    tid_short = thread_id[:20] + ("…" if len(thread_id) > 20 else "")
-    escaped_tid = _html.escape(thread_id, quote=True)
-    escaped_tid_short = _html.escape(tid_short, quote=True)
+    selected_js = _safe_json_for_script(selected_channel)
+    title_channel = selected_channel or "Channels"
+    escaped_title = _html.escape(title_channel, quote=True)
     return f"""<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Thread {escaped_tid_short}</title>
+  <title>{escaped_title} - Agent Deliberations</title>
   <style>
-    :root{{--bg:#0a0f1a;--surface-0:#111827;--surface-1:#1a2332;--surface-2:#1f2b3d;--text:#e5e7eb;--text-dim:#6b7280;--border:rgba(255,255,255,0.06);--radius-sm:8px}}
+    :root{{--bg:#101112;--panel:#17191b;--panel-2:#202326;--line:#30343a;--text:#f3f4f2;--muted:#9ca3a3;--teal:#3dd6c6;--orange:#f59e0b;--blue:#69a7ff;--green:#55d17f;--violet:#b99cff;--red:#fb7185;--topnav-h:45px}}
     *{{box-sizing:border-box;margin:0}}
-    body{{font-family:-apple-system,BlinkMacSystemFont,'Inter','Segoe UI',sans-serif;background:var(--bg);color:var(--text);line-height:1.5;-webkit-font-smoothing:antialiased}}
+    body{{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:var(--bg);color:var(--text);line-height:1.45;-webkit-font-smoothing:antialiased}}
 {top_nav_css}
-    .hdr{{background:linear-gradient(180deg,rgba(17,24,39,.95),rgba(10,15,26,.98));border-bottom:1px solid var(--border);padding:16px 24px;position:sticky;top:var(--topnav-h, 45px);z-index:50;backdrop-filter:blur(12px)}}
-    .hdr-row{{display:flex;align-items:center;gap:12px;flex-wrap:wrap}}
-    .back{{color:#38bdf8;text-decoration:none;font-size:13px}}.back:hover{{text-decoration:underline}}
-    .tid{{font-size:13px;font-weight:600;font-family:monospace;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:420px;color:#e5e7eb}}
-    .meta{{font-size:11px;color:var(--text-dim);margin-top:4px}}
-    .feed{{max-width:860px;margin:24px auto;padding:0 24px 80px}}
-    .bubble{{margin-bottom:16px;max-width:720px}}
-    .bubble.claude{{border-left:3px solid #38bdf8}}.bubble.codex{{border-left:3px solid #4ade80}}
-    .bubble.gemini{{border-left:3px solid #a78bfa}}.bubble.user{{border-left:3px solid #fbbf24}}
-    .bi{{background:var(--surface-0);border:1px solid var(--border);border-left:none;border-radius:0 var(--radius-sm) var(--radius-sm) 0;padding:12px 16px}}
-    .bm{{font-size:11px;color:var(--text-dim);margin-bottom:6px;display:flex;align-items:center;gap:8px}}
-    .an{{font-weight:700}}.an.claude{{color:#38bdf8}}.an.codex{{color:#4ade80}}.an.gemini{{color:#a78bfa}}.an.user{{color:#fbbf24}}
-    .mt{{background:var(--surface-2);padding:1px 6px;border-radius:4px;font-size:10px;font-family:monospace}}
-    .bb{{font-size:13px;white-space:pre-wrap;word-break:break-word}}
-    .vote-agree{{background:rgba(74,222,128,.2);color:#4ade80;padding:1px 6px;border-radius:4px;font-weight:700}}
-    .vote-option{{background:rgba(56,189,248,.2);color:#38bdf8;padding:1px 6px;border-radius:4px;font-weight:700}}
-    .vote-defer{{background:rgba(156,163,175,.2);color:#9ca3af;padding:1px 6px;border-radius:4px;font-weight:700}}
-    .hb{{font-size:11px;color:var(--text-dim);padding:3px 0 6px 16px}}
-    .pill{{display:inline-flex;padding:2px 8px;border-radius:10px;font-size:11px;font-weight:500}}
-    .p-ok{{background:rgba(74,222,128,.1);color:#4ade80}}.p-fail{{background:rgba(248,113,113,.1);color:#f87171}}.p-info{{background:rgba(56,189,248,.1);color:#38bdf8}}
-    .empty{{text-align:center;color:var(--text-dim);padding:60px 0;font-size:14px}}
+    .channels-app{{height:calc(100vh - var(--topnav-h, 45px));display:grid;grid-template-columns:240px minmax(0,1fr);border-top:1px solid var(--line)}}
+    .channels-sidebar{{background:#121416;border-right:1px solid var(--line);padding:14px 10px;overflow:auto}}
+    .sidebar-title{{font-size:11px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);padding:4px 10px 10px}}
+    .channel-link{{display:grid;grid-template-columns:minmax(0,1fr) auto;gap:8px;align-items:center;color:var(--text);text-decoration:none;border-radius:6px;padding:7px 10px;font-size:13px;min-height:34px}}
+    .channel-link:hover,.channel-link.active{{background:var(--panel-2)}}
+    .channel-name{{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}}
+    .unread-badge{{display:none;min-width:18px;padding:1px 6px;border-radius:999px;background:var(--orange);color:#16120a;font-size:11px;font-weight:800;text-align:center}}
+    .unread-badge.visible{{display:inline-block}}
+    .sidebar-meta{{font-size:11px;color:var(--muted);padding:10px}}
+    .channel-main{{min-width:0;display:grid;grid-template-rows:auto minmax(0,1fr) auto;background:var(--bg)}}
+    .channel-header{{border-bottom:1px solid var(--line);background:rgba(23,25,27,.96);padding:14px 18px}}
+    .channel-header h1{{font-size:18px;font-weight:750;letter-spacing:0}}
+    .channel-header p{{font-size:12px;color:var(--muted);margin-top:2px}}
+    .messages{{overflow:auto;padding:16px 18px 28px;scrollbar-gutter:stable}}
+    .empty{{color:var(--muted);font-size:13px;padding:28px 4px}}
+    .event-row{{max-width:900px;margin:0 0 12px;border-left:3px solid var(--line);padding-left:10px}}
+    .event-row.claude{{border-left-color:var(--blue)}}.event-row.codex{{border-left-color:var(--green)}}.event-row.gemini{{border-left-color:var(--violet)}}
+    .event-row.user{{border-left-color:var(--orange);background:rgba(245,158,11,.08);padding:10px 12px;border-radius:0 6px 6px 0}}
+    .message-meta{{display:flex;align-items:center;gap:8px;flex-wrap:wrap;color:var(--muted);font-size:11px;margin-bottom:4px}}
+    .agent-name{{font-weight:800}}.agent-name.claude{{color:var(--blue)}}.agent-name.codex{{color:var(--green)}}.agent-name.gemini{{color:var(--violet)}}.agent-name.user{{color:var(--orange)}}
+    .model-tag,.event-pill{{background:var(--panel-2);border:1px solid var(--line);border-radius:5px;padding:1px 6px;font-size:10px;color:var(--muted)}}
+    .message-body{{font-size:13px;white-space:pre-wrap;word-break:break-word;color:var(--text)}}
+    .event-note{{color:var(--muted);font-size:12px;padding:2px 0}}
+    .post-form{{display:grid;grid-template-columns:minmax(0,1fr) auto;gap:10px;border-top:1px solid var(--line);background:var(--panel);padding:12px 18px}}
+    .post-input{{width:100%;min-height:44px;max-height:150px;resize:vertical;border:1px solid var(--line);border-radius:6px;background:#0f1011;color:var(--text);padding:10px 12px;font:13px/1.4 ui-monospace,SFMono-Regular,Menlo,monospace}}
+    .post-input:focus{{outline:2px solid rgba(61,214,198,.35);border-color:var(--teal)}}
+    .post-button{{border:1px solid rgba(245,158,11,.6);background:var(--orange);color:#171207;border-radius:6px;padding:0 16px;font-size:13px;font-weight:800;cursor:pointer}}
+    .post-button:disabled{{opacity:.55;cursor:not-allowed}}
+    .form-status{{grid-column:1 / -1;color:var(--muted);font-size:12px;min-height:16px}}
+    @media(max-width:760px){{.channels-app{{grid-template-columns:1fr;height:auto;min-height:calc(100vh - var(--topnav-h, 45px))}}.channels-sidebar{{max-height:210px;border-right:0;border-bottom:1px solid var(--line)}}.channel-main{{min-height:70vh}}}}
   </style>
 </head>
 <body>
 {render_top_nav_fn("channels")}
-<div class="hdr">
-  <div class="hdr-row"><a class="back" href="/channels">&larr; Channels</a><div class="tid" title="{escaped_tid}">{escaped_tid}</div></div>
-  <div class="meta"><span id="ec">0 events</span> &middot; <span id="lu">connecting&#8230;</span></div>
+<div class="channels-app" data-selected-channel="{_html.escape(selected_channel or "", quote=True)}">
+  <nav class="channels-sidebar" aria-label="Channels">
+    <div class="sidebar-title">Channels</div>
+    <div id="channelList"></div>
+    <div class="sidebar-meta" id="sidebarMeta">Loading...</div>
+  </nav>
+  <main class="channel-main">
+    <header class="channel-header">
+      <h1 id="channelTitle">Agent Deliberations</h1>
+      <p><span id="channelMeta">Select a channel</span> · <span id="pollState">idle</span></p>
+    </header>
+    <!-- delta-render: message nodes use data-message-id and renderedMsgIds; existing nodes are never overwritten -->
+    <section class="messages" id="messageList" aria-live="polite">
+      <div class="empty" id="emptyState">Waiting for channel activity...</div>
+    </section>
+    <form class="post-form" id="postForm">
+      <textarea class="post-input" id="postBody" name="body" maxlength="8000" placeholder="Post to the selected channel"></textarea>
+      <button class="post-button" id="postButton" type="submit">Post</button>
+      <div class="form-status" id="formStatus"></div>
+    </form>
+  </main>
 </div>
-<div class="feed" id="feed"><div class="empty" id="emp">Waiting for events&#8230;</div></div>
 <script>
-const TID={tid_js};
-let sinceId=0,atBottom=true,hbEl=null,hbN=0,totalEvents=0;
-const feed=document.getElementById("feed");
-feed.addEventListener("scroll",()=>{{atBottom=(feed.scrollHeight-feed.scrollTop-feed.clientHeight)<40;}});
-function esc(s){{return String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;");}}
-function timeAgo(iso){{if(!iso)return"";const d=Math.floor((Date.now()-new Date(iso))/1000);if(d<60)return d+"s ago";if(d<3600)return Math.floor(d/60)+"m ago";return Math.floor(d/3600)+"h ago";}}
-function hiliteVotes(t){{return t.replace(/\\[(AGREE)\\]/g,'<span class="vote-agree">[$1]</span>').replace(/\\[(OPTION [A-Z0-9]+)\\]/g,'<span class="vote-option">[$1]</span>').replace(/\\[(DEFER)\\]/g,'<span class="vote-defer">[$1]</span>');}}
-function pill(cls,html){{return`<div style="padding:2px 0 6px 16px"><span class="pill ${{cls}}">${{html}}</span></div>`;}}
-function renderEv(ev){{
-  const e=ev.event;
-  if(e==="heartbeat"){{
-    if(!hbEl){{hbEl=document.createElement("div");hbEl.className="hb";hbN=0;feed.appendChild(hbEl);}}
-    hbN++;hbEl.textContent="(♥ "+hbN+" heartbeat"+(hbN>1?"s":"")+" elapsed="+(ev.elapsed_s||"?")+"s)";
-    return;
-  }}
-  hbEl=null;
-  const el=document.createElement("div");
-  if(e==="delivery_delivered"){{el.innerHTML=pill("p-ok","&#10003; delivered "+esc(ev.delivery_id||""));}}
-  else if(e==="delivery_failed"){{el.innerHTML=pill("p-fail","&#10007; failed "+esc(ev.error_kind||""));}}
-  else if(e==="model_cascade"){{el.innerHTML=pill("p-info","cascade "+esc(ev.from||"")+" &rarr; "+esc(ev.to||""));}}
-  else if(e==="reply_started"){{el.innerHTML=pill("p-info","&#8635; "+esc(ev.agent||"?")+" started");}}
-  else if(e==="reply_complete"){{
-    const a=ev.agent||"unknown";
-    const ac=["claude","codex","gemini","user"].includes(a)?a:"";
-    const body=ev.body?hiliteVotes(esc(ev.body)):'<em style="color:var(--text-dim)">no body</em>';
-    el.className="bubble "+ac;
-    el.innerHTML=`<div class="bi"><div class="bm"><span class="an ${{ac}}">${{esc(a)}}</span>${{ev.model?`<span class="mt">${{esc(ev.model)}}</span>`:""}}
-      <span>${{esc((ev.ts||"").slice(0,19).replace("T"," "))}}</span></div><div class="bb">${{body}}</div></div>`;
-  }} else {{return;}}
-  feed.appendChild(el);
-}}
-function poll(){{
-  fetch("/api/channel/"+encodeURIComponent(TID)+"/events?since_event_id="+sinceId)
-    .then(r=>r.json()).then(data=>{{
-      const evs=data.events||[];
-      if(evs.length){{
-        const emp=document.getElementById("emp");if(emp)emp.remove();
-        evs.forEach(renderEv);
-        sinceId=data.next_since_event_id||sinceId;
-        totalEvents+=evs.length;
-        document.getElementById("ec").textContent=totalEvents+" event"+(totalEvents===1?"":"s");
-        document.getElementById("lu").textContent="updated "+timeAgo(evs[evs.length-1].ts);
-        if(atBottom)feed.scrollTop=feed.scrollHeight;
-      }}
-    }}).catch(()=>{{document.getElementById("lu").textContent="API unavailable";}});
-  setTimeout(poll,2000);
-}}
-poll();
+const INITIAL_CHANNEL = {selected_js};
+const DEFAULT_POLL_MS = 5000;
+const TIGHT_POLL_MS = 1000;
+const QUIET_RESET_MS = 30000;
+let selectedChannel = INITIAL_CHANNEL;
+let sinceId = 0;
+let currentFetchId = 0;
+let pollTimer = null;
+let lastEventType = "";
+let lastNewEventAt = 0;
+let channels = [];
+let hasBooted = false;
+const renderedMsgIds = new Set();
+const channelList = document.getElementById("channelList");
+const messageList = document.getElementById("messageList");
+const emptyState = document.getElementById("emptyState");
+const postForm = document.getElementById("postForm");
+const postBody = document.getElementById("postBody");
+const postButton = document.getElementById("postButton");
+const formStatus = document.getElementById("formStatus");
+function lastVisitedKey(name){{return "kdjo_channel_lastvisited_"+name;}}
+function timeAgo(iso){{if(!iso)return"no activity";const d=Math.floor((Date.now()-new Date(iso))/1000);if(d<60)return d+"s ago";if(d<3600)return Math.floor(d/60)+"m ago";if(d<86400)return Math.floor(d/3600)+"h ago";return Math.floor(d/86400)+"d ago";}}
+function setText(el,value){{el.textContent=value == null ? "" : String(value);}}
+function rememberVisited(name){{if(name)localStorage.setItem(lastVisitedKey(name),new Date().toISOString());}}
+function computePollDelayMs(now=Date.now()){{if((lastEventType==="reply_started"||lastEventType==="heartbeat")&&lastNewEventAt&&now-lastNewEventAt<QUIET_RESET_MS)return TIGHT_POLL_MS;return DEFAULT_POLL_MS;}}
+function isNearBottom(){{return messageList.scrollHeight-messageList.scrollTop-messageList.clientHeight<48;}}
+function resetMessages(){{renderedMsgIds.clear();sinceId=0;lastEventType="";lastNewEventAt=0;messageList.replaceChildren(emptyState);emptyState.style.display="block";}}
+function renderSidebar(){{channelList.replaceChildren();channels.forEach(ch=>{{const a=document.createElement("a");a.className="channel-link"+(ch.name===selectedChannel?" active":"");a.href="/channels/"+encodeURIComponent(ch.name);a.dataset.channelName=ch.name;const name=document.createElement("span");name.className="channel-name";name.textContent="# "+ch.name;const badge=document.createElement("span");badge.className="unread-badge";badge.dataset.unreadFor=ch.name;a.append(name,badge);a.addEventListener("click",()=>rememberVisited(ch.name));channelList.appendChild(a);}});document.getElementById("sidebarMeta").textContent=channels.length+" channel"+(channels.length===1?"":"s");updateUnreadBadges();}}
+function updateUnreadBadges(){{channels.forEach(ch=>{{const badge=channelList.querySelector(`[data-unread-for="${{CSS.escape(ch.name)}}"]`);if(!badge)return;const last=localStorage.getItem(lastVisitedKey(ch.name));if(ch.name===selectedChannel||!ch.last_event_ts||last&&new Date(ch.last_event_ts)<=new Date(last)){{badge.classList.remove("visible");badge.textContent="";return;}}if(!last){{badge.textContent=String(ch.event_count||1);badge.classList.add("visible");return;}}fetch("/api/channel/"+encodeURIComponent(ch.name)+"/events?since_ts="+encodeURIComponent(last)).then(r=>r.json()).then(data=>{{const n=(data.events||[]).length;if(n>0){{badge.textContent=String(n);badge.classList.add("visible");}}else{{badge.classList.remove("visible");badge.textContent="";}}}}).catch(()=>{{badge.textContent="!";badge.classList.add("visible");}});}});}}
+function appendMeta(parent,ev,agent){{const meta=document.createElement("div");meta.className="message-meta";const name=document.createElement("span");name.className="agent-name "+agent;name.textContent=agent==="user"?"👤 user":agent;meta.appendChild(name);if(ev.from_model||ev.model){{const model=document.createElement("span");model.className="model-tag";model.textContent=ev.from_model||ev.model;meta.appendChild(model);}}const stamp=document.createElement("span");stamp.textContent=(ev.ts||ev.created_at||"").slice(0,19).replace("T"," ");meta.appendChild(stamp);parent.appendChild(meta);}}
+function appendBody(parent,body){{const div=document.createElement("div");div.className="message-body";div.textContent=body||"";parent.appendChild(div);}}
+function appendNote(ev,text,cls=""){{const key=String(ev.event_id||"")+"-"+String(ev.ts||"");if(renderedMsgIds.has(key))return;renderedMsgIds.add(key);const row=document.createElement("div");row.className="event-row "+cls;row.dataset.eventId=String(ev.event_id||"");const note=document.createElement("div");note.className="event-note";note.textContent=text;row.appendChild(note);messageList.appendChild(row);}}
+function appendMessage(ev){{const key=ev.message_id||String(ev.event_id||"")+"-"+String(ev.ts||"");if(renderedMsgIds.has(key))return;renderedMsgIds.add(key);const agent=(ev.from_agent||ev.agent||"unknown").toLowerCase();const cls=["claude","codex","gemini","user"].includes(agent)?agent:"";const row=document.createElement("article");row.className="event-row "+cls;row.dataset.messageId=key;row.dataset.eventId=String(ev.event_id||"");appendMeta(row,ev,agent);appendBody(row,ev.body||"");messageList.appendChild(row);}}
+function renderEvent(ev){{if(emptyState)emptyState.style.display="none";if(ev.event==="message_posted"&&ev.body!==undefined)appendMessage(ev);else if(ev.event==="reply_complete")appendMessage(ev);else if(ev.event==="reply_started")appendNote(ev,(ev.agent||"agent")+" started replying","");else if(ev.event==="heartbeat")appendNote(ev,"heartbeat elapsed="+(ev.elapsed_s||"?")+"s","");else if(ev.event==="delivery_failed")appendNote(ev,"delivery failed "+(ev.error_kind||""),"");else if(ev.event==="delivery_delivered")appendNote(ev,"delivered "+(ev.delivery_id||""),"");else if(ev.event==="model_cascade")appendNote(ev,"cascade "+(ev.from||"")+" -> "+(ev.to||""),"");}}
+function applyEvents(events,nextSince){{if(!events.length)return;const stick=isNearBottom();events.forEach(renderEvent);sinceId=Math.max(sinceId,nextSince||sinceId);lastEventType=events[events.length-1].event||"";lastNewEventAt=Date.now();document.getElementById("channelMeta").textContent=events.length+" new event"+(events.length===1?"":"s")+" · last "+timeAgo(events[events.length-1].ts);if(stick)messageList.scrollTop=messageList.scrollHeight;rememberVisited(selectedChannel);updateUnreadBadges();}}
+function schedulePoll(){{clearTimeout(pollTimer);pollTimer=setTimeout(poll,computePollDelayMs());document.getElementById("pollState").textContent="next poll "+computePollDelayMs()/1000+"s";}}
+function poll(){{if(!selectedChannel){{schedulePoll();return;}}const myFetchId=++currentFetchId;fetch("/api/channel/"+encodeURIComponent(selectedChannel)+"/events?since_event_id="+sinceId).then(r=>r.json()).then(data=>{{if(myFetchId!==currentFetchId)return;applyEvents(data.events||[],data.next_since_event_id);}}).catch(()=>{{if(myFetchId===currentFetchId)document.getElementById("pollState").textContent="API unavailable";}}).finally(()=>{{if(myFetchId===currentFetchId)schedulePoll();}});}}
+function chooseChannel(name){{selectedChannel=name;if(!selectedChannel&&channels.length)selectedChannel=channels[0].name;document.getElementById("channelTitle").textContent=selectedChannel?"# "+selectedChannel:"Agent Deliberations";postButton.disabled=!selectedChannel;resetMessages();rememberVisited(selectedChannel);renderSidebar();poll();}}
+function loadChannels(){{fetch("/api/channels").then(r=>r.json()).then(data=>{{channels=data.channels||[];if(selectedChannel&&!channels.some(ch=>ch.name===selectedChannel))channels.unshift({{name:selectedChannel,event_count:0,last_event_ts:null,threads:[]}});renderSidebar();if(!hasBooted){{hasBooted=true;chooseChannel(selectedChannel);}}}}).catch(()=>{{document.getElementById("sidebarMeta").textContent="API unavailable";}});}}
+postForm.addEventListener("submit",ev=>{{ev.preventDefault();if(!selectedChannel)return;const body=postBody.value;if(!body.trim()){{formStatus.textContent="Body is required.";return;}}postButton.disabled=true;formStatus.textContent="Posting...";fetch("/api/channel/"+encodeURIComponent(selectedChannel)+"/post",{{method:"POST",headers:{{"Content-Type":"application/json"}},body:JSON.stringify({{body,from_agent:"user"}})}}).then(async r=>{{const data=await r.json();if(!r.ok)throw new Error(data.error||"post failed");postBody.value="";formStatus.textContent="Posted.";rememberVisited(selectedChannel);poll();loadChannels();}}).catch(err=>{{formStatus.textContent=err.message;}}).finally(()=>{{postButton.disabled=false;postBody.focus();}});}});
+loadChannels();
 </script>
 </body></html>"""
+
+
+def render_channels_index_html(
+    *,
+    top_nav_css: str,
+    render_top_nav_fn: Callable[[str], str],
+) -> str:
+    return render_channels_chat_html(
+        None,
+        top_nav_css=top_nav_css,
+        render_top_nav_fn=render_top_nav_fn,
+    )
+
+
+def render_channel_thread_html(
+    channel_name: str,
+    *,
+    top_nav_css: str,
+    render_top_nav_fn: Callable[[str], str],
+) -> str:
+    return render_channels_chat_html(
+        channel_name,
+        top_nav_css=top_nav_css,
+        render_top_nav_fn=render_top_nav_fn,
+    )
+
+
+def _parse_post_body(body_bytes: bytes | None, content_type: str) -> dict[str, Any]:
+    raw = (body_bytes or b"").decode("utf-8", errors="replace")
+    if "application/json" in content_type:
+        try:
+            payload = _json.loads(raw or "{}")
+        except _json.JSONDecodeError as exc:
+            raise ValueError("invalid_json") from exc
+        if not isinstance(payload, dict):
+            raise ValueError("invalid_json")
+        return payload
+
+    parsed = parse_qs(raw, keep_blank_values=True)
+    payload: dict[str, Any] = {}
+    for key, values in parsed.items():
+        if key == "to":
+            payload[key] = values
+        else:
+            payload[key] = values[-1] if values else ""
+    return payload
+
+
+def _parse_to_agents(value: Any) -> list[str] | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, str):
+        return [agent.strip() for agent in value.split(",") if agent.strip()]
+    if isinstance(value, list):
+        agents: list[str] = []
+        for item in value:
+            if isinstance(item, str) and item.strip():
+                agents.append(item.strip())
+        return agents
+    raise ValueError("invalid_to")
+
+
+def route_channel_post_request(
+    path: str,
+    *,
+    body_bytes: bytes | None,
+    content_type: str,
+    bridge_db_path: Path | None = None,
+) -> RouteResponse | None:
+    if not (path.startswith("/api/channel/") and path.endswith("/post")):
+        return None
+
+    raw_channel = path[len("/api/channel/") : -len("/post")]
+    channel_name = unquote(raw_channel).strip("/")
+    if not channel_name:
+        return _json_response(400, {"ok": False, "error": "missing_channel"})
+
+    try:
+        payload = _parse_post_body(body_bytes, content_type)
+        body_value = payload.get("body")
+        body = body_value if isinstance(body_value, str) else ""
+        if not body.strip():
+            return _json_response(400, {"ok": False, "error": "body_required"})
+        if len(body) > 8000:
+            return _json_response(400, {"ok": False, "error": "body_too_long"})
+        from_agent = payload.get("from_agent", "user")
+        if from_agent != "user":
+            return _json_response(400, {"ok": False, "error": "invalid_from_agent"})
+        to_agents = _parse_to_agents(payload.get("to"))
+    except ValueError as exc:
+        return _json_response(400, {"ok": False, "error": str(exc)})
+
+    try:
+        from ai_agent_bridge import _db as bridge_db
+        from ai_agent_bridge._channels import get_channel, post
+
+        with _POST_DB_LOCK:
+            old_db_path = bridge_db.DB_PATH
+            if bridge_db_path is not None:
+                bridge_db.DB_PATH = bridge_db_path
+            try:
+                if get_channel(channel_name) is None:
+                    return _json_response(404, {"ok": False, "error": "channel_not_found"})
+                result = post(
+                    channel=channel_name,
+                    from_agent="user",
+                    body=body,
+                    to_agents=to_agents,
+                    auto_snapshot=False,
+                    context_rev_shared="",
+                    context_rev_channel="",
+                    monitor_state_snapshot=None,
+                )
+            finally:
+                bridge_db.DB_PATH = old_db_path
+    except Exception as exc:  # noqa: BLE001 - endpoint contract requires JSON 500
+        return _json_response(
+            500,
+            {
+                "ok": False,
+                "error": "internal_error",
+                "exception": type(exc).__name__,
+                "message": str(exc),
+            },
+        )
+
+    return _json_response(
+        200,
+        {
+            "ok": True,
+            "message_id": result.get("message_id"),
+            "thread_id": result.get("thread_id"),
+            "ts": result.get("created_at"),
+        },
+    )
 
 
 def route_channel_page_request(
@@ -464,10 +718,10 @@ def route_channel_api_request(
             "application/json; charset=utf-8",
         )
     if path.startswith("/api/channel/") and path.endswith("/events"):
-        raw_thread_id = path[len("/api/channel/") : -len("/events")]
-        thread_id = unquote(raw_thread_id).strip("/")
-        if not thread_id:
-            return 400, {"error": "missing_thread_id"}, "application/json; charset=utf-8"
+        raw_name = path[len("/api/channel/") : -len("/events")]
+        name = unquote(raw_name).strip("/")
+        if not name:
+            return 400, {"error": "missing_channel_or_thread"}, "application/json; charset=utf-8"
         try:
             since_raw = query.get("since_event_id", ["0"])[0]
             if since_raw is None:
@@ -475,11 +729,30 @@ def route_channel_api_request(
             since_event_id = int(since_raw)
         except (TypeError, ValueError):
             return 400, {"error": "invalid_since_event_id"}, "application/json; charset=utf-8"
+        since_ts = query.get("since_ts", [None])[0]
+        if channel_exists_in_db(
+            repo_root,
+            name,
+            resolve_bridge_db_path_fn=resolve_bridge_db_path_fn,
+            query_sqlite_rows_fn=query_sqlite_rows_fn,
+        ):
+            return (
+                200,
+                build_channel_timeline_payload(
+                    repo_root,
+                    name,
+                    resolve_bridge_db_path_fn=resolve_bridge_db_path_fn,
+                    query_sqlite_rows_fn=query_sqlite_rows_fn,
+                    since_event_id=since_event_id,
+                    since_ts=since_ts,
+                ),
+                "application/json; charset=utf-8",
+            )
         from ai_agent_bridge._channels_watch import read_channel_events
         return (
             200,
             build_channel_events_payload(
-                thread_id,
+                name,
                 read_channel_events_fn=read_channel_events,
                 since_event_id=since_event_id,
             ),

--- a/tests/test_channel_delta_render.py
+++ b/tests/test_channel_delta_render.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_local_api():
+    module_path = Path(__file__).resolve().parent.parent / "scripts" / "local_api.py"
+    spec = importlib.util.spec_from_file_location("local_api_channel_delta", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+local_api = _load_local_api()
+
+
+def test_channel_shell_contains_delta_append_markers(tmp_path: Path) -> None:
+    status, body, content_type = local_api.route_request(tmp_path, "/channels/shared")
+
+    assert status == 200
+    assert "text/html" in content_type
+    assert 'class="channels-sidebar"' in body
+    assert 'class="channel-main"' in body
+    assert 'class="messages" id="messageList"' in body
+    assert "const renderedMsgIds = new Set();" in body
+    assert "row.dataset.messageId" in body
+    assert "data-message-id" in body
+    assert "messageList.appendChild(row)" in body
+    assert "messageList.replaceChildren(emptyState)" in body
+    assert "messageList.innerHTML" not in body
+
+
+def test_channel_shell_contains_unread_localstorage_markers(tmp_path: Path) -> None:
+    _, body, _ = local_api.route_request(tmp_path, "/channels")
+
+    assert "kdjo_channel_lastvisited_" in body
+    assert "unread-badge" in body
+    assert "since_ts=" in body
+    assert "/channels/+encodeURIComponent" not in body
+    assert 'a.href="/channels/"+encodeURIComponent(ch.name)' in body

--- a/tests/test_channel_poll_cadence.py
+++ b/tests/test_channel_poll_cadence.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_local_api():
+    module_path = Path(__file__).resolve().parent.parent / "scripts" / "local_api.py"
+    spec = importlib.util.spec_from_file_location("local_api_channel_cadence", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+local_api = _load_local_api()
+
+
+def test_channel_shell_contains_auto_tightening_poll_cadence(
+    tmp_path: Path,
+) -> None:
+    status, body, _ = local_api.route_request(tmp_path, "/channels/shared")
+
+    assert status == 200
+    assert "const DEFAULT_POLL_MS = 5000;" in body
+    assert "const TIGHT_POLL_MS = 1000;" in body
+    assert "const QUIET_RESET_MS = 30000;" in body
+    assert "function computePollDelayMs" in body
+    assert 'lastEventType==="reply_started"||lastEventType==="heartbeat"' in body
+    assert "return TIGHT_POLL_MS" in body
+    assert "return DEFAULT_POLL_MS" in body
+    assert 'ev.event==="reply_complete"' in body
+
+
+def test_channel_shell_contains_stale_fetch_protection(tmp_path: Path) -> None:
+    _, body, _ = local_api.route_request(tmp_path, "/channels/shared")
+
+    assert "let currentFetchId = 0;" in body
+    assert "const myFetchId=++currentFetchId" in body
+    assert "myFetchId!==currentFetchId" in body

--- a/tests/test_channel_post_endpoint.py
+++ b/tests/test_channel_post_endpoint.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+
+def _load_local_api():
+    module_path = Path(__file__).resolve().parent.parent / "scripts" / "local_api.py"
+    spec = importlib.util.spec_from_file_location("local_api_channel_post", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+local_api = _load_local_api()
+
+
+def _use_bridge_db(monkeypatch, db_path: Path) -> None:
+    bridge_db = importlib.import_module("ai_agent_bridge._db")
+    monkeypatch.setenv("AB_DB_PATH", str(db_path))
+    monkeypatch.setattr(bridge_db, "DB_PATH", db_path)
+
+
+def _create_channel(name: str) -> None:
+    channels = importlib.import_module("ai_agent_bridge._channels")
+    channels.create_channel(name, subscribers=["claude", "gemini", "codex"])
+
+
+def test_post_endpoint_writes_message_and_message_posted_event(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db_path = tmp_path / ".bridge" / "messages.db"
+    _use_bridge_db(monkeypatch, db_path)
+    _create_channel("shared")
+
+    status, payload, content_type = local_api.route_post_request(
+        tmp_path,
+        "/api/channel/shared/post",
+        body_bytes=json.dumps({"body": "hello", "from_agent": "user"}).encode(),
+        content_type="application/json",
+    )
+
+    assert status == 200
+    assert "application/json" in content_type
+    assert payload["ok"] is True
+    assert payload["message_id"]
+    assert payload["thread_id"]
+    assert payload["ts"]
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        message = conn.execute(
+            "SELECT * FROM channel_messages WHERE message_id = ?",
+            (payload["message_id"],),
+        ).fetchone()
+        assert message is not None
+        assert message["channel"] == "shared"
+        assert message["from_agent"] == "user"
+        assert message["body"] == "hello"
+
+        event = conn.execute(
+            """
+            SELECT * FROM channel_events
+            WHERE thread_id = ? AND event = 'message_posted'
+            """,
+            (payload["thread_id"],),
+        ).fetchone()
+        assert event is not None
+        event_payload = json.loads(event["payload_json"])
+        assert event_payload["message_id"] == payload["message_id"]
+        assert event_payload["from_agent"] == "user"
+    finally:
+        conn.close()
+
+
+def test_post_endpoint_rejects_invalid_body(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / ".bridge" / "messages.db"
+    _use_bridge_db(monkeypatch, db_path)
+    _create_channel("shared")
+
+    status, payload, _ = local_api.route_post_request(
+        tmp_path,
+        "/api/channel/shared/post",
+        body_bytes=b"body=%20%20%20",
+        content_type="application/x-www-form-urlencoded",
+    )
+
+    assert status == 400
+    assert payload == {"ok": False, "error": "body_required"}
+
+
+def test_post_endpoint_rejects_missing_channel(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / ".bridge" / "messages.db"
+    _use_bridge_db(monkeypatch, db_path)
+
+    status, payload, _ = local_api.route_post_request(
+        tmp_path,
+        "/api/channel/no-such-channel/post",
+        body_bytes=b"body=hello",
+        content_type="application/x-www-form-urlencoded",
+    )
+
+    assert status == 404
+    assert payload == {"ok": False, "error": "channel_not_found"}

--- a/tests/test_local_api_channels_ui.py
+++ b/tests/test_local_api_channels_ui.py
@@ -43,11 +43,5 @@ def test_channel_thread_xss_escaping(tmp_path: Path) -> None:
     )
     assert status == 200
     assert "&lt;script&gt;" in body
-    # Any line containing the raw tag must only be the JS const TID= declaration
     raw_tag = "<script>alert(1)</script>"
-    bad_lines = [
-        line
-        for line in body.splitlines()
-        if raw_tag in line and "const TID=" not in line
-    ]
-    assert bad_lines == [], f"Raw XSS payload found outside JS const: {bad_lines}"
+    assert raw_tag not in body, f"raw tag {raw_tag!r} leaked into rendered page"

--- a/tests/test_local_api_channels_ui.py
+++ b/tests/test_local_api_channels_ui.py
@@ -45,5 +45,9 @@ def test_channel_thread_xss_escaping(tmp_path: Path) -> None:
     assert "&lt;script&gt;" in body
     # Any line containing the raw tag must only be the JS const TID= declaration
     raw_tag = "<script>alert(1)</script>"
-    bad_lines = [l for l in body.splitlines() if raw_tag in l and "const TID=" not in l]
+    bad_lines = [
+        line
+        for line in body.splitlines()
+        if raw_tag in line and "const TID=" not in line
+    ]
     assert bad_lines == [], f"Raw XSS payload found outside JS const: {bad_lines}"

--- a/tests/test_local_api_security.py
+++ b/tests/test_local_api_security.py
@@ -97,7 +97,7 @@ def test_not_modified_etag_header_does_not_split_on_crlf(monkeypatch, tmp_path: 
 
 
 def test_post_response_headers_do_not_split_on_crlf(monkeypatch, tmp_path: Path) -> None:
-    def fake_route_post_request(_repo_root: Path, _path: str):
+    def fake_route_post_request(_repo_root: Path, _path: str, **_kwargs: object):
         return 202, {"ok": True}, "application/json\r\nX-Injected-Post: 1"
 
     monkeypatch.setattr(local_api, "route_post_request", fake_route_post_request)


### PR DESCRIPTION
## Summary

Closes #965.

Implements D2 from `docs/decisions/2026-05-07-deliberation-ui-roadmap.md`: `/channels` is now a Slack-shaped channel chat shell with topnav, sidebar, channel main pane, delta-appended messages, a user post form, unread badges backed by `localStorage`, stale-fetch protection, and auto-tightening poll cadence.

The new `POST /api/channel/<channel>/post` accepts JSON or form bodies, validates body length, rejects missing channels, and writes through `scripts.ai_agent_bridge._channels.post()` so `channel_messages` and `message_posted` event emission stay atomic.

## LOC delta

```text
scripts/local_api.py                  +32  -2
scripts/local_api/routes/channels.py +433 -160
tests/test_channel_delta_render.py    +44  -0
tests/test_channel_poll_cadence.py    +42  -0
tests/test_channel_post_endpoint.py  +112  -0
tests/test_local_api_channels_ui.py    +5  -1
```

## Validation

```text
.venv/bin/ruff check scripts/local_api scripts/ai_agent_bridge tests/test_local_api*.py tests/test_channel_*.py
# All checks passed

.venv/bin/pytest tests/test_local_api*.py tests/test_bridge_channels.py tests/test_channels_d0.py \
  tests/test_ai_agent_bridge_channel_watch.py tests/test_ab_post_writes_message_posted_event.py \
  tests/test_channel_rollup_works_without_events.py tests/test_channel_post_endpoint.py \
  tests/test_channel_delta_render.py tests/test_channel_poll_cadence.py -q --timeout=60
# 253 passed in 9.04s
```

Channel-related coverage includes the 6 pre-existing local API/channel UI tests plus the 3 new D2 test files.

Live smoke on `127.0.0.1:8772`:

```text
GET /channels: HTML includes topnav, .channels-sidebar, .channel-main, message list, post form.
POST /api/channel/shared/post: {\"ok\": true, \"message_id\": \"78e685ba725241a59bf986877c4906bc\", ...}
GET /api/channel/shared/events: returned enriched message_posted events with raw body in JSON for JS textContent rendering.
GET /api/channels: shared rollup picked up the new thread/event.
```