### PR TITLE
feat(388): rewrite module-4.1-volumes (#388 pilot)

### DIFF
--- a/src/content/docs/k8s/cka/part4-storage/module-4.1-volumes.md
+++ b/src/content/docs/k8s/cka/part4-storage/module-4.1-volumes.md
@@ -3,6 +3,7 @@ title: "Module 4.1: Volumes"
 slug: k8s/cka/part4-storage/module-4.1-volumes
 sidebar:
   order: 2
+revision_pending: false
 ---
 
 > **Complexity**: `[MEDIUM]` - Foundation for all storage concepts
@@ -13,39 +14,27 @@ sidebar:
 
 ## What You'll Be Able to Do
 
-After completing this comprehensive module, you will be able to:
-- **Design** resilient storage architectures using emptyDir, hostPath, and projected volumes to satisfy strict distributed application requirements.
-- **Implement** precision volume mounts for containers by specifying paths, sub-paths, and restrictive access constraints correctly.
-- **Evaluate** the distinct lifecycle characteristics of various ephemeral volumes to prevent unintended data loss in production environments.
-- **Diagnose** complex volume mount failures by thoroughly analyzing pod events, inspecting node paths, and understanding low-level kubelet behaviors.
-- **Compare** ephemeral storage strategies against persistent volume capabilities to select the right tool for stateful workloads.
+After completing this module, you will be able to:
+
+- **Design** pod-scoped ephemeral volume layouts with `emptyDir`, projected volumes, and read-only mounts that support multi-container application patterns.
+- **Implement** secure `hostPath`, ConfigMap, Secret, and `subPath` mounts with explicit paths, permissions, and lifecycle expectations.
+- **Evaluate** volume lifecycle boundaries so you can predict what data survives a container restart, pod deletion, node drain, or reschedule.
+- **Diagnose** `FailedMount`, `ContainerCreating`, and stale-configuration symptoms by reading pod events, mount definitions, and kubelet behavior.
+- **Compare** ephemeral volume choices with PersistentVolumeClaim-based persistence before choosing storage for stateful workloads.
 
 ## Why This Module Matters
 
-A major financial services company once deployed a critical caching service using containers without properly configured volumes. To optimize for speed, the application wrote gigabytes of active financial session data directly to its local ephemeral container filesystem. During a routine node memory pressure event, the kubelet evicted several pods to preserve overall system stability. 
+Hypothetical scenario: your team ships a small API that caches user session summaries in the container filesystem because the cache is "only temporary." The application works during a demo, passes the first smoke test, and even survives a process crash because the deployment controller quickly starts another container. Then a node drain reschedules the pod, the replacement pod starts on a different node, and the entire cache disappears because the data was never stored outside the pod's local lifecycle boundary.
 
-Because the container runtime immediately destroyed those evicted containers, and because the critical session data resided entirely within the ephemeral container overlay layers, all active user sessions were instantly wiped out. Millions of authenticated users were forcefully logged out in the middle of transactions, resulting in a severe drop in active trading volume, massive customer complaints, and significant, measurable revenue loss. The outage required hours of manual database reconciliation.
+That scenario is not an exotic storage failure; it is the default consequence of treating a container filesystem like a durable disk. Containers are designed to be replaceable processes. Their writable layers are implementation details of the runtime, not an application storage contract. Kubernetes volumes give you that contract, but each volume type draws the boundary in a different place: some survive a container restart, some survive a pod restart on the same node, some expose node files directly, and some simply project API objects into a directory tree.
 
-This disaster could have been prevented entirely by understanding the fundamentals of Kubernetes volumes. Containers are strictly ephemeral by design; their filesystems are tied directly to their specific, temporary runtime instances. When a container crashes, the kubelet restarts it, but the new container starts with a clean slate identical to the base image artifact. Kubernetes volumes solve this by abstracting storage away from the individual container lifecycle, allowing data to persist across process restarts and be shared securely among multiple containers within the same pod.
+This distinction matters on the CKA exam because storage questions often hide inside ordinary pod troubleshooting. A pod stuck in `ContainerCreating` may have a missing Secret, a bad `hostPath` type, an unbound PVC, or a ConfigMap key that was mounted with the wrong path. A running application may still be wrong because a `subPath` mount froze a configuration file that the operator expected to update dynamically. You do not need to memorize every storage feature, but you do need to reason clearly about lifecycle, mount behavior, security scope, and the operational blast radius of each choice.
 
-For the Certified Kubernetes Administrator (CKA) exam, mastering these volume concepts is absolutely not optional. You will be explicitly required to configure ephemeral storage for high-speed caching, inject configuration data securely, and troubleshoot complex mount failures under intense time pressure. The concepts learned here form the absolute foundation for advanced persistent storage, which heavily dictates the reliability of stateful applications in production environments. Without a robust understanding of both ephemeral mounts and the underlying mechanisms of persistence, designing highly available microservices is virtually impossible.
+Think of a container as a desk with drawers that are cleaned whenever the desk is replaced. A pod-scoped volume is a filing cabinet assigned to that desk group: it remains while the pod remains, and multiple containers in the pod can open the same drawer. A `hostPath` mount is more like handing the desk worker a key to the building's maintenance room, which is sometimes necessary for building staff but dangerous for ordinary office work. A PersistentVolumeClaim is a leased storage unit outside the room entirely, and the next module goes deep on that longer-lived contract.
 
-> **The Filing Cabinet Analogy**
->
-> Think of a container as a desk with drawers that get emptied every time you leave work. A volume is like a filing cabinet in the corner - it keeps your files even when you're gone. Some cabinets are shared between desks (emptyDir), some are building-wide storage (PV), and some are just mirrors of the company directory (configMap/secret projected volumes).
+## Container Filesystems and Pod-Scoped Storage
 
-## Did You Know?
-
-- The current stable Kubernetes release is v1.35, and while legacy in-tree plugins exist in older documentation, all major cloud provider volume plugins have completed their Container Storage Interface (CSI) migrations unconditionally.
-- A `serviceAccountToken` projected volume source defaults to a token expiration of 3600 seconds, ensuring that long-lived static tokens are no longer the default security risk.
-- *Note: Historical records indicate* generic ephemeral volumes reached stable status historically in Kubernetes v1.23, automatically creating a per-Pod PersistentVolumeClaim that is garbage collected when the pod is deleted.
-- *Note: Historical records indicate* CSI inline ephemeral volumes, which reached stable historically in v1.25, are completely exempt from storage resource usage limits enforced by the kubelet.
-
-## Section 1: The Container Storage Problem
-
-When building cloud-native applications, you must constantly and proactively design for failure. Containers are not full virtual machines; they are ephemeral processes running in a tightly isolated execution environment provided by the Linux kernel. This isolation extends deeply into the filesystem layer. When your application writes a file inside a running container, you are actually writing to a writable "upper" layer overlaid on top of the read-only container image layers. This overlay filesystem is notoriously inefficient for heavy I/O operations and fundamentally volatile.
-
-More importantly, if the application process crashes, or if the kubelet decides to restart the container due to a failing liveness probe, that writable layer is entirely discarded without warning. The replacement container boots up with the exact filesystem state defined by the original, pristine image artifact. All previous state is lost.
+When a process writes into a normal container path, it is writing into the container runtime's writable layer, usually an overlay on top of the image layers. That layer is convenient because it makes immutable images feel writable at runtime, but it is not meant for meaningful application state. It is tied to the specific container instance, can be inefficient for heavy I/O, and disappears when the container is replaced. Before you design any volume, pause on that first principle: the image is the recipe, the container filesystem is the scratch counter, and a volume is the place where you deliberately decide data should live.
 
 ```mermaid
 flowchart LR
@@ -62,13 +51,7 @@ flowchart LR
     ContainerA -- Restart = Data Loss --> ContainerB
 ```
 
-This default behavior makes standard container filesystems fundamentally unsuitable for storing any data that must survive an application crash. Whether it is an application log file, a downloaded machine learning dataset, or a temporary session cache, the data is entirely dependent on the continuous execution of that specific container instance. When the container dies, the data dies with it.
-
-## Section 2: How Volumes Solve This
-
-Kubernetes volumes explicitly solve the ephemeral data problem by aggressively decoupling storage lifecycle from the container lifecycle. A volume is an explicit directory, possibly pre-populated with initial data, which is accessible to all the containers within a pod. The exact medium that backs it, how it is provisioned, and its lifecycle rules are determined by the particular volume type used in the Pod specification.
-
-Crucially, a volume is tied directly to the lifecycle of the **Pod**, not the individual container. This architectural distinction means that if a container crashes and is subsequently restarted by the kubelet, the volume remains completely intact. The newly started container can immediately access the exact same data left behind by its predecessor. 
+Kubernetes volumes solve this by decoupling selected directories from the individual container lifecycle. A pod declares a volume under `spec.volumes`, and each container that needs it declares a `volumeMount` with a mount path. The kubelet prepares the volume on the node before starting the container, then asks the container runtime to mount that prepared directory or file into the container namespace. The important boundary is that most basic volumes are tied to the pod, not to one container, so a restarted container sees the same mounted directory while the pod still exists.
 
 ```mermaid
 flowchart TD
@@ -88,11 +71,9 @@ flowchart TD
     end
 ```
 
-By defining a volume in the pod specification and mounting it into the container's filesystem, administrators gain precise control over what data is ephemeral and what data persists across immediate process crashes. This is the cornerstone of state management in Kubernetes.
+That pod boundary is powerful, but it is easy to overread. If one container in a pod crashes and restarts, an `emptyDir` volume remains. If the pod is deleted, evicted, or rescheduled onto another node, the `emptyDir` disappears because the old pod instance is gone. If your design needs to survive pod replacement, use a PersistentVolumeClaim or an external service instead of hoping that a pod-scoped volume behaves like a durable disk. Pause and predict: if a writer container stores 200Mi of cache in a shared `emptyDir`, then only that container restarts, what should the reader container see, and why?
 
-## Section 3: Volume Types Overview
-
-Kubernetes offers numerous volume types to solve radically different architectural challenges. Some are backed by local node disks, others by network-attached storage arrays, and some are populated directly by Kubernetes API objects. Understanding the distinctions is paramount.
+Kubernetes offers many volume types because "storage" covers several different jobs. Some volumes provide scratch space, some inject configuration, some expose node files for system agents, and some connect pods to durable storage. The table below is a practical first-pass map, not a substitute for reading the exact lifecycle rules before you deploy a workload.
 
 | Volume Type | Lifetime | Use Case | Data Persistence |
 |-------------|----------|----------|------------------|
@@ -104,7 +85,11 @@ Kubernetes offers numerous volume types to solve radically different architectur
 | persistentVolumeClaim | PV lifetime | Persistent data | Survives pod deletion |
 | image | Image lifetime | OCI image content as read-only volume | Read-only, pulled from registry |
 
-In modern architectures, Kubernetes has continuously expanded the types of ephemeral storage available. The `image` volume type allows mounting files directly from OCI images or artifacts as read-only volumes. No init containers or complex bootstrap scripts are needed. This is perfect for distributing ML models, massive config bundles, or static web assets. *Note: Historical sources indicate the image volume type (OCI artifact / container image as volume) reached beta in Kubernetes v1.33.*
+The table is also a reminder that two volumes can look identical inside a container while having completely different ownership outside it. A file at `/etc/app/config.yaml` might come from a ConfigMap, a projected volume, a `subPath` bind mount, or an ordinary image layer. The application path alone does not tell you what Kubernetes will do during an update, restart, or deletion. When troubleshooting, always trace from the mount path back to `volumeMounts`, then back to `volumes`, then back to the Kubernetes object or node path that supplies the content.
+
+This tracing habit is useful because volume bugs often masquerade as application bugs. A process that says "file not found" may be missing a ConfigMap key, but it may also be reading a path hidden by a directory mount. A process that says "permission denied" may be running as a non-root user against a Secret file mode that only root can read. A process that starts correctly and later becomes stale may have a reload problem rather than a Kubernetes mount problem. The CKA exam expects you to separate those layers quickly instead of changing YAML blindly.
+
+The `image` volume type is worth calling out because it changes how some teams distribute read-only assets. Instead of baking a model file, rules bundle, or static asset tree into the main application image, a pod can mount an OCI image or artifact as a read-only volume. That keeps application images smaller and makes large read-only content independently versioned. As of the Kubernetes 1.35 target for this curriculum, you should treat this as a modern volume option that is useful for immutable content, not as a replacement for writable application storage.
 
 ```yaml
 volumes:
@@ -114,23 +99,11 @@ volumes:
     pullPolicy: IfNotPresent
 ```
 
-### The Shift to CSI and Deprecations
+The broader storage ecosystem has also moved away from in-tree cloud-provider volume plugins. Historically, Kubernetes carried drivers such as cloud disks directly in core, which made every storage vendor change a Kubernetes release concern. The Container Storage Interface separates that responsibility: Kubernetes defines the interface, while storage vendors ship CSI drivers. In Kubernetes 1.35, modern clusters should rely on CSI for advanced storage behavior, and old in-tree specifications are either migrated, deprecated, or maintained only for compatibility with older manifests.
 
-Historically, Kubernetes included storage drivers directly within its core codebase (known as "in-tree" plugins). As the storage ecosystem rapidly expanded, this tightly coupled architecture became impossible to maintain. To resolve this, Kubernetes introduced the Container Storage Interface (CSI), standardizing how storage vendors develop plugins independently.
+## EmptyDir and Other Ephemeral Volume Choices
 
-All major in-tree cloud volume plugin CSI migrations are complete and unconditional as of Kubernetes v1.35. If you attempt to use the old in-tree specifications, the kubelet will transparently translate them to their corresponding CSI drivers. Furthermore, older native volume types are obsolete. The `gcePersistentDisk` in-tree volume plugin is deprecated. The `gitRepo` volume type is deprecated. The `portworxVolume` in-tree volume type is deprecated. Finally, `flexVolume` is deprecated. *Note: Historical records suggest CSI volume plugin migration for vSphere (vsphereVolume) reached GA historically in v1.26 and the feature gate was removed in v1.28.* Modern clusters rely exclusively on CSI drivers for advanced storage operations.
-
-## Section 4: Ephemeral Volumes In-Depth
-
-### What Is emptyDir?
-
-The `emptyDir` volume type is the most fundamental and heavily utilized Kubernetes ephemeral volume. It is created exactly when a pod is assigned to a node. As the name explicitly implies, it begins its life entirely empty. 
-
-The lifetime of an `emptyDir` is strictly bound to the pod. As long as that pod continues to run on that specific node, the `emptyDir` exists. Consequently, `emptyDir` volumes survive container crashes but are deleted permanently when a Pod is removed from a node (e.g., during scale-down, eviction, or manual deletion).
-
-### Basic emptyDir Usage
-
-The most common architectural pattern for an `emptyDir` is sharing data between two containers running in the exact same pod (often referred to as the classic sidecar pattern). For instance, one container might continually fetch new data from an external API and write it to disk, while a second container reads that data and serves it to clients.
+The `emptyDir` volume is the simplest useful volume because it begins empty when the pod is assigned to a node and remains available until that pod leaves the node. It is excellent for shared scratch data, sidecar handoff, temporary downloads, local sort space, and caches where losing the data is acceptable. It is not excellent for databases, message queues, user uploads, or anything whose loss becomes an incident. The question to ask is not "will this be fast," but "what is the exact event after which this data may vanish?"
 
 ```yaml
 apiVersion: v1
@@ -156,11 +129,11 @@ spec:
     emptyDir: {}
 ```
 
-In the robust example above, the `writer` container creates a text file, and the `reader` container accesses it. Because they both mount the exact same `emptyDir` volume definition (`shared-storage`), they effectively share a local directory.
+This example shows the classic sidecar pattern. The writer and reader are separate containers, but both mount the same volume name, so `/data` points to the same pod-scoped directory for both of them. The reader does not need a network call or a shared external service to consume a file from the writer. That simplicity is useful for log shippers, content preprocessors, local adapters, and small coordination files, provided the team accepts that deleting the pod deletes the shared directory.
 
-### emptyDir with Memory Backing
+The sidecar pattern works best when the shared files are an implementation detail of one pod rather than a coordination mechanism for the whole service. If several replicas need to share the same file, `emptyDir` is the wrong abstraction because each pod receives its own independent directory. If a controller replaces one replica, the new pod receives a new directory even when the pod has the same labels and serves the same traffic. That separation is usually good because replicas should be disposable, but it surprises teams that use local files as hidden cluster-wide state.
 
-By default, an `emptyDir` volume is backed by whatever storage medium is backing the node's local container runtime storage—usually a standard spinning disk or local SSD. However, Kubernetes allows you to instruct the kubelet to back the volume explicitly with RAM.
+You can ask the kubelet to back an `emptyDir` with memory by setting `medium: Memory`. That creates a tmpfs-backed volume, which is fast and keeps sensitive temporary material off physical disk. The tradeoff is that tmpfs usage is memory usage. If a container uses 350Mi of heap and writes 200Mi into a memory-backed `emptyDir`, the workload's effective memory pressure is the sum of those two numbers, and the pod can be killed even though the application heap alone looked reasonable.
 
 ```yaml
 apiVersion: v1
@@ -182,16 +155,7 @@ spec:
       sizeLimit: 100Mi      # Important! Limit memory usage
 ```
 
-**When to definitively use Memory-backed emptyDir**:
-- Storing temporary cryptographic credentials that should never touch physical disk.
-- High-speed caching where I/O latency must be microsecond-level.
-- Scratch space for intensive computation like sorting large datasets.
-
-It is crucial to understand that `emptyDir` with `medium: Memory` is backed by a RAM-based filesystem (tmpfs) and counts against the container's memory limit. If you store too much data in a memory-backed `emptyDir`, the kubelet will calculate that usage as part of the container's overall memory footprint, potentially resulting in a catastrophic Out Of Memory (OOM) kill.
-
-### emptyDir Size Limits
-
-To prevent a single runaway pod from exhausting the node's local disk space and causing a node-wide outage, you should always configure a `sizeLimit` for your `emptyDir` volumes.
+Disk-backed `emptyDir` also needs boundaries. Without a size limit, a noisy pod can consume local node storage and force unrelated workloads into eviction pressure. A `sizeLimit` gives the kubelet a concrete line to enforce and gives the platform team a way to reason about worst-case node usage. It does not make the data durable; it only makes the temporary storage safer to share on a multi-tenant node.
 
 ```yaml
 volumes:
@@ -200,21 +164,17 @@ volumes:
     sizeLimit: 500Mi    # Limit disk usage
 ```
 
-If the pod exceeds this hard limit, the kubelet will actively evict the pod from the node. This is a vital defensive mechanism in multi-tenant clusters to ensure noisy neighbors do not compromise node stability.
+Generic ephemeral volumes and CSI inline ephemeral volumes extend this idea for drivers that can provision storage dynamically for a pod. A generic ephemeral volume creates a per-pod PVC behind the scenes and deletes it when the pod is deleted, which gives temporary workloads access to storage-class behavior without making the claim a long-lived application object. CSI inline ephemeral volumes depend on driver support and can be useful for specialized local or network-backed temporary storage. The design judgment remains the same: ephemeral means the data belongs to the pod's temporary lifecycle, even when the implementation looks more sophisticated than `emptyDir`.
 
-> **Pause and predict**: A pod has two containers sharing an `emptyDir` volume. Container A writes 200Mi of cache data, then crashes. The kubelet restarts Container A on the same node. Is the 200Mi of data still there? What if the entire pod gets evicted?
+One practical way to evaluate ephemeral storage is to write the cleanup rule in plain language before writing YAML. For example, "this cache may disappear whenever the pod disappears" points toward `emptyDir`, while "this generated report must be available to the replacement pod" points away from it. The rule should also name the rebuild cost. A cache that takes two seconds to repopulate is different from a search index that takes several hours, even if both are technically derivable from another system.
 
-### Generic and CSI Ephemeral Volumes
+Resource accounting should be part of that same evaluation. Disk-backed `emptyDir` consumes node ephemeral storage, which competes with logs, image layers, and other pods. Memory-backed `emptyDir` consumes memory, which competes with process heap and page cache. Generic ephemeral volumes may consume backend storage provisioned by a CSI driver. The word "temporary" does not mean "free"; it means the platform is allowed to remove the data when the owner lifecycle ends.
 
-Beyond `emptyDir`, Kubernetes supports advanced ephemeral paradigms. Generic ephemeral volumes reached stable (GA) historically in v1.23. These generic ephemeral volumes automatically create a per-Pod PVC that is exclusively owned by the Pod and deleted when the Pod is deleted, bringing dynamic provisioning capabilities to temporary storage.
+Before running the next example in a real cluster, predict the result of each lifecycle event. A container restart should preserve the shared directory, a pod delete should remove it, and a node reschedule should not carry it to the new node. If your expected behavior differs from those three statements, the workload is asking for persistence and should move to a PVC-backed design in the next module.
 
-Additionally, CSI inline ephemeral volumes reached stable (GA) historically in v1.25. A unique characteristic of these volumes is that CSI ephemeral volumes are not subject to storage resource usage limits enforced by the kubelet, making them powerful but potentially risky if unmonitored. 
+## HostPath for Node Filesystems
 
-## Section 5: hostPath Volumes
-
-### What Is hostPath?
-
-A `hostPath` volume mounts a file or directory from the host node's underlying filesystem directly into your pod. Unlike an `emptyDir`, the data already exists on the node (or will be created there), and it survives the deletion of the pod.
+A `hostPath` volume mounts a path from the node's filesystem directly into the pod. That is a very different trust model from `emptyDir`. Instead of giving the pod a scratch directory prepared for that pod, you are exposing a piece of the node itself. For logging agents, monitoring agents, CNI tools, CSI components, and tightly controlled debug pods, this can be the correct tool. For ordinary application pods, it is usually a security smell and a scheduling trap.
 
 ```mermaid
 flowchart LR
@@ -233,11 +193,7 @@ flowchart LR
     A -. hostPath mount .-> G
 ```
 
-While undeniably powerful, `hostPath` presents severe security and scheduling challenges. If your pod relies on a specific file path on the node, it can only run successfully on nodes where that precise file path exists. If the scheduler places the pod on a node lacking the required directory structure, the pod will fail to start and remain pending or crashlooping.
-
-### hostPath Configuration
-
-When defining a `hostPath`, you specify the exact path on the node and optionally a type that validates the target before mounting. It is strongly recommended to mount these volumes as read-only whenever technically possible to drastically reduce the attack surface.
+The first operational risk is placement. A pod that needs `/data/myapp` can only run correctly on nodes where that path exists with the expected type and permissions. The scheduler does not inspect arbitrary node directories before assigning the pod. If the path is missing or wrong, the pod can end up stuck while the kubelet reports mount errors. You can reduce ambiguity by setting the `type` field, but you still need node preparation, node labels, affinity, or a DaemonSet pattern when the workload genuinely depends on local node files.
 
 ```yaml
 apiVersion: v1
@@ -260,9 +216,7 @@ spec:
       type: Directory          # Must be a directory
 ```
 
-### hostPath Types
-
-The `type` field allows the kubelet to strictly verify the node's filesystem before attempting to start the pod.
+The `type` field tells the kubelet what it should require before mounting. An empty type performs no validation, which makes failures harder to diagnose and can hide dangerous assumptions. `DirectoryOrCreate` and `FileOrCreate` are convenient, but they can also create root-owned paths with permissions that surprise an application. In a security-sensitive design, prefer exact existing paths, read-only mounts, and a narrow directory tree over broad filesystem access.
 
 | Type | Behavior |
 |------|----------|
@@ -275,9 +229,7 @@ The `type` field allows the kubelet to strictly verify the node's filesystem bef
 | `CharDevice` | Must exist, must be char device |
 | `BlockDevice` | Must exist, must be block device |
 
-### hostPath Security Risks
-
-Because `hostPath` provides direct, unfiltered access to the underlying node filesystem, it is an enormous security risk. If a container is compromised, a writable `hostPath` mount can easily allow the attacker to break out of the container boundary, modify node configuration files, and take over the entire node.
+The second operational risk is privilege. A writable `hostPath` to a sensitive directory can turn a container compromise into a node compromise because the attacker is no longer confined to files inside the container. Mounting `/`, kubelet directories, container runtime sockets, or host credential paths gives the pod access to resources that platform teams normally protect carefully. Pod Security Admission profiles commonly restrict `hostPath` for that reason, and managed clusters may add additional policy controls.
 
 ```yaml
 # DANGEROUS - Never do this in production!
@@ -288,18 +240,11 @@ volumes:
     type: Directory
 ```
 
-Most managed Kubernetes clusters and strict Pod Security Admission profiles actively ban the use of `hostPath` for standard application workloads.
+A legitimate `hostPath` design narrows the path to the minimum useful directory, marks mounts read-only when possible, and runs in a namespace governed by explicit platform policy. A log collector is a good example because the data exists on the node and the agent's job is to read it. Even there, the mount should be targeted. A DaemonSet that mounts `/var/log` read-only is easier to defend than one that mounts `/` and promises to behave.
 
-**Safe uses of hostPath**:
-- DaemonSets that need explicit node access (log collectors, monitoring agents).
-- Node-level debugging (temporary troubleshooting only).
-- Docker socket access for CI/CD (use with extreme caution, often replaced by rootless builds).
+DaemonSets are a natural fit for many `hostPath` cases because they make the node relationship explicit. A Deployment asks the scheduler for some suitable node, but a DaemonSet says the workload belongs on every matching node. That model fits log collection, node metrics, local security scanning, and storage-node helpers better than a random replica set. If only a subset of nodes has the required path or hardware, combine the DaemonSet with labels, tolerations, and node selectors so the scheduling contract matches the filesystem contract.
 
-> **Stop and think**: A developer proposes mounting `hostPath: /var/run/docker.sock` into their CI/CD pod to build container images. What specific security risks does this create, and what alternative approaches would you recommend?
-
-### hostPath in DaemonSets
-
-The primary legitimate use case for `hostPath` is within system administration tools deployed as DaemonSets. For instance, a logging agent needs to read the container logs produced by the container runtime. These logs exist exclusively on the node's filesystem, making `hostPath` the correct technical choice.
+During review, ask whether the `hostPath` path is an input, an output, or both. A read-only input path for logs is much safer than a writable output path where the application stores business data on whichever node happened to run the pod. Node-local output also creates backup and migration questions that Kubernetes cannot answer for you. If the business cares about the data, a node path is usually the wrong place to leave it because node replacement, autoscaling, and repair workflows can remove that state outside the pod's awareness.
 
 ```yaml
 apiVersion: apps/v1
@@ -336,13 +281,11 @@ spec:
           type: Directory
 ```
 
-## Section 6: Projected Volumes
+Stop and think before approving a `hostPath` pull request: does this pod truly need node files, or is it using the node as a shortcut around proper storage and permissions? If a developer proposes mounting a container runtime socket into a CI pod, the risk is not merely "the build can read some files." The pod may be able to control the runtime, start privileged containers, or access host resources indirectly. Safer alternatives include rootless builders, purpose-built build services, remote builders, or tightly scoped platform-owned build nodes.
 
-### What Are Projected Volumes?
+## Projected, ConfigMap, and Secret Volumes
 
-Often, a single microservice application requires configuration data from multiple distinct sources. For example, you might need an application properties file (`app.conf`) from a ConfigMap, a database password from a Secret, and the pod's own metadata from the Downward API.
-
-Historically, this required declaring multiple individual volumes and mounting them into completely different directories within the container. A `projected` volume solves this architectural hurdle elegantly by mapping several existing volume sources into a single, unified directory tree inside the container. You can combine resources listed under `projected.sources` seamlessly.
+Configuration volumes solve a different problem from scratch storage. Applications need files such as `nginx.conf`, TLS material, feature flags, service account tokens, and pod metadata, but baking every value into an image makes releases slow and brittle. Kubernetes lets you store non-sensitive configuration in ConfigMaps, sensitive values in Secrets, selected pod metadata through the Downward API, and short-lived service account tokens through token projection. A projected volume combines several of those sources into one directory tree so the application sees a clean filesystem layout.
 
 ```mermaid
 flowchart LR
@@ -364,9 +307,7 @@ flowchart LR
     C --> H & I
 ```
 
-### Projected Volume Configuration
-
-To configure a projected volume, you comprehensively list the individual sources under the `projected.sources` array.
+Use a projected volume when the application wants one coherent directory, but the source data belongs to multiple Kubernetes objects. The pod specification lists each source under `projected.sources`, and each source can map keys to paths. This is cleaner than scattering four mounts across four directories and then teaching the application to search all of them. It also makes the security review easier because one read-only mount point can contain the exact files the process needs.
 
 ```yaml
 apiVersion: v1
@@ -413,9 +354,7 @@ spec:
               resource: limits.cpu
 ```
 
-### Secure Token Projection
-
-One of the most absolutely critical uses of projected volumes is securely injecting service account tokens into pods. Modern Kubernetes clusters heavily use projected service account tokens to ensure tokens are time-bound, audience-restricted, and strictly tied to the pod lifecycle.
+Projected service account tokens are especially important for modern clusters. Legacy long-lived tokens are a poor default for pods because they can outlive the workload and may be useful to an attacker after compromise. A projected `serviceAccountToken` can be audience-bound and time-bound, with a default expiration of 3600 seconds and automatic kubelet rotation. The file path still looks simple to the application, but the credential lifecycle is much better aligned with the pod.
 
 ```yaml
 apiVersion: v1
@@ -441,24 +380,7 @@ spec:
           audience: api               # Intended audience
 ```
 
-The `serviceAccountToken` projected volume token expiration defaults to 3600 seconds (1 hour) with a minimum of 600 seconds (10 minutes). If the pod lives longer than the token's lifespan, the kubelet automatically rotates it in the background by securely updating the projected file. 
-
-Furthermore, Kubernetes is introducing advanced projection sources. *Note: Historical tracking suggests the `clusterTrustBundle` projected volume source is beta in Kubernetes v1.33 and disabled by default. Similarly, the `podCertificate` projected volume source is beta in Kubernetes v1.35 and disabled by default.*
-
-### Projected Volume Use Cases
-
-| Use Case | Sources Combined |
-|----------|------------------|
-| App config bundle | configMap + secret |
-| Pod identity | serviceAccountToken + downwardAPI |
-| Full config injection | configMap + secret + downwardAPI |
-| Sidecar config | Multiple configMaps |
-
-## Section 7: ConfigMap and Secret Volumes
-
-### ConfigMap as Volume
-
-ConfigMaps store non-confidential data in standard key-value pairs. While you can inject them as simple environment variables, mounting them as a volume is generally preferred for sophisticated applications because it inherently supports automatic dynamic updates and allows for injecting complex, multi-line configuration file structures (like an `nginx.conf`).
+ConfigMap volumes are the usual choice for non-confidential files. Mounting a ConfigMap as a directory works well for applications that read structured configuration from disk, such as web server fragments or application property files. This is often better than environment variables when the value is multi-line, when the application already expects a file, or when operators need to update the data without rebuilding an image. The application still needs a reload strategy because Kubernetes can update the file on disk without forcing the process to reread it.
 
 ```yaml
 apiVersion: v1
@@ -474,6 +396,10 @@ data:
       }
     }
 ```
+
+The matching pod can mount the ConfigMap at the directory where the application expects configuration. The `items` list lets you select specific keys and rename them on disk, which is useful when the ConfigMap key name differs from the application filename. Be careful when mounting an entire directory over an existing path, because the mount hides files from the image at that path. If the image already contains required defaults in the same directory, consider a dedicated mount point or a carefully chosen `subPath`.
+
+Directory shadowing is one of the easiest configuration mistakes to miss in review. Suppose an image contains `/etc/myapp/defaults.yaml` and `/etc/myapp/plugins.yaml`, and you mount a ConfigMap at `/etc/myapp` containing only `app.yaml`. Inside the container, the mounted directory hides the image's original files at that path, so the application may fail because its defaults vanished. Kubernetes did exactly what you requested; the design failed because the mount point was broader than the intended change.
 
 ```yaml
 apiVersion: v1
@@ -498,9 +424,7 @@ spec:
         path: default.conf     # Rename the file
 ```
 
-### Secret as Volume
-
-Secrets function nearly identically to ConfigMaps but are intended exclusively for highly sensitive data like database passwords, API keys, or TLS certificates. When mounted as a volume, they are written to a `tmpfs` file system by the kubelet, meaning the highly sensitive data is stored directly in memory and never written to the node's physical disk storage.
+Secret volumes behave similarly from the pod's perspective, but they carry a different security expectation. Kubernetes Secrets are not a complete secret-management system by themselves; they still require RBAC, encryption at rest where appropriate, and careful access control. However, mounting a Secret as a volume is often preferable to putting secret values in environment variables because file permissions can be restricted, the content can be rotated on disk, and the kubelet stores the material in a memory-backed filesystem for the pod.
 
 ```yaml
 apiVersion: v1
@@ -512,6 +436,10 @@ data:
   tls.crt: <base64-encoded-cert>
   tls.key: <base64-encoded-key>
 ```
+
+Use restrictive file modes for Secret material and keep the mount read-only. The `defaultMode` field is written in YAML as an integer, and examples commonly use octal-looking values such as `0400`. The exact application user must still be able to read the file, so test the effective permissions with the image's runtime user rather than assuming root-like behavior. A secure mount that the process cannot read will fail just as surely as an insecure mount that auditors reject.
+
+Secret volume design should also include rotation behavior. If the kubelet updates the mounted Secret file but the application opens the credential only at startup, the old credential may remain in use until the pod restarts. If the application watches the file and reconnects cleanly, the same Secret volume can support smoother rotation. Neither behavior is automatic from the Secret object alone. The storage layer can deliver bytes to disk, but the process still controls when it reads them and what it does after the value changes.
 
 ```yaml
 apiVersion: v1
@@ -533,9 +461,7 @@ spec:
       defaultMode: 0400       # Restrictive permissions
 ```
 
-### Auto-Updates for ConfigMap/Secret Volumes
-
-A massive operational advantage of mounting ConfigMaps and Secrets as directories rather than environment variables is that the kubelet updates them automatically when the underlying Kubernetes API object changes.
+The kubelet updates mounted ConfigMap and Secret volumes by using an atomic symlink swap. That means the application should never see a half-written file during the update. It also means the process must either watch the file, poll the file, or be restarted to load the new value into memory. The volume update and the application reload are separate steps, and many production bugs come from proving the file changed while forgetting the process still holds old configuration in memory.
 
 ```mermaid
 flowchart LR
@@ -550,11 +476,9 @@ flowchart LR
     B -.-> Caveats
 ```
 
-The kubelet achieves this robust update process via an atomic symlink swap, ensuring the application never accidentally reads a partially updated or corrupt file. However, the application process must be explicitly written to detect file changes (via inotify or polling); otherwise, it will blindly continue using the configuration it loaded into memory at startup.
+The `subPath` feature is a precise tool for mounting one file from a volume into an existing directory without hiding the rest of that directory. It is useful when an image already contains a directory full of defaults and you only want to replace one file. Its major trap is update behavior: a `subPath` bind mount does not follow the kubelet's atomic symlink swap, so a ConfigMap or Secret update will not appear in the mounted file. Pause and predict: if `/etc/config/app.conf` is a full ConfigMap directory mount, then you update the ConfigMap and wait for the kubelet sync period, what should `cat` show; now what changes if that file was mounted through `subPath`?
 
-### subPath Mounts (No Auto-Update)
-
-Sometimes, you need to mount a single file into a directory that already contains other vital files, without overshadowing the entire directory contents. The `subPath` property allows this surgical injection.
+The tradeoff makes `subPath` neither good nor bad by itself. It is good when the file should be fixed for the life of the pod, when replacing an entire directory would hide image content, or when a rollout restart is the intended reload mechanism. It is bad when operators expect a live configuration pipeline and never document that pod recreation is required. A mature module template or Helm chart should make that reload contract visible so future maintainers do not infer the wrong behavior from the filename.
 
 ```yaml
 volumeMounts:
@@ -564,145 +488,178 @@ volumeMounts:
   readOnly: true
 ```
 
-While incredibly useful, you must deeply understand a critical architectural limitation: files mounted via `subPath` are fundamentally isolated from the kubelet's atomic update mechanism. Because the container runtime bind-mounts the specific file descriptor directly, the bind-mounted files cannot follow the symlink swaps occurring on the host. They will never automatically reflect changes made to the source ConfigMap or Secret.
+Projected volume sources continue to evolve. Kubernetes documentation for current releases includes advanced projection sources such as cluster trust bundles and pod certificates behind their respective feature states. For the CKA, the everyday skills matter more: combine ConfigMap, Secret, Downward API, and service account token sources correctly; mount them read-only; understand automatic update limits; and recognize stale `subPath` behavior during troubleshooting.
 
-> **Pause and predict**: You mount a ConfigMap as a volume at `/etc/config` (without subPath). You then update the ConfigMap with `kubectl edit`. After a minute, you `exec` into the pod and `cat /etc/config/app.conf`. Do you see the old or new content? Now imagine you used a `subPath` mount instead -- does your answer change?
+| Use Case | Sources Combined |
+|----------|------------------|
+| App config bundle | configMap + secret |
+| Pod identity | serviceAccountToken + downwardAPI |
+| Full config injection | configMap + secret + downwardAPI |
+| Sidecar config | Multiple configMaps |
 
-## Section 8: Transitioning to Persistent Storage
+## From Ephemeral Volumes to Persistent Storage
 
-While the volume types discussed above handle ephemeral storage exceptionally well, enterprise applications inevitably require robust, persistent data storage that outlives both the pod and the node it is running on. A PersistentVolume represents a piece of storage in the cluster that has been provisioned by an administrator or dynamically provisioned using a StorageClass. Kubernetes PersistentVolumes support four access modes: ReadWriteOnce, ReadOnlyMany, ReadWriteMany, and ReadWriteOncePod. 
+Ephemeral volumes are not inferior; they are scoped. A cache, scratch directory, token projection, or sidecar handoff should often be ephemeral because durability would add cost and cleanup complexity without improving the application. Persistent storage becomes necessary when the data has value after pod replacement: database files, queue state, uploaded content, indexes that are expensive to rebuild, and any state that defines the service rather than accelerates it. The mistake is not using `emptyDir`; the mistake is using it after the recovery requirement says the data must outlive the pod.
 
-*Note: Historical documentation suggests the `ReadWriteOncePod` (RWOP) access mode reached GA historically in v1.29, strictly preventing more than one pod from accessing a volume simultaneously across the entire cluster.* 
+PersistentVolumes and PersistentVolumeClaims introduce a storage object that can survive pod deletion and, depending on the backend, node failure. A PersistentVolume represents storage in the cluster, while a PersistentVolumeClaim is a namespaced request for storage by a workload. Access modes such as ReadWriteOnce, ReadOnlyMany, ReadWriteMany, and ReadWriteOncePod describe how the volume may be mounted, but they do not magically make every backend support every access pattern. ReadWriteOncePod is the strictest single-pod option and is useful when accidental multi-pod attachment would corrupt state.
 
-Furthermore, a PersistentVolume passes through four lifecycle phases: Available, Bound, Released, Failed. Administrators also dictate what happens to the data when the claim is removed. PersistentVolume reclaim policies are Delete (default), Retain, and Recycle. Be aware that the Recycle reclaim policy is deprecated and only supported by NFS and HostPath volume types. Kubernetes also supports two volume modes for PersistentVolumes: Filesystem (default) and Block. When working with stateful persistence, PVC and PV deletion protection uses finalizers (`kubernetes.io/pvc-protection` and `kubernetes.io/pv-protection`) to actively prevent accidental deletion of volumes currently in use.
+StorageClasses handle dynamic provisioning. With `volumeBindingMode: WaitForFirstConsumer`, Kubernetes delays provisioning and binding until a pod using the claim is scheduled, which helps avoid creating a volume in a zone where the pod cannot run. Setting `storageClassName: ""` on a PVC opts out of default dynamic provisioning and asks Kubernetes to match an existing PV. These details belong mainly to the next module, but they explain why the decision between `emptyDir` and PVC is an architectural decision, not just a YAML edit.
 
-### StorageClasses and Provisioning
+Advanced persistent-storage features such as expansion, snapshots, cloning, volume populators, and VolumeAttributesClass depend heavily on CSI drivers and cluster controllers. They are powerful when you operate databases and stateful services, but they do not change the foundation from this module. First decide the lifecycle boundary. Then decide whether the node, pod, API object, or external storage backend owns the data. Only after that should you choose a feature such as snapshotting, cloning, or dynamic IOPS changes.
 
-Dynamic provisioning is handled seamlessly by StorageClasses. Setting StorageClass `volumeBindingMode: WaitForFirstConsumer` delays PV binding and provisioning until a Pod using the PVC is successfully scheduled. This brilliantly prevents a volume from being created in a specific availability zone where the pending pod cannot ultimately be scheduled due to CPU or memory constraints. If multiple default StorageClasses exist, the most recently created one is used.
+Hardware and cloud limits still matter. Cloud block volumes often have per-node attachment caps, and the scheduler needs accurate driver information to avoid placing too many volume-using pods on the same node. Storage capacity tracking, dynamic volume limits, and newer CSI node allocatable count behavior exist because storage is a physical resource even when Kubernetes presents it through clean API objects. This is why a storage incident can look like scheduling, security, and application failure all at once.
 
-Conversely, setting `storageClassName: ""` on a PVC explicitly opts out of dynamic provisioning from the default StorageClass, forcing the claim to seek an existing, manually created PV that meets its criteria. The older `volume.beta.kubernetes.io/storage-class` annotation on PVCs is entirely deprecated; the `storageClassName` field should always be used instead. Note that NFS volumes have no built-in dynamic provisioner in Kubernetes; an external provisioner is strictly required for dynamic provisioning.
+For this introductory volumes module, you do not need to implement every persistent-storage feature yet. You do need to recognize when a problem statement crosses the boundary from pod-scoped data into durable state. Phrases such as "after rescheduling," "after node replacement," "during a rolling update," and "after deleting the pod" are signals that the examiner or incident report is testing storage lifecycle thinking. If the data must remain valid across those events, an ephemeral volume may still be useful for scratch work, but it cannot be the source of truth.
 
-## Section 9: Advanced Storage Capabilities and Limits
+The reverse mistake is also common: teams sometimes put disposable cache data on expensive durable volumes because persistence feels safer. That can slow scheduling, consume attach slots, complicate cleanup, and make recovery procedures harder than necessary. A durable cache may also preserve corrupted or stale derived data longer than intended. Good design is not maximum persistence everywhere; it is matching persistence to recovery value, rebuild cost, and operational ownership.
 
-Modern Kubernetes clusters (v1.35+) provide advanced mechanisms to augment persistent storage behavior dynamically. These operations usually require highly capable Container Storage Interface (CSI) drivers.
+## Diagnosing Volume Mount Failures
 
-### Expansion, Cloning, and Snapshots
+Volume failures usually surface as pods stuck in `ContainerCreating`, application containers that start without expected files, or workloads that keep using stale configuration. The fastest diagnostic path starts with `kubectl describe pod` because the Events section usually names the failing volume and reports whether the kubelet could not find a ConfigMap, mount a Secret, validate a `hostPath`, attach a CSI volume, or bind a PVC. Read those events slowly; the useful clue is often the exact volume name rather than the top-level pod phase.
 
-Volume expansion via `allowVolumeExpansion` only supports safely growing a volume, not shrinking it. *Note: Historical context indicates volume expansion via CSI requires Kubernetes v1.24 or later.*
+When `hostPath` is involved, always connect the event to the specific node where the pod landed. A path existing on your laptop, on one worker, or in a previous cluster image does not prove it exists on the scheduled node. If the type is `Directory`, the kubelet requires an existing directory. If the type is `DirectoryOrCreate`, the kubelet may create a path that then has ownership or permission details the app did not expect. Node-specific problems require node-specific evidence.
 
-Snapshotting relies heavily on external controllers. VolumeSnapshot objects use a stable v1 API (`snapshot.storage.k8s.io/v1`). However, VolumeSnapshot support is only available for clusters leveraging CSI drivers. A common misconception is who exactly manages this; the VolumeSnapshot controller (snapshot controller) is installed by the Kubernetes distribution or cluster administrator, not automatically by the CSI driver itself.
+For ConfigMap and Secret mounts, separate mount failure from application reload failure. A missing object or missing key can block startup. A successful mount followed by a later ConfigMap update may update files on disk without changing process behavior. A `subPath` mount may never update at all until the pod is restarted. Which approach would you choose for an application that must reload TLS certificates without restarting, and what application behavior would you verify before trusting that design in production?
 
-PVC cloning (using a PVC as a volume data source) is only available for CSI drivers and only with dynamic provisioners. Furthermore, PVC cloning requires the source PVC and the clone to be in the exact same namespace, and PVC cloning requires the VolumeMode of both the source and destination to match perfectly. Once completed, PVC cloning produces a wholly independent copy of the source PVC; the source can be freely modified or deleted after cloning. Advanced use cases like the `CrossNamespaceVolumeDataSource` feature gate (cross-namespace PVC cloning) is alpha since v1.26 and remains disabled by default in v1.35. Extending data sources even further, Volume Populators reached GA historically in v1.33.
+If pod events are vague, inspect kubelet logs on the node and the relevant CSI driver components for lower-level errors. Permission denied messages, timeout errors, attach-limit failures, and driver-specific mount responses may never appear cleanly in the application logs because the application has not started. A good troubleshooting habit is to trace the storage path from API object to kubelet preparation to container mount to process read. Skipping a layer often leads to confident but wrong fixes.
 
-### Attributes and Hardware Limits
+A useful debug sequence is to name the failing volume, then name the source object or path, then name the consumer path. For a ConfigMap, that means checking the object, the selected key, and the mount path. For a Secret, add RBAC and file mode to the checklist. For `hostPath`, add the scheduled node and path type. For PVCs, add claim phase, storage class, events, and CSI driver health. The sequence keeps you from jumping straight to application logs when the container never had a valid filesystem view.
 
-CSI drivers can dynamically adjust underlying volume capabilities. `VolumeAttributesClass` requires a CSI driver that implements the `ModifyVolume` API. `VolumeAttributesClass` parameters are immutable after creation, and a PVC's `volumeAttributesClassName` field is mutable, allowing seamless live updates to underlying storage IOPS and throughput without remounting. According to the `VolumeAttributesClass` concept page, it reached stable in Kubernetes v1.34; however, the v1.33 release blog credits it as reaching GA in v1.33. Due to this conflict, the exact minor version marking stability may vary depending on the authoritative source consulted. We maintain v1.35 as our primary focus.
+You should also distinguish one-time mount errors from later drift. A missing ConfigMap key prevents a pod from starting. A changed ConfigMap that the process does not reload creates stale behavior after a healthy start. A `hostPath` directory removed from one node may only break pods scheduled to that node. A node reaching disk pressure may evict pods that use local ephemeral storage heavily. These cases all involve volumes, but they require different fixes, so the timeline of the symptom matters as much as the YAML.
 
-Finally, cluster operators must be acutely aware of hard attachment limits. Dynamic volume limits (scheduler awareness of per-node volume count caps) reached stable historically in v1.17. Storage capacity tracking reached GA historically in v1.24, but storage capacity tracking requires `WaitForFirstConsumer` volume binding mode and `CSIDriver.StorageCapacity: true`.
+## Patterns & Anti-Patterns
 
-Hardware constraints vary wildly by cloud provider:
-- The default per-node Amazon EBS volume attachment limit is roughly 39 volumes.
-- The default per-node Google Persistent Disk volume limit is 16 volumes (up to 127 depending tightly on node instance type).
-- The default per-node Azure Disk volume limit is 16 volumes (up to 64 depending on node size).
+Good storage design starts by naming the lifecycle owner. If the pod owns the data, use pod-scoped ephemeral volumes. If the node owns the data, restrict `hostPath` to platform workloads and enforce policy. If the Kubernetes API owns the data, use ConfigMap, Secret, Downward API, or projected volumes. If the business process owns the data, use a PVC or an external managed service. This framing prevents the common habit of choosing a volume type because it is familiar rather than because it matches the failure model.
 
-To provide vital flexibility against these strict hardcaps, Mutable CSI Node Allocatable Count (allowing CSI drivers to dynamically adjust max attachable volume counts) is beta in Kubernetes v1.35 and enabled by default.
+| Pattern | When to Use | Why It Works | Scaling Consideration |
+|---------|-------------|--------------|-----------------------|
+| Shared `emptyDir` sidecar handoff | Two containers in one pod need fast local file exchange | The pod owns the shared directory and both containers see the same files | Keep size limits small enough to protect node storage |
+| Read-only projected config bundle | An app needs config, identity, and metadata in one directory | Multiple API-backed sources appear as a single mount tree | Define reload behavior and avoid `subPath` for live updates |
+| Narrow read-only `hostPath` DaemonSet | A platform agent must read node logs or sockets | A DaemonSet aligns one pod with each node and the path is node-owned | Use policy, node labels, and exact path types |
+| PVC for durable state | Data must survive pod deletion or rescheduling | Storage lifecycle is decoupled from workload lifecycle | Choose access mode, reclaim policy, and binding mode deliberately |
 
-## Section 10: Diagnosing Volume Mount Failures
+Anti-patterns usually appear when a team reaches for storage to bypass another design problem. A writable `hostPath` can bypass RBAC and node isolation. An `emptyDir` can hide the absence of a backup or persistence plan. A Secret environment variable can be easy to set but hard to rotate safely. A `subPath` mount can preserve image defaults but silently defeat live configuration updates. Each anti-pattern starts with a convenience and ends with a lifecycle or security surprise.
 
-When a volume mount fails, the pod will typically be stuck indefinitely in the `ContainerCreating` state. To accurately diagnose the root failure, you must methodically analyze the pod's events, the node's filesystem state, and the kubelet's internal behavior.
+| Anti-Pattern | What Goes Wrong | Better Alternative |
+|--------------|-----------------|--------------------|
+| Database files on `emptyDir` | Pod replacement deletes the database state | Use a StatefulSet with PVC templates |
+| Broad writable `hostPath` | Container compromise can become node compromise | Use narrow read-only paths or a platform-owned agent |
+| No `emptyDir.sizeLimit` | One pod can exhaust node ephemeral storage | Set explicit limits and monitor eviction signals |
+| `subPath` for live config | Source updates do not reach the mounted file | Mount the directory or restart the pod intentionally |
+| Secret values in casual env vars | Rotation and exposure are harder to control | Mount Secret files with restrictive permissions |
+| PVC used for disposable cache | Durable storage cost and cleanup increase unnecessarily | Use bounded `emptyDir` or external cache semantics |
 
-1. **Check Pod Events:** Use `kubectl describe pod <pod-name>` and look intensely at the `Events` section at the bottom. You will often see `FailedMount` warnings. These text events clearly indicate whether the exact issue is a missing ConfigMap/Secret, an unprovisioned PersistentVolumeClaim, or a hostPath directory that literally doesn't exist on the assigned node.
-2. **Verify Node Paths:** If utilizing `hostPath`, ensure the requested directory actually exists on the specific worker node where the pod was scheduled. The kube-scheduler does not verify hostPath directories before assignment unless specific node affinity rules are manually applied.
-3. **Inspect Kubelet Logs:** If the pod events are vague or unhelpful, the kubelet logs on the node (accessible via `journalctl -u kubelet`) will provide low-level debug details about exactly why the bind mount or volume attachment failed, such as obscure permission denied errors, timeout issues, or CSI driver crashes.
+## Decision Framework
+
+Choose the volume type by walking from consequence to implementation. First ask what happens if the container restarts, then what happens if the pod is deleted, then what happens if the node is drained, and finally who is allowed to read or write the data. That order matters because a command that makes the pod start is not the same as a design that meets the recovery objective. In exam conditions, this framework also helps you eliminate attractive but wrong answers quickly.
+
+```mermaid
+flowchart TD
+    A[What owns the data lifecycle?] --> B{Only this pod?}
+    B -- Yes --> C{Needs local file sharing or scratch?}
+    C -- Yes --> D[Use emptyDir with sizeLimit]
+    C -- No --> E[Use projected/config/secret volume]
+    B -- No --> F{Node-owned data?}
+    F -- Yes --> G[Use narrow read-only hostPath, usually in DaemonSet]
+    F -- No --> H{Must survive pod deletion?}
+    H -- Yes --> I[Use PersistentVolumeClaim]
+    H -- No --> J[Use external service or redesign state]
+```
+
+The framework should be paired with a security review. If the mount exposes credentials, set read-only mounts, restrictive modes, and an application reload plan. If the mount exposes node files, require a platform-owned namespace and a clear reason ordinary Kubernetes APIs cannot solve the problem. If the data is large or expensive to rebuild, ask whether a PVC is sufficient or whether the application also needs backups, snapshots, and restore tests. Storage correctness is not only about mounting the right path; it is about knowing what failure you can tolerate.
+
+| Requirement | Prefer | Avoid | Reason |
+|-------------|--------|-------|--------|
+| Share scratch files between sidecar containers | `emptyDir` | Container writable layer | The pod, not one container, owns the files |
+| Inject app config and labels together | `projected` | Many unrelated mount points | One directory gives a clearer contract |
+| Read node logs from every worker | `hostPath` in DaemonSet | App deployment with broad paths | The node owns the files and one agent should run per node |
+| Persist database state | PVC | `emptyDir` or `hostPath` | The data must outlive pod and node placement |
+| Live-update ConfigMap directory | Full ConfigMap mount | `subPath` | Full mounts follow kubelet update mechanics |
+| Mount one file over image defaults | `subPath` with restart plan | Whole directory mount | The design trades live update for surgical placement |
+
+## Did You Know?
+
+- Kubernetes 1.35 keeps the CSI model as the modern storage extension path, so current storage learning should center on CSI behavior rather than old in-tree cloud volume plugins.
+- A projected `serviceAccountToken` defaults to an expiration of 3600 seconds, and the kubelet can rotate the mounted token file while the pod continues running.
+- Generic ephemeral volumes have been stable since Kubernetes 1.23, and they create a per-pod PVC that is garbage collected with the pod.
+- CSI inline ephemeral volumes have been stable since Kubernetes 1.25, but their resource accounting depends on driver behavior, so operators must monitor them deliberately.
 
 ## Common Mistakes
 
-| Mistake | Problem | Solution |
-|---------|---------|----------|
-| emptyDir for persistent data | Data lost when pod deleted | Use PersistentVolumeClaim |
-| hostPath in production | Security vulnerability | Use PVC or avoid entirely |
-| No sizeLimit on emptyDir | Pod can fill node disk | Always set sizeLimit |
-| subPath expecting updates | Config changes not reflected | Use full mount or restart pod |
-| Memory emptyDir without limit | OOM kills | Set sizeLimit, count against memory |
-| hostPath type: `""` | No validation, silent failures | Use explicit type like Directory |
-| Confusing `ReadWriteOnce` with `ReadWriteOncePod` | `ReadWriteOnce` allows multiple pods on the same node to write | Use `ReadWriteOncePod` for strict single-pod isolation |
-| Relying on `subPath` for live config updates | `subPath` bypasses symlink swaps, never auto-updates | Mount whole directories or handle application restarts gracefully |
+| Mistake | Why It Happens | How to Fix It |
+|---------|----------------|---------------|
+| Using `emptyDir` for persistent data | It survives container restarts, so teams overgeneralize that behavior to pod replacement | Use a PersistentVolumeClaim for data that must survive pod deletion or rescheduling |
+| Mounting broad writable `hostPath` paths | It is a fast way to reach node files during debugging | Restrict the path, set `readOnly: true`, use explicit `type`, and keep it to platform workloads |
+| Omitting `emptyDir.sizeLimit` | Temporary storage feels harmless until load or a bug creates unbounded files | Set a size limit and monitor node ephemeral storage pressure |
+| Expecting `subPath` mounts to auto-update | The file looks like it came from a ConfigMap or Secret | Use a full directory mount for live updates or restart pods deliberately |
+| Using memory-backed `emptyDir` without memory planning | Teams count only application heap usage | Include tmpfs usage in memory limits and set a conservative `sizeLimit` |
+| Leaving `hostPath.type` empty | Examples often omit validation for brevity | Use `Directory`, `File`, or another explicit type so kubelet failures are clear |
+| Confusing `ReadWriteOnce` with `ReadWriteOncePod` | The names sound like the same single-writer guarantee | Use `ReadWriteOncePod` when the requirement is strict single-pod access |
+| Treating file update as application reload | Operators see the mounted file change and assume the process changed behavior | Verify the application watches files, reloads on signal, or restarts cleanly |
 
 ## Quiz
 
-### Q1: Data Loss Investigation
-A developer has a sidecar logging pod with two containers: a `writer` that produces logs to `/logs/app.log` and a `reader` that tails the log file. They use an `emptyDir` volume. The writer container crashes due to an OOM kill, but the pod stays running. The developer panics and says all logs are gone. Are they correct? What if the node itself reboots and the pod is rescheduled to a different node?
-
 <details>
-<summary>Answer</summary>
+<summary>Question 1: A developer has a sidecar logging pod with two containers sharing an `emptyDir`; the writer crashes but the pod stays running. Are the logs gone, and what changes if the pod is rescheduled?</summary>
 
-The developer is wrong about the first scenario. When a container crashes but the pod stays running, emptyDir data **persists** because emptyDir lifetime is tied to the pod, not individual containers. The kubelet restarts the container, and `/logs/app.log` is still there. However, if the node reboots and the pod is rescheduled to a different node, the emptyDir data **is lost** because emptyDir storage lives on the original node's filesystem (or RAM). For logs that must survive pod rescheduling, they should use a PersistentVolumeClaim instead.
+The logs are not gone after only the writer container crashes because the `emptyDir` lifecycle is tied to the pod, not to one container. The restarted writer and the still-running reader see the same pod-scoped directory. If the pod is deleted, evicted, or rescheduled to a different node, the `emptyDir` is removed with the old pod instance. Logs that must survive that boundary should be shipped externally or stored through persistent storage rather than kept only in `emptyDir`.
 
 </details>
 
-### Q2: Memory Pressure Mystery
-A team deploys a pod with `emptyDir.medium: Memory` and `sizeLimit: 256Mi`. The pod's container has `resources.limits.memory: 512Mi`. During a load test, the container writes 200Mi of temp data to the emptyDir. Shortly after, the pod gets OOM-killed despite the application itself only using 350Mi of heap memory. What happened?
-
 <details>
-<summary>Answer</summary>
+<summary>Question 2: A pod uses `emptyDir.medium: Memory` with a 256Mi size limit and a container memory limit of 512Mi. The app heap is 350Mi, the tmpfs data is 200Mi, and the pod is OOM-killed. What happened?</summary>
 
-Memory-backed emptyDir counts against the container's memory limit. The container was using 350Mi of heap memory **plus** 200Mi of tmpfs data in the emptyDir, totaling 550Mi -- which exceeds the 512Mi memory limit. The kubelet saw total memory usage exceed the limit and OOM-killed the pod. The fix is to either increase the memory limit to account for emptyDir usage (e.g., `768Mi`), reduce the sizeLimit on the emptyDir, or switch to disk-backed emptyDir if the data is not sensitive and speed is not critical.
+The tmpfs-backed `emptyDir` counted toward memory pressure, so the effective usage was roughly the application heap plus the memory-backed files. The size limit constrained the volume size, but it did not make those bytes free from the container's memory budget. The fix is to raise memory limits to include expected tmpfs use, reduce the volume size, or switch to disk-backed `emptyDir` if the data does not need memory backing. This is an evaluate-lifecycle question because the storage medium changes the failure mode.
 
 </details>
 
-### Q3: Security Audit Failure
-During a security audit, a DaemonSet for log collection is flagged. It mounts `hostPath: /` with type `""` (empty string) and no `readOnly` setting. The team argues they only read `/var/log`. Why did the auditor flag this, and how should the DaemonSet be reconfigured?
-
 <details>
-<summary>Answer</summary>
+<summary>Question 3: A log collector DaemonSet mounts `hostPath: /` with an empty type and no `readOnly`. The team says it only reads `/var/log`. Why should the design be rejected?</summary>
 
-The auditor correctly flagged this configuration due to three severe security violations. First, mounting `/` gives the pod unfiltered access to the **entire node filesystem**, exposing highly sensitive files like `/etc/shadow` and kubelet credentials. Second, using an empty string `""` for the type performs no validation, meaning the mount could traverse malicious symlinks or attach to unexpected paths. Third, omitting `readOnly: true` allows the container to freely **write** to the host filesystem, providing a trivial vector for container escape attacks and node takeover. To remediate this, the team must restrict the mount paths to exactly what is needed (`/var/log` and `/var/lib/docker/containers`), explicitly set the type to `Directory`, and enforce `readOnly: true` on all mounts.
+The declared mount gives the pod access to the entire node filesystem, not just the directory the application promises to read. An empty `type` skips useful kubelet validation, and a missing `readOnly` flag leaves the host path writable from the container. The safer design mounts only required paths such as `/var/log`, uses `type: Directory`, and marks each mount read-only. Because this is node-owned data, the workload should also be a platform-controlled DaemonSet with policy around who can deploy it.
 
 </details>
 
-### Q4: Config Injection Architecture
-Your application needs its config file (`app.conf`), a database password, the pod's own labels, and a short-lived service account token -- all in `/etc/app/`. A junior developer creates four separate volume mounts. What single Kubernetes feature replaces all four, and what are the four source types it combines?
-
 <details>
-<summary>Answer</summary>
+<summary>Question 4: An application needs `app.conf`, a database password, pod labels, and a short-lived service account token under `/etc/app`. What volume design would you implement?</summary>
 
-A **projected volume** combines all four sources into a single mount point. The four source types are: (1) **configMap** for the `app.conf` file, (2) **secret** for the database password, (3) **downwardAPI** for the pod's labels, and (4) **serviceAccountToken** for a short-lived, audience-scoped token. This is cleaner than four separate mounts because it presents a unified `/etc/app/` directory and simplifies the pod spec. Projected service account tokens are also more secure than legacy tokens because they are time-limited and audience-bound.
+Use a projected volume mounted read-only at `/etc/app`. The sources would be a ConfigMap for `app.conf`, a Secret for the password, a Downward API source for labels, and a `serviceAccountToken` source for the short-lived token. This design is better than four unrelated mount points because it gives the process one directory contract and keeps each source managed by the appropriate Kubernetes API. It also supports modern token rotation semantics instead of relying on long-lived credentials.
 
 </details>
 
-### Q5: Rolling Config Update Gone Wrong
-A team mounts a ConfigMap as a volume at `/etc/nginx/conf.d/`. They update the ConfigMap with a new `nginx.conf`. After 2 minutes, they exec into the pod and see the new config file. But nginx is still serving the old configuration. Separately, another team member used `subPath` to mount a single ConfigMap key as `/etc/app/settings.yaml`. After the same ConfigMap update, that file still shows the old content. Explain both behaviors and the fix for each.
-
 <details>
-<summary>Answer</summary>
+<summary>Question 5: A ConfigMap directory mount shows new file content after an update, but the application still serves old behavior; a separate `subPath` mount never shows the new content. Explain both symptoms.</summary>
 
-For the nginx case: Kubernetes **did** auto-update the mounted files (within ~1 minute via atomic symlink swap), but nginx does not watch for file changes -- it loads config at startup. The fix is to either restart the pod (`kubectl rollout restart`) or send nginx a reload signal (`nginx -s reload`). For the subPath case: subPath mounts **never auto-update** when the source ConfigMap changes -- this is a fundamental limitation. The kubelet's symlink-swap mechanism only works for full directory mounts. The fix is to either use a full directory mount instead of subPath, or restart the pod to pick up changes. This is a common exam trap -- knowing the subPath update limitation is critical.
+The full ConfigMap directory mount can update on disk through the kubelet's atomic symlink swap, but the application may have loaded the old value into memory and never reloaded it. That fix is an application reload, signal, or rollout restart depending on the process. The `subPath` case is different because the bind-mounted file does not follow the updated symlink target, so the mounted file remains stale until the pod is recreated. The correct design depends on whether the team needs live file updates or surgical placement of one file.
 
 </details>
 
-### Q6: Choosing the Right Volume Type
-A StatefulSet's pods keep losing their data on restart. The developer used `emptyDir` volumes for the database data directory. What is wrong with this design, what volume type should they use instead, and what Kubernetes resources need to be created to support it?
+<details>
+<summary>Question 6: A StatefulSet keeps losing database files because the template uses `emptyDir` for the data directory. What should you compare and change before approving the fix?</summary>
+
+Compare the lifecycle requirement with the volume lifecycle. Database files must survive pod deletion and rescheduling, while `emptyDir` belongs to one pod instance on one node. The fix is to use PVC-backed storage, typically through `volumeClaimTemplates` in the StatefulSet so each replica receives its own claim. You should also evaluate access mode, reclaim policy, storage class binding mode, backup expectations, and whether the application can tolerate the selected backend's semantics.
+
+</details>
 
 <details>
-<summary>Answer</summary>
+<summary>Question 7: A pod is stuck in `ContainerCreating` after adding a Secret volume. The Secret exists, but one selected key name is wrong. Where do you diagnose it, and what correction do you make?</summary>
 
-`emptyDir` is tied to the pod's lifecycle -- when the pod is deleted or rescheduled, the data is gone. For a database that needs persistent data, they should use a **PersistentVolumeClaim** instead. For StatefulSets specifically, they should use `volumeClaimTemplates` in the StatefulSet spec, which automatically creates a unique PVC for each replica. The required resources are: a **StorageClass** (or use the cluster default) to enable dynamic provisioning, and the **volumeClaimTemplates** section in the StatefulSet spec. Each pod will get its own PV that persists across restarts and rescheduling. The reclaim policy should be set to `Retain` for production databases to prevent accidental data loss.
+Start with `kubectl describe pod` and read the Events section because the kubelet usually reports the volume name and missing key or object. Then compare the pod's `secret.items` entries with the actual Secret keys rather than guessing from application logs, since the container may not have started. The correction is to fix the key name, update the Secret, or change the pod spec to mount the key that exists. This is a mount failure, not an application runtime failure.
 
 </details>
 
 ## Hands-On Exercise: Multi-Container Volume Sharing
 
-### Scenario
-Create a functional Kubernetes pod with two distinct containers that share stateful data through ephemeral volumes. One container actively writes application logs, and the second container continuously processes them.
+Exercise scenario: create a functional Kubernetes pod with two containers that share data through an `emptyDir`. One container writes application log lines, and the second container reads them from a read-only mount. The goal is not just to make the pod run; it is to observe the lifecycle contract by checking that both containers see the same files and by reasoning about what would happen after a pod deletion.
 
 ### Setup
 
 ```bash
 # Create namespace
-k create ns volume-lab
+kubectl create namespace volume-lab
 
 # Create the multi-container pod
-cat <<EOF | k apply -f -
+cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: Pod
 metadata:
@@ -747,78 +704,121 @@ spec:
 EOF
 ```
 
-### Tasks
+### Task 1: Verify the pod is running
 
-1. **Verify the pod is running**:
 ```bash
-k get pod log-processor -n volume-lab
+kubectl get pod log-processor -n volume-lab
 ```
 
-2. **Check writer is creating logs**:
+<details>
+<summary>Solution</summary>
+
+The pod should eventually show `Running` with both containers ready. If it remains in `ContainerCreating`, describe the pod and inspect Events for image pull, volume, or scheduling errors before continuing.
+
+</details>
+
+### Task 2: Check that the writer creates logs
+
 ```bash
-k exec -n volume-lab log-processor -c writer -- cat /logs/app.log
+kubectl exec -n volume-lab log-processor -c writer -- cat /logs/app.log
 ```
 
-3. **Check reader can see the logs**:
+<details>
+<summary>Solution</summary>
+
+You should see timestamped log entries appended by the writer container. If the file is missing, wait a few seconds and rerun the command because the writer loop creates entries over time.
+
+</details>
+
+### Task 3: Check that the reader sees the same logs
+
 ```bash
-k logs -n volume-lab log-processor -c reader
+kubectl logs -n volume-lab log-processor -c reader
 ```
 
-4. **Verify volume sharing**:
+<details>
+<summary>Solution</summary>
+
+The reader should print the same log stream because its `/logs` path is the same `emptyDir` volume mounted read-only. This confirms cross-container sharing inside one pod.
+
+</details>
+
+### Task 4: Verify shared writes and reads
+
 ```bash
 # Write from writer
-k exec -n volume-lab log-processor -c writer -- sh -c 'echo "TEST MESSAGE" >> /logs/app.log'
+kubectl exec -n volume-lab log-processor -c writer -- sh -c 'echo "TEST MESSAGE" >> /logs/app.log'
 
 # Read from reader
-k exec -n volume-lab log-processor -c reader -- tail -1 /logs/app.log
+kubectl exec -n volume-lab log-processor -c reader -- tail -1 /logs/app.log
 ```
 
-5. **Check emptyDir location on node** (for deep understanding):
+<details>
+<summary>Solution</summary>
+
+The final line should be `TEST MESSAGE`. The reader can read the file even though its mount is read-only because the volume permissions affect writes from that container, not visibility of data written by the other container.
+
+</details>
+
+### Task 5: Locate the node and reason about where `emptyDir` lives
+
 ```bash
-k get pod log-processor -n volume-lab -o jsonpath='{.status.hostIP}'
+kubectl get pod log-processor -n volume-lab -o jsonpath='{.status.hostIP}'
 # emptyDir is at /var/lib/kubelet/pods/<pod-uid>/volumes/kubernetes.io~empty-dir/log-volume
 ```
 
+<details>
+<summary>Solution</summary>
+
+The host IP tells you which node currently owns the pod-scoped volume. The path shown in the comment is useful for understanding kubelet layout, but do not build application behavior that depends on reading that path directly.
+
+</details>
+
 ### Success Criteria
+
 - [ ] Pod is currently running with both containers active and healthy.
 - [ ] Writer is successfully creating log entries every 5 seconds.
 - [ ] Reader can clearly see logs written by the writer container.
-- [ ] Data fully persists across container restarts (test by running `k exec -n volume-lab log-processor -c writer -- kill 1`).
+- [ ] Data persists across a writer container restart, such as `kubectl exec -n volume-lab log-processor -c writer -- kill 1`, while the pod remains the same.
 
 ### Bonus Challenge
 
-Architect a third container in the pod that continuously monitors the disk usage of the shared volume and safely writes warnings when usage exceeds 80%.
+Architect a third container in the pod that continuously monitors disk usage of the shared volume and writes warnings when usage exceeds 80 percent. Keep the monitor read-only if it only reads file sizes, and explain whether its warning file should live in the same volume or in a separate path.
 
 ### Cleanup
 
 ```bash
-k delete ns volume-lab
+kubectl delete namespace volume-lab
 ```
 
 ## Practice Drills
 
-Practice these critical scenarios for exam readiness:
+Use these drills to build speed after you understand the lifecycle rules. They are intentionally short because the exam rewards clean YAML edits under time pressure, but do not treat them as a replacement for the reasoning above.
 
-### Drill 1: Create emptyDir Pod (2 min)
+### Drill 1: Create emptyDir Pod
+
 ```bash
 # Task: Create a pod with emptyDir volume mounted at /cache
-# Hint: k run cache-pod --image=busybox --dry-run=client -o yaml > pod.yaml
+# Hint: kubectl run cache-pod --image=busybox --dry-run=client -o yaml > pod.yaml
 # Then add volumes section
 ```
 
-### Drill 2: Memory-Backed emptyDir (2 min)
+### Drill 2: Memory-Backed emptyDir
+
 ```bash
 # Task: Create emptyDir backed by RAM with 64Mi limit
 # Key fields: emptyDir.medium: Memory, emptyDir.sizeLimit: 64Mi
 ```
 
-### Drill 3: hostPath Read-Only (2 min)
+### Drill 3: hostPath Read-Only
+
 ```bash
 # Task: Mount /var/log from host as read-only volume
 # Important: Always use readOnly: true for hostPath when possible
 ```
 
-### Drill 4: Projected Volume (3 min)
+### Drill 4: Projected Volume
+
 ```bash
 # Task: Create projected volume combining:
 # - ConfigMap "app-config"
@@ -826,32 +826,50 @@ Practice these critical scenarios for exam readiness:
 # Mount at /etc/app
 ```
 
-### Drill 5: ConfigMap Volume with Items (2 min)
+### Drill 5: ConfigMap Volume with Items
+
 ```bash
 # Task: Mount only "app.conf" key from ConfigMap as "config.yaml"
 # Use configMap.items to select and rename
 ```
 
-### Drill 6: subPath Mount (2 min)
+### Drill 6: subPath Mount
+
 ```bash
 # Task: Mount single file from ConfigMap into /etc/myapp/config.yaml
 # Without overwriting other files in /etc/myapp
 ```
 
-### Drill 7: Volume Sharing Between Containers (3 min)
+### Drill 7: Volume Sharing Between Containers
+
 ```bash
 # Task: Create pod with 2 containers sharing emptyDir
 # Container 1 writes to /shared/data.txt
 # Container 2 reads from /shared/data.txt
 ```
 
-### Drill 8: Debug Volume Mount Issues (2 min)
+### Drill 8: Debug Volume Mount Issues
+
 ```bash
 # Given: Pod stuck in ContainerCreating
-# Task: Identify if it's a volume mount issue
-# Commands: k describe pod, check Events section
+# Task: Identify if it is a volume mount issue
+# Commands: kubectl describe pod, check Events section
 ```
+
+## Sources
+
+- https://kubernetes.io/docs/concepts/storage/volumes/
+- https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/
+- https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+- https://kubernetes.io/docs/concepts/storage/storage-classes/
+- https://kubernetes.io/docs/concepts/configuration/configmap/
+- https://kubernetes.io/docs/concepts/configuration/secret/
+- https://kubernetes.io/docs/tasks/configure-pod-container/configure-projected-volume-storage/
+- https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+- https://kubernetes.io/docs/concepts/security/pod-security-standards/
+- https://kubernetes.io/docs/concepts/storage/volume-snapshots/
+- https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
 
 ## Next Module
 
-Continue to [Module 4.2: PersistentVolumes & PersistentVolumeClaims](../module-4.2-pv-pvc/) to dive deeply into persistent storage architectures, storage classes, and lifecycle management that survives pod and node deletion.
+Continue to [Module 4.2: PersistentVolumes & PersistentVolumeClaims](../module-4.2-pv-pvc/) to dive deeply into storage classes, claims, access modes, and lifecycle management that survives pod and node deletion.


### PR DESCRIPTION
## Summary
- Rewrote src/content/docs/k8s/cka/part4-storage/module-4.1-volumes.md for #388 density, structure, alignment, anti-leak, and protected-asset gates.
- Cleared revision_pending: false.

## Verifier
- Command: ../../.venv/bin/python scripts/quality/verify_module.py --glob src/content/docs/k8s/cka/part4-storage/module-4.1-volumes.md --skip-source-check --summary --quiet
- Result: T0, all non-source gates pass.
- Metrics: body_words=5092, mean_wpp=79.6, median_wpp=81.5, short_rate=0.016, max_run=1.
- Sources: 11 URLs counted; reachability intentionally skipped with --skip-source-check per dispatch.

## Protected Assets
- Preserved protected coverage and assets from the original module.
- Counts before: 34 code blocks, 5 mermaid diagrams, 4 tables.
- Counts after: 35 code blocks, 6 mermaid diagrams, 7 tables.
- Runnable shell examples now use full kubectl; no k shorthand remains.

## Commit
- 950c21ef34db53f6e63c1c1057c5fd47afbeb6e5