### PR TITLE
fix(local-api): harden deliberation thread UI

### DIFF
--- a/scripts/local_api/routes/channels.py
+++ b/scripts/local_api/routes/channels.py
@@ -574,6 +574,7 @@ def build_channel_timeline_payload(
     query_sqlite_rows_fn: Callable[..., list[dict[str, Any]]],
     since_event_id: int = 0,
     since_ts: str | None = None,
+    thread_id: str | None = None,
 ) -> dict[str, Any]:
     """Return channel events enriched with posted message bodies.
 
@@ -582,7 +583,40 @@ def build_channel_timeline_payload(
     the bridge primitive, so this read path joins them at render time.
     """
     db_path = resolve_bridge_db_path_fn(repo_root)
-    params: list[Any] = [channel_name, since_event_id]
+    if thread_id:
+        channel_rows = query_sqlite_rows_fn(
+            db_path,
+            """
+            SELECT channel
+            FROM channel_messages
+            WHERE thread_id = ?
+            ORDER BY round_index ASC, created_at ASC, rowid ASC
+            LIMIT 1
+            """,
+            (thread_id,),
+            limit=1,
+        )
+        if channel_rows and isinstance(channel_rows[0].get("channel"), str):
+            channel_name = channel_rows[0]["channel"]
+        scope_clause = """
+        ce.thread_id = ?
+        AND EXISTS (
+          SELECT 1
+          FROM channel_messages cm
+          WHERE cm.thread_id = ce.thread_id
+        )
+        """
+        params: list[Any] = [thread_id, since_event_id]
+    else:
+        scope_clause = """
+        EXISTS (
+          SELECT 1
+          FROM channel_messages cm
+          WHERE cm.channel = ?
+            AND cm.thread_id = ce.thread_id
+        )
+        """
+        params = [channel_name, since_event_id]
     since_clause = ""
     if since_ts:
         since_clause = "AND ce.ts > ?"
@@ -607,12 +641,7 @@ def build_channel_timeline_payload(
         FROM channel_events ce
         LEFT JOIN channel_messages posted
           ON posted.message_id = json_extract(ce.payload_json, '$.message_id')
-        WHERE EXISTS (
-          SELECT 1
-          FROM channel_messages cm
-          WHERE cm.channel = ?
-            AND cm.thread_id = ce.thread_id
-        )
+        WHERE {scope_clause}
           AND ce.event_id > ?
           {since_clause}
         ORDER BY ce.event_id ASC
@@ -657,6 +686,7 @@ def build_channel_timeline_payload(
 
     return {
         "channel": channel_name,
+        "thread_id": thread_id,
         "events": events,
         "count": len(events),
         "next_since_event_id": next_since_event_id,
@@ -674,6 +704,21 @@ def channel_exists_in_db(
         resolve_bridge_db_path_fn(repo_root),
         "SELECT 1 AS found FROM channels WHERE name = ? LIMIT 1",
         (channel_name,),
+    )
+    return bool(rows)
+
+
+def thread_exists_in_db(
+    repo_root: Path,
+    thread_id: str,
+    *,
+    resolve_bridge_db_path_fn: Callable[[Path], Path],
+    query_sqlite_rows_fn: Callable[..., list[dict[str, Any]]],
+) -> bool:
+    rows = query_sqlite_rows_fn(
+        resolve_bridge_db_path_fn(repo_root),
+        "SELECT 1 AS found FROM channel_messages WHERE thread_id = ? LIMIT 1",
+        (thread_id,),
     )
     return bool(rows)
 
@@ -700,7 +745,7 @@ def render_channels_chat_html(
     *{{box-sizing:border-box;margin:0}}
     body{{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:var(--bg);color:var(--text);line-height:1.45;-webkit-font-smoothing:antialiased}}
 {top_nav_css}
-    .channels-app{{height:calc(100vh - var(--topnav-h, 45px));display:grid;grid-template-columns:240px minmax(0,1fr);border-top:1px solid var(--line)}}
+    .channels-app{{height:calc(100dvh - var(--topnav-h, 45px) - var(--search-widget-h, 53px));display:grid;grid-template-columns:240px minmax(0,1fr);border-top:1px solid var(--line)}}
     .channels-sidebar{{background:#121416;border-right:1px solid var(--line);padding:14px 10px;overflow:auto}}
     .sidebar-title{{font-size:11px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);padding:4px 10px 10px}}
     .channel-link{{display:grid;grid-template-columns:minmax(0,1fr) auto;gap:8px;align-items:center;color:var(--text);text-decoration:none;border-radius:6px;padding:7px 10px;font-size:13px;min-height:34px}}
@@ -780,7 +825,7 @@ def render_channels_chat_html(
     .turn-body{{min-width:0;border:1px solid var(--line);border-radius:6px;background:#0d0f10;overflow:hidden}}
     .turn-body h3{{font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);padding:8px 10px;border-bottom:1px solid var(--line);background:#121416}}
     .turn-body pre{{white-space:pre-wrap;word-break:break-word;color:var(--text);font:12px/1.45 ui-monospace,SFMono-Regular,Menlo,monospace;padding:10px;max-height:62vh;overflow:auto}}
-    @media(max-width:760px){{.channels-app{{grid-template-columns:1fr;height:auto;min-height:calc(100vh - var(--topnav-h, 45px))}}.channels-sidebar{{max-height:210px;border-right:0;border-bottom:1px solid var(--line)}}.channel-main{{min-height:70vh}}.channel-header{{align-items:flex-start;flex-direction:column}}.view-toggle{{width:100%}}}}
+    @media(max-width:760px){{.channels-app{{grid-template-columns:1fr;height:auto;min-height:calc(100dvh - var(--topnav-h, 45px) - var(--search-widget-h, 53px))}}.channels-sidebar{{max-height:210px;border-right:0;border-bottom:1px solid var(--line)}}.channel-main{{min-height:70vh}}.channel-header{{align-items:flex-start;flex-direction:column}}.view-toggle{{width:100%}}}}
   </style>
 </head>
 <body>
@@ -909,6 +954,8 @@ function isNearBottom(){{return messageList.scrollHeight-messageList.scrollTop-m
 function resetMessages(){{renderedMsgIds.clear();sinceId=0;lastEventType="";lastNewEventAt=0;focusedMessageIndex=-1;messageList.replaceChildren(emptyState);emptyState.style.display="block";}}
 function hasStructuredVotes(summary){{return !!(summary&&summary.rounds&&summary.rounds.some(round=>(round.turns||[]).some(turn=>turn.vote)));}}
 function defaultViewForSummary(summary){{if(REQUESTED_VIEW)return REQUESTED_VIEW;if(summary&&(summary.status==="converged"||summary.decision_id))return"graph";return DEFAULT_VIEW;}}
+function shortThreadId(value){{return String(value||"").slice(0,8);}}
+function updateThreadHeading(summary){{if(!summary||!summary.thread_id||selectedChannel!==summary.thread_id||!summary.channel)return;threadSummary=summary;const title=document.getElementById("channelTitle");const meta=document.getElementById("channelMeta");title.textContent="# "+summary.channel;const pieces=["thread "+shortThreadId(summary.thread_id)];if(summary.rounds&&summary.rounds.length)pieces.push(summary.rounds.length+" round"+(summary.rounds.length===1?"":"s"));if(summary.decision_id)pieces.push("decision linked");meta.textContent=pieces.join(" · ");renderSidebar();}}
 function setView(view,updateUrl=true){{currentView=view==="graph"?"graph":"chat";messageList.hidden=currentView!=="chat";graphView.hidden=currentView!=="graph";document.querySelectorAll("[data-view-toggle]").forEach(btn=>btn.classList.toggle("active",btn.dataset.viewToggle===currentView));if(updateUrl){{const url=new URL(window.location.href);url.searchParams.set("view",currentView);history.replaceState(null,"",url);}}}}
 function voteClass(vote){{if(!vote)return"null";if(vote==="AGREE")return"agree";if(vote==="DEFER")return"defer";if(vote.startsWith("NEEDS"))return"needs";if(vote.startsWith("OPTION "))return"option";return"null";}}
 function agentColumns(summary){{const seen=new Set();(summary.rounds||[]).forEach(round=>(round.turns||[]).forEach(turn=>seen.add(turn.agent)));return Array.from(seen).sort((a,b)=>{{const order={{claude:0,codex:1,gemini:2}};return (order[a]??100)-(order[b]??100)||a.localeCompare(b);}});}}
@@ -920,10 +967,10 @@ function githubCommitUrl(sha){{return "https://github.com/kube-dojo/kube-dojo.gi
 function githubPrUrl(number){{return "https://github.com/kube-dojo/kube-dojo.github.io/pull/"+encodeURIComponent(number);}}
 function renderLineage(footer,decisionId){{if(!decisionId)return;const line=document.createElement("span");line.className="decision-lineage";line.textContent="Influenced: loading...";footer.appendChild(line);fetch("/api/decision/"+encodeURIComponent(basename(decisionId))+"/lineage").then(r=>r.json()).then(data=>{{const lineage=data.lineage||{{}};const prs=lineage.prs||[];const prShas=new Set(prs.map(pr=>pr.sha).filter(Boolean));const commits=(lineage.commits||[]).filter(commit=>!prShas.has(commit.sha));const parts=[];prs.forEach(pr=>{{const a=document.createElement("a");a.href=githubPrUrl(pr.number);a.textContent="PR #"+pr.number;parts.push(a);}});commits.slice(0,6).forEach(commit=>{{const a=document.createElement("a");a.href=githubCommitUrl(commit.sha);a.textContent="commit "+String(commit.sha||"").slice(0,8);parts.push(a);}});line.textContent="Influenced: ";if(!parts.length){{line.appendChild(document.createTextNode("none found"));return;}}parts.forEach((part,idx)=>{{if(idx)line.appendChild(document.createTextNode(" · "));line.appendChild(part);}});}}).catch(()=>{{line.textContent="Influenced: unavailable";}});}}
 function renderGraph(summary){{threadSummary=summary;graphMount.replaceChildren();const structured=hasStructuredVotes(summary);graphFallback.hidden=structured;if(!summary||!structured)return;const agents=agentColumns(summary);const card=document.createElement("div");card.className="graph-card";const table=document.createElement("table");table.className="decision-graph";const thead=document.createElement("thead");const headRow=document.createElement("tr");["Round",...agents].forEach(label=>{{const th=document.createElement("th");th.textContent=label;headRow.appendChild(th);}});thead.appendChild(headRow);table.appendChild(thead);const tbody=document.createElement("tbody");(summary.rounds||[]).forEach(round=>{{const tr=document.createElement("tr");const label=document.createElement("td");label.innerHTML="<span class='round-label'>ROUND "+String(round.round_idx)+"</span><span class='round-cost'>"+formatMoney(round.cost_usd)+" · "+formatElapsed(round.elapsed_s)+"</span>";tr.appendChild(label);agents.forEach(agent=>{{const td=document.createElement("td");const turn=(round.turns||[]).find(item=>item.agent===agent);if(turn){{const btn=document.createElement("button");btn.type="button";btn.className="vote-chip "+voteClass(turn.vote);btn.textContent=agent+": ["+(turn.vote||"NO VOTE")+"]";btn.addEventListener("click",()=>openTurnModal(round,turn));td.appendChild(btn);}}else{{const missed=document.createElement("span");missed.className="missed";missed.textContent="<missed>";td.appendChild(missed);}}tr.appendChild(td);}});tbody.appendChild(tr);}});table.appendChild(tbody);card.appendChild(table);const footer=document.createElement("div");footer.className="decision-footer";footer.innerHTML="<strong>DECISION</strong> → Selected: "+selectedDecision(summary)+(summary.decision_id?" · Linked: "+summary.decision_id:" · Linked: none")+" · Total: "+formatMoney(summary.total_cost_usd)+" / "+formatElapsed(summary.total_elapsed_s);renderLineage(footer,summary.decision_id);card.appendChild(footer);graphMount.appendChild(card);}}
-function loadSummary(){{const myFetchId=++summaryFetchId;threadSummary=null;graphMount.replaceChildren();graphFallback.hidden=true;if(!selectedChannel){{setView("chat",false);return;}}fetch("/api/channel/"+encodeURIComponent(selectedChannel)+"/summary").then(r=>r.json()).then(summary=>{{if(myFetchId!==summaryFetchId)return;renderGraph(summary);setView(defaultViewForSummary(summary),false);}}).catch(()=>{{if(myFetchId===summaryFetchId){{graphFallback.hidden=false;setView("chat",false);}}}});}}
+function loadSummary(){{const myFetchId=++summaryFetchId;threadSummary=null;graphMount.replaceChildren();graphFallback.hidden=true;if(!selectedChannel){{setView("chat",false);return;}}fetch("/api/channel/"+encodeURIComponent(selectedChannel)+"/summary").then(r=>r.json()).then(summary=>{{if(myFetchId!==summaryFetchId)return;updateThreadHeading(summary);renderGraph(summary);setView(defaultViewForSummary(summary),false);}}).catch(()=>{{if(myFetchId===summaryFetchId){{graphFallback.hidden=false;setView("chat",false);}}}});}}
 function openTurnModal(round,turn){{turnModalTitle.textContent="Round "+String(round.round_idx)+" · "+String(turn.agent||"turn");turnModalBody.replaceChildren();const turns=(round.turns||[]).length>1?round.turns:[turn];turns.forEach(item=>{{const wrap=document.createElement("section");wrap.className="turn-body";const h=document.createElement("h3");h.textContent=String(item.agent||"agent")+" · "+String(item.vote||"no vote")+" · "+String(item.model||"");const pre=document.createElement("pre");pre.textContent=String(item.body||item.body_preview||"");wrap.append(h,pre);turnModalBody.appendChild(wrap);}});turnModal.hidden=false;turnModalClose.focus();}}
 function closeTurnModal(){{turnModal.hidden=true;turnModalBody.replaceChildren();}}
-function renderSidebar(){{channelList.replaceChildren();channels.forEach(ch=>{{const a=document.createElement("a");a.className="channel-link"+(ch.name===selectedChannel?" active":"");a.href="/channels/"+encodeURIComponent(ch.name);a.dataset.channelName=ch.name;const name=document.createElement("span");name.className="channel-name";name.textContent="# "+ch.name;const badge=document.createElement("span");badge.className="unread-badge";badge.dataset.unreadFor=ch.name;a.append(name,badge);a.addEventListener("click",()=>rememberVisited(ch.name));channelList.appendChild(a);}});document.getElementById("sidebarMeta").textContent=channels.length+" channel"+(channels.length===1?"":"s");updateUnreadBadges();}}
+function renderSidebar(){{channelList.replaceChildren();let syntheticThreads=0;channels.forEach(ch=>{{const a=document.createElement("a");a.className="channel-link"+(ch.name===selectedChannel?" active":"");a.href="/channels/"+encodeURIComponent(ch.name);a.dataset.channelName=ch.name;const name=document.createElement("span");name.className="channel-name";if(ch.name===selectedChannel&&threadSummary&&threadSummary.thread_id===selectedChannel&&threadSummary.channel){{syntheticThreads+=1;name.textContent="thread "+shortThreadId(selectedChannel)+" · # "+threadSummary.channel;}}else{{name.textContent="# "+ch.name;}}const badge=document.createElement("span");badge.className="unread-badge";badge.dataset.unreadFor=ch.name;a.append(name,badge);a.addEventListener("click",()=>rememberVisited(ch.name));channelList.appendChild(a);}});const channelCount=Math.max(0,channels.length-syntheticThreads);document.getElementById("sidebarMeta").textContent=channelCount+" channel"+(channelCount===1?"":"s")+(syntheticThreads?" · "+syntheticThreads+" thread"+(syntheticThreads===1?"":"s"):"");updateUnreadBadges();}}
 function updateUnreadBadges(){{channels.forEach(ch=>{{const badge=channelList.querySelector(`[data-unread-for="${{CSS.escape(ch.name)}}"]`);if(!badge)return;const last=localStorage.getItem(lastVisitedKey(ch.name));if(ch.name===selectedChannel||!ch.last_event_ts||last&&new Date(ch.last_event_ts)<=new Date(last)){{badge.classList.remove("visible");badge.textContent="";return;}}if(!last){{badge.textContent=String(ch.event_count||1);badge.classList.add("visible");return;}}fetch("/api/channel/"+encodeURIComponent(ch.name)+"/events?since_ts="+encodeURIComponent(last)).then(r=>r.json()).then(data=>{{const n=(data.events||[]).length;if(n>0){{badge.textContent=String(n);badge.classList.add("visible");}}else{{badge.classList.remove("visible");badge.textContent="";}}}}).catch(()=>{{badge.textContent="!";badge.classList.add("visible");}});}});}}
 function appendMeta(parent,ev,agent){{const meta=document.createElement("div");meta.className="message-meta";const name=document.createElement("span");name.className="agent-name "+agent;name.textContent=agent==="user"?"👤 user":agent;meta.appendChild(name);if(ev.from_model||ev.model){{const model=document.createElement("span");model.className="model-tag";model.textContent=ev.from_model||ev.model;meta.appendChild(model);}}const stamp=document.createElement("span");stamp.textContent=(ev.ts||ev.created_at||"").slice(0,19).replace("T"," ");meta.appendChild(stamp);parent.appendChild(meta);}}
 function appendBody(parent,body){{const div=document.createElement("div");div.className="message-body";div.textContent=body||"";parent.appendChild(div);}}
@@ -1070,13 +1117,33 @@ def route_channel_post_request(
             if bridge_db_path is not None:
                 bridge_db.DB_PATH = bridge_db_path
             try:
+                target_channel = channel_name
+                parent_id = None
                 if get_channel(channel_name) is None:
-                    return _json_response(404, {"ok": False, "error": "channel_not_found"})
+                    conn = bridge_db.get_db()
+                    try:
+                        thread_row = conn.execute(
+                            """
+                            SELECT channel, message_id
+                            FROM channel_messages
+                            WHERE thread_id = ?
+                            ORDER BY round_index ASC, created_at ASC, rowid ASC
+                            LIMIT 1
+                            """,
+                            (channel_name,),
+                        ).fetchone()
+                    finally:
+                        conn.close()
+                    if thread_row is None:
+                        return _json_response(404, {"ok": False, "error": "channel_not_found"})
+                    target_channel = thread_row["channel"]
+                    parent_id = thread_row["message_id"]
                 result = post(
-                    channel=channel_name,
+                    channel=target_channel,
                     from_agent="user",
                     body=body,
                     to_agents=to_agents,
+                    parent_id=parent_id,
                     auto_snapshot=False,
                     context_rev_shared="",
                     context_rev_channel="",
@@ -1101,6 +1168,7 @@ def route_channel_post_request(
             "ok": True,
             "message_id": result.get("message_id"),
             "thread_id": result.get("thread_id"),
+            "parent_id": result.get("parent_id"),
             "ts": result.get("created_at"),
         },
     )
@@ -1200,6 +1268,25 @@ def route_channel_api_request(
                     query_sqlite_rows_fn=query_sqlite_rows_fn,
                     since_event_id=since_event_id,
                     since_ts=since_ts,
+                ),
+                "application/json; charset=utf-8",
+            )
+        if thread_exists_in_db(
+            repo_root,
+            name,
+            resolve_bridge_db_path_fn=resolve_bridge_db_path_fn,
+            query_sqlite_rows_fn=query_sqlite_rows_fn,
+        ):
+            return (
+                200,
+                build_channel_timeline_payload(
+                    repo_root,
+                    "",
+                    resolve_bridge_db_path_fn=resolve_bridge_db_path_fn,
+                    query_sqlite_rows_fn=query_sqlite_rows_fn,
+                    since_event_id=since_event_id,
+                    since_ts=since_ts,
+                    thread_id=name,
                 ),
                 "application/json; charset=utf-8",
             )

--- a/scripts/local_api/routes/ui_fragments.py
+++ b/scripts/local_api/routes/ui_fragments.py
@@ -116,7 +116,9 @@ def render_afk_notify_markup() -> str:
 def render_search_widget() -> str:
     return """
 <style>
-  .search-widget{position:sticky;top:var(--topnav-h,45px);z-index:55;background:#121416;border-bottom:1px solid var(--line,rgba(255,255,255,.08));padding:8px 24px;--search-widget-h:53px}
+  /* Keep in sync with .channels-app height calculations in channels.py. */
+  :root{--search-widget-h:53px}
+  .search-widget{position:sticky;top:var(--topnav-h,45px);z-index:55;background:#121416;border-bottom:1px solid var(--line,rgba(255,255,255,.08));padding:8px 24px}
   .search-box{position:relative;max-width:720px}
   .search-input{width:100%;height:36px;border:1px solid var(--line,rgba(255,255,255,.12));border-radius:6px;background:#0f1011;color:var(--text,#f3f4f2);padding:0 12px;font:13px/1.4 ui-monospace,SFMono-Regular,Menlo,monospace}
   .search-input:focus{outline:2px solid rgba(61,214,198,.35);border-color:var(--teal,#3dd6c6)}
@@ -194,21 +196,23 @@ def render_search_widget() -> str:
     const query = input.value.trim();
     if (query.length < 2) {
       close();
-      return;
+      return [];
     }
     try {
       const res = await fetch("/api/search?q=" + encodeURIComponent(query) + "&kind=all&limit=10", {cache: "no-store"});
       if (!res.ok) {
         close();
-        return;
+        return [];
       }
       const data = await res.json();
       results = Array.isArray(data.results) ? data.results : [];
       active = -1;
       render();
+      return results;
     } catch {
       close();
     }
+    return [];
   }
   input.addEventListener("input", () => {
     clearTimeout(timer);
@@ -231,6 +235,12 @@ def render_search_widget() -> str:
       event.preventDefault();
       navigate(results[active]);
     }
+  });
+  input.addEventListener("keydown", async event => {
+    if (event.key !== "Enter" || !dropdown.hidden || input.value.trim().length < 2) return;
+    event.preventDefault();
+    const freshResults = await runSearch();
+    navigate(freshResults[0]);
   });
   dropdown.addEventListener("mousedown", event => {
     const row = event.target.closest(".search-result");

--- a/tests/test_local_api_channels.py
+++ b/tests/test_local_api_channels.py
@@ -3,14 +3,17 @@ from __future__ import annotations
 import importlib.util
 import json
 import sqlite3
+import sys
 from pathlib import Path
 from typing import Any
 
-import sys
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
 
 
 def _load_local_api():
-    module_path = Path(__file__).resolve().parent.parent / "scripts" / "local_api.py"
+    module_path = SCRIPTS_DIR / "local_api.py"
     spec = importlib.util.spec_from_file_location("local_api_channels", module_path)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
@@ -101,8 +104,10 @@ def _seed_channel_events(db_path: Path, events: list[dict[str, Any]], *, thread_
 def _use_bridge_db(monkeypatch, db_path: Path) -> None:
     import importlib
 
+    bridge_config = importlib.import_module("ai_agent_bridge._config")
     bridge_db = importlib.import_module("ai_agent_bridge._db")
     monkeypatch.setenv("AB_DB_PATH", str(db_path))
+    monkeypatch.setattr(bridge_config, "DB_PATH", db_path)
     monkeypatch.setattr(bridge_db, "DB_PATH", db_path)
 
 
@@ -352,3 +357,88 @@ def test_api_channel_events_since_event_id_filters(tmp_path: Path, monkeypatch) 
         }
     ]
     assert payload["next_since_event_id"] == 3
+
+
+def _seed_bridge_thread(db_path: Path, monkeypatch) -> tuple[Any, dict[str, Any], dict[str, Any]]:
+    import importlib
+
+    _use_bridge_db(monkeypatch, db_path)
+    bridge_channels = importlib.import_module("ai_agent_bridge._channels")
+    bridge_db = importlib.import_module("ai_agent_bridge._db")
+    bridge_db.init_db().close()
+    bridge_channels.create_channel("deliberation-ui-roadmap")
+    root = bridge_channels.post(
+        "deliberation-ui-roadmap",
+        "claude",
+        "Root decision prompt",
+        auto_snapshot=False,
+    )
+    reply = bridge_channels.post(
+        "deliberation-ui-roadmap",
+        "codex",
+        "[AGREE] Reply with implementation detail",
+        parent_id=root["message_id"],
+        auto_snapshot=False,
+    )
+    return bridge_db, root, reply
+
+
+def test_api_channel_thread_events_include_message_bodies(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "messages.db"
+    _, root, reply = _seed_bridge_thread(db_path, monkeypatch)
+
+    status_code, payload, _ = local_api.route_request(
+        tmp_path,
+        f"/api/channel/{root['thread_id']}/events",
+    )
+
+    assert status_code == 200
+    assert payload["thread_id"] == root["thread_id"]
+    assert payload["channel"] == "deliberation-ui-roadmap"
+    posted_events = [
+        event for event in payload["events"] if event["event"] == "message_posted"
+    ]
+    assert [event["message_id"] for event in posted_events] == [
+        root["message_id"],
+        reply["message_id"],
+    ]
+    assert [event["body"] for event in posted_events] == [
+        "Root decision prompt",
+        "[AGREE] Reply with implementation detail",
+    ]
+
+
+def test_api_channel_thread_post_replies_into_existing_thread(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "messages.db"
+    bridge_db, root, _ = _seed_bridge_thread(db_path, monkeypatch)
+
+    status_code, payload, _ = local_api.route_post_request(
+        tmp_path,
+        f"/api/channel/{root['thread_id']}/post",
+        body_bytes=json.dumps({"body": "Human follow-up"}).encode(),
+        content_type="application/json",
+    )
+
+    assert status_code == 200
+    assert payload["ok"] is True
+    assert payload["thread_id"] == root["thread_id"]
+    assert payload["parent_id"] == root["message_id"]
+    conn = bridge_db.get_db()
+    try:
+        row = conn.execute(
+            """
+            SELECT channel, thread_id, parent_id, from_agent, body
+            FROM channel_messages
+            WHERE message_id = ?
+            """,
+            (payload["message_id"],),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert row is not None
+    assert row["channel"] == "deliberation-ui-roadmap"
+    assert row["thread_id"] == root["thread_id"]
+    assert row["parent_id"] == root["message_id"]
+    assert row["from_agent"] == "user"
+    assert row["body"] == "Human follow-up"

--- a/tests/test_local_api_channels_ui.py
+++ b/tests/test_local_api_channels_ui.py
@@ -34,6 +34,9 @@ def test_channel_thread_returns_html_with_thread_id(tmp_path: Path) -> None:
     assert "text/html" in content_type
     assert "abc123" in body
     assert "/api/channel/" in body
+    assert "var(--search-widget-h, 53px)" in body
+    assert "updateThreadHeading(summary)" in body
+    assert 'name.textContent="thread "+shortThreadId(selectedChannel)' in body
 
 
 def test_channel_thread_xss_escaping(tmp_path: Path) -> None:
@@ -45,3 +48,12 @@ def test_channel_thread_xss_escaping(tmp_path: Path) -> None:
     assert "&lt;script&gt;" in body
     raw_tag = "<script>alert(1)</script>"
     assert raw_tag not in body, f"raw tag {raw_tag!r} leaked into rendered page"
+
+
+def test_global_search_enter_path_handles_closed_dropdown(tmp_path: Path) -> None:
+    status, body, content_type = local_api.route_request(tmp_path, "/channels")
+    assert status == 200
+    assert "text/html" in content_type
+    assert 'if (event.key !== "Enter" || !dropdown.hidden' in body
+    assert "return [];" in body
+    assert "const freshResults = await runSearch();" in body


### PR DESCRIPTION
## Summary
- Fix decision-linked `/channels/<thread_id>` pages so thread-mode event payloads resolve the hosting channel and include posted message bodies.
- Allow `/api/channel/<thread_id>/post` to reply into the existing bridge thread instead of treating the thread id as a missing channel.
- Polish the local API UI around thread labels, search Enter behavior, and search-widget height accounting.
- Add regression coverage for thread-id events, thread-id posting, and the UI/search snippets.

## Verification
- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/ruff check scripts/local_api/routes/channels.py scripts/local_api/routes/ui_fragments.py tests/test_local_api_channels.py tests/test_local_api_channels_ui.py`
- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python -m pytest tests/test_local_api_channels.py tests/test_local_api_channels_ui.py tests/test_search_endpoint_validation.py tests/test_search_kind_filter.py tests/test_search_fts_channels.py tests/test_search_fts_decisions.py` (`22 passed` after rebasing on origin/main)
- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/test_pipeline.py` (`166 tests ... OK`)
- Browser/read-only local API check against the D-series thread confirmed graph/chat render and `/api/channel/a82ab60b4ce1457aa450f18dac7e8a54/events` returns `channel=deliberation-ui-roadmap` with message bodies.

## Review
Cross-family Claude review will be posted as a PR comment before merge.
