### PR TITLE
feat(local-api): D5 — AFK-notify on decision card emission (#969)

### DIFF
--- a/scripts/local_api/routes/channels.py
+++ b/scripts/local_api/routes/channels.py
@@ -8,6 +8,14 @@ from pathlib import Path
 from typing import Any, Callable
 from urllib.parse import parse_qs, unquote
 
+try:
+    from local_api.routes.ui_fragments import AFK_NOTIFY_CSS, render_afk_notify_markup
+except ModuleNotFoundError:
+    from scripts.local_api.routes.ui_fragments import (
+        AFK_NOTIFY_CSS,
+        render_afk_notify_markup,
+    )
+
 
 RouteResponse = tuple[int, Any, str]
 _POST_DB_LOCK = _threading.Lock()
@@ -648,6 +656,7 @@ def render_channels_chat_html(
     .sidebar-title{{font-size:11px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);padding:4px 10px 10px}}
     .channel-link{{display:grid;grid-template-columns:minmax(0,1fr) auto;gap:8px;align-items:center;color:var(--text);text-decoration:none;border-radius:6px;padding:7px 10px;font-size:13px;min-height:34px}}
     .channel-link:hover,.channel-link.active{{background:var(--panel-2)}}
+{AFK_NOTIFY_CSS}
     .channel-name{{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}}
     .unread-badge{{display:none;min-width:18px;padding:1px 6px;border-radius:999px;background:var(--orange);color:#16120a;font-size:11px;font-weight:800;text-align:center}}
     .unread-badge.visible{{display:inline-block}}
@@ -727,6 +736,7 @@ def render_channels_chat_html(
 </head>
 <body>
 {render_top_nav_fn("channels")}
+{render_afk_notify_markup()}
 <div class="channels-app" data-selected-channel="{_html.escape(selected_channel or "", quote=True)}">
   <nav class="channels-sidebar" aria-label="Channels">
     <div class="sidebar-title">Channels</div>

--- a/scripts/local_api/routes/decisions.py
+++ b/scripts/local_api/routes/decisions.py
@@ -13,6 +13,14 @@ from pathlib import Path
 from typing import Any, Callable
 from urllib.parse import unquote
 
+try:
+    from local_api.routes.ui_fragments import AFK_NOTIFY_CSS, render_afk_notify_markup
+except ModuleNotFoundError:
+    from scripts.local_api.routes.ui_fragments import (
+        AFK_NOTIFY_CSS,
+        render_afk_notify_markup,
+    )
+
 
 RouteResponse = tuple[int, Any, str]
 _THREAD_ID_RE = _re.compile(r"\b[a-f0-9]{32}\b", _re.IGNORECASE)
@@ -332,6 +340,7 @@ def build_pending_decisions(repo_root: Path) -> dict[str, Any]:
             except OSError:
                 continue
             status = _status_for_path(rel, mtime)
+            is_stale = status == "stale"
             if status == "stale":
                 stale += 1
             else:
@@ -342,6 +351,7 @@ def build_pending_decisions(repo_root: Path) -> dict[str, Any]:
                     "decision_path": rel,
                     "status": status,
                     "mtime": mtime,
+                    "is_stale": is_stale,
                 }
             )
     return {"pending": pending, "stale": stale, "files": files}
@@ -372,8 +382,9 @@ def render_decisions_index_html(
 
     rows = []
     for item in decisions:
+        row_id = "card-" + str(item["filename"])
         rows.append(
-            "<tr>"
+            f'<tr class="decision-card" id="{_html.escape(row_id, quote=True)}">'
             f'<td><a href="{_html.escape(str(item["href"]), quote=True)}">{_html.escape(str(item["title"]))}</a>'
             f'<span>{_html.escape(str(item["decision_path"]))}</span></td>'
             f'<td>{_html.escape(str(item["date"]))}</td>'
@@ -400,6 +411,7 @@ def render_decisions_index_html(
     .meta{{color:var(--muted);font-size:13px;margin-top:4px}}
     .banner{{border:1px solid rgba(245,158,11,.55);background:rgba(245,158,11,.11);color:#f8d9a0;border-radius:6px;padding:12px 14px;margin-bottom:16px;font-weight:750}}
     .banner.stale{{border-color:rgba(251,113,133,.65);background:rgba(251,113,133,.11);color:#fecdd3}}
+{AFK_NOTIFY_CSS}
     table{{width:100%;border-collapse:collapse;background:var(--panel);border:1px solid var(--line);border-radius:8px;overflow:hidden}}
     th,td{{padding:11px 12px;border-bottom:1px solid var(--line);text-align:left;font-size:13px;vertical-align:middle}}
     th{{background:#121416;color:var(--muted);font-size:10px;text-transform:uppercase;letter-spacing:.06em}}
@@ -411,6 +423,8 @@ def render_decisions_index_html(
     .status-badge.decided{{background:rgba(85,209,127,.13);color:#9ef0b7}}
     .status-badge.pending{{background:rgba(245,158,11,.14);color:#f8d9a0}}
     .status-badge.stale{{background:rgba(251,113,133,.14);color:#fecdd3}}
+    tr.decision-card:target{{animation:decision-target-highlight 3s ease-out}}
+    @keyframes decision-target-highlight{{0%,70%{{outline:2px solid #fde047;background:rgba(253,224,71,.16)}}100%{{outline:2px solid transparent;background:transparent}}}}
     .empty{{color:var(--muted);text-align:center;padding:30px}}
     @media(max-width:760px){{.page-head{{align-items:flex-start;flex-direction:column}}table{{display:block;overflow:auto}}}}
   </style>
@@ -427,6 +441,7 @@ def render_decisions_index_html(
     <tbody>{body_rows}</tbody>
   </table>
 </main>
+{render_afk_notify_markup()}
 </body>
 </html>"""
 

--- a/scripts/local_api/routes/ui_fragments.py
+++ b/scripts/local_api/routes/ui_fragments.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+
+AFK_NOTIFY_CSS = """
+    .afk-notify{position:fixed;right:18px;bottom:18px;z-index:30;display:flex;align-items:center;gap:10px;max-width:min(440px,calc(100vw - 36px));border:1px solid rgba(61,214,198,.5);background:#121416;color:var(--text);border-radius:6px;padding:10px 12px;box-shadow:0 18px 60px rgba(0,0,0,.4);font-size:13px}
+    .afk-notify[hidden]{display:none}
+    .afk-notify span{color:var(--text);font-size:13px;margin:0}
+    .afk-notify button{border:1px solid var(--line);border-radius:5px;background:var(--panel-2);color:var(--text);padding:6px 9px;font-size:12px;font-weight:800;cursor:pointer;white-space:nowrap}
+    .afk-notify button:first-of-type{background:var(--teal);border-color:var(--teal);color:#071211}
+"""
+
+
+def render_afk_notify_markup() -> str:
+    return """
+<div class="afk-notify" id="afk-notify" hidden>
+  <span>Get notified when decisions need your call</span>
+  <button type="button" id="afk-notify-enable">Enable</button>
+  <button type="button" id="afk-notify-dismiss">Not now</button>
+</div>
+<script>
+(() => {
+  const OPT_OUT = "kdjo_notify_optout";
+  const SNAPSHOT = "kdjo_pending_files";
+  const POLL_MS = 60000;
+  const banner = document.getElementById("afk-notify");
+  const enable = document.getElementById("afk-notify-enable");
+  const dismiss = document.getElementById("afk-notify-dismiss");
+  const supported = "Notification" in window;
+  const optedOut = () => localStorage.getItem(OPT_OUT) === "1";
+  function readSnapshot() {
+    try {
+      const parsed = JSON.parse(localStorage.getItem(SNAPSHOT) || "[]");
+      if (Array.isArray(parsed)) {
+        return new Map(parsed.map(item => {
+          if (typeof item === "string") return [item, {is_stale: false}];
+          return [String(item.filename || ""), {is_stale: !!item.is_stale}];
+        }).filter(([name]) => name));
+      }
+      return new Map(Object.entries(parsed || {}).map(([name, state]) => [
+        String(name),
+        {is_stale: !!(state && state.is_stale)}
+      ]));
+    } catch {
+      return new Map();
+    }
+  }
+  function writeSnapshot(files) {
+    const snapshot = files
+      .filter(file => file && file.filename)
+      .map(file => ({filename: String(file.filename), is_stale: !!file.is_stale}));
+    localStorage.setItem(SNAPSHOT, JSON.stringify(snapshot));
+  }
+  function ageLabel(file) {
+    if (file.is_stale) return "stale (>24h)";
+    const age = Math.max(0, Math.floor((Date.now() - Number(file.mtime || 0) * 1000) / 1000));
+    if (age < 60) return age + "s ago";
+    if (age < 3600) return Math.floor(age / 60) + "m ago";
+    if (age < 86400) return Math.floor(age / 3600) + "h ago";
+    return Math.floor(age / 86400) + "d ago";
+  }
+  function suppressNotifications() {
+    return document.visibilityState === "visible" && window.location.pathname === "/decisions";
+  }
+  function notify(title, file) {
+    if (!supported || optedOut() || Notification.permission !== "granted" || suppressNotifications()) return;
+    const notification = new Notification(title, {
+      body: file.filename + " — " + ageLabel(file),
+      tag: "kdjo-decision-" + file.filename
+    });
+    notification.onclick = () => {
+      window.focus();
+      window.location.href = "/decisions#card-" + encodeURIComponent(file.filename);
+      notification.close();
+    };
+  }
+  async function pollPendingDecisions() {
+    if (optedOut()) return;
+    try {
+      const res = await fetch("/api/decisions/pending", {cache: "no-store"});
+      if (!res.ok) return;
+      const data = await res.json();
+      const files = Array.isArray(data.files) ? data.files : [];
+      const previous = readSnapshot();
+      files.forEach(file => {
+        if (!file || !file.filename) return;
+        const before = previous.get(String(file.filename));
+        if (!before) notify("Decision pending", file);
+        else if (!before.is_stale && file.is_stale) notify("Decision stale", file);
+      });
+      writeSnapshot(files);
+    } catch {
+      // Local monitor pages should stay quiet when the API is unavailable.
+    }
+  }
+  function maybeShowBanner() {
+    if (!banner || !supported || optedOut() || Notification.permission !== "default") return;
+    banner.hidden = false;
+  }
+  enable?.addEventListener("click", async () => {
+    if (!supported || optedOut()) return;
+    banner.hidden = true;
+    await Notification.requestPermission();
+    await pollPendingDecisions();
+  });
+  dismiss?.addEventListener("click", () => {
+    localStorage.setItem(OPT_OUT, "1");
+    if (banner) banner.hidden = true;
+  });
+  maybeShowBanner();
+  pollPendingDecisions();
+  setInterval(pollPendingDecisions, POLL_MS);
+})();
+</script>"""

--- a/tests/test_decision_card_anchor.py
+++ b/tests/test_decision_card_anchor.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_decisions_module():
+    module_path = (
+        Path(__file__).resolve().parent.parent
+        / "scripts"
+        / "local_api"
+        / "routes"
+        / "decisions.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "local_api_decision_card_anchor",
+        module_path,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+decisions = _load_decisions_module()
+
+
+def test_decisions_index_rows_have_card_ids_and_target_css(tmp_path: Path) -> None:
+    decisions_dir = tmp_path / "docs" / "decisions"
+    pending_dir = decisions_dir / "pending"
+    pending_dir.mkdir(parents=True)
+    decided = decisions_dir / "2026-05-08-decided.md"
+    pending = pending_dir / "2026-05-08-pending.md"
+    decided.write_text("# Decided\n", encoding="utf-8")
+    pending.write_text("# Pending\n", encoding="utf-8")
+
+    html = decisions.render_decisions_index_html(
+        tmp_path,
+        top_nav_css="",
+        render_top_nav_fn=lambda active: f"<nav>{active}</nav>",
+    )
+
+    assert 'id="card-2026-05-08-decided.md"' in html
+    assert 'id="card-2026-05-08-pending.md"' in html
+    assert "tr.decision-card:target" in html
+    assert "@keyframes decision-target-highlight" in html

--- a/tests/test_decision_pending_endpoint_shape.py
+++ b/tests/test_decision_pending_endpoint_shape.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import time
+from pathlib import Path
+
+
+def _load_decisions_module():
+    module_path = (
+        Path(__file__).resolve().parent.parent
+        / "scripts"
+        / "local_api"
+        / "routes"
+        / "decisions.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "local_api_decision_pending_endpoint_shape",
+        module_path,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+decisions = _load_decisions_module()
+
+
+def test_pending_endpoint_returns_mtime_and_is_stale(tmp_path: Path) -> None:
+    pending_dir = tmp_path / "docs" / "decisions" / "pending"
+    pending_dir.mkdir(parents=True)
+    fresh = pending_dir / "2026-05-08-fresh.md"
+    old = pending_dir / "2026-05-07-old.md"
+    fresh.write_text("# Fresh\n", encoding="utf-8")
+    old.write_text("# Old\n", encoding="utf-8")
+    old_mtime = time.time() - (25 * 3600)
+    os.utime(old, (old_mtime, old_mtime))
+
+    status, payload, content_type = decisions.route_decision_api_request(
+        tmp_path,
+        "/api/decisions/pending",
+    )
+
+    assert status == 200
+    assert "application/json" in content_type
+    assert payload["pending"] == 1
+    assert payload["stale"] == 1
+    files = {item["filename"]: item for item in payload["files"]}
+    assert set(files) == {"2026-05-08-fresh.md", "2026-05-07-old.md"}
+    assert isinstance(files["2026-05-08-fresh.md"]["mtime"], float)
+    assert isinstance(files["2026-05-07-old.md"]["mtime"], float)
+    assert files["2026-05-08-fresh.md"]["is_stale"] is False
+    assert files["2026-05-07-old.md"]["is_stale"] is True


### PR DESCRIPTION
Closes #969

Summary:
- Adds a shared AFK notification banner/poller to /channels and /decisions using the Browser Notification API.
- Adds decision card anchors and :target highlight CSS for notification click-through.
- Extends /api/decisions/pending file entries with is_stale while preserving mtime/status.
- Adds endpoint shape and decision-card anchor regression tests.

Validation:
- .venv/bin/ruff check scripts/local_api scripts/ai_agent_bridge tests/test_decision*.py tests/test_channel*.py
- .venv/bin/pytest tests/test_local_api*.py tests/test_bridge_channels.py tests/test_channels_d0.py tests/test_ai_agent_bridge_channel_watch.py tests/test_ab_post_writes_message_posted_event.py tests/test_channel_rollup_works_without_events.py tests/test_channel_post_endpoint.py tests/test_channel_delta_render.py tests/test_channel_poll_cadence.py tests/test_channel_summary_parse_rounds.py tests/test_channel_summary_parse_votes.py tests/test_channel_summary_parse_cost.py tests/test_channel_summary_fallback_to_chat.py tests/test_decision_lineage_resolves.py tests/test_decision_stale_detection.py tests/test_decision_lineage_cache.py tests/test_channel_keyboard_nav.py tests/test_decision_pending_endpoint_shape.py tests/test_decision_card_anchor.py -q --timeout=60
- .venv/bin/python scripts/test_pipeline.py
- Live smoke on 127.0.0.1:8778 for /decisions, /channels, and /api/decisions/pending

Notes:
- npm run build skipped: no src/content/docs or Astro config changes.
- Generated runtime artifacts were not staged.
- Requires independent-family review before merge.