### PR TITLE
chore(html-migration): add HTML-first artifact policy pointer to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,8 @@ Convention: each agent ends its turn with `[AGREE]` / `[OPTION X]` / `[DEFER]`. 
 
 **Ukrainian translation**: ~40% (Prerequisites, CKA, CKAD). Files in `src/content/docs/uk/`.
 
+> **HTML-first artifact policy:** see [`docs/migrations/html-first/plan.html`](docs/migrations/html-first/plan.html) — orchestrator artifacts (audit reports, dispatch briefs, bug autopsies, batch summaries, PR review explainers, session handoffs) default to HTML; STATUS.md / CLAUDE.md / `.claude/rules/` / memory stay Markdown.
+
 ## Session Workflow
 
 1. **Orient via `/api/briefing/session`** (see *Agent Orientation* above). `STATUS.md` is the fallback when the API is down.


### PR DESCRIPTION
Adds a Project Overview callout in CLAUDE.md pointing agents to the HTML-first artifact policy and clarifying that orchestrator artifacts default to HTML while STATUS.md, CLAUDE.md, .claude/rules/, and memory stay Markdown.