### PR TITLE
feat(local-api): D6 — FTS5 search across channels + decisions (closes #970)

### DIFF
--- a/scripts/ai_agent_bridge/_db.py
+++ b/scripts/ai_agent_bridge/_db.py
@@ -20,6 +20,7 @@ import sqlite3
 from datetime import UTC, datetime
 
 from ._config import DB_PATH
+from ._fts import setup_fts_tables
 
 # ── Schema definitions ─────────────────────────────────────────────────
 # Kept at module scope so tests and tooling can import them.
@@ -169,6 +170,7 @@ def init_db():
     conn.executescript(_LEGACY_SCHEMA)
     conn.executescript(_CHANNELS_SCHEMA)
     conn.executescript(_CHANNEL_EVENTS_SCHEMA)
+    setup_fts_tables(conn)
     conn.commit()
     return conn
 
@@ -273,6 +275,7 @@ def get_db():
                         """
                     )
 
+        setup_fts_tables(conn)
         conn.commit()
     except Exception:
         conn.rollback()

--- a/scripts/ai_agent_bridge/_fts.py
+++ b/scripts/ai_agent_bridge/_fts.py
@@ -1,0 +1,128 @@
+"""FTS5 setup for bridge-backed local API search."""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+_CHANNEL_MESSAGES_FTS_SCHEMA = """
+CREATE VIRTUAL TABLE IF NOT EXISTS channel_messages_fts USING fts5(
+    body,
+    channel UNINDEXED,
+    thread_id UNINDEXED,
+    message_id UNINDEXED,
+    from_agent UNINDEXED,
+    created_at UNINDEXED,
+    content='channel_messages',
+    content_rowid='rowid'
+);
+
+CREATE TRIGGER IF NOT EXISTS channel_messages_fts_ins
+AFTER INSERT ON channel_messages
+BEGIN
+    INSERT INTO channel_messages_fts(
+        rowid, body, channel, thread_id, message_id, from_agent, created_at
+    )
+    VALUES (
+        new.rowid, new.body, new.channel, new.thread_id,
+        new.message_id, new.from_agent, new.created_at
+    );
+END;
+
+CREATE TRIGGER IF NOT EXISTS channel_messages_fts_del
+AFTER DELETE ON channel_messages
+BEGIN
+    INSERT INTO channel_messages_fts(
+        channel_messages_fts, rowid, body, channel, thread_id,
+        message_id, from_agent, created_at
+    )
+    VALUES (
+        'delete', old.rowid, old.body, old.channel, old.thread_id,
+        old.message_id, old.from_agent, old.created_at
+    );
+END;
+
+CREATE TRIGGER IF NOT EXISTS channel_messages_fts_upd
+AFTER UPDATE ON channel_messages
+BEGIN
+    INSERT INTO channel_messages_fts(
+        channel_messages_fts, rowid, body, channel, thread_id,
+        message_id, from_agent, created_at
+    )
+    VALUES (
+        'delete', old.rowid, old.body, old.channel, old.thread_id,
+        old.message_id, old.from_agent, old.created_at
+    );
+    INSERT INTO channel_messages_fts(
+        rowid, body, channel, thread_id, message_id, from_agent, created_at
+    )
+    VALUES (
+        new.rowid, new.body, new.channel, new.thread_id,
+        new.message_id, new.from_agent, new.created_at
+    );
+END;
+"""
+
+_DECISIONS_FTS_SCHEMA = """
+CREATE VIRTUAL TABLE IF NOT EXISTS decisions_fts USING fts5(
+    title,
+    body,
+    filename UNINDEXED,
+    mtime UNINDEXED,
+    status UNINDEXED
+);
+"""
+
+
+def _object_exists(conn: sqlite3.Connection, object_type: str, name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = ? AND name = ? LIMIT 1",
+        (object_type, name),
+    ).fetchone()
+    return row is not None
+
+
+def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
+    return _object_exists(conn, "table", name)
+
+
+def _channel_fts_indexed_count(conn: sqlite3.Connection) -> int:
+    if not _table_exists(conn, "channel_messages_fts_docsize"):
+        return 0
+    row = conn.execute("SELECT COUNT(*) FROM channel_messages_fts_docsize").fetchone()
+    return int(row[0] if row else 0)
+
+
+def setup_channel_messages_fts(conn: sqlite3.Connection) -> None:
+    """Create and backfill the channel message FTS index if possible."""
+    if not _table_exists(conn, "channel_messages"):
+        return
+
+    created = not _table_exists(conn, "channel_messages_fts")
+    triggers_missing = any(
+        not _object_exists(conn, "trigger", name)
+        for name in (
+            "channel_messages_fts_ins",
+            "channel_messages_fts_del",
+            "channel_messages_fts_upd",
+        )
+    )
+    if created or triggers_missing:
+        conn.executescript(_CHANNEL_MESSAGES_FTS_SCHEMA)
+
+    source_count_row = conn.execute("SELECT COUNT(*) FROM channel_messages").fetchone()
+    source_count = int(source_count_row[0] if source_count_row else 0)
+    if source_count and (created or _channel_fts_indexed_count(conn) == 0):
+        conn.execute("INSERT INTO channel_messages_fts(channel_messages_fts) VALUES ('rebuild')")
+
+
+def setup_decisions_fts(conn: sqlite3.Connection) -> None:
+    """Create the filesystem-backed decision-card FTS index."""
+    if not _table_exists(conn, "decisions_fts"):
+        conn.executescript(_DECISIONS_FTS_SCHEMA)
+
+
+def setup_fts_tables(conn: sqlite3.Connection) -> None:
+    """Idempotently install all FTS tables used by the local API."""
+    setup_channel_messages_fts(conn)
+    setup_decisions_fts(conn)

--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -54,8 +54,24 @@ def _load_decision_routes_module() -> Any:
     return module
 
 
+def _load_search_routes_module() -> Any:
+    module_name = "_local_api_routes_search"
+    loaded = sys.modules.get(module_name)
+    if loaded is not None:
+        return loaded
+    module_path = Path(__file__).resolve().with_name("local_api") / "routes" / "search.py"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load search routes from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
 _CHANNEL_ROUTES = _load_channel_routes_module()
 _DECISION_ROUTES = _load_decision_routes_module()
+_SEARCH_ROUTES = _load_search_routes_module()
 
 # Heavy imports (pipeline_v2, status, translation_v2, ztt_status) are deferred
 # into the handlers that actually need them. Measured: moving these out of the
@@ -7081,6 +7097,7 @@ def build_api_schema() -> dict[str, Any]:
             {"path": "/api/decisions", "desc": "List decision files with status and lineage counts"},
             {"path": "/api/decisions/pending", "desc": "Pending/stale decision count for cold-start agents"},
             {"path": "/api/decision/{filename}/lineage", "desc": "Decision lineage scanner result"},
+            {"path": "/api/search", "desc": "FTS5 search across channel messages and decision cards"},
             {"path": "/api/quality/scores", "desc": "Live heuristic rubric scores from current English module files"},
             {
                 "path": "/api/quality/board",
@@ -7446,6 +7463,14 @@ def route_request(repo_root: Path, raw_path: str) -> tuple[int, Any, str]:
         except (TypeError, ValueError):
             limit = 100
         return 200, build_bridge_messages(repo_root, since, limit), "application/json; charset=utf-8"
+    search_api = _SEARCH_ROUTES.route_search_request(
+        repo_root,
+        path,
+        query,
+        bridge_db_path=_resolve_bridge_db_path(repo_root),
+    )
+    if search_api is not None:
+        return search_api
     decision_api = _DECISION_ROUTES.route_decision_api_request(repo_root, path)
     if decision_api is not None:
         return decision_api

--- a/scripts/local_api/routes/channels.py
+++ b/scripts/local_api/routes/channels.py
@@ -9,11 +9,16 @@ from typing import Any, Callable
 from urllib.parse import parse_qs, unquote
 
 try:
-    from local_api.routes.ui_fragments import AFK_NOTIFY_CSS, render_afk_notify_markup
+    from local_api.routes.ui_fragments import (
+        AFK_NOTIFY_CSS,
+        render_afk_notify_markup,
+        render_search_widget,
+    )
 except ModuleNotFoundError:
     from scripts.local_api.routes.ui_fragments import (
         AFK_NOTIFY_CSS,
         render_afk_notify_markup,
+        render_search_widget,
     )
 
 
@@ -736,6 +741,7 @@ def render_channels_chat_html(
 </head>
 <body>
 {render_top_nav_fn("channels")}
+{render_search_widget()}
 {render_afk_notify_markup()}
 <div class="channels-app" data-selected-channel="{_html.escape(selected_channel or "", quote=True)}">
   <nav class="channels-sidebar" aria-label="Channels">

--- a/scripts/local_api/routes/decisions.py
+++ b/scripts/local_api/routes/decisions.py
@@ -5,6 +5,7 @@ import hashlib
 import json as _json
 import os
 import re as _re
+import sqlite3
 import subprocess
 import threading
 import time
@@ -14,11 +15,18 @@ from typing import Any, Callable
 from urllib.parse import unquote
 
 try:
-    from local_api.routes.ui_fragments import AFK_NOTIFY_CSS, render_afk_notify_markup
+    from ai_agent_bridge._fts import setup_decisions_fts
+    from local_api.routes.ui_fragments import (
+        AFK_NOTIFY_CSS,
+        render_afk_notify_markup,
+        render_search_widget,
+    )
 except ModuleNotFoundError:
+    from scripts.ai_agent_bridge._fts import setup_decisions_fts
     from scripts.local_api.routes.ui_fragments import (
         AFK_NOTIFY_CSS,
         render_afk_notify_markup,
+        render_search_widget,
     )
 
 
@@ -32,6 +40,8 @@ _SAFE_DECISION_FILENAME_RE = _re.compile(r"^[A-Za-z0-9._-]+\.md$")
 _STALE_SECONDS = 24 * 3600
 _CACHE_VERSION = 6
 _CACHE_LOCK = threading.Lock()
+_DECISIONS_FTS_LOCK = threading.Lock()
+_DECISIONS_FTS_META: dict[str, dict[str, float]] = {}
 
 
 def _json_response(status: int, payload: dict[str, Any]) -> RouteResponse:
@@ -270,6 +280,10 @@ def _decision_files(repo_root: Path) -> list[Path]:
     return files
 
 
+def _bridge_db_path(repo_root: Path) -> Path:
+    return repo_root / ".bridge" / "messages.db"
+
+
 def _decision_title(body: str, filename: str) -> str:
     for line in body.splitlines():
         stripped = line.strip()
@@ -283,6 +297,77 @@ def _decision_date(body: str, filename: str) -> str:
     if match:
         return match.group(1).strip()
     return filename[:10] if len(filename) >= 10 else ""
+
+
+def _refresh_decisions_fts(
+    repo_root: Path,
+    *,
+    db_path: Path | None = None,
+    create_db: bool = True,
+) -> dict[str, Any]:
+    """Refresh changed decision markdown rows in ``decisions_fts``."""
+    target_db = db_path or _bridge_db_path(repo_root)
+    if not create_db and not target_db.exists():
+        return {"scanned": 0, "updated": [], "deleted": []}
+
+    files = _decision_files(repo_root)
+    current_names = {path.name for path in files}
+    cache_key = f"{repo_root.resolve()}::{target_db.resolve()}"
+
+    with _DECISIONS_FTS_LOCK:
+        target_db.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(target_db)
+        try:
+            setup_decisions_fts(conn)
+            meta = _DECISIONS_FTS_META.setdefault(cache_key, {})
+            updated: list[str] = []
+            deleted: list[str] = []
+            existing_names = {
+                str(row[0])
+                for row in conn.execute("SELECT filename FROM decisions_fts").fetchall()
+            }
+
+            for filename in sorted((set(meta) | existing_names) - current_names):
+                conn.execute("DELETE FROM decisions_fts WHERE filename = ?", (filename,))
+                meta.pop(filename, None)
+                deleted.append(filename)
+
+            for path in files:
+                try:
+                    mtime = path.stat().st_mtime
+                except OSError:
+                    continue
+                filename = path.name
+                if meta.get(filename) == mtime:
+                    continue
+                try:
+                    body = path.read_text(encoding="utf-8")
+                    rel = path.relative_to(repo_root).as_posix()
+                except OSError:
+                    continue
+                conn.execute("DELETE FROM decisions_fts WHERE filename = ?", (filename,))
+                conn.execute(
+                    """
+                    INSERT INTO decisions_fts(title, body, filename, mtime, status)
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (
+                        _decision_title(body, filename),
+                        body,
+                        filename,
+                        repr(mtime),
+                        _status_for_path(rel, mtime),
+                    ),
+                )
+                meta[filename] = mtime
+                updated.append(filename)
+            conn.commit()
+            return {"scanned": len(files), "updated": updated, "deleted": deleted}
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
 
 
 def build_decisions_index(repo_root: Path) -> dict[str, Any]:
@@ -431,6 +516,7 @@ def render_decisions_index_html(
 </head>
 <body>
 {render_top_nav_fn("decisions")}
+{render_search_widget()}
 <main>
   <div class="page-head">
     <div><h1>Decisions</h1><div class="meta">{int(counts["total"])} total · {int(counts["decided"])} decided · {int(counts["pending"])} pending · {int(counts["stale"])} stale</div></div>
@@ -444,6 +530,12 @@ def render_decisions_index_html(
 {render_afk_notify_markup()}
 </body>
 </html>"""
+
+
+try:
+    _refresh_decisions_fts(Path(__file__).resolve().parents[3], create_db=False)
+except Exception:
+    pass
 
 
 def _render_markdownish(body: str) -> str:

--- a/scripts/local_api/routes/search.py
+++ b/scripts/local_api/routes/search.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import html as _html
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any
+
+try:
+    from ai_agent_bridge._fts import setup_fts_tables
+    from local_api.routes.decisions import _refresh_decisions_fts
+except ModuleNotFoundError:
+    from scripts.ai_agent_bridge._fts import setup_fts_tables
+    from scripts.local_api.routes.decisions import _refresh_decisions_fts
+
+
+RouteResponse = tuple[int, Any, str]
+_VALID_KINDS = {"channels", "decisions", "all"}
+_MARK_START = "__KDJO_MARK_START__"
+_MARK_END = "__KDJO_MARK_END__"
+
+
+def _json_response(status: int, payload: dict[str, Any]) -> RouteResponse:
+    return status, payload, "application/json; charset=utf-8"
+
+
+def _safe_snippet(value: str | None) -> str:
+    if not value:
+        return ""
+    marked = value.replace("<mark>", _MARK_START).replace("</mark>", _MARK_END)
+    escaped = _html.escape(marked)
+    return escaped.replace(_MARK_START, "<mark>").replace(_MARK_END, "</mark>")
+
+
+def _sanitize_fts_query(raw: str) -> str | None:
+    query = " ".join(raw.replace("\x00", " ").split()).strip()
+    query = query.lstrip("*^").strip()
+    if not query:
+        return None
+
+    terms: list[str] = []
+    for token in query.split():
+        cleaned = token.lstrip("*^").strip()
+        if not cleaned or not any(char.isalnum() for char in cleaned):
+            continue
+        terms.append(f'"{cleaned.replace("\"", "\"\"")}"')
+    return " ".join(terms) if terms else None
+
+
+def _parse_limit(query: dict[str, list[str]]) -> tuple[int | None, str | None]:
+    raw = query.get("limit", ["20"])[0]
+    try:
+        limit = int(raw)
+    except (TypeError, ValueError):
+        return None, "invalid_limit"
+    if limit < 1 or limit > 100:
+        return None, "invalid_limit"
+    return limit, None
+
+
+def _ensure_fts(conn: sqlite3.Connection) -> None:
+    setup_fts_tables(conn)
+    conn.commit()
+
+
+def _query_channel_results(
+    conn: sqlite3.Connection,
+    fts_query: str,
+    *,
+    limit: int,
+) -> list[dict[str, Any]]:
+    try:
+        rows = conn.execute(
+            """
+            SELECT
+              channel,
+              thread_id,
+              message_id,
+              from_agent,
+              snippet(channel_messages_fts, 0, '<mark>', '</mark>', '...', 18) AS snippet,
+              bm25(channel_messages_fts) AS rank
+            FROM channel_messages_fts
+            WHERE channel_messages_fts MATCH ?
+            ORDER BY rank ASC
+            LIMIT ?
+            """,
+            (fts_query, limit),
+        ).fetchall()
+    except sqlite3.OperationalError as exc:
+        if "no such table" in str(exc):
+            return []
+        raise
+    return [
+        {
+            "kind": "channel",
+            "channel": row["channel"],
+            "thread_id": row["thread_id"],
+            "message_id": row["message_id"],
+            "from_agent": row["from_agent"],
+            "snippet": _safe_snippet(row["snippet"]),
+            "rank": float(row["rank"]),
+            "url": f"/channels/{row['thread_id']}",
+        }
+        for row in rows
+    ]
+
+
+def _query_decision_results(
+    conn: sqlite3.Connection,
+    fts_query: str,
+    *,
+    limit: int,
+) -> list[dict[str, Any]]:
+    rows = conn.execute(
+        """
+        SELECT
+          title,
+          filename,
+          snippet(decisions_fts, -1, '<mark>', '</mark>', '...', 18) AS snippet,
+          bm25(decisions_fts) AS rank
+        FROM decisions_fts
+        WHERE decisions_fts MATCH ?
+        ORDER BY rank ASC
+        LIMIT ?
+        """,
+        (fts_query, limit),
+    ).fetchall()
+    return [
+        {
+            "kind": "decision",
+            "filename": row["filename"],
+            "title": row["title"],
+            "snippet": _safe_snippet(row["snippet"]),
+            "rank": float(row["rank"]),
+            "url": f"/decisions#card-{row['filename']}",
+        }
+        for row in rows
+    ]
+
+
+def build_search_payload(
+    repo_root: Path,
+    query: dict[str, list[str]],
+    *,
+    bridge_db_path: Path,
+) -> RouteResponse:
+    raw_query = query.get("q", [""])[0]
+    if raw_query is None or not raw_query.strip():
+        return _json_response(400, {"error": "query required"})
+    if len(raw_query) > 256:
+        return _json_response(400, {"error": "query too long"})
+
+    kind = query.get("kind", ["all"])[0] or "all"
+    if kind not in _VALID_KINDS:
+        return _json_response(400, {"error": "invalid kind", "supported": sorted(_VALID_KINDS)})
+    limit, limit_error = _parse_limit(query)
+    if limit_error or limit is None:
+        return _json_response(400, {"error": "invalid limit", "max": 100})
+
+    fts_query = _sanitize_fts_query(raw_query)
+    if fts_query is None:
+        return _json_response(400, {"error": "query required"})
+
+    started = time.perf_counter()
+    if kind in {"decisions", "all"}:
+        _refresh_decisions_fts(repo_root, db_path=bridge_db_path)
+
+    bridge_db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(bridge_db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        _ensure_fts(conn)
+        results: list[dict[str, Any]] = []
+        if kind in {"channels", "all"}:
+            results.extend(_query_channel_results(conn, fts_query, limit=limit))
+        if kind in {"decisions", "all"}:
+            results.extend(_query_decision_results(conn, fts_query, limit=limit))
+    except sqlite3.OperationalError as exc:
+        if "fts5" in str(exc).lower() or "syntax error" in str(exc).lower():
+            return _json_response(400, {"error": "invalid query"})
+        raise
+    finally:
+        conn.close()
+
+    results.sort(key=lambda item: (float(item["rank"]), str(item["kind"])))
+    took_ms = int((time.perf_counter() - started) * 1000)
+    return _json_response(
+        200,
+        {
+            "query": raw_query,
+            "kind": kind,
+            "took_ms": took_ms,
+            "results": results[:limit],
+        },
+    )
+
+
+def route_search_request(
+    repo_root: Path,
+    path: str,
+    query: dict[str, list[str]],
+    *,
+    bridge_db_path: Path,
+) -> RouteResponse | None:
+    if path != "/api/search":
+        return None
+    return build_search_payload(repo_root, query, bridge_db_path=bridge_db_path)

--- a/scripts/local_api/routes/ui_fragments.py
+++ b/scripts/local_api/routes/ui_fragments.py
@@ -111,3 +111,135 @@ def render_afk_notify_markup() -> str:
   setInterval(pollPendingDecisions, POLL_MS);
 })();
 </script>"""
+
+
+def render_search_widget() -> str:
+    return """
+<style>
+  .search-widget{position:sticky;top:var(--topnav-h,45px);z-index:55;background:#121416;border-bottom:1px solid var(--line,rgba(255,255,255,.08));padding:8px 24px;--search-widget-h:53px}
+  .search-box{position:relative;max-width:720px}
+  .search-input{width:100%;height:36px;border:1px solid var(--line,rgba(255,255,255,.12));border-radius:6px;background:#0f1011;color:var(--text,#f3f4f2);padding:0 12px;font:13px/1.4 ui-monospace,SFMono-Regular,Menlo,monospace}
+  .search-input:focus{outline:2px solid rgba(61,214,198,.35);border-color:var(--teal,#3dd6c6)}
+  .search-dropdown{position:absolute;top:42px;left:0;right:0;z-index:70;display:grid;gap:2px;max-height:min(420px,70vh);overflow:auto;border:1px solid var(--line,rgba(255,255,255,.12));border-radius:6px;background:#101112;box-shadow:0 18px 64px rgba(0,0,0,.45);padding:5px}
+  .search-dropdown[hidden]{display:none}
+  .search-result{display:grid;grid-template-columns:auto minmax(0,1fr);gap:9px;border:1px solid transparent;border-radius:5px;background:transparent;color:var(--text,#f3f4f2);padding:8px;text-align:left;cursor:pointer}
+  .search-result.active,.search-result:hover{border-color:rgba(61,214,198,.45);background:rgba(61,214,198,.11)}
+  .search-chip{align-self:start;border:1px solid var(--line,rgba(255,255,255,.12));border-radius:999px;padding:2px 6px;color:var(--muted,#9ca3a3);font-size:10px;font-weight:850;letter-spacing:.04em}
+  .search-result-title{font-size:12px;font-weight:850;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .search-snippet{font-size:12px;color:var(--muted,#9ca3a3);margin-top:2px;line-height:1.35}
+  .search-snippet mark{background:rgba(253,224,71,.22);color:#fde68a;border-radius:3px;padding:0 2px}
+  .search-empty{color:var(--muted,#9ca3a3);font-size:12px;padding:10px}
+  @media(max-width:760px){.search-widget{padding:8px 12px}.search-dropdown{max-height:62vh}}
+</style>
+<div class="search-widget" data-search-widget>
+  <div class="search-box">
+    <input class="search-input" type="search" placeholder="Search messages + decisions" autocomplete="off" aria-label="Search messages and decisions">
+    <div class="search-dropdown" role="listbox" hidden></div>
+  </div>
+</div>
+<script>
+(() => {
+  const root = document.querySelector("[data-search-widget]");
+  if (!root) return;
+  const input = root.querySelector(".search-input");
+  const dropdown = root.querySelector(".search-dropdown");
+  let timer = null;
+  let results = [];
+  let active = -1;
+  const escapeHtml = value => String(value || "").replace(/[&<>"']/g, ch => ({
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#39;"
+  }[ch]));
+  function close() {
+    dropdown.hidden = true;
+    dropdown.innerHTML = "";
+    results = [];
+    active = -1;
+  }
+  function setActive(index) {
+    active = index;
+    dropdown.querySelectorAll(".search-result").forEach((row, idx) => {
+      row.classList.toggle("active", idx === active);
+      if (idx === active) row.scrollIntoView({block: "nearest"});
+    });
+  }
+  function navigate(result) {
+    if (result && result.url) window.location.href = result.url;
+  }
+  function render() {
+    if (!results.length) {
+      dropdown.innerHTML = '<div class="search-empty">No matches</div>';
+      dropdown.hidden = false;
+      return;
+    }
+    dropdown.innerHTML = results.map((result, idx) => {
+      const isDecision = result.kind === "decision";
+      const chip = isDecision ? "DECISION" : "CHAT";
+      const title = isDecision
+        ? (result.title || result.filename || "Decision")
+        : ((result.from_agent || "agent") + " in " + (result.channel || "channel"));
+      return '<button type="button" class="search-result" data-index="' + idx + '" role="option">' +
+        '<span class="search-chip">' + chip + '</span>' +
+        '<span><span class="search-result-title">' + escapeHtml(title) + '</span>' +
+        '<span class="search-snippet">' + (result.snippet || "") + '</span></span>' +
+      '</button>';
+    }).join("");
+    dropdown.hidden = false;
+    setActive(0);
+  }
+  async function runSearch() {
+    const query = input.value.trim();
+    if (query.length < 2) {
+      close();
+      return;
+    }
+    try {
+      const res = await fetch("/api/search?q=" + encodeURIComponent(query) + "&kind=all&limit=10", {cache: "no-store"});
+      if (!res.ok) {
+        close();
+        return;
+      }
+      const data = await res.json();
+      results = Array.isArray(data.results) ? data.results : [];
+      active = -1;
+      render();
+    } catch {
+      close();
+    }
+  }
+  input.addEventListener("input", () => {
+    clearTimeout(timer);
+    timer = setTimeout(runSearch, 200);
+  });
+  input.addEventListener("keydown", event => {
+    if (event.key === "Escape") {
+      close();
+      input.blur();
+      return;
+    }
+    if (dropdown.hidden) return;
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setActive(Math.min(results.length - 1, active + 1));
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActive(Math.max(0, active - 1));
+    } else if (event.key === "Enter") {
+      event.preventDefault();
+      navigate(results[active]);
+    }
+  });
+  dropdown.addEventListener("mousedown", event => {
+    const row = event.target.closest(".search-result");
+    if (!row) return;
+    event.preventDefault();
+    navigate(results[Number(row.dataset.index)]);
+  });
+  document.addEventListener("click", event => {
+    if (!root.contains(event.target)) close();
+  });
+})();
+</script>"""

--- a/tests/test_search_endpoint_validation.py
+++ b/tests/test_search_endpoint_validation.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from local_api.routes import search as search_route
+
+
+def test_search_endpoint_rejects_empty_query(tmp_path: Path) -> None:
+    status, payload, _ = search_route.route_search_request(
+        tmp_path,
+        "/api/search",
+        {"q": [""], "kind": ["all"]},
+        bridge_db_path=tmp_path / "messages.db",
+    )
+    assert status == 400
+    assert payload["error"] == "query required"
+
+
+def test_search_endpoint_rejects_long_query(tmp_path: Path) -> None:
+    status, payload, _ = search_route.route_search_request(
+        tmp_path,
+        "/api/search",
+        {"q": ["x" * 257], "kind": ["all"]},
+        bridge_db_path=tmp_path / "messages.db",
+    )
+    assert status == 400
+    assert payload["error"] == "query too long"
+
+
+def test_search_endpoint_rejects_limit_over_100(tmp_path: Path) -> None:
+    status, payload, _ = search_route.route_search_request(
+        tmp_path,
+        "/api/search",
+        {"q": ["test"], "kind": ["all"], "limit": ["101"]},
+        bridge_db_path=tmp_path / "messages.db",
+    )
+    assert status == 400
+    assert payload["error"] == "invalid limit"
+
+
+def test_search_endpoint_rejects_bad_kind(tmp_path: Path) -> None:
+    status, payload, _ = search_route.route_search_request(
+        tmp_path,
+        "/api/search",
+        {"q": ["test"], "kind": ["garbage"]},
+        bridge_db_path=tmp_path / "messages.db",
+    )
+    assert status == 400
+    assert payload["error"] == "invalid kind"

--- a/tests/test_search_fts_channels.py
+++ b/tests/test_search_fts_channels.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from ai_agent_bridge import _channels, _config, _db
+from local_api.routes import search as search_route
+
+
+def _init_bridge_db(db_path: Path) -> None:
+    with patch.object(_config, "DB_PATH", db_path), patch.object(_db, "DB_PATH", db_path):
+        conn = _db.init_db()
+        conn.close()
+
+
+def test_channel_messages_fts_triggers_insert_and_rank_results(tmp_path: Path) -> None:
+    db_path = tmp_path / "messages.db"
+    _init_bridge_db(db_path)
+
+    with patch.object(_config, "DB_PATH", db_path), patch.object(_db, "DB_PATH", db_path):
+        _channels.create_channel("search-topic")
+        weaker = _channels.post(
+            "search-topic",
+            "claude",
+            "needle appears once",
+            auto_snapshot=False,
+        )
+        stronger = _channels.post(
+            "search-topic",
+            "codex",
+            "needle needle needle appears more often",
+            auto_snapshot=False,
+        )
+
+        conn = _db.get_db()
+        try:
+            unique_token = "uniquetokenfts"
+            conn.execute(
+                """
+                INSERT INTO channel_messages(
+                    message_id, channel, thread_id, round_index,
+                    from_agent, body, created_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    "directftsmessage",
+                    "search-topic",
+                    "directftsthread",
+                    0,
+                    "user",
+                    f"direct insert {unique_token}",
+                    "2026-01-01T00:00:00+00:00",
+                ),
+            )
+            conn.commit()
+            rows = conn.execute(
+                "SELECT message_id FROM channel_messages_fts WHERE channel_messages_fts MATCH ?",
+                (f'"{unique_token}"',),
+            ).fetchall()
+            assert [row["message_id"] for row in rows] == ["directftsmessage"]
+        finally:
+            conn.close()
+
+    status, payload, _ = search_route.build_search_payload(
+        tmp_path,
+        {"q": ["needle"], "kind": ["channels"], "limit": ["10"]},
+        bridge_db_path=db_path,
+    )
+    assert status == 200
+    result_ids = [item["message_id"] for item in payload["results"]]
+    assert result_ids.index(stronger["message_id"]) < result_ids.index(weaker["message_id"])
+    assert payload["results"][0]["rank"] <= payload["results"][1]["rank"]

--- a/tests/test_search_fts_decisions.py
+++ b/tests/test_search_fts_decisions.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from local_api.routes import decisions, search as search_route
+
+
+def test_decisions_fts_indexes_and_refreshes_only_touched_file(tmp_path: Path) -> None:
+    db_path = tmp_path / "messages.db"
+    decisions_dir = tmp_path / "docs" / "decisions"
+    pending_dir = decisions_dir / "pending"
+    pending_dir.mkdir(parents=True)
+    first = decisions_dir / "first.md"
+    second = pending_dir / "second.md"
+    first.write_text("# First Decision\n\nsharedterm alpha\n", encoding="utf-8")
+    second.write_text("# Second Decision\n\nsharedterm beta\n", encoding="utf-8")
+
+    decisions._DECISIONS_FTS_META.clear()
+    refreshed = decisions._refresh_decisions_fts(tmp_path, db_path=db_path)
+    assert refreshed["scanned"] == 2
+    assert set(refreshed["updated"]) == {"first.md", "second.md"}
+
+    status, payload, _ = search_route.build_search_payload(
+        tmp_path,
+        {"q": ["sharedterm"], "kind": ["decisions"], "limit": ["10"]},
+        bridge_db_path=db_path,
+    )
+    assert status == 200
+    assert {item["filename"] for item in payload["results"]} == {"first.md", "second.md"}
+
+    first.write_text("# First Decision Updated\n\nsharedterm updatedunique\n", encoding="utf-8")
+    new_mtime = time.time() + 10
+    os.utime(first, (new_mtime, new_mtime))
+    refreshed = decisions._refresh_decisions_fts(tmp_path, db_path=db_path)
+    assert refreshed["updated"] == ["first.md"]
+    assert refreshed["deleted"] == []
+
+    status, payload, _ = search_route.build_search_payload(
+        tmp_path,
+        {"q": ["updatedunique"], "kind": ["decisions"], "limit": ["10"]},
+        bridge_db_path=db_path,
+    )
+    assert status == 200
+    assert [item["filename"] for item in payload["results"]] == ["first.md"]
+    assert payload["results"][0]["title"] == "First Decision Updated"

--- a/tests/test_search_kind_filter.py
+++ b/tests/test_search_kind_filter.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from ai_agent_bridge import _channels, _config, _db
+from local_api.routes import decisions, search as search_route
+
+
+def _seed_search_corpus(repo_root: Path, db_path: Path) -> None:
+    decisions_dir = repo_root / "docs" / "decisions"
+    decisions_dir.mkdir(parents=True)
+    (decisions_dir / "choice.md").write_text(
+        "# Searchable Decision\n\nfiltertoken in decision body\n",
+        encoding="utf-8",
+    )
+    decisions._DECISIONS_FTS_META.clear()
+
+    with patch.object(_config, "DB_PATH", db_path), patch.object(_db, "DB_PATH", db_path):
+        conn = _db.init_db()
+        conn.close()
+        _channels.create_channel("filter-channel")
+        _channels.post(
+            "filter-channel",
+            "gemini",
+            "filtertoken in channel body",
+            auto_snapshot=False,
+        )
+
+
+def test_search_kind_filters_channels_decisions_and_all(tmp_path: Path) -> None:
+    db_path = tmp_path / "messages.db"
+    _seed_search_corpus(tmp_path, db_path)
+
+    status, payload, _ = search_route.route_search_request(
+        tmp_path,
+        "/api/search",
+        {"q": ["filtertoken"], "kind": ["channels"]},
+        bridge_db_path=db_path,
+    )
+    assert status == 200
+    assert {item["kind"] for item in payload["results"]} == {"channel"}
+
+    status, payload, _ = search_route.route_search_request(
+        tmp_path,
+        "/api/search",
+        {"q": ["filtertoken"], "kind": ["decisions"]},
+        bridge_db_path=db_path,
+    )
+    assert status == 200
+    assert {item["kind"] for item in payload["results"]} == {"decision"}
+
+    status, payload, _ = search_route.route_search_request(
+        tmp_path,
+        "/api/search",
+        {"q": ["filtertoken"], "kind": ["all"]},
+        bridge_db_path=db_path,
+    )
+    assert status == 200
+    assert {item["kind"] for item in payload["results"]} == {"channel", "decision"}
+
+    status, payload, _ = search_route.route_search_request(
+        tmp_path,
+        "/api/search",
+        {"q": ["filtertoken"], "kind": ["garbage"]},
+        bridge_db_path=db_path,
+    )
+    assert status == 400
+    assert payload["error"] == "invalid kind"


### PR DESCRIPTION
## Summary
- Adds collocated FTS5 tables for channel message bodies and decision markdown cards in .bridge/messages.db.
- Wires /api/search with kind filtering, validation, bm25 ranking, snippets, and decision mtime refresh.
- Adds the shared search widget to /channels and /decisions without changing the existing Cmd+K switcher.

Closes #970

## Validation
- .venv/bin/ruff check scripts/local_api scripts/ai_agent_bridge tests/test_search*.py
- .venv/bin/pytest tests/test_local_api*.py tests/test_bridge_channels.py tests/test_channels_d0.py tests/test_ai_agent_bridge_channel_watch.py tests/test_ab_post_writes_message_posted_event.py tests/test_channel_rollup_works_without_events.py tests/test_channel_post_endpoint.py tests/test_channel_delta_render.py tests/test_channel_poll_cadence.py tests/test_channel_summary_parse_rounds.py tests/test_channel_summary_parse_votes.py tests/test_channel_summary_parse_cost.py tests/test_channel_summary_fallback_to_chat.py tests/test_decision_lineage_resolves.py tests/test_decision_stale_detection.py tests/test_decision_lineage_cache.py tests/test_channel_keyboard_nav.py tests/test_decision_pending_endpoint_shape.py tests/test_decision_card_anchor.py tests/test_search_fts_channels.py tests/test_search_fts_decisions.py tests/test_search_kind_filter.py tests/test_search_endpoint_validation.py -q --timeout=60 (273 passed)
- .venv/bin/python scripts/test_pipeline.py (166 tests OK)
- git diff --check
- Live smoke on 127.0.0.1:8779: channel search, decision search, all search, 400 validation errors, widget renders on /channels and /decisions

## Diff
- 11 files changed, 845 insertions, 2 deletions
- No generated artifacts staged
- npm run build skipped: no src/content/docs or Astro config changes