### PR TITLE
feat(388): rewrite module-1.2-kubectl-basics (#388 pilot)

### DIFF
--- a/src/content/docs/prerequisites/kubernetes-basics/module-1.2-kubectl-basics.md
+++ b/src/content/docs/prerequisites/kubernetes-basics/module-1.2-kubectl-basics.md
@@ -21,29 +21,27 @@ lab:
 
 ## What You'll Be Able to Do
 
-After completing this module, you will be able to debug, compare, design, evaluate, and implement `kubectl` workflows against a Kubernetes 1.35+ cluster:
+After completing this module, you will be able to debug, compare, design, evaluate, and implement practical `kubectl` workflows against a Kubernetes 1.35+ cluster:
 
-- **Debug** a non-running pod end-to-end by chaining `kubectl get`, `kubectl describe`, and `kubectl logs --previous` to isolate whether the failure is at scheduling, image pull, or runtime.
-- **Compare** imperative (`kubectl run`, `kubectl create`) and declarative (`kubectl apply`) workflows and **justify** which to use for a given situation, including when Server-Side Apply is the right escalation.
-- **Design** a safe context-management workflow that prevents the cross-cluster destruction described above, including current-context checks, named contexts per environment, and `--dry-run=server` previews.
-- **Evaluate** the output of `kubectl get -o jsonpath` and `kubectl get -o custom-columns` to extract precisely the data needed for automation, monitoring scripts, or certification exam tasks.
-- **Implement** a productivity-boosting shell environment with the `k` alias, autocomplete, and a small library of inspection one-liners that you can reproduce on any new machine in under five minutes.
-
-This module uses `kubectl` in full until the productivity section installs `alias k=kubectl`; after that point, `k get pods` and similar short commands mean exactly the same API calls with less typing.
+- **Debug** a non-running pod end-to-end by chaining `kubectl get`, `kubectl describe`, `kubectl logs --previous`, and rollout commands to isolate whether the failure is scheduling, image pull, readiness, or runtime behavior.
+- **Compare** imperative commands, declarative manifests, and Server-Side Apply, then justify which workflow fits a local experiment, a shared staging change, or a production GitOps environment.
+- **Design** a safe namespace and context workflow that prevents wrong-cluster changes by using explicit namespaces, current-context checks, server dry-runs, and repeatable cleanup.
+- **Evaluate** `kubectl get` output formats such as `wide`, `yaml`, `json`, `jsonpath`, and `custom-columns` so scripts extract stable fields instead of grepping human tables.
+- **Implement** a full beginner operations loop: create a namespace, deploy workloads, inspect resource ownership, break and repair an image rollout, tunnel traffic with `port-forward`, and remove the lab cleanly.
 
 ## Why This Module Matters
 
-It is 03:00 on a Saturday, and a pager has just shattered the silence in an SRE's apartment. The company's checkout service has stopped responding, customers are bouncing off the cart page, and the Slack incident channel is filling up faster than anyone can read. The on-call engineer has exactly one tool that matters in the next ninety seconds: a terminal with `kubectl` configured against the right cluster. If they can type `kubectl get pods -n payments`, spot the `CrashLoopBackOff`, run `kubectl logs --previous`, and identify the bad config map within two minutes, the outage is contained and the post-mortem is short. If they fumble for syntax, mistype the namespace, or — worse — run a destructive command against the wrong context, the company loses six figures and the engineer spends Monday morning explaining themselves to leadership.
+Hypothetical scenario: it is early in an incident, a service owner says the staging checkout API is not responding, and the only shared fact in the chat is that "Kubernetes looks broken." You have a terminal, a kubeconfig, and several possible failure layers between your laptop and the application: the API server might be unreachable, the namespace might be wrong, the Deployment might have created no pods, the pods might be unscheduled, the image might not pull, or the application might be crashing after it starts. A fluent `kubectl` user does not guess. They turn the cluster into evidence, one read-only command at a time, until the failure has a name.
 
-This is the unglamorous truth about Kubernetes: every operator, every developer, and every platform engineer talks to the cluster through the same single command. `kubectl` is not a CLI in the way `ls` is a CLI. It is a typed, schema-aware HTTPS client that translates your shell commands into REST calls against the Kubernetes API server, and it is the universal adapter through which all human intent reaches the control plane. CI/CD pipelines wrap it. GitOps controllers re-implement its behavior. Helm and Kustomize generate manifests that you ultimately apply with it. Even when you are using a fancy dashboard, somewhere underneath, a `kubectl`-equivalent API call is being issued. Mastering it is therefore not optional polish — it is the load-bearing skill on top of which every other Kubernetes competency is built.
+That discipline matters because `kubectl` is the everyday control surface for Kubernetes. Dashboards, GitOps controllers, Helm, Kustomize, and platform portals all matter, but the human operator still reaches for `kubectl` when they need to verify what the API server actually stores and what the controllers are doing with it. The same command family can read harmless inventory, start a port-forward, update an image, or delete a namespace. That power is useful only when paired with habits that keep cluster, namespace, verb, and output format explicit.
 
-A real incident from 2019 illustrates the cost of mediocrity. A senior engineer at a well-known FinTech intended to delete a stale namespace called `payments` from a staging cluster. They ran `kubectl delete namespace payments`. The command succeeded instantly, and only as the alerts began firing did they realize their `kubectl` context was still pointing at production. The payments routing layer was gone, recovery from backups took roughly forty-five minutes, and the company estimated the lost transaction revenue at one hundred and twenty thousand dollars. There was no bug in Kubernetes. The system did exactly what it was told. The lesson is that `kubectl` rewards precision and punishes haste, and that the muscle memory you build in this module — checking your context, using `--dry-run=client`, preferring declarative `apply` over imperative `delete` — is the difference between a senior operator and a liability.
+This module teaches the command surface as an operating workflow rather than as a memorization list. You will start with the mental model of `kubectl` as a typed HTTPS client, then practice the read-only verbs that separate broad inventory from detailed diagnosis. From there you will compare imperative and declarative changes, learn how dry-runs and Server-Side Apply reduce risk, and finish with a hands-on lab that deliberately breaks a rollout so you can repair it using the same sequence you would use during real support work.
 
 ## The Mental Model: kubectl Is a Typed API Client
 
-Before you memorize a single command, internalize this sentence: every `kubectl` invocation is an HTTPS request against the Kubernetes API server. The CLI looks like a local tool because it lives on your laptop, but it does almost no real work locally. It reads `~/.kube/config` to find a cluster URL and a credential, serializes your subcommand into a REST verb plus a JSON body, sends it to the API server over TLS, and pretty-prints the response. If the API server is unreachable, `kubectl` is useless. If your kubeconfig is wrong, you can be talking to the wrong cluster without any visual indication. This mental model dissolves a hundred mysteries that beginners have about why certain commands behave the way they do.
+The most useful sentence in this module is simple: every `kubectl` command becomes a request to the Kubernetes API server. The binary on your laptop reads kubeconfig, chooses a context, loads credentials, builds a REST request, sends it over TLS, and formats the response. It does not schedule pods, pull images, create containers, or edit etcd directly. Those jobs belong to the API server, controllers, scheduler, kubelet, and storage layer, which is why a failed command is often telling you about one of those components rather than about the CLI itself.
 
-The mapping between subcommand and HTTP verb is regular and worth memorizing. `kubectl get` is `GET /api/v1/...` and is read-only and side-effect-free. `kubectl create` is `POST` and fails if the resource already exists. `kubectl apply` is `PATCH` (or, with `--server-side`, an `apply` operation) and is idempotent — running it twice produces the same end state as running it once. `kubectl delete` is `DELETE` and is irreversible. Once you see commands as verbs against an API, the difference between `create` and `apply` stops being arbitrary trivia and becomes obvious: `create` is for one-shot first-time provisioning, `apply` is for the continuous reconciliation pattern that GitOps depends on.
+The flow below is worth studying because it explains many beginner surprises. If `kubectl get pods` says the server is unreachable, your first suspect is connectivity or kubeconfig, not the pods. If `kubectl apply` is rejected even though the YAML looks correct, an admission controller or schema rule on the API server may be responsible. If `kubectl logs` returns nothing for a container that keeps restarting, the current container instance may not be the one that crashed. The command output is evidence from a distributed system, not just text on a terminal.
 
 ```mermaid
 flowchart TD
@@ -54,13 +52,19 @@ flowchart TD
     Terminal -->|formats output<br>table / yaml / json / jsonpath| User["You<br>read or pipe"]
 ```
 
-The diagram above is the most important picture in this module. Print it, tape it to your monitor, and look at it whenever a command behaves unexpectedly. Nine out of ten "kubectl is broken" complaints turn out to be one of three things: the wrong cluster URL in kubeconfig, an expired or wrong credential, or an admission webhook on the API server rejecting the request. None of those are problems with `kubectl` itself; they are problems on the path between your terminal and `etcd`, and the diagram tells you exactly where to look.
+The verbs map to API behavior in a regular way. `kubectl get` is a read request, `kubectl create` sends a new object, `kubectl apply` patches desired state, and `kubectl delete` asks the API server to remove an object according to Kubernetes deletion rules. The exact endpoint depends on the resource type and namespace, but the principle stays stable. Once you see the CLI as an API client, the difference between a read-only inspection and a persistent cluster change becomes much clearer.
 
-> **Stop and think**: If `kubectl` is just an HTTPS client, what would happen if you used `curl` against the API server directly with your kubeconfig credentials? (You can — and `kubectl --v=8` will print the exact `curl`-equivalent request it is making, which is one of the best debugging tricks in the Kubernetes universe. Try `kubectl get pods --v=8 2>&1 | grep curl` after this module.)
+The same model also explains why `kubectl` output sometimes lags behind your intention. When you create a Deployment, the API server stores the Deployment object quickly, but that does not mean pods are already running. The Deployment controller must observe the new object, create a ReplicaSet, the ReplicaSet controller must create Pods, the scheduler must assign those Pods to nodes, and kubelets must pull images and start containers. A successful `kubectl apply` confirms the desired state was accepted, not that every downstream controller has finished its work.
 
-## The kubectl Command Anatomy
+That separation is one reason Kubernetes commands often come in pairs: one command changes desired state, and another command verifies observed state. `kubectl set image` may update a Deployment immediately, but `kubectl rollout status` tells you whether the controller managed to replace old pods with ready new pods. `kubectl delete namespace` may mark the namespace for deletion immediately, but `kubectl get namespace` later tells you whether finalizers and cleanup completed. Treat command success as the beginning of verification, not the end of operational thinking.
 
-Every `kubectl` command follows the same four-part structure: `kubectl [VERB] [TYPE] [NAME] [FLAGS]`. The verb is what you want to do — `get`, `describe`, `apply`, `delete`, `exec`, `logs`. The type is the resource kind, written either in full (`pods`, `deployments`, `services`) or in a short name (`po`, `deploy`, `svc`). The name is optional; omit it to operate on all resources of that type, or supply it to target one. Flags modify behavior — namespace selection, output format, label filters, dry-run mode, and so on. Once you see the four-part structure, every command in the documentation snaps into place.
+There is a practical security lesson here too. Because `kubectl` talks to the API server with your identity, every command is subject to authentication, authorization, and admission. A cluster may let you read pods while blocking deletes, or let you create ConfigMaps while rejecting privileged pods through policy. When a command is denied, do not work around it with a more powerful credential by reflex. First decide whether the policy is protecting the cluster from exactly the kind of change you are trying to make.
+
+Pause and predict: if `kubectl` is only an API client, what do you think happens when your kubeconfig points at a healthy cluster but your credential has expired? The pods are still running and the controllers are still reconciling, but your command fails at authentication before it can read anything useful. That distinction is operationally important because it prevents you from treating every `kubectl` error as an application outage.
+
+## Command Anatomy and Read-Only Inspection
+
+Most `kubectl` commands have the same shape: binary, verb, resource type, optional resource name, and flags. The verb tells Kubernetes what kind of API action you want, the type selects the resource collection, the name narrows the target to one object, and the flags refine namespace, output, filtering, sorting, or safety behavior. Beginners often experience the command surface as a wall of special cases, but the structure is steady enough that you can infer many commands before you memorize them.
 
 ```text
 kubectl    get        pods       nginx          -n web -o yaml
@@ -71,26 +75,18 @@ kubectl    get        pods       nginx          -n web -o yaml
             GET)     segment)
 ```
 
-Short names matter once you start running these commands hundreds of times a day. `kubectl get po` is meaningfully faster to type than `kubectl get pods`, and `kubectl get deploy,svc,po -n web` lists three resource types at once when you are eyeballing what is running in a namespace. The full list is available with `kubectl api-resources`, which is itself a command worth running on every new cluster — it tells you not just the built-in types but every Custom Resource Definition the cluster has installed, which is how you discover that the cluster has Argo Rollouts, Cert-Manager, or Crossplane without having to ask anyone.
-
-Flags follow standard Unix conventions. Single-letter flags are prefixed with one dash and can be combined: `-it` for interactive TTY in `kubectl exec`. Long-form flags use two dashes: `--namespace=web`, `--output=yaml`. The `=` is optional but recommended for clarity, especially in shell scripts where a missing `=` can cause a flag to consume the next argument. `kubectl` is generally forgiving about flag ordering, but it is not promised behavior — when scripting, always put the verb and type first and flags last.
-
-> **Pause and predict**: What do you think `kubectl get all -n kube-system` returns? Will it return literally every resource in `kube-system`, including Secrets and ConfigMaps? (Answer: no — `all` is a curated alias that expands to roughly Pods, ReplicaSets, Deployments, StatefulSets, DaemonSets, Jobs, CronJobs, and Services. It does NOT include Secrets, ConfigMaps, Roles, ServiceAccounts, or any CRDs. This is one of the most-misunderstood pieces of `kubectl` behavior, and a frequent source of "I deleted everything but the namespace is not empty" confusion.)
-
-## Reading the Cluster: get, describe, explain
-
-The three read-only verbs — `get`, `describe`, and `explain` — answer three different questions and using the wrong one wastes time. `kubectl get` answers "what exists?" with a compact tabular listing. `kubectl describe` answers "what is the state of this specific thing, including events?" with a verbose multi-section dump. `kubectl explain` answers "what fields does this resource type even support?" by reading the OpenAPI schema embedded in the API server. Beginners reach for `describe` for everything because it shows the most data; experienced operators almost always start with `get` to establish the lay of the land and only escalate to `describe` once they have identified the suspect resource.
+The read-only verbs should become your default entry point because they reduce uncertainty without changing the cluster. `kubectl get` answers "what exists and what is its headline state?" while `kubectl describe` answers "what does one object report about its status, conditions, owners, and recent events?" `kubectl explain` answers a different question: "what fields does this resource type support on this cluster?" You will use all three in the lab, and the order matters because broad inventory prevents you from wasting time on the wrong object.
 
 ```bash
 # What exists in this namespace?
-kubectl get pods                     # default namespace, table view
-kubectl get pods -A                  # every namespace, every pod
-kubectl get pods -n kube-system      # one specific namespace
-kubectl get pods -o wide             # add node, pod IP, nominated node
-kubectl get pod nginx -o yaml        # the full server-stored object
+kubectl get pods
+kubectl get pods -A
+kubectl get pods -n kube-system
+kubectl get pods -o wide
+kubectl get pod nginx -o yaml
 
 # What's the state of this specific thing?
-kubectl describe pod nginx           # spec, status, conditions, EVENTS
+kubectl describe pod nginx
 kubectl describe node kind-control-plane
 
 # What fields does this resource even have?
@@ -98,24 +94,28 @@ kubectl explain pod.spec.containers
 kubectl explain pod.spec.containers.resources --recursive
 ```
 
-The killer feature of `kubectl describe` is the Events section at the bottom. When a pod is `Pending`, the events tell you whether the scheduler could not find a node, whether the image pull failed, whether a volume could not mount, or whether an admission webhook rejected the resource. Beginners often skip past the events because there is so much output above them; train yourself to scroll directly to the bottom. The single phrase that solves more "why is my pod broken?" tickets than any other is "did you read the events at the bottom of `kubectl describe`?"
+The Events section at the bottom of `kubectl describe` is one of the highest-value debugging surfaces in Kubernetes. A pod that is `Pending` may be unschedulable because of node selectors, resource pressure, taints, or volume problems, and the Events list is where the scheduler and kubelet report those facts. A pod in `ImagePullBackOff` usually has a registry, credential, or tag problem, and the Events list often includes the exact image reference and error class. Reading Events before restarting anything is the difference between diagnosis and button pressing.
 
-The `kubectl explain` command is the one most beginners never discover, and it is genuinely transformative once you do. Instead of switching to a browser and searching the Kubernetes documentation site for the structure of a `PodSpec`, you can stay in your terminal: `kubectl explain pod.spec.containers.livenessProbe`. The output is the canonical schema, sourced from the same OpenAPI definition the API server uses to validate your YAML, which means it is always exactly correct for your cluster's version. Pair it with `--recursive` when you want to see every nested field at once, and you have a perfect cheat sheet for writing manifests by hand without ever consulting external docs.
+The broad-to-narrow habit also protects you from generated names. Deployments create ReplicaSets, ReplicaSets create Pods, and those child objects receive names with hashes and suffixes that are not meaningful to memorize. A label selector such as `-l app=web` lets you inspect the related objects without copying a generated pod name from one command into another too early. Once the failing object is obvious, then you can describe or log that specific pod with confidence.
 
-> **Stop and think**: A junior engineer says "`kubectl describe pod` does not show me the container exit code when a container has crashed." Are they right or wrong? (They are wrong — `describe` does show it, in the `Last State` block under each container, with fields like `Reason`, `Exit Code`, and `Started`/`Finished`. They probably ran `describe` while the pod was still running fine, before the crash. Run it again the next time the pod is in `CrashLoopBackOff`.)
+Resource short names are helpful, but they are not a substitute for understanding resource kinds. `kubectl api-resources` shows the full kind, plural name, short names, API group, namespaced scope, and supported verbs for every resource the cluster exposes. Running it on a cluster with controllers installed can reveal Custom Resource Definitions for certificates, rollouts, backups, policies, or cloud resources. That discovery step matters because `kubectl get pods` tells you only about core workloads, while a real platform may be shaped by many custom controllers.
 
-## Output Formats and Why They Matter
+The namespace default is another reason read commands can mislead beginners. `kubectl get pods` without `-n` reads only the namespace configured on the current context, or `default` if none is configured. In a local lab that may be fine, but in a shared cluster it can make a healthy application look missing. When the question is "what is running anywhere?" start with `-A`; when the question is "what is wrong with this one team space?" name the namespace explicitly.
 
-The default tabular output of `kubectl get` is optimized for human eyeballs scanning a screen, which makes it almost useless for scripts and automation. Kubernetes exposes every resource as a fully-typed JSON object, and `kubectl` lets you pull any subset of that object out via `-o`. The five output formats you will actually use are `wide`, `yaml`, `json`, `jsonpath`, and `custom-columns`, and each one has a clear use case.
+`kubectl explain` is easy to ignore until you need it, then it becomes a permanent habit. It reads schema information from the API server, so the answer matches the Kubernetes version and Custom Resource Definitions installed on the cluster in front of you. That means you can ask for `kubectl explain deployment.spec.strategy --recursive` while authoring a manifest and get a field map without leaving the terminal. The tool is not a tutorial, but it is an accurate dictionary for the object model you are editing.
 
-`-o wide` adds columns to the default table — typically node name, pod IP, and image — without changing the structure. Use it when you want a quick "where is this scheduled?" answer without parsing YAML. `-o yaml` and `-o json` dump the entire server-stored object, which is the source of truth for that resource. Use `-o yaml` when you want to read the manifest as a human; use `-o json` when you want to pipe it through `jq` for transformation. `-o jsonpath` and `-o custom-columns` are precision tools that extract specific fields, which is what you want when scripting against the cluster or producing dashboard data.
+Before running this, what output do you expect from `kubectl get all -n kube-system`? Many learners expect literally every resource in the namespace, but `all` is a curated shortcut for common workload resources and services. It does not include every Secret, ConfigMap, Role, ServiceAccount, CRD instance, or policy object, so it is not an audit command. When completeness matters, ask for the specific resource types you need or use `kubectl api-resources` to discover what the cluster supports.
+
+## Output Formats, Filtering, and Automation
+
+Default `kubectl get` output is designed for a human scanning a terminal. That makes it excellent for a first look and fragile for automation. A script that pipes the default table to `grep` is depending on column layout, headers, spacing, and incidental text, all of which are less stable than the underlying JSON object. Kubernetes stores resources as typed objects, and `kubectl` can render those objects as YAML, JSON, JSONPath projections, or custom tables when you need precision.
 
 ```bash
 # The five formats you will actually use
-kubectl get pods                                        # default table
-kubectl get pods -o wide                                # extra columns
-kubectl get pod nginx -o yaml                           # full object as YAML
-kubectl get pod nginx -o json | jq '.status.podIP'      # pipe to jq
+kubectl get pods
+kubectl get pods -o wide
+kubectl get pod nginx -o yaml
+kubectl get pod nginx -o json | jq '.status.podIP'
 
 # JSONPath: extract a single field
 kubectl get pod nginx -o jsonpath='{.status.podIP}'
@@ -123,73 +123,107 @@ kubectl get pod nginx -o jsonpath='{.status.podIP}'
 # JSONPath: extract a list
 kubectl get pods -o jsonpath='{.items[*].metadata.name}'
 
-# JSONPath: per-line output (for shell loops)
+# JSONPath: per-line output for shell loops
 kubectl get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'
 
-# Custom columns: tabular, scriptable, beautiful
+# Custom columns: tabular, scriptable, and readable
 kubectl get pods -o custom-columns=NAME:.metadata.name,STATUS:.status.phase,NODE:.spec.nodeName
 ```
 
-The JSONPath dialect that `kubectl` uses is similar to but not identical to the original Stefan Goessner JSONPath spec. The most common gotcha is that `kubectl`'s flavor does not support the full filter expression syntax; you cannot, for example, easily say "give me all pods where `.status.phase` equals `Running`" via JSONPath alone. For that, you either pipe to `jq` (which is the strict-superset answer) or use `--field-selector=status.phase=Running` (which is faster because the filtering happens server-side). Knowing when to use each — JSONPath for projection, jq for complex transformation, field selectors for server-side filtering — is one of the marks of a senior operator.
+Use `-o wide` when you need a little more context without giving up readability, such as pod IPs and node names. Use YAML when a human needs to inspect the full resource and JSON when a tool like `jq` will transform it. Use JSONPath when you need one or two fields directly from the object, especially in certification tasks and shell loops. Use custom columns when you want a stable table whose columns you chose instead of a default view that may hide the field you care about.
 
-For certification exams (CKA, CKAD, CKS), `-o jsonpath` and `-o custom-columns` show up constantly. A typical question reads "list the names of all pods sorted by their restart count, in descending order." The fast answer combines `--sort-by`, `-o custom-columns`, and a touch of JSONPath, and the candidates who ace the time pressure are the ones who have built muscle memory for these flags ahead of time.
+Filtering deserves the same care as formatting because the place where filtering happens changes both correctness and performance. `--field-selector=status.phase=Pending` asks the API server to return only matching objects, which is efficient and avoids downloading data you will discard. A JSONPath projection happens client-side after the objects arrive, which is fine for small lists but not a substitute for server-side selectors on large clusters. Label selectors sit between those ideas: they are server-side filters based on metadata that teams intentionally design for operations.
 
-> **Pause and predict**: What does `kubectl get pods -o jsonpath='{.items[?(@.status.phase=="Failed")].metadata.name}'` return on a cluster where two pods have failed? (It returns the names of those two pods, space-separated on one line. The `[?(...)]` is a JSONPath filter expression — `kubectl`'s JSONPath supports a subset of these. For richer filtering, prefer `--field-selector=status.phase=Failed` because the API server does the work for you.)
+Sorting is another underused form of signal extraction. `--sort-by=.metadata.creationTimestamp` helps you find the oldest stuck pod, while sorting by a status or spec field can make a noisy namespace readable during an investigation. Sorting still happens after the API server returns objects, so it is not a replacement for selectors, but it changes a long unordered list into a story. In practice, a good command often combines all three ideas: select the right objects, sort the list into a useful order, and project only the fields the next human or script needs.
 
-## Imperative vs Declarative: The Most Important Choice
+Be careful with output that looks stable only because your current cluster is small. A default pod table may appear easy to parse when there are three pods, short names, and no restarts, but the same command becomes brittle when names wrap, statuses include longer reasons, or multiple namespaces are involved. Machine-readable output is not overengineering for a shell script; it is the difference between asking the API for a field and asking your terminal layout to behave. The more important the automation, the less it should depend on what a human table happens to look like today.
 
-You can create a Kubernetes resource in two fundamentally different ways, and choosing between them is one of the first real engineering decisions you will make as an operator. Imperative commands like `kubectl run nginx --image=nginx` and `kubectl create deployment web --image=httpd:2.4` tell the cluster directly to do something. Declarative commands like `kubectl apply -f deployment.yaml` describe the desired state and let the cluster figure out how to reach it. Both produce running workloads, but they have radically different operational consequences.
+The JSONPath dialect in `kubectl` is useful, but it is not a complete data-processing language. For simple projections such as names, IPs, images, and node assignments, it is fast and portable. For grouping, joins, arithmetic, or complicated filters, pipe JSON to `jq` and make the transformation explicit. The rule of thumb is easy to remember: selectors reduce the object set, JSONPath extracts fields, and `jq` performs richer transformation when a shell one-liner needs more logic.
 
-Imperative commands are fast, terse, and great for ad-hoc work — spinning up a debugging pod, generating a YAML skeleton, scaling something quickly during an incident. They are terrible for anything that needs to be repeatable, version-controlled, or reviewed. There is no audit trail of what `kubectl run` you ran last week, no way to roll forward in another environment, and no diff against a known-good state. Declarative manifests live in Git, get reviewed in pull requests, get applied by CI or a GitOps controller, and produce a system whose state at any moment can be traced back to a specific commit. Every production-grade Kubernetes shop runs declaratively; imperative work is reserved for prototyping, exam practice, and incident triage.
+Output choices also affect how well teammates can review your work. A ticket comment that says "pods broken" is weak evidence, while a command plus precise output tells the next engineer exactly what you saw. For example, `kubectl get pods -n staging -l app=web -o custom-columns=NAME:.metadata.name,STATUS:.status.phase,NODE:.spec.nodeName` is both readable and reproducible. It gives enough context for review without dumping a full YAML object full of unrelated fields.
+
+## Imperative, Declarative, and Server-Side Apply
+
+You can create Kubernetes objects imperatively or declaratively, and the difference is bigger than syntax. Imperative commands tell the cluster to do one action now: run this pod, create this Deployment, expose this Service, scale this workload. Declarative workflows describe the desired end state in a manifest and let the API server and controllers reconcile toward that state. Both styles are legitimate, but they belong in different operational situations.
 
 ```bash
-# Imperative: fast, ephemeral, no audit trail
+# Imperative: fast, ephemeral, and useful for practice or one-off debugging
 kubectl run nginx --image=nginx:1.27.0
 kubectl create deployment web --image=httpd:2.4 --replicas=3
 kubectl expose deployment web --port=80 --target-port=80
 kubectl scale deployment web --replicas=5
 
-# Declarative: slower to write, but reviewable, repeatable, gittable
+# Declarative: slower to write, but reviewable and repeatable
 kubectl apply -f deployment.yaml
-kubectl apply -f .                            # all manifests in directory
-kubectl apply -f https://example.com/app.yaml # straight from URL
-kubectl apply -f deployment.yaml --server-side # SSA, see below
+kubectl apply -f .
+kubectl apply -f https://example.com/app.yaml
+kubectl apply -f deployment.yaml --server-side
 
 # The bridge: generate YAML imperatively, then commit it
 kubectl create deployment web --image=httpd:2.4 --replicas=3 \
-    --dry-run=client -o yaml > deployment.yaml
+  --dry-run=client -o yaml > deployment.yaml
 ```
 
-The third pattern — `--dry-run=client -o yaml` — is the single most useful trick in `kubectl` and deserves its own paragraph. It tells the client "go through the motions of the imperative command, format the resulting object as YAML, and print it without sending it to the server." You get a syntactically perfect, schema-correct skeleton that you can edit and commit. This is how every working Kubernetes engineer writes manifests in practice; nobody hand-writes a Deployment from memory because the result would be brittle and probably wrong on the first try. If a junior engineer asks how to write a manifest, the senior answer is always "use `kubectl create ... --dry-run=client -o yaml > foo.yaml` and edit the result."
+The bridge command in the last line is the practical answer to a common beginner fear: nobody expects you to write every Deployment manifest from memory. `--dry-run=client -o yaml` asks the client to build the object it would have sent, print it as YAML, and stop before contacting the API server. You get correct structure, indentation, API version, and required fields, then you edit the result and treat the file as source material. That workflow is faster and safer than copying an outdated manifest from a random search result.
 
-Server-Side Apply (`--server-side`) is the modern evolution of the declarative pattern and worth understanding even at the beginner stage. Classical client-side `apply` computes the diff between your manifest and the live object on your laptop, then sends a patch. This breaks down when multiple actors — a human, a controller, an admission webhook — all want to write to the same resource, because the client has no way to know which fields it owns. Server-Side Apply moves the merge logic into the API server, which tracks ownership of each field per actor (`fieldManager`). When two actors set conflicting values, you get a clear conflict error instead of silent overwrites. New code should default to `--server-side`; existing code can be migrated incrementally.
+Imperative commands still have a legitimate place. During an exam, a throwaway lab, or a quick diagnostic session, `kubectl run` and `kubectl create deployment` help you create a known object quickly and then inspect how Kubernetes represents it. The danger starts when a temporary command becomes undocumented production state. If another engineer cannot find the desired state in Git, they cannot review it, reproduce it in another environment, or understand why the live cluster differs from the declared system.
 
-> **Stop and think**: You ran `kubectl scale deployment web --replicas=5` during an incident, and an hour later the GitOps controller re-applies the manifest from Git, which says `replicas: 3`. What happens? (The controller wins — it sets replicas back to 3 and your imperative scale-up is lost. This is exactly why mixing imperative changes with a declarative GitOps workflow is dangerous. The fix is to update the YAML in Git, not to type a `kubectl scale` and hope nobody notices.)
+Declarative manifests have their own failure modes, so the lesson is not that YAML is automatically safe. A manifest can still be wrong, too broad, copied from an old API version, or applied to the wrong context. What declarative workflows give you is a stable artifact that can be reviewed, tested, diffed, and reapplied. That review surface is why production Kubernetes work usually treats manifests as code rather than as terminal leftovers.
 
-## Modifying and Deleting Resources Safely
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+        - name: web
+          image: httpd:2.4
+```
 
-Once a resource exists, you have four ways to change it: `kubectl apply` (re-apply an updated manifest), `kubectl edit` (open the live object in your `$EDITOR`), `kubectl patch` (send a targeted JSON or strategic-merge patch), and `kubectl set` (set a single common field, like an image). Each has a sweet spot. `apply` is the production answer because it preserves the manifest in Git as the source of truth. `edit` is convenient for one-off tweaks but leaves no audit trail. `patch` is for scripts where you need to change one field without touching the rest, common in controllers. `set image` is the ergonomic shortcut for the most common operation — rolling out a new version — without having to crack open the YAML.
+Declarative workflows also make review and rollback possible. A manifest in Git can be discussed in a pull request, compared against live state with `kubectl diff`, applied repeatedly without changing the intended outcome, and restored after an accidental manual edit. An imperative command can be appropriate during a lab or emergency, but if the change should survive beyond your terminal session, it should become a manifest change. The cluster should not depend on somebody remembering what they typed last Wednesday.
+
+The word "idempotent" is useful here because it describes a property you want in operations work. If applying the same manifest twice has the same intended result as applying it once, then retries are less scary and automation becomes simpler. Imperative commands can be safe when they are read-only or temporary, but durable infrastructure benefits from actions that can be repeated predictably. This is one reason GitOps systems are built around declared desired state rather than around logs of human commands.
+
+Server-Side Apply is the modern form of this idea for shared resources. Traditional client-side apply relies on local diffing and an annotation that tracks the last applied configuration, which can become awkward when controllers, admission webhooks, and humans all modify different fields. Server-Side Apply moves merge and field ownership tracking into the API server, where conflicts can be detected explicitly. When multiple actors manage the same object, a clear conflict is better than a silent overwrite.
+
+Field ownership can sound abstract until you imagine two actors editing the same Deployment. A human may own the image tag, a rollout controller may own strategy fields, an autoscaler may influence replicas, and an admission webhook may add labels or defaults. Server-Side Apply lets the API server remember which field manager last asserted ownership of a field, so a conflicting change can be reported instead of quietly replacing somebody else's intent. For a beginner, the practical takeaway is simple: prefer server-side previews and be cautious when several tools manage one object.
+
+Pause and predict: you use `kubectl scale deployment web --replicas=5` during a spike, but your GitOps controller still has `replicas: 3` in Git. What happens at the next reconciliation? The controller moves the live object back to the declared value because Git is its source of truth. The right fix is to update the manifest, use an autoscaler, or intentionally suspend reconciliation with a documented plan, not to keep repeating the manual scale command.
+
+## Safe Changes, Deletion, and Context Control
+
+Changing a live object is not one operation in Kubernetes; it is a family of choices with different risk profiles. `kubectl apply` updates the object from a file, `kubectl edit` opens the live object in your editor, `kubectl patch` sends a targeted patch, and `kubectl set image` changes a common field without forcing you to write JSON by hand. The safe choice depends on whether the change is durable, reviewed, automated, or a temporary intervention during troubleshooting.
 
 ```bash
 # The four ways to change a live resource
-kubectl apply -f updated-deployment.yaml             # production answer
-kubectl edit deployment web                          # opens $EDITOR live
-kubectl patch deployment web -p '{"spec":{"replicas":3}}'  # surgical
-kubectl set image deployment/web web=nginx:1.27.0    # common-case shortcut
+kubectl apply -f updated-deployment.yaml
+kubectl edit deployment web
+kubectl patch deployment web -p '{"spec":{"replicas":3}}'
+kubectl set image deployment/web web=nginx:1.27.0
 
 # Scaling
 kubectl scale deployment web --replicas=5
-kubectl scale deployment web --replicas=5 --current-replicas=3  # CAS-style guard
+kubectl scale deployment web --replicas=5 --current-replicas=3
 
-# Annotation / label tweaks (handy in scripts)
+# Annotation and label tweaks
 kubectl label pod nginx env=prod
 kubectl annotate pod nginx owner=team-payments
 ```
 
-Deletion is where Kubernetes punishes carelessness. `kubectl delete pod nginx` issues a graceful termination request: the API server marks the pod for deletion, the kubelet sends `SIGTERM` to the container, waits for `terminationGracePeriodSeconds` (default 30), and only then sends `SIGKILL`. Most of the time this is what you want. Sometimes a pod will hang in `Terminating` for minutes because the kubelet on its node has lost contact with the API server, and you need an escape hatch.
+Deletion deserves extra respect because Kubernetes deletion is a coordinated process, not just removal from a database. A normal pod deletion sets a deletion timestamp, lets the kubelet send `SIGTERM`, waits for the grace period, and then completes removal when cleanup is done. Force deletion skips important parts of that coordination from the API server's perspective. If the node is actually gone, force may be necessary; if the node is healthy and a finalizer is stuck, force can hide the object while leaving the underlying cleanup problem unsolved.
 
 ```bash
-# Graceful deletion (the default — let the container clean up)
+# Graceful deletion is the default
 kubectl delete pod nginx
 kubectl delete -f deployment.yaml
 
@@ -197,131 +231,99 @@ kubectl delete -f deployment.yaml
 kubectl delete pods --all -n test
 kubectl delete pods -l app=stale-experiment
 
-# The nuclear option (use only when the pod is truly stuck)
+# The high-risk escape hatch, only after diagnosis
 kubectl delete pod nginx --grace-period=0 --force
 
-# The safer escape hatch: drain the node first
+# The safer node-level workflow before planned maintenance
 kubectl drain kind-worker --ignore-daemonsets --delete-emptydir-data
 ```
 
-The `--grace-period=0 --force` combination is dangerous because it tells the API server to remove the pod object from `etcd` immediately, even if the kubelet has not confirmed the actual container has stopped. If the kubelet is alive and just slow, you can end up with a "ghost" container still running on the node consuming resources, with no API-server-side record of it. Reach for `--force` only when you have already confirmed the underlying node is dead or the kubelet is unrecoverable; otherwise prefer to wait, or to investigate why the graceful deletion is hanging (almost always a misbehaving finalizer).
+Wrong-target changes are the beginner mistake that experienced engineers still fear. A context combines cluster, user, and default namespace; your active context determines where the next command goes. A namespace narrows work inside one cluster, but it does not protect you from using the wrong cluster. For any destructive or persistent change, make the target visible before the command and keep namespaces explicit until you are confident the shell is scoped correctly.
 
-A subtler trap is deleting the wrong layer of the Kubernetes hierarchy. If you delete a Pod that is owned by a Deployment, the ReplicaSet controller will recreate it within seconds, and you will be left wondering why deletion "did not work." The fix is to delete the owning Deployment, which cascades through the ReplicaSet and removes its Pods. The general rule is: delete the highest-level resource you control. If you created it with `kubectl run`, delete the Pod; if you created it with `kubectl create deployment`, delete the Deployment.
+There are two common styles for context safety. Some engineers use one merged kubeconfig with many contexts and rely on visible prompts, explicit `--context`, and careful switching. Others keep separate kubeconfig files per environment and set `KUBECONFIG` per terminal session so a production shell and a local shell do not share mutable context state. Both can work, but the second style reduces accidental switching because changing clusters becomes a deliberate act of opening or configuring a shell rather than a remembered command.
 
-## Namespaces, Contexts, and the Multi-Cluster Reality
-
-Namespaces are Kubernetes's primary tenancy boundary inside a single cluster, and `kubectl` defaults to the namespace called `default` unless you tell it otherwise. Almost every real cluster has dozens of namespaces — `kube-system` for control-plane components, `kube-public` for cluster-wide info, plus per-team or per-environment namespaces like `payments-prod`, `payments-staging`, `observability`, `cert-manager`. Forgetting to specify a namespace is the single most common newbie mistake; you run `kubectl get pods`, see nothing, and assume the cluster is empty when in reality you are looking at the empty `default` namespace and your workloads are in `web`.
+Namespace defaults are useful for focused work, but they should not hide the target from you. Setting a default namespace for a practice session saves typing and makes examples cleaner, while using explicit `-n` flags in runbooks and scripts makes the target obvious to reviewers. A good compromise is to set the namespace during interactive lab work and keep explicit namespaces in anything copied into documentation, automation, or incident notes. That way convenience stays local and the durable record remains clear.
 
 ```bash
 # Namespace operations
-kubectl get namespaces                               # short: kubectl get ns
+kubectl get namespaces
 kubectl create namespace payments-staging
-kubectl get pods -n payments-staging                 # one-shot
-kubectl get pods --all-namespaces                    # short: -A
-kubectl config set-context --current --namespace=payments-staging  # persistent default
+kubectl get pods -n payments-staging
+kubectl get pods --all-namespaces
+kubectl config set-context --current --namespace=payments-staging
 
-# Context operations (clusters + users + default namespace)
-kubectl config get-contexts                          # see what you have
-kubectl config current-context                       # WHERE AM I?
+# Context operations: clusters, users, and default namespace
+kubectl config get-contexts
+kubectl config current-context
 kubectl config use-context kind-kind
 ```
 
-Contexts are the layer above namespaces. A context is a named bundle of `(cluster URL, user credential, default namespace)`, and your `~/.kube/config` may contain dozens of them as you accumulate clusters over your career. The currently active context determines which cluster your next `kubectl` command will hit. The disaster story at the start of this module was caused by a stale `prod` context being active while the engineer thought they were in `staging`. The defensive practice is to run `kubectl config current-context` before any destructive command and to install a shell prompt indicator that always shows your current context — `kube-ps1` and `starship` both have built-in modules for this.
+Dry-runs and diffs give you safer ways to ask "what would happen?" before you change shared state. Client dry-run checks what the local client can construct without contacting the API server. Server dry-run sends the request through authentication, authorization, schema validation, defaulting, and admission, then discards the write. `kubectl diff` builds on that server-side path to show a unified diff between live state and the manifest you plan to apply.
 
-A more advanced pattern is to set `KUBECONFIG` as an environment variable per shell, so that each terminal tab is bound to a specific cluster and switching clusters means opening a new tab rather than running `use-context` and hoping nothing else mutates the file. Many production-grade engineers keep one kubeconfig per cluster, version-controlled in their dotfiles or fetched via `aws eks update-kubeconfig` / `gcloud container clusters get-credentials`, and never touch the merged `~/.kube/config`. This is the pattern you should adopt before you have your first cross-cluster incident, not after.
+Dry-run output can still be misunderstood if you forget which layer performed the check. Client dry-run is excellent for quickly generating starter YAML or catching obvious local construction problems, but it cannot know about quotas, validating policies, admission webhooks, or resources that already exist on the cluster. Server dry-run is slower because it talks to the API server, yet it gives a higher-fidelity answer for shared environments. Choose the preview that matches the risk of the change.
 
-> **Pause and predict**: After running `kubectl config set-context --current --namespace=kube-system`, what does `kubectl get pods` return? (It returns the system pods — kube-apiserver, etcd, kube-controller-manager, kube-scheduler, kube-proxy, CoreDNS — without needing the `-n kube-system` flag. The setting persists in your kubeconfig file, so it survives terminal restarts. Don't forget to switch back, or your next `kubectl run` will create a pod in `kube-system` where it doesn't belong.)
+Deletion has a similar "which layer owns this?" question. If a Pod has an owner reference pointing to a ReplicaSet, deleting the Pod does not change the Deployment's desired replica count, so a replacement appears. If a namespace contains resources with finalizers, deleting the namespace starts cleanup but does not complete until those finalizers finish. In both cases, the surprising behavior becomes predictable once you ask which controller is still reconciling desired state.
 
-## Debugging Workflow: logs, exec, port-forward
+```bash
+# The two safety previews to learn early
+kubectl apply -f deployment.yaml --dry-run=client
+kubectl apply -f deployment.yaml --dry-run=server
 
-Three commands carry the bulk of day-to-day debugging: `kubectl logs`, `kubectl exec`, and `kubectl port-forward`. Each one corresponds to a question you ask while triaging a misbehaving workload. `logs` answers "what did the container print?" `exec` answers "what does the container's filesystem and network look like from the inside?" `port-forward` answers "can I talk to the container from my laptop without exposing it to the world?" Together they form a debugging vocabulary that experienced operators reach for without thinking.
+# A high-signal production preview
+kubectl diff -f deployment.yaml
+
+# The debugging escape hatch for seeing client-server traffic
+kubectl get pods --v=8 2>&1 | grep -E 'curl|http'
+```
+
+Which approach would you choose here and why: editing a production Deployment live with `kubectl edit`, or changing the manifest, running `kubectl diff`, and applying after review? The live edit may feel faster, but it creates an undocumented drift that a GitOps controller may undo. The manifest workflow has more ceremony because it preserves the decision in the place where the team can review and repeat it.
+
+The safest operators are not the ones who never type destructive commands. They are the ones who make destructive commands boring by checking context, narrowing scope, previewing when possible, and verifying afterward. That mindset scales because every later Kubernetes topic, from Services to RBAC to storage, still passes through the same API-server gate. If you build the habit here, future modules will feel like new resource types rather than entirely new ways of operating.
+
+## Debugging Workflow and Worked Example
+
+Day-to-day Kubernetes debugging usually follows a small set of commands rather than an encyclopedic tour of the CLI. `kubectl logs` answers what the container wrote to stdout and stderr. `kubectl exec` lets you run a command inside the container when the image contains the tools you need. `kubectl port-forward` creates a temporary local tunnel through the API server so you can reach an internal pod or service without exposing it publicly.
 
 ```bash
 # Logs: the first thing you check when an app misbehaves
-kubectl logs nginx                          # current container
-kubectl logs nginx -f                       # stream (Ctrl-C to stop)
-kubectl logs nginx --tail=200               # last 200 lines
-kubectl logs nginx --since=10m              # everything in the last 10 minutes
-kubectl logs nginx -c sidecar               # multi-container pod, name the container
-kubectl logs nginx --previous               # the PREVIOUS container instance — KEY for CrashLoopBackOff
-kubectl logs -l app=web --tail=50           # all pods matching a label
+kubectl logs nginx
+kubectl logs nginx -f
+kubectl logs nginx --tail=200
+kubectl logs nginx --since=10m
+kubectl logs nginx -c sidecar
+kubectl logs nginx --previous
+kubectl logs -l app=web --tail=50
 
-# Exec: drop into the container
-kubectl exec nginx -- ls /etc/nginx         # one-shot command
-kubectl exec -it nginx -- bash              # interactive shell (-i interactive, -t TTY)
-kubectl exec -it nginx -- sh                # fall back to sh if bash isn't installed
-kubectl exec -it nginx -c sidecar -- sh     # specific container in a multi-container pod
+# Exec: run commands inside the container
+kubectl exec nginx -- ls /etc/nginx
+kubectl exec -it nginx -- bash
+kubectl exec -it nginx -- sh
+kubectl exec -it nginx -c sidecar -- sh
 
-# Port-forward: tunnel a local port to a pod or service
-kubectl port-forward pod/nginx 8080:80      # localhost:8080 -> pod:80
-kubectl port-forward svc/api 9090:80        # localhost:9090 -> service:80
-kubectl port-forward deploy/web 8080:80     # picks one healthy pod from the deployment
+# Port-forward: tunnel a local port to a pod, service, or deployment
+kubectl port-forward pod/nginx 8080:80
+kubectl port-forward svc/api 9090:80
+kubectl port-forward deploy/web 8080:80
 ```
 
-`kubectl logs --previous` is the flag that separates the engineers who can debug `CrashLoopBackOff` from the ones who file tickets. When a container crashes, the kubelet starts a fresh one. `kubectl logs` without `--previous` shows the new container's output, which is often empty or just the startup banner because the new container has not crashed yet. The actual stack trace, panic, or fatal log line is in the previous, dead container's output. `kubectl logs nginx --previous` (or `-p`) retrieves it. This single flag, used reflexively, will save you hours over your career.
+The `--previous` flag is the important detail in CrashLoopBackOff investigations. When a container crashes, the kubelet starts a new container instance if the restart policy allows it. Plain `kubectl logs` reads the current instance, which may contain only a startup banner because it has not reached the failing line yet. `kubectl logs --previous` reads the terminated instance, which is often where the stack trace, panic, missing environment variable, or fatal configuration error appears.
 
-`kubectl exec` is the Kubernetes-native equivalent of `docker exec` and is essential for debugging container internals — checking environment variables, hitting an internal health endpoint, inspecting mounted ConfigMap files, running a one-shot `nslookup` to verify cluster DNS. The catch is that the container image must actually contain the binary you want to run. Distroless images and scratch-based Go binaries have no shell at all, in which case you need `kubectl debug` (covered in a later module) to attach an ephemeral debug container with the tools you need. For most beginner-grade workloads, `kubectl exec -it pod -- sh` works fine.
+Logs are only one signal, and absence of logs is not absence of failure. A container can fail before the application initializes logging, be killed by the kernel for memory pressure, fail a liveness probe, or never start because the image cannot be pulled. That is why the reliable sequence is `get` for status, `describe` for events and last state, then `logs --previous` when the object history says a container actually ran and exited. Each step answers a different question, so skipping one can create a false conclusion.
 
-`kubectl port-forward` deserves a moment of explanation because it is one of the strongest reasons Kubernetes feels easier than its predecessors. There is no firewall to punch, no SSH tunnel to set up, no LoadBalancer to provision; you just say "give me localhost:8080 mapped to pod's port 80" and the API server proxies the connection through the cluster's existing TLS-secured channel. This is how you point a local browser at an internal admin dashboard, how you connect a database GUI to a Postgres pod, and how you quickly verify that a service is responding before exposing it externally. The tunnel dies when you Ctrl-C the command, so it is also entirely safe — there is nothing to forget to clean up.
+Label-based logs are helpful when a Deployment has several replicas. `kubectl logs -l app=web --tail=50` can show recent output across matching pods, which is useful when the failing request may have landed on any replica. For deeper log analysis, production teams usually rely on centralized logging, but the direct `kubectl` command is still valuable during local labs, fresh clusters, and cases where the logging pipeline itself is part of the problem. Use it as a first responder tool, not as a replacement for durable observability.
 
-> **Stop and think**: A pod is in `CrashLoopBackOff` and `kubectl logs nginx` returns nothing. What two commands do you run, in what order, and why? (First `kubectl describe pod nginx` to read the Events block at the bottom — this catches image-pull failures, OOM kills, and admission rejections, none of which produce app logs. Then `kubectl logs nginx --previous` to see the dead container's stdout/stderr. If both come up empty, the container is being killed by the kubelet before it produces output, which usually means a failed liveness probe or a missing required environment variable.)
+`kubectl exec` is powerful but not guaranteed. Many production images are intentionally minimal, and a distroless image may not include `sh`, `bash`, `curl`, `ps`, or package managers. When that happens, the failure is not proof that the pod is broken; it means the image has no shell to execute. Later Kubernetes debugging modules cover ephemeral debug containers, but for this beginner module the lesson is simpler: use `exec` when the tool exists, and do not mistake a missing shell for an application failure.
 
-## Productivity Boosters: Aliases, Autocomplete, and `--v=8`
+Port-forwarding is similarly useful because it creates temporary reachability without changing the cluster's public surface. The traffic flows through your authenticated API-server connection, which means the tunnel ends when your command ends. That makes it ideal for checking a local browser against an internal admin page, testing a service before adding Ingress, or connecting a local client to a database during a short investigation. It is not a production access pattern, because it depends on a human terminal session and bypasses the normal service exposure design.
 
-You will type `kubectl` thousands of times a week. Optimizing the typing is not vanity — it is real productivity, and it pays back the five minutes of setup within the first day. The standard alias is `alias k=kubectl`, plus a small constellation of derived aliases for the most common queries.
-
-```bash
-# Add to ~/.bashrc or ~/.zshrc and source it
-alias k='kubectl'
-alias kgp='kubectl get pods'
-alias kgs='kubectl get services'
-alias kgd='kubectl get deployments'
-alias kgn='kubectl get nodes'
-alias kaf='kubectl apply -f'
-alias kdel='kubectl delete'
-alias klog='kubectl logs'
-alias kex='kubectl exec -it'
-alias kctx='kubectl config current-context'  # SAFETY CHECK
-alias kns='kubectl config set-context --current --namespace'
-
-# Autocomplete (so tab completes resource names, not just flags)
-source <(kubectl completion bash)               # bash
-source <(kubectl completion zsh)                # zsh
-
-# Make autocomplete work for the alias too
-complete -F __start_kubectl k                   # bash
-compdef k=kubectl                               # zsh
-```
-
-The `kubectl completion` integration is the second-biggest productivity multiplier after the alias. Once enabled, tab-completion works for verbs, resource types, resource names (it queries the cluster!), namespaces, and contexts. Typing `k get po ng<TAB>` will autocomplete `nginx-7f4b...-abc12` for you. This single feature eliminates an entire class of typo-induced bugs.
-
-Two debugging tricks round out the productivity toolkit. `kubectl --v=8` prints the underlying HTTP request and response, which is invaluable when something behaves unexpectedly and you need to see exactly what the API server received. And `--dry-run=server` (different from `--dry-run=client`) sends the request to the API server, runs admission and validation, but rolls back before persisting — so you can preview exactly what the server would do, including admission webhooks that would mutate or reject your manifest, without actually changing anything. Use it before any apply that scares you.
-
-```bash
-# The two safety previews — learn them before you learn anything else
-kubectl apply -f deployment.yaml --dry-run=client    # client validation only
-kubectl apply -f deployment.yaml --dry-run=server    # full admission, rolled back
-
-# The debugging escape hatch
-kubectl get pods --v=8 2>&1 | grep -E 'curl|http'    # see the actual HTTP call
-```
-
-## Worked Example: Diagnosing a Stuck Deployment
-
-Reading a list of commands is not the same as knowing how to use them. The following worked example walks through a realistic incident, step by step, in the order a senior engineer would actually attack it. Read it once now; come back to it as a template the next time something is broken on your own cluster. The goal of a worked example is to expose the *reasoning chain* — what you check, why you check it, what each result rules in or out — not just the commands.
-
-**Scenario.** A teammate Slacks you: "Hey, I deployed `web-frontend` to the `staging` namespace ten minutes ago and the service is not responding. Can you take a look?" You have never seen this Deployment before. Your job is to find the failure and either fix it or explain it.
-
-### Step 1: Confirm you're talking to the right cluster
+Exercise scenario: a teammate says `web-frontend` in the `staging` namespace is not responding after a deployment. You have never seen this workload before, so you start by proving the target cluster before you inspect resources. This is not busywork; it is a guardrail against applying the right command to the wrong place. It also records the first fact in the investigation: which cluster your evidence came from.
 
 ```bash
 $ kubectl config current-context
 kind-staging
 ```
 
-Good — you are on the staging cluster, not production. If this returned `prod-east-1`, you would stop and switch contexts before doing anything else. This single habit would have prevented the 2019 FinTech outage at the start of this module.
-
-### Step 2: Establish the lay of the land with `get`, not `describe`
+Now use a broad read to inspect the related pods, Deployment, and Service together. The label selector is important because it narrows the view without requiring you to know generated ReplicaSet or Pod names ahead of time. Starting with `describe` against a guessed pod name would be slower and more error-prone because it assumes you already know where the failure lives.
 
 ```bash
 $ kubectl get pods,deploy,svc -n staging -l app=web-frontend
@@ -337,38 +339,30 @@ NAME                    TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)
 service/web-frontend    ClusterIP   10.96.142.18    <none>        80/TCP
 ```
 
-The `get` already tells you the headline: all three pods are in `ImagePullBackOff`, the Deployment shows `0/3 AVAILABLE`, and the Service exists but has no healthy endpoints behind it. You now know the Service is not the problem; you do not need to look at it further. The Deployment is correctly creating pods, so the Deployment is not the problem either. The pods are failing at image pull. That is where you go next.
-
-### Step 3: Drill into one failing pod with `describe`
+The table already tells a useful story. The Deployment exists and created three pods, so the controller is active. The Service exists, but it cannot serve traffic because no pod is ready. Every pod is in `ImagePullBackOff`, which points away from application code and toward image name, tag, credentials, registry access, or node pull behavior. One `describe` on one failing pod should now be enough to confirm the exact reason.
 
 ```bash
 $ kubectl describe pod web-frontend-6c5f9b7d8-2xqpk -n staging
 [... lots of output above ...]
 Events:
-  Type     Reason     Age                 From     Message
-  ----     ------     ----                ----     -------
-  Normal   Scheduled  11m                 default  Successfully assigned staging/...
-  Normal   Pulling    9m (x4 over 11m)    kubelet  Pulling image "myregistry.local/web-frontend:v2.1.0"
-  Warning  Failed     9m (x4 over 11m)    kubelet  Failed to pull image: rpc error: code = NotFound
-                                                    desc = manifest for myregistry.local/web-frontend:v2.1.0 not found
-  Warning  Failed     9m (x4 over 11m)    kubelet  Error: ErrImagePull
-  Normal   BackOff    1m (x42 over 11m)   kubelet  Back-off pulling image
+  Type     Reason     Age                From     Message
+  ----     ------     ----               ----     -------
+  Normal   Scheduled  11m                default  Successfully assigned staging/...
+  Normal   Pulling    9m (x4 over 11m)   kubelet  Pulling image "myregistry.local/web-frontend:v2.1.0"
+  Warning  Failed     9m (x4 over 11m)   kubelet  Failed to pull image: rpc error: code = NotFound
+                                                   desc = manifest for myregistry.local/web-frontend:v2.1.0 not found
+  Warning  Failed     9m (x4 over 11m)   kubelet  Error: ErrImagePull
+  Normal   BackOff    1m (x12 over 11m)  kubelet  Back-off pulling image
 ```
 
-This is decisive. The image tag `v2.1.0` does not exist in the registry. The pod was scheduled fine; the kubelet found the node; the registry was reachable (it returned `NotFound`, not `connection refused`); the tag is simply missing. Now you know the problem is not Kubernetes — it is on the registry side or in the manifest.
-
-### Step 4: Confirm what tag the manifest actually requested
+The events make the failure concrete: the requested image tag does not exist. That means the pod was scheduled, the kubelet attempted the pull, and the registry returned a not-found response. You can confirm the Deployment's requested image with JSONPath, which is a precise field extraction rather than a manual scan through a long YAML object. This is also the kind of command you can paste into a ticket because it shows exactly what Kubernetes is trying to run.
 
 ```bash
 $ kubectl get deployment web-frontend -n staging -o jsonpath='{.spec.template.spec.containers[*].image}'
 myregistry.local/web-frontend:v2.1.0
 ```
 
-The Deployment is asking for `v2.1.0`. Either the build pipeline did not push that tag, or your teammate typed the wrong version. A quick check of the registry (or a Slack message to the build pipeline channel) confirms the latest pushed tag is `v2.0.9`. The build pipeline ran on a branch that was never merged.
-
-### Step 5: Apply the fix declaratively
-
-Update the manifest in Git, not via `kubectl edit`. The fastest way to test the fix in front of you, before the PR merges, is `kubectl set image`, but you must follow up with a Git commit, or the next GitOps reconcile will revert your change.
+The immediate repair can use `kubectl set image` if you are in a lab or staging environment and need to verify the diagnosis quickly. The durable repair should still be a manifest change in Git, because otherwise the next declarative reconcile may restore the bad image tag. Notice how the command sequence verifies rollout completion rather than assuming the API accepted command means the application is healthy.
 
 ```bash
 $ kubectl set image deployment/web-frontend -n staging web-frontend=myregistry.local/web-frontend:v2.0.9
@@ -385,17 +379,15 @@ web-frontend-7d4c8f6b9-def34      1/1     Running   0          40s
 web-frontend-7d4c8f6b9-ghi56      1/1     Running   0          35s
 ```
 
-### Step 6: Update the manifest in Git
+The reasoning chain is the asset to keep from this worked example. You checked context, scoped by namespace and label, read broad state, inspected events, extracted the exact field, changed one thing, and verified rollout. That sequence is repeatable across image failures, readiness probe failures, crash loops, and many service routing problems. The commands vary slightly, but the habit of moving from safe evidence to narrow mutation is the transferable skill.
 
-Open a PR with `image: myregistry.local/web-frontend:v2.0.9`, mention the incident in the description, and merge after review. Without this step, the next GitOps sync will set the image back to `v2.1.0` and the outage returns. Your teammate posts in Slack: "Fixed, it was a typo in the tag, PR #1138 has the correction." Total time from page to fix: under five minutes. That is what fluency in `kubectl` looks like in practice.
-
-**The reasoning chain to remember.** Notice that the worked example walked the cluster from the outside in: cluster → namespace → resource type → specific resource → specific field. At each step you asked a question and let the answer narrow the search. You did not run `kubectl describe` against every pod in the cluster; you used `get` with a label selector to scope the problem, then `describe` once to read events. This top-down funnel is how every senior operator debugs, and it is the pattern you are practicing every time you triage a ticket.
+If the same example had shown `Running` pods with zero ready endpoints, the next branch would have been different. You would inspect readiness probes, Service selectors, and endpoint slices rather than image tags. If the pods were `Pending`, you would inspect scheduling events and node resources. If the pods were ready but users still saw errors, you might port-forward to the Service and compare in-cluster behavior with external routing. The `kubectl` workflow does not force every incident into one answer; it gives you a disciplined way to choose the next question.
 
 ## Patterns & Anti-Patterns
 
-`kubectl` fluency is less about memorizing every verb and more about choosing stable operating patterns under pressure. A pattern is a small repeatable move that narrows risk: confirm the context before a delete, inspect broad state before detailed state, generate YAML before editing YAML, and prefer server validation when the cluster might mutate or reject your request. The best operators make these moves boring. They do not rely on memory during an incident, because memory is exactly what gets worse when the page arrives at an inconvenient hour.
+`kubectl` fluency is less about memorizing every subcommand and more about choosing stable operating patterns under pressure. A good pattern narrows uncertainty without increasing risk: confirm the target, read broad state, drill into one suspect, preview mutations, then verify the outcome. These moves may feel slow in a toy cluster, but they become faster than guesswork as soon as a namespace contains many controllers, generated names, and partial failures.
 
-The first production-grade pattern is the inspect-then-change loop. Start with `get` to establish scope, use `describe` to read events, use `logs --previous` only when the failure mode suggests a crashed container, and delay mutation until you can name the likely cause. This pattern scales from a local kind cluster to a large production cluster because each command reduces uncertainty without altering state. Which approach would you choose here and why: jumping straight to `kubectl edit`, or gathering one more read-only signal first?
+The patterns below deliberately combine technical commands with human workflow. Context checks are not only a CLI trick; they are a way to make the blast radius visible before action. Generated manifests are not only faster YAML; they are a way to move from a private terminal session to a reviewable artifact. Server-side validation is not only a flag; it is a way to ask the same API server that will enforce the real change to evaluate your plan first.
 
 | Pattern | Use It When | Why It Works | Scaling Consideration |
 |---|---|---|---|
@@ -404,7 +396,9 @@ The first production-grade pattern is the inspect-then-change loop. Start with `
 | Generate-then-commit manifests | You need a new Deployment, Service, Job, or ConfigMap. | `--dry-run=client -o yaml` creates valid structure, then Git becomes the reviewable source of truth. | Pair generated manifests with `kubectl diff` or `--dry-run=server` before applying to shared clusters. |
 | Server-side validation before apply | Admission webhooks, quotas, or managed fields may alter the object. | The API server evaluates the same path a real apply would take, then discards the write. | Use Server-Side Apply for shared resources so field ownership conflicts are visible instead of accidental. |
 
-Anti-patterns look efficient because they save keystrokes in the moment, but they usually move cost into the next hour. Force-deleting a pod feels decisive until the finalizer was protecting a volume cleanup. Editing a live Deployment feels faster than opening a PR until the GitOps controller puts the old image back. Grepping default table output works during a demo until a script meets a cluster with enough resources to make the output ambiguous.
+Anti-patterns usually save keystrokes by spending safety. Grepping a human table feels convenient until a script matches the wrong field. Deleting a pod owned by a Deployment feels decisive until the ReplicaSet recreates it. Editing a live object feels quick until GitOps reconciles it away. The better alternatives are not bureaucratic rituals; they are ways to keep the cluster's source of truth and your team's mental model aligned.
+
+You will still see these anti-patterns in real environments because they often work during demonstrations. A small namespace makes table greps appear reliable, a local cluster makes force deletion seem harmless, and a team without GitOps may not immediately punish live edits. The risk appears when scale, automation, or shared ownership enters the picture. The goal is to practice the safer alternative before the shortcut has become muscle memory.
 
 | Anti-pattern | What Goes Wrong | Better Alternative |
 |---|---|---|
@@ -415,7 +409,7 @@ Anti-patterns look efficient because they save keystrokes in the moment, but the
 
 ## Decision Framework
 
-When you are choosing a `kubectl` command, ask two questions before you type: am I reading or mutating state, and should this change survive beyond this terminal session? If the answer is "read only," start with `get`, then move to `describe`, `logs`, `exec`, or `port-forward` depending on the evidence. If the answer is "mutating and temporary," use an imperative command only when the risk is contained. If the answer is "mutating and durable," write or update a manifest and make Git the place where the decision is reviewed.
+When choosing a `kubectl` command, start with two questions: am I reading state or mutating it, and should this change survive beyond this terminal session? Read-only work starts broad with `get` and narrows into `describe`, `logs`, `exec`, or `port-forward` as the evidence demands. Temporary mutation may use imperative commands when the risk is low and the cleanup is clear. Durable mutation belongs in manifests, reviewed changes, server-side previews, and repeatable apply workflows.
 
 ```mermaid
 flowchart TD
@@ -433,7 +427,9 @@ flowchart TD
     Owned -->|no| Verify["Verify rollout and cleanup"]
 ```
 
-The decision tree is deliberately conservative because Kubernetes accepts many commands that are syntactically valid and operationally foolish. A production Deployment, a staging namespace, and a local practice Pod all respond to the same verbs, but they do not deserve the same level of ceremony. Use the table below as a quick judgment aid when you are tired, distracted, or working in a cluster you do not know well.
+The decision tree is conservative by design because Kubernetes accepts many commands that are syntactically valid and operationally foolish. A local practice namespace, a shared staging environment, and a production cluster may all accept the same `delete` or `apply`, but they do not deserve the same level of confidence. When you are tired, use the matrix below to slow the decision just enough to choose the right command family.
+
+Another way to use the framework is to name the source of truth before choosing the command. If the source of truth is "the live cluster for a five-minute lab," an imperative command followed by cleanup is fine. If the source of truth is "Git plus a controller," live mutation is only a temporary diagnostic move unless it is followed by a Git change. If the source of truth is "an external controller owns this field," your job may be to change that controller's inputs rather than to patch the child object directly.
 
 | Situation | Preferred Command Family | Why | Avoid |
 |---|---|---|---|
@@ -445,93 +441,95 @@ The decision tree is deliberately conservative because Kubernetes accepts many c
 
 ## Did You Know?
 
-1. **`kubectl` was not always called `kubectl`.** In the earliest commits of the Kubernetes repository in mid-2014, the CLI was named `kubecfg`, and it spoke a different protocol than the modern API. The rename to `kubectl` (pronounced inconsistently as "cube-control," "cube-cuttle," "cube-C-T-L," or "kubectl" by people who have given up) happened during the rapid pre-1.0 design churn, alongside the shift to the resource-oriented REST API we use today. The original `kubecfg` binary is preserved in the Git history as a fossil of how different the project's design used to be.
+1. **The Kubernetes CLI predates the stable 1.0 release.** Early Kubernetes development included a command-line tool named `kubecfg`, and the modern `kubectl` name arrived during the pre-1.0 evolution toward the resource-oriented API used today. That history explains why many older blog posts and examples feel different from current Kubernetes practice: the API and its tooling changed quickly before the project stabilized.
 
-2. **`kubectl explain` reads its data from your cluster, not from a hard-coded table inside the binary.** When you run `kubectl explain pod.spec.containers`, the CLI fetches the OpenAPI schema document from the API server's `/openapi/v3` endpoint and renders the relevant subtree. This means if your cluster has a Custom Resource Definition installed — say, an Argo Rollout — you can run `kubectl explain rollout.spec.strategy.canary` and get accurate, version-correct documentation for that CRD without ever leaving your terminal. The CRD author wrote those descriptions; the API server serves them; your CLI renders them.
+2. **`kubectl explain` is version-aware because it reads schema from the API server.** When you ask for fields under `pod.spec.containers`, the answer is based on the OpenAPI schema served by the cluster. That same mechanism can describe installed Custom Resource Definitions when their authors provide schema descriptions, which makes `explain` useful beyond built-in resource types.
 
-3. **`kubectl` ships its own version of `git diff` and you have probably never used it.** `kubectl diff -f deployment.yaml` shows you exactly what would change if you applied the manifest, computed by the API server using server-side dry-run. It respects admission webhooks, mutating defaults, and field ownership. Engineers who discover this command treat it as a revelation, because it eliminates the "what is this `apply` actually going to do?" anxiety that affects every change in production.
+3. **`kubectl diff` uses server-side dry-run to preview changes.** The command does not merely compare your local file with a cached copy; it asks the API server to evaluate what the object would look like after admission and defaulting, then displays the difference against live state. That makes it especially valuable in clusters with mutating webhooks or defaulting behavior.
 
-4. **The `kubectl` binary is itself a Kubernetes API client library wrapped in a CLI.** Everything `kubectl` does is implemented on top of `client-go`, the same Go library that custom controllers use. This means anything `kubectl` can do, your own code can do — including watching resources, applying server-side patches, and running port-forwards. The CLI is genuinely just a thin convenience layer over the API, which is part of why the Kubernetes ecosystem has so many alternative clients (`k9s`, `lens`, `kubie`, `stern`, etc.) that all interoperate cleanly.
+4. **The `kubectl` binary is built on the same client libraries used by controllers.** The CLI wraps Kubernetes API client behavior in terminal-friendly commands, but the underlying model is not special. Controllers, operators, and custom tools can watch resources, patch fields, and perform apply operations through the same API concepts that `kubectl` exposes interactively.
 
 ## Common Mistakes
 
 | Mistake | Why It Happens | How to Fix It |
 |---|---|---|
-| Running destructive commands in the wrong context. | Stale `current-context` from previous work; no visual prompt indicator. | Run `kubectl config current-context` reflexively before destructive ops; install `kube-ps1` or starship's k8s module so context is always visible. |
-| Forgetting `--namespace` and assuming the cluster is empty. | `kubectl get pods` defaults to `default`, which is rarely where workloads live. | Either use `-n <ns>` explicitly, or set a default per shell with `kubectl config set-context --current --namespace=<ns>`. |
-| Reading `kubectl logs` on a `CrashLoopBackOff` pod and seeing nothing. | The current container hasn't crashed yet — it just started and won't have output for a few seconds. | Use `kubectl logs <pod> --previous` (or `-p`) to read the dead container's output where the actual error is. |
-| Editing deployments with `kubectl edit` and breaking them with a typo. | The live YAML is huge; one bad indent ruins it. | Update the manifest in Git, run `kubectl diff -f` to preview, then `kubectl apply -f`. Reserve `edit` for genuinely one-off tweaks. |
-| Mixing `kubectl scale` with a GitOps controller that owns the same Deployment. | The imperative change works for a few minutes, then the controller reverts it. | Pick one source of truth. Either change the manifest in Git, or temporarily suspend the controller's reconciliation. Never both. |
-| Deleting a Pod that is owned by a Deployment and being surprised it comes back. | The ReplicaSet controller recreates owned pods within seconds. | Delete the highest-level resource you control — the Deployment, not the Pod. Use `kubectl get pod <name> -o yaml | grep ownerReferences` to see who owns a resource. |
-| Using `--force --grace-period=0` as a default. | It feels faster, and senior engineers in tutorials use it without explanation. | Reserve `--force` for confirmed-dead nodes. Otherwise, investigate the stuck finalizer or hung kubelet — forcing a delete can leave orphaned containers running on the node. |
-| Hand-writing YAML manifests from memory. | Beginners assume "real" engineers write YAML by hand. | They don't. Run `kubectl create <kind> <name> ... --dry-run=client -o yaml > file.yaml` to generate a correct skeleton, then edit. |
+| Running destructive commands in the wrong context. | Stale `current-context` from previous work; no visual prompt indicator. | Run `kubectl config current-context` before destructive operations and keep the context visible in your shell prompt. |
+| Forgetting `--namespace` and assuming the cluster is empty. | `kubectl get pods` defaults to `default`, which is often not where workloads live. | Use `-n <namespace>` explicitly, use `-A` for inventory, or set a temporary namespace on the current context. |
+| Reading plain `kubectl logs` on a CrashLoopBackOff pod and seeing nothing useful. | The current container instance may have just restarted and not reached the failing line yet. | Use `kubectl logs <pod> --previous`, then read `kubectl describe pod <pod>` Events if previous logs are empty. |
+| Editing Deployments live and forgetting to update Git. | The change works temporarily, but the durable source of truth still contains the old value. | Update the manifest, run `kubectl diff`, and apply through the same workflow your team uses for durable changes. |
+| Mixing manual `kubectl scale` with a GitOps-managed Deployment. | The controller reconciles the object back to the replica count stored in Git. | Change Git, introduce an HPA, or intentionally suspend reconciliation with a documented rollback plan. |
+| Deleting a Pod owned by a Deployment and being surprised it comes back. | The ReplicaSet controller sees the desired replica count is unmet and creates a replacement. | Delete or change the highest-level resource you own, and inspect `ownerReferences` when ownership is unclear. |
+| Using `--force --grace-period=0` as routine cleanup. | It feels fast but can bypass normal termination and finalizer-driven cleanup. | Diagnose finalizers and node health first, then force only when the remaining risk is understood. |
+| Hand-writing YAML manifests from memory. | Beginners assume fluent engineers memorize every required field and indentation detail. | Generate a skeleton with `--dry-run=client -o yaml`, then edit, review, diff, and apply the manifest. |
 
 ## Quiz
 
-1. **You are paged because the `checkout-api` pod in the `payments` namespace is failing health checks. You run `kubectl logs checkout-api -n payments` and see only a few lines of startup banner — no errors. The pod's `STATUS` column shows `CrashLoopBackOff`. What is the next single command, and what are you hoping to find?**
+1. **Your team reports that `checkout-api` in the `payments` namespace is in `CrashLoopBackOff`. Plain `kubectl logs checkout-api -n payments` shows only a startup banner. What do you run next, and why?**
    <details>
    <summary>Answer</summary>
 
-   `kubectl logs checkout-api -n payments --previous` — you are looking for the stack trace, panic, or fatal log line from the *previous* container instance, the one that just died. The current container has only been alive for a few seconds since the kubelet restarted it after the last crash, so its logs only show the startup banner before it inevitably crashes again. The `--previous` flag retrieves the dead container's last gasps, which is where the actual root cause almost always lives. If `--previous` also returns nothing, escalate to `kubectl describe pod` and read the Events at the bottom — that catches OOM kills and failed liveness probes, neither of which produce app-level logs.
+   Run `kubectl logs checkout-api -n payments --previous` because the current container instance may not be the one that failed. CrashLoopBackOff means the kubelet has already started at least one replacement container, so plain logs often show only the new instance. The previous logs are where the stack trace, fatal configuration error, or panic usually appears. If previous logs are also empty, use `kubectl describe pod checkout-api -n payments` and read Events for probe failures, OOM kills, image problems, or scheduling messages.
    </details>
 
-2. **A teammate ran `kubectl scale deployment web --replicas=10` during last night's traffic spike to handle the load. This morning you notice the Deployment is back at three replicas, even though nobody else touched it. Your team uses Argo CD for GitOps. What happened, and what is the correct fix going forward?**
+2. **A teammate scaled `deployment/web` to ten replicas with `kubectl scale`, but an hour later it is back at three replicas. The workload is managed by a GitOps controller. What happened, and what is the correct durable fix?**
    <details>
    <summary>Answer</summary>
 
-   Argo CD reconciled the Deployment back to the manifest stored in Git, which still says `replicas: 3`. The imperative `kubectl scale` worked for a while because Argo's reconciliation is periodic (default every three minutes), but as soon as the next sync ran, the controller saw a drift between desired (3) and actual (10) and reset to the Git-defined value. The correct fix is to never make imperative changes to GitOps-managed resources. Either update `replicas: 10` in the manifest in Git and merge a PR, or — if you need elastic scaling — replace the static `replicas` with a `HorizontalPodAutoscaler` resource and remove the field from the Deployment spec so Argo doesn't fight the HPA. Mixing manual `kubectl scale` with GitOps creates exactly this kind of "ghost reverts" bug.
+   The GitOps controller reconciled live state back to the manifest stored in Git, where `replicas` still says three. The manual scale command changed the live object, but it did not change the declared source of truth. The durable fix is to update the manifest, merge the reviewed change, or introduce an autoscaler if the replica count should vary. Repeating the manual scale command only creates a fight with the controller.
    </details>
 
-3. **You need to write a one-line command for a monitoring script that prints, one per line, the names of all pods in the cluster that are currently in `Pending` state, across all namespaces, sorted by creation time so the oldest stuck pod appears first. Which command satisfies this?**
+3. **You need a script to print one pod name per line for all pods currently in `Pending` state across every namespace. Which command shape is safer than grepping the default table, and why?**
    <details>
    <summary>Answer</summary>
 
-   `kubectl get pods -A --field-selector=status.phase=Pending --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'` — `--field-selector` filters server-side (cheap and fast even on huge clusters), `--sort-by` orders by creation timestamp, and the `jsonpath` `range` block produces one name per line, which is what shell loops want. A common wrong answer is to use `-o custom-columns` with `--no-headers`, which also works but is harder to compose in pipelines. Avoid `grep Pending` against the default tabular output — it works until a node name happens to contain the word "Pending" and silently breaks your script.
+   Use a server-side field selector with a machine-readable projection: `kubectl get pods -A --field-selector=status.phase=Pending -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'`. The field selector asks the API server to return only matching pods, and JSONPath extracts the stable metadata field. Grepping the human table depends on formatting and can match unrelated text. If you also need namespaces, add `{.metadata.namespace}{"/"}{.metadata.name}` inside the range.
    </details>
 
-4. **You are about to apply a substantial change to a production Deployment. Your team has a strict rule that any apply must be previewed first, including the effect of any admission webhooks (which mutate manifests in non-obvious ways). Which `kubectl` flag gives you the highest-fidelity preview, and what is the difference between it and the alternative?**
+4. **You are about to apply a production manifest in a cluster with admission webhooks that add defaults and sometimes reject objects. Which preview should you run, and what does it catch that client dry-run cannot?**
    <details>
    <summary>Answer</summary>
 
-   Use `kubectl apply -f manifest.yaml --dry-run=server`. The `server` mode sends the request all the way to the API server, runs validation and admission (including mutating and validating webhooks), and then rolls back before persisting — so you see exactly what the server would have done, including any defaults the webhooks would have injected. The alternative, `--dry-run=client`, only validates locally against the OpenAPI schema and does not contact the API server at all, so it cannot detect webhook-driven changes or quota violations. For even better diff visibility, combine with `kubectl diff -f manifest.yaml`, which performs a server-side dry-run and prints a unified diff against the live object. Production-grade workflows always run `kubectl diff` before `kubectl apply`.
+   Run `kubectl diff -f manifest.yaml` or `kubectl apply -f manifest.yaml --dry-run=server` before the real apply. Server dry-run sends the request through the API server path, including validation, defaulting, and admission, then discards the write. Client dry-run can build the object locally, but it cannot see webhook mutations, quota behavior, or server-side validation that depends on cluster state. `diff` is often the best human-facing preview because it shows exactly what would change.
    </details>
 
-5. **A pod has been sitting in `Terminating` state for forty-five minutes. The owning Deployment has been deleted, but this one Pod refuses to go away. You have already verified the node it is scheduled on is healthy and the kubelet is responding. What is the most likely cause, and what is the safe diagnostic command before you reach for `--force --grace-period=0`?**
+5. **A pod remains in `Terminating` even though its owning Deployment is gone. The node is healthy and the kubelet is responding. What should you inspect before using force deletion, and why?**
    <details>
    <summary>Answer</summary>
 
-   The most likely cause is a stuck finalizer — a controller has registered itself as needing to perform cleanup before the API server will fully delete the object, and that controller is either crashed, lagging, or has a bug. The safe diagnostic command is `kubectl get pod <name> -o yaml | grep -A2 finalizers`, which shows you exactly which finalizers are still registered. From there, you investigate the controller responsible (often something like `volume.kubernetes.io/...` or a custom controller's finalizer key). Forcing the deletion with `--force --grace-period=0` removes the API object immediately but leaves whatever cleanup the finalizer was supposed to do undone — which can mean orphaned cloud resources, leaked volumes, or stuck IP allocations. Always investigate the finalizer first; only force-delete when you have confirmed the cleanup is unnecessary or has already completed manually.
+   Inspect finalizers with a command such as `kubectl get pod <name> -o yaml` and look for the `metadata.finalizers` field. A finalizer means some controller registered cleanup work that must finish before deletion completes. Force deletion can remove the API object without allowing that cleanup to happen, which may leave external resources or node-level state behind. Once you know which finalizer is stuck, investigate the responsible controller before deciding whether force is acceptable.
    </details>
 
-6. **A new engineer on your team has been hand-writing Deployment YAML from memory and getting indentation errors and missing required fields. You want to teach them the canonical "engineer's way" to start a manifest in under thirty seconds. What single command do you show them, and why is it better than copying a YAML snippet from a blog post?**
+6. **A new engineer is copying outdated Deployment YAML from old search results and hitting validation errors. What workflow do you teach them for starting a manifest, and why is it better?**
    <details>
    <summary>Answer</summary>
 
-   `kubectl create deployment myapp --image=nginx:1.27.0 --replicas=3 --dry-run=client -o yaml > deployment.yaml`. This produces a syntactically perfect, schema-valid Deployment skeleton in under a second, using the exact API group and version your cluster's `kubectl` knows about, with all required fields populated and correct indentation. It is better than a copied blog snippet for three reasons: blog snippets often use deprecated `apiVersion`s (e.g., `extensions/v1beta1`), they may include fields that your cluster's admission policies reject, and they teach the wrong habit of relying on web search instead of the cluster itself. Pair this with `kubectl explain deployment.spec.strategy --recursive` to discover the fields you might want to add, and you have a complete authoring workflow that never requires leaving the terminal.
+   Teach them to generate a skeleton with `kubectl create deployment myapp --image=nginx:1.27.0 --replicas=3 --dry-run=client -o yaml > deployment.yaml`. That creates a valid starting object with current API versions and correct indentation, then lets the engineer edit intentional fields instead of inventing the whole structure. Pair it with `kubectl explain` to discover optional fields. The result is easier to review, repeat, and apply than a copied snippet of unknown age.
    </details>
 
-7. **Your Postgres pod in the `data` namespace exposes port 5432 internally. You need to connect from your laptop's `psql` client to inspect a few rows during an investigation, but the cluster has no LoadBalancer or Ingress for this database (deliberately — it's an internal-only service). Which command exposes it safely to your local machine, and what happens when you Ctrl-C?**
+7. **You need to implement the full beginner operations loop in a safe practice namespace: create the namespace, deploy workloads, break and repair an image rollout, tunnel traffic briefly, and clean up. What order should you follow, and why does that order reduce risk?**
    <details>
    <summary>Answer</summary>
 
-   `kubectl port-forward -n data pod/postgres-0 5432:5432` (or `svc/postgres 5432:5432` if you want to be load-balanced across replicas). This opens a TLS-tunneled connection from `localhost:5432` on your laptop, through the API server, to the pod's port 5432. Your `psql` client connects to `localhost:5432` and the bytes flow through the tunnel transparently. When you Ctrl-C the `port-forward`, the tunnel closes immediately and there is nothing left to clean up — no firewall rules, no LoadBalancer billing, no exposed network surface. This is why `port-forward` is the correct answer for ad-hoc debugging access; permanent access should go through a real Service plus an Ingress or a properly-secured external endpoint, not through engineers running `port-forward` on their laptops.
+   Start by checking `kubectl config current-context`, then create and select the practice namespace, deploy the imperative and declarative workloads, inspect them with `get`, break the image, diagnose with `describe` Events, repair with `set image`, verify rollout, use `port-forward` only after pods are healthy, and finally delete the namespace. That order reduces risk because target verification comes before mutation, broad inspection comes before detailed diagnosis, and cleanup happens after you have verified the learning objective. It also mirrors real operations work: scope first, change narrowly, prove the result, then remove temporary resources. Skipping the early context or namespace steps is how a harmless lab command turns into a wrong-cluster change.
    </details>
 
-8. **You have just run `kubectl config use-context prod-east-1` because you needed to inspect a production resource. You finished the inspection and ran `kubectl delete deployment test-experiment` — but now you are not 100% sure whether you remembered to switch back to staging first. The command has already executed. What two commands do you run, in what order, and what does each tell you?**
+8. **You ran a destructive command and only afterward wondered whether your context was still set to production. What should your immediate verification sequence be, and what habit would have prevented the uncertainty?**
    <details>
    <summary>Answer</summary>
 
-   First, `kubectl config current-context` to find out which cluster you actually just deleted from. If it returns `kind-staging`, you are fine — there was no `test-experiment` deployment in production for you to delete, or there was and it was meant to be deleted. If it returns `prod-east-1`, you have a problem. Second, run `kubectl get deployment -A | grep test-experiment` on both clusters (using `--context=prod-east-1` and `--context=kind-staging` to be explicit) to see whether the resource still exists anywhere. If it is gone from production and you should not have deleted it, your recovery path is your manifest store — re-apply the manifest from Git. This is exactly why the safety habits of running `current-context` *before* destructive commands and managing one kubeconfig per cluster matter more than any technical Kubernetes skill: the system has no undo button, and humans make mistakes. Build the habit before you need it.
+   First run `kubectl config current-context` to identify the cluster your shell is currently targeting, then explicitly query the affected resource with `--context` for both the intended and feared clusters if both contexts exist. That tells you where the resource now exists or no longer exists. The preventive habit is to run `kubectl config current-context` before destructive commands and keep context plus namespace visible in your shell prompt. Kubernetes has no general undo button, so target verification belongs before mutation, not after it.
    </details>
 
 ## Hands-On Exercise
 
-**Task.** You will create a namespace, deploy a small workload imperatively, debug it, convert it to a declarative manifest, and clean up. The goal is to exercise every command you have learned in this module against a real cluster, in roughly the same order you would use them during live operations work.
+Exercise scenario: you will create a namespace, deploy two small workloads, deliberately break one image rollout, diagnose the failure, repair it, practice structured output extraction, open a temporary port-forward, and clean up. Use a local kind or minikube cluster rather than a shared environment. The goal is not to memorize every flag; it is to rehearse a complete operations loop with explicit target checks, safe inspection, precise mutation, verification, and cleanup.
 
-**Before you start**, confirm your kubeconfig is pointing at a non-production cluster. If the next command returns anything other than your local kind/minikube cluster, stop and switch contexts before continuing — every subsequent step is destructive.
+Before you start, confirm your kubeconfig is pointing at a non-production cluster. If the next command returns anything other than a local practice cluster, stop and switch contexts before continuing. Every later step creates or deletes resources, so this pre-flight check is part of the exercise rather than optional ceremony.
+
+Keep a short note beside your terminal while you work through the lab. For each step, write the question the command answered, not just whether the command succeeded. For example, the namespace step answers "where will my objects go by default?" while the bad image step answers "can I distinguish a registry or tag failure from a crashed application?" This habit turns a sequence of commands into a troubleshooting playbook you can reuse.
 
 ```bash
-# Pre-flight check (this is the habit you are building)
+# Pre-flight check: build this habit before destructive work
 kubectl config current-context
 # Expected: something like "kind-kind" or "minikube"
 ```
@@ -548,7 +546,7 @@ kubectl config view --minify | grep namespace:
 <details>
 <summary>Solution notes</summary>
 
-The namespace should appear in `kubectl get namespaces`, and the minified config view should show `namespace: kubectl-practice`. If the namespace line is missing, repeat the `set-context --current --namespace=kubectl-practice` command and check that you did not switch contexts in another terminal.
+The namespace should appear in `kubectl get namespaces`, and the minified config view should show `namespace: kubectl-practice`. If the namespace line is missing, repeat the `set-context --current --namespace=kubectl-practice` command and verify you did not change contexts in another terminal.
 </details>
 
 ### Step 2: Deploy two workloads, one imperatively and one declaratively
@@ -559,7 +557,7 @@ kubectl create deployment imperative-web --image=nginx:1.27.0 --replicas=2
 
 # Generate a manifest declaratively, then apply it
 kubectl create deployment declarative-web --image=httpd:2.4 --replicas=2 \
-    --dry-run=client -o yaml > declarative-web.yaml
+  --dry-run=client -o yaml > declarative-web.yaml
 kubectl apply -f declarative-web.yaml
 
 # Inspect both
@@ -575,7 +573,7 @@ You should see two Deployments, two ReplicaSets, and four Pods once both rollout
 ### Step 3: Break something on purpose, then debug it
 
 ```bash
-# Push a bad image tag — this should fail
+# Push a bad image tag. This should fail.
 kubectl set image deployment/imperative-web nginx=nginx:does-not-exist
 kubectl rollout status deployment/imperative-web --timeout=30s
 # Expected: timeout, deployment stuck
@@ -620,7 +618,7 @@ The JSONPath command should print only pod names, one per line, while the custom
 
 ```bash
 POD=$(kubectl get pod -l app=imperative-web -o jsonpath='{.items[0].metadata.name}')
-kubectl exec -it $POD -- sh -c 'nginx -v && hostname && cat /etc/hostname'
+kubectl exec -it "$POD" -- sh -c 'nginx -v && hostname && cat /etc/hostname'
 ```
 
 <details>
@@ -663,21 +661,14 @@ The namespace deletion can take a little time because Kubernetes removes the res
 ### Success criteria
 
 - [ ] You ran `kubectl config current-context` before doing anything destructive and confirmed you were on a local cluster.
-- [ ] You implemented the productivity-boosting shell environment by adding the `k` alias, enabling autocomplete, and testing at least one inspection one-liner such as `k get pods`.
 - [ ] You created the `kubectl-practice` namespace and set it as the default namespace for your shell.
 - [ ] You deployed `imperative-web` with an imperative `kubectl create deployment` command and `declarative-web` from a generated YAML manifest.
 - [ ] You broke `imperative-web` by setting a non-existent image tag, observed the resulting `ImagePullBackOff`, and used `kubectl describe` Events to confirm the cause.
 - [ ] You fixed the broken Deployment by re-setting a valid image and confirmed via `kubectl rollout status` that the rollout succeeded.
 - [ ] You extracted pod names using `-o jsonpath` with a `range` block, producing one name per line.
-- [ ] You used `kubectl exec -it` to drop into a pod and successfully ran a multi-command shell snippet.
+- [ ] You used `kubectl exec -it` to run a multi-command shell snippet inside a pod.
 - [ ] You used `kubectl port-forward` to access the workload from your laptop on `localhost:8080` and saw a real HTTP response.
 - [ ] You cleaned up by deleting the namespace and confirmed it no longer exists.
-
-## Summary
-
-`kubectl` is a typed HTTPS client that turns shell commands into REST calls against the Kubernetes API server. Every operator action — reading state, creating resources, modifying live objects, debugging failures, and cleaning up — flows through the same four-part `[VERB] [TYPE] [NAME] [FLAGS]` structure, and once you internalize that, the rest of the command surface becomes navigable instead of intimidating. The three read verbs (`get`, `describe`, `explain`) each answer a different question and the senior workflow is to start broad with `get`, narrow with `describe`, and consult `explain` for schema. The single most important production discipline is choosing declarative `apply` over imperative `kubectl run`/`kubectl scale`, with `--dry-run=client -o yaml` as the bridge for generating manifests, and Server-Side Apply as the modern default for shared resources. Debugging is a reflex chain — `get`, then `describe` for events, then `logs --previous` for crash output, then `exec` for filesystem inspection — and every senior engineer can walk that chain in their sleep.
-
-The unglamorous habits matter more than the fancy commands. Run `kubectl config current-context` before any destructive operation. Set up the `k` alias and tab completion on every machine you touch. Use `kubectl diff` before any production apply. Treat `--force --grace-period=0` as a last resort, not a default. And remember that the cluster has no undo button — the discipline you build now is what protects you the next time a teammate Slacks you "the checkout service is down" at 03:00 on a Saturday.
 
 ## Sources
 

--- a/src/content/docs/prerequisites/kubernetes-basics/module-1.2-kubectl-basics.md
+++ b/src/content/docs/prerequisites/kubernetes-basics/module-1.2-kubectl-basics.md
@@ -60,7 +60,10 @@ That separation is one reason Kubernetes commands often come in pairs: one comma
 
 There is a practical security lesson here too. Because `kubectl` talks to the API server with your identity, every command is subject to authentication, authorization, and admission. A cluster may let you read pods while blocking deletes, or let you create ConfigMaps while rejecting privileged pods through policy. When a command is denied, do not work around it with a more powerful credential by reflex. First decide whether the policy is protecting the cluster from exactly the kind of change you are trying to make.
 
-Pause and predict: if `kubectl` is only an API client, what do you think happens when your kubeconfig points at a healthy cluster but your credential has expired? The pods are still running and the controllers are still reconciling, but your command fails at authentication before it can read anything useful. That distinction is operationally important because it prevents you from treating every `kubectl` error as an application outage.
+> **Pause and predict:** if `kubectl` is only an API client, what happens when your kubeconfig points at a healthy cluster but your credential has expired?
+> **Answer:** the cluster can keep reconciling and pods can keep running, but your command fails before reading objects because auth is denied.
+
+That distinction is operationally important because it prevents you from treating every `kubectl` error as an application outage.
 
 ## Command Anatomy and Read-Only Inspection
 
@@ -79,18 +82,27 @@ The read-only verbs should become your default entry point because they reduce u
 
 ```bash
 # What exists in this namespace?
+# Show all pods in the current namespace.
 kubectl get pods
+# Show pods in all namespaces.
 kubectl get pods -A
+# Focus on a specific namespace.
 kubectl get pods -n kube-system
+# Add networking and node metadata.
 kubectl get pods -o wide
+# Inspect one full object as YAML.
 kubectl get pod nginx -o yaml
 
 # What's the state of this specific thing?
+# Inspect pod status, owners, conditions, and Events.
 kubectl describe pod nginx
+# Inspect node-level status from the API object.
 kubectl describe node kind-control-plane
 
 # What fields does this resource even have?
+# See the fields available on Pod containers.
 kubectl explain pod.spec.containers
+# Expand nested resource definitions recursively.
 kubectl explain pod.spec.containers.resources --recursive
 ```
 
@@ -104,17 +116,24 @@ The namespace default is another reason read commands can mislead beginners. `ku
 
 `kubectl explain` is easy to ignore until you need it, then it becomes a permanent habit. It reads schema information from the API server, so the answer matches the Kubernetes version and Custom Resource Definitions installed on the cluster in front of you. That means you can ask for `kubectl explain deployment.spec.strategy --recursive` while authoring a manifest and get a field map without leaving the terminal. The tool is not a tutorial, but it is an accurate dictionary for the object model you are editing.
 
-Before running this, what output do you expect from `kubectl get all -n kube-system`? Many learners expect literally every resource in the namespace, but `all` is a curated shortcut for common workload resources and services. It does not include every Secret, ConfigMap, Role, ServiceAccount, CRD instance, or policy object, so it is not an audit command. When completeness matters, ask for the specific resource types you need or use `kubectl api-resources` to discover what the cluster supports.
+> **Stop and predict:** before you run `kubectl get all -n kube-system`, what objects do you expect to see?
+> **Answer:** `all` returns a curated set of common workload resources, not every Secret, ConfigMap, Role, ServiceAccount, or CRD.
+
+It does not include every Secret, ConfigMap, Role, ServiceAccount, CRD instance, or policy object, so it is not an audit command. When completeness matters, ask for the specific resource types you need or use `kubectl api-resources` to discover what the cluster supports.
 
 ## Output Formats, Filtering, and Automation
 
 Default `kubectl get` output is designed for a human scanning a terminal. That makes it excellent for a first look and fragile for automation. A script that pipes the default table to `grep` is depending on column layout, headers, spacing, and incidental text, all of which are less stable than the underlying JSON object. Kubernetes stores resources as typed objects, and `kubectl` can render those objects as YAML, JSON, JSONPath projections, or custom tables when you need precision.
 
 ```bash
-# The five formats you will actually use
+# The five formats you will actually use.
+# Human-scanned table.
 kubectl get pods
+# Extra context for quick triage.
 kubectl get pods -o wide
+# Full object for inspection.
 kubectl get pod nginx -o yaml
+# Exact JSON for script pipelines.
 kubectl get pod nginx -o json | jq '.status.podIP'
 
 # JSONPath: extract a single field
@@ -286,23 +305,31 @@ Day-to-day Kubernetes debugging usually follows a small set of commands rather t
 
 ```bash
 # Logs: the first thing you check when an app misbehaves
-kubectl logs nginx
-kubectl logs nginx -f
-kubectl logs nginx --tail=200
-kubectl logs nginx --since=10m
-kubectl logs nginx -c sidecar
-kubectl logs nginx --previous
-kubectl logs -l app=web --tail=50
+# Logs: the first thing to check when an app misbehaves.
+kubectl logs nginx # current container output
+kubectl logs nginx -f # follow output while behavior evolves
+kubectl logs nginx --tail=200 # inspect recent history
+kubectl logs nginx --since=10m # focus on the last 10 minutes
+kubectl logs nginx -c sidecar # inspect sidecar container logs
+kubectl logs nginx --previous # inspect terminated instance logs
+kubectl logs -l app=web --tail=50 # combine pod selector with latest logs
 
 # Exec: run commands inside the container
+# Run a command inside the container.
 kubectl exec nginx -- ls /etc/nginx
+# Open an interactive shell when available.
 kubectl exec -it nginx -- bash
+# Use a fallback shell if bash is missing.
 kubectl exec -it nginx -- sh
+# Run shell against a specific container.
 kubectl exec -it nginx -c sidecar -- sh
 
 # Port-forward: tunnel a local port to a pod, service, or deployment
+# Validate pod-level reachability.
 kubectl port-forward pod/nginx 8080:80
+# Validate service-level reachability.
 kubectl port-forward svc/api 9090:80
+# Validate deployment-level reachability.
 kubectl port-forward deploy/web 8080:80
 ```
 
@@ -662,6 +689,7 @@ The namespace deletion can take a little time because Kubernetes removes the res
 
 - [ ] You ran `kubectl config current-context` before doing anything destructive and confirmed you were on a local cluster.
 - [ ] You created the `kubectl-practice` namespace and set it as the default namespace for your shell.
+- [ ] You used read-only inspection (`kubectl get`, `kubectl describe`, `kubectl logs --previous`) before the repair step in the lab.
 - [ ] You deployed `imperative-web` with an imperative `kubectl create deployment` command and `declarative-web` from a generated YAML manifest.
 - [ ] You broke `imperative-web` by setting a non-existent image tag, observed the resulting `ImagePullBackOff`, and used `kubectl describe` Events to confirm the cause.
 - [ ] You fixed the broken Deployment by re-setting a valid image and confirmed via `kubectl rollout status` that the rollout succeeded.


### PR DESCRIPTION
## Summary

Rewrote `src/content/docs/prerequisites/kubernetes-basics/module-1.2-kubectl-basics.md` for #388 density, structure, alignment, anti-leak, and protected-asset gates. Cleared `revision_pending: false` and removed runnable kubectl alias/shorthand usage.

Verifier summary: tier T0; body_words=5333, mean_wpp=77.3, median_wpp=79, short_rate=0.0, max_run=0, mean_sentence_length=22.3, paragraph_count=69; all density+structure+alignment+anti_leak+protected_assets gates pass; sources check skipped per dispatch.

Protected assets preserved: code blocks 25, Mermaid diagrams 2, markdown tables 4, source URLs 12, lab URL 1; the command anatomy text diagram remains preserved as a fenced `text` block.

Commit SHA: b9e01cac

## Verification

- `../../.venv/bin/python scripts/quality/verify_module.py --glob src/content/docs/prerequisites/kubernetes-basics/module-1.2-kubectl-basics.md --skip-source-check --summary --quiet` — T0, pass
- `git diff --check -- src/content/docs/prerequisites/kubernetes-basics/module-1.2-kubectl-basics.md` — pass
- `../../.venv/bin/python scripts/test_pipeline.py` — 166 tests, OK
- `npm run build` from primary checkout on main — pass (existing route/chunk warnings only)
