### PR TITLE
fix(scripts): detach session-up services so they survive shell exit

### DIFF
--- a/scripts/services-up
+++ b/scripts/services-up
@@ -16,6 +16,38 @@ mkdir -p logs/pipeline .pids
 
 mode="${1:-all}"
 
+launch_detached() {
+  local pid_file="$1"
+  local log_file="$2"
+  shift 2
+  "$VENV_PY" - "$REPO_ROOT" "$pid_file" "$log_file" "$@" <<'PY'
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+repo_root = Path(sys.argv[1])
+pid_path = repo_root / sys.argv[2]
+log_path = repo_root / sys.argv[3]
+cmd = sys.argv[4:]
+
+pid_path.parent.mkdir(parents=True, exist_ok=True)
+log_path.parent.mkdir(parents=True, exist_ok=True)
+with log_path.open("ab", buffering=0) as log:
+    proc = subprocess.Popen(
+        cmd,
+        cwd=repo_root,
+        stdin=subprocess.DEVNULL,
+        stdout=log,
+        stderr=subprocess.STDOUT,
+        env=os.environ.copy(),
+        start_new_session=True,
+        close_fds=True,
+    )
+pid_path.write_text(f"{proc.pid}\n", encoding="utf-8")
+PY
+}
+
 is_alive() {
   local pid_file="$1"
   [ -f "$pid_file" ] || return 1
@@ -30,9 +62,8 @@ start_api() {
     echo "api: already running (pid $(cat .pids/api.pid))"
     return
   fi
-  nohup "$VENV_PY" scripts/local_api.py --host 127.0.0.1 --port 8768 \
-    > logs/api.log 2>&1 &
-  echo $! > .pids/api.pid
+  launch_detached .pids/api.pid logs/api.log \
+    "$VENV_PY" scripts/local_api.py --host 127.0.0.1 --port 8768
   sleep 1
   if is_alive .pids/api.pid; then
     echo "api: started (pid $(cat .pids/api.pid))"
@@ -49,10 +80,9 @@ start_worker() {
     echo "v2-${role}-worker: already running (pid $(cat "$pid_file"))"
     return
   fi
-  PYTHONPATH=scripts nohup "$VENV_PY" -m pipeline_v2.cli "${role}-worker" loop \
-    --worker-id "v2-${role}-01" --sleep-seconds 30 \
-    > "logs/pipeline/${role}-worker.log" 2>&1 &
-  echo $! > "$pid_file"
+  launch_detached "$pid_file" "logs/pipeline/${role}-worker.log" \
+    env PYTHONPATH=scripts "$VENV_PY" -m pipeline_v2.cli "${role}-worker" loop \
+      --worker-id "v2-${role}-01" --sleep-seconds 30
   sleep 1
   if is_alive "$pid_file"; then
     echo "v2-${role}-worker: started (pid $(cat "$pid_file"))"


### PR DESCRIPTION
## Summary

Replaces `nohup ... &` in `scripts/services-up` with a `launch_detached` Python helper that uses `subprocess.Popen(..., start_new_session=True, close_fds=True)`. The shell `&` background still inherits the controlling terminal's session group — when Claude Code's parent shell exits, services die with it. The Python `start_new_session=True` creates a new POSIX session and properly detaches the process group.

Affected services in this script:
- `start_api` (local_api.py on :8768)
- `start_worker` (pipeline_v2 writer/verifier loops)

## Why now

The current pattern looks detached but isn't — services were dying on Claude Code session exit, requiring a manual `services-up` re-run at the start of every new session. After this PR, they survive.

## Diff scope

`scripts/services-up` only. +37 / -7. No other files touched.

## Test plan

- [ ] `./scripts/services-up all` — services start, log to `logs/api.log` and `logs/pipeline/*-worker.log`
- [ ] Exit the parent shell — services keep running (`ps -ef | grep local_api.py` shows the PID alive)
- [ ] `./scripts/services-up status` (or whatever the verb is) — reports services as running
- [ ] Restart shell, `./scripts/services-up all` again — `is_alive` correctly reports already-running, no duplicate process