### PR TITLE
feat(infra): wire UK pipeline cron via launchd (#958, #960 wiring)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,9 @@ docs/quality-progress.tsv.lock
 .claude/scheduled_tasks.lock
 .claude/local_api.db
 
+# launchd runtime logs
+.pipeline/launchd-logs/
+
 # Agent bridge runtime
 .bridge/
 .agent/

--- a/infra/launchd/README.md
+++ b/infra/launchd/README.md
@@ -1,0 +1,47 @@
+# UK Pipeline LaunchAgents
+
+## Purpose
+
+This local launchd wiring runs the Ukrainian pipeline maintenance jobs daily on a developer machine. It detects stale UK translations at 03:00, then runs the translation worker loop at 03:30 to drain a small capped batch from the local queue. The jobs are local-only and write logs under `.pipeline/launchd-logs/`.
+
+## Why launchd, not GitHub Actions
+
+Both target scripts depend on **local state** that GH Actions runners cannot share:
+
+1. `scripts/translation_v2.py worker loop` reads/writes `.pipeline/translation_v2.db` (local SQLite via ControlPlane) and uses **Gemini OAuth** via `dispatch_gemini_with_retry` (per-account creds, not a shared API key -- see `KUBEDOJO_GEMINI_SUBSCRIPTION=1` in `.envrc`).
+2. `scripts/detect_uk_divergence.py` enqueues into the **same** local SQLite DB.
+3. Neither script auto-commits or pushes; UK files written under `src/content/docs/uk/` are reviewed locally before manual commit.
+
+## Schedule
+
+| Job | Time | Cap |
+|---|---|---|
+| uk-divergence-detect | 03:00 daily | (full scan; no enqueue cap) |
+| translation-worker-loop | 03:30 daily | `--max-calls 3 --sleep-seconds 30` |
+
+## Install
+
+```bash
+./infra/launchd/install.sh
+```
+
+## Verify
+
+```bash
+launchctl list | grep kubedojo
+ls -la .pipeline/launchd-logs/
+```
+
+## Uninstall
+
+```bash
+./infra/launchd/uninstall.sh
+```
+
+## Troubleshooting
+
+- `.venv/bin/python` must exist (run `python3 -m venv .venv && .venv/bin/pip install -r requirements.txt` if missing).
+- Gemini OAuth creds must be live (`~/.gemini/oauth_creds.json` or whatever `dispatch_gemini_with_retry` uses).
+- launchd jobs run with a stripped environment -- anything not in `EnvironmentVariables` is unavailable.
+- To trigger a job manually for testing: `launchctl start com.kubedojo.uk-divergence-detect`.
+- To check next fire time: `launchctl list <label>` (look at `LastExitStatus`, `PID`).

--- a/infra/launchd/com.kubedojo.translation-worker-loop.plist.tmpl
+++ b/infra/launchd/com.kubedojo.translation-worker-loop.plist.tmpl
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.kubedojo.translation-worker-loop</string>
+	<key>WorkingDirectory</key>
+	<string>{{REPO_ROOT}}</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>{{REPO_ROOT}}/.venv/bin/python</string>
+		<string>{{REPO_ROOT}}/scripts/translation_v2.py</string>
+		<string>worker</string>
+		<string>loop</string>
+		<string>--max-calls</string>
+		<string>3</string>
+		<string>--sleep-seconds</string>
+		<string>30</string>
+	</array>
+	<key>StartCalendarInterval</key>
+	<dict>
+		<key>Hour</key>
+		<integer>3</integer>
+		<key>Minute</key>
+		<integer>30</integer>
+	</dict>
+	<key>RunAtLoad</key>
+	<false/>
+	<key>StandardOutPath</key>
+	<string>{{REPO_ROOT}}/.pipeline/launchd-logs/translation-worker-loop.out.log</string>
+	<key>StandardErrorPath</key>
+	<string>{{REPO_ROOT}}/.pipeline/launchd-logs/translation-worker-loop.err.log</string>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>HOME</key>
+		<string>{{HOME}}</string>
+		<key>PATH</key>
+		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+		<key>KUBEDOJO_GEMINI_SUBSCRIPTION</key>
+		<string>1</string>
+	</dict>
+</dict>
+</plist>

--- a/infra/launchd/com.kubedojo.uk-divergence-detect.plist.tmpl
+++ b/infra/launchd/com.kubedojo.uk-divergence-detect.plist.tmpl
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.kubedojo.uk-divergence-detect</string>
+	<key>WorkingDirectory</key>
+	<string>{{REPO_ROOT}}</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>{{REPO_ROOT}}/.venv/bin/python</string>
+		<string>{{REPO_ROOT}}/scripts/detect_uk_divergence.py</string>
+		<string>--json</string>
+	</array>
+	<key>StartCalendarInterval</key>
+	<dict>
+		<key>Hour</key>
+		<integer>3</integer>
+		<key>Minute</key>
+		<integer>0</integer>
+	</dict>
+	<key>RunAtLoad</key>
+	<false/>
+	<key>StandardOutPath</key>
+	<string>{{REPO_ROOT}}/.pipeline/launchd-logs/uk-divergence-detect.out.log</string>
+	<key>StandardErrorPath</key>
+	<string>{{REPO_ROOT}}/.pipeline/launchd-logs/uk-divergence-detect.err.log</string>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>HOME</key>
+		<string>{{HOME}}</string>
+		<key>PATH</key>
+		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+	</dict>
+</dict>
+</plist>

--- a/infra/launchd/install.sh
+++ b/infra/launchd/install.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HOME="${HOME:?HOME must be set}"
+LAUNCH_AGENTS_DIR="$HOME/Library/LaunchAgents"
+LOG_DIR="$REPO_ROOT/.pipeline/launchd-logs"
+
+sed_escape() {
+	printf '%s' "$1" | sed 's/[&|]/\\&/g'
+}
+
+escaped_home="$(sed_escape "$HOME")"
+escaped_repo_root="$(sed_escape "$REPO_ROOT")"
+
+mkdir -p "$LOG_DIR"
+mkdir -p "$LAUNCH_AGENTS_DIR"
+
+for tmpl in "$SCRIPT_DIR"/*.plist.tmpl; do
+	plist_name="$(basename "${tmpl%.tmpl}")"
+	target="$LAUNCH_AGENTS_DIR/$plist_name"
+
+	sed \
+		-e "s|{{HOME}}|$escaped_home|g" \
+		-e "s|{{REPO_ROOT}}|$escaped_repo_root|g" \
+		"$tmpl" > "$target"
+
+	launchctl unload "$target" >/dev/null 2>&1 || true
+	launchctl load "$target"
+done
+
+launchctl list | grep -E 'kubedojo' || echo "(no kubedojo jobs registered yet)"
+echo "Installed. Logs at: $LOG_DIR/"

--- a/infra/launchd/uninstall.sh
+++ b/infra/launchd/uninstall.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOME="${HOME:?HOME must be set}"
+LAUNCH_AGENTS_DIR="$HOME/Library/LaunchAgents"
+
+for tmpl in "$SCRIPT_DIR"/*.plist.tmpl; do
+	plist_name="$(basename "${tmpl%.tmpl}")"
+	label="${plist_name%.plist}"
+	target="$LAUNCH_AGENTS_DIR/$plist_name"
+
+	launchctl unload "$target" >/dev/null 2>&1 || true
+	rm -f "$target"
+done
+
+echo "Uninstalled."


### PR DESCRIPTION
Summary:
- Adds local launchd templates for daily UK divergence detection and capped translation worker draining.
- Adds install/uninstall scripts with {{HOME}}/{{REPO_ROOT}} substitution and launchd log directory setup.
- Documents why this must run locally instead of GitHub Actions.

Test plan:
- [x] plutil -lint passes on both templates.
- [x] plutil -lint passes after temp substitution of HOME and REPO_ROOT.
- [x] bash -n infra/launchd/install.sh and bash -n infra/launchd/uninstall.sh pass.
- [x] git diff --check passes.
- [ ] install.sh runs cleanly: not executed per task instruction not to run launchctl load from dispatch.
- [ ] cron fires at next 03:00: pending local installation by user.

Closes #958.
Closes #960.