### PR TITLE
feat(388): rewrite module-4.2-pv-pvc (#388 pilot)

### DIFF
--- a/src/content/docs/k8s/cka/part4-storage/module-4.2-pv-pvc.md
+++ b/src/content/docs/k8s/cka/part4-storage/module-4.2-pv-pvc.md
@@ -1,6 +1,7 @@
 ---
 title: "Module 4.2: PersistentVolumes & PersistentVolumeClaims"
 slug: k8s/cka/part4-storage/module-4.2-pv-pvc
+revision_pending: false
 sidebar:
   order: 3
 lab:
@@ -22,44 +23,30 @@ lab:
 ## What You'll Be Able to Do
 
 After this module, you will be able to:
-- **Design** storage architectures that firmly decouple storage provisioning from application consumption.
-- **Diagnose** volume binding failures by analyzing access modes, capacities, selectors, and StorageClass configurations.
-- **Implement** static provisioning for local storage and trigger dynamic provisioning using StorageClasses.
-- **Evaluate** reclaim policies to select the most appropriate data retention strategies for production workloads.
-- **Compare** filesystem and block volume modes for specialized applications such as high-performance databases.
 
----
+- **Design** storage architectures that decouple storage provisioning from application consumption.
+- **Diagnose** volume binding failures by analyzing access modes, capacity, selectors, namespace scope, and StorageClass configuration.
+- **Implement** static provisioning with PersistentVolumes and PersistentVolumeClaims, then consume the claim from a Pod.
+- **Evaluate** reclaim policies and finalizers to choose safer data retention behavior for production workloads.
+- **Compare** filesystem and block volume modes, single-node and multi-node access modes, and static and dynamic provisioning tradeoffs.
 
 ## Why This Module Matters
 
-In 2021, a Site Reliability Engineer at CloudRetail Inc. encountered a seemingly routine task: tearing down a deprecated namespace that housed legacy testing applications. Because the PersistentVolumeClaims (PVCs) within that namespace were dynamically provisioned using a default `Delete` reclaim policy, removing the PVCs instantly triggered the automated deletion of the underlying cloud disks. Unbeknownst to the admin, a critical production database had been temporarily cross-mounted to one of those volumes for a migration task. The resulting data loss cost the company over $400,000 in downtime and engineering recovery efforts.
+Hypothetical scenario: a team migrates a stateful reporting application from a single virtual machine into Kubernetes. The container starts cleanly, writes reports to `/data`, and passes the first smoke test, but the team used an `emptyDir` volume because it was quick to define. The next node drain recreates the Pod somewhere else, the reports vanish with the old Pod sandbox, and the team learns the uncomfortable difference between "the application is running" and "the application state survived a normal cluster operation."
 
-This incident highlights a fundamental Kubernetes concept: the absolute decoupling of the storage lifecycle from the workload lifecycle. PersistentVolumes (PVs) and PersistentVolumeClaims (PVCs) act as an indispensable abstraction layer. They shield developers from the mechanics of block storage provisioning while granting administrators granular control over storage capacity, performance tiers, and data retention policies. 
+PersistentVolumes and PersistentVolumeClaims exist because storage has a different lifecycle from compute. A Pod is deliberately replaceable; a database file, uploaded document, queue checkpoint, or audit archive often is not. Kubernetes therefore splits the storage conversation into two API objects: an administrator or provisioner makes capacity available as a PersistentVolume, and a workload owner asks for capacity through a PersistentVolumeClaim. That split lets application YAML stay portable while storage policy remains under cluster control.
 
-By mastering PVs and PVCs, you ensure that ephemeral pod restarts never lead to permanent data loss, and that critical state is preserved regardless of application or node failures. The Certified Kubernetes Administrator (CKA) exam heavily emphasizes these mechanics, testing your ability to manually bind volumes, troubleshoot pending claims, and architect resilient persistent storage solutions.
+The CKA exam expects you to reason through this split under time pressure. You may be asked to create a manual `hostPath` PV, bind a PVC by class and label, diagnose why a claim remains `Pending`, or recover a retained volume after a PVC was deleted. The commands are not the hard part; the hard part is reading the relationship between PV, PVC, StorageClass, Pod, access mode, volume mode, and reclaim policy without assuming that Kubernetes will guess the intent you forgot to encode.
 
-> **The Apartment Rental Analogy**
->
-> Think of storage like renting an apartment. The **PersistentVolume** is the actual apartment - it exists whether anyone lives there or not. The **PersistentVolumeClaim** is like a tenant's application form specifying their needs: "I need 2 bedrooms, central location, parking spot." The building manager (Kubernetes) matches applications to available apartments. The tenant (pod) doesn't need to know which specific apartment they got - just that it meets their requirements.
+Think of storage like renting an apartment. The PersistentVolume is the actual apartment: it has a size, location, building rules, and an owner even when no tenant lives there. The PersistentVolumeClaim is the application form: "I need at least this much space, with these access rules, from this class of apartments." The Pod is the tenant moving in after the claim is approved. The tenant should not need to know every detail of the building, but the application form must still match an apartment that really exists.
 
----
+## The PV/PVC Contract
 
-## Did You Know?
+A PersistentVolume is a cluster-scoped API resource that represents storage available to the cluster. It may point at NFS, local disk, Fibre Channel, iSCSI, a CSI-backed cloud disk, or another supported backend. The key idea is scope: a PV does not live in a namespace, and it is not owned by a single Pod. It is a durable storage object with its own status, capacity, access modes, reclaim policy, and backend-specific configuration.
 
-- **Fact 1:** The in-tree AWS Elastic Block Store and Azure Disk plugins were officially deprecated in Kubernetes v1.19 and entirely removed in v1.27 in favor of CSI drivers.
-- **Fact 2:** Volume expansion has been a stable feature since Kubernetes v1.24, allowing administrators to resize existing XFS, Ext3, and Ext4 volumes dynamically without creating new PVs.
-- **Fact 3:** Cross-namespace volume data source support, which allows cloning a PVC from an object in another namespace, was introduced as an alpha feature gated in Kubernetes v1.26.
-- **Fact 4:** A stable v1.33 feature introduced explicitly robust PV deletion-protection finalizers to prevent the deletion of CSI volumes before the backend cleanup is fully complete.
+A PersistentVolumeClaim is a namespaced request for storage. Developers create PVCs because they should not have to encode cloud disk IDs or NFS export paths in every Pod template. The PVC describes the required size, access mode, volume mode, StorageClass, and optional selectors. Kubernetes then binds the claim to a compatible PV, either one that already exists or one created dynamically by a provisioner.
 
----
-
-## Part 1: The Storage Abstraction Model
-
-### Concept: The Abstraction Layer
-
-A PersistentVolume (PV) is a cluster-scoped API resource that abstracts storage from workloads and is independent of any individual Pod. It represents a piece of physical storage in the cluster, provisioned either manually by a cluster administrator or dynamically by a provisioner. Because PVs are cluster-scoped, they do not belong to any specific namespace.
-
-A PersistentVolumeClaim (PVC) is a request for storage (including size and access mode) and is the user-facing object that consumes PV resources. Developers create PVCs to request storage without needing to understand the underlying infrastructure. Crucially, PersistentVolumeClaims are namespaced objects; this limits multi-claim access mode use to within a namespace. A Pod can only mount a PVC if both the Pod and the PVC reside in the exact same namespace.
+The binding is intentionally exclusive. Once a PVC is bound to a PV, that PV is reserved for that claim and cannot be split across other claims, even when the claim requested less space than the PV provides. This exclusivity surprises learners who expect Kubernetes to carve a 20Gi slice out of a 50Gi PV, but Kubernetes treats the PV as the allocation unit. If the cluster needs fine-grained sizing, dynamic provisioning is usually the better operational model.
 
 ```mermaid
 flowchart TD
@@ -79,9 +66,7 @@ flowchart TD
     PVC -->|Mount in Pod| Pod[Pod<br>/data]
 ```
 
-### Concept: Separation of Concerns
-
-This decoupled architecture clearly separates administrative duties from development workflows.
+The diagram shows the main responsibility boundary. Administrators care about what storage exists and what policy applies to it. Developers care about how much storage an application needs and where that storage appears inside a container. The Kubernetes control plane sits between those roles and performs matching, but it only matches on declared properties. If the PVC asks for `ReadWriteMany` and all available PVs offer only `ReadWriteOnce`, there is no hidden negotiation.
 
 | Concern | Who Handles It | Resource |
 |---------|---------------|----------|
@@ -90,52 +75,24 @@ This decoupled architecture clearly separates administrative duties from develop
 | Where to mount it? | Developer | Pod spec |
 | Storage backend details | Admin | PV + StorageClass |
 
----
+The resource chain is easiest to debug when you keep the objects in order. A StorageClass describes how dynamic storage should be created. A PV represents actual capacity. A PVC requests capacity. A Pod references the PVC by name. If the Pod cannot mount storage, you should not start by editing the container image; first inspect whether the PVC is bound, which PV it selected, and whether the selected backend can be attached to the node where the Pod landed.
 
-## Part 2: PV/PVC Lifecycle & Reclaim Policies
++-------------------+      +-------------------+      +-------------------+
+| StorageClass      | ---> | PersistentVolume  | ---> | Backend storage   |
+| policy + driver   |      | capacity + mode   |      | disk, NFS, local  |
++-------------------+      +-------------------+      +-------------------+
+          ^                         ^
+          |                         |
++-------------------+      +-------------------+
+| PersistentVolume  | ---> | Pod volume mount  |
+| Claim request     |      | container path    |
++-------------------+      +-------------------+
 
-### Concept: Volume Phases
+Pause and predict: if a PVC is created in the `frontend` namespace and a Pod in the `backend` namespace uses the same claim name, what object lookup does the kubelet attempt? The PV is cluster-scoped, but the Pod never mounts a PV directly. It references a PVC in its own namespace, so the namespace boundary remains part of the storage contract even after a cluster-scoped PV has been bound.
 
-The lifecycle of a PV involves several distinct phases:
-- **Available:** The PV is ready to be bound to a PVC.
-- **Bound:** The PV is successfully linked to a specific PVC.
-- **Released:** The PVC was deleted, but the PV still holds the data and is awaiting administrative reclaim.
-- **Failed:** The automated reclamation process has failed.
+## Defining Volumes, Claims, and Binding Rules
 
-```mermaid
-flowchart LR
-    C[PV Created] --> A[Available]
-    A -->|PVC Created & Matched| B[Bound]
-    B -->|PVC Deleted| R[Released]
-    R -->|Retain/Delete/Recycle| REC[Reclaim]
-
-    classDef phase fill:#f9f,stroke:#333,stroke-width:2px;
-    class A,B,R,REC phase;
-```
-
-### Concept: Reclaim Policies and Protection
-
-When a PVC is deleted, the cluster looks at the PV's `persistentVolumeReclaimPolicy` to determine what to do with the underlying data. Current PV reclaim policies are Retain, Recycle, and Delete. 
-
-In Kubernetes 1.35, only `nfs` and `hostPath` volume types support the Recycle reclaim policy, which performs a basic scrub, though it is largely deprecated in modern clusters. The Retain policy preserves the data for manual recovery, while Delete immediately destroys the backend storage.
-
-| Policy | Behavior | Use Case |
-|--------|----------|----------|
-| Retain | PV preserved after PVC deletion | Production data, manual cleanup |
-| Delete | PV and underlying storage deleted | Dynamic provisioning, dev/test |
-| Recycle | Basic scrub (`rm -rf /data/*`) | **Deprecated** - don't use |
-
-To prevent accidental data loss while workloads are still running, Storage Object in Use Protection delays deletion of an actively used PVC or bound PV until usage ends. Furthermore, PV deletion-protection finalizers include a stable v1.33 feature for preventing deletion of CSI volumes before backend cleanup has successfully executed, preventing orphaned disks in cloud environments.
-
-> **Stop and think**: A junior admin creates a PV with `reclaimPolicy: Delete` for a production PostgreSQL database. A developer accidentally deletes the PVC. What happens to the data? What reclaim policy should have been used, and what additional steps would be needed to reuse that PV after a PVC deletion?
-
----
-
-## Part 3: PersistentVolume Specification
-
-### Defining a PV
-
-Kubernetes currently lists `csi`, `fc`, `hostPath`, `iscsi`, `local`, and `nfs` as supported PV plugins, and marks several in-tree drivers as deprecated. The storage docs explicitly state that AWS Elastic Block Store and Azure Disk in-tree drivers were deprecated in v1.19 and removed in v1.27; these in-tree types are not included in Kubernetes 1.35 docs. You must use the Container Storage Interface (CSI) for modern cloud integrations.
+A PV specification begins with capacity, access modes, volume mode, reclaim policy, class, optional mount options, and backend details. The backend section is the part that changes between NFS, local disk, CSI, and test-only `hostPath`, but the contract fields stay recognizable. Treat those contract fields as the part that Kubernetes can reason about; the backend-specific fields tell a plugin or kubelet how to reach the storage after a match has been made.
 
 ```yaml
 apiVersion: v1
@@ -161,9 +118,7 @@ spec:
     server: nfs-server.example.com
 ```
 
-### Volume Modes
-
-Kubernetes supports both `Filesystem` and `Block` volume modes; Filesystem is the default when `volumeMode` is omitted. Block mode is utilized by specific databases that require raw, unformatted block devices to optimize their own internal file management.
+`volumeMode` answers a different question from access mode. `Filesystem` means Kubernetes mounts a filesystem at a directory inside the container, which is the default and the right choice for most application data paths. `Block` exposes a raw block device to the container, which is useful for software that manages its own disk layout. A database using raw block mode is not "more persistent" than filesystem mode; it is simply receiving a different interface.
 
 ```yaml
 spec:
@@ -172,27 +127,19 @@ spec:
   volumeMode: Block         # Raw block device (for databases)
 ```
 
-### Access Modes
-
-PVC access modes include RWO, ROX, RWX, and RWOP; RWOP restricts access to a single Pod and is supported only for CSI volumes. Note that a PVC can claim only one access mode at a time.
+Access modes describe how the volume may be mounted by nodes or, for `ReadWriteOncePod`, by a single Pod. They are used during PV/PVC matching, and in some cases they constrain attachment, but they are not a complete permission system. For example, `ReadOnlyMany` in the API does not magically make a misconfigured backend immutable after mount; the storage implementation still matters. For exam work, use the access mode to explain scheduling and binding behavior, then verify the backend supports the mode you selected.
 
 | Mode | Abbreviation | Description |
 |------|--------------|-------------|
 | ReadWriteOnce | RWO | Single node read-write |
 | ReadOnlyMany | ROX | Multiple nodes read-only |
 | ReadWriteMany | RWX | Multiple nodes read-write |
-| ReadWriteOncePod | RWOP | Single pod read-write (Supported via CSI) |
+| ReadWriteOncePod | RWOP | Single pod read-write, supported through CSI |
 
-**Backend support varies** (applicable to both in-tree and CSI drivers):
-- **NFS**: RWO, ROX, RWX
-- **AWS EBS**: RWO only
-- **GCE PD**: RWO, ROX
-- **Azure Disk**: RWO only
-- **Local**: RWO only
+Backend support varies. NFS commonly supports RWO, ROX, and RWX, making it useful for shared content. Cloud block disks such as AWS EBS and Azure Disk are usually RWO because a single disk attachment is coordinated to one node at a time. GCE Persistent Disk supports RWO and ROX in common Kubernetes tables. Local PVs are RWO because the path exists on one node, and `ReadWriteOncePod` is a CSI-oriented mode for enforcing a single writer Pod across the cluster.
 
-### Common PV Types
+A `hostPath` PV is acceptable for a local learning lab, but it is not a production pattern for a multi-node cluster. It stores data on a node filesystem path, so the data is tied to that node and not protected by an external storage system. The Kubernetes storage docs call out `hostPath` as single-node testing material; when you need node-local production storage, use local PVs with explicit node affinity and a clear failure-domain story.
 
-**hostPath PV** (testing only):
 ```yaml
 apiVersion: v1
 kind: PersistentVolume
@@ -210,7 +157,8 @@ spec:
     type: DirectoryOrCreate
 ```
 
-**NFS PV**:
+An NFS PV demonstrates a shared network filesystem. Multiple nodes can reach the same export, so RWX becomes possible when the NFS server and export permissions are configured correctly. The tradeoff is that the NFS server becomes part of the application dependency chain. A Kubernetes manifest can request RWX, but it cannot make a slow, unavailable, or incorrectly exported NFS server behave like resilient storage.
+
 ```yaml
 apiVersion: v1
 kind: PersistentVolume
@@ -228,7 +176,8 @@ spec:
     path: /exports/share
 ```
 
-**Local PV** (node-specific):
+A local PV is different from `hostPath` because it is an explicit PersistentVolume object with scheduling information. The required `nodeAffinity` tells Kubernetes where the storage exists, allowing the scheduler to place consuming Pods on the correct node. Without that affinity, a Pod could be scheduled to a node that does not have `/mnt/disks/ssd1`, and the mount failure would look like a storage problem even though the real issue is missing topology metadata.
+
 ```yaml
 apiVersion: v1
 kind: PersistentVolume
@@ -253,11 +202,20 @@ spec:
           - worker-node-1
 ```
 
----
+The lifecycle of a PV is short to name but important to interpret. `Available` means the PV can still bind. `Bound` means it is linked to one PVC. `Released` means the PVC was deleted, but the PV still remembers that old claim and may still contain data. `Failed` means automated reclamation did not complete. The `Released` phase is the one that catches administrators, because a retained volume is not automatically safe for a new claim.
 
-## Part 4: PersistentVolumeClaims & Binding Rules
+```mermaid
+flowchart LR
+    C[PV Created] --> A[Available]
+    A -->|PVC Created & Matched| B[Bound]
+    B -->|PVC Deleted| R[Released]
+    R -->|Retain/Delete/Recycle| REC[Reclaim]
 
-### Defining a PVC
+    classDef phase fill:#f9f,stroke:#333,stroke-width:2px;
+    class A,B,R,REC phase;
+```
+
+A PVC is smaller and more application-facing. It names the namespace, access mode, volume mode, requested capacity, StorageClass, and optional selectors. The `resources.requests.storage` value is a minimum, not an exact partition request, so a 50Gi claim can bind to a 100Gi PV. The `storageClassName` field is exact, including the important difference between an omitted field and an explicit empty string.
 
 ```yaml
 apiVersion: v1
@@ -279,13 +237,7 @@ spec:
       environment: production
 ```
 
-### Binding Mechanics
-
-PV–PVC binding is exclusive and one-to-one, with ClaimRef linking both resources bi-directionally. A PVC binds to a PV when:
-1. **storageClassName** matches (or both empty)
-2. **accessModes** requested are available in PV
-3. **resources.requests.storage** <= PV capacity
-4. **selector** (if specified) matches PV labels. 
+Kubernetes binds a PVC to a PV when the class, requested access mode, volume mode, capacity, and selector constraints are compatible. A selector can narrow the eligible PV set by label, and `volumeName` can ask for one PV by name. If the requested PV is already bound to another claim, the new claim remains pending because PV/PVC binding is one-to-one. Kubernetes will not steal a PV just because a newer claim is more specific.
 
 ```mermaid
 flowchart LR
@@ -302,10 +254,10 @@ flowchart LR
         A4[30Gi RWO]
     end
     subgraph Match[Result]
-        M1[✓ Size OK, mode OK]
-        M2[✗ Access mode mismatch]
-        M3[✗ StorageClass mismatch]
-        M4[✗ Size too small]
+        M1[Size OK, mode OK]
+        M2[Access mode mismatch]
+        M3[StorageClass mismatch]
+        M4[Size too small]
     end
 
     R1 -.-> A1 -.-> M1
@@ -314,13 +266,11 @@ flowchart LR
     R4 -.-> A4 -.-> M4
 ```
 
-A PVC can explicitly bind to a specific PV using `volumeName`, and if that PV is already bound to another PVC, binding remains pending.
-
-### Creating PVC via kubectl
+Before running this, what output do you expect from `kubectl get pvc` if no compatible PV exists and no dynamic provisioner can satisfy the claim? The claim should remain `Pending`, and `kubectl describe pvc` should show events that explain the missing match. Those events are often more useful than the YAML because they tell you which controller decision failed.
 
 ```bash
-# Quick way to create a PVC (limited options)
-cat <<EOF | k apply -f -
+# Quick way to create a PVC with explicit YAML.
+cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -335,52 +285,40 @@ spec:
 EOF
 ```
 
-### Checking PVC Status
+After creating a claim, inspect it from both directions. The PVC status tells you whether the claim is bound, and the PV `CLAIM` column tells you which namespace and claim consumed the volume. If you only inspect the Pod, you may miss that the Pod is waiting on a claim that never bound. If you only inspect the PV, you may miss that the Pod is in the wrong namespace for the PVC it references.
 
 ```bash
 # List PVCs
-k get pvc
+kubectl get pvc
 # NAME       STATUS   VOLUME   CAPACITY   ACCESS MODES   STORAGECLASS
 # my-claim   Bound    pv-001   10Gi       RWO            standard
 
 # Detailed view
-k describe pvc my-claim
+kubectl describe pvc my-claim
 
 # Check which PV it bound to
-k get pvc my-claim -o jsonpath='{.spec.volumeName}'
+kubectl get pvc my-claim -o jsonpath='{.spec.volumeName}'
 ```
 
----
+## StorageClasses, Dynamic Provisioning, and Data Sources
 
-## Part 5: StorageClasses & Dynamic Provisioning
+Static provisioning is explicit: someone creates the PV before the claim arrives. Dynamic provisioning is demand-driven: a PVC references a StorageClass, and the provisioner creates a PV that satisfies that claim. Dynamic provisioning is the normal production path for many cloud and CSI-backed clusters because it avoids maintaining piles of pre-sized PV objects and reduces wasted capacity from oversized static volumes.
 
-If no matching static PV exists, Kubernetes may dynamically provision a PV from StorageClass when the PVC requests a class; if a PV is dynamically provisioned for that PVC, it is bound to that PVC. 
+A StorageClass contains a `provisioner`, optional backend `parameters`, a `reclaimPolicy`, `allowVolumeExpansion`, and `volumeBindingMode`. The reclaim policy on dynamically created PVs comes from the StorageClass, so a StorageClass is also a data-retention policy surface. If the class says `Delete`, then deleting the PVC normally leads to deletion of the dynamically provisioned backend storage after protection and finalizer rules are satisfied.
 
-A StorageClass object includes fields such as `provisioner`, `reclaimPolicy`, `parameters`, `allowVolumeExpansion`, and `volumeBindingMode`.
+Defaulting behavior is a frequent exam trap. If a PVC omits `storageClassName` and a default StorageClass exists, the admission controller may assign the default class and trigger dynamic provisioning. If a PVC sets `storageClassName: ""`, it is asking for a no-class PV and should not be defaulted to the cluster default. The empty string is not decoration; it is how you opt into manual no-class binding.
 
-If the DefaultStorageClass admission controller is enabled, a PVC without `storageClassName` may receive the default class; if it is absent, PVCs without a class are not automatically defaulted until one is available. When more than one StorageClass is marked as default, Kubernetes uses the most recently created default. 
+`volumeBindingMode` controls when binding or provisioning happens. The default `Immediate` mode binds or provisions as soon as the claim is created, before a consuming Pod is scheduled. `WaitForFirstConsumer` delays binding until a Pod exists, allowing node selectors, affinity, taints, topology zones, and local volume constraints to influence the decision. For local PVs and topology-aware CSI drivers, this delay can be the difference between a schedulable workload and a perfectly valid volume created in the wrong place.
 
-Crucially, a PVC using `storageClassName: ""` is explicitly treated as a request for a no-class PV and does not trigger class defaulting in the same way as an unset `storageClassName`.
+Snapshots and cloning extend the same claim model rather than replacing it. VolumeSnapshot and VolumeSnapshotContent are CustomResourceDefinitions served by the CSI snapshot ecosystem, not core PV objects. A PVC can be created from a snapshot through `dataSource` when the CSI driver and snapshot controller support it. A clone can use another PVC as a data source, with namespace and provisioner limitations. In Kubernetes 1.35, cross-namespace data sources remain a feature that requires explicit enablement and supporting objects such as ReferenceGrant, so do not design around it as a default assumption.
 
-### Volume Binding Modes
+Expansion is safer than shrinking because the API permits growth but not reduction below the current size. Stable PVC expansion has been available since Kubernetes v1.24 for supported drivers, and filesystem expansion applies to filesystems such as XFS, Ext3, and Ext4 when the storage backend allows it. Shrinking would require proving that every byte above the new boundary is unused and that the filesystem can contract safely, so Kubernetes does not offer it as a normal PVC edit.
 
-If unset, StorageClass `volumeBindingMode` defaults to Immediate, while `WaitForFirstConsumer` delays binding/provisioning until a consuming Pod is scheduled. For topology-aware provisioners, using Immediate mode can create unschedulable Pods; using WaitForFirstConsumer lets scheduling constraints participate in PV selection. In Kubernetes 1.35, local volume types do not support dynamic provisioning; a StorageClass with `WaitForFirstConsumer` is still used to delay binding.
+Which approach would you choose here and why: a manually created `Retain` PV for a database migration window, or a dynamically provisioned `Delete` PV from a default StorageClass? The answer depends on whether deletion safety or automation matters more for that workload. For production data migration, deliberate retention usually beats convenience. For disposable test data, dynamic provisioning with automatic cleanup may be the correct operational choice.
 
----
+## Consuming Claims from Pods and Workloads
 
-## Part 6: Expansion, Snapshots, and Cloning
-
-The default PVC expansion capability is stable since Kubernetes v1.24, and PVC expansion resizes the existing volume rather than creating a new PV. Kubernetes does not support shrinking PVCs below their current size; expansion of filesystem-backed volumes applies to XFS, Ext3, and Ext4.
-
-VolumeSnapshot and VolumeSnapshotContent are CRDs (not core API objects), and snapshot support is available only for out-of-tree CSI volume plugins. Snapshots can be provisioned either pre-provisioned or dynamically, and a PVC can be created from a VolumeSnapshot via `dataSource`.
-
-CSI volume cloning uses an existing PVC as `dataSource`, only supports dynamic CSI provisioners, and requires source/destination PVCs to be in the same namespace. `dataSourceRef` and `dataSource` cannot be independently divergent after creation; when cross-namespace mode is enabled, `dataSourceRef` can reference objects in other namespaces with feature-gate + ReferenceGrant requirements. Cross-namespace volume data source support is an alpha feature gated at v1.26 and requires enabling `AnyVolumeDataSource` and `CrossNamespaceVolumeDataSource` in control-plane components and csi-provisioner.
-
----
-
-## Part 7: Using PVCs in Pods
-
-### Basic Pod with PVC
+A Pod consumes storage by naming a PVC in `spec.volumes`, then mounting that volume into one or more containers. The Pod does not name the PV, the backend disk, or the StorageClass. This indirection is what lets application YAML remain stable while the cluster changes storage implementation. If the claim name is wrong or the namespace differs, the Pod cannot resolve the claim even if a matching cluster-scoped PV exists.
 
 ```yaml
 apiVersion: v1
@@ -400,7 +338,7 @@ spec:
       claimName: my-claim              # Reference the PVC name
 ```
 
-### PVC in Deployments
+Deployments add a scaling question. Multiple replicas can reference the same PVC, but the backend and access mode decide whether that is actually usable. A three-replica Deployment mounting one RWO block disk may work while all Pods happen to land on one node, then fail with a multi-attach error when another replica lands elsewhere. If all replicas must read and write the same files, use RWX-capable storage. If each replica needs its own stable disk, use a StatefulSet with `volumeClaimTemplates`.
 
 ```yaml
 apiVersion: apps/v1
@@ -429,13 +367,7 @@ spec:
           claimName: shared-pvc        # Must be RWX for multi-replica
 ```
 
-**Important**: For Deployments with multiple replicas, you need:
-- A PVC with `ReadWriteMany` access mode, OR
-- A StatefulSet with volumeClaimTemplates (each replica gets its own PVC)
-
-> **Pause and predict**: You create a Deployment with 3 replicas, each mounting the same PVC with access mode `ReadWriteOnce`. Replica 1 starts fine on node-1. What happens when replica 2 gets scheduled to node-2? Would changing to `ReadWriteOncePod` (RWOP) make things better or worse?
-
-### Read-Only PVC Mount
+Read-only mounting is a Pod-level consumption choice. The PVC and PV still declare access modes for matching and attachment, but a Pod can request a read-only mount when it should not write to a shared dataset. This is useful for shared content, model files, or configuration snapshots where the storage administrator controls updates separately from application runtime behavior.
 
 ```yaml
 volumes:
@@ -445,11 +377,9 @@ volumes:
     readOnly: true                     # Mount as read-only
 ```
 
----
+Pause and predict: you create a Deployment with three replicas, each mounting the same PVC with access mode `ReadWriteOnce`. Replica one starts on `node-1`. What happens when replica two is scheduled to `node-2`, and would `ReadWriteOncePod` make the sharing problem better or worse? RWO permits one node, while RWOP intentionally narrows the writer to one Pod, so RWOP is stricter and does not make a shared multi-replica writer design work.
 
-## Part 8: Selectors and Volume Matching
-
-You can strictly govern which static PVs your PVC is allowed to bind to by utilizing label selectors. Both `matchLabels` and `matchExpressions` are supported. 
+Selectors make static binding more deliberate. A PVC selector is not a scheduling selector and does not choose a node; it chooses eligible PV objects by label. This is useful when an administrator publishes several manual PVs with different performance or environment labels. The claim can then request `type: ssd` and `speed: fast` without hard-coding the PV name, preserving some flexibility while avoiding accidental binding to cheaper storage.
 
 ```yaml
 # PV with labels
@@ -470,6 +400,8 @@ spec:
   hostPath:
     path: /mnt/ssd
 ```
+
+When you combine `matchLabels` and `matchExpressions`, all constraints must be satisfied. That makes selectors powerful but easy to overconstrain. A typo in `region`, a class mismatch, or an access-mode mismatch all produce the same visible symptom at first: the PVC stays `Pending`. The fix is not to delete and recreate objects randomly; describe the PVC, inspect the events, then compare each declared constraint against the candidate PVs.
 
 ```yaml
 # PVC selecting specific PV
@@ -496,9 +428,7 @@ spec:
         - us-west
 ```
 
-### Direct Volume Selection
-
-Force a PVC to bind to a specific PV by name:
+Direct binding with `volumeName` is sharper. It tells Kubernetes which PV the claim wants, and it is valuable during recovery or carefully controlled migrations. It is also less flexible because a typo, incompatible field, or already-bound PV leaves the claim waiting. Use it when you need deterministic binding to a known retained volume, not as a default replacement for labels and StorageClasses.
 
 ```yaml
 apiVersion: v1
@@ -515,11 +445,49 @@ spec:
   volumeName: pv-fast-ssd             # Bind to this specific PV
 ```
 
----
+## Diagnosing Pending Claims and Mount Failures
 
-## Part 9: PV Release and Cleanup
+Storage troubleshooting becomes much easier when you separate binding problems from mounting problems. A binding problem happens before a Pod can use the volume: the PVC is not `Bound`, so there is no selected PV to mount. A mounting problem happens after binding: the PVC is bound, but the kubelet or storage plugin cannot attach, stage, publish, or mount the backend on the chosen node. The visible symptom may still be a stuck Pod, but the object to inspect first is different.
 
-When a PVC is deleted, the status of the bounded PV changes immediately to `Released`. 
+Start with the PVC status and events. If the claim is `Pending`, Kubernetes has not found or created compatible storage. Compare `storageClassName`, requested capacity, access mode, volume mode, selector labels, and `volumeName` if present. Do not assume that a larger PV always matches; the class and access mode still have to line up. Also check whether the cluster defaulted the StorageClass, because an omitted class can silently turn a manual-binding exercise into a dynamic-provisioning request.
+
+Next inspect the PV candidates. A PV in `Available` can bind if its fields satisfy the claim. A PV in `Bound` is already reserved, even if the workload that originally used it is gone. A PV in `Released` is especially deceptive because it looks close to usable, yet the old `claimRef` usually prevents normal binding. If a learner sees `Released` and immediately patches away the reference, they may recover data correctly, or they may expose another workload's old files. That is why the data decision comes before the API cleanup.
+
+Then inspect the Pod only after you know the claim is bound. If the Pod is stuck in `Pending`, scheduling constraints may not be satisfiable with the selected volume. Local PVs and zonal disks make this common because the scheduler must place the Pod where the storage can be reached. If the Pod is stuck in `ContainerCreating`, look for attach and mount events. A multi-attach error points toward access mode or backend attachment limits, while a permission or path error points toward the storage backend or mount options.
+
+Namespace mistakes deserve their own mental check because they are easy to miss in a fast exam environment. `kubectl get pvc` without `-n` shows claims in the current namespace, not every namespace. A Pod in `backend` that references `claimName: data` is not asking for a PVC called `data` anywhere in the cluster; it is asking for `backend/data`. The PV may show `frontend/data` in its claim column and still be perfectly healthy. The Pod is failing because it is looking in the wrong namespace.
+
+Capacity mismatch is also more nuanced than "too small or big enough." The PVC request is a lower bound, so a larger PV may bind. However, once it binds, the entire PV is consumed by that claim. This matters when teams statically pre-create a few large PVs and then wonder why many small claims cannot share them. If the cluster needs many precisely sized volumes, dynamic provisioning is not just convenient; it is a capacity-management tool that reduces stranded space.
+
+Access mode mismatch often appears during scaling rather than during the first deployment. A single RWO claim may bind and mount successfully for one Pod, which makes the YAML look correct during a smoke test. The failure appears when the controller creates another replica on a different node and the storage backend refuses a second writer attachment. The fix is not to keep deleting Pods until they co-locate. The fix is to choose storage semantics that match the controller pattern: RWX for shared files, or per-replica claims for independent state.
+
+Volume mode mismatch is rarer in beginner labs but important in real systems. A claim requesting `Block` will not bind to a PV offering `Filesystem` mode, and a Pod that expects a mounted directory is not the same as a Pod that expects a raw device. When diagnosing specialized databases, look for the volume mode before assuming the access mode is the only interesting field. A correct block-mode claim can be essential for software that formats and manages the device internally, while a normal web application usually wants filesystem mode.
+
+StorageClass problems divide into three groups. The first is an exact-name mismatch between PV and PVC, which blocks static binding. The second is default class assignment when the PVC omitted `storageClassName`, which may create a different dynamic PV than expected. The third is provisioner failure, where the claim names a class correctly but the external provisioner cannot create storage because of quota, credentials, topology, missing driver components, or invalid parameters. The PVC events usually distinguish those cases if you read them closely.
+
+Selectors should be treated as filters, not preferences. If a PVC selector asks for `type: ssd` and `region In [us-east, us-west]`, a PV missing either label is invisible to that claim even if every other field matches. This is useful for guardrails, but it can produce frustrating pending claims when labels drift or when administrators rename label keys. In static storage pools, standardize label keys and document them the same way you document StorageClass names.
+
+Reclaim-policy diagnosis begins after deletion. If a dynamically provisioned PV disappears after the claim is deleted, inspect the StorageClass that created it and check whether `Delete` was expected. If a retained PV remains, inspect whether the backend asset still exists and whether the PV is meant for recovery or disposal. If finalizers keep an object in terminating state, do not remove them casually. Finalizers are usually telling you that a controller still needs to finish cleanup, and bypassing them can leave real storage in an uncertain state.
+
+For CKA-style work, practice stating the likely failure in one sentence before editing anything. "This claim is pending because it asks for RWX but only RWO PVs match the class." "This Pod is stuck because the RWO disk is already attached to another node." "This retained PV cannot rebind because the stale claim reference remains." That habit keeps troubleshooting grounded in Kubernetes object state instead of guesswork. It also makes your exam answer faster because each sentence maps directly to a command you can run and a field you can verify.
+
+There is one more practical habit that separates reliable storage debugging from random edits: always preserve the current object evidence before replacing manifests. A PVC event message can disappear after a successful bind, and a Pod mount error can change after the controller retries. Reading the current events, selected PV name, claim reference, StorageClass name, and node assignment gives you a timeline. That timeline matters when several controllers are acting at once, especially with dynamic provisioning where a PVC, PV, external provisioner, scheduler, attacher, and kubelet all participate.
+
+This timeline also helps you decide whether a problem belongs to Kubernetes matching logic or to the storage system outside Kubernetes. If the PVC never binds, stay inside the API fields and controller events. If the PVC binds and the Pod cannot mount, move outward toward node placement, CSI driver health, backend reachability, permissions, and mount options. A good administrator changes one layer at a time because storage failures often have multiple tempting symptoms and only one root cause.
+
+## Reclaim Policy, Protection, and Recovery
+
+Reclaim policy is where storage lifecycle becomes a business decision. `Retain` preserves the backend data after the PVC is deleted and requires an administrator to decide what happens next. `Delete` allows the PV and backing storage to be deleted automatically, which is convenient for dynamically provisioned ephemeral environments. `Recycle` performs a basic scrub for limited plugin types and is effectively a legacy option that modern clusters should avoid.
+
+| Policy | Behavior | Use Case |
+|--------|----------|----------|
+| Retain | PV preserved after PVC deletion | Production data, manual cleanup |
+| Delete | PV and underlying storage deleted | Dynamic provisioning, dev/test |
+| Recycle | Basic scrub (`rm -rf /data/*`) | Deprecated pattern, avoid for new designs |
+
+In Kubernetes 1.35, only `nfs` and `hostPath` volume types support the Recycle reclaim policy, and even there it is not the design you should reach for. The modern choice is usually between `Retain` and `Delete`. Select `Retain` when accidental deletion would be worse than manual cleanup. Select `Delete` when the storage is disposable or when the provisioner owns the full lifecycle and cleanup is part of the expected workflow.
+
+Storage object protection and finalizers reduce timing hazards, but they do not replace good policy. Kubernetes delays deletion of actively used PVCs and bound PVs until they are no longer in use. PersistentVolume deletion-protection finalizers became stable in v1.33 and help ensure PVs with a `Delete` reclaim policy are removed only after backing storage cleanup completes. That protects against orphaned or prematurely removed storage in supported paths, but it does not mean a deleted PVC with a `Delete` policy is recoverable by default.
 
 ```mermaid
 flowchart TD
@@ -529,106 +497,123 @@ flowchart TD
     C -->|Delete| E[PV and storage deleted automatically.]
 ```
 
-### Reclaiming a Released PV
+The `Released` state is deliberately cautious. A retained PV still contains the previous claimant's data and still has a `claimRef` pointing at the old PVC identity. That old identity includes more than the human-readable claim name, so creating a new PVC with the same name is not enough. The administrator must either delete and recreate the PV around the same backend storage after cleanup, or intentionally clear the old claim reference when reuse is safe.
 
 ```bash
 # Check PV status
-k get pv pv-data
+kubectl get pv pv-data
 # NAME      CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS     CLAIM
 # pv-data   100Gi      RWO            Retain           Released   default/old-claim
 
 # Remove the claim reference to make PV available again
-k patch pv pv-data -p '{"spec":{"claimRef": null}}'
+kubectl patch pv pv-data -p '{"spec":{"claimRef": null}}'
 
 # Verify it's Available
-k get pv pv-data
+kubectl get pv pv-data
 # STATUS: Available
 ```
 
-### Manually Deleting Data
+If you patch away `claimRef` without cleaning the backend, the next claim that binds can see the old data. Sometimes that is the goal, such as recovering a deleted database claim. Sometimes it is a data exposure incident waiting to happen, such as binding a new development workload to an old production export. Treat reclaim as a controlled procedure: identify the backend, decide whether to preserve or scrub, then make the API object reusable only after the data decision is complete.
 
-For Retain policy, data remains on the storage. Clean up steps:
-1. Back up data if needed
-2. Delete data from underlying storage
-3. Remove claimRef (as above) or delete/recreate PV
+## Patterns & Anti-Patterns
 
-> **Pause and predict**: You have a PV in `Released` state after its PVC was deleted. You patch the PV to remove the `claimRef`, making it `Available` again. A new PVC binds to it. Will the new PVC see the old data that was on the volume, or will it be empty?
+Good PV/PVC design starts by separating workload intent from storage implementation. The workload should ask for durability, capacity, and access semantics; the cluster should decide how those requirements map to provisioners and backend systems. When those concerns are mixed, application teams start depending on cloud disk IDs, administrators lose policy control, and recovery procedures become a hunt through unrelated manifests.
 
----
+| Pattern | When to Use It | Why It Works |
+|---------|----------------|--------------|
+| Dynamic provisioning with a named StorageClass | Most cloud or CSI-backed application storage | Claims create right-sized PVs and inherit provisioner policy consistently |
+| Static `Retain` PV for controlled migration or recovery | Importing existing data or protecting production datasets | The backend survives PVC deletion and can be recovered deliberately |
+| `WaitForFirstConsumer` for topology-aware storage | Local PVs and zonal CSI drivers | Pod scheduling constraints participate before binding or provisioning |
+| RWX backend for shared writer workloads | Multiple replicas need the same mounted filesystem | The storage backend, not just the manifest, supports multi-node access |
+
+The matching anti-pattern is treating PVCs as magic shared folders. A PVC does not make an RWO disk safe for three writers across three nodes. A StorageClass does not guarantee that retained data will be safe after someone deletes a claim. A selector does not fix a class mismatch. The API is precise, and most storage failures are caused by asking for a property the backend does not actually provide.
+
+| Anti-Pattern | What Goes Wrong | Better Alternative |
+|--------------|-----------------|--------------------|
+| One RWO PVC mounted by a scaled Deployment | Multi-attach errors or accidental single-node coupling | Use RWX storage or StatefulSet `volumeClaimTemplates` |
+| Omitted `storageClassName` for manual binding | Default class may trigger dynamic provisioning | Set `storageClassName: ""` on both no-class PV and PVC |
+| `Delete` reclaim policy on valuable data | Claim deletion can remove the backend storage | Use `Retain` and document the recovery workflow |
+| Local PV without node affinity | Pod can schedule where the disk does not exist | Declare required node affinity and prefer `WaitForFirstConsumer` |
+
+Scaling considerations follow directly from these patterns. Shared filesystems simplify multi-reader or multi-writer workloads, but they centralize performance and availability around a network service. Block volumes deliver strong performance for a single writer, but they rarely solve shared write semantics. Local disks can be fast, but they tie data availability to node health. A strong design names the tradeoff instead of hiding it behind a generic claim.
+
+## Decision Framework
+
+When storage design feels unclear, begin with the workload's data shape. Ask whether the data is disposable, reconstructable, or authoritative. Then ask whether one Pod writes it, many Pods read it, or many Pods write it. Finally, ask whether the storage may be created on demand or must point at existing data. These questions usually choose the PV/PVC pattern before you write any YAML.
+
+| Decision Point | Choose This | When the Answer Is |
+|----------------|-------------|--------------------|
+| Provisioning model | Dynamic StorageClass | The cluster may create new backend storage per claim |
+| Provisioning model | Static PV | Storage already exists or must be curated manually |
+| Reclaim policy | Retain | Data must survive accidental claim deletion |
+| Reclaim policy | Delete | Data is disposable or owned by automated lifecycle |
+| Access mode | RWO or RWOP | A single node or a single Pod should write |
+| Access mode | RWX | Multiple nodes must read and write the same filesystem |
+| Binding mode | WaitForFirstConsumer | Topology affects where storage can be attached |
+| Volume mode | Block | The application expects a raw device and manages layout |
+
+Use this mental flow during troubleshooting as well as design. If a claim is `Pending`, compare class, capacity, access mode, volume mode, selector, and binding mode. If a Pod is stuck in `ContainerCreating`, check attachment and mount events, especially for RWO disks used by multiple replicas. If a PV is `Released`, stop and decide whether you are recovering data or scrubbing data before you make the PV available again.
+
+## Did You Know?
+
+- **Fact 1:** The in-tree AWS Elastic Block Store and Azure Disk plugins were deprecated in Kubernetes v1.19, and their migration path moved production use toward CSI drivers rather than new in-tree plugins.
+- **Fact 2:** PVC expansion has been stable since Kubernetes v1.24 for supported drivers and filesystems such as XFS, Ext3, and Ext4, but Kubernetes does not support shrinking an existing PVC.
+- **Fact 3:** Cross-namespace volume data sources were introduced as an alpha feature in Kubernetes v1.26 and require explicit feature gates plus ReferenceGrant-style permission controls.
+- **Fact 4:** PersistentVolume deletion-protection finalizers reached stable status in Kubernetes v1.33, helping coordinate `Delete` reclaim policy cleanup with backend storage deletion.
 
 ## Common Mistakes
 
-| Mistake | Problem | Solution |
-|---------|---------|----------|
-| PVC stuck in Pending | No matching PV available | Check storageClassName, size, access modes |
-| Access mode mismatch | PVC requesting RWX, PV only has RWO | Use compatible access modes |
-| StorageClass mismatch | PVC and PV have different storageClassName | Align storageClassName or use "" for both |
-| Deleted PVC, lost data | Reclaim policy was Delete | Use Retain for important data |
-| Can't reuse Released PV | claimRef still set | Patch PV to remove claimRef |
-| Local PV missing nodeAffinity | Pod can't find volume | Add required nodeAffinity section |
-| PVC in wrong namespace | Pod can't reference it | PVCs must be in same namespace as pod |
-
----
+| Mistake | Why It Happens | How to Fix It |
+|---------|----------------|---------------|
+| PVC stays `Pending` even though a PV exists | The class, access mode, volume mode, capacity, or selector does not actually match | Run `kubectl describe pvc`, inspect Events, then compare every matching field against candidate PVs |
+| Manual PV ignored by a PVC | The claim omitted `storageClassName`, so the default StorageClass was applied | Set `storageClassName: ""` on the PVC and on the no-class PV |
+| Multi-replica Deployment fails with one RWO claim | RWO permits one node, not a shared multi-node writer design | Use RWX-capable storage or give each replica its own claim through a StatefulSet |
+| Valuable data disappears after claim deletion | The dynamically provisioned PV inherited `Delete` reclaim policy from the StorageClass | Use `Retain` for data that requires manual recovery, and document cleanup steps |
+| Released PV cannot bind to a new claim | The old `claimRef` still points at the deleted PVC identity | Verify data handling, then remove `claimRef` or recreate the PV around the backend |
+| Local PV causes mount failures on another node | The PV did not declare required node affinity for the physical disk location | Add `nodeAffinity` and use a StorageClass with `WaitForFirstConsumer` when appropriate |
+| Pod cannot find a claim that already exists elsewhere | PVCs are namespaced, while PVs are cluster-scoped | Create the Pod and PVC in the same namespace or create a separate claim for that namespace |
 
 ## Quiz
 
-### Q1: Cross-Namespace Storage Mystery
-A developer in the `frontend` namespace creates a PVC requesting 10Gi with `storageClassName: manual`. An admin has created a 50Gi PV with `storageClassName: manual` in the cluster. The PVC binds successfully. But when the developer tries to reference this PVC from a pod in the `backend` namespace, the pod fails. Why does the pod fail, and what is the correct approach?
-
 <details>
-<summary>Answer</summary>
+<summary>Question 1: A developer creates a PVC in `frontend`, then mounts the same claim name from a Pod in `backend`. The PV is cluster-scoped and already bound. Why does the Pod fail, and what should you change?</summary>
 
-PersistentVolumes are **cluster-scoped** (no namespace), so the PV itself is visible everywhere. However, PersistentVolumeClaims are **namespaced** -- the PVC `my-claim` in `frontend` cannot be referenced by a pod in `backend`. The pod fails because it cannot find a PVC with that name in its own namespace. The correct approach is to create a separate PVC in the `backend` namespace. Note that the 50Gi PV is already bound to the `frontend` PVC exclusively, so the `backend` PVC would need its own PV or dynamic provisioning.
+The Pod fails because it resolves the PVC name inside its own namespace. The PV being cluster-scoped does not let a Pod bypass the namespaced PVC lookup. Create the consuming Pod in the same namespace as the claim, or create a separate PVC in `backend` that can bind to its own compatible PV. This tests the design boundary between cluster-scoped storage capacity and namespaced storage consumption.
 
 </details>
 
-### Q2: Wasted Storage Investigation
-Your cluster has three PVs: 10Gi, 50Gi, and 100Gi, all with `storageClassName: standard` and `accessModes: [ReadWriteOnce]`. A developer creates a PVC requesting 20Gi with the same StorageClass. After binding, they complain that `kubectl get pvc` shows 50Gi capacity, not 20Gi. They ask: "Where did the extra 30Gi go? Can another PVC use it?"
-
 <details>
-<summary>Answer</summary>
+<summary>Question 2: A claim requests 20Gi from three static PVs sized 10Gi, 50Gi, and 100Gi, all with the same class and RWO mode. It binds to the 50Gi PV. Can another claim use the remaining 30Gi?</summary>
 
-Kubernetes selects the **smallest PV that satisfies the request** -- the 10Gi PV is too small, so the 50Gi PV binds. The binding is exclusive: the entire 50Gi PV is reserved for this PVC, even though only 20Gi was requested. No other PVC can use the remaining 30Gi -- it is effectively wasted. This is a key reason dynamic provisioning (via StorageClasses) is preferred in production: it creates PVs sized exactly to the request. To avoid waste with static provisioning, admins should create PVs that closely match expected PVC sizes.
+No. Kubernetes binds the entire PV to one PVC, even when the claim requested less than the PV capacity. The 10Gi PV is too small, and the 50Gi PV is the smallest compatible match, but the unused capacity is not split for another claim. Dynamic provisioning avoids much of this waste by creating a PV sized for the request.
 
 </details>
 
-### Q3: Multi-Replica Deployment Failure
-A team deploys a 3-replica Deployment where each pod mounts the same PVC (access mode `ReadWriteOnce`). Replica 1 starts on node-A. Replica 2 is scheduled to node-B but gets stuck in `ContainerCreating` with a Multi-Attach error. What is the root cause, and what are two different solutions?
-
 <details>
-<summary>Answer</summary>
+<summary>Question 3: A three-replica Deployment mounts one RWO PVC. One Pod runs on `node-a`, and another Pod on `node-b` reports a multi-attach error. What is the root cause, and what are two valid fixes?</summary>
 
-`ReadWriteOnce` (RWO) means the volume can only be mounted by a **single node** at a time. Replica 2 on node-B cannot attach the volume that is already mounted on node-A. Two solutions: (1) Switch to a storage backend that supports `ReadWriteMany` (RWX) like NFS, and change the PVC access mode to RWX so all replicas on different nodes can mount it simultaneously. (2) Convert the Deployment to a **StatefulSet** with `volumeClaimTemplates`, which gives each replica its own independent PVC and PV -- this is the correct pattern for stateful workloads like databases where each replica needs its own storage.
+The root cause is that the selected backend and RWO access mode do not support simultaneous read-write attachment from multiple nodes. One fix is to use storage that supports RWX, such as an appropriate shared filesystem, and request `ReadWriteMany`. Another fix is to redesign the workload as a StatefulSet with `volumeClaimTemplates` so each replica receives its own PVC and PV. `ReadWriteOncePod` would be stricter, not a solution for shared writers.
 
 </details>
 
-### Q4: Released PV Recovery
-A production PostgreSQL PVC was accidentally deleted. The PV has `reclaimPolicy: Retain` and now shows status `Released`. The team needs to recover the data. They try creating a new PVC with the same name and spec, but it stays `Pending` instead of binding to the Released PV. What is blocking the binding, and what are the exact steps to recover?
-
 <details>
-<summary>Answer</summary>
+<summary>Question 4: A production PVC is deleted, and its PV shows `Released` with `persistentVolumeReclaimPolicy: Retain`. A new claim with the same name remains `Pending`. What blocks recovery?</summary>
 
-A Released PV still has a `claimRef` pointing to the old, deleted PVC. Even though a new PVC has the same name, the PV controller will not rebind it automatically because the UID in the claimRef does not match. The recovery steps are: (1) Verify the PV still has data: `kubectl get pv <name> -o yaml` and check the backend path. (2) Remove the stale claimRef: `kubectl patch pv <name> -p '{"spec":{"claimRef": null}}'`. This changes the PV status to `Available`. (3) Create the new PVC with matching storageClassName, access modes, and optionally `volumeName: <pv-name>` to force binding to that specific PV. The data on the underlying storage is preserved throughout this process because the Retain policy prevents deletion.
+The retained PV still has a `claimRef` to the old PVC identity, so it is not treated as freely available for the new claim. First verify whether the data should be preserved or scrubbed, because the backend still contains the old data. For recovery, remove the stale `claimRef` or recreate the PV around the same backend storage, then create a compatible PVC, often with `volumeName` to force the intended bind. The Retain policy preserved the data, but it did not automatically approve reuse.
 
 </details>
 
-### Q5: Static Binding Trap
-A developer creates a PVC without specifying `storageClassName`. The cluster has a default StorageClass. Meanwhile, an admin has manually created a PV with `storageClassName: ""`. The PVC never binds to the manual PV and instead triggers dynamic provisioning. Why, and how should the PVC be configured for manual binding?
-
 <details>
-<summary>Answer</summary>
+<summary>Question 5: A cluster has a default StorageClass. An administrator creates a manual PV with `storageClassName: ""`, but a developer's PVC omits `storageClassName` and triggers dynamic provisioning. Why?</summary>
 
-When `storageClassName` is **omitted** from a PVC, Kubernetes uses the cluster's **default StorageClass**, which triggers dynamic provisioning -- it does not look for PVs with empty storageClassName. To explicitly opt out of dynamic provisioning and bind to the manual PV, the PVC must set `storageClassName: ""` (empty string). This tells Kubernetes: "only bind to PVs that also have no StorageClass, and do not trigger any provisioner." Both the PV and PVC must have `storageClassName: ""` for manual binding to work. This distinction between "omitted" and "empty string" is a common exam gotcha.
+Omitting `storageClassName` lets defaulting assign the cluster's default StorageClass when that admission behavior is enabled. An explicit empty string is different: it requests a no-class PV and prevents default class assignment. To bind to the manual PV, set `storageClassName: ""` on the PVC as well. This is one of the highest-value CKA storage distinctions because both manifests can look superficially reasonable.
 
 </details>
 
-### Q6: Local PV Scheduling Failure
-A team creates a local PV backed by an SSD at `/mnt/disks/ssd1` on `worker-node-1`, but forgets to add `nodeAffinity`. A pod using this PV gets scheduled to `worker-node-2` and fails with a mount error. Explain why the nodeAffinity is required for local PVs (but not for NFS or cloud PVs), and write the nodeAffinity section needed.
-
 <details>
-<summary>Answer</summary>
+<summary>Question 6: A local PV points at `/mnt/disks/ssd1` on `worker-node-1`, but the Pod schedules to `worker-node-2` and fails to mount. What field is missing, and why is it not needed for NFS?</summary>
 
-Local PVs reference storage that is **physically attached to a specific node** -- the path `/mnt/disks/ssd1` only exists on `worker-node-1`. Without nodeAffinity, the scheduler does not know which node has the storage and may schedule the pod anywhere. NFS and cloud PVs do not need this because NFS is network-accessible from all nodes, and cloud PVs are attached dynamically by the CSI driver. The required nodeAffinity section constrains the scheduler to place pods on the correct node:
+The local PV is missing required node affinity that tells the scheduler where the physical disk exists. NFS is network-accessible when correctly configured, so the storage path is not tied to one Kubernetes node in the same way. Add node affinity for `kubernetes.io/hostname=worker-node-1`, and prefer `WaitForFirstConsumer` for local storage classes so scheduling and binding happen with topology in mind.
 
 ```yaml
 nodeAffinity:
@@ -641,48 +626,41 @@ nodeAffinity:
         - worker-node-1
 ```
 
-This ensures pods using the local PV are only scheduled to `worker-node-1` where the disk exists.
-
 </details>
-
-### Q7: Snapshot Restoration Failure
-A team wants to restore a database from a snapshot using dynamic provisioning. They create a PVC with a `dataSource` pointing to a VolumeSnapshot, but the PVC remains in a Pending state indefinitely. What is the most likely cause related to the volume plugin being used?
 
 <details>
-<summary>Answer</summary>
+<summary>Question 7: A team creates a PVC from a VolumeSnapshot, but the claim remains `Pending`. The StorageClass uses an old in-tree style volume plugin. What should you investigate first?</summary>
 
-VolumeSnapshot and VolumeSnapshotContent are Custom Resource Definitions (CRDs), and snapshot support is exclusively available for out-of-tree CSI volume plugins. If the cluster is still utilizing a legacy in-tree volume plugin, or an external provisioner that lacks snapshot capabilities, the dynamic provisioner will silently fail to process the `dataSource` request. In-tree plugins have been systematically deprecated and removed in recent Kubernetes releases. You must verify that the StorageClass and the storage backend rely on a modern CSI driver that natively implements the snapshotting API features.
+Investigate whether the workload is actually using a CSI driver with snapshot support and the required snapshot CRDs and controllers installed. VolumeSnapshot support is part of the CSI snapshot ecosystem, not a universal feature of every legacy plugin. The PVC may be valid YAML while the provisioner cannot satisfy the `dataSource`. The fix is to use a supported CSI driver and snapshot setup, not to keep recreating the same claim.
 
 </details>
-
-### Q8: Volume Expansion Limitation
-An administrator attempts to reduce cluster storage costs by shrinking a dynamically provisioned 500Gi PVC down to 100Gi. They successfully edit the PVC manifest and apply it, but the volume size does not change on the storage backend. Why did this operation fail, and what are the specific rules regarding volume resizing?
 
 <details>
-<summary>Answer</summary>
+<summary>Question 8: An administrator tries to shrink a 500Gi PVC to 100Gi to save cost. The edit is accepted by their local file but the cluster does not reduce the backend volume. What rule explains this?</summary>
 
-Kubernetes emphatically does not support shrinking PVCs below their current size. The volume expansion feature strictly allows resizing the existing volume upwards to accommodate growing data needs. It seamlessly applies to filesystem-backed volumes (such as XFS, Ext3, and Ext4) without creating a new PV, but reducing capacity is fundamentally unsafe for the integrity of the underlying data. Attempting to shrink a filesystem could easily truncate active files or corrupt database records, which is why it is explicitly blocked by the Kubernetes API. If you genuinely need a smaller volume, you must manually create a new PVC, migrate the data using a temporary utility Pod, and cleanly delete the oversized volume.
+Kubernetes supports expanding PVCs for supported drivers, but it does not support shrinking an existing PVC below its current size. Shrinking can corrupt filesystems and application data because the platform cannot safely know what data lives beyond the smaller boundary. To reduce size, create a new smaller PVC, migrate the data deliberately, verify the application, and then clean up the old volume according to its reclaim policy.
 
 </details>
-
----
 
 ## Hands-On Exercise: Static PV Provisioning
 
-### Scenario
-Create a PV and PVC, then use the storage in a pod. Verify data persists across pod deletion.
+Exercise scenario: you will create a manual PV and PVC, mount the claim into a Pod, prove that data survives Pod deletion, and then observe the `Released` state after deleting the claim. The backend uses `hostPath` because it runs in simple lab clusters, but the operational lessons are the same for safer backends: class matching matters, claim namespace matters, and retained data remains on the backend until someone deliberately handles it.
 
 ### Setup
 
+Create a namespace for the lab so the claim and Pod are isolated from the rest of the cluster. The PV remains cluster-scoped, which lets you see the namespace boundary clearly when the PV `CLAIM` column later shows `pv-lab/lab-pvc`.
+
 ```bash
 # Create namespace
-k create ns pv-lab
+kubectl create ns pv-lab
 ```
 
 ### Task 1: Create a PersistentVolume
 
+Create a 1Gi manual PV with a `Retain` reclaim policy and a label that the PVC can select. The `hostPath` backend is intentionally simple for a lab, but do not treat it as a multi-node production storage design. Your goal is to observe matching and lifecycle behavior, not to build resilient storage on `/tmp`.
+
 ```bash
-cat <<EOF | k apply -f -
+cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -702,16 +680,19 @@ spec:
 EOF
 ```
 
-Verify:
+Verify that the PV exists before creating the claim. If it is not `Available`, inspect the manifest and events before continuing, because a claim cannot bind to a PV that is already reserved or invalid.
+
 ```bash
-k get pv lab-pv
+kubectl get pv lab-pv
 # STATUS should be "Available"
 ```
 
 ### Task 2: Create a PersistentVolumeClaim
 
+Create a namespaced PVC that requests 500Mi, matches `storageClassName: manual`, and selects the `lab: storage` label. The claim requests less than the PV capacity, which demonstrates that Kubernetes can bind a smaller request to a larger PV while still reserving the whole PV.
+
 ```bash
-cat <<EOF | k apply -f -
+cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -730,19 +711,22 @@ spec:
 EOF
 ```
 
-Verify binding:
+Verify binding from both the namespaced claim and the cluster-scoped volume. The PVC should show `Bound`, and the PV should show a claim reference of `pv-lab/lab-pvc`.
+
 ```bash
-k get pvc -n pv-lab
+kubectl get pvc -n pv-lab
 # STATUS should be "Bound"
 
-k get pv lab-pv
+kubectl get pv lab-pv
 # CLAIM should show "pv-lab/lab-pvc"
 ```
 
-### Task 3: Use PVC in a Pod
+### Task 3: Use the PVC in a Pod
+
+Create a small BusyBox Pod that writes a timestamp into `/data/timestamp.txt`. The Pod references the PVC by claim name, not by PV name, because Pods consume claims. If the Pod stays pending or cannot mount, describe the Pod and PVC rather than changing the container command first.
 
 ```bash
-cat <<EOF | k apply -f -
+cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: Pod
 metadata:
@@ -763,22 +747,25 @@ spec:
 EOF
 ```
 
-Verify pod is running:
+Wait for readiness before checking the file. A mount failure usually appears before the container reaches Ready, so this command gives you a clean signal that the PVC was usable by the Pod.
+
 ```bash
-k wait --for=condition=Ready pod/storage-pod -n pv-lab --timeout=60s
+kubectl wait --for=condition=Ready pod/storage-pod -n pv-lab --timeout=60s
 ```
 
 ### Task 4: Verify Data Persistence
 
+Read the timestamp, delete the Pod, then recreate a second Pod that mounts the same claim. The original timestamp should still be present because the data lives on the PV backend, not in the old container filesystem. This is the practical difference between a persistent volume and ephemeral container storage.
+
 ```bash
 # Check the written data
-k exec -n pv-lab storage-pod -- cat /data/timestamp.txt
+kubectl exec -n pv-lab storage-pod -- cat /data/timestamp.txt
 
 # Delete the pod
-k delete pod -n pv-lab storage-pod
+kubectl delete pod -n pv-lab storage-pod
 
 # Recreate pod
-cat <<EOF | k apply -f -
+cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: Pod
 metadata:
@@ -799,100 +786,110 @@ spec:
 EOF
 
 # Wait for pod to be ready
-k wait --for=condition=Ready pod/storage-pod-v2 -n pv-lab --timeout=60s
+kubectl wait --for=condition=Ready pod/storage-pod-v2 -n pv-lab --timeout=60s
 
 # Verify data persisted
-k logs -n pv-lab storage-pod-v2
+kubectl logs -n pv-lab storage-pod-v2
 # Should show the original timestamp
 ```
 
 ### Task 5: Test Released State
 
+Delete the Pod before deleting the PVC, then observe that the PV moves to `Released` because its reclaim policy is `Retain`. Clearing `claimRef` makes the PV available again, but remember what the lab just proved: the backend data remains unless you remove it yourself.
+
 ```bash
 # Delete the PVC (pod must be deleted first)
-k delete pod -n pv-lab storage-pod-v2
-k delete pvc -n pv-lab lab-pvc
+kubectl delete pod -n pv-lab storage-pod-v2
+kubectl delete pvc -n pv-lab lab-pvc
 
 # Check PV status
-k get pv lab-pv
+kubectl get pv lab-pv
 # STATUS should be "Released" (because of Retain policy)
 
 # Make PV available again
-k patch pv lab-pv -p '{"spec":{"claimRef": null}}'
+kubectl patch pv lab-pv -p '{"spec":{"claimRef": null}}'
 
-k get pv lab-pv
+kubectl get pv lab-pv
 # STATUS should be "Available"
 ```
 
 ### Success Criteria
-- [ ] PV created and shows "Available"
-- [ ] PVC created and binds to PV
-- [ ] Pod can write data to mounted volume
-- [ ] Data persists after pod deletion
-- [ ] PV shows "Released" after PVC deletion
-- [ ] PV can be made "Available" again
+
+- [ ] PV created and shows `Available`.
+- [ ] PVC created in `pv-lab` and binds to `lab-pv`.
+- [ ] Pod can write data to the mounted claim.
+- [ ] Data persists after deleting and recreating the Pod.
+- [ ] PV shows `Released` after PVC deletion because the reclaim policy is `Retain`.
+- [ ] PV can be made `Available` again after deliberately clearing `claimRef`.
 
 ### Cleanup
 
+Clean up the namespace and PV after the lab. In a real retained-storage workflow, you would also inspect and clean the backend data path before reuse or final removal.
+
 ```bash
-k delete ns pv-lab
-k delete pv lab-pv
+kubectl delete ns pv-lab
+kubectl delete pv lab-pv
 ```
 
----
+### Practice Drills
 
-## Practice Drills
+Use these short drills to build speed after you complete the full lab. They are intentionally framed as tasks rather than full solutions so you practice translating storage requirements into manifests and inspection commands.
 
-### Drill 1: Create PV (2 min)
 ```bash
-# Task: Create 5Gi PV with RWO access, Retain policy, storageClassName "slow"
+# Task: Create a 5Gi PV with RWO access, Retain policy, storageClassName "slow".
 # Backend: hostPath /mnt/data
 ```
 
-### Drill 2: Create PVC (1 min)
 ```bash
-# Task: Create PVC requesting 2Gi with RWO, storageClassName "slow"
+# Task: Create a PVC requesting 2Gi with RWO and storageClassName "slow".
 ```
 
-### Drill 3: Check Binding (1 min)
 ```bash
-# Task: Verify PVC bound to correct PV
-# Commands: k get pvc, k get pv, check CLAIM column
+# Task: Verify the PVC bound to the correct PV.
+# Commands to consider: kubectl get pvc, kubectl get pv, and the CLAIM column.
 ```
 
-### Drill 4: PVC Selector (2 min)
 ```bash
-# Task: Create PVC that only binds to PVs with label "tier: gold"
-# Use selector.matchLabels
+# Task: Create a PVC that only binds to PVs with label "tier: gold".
+# Use selector.matchLabels.
 ```
 
-### Drill 5: Pod with PVC (2 min)
 ```bash
-# Task: Create pod mounting PVC "data-pvc" at /app/data
-# Image: nginx
+# Task: Create a Pod mounting PVC "data-pvc" at /app/data.
+# Image: nginx:1.25
 ```
 
-### Drill 6: Troubleshoot Pending PVC (2 min)
 ```bash
-# Given: PVC stuck in Pending
-# Task: Identify why it won't bind
-# Check: k describe pvc, look at Events
+# Given: a PVC is stuck in Pending.
+# Task: identify why it will not bind.
+# Check: kubectl describe pvc, then read the Events section.
 ```
 
-### Drill 7: Reclaim Released PV (1 min)
 ```bash
-# Task: Make a "Released" PV available again
-# Command: k patch pv <name> -p '{"spec":{"claimRef": null}}'
+# Task: Make a Released PV available again after you have handled the data.
+# Command shape: kubectl patch pv <name> -p '{"spec":{"claimRef": null}}'
 ```
 
-### Drill 8: Local PV with nodeAffinity (3 min)
 ```bash
-# Task: Create local PV that only works on node "worker-1"
-# Include required nodeAffinity section
+# Task: Create a local PV that only works on node "worker-1".
+# Include the required nodeAffinity section.
 ```
 
----
+## Sources
+
+- https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+- https://v1-35.docs.kubernetes.io/docs/concepts/storage/persistent-volumes/
+- https://kubernetes.io/docs/concepts/storage/storage-classes/
+- https://kubernetes.io/docs/concepts/storage/volumes/
+- https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/
+- https://kubernetes.io/docs/concepts/storage/volume-snapshots/
+- https://kubernetes.io/docs/concepts/storage/volume-pvc-datasource/
+- https://kubernetes.io/docs/tasks/administer-cluster/change-pv-reclaim-policy/
+- https://kubernetes.io/docs/tasks/administer-cluster/change-pv-access-mode-readwriteoncepod/
+- https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/
+- https://kubernetes-csi.github.io/docs/
+- https://github.com/container-storage-interface/spec/blob/master/spec.md
 
 ## Next Module
 
-Continue to [Module 4.3: StorageClasses & Dynamic Provisioning](../module-4.3-storageclasses/) to learn how to move past manual volume matching and enable fully automated, on-demand storage provisioning for your workloads.
+Continue to [Module 4.3: StorageClasses & Dynamic Provisioning](../module-4.3-storageclasses/) to learn how to move past manual volume matching and enable automated, on-demand storage provisioning for your workloads.


### PR DESCRIPTION
## Summary
- Rewrote Module 4.2 PersistentVolumes & PersistentVolumeClaims in place and cleared revision_pending.
- Preserved protected assets and replaced runnable kubectl shorthand with full kubectl commands.

## Verifier
- Required verifier with --skip-source-check: tier T0; body_words=5034, mean_wpp=67.1, median_wpp=72, short_rate=0.013, max_run=1.
- Optional full source reachability check: tier T0; sources 12/12 reachable (200), 0 redirects, 0 404, 0 fetch_failed.

## Protected assets
- Before: code_blocks=38, mermaid_diagrams=4, ascii_diagrams=1, tables=4.
- After: code_blocks=38, mermaid_diagrams=4, ascii_diagrams=1, tables=7.

## Commit
- d5d85edab92552f1184ec927859861c0a81f0f66