### PR TITLE
chore(local-api): D-series follow-up nits (closes #992 #996 #999 #1004)

### DIFF
--- a/scripts/ai_agent_bridge/_claude.py
+++ b/scripts/ai_agent_bridge/_claude.py
@@ -60,8 +60,12 @@ def process_for_claude(message_id: int, new_session: bool = False,
     if not msg:
         return
 
-    session = get_session(msg['task_id']) if msg['task_id'] else {"claude": None, "gemini": None}
-    claude_session_id = session["claude"] if not new_session else None
+    session = (
+        get_session(msg['task_id'])
+        if msg['task_id']
+        else {"claude_session_id": None, "gemini_session_id": None}
+    )
+    claude_session_id = session["claude_session_id"] if not new_session else None
 
     _print_claude_message_info(msg, fire_and_forget, no_timeout, claude_session_id)
 

--- a/scripts/ai_agent_bridge/_db.py
+++ b/scripts/ai_agent_bridge/_db.py
@@ -18,6 +18,7 @@ in the B.1 design round (task bridge-b1-schema-design, 2026-04-11).
 
 import sqlite3
 from datetime import UTC, datetime
+from typing import Literal, overload
 
 from ._config import DB_PATH
 from ._fts import setup_fts_tables
@@ -139,6 +140,10 @@ CREATE TABLE IF NOT EXISTS channel_events (
 
 CREATE INDEX IF NOT EXISTS idx_channel_events_thread_event
     ON channel_events(thread_id, event_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_channel_events_message_posted
+    ON channel_events (event, json_extract(payload_json, '$.message_id'))
+    WHERE event = 'message_posted';
 """
 
 
@@ -274,6 +279,20 @@ def get_db():
                         ON channel_events(thread_id, event_id)
                         """
                     )
+                cursor.execute(
+                    "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_channel_events_message_posted'"
+                )
+                if not cursor.fetchone():
+                    conn.execute(
+                        """
+                        CREATE UNIQUE INDEX IF NOT EXISTS idx_channel_events_message_posted
+                        ON channel_events (
+                            event,
+                            json_extract(payload_json, '$.message_id')
+                        )
+                        WHERE event = 'message_posted'
+                        """
+                    )
 
         setup_fts_tables(conn)
         conn.commit()
@@ -285,14 +304,8 @@ def get_db():
 
 def get_session(task_id: str) -> dict:
     """Get session IDs for a task."""
-    empty = {
-        "claude": None,
-        "gemini": None,
-        "codex": None,
-    }
     if not task_id:
         return {
-            **empty,
             "claude_session_id": None,
             "gemini_session_id": None,
             "codex_session_id": None,
@@ -309,15 +322,11 @@ def get_session(task_id: str) -> dict:
 
     if row:
         return {
-            "claude": row[0],
-            "gemini": row[1],
-            "codex": row[2],
             "claude_session_id": row[0],
             "gemini_session_id": row[1],
             "codex_session_id": row[2],
         }
     return {
-        **empty,
         "claude_session_id": None,
         "gemini_session_id": None,
         "codex_session_id": None,
@@ -334,6 +343,32 @@ def _session_column(agent: str) -> str:
     if agent not in columns:
         raise ValueError(f"Unknown session agent: {agent}")
     return columns[agent]
+
+
+@overload
+def set_session(
+    task_id: str,
+    agent: Literal["claude", "gemini", "codex"],
+    session_id: str,
+    *,
+    claude_session_id: None = None,
+    gemini_session_id: None = None,
+    codex_session_id: None = None,
+) -> None:
+    ...
+
+
+@overload
+def set_session(
+    task_id: str,
+    agent: None = None,
+    session_id: None = None,
+    *,
+    claude_session_id: str | None = None,
+    gemini_session_id: str | None = None,
+    codex_session_id: str | None = None,
+) -> None:
+    ...
 
 
 def set_session(

--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -7177,9 +7177,12 @@ def route_request(repo_root: Path, raw_path: str) -> tuple[int, Any, str]:
     if decision_page is not None:
         return decision_page
     channel_page = _CHANNEL_ROUTES.route_channel_page_request(
+        repo_root,
         path,
         top_nav_css=_TOP_NAV_CSS,
         render_top_nav_fn=_render_top_nav,
+        resolve_bridge_db_path_fn=_resolve_bridge_db_path,
+        query_sqlite_rows_fn=_query_sqlite_rows,
     )
     if channel_page is not None:
         return channel_page

--- a/scripts/local_api/routes/channels.py
+++ b/scripts/local_api/routes/channels.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import html as _html
 import json as _json
+import logging as _logging
 import os as _os
 import re as _re
 import threading as _threading
@@ -24,6 +25,7 @@ except ModuleNotFoundError:
 
 
 RouteResponse = tuple[int, Any, str]
+_LOG = _logging.getLogger(__name__)
 _POST_DB_LOCK = _threading.Lock()
 _VOTE_RE = _re.compile(r"\[(AGREE|OPTION [A-Z][\w'’′‘]?|DEFER|NEEDS[- ]CHANGES)\]")
 
@@ -282,6 +284,12 @@ def build_channel_threads_index(
             # high cap keeps busy deliberations enriched without paginating.
             limit=_SUPPLEMENTARY_EVENTS_LIMIT,
         )
+        if len(event_rows) >= _SUPPLEMENTARY_EVENTS_LIMIT:
+            _LOG.warning(
+                "channel events query hit limit (%d rows); raise "
+                "KUBEDOJO_CHANNEL_EVENTS_LIMIT to see more",
+                _SUPPLEMENTARY_EVENTS_LIMIT,
+            )
         agents_by_thread: dict[str, set[str]] = {}
         latest_reply_state: dict[str, tuple[int, dict[str, Any]]] = {}
         for event_row in event_rows:

--- a/scripts/local_api/routes/channels.py
+++ b/scripts/local_api/routes/channels.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import html as _html
 import json as _json
+import os as _os
 import re as _re
 import threading as _threading
 from pathlib import Path
@@ -24,7 +25,17 @@ except ModuleNotFoundError:
 
 RouteResponse = tuple[int, Any, str]
 _POST_DB_LOCK = _threading.Lock()
-_VOTE_RE = _re.compile(r"\[(AGREE|OPTION [A-Z][\w'’′]?|DEFER|NEEDS[- ]CHANGES)\]")
+_VOTE_RE = _re.compile(r"\[(AGREE|OPTION [A-Z][\w'’′‘]?|DEFER|NEEDS[- ]CHANGES)\]")
+
+
+def _int_from_env(name: str, default: int) -> int:
+    try:
+        return int(_os.environ.get(name, str(default)))
+    except ValueError:
+        return default
+
+
+_SUPPLEMENTARY_EVENTS_LIMIT = _int_from_env("KUBEDOJO_CHANNEL_EVENTS_LIMIT", 10000)
 
 
 def _json_response(status: int, payload: dict[str, Any]) -> RouteResponse:
@@ -46,7 +57,16 @@ def _channel_event_sort_key(channel: dict[str, Any]) -> str:
 
 
 def extract_thread_vote(body: str) -> str | None:
-    matches = _VOTE_RE.findall(body)
+    """Return a protocol vote from the final non-empty line only.
+
+    ``[DISAGREE]`` is intentionally not a protocol token. Count only
+    ``[AGREE]``, ``[OPTION X]`` variants, ``[DEFER]``, and
+    ``[NEEDS CHANGES]`` / ``[NEEDS-CHANGES]``.
+    """
+    lines = [line.strip() for line in body.splitlines() if line.strip()]
+    if not lines:
+        return None
+    matches = _VOTE_RE.findall(lines[-1])
     return matches[-1] if matches else None
 
 
@@ -77,7 +97,6 @@ def _thread_status(rounds: list[dict[str, Any]]) -> str:
         final_votes
         and len(final_votes) == len(final_turns)
         and all(vote == "AGREE" for vote in final_votes)
-        and "DEFER" not in final_votes
     ):
         return "converged"
     option_votes = {
@@ -88,6 +107,12 @@ def _thread_status(rounds: list[dict[str, Any]]) -> str:
     if len(option_votes) >= 2:
         return "diverged"
     return "in_flight"
+
+
+def _default_view_for_summary(summary: dict[str, Any]) -> str:
+    if summary.get("status") == "converged" or summary.get("decision_id"):
+        return "graph"
+    return "chat"
 
 
 def _decision_frontmatter_or_first_section(path: Path) -> str:
@@ -253,7 +278,9 @@ def build_channel_threads_index(
             FROM channel_events
             ORDER BY event_id ASC
             """,
-            limit=10000,
+            # The progress stream is supplementary to channel_messages; this
+            # high cap keeps busy deliberations enriched without paginating.
+            limit=_SUPPLEMENTARY_EVENTS_LIMIT,
         )
         agents_by_thread: dict[str, set[str]] = {}
         latest_reply_state: dict[str, tuple[int, dict[str, Any]]] = {}
@@ -344,6 +371,10 @@ def build_channel_threads_index(
             continue
         threads.append({
             "thread_id": thread_id,
+            "subject": None,
+            "thread_started_at": None,
+            "thread_last_at": None,
+            "message_count": None,
             "first_event_ts": row.get("first_event_ts"),
             "last_event_ts": row.get("last_event_ts"),
             "event_count": int(row.get("event_count") or 0),
@@ -363,6 +394,9 @@ def build_channel_threads_index(
                 )
                 if isinstance(agent_row.get("agent"), str)
             ],
+            "model_cascades": None,
+            "reply_state": None,
+            "vote_counts": None,
         })
 
     return _finalize_channel_rollup(
@@ -441,7 +475,7 @@ def build_channel_thread_summary(
         ORDER BY cm.round_index ASC, cm.created_at ASC, cm.rowid ASC
         """,
         (thread_id,),
-        limit=10000,
+        limit=_SUPPLEMENTARY_EVENTS_LIMIT,
     )
 
     channel = ""
@@ -576,7 +610,7 @@ def build_channel_timeline_payload(
         ORDER BY ce.event_id ASC
         """,
         tuple(params),
-        limit=10000,
+        limit=_SUPPLEMENTARY_EVENTS_LIMIT,
     )
 
     events: list[dict[str, Any]] = []
@@ -641,10 +675,12 @@ def render_channels_chat_html(
     *,
     top_nav_css: str,
     render_top_nav_fn: Callable[[str], str],
+    default_view: str = "chat",
 ) -> str:
     selected_js = _safe_json_for_script(selected_channel)
     title_channel = selected_channel or "Channels"
     escaped_title = _html.escape(title_channel, quote=True)
+    escaped_default_view = _html.escape(default_view, quote=True)
     return f"""<!doctype html>
 <html lang="en">
 <head>
@@ -743,7 +779,7 @@ def render_channels_chat_html(
 {render_top_nav_fn("channels")}
 {render_search_widget()}
 {render_afk_notify_markup()}
-<div class="channels-app" data-selected-channel="{_html.escape(selected_channel or "", quote=True)}">
+<div class="channels-app" data-selected-channel="{_html.escape(selected_channel or "", quote=True)}" data-default-view="{escaped_default_view}">
   <nav class="channels-sidebar" aria-label="Channels">
     <div class="sidebar-title">Channels</div>
     <div id="channelList"></div>
@@ -816,6 +852,7 @@ def render_channels_chat_html(
 </div>
 <script>
 const INITIAL_CHANNEL = {selected_js};
+const DEFAULT_VIEW = document.querySelector(".channels-app")?.dataset.defaultView || "chat";
 const INITIAL_PARAMS = new URLSearchParams(window.location.search);
 const REQUESTED_VIEW = ["chat","graph"].includes(INITIAL_PARAMS.get("view")) ? INITIAL_PARAMS.get("view") : null;
 const DEFAULT_POLL_MS = 5000;
@@ -829,7 +866,7 @@ let lastEventType = "";
 let lastNewEventAt = 0;
 let channels = [];
 let hasBooted = false;
-let currentView = REQUESTED_VIEW || "chat";
+let currentView = REQUESTED_VIEW || DEFAULT_VIEW;
 let threadSummary = null;
 let summaryFetchId = 0;
 let focusedMessageIndex = -1;
@@ -863,7 +900,7 @@ function computePollDelayMs(now=Date.now()){{if((lastEventType==="reply_started"
 function isNearBottom(){{return messageList.scrollHeight-messageList.scrollTop-messageList.clientHeight<48;}}
 function resetMessages(){{renderedMsgIds.clear();sinceId=0;lastEventType="";lastNewEventAt=0;focusedMessageIndex=-1;messageList.replaceChildren(emptyState);emptyState.style.display="block";}}
 function hasStructuredVotes(summary){{return !!(summary&&summary.rounds&&summary.rounds.some(round=>(round.turns||[]).some(turn=>turn.vote)));}}
-function defaultViewForSummary(summary){{if(REQUESTED_VIEW)return REQUESTED_VIEW;if(summary&&(summary.status==="converged"||summary.decision_id))return"graph";return"chat";}}
+function defaultViewForSummary(summary){{if(REQUESTED_VIEW)return REQUESTED_VIEW;if(summary&&(summary.status==="converged"||summary.decision_id))return"graph";return DEFAULT_VIEW;}}
 function setView(view,updateUrl=true){{currentView=view==="graph"?"graph":"chat";messageList.hidden=currentView!=="chat";graphView.hidden=currentView!=="graph";document.querySelectorAll("[data-view-toggle]").forEach(btn=>btn.classList.toggle("active",btn.dataset.viewToggle===currentView));if(updateUrl){{const url=new URL(window.location.href);url.searchParams.set("view",currentView);history.replaceState(null,"",url);}}}}
 function voteClass(vote){{if(!vote)return"null";if(vote==="AGREE")return"agree";if(vote==="DEFER")return"defer";if(vote.startsWith("NEEDS"))return"needs";if(vote.startsWith("OPTION "))return"option";return"null";}}
 function agentColumns(summary){{const seen=new Set();(summary.rounds||[]).forEach(round=>(round.turns||[]).forEach(turn=>seen.add(turn.agent)));return Array.from(seen).sort((a,b)=>{{const order={{claude:0,codex:1,gemini:2}};return (order[a]??100)-(order[b]??100)||a.localeCompare(b);}});}}
@@ -941,11 +978,13 @@ def render_channel_thread_html(
     *,
     top_nav_css: str,
     render_top_nav_fn: Callable[[str], str],
+    default_view: str = "chat",
 ) -> str:
     return render_channels_chat_html(
         channel_name,
         top_nav_css=top_nav_css,
         render_top_nav_fn=render_top_nav_fn,
+        default_view=default_view,
     )
 
 
@@ -1060,10 +1099,13 @@ def route_channel_post_request(
 
 
 def route_channel_page_request(
+    repo_root: Path,
     path: str,
     *,
     top_nav_css: str,
     render_top_nav_fn: Callable[[str], str],
+    resolve_bridge_db_path_fn: Callable[[Path], Path],
+    query_sqlite_rows_fn: Callable[..., list[dict[str, Any]]],
 ) -> RouteResponse | None:
     if path == "/channels":
         return 200, render_channels_index_html(
@@ -1072,10 +1114,17 @@ def route_channel_page_request(
         ), "text/html; charset=utf-8"
     if path.startswith("/channels/"):
         raw_tid = unquote(path[len("/channels/"):]).strip("/")
+        summary = build_channel_thread_summary(
+            repo_root,
+            raw_tid,
+            resolve_bridge_db_path_fn=resolve_bridge_db_path_fn,
+            query_sqlite_rows_fn=query_sqlite_rows_fn,
+        )
         return 200, render_channel_thread_html(
             raw_tid,
             top_nav_css=top_nav_css,
             render_top_nav_fn=render_top_nav_fn,
+            default_view=_default_view_for_summary(summary),
         ), "text/html; charset=utf-8"
     return None
 

--- a/scripts/local_api/routes/search.py
+++ b/scripts/local_api/routes/search.py
@@ -34,13 +34,13 @@ def _safe_snippet(value: str | None) -> str:
 
 def _sanitize_fts_query(raw: str) -> str | None:
     query = " ".join(raw.replace("\x00", " ").split()).strip()
-    query = query.lstrip("*^").strip()
+    query = query.lstrip("*^()[]").strip()
     if not query:
         return None
 
     terms: list[str] = []
     for token in query.split():
-        cleaned = token.lstrip("*^").strip()
+        cleaned = token.lstrip("*^()[]").strip()
         if not cleaned or not any(char.isalnum() for char in cleaned):
             continue
         terms.append(f'"{cleaned.replace("\"", "\"\"")}"')
@@ -111,20 +111,25 @@ def _query_decision_results(
     *,
     limit: int,
 ) -> list[dict[str, Any]]:
-    rows = conn.execute(
-        """
-        SELECT
-          title,
-          filename,
-          snippet(decisions_fts, -1, '<mark>', '</mark>', '...', 18) AS snippet,
-          bm25(decisions_fts) AS rank
-        FROM decisions_fts
-        WHERE decisions_fts MATCH ?
-        ORDER BY rank ASC
-        LIMIT ?
-        """,
-        (fts_query, limit),
-    ).fetchall()
+    try:
+        rows = conn.execute(
+            """
+            SELECT
+              title,
+              filename,
+              snippet(decisions_fts, -1, '<mark>', '</mark>', '...', 18) AS snippet,
+              bm25(decisions_fts) AS rank
+            FROM decisions_fts
+            WHERE decisions_fts MATCH ?
+            ORDER BY rank ASC
+            LIMIT ?
+            """,
+            (fts_query, limit),
+        ).fetchall()
+    except sqlite3.OperationalError as exc:
+        if "no such table" in str(exc):
+            return []
+        raise
     return [
         {
             "kind": "decision",

--- a/scripts/local_api/routes/search.py
+++ b/scripts/local_api/routes/search.py
@@ -40,7 +40,7 @@ def _sanitize_fts_query(raw: str) -> str | None:
 
     terms: list[str] = []
     for token in query.split():
-        cleaned = token.lstrip("*^()[]").strip()
+        cleaned = token.strip("*^()[]").strip()
         if not cleaned or not any(char.isalnum() for char in cleaned):
             continue
         terms.append(f'"{cleaned.replace("\"", "\"\"")}"')

--- a/tests/test_ab_post_writes_message_posted_event.py
+++ b/tests/test_ab_post_writes_message_posted_event.py
@@ -114,3 +114,34 @@ def test_channel_backfill_events_is_idempotent(isolate_db: Path, capsys) -> None
         conn.close()
 
     assert count == 1
+
+
+def test_message_posted_unique_index_blocks_duplicate_payload(
+    isolate_db: Path,
+) -> None:
+    conn = sqlite3.connect(isolate_db)
+    payload = json.dumps({"message_id": "dup-message"}, sort_keys=True)
+    try:
+        conn.execute(
+            """
+            INSERT INTO channel_events (delivery_id, thread_id, event, payload_json, ts)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (None, "thread-a", "message_posted", payload, "2026-05-07T12:00:00+00:00"),
+        )
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                """
+                INSERT INTO channel_events (delivery_id, thread_id, event, payload_json, ts)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    None,
+                    "thread-b",
+                    "message_posted",
+                    payload,
+                    "2026-05-07T12:01:00+00:00",
+                ),
+            )
+    finally:
+        conn.close()

--- a/tests/test_channel_summary_parse_votes.py
+++ b/tests/test_channel_summary_parse_votes.py
@@ -29,10 +29,14 @@ def test_vote_regex_extracts_last_structured_vote() -> None:
         ("I considered [OPTION B], but final is [AGREE]", "AGREE"),
         ("Ship [OPTION A]", "OPTION A"),
         ("Use the alternate [OPTION A′]", "OPTION A′"),
+        ("Use the alternate [OPTION A‘]", "OPTION A‘"),
         ("Pause this [DEFER]", "DEFER"),
         ("Not ready [NEEDS-CHANGES]", "NEEDS-CHANGES"),
         ("Not ready [NEEDS CHANGES]", "NEEDS CHANGES"),
         ("No bracketed vote here", None),
+        ("Earlier fallback [DEFER]\nFinal line [DISAGREE]", None),
+        ("Earlier fallback [DEFER]\nFinal line without protocol", None),
+        ("Earlier fallback [DEFER]\n\nFinal line [AGREE]", "AGREE"),
     ]
 
     for body, expected in cases:

--- a/tests/test_inbox_integration.py
+++ b/tests/test_inbox_integration.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from agent_runtime.result import Result
+from ai_agent_bridge import _channels, _cli, _db
+
+
+@pytest.fixture(autouse=True)
+def isolate_db(tmp_path):
+    db_file = tmp_path / "messages.db"
+    with patch("ai_agent_bridge._config.DB_PATH", db_file), \
+         patch("ai_agent_bridge._db.DB_PATH", db_file):
+        _db.init_db()
+        yield db_file
+
+
+def _run_cli(argv: list[str]) -> int:
+    with patch.object(sys, "argv", ["ab", *argv]):
+        try:
+            _cli.main()
+        except SystemExit as exc:
+            return exc.code if isinstance(exc.code, int) else 0
+    return 0
+
+
+@patch("agent_runtime.runner.invoke")
+def test_discuss_routes_cold_warm_and_fresh_session_modes(
+    mock_invoke,
+    monkeypatch,
+) -> None:
+    _channels.create_channel("session-modes")
+    monkeypatch.setattr(_channels, "fetch_monitor_state", lambda: None)
+    ids = iter(range(1, 1000))
+    monkeypatch.setattr(_channels, "_new_id", lambda: f"session-mode-{next(ids):04d}")
+
+    def _result(agent: str, *_args, **_kwargs) -> Result:
+        return Result(
+            ok=True,
+            agent=agent,
+            model="test-model",
+            mode="danger" if agent == "codex" else "read-only",
+            response=f"{agent} reply\n[AGREE]",
+            stderr_excerpt=None,
+            duration_s=0.1,
+            session_id="claude-session" if agent == "claude" else "codex-session",
+            rate_limited=False,
+            stalled=False,
+            returncode=0,
+            usage_record={},
+        )
+
+    mock_invoke.side_effect = _result
+
+    exit_code = _run_cli(
+        [
+            "discuss",
+            "session-modes",
+            "topic",
+            "--with",
+            "claude,codex",
+            "--max-rounds",
+            "2",
+        ]
+    )
+
+    assert exit_code == 0
+    claude_calls = [
+        call for call in mock_invoke.call_args_list if call.args[0] == "claude"
+    ]
+    codex_calls = [
+        call for call in mock_invoke.call_args_list if call.args[0] == "codex"
+    ]
+    assert [call.kwargs["session_id"] for call in claude_calls] == [
+        None,
+        "claude-session",
+    ]
+    assert all(call.kwargs["session_id"] is None for call in codex_calls)
+    assert all(call.kwargs["mode"] == "danger" for call in codex_calls)
+    assert (
+        _db.get_session("discuss:session-mode-0001")["claude_session_id"]
+        == "claude-session"
+    )

--- a/tests/test_local_api_channels.py
+++ b/tests/test_local_api_channels.py
@@ -20,6 +20,7 @@ def _load_local_api():
 
 
 local_api = _load_local_api()
+channels_route = local_api._CHANNEL_ROUTES
 
 
 def _init_channel_events_db(db_path: Path) -> None:
@@ -81,6 +82,102 @@ def test_api_channels_returns_empty_shape(tmp_path: Path, monkeypatch) -> None:
     status_code, payload, _ = local_api.route_request(tmp_path, "/api/channels")
     assert status_code == 200
     assert payload == {"channels": []}
+
+
+def test_api_channels_legacy_event_fallback_uses_full_thread_shape(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db_path = tmp_path / "messages.db"
+    _use_bridge_db(monkeypatch, db_path)
+    _init_channel_events_db(db_path)
+    _seed_channel_events(
+        db_path,
+        [
+            {
+                "event": "reply_started",
+                "payload": {"agent": "codex"},
+                "ts": "2026-05-07T15:00:00+00:00",
+            },
+        ],
+        thread_id="legacy-thread",
+    )
+
+    status_code, payload, _ = local_api.route_request(tmp_path, "/api/channels")
+
+    assert status_code == 200
+    thread = payload["channels"][0]["threads"][0]
+    for key in (
+        "subject",
+        "thread_started_at",
+        "thread_last_at",
+        "message_count",
+        "model_cascades",
+        "reply_state",
+        "vote_counts",
+    ):
+        assert key in thread
+        assert thread[key] is None
+
+
+def test_channel_page_default_view_attribute_reflects_thread_status(
+    tmp_path: Path,
+) -> None:
+    def _render_top_nav(_active: str) -> str:
+        return ""
+
+    def _resolve(_repo_root: Path) -> Path:
+        return tmp_path / "messages.db"
+
+    def _rows_for_converged(*_args: Any, **_kwargs: Any) -> list[dict[str, Any]]:
+        return [
+            {
+                "message_id": "m1",
+                "channel": "topic",
+                "thread_id": "thread-1",
+                "round_index": 1,
+                "from_agent": "claude",
+                "from_model": "test",
+                "body": "Ready\n[AGREE]",
+                "created_at": "2026-05-07T15:00:00+00:00",
+                "cascade_cost_usd": 0,
+                "cascade_elapsed_s": 0,
+            },
+            {
+                "message_id": "m2",
+                "channel": "topic",
+                "thread_id": "thread-1",
+                "round_index": 1,
+                "from_agent": "codex",
+                "from_model": "test",
+                "body": "Ready\n[AGREE]",
+                "created_at": "2026-05-07T15:00:01+00:00",
+                "cascade_cost_usd": 0,
+                "cascade_elapsed_s": 0,
+            },
+        ]
+
+    status, html, _ = channels_route.route_channel_page_request(
+        tmp_path,
+        "/channels/thread-1",
+        top_nav_css="",
+        render_top_nav_fn=_render_top_nav,
+        resolve_bridge_db_path_fn=_resolve,
+        query_sqlite_rows_fn=_rows_for_converged,
+    )
+    assert status == 200
+    assert 'data-default-view="graph"' in html
+
+    status, html, _ = channels_route.route_channel_page_request(
+        tmp_path,
+        "/channels/thread-2",
+        top_nav_css="",
+        render_top_nav_fn=_render_top_nav,
+        resolve_bridge_db_path_fn=_resolve,
+        query_sqlite_rows_fn=lambda *_args, **_kwargs: [],
+    )
+    assert status == 200
+    assert 'data-default-view="chat"' in html
 
 
 def test_api_channel_events_returns_events_in_order(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_local_api_channels.py
+++ b/tests/test_local_api_channels.py
@@ -44,6 +44,36 @@ def _init_channel_events_db(db_path: Path) -> None:
         conn.close()
 
 
+def _init_channel_messages_db(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS channel_messages (
+              message_id TEXT PRIMARY KEY,
+              channel TEXT NOT NULL,
+              thread_id TEXT NOT NULL,
+              parent_id TEXT,
+              correlation_id TEXT,
+              round_index INTEGER DEFAULT 0,
+              from_agent TEXT NOT NULL,
+              from_model TEXT,
+              kind TEXT DEFAULT 'post',
+              body TEXT NOT NULL,
+              attachments TEXT,
+              context_rev_shared TEXT,
+              context_rev_channel TEXT,
+              monitor_state_snapshot TEXT,
+              created_at TEXT NOT NULL
+            );
+            """
+        )
+    finally:
+        conn.commit()
+        conn.close()
+
+
 def _seed_channel_events(db_path: Path, events: list[dict[str, Any]], *, thread_id: str) -> None:
     conn = sqlite3.connect(db_path)
     try:
@@ -74,6 +104,53 @@ def _use_bridge_db(monkeypatch, db_path: Path) -> None:
     bridge_db = importlib.import_module("ai_agent_bridge._db")
     monkeypatch.setenv("AB_DB_PATH", str(db_path))
     monkeypatch.setattr(bridge_db, "DB_PATH", db_path)
+
+
+def test_channel_threads_index_warns_when_supplementary_events_hit_limit(
+    tmp_path: Path,
+    monkeypatch,
+    caplog,
+) -> None:
+    db_path = tmp_path / "messages.db"
+    _init_channel_messages_db(db_path)
+    _init_channel_events_db(db_path)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            INSERT INTO channel_messages (
+              message_id, channel, thread_id, from_agent, body, created_at
+            )
+            VALUES ('m1', 'topic', 'thread-1', 'user', 'subject', '2026-05-08T00:00:00Z')
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    _seed_channel_events(
+        db_path,
+        [
+            {
+                "event": "reply_started",
+                "payload": {"agent": "codex"},
+                "ts": f"2026-05-08T00:00:0{idx}Z",
+            }
+            for idx in range(4)
+        ],
+        thread_id="thread-1",
+    )
+
+    monkeypatch.setattr(channels_route, "_SUPPLEMENTARY_EVENTS_LIMIT", 3)
+    with caplog.at_level("WARNING", logger=channels_route.__name__):
+        payload = channels_route.build_channel_threads_index(
+            tmp_path,
+            list_channels_fn=lambda: [{"name": "topic", "created_at": None}],
+            resolve_bridge_db_path_fn=lambda _repo_root: db_path,
+            query_sqlite_rows_fn=local_api._query_sqlite_rows,
+        )
+
+    assert payload["channels"][0]["threads"][0]["event_count"] == 3
+    assert "channel events query hit limit (3 rows)" in caplog.text
 
 
 def test_api_channels_returns_empty_shape(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_search_endpoint_validation.py
+++ b/tests/test_search_endpoint_validation.py
@@ -55,7 +55,54 @@ def test_search_endpoint_rejects_bad_kind(tmp_path: Path) -> None:
 
 def test_search_sanitizer_strips_leading_parens_and_brackets() -> None:
     assert search_route._sanitize_fts_query("([needle") == '"needle"'
+    assert search_route._sanitize_fts_query("(needle)") == '"needle"'
     assert search_route._sanitize_fts_query("() []") is None
+
+
+def test_search_endpoint_balanced_parens_match_plain_channel_query(tmp_path: Path) -> None:
+    db_path = tmp_path / "messages.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE channel_messages (
+              message_id TEXT PRIMARY KEY,
+              channel TEXT NOT NULL,
+              thread_id TEXT NOT NULL,
+              from_agent TEXT NOT NULL,
+              body TEXT NOT NULL,
+              created_at TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO channel_messages (
+              message_id, channel, thread_id, from_agent, body, created_at
+            )
+            VALUES ('m1', 'topic', 'thread-1', 'codex', 'needle haystack', '2026-05-08T00:00:00Z')
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    paren_status, paren_payload, _ = search_route.route_search_request(
+        tmp_path,
+        "/api/search",
+        {"q": ["(needle)"], "kind": ["channels"]},
+        bridge_db_path=db_path,
+    )
+    plain_status, plain_payload, _ = search_route.route_search_request(
+        tmp_path,
+        "/api/search",
+        {"q": ["needle"], "kind": ["channels"]},
+        bridge_db_path=db_path,
+    )
+
+    assert paren_status == 200
+    assert plain_status == 200
+    assert paren_payload["results"] == plain_payload["results"]
 
 
 def test_query_decision_results_missing_table_returns_empty() -> None:

--- a/tests/test_search_endpoint_validation.py
+++ b/tests/test_search_endpoint_validation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sqlite3
 import sys
 from pathlib import Path
 
@@ -50,3 +51,17 @@ def test_search_endpoint_rejects_bad_kind(tmp_path: Path) -> None:
     )
     assert status == 400
     assert payload["error"] == "invalid kind"
+
+
+def test_search_sanitizer_strips_leading_parens_and_brackets() -> None:
+    assert search_route._sanitize_fts_query("([needle") == '"needle"'
+    assert search_route._sanitize_fts_query("() []") is None
+
+
+def test_query_decision_results_missing_table_returns_empty() -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    try:
+        assert search_route._query_decision_results(conn, '"needle"', limit=10) == []
+    finally:
+        conn.close()


### PR DESCRIPTION
Batches the 4 follow-up nit-tracking issues from the D-series.

## Closes
- Closes #992 — PR #985 deferred nits
- Closes #996 — D1.5 nits
- Closes #999 — D3 nits
- Closes #1004 — D6 nits

## Per-issue summary

### #992 — PR #985 deferred nits
- Removed internal callers from `get_session` legacy short keys; `get_session` now returns only full `*_session_id` keys.
- Added an `ab discuss` integration test covering cold/warm/fresh session routing through dispatch.
- Added `@overload` stubs for the supported `set_session` call styles.

### #996 — D1.5 channel rollup nits
- Legacy fallback in `build_channel_threads_index` now returns `subject`, `thread_started_at`, `thread_last_at`, `message_count`, `model_cascades`, `reply_state`, and `vote_counts` with `None` defaults.
- Added a partial UNIQUE INDEX on `(event, json_extract(payload_json, '$.message_id')) WHERE event = 'message_posted'` for DB-level duplicate protection.
- Extracted the supplementary channel-event query cap to `_SUPPLEMENTARY_EVENTS_LIMIT`, with optional `KUBEDOJO_CHANNEL_EVENTS_LIMIT` override.

### #999 — D3 Decision Graph nits
- Server-renders `data-default-view` for thread pages so converged/linked threads can start in Graph view on first paint.
- Removed the dead `and "DEFER" not in final_votes` guard from `_thread_status`.
- Tightened vote parsing to the last non-empty line only, kept `[DISAGREE]` non-protocol, and added U+2018 left-curly-quote support for option tokens.

### #1004 — D6 FTS5 search nits
- Added the same missing-table `OperationalError` guard to `_query_decision_results` that channel search already had.
- Extended FTS sanitizer leading-strip handling for `()[]`, dropping tokens that become empty and returning `None` when all tokens drop.

## Validation

- `.venv/bin/ruff check` on changed files: pass
- Exact broad ruff command from task: reports 12 unrelated pre-existing findings in `tests/test_detect_uk_divergence.py`, `tests/test_run_388_batch.py`, and `tests/test_worktree_brief.py`; changed files are clean.
- Requested D-series pytest slice: `279 passed in 11.20s`
- Inbox regression slice: `24 passed, 1 skipped in 0.39s`
- `.venv/bin/python scripts/test_pipeline.py`: `166 tests`, pass
- Live smoke:
  - `/channels/a82ab60b4ce1457aa450f18dac7e8a54` emitted `data-default-view="graph"`
  - `/api/search?q=()&kind=all` returned `400`

No Astro build run: no `src/content/docs/` or Astro config changes.
