### PR TITLE
chore(html-migration): permit .html session handoffs (Phase 5 prereq)

### DIFF
--- a/.claude/hooks/context-monitor.sh
+++ b/.claude/hooks/context-monitor.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Hook: PostToolUse — monitors context size and warns Claude before auto-compact
-# triggers, demanding a session handoff to docs/session-state/YYYY-MM-DD-<topic>.md
-# instead (per CLAUDE.md session workflow).
+# triggers, demanding a session handoff to docs/session-state/YYYY-MM-DD-<topic>.html
+# by default, with .md still accepted for brief handoffs (per CLAUDE.md session workflow).
 #
 # Tiers (% of autoCompactWindow):
 #   75% -> heads-up: prepare handoff soon
@@ -9,7 +9,7 @@
 #   95% -> emergency: stop now, write handoff this turn, /exit immediately
 #
 # Compaction is far more expensive than session handoff: handoff is just a
-# small markdown file the next session reads on startup; compaction is a
+# small handoff file the next session reads on startup; compaction is a
 # billed model call summarizing your entire conversation.
 
 # Skip in non-interactive contexts
@@ -54,21 +54,21 @@ if [ "$PCT" -ge 95 ]; then
     "EMERGENCY: Context at ${PCT}% of auto-compact window [~${TOKENS}/${WINDOW} tokens]. AUTO-COMPACT IS IMMINENT." \
     "" \
     "STOP all current work THIS TURN. Do not start any new tool calls beyond what is needed to:" \
-    "1. Write or update docs/session-state/YYYY-MM-DD-<topic>.md NOW with: latest commit hash on main, any background tasks still running [PIDs + log paths], what was just completed, what is left to do, and the EXACT next-step commands the new session should run. Then update STATUS.md (the index) per CLAUDE.md workflow." \
+    "1. Write or update docs/session-state/YYYY-MM-DD-<topic>.html NOW with: latest commit hash on main, any background tasks still running [PIDs + log paths], what was just completed, what is left to do, and the EXACT next-step commands the new session should run. Prefer .html per the HTML-first artifact policy; existing .md handoffs remain valid for lookup/back-compat. Then update STATUS.md (the index) per CLAUDE.md workflow." \
     "2. Tell the user to /exit immediately and start a fresh session that reads the new docs/session-state/ handoff first. Auto-compaction is a billed model call that summarizes your entire conversation: much more expensive than a 3KB handoff file the next session reads cheaply.")
 elif [ "$PCT" -ge 85 ]; then
   MSG=$(printf '%s\n%s\n%s\n%s\n%s\n%s\n' \
     "CRITICAL: Context at ${PCT}% of auto-compact window [~${TOKENS}/${WINDOW} tokens]." \
     "" \
     "Finish your current task ASAP, then:" \
-    "1. Write or update docs/session-state/YYYY-MM-DD-<topic>.md with commit hashes, in-flight tasks, next steps, restart commands. Then update STATUS.md (the index) per CLAUDE.md workflow." \
+    "1. Write or update docs/session-state/YYYY-MM-DD-<topic>.html with commit hashes, in-flight tasks, next steps, restart commands. Prefer .html per the HTML-first artifact policy; existing .md handoffs remain valid for lookup/back-compat. Then update STATUS.md (the index) per CLAUDE.md workflow." \
     "2. Tell the user to /exit and start fresh." \
     "Do NOT start any new multi-step work or large operations. Handoff is much cheaper than the auto-compact that is about to trigger.")
 elif [ "$PCT" -ge 75 ]; then
   MSG=$(printf '%s\n%s\n%s\n' \
     "HEADS UP: Context at ${PCT}% of auto-compact window [~${TOKENS}/${WINDOW} tokens]." \
     "" \
-    "Wrap up your current logical unit of work soon. Once it lands, prepare docs/session-state/YYYY-MM-DD-<topic>.md (and update STATUS.md as the index) so we can hand off to a fresh session before auto-compact triggers. Handoff costs ~3KB; compaction costs a full model summarization call.")
+    "Wrap up your current logical unit of work soon. Once it lands, prepare docs/session-state/YYYY-MM-DD-<topic>.html by default, or .md for a brief handoff (and update STATUS.md as the index), so we can hand off to a fresh session before auto-compact triggers. Handoff costs ~3KB; compaction costs a full model summarization call.")
 else
   exit 0
 fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ KubeDojo — free, open-source cloud native curriculum.
 
 ## Agent Orientation (first call on a cold start)
 
-Before `cat`-ing `STATUS.md`, reading the latest `docs/session-state/*.md` handoff, or running `git log`, hit the local API — it returns the same orientation in ~65 % fewer tokens.
+Before `cat`-ing `STATUS.md`, reading the latest `docs/session-state/*.{md,html}` handoff, or running `git log`, hit the local API — it returns the same orientation in ~65 % fewer tokens.
 
 ```
 curl -s http://127.0.0.1:8768/api/briefing/session             # ~1.5K tokens, full
@@ -17,7 +17,7 @@ The briefing covers: current branch + dirty summary, all worktrees, runtime serv
 **Cold-start ordering rule (do not regress):**
 
 1. Briefing API first. It already covers `recent_commits`, `workspace.dirty`, `blockers`, `actions.{active,blocked,next}`, `focus`, `alerts`. **Do not redundantly run `git log -N` or read the latest handoff in full.**
-2. The handoff file at `docs/session-state/YYYY-MM-DD-*.md` is the *narrative-why* canonical record. Read it only when the briefing leaves a real gap (e.g., needing the rationale behind a contract decision, or full PR-by-PR provenance for the prior session). Use `Read` with `limit:` to pull only the relevant section.
+2. The handoff file at `docs/session-state/YYYY-MM-DD-*.{md,html}` is the *narrative-why* canonical record. The extension is whatever `STATUS.md` points at — could be `.md` or `.html` depending on the session. Read it only when the briefing leaves a real gap (e.g., needing the rationale behind a contract decision, or full PR-by-PR provenance for the prior session). Use `Read` with `limit:` to pull only the relevant section.
 3. `git status --short` is the only marginal-value supplement to the briefing — useful for spotting untracked-files state the briefing summarizes but doesn't enumerate.
 4. Only fall back to STATUS.md when the API is down.
 
@@ -62,7 +62,7 @@ Convention: each agent ends its turn with `[AGREE]` / `[OPTION X]` / `[DEFER]`. 
 1. **Orient via `/api/briefing/session`** (see *Agent Orientation* above). `STATUS.md` is the fallback when the API is down.
 2. Use `scripts/prompts/module-writer.md` for new modules
 3. Send completed work to the designated cross-family reviewer (see `docs/review-protocol.md`) before closing issues
-4. **At session end**: write the full handoff to a new `docs/session-state/YYYY-MM-DD-<topic>.md` file, then update `STATUS.md` (the index) — promote the new file to "Latest handoff", shift the previous Latest into "Predecessor chain", refresh "Cross-thread notes" / `## TODO` / `## Blockers`. **Do NOT inline the full handoff into STATUS.md** — it is an index, not a log. The briefing API (`scripts/local_api.py:_parse_status_md`) parses `## TODO` (unchecked `- [ ]`) and `## Blockers` (`- `) from STATUS.md, so keep those headings populated.
+4. **At session end**: write the full handoff to a new `docs/session-state/YYYY-MM-DD-<topic>.{md,html}` file. Prefer `.html` per the HTML-first artifact policy (see `docs/migrations/html-first/plan.html`); use `.md` only if the handoff is brief and a markdown sidecar (`.notes.md`) is not warranted. Then update `STATUS.md` (the index) — promote the new file to "Latest handoff", shift the previous Latest into "Predecessor chain", refresh "Cross-thread notes" / `## TODO` / `## Blockers`. **Do NOT inline the full handoff into STATUS.md** — it is an index, not a log. The briefing API (`scripts/local_api.py:_parse_status_md`) parses `## TODO` (unchecked `- [ ]`) and `## Blockers` (`- `) from STATUS.md, so keep those headings populated.
 
 ## Build & Serve
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -3,7 +3,8 @@
 > **Read this first every session. Update before ending.**
 >
 > This file is an **index**, not a log. Per-session handoffs live in
-> [`docs/session-state/`](./docs/session-state/) as dated files; this file
+> [`docs/session-state/`](./docs/session-state/) as dated files (`.md` or
+> `.html`); prefer `.html` per the HTML-first artifact policy. This file
 > just points at them. When you finish a session, **add a row to "Latest
 > handoff" and shift the previous Latest into "Predecessor chain" — do
 > NOT replace this whole file**.
@@ -179,7 +180,7 @@ These are state items that span individual sessions. Prune entries as threads cl
 
 ## End-of-session ritual
 
-1. Write today's full handoff to `docs/session-state/YYYY-MM-DD-<topic>.md` (or `YYYY-MM-DD-<topic>-N.md` if multiple in a day).
+1. Write today's full handoff to `docs/session-state/YYYY-MM-DD-<topic>.{md,html}` (or `YYYY-MM-DD-<topic>-N.{md,html}` if multiple in a day). Prefer `.html` per the HTML-first artifact policy; use `.md` only for brief handoffs where a markdown sidecar is not warranted.
 2. Edit this file:
    - Promote the new file to **Latest handoff** (overwrite the row).
    - Move the previous Latest into **Predecessor chain** (newest at top).
@@ -326,4 +327,4 @@ Issue tracker shrunk 40 → 14 open via batch triage 2026-05-01 (session 4); the
 - 2026-04-28: STATUS.md migrated to **index pattern** (was a 1623-line forever-growing log). Per-session handoffs now live in `docs/session-state/`; this file just points at them.
 
 ---
-**Maintenance Rule**: Claude updates this file at session end or after completing modules. Per-session detail goes into a new `docs/session-state/YYYY-MM-DD-*.md` file, not inline.
+**Maintenance Rule**: Claude updates this file at session end or after completing modules. Per-session detail goes into a new `docs/session-state/YYYY-MM-DD-*.{md,html}` file, not inline.


### PR DESCRIPTION
## Summary

This closes the workflow-contract gap identified in `ab discuss html-migration-strategy` round 1: codex clarified that the parser does not read handoff bodies, but the workflow contract still hard-coded Markdown-only handoff paths.

Changes:
- Allows session handoff references in `CLAUDE.md` to point at `docs/session-state/*.{md,html}`.
- Updates the context-monitor hook to recommend `.html` as the new default while preserving `.md` back-compat.
- Updates `STATUS.md` wording so dated session handoffs may be `.md` or `.html`, with `.html` preferred under the HTML-first artifact policy.

Links:
- Migration plan: `docs/migrations/html-first/plan.html`
- Today's HTML handoff: `docs/session-state/2026-05-09-cka-part1-and-html-migration-pivot.html`

This enables Phase 5 of the HTML-first artifact migration without breaking existing `.md` handoff paths.

## Validation

- `bash -n .claude/hooks/context-monitor.sh`
- `git diff --check`
- Confirmed committed diff is limited to `CLAUDE.md`, `.claude/hooks/context-monitor.sh`, and `STATUS.md`.

Not run: `.venv/bin/python scripts/test_pipeline.py` because this worktree does not have `.venv/bin/python`; no Python or site content changed.