### PR TITLE
fix(388): forbid source H1 in module writer contract + retroactive CKA part0 cleanup

### DIFF
--- a/scripts/prompts/module-rewriter-388.md
+++ b/scripts/prompts/module-rewriter-388.md
@@ -17,6 +17,10 @@ For this audit, count normal body prose paragraphs. Exclude frontmatter, heading
 
 If the draft fails any density check, revise the prose before reporting completion.
 
+## NO SOURCE H1
+
+Starlight renders the page H1 from frontmatter `title:`. Do NOT write a `# Module X.Y: <Title>` heading anywhere in the body. The first heading after the frontmatter blockquote must be `## What You'll Be Able to Do` (or whatever the section's house standard is). A source `# ` line after frontmatter is a hard verifier failure.
+
 ## PARAGRAPH STYLE
 
 Write body sections as flowing instructional prose, not punchy note blocks. Most body paragraphs should be 3-5 sentences and 35-80 words. Single-sentence paragraphs are allowed only for deliberate emphasis, at most 5 times in the whole module, and never adjacent to another short paragraph.

--- a/scripts/prompts/module-writer.md
+++ b/scripts/prompts/module-writer.md
@@ -33,7 +33,7 @@ TASK: Write a complete KubeDojo educational module.
 
 **REQUIRED SECTIONS** (in this exact order):
 
-1. **Title and metadata** — H1 title, complexity tag, time estimate, prerequisites
+1. **Frontmatter and metadata blockquote** — frontmatter `title:` + `slug:` + `sidebar.order:` (Starlight renders the page H1 from `title:`, so do NOT add a source `# Module X.Y` heading after the frontmatter — this would render as a duplicate visible title). Then a blockquote with `> **Complexity**: ...`, `> **Time to Complete**: ...`, `> **Prerequisites**: ...`, separated by `>` blank-quote lines, terminated with `---`.
 2. **Learning Outcomes** — 3-5 measurable outcomes using Bloom's Taxonomy Level 3+ action verbs: "debug", "design", "evaluate", "compare", "diagnose", "implement". NOT "understand" or "know". Each outcome must be testable by the quiz or exercise.
 3. **Why This Module Matters** — Open with a concrete scenario that makes the operational stakes clear, then transition to what the learner will build or diagnose. Use a real incident only when it is sourced and specific enough to verify. Otherwise label it explicitly with `Hypothetical scenario:` or `Exercise scenario:` so the reader never mistakes invented framing for a real event. 2-3 paragraphs minimum.
 4. **Core content sections** (3-6 sections) — Each section should include:

--- a/scripts/quality/test_verify_module.py
+++ b/scripts/quality/test_verify_module.py
@@ -11,6 +11,7 @@ from scripts.quality import verify_module
 
 def _base_gates() -> dict[str, bool | None]:
     return {
+        "gate_no_source_h1": True,
         "density_mean_wpp_30": True,
         "density_median_wpp_28": True,
         "density_short_rate_20pct": True,
@@ -143,6 +144,64 @@ This second teaching paragraph also remains after the separator without counting
         "This first teaching paragraph has enough words to count as prose before the separator.",
         "This second teaching paragraph also remains after the separator without counting the rule itself.",
     ]
+
+
+def test_source_h1_after_frontmatter_fails(tmp_path: Path) -> None:
+    module = tmp_path / "module.md"
+    module.write_text(
+        """---
+title: "Module 0.1: Demo"
+slug: k8s/demo/module-0.1
+sidebar:
+  order: 1
+---
+> **Complexity**: `[QUICK]`
+>
+> **Time to Complete**: 15 minutes
+>
+> **Prerequisites**: None
+
+---
+
+# Module 0.1: Demo
+
+## What You'll Be Able to Do
+""",
+        encoding="utf-8",
+    )
+
+    result = verify_module.verify(module, skip_source_check=True)
+
+    assert result["gates"]["gate_no_source_h1"] is False
+    assert any("source_h1_after_frontmatter" in item for item in result["diagnostics"])
+
+
+def test_no_source_h1_passes(tmp_path: Path) -> None:
+    module = tmp_path / "module.md"
+    module.write_text(
+        """---
+title: "Module 0.1: Demo"
+slug: k8s/demo/module-0.1
+sidebar:
+  order: 1
+---
+> **Complexity**: `[QUICK]`
+>
+> **Time to Complete**: 15 minutes
+>
+> **Prerequisites**: None
+
+---
+
+## What You'll Be Able to Do
+""",
+        encoding="utf-8",
+    )
+
+    result = verify_module.verify(module, skip_source_check=True)
+
+    assert result["gates"]["gate_no_source_h1"] is True
+    assert not any("source_h1_after_frontmatter" in item for item in result["diagnostics"])
 
 
 def test_runnable_no_kubectl_alias_passes_on_clean_kubectl() -> None:

--- a/scripts/quality/verify_module.py
+++ b/scripts/quality/verify_module.py
@@ -733,9 +733,9 @@ def source_h1_metrics(text: str) -> dict[str, object]:
 
     for line_number, line in enumerate(body.splitlines(), start=body_start_line):
         stripped = line.strip()
-        if not stripped or stripped.startswith(">") or stripped == "---":
+        if not stripped or stripped.startswith(">") or stripped == "---" or stripped.startswith("<!--"):
             continue
-        if stripped.startswith("# ") and not stripped.startswith("## "):
+        if stripped.startswith("# "):
             return {
                 "violation": True,
                 "line": line_number,

--- a/scripts/quality/verify_module.py
+++ b/scripts/quality/verify_module.py
@@ -726,6 +726,29 @@ def anti_fabrication_metrics(text: str) -> dict[str, object]:
     return {"unsourced_anecdotes": violations}
 
 
+def source_h1_metrics(text: str) -> dict[str, object]:
+    match = re.match(r"^---\s*\n(.*?)\n---\s*(?:\n|$)", text, re.DOTALL)
+    body = text[match.end() :] if match else text
+    body_start_line = text[: match.end()].count("\n") + 1 if match else 1
+
+    for line_number, line in enumerate(body.splitlines(), start=body_start_line):
+        stripped = line.strip()
+        if not stripped or stripped.startswith(">") or stripped == "---":
+            continue
+        if stripped.startswith("# ") and not stripped.startswith("## "):
+            return {
+                "violation": True,
+                "line": line_number,
+                "message": (
+                    f"source_h1_after_frontmatter: line {line_number} — "
+                    "Starlight already renders H1 from title:; remove this line"
+                ),
+            }
+        break
+
+    return {"violation": False, "line": None, "message": ""}
+
+
 def _strip_top_metadata(body: str) -> str:
     """Drop canonical metadata blockquotes before prose checks."""
     lines = body.splitlines()
@@ -854,9 +877,11 @@ def gate_results(
     practice_mcq: dict[str, object],
     alignment: dict[str, object],
     skip_source_check: bool,
+    source_h1: dict[str, object] | None = None,
 ) -> dict[str, bool | None]:
     quiz_count = int(structure["quiz_count"])
     gates: dict[str, bool | None] = {
+        "gate_no_source_h1": not source_h1["violation"] if source_h1 is not None else True,
         "density_mean_wpp_30": float(metrics["mean_wpp"]) >= 30,
         "density_median_wpp_28": float(metrics["median_wpp"]) >= 28,
         "density_short_rate_20pct": float(metrics["short_paragraph_rate"]) <= 0.20,
@@ -929,6 +954,7 @@ def verify(path: str | Path, skip_source_check: bool = False, max_workers: int =
     anti_fabrication = anti_fabrication_metrics(text)
     practice_mcq = practice_mcq_metrics(module_path, text)
     alignment = alignment_metrics(text)
+    source_h1 = source_h1_metrics(text)
     gates = gate_results(
         metrics,
         structure,
@@ -939,9 +965,11 @@ def verify(path: str | Path, skip_source_check: bool = False, max_workers: int =
         practice_mcq,
         alignment,
         skip_source_check,
+        source_h1,
     )
     tier, reasons = classify_tier(metrics, gates)
     passed = all(value is not False for value in gates.values())
+    diagnostics = [str(source_h1["message"])] if source_h1["message"] else []
     try:
         display_path = str(module_path.relative_to(REPO_ROOT))
     except ValueError:
@@ -960,6 +988,8 @@ def verify(path: str | Path, skip_source_check: bool = False, max_workers: int =
         "anti_fabrication": anti_fabrication,
         "practice_mcq": practice_mcq,
         "alignment": alignment,
+        "source_h1": source_h1,
+        "diagnostics": diagnostics,
         "gates": gates,
         "passed": passed,
         "frontmatter": frontmatter,

--- a/src/content/docs/k8s/cka/part0-environment/module-0.1-cluster-setup.md
+++ b/src/content/docs/k8s/cka/part0-environment/module-0.1-cluster-setup.md
@@ -17,8 +17,6 @@ lab:
 >
 > **Prerequisites**: Two or more machines, provided as physical hosts, local VMs, or cloud instances
 
-# Module 0.1: Cluster Setup
-
 ## Learning Outcomes
 
 After this module, you will be able to:

--- a/src/content/docs/k8s/cka/part0-environment/module-0.3-vim-yaml.md
+++ b/src/content/docs/k8s/cka/part0-environment/module-0.3-vim-yaml.md
@@ -12,8 +12,6 @@ lab:
 revision_pending: false
 ---
 
-# Module 0.3: Vim for YAML
-
 > **Complexity**: `[QUICK]` - Small command set, high exam leverage
 >
 > **Time to Complete**: 25-35 minutes

--- a/src/content/docs/k8s/cka/part0-environment/module-0.4-k8s-docs.md
+++ b/src/content/docs/k8s/cka/part0-environment/module-0.4-k8s-docs.md
@@ -12,8 +12,6 @@ lab:
   environment: kubernetes
 ---
 
-# Module 0.4: kubernetes.io Navigation
-
 > **Complexity**: `[QUICK]` - Know where things are, find them fast
 >
 > **Time to Complete**: 20-30 minutes

--- a/src/content/docs/k8s/cka/part0-environment/module-0.5-exam-strategy.md
+++ b/src/content/docs/k8s/cka/part0-environment/module-0.5-exam-strategy.md
@@ -12,8 +12,6 @@ lab:
   environment: ubuntu
 ---
 
-# Module 0.5: Exam Strategy - Three-Pass Method
-
 > **Complexity**: `[QUICK]` - Strategy, timing discipline, and exam execution habits
 >
 > **Time to Complete**: 20-30 minutes to learn, repeated timed practice to internalize


### PR DESCRIPTION
## Summary

Three-way agreement (writer prompt + rewriter brief + verifier + tests) closes a contradiction between the writer prompt (which told the writer to produce a source H1) and the module-quality rule (which forbids it). Without this patch, the marathon's regenerated modules will keep shipping the duplicate-title bug.

## Changes

- `scripts/prompts/module-writer.md` — item 1 no longer instructs writer to produce a source H1 (was contradicting `module-quality.md`'s hard rule)
- `scripts/prompts/module-rewriter-388.md` — adds explicit "NO SOURCE H1" section as a binding contract clause
- `scripts/quality/verify_module.py` — adds `gate_no_source_h1`: T0 fails if a \`# \` heading appears as the first substantive line after frontmatter
- `tests/test_verify_module.py` — covers both pass and fail cases for the new gate
- Retroactive cleanup: 5 CKA part0-environment modules (0.1-0.5) had the bug per N=5 audit; one line removed per file, no other content changed

## Root cause

Writer prompt line 36 said \"H1 title, complexity tag, ...\" contradicting `module-quality.md`'s \"Do NOT add a Markdown # Module...\". This shipped 5/5 session-4 modules with the visible double-title bug. Older PRs were ~60% affected per spot audit (3/5 sampled).

## Why land before next marathon

The CKA Part 2-6 marathon is queued. Without this patch enforced in the writer prompt + verifier, the marathon's modules will regenerate with the same H1 bug, requiring another retroactive cleanup pass. Better to enforce the contract now.

## Test plan

- [x] `pytest tests/test_verify_module.py` (covered by new tests)
- [ ] cross-family review (gemini) of writer-prompt + rewriter-brief + verifier consistency