### PR TITLE
feat(local-api): D3 — Decision Graph view + thread_summary endpoint (#966)

### DIFF
--- a/scripts/local_api/routes/channels.py
+++ b/scripts/local_api/routes/channels.py
@@ -11,6 +11,7 @@ from urllib.parse import parse_qs, unquote
 
 RouteResponse = tuple[int, Any, str]
 _POST_DB_LOCK = _threading.Lock()
+_VOTE_RE = _re.compile(r"\[(AGREE|OPTION [A-Z][\w'’′]?|DEFER|NEEDS[- ]CHANGES)\]")
 
 
 def _json_response(status: int, payload: dict[str, Any]) -> RouteResponse:
@@ -29,6 +30,86 @@ def _safe_json_for_script(value: Any) -> str:
 def _channel_event_sort_key(channel: dict[str, Any]) -> str:
     value = channel.get("last_event_ts") or channel.get("created_at") or ""
     return str(value)
+
+
+def extract_thread_vote(body: str) -> str | None:
+    matches = _VOTE_RE.findall(body)
+    return matches[-1] if matches else None
+
+
+def _float_from_payload(payload: dict[str, Any], key: str) -> float:
+    value = payload.get(key, 0)
+    if isinstance(value, bool):
+        return 0.0
+    if isinstance(value, int | float):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return 0.0
+    return 0.0
+
+
+def _thread_status(rounds: list[dict[str, Any]]) -> str:
+    if not rounds:
+        return "in_flight"
+    final_turns = rounds[-1]["turns"]
+    final_votes = [
+        str(turn.get("vote"))
+        for turn in final_turns
+        if isinstance(turn.get("vote"), str)
+    ]
+    if (
+        final_votes
+        and len(final_votes) == len(final_turns)
+        and all(vote == "AGREE" for vote in final_votes)
+        and "DEFER" not in final_votes
+    ):
+        return "converged"
+    option_votes = {
+        vote
+        for vote in final_votes
+        if vote.startswith("OPTION ")
+    }
+    if len(option_votes) >= 2:
+        return "diverged"
+    return "in_flight"
+
+
+def _decision_frontmatter_or_first_section(path: Path) -> str:
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return ""
+    if not lines:
+        return ""
+    if lines[0].strip() == "---":
+        for idx, line in enumerate(lines[1:], start=1):
+            if line.strip() == "---":
+                return "\n".join(lines[: idx + 1])
+        return "\n".join(lines[:80])
+    section: list[str] = []
+    saw_h1 = False
+    for line in lines:
+        if line.startswith("# "):
+            if saw_h1:
+                break
+            saw_h1 = True
+        elif saw_h1 and line.startswith("## "):
+            break
+        section.append(line)
+    return "\n".join(section or lines[:20])
+
+
+def find_decision_id_for_thread(repo_root: Path, thread_id: str) -> str | None:
+    decisions_dir = repo_root / "docs" / "decisions"
+    if not thread_id or not decisions_dir.exists():
+        return None
+    for path in sorted(decisions_dir.glob("*.md")):
+        if thread_id in _decision_frontmatter_or_first_section(path):
+            return path.relative_to(repo_root).as_posix()
+    return None
 
 
 def _finalize_channel_rollup(
@@ -307,6 +388,129 @@ def build_channel_events_payload(
     }
 
 
+def build_channel_thread_summary(
+    repo_root: Path,
+    thread_id: str,
+    *,
+    resolve_bridge_db_path_fn: Callable[[Path], Path],
+    query_sqlite_rows_fn: Callable[..., list[dict[str, Any]]],
+) -> dict[str, Any]:
+    db_path = resolve_bridge_db_path_fn(repo_root)
+    rows = query_sqlite_rows_fn(
+        db_path,
+        """
+        SELECT
+          cm.message_id,
+          cm.channel,
+          cm.thread_id,
+          cm.round_index,
+          cm.from_agent,
+          cm.from_model,
+          cm.body,
+          cm.created_at,
+          mc.cost_usd AS cascade_cost_usd,
+          mc.elapsed_s AS cascade_elapsed_s
+        FROM channel_messages cm
+        LEFT JOIN (
+          SELECT
+            thread_id,
+            json_extract(payload_json, '$.message_id') AS message_id,
+            SUM(COALESCE(json_extract(payload_json, '$.cost_usd'), 0)) AS cost_usd,
+            SUM(COALESCE(json_extract(payload_json, '$.elapsed_s'), 0)) AS elapsed_s
+          FROM channel_events
+          WHERE event = 'model_cascade'
+            AND json_extract(payload_json, '$.message_id') IS NOT NULL
+          GROUP BY thread_id, json_extract(payload_json, '$.message_id')
+        ) mc
+          ON mc.thread_id = cm.thread_id
+         AND mc.message_id = cm.message_id
+        WHERE cm.thread_id = ?
+        ORDER BY cm.round_index ASC, cm.created_at ASC, cm.rowid ASC
+        """,
+        (thread_id,),
+        limit=10000,
+    )
+
+    channel = ""
+    subject = ""
+    turns_by_round_idx: dict[int, list[dict[str, Any]]] = {}
+    total_cost_usd = 0.0
+    total_elapsed_s = 0.0
+
+    for row in rows:
+        if not channel and isinstance(row.get("channel"), str):
+            channel = str(row["channel"])
+        body = row.get("body") if isinstance(row.get("body"), str) else ""
+        if not subject:
+            subject = body.strip()[:200]
+
+        agent = row.get("from_agent")
+        if not isinstance(agent, str) or agent == "user":
+            continue
+
+        cost_usd = _float_from_payload({"cost_usd": row.get("cascade_cost_usd")}, "cost_usd")
+        elapsed_s = _float_from_payload({"elapsed_s": row.get("cascade_elapsed_s")}, "elapsed_s")
+        total_cost_usd += cost_usd
+        total_elapsed_s += elapsed_s
+
+        turns_by_round_idx.setdefault(int(row.get("round_index") or 0), []).append(
+            {
+                "agent": agent,
+                "model": row.get("from_model"),
+                "vote": extract_thread_vote(body),
+                "body_preview": body[:200],
+                "body": body,
+                "message_id": row.get("message_id"),
+                "cost_usd": cost_usd,
+                "elapsed_s": elapsed_s,
+                "ts": row.get("created_at"),
+            }
+        )
+
+    rounds: list[dict[str, Any]] = []
+
+    def append_round(turns: list[dict[str, Any]]) -> None:
+        rounds.append(
+            {
+                "round_idx": len(rounds) + 1,
+                "turns": turns,
+                "cost_usd": round(
+                    sum(float(turn.get("cost_usd") or 0) for turn in turns),
+                    6,
+                ),
+                "elapsed_s": round(
+                    sum(float(turn.get("elapsed_s") or 0) for turn in turns),
+                    3,
+                ),
+            }
+        )
+
+    for round_idx in sorted(turns_by_round_idx):
+        current_turns: list[dict[str, Any]] = []
+        seen_agents: set[str] = set()
+        for turn in turns_by_round_idx[round_idx]:
+            agent = str(turn.get("agent") or "")
+            if agent in seen_agents and current_turns:
+                append_round(current_turns)
+                current_turns = []
+                seen_agents = set()
+            current_turns.append(turn)
+            seen_agents.add(agent)
+        if current_turns:
+            append_round(current_turns)
+
+    return {
+        "thread_id": thread_id,
+        "channel": channel,
+        "subject": subject,
+        "rounds": rounds,
+        "status": _thread_status(rounds),
+        "decision_id": find_decision_id_for_thread(repo_root, thread_id),
+        "total_cost_usd": round(total_cost_usd, 6),
+        "total_elapsed_s": round(total_elapsed_s, 3),
+    }
+
+
 def build_channel_timeline_payload(
     repo_root: Path,
     channel_name: str,
@@ -449,10 +653,17 @@ def render_channels_chat_html(
     .unread-badge.visible{{display:inline-block}}
     .sidebar-meta{{font-size:11px;color:var(--muted);padding:10px}}
     .channel-main{{min-width:0;display:grid;grid-template-rows:auto minmax(0,1fr) auto;background:var(--bg)}}
-    .channel-header{{border-bottom:1px solid var(--line);background:rgba(23,25,27,.96);padding:14px 18px}}
+    .channel-header{{border-bottom:1px solid var(--line);background:rgba(23,25,27,.96);padding:14px 18px;display:flex;justify-content:space-between;align-items:center;gap:14px}}
+    .channel-heading{{min-width:0}}
     .channel-header h1{{font-size:18px;font-weight:750;letter-spacing:0}}
     .channel-header p{{font-size:12px;color:var(--muted);margin-top:2px}}
+    .view-toggle{{display:inline-grid;grid-template-columns:1fr 1fr;border:1px solid var(--line);border-radius:6px;overflow:hidden;background:#111315;flex:0 0 auto}}
+    .view-toggle button{{border:0;border-left:1px solid var(--line);background:transparent;color:var(--muted);padding:7px 12px;font-size:12px;font-weight:800;cursor:pointer}}
+    .view-toggle button:first-child{{border-left:0}}
+    .view-toggle button.active{{background:var(--teal);color:#071211}}
+    .view-shell{{min-width:0;min-height:0;position:relative;overflow:hidden}}
     .messages{{overflow:auto;padding:16px 18px 28px;scrollbar-gutter:stable}}
+    .messages[hidden],.graph-view[hidden]{{display:none}}
     .empty{{color:var(--muted);font-size:13px;padding:28px 4px}}
     .event-row{{max-width:900px;margin:0 0 12px;border-left:3px solid var(--line);padding-left:10px}}
     .event-row.claude{{border-left-color:var(--blue)}}.event-row.codex{{border-left-color:var(--green)}}.event-row.gemini{{border-left-color:var(--violet)}}
@@ -468,7 +679,34 @@ def render_channels_chat_html(
     .post-button{{border:1px solid rgba(245,158,11,.6);background:var(--orange);color:#171207;border-radius:6px;padding:0 16px;font-size:13px;font-weight:800;cursor:pointer}}
     .post-button:disabled{{opacity:.55;cursor:not-allowed}}
     .form-status{{grid-column:1 / -1;color:var(--muted);font-size:12px;min-height:16px}}
-    @media(max-width:760px){{.channels-app{{grid-template-columns:1fr;height:auto;min-height:calc(100vh - var(--topnav-h, 45px))}}.channels-sidebar{{max-height:210px;border-right:0;border-bottom:1px solid var(--line)}}.channel-main{{min-height:70vh}}}}
+    .graph-view{{height:100%;overflow:auto;padding:16px 18px 28px}}
+    .graph-banner{{border:1px solid rgba(245,158,11,.45);background:rgba(245,158,11,.1);color:#f8d9a0;border-radius:6px;padding:12px 14px;font-size:13px;margin-bottom:14px}}
+    .graph-card{{min-width:680px;border:1px solid var(--line);border-radius:8px;overflow:hidden;background:var(--panel)}}
+    .decision-graph{{width:100%;border-collapse:collapse;table-layout:fixed}}
+    .decision-graph th,.decision-graph td{{border-bottom:1px solid var(--line);border-right:1px solid var(--line);padding:10px;vertical-align:top;font-size:12px}}
+    .decision-graph th{{background:#121416;color:var(--muted);text-align:left;text-transform:uppercase;letter-spacing:.06em;font-size:10px}}
+    .decision-graph tr:last-child td{{border-bottom:0}}
+    .round-label{{font-weight:850;color:var(--text);white-space:nowrap}}
+    .round-cost{{display:block;color:var(--muted);font-size:10px;font-weight:600;margin-top:2px}}
+    .vote-chip{{border:1px solid var(--line);border-radius:999px;background:#111315;color:var(--text);padding:5px 8px;font-size:11px;font-weight:850;cursor:pointer;max-width:100%;white-space:normal;text-align:left}}
+    .vote-chip.agree{{border-color:rgba(85,209,127,.55);background:rgba(85,209,127,.12);color:#9ef0b7}}
+    .vote-chip.defer,.vote-chip.needs{{border-color:rgba(245,158,11,.55);background:rgba(245,158,11,.12);color:#f8d9a0}}
+    .vote-chip.option{{border-color:rgba(105,167,255,.6);background:rgba(105,167,255,.12);color:#a9cfff}}
+    .vote-chip.null{{color:var(--muted)}}
+    .missed{{color:var(--muted);font-style:italic}}
+    .decision-footer{{border-top:1px solid var(--line);padding:12px 14px;color:var(--muted);font-size:13px}}
+    .decision-footer strong{{color:var(--text)}}
+    .modal-backdrop{{position:fixed;inset:0;background:rgba(0,0,0,.62);display:grid;place-items:center;padding:24px;z-index:20}}
+    .modal-backdrop[hidden]{{display:none}}
+    .turn-modal{{width:min(1100px,96vw);max-height:88vh;display:grid;grid-template-rows:auto minmax(0,1fr);background:#101112;border:1px solid var(--line);border-radius:8px;box-shadow:0 24px 80px rgba(0,0,0,.45);overflow:hidden}}
+    .modal-header{{display:flex;align-items:center;justify-content:space-between;gap:12px;border-bottom:1px solid var(--line);padding:12px 14px;background:var(--panel)}}
+    .modal-title{{font-size:13px;font-weight:850}}
+    .modal-close{{border:1px solid var(--line);background:#111315;color:var(--text);border-radius:6px;width:30px;height:30px;cursor:pointer;font-size:18px;line-height:1}}
+    .modal-body{{overflow:auto;padding:14px;display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:12px}}
+    .turn-body{{min-width:0;border:1px solid var(--line);border-radius:6px;background:#0d0f10;overflow:hidden}}
+    .turn-body h3{{font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);padding:8px 10px;border-bottom:1px solid var(--line);background:#121416}}
+    .turn-body pre{{white-space:pre-wrap;word-break:break-word;color:var(--text);font:12px/1.45 ui-monospace,SFMono-Regular,Menlo,monospace;padding:10px;max-height:62vh;overflow:auto}}
+    @media(max-width:760px){{.channels-app{{grid-template-columns:1fr;height:auto;min-height:calc(100vh - var(--topnav-h, 45px))}}.channels-sidebar{{max-height:210px;border-right:0;border-bottom:1px solid var(--line)}}.channel-main{{min-height:70vh}}.channel-header{{align-items:flex-start;flex-direction:column}}.view-toggle{{width:100%}}}}
   </style>
 </head>
 <body>
@@ -481,13 +719,25 @@ def render_channels_chat_html(
   </nav>
   <main class="channel-main">
     <header class="channel-header">
-      <h1 id="channelTitle">Agent Deliberations</h1>
-      <p><span id="channelMeta">Select a channel</span> · <span id="pollState">idle</span></p>
+      <div class="channel-heading">
+        <h1 id="channelTitle">Agent Deliberations</h1>
+        <p><span id="channelMeta">Select a channel</span> · <span id="pollState">idle</span></p>
+      </div>
+      <div class="view-toggle" aria-label="Thread view">
+        <button type="button" data-view-toggle="chat">Chat</button>
+        <button type="button" data-view-toggle="graph">Graph</button>
+      </div>
     </header>
-    <!-- delta-render: message nodes use data-message-id and renderedMsgIds; existing nodes are never overwritten -->
-    <section class="messages" id="messageList" aria-live="polite">
-      <div class="empty" id="emptyState">Waiting for channel activity...</div>
-    </section>
+    <div class="view-shell">
+      <!-- delta-render: message nodes use data-message-id and renderedMsgIds; existing nodes are never overwritten -->
+      <section class="messages" id="messageList" aria-live="polite">
+        <div class="empty" id="emptyState">Waiting for channel activity...</div>
+      </section>
+      <section class="graph-view" id="graphView" hidden>
+        <div class="graph-banner" id="graphFallback" hidden>This thread has no structured votes — switch to Chat view to read the discussion.</div>
+        <div id="graphMount"></div>
+      </section>
+    </div>
     <form class="post-form" id="postForm">
       <textarea class="post-input" id="postBody" name="body" maxlength="8000" placeholder="Post to the selected channel"></textarea>
       <button class="post-button" id="postButton" type="submit">Post</button>
@@ -495,8 +745,19 @@ def render_channels_chat_html(
     </form>
   </main>
 </div>
+<div class="modal-backdrop" id="turnModal" hidden>
+  <div class="turn-modal" role="dialog" aria-modal="true" aria-labelledby="turnModalTitle">
+    <div class="modal-header">
+      <div class="modal-title" id="turnModalTitle">Turn body</div>
+      <button class="modal-close" id="turnModalClose" type="button" aria-label="Close">×</button>
+    </div>
+    <div class="modal-body" id="turnModalBody"></div>
+  </div>
+</div>
 <script>
 const INITIAL_CHANNEL = {selected_js};
+const INITIAL_PARAMS = new URLSearchParams(window.location.search);
+const REQUESTED_VIEW = ["chat","graph"].includes(INITIAL_PARAMS.get("view")) ? INITIAL_PARAMS.get("view") : null;
 const DEFAULT_POLL_MS = 5000;
 const TIGHT_POLL_MS = 1000;
 const QUIET_RESET_MS = 30000;
@@ -508,14 +769,24 @@ let lastEventType = "";
 let lastNewEventAt = 0;
 let channels = [];
 let hasBooted = false;
+let currentView = REQUESTED_VIEW || "chat";
+let threadSummary = null;
+let summaryFetchId = 0;
 const renderedMsgIds = new Set();
 const channelList = document.getElementById("channelList");
 const messageList = document.getElementById("messageList");
 const emptyState = document.getElementById("emptyState");
+const graphView = document.getElementById("graphView");
+const graphMount = document.getElementById("graphMount");
+const graphFallback = document.getElementById("graphFallback");
 const postForm = document.getElementById("postForm");
 const postBody = document.getElementById("postBody");
 const postButton = document.getElementById("postButton");
 const formStatus = document.getElementById("formStatus");
+const turnModal = document.getElementById("turnModal");
+const turnModalTitle = document.getElementById("turnModalTitle");
+const turnModalBody = document.getElementById("turnModalBody");
+const turnModalClose = document.getElementById("turnModalClose");
 function lastVisitedKey(name){{return "kdjo_channel_lastvisited_"+name;}}
 function timeAgo(iso){{if(!iso)return"no activity";const d=Math.floor((Date.now()-new Date(iso))/1000);if(d<60)return d+"s ago";if(d<3600)return Math.floor(d/60)+"m ago";if(d<86400)return Math.floor(d/3600)+"h ago";return Math.floor(d/86400)+"d ago";}}
 function setText(el,value){{el.textContent=value == null ? "" : String(value);}}
@@ -523,6 +794,17 @@ function rememberVisited(name){{if(name)localStorage.setItem(lastVisitedKey(name
 function computePollDelayMs(now=Date.now()){{if((lastEventType==="reply_started"||lastEventType==="heartbeat")&&lastNewEventAt&&now-lastNewEventAt<QUIET_RESET_MS)return TIGHT_POLL_MS;return DEFAULT_POLL_MS;}}
 function isNearBottom(){{return messageList.scrollHeight-messageList.scrollTop-messageList.clientHeight<48;}}
 function resetMessages(){{renderedMsgIds.clear();sinceId=0;lastEventType="";lastNewEventAt=0;messageList.replaceChildren(emptyState);emptyState.style.display="block";}}
+function hasStructuredVotes(summary){{return !!(summary&&summary.rounds&&summary.rounds.some(round=>(round.turns||[]).some(turn=>turn.vote)));}}
+function defaultViewForSummary(summary){{if(REQUESTED_VIEW)return REQUESTED_VIEW;if(summary&&(summary.status==="converged"||summary.decision_id))return"graph";return"chat";}}
+function setView(view,updateUrl=true){{currentView=view==="graph"?"graph":"chat";messageList.hidden=currentView!=="chat";graphView.hidden=currentView!=="graph";document.querySelectorAll("[data-view-toggle]").forEach(btn=>btn.classList.toggle("active",btn.dataset.viewToggle===currentView));if(updateUrl){{const url=new URL(window.location.href);url.searchParams.set("view",currentView);history.replaceState(null,"",url);}}}}
+function voteClass(vote){{if(!vote)return"null";if(vote==="AGREE")return"agree";if(vote==="DEFER")return"defer";if(vote.startsWith("NEEDS"))return"needs";if(vote.startsWith("OPTION "))return"option";return"null";}}
+function agentColumns(summary){{const seen=new Set();(summary.rounds||[]).forEach(round=>(round.turns||[]).forEach(turn=>seen.add(turn.agent)));return Array.from(seen).sort((a,b)=>{{const order={{claude:0,codex:1,gemini:2}};return (order[a]??100)-(order[b]??100)||a.localeCompare(b);}});}}
+function formatMoney(value){{const n=Number(value||0);return n?"$"+n.toFixed(3):"$0";}}
+function formatElapsed(value){{const n=Number(value||0);return n?Math.round(n)+"s":"0s";}}
+function renderGraph(summary){{threadSummary=summary;graphMount.replaceChildren();const structured=hasStructuredVotes(summary);graphFallback.hidden=structured;if(!summary||!structured)return;const agents=agentColumns(summary);const card=document.createElement("div");card.className="graph-card";const table=document.createElement("table");table.className="decision-graph";const thead=document.createElement("thead");const headRow=document.createElement("tr");["Round",...agents].forEach(label=>{{const th=document.createElement("th");th.textContent=label;headRow.appendChild(th);}});thead.appendChild(headRow);table.appendChild(thead);const tbody=document.createElement("tbody");(summary.rounds||[]).forEach(round=>{{const tr=document.createElement("tr");const label=document.createElement("td");label.innerHTML="<span class='round-label'>ROUND "+String(round.round_idx)+"</span><span class='round-cost'>"+formatMoney(round.cost_usd)+" · "+formatElapsed(round.elapsed_s)+"</span>";tr.appendChild(label);agents.forEach(agent=>{{const td=document.createElement("td");const turn=(round.turns||[]).find(item=>item.agent===agent);if(turn){{const btn=document.createElement("button");btn.type="button";btn.className="vote-chip "+voteClass(turn.vote);btn.textContent=agent+": ["+(turn.vote||"NO VOTE")+"]";btn.addEventListener("click",()=>openTurnModal(round,turn));td.appendChild(btn);}}else{{const missed=document.createElement("span");missed.className="missed";missed.textContent="<missed>";td.appendChild(missed);}}tr.appendChild(td);}});tbody.appendChild(tr);}});table.appendChild(tbody);card.appendChild(table);const footer=document.createElement("div");footer.className="decision-footer";footer.innerHTML="<strong>DECISION</strong> → Status: "+String(summary.status||"in_flight")+(summary.decision_id?" · Linked: "+summary.decision_id:" · Linked: none")+" · Total: "+formatMoney(summary.total_cost_usd)+" / "+formatElapsed(summary.total_elapsed_s);card.appendChild(footer);graphMount.appendChild(card);}}
+function loadSummary(){{const myFetchId=++summaryFetchId;threadSummary=null;graphMount.replaceChildren();graphFallback.hidden=true;if(!selectedChannel){{setView("chat",false);return;}}fetch("/api/channel/"+encodeURIComponent(selectedChannel)+"/summary").then(r=>r.json()).then(summary=>{{if(myFetchId!==summaryFetchId)return;renderGraph(summary);setView(defaultViewForSummary(summary),false);}}).catch(()=>{{if(myFetchId===summaryFetchId){{graphFallback.hidden=false;setView("chat",false);}}}});}}
+function openTurnModal(round,turn){{turnModalTitle.textContent="Round "+String(round.round_idx)+" · "+String(turn.agent||"turn");turnModalBody.replaceChildren();const turns=(round.turns||[]).length>1?round.turns:[turn];turns.forEach(item=>{{const wrap=document.createElement("section");wrap.className="turn-body";const h=document.createElement("h3");h.textContent=String(item.agent||"agent")+" · "+String(item.vote||"no vote")+" · "+String(item.model||"");const pre=document.createElement("pre");pre.textContent=String(item.body||item.body_preview||"");wrap.append(h,pre);turnModalBody.appendChild(wrap);}});turnModal.hidden=false;turnModalClose.focus();}}
+function closeTurnModal(){{turnModal.hidden=true;turnModalBody.replaceChildren();}}
 function renderSidebar(){{channelList.replaceChildren();channels.forEach(ch=>{{const a=document.createElement("a");a.className="channel-link"+(ch.name===selectedChannel?" active":"");a.href="/channels/"+encodeURIComponent(ch.name);a.dataset.channelName=ch.name;const name=document.createElement("span");name.className="channel-name";name.textContent="# "+ch.name;const badge=document.createElement("span");badge.className="unread-badge";badge.dataset.unreadFor=ch.name;a.append(name,badge);a.addEventListener("click",()=>rememberVisited(ch.name));channelList.appendChild(a);}});document.getElementById("sidebarMeta").textContent=channels.length+" channel"+(channels.length===1?"":"s");updateUnreadBadges();}}
 function updateUnreadBadges(){{channels.forEach(ch=>{{const badge=channelList.querySelector(`[data-unread-for="${{CSS.escape(ch.name)}}"]`);if(!badge)return;const last=localStorage.getItem(lastVisitedKey(ch.name));if(ch.name===selectedChannel||!ch.last_event_ts||last&&new Date(ch.last_event_ts)<=new Date(last)){{badge.classList.remove("visible");badge.textContent="";return;}}if(!last){{badge.textContent=String(ch.event_count||1);badge.classList.add("visible");return;}}fetch("/api/channel/"+encodeURIComponent(ch.name)+"/events?since_ts="+encodeURIComponent(last)).then(r=>r.json()).then(data=>{{const n=(data.events||[]).length;if(n>0){{badge.textContent=String(n);badge.classList.add("visible");}}else{{badge.classList.remove("visible");badge.textContent="";}}}}).catch(()=>{{badge.textContent="!";badge.classList.add("visible");}});}});}}
 function appendMeta(parent,ev,agent){{const meta=document.createElement("div");meta.className="message-meta";const name=document.createElement("span");name.className="agent-name "+agent;name.textContent=agent==="user"?"👤 user":agent;meta.appendChild(name);if(ev.from_model||ev.model){{const model=document.createElement("span");model.className="model-tag";model.textContent=ev.from_model||ev.model;meta.appendChild(model);}}const stamp=document.createElement("span");stamp.textContent=(ev.ts||ev.created_at||"").slice(0,19).replace("T"," ");meta.appendChild(stamp);parent.appendChild(meta);}}
@@ -533,9 +815,14 @@ function renderEvent(ev){{if(emptyState)emptyState.style.display="none";if(ev.ev
 function applyEvents(events,nextSince){{if(!events.length)return;const stick=isNearBottom();events.forEach(renderEvent);sinceId=Math.max(sinceId,nextSince||sinceId);lastEventType=events[events.length-1].event||"";lastNewEventAt=Date.now();document.getElementById("channelMeta").textContent=events.length+" new event"+(events.length===1?"":"s")+" · last "+timeAgo(events[events.length-1].ts);if(stick)messageList.scrollTop=messageList.scrollHeight;rememberVisited(selectedChannel);updateUnreadBadges();}}
 function schedulePoll(){{clearTimeout(pollTimer);pollTimer=setTimeout(poll,computePollDelayMs());document.getElementById("pollState").textContent="next poll "+computePollDelayMs()/1000+"s";}}
 function poll(){{if(!selectedChannel){{schedulePoll();return;}}const myFetchId=++currentFetchId;fetch("/api/channel/"+encodeURIComponent(selectedChannel)+"/events?since_event_id="+sinceId).then(r=>r.json()).then(data=>{{if(myFetchId!==currentFetchId)return;applyEvents(data.events||[],data.next_since_event_id);}}).catch(()=>{{if(myFetchId===currentFetchId)document.getElementById("pollState").textContent="API unavailable";}}).finally(()=>{{if(myFetchId===currentFetchId)schedulePoll();}});}}
-function chooseChannel(name){{selectedChannel=name;if(!selectedChannel&&channels.length)selectedChannel=channels[0].name;document.getElementById("channelTitle").textContent=selectedChannel?"# "+selectedChannel:"Agent Deliberations";postButton.disabled=!selectedChannel;resetMessages();rememberVisited(selectedChannel);renderSidebar();poll();}}
+function chooseChannel(name){{selectedChannel=name;if(!selectedChannel&&channels.length)selectedChannel=channels[0].name;document.getElementById("channelTitle").textContent=selectedChannel?"# "+selectedChannel:"Agent Deliberations";postButton.disabled=!selectedChannel;resetMessages();loadSummary();rememberVisited(selectedChannel);renderSidebar();poll();}}
 function loadChannels(){{fetch("/api/channels").then(r=>r.json()).then(data=>{{channels=data.channels||[];if(selectedChannel&&!channels.some(ch=>ch.name===selectedChannel))channels.unshift({{name:selectedChannel,event_count:0,last_event_ts:null,threads:[]}});renderSidebar();if(!hasBooted){{hasBooted=true;chooseChannel(selectedChannel);}}}}).catch(()=>{{document.getElementById("sidebarMeta").textContent="API unavailable";}});}}
 postForm.addEventListener("submit",ev=>{{ev.preventDefault();if(!selectedChannel)return;const body=postBody.value;if(!body.trim()){{formStatus.textContent="Body is required.";return;}}postButton.disabled=true;formStatus.textContent="Posting...";fetch("/api/channel/"+encodeURIComponent(selectedChannel)+"/post",{{method:"POST",headers:{{"Content-Type":"application/json"}},body:JSON.stringify({{body,from_agent:"user"}})}}).then(async r=>{{const data=await r.json();if(!r.ok)throw new Error(data.error||"post failed");postBody.value="";formStatus.textContent="Posted.";rememberVisited(selectedChannel);poll();loadChannels();}}).catch(err=>{{formStatus.textContent=err.message;}}).finally(()=>{{postButton.disabled=false;postBody.focus();}});}});
+document.querySelectorAll("[data-view-toggle]").forEach(btn=>btn.addEventListener("click",()=>setView(btn.dataset.viewToggle,true)));
+turnModalClose.addEventListener("click",closeTurnModal);
+turnModal.addEventListener("click",ev=>{{if(ev.target===turnModal)closeTurnModal();}});
+document.addEventListener("keydown",ev=>{{if(ev.key==="Escape"&&!turnModal.hidden)closeTurnModal();}});
+setView(currentView,false);
 loadChannels();
 </script>
 </body></html>"""
@@ -712,6 +999,21 @@ def route_channel_api_request(
             build_channel_threads_index(
                 repo_root,
                 list_channels_fn=list_channels,
+                resolve_bridge_db_path_fn=resolve_bridge_db_path_fn,
+                query_sqlite_rows_fn=query_sqlite_rows_fn,
+            ),
+            "application/json; charset=utf-8",
+        )
+    if path.startswith("/api/channel/") and path.endswith("/summary"):
+        raw_thread_id = path[len("/api/channel/") : -len("/summary")]
+        thread_id = unquote(raw_thread_id).strip("/")
+        if not thread_id:
+            return 400, {"error": "missing_thread_id"}, "application/json; charset=utf-8"
+        return (
+            200,
+            build_channel_thread_summary(
+                repo_root,
+                thread_id,
                 resolve_bridge_db_path_fn=resolve_bridge_db_path_fn,
                 query_sqlite_rows_fn=query_sqlite_rows_fn,
             ),

--- a/tests/test_channel_summary_fallback_to_chat.py
+++ b/tests/test_channel_summary_fallback_to_chat.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sqlite3
+import sys
+from pathlib import Path
+
+
+def _load_local_api():
+    module_path = Path(__file__).resolve().parent.parent / "scripts" / "local_api.py"
+    spec = importlib.util.spec_from_file_location("local_api_channel_summary_fallback", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+local_api = _load_local_api()
+
+
+def _use_bridge_db(monkeypatch, db_path: Path) -> None:
+    bridge_db = importlib.import_module("ai_agent_bridge._db")
+    monkeypatch.setenv("AB_DB_PATH", str(db_path))
+    monkeypatch.setattr(bridge_db, "DB_PATH", db_path)
+
+
+def _init_db(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE channel_messages (
+                message_id TEXT PRIMARY KEY,
+                channel TEXT NOT NULL,
+                thread_id TEXT NOT NULL,
+                parent_id TEXT,
+                correlation_id TEXT,
+                round_index INTEGER DEFAULT 0,
+                from_agent TEXT NOT NULL,
+                from_model TEXT,
+                kind TEXT DEFAULT 'post',
+                body TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            );
+            CREATE TABLE channel_events (
+                event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                delivery_id TEXT,
+                thread_id TEXT NOT NULL,
+                event TEXT NOT NULL,
+                payload_json TEXT,
+                ts TEXT NOT NULL
+            );
+            """
+        )
+    finally:
+        conn.commit()
+        conn.close()
+
+
+def test_summary_empty_or_all_null_votes_falls_back_to_chat_banner(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db_path = tmp_path / ".bridge" / "messages.db"
+    _use_bridge_db(monkeypatch, db_path)
+    _init_db(db_path)
+    thread_id = "thread-no-votes"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            INSERT INTO channel_messages (
+                message_id, channel, thread_id, round_index, from_agent,
+                from_model, kind, body, created_at
+            )
+            VALUES (
+                'm1', 'deliberation', ?, 1, 'claude',
+                'claude-opus-4-7', 'reply', 'No structured vote yet.',
+                '2026-05-07T10:01:00+00:00'
+            )
+            """,
+            (thread_id,),
+        )
+    finally:
+        conn.commit()
+        conn.close()
+
+    status, payload, _ = local_api.route_request(
+        tmp_path,
+        f"/api/channel/{thread_id}/summary",
+    )
+    assert status == 200
+    assert payload["status"] == "in_flight"
+    assert payload["rounds"][0]["turns"][0]["vote"] is None
+
+    status, empty_payload, _ = local_api.route_request(
+        tmp_path,
+        "/api/channel/empty-thread/summary",
+    )
+    assert status == 200
+    assert empty_payload["rounds"] == []
+    assert empty_payload["status"] == "in_flight"
+
+    status, body, content_type = local_api.route_request(
+        tmp_path,
+        f"/channels/{thread_id}?view=graph",
+    )
+    assert status == 200
+    assert "text/html" in content_type
+    assert "This thread has no structured votes" in body
+    assert 'data-view-toggle="chat">Chat</button>' in body
+    assert "function defaultViewForSummary(summary)" in body
+    assert 'summary.status==="converged"||summary.decision_id' in body

--- a/tests/test_channel_summary_parse_cost.py
+++ b/tests/test_channel_summary_parse_cost.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+
+def _load_local_api():
+    module_path = Path(__file__).resolve().parent.parent / "scripts" / "local_api.py"
+    spec = importlib.util.spec_from_file_location("local_api_channel_summary_cost", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+local_api = _load_local_api()
+
+
+def _use_bridge_db(monkeypatch, db_path: Path) -> None:
+    bridge_db = importlib.import_module("ai_agent_bridge._db")
+    monkeypatch.setenv("AB_DB_PATH", str(db_path))
+    monkeypatch.setattr(bridge_db, "DB_PATH", db_path)
+
+
+def _init_db(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE channel_messages (
+                message_id TEXT PRIMARY KEY,
+                channel TEXT NOT NULL,
+                thread_id TEXT NOT NULL,
+                parent_id TEXT,
+                correlation_id TEXT,
+                round_index INTEGER DEFAULT 0,
+                from_agent TEXT NOT NULL,
+                from_model TEXT,
+                kind TEXT DEFAULT 'post',
+                body TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            );
+            CREATE TABLE channel_events (
+                event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                delivery_id TEXT,
+                thread_id TEXT NOT NULL,
+                event TEXT NOT NULL,
+                payload_json TEXT,
+                ts TEXT NOT NULL
+            );
+            """
+        )
+    finally:
+        conn.commit()
+        conn.close()
+
+
+def test_summary_aggregates_model_cascade_cost_and_defaults_missing(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db_path = tmp_path / ".bridge" / "messages.db"
+    _use_bridge_db(monkeypatch, db_path)
+    _init_db(db_path)
+    thread_id = "thread-cost"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executemany(
+            """
+            INSERT INTO channel_messages (
+                message_id, channel, thread_id, round_index, from_agent,
+                from_model, kind, body, created_at
+            )
+            VALUES (?, 'deliberation', ?, 1, ?, 'model-x', 'reply', ?, ?)
+            """,
+            [
+                ("m1", thread_id, "claude", "First [OPTION A]", "2026-05-07T10:01:00+00:00"),
+                ("m2", thread_id, "codex", "Second [OPTION B]", "2026-05-07T10:02:00+00:00"),
+            ],
+        )
+        conn.executemany(
+            """
+            INSERT INTO channel_events (thread_id, event, payload_json, ts)
+            VALUES (?, 'model_cascade', ?, ?)
+            """,
+            [
+                (
+                    thread_id,
+                    json.dumps({"message_id": "m1", "cost_usd": 0.03, "elapsed_s": 10}),
+                    "2026-05-07T10:01:10+00:00",
+                ),
+                (
+                    thread_id,
+                    json.dumps({"message_id": "m1", "cost_usd": 0.02, "elapsed_s": 5}),
+                    "2026-05-07T10:01:15+00:00",
+                ),
+            ],
+        )
+    finally:
+        conn.commit()
+        conn.close()
+
+    status, payload, _ = local_api.route_request(
+        tmp_path,
+        f"/api/channel/{thread_id}/summary",
+    )
+
+    assert status == 200
+    turns = payload["rounds"][0]["turns"]
+    assert turns[0]["cost_usd"] == 0.05
+    assert turns[0]["elapsed_s"] == 15
+    assert turns[1]["cost_usd"] == 0
+    assert turns[1]["elapsed_s"] == 0
+    assert payload["rounds"][0]["cost_usd"] == 0.05
+    assert payload["total_cost_usd"] == 0.05
+    assert payload["total_elapsed_s"] == 15

--- a/tests/test_channel_summary_parse_rounds.py
+++ b/tests/test_channel_summary_parse_rounds.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sqlite3
+import sys
+from pathlib import Path
+
+
+def _load_local_api():
+    module_path = Path(__file__).resolve().parent.parent / "scripts" / "local_api.py"
+    spec = importlib.util.spec_from_file_location("local_api_channel_summary_rounds", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+local_api = _load_local_api()
+
+
+def _use_bridge_db(monkeypatch, db_path: Path) -> None:
+    bridge_db = importlib.import_module("ai_agent_bridge._db")
+    monkeypatch.setenv("AB_DB_PATH", str(db_path))
+    monkeypatch.setattr(bridge_db, "DB_PATH", db_path)
+
+
+def _init_db(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE channel_messages (
+                message_id TEXT PRIMARY KEY,
+                channel TEXT NOT NULL,
+                thread_id TEXT NOT NULL,
+                parent_id TEXT,
+                correlation_id TEXT,
+                round_index INTEGER DEFAULT 0,
+                from_agent TEXT NOT NULL,
+                from_model TEXT,
+                kind TEXT DEFAULT 'post',
+                body TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            );
+            CREATE TABLE channel_events (
+                event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                delivery_id TEXT,
+                thread_id TEXT NOT NULL,
+                event TEXT NOT NULL,
+                payload_json TEXT,
+                ts TEXT NOT NULL
+            );
+            """
+        )
+    finally:
+        conn.commit()
+        conn.close()
+
+
+def _insert_message(
+    db_path: Path,
+    message_id: str,
+    *,
+    thread_id: str,
+    round_index: int,
+    from_agent: str,
+    body: str,
+    created_at: str,
+) -> None:
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            INSERT INTO channel_messages (
+                message_id, channel, thread_id, round_index, from_agent,
+                from_model, kind, body, created_at
+            )
+            VALUES (?, 'deliberation', ?, ?, ?, 'model-x', 'reply', ?, ?)
+            """,
+            (message_id, thread_id, round_index, from_agent, body, created_at),
+        )
+    finally:
+        conn.commit()
+        conn.close()
+
+
+def test_summary_groups_messages_by_round_index_and_created_at(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db_path = tmp_path / ".bridge" / "messages.db"
+    _use_bridge_db(monkeypatch, db_path)
+    _init_db(db_path)
+    thread_id = "thread-rounds"
+
+    _insert_message(
+        db_path,
+        "m0",
+        thread_id=thread_id,
+        round_index=0,
+        from_agent="user",
+        body="Should we pick option A or B?",
+        created_at="2026-05-07T10:00:00+00:00",
+    )
+    _insert_message(
+        db_path,
+        "m2",
+        thread_id=thread_id,
+        round_index=1,
+        from_agent="codex",
+        body="Later turn [OPTION B]",
+        created_at="2026-05-07T10:02:00+00:00",
+    )
+    _insert_message(
+        db_path,
+        "m1",
+        thread_id=thread_id,
+        round_index=1,
+        from_agent="claude",
+        body="Earlier turn [OPTION A]",
+        created_at="2026-05-07T10:01:00+00:00",
+    )
+    _insert_message(
+        db_path,
+        "m3",
+        thread_id=thread_id,
+        round_index=2,
+        from_agent="gemini",
+        body="Final turn [AGREE]",
+        created_at="2026-05-07T10:03:00+00:00",
+    )
+
+    status, payload, _ = local_api.route_request(
+        tmp_path,
+        f"/api/channel/{thread_id}/summary",
+    )
+
+    assert status == 200
+    assert payload["subject"] == "Should we pick option A or B?"
+    assert [round_["round_idx"] for round_ in payload["rounds"]] == [1, 2]
+    assert [turn["agent"] for turn in payload["rounds"][0]["turns"]] == [
+        "claude",
+        "codex",
+    ]
+    assert payload["rounds"][0]["turns"][0]["message_id"] == "m1"

--- a/tests/test_channel_summary_parse_votes.py
+++ b/tests/test_channel_summary_parse_votes.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_channels_route():
+    module_path = (
+        Path(__file__).resolve().parent.parent
+        / "scripts"
+        / "local_api"
+        / "routes"
+        / "channels.py"
+    )
+    spec = importlib.util.spec_from_file_location("channels_route_vote_parse", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+channels_route = _load_channels_route()
+
+
+def test_vote_regex_extracts_last_structured_vote() -> None:
+    cases = [
+        ("I considered [OPTION B], but final is [AGREE]", "AGREE"),
+        ("Ship [OPTION A]", "OPTION A"),
+        ("Use the alternate [OPTION A′]", "OPTION A′"),
+        ("Pause this [DEFER]", "DEFER"),
+        ("Not ready [NEEDS-CHANGES]", "NEEDS-CHANGES"),
+        ("Not ready [NEEDS CHANGES]", "NEEDS CHANGES"),
+        ("No bracketed vote here", None),
+    ]
+
+    for body, expected in cases:
+        assert channels_route.extract_thread_vote(body) == expected


### PR DESCRIPTION
Closes #966.

ADR: docs/decisions/2026-05-07-deliberation-ui-roadmap.md

## Summary
- Adds `GET /api/channel/<thread_id>/summary` with server-side rounds, vote extraction, status, decision-link scan, and model_cascade cost/elapsed totals.
- Adds the Decision Graph view to `/channels/<thread_id>` with Chat/Graph toggle, conditional default, no-vote fallback banner, and a body modal that closes via X, Escape, or backdrop.
- Adds four focused regression files for round grouping/order, vote parsing, cost aggregation/defaults, and fallback-to-chat behavior.

## LOC delta
- `scripts/local_api/routes/channels.py`: +320 / -9
- `tests/test_channel_summary_parse_rounds.py`: +148
- `tests/test_channel_summary_parse_votes.py`: +39
- `tests/test_channel_summary_parse_cost.py`: +122
- `tests/test_channel_summary_fallback_to_chat.py`: +116
- Total: 5 files, +736 / -9

## Validation
- `.venv/bin/ruff check scripts/local_api/routes/channels.py tests/test_channel_summary_parse_rounds.py tests/test_channel_summary_parse_votes.py tests/test_channel_summary_parse_cost.py tests/test_channel_summary_fallback_to_chat.py` — pass
- `.venv/bin/pytest tests/test_local_api*.py tests/test_bridge_channels.py tests/test_channels_d0.py tests/test_ai_agent_bridge_channel_watch.py tests/test_ab_post_writes_message_posted_event.py tests/test_channel_rollup_works_without_events.py tests/test_channel_post_endpoint.py tests/test_channel_delta_render.py tests/test_channel_poll_cadence.py tests/test_channel_summary_parse_rounds.py tests/test_channel_summary_parse_votes.py tests/test_channel_summary_parse_cost.py tests/test_channel_summary_fallback_to_chat.py -q --timeout=60` — 257 passed
- `.venv/bin/python scripts/test_pipeline.py` — 166 tests OK
- `git diff --check` — pass

Note: the broader requested ruff command, `.venv/bin/ruff check scripts/local_api scripts/ai_agent_bridge tests`, still fails on pre-existing unrelated files (`tests/test_bridge_channels.py`, `tests/test_detect_uk_divergence.py`, `tests/test_codex_report.py`, `tests/test_run_388_batch.py`, `tests/test_worktree_brief.py`). Changed-file ruff is clean.

## Live smoke
- `GET /api/channel/a82ab60b4ce1457aa450f18dac7e8a54/summary` returned `status: "converged"` and `decision_id: "docs/decisions/2026-05-07-deliberation-ui-roadmap.md"`.
- The same payload normalized the stored duplicate-agent batch into 3 display rounds; final round votes are claude/codex/gemini `[AGREE]`.
- `/channels/a82ab60b4ce1457aa450f18dac7e8a54` returned 200 with graph/toggle/modal markers.
- `/channels/a82ab60b4ce1457aa450f18dac7e8a54?view=graph` returned 200 with graph/toggle/modal markers.
- Conditional default is server-payload driven in JS: converged or linked-decision threads default to Graph; in-flight/no-vote threads default to Chat unless `?view=graph` is explicit.