### PR TITLE
feat(388): rewrite module-2.8-scheduler-lifecycle-theory (#388 pilot)

### DIFF
--- a/src/content/docs/k8s/cka/part2-workloads-scheduling/module-2.8-scheduler-lifecycle-theory.md
+++ b/src/content/docs/k8s/cka/part2-workloads-scheduling/module-2.8-scheduler-lifecycle-theory.md
@@ -3,6 +3,7 @@ title: "Module 2.8: Scheduler & Pod Lifecycle Theory"
 slug: k8s/cka/part2-workloads-scheduling/module-2.8-scheduler-lifecycle-theory
 sidebar:
   order: 9
+revision_pending: false
 lab:
   id: cka-2.8-scheduler-lifecycle
   url: https://killercoda.com/kubedojo/scenario/cka-2.8-scheduler-lifecycle
@@ -17,37 +18,31 @@ lab:
 >
 > **Prerequisites**: Module 2.5 (Resource Management), Module 2.6 (Scheduling)
 
-> **Historical Note**: Features discussed here evolved significantly from early Kubernetes versions. Historically, APIs evolved through v1.1, v1.2, v1.3, v1.4, and v1.5. Later versions like v1.27 introduced further refinements. Today, we explicitly target Kubernetes 1.35 (the current stable release). References to numeric values like 1.5 in CPU amounts do not denote Kubernetes versions.
-
 ---
+
+## What You'll Be Able to Do
+
+- **Diagnose** Pending scheduler filter failures by comparing pod requests, taints, affinity, and events.
+- **Design** PriorityClass preemption behavior that protects critical workloads while limiting disruption.
+- **Evaluate** QoS eviction risk from pod resource requests, limits, and node pressure.
+- **Debug** kubelet node-pressure eviction using signals, conditions, taints, and replacement behavior.
+- **Implement** graceful termination and PodDisruptionBudget rules for drains, preemption, and shutdown.
 
 ## Why This Module Matters
 
-During peak traffic conditions, unclassified critical workloads can sit Pending if scheduling constraints are mis-modeled and preemption policy is incomplete. Even short-lived resource pressure becomes a customer-visible outage if PriorityClasses, PDBs, and workload QoS are not aligned with business criticality.
+Hypothetical scenario: your team rolls out a latency-sensitive API during a marketing launch, and the new pods sit Pending while lower-priority batch workers keep running. The cluster has enough total CPU across all nodes, but no single node has the right combination of free CPU, tolerations, volume topology, and disruption budget room. From outside Kubernetes, this looks like a simple capacity problem; inside the control plane, it is a chain of scheduling, preemption, eviction, and lifecycle decisions.
 
-This module matters because Kubernetes scheduling and eviction are not abstract background processes—they are the direct arbiters of your application's reliability under stress. You will learn to design resilience through PriorityClasses, configure guaranteed QoS for critical components, and evaluate eviction signals before they trigger outages. These concepts determine whether your critical pods run or sit Pending, whether evictions hit the right targets, and whether your stateful services shut down gracefully.
+This module matters because the scheduler and kubelet are the two components that turn resource intent into runtime behavior. The scheduler decides whether a pod can be placed, which node is the best fit, and whether lower-priority pods should be preempted to make room. The kubelet later decides what happens when a node runs out of memory, disk, or process IDs, and it also controls the shutdown sequence when pods are deleted, evicted, or preempted.
 
-> **CKA Exam Relevance**: Scheduling troubleshooting, PriorityClasses, QoS classification, PDB behavior, and graceful termination are all tested. Understanding the scheduler pipeline lets you diagnose Pending pods in seconds instead of minutes.
+For the CKA, this topic is valuable because it teaches a reliable troubleshooting path instead of a bag of memorized commands. A Pending pod is usually not mysterious once you know where Filter stops, where Score begins, and how events summarize rejected nodes. An unexpected termination is also easier to explain when you can connect QoS class, eviction signals, node conditions, PDB behavior, and graceful shutdown timing into one operational story.
 
----
+Kubernetes 1.35 keeps the same core mental model used by modern scheduler and kubelet documentation: pods declare requirements, the scheduler finds feasible nodes, the kubelet enforces node-local safety, and controllers repair desired state after disruption. Historical features evolved across many earlier releases, but for this module you should reason from current Kubernetes 1.35 behavior and treat older release details as background only. The exam rewards that current model because it maps directly to `kubectl describe`, pod events, node conditions, and object specifications.
 
-## What You'll Learn
+## The Scheduler Pipeline
 
-By the end of this module, you'll be able to:
-- **Diagnose** pending pods by tracing the scheduler's Filter, Score, and Bind phases.
-- **Design** PriorityClasses and predict preemption behavior for critical workloads.
-- **Evaluate** a pod's QoS class from its resource spec and determine eviction likelihood.
-- **Compare** kubelet eviction signals, analyzing soft versus hard threshold types.
-- **Implement** graceful termination flows using PreStop hooks and PodDisruptionBudgets.
-- **Debug** unexpected pod terminations and resource pressure on the CKA exam.
+When you create a pod without `spec.nodeName`, it enters the scheduling queue and waits for kube-scheduler to assign it to a node. The scheduler is not simply looking for the emptiest machine; it is running a plugin pipeline that first eliminates impossible nodes and then ranks the nodes that remain. This distinction matters because a pod that fails Filter cannot be rescued by a high Score, while a pod that passes Filter may still land on one node instead of another because scoring preferences make the placement better.
 
----
-
-## Part 1: The Scheduler Pipeline
-
-### 1.1 Overview
-
-When you create a pod, the kube-scheduler watches for unscheduled pods (those with `spec.nodeName` unset) and runs a three-phase pipeline to assign each pod to a node. This process is continuous and deeply integrated into the Kubernetes control plane. The scheduler evaluates every node against the requirements of the pod, ensuring that workloads are distributed efficiently and safely across the cluster.
+The cleanest way to troubleshoot the pipeline is to ask three questions in order. First, what hard constraints must be true before the pod can run anywhere? Second, among the nodes that satisfy those constraints, what preferences make one node better than another? Third, after the scheduler chooses a node, did the bind operation actually write the assignment so the kubelet can start the pod? Those questions match the Filter, Score, and Bind phases.
 
 ```mermaid
 flowchart TD
@@ -107,9 +102,7 @@ flowchart TD
 ```
 </details>
 
-### 1.2 Phase 1: Filter (Predicates)
-
-The filter phase eliminates nodes that cannot run the pod. Each filter plugin is a hard constraint -- if any single filter rejects a node, that node is removed from consideration. These predicates are the absolute non-negotiables for workload placement.
+Filter is the hard-gate phase. A node that lacks allocatable CPU, has an untolerated `NoSchedule` taint, violates required node affinity, cannot satisfy a volume topology rule, or would break required pod anti-affinity is removed from the candidate set. The scheduler records the reasons as pod events, which is why `kubectl describe pod <name>` is usually the fastest first command when a pod is Pending.
 
 | Filter Plugin | What It Checks |
 |---|---|
@@ -121,9 +114,7 @@ The filter phase eliminates nodes that cannot run the pod. Each filter plugin is
 | `PodTopologySpread` | Does placing here violate `maxSkew` with `whenUnsatisfiable: DoNotSchedule`? |
 | `InterPodAffinity` | Does placement violate required pod anti-affinity rules? |
 
-For example, `NodeResourcesFit` physically compares the sum of the pod's container requests against the node's allocatable capacity. If a node lacks sufficient CPU, it's filtered out immediately.
-
-**What happens when no node passes filtering?** The pod remains in Pending state. The scheduler records an event on the pod explaining which constraints failed on each node. You see messages like:
+The important detail is that Filter evaluates requested resources, not live usage. If a node is idle but its allocatable CPU is already reserved by existing pod requests, a new CPU-heavy pod still fails `NodeResourcesFit`. That can feel surprising to new operators because dashboard CPU graphs may show room, but the scheduler protects capacity promises rather than betting on current usage staying low.
 
 ```text
 0/5 nodes are available: 2 insufficient cpu, 2 node(s) had taint
@@ -131,11 +122,9 @@ For example, `NodeResourcesFit` physically compares the sum of the pod's contain
 Pod topology spread constraints.
 ```
 
-The scheduler retries on its next scheduling cycle (triggered by cluster state changes such as a new node joining, a pod being deleted, or resource becoming available).
+Pause and predict: if the event says two nodes have insufficient CPU and one node has an untolerated taint, would lowering the pod's memory request help? It would not address the CPU or taint failures, so the pod would remain Pending unless another constraint also mentioned memory. This habit of matching the fix to the failed filter reason keeps exam troubleshooting precise.
 
-### 1.3 Phase 2: Score (Priorities)
-
-For nodes that pass all filters, the scheduler scores each one. Every scoring plugin assigns a value from 0 to 100, and scores are multiplied by plugin weights and summed. This phase transforms the "can it run?" question into "where should it run optimally?"
+Score begins only after at least one node survives Filter. Each scoring plugin gives feasible nodes a score, usually in the zero-to-one-hundred range, and the scheduler combines those scores with plugin weights. Scoring preferences can spread workloads, improve topology balance, favor nodes with cached images, or prefer nodes that better satisfy soft affinity. Those preferences are useful, but they never make an infeasible node legal.
 
 | Score Plugin | What It Favors |
 |---|---|
@@ -146,25 +135,15 @@ For nodes that pass all filters, the scheduler scores each one. Every scoring pl
 | `TaintToleration` | Nodes with fewer tolerations needed (prefer "cleaner" nodes) |
 | `PodTopologySpread` | Nodes that improve topology balance |
 
-These plugins operate cooperatively. `ImageLocality` provides a slight boost to nodes that already have large container images cached, saving pull time. `NodeResourcesLeastAllocated` actively combats hotspots by naturally dispersing new workloads across underutilized machines. 
+Ties are intentionally not a placement contract. If two feasible nodes receive the same total score, the scheduler may break the tie randomly to avoid concentrating otherwise identical work on one node. If you require exact placement, use a hard mechanism such as node affinity, a node selector, taints and tolerations, or explicit `spec.nodeName` for special cases; do not reverse-engineer a scoring tie and depend on it.
 
-**What if two nodes score equally?** The scheduler breaks ties randomly. This prevents hot-spotting a single node when the cluster is uniformly loaded. You should not depend on deterministic placement -- if you need a pod on a specific node, use `nodeSelector` or `nodeName`.
+Bind is the handoff from scheduler decision to node execution. The scheduler writes a binding that sets `spec.nodeName`, and the kubelet on that node notices the assignment through the API server. From there the kubelet pulls images, prepares volumes, creates sandboxes, and starts containers. If the pod has no useful events at all, include scheduler health in your investigation because the normal Filter failure trail may never have been produced.
 
-### 1.4 Phase 3: Bind
+## Priority, Preemption, and Disruption Tradeoffs
 
-The scheduler creates a `Binding` object that sets `spec.nodeName` on the pod. The kubelet on that node detects the assignment, pulls images, mounts volumes, and starts containers. The bind phase also runs permit and reserve plugins (for features like volume binding confirmation and gang scheduling), finalizing the transaction with the API Server.
+Priority tells Kubernetes which pending pods deserve scheduling attention first and which running pods may be displaced when a higher-priority pod cannot fit. This is a powerful reliability tool, but it is also a sharp edge because the cluster can remove healthy lower-priority pods to make room. A good priority design therefore names business intent, separates critical workloads from batch work, and avoids making every application "critical" just because it has users.
 
-> **Exam Tip**: When troubleshooting a Pending pod, always start with `kubectl describe pod <name>`. The Events section tells you exactly which filter phase failed. If there are no events at all, the scheduler may not be running.
-
----
-
-## Part 2: Priority and Preemption
-
-> **Pause and predict**: A high-priority pod (priority 1000000) is Pending because no node has enough resources. The cluster has nodes full of low-priority batch jobs (priority 100). Will Kubernetes automatically make room for the high-priority pod, or does it just wait? What determines which pods get evicted?
-
-### 2.1 PriorityClasses
-
-A PriorityClass assigns a numeric priority value to pods. Higher values mean higher priority. The scheduler uses this value during preemption decisions. A well-designed priority schema prevents critical daemons and revenue-generating services from starving due to aggressive background jobs.
+Pause and predict: a high-priority pod with priority `1000000` is Pending because no node has enough free CPU, while low-priority batch pods are already running. Kubernetes can preempt lower-priority pods if the incoming pod's PriorityClass allows it, but it will first evaluate which node could host the pending pod after removing victims. The scheduler tries to minimize disruption, but it is optimizing for the higher-priority pod's placement, not for keeping every lower-priority workload alive.
 
 ```yaml
 apiVersion: scheduling.k8s.io/v1
@@ -199,14 +178,14 @@ preemptionPolicy: Never
 description: "Batch jobs that should never preempt others"
 ```
 
-**Built-in PriorityClasses** (do not modify these):
+The `preemptionPolicy` field deserves careful reading. `PreemptLowerPriority` means a pending pod may trigger eviction of lower-priority pods if doing so makes placement possible. `Never` means the pod can still move ahead of lower-priority pending pods in the scheduling queue, but it will not evict already-running pods. That distinction is useful for important but non-disruptive work, such as reports that should run soon but should not interrupt live services.
 
 | Name | Value | Used By |
 |---|---|---|
 | `system-cluster-critical` | 2000000000 | Cluster-essential components (CoreDNS, kube-proxy) |
 | `system-node-critical` | 2000001000 | Node-essential components (kubelet static pods) |
 
-Assign a PriorityClass to a pod directly in its specification:
+Built-in PriorityClasses exist for cluster and node critical components, and you should not reuse their values for ordinary application tiers. If application teams assign values near system priority, they make it harder for the cluster to protect its own control-plane dependencies during pressure. A practical production scheme usually has a small number of named tiers, clear ownership rules for who may use each tier, and review around any workload that can preempt others.
 
 ```yaml
 apiVersion: v1
@@ -227,9 +206,7 @@ spec:
         memory: 4Gi
 ```
 
-### 2.2 How Preemption Works
-
-When a high-priority pod cannot be scheduled (all nodes fail the filter phase), the scheduler enters the preemption cycle:
+Preemption starts only when the pending pod cannot be scheduled normally. The scheduler simulates each candidate node by asking whether removing lower-priority pods would make the high-priority pod fit, then it chooses victim sets and checks disruption impact. The pending pod may receive `nominatedNodeName`, but nomination is not a guarantee; the pod still has to pass a later scheduling cycle after victims terminate, and another even-higher-priority pod may change the situation.
 
 ```mermaid
 sequenceDiagram
@@ -285,9 +262,7 @@ sequenceDiagram
 ```
 </details>
 
-### 2.3 Worked Example
-
-Consider a 3-node cluster, each with 4 CPU allocatable:
+Consider a three-node cluster where each node has four allocatable CPUs. A new `fraud-detector` pod needs two CPUs and has priority `1000000`. No node has two CPUs free, so ordinary scheduling fails, but every node has lower-priority pods that could be removed. This is the moment where preemption analysis is useful because total cluster capacity is irrelevant unless one node can be made feasible for the incoming pod.
 
 | Node | Running Pods | CPU Used | Available |
 |---|---|---|---|
@@ -295,32 +270,15 @@ Consider a 3-node cluster, each with 4 CPU allocatable:
 | node-2 | web-api (priority 500, 3 CPU) | 3 CPU | 1 CPU |
 | node-3 | monitoring (priority 800, 2 CPU), logger (priority 50, 1.5 CPU) | 3.5 CPU | 0.5 CPU |
 
-A new pod `fraud-detector` (priority 1000000, needs 2 CPU) is created.
+The scheduler evaluates each node as a possible landing zone. On `node-1`, evicting `batch-a` frees enough CPU with one victim. On `node-2`, evicting `web-api` also works, but that victim has higher priority than the batch pod. On `node-3`, evicting `logger` combines the already-free half CPU with the released one-and-a-half CPUs, making exactly enough room with a lower-priority victim.
 
-**Filter phase**: No node has 2 CPU free. All fail. Pod is Pending.
+The best candidate is therefore `node-3`, assuming no other constraints change the decision. The scheduler can nominate that node, terminate `logger` gracefully, and schedule the high-priority pod in a later cycle after resources are actually free. The key lesson is that preemption is not a blind "kill lowest-priority pod anywhere" operation; it is a node-specific feasibility calculation.
 
-**Preemption analysis**:
-- **node-1**: Evict batch-a (priority 100, 2 CPU) -- frees 2 CPU. Victim priority 100. One victim.
-- **node-2**: Evict web-api (priority 500, 3 CPU) -- frees 3 CPU. Victim priority 500. One victim, but higher priority.
-- **node-3**: 0.5 CPU is already free. Evict logger (priority 50, 1.5 CPU) and the node reaches 2 CPU available, which is enough for the pending pod. One victim, and that victim has the lowest priority in the cluster.
+PDBs complicate that calculation because they express how many matching pods must remain available during voluntary disruption. During scheduler preemption, Kubernetes tries to avoid violating PDBs, but PDBs are not an absolute barrier if every workable victim set would violate a budget. That soft treatment prevents a badly chosen PDB from blocking genuinely higher-priority recovery work forever, but it also means PDBs should not be your only protection for critical availability.
 
-**Decision**: node-3 is the best candidate. It requires only one victim, and that victim has lower priority than node-1's best victim (50 vs 100). The scheduler sets `nominatedNodeName: node-3` on fraud-detector, terminates logger gracefully, and schedules fraud-detector in the next cycle.
+## QoS, Requests, Limits, and Eviction Risk
 
-### 2.4 PDB Interaction with Preemption
-
-PodDisruptionBudgets limit voluntary disruptions. During preemption, the scheduler respects PDBs as a preference, not a hard constraint. In Kubernetes 1.35+: - The scheduler **tries** to avoid PDB violations when selecting victims.
-
-If every candidate node requires a PDB violation, preemption still proceeds -- the high-priority pod takes precedence. This prevents a scenario where misconfigured or overly restrictive PDBs lock up the cluster and prevent critical security or system daemonsets from being placed. PDBs are a **hard constraint** for `kubectl drain` and voluntary eviction API calls, but a **soft constraint** for scheduler preemption.
-
-This distinction is critical: PDBs protect against planned maintenance but do not fully block priority-based preemption.
-
----
-
-## Part 3: QoS Classes
-
-### 3.1 How QoS Class Is Determined
-
-Kubernetes automatically assigns a QoS class to every pod based on the resource requests and limits of its containers. You do not set QoS class directly -- it is derived. Understanding this derivation is key to protecting workloads from random eviction.
+Kubernetes assigns each pod a QoS class from its container resource requests and limits. You do not set the QoS class directly; it is derived from whether every container has CPU and memory requests equal to limits, whether at least one request or limit exists, or whether no resource guarantees exist at all. This derived label becomes important under node pressure because the kubelet uses it to decide which pods are safest to evict first.
 
 | QoS Class | Condition | Eviction Priority |
 |---|---|---|
@@ -328,9 +286,7 @@ Kubernetes automatically assigns a QoS class to every pod based on the resource 
 | **Burstable** | At least one container has a request or limit set, but not Guaranteed | Middle |
 | **BestEffort** | No container has any request or limit | First evicted |
 
-### 3.2 YAML Examples for Each QoS Class
-
-**Guaranteed** -- requests equal limits for all resources in all containers. This represents workloads that have strict reservations and cannot tolerate CPU throttling or sudden memory starvation.
+Guaranteed pods are the most protected because they make a clear reservation contract. Every container must have both CPU and memory requests, every matching limit must be equal, and every container in the pod must satisfy the same rule. If one sidecar omits memory resources while the main container is perfect, the whole pod is no longer Guaranteed because Kubernetes evaluates the pod as a unit.
 
 ```yaml
 apiVersion: v1
@@ -350,14 +306,12 @@ spec:
         memory: 256Mi
 ```
 
-Verify:
-
 ```bash
-k get pod qos-guaranteed -o jsonpath='{.status.qosClass}'
+kubectl get pod qos-guaranteed -o jsonpath='{.status.qosClass}'
 # Output: Guaranteed
 ```
 
-**Burstable** -- requests set but not equal to limits (or limits missing for one resource):
+Burstable pods have some resource intent but not a strict one-to-one request and limit match across every container. This is the common class for services that reserve enough CPU and memory to be scheduled sensibly but allow some temporary headroom. Burstable is not wrong; it is simply a tradeoff that accepts more eviction exposure than Guaranteed in exchange for flexible runtime behavior.
 
 ```yaml
 apiVersion: v1
@@ -377,14 +331,12 @@ spec:
         memory: 512Mi
 ```
 
-Verify:
-
 ```bash
-k get pod qos-burstable -o jsonpath='{.status.qosClass}'
+kubectl get pod qos-burstable -o jsonpath='{.status.qosClass}'
 # Output: Burstable
 ```
 
-**BestEffort** -- no requests, no limits on any container:
+BestEffort pods have no CPU or memory requests and no limits on any container. They can be useful for disposable experiments or low-value batch work, but they are first in line when a node needs to reclaim resources. On a busy production node, BestEffort is a clear statement that the workload may be sacrificed before workloads with explicit reservations.
 
 ```yaml
 apiVersion: v1
@@ -397,36 +349,20 @@ spec:
     image: nginx:1.35
 ```
 
-Verify:
-
 ```bash
-k get pod qos-besteffort -o jsonpath='{.status.qosClass}'
+kubectl get pod qos-besteffort -o jsonpath='{.status.qosClass}'
 # Output: BestEffort
 ```
 
-### 3.3 Edge Cases
+Before running this, what QoS class do you expect if a pod sets memory requests equal to memory limits but leaves CPU limits higher than CPU requests? The answer is Burstable, because Guaranteed requires equality for both CPU and memory across every container. This is a common exam trap because one resource can look perfect while the other quietly moves the pod into the middle eviction tier.
 
-- If you set only `limits` (no `requests`), Kubernetes auto-sets `requests = limits`, making the pod Guaranteed (if done for all containers and all resources).
-- A pod with two containers where one is Guaranteed and the other has no resources is classified as **Burstable**, not Guaranteed.
-- `cpu` and `memory` both matter. If requests equal limits for CPU but not memory, the pod is Burstable.
-- Ephemeral storage requests/limits do not affect QoS classification.
+QoS does not change the scheduler's resource fit calculation by itself. The scheduler primarily uses requests to decide whether a pod fits on a node, while limits are enforced later by the kubelet and runtime. A Guaranteed pod requesting two CPUs and a Burstable pod requesting two CPUs consume the same scheduling capacity, even though they receive different treatment when node pressure forces eviction choices.
 
-### 3.4 QoS and Scheduling
+There are edge cases worth remembering because they explain many "why is this pod Burstable?" surprises. If you set a limit but omit the matching request, Kubernetes may default the request from the limit for that container and resource, but every container and both CPU and memory must still satisfy the Guaranteed rule. Ephemeral storage requests and limits affect scheduling and eviction for storage pressure, but they do not determine the CPU and memory QoS class in the same way.
 
-QoS class does **not** affect scheduling. The scheduler only looks at `requests` to determine if a pod fits on a node. `limits` are enforced at runtime by the kubelet and container runtime (CPU throttling, OOM kill for memory). This means:
+## Kubelet Eviction and Node Pressure
 
-- A Guaranteed pod with `requests: 2 CPU` and a Burstable pod with `requests: 2 CPU` are scheduled identically
-- QoS class only matters during **eviction** (next section)
-
----
-
-## Part 4: Eviction and Node Pressure
-
-### 4.1 Kubelet Eviction Manager
-
-The kubelet monitors resource signals on the node and evicts pods when thresholds are crossed. This is separate from the scheduler -- eviction is a kubelet decision on a specific node. It acts as a last line of defense to prevent a single pod from crashing the entire underlying host operating system.
-
-**Eviction signals**:
+The scheduler makes placement decisions, but the kubelet protects a node that is already running workloads. It monitors local signals such as available memory, root filesystem space, image filesystem space, and available process IDs. When thresholds are crossed, the kubelet may evict pods to keep the operating system and node services alive, which is why evicted pods often point to node pressure rather than a scheduler decision.
 
 | Signal | Description | Typical Soft Threshold | Typical Hard Threshold |
 |---|---|---|---|
@@ -435,13 +371,7 @@ The kubelet monitors resource signals on the node and evicts pods when threshold
 | `imagefs.available` | Free disk on image filesystem | < 15% (grace 120s) | < 10% |
 | `pid.available` | Free PIDs | < 1000 (grace 60s) | < 500 |
 
-### 4.2 Soft vs Hard Thresholds
-
-- **Soft thresholds** include a grace period. The kubelet waits for the grace period to expire before evicting. If resource usage drops below the threshold during the grace period, no eviction occurs. Configure with `--eviction-soft` and `--eviction-soft-grace-period`.
-
-- **Hard thresholds** are immediate. When crossed, the kubelet evicts pods without waiting. Configure with `--eviction-hard`.
-
-### 4.3 Eviction Decision Flow
+Soft thresholds include a grace period, so the kubelet waits to see whether the pressure clears before evicting. Hard thresholds are immediate because the node is close enough to failure that waiting would endanger the host. In either case, the goal is not fairness among applications; the goal is preserving node stability by reclaiming resources from pods according to Kubernetes eviction rules.
 
 ```mermaid
 flowchart TD
@@ -486,8 +416,8 @@ flowchart TD
 │  │     (sorted by usage relative to requests)           │       │
 │  │                                                      │       │
 │  │  3. Guaranteed / Burstable within their requests     │       │
-│  │     (only if still under pressure after 1+2)         │       │
-│  │     Almost never reached in practice                 │       │
+│  │     (only if still under pressure after 1+2)         │
+│  │     Almost never reached in practice                 │
 │  └──────────────────────────────────────────────────────┘       │
 │       │                                                          │
 │       ▼                                                          │
@@ -500,16 +430,9 @@ flowchart TD
 ```
 </details>
 
-### 4.4 What Happens to Evicted Pods?
+Eviction order starts with pods that have the weakest resource claim. BestEffort pods are evicted first, then Burstable pods that exceed their requests, and only later pods that are within their requests or Guaranteed. This ordering is why requests matter twice: they affect whether a pod can be scheduled, and they later define the line between expected usage and excess usage when the kubelet is under pressure.
 
-When a pod is evicted:
-1. The pod's status becomes `Failed` with reason `Evicted`
-2. The pod remains visible in `k get pods` until garbage collected
-3. If the pod is owned by a controller (Deployment, ReplicaSet, StatefulSet, Job), the controller creates a replacement pod. The replacement is scheduled by the scheduler and may land on any eligible node.
-4. Standalone pods (no controller) are **permanently lost**. This is why you should usually use controllers.
-5. The evicted pod's node has a taint applied temporarily (`node.kubernetes.io/memory-pressure`, etc.) to prevent new pods from being scheduled there while it recovers.
-
-### 4.5 Node Conditions Under Pressure
+When a pod is evicted, its status becomes `Failed` with reason `Evicted`, and it may remain visible until garbage collection removes it. A controller such as a Deployment, ReplicaSet, StatefulSet, or Job can create a replacement pod, but a standalone pod has no controller to repair it. The replacement is a new pod, so it goes through scheduling again and may land on any eligible node with sufficient capacity and matching constraints.
 
 | Condition | Triggered By | Effect |
 |---|---|---|
@@ -517,15 +440,13 @@ When a pod is evicted:
 | `DiskPressure` | `nodefs.available` or `imagefs.available` below threshold | Taint applied, no new pods |
 | `PIDPressure` | `pid.available` below threshold | Taint applied, no new pods |
 
-> **Exam Tip**: If pods keep getting evicted and rescheduled to the same node, check whether the node's pressure taints are being cleared prematurely. Use `k describe node <name>` and look at the Conditions and Taints sections.
+Node pressure also affects future scheduling because the node reports conditions and may receive taints such as `node.kubernetes.io/memory-pressure`. That protects the node from receiving more unsuitable work while it recovers. If pods keep cycling back to the same troubled node, inspect node conditions, taints, allocatable resources, and controller behavior instead of only looking at the evicted pod.
 
----
+Which approach would you choose here and why: increase memory limits on a Burstable pod that is repeatedly evicted, or increase its memory request? Increasing the limit may reduce container OOM kills, but it does not improve the pod's scheduling reservation or its position relative to request-based eviction pressure. If the service genuinely needs more memory to be protected, the request is the field that changes the scheduler contract and the kubelet's eviction comparison.
 
-## Part 5: Pod Lifecycle Signals
+## Pod Termination, Graceful Shutdown, and PDBs
 
-### 5.1 Termination Sequence
-
-When a pod is terminated (whether by deletion, preemption, eviction, or scale-down), Kubernetes follows a specific sequence to prevent dropped connections and data corruption.
+Pod termination is a coordinated sequence rather than a single kill signal. The API server marks the pod for deletion, endpoint controllers remove it from Service endpoint sets, the kubelet runs any PreStop hook, and then the kubelet sends SIGTERM to container process one. The grace period starts when deletion begins, not when the application finally receives SIGTERM, so long PreStop hooks can consume shutdown time that the application expected to use.
 
 ```mermaid
 sequenceDiagram
@@ -581,9 +502,7 @@ sequenceDiagram
 ```
 </details>
 
-> **Stop and think**: You set `terminationGracePeriodSeconds: 30` and a PreStop hook that runs `sleep 20`. After the PreStop completes, your app receives SIGTERM. How many seconds does it have before SIGKILL? What if your PreStop hook takes 35 seconds -- longer than the grace period?
-
-### 5.2 Configuring Graceful Shutdown
+Stop and think: you set `terminationGracePeriodSeconds: 30` and a PreStop hook that sleeps for twenty seconds. The application does not receive a full thirty seconds after the hook; it receives roughly the remaining ten seconds before SIGKILL. If the hook itself runs longer than the grace period, Kubernetes may grant a short extension in some cases, but you should design as if the hook and application shutdown share the same budget.
 
 ```yaml
 apiVersion: v1
@@ -603,13 +522,7 @@ spec:
     - containerPort: 8080
 ```
 
-**Key points**:
-- The grace period timer starts when the pod is marked for deletion, **not** when SIGTERM is sent.
-- PreStop hook time counts against the grace period. If your PreStop takes 20s and grace period is 30s, the app has only 10s after SIGTERM before SIGKILL.
-- Set grace period long enough for: PreStop execution + application drain time + safety margin.
-- For databases or stateful services, 60-120s is common. For simple web servers, 15-30s usually suffices.
-
-### 5.3 When to Set Longer Grace Periods
+A graceful shutdown budget should include endpoint propagation, PreStop behavior, application drain time, and a small margin for variance. Stateless web servers often need a shorter grace period than databases, message consumers, or batch processors that must checkpoint work. The correct value is not "as high as possible" because long termination can slow rollouts and drains; the correct value is long enough for the application to stop accepting work and finish the work it already accepted.
 
 | Workload Type | Recommended Grace Period | Why |
 |---|---|---|
@@ -619,11 +532,7 @@ spec:
 | Batch processor | 60-300s | May need to checkpoint partial work |
 | Message queue consumer | 30-60s | Must finish processing current message |
 
-> **Pause and predict**: A 3-replica Deployment has a PDB with `minAvailable: 3`. A cluster administrator runs `kubectl drain` on a node hosting one of those replicas. What happens -- does the drain succeed, block, or partially proceed? Now consider: what if the node crashes instead of being drained?
-
-### 5.4 PodDisruptionBudgets (PDBs)
-
-PDBs protect applications from voluntary disruptions -- planned operations like `kubectl drain`, cluster upgrades, or autoscaler scale-down. They ensure that administrators performing routine maintenance do not inadvertently take down critical user-facing services.
+PDBs sit beside graceful termination because they control how many matching pods may be voluntarily disrupted at once. They do not make a pod immortal, and they do not protect against a node crash, kernel OOM kill, or hard kubelet eviction. They are a promise made to voluntary operations such as drain, cluster upgrade, autoscaler scale-down, and eviction API calls that the operation should not reduce availability below the declared budget.
 
 ```yaml
 apiVersion: policy/v1
@@ -637,8 +546,6 @@ spec:
       app: web-api
 ```
 
-Alternative -- specify maximum unavailable:
-
 ```yaml
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -651,119 +558,188 @@ spec:
       app: web-api
 ```
 
-**PDB rules**:
-- `minAvailable` and `maxUnavailable` are mutually exclusive -- use one or the other.
-- Can be an integer (2) or percentage ("25%").
-- PDBs only limit **voluntary** disruptions (drain, preemption, eviction API). They do **not** prevent involuntary disruptions (node crash, OOM kill, kubelet eviction under hard pressure).
-- A drain operation will block indefinitely if a PDB cannot be satisfied. Always set `--timeout` with `kubectl drain`.
+`minAvailable` and `maxUnavailable` are mutually exclusive ways to express the same protection. `minAvailable: 2` says at least two selected pods must stay available, while `maxUnavailable: 1` says at most one selected pod may be unavailable during voluntary disruption. Percentages are allowed, but for small replica counts an integer is easier to reason about during exams because rounding behavior can surprise you under pressure.
 
 ```bash
 # Drain with timeout to avoid hanging forever
-k drain node-2 --ignore-daemonsets --delete-emptydir-data --timeout=300s
+kubectl drain node-2 --ignore-daemonsets --delete-emptydir-data --timeout=300s
 ```
 
-### 5.5 Voluntary vs Involuntary Disruptions
+Pause and predict: a three-replica Deployment has a PDB with `minAvailable: 3`, and one of its replicas is on a node you want to drain. The drain blocks because evicting that pod would reduce available replicas below the PDB requirement. If the node crashes instead, the PDB cannot stop the involuntary loss; the controller must create a replacement, and the cluster must have capacity to run it.
 
 | Type | Examples | Honors PDB? |
 |---|---|---|
 | **Voluntary** | `kubectl drain`, cluster upgrade, autoscaler scale-down, preemption | Yes |
 | **Involuntary** | Node crash, OOM kill, kubelet hard eviction, hardware failure | No |
 
-Understanding this distinction is essential. A PDB with `minAvailable: 3` on a 3-replica Deployment means `kubectl drain` will refuse to evict any of those pods (it would drop below 3). But if the node crashes, those pods are gone regardless of the PDB.
+This voluntary versus involuntary distinction should shape how you design availability. PDBs help maintenance workflows proceed safely, but replicas, topology spread, resource requests, probes, and adequate spare capacity are what make unexpected failures survivable. In scheduling lifecycle troubleshooting, always ask whether the disruption was planned through the API or forced by node reality.
 
----
+## Worked Diagnostic Walkthrough
+
+Exercise scenario: a Deployment rollout creates five new pods, and two become Running while three remain Pending. The application team says the cluster has enough total unused CPU, and a dashboard appears to support that claim. Your first move should not be to lower requests randomly; it should be to read the Pending pod events and separate total cluster capacity from per-node feasibility.
+
+The scheduler can only bind a pod to one node, so capacity fragmented across many nodes does not help a pod whose request must fit on a single node. If three nodes each have half a CPU free and the pod requests one full CPU, the cluster has one-and-a-half CPUs free in total but no feasible node. That is a scheduling fit problem, not a kubelet eviction problem and not a PDB problem.
+
+After reading the events, suppose you see both insufficient CPU and untolerated taints. Treat those as separate blockers rather than picking the first one that looks familiar. Reducing the CPU request might make some nodes feasible, but the tainted node still requires a matching toleration if the workload is allowed there. Adding a toleration might make the tainted node legal, but it does nothing for nodes that genuinely lack requested CPU.
+
+The next question is whether the pod should be allowed to run on the tainted node at all. A taint usually means the node is reserved for a special purpose, such as control-plane duties, GPUs, storage, or another isolated workload class. If the application has no business running there, the correct fix is capacity or request tuning on ordinary worker nodes. If it does belong there, add the toleration deliberately and consider adding affinity so the scheduler intent is explicit.
+
+Now imagine the same Pending pod has high priority and the cluster is full of lower-priority batch work. Preemption can help only if removing lower-priority pods from one node creates a feasible placement. If every node also fails a required node affinity rule or volume topology rule, preemption cannot solve the placement because victims do not change those hard constraints. This is why preemption troubleshooting still begins with Filter reasons.
+
+If preemption does proceed, watch for the gap between nomination and binding. A pending pod may show a nominated node while victim pods terminate gracefully, and the incoming pod may still wait until the next scheduling cycle. During that window, events can look confusing because the scheduler has chosen a path but the kubelet has not yet freed the resources. Read `nominatedNodeName` as a clue, not as proof that the pod is already scheduled.
+
+PDBs add another layer to that story because they influence which victims are least disruptive. A budget protecting batch pods may make one node less attractive as a preemption target, while another node with unprotected disposable work may be easier to use. The scheduler attempts to respect PDBs during preemption, but if every possible path violates a budget, higher priority can still win. That behavior is intentional because availability policy cannot be allowed to deadlock critical recovery forever.
+
+For a CKA-style answer, describe the exact component making the decision. The scheduler filters and scores Pending pods, then may nominate lower-priority victims. The kubelet evicts already-running pods under node pressure and manages termination signals. The eviction API and PDB controller regulate voluntary disruptions such as drain. Controllers such as Deployments create replacement pods after disruption, but the scheduler still decides where those replacements land.
+
+Now move from Pending to Evicted. If a pod has reason `Evicted`, do not spend your first minute editing affinity rules because the pod was already running before the kubelet removed it. Inspect the node that hosted it, look at pressure conditions, and compare the pod's QoS class and actual usage with its requests. A BestEffort pod evicted under MemoryPressure is behaving exactly as Kubernetes promises, even if the application owner expected it to be durable.
+
+Burstable workloads require more judgment because their risk depends on requests and actual usage. A Burstable pod that stays within its memory request is better protected than one that regularly exceeds the request by a large margin. If the application routinely needs more memory than requested, the fix is not merely raising the limit; the request should also reflect the memory the workload needs to be treated as expected usage during pressure.
+
+Guaranteed QoS is valuable, but it is not a license to ignore capacity. If every important service is Guaranteed with oversized requests, the scheduler may leave new work Pending because allocatable resources are already reserved. Guaranteed is best for workloads whose resource envelope is known and whose eviction cost is high. For services with variable load, a carefully chosen Burstable profile may be more efficient while still avoiding BestEffort risk.
+
+Disk pressure follows the same diagnostic structure but uses different signals. If `nodefs.available` or `imagefs.available` crosses thresholds, the kubelet may reclaim images and evict pods to protect the node. Application teams often focus on memory because it is familiar, but ephemeral storage usage can also trigger evictions. Check logs, temporary files, emptyDir usage, and image churn when DiskPressure appears in node conditions.
+
+PIDPressure is less common in beginner labs but important in production. A process leak inside a container can consume process IDs on the host, and the kubelet may have to evict pods to preserve node health. If you see PIDPressure, ask whether a workload is forking unexpectedly, whether probes or sidecars are creating excessive processes, and whether the node has enough PID capacity for the workload mix.
+
+Drains are different again because they are voluntary maintenance operations. If a drain hangs, check PDB status before assuming the command is broken. A PDB with zero allowed disruptions is doing its job when it blocks eviction. The right fix may be scaling the Deployment, waiting for unavailable replicas to recover, widening the budget temporarily, or choosing a maintenance order that preserves application availability.
+
+The labels on the PDB matter as much as the numeric budget. A PDB that selects no pods protects nothing, while a PDB that selects too many pods may couple unrelated applications into one disruption budget. During troubleshooting, compare the PDB selector with pod labels and controller labels. A common root cause is a label changed during a rollout while the PDB kept selecting the old shape or accidentally selected multiple releases.
+
+Graceful termination problems often show up as dropped requests during rollout even when scheduling and PDBs are correct. Endpoint removal, PreStop hooks, SIGTERM handling, and application readiness all have to cooperate. If the app keeps accepting traffic after deletion starts, it may receive work it cannot finish before SIGKILL. If the PreStop hook sleeps too long, it may leave almost no time for the app to process SIGTERM.
+
+A better shutdown design makes the application stop advertising readiness before it stops serving already-accepted work. Kubernetes endpoint removal reduces new traffic, while the application uses SIGTERM to drain outstanding requests. The grace period must cover both the platform-side transition and the application-side cleanup. For stateful systems, that may include flushing logs, closing database connections, checkpointing offsets, or handing off leadership.
+
+Tie the lifecycle pieces together during a rollout. A new ReplicaSet creates pods, the scheduler places them, the kubelet starts containers, readiness controls Service endpoints, and the old pods terminate according to grace periods and PDB constraints. If any link is poorly configured, the rollout may be slow, unavailable, or noisy. Debugging is faster when you trace the rollout as a sequence instead of treating each symptom as isolated.
+
+The same sequence explains cluster autoscaler scale-down. A node can be removed only if its pods can be evicted according to disruption rules and rescheduled elsewhere according to scheduling constraints. High requests, strict affinity, local storage, or tight PDBs can all make a node hard to drain. When autoscaling seems stuck, inspect the pods on candidate nodes and ask which constraint prevents safe movement.
+
+For exam practice, build a verbal checklist and use it consistently. Pending means scheduler events, node fit, taints, affinity, topology, priority, and preemption. Evicted means pod status, node conditions, QoS, requests, and kubelet pressure signals. Terminating or drain problems mean PDBs, grace periods, PreStop hooks, endpoint behavior, and controller replacements. This checklist is faster than searching every Kubernetes object at random.
+
+The final design lesson is that scheduling lifecycle reliability is mostly decided before an incident. Requests express capacity needs, priorities express importance, PDBs express disruption tolerance, QoS emerges from requests and limits, and termination settings express shutdown time. Kubernetes can enforce those contracts, but it cannot infer business criticality or application drain behavior that you never declared. Good operators make those contracts visible in manifests before pressure arrives.
+
+A useful way to review any manifest is to ask what happens during scarcity. If CPU is scarce, requests and priority decide whether the pod can be placed or whether it can displace another pod. If memory is scarce after placement, QoS and request-relative usage influence kubelet eviction decisions. If nodes are scarce during maintenance, PDBs and topology determine whether pods can move without breaking availability.
+
+Another useful review question is what happens during replacement. A controller may create a new pod quickly, but the new pod still has to pass the same scheduling filters as the old one. If every remaining node violates affinity or lacks requested resources, replacement stalls even though the controller is healthy. That is why resilience requires both a controller and a feasible landing zone for replacement pods.
+
+Finally, remember that lifecycle settings are part of scheduling design because disruption is not complete until the old pod exits and the replacement is available. A long grace period can preserve requests but slow node drains, while a short grace period can speed rollouts but risk dropped work. The right design balances service-level needs with cluster operations, then verifies that balance through events, readiness, and PDB status.
+
+## Patterns & Anti-Patterns
+
+Reliable scheduling design usually starts with small, named policy sets rather than one-off pod fields. PriorityClasses, PDBs, QoS targets, graceful shutdown budgets, topology rules, and requests should fit together so each workload communicates what it needs and how it may be disrupted. When these pieces are designed independently, the cluster may obey each object correctly while still producing an outage-shaped result.
+
+| Pattern | When to Use | Why It Works |
+|---|---|---|
+| Three-tier PriorityClass scheme | Critical services, ordinary services, and disposable batch share a cluster | Keeps preemption meaningful without making every workload top priority |
+| Guaranteed QoS for small critical control-plane helpers | Workloads must survive node pressure and have predictable usage | Equal requests and limits express a clear reservation and improve eviction protection |
+| PDB per production controller | Rolling maintenance, node drains, and autoscaler scale-down must preserve availability | Voluntary disruption is limited before maintenance removes too many replicas |
+| Explicit termination budget | Applications need time to drain connections or checkpoint state | PreStop and SIGTERM timing are designed instead of discovered during a rollout |
+
+The main scaling consideration is operational consistency. If every namespace invents its own priorities, budgets, and shutdown expectations, cluster-wide behavior becomes impossible to predict during pressure. A platform team can help by publishing allowed PriorityClasses, recommended PDB patterns by replica count, and resource-request review guidance so application teams make local decisions within a shared scheduling model.
+
+| Anti-Pattern | What Goes Wrong | Better Alternative |
+|---|---|---|
+| Marking all services critical | Preemption loses meaning and lower-priority recovery cannot happen | Reserve high priority for a reviewed set of workloads |
+| Using BestEffort for production APIs | The kubelet evicts them first under node pressure | Set realistic requests and choose Burstable or Guaranteed intentionally |
+| Setting `maxUnavailable: 0` everywhere | Drains and upgrades block across the cluster | Use enough replicas and allow at least one voluntary disruption when possible |
+| Long PreStop with short grace period | The application receives SIGTERM too late to drain | Budget hook time and application shutdown together |
+
+A subtle anti-pattern is treating Pending, Preempted, Evicted, and Terminating as the same kind of failure. Pending is a scheduling feasibility problem, preemption is a priority-driven displacement problem, eviction is a kubelet pressure response, and termination is a lifecycle sequence. Mixing those terms leads to random fixes; separating them points you at the component and object field that actually controls the behavior.
+
+## Decision Framework
+
+Use this framework when you face a scheduling or lifecycle symptom during the exam or in a real cluster. Start from the visible pod state, identify the responsible component, and then inspect the object fields that component uses. This prevents you from changing PDBs for a kubelet hard eviction, changing limits for a Filter failure caused by requests, or adding tolerations when the real problem is a volume topology mismatch.
+
+| Symptom | First Place to Look | Likely Component | High-Value Fix |
+|---|---|---|---|
+| Pod is Pending with filter events | Pod events and node descriptions | Scheduler Filter | Adjust requests, tolerations, affinity, topology, or capacity |
+| High-priority pod waits behind running batch | PriorityClass and preemption events | Scheduler Preemption | Confirm priority values, preemption policy, PDB impact, and victim feasibility |
+| Pod failed with reason `Evicted` | Pod status, node conditions, kubelet events | Kubelet Eviction Manager | Inspect pressure signal, QoS class, requests, and node capacity |
+| Drain hangs | PDB status and matching labels | Eviction API and PDB controller | Scale replicas, relax budget, or use a timeout while preserving availability |
+| Shutdown drops requests | Pod lifecycle hooks and grace period | Kubelet Termination Flow | Increase grace period, shorten PreStop, and drain traffic earlier |
+
+The fastest exam path is usually `kubectl describe pod`, then `kubectl describe node`, then the controlling object. Pod events tell you whether the scheduler rejected nodes, the kubelet evicted a running pod, or a controller is replacing replicas. Node descriptions show allocatable resources, pressure conditions, and taints. The controller explains whether replacements should appear and whether PDB selectors match the pods you think they protect.
+
+If the symptom is Pending, ask whether a single node can ever satisfy the pod. If the answer is no, preemption cannot help unless removing lower-priority pods on one node makes it feasible. If the symptom is eviction, ask whether the pod exceeded its request or had no request at all. If the symptom is drain blocking, ask whether the PDB budget is already consumed by unavailable replicas before blaming the drain command.
 
 ## Did You Know?
 
-1. **Scheduling throughput**: In large clusters, the kube-scheduler can make over 10,000 scheduling decisions per second. It achieves this by evaluating only a percentage of nodes (controlled by `percentageOfNodesToScore`) rather than all nodes in clusters with hundreds of nodes.
-2. **nominatedNodeName**: When a pod triggers preemption, the scheduler sets `nominatedNodeName` on the pending pod. However, this is not a guarantee -- another higher-priority pod might claim that node first. The pod must still pass filter and score phases in the next cycle.
-3. **Eviction vs OOM Kill**: Kubelet eviction and Linux OOM Kill are different mechanisms. Kubelet eviction is proactive (happens before memory is fully exhausted) and respects QoS ordering. OOM Kill is reactive (kernel kills a process when memory is truly exhausted) and uses `oom_score_adj` -- which Kubernetes sets based on QoS class: BestEffort gets 1000 (most likely killed), Guaranteed gets -997 (least likely).
-4. **PDB with zero budget**: Setting `maxUnavailable: 0` creates a PDB that blocks all voluntary disruptions. This is sometimes used for singleton services during critical business periods, but it will also block node drains and cluster upgrades. Use with caution.
-
----
+1. **Scheduling throughput**: In large clusters, kube-scheduler can make thousands of scheduling decisions per second by evaluating a percentage of nodes rather than every node in very large clusters.
+2. **`nominatedNodeName` is provisional**: A preempting pod may nominate a node, but the pod must still pass a future scheduling cycle before it is actually bound.
+3. **Eviction and OOM kill are different**: Kubelet eviction is proactive and follows Kubernetes QoS ordering, while the Linux OOM killer reacts when memory is exhausted and uses `oom_score_adj`.
+4. **A zero-disruption PDB is powerful**: `maxUnavailable: 0` can block voluntary disruptions during critical windows, but it can also block ordinary drains and upgrades.
 
 ## Common Mistakes
 
-| Mistake | Why It Fails | What to Do Instead |
+| Mistake | Why It Happens | How to Fix It |
 |---|---|---|
-| Not setting any PriorityClass | Critical services compete equally with batch jobs; no preemption possible | Define at least 3 priority tiers: critical, default, batch |
-| Setting limits without requests | Pod gets Burstable QoS but may be scheduled on overcommitted nodes | Always set requests; set limits equal to requests for Guaranteed QoS on critical pods |
-| Forgetting PDB during cluster upgrades | Drain evicts all replicas simultaneously, causing downtime | Create PDBs for every production Deployment before upgrading |
-| Setting `terminationGracePeriodSeconds: 0` | No graceful shutdown; in-flight requests dropped, data corruption risk | Use at least 15s; longer for stateful workloads |
-| Assuming PDBs protect against all disruptions | Node crash, OOM, and kubelet hard eviction ignore PDBs | Design for involuntary disruption: replicas across zones, persistent storage, idempotent operations |
-| Setting `maxUnavailable: 0` on PDB | Blocks all voluntary disruptions including node drains and upgrades | Use `maxUnavailable: 1` or `minAvailable: N-1` to allow rolling operations |
-Pod may remain Pending until a node has capacity -- it cannot preempt
-| Ignoring QoS class on batch jobs | Batch jobs with Guaranteed QoS are evicted last, blocking eviction of pods you care more about | Set batch jobs to BestEffort or Burstable with low requests |
-
----
+| Not setting any PriorityClass | Critical services compete equally with batch jobs, so preemption cannot express business importance | Define a small reviewed set of priority tiers and assign them deliberately |
+| Treating limits as scheduling reservations | Limits feel like capacity, but the scheduler fits pods using requests | Set realistic CPU and memory requests, then choose limits based on runtime risk |
+| Forgetting PDBs before cluster upgrades | Drain operations may evict too many replicas or block unexpectedly | Create PDBs for production controllers and test allowed disruptions before maintenance |
+| Setting `terminationGracePeriodSeconds: 0` | The pod receives no useful graceful shutdown window | Use a budget that includes endpoint removal, PreStop time, application drain, and margin |
+| Assuming PDBs prevent every outage | Node crashes, hard evictions, and kernel OOM kills are involuntary | Combine PDBs with replicas, topology spread, resource requests, and spare capacity |
+| Giving batch jobs Guaranteed QoS by accident | Equal requests and limits make disposable work harder to evict under pressure | Use lower priority and appropriate Burstable or BestEffort settings for expendable work |
+| Diagnosing evictions as scheduler bugs | Evicted pods were already running, so the kubelet made the decision | Inspect pod reason, node pressure conditions, QoS class, and kubelet events |
 
 ## Quiz
 
-Test your understanding of scheduler internals, priority, QoS, and lifecycle.
+Test your understanding with scenario-first questions. Use the answer blocks to check the reasoning path, not just the final fix.
 
 <details>
-<summary>1. A pod is stuck Pending. <code>k describe pod</code> shows: "0/3 nodes are available: 2 insufficient cpu, 1 node(s) had taint {gpu=true: NoSchedule}." What do you check?</summary>
+<summary>1. A pod is Pending and events say two nodes have insufficient CPU while one node has an untolerated GPU taint. How do you diagnose the scheduler filter failure?</summary>
 
-Two nodes lack sufficient CPU for this pod's requests, and one node has a `gpu=true:NoSchedule` taint that the pod does not tolerate. You should first check the pod's CPU requests with `k get pod -o yaml` and compare against node allocatable resources with `k describe node`. If requests are correct, either scale down other workloads, add nodes with more CPU, or add a toleration for the GPU taint if the pod should run on GPU nodes. The key insight is that all three nodes failed the filter phase for different reasons.
+Start by comparing the pod's CPU request with node allocatable CPU, then inspect the GPU taint and the pod's tolerations. Lowering memory limits would not address the reported CPU or taint failures because Filter stops on hard constraints. If the pod should use a GPU node, add the correct toleration and any required node affinity; otherwise add capacity or reduce the CPU request to a realistic value. This diagnoses the Pending scheduler filter failure by matching each event reason to the field that controls it.
 </details>
 
 <details>
-<summary>2. You have a pod with <code>requests.cpu: 500m, limits.cpu: 1000m, requests.memory: 256Mi, limits.memory: 256Mi</code>. What is its QoS class and why?</summary>
+<summary>2. A critical pod has priority 1000000 and `preemptionPolicy: Never`, while lower-priority batch pods fill every node. What PriorityClass preemption behavior should you expect?</summary>
 
-The QoS class is **Burstable**. For a pod to be Guaranteed, requests must equal limits for both CPU and memory across all containers. Here, memory requests equal limits (256Mi), but CPU requests (500m) do not equal CPU limits (1000m). Since at least one resource has requests set but not equal to limits, the pod is classified as Burstable. To make it Guaranteed, set `requests.cpu` equal to `limits.cpu`.
+The pod can be ordered ahead of lower-priority pending pods, but it will not preempt running batch pods. `preemptionPolicy: Never` disables displacement even when the numeric priority is high. The pod remains Pending until capacity appears through completion, scale-out, manual deletion, or a policy change. Use this behavior for important non-disruptive work, not for workloads that must make room during pressure.
 </details>
 
 <details>
-<summary>3. Pod X has priority 1000 and needs 2 CPU. Node A has Pod Y (priority 100, 1.5 CPU) and Pod Z (priority 500, 1 CPU) running, with 0.5 CPU free. Which pod(s) will the scheduler preempt?</summary>
+<summary>3. A pod has CPU request 500m, CPU limit 1000m, memory request 256Mi, and memory limit 256Mi. How do you evaluate QoS eviction risk?</summary>
 
-The scheduler will preempt Pod Y (priority 100, 1.5 CPU) because it is the lowest-priority pod and freeing it provides 2 CPU total (1.5 CPU from Y + 0.5 CPU already free), which is exactly enough for Pod X. The scheduler generally tries to preempt the lowest-priority set of pods needed to satisfy the incoming pod's resource requests. Pod Z (priority 500) is spared because evicting Pod Y alone frees sufficient resources.
+The pod is Burstable because Guaranteed requires CPU and memory requests to equal limits for every container. Its memory pair is equal, but its CPU request is lower than its CPU limit. Under node pressure it is safer than BestEffort but less protected than Guaranteed, especially if it exceeds its request. To make it Guaranteed, align CPU request and limit as well as memory request and limit across all containers.
 </details>
 
 <details>
-<summary>4. During a <code>kubectl drain</code>, the operation hangs indefinitely. The node has 3 pods from a Deployment with a PDB of <code>minAvailable: 3</code> and the Deployment has 3 replicas. What is wrong?</summary>
+<summary>4. A node reports MemoryPressure and pods fail with reason `Evicted`. How do you debug kubelet node-pressure eviction?</summary>
 
-The PDB requires at least 3 pods to be available at all times, but the Deployment only has 3 replicas. Draining would require evicting at least one pod from this node, which would drop the available count below 3, violating the PDB. The drain operation blocks because it respects PDBs. Fix by either scaling the Deployment to 4+ replicas (so one can be evicted while 3 remain), changing the PDB to `minAvailable: 2`, or using `--timeout` on the drain command and addressing the PDB separately.
+Look at node conditions, taints, kubelet events, and each evicted pod's QoS class and resource requests. The scheduler is not the component evicting already-running pods; the kubelet is reacting to local pressure signals. BestEffort pods and Burstable pods above their requests are expected to be evicted before Guaranteed pods. The durable fix may be better requests, less node overcommitment, additional capacity, or removing the workload causing pressure.
 </details>
 
 <details>
-<summary>5. A node enters MemoryPressure condition. There are 3 pods: a Guaranteed pod using 1Gi, a Burstable pod using 1.5x its memory request, and a BestEffort pod using 500Mi. In what order does the kubelet evict them?</summary>
+<summary>5. During `kubectl drain`, a three-replica Deployment with `minAvailable: 3` blocks eviction from one node. How should you implement PDB rules for the drain?</summary>
 
-The kubelet evicts in QoS order: BestEffort first, then Burstable pods exceeding their requests, then Guaranteed pods. So the BestEffort pod (500Mi, no requests) is evicted first. If pressure persists, the Burstable pod is evicted next because it is using 1.5x its memory request (exceeding its reservation). The Guaranteed pod is evicted last, and only if the node is still under pressure after evicting the first two -- which is rare in practice because Guaranteed pods use exactly what they requested.
+The PDB requires all three replicas to remain available, so voluntary eviction of any matching pod violates the budget. You can scale the Deployment up before the drain, change the PDB to `minAvailable: 2`, or use `maxUnavailable: 1` if one unavailable replica is acceptable. A timeout prevents the command from hanging forever, but it does not solve the availability policy. The fix is to align replica count and PDB budget with the disruption you need to perform.
 </details>
 
 <details>
-<summary>6. You set <code>terminationGracePeriodSeconds: 30</code> and a PreStop hook that runs <code>sleep 25</code>. How much time does your application have to handle SIGTERM before SIGKILL?</summary>
+<summary>6. A PreStop hook sleeps for twenty-five seconds and `terminationGracePeriodSeconds` is thirty. What shutdown behavior should you expect?</summary>
 
-Your application has approximately 5 seconds. The grace period countdown begins when the pod is marked for deletion, and the PreStop hook runs first. The PreStop hook consumes 25 seconds of the 30-second grace period. After the PreStop hook completes, SIGTERM is sent, and only 5 seconds remain before SIGKILL. If your application needs more shutdown time, increase `terminationGracePeriodSeconds` to account for both the PreStop hook duration and the application's drain time.
+The application receives only about five seconds after the hook finishes because the grace countdown starts when deletion begins. PreStop execution consumes part of the same budget that SIGTERM handling uses. If the application needs twenty seconds to drain, this configuration is too short. Increase the grace period, shorten the hook, or move some traffic-drain behavior earlier in the shutdown path.
 </details>
 
 <details>
-<summary>7. A pod has <code>preemptionPolicy: Never</code> and priority 1000000. Node capacity is full with priority-100 pods. What happens?</summary>
+<summary>7. A node crash removes one replica from a Deployment protected by `maxUnavailable: 1`, and a drain starts before the replacement is ready. What happens?</summary>
 
-The pod remains Pending indefinitely. Despite having a high priority value (1000000), the `preemptionPolicy: Never` setting means the scheduler will never evict lower-priority pods to make room for it. The pod must wait until resources become available through other means: pods completing, nodes scaling up, or manual intervention. The `preemptionPolicy: Never` is designed for workloads that are important enough to run before other pending pods in the queue but should not displace running workloads.
+The crash is involuntary, so the PDB could not prevent the first loss, but the unavailable replica still consumes the disruption budget. A voluntary drain that would evict a second replica should block until the replacement becomes available or the budget changes. This is why spare capacity and fast replacement scheduling matter alongside PDBs. PDBs protect planned disruption; they do not erase the consequences of unplanned failures.
 </details>
-
-<details>
-<summary>8. You create a PDB with <code>maxUnavailable: 1</code> for a 3-replica Deployment. A node crashes, taking one pod with it. Can <code>kubectl drain</code> a second node that hosts another replica?</summary>
-
-Yes, but it depends on timing. When the node crashes, one pod becomes unavailable (involuntary disruption -- PDB does not prevent this). The PDB allows `maxUnavailable: 1`, and one pod is already unavailable. If the Deployment controller has not yet created a replacement pod on a healthy node, `kubectl drain` will block because draining would make 2 pods unavailable, violating the PDB. Once the replacement pod is running and healthy, the PDB is satisfied again (1 unavailable is within budget), and the drain can proceed. This is why it is important to ensure your cluster has enough capacity for replacement pods.
-</details>
-
----
 
 ## Hands-On Exercise
 
-This exercise walks you through QoS classification, preemption, simulated eviction behavior, and PDB-protected drains. Run these on a kind or minikube cluster to verify the concepts locally.
+This exercise walks through QoS classification, preemption observation, kubelet eviction indicators, and PDB-protected drains. Run it on a disposable kind or minikube cluster because drain and preemption tests intentionally disrupt pods. If your local cluster has very small allocatable CPU, adjust replica counts and requests downward while preserving the same relationships between high and low priority.
 
 <details>
-<summary>Step 1: Create Pods with Different QoS Classes</summary>
+<summary>Step 1: Create pods with different QoS classes</summary>
 
 ```bash
 # Create a namespace for this exercise
-k create namespace scheduler-lab
+kubectl create namespace scheduler-lab
 
 # Guaranteed QoS pod
-cat <<'EOF' | k apply -f -
+cat <<'EOF' | kubectl apply -f -
 apiVersion: v1
 kind: Pod
 metadata:
@@ -783,7 +759,7 @@ spec:
 EOF
 
 # Burstable QoS pod
-cat <<'EOF' | k apply -f -
+cat <<'EOF' | kubectl apply -f -
 apiVersion: v1
 kind: Pod
 metadata:
@@ -803,7 +779,7 @@ spec:
 EOF
 
 # BestEffort QoS pod
-cat <<'EOF' | k apply -f -
+cat <<'EOF' | kubectl apply -f -
 apiVersion: v1
 kind: Pod
 metadata:
@@ -819,7 +795,7 @@ EOF
 Verify QoS classification:
 
 ```bash
-k get pods -n scheduler-lab -o custom-columns=\
+kubectl get pods -n scheduler-lab -o custom-columns=\
 NAME:.metadata.name,\
 QOS:.status.qosClass,\
 STATUS:.status.phase
@@ -836,11 +812,11 @@ qos-guaranteed    Guaranteed   Running
 </details>
 
 <details>
-<summary>Step 2: Set Up PriorityClasses and Observe Preemption</summary>
+<summary>Step 2: Set up PriorityClasses and observe preemption</summary>
 
 ```bash
 # Create PriorityClasses
-cat <<'EOF' | k apply -f -
+cat <<'EOF' | kubectl apply -f -
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
@@ -858,24 +834,24 @@ globalDefault: false
 description: "Low priority for batch workloads"
 EOF
 
-# Fill the node with low-priority pods
-# Adjust CPU requests based on your cluster's allocatable CPU
-k create deployment low-batch \
+# Fill the node with low-priority pods.
+# Adjust CPU requests based on your cluster's allocatable CPU.
+kubectl create deployment low-batch \
   --image=nginx:1.35 \
   --replicas=10 \
   -n scheduler-lab
 
-# Patch to add priority and resource requests
-k patch deployment low-batch -n scheduler-lab --type=json -p='[
+# Patch to add priority and resource requests.
+kubectl patch deployment low-batch -n scheduler-lab --type=json -p='[
   {"op": "add", "path": "/spec/template/spec/priorityClassName", "value": "low-priority"},
   {"op": "add", "path": "/spec/template/spec/containers/0/resources", "value": {"requests": {"cpu": "100m", "memory": "64Mi"}}}
 ]'
 
-# Wait for pods to be running
-k rollout status deployment/low-batch -n scheduler-lab --timeout=60s
+# Wait for pods to be running.
+kubectl rollout status deployment/low-batch -n scheduler-lab --timeout=60s
 
-# Now create a high-priority pod that requests significant resources
-cat <<'EOF' | k apply -f -
+# Now create a high-priority pod that requests significant resources.
+cat <<'EOF' | kubectl apply -f -
 apiVersion: v1
 kind: Pod
 metadata:
@@ -892,54 +868,53 @@ spec:
         memory: 256Mi
 EOF
 
-# Check events -- look for preemption messages
-k get events -n scheduler-lab --sort-by='.lastTimestamp' | tail -20
+# Check events and look for preemption messages.
+kubectl get events -n scheduler-lab --sort-by='.lastTimestamp' | tail -20
 
-# Verify the critical pod is running
-k get pod critical-service -n scheduler-lab
+# Verify the critical pod is running.
+kubectl get pod critical-service -n scheduler-lab
 
-# Check if any low-priority pods were preempted
-k get pods -n scheduler-lab -o wide
+# Check if any low-priority pods were preempted.
+kubectl get pods -n scheduler-lab -o wide
 ```
 </details>
 
 <details>
-<summary>Step 3: Observe Eviction Ordering with Memory Stress</summary>
+<summary>Step 3: Observe eviction indicators with memory-pressure concepts</summary>
 
 ```bash
-# Check current node conditions
-k describe nodes | grep -A 5 "Conditions:"
+# Check current node conditions.
+kubectl describe nodes | grep -A 5 "Conditions:"
 
-# View the oom_score_adj values set by kubelet for each QoS class
-# (requires exec access to the node -- works in kind)
-k get pods -n scheduler-lab -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.qosClass}{"\n"}{end}'
+# View the QoS classes that kubelet uses when calculating eviction priority.
+kubectl get pods -n scheduler-lab -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.qosClass}{"\n"}{end}'
 
 # To see oom_score_adj for a specific pod's container:
-k exec qos-besteffort -n scheduler-lab -- cat /proc/1/oom_score_adj
+kubectl exec qos-besteffort -n scheduler-lab -- cat /proc/1/oom_score_adj
 # Expected: 1000 (most likely to be OOM killed)
 
-k exec qos-guaranteed -n scheduler-lab -- cat /proc/1/oom_score_adj
+kubectl exec qos-guaranteed -n scheduler-lab -- cat /proc/1/oom_score_adj
 # Expected: -997 (least likely to be OOM killed)
 
-k exec qos-burstable -n scheduler-lab -- cat /proc/1/oom_score_adj
+kubectl exec qos-burstable -n scheduler-lab -- cat /proc/1/oom_score_adj
 # Expected: value between -997 and 1000 (calculated based on requests ratio)
 ```
 </details>
 
 <details>
-<summary>Step 4: PDB-Protected Drain</summary>
+<summary>Step 4: Test a PDB-protected drain</summary>
 
 ```bash
-# Create a Deployment with multiple replicas
-k create deployment web-app \
+# Create a Deployment with multiple replicas.
+kubectl create deployment web-app \
   --image=nginx:1.35 \
   --replicas=3 \
   -n scheduler-lab
 
-k rollout status deployment/web-app -n scheduler-lab --timeout=60s
+kubectl rollout status deployment/web-app -n scheduler-lab --timeout=60s
 
-# Create a PDB
-cat <<'EOF' | k apply -f -
+# Create a PDB.
+cat <<'EOF' | kubectl apply -f -
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -952,26 +927,26 @@ spec:
       app: web-app
 EOF
 
-# Verify PDB status
-k get pdb -n scheduler-lab
+# Verify PDB status.
+kubectl get pdb -n scheduler-lab
 # ALLOWED DISRUPTIONS should be 1 (3 replicas - 2 minAvailable)
 
-# Find which node has web-app pods
-k get pods -n scheduler-lab -l app=web-app -o wide
+# Find which node has web-app pods.
+kubectl get pods -n scheduler-lab -l app=web-app -o wide
 
-# Try draining a node that has a web-app pod (use --dry-run first)
-NODE=$(k get pods -n scheduler-lab -l app=web-app -o jsonpath='{.items[0].spec.nodeName}')
-k drain $NODE --ignore-daemonsets --delete-emptydir-data --dry-run=client
+# Try draining a node that has a web-app pod with a client-side dry run first.
+NODE=$(kubectl get pods -n scheduler-lab -l app=web-app -o jsonpath='{.items[0].spec.nodeName}')
+kubectl drain "$NODE" --ignore-daemonsets --delete-emptydir-data --dry-run=client
 
-# Perform actual drain with timeout
-k drain $NODE --ignore-daemonsets --delete-emptydir-data --timeout=120s
+# Perform actual drain with a timeout.
+kubectl drain "$NODE" --ignore-daemonsets --delete-emptydir-data --timeout=120s
 
-# Observe: PDB allows draining one pod at a time
-k get pods -n scheduler-lab -l app=web-app -o wide
-k get pdb -n scheduler-lab
+# Observe that the PDB allows draining one pod at a time.
+kubectl get pods -n scheduler-lab -l app=web-app -o wide
+kubectl get pdb -n scheduler-lab
 
-# Uncordon the node when done
-k uncordon $NODE
+# Uncordon the node when done.
+kubectl uncordon "$NODE"
 ```
 </details>
 
@@ -979,41 +954,47 @@ k uncordon $NODE
 <summary>Cleanup</summary>
 
 ```bash
-k delete namespace scheduler-lab
-k delete priorityclass high-priority low-priority
+kubectl delete namespace scheduler-lab
+kubectl delete priorityclass high-priority low-priority
 ```
 </details>
 
 ### Success Checklist
-- [ ] You correctly identified the QoS class for a Guarantee, Burstable, and BestEffort pod.
-- [ ] You forced a preemption event and validated via `k get events`.
-- [ ] You viewed the OS-level `oom_score_adj` matching the QoS classes.
-- [ ] You successfully paused a `kubectl drain` by utilizing a strict PDB constraints layout.
 
----
+- [ ] Diagnose Pending scheduler filter failures by comparing pod requests, taints, affinity, and events.
+- [ ] Design PriorityClass preemption behavior that protects critical workloads while limiting disruption.
+- [ ] Evaluate QoS eviction risk from pod resource requests, limits, and node pressure.
+- [ ] Debug kubelet node-pressure eviction using signals, conditions, taints, and replacement behavior.
+- [ ] Implement graceful termination and PodDisruptionBudget rules for drains, preemption, and shutdown.
 
 ## Practice Drills
 
-Timed drills for CKA exam preparation. Practice until you can complete each within the target time.
+Timed practice is useful because scheduler lifecycle questions often look long but collapse quickly once you identify the responsible component. Repeat these drills until you can state whether the scheduler, kubelet, PDB controller, or workload controller is making the decision. The goal is not to memorize every command; it is to build a fast diagnostic loop from symptom to component to controlling field.
 
 | # | Drill | Target Time |
 |---|---|---|
 | 1 | Create three pods (Guaranteed, Burstable, BestEffort) and verify their QoS class using jsonpath | 3 min |
-| 2 | Create two PriorityClasses (high=10000, low=100) and a pod using each. Verify with `k get pod -o yaml \| grep priority` | 2 min |
+| 2 | Create two PriorityClasses (high=10000, low=100) and a pod using each. Verify with `kubectl get pod -o yaml \| grep priority` | 2 min |
 | 3 | Create a 3-replica Deployment with a PDB (`maxUnavailable: 1`). Drain a node and verify only one pod is evicted at a time | 5 min |
-| 4 | A pod is Pending. Use `k describe pod` and `k describe node` to identify whether the issue is insufficient resources, taints, or affinity | 3 min |
+| 4 | A pod is Pending. Use `kubectl describe pod` and `kubectl describe node` to identify whether the issue is insufficient resources, taints, or affinity | 3 min |
 | 5 | Create a pod with a PreStop hook that writes to a log file, delete it with `--grace-period=60`, and verify the hook ran by checking the log | 4 min |
-| 6 | Given a cluster with resource fragmentation (no single node has 2 CPU free, but total cluster has 6 CPU free), explain why a pod requesting 2 CPU is Pending and propose two fixes | 2 min |
-
----
-
-## Next Module
-
-Continue to [Module 2.9: Autoscaling (HPA, VPA, Cluster)](/k8s/cka/part2-workloads-scheduling/module-2.9-autoscaling/) to learn how Kubernetes automatically adjusts resources based on demand and gracefully evicts workloads during downsizing.
+| 6 | Given a cluster with resource fragmentation, explain why a pod requesting 2 CPU is Pending and propose two fixes | 2 min |
 
 ## Sources
 
-- [Kubernetes Scheduler](https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/) — Best primary reference for unscheduled Pods, feasible nodes, scoring, binding, and random tie-breaking.
-- [Pod Priority and Preemption](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) — Covers PriorityClasses, preemption flow, `nominatedNodeName`, and best-effort PDB handling during preemption.
-- [Node-pressure Eviction](https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/) — Primary source for kubelet eviction signals, default hard thresholds, node conditions, taints, and OOM/eviction behavior.
-- [Pod Lifecycle](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/) — Best high-level reference for Pod phases, graceful termination flow, and shutdown behavior under Kubernetes 1.35-era docs.
+- [Kubernetes Scheduler](https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/)
+- [Pod Priority and Preemption](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/)
+- [Node-pressure Eviction](https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/)
+- [Pod Lifecycle](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/)
+- [Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/)
+- [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
+- [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+- [Pod Quality of Service Classes](https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/)
+- [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)
+- [Disruptions](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/)
+- [Container Lifecycle Hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/)
+- [API Reference: PriorityClass](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/priority-class-v1/)
+
+## Next Module
+
+Continue to [Module 2.9: Autoscaling (HPA, VPA, Cluster)](/k8s/cka/part2-workloads-scheduling/module-2.9-autoscaling/) to learn how Kubernetes automatically adjusts resources based on demand and how autoscaling decisions interact with scheduling pressure.


### PR DESCRIPTION
## Summary
- Rewrote Module 2.8 scheduler lifecycle theory for #388 density, structure, alignment, and anti-leak gates.
- Cleared `revision_pending` to false.
- Preserved scheduler, preemption, QoS, eviction, termination, PDB, quiz, lab, diagram, code, table, and source coverage while correcting runnable shell examples to full `kubectl`.

## Verifier
- `verify_module.py --skip-source-check`: tier T0; body_words=5016, mean_wpp=66.9, median_wpp=67, short_rate=0.0, max_run=0, mean_sentence_length=20.2; failure_gates={}

## Protected Assets
- Before: code_blocks=30, mermaid_diagrams=4, ascii_diagrams=0, tables=11, sources=4.
- After: code_blocks=30, mermaid_diagrams=4, ascii_diagrams=0, tables=14, sources=12.
- Confirmation: protected diagrams/code blocks were preserved in topic and count, with shell snippets updated from alias shorthand to full `kubectl` for verifier compliance.

## Checks
- PASS: deterministic verifier T0 using primary checkout venv because this worktree has no local `.venv/bin/python`.
- PASS: `git diff --check` on the changed module.
- PASS: forbidden-token / kubectl-alias grep returned no matches.
- NOTE: source reachability check intentionally skipped per #388 procedure; Sources section contains 12 primary Kubernetes URLs.
- NOTE: `npm run build` was not run because the primary checkout is dirty with unrelated user files, and this task restricts modifications to the single module file.

Commit: cf4c4e7f27f6cf66753e9ac8d525ef01321d18fa