### PR TITLE
feat(388): rewrite private-llm-serving (#388 pilot)

### DIFF
--- a/src/content/docs/on-premises/ai-ml-infrastructure/module-9.3-private-llm-serving.md
+++ b/src/content/docs/on-premises/ai-ml-infrastructure/module-9.3-private-llm-serving.md
@@ -1004,7 +1004,7 @@ If multi-GPU experiments show NCCL errors, confirm `/dev/shm` is mounted, inspec
 ## Sources
 
 - https://docs.vllm.ai/en/v0.7.2/serving/openai_compatible_server.html
-- https://docs.vllm.ai/en/v0.4.2/
+- https://docs.vllm.ai/en/v0.7.2/
 - https://docs.vllm.ai/en/v0.7.2/features/quantization/
 - https://huggingface.co/docs/text-generation-inference/en/index
 - https://huggingface.co/docs/text-generation-inference/en/conceptual/quantization

--- a/src/content/docs/on-premises/ai-ml-infrastructure/module-9.3-private-llm-serving.md
+++ b/src/content/docs/on-premises/ai-ml-infrastructure/module-9.3-private-llm-serving.md
@@ -4,149 +4,38 @@ description: "Deploy, scale, and optimize large language models on bare-metal Ku
 slug: on-premises/ai-ml-infrastructure/module-9.3-private-llm-serving
 sidebar:
   order: 93
+revision_pending: false
 ---
 
-# Private LLM Serving
+> **Complexity**: Advanced
+>
+> **Time to Complete**: 90-120 minutes
+>
+> **Prerequisites**: Kubernetes workloads, Services, resource requests and limits, GPU scheduling basics, Prometheus metrics, container logs, and basic LLM terminology
 
-**Complexity:** Advanced  
-**Time:** 90-120 minutes  
-**Prerequisites:** Kubernetes workloads, Services, resource requests and limits, GPU scheduling basics, Prometheus metrics, container logs, basic LLM terminology
-
-Private LLM serving means operating large language models on infrastructure your organization controls.
-
-That sounds like a deployment problem.
-
-It is also a capacity-planning problem.
-
-It is also a latency problem.
-
-It is also a security problem.
-
-It is also a cost problem.
-
-A cloud API hides the inference fleet behind one endpoint.
-
-A private deployment puts the fleet in your hands.
-
-The model weights must fit.
-
-The KV cache must fit.
-
-The scheduler must keep the GPU busy.
-
-The API must behave like the application expects.
-
-The platform must expose useful metrics before users notice degraded service.
-
-Operating Large Language Models (LLMs) on bare-metal Kubernetes shifts the operational bottleneck from CPU and network I/O to GPU memory bandwidth and interconnect speed. Private LLM serving requires specialized inference engines capable of managing the KV cache, batching requests dynamically, and handling asynchronous token streaming.
-
-This module teaches the operational primitives for serving open-weights models such as Llama, Mixtral, and Qwen on proprietary infrastructure using engines like vLLM and Text Generation Inference (TGI), wrapped in orchestrators like KServe.
-
-You will start with the physics of inference.
-
-You will then connect those constraints to Kubernetes manifests.
-
-You will compare engine choices.
-
-You will work through a failing deployment.
-
-You will finish by deploying a quantized model, testing the OpenAI-compatible API, and checking the signals that tell you whether the service is healthy.
+---
 
 ## Learning Outcomes
 
 By the end of this module, you will be able to:
 
-- **Design** a private LLM serving deployment that matches model size, context length, GPU memory, and expected traffic patterns.
+- **Design** private LLM serving deployments that match model size, context length, GPU memory, and traffic patterns.
 - **Configure** vLLM runtime parameters for KV cache sizing, continuous batching, quantization, and OpenAI-compatible serving on Kubernetes.
-- **Compare** vLLM, TGI, Ollama, KServe, and commercial serving options against production constraints such as throughput, observability, and multi-GPU support.
+- **Compare** vLLM, TGI, Ollama, KServe, NIM, and Triton against throughput, observability, multi-GPU, and support constraints.
 - **Debug** GPU scheduling, startup, NCCL, context-length, and autoscaling failures using Kubernetes events, logs, and serving metrics.
-- **Evaluate** when to split workloads, quantize weights, add replicas, or change model parallelism to improve latency and reliability.
+- **Evaluate** when to split workloads, quantize weights, add replicas, or change tensor parallelism to improve latency and reliability.
 
 ## Why This Module Matters
 
-A healthcare company moves its clinical summarization assistant from a public API to an internal Kubernetes platform.
+Hypothetical scenario: a healthcare platform team moves a clinical summarization assistant from a public model API to an internal Kubernetes platform because prompts may contain regulated records, audit trails must stay local, and finance wants GPU spend to be visible before the endpoint becomes a critical workflow. The first smoke test looks successful because a short prompt returns a plausible answer, the pod is `Running`, and the application can reach an OpenAI-compatible route. The trouble starts when production traffic mixes short chat prompts, long transcripts, retries from impatient clients, and background summarization jobs that all share the same GPU-backed serving engine.
 
-The reason is not fashion.
+The platform team quickly learns that private LLM serving is not just a Deployment manifest with a GPU limit. Model weights must fit in VRAM, the KV cache must have enough headroom for active prompts, the scheduler must keep the GPU busy without starving short requests, and the API must behave the way application teams expect during streaming, overload, and rollout. Kubernetes can tell you that a pod is healthy while the model service is still unusable because queue time, time to first token, and KV cache pressure are hidden inside the inference runtime.
 
-The assistant processes sensitive notes.
-
-The security team requires private network paths.
-
-The compliance team requires local auditability.
-
-The finance team wants predictable GPU spend.
-
-The clinicians expect the assistant to respond quickly during patient intake.
-
-The platform team deploys an open-weights model on an on-premises GPU node.
-
-The first demo works.
-
-A short prompt returns a good answer.
-
-Then production traffic arrives.
-
-Some users send long transcripts.
-
-Some users ask short chat questions.
-
-Some integrations retry after a slow response.
-
-The GPU memory looks full even when traffic is low.
-
-The pod sometimes starts and sometimes crashes.
-
-The application team asks for autoscaling.
-
-The platform team discovers that CPU and RAM charts do not explain the problem.
-
-The real bottleneck is hidden inside the inference engine.
-
-The KV cache is filling.
-
-The scheduler queue is growing.
-
-The longest requests are blocking short interactive requests.
-
-The model fits only because it was quantized.
-
-The node has enough GPU memory for weights, but not enough headroom for the runtime.
-
-Private LLM serving turns platform engineers into inference operators.
-
-They must reason about memory bandwidth, token flow, request queues, GPU topology, model formats, and Kubernetes orchestration at the same time.
-
-A private endpoint that answers one request is a demo.
-
-A private endpoint that keeps latency predictable under mixed traffic is an infrastructure product.
-
-That is the skill this module builds.
+This module treats private LLM serving as an infrastructure product. You will connect the physics of prefill and decode to runtime flags, compare engines such as vLLM and TGI, reason about quantization and tensor parallelism, and work through a slow vLLM deployment where the correct answer is not simply "add more GPU." By the end, you should be able to defend a serving design using evidence: model memory, context policy, request shape, observability, isolation, and Kubernetes failure signals.
 
 ## The Serving Stack at a Glance
 
-A private LLM deployment has more moving parts than a normal stateless web service.
-
-The container does not just run application code.
-
-It loads model weights.
-
-It reserves GPU memory.
-
-It starts an HTTP server.
-
-It tokenizes prompts.
-
-It batches requests.
-
-It streams tokens back to clients.
-
-It exposes engine metrics.
-
-Kubernetes still schedules and restarts the pod, but Kubernetes does not understand token latency by default.
-
-The inference engine is where most serving intelligence lives.
-
-A useful mental model is to separate the stack into five layers.
+A private LLM deployment has more moving parts than a normal stateless web service because the container does not only execute application code. It loads model weights, reserves GPU memory, tokenizes prompts, batches active sequences, streams output tokens, and exposes engine metrics while Kubernetes schedules and restarts the pod around it. Kubernetes understands pods, Services, resources, probes, and events; the inference engine understands token counts, KV cache pages, queue length, and decoding loops. A useful operating model separates the route, serving abstraction, engine, and hardware layers so you can identify which part is actually failing.
 
 ```text
 +-----------------------------------------------------------------------+
@@ -180,66 +69,20 @@ A useful mental model is to separate the stack into five layers.
 +-----------------------------------------------------------------------+
 ```
 
-Each layer can fail differently.
+Each layer produces different evidence when it breaks. A Gateway issue may surface as `503` responses, a Service selector mismatch may produce no endpoints, a scheduler issue may leave the pod in `Pending`, a gated model may fail during download, and a GPU memory issue may crash only after the container starts loading weights. A workload-mixing issue can be more subtle: the endpoint returns good answers under light traffic, then short chat requests wait behind long prompts because the engine has filled active batch slots and KV cache pages.
 
-A Gateway problem may produce `503` responses.
-
-A Service selector problem may produce no endpoints.
-
-A scheduler problem may leave pods in `Pending`.
-
-A model download problem may produce authorization errors.
-
-A GPU memory problem may crash after the container starts.
-
-A workload-mixing problem may look like random latency spikes.
-
-This is why private LLM serving requires end-to-end reasoning.
-
-You cannot debug it by looking at only one dashboard.
+The operator's job is to keep the API view and the engine view connected. The API view tells you whether clients can send the request shape they expect, including streaming chat completions and status codes during overload. The engine view tells you whether the deployment can survive representative token counts, concurrent users, and rollout conditions. Before running any command in this module, keep that split in mind: a working HTTP route is necessary, but it is not proof that the service has enough inference capacity.
 
 ## The Physics of LLM Inference
 
-LLM inference consists of two distinct phases.
+LLM inference has two phases that stress hardware differently. During prefill, the model processes the input prompt and builds attention state for the sequence; this phase is often compute-heavy because the GPU can run large matrix operations over the prompt. During decode, the model emits output tokens one at a time; this phase repeatedly reads weights and attention state from high-bandwidth GPU memory, so memory bandwidth and cache management dominate more often than raw floating-point peak. If you tune a serving stack without separating these phases, you will misread both latency and utilization.
 
-Understanding these phases is critical for tuning deployment manifests and explaining why a GPU may be expensive but still slow.
+1. **Prefill phase, also called time to first token or TTFT:** The model processes the prompt all at once and prepares the first generated token. Long documents, large retrieved contexts, and verbose chat history increase prefill work and KV cache allocation.
+2. **Decode phase, often measured as time per output token or TPOT:** The model generates one token after another autoregressively. Long answers, code generation, and batch jobs keep decode running long after the first token appears.
 
-1. **Prefill Phase (Time to First Token - TTFT):** The model processes the input prompt all at once. This phase is heavily **compute-bound**. The GPU matrix multiplication units, especially Tensor Cores on NVIDIA hardware, can be fully saturated.
-2. **Decode Phase (Time Per Output Token - TPOT):** The model generates tokens one by one autoregressively. Each new token requires reading model weights and attention state from GPU High Bandwidth Memory (HBM). This phase is heavily **memory-bandwidth-bound**.
+A short prompt with a long answer stresses decode, a long document with a short answer stresses prefill and cache capacity, and a chatbot with many concurrent users stresses the scheduler that decides which sequences enter each iteration. The same GPU can therefore feel fast for one workload and slow for another. Pause and predict: if two users share the same model and one sends a long transcript while the other asks a short operational question, which latency metric will reveal the short user's pain first, TTFT or total request duration?
 
-The prefill phase answers the question:
-
-"How quickly can the model understand the prompt?"
-
-The decode phase answers the question:
-
-"How quickly can the model emit each next token?"
-
-A short prompt with a long answer stresses decode.
-
-A long document with a short answer stresses prefill and KV cache capacity.
-
-A chatbot with many concurrent users stresses the scheduler.
-
-A summarization system with long context windows stresses memory.
-
-The two phases share hardware but create different bottlenecks.
-
-Because the decode phase underutilizes compute while stressing memory bandwidth, serving one request at a time is inefficient.
-
-The engine reads the same model weights repeatedly for one sequence.
-
-Inference engines improve utilization by grouping multiple requests together.
-
-The engine reads weights once and applies them to many active sequences.
-
-This is why the serving engine matters.
-
-A plain Python loop around `model.generate()` is not enough for production.
-
-### Token Flow
-
-A single request moves through the serving engine in stages.
+A single request moves through the serving engine in stages, and each stage gives you a different place to look during debugging. Tokenization and HTTP handling can bottleneck on CPU, prefill can bottleneck on compute and prompt size, decode can bottleneck on memory bandwidth, and streaming can expose network or client timeout behavior. The application sees one API call, but the engine sees token IDs, active sequences, cache pages, scheduling iterations, and output limits.
 
 ```text
 +----------------+     +----------------+     +-----------------------+
@@ -254,45 +97,9 @@ A single request moves through the serving engine in stages.
 +----------------+     +----------------+     +-----------------------+
 ```
 
-The application sees an API call.
+Traditional static batching wastes GPU work when sequence lengths vary because the batch behaves like a group reservation: if one request finishes early, its slot can sit idle until the longest request completes. Modern LLM engines use continuous batching, also called in-flight batching, so finished sequences can leave and new sequences can enter between decoding iterations. This keeps memory bandwidth busier and improves throughput under mixed traffic, but it also means the runtime needs a careful way to remember the attention state for sequences that are still active.
 
-The engine sees token counts, batch slots, KV cache pages, and scheduling decisions.
-
-A platform engineer needs both views.
-
-The API view tells you whether the app contract works.
-
-The engine view tells you whether the deployment can survive load.
-
-### Continuous Batching and PagedAttention
-
-Traditional static batching required all requests in a batch to finish before a new batch could start.
-
-That wastes cycles when sequence lengths vary.
-
-If one request asks for a short answer and another asks for a long answer, the short one finishes early.
-
-In a static batch, the slot may sit idle until the long request finishes.
-
-Modern inference relies on **Continuous Batching**, also known as in-flight batching.
-
-As soon as one sequence emits its end-of-sequence token or reaches its output limit, a new prompt from the queue is swapped into the active batch.
-
-The batch is not a fixed group of requests.
-
-It is a moving set of active sequences.
-
-That moving set keeps memory bandwidth busy.
-
-> **Stop and think:** If continuous batching allows sequences to be swapped out dynamically, how does the engine keep track of the attention state for an incomplete sequence without running out of memory?
-
-To support continuous batching without memory fragmentation, engines use **PagedAttention**.
-
-Similar to operating system virtual memory, PagedAttention divides the KV cache into fixed-size blocks.
-
-Instead of requiring one large contiguous allocation per sequence, the engine can map each sequence to a set of cache pages.
-
-That makes it easier to add, remove, and grow sequences dynamically.
+PagedAttention solves the cache-fragmentation problem by treating the KV cache more like virtual memory than one giant contiguous buffer per request. The engine divides cache memory into fixed-size blocks, maps each active sequence to the blocks it needs, and returns blocks when a sequence completes or is evicted. This is the mechanism that lets continuous batching admit new work without constantly copying huge cache regions, and it is why context length policy has a direct effect on how many users the endpoint can serve.
 
 ```text
 +----------------------+        +--------------------------------------+
@@ -305,51 +112,13 @@ That makes it easier to add, remove, and grow sequences dynamically.
 +----------------------+        +--------------------------------------+
 ```
 
-The page mapping matters operationally.
+The page mapping matters operationally because every context-length decision becomes a cache-admission decision. If the cache has enough free pages, the engine can admit more active sequences; if it is nearly full, new requests wait; if one large request consumes too many pages, short requests can suffer even when their own prompts are tiny. Before increasing `--max-model-len`, ask what behavior you want when users send prompts near that limit, because the model's theoretical maximum context length is not automatically your production policy.
 
-If the cache has enough free pages, the engine admits more work.
-
-If the cache is nearly full, new requests queue.
-
-If the context length is too high for the GPU memory budget, one large request can consume enough pages to harm everyone else.
-
-> **Pause and predict:** If you allocate nearly all GPU memory to the KV cache, what will happen when PyTorch tries to initialize its CUDA context?
-
-:::note
-When configuring vLLM, the `gpu-memory-utilization` flag reserves a portion of GPU HBM for model execution and KV cache planning. If you set this too high on a shared or tightly sized GPU, PyTorch, CUDA, and communication libraries may not have enough headroom to initialize. If you set it too low, your batch sizes will be artificially constrained, reducing throughput.
-:::
-
-The value is not a moral preference.
-
-It is a capacity tradeoff.
-
-Higher utilization can increase the number of active tokens.
-
-Higher utilization can also make startup fragile.
-
-Lower utilization can leave memory unused.
-
-Lower utilization can also keep the service stable during model load and runtime spikes.
-
-### The Four Numbers That Decide Whether a Model Fits
-
-Before writing a Deployment manifest, estimate four numbers.
-
-First, estimate model weight memory.
-
-Second, estimate KV cache memory.
-
-Third, reserve runtime overhead.
-
-Fourth, confirm the node has enough CPU and system RAM to feed the GPU.
-
-A rough model-weight estimate is:
+Before writing a Deployment manifest, estimate four numbers: model weight memory, KV cache memory, runtime overhead, and CPU plus system RAM required to feed the GPU. Weight memory is roughly `parameter_count * bytes_per_parameter`, but exact values depend on architecture, quantization format, metadata, loaded adapters, and runtime kernels. Startup proves that weights and initialization fit; serving proves that weights, runtime overhead, and cache fit together under representative prompt lengths.
 
 ```text
 parameter_count * bytes_per_parameter
 ```
-
-Examples:
 
 ```text
 8B model in FP16  ~= 16 GB for weights
@@ -358,34 +127,9 @@ Examples:
 70B model in 4-bit ~= 35-45 GB for weights, depending on format and metadata
 ```
 
-These are planning numbers, not exact vendor promises.
+The KV cache depends on layer count, hidden size, active sequences, context length, cache dtype, and batching strategy, which makes it workload-dependent rather than a fixed property of the model. This is why a model can start cleanly and still fail during normal usage. If the deployment barely fits at startup, long prompts and concurrent users may push the endpoint into queue growth, request rejection, or CUDA out-of-memory errors even though the Kubernetes pod originally looked healthy.
 
-The exact footprint depends on architecture, quantization format, runtime kernels, and loaded adapters.
-
-The KV cache depends on:
-
-- number of layers
-- hidden size
-- number of concurrent sequences
-- context length
-- dtype used for cache
-- batching strategy
-
-A useful operational rule is:
-
-If a model barely fits at startup, it may still fail under real prompts.
-
-Startup proves the weights fit.
-
-Serving proves the weights and cache fit together.
-
-### Latency Metrics That Actually Matter
-
-Private LLM serving teams often start with average response time.
-
-Average response time is too blunt.
-
-Use metrics that separate user experience from engine mechanics.
+Latency metrics should separate user experience from engine mechanics. Average response time is too blunt because a streaming chat service may feel responsive when TTFT is low even if total generation lasts many seconds, while a batch summarizer may care more about aggregate tokens per second and completion deadlines. Use a small set of metrics that explain where time is spent and whether the serving engine is saturated.
 
 | Metric | What It Means | Why It Matters |
 | :--- | :--- | :--- |
@@ -397,19 +141,11 @@ Use metrics that separate user experience from engine mechanics.
 | KV cache usage | Portion of cache pages in use | Predicts admission pressure and OOM risk |
 | Error rate | Failed or rejected requests | Reveals overload, auth, routing, or runtime failures |
 
-Do not tune only for maximum tokens per second.
-
-A batch summarization service may value throughput.
-
-An interactive chat service may value low TTFT.
-
-A retrieval-augmented generation service may value consistent tail latency.
-
-The same GPU can be configured differently for each.
+Do not tune only for maximum tokens per second. A batch summarization service may accept higher TTFT in exchange for efficient throughput, while an interactive chat service should protect short prompts from waiting behind long documents. The same model and GPU can be configured differently for each class of work, so the right question is not "is the model fast?" but "is this endpoint tuned for this request shape and service objective?"
 
 ## Inference Engine Landscape
 
-Selecting the right engine dictates your container configuration, available metrics, request API, model format, and hardware utilization limits.
+The inference engine dictates container flags, model formats, metrics, request APIs, multi-GPU behavior, and many failure modes. vLLM is commonly chosen for high-throughput GPU serving, continuous batching, PagedAttention, and OpenAI-compatible API serving. Text Generation Inference, or TGI, is common where Hugging Face model lifecycle and production server features are already part of the platform. Ollama is useful for local development, edge-style experiments, and small internal tools, but it is rarely the first choice for a shared high-concurrency enterprise endpoint.
 
 | Feature / Engine | vLLM | Text Generation Inference (TGI) | Ollama |
 | :--- | :--- | :--- | :--- |
@@ -420,27 +156,7 @@ Selecting the right engine dictates your container configuration, available metr
 | **Multi-GPU** | Tensor Parallelism (Ray/NCCL) | Tensor Parallelism (NCCL) | Limited/Basic |
 | **Metrics** | Prometheus endpoint built-in | Prometheus endpoint built-in | None native (requires exporters) |
 
-For bare-metal production, **vLLM** and **TGI** are common choices.
-
-vLLM is often selected when the platform team wants aggressive continuous batching, OpenAI-compatible serving, and strong throughput on GPU-backed workloads.
-
-TGI is often selected when the team is already deep in the Hugging Face ecosystem and wants a production server with good model-hub integration.
-
-Ollama is useful for local development, small internal tools, or edge-style deployments.
-
-It is usually not the first choice for a high-concurrency shared enterprise endpoint.
-
-Commercial alternatives are also common in enterprise Kubernetes environments.
-
-**NVIDIA NIM** packages optimized inference containers and operational guidance for supported models.
-
-**NVIDIA Triton Inference Server** can serve multiple model backends, including TensorRT-LLM and vLLM-style paths depending on the deployment pattern.
-
-These can be valuable when vendor support, standardized packaging, or integration with NVIDIA tooling matters more than maximum flexibility.
-
-### Decision Matrix
-
-Choose based on the workload, not only the benchmark.
+Commercial serving paths also appear in private Kubernetes environments. NVIDIA NIM packages optimized containers and supported model paths for teams that value vendor-tested runtime packaging, while NVIDIA Triton Inference Server can be useful when the platform already standardizes on multi-backend inference and TensorRT-LLM style optimization. These options can reduce operational ambiguity, but they do not remove the need to set context policy, provision GPUs, observe latency, and test the real workload.
 
 | Constraint | Good Fit | Why |
 | :--- | :--- | :--- |
@@ -451,23 +167,9 @@ Choose based on the workload, not only the benchmark.
 | Multi-model inference platform | KServe plus selected runtimes | Controller layer can standardize routing and rollout patterns |
 | Highest control over manifests | Raw Deployments | Fewer abstractions, but more platform work |
 
-A senior operator should be able to explain why an engine was chosen.
+A senior operator should be able to explain the engine choice without leaning on popularity. A defensible answer includes model support, quantization support, batching behavior, API contract, metrics, GPU topology, operational skill, support model, and failure behavior under overload. Which approach would you choose for a regulated internal chat endpoint that must preserve OpenAI-style client compatibility but also provide Prometheus metrics and strong GPU utilization, and what evidence would you gather before committing?
 
-"Everyone uses it" is not enough.
-
-A defensible answer includes model support, metrics, batching, API contract, GPU topology, operational skill, and failure behavior.
-
-### OpenAI-Compatible APIs
-
-Many private deployments expose OpenAI-compatible endpoints.
-
-This is operationally useful.
-
-Applications can switch from a public API to a private endpoint with smaller code changes.
-
-SDKs, proxies, and internal tools often already understand the request format.
-
-A typical chat request looks like this:
+Many private deployments expose OpenAI-compatible endpoints because application teams already have SDKs, proxies, and request schemas built around `/v1/chat/completions`. Compatibility lowers migration friction, but it is not the same as operational equivalence. Two endpoints may accept the same JSON shape while behaving very differently under streaming, long prompts, client retries, server-side limits, and queue saturation.
 
 ```bash
 curl -X POST http://127.0.0.1:8080/v1/chat/completions \
@@ -483,53 +185,11 @@ curl -X POST http://127.0.0.1:8080/v1/chat/completions \
   }'
 ```
 
-The API shape hides important internal differences.
+The API request above is intentionally simple, but production readiness depends on what happens around it. Does the endpoint stream promptly when the prompt is long, does it reject requests with a clear error when limits are exceeded, does it expose metrics that distinguish queue time from generation time, and does it apply authentication before expensive work begins? Treat OpenAI compatibility as the interface contract, then test the runtime as the capacity contract.
 
-Two endpoints may both accept `/v1/chat/completions`.
+## Quantization and Multi-GPU Capacity Planning
 
-One may have excellent streaming latency.
-
-One may queue badly under long prompts.
-
-One may expose useful Prometheus metrics.
-
-One may have weak visibility into cache pressure.
-
-Compatibility is the starting point.
-
-Operational behavior is the deciding factor.
-
-## Quantization Strategies for Bare Metal
-
-If you cannot afford large multi-GPU nodes for every model, quantization is one of your primary levers.
-
-Quantization reduces the precision of model weights.
-
-That reduces VRAM requirements.
-
-It can also improve decode speed because less data must be moved through memory.
-
-But quantization is not free.
-
-The wrong format can reduce quality, disable optimized kernels, or slow production inference.
-
-Start with the operational question:
-
-What model quality is required, and what hardware budget is available?
-
-Then choose the lowest precision that meets quality and latency requirements.
-
-1. **FP16 / BF16:** Unquantized baseline. This is safest for quality and easiest to reason about, but it consumes the most VRAM.
-2. **AWQ (Activation-aware Weight Quantization):** 4-bit weight quantization. It is widely used for GPU inference and is often a strong fit for vLLM.
-3. **GPTQ:** Another 4-bit weight quantization approach. It can be useful when the model distribution provides GPTQ artifacts and the runtime has optimized kernels.
-4. **FP8:** Strong option on hardware that supports it well. It can provide high throughput with less memory than FP16 while preserving good quality for many workloads.
-5. **GGUF:** Common with `llama.cpp` and Ollama. It is excellent for local and CPU-oriented workflows, but it is not usually the best format for high-batch GPU serving.
-
-:::caution
-Do not assume `BitsAndBytes` is the right production serving format just because it is familiar from fine-tuning workflows. Some quantization approaches are convenient for experimentation but use kernels that are not ideal for high-throughput inference. Validate throughput, latency, and quality with the actual serving engine before standardizing on a format.
-:::
-
-### Quantization Tradeoff Table
+Quantization is one of the primary levers for private LLM serving because it reduces the precision of model weights, lowers VRAM requirements, and can improve decode speed by reducing memory movement. It is not a free upgrade. The wrong format can reduce answer quality, disable optimized kernels, slow inference, or force you into an engine that does not match the rest of the platform. Start with the operational question: what answer quality, context length, throughput, and hardware budget does this endpoint actually require?
 
 | Format | Typical Memory Reduction | Production Serving Fit | What to Validate |
 | :--- | :--- | :--- | :--- |
@@ -539,105 +199,28 @@ Do not assume `BitsAndBytes` is the right production serving format just because
 | FP8 | Medium to high | Strong on supported accelerators | Hardware support and quality |
 | GGUF | Variable | Good local and CPU fit | Whether GPU serving goals still hold |
 
-Quantization should be tested with representative prompts.
+FP16 and BF16 are the easiest baselines to reason about because they avoid many quantization-specific quality and kernel questions, but they consume the most memory. AWQ and GPTQ are common 4-bit approaches for GPU serving when pre-quantized artifacts and optimized kernels exist. FP8 can be strong on hardware that supports it well. GGUF is excellent in llama.cpp and Ollama-style workflows, especially for local and CPU-oriented usage, but it should not be assumed to be the right artifact for a high-concurrency GPU endpoint.
 
-A generic benchmark may miss domain failures.
+Representative evaluation matters more than generic benchmark confidence. A coding assistant, legal summarizer, and clinical note assistant can react differently to the same quantization level because the errors that matter are domain-specific. Build a small evaluation set before declaring a quantized model production-ready, and include prompts that resemble your actual failures: long context, terse questions, structured output, domain vocabulary, and safety-sensitive edge cases.
 
-For example, a coding assistant, legal summarizer, and clinical note assistant may react differently to the same quantization level.
+Before running this, what output do you expect from a one-GPU endpoint if an 8B FP16 model narrowly fits but the service also needs a 4096-token context window and multiple concurrent chat users? A practical first test is an AWQ artifact served by the target engine, because quantized weights free memory for KV cache pages while preserving a useful GPU serving path. You would still cap context length, benchmark quality, and verify latency rather than relying on the hope that most users will send short prompts.
 
-A platform team should create a small evaluation set before declaring a quantized model production-ready.
+When a model exceeds the memory of one GPU, you need a splitting strategy rather than more replicas of a pod that cannot load. Tensor parallelism slices matrix operations across multiple GPUs and is usually the first approach to evaluate on a single node with fast GPU interconnect, such as NVLink. Pipeline parallelism slices model layers across stages and can be necessary for very large models, but it introduces pipeline bubbles and network sensitivity that must be measured carefully.
 
-### Active Learning Prompt
-
-Your team has one 24 GB GPU and wants to serve an 8B model for internal chat.
-
-The FP16 weights fit only narrowly, and the team also wants a 4096-token context window.
-
-Which would you try first?
-
-- Keep FP16 and set a low concurrency limit.
-- Use AWQ and reserve more VRAM for the KV cache.
-- Use a much larger context window and hope most users send short prompts.
-
-Write your choice before reading on.
-
-A practical answer is to test an AWQ model.
-
-The quantized weights free memory for the KV cache.
-
-That improves concurrency and reduces the risk that normal prompts exhaust the cache.
-
-You would still cap context length and benchmark quality.
-
-You would not rely on "most users send short prompts" as a production control.
-
-## Multi-GPU Scaling: Tensor Parallelism vs. Pipeline Parallelism
-
-When a model's weights exceed the memory of a single GPU, the model must be split.
-
-For example, a 70B parameter model in FP16 requires far more VRAM than a single 80 GB GPU can provide once runtime and KV cache overhead are included.
-
-There are two major splitting strategies.
-
-- **Tensor Parallelism (TP):** Slices individual matrix operations across multiple GPUs. It requires high-bandwidth interconnects such as NVLink for good performance. In Kubernetes, this usually means the GPUs must reside on the same physical node. In vLLM, this is configured with `--tensor-parallel-size`.
-- **Pipeline Parallelism (PP):** Slices the model by layers. Early layers run on one GPU or node, later layers run on another. It can span across nodes in some systems, but it introduces pipeline bubbles and network sensitivity.
-
-Tensor parallelism is usually the first choice for a multi-GPU node with fast interconnect.
-
-Pipeline parallelism is more complex.
-
-It may be necessary for very large models, but it requires careful measurement.
-
-### GPU Topology Matters
-
-Not all "four GPU" nodes are equal.
-
-A node with NVLink between GPUs behaves differently from a node where GPUs communicate only over PCIe.
-
-A node with two separate CPU sockets may have Non-Uniform Memory Access effects.
-
-A pod asking for multiple GPUs does not automatically guarantee ideal topology.
-
-Kubernetes schedules extended resources.
-
-It does not fully understand every GPU interconnect detail by default.
-
-Use node labels, runtime topology features, or operator-provided metadata when placement matters.
+GPU topology turns a simple "four GPU node" statement into an engineering question. Four GPUs connected with high-bandwidth interconnect behave differently from four GPUs that communicate only over PCIe, and a dual-socket host can add non-uniform memory effects that matter under load. Kubernetes schedules extended resources such as `nvidia.com/gpu`; it does not automatically prove that the selected GPUs have the topology your tensor-parallel runtime expects.
 
 ```bash
 kubectl describe node <gpu-node-name>
 ```
 
-Look for allocatable GPU count, device plugin health, and labels added by the GPU operator.
-
-For NVIDIA environments, GPU Feature Discovery can label nodes with useful hardware properties.
-
-Those labels can guide scheduling.
-
-A basic node selector may look like this:
+Look for allocatable GPU count, device plugin health, and labels added by the GPU operator or GPU Feature Discovery. A basic node selector may be enough for a lab, but production pools usually distinguish GPU model, memory size, interconnect class, and placement policy. The goal is to prevent a model from landing on a node class that technically advertises a GPU but cannot run the model reliably.
 
 ```yaml
 nodeSelector:
   nvidia.com/gpu.present: "true"
 ```
 
-A more production-ready setup often uses labels that distinguish GPU model, memory size, or node pool.
-
-The goal is to avoid scheduling a model onto a node class that cannot run it reliably.
-
-### NCCL and Shared Memory
-
-NCCL is the NVIDIA Collective Communications Library.
-
-Tensor-parallel inference depends on it for communication between GPU workers.
-
-When NCCL fails, the failure may look like a random model crash.
-
-It is often a communication, shared memory, topology, or timeout issue.
-
-The default container shared memory allocation can be too small for multi-GPU inference.
-
-Mounting a memory-backed `emptyDir` to `/dev/shm` gives the workers more room for inter-process communication.
+NCCL, the NVIDIA Collective Communications Library, becomes part of your serving reliability story when tensor-parallel workers need to coordinate across GPUs. NCCL failures often look like random model crashes unless you connect them to shared memory, topology, CPU contention, and timeout behavior. The default container shared memory allocation can be too small, so multi-GPU inference commonly mounts a memory-backed `emptyDir` at `/dev/shm`.
 
 ```yaml
 volumeMounts:
@@ -650,63 +233,13 @@ volumes:
     sizeLimit: 2Gi
 ```
 
-For high-throughput multi-GPU workloads, you may need a larger value.
+The `2Gi` value is a starting point from the preserved lab pattern, not a universal truth. Larger models, more workers, and heavier traffic may need more shared memory, while smaller single-GPU deployments may not be sensitive to it. Measure under representative load before turning a copied value into a platform standard.
 
-Measure rather than copying one number forever.
+## Orchestrating with KServe and Kubernetes
 
-## Orchestrating with KServe
+Running raw Deployments of vLLM is a useful first step because it exposes the mechanics: resource requests, model loading, cache volumes, service routing, probes, and logs. Production teams often need a higher-level serving abstraction once they operate multiple models, rollout patterns, autoscaling policies, traffic splits, and governance rules. KServe can provide that Kubernetes-native abstraction through custom resources, but it does not remove the physics of model memory, cache pressure, or request shape.
 
-Running raw Deployments of vLLM works.
-
-For a single endpoint, it may even be the right first step.
-
-But production teams usually need more than a pod.
-
-They need model rollout patterns.
-
-They need standardized routing.
-
-They need autoscaling integration.
-
-They need traffic splitting.
-
-They need a consistent API for serving different model types.
-
-That is where **KServe** can help.
-
-KServe is built around Kubernetes controllers and CRDs for model serving.
-
-It can integrate with Knative Serving for request-based autoscaling and scale-to-zero patterns.
-
-It can also run in modes that behave more like raw Kubernetes Deployments depending on runtime and feature needs.
-
-For LLM workloads, KServe is useful when the organization wants a standard serving abstraction.
-
-It is not magic.
-
-The runtime still needs enough GPU memory.
-
-The autoscaler still needs meaningful metrics.
-
-The model still needs sane context limits.
-
-The route still needs authentication and traffic management.
-
-> **Stop and think:** How do you autoscale a pod that deliberately consumes nearly all of its GPU memory allocation upon startup?
-
-CPU and memory autoscaling are weak signals for LLM serving.
-
-A vLLM container may allocate a large portion of GPU memory before receiving traffic.
-
-A pod can look "full" while idle.
-
-A CPU spike may indicate tokenization pressure, but not necessarily GPU saturation.
-
-A better autoscaling signal comes from concurrency, queue length, token throughput, and KV cache pressure.
-
-:::caution
-KServe multi-node or multi-GPU LLM serving may have runtime-specific limitations depending on the version, deployment mode, and backend. Always validate whether autoscaling, RawDeployment mode, Knative mode, and the selected runtime support your exact topology before promising scale behavior to application teams.
-:::
+KServe is useful when the organization wants a standard API for model serving across runtimes and model types. It can integrate with Knative Serving for request-based routing and autoscaling, or run in modes that behave more like conventional Kubernetes Deployments depending on installation and runtime choices. The important point is that the controller organizes serving resources; the selected runtime still needs enough GPU memory, a sane context limit, a useful metrics path, and an authentication boundary.
 
 ```mermaid
 graph TD
@@ -715,63 +248,18 @@ graph TD
     KubeProxy --> KServe[KServe InferenceService]
     KServe --> Pod1[vLLM Pod - GPU 0]
     KServe --> Pod2[vLLM Pod - GPU 1]
-    
+
     subgraph Kubernetes Node
         Pod1 --> GPU1[NVIDIA A100]
         Pod2 --> GPU2[NVIDIA A100]
     end
 ```
 
-The diagram shows a simplified request path.
+Autoscaling is where many private LLM designs become misleading. CPU and container memory are weak demand signals because an LLM container may allocate most of its GPU memory during startup before it receives any traffic. CPU can be busy with tokenization and HTTP handling while the GPU is underfed, or CPU can look moderate while the engine scheduler queue and KV cache are saturated. Better scaling signals are closer to inference pressure: concurrency, queue length, TTFT tail latency, request rejection, timeout rate, tokens per second per replica, and cache usage.
 
-In a real platform, you may also have authentication, authorization, request logging, rate limits, a model registry, and observability pipelines.
+Knative can help with concurrency-based scaling, and KServe can help standardize the lifecycle, but engine-specific metrics may require Prometheus Adapter or another custom metrics path. Be cautious with scale-to-zero for large model endpoints because cold starts can include image pull, model weight download, cache warmup, GPU initialization, and readiness. For interactive chat, a minimum replica count is often part of the user experience contract even if scale-to-zero looks attractive on a cost spreadsheet.
 
-Do not hide those concerns under "the model endpoint."
-
-They are part of the product.
-
-### Autoscaling Metrics
-
-CPU and Memory metrics are often misleading for LLM autoscaling.
-
-LLM containers may allocate most available VRAM at startup due to model loading and KV cache planning.
-
-CPU can be busy with tokenization or HTTP handling even when the GPU is not saturated.
-
-Scale on signals closer to inference pressure:
-
-1. **Concurrency or Queue Length:** The number of requests waiting in the engine scheduler queue. If the queue grows and stays elevated, users are waiting before inference starts.
-2. **KV Cache Utilization:** Exposed by vLLM through metrics such as GPU cache usage. If cache usage stays very high, the engine has limited room for more active tokens.
-3. **TTFT Tail Latency:** If p95 or p99 time to first token grows, users feel the service is slow even if total throughput is high.
-4. **Request Rejection or Timeout Rate:** If the server starts rejecting requests or clients time out, the fleet is already overloaded.
-5. **Tokens per Second per Replica:** If adding traffic does not increase tokens per second, the replica is saturated or bottlenecked elsewhere.
-
-KServe and Knative can help with concurrency-based scaling.
-
-For engine-specific metrics, you may need Prometheus Adapter or a custom autoscaling path.
-
-The key is to use signals that change with actual demand.
-
-### Workload Segmentation
-
-One of the most important senior-level serving decisions is to split workloads.
-
-A single endpoint is simpler for consumers.
-
-It can be worse for latency.
-
-Consider two request classes:
-
-- interactive chat with short prompts and short answers
-- batch summarization with long prompts and long answers
-
-If they share one engine, the summarization requests can consume KV cache pages and batch slots.
-
-Interactive users then wait behind long-running work.
-
-This is head-of-line blocking.
-
-A better architecture is often two InferenceServices or Deployments.
+One of the most important senior-level serving decisions is workload segmentation. A single endpoint is simpler for consumers, but it can produce head-of-line blocking when interactive chat and long batch summarization share the same engine. Long prompts consume KV cache pages and active batch slots, so a short chat request can wait behind work that has a completely different service objective. Isolation is often cheaper than trying to tune one endpoint for incompatible request shapes.
 
 ```text
 +-------------------+        +----------------------------+
@@ -787,45 +275,13 @@ A better architecture is often two InferenceServices or Deployments.
 +-------------------+        +----------------------------+
 ```
 
-This is not duplication for its own sake.
-
-It is isolation.
-
-Different request shapes deserve different limits.
-
-Different SLOs deserve different serving pools.
-
-Different cost centers may deserve different quotas.
+Separate serving pools also create cleaner ownership boundaries. Chat can use lower context caps, lower maximum output tokens, strict TTFT alerts, and possibly more warm replicas. Batch summarization can accept higher queue time, larger context windows, throughput-oriented batching, and different cost allocation. The split should be visible in routing, quotas, dashboards, and runbooks so application teams know which endpoint they are consuming and why.
 
 ## Worked Example: Debugging a Slow and Unstable vLLM Deployment
 
-Before you build the lab deployment, walk through a failure.
+Exercise scenario: a platform team deploys an internal assistant on a single GPU node using an 8B AWQ model. Smoke tests pass, but during a demo some users wait more than 20 seconds for the first token and a few requests fail with server errors. The pod does not always restart, CPU usage is moderate, and container memory looks high all the time, so the team is unsure whether to add replicas, lower context length, split workloads, or change the model.
 
-This example shows how to connect symptoms to engine and Kubernetes causes.
-
-### Scenario
-
-A platform team deploys an internal assistant on a single GPU node.
-
-The model is an 8B AWQ model.
-
-The service works during smoke tests.
-
-During a company demo, users report that the first token sometimes takes more than 20 seconds.
-
-A few requests fail with server errors.
-
-The pod does not always restart.
-
-CPU usage is moderate.
-
-Container memory looks high all the time.
-
-The team is unsure whether to add replicas, lower context length, or change the model.
-
-### Input Evidence
-
-The team gathers these observations.
+The first step is to avoid treating `Running` as proof of serving health. Kubernetes status can rule out a crash loop, but it cannot tell you whether the engine queue is saturated. Start with pod state, then immediately move to logs and metrics that expose scheduler and cache behavior.
 
 ```bash
 kubectl get pods -l app=vllm
@@ -836,11 +292,7 @@ NAME                              READY   STATUS    RESTARTS   AGE
 vllm-llama3-8b-6d789c9d6c-x2mps   1/1     Running   0          2h
 ```
 
-The pod is running.
-
-That rules out a simple crash loop.
-
-Now inspect logs.
+The pod is running, which rules out a simple crash loop, but it does not explain why users are waiting. The next evidence source is the engine log, because queue growth and cache pressure are runtime symptoms rather than Kubernetes scheduling symptoms. A healthy pod can still be a saturated serving system.
 
 ```bash
 kubectl logs deployment/vllm-llama3-8b --tail=80
@@ -854,13 +306,7 @@ INFO engine.py: Avg generation tokens: 220
 WARNING server.py: Request timeout while waiting for scheduling
 ```
 
-The queue is growing.
-
-KV cache usage is high.
-
-Average prompt length is much larger than the team expected.
-
-Now test a short request manually.
+This evidence points away from a generic networking problem. The scheduler queue is growing, KV cache usage is high, and average prompt length is far larger than the team expected for chat. A short manual request is useful because it tests whether small work can bypass the congestion or whether it waits behind the same saturated engine.
 
 ```bash
 curl -s -X POST http://127.0.0.1:8080/v1/chat/completions \
@@ -875,31 +321,7 @@ curl -s -X POST http://127.0.0.1:8080/v1/chat/completions \
   }'
 ```
 
-The short request also waits.
-
-That suggests the short request is stuck behind existing work.
-
-It is not a prompt-quality issue.
-
-It is an admission and scheduling issue.
-
-### Step 1: Interpret the Symptom
-
-High container memory is expected.
-
-It does not prove overload.
-
-High KV cache usage plus queue growth is meaningful.
-
-The engine has too many active tokens relative to available cache.
-
-The long prompts are consuming pages.
-
-The short request waits because there is no immediate capacity.
-
-### Step 2: Check Runtime Limits
-
-The manifest shows:
+If the short request waits, the likely problem is admission and scheduling rather than prompt quality. The runtime has too many active tokens relative to the available KV cache, so a tiny request still waits for capacity. This is the key diagnostic shift: the pod is healthy, the Service can route, the model can answer, but the endpoint violates the chat SLO because its runtime configuration allows request shapes that consume too much cache.
 
 ```yaml
 args:
@@ -909,17 +331,7 @@ args:
 - "32768"
 ```
 
-The model can accept long context.
-
-The service probably should not.
-
-For an internal assistant, most chat requests may not need a 32k token cap.
-
-A high context limit allows a few large prompts to consume the cache.
-
-### Step 3: Pick the Least Risky Fix
-
-The team considers three options.
+The model can accept long context, but the service probably should not allow that context for an interactive assistant. A high context cap allows a few large prompts to consume cache pages and batch slots, which blocks short requests even if most users send normal chat messages. The immediate stabilization fix is to lower the chat endpoint context cap; the durable architecture is to route long document summarization to a separate deployment tuned for throughput.
 
 | Option | Effect | Risk |
 | :--- | :--- | :--- |
@@ -927,13 +339,7 @@ The team considers three options.
 | Lower `--max-model-len` | Prevents large prompts from consuming too much cache | May reject or truncate some workflows |
 | Split batch and chat endpoints | Isolates workload classes | Requires routing and product agreement |
 
-The immediate stabilization fix is to lower the chat endpoint context cap.
-
-The durable architecture is to split long summarization from interactive chat.
-
-### Step 4: Apply a Focused Change
-
-For the chat endpoint, change:
+For the chat endpoint, a focused change is to cap context length to a value aligned with the product's actual usage. The number below is not a universal recommendation; it is a defensible policy for an endpoint whose primary goal is short interactive chat. Long documents should go to a different endpoint with explicit limits and a different latency objective.
 
 ```yaml
 args:
@@ -941,13 +347,7 @@ args:
 - "4096"
 ```
 
-Then route long document summarization to a separate deployment tuned for throughput.
-
-That second deployment can use a larger context length and a less strict latency SLO.
-
-### Step 5: Verify the Fix
-
-After rollout, check three signals.
+After rollout, verify behavior with signals that connect to the root cause. The expected outcome is not low GPU memory usage, because model-serving runtimes often reserve memory by design. The expected outcome is a shorter scheduler queue, lower sustained KV cache pressure, improved TTFT for short requests, and controlled rejection or routing for oversized prompts.
 
 ```bash
 kubectl rollout status deployment/vllm-llama3-8b
@@ -970,57 +370,13 @@ curl -s -w "\nHTTP %{http_code}\n" -X POST http://127.0.0.1:8080/v1/chat/complet
   }'
 ```
 
-The expected outcome is not "zero GPU memory usage."
-
-The expected outcome is:
-
-- shorter scheduler queue
-- lower sustained KV cache pressure
-- improved TTFT for short requests
-- controlled rejection or routing for oversized prompts
-
-### Lesson
-
-The fix came from matching evidence to inference mechanics.
-
-Kubernetes said the pod was healthy.
-
-The engine metrics said the service was saturated.
-
-The runtime config allowed request shapes that violated the chat SLO.
-
-The correct response was not simply "add more GPU."
-
-It was to control context length and separate workload classes.
+The lesson is that the fix came from matching evidence to inference mechanics. Kubernetes said the pod was alive, the engine metrics said the service was saturated, and the runtime config allowed request shapes that violated the chat SLO. Adding replicas might help later, but the first correction is to control context length and separate incompatible workload classes.
 
 ## Production Deployment Design
 
-A production-grade private LLM endpoint needs more than a working container.
+A production-grade private LLM endpoint needs a deployment contract, not just a working container. The contract should name the model and revision, quantization format, maximum context length, maximum output tokens, GPU type and count, scaling strategy, request timeout, authentication path, logging policy, metrics, alerts, rollout plan, rollback plan, and model-loading strategy. Without that contract, each rollout becomes a new experiment and each incident starts with rediscovering what the endpoint was supposed to guarantee.
 
-It needs a deployment contract.
-
-That contract should specify:
-
-- model name and version
-- quantization format
-- maximum context length
-- maximum output tokens
-- GPU type and count
-- scaling strategy
-- request timeout
-- authentication path
-- logging policy
-- metrics and alerts
-- rollout and rollback procedure
-- cache and model download strategy
-
-### Model Loading and Cache Strategy
-
-Model loading can dominate startup time.
-
-If every pod downloads weights from the internet during rollout, startup becomes slow and fragile.
-
-In private environments, teams often prefer one of these patterns:
+Model loading can dominate startup time. If every pod downloads weights from the public internet during rollout, startup becomes slow, fragile, and dependent on external authentication and network conditions. Private environments often prefer internal registries, node-local caches, or pre-approved mirrors so model artifacts can be scanned, versioned, pinned, and reproduced.
 
 | Pattern | Description | Tradeoff |
 | :--- | :--- | :--- |
@@ -1029,42 +385,14 @@ In private environments, teams often prefer one of these patterns:
 | Node-local cache | Weights are cached on local disk or persistent volume | Good balance, but requires cache management |
 | Internal model registry | Runtime pulls from approved internal storage | Strong governance, but more platform work |
 
-For regulated environments, an internal registry is usually preferred.
-
-It allows approval, scanning, versioning, and reproducibility.
-
-A pod that silently pulls a new model revision is hard to audit.
-
-Pin model revisions where possible.
-
-### Secrets and Access
-
-Some models require license acceptance or access tokens.
-
-Do not place tokens directly in manifests.
-
-Use Kubernetes Secrets.
+Some models require license acceptance or access tokens, and those credentials should never appear directly in manifests. Use Kubernetes Secrets, restrict who can read them, and keep logs from printing environment variables or request bodies. Model access is part of supply-chain security because a model name without a pinned revision is not a stable production artifact.
 
 ```bash
 kubectl create secret generic hf-token-secret \
   --from-literal=token="$HUGGING_FACE_HUB_TOKEN"
 ```
 
-Mount or inject the token only into the namespace that needs it.
-
-Restrict who can read the Secret.
-
-Remember that logs may accidentally expose environment variables if scripts print too much.
-
-Model access is part of supply-chain security.
-
-### Resource Requests and Limits
-
-GPU resources are expressed as extended resources.
-
-For NVIDIA GPUs, the common resource key is `nvidia.com/gpu`.
-
-A pod requesting one GPU should include both request and limit.
+GPU resources are expressed as extended resources, and for NVIDIA clusters the common key is `nvidia.com/gpu`. In many common configurations, requests and limits for extended resources should match, and the device plugin advertises what is allocatable. If no GPU is available, the pod remains `Pending`, which is a scheduling problem rather than a model-serving problem.
 
 ```yaml
 resources:
@@ -1078,80 +406,11 @@ resources:
     cpu: "2"
 ```
 
-For extended resources, Kubernetes requires requests and limits to match in many common configurations.
+CPU is not optional just because inference runs on a GPU. The CPU handles HTTP parsing, tokenization, scheduling logic, streaming responses, metrics export, and background cache work. If CPU is under-provisioned, the GPU can wait for work and utilization graphs become confusing: the expensive accelerator is present, but the serving pipeline is underfed.
 
-The device plugin advertises available GPUs.
+Health checks deserve care because naive probes can lie or cause harm. A TCP probe may pass before weights are loaded, while a heavy generation request used as a readiness probe can waste capacity and overload a cold service. Prefer runtime health or metadata endpoints when available, and make readiness prove that the server is ready without forcing the kubelet to generate tokens on every probe interval.
 
-If no GPU is available, the pod stays in `Pending`.
-
-### CPU Is Not Optional
-
-A GPU endpoint still needs CPU.
-
-The CPU handles:
-
-- HTTP request parsing
-- tokenization
-- scheduling logic
-- streaming responses
-- metrics export
-- background model and cache tasks
-
-If CPU is under-provisioned, the GPU may wait for work.
-
-This looks wasteful and confusing.
-
-A pod can have an expensive GPU and still bottleneck on tokenization.
-
-For high-throughput endpoints, benchmark CPU settings.
-
-Do not assume `cpu: 1` is enough just because the model runs on GPU.
-
-### Health Checks
-
-Be careful with readiness probes.
-
-A simple TCP check may pass before the model is fully loaded.
-
-A heavy generation request as a probe can overload the service.
-
-A good readiness strategy confirms that the server is listening and the model is ready without consuming excessive resources.
-
-Some runtimes provide health endpoints.
-
-Use those when available.
-
-If not, use a lightweight model-list or metadata endpoint.
-
-Avoid making every kubelet probe generate tokens.
-
-## Kubernetes Manifest Walkthrough
-
-The lab uses a raw Deployment first.
-
-This is intentional.
-
-A raw Deployment exposes the mechanics.
-
-Once you understand the mechanics, KServe becomes easier.
-
-### Deployment Shape
-
-A vLLM deployment needs:
-
-- container image
-- model identifier
-- quantization setting
-- GPU memory setting
-- context limit
-- service port
-- GPU resource limit
-- Hugging Face token when needed
-- cache volume
-- shared memory volume
-- Prometheus scrape annotations if your monitoring stack uses them
-
-Here is the core pattern.
+The raw Deployment below is intentionally explicit. It preserves the operational controls you need to reason about: model identifier, quantization, GPU memory planning, context cap, service port, GPU resource request, cache volume, shared memory, and Prometheus annotations. Once you understand this shape, a KServe abstraction becomes easier to review because you know which constraints still have to surface somewhere.
 
 ```yaml
 apiVersion: apps/v1
@@ -1223,13 +482,7 @@ spec:
           sizeLimit: 2Gi
 ```
 
-This manifest uses `python3` because it is the command inside the container image.
-
-That is different from repository scripts, where this project requires `.venv/bin/python`.
-
-For Kubernetes manifests, use the runtime command expected by the container image.
-
-### Why Each Argument Exists
+The `python3` command in the manifest is the runtime command expected inside the container image, which is different from repository scripts in this project that must use `.venv/bin/python`. The context cap is one of the most important arguments because it turns model capability into endpoint policy. Do not blindly use the maximum advertised context length unless you have verified the cache, latency, and overload behavior for that request shape.
 
 | Argument | Purpose | Operational Risk If Wrong |
 | :--- | :--- | :--- |
@@ -1239,17 +492,7 @@ For Kubernetes manifests, use the runtime command expected by the container imag
 | `--max-model-len` | Caps context length | Context OOM or rejected valid workloads |
 | `--port` | Exposes HTTP server | Service cannot route if mismatched |
 
-The context cap is one of the most important controls.
-
-Do not blindly use a model's maximum advertised context length.
-
-The maximum is a capability.
-
-Your serving endpoint needs a policy.
-
-### Service Shape
-
-The Service gives the cluster a stable name.
+The Service gives the cluster a stable name and hides pod churn from clients. If the selector does not match the pod labels, the Service will have no endpoints and the failure looks like networking even though it is really a label mismatch. Verify the routing object before spending time on model logs.
 
 ```yaml
 apiVersion: v1
@@ -1266,31 +509,15 @@ spec:
     targetPort: 8000
 ```
 
-If the Service selector does not match the pod labels, the Service will have no endpoints.
-
-That failure looks like networking.
-
-It is actually a label mismatch.
-
-Check it with:
-
 ```bash
 kubectl get endpoints vllm-service
 ```
-
-or, on newer clusters:
 
 ```bash
 kubectl get endpointslices -l kubernetes.io/service-name=vllm-service
 ```
 
-### KServe Shape
-
-A KServe deployment is more abstract.
-
-The exact spec depends on installed KServe version and runtime.
-
-The concept is:
+A KServe deployment is more abstract, and the exact fields depend on your installed KServe version, runtime, and deployment mode. Treat the following YAML as a shape rather than a universal manifest. The key lesson is that KServe organizes serving resources, but it does not remove the need to request GPUs, choose a runtime, set limits, and validate the selected version's supported fields.
 
 ```yaml
 apiVersion: serving.kserve.io/v1beta1
@@ -1316,39 +543,11 @@ spec:
           memory: "16Gi"
 ```
 
-Treat this as a shape, not a universal manifest.
+## Observability, Security, and Governance
 
-KServe runtimes change over time.
+A private LLM service needs metrics before it needs heroic debugging. Use three dashboards as a minimum: Kubernetes health for pod status, restarts, scheduling failures, CPU, memory, and node conditions; GPU health for memory, utilization, temperature, power, and device errors; and serving health for request rate, error rate, TTFT, TPOT, queue length, KV cache pressure, and tokens per second. The dashboards should answer both "is the pod alive?" and "is the model service meeting its contract?"
 
-Always confirm the runtime, version, and supported fields in your cluster.
-
-The important lesson is that KServe does not remove inference constraints.
-
-It organizes them.
-
-## Observability and Alerting
-
-A private LLM service needs metrics before it needs heroic debugging.
-
-Start with three dashboards.
-
-First, a Kubernetes dashboard.
-
-This shows pod status, restarts, scheduling failures, CPU, memory, and node health.
-
-Second, a GPU dashboard.
-
-This shows GPU memory, utilization, temperature, power, and device health.
-
-Third, a serving dashboard.
-
-This shows request rate, error rate, TTFT, TPOT, queue length, KV cache usage, and tokens per second.
-
-### Useful Prometheus Signals
-
-vLLM exposes Prometheus metrics from the serving endpoint.
-
-Metric names can vary by version, so inspect `/metrics` in your deployment.
+vLLM exposes Prometheus metrics from the serving endpoint, but names can vary by version, so inspect `/metrics` in your deployment rather than relying on memory. Look for request success and failure, prompt tokens, generation tokens, time to first token, time per output token, scheduler queue, GPU cache usage, running requests, and waiting requests. Tie alerts to user impact instead of firing on normal memory reservation.
 
 ```bash
 kubectl port-forward svc/vllm-service 8080:80
@@ -1358,281 +557,193 @@ kubectl port-forward svc/vllm-service 8080:80
 curl -s http://127.0.0.1:8080/metrics | head -80
 ```
 
-Look for metrics related to:
+Good alerts combine symptoms. p95 TTFT above the chat SLO for several minutes, scheduler queue growth, error-rate spikes, pod restart loops after rollout, and high KV cache usage while queue length rises are all stronger than GPU memory alone. GPU memory can be high when the service is idle because the runtime has intentionally reserved memory for weights and cache planning, so memory only becomes actionable when paired with latency, queue, or error evidence.
 
-- request success and failure
-- prompt tokens
-- generation tokens
-- time to first token
-- time per output token
-- scheduler queue
-- GPU cache usage
-- running requests
-- waiting requests
+Logs should answer operational questions without leaking prompt content. You need to know whether the model loaded, authorization failed, context limits were hit, CUDA or NCCL errors occurred, and scheduler queues are growing. You generally should not log raw prompts for internal assistants because prompts may contain secrets, customer data, source code, or regulated records; separate operational metadata from user content and define retention rules before production traffic arrives.
 
-A good alert is tied to user impact.
+Private serving does not automatically mean secure serving. It means the organization controls the environment and therefore owns the controls. Put the endpoint behind an internal Gateway or Ingress, require authentication, use namespace and NetworkPolicy boundaries where appropriate, restrict Secret access, and avoid exposing the model Service to every namespace by accident. A plain ClusterIP Service can be reachable from many in-cluster clients unless policy says otherwise.
 
-For example:
+Treat models like dependencies rather than blobs. Track source, license, revision or digest, quantization process, evaluation results, approval owner, deployment date, rollback option, and known limitations. A manifest that references only a model name can silently pull different tokenizer or weight files in a later rollout, which makes audit and rollback difficult. Pin revisions or serve approved artifacts from an internal registry when reproducibility matters.
 
-- p95 TTFT above the chat SLO for several minutes
-- scheduler queue sustained above a threshold
-- error rate above the normal baseline
-- pod restart loop after rollout
-- GPU cache usage high while queue grows
+Data handling is part of the serving design because LLM prompts can contain secrets, personal data, source code, and regulated records. Decide what is logged, what is stored, who can query traces, and how long request metadata is retained. Private infrastructure reduces third-party exposure, but it does not remove internal governance duties, and it can make internal misuse easier if network and authorization boundaries are weak.
 
-A weak alert is one that fires constantly even when users are happy.
+## Patterns & Anti-Patterns
 
-GPU memory usage alone is often a weak alert for LLM serving.
+Patterns are useful only when they name the constraint they solve. In private LLM serving, the strongest patterns usually reduce ambiguity: isolate workload classes, make context length a policy, pin artifacts, and scale on signals that represent inference pressure. These choices may look less convenient than one shared endpoint, but they give operators clearer runbooks and users more predictable behavior.
 
-High GPU memory can be normal.
+| Pattern | When to Use It | Why It Works | Scaling Consideration |
+| :--- | :--- | :--- | :--- |
+| Separate chat and batch serving pools | Request shapes and SLOs differ | Prevents long prompts from blocking interactive users | Route by product workflow and enforce endpoint-specific limits |
+| Pin model revisions and quantization artifacts | Production must be reproducible | Avoids silent model or tokenizer drift during rollout | Store approved artifacts in an internal registry or cache |
+| Scale on queue, concurrency, and TTFT | CPU and memory do not explain demand | Measures user-visible saturation earlier | Use custom metrics when engine metrics are not native HPA inputs |
+| Start with raw Deployment before abstraction | Team is learning a new runtime | Exposes resource and runtime mechanics clearly | Move to KServe after controls and observability are understood |
 
-High GPU memory plus queue growth and latency is meaningful.
+Anti-patterns tend to come from treating LLM endpoints like ordinary stateless services. A web service that uses more memory under load may scale acceptably on memory, but an LLM runtime can reserve memory before traffic. A normal API may tolerate one shared route, but mixed prompt lengths can create head-of-line blocking. A normal dependency upgrade may be easy to roll back, but a model artifact can change output quality, tokenizer behavior, and memory footprint at the same time.
 
-### Logging
+| Anti-Pattern | What Goes Wrong | Better Alternative |
+| :--- | :--- | :--- |
+| One endpoint for every request shape | Batch jobs consume cache and delay chat | Split endpoints by SLO, context cap, and output limits |
+| Maximum context by default | A few large prompts reduce fleet capacity | Set endpoint-specific context policy and reject or route oversized work |
+| Memory-only autoscaling | Runtime reservation looks like load | Use queue length, concurrency, TTFT, errors, and cache pressure |
+| Unpinned model names | Rollouts are hard to reproduce | Pin revisions, digests, or approved internal artifacts |
+| Heavy readiness generation | Probes waste GPU capacity | Use lightweight health or metadata endpoints when available |
 
-Logs should answer operational questions.
+## Decision Framework
 
-Can the model load?
+Use the decision framework to turn an ambiguous serving request into concrete engineering choices. Start with the workload rather than the tool: identify whether the endpoint is interactive, batch, retrieval-augmented, code-oriented, or multi-tenant; estimate prompt and output token ranges; define the latency objective; then choose model size, quantization, engine, topology, and orchestration. The order matters because a model that fits your favorite engine may still be wrong for the product's request shape.
 
-Did authorization fail?
+```text
+Start
+  |
+  v
+Is the workload interactive with strict TTFT?
+  |-- yes --> cap context, protect short prompts, prefer warm replicas
+  |-- no  --> optimize throughput, batch efficiency, and completion deadline
+  |
+  v
+Does the model plus KV cache fit on one GPU?
+  |-- yes --> single-GPU deployment, benchmark CPU and cache pressure
+  |-- no  --> evaluate quantization, then tensor parallelism on fast interconnect
+  |
+  v
+Do teams need standardized model lifecycle?
+  |-- yes --> evaluate KServe plus approved runtimes
+  |-- no  --> raw Deployment may be clearer for the first production endpoint
+  |
+  v
+Can metrics explain queue, TTFT, TPOT, cache, and errors?
+  |-- yes --> set alerts and rollout gates
+  |-- no  --> add observability before accepting production traffic
+```
 
-Is the scheduler queue growing?
+| Decision | Choose This When | Avoid This When |
+| :--- | :--- | :--- |
+| vLLM raw Deployment | You need direct runtime control and OpenAI-compatible serving | The platform needs standardized multi-model lifecycle immediately |
+| TGI | Hugging Face lifecycle and TGI features fit the model path | Required model or quantization format is not supported well |
+| KServe | Multiple teams need a consistent serving API | The team has not validated runtime limits and metrics yet |
+| Quantized 8B model | Hardware budget is tight and quality is acceptable | Domain evaluation shows unacceptable degradation |
+| Tensor parallelism | One model needs multiple GPUs on a fast interconnect | Topology is weak or operational skill is not ready |
+| Workload split | Chat and batch have different token shapes | Traffic is tiny and operational simplicity matters more |
 
-Are requests timing out?
-
-Are context limits being hit?
-
-Are CUDA or NCCL errors happening?
-
-Avoid logging raw user prompts unless your privacy and compliance rules explicitly allow it.
-
-For internal assistants, prompts may contain sensitive business data.
-
-A secure serving platform separates operational metadata from prompt content.
-
-## Security and Governance
-
-Private serving does not automatically mean secure serving.
-
-It means the organization controls the environment.
-
-The platform team still needs to design the controls.
-
-### Network Controls
-
-Place the serving endpoint behind an internal Gateway or Ingress.
-
-Require authentication.
-
-Use namespace and NetworkPolicy boundaries where appropriate.
-
-Do not expose the model service directly to every namespace by accident.
-
-A simple internal Service is reachable from many places inside the cluster unless policies restrict it.
-
-### Model Supply Chain
-
-Models are artifacts.
-
-Treat them like dependencies.
-
-Track:
-
-- model source
-- license
-- revision or digest
-- quantization process
-- evaluation results
-- approval owner
-- deployment date
-- rollback option
-
-A model name without a pinned revision is not a stable production artifact.
-
-### Data Handling
-
-LLM prompts can contain secrets.
-
-They can contain customer data.
-
-They can contain source code.
-
-They can contain regulated records.
-
-Decide what is logged.
-
-Decide what is stored.
-
-Decide who can query traces.
-
-Decide how long request metadata is retained.
-
-Private infrastructure reduces third-party exposure, but it does not remove internal governance duties.
+The framework is not a substitute for measurement. It helps you decide what to measure and how to interpret the result. A strong production review should include a small load test with representative prompt lengths, a startup and rollout test, a failure-mode test for missing model access, and a dashboard check that proves the team can see queue, cache, and latency symptoms before users report them.
 
 ## Did You Know?
 
-1. LLM serving often becomes memory-bandwidth-bound during decode, so a GPU can show modest compute utilization while still being the limiting resource.
-2. A model's advertised maximum context length is not a safe default for production; the serving endpoint should set a context policy based on VRAM, workload, and SLOs.
-3. Continuous batching improves throughput by replacing finished sequences with new work instead of waiting for a whole static batch to finish.
-4. A healthy Kubernetes pod can still provide poor LLM service when the inference scheduler queue and KV cache are saturated.
+1. LLM decode can be memory-bandwidth-bound, so a GPU may show modest compute utilization while still being the limiting resource for output token speed.
+2. vLLM's `--gpu-memory-utilization` default has historically been documented as `0.9`, which is a planning limit for the vLLM instance rather than a guarantee that every model will start.
+3. TGI exposes Prometheus metrics such as queue duration, generated tokens, input length, and request duration, which makes it possible to separate demand from generation speed.
+4. Kubernetes device plugins advertise GPUs as extended resources such as `nvidia.com/gpu`, so a pod can be `Pending` for GPU capacity reasons even when CPU and memory are available.
 
 ## Common Mistakes
 
-| Mistake | Why It Hurts | Better Practice |
+| Mistake | Why It Happens | How to Fix It |
 | :--- | :--- | :--- |
 | Scaling on container memory alone | LLM runtimes may reserve memory at startup, so memory looks high even when idle | Scale on queue length, concurrency, TTFT, and KV cache pressure |
-| Setting context length to the model maximum | A few long prompts can consume cache and block short requests | Set endpoint-specific context caps and split workloads |
-| Using one endpoint for chat and batch summarization | Long jobs cause head-of-line blocking for interactive users | Use separate serving pools with different limits and SLOs |
-| Ignoring CPU requests | Tokenization and scheduling can starve the GPU | Benchmark CPU settings and provision enough cores |
-| Forgetting `/dev/shm` for multi-GPU serving | NCCL communication can fail under load | Mount a memory-backed `emptyDir` sized for the workload |
-| Treating OpenAI-compatible API as full operational equivalence | Same request format can hide very different latency and metrics behavior | Validate streaming, errors, metrics, and overload behavior |
-| Pulling unpinned model revisions at startup | Rollouts become hard to reproduce and audit | Pin model revisions or serve from an approved internal registry |
-| Raising `gpu-memory-utilization` without testing startup | Runtime overhead may not fit and the pod may crash | Increase gradually and verify model load plus representative traffic |
+| Setting context length to the model maximum | The maximum looks like a capability to expose, but a few long prompts can consume cache and block short requests | Set endpoint-specific context caps and split workloads |
+| Using one endpoint for chat and batch summarization | A single route is simpler for consumers and demos | Use separate serving pools with different limits and SLOs |
+| Ignoring CPU requests | Teams focus on the expensive GPU and forget tokenization and HTTP handling | Benchmark CPU settings and provision enough cores |
+| Forgetting `/dev/shm` for multi-GPU serving | Single-GPU smoke tests do not exercise NCCL communication paths | Mount a memory-backed `emptyDir` sized for the workload |
+| Treating OpenAI-compatible API as full operational equivalence | The same request format hides different latency, limits, and metrics behavior | Validate streaming, errors, metrics, and overload behavior |
+| Pulling unpinned model revisions at startup | Model names feel stable during early experiments | Pin model revisions or serve from an approved internal registry |
+| Raising `gpu-memory-utilization` without testing startup | More reserved memory looks like more throughput | Increase gradually and verify model load plus representative traffic |
 
 ## Quiz
 
-**1. Your team deploys a private chat assistant on a single GPU. The pod is `Running`, GPU memory is high, and short chat prompts suddenly wait behind long document prompts. Which change best addresses the root cause while preserving the chat user experience?**
-
-- A) Increase the chat client's HTTP timeout and keep one shared endpoint.
-- B) Split chat and document summarization into separate serving deployments with different context and output limits.
-- C) Disable streaming so all users receive complete answers at the same time.
-- D) Remove the Service and connect clients directly to the pod IP.
-
 <details>
-<summary>Answer</summary>
+<summary>1. Your team deploys a private chat assistant on a single GPU. The pod is `Running`, GPU memory is high, and short chat prompts wait behind long document prompts. Which change best addresses the root cause while preserving chat latency?</summary>
 
-**Correct answer: B**
+A) Increase the chat client's HTTP timeout and keep one shared endpoint.
+B) Split chat and document summarization into separate serving deployments with different context and output limits.
+C) Disable streaming so every user receives complete answers at the same time.
+D) Remove the Service and connect clients directly to the pod IP.
 
-The symptom is head-of-line blocking caused by mixed request shapes. Long document prompts consume KV cache and active batch capacity, so short chat requests wait even though the pod is technically healthy. Splitting workloads lets the chat deployment enforce lower context and output limits while the batch deployment can optimize for throughput.
+**Correct answer: B.** The symptom is head-of-line blocking caused by mixed request shapes, so option B isolates chat from long document work and lets each endpoint enforce a different policy. Option A hides the user-visible pain without reducing cache pressure. Option C makes perceived latency worse and does not change scheduling. Option D bypasses stable service routing and does nothing about the saturated engine.
 
 </details>
 
-**2. A vLLM pod crashes during startup after you change `--gpu-memory-utilization` from `0.85` to `0.98`. No user traffic has reached the pod. What should you check first?**
-
-- A) Whether the runtime has enough unreserved GPU memory for CUDA, PyTorch, kernels, and model initialization overhead.
-- B) Whether the external DNS record points to the Service.
-- C) Whether the chat prompt template includes a system message.
-- D) Whether the Knative autoscaler has already reached maximum replicas.
-
 <details>
-<summary>Answer</summary>
+<summary>2. A vLLM pod crashes during startup after you change `--gpu-memory-utilization` from `0.85` to `0.98`. No user traffic has reached the pod. What should you check first?</summary>
 
-**Correct answer: A**
+A) Whether the runtime has enough unreserved GPU memory for CUDA, PyTorch, kernels, and model initialization overhead.
+B) Whether the external DNS record points to the Service.
+C) Whether the chat prompt template includes a system message.
+D) Whether the Knative autoscaler has already reached maximum replicas.
 
-The failure happens before traffic, so request load and autoscaling are unlikely to be the immediate cause. Reserving too much GPU memory can leave insufficient headroom for runtime initialization. Lower the setting, verify startup, then increase only after testing with representative prompts.
+**Correct answer: A.** The failure happens before traffic, so option A matches the startup phase and the memory-planning change. Option B would affect routing after the server is ready, not CUDA initialization. Option C affects answer style, not model load. Option D is not relevant until requests are flowing and autoscaling decisions are being made.
 
 </details>
 
-**3. A platform team wants to serve a 70B model on a node with multiple GPUs connected by high-bandwidth interconnect. The model is too large for one GPU. Which approach should they evaluate first for efficient single-node serving?**
-
-- A) Tensor parallelism with a tensor parallel size matching the intended GPU count.
-- B) A Kubernetes Service with more ports.
-- C) A larger `/tmp` directory in the container.
-- D) More replicas of a pod that still requests only one GPU and loads the full model.
-
 <details>
-<summary>Answer</summary>
+<summary>3. A platform team wants to serve a 70B model on a node with multiple GPUs connected by high-bandwidth interconnect. The model is too large for one GPU. Which approach should they evaluate first for efficient single-node serving?</summary>
 
-**Correct answer: A**
+A) Tensor parallelism with a tensor parallel size matching the intended GPU count.
+B) A Kubernetes Service with more ports.
+C) A larger `/tmp` directory in the container.
+D) More replicas of a pod that still requests only one GPU and loads the full model.
 
-Tensor parallelism splits model operations across multiple GPUs and is commonly used when a model cannot fit on one GPU. It depends on fast interconnect and communication libraries such as NCCL. More replicas do not help if each replica still cannot load the model.
+**Correct answer: A.** Tensor parallelism is designed to split model operations across GPUs, so option A addresses the memory and compute constraint. Option B changes routing, not model placement. Option C may help unrelated scratch-space issues but does not split weights. Option D repeats a pod shape that still cannot load the model.
 
 </details>
 
-**4. Your observability dashboard shows p95 TTFT increasing, scheduler queue length growing, and KV cache usage staying high. CPU is only moderate. What is the best interpretation?**
-
-- A) The service is probably saturated at the inference scheduler or cache level, even though CPU is not maxed.
-- B) Kubernetes must have scheduled the pod onto a CPU-only node.
-- C) The model quality has degraded because quantization changed the vocabulary.
-- D) The Service selector is broken.
-
 <details>
-<summary>Answer</summary>
+<summary>4. Your observability dashboard shows p95 TTFT increasing, scheduler queue length growing, and KV cache usage staying high. CPU is only moderate. What is the best interpretation?</summary>
 
-**Correct answer: A**
+A) The service is probably saturated at the inference scheduler or cache level, even though CPU is not maxed.
+B) Kubernetes must have scheduled the pod onto a CPU-only node.
+C) The model quality has degraded because quantization changed the vocabulary.
+D) The Service selector is broken.
 
-TTFT growth plus queue growth indicates requests are waiting before execution. Sustained high KV cache usage means active tokens are consuming the engine's admission capacity. CPU does not need to be maxed for an LLM endpoint to be saturated.
+**Correct answer: A.** TTFT growth plus queue growth means requests wait before execution, and high KV cache usage explains why admission is constrained. Option B is unlikely because the model is running and exposing engine metrics. Option C invents a quality explanation for a latency symptom. Option D would usually produce routing failures or no endpoints rather than a growing engine queue.
 
 </details>
 
-**5. A developer asks to use a GGUF model artifact because it worked well on their laptop with Ollama. The production target is high-concurrency GPU serving on Kubernetes. What is the most useful response?**
-
-- A) Accept GGUF because every quantized format behaves the same once it is on a GPU.
-- B) Reject all quantization and require FP16 for every private model.
-- C) Evaluate a GPU-serving-oriented format such as AWQ, GPTQ, or FP8 with the selected engine before choosing the artifact.
-- D) Move Kubernetes to a different namespace.
-
 <details>
-<summary>Answer</summary>
+<summary>5. A developer asks to use a GGUF model artifact because it worked well on their laptop with Ollama. The production target is high-concurrency GPU serving on Kubernetes. What is the most useful response?</summary>
 
-**Correct answer: C**
+A) Accept GGUF because every quantized format behaves the same once it is on a GPU.
+B) Reject all quantization and require FP16 for every private model.
+C) Evaluate a GPU-serving-oriented format such as AWQ, GPTQ, or FP8 with the selected engine before choosing the artifact.
+D) Move Kubernetes to a different namespace.
 
-GGUF is excellent for local and CPU-oriented workflows, but it is not automatically the best choice for high-throughput GPU serving. The production decision should test a format that the chosen inference engine can serve with optimized kernels while meeting quality requirements.
+**Correct answer: C.** Option C respects the developer's evidence while testing the artifact against the actual production engine and workload. Option A ignores kernel and runtime differences between formats. Option B may waste hardware and is not justified without quality evidence. Option D changes nothing about model format or serving performance.
 
 </details>
 
-**6. A KServe InferenceService wraps a vLLM runtime. The application team asks why the autoscaler should not use normal container memory utilization. What is the best explanation?**
-
-- A) Kubernetes cannot observe any memory metrics for pods that use GPUs.
-- B) LLM runtimes often allocate large memory regions at startup, so memory utilization is not a reliable measure of live request pressure.
-- C) Autoscaling is impossible for all private LLM workloads.
-- D) Container memory only matters for CPU-only models.
-
 <details>
-<summary>Answer</summary>
+<summary>6. A KServe InferenceService wraps a vLLM runtime. The application team asks why autoscaling should not use normal container memory utilization. What is the best explanation?</summary>
 
-**Correct answer: B**
+A) Kubernetes cannot observe any memory metrics for pods that use GPUs.
+B) LLM runtimes often allocate large memory regions at startup, so memory utilization is not a reliable measure of live request pressure.
+C) Autoscaling is impossible for all private LLM workloads.
+D) Container memory only matters for CPU-only models.
 
-LLM serving engines may reserve GPU memory for weights and KV cache planning before requests arrive. That makes memory look high even when demand is low. Queue length, concurrency, TTFT, request failures, and KV cache pressure are better indicators of serving load.
+**Correct answer: B.** Option B explains why memory can look high before demand arrives and why queue, concurrency, TTFT, errors, and cache pressure are better signals. Option A is too broad because Kubernetes and GPU exporters can expose memory-related metrics. Option C is false; autoscaling is possible with the right signals and cold-start expectations. Option D ignores the real system RAM and runtime needs of GPU-backed pods.
 
 </details>
 
-**7. A multi-GPU vLLM pod fails under load with NCCL timeout messages. The model loads successfully, and single-GPU tests worked earlier. Which manifest issue should you investigate early?**
-
-- A) Whether a memory-backed `/dev/shm` volume is mounted and sized appropriately.
-- B) Whether the Service uses port `80`.
-- C) Whether the pod label is alphabetically first in the namespace.
-- D) Whether the model temperature is set to zero.
-
 <details>
-<summary>Answer</summary>
+<summary>7. A multi-GPU vLLM pod fails under load with NCCL timeout messages. The model loads successfully, and single-GPU tests worked earlier. Which manifest issue should you investigate early?</summary>
 
-**Correct answer: A**
+A) Whether a memory-backed `/dev/shm` volume is mounted and sized appropriately.
+B) Whether the Service uses port `80`.
+C) Whether the pod label is alphabetically first in the namespace.
+D) Whether the model temperature is set to zero.
 
-NCCL depends on reliable communication between GPU workers. A small default shared memory allocation can contribute to failures under multi-GPU load. Mounting an appropriately sized memory-backed `emptyDir` at `/dev/shm` is a common production requirement.
+**Correct answer: A.** NCCL depends on reliable communication between GPU workers, and shared memory is a common container-level requirement for multi-GPU inference. Option B can affect routing but not NCCL synchronization under load. Option C is irrelevant to Kubernetes scheduling and runtime communication. Option D affects sampling randomness, not GPU worker coordination.
 
 </details>
 
 ## Hands-On Exercise: Deploy and Validate a Quantized vLLM Endpoint
 
-In this lab, you will deploy a 4-bit AWQ quantized Llama 3 8B model using vLLM on a Kubernetes node with an NVIDIA GPU.
-
-You will also verify the Service, call the OpenAI-compatible endpoint, inspect logs, and reason about common failures.
-
-The lab uses `kubectl`.
-
-After the first command, you may use the alias `k` if your shell already defines it.
-
-If not, continue using `kubectl`.
+In this lab, you will deploy a 4-bit AWQ quantized Llama 3 8B model using vLLM on a Kubernetes cluster running version 1.35 or newer with an NVIDIA GPU node. You will verify GPU capacity, create the optional model-access Secret, deploy vLLM, create a Service, call the OpenAI-compatible endpoint, inspect logs and metrics, and reason about context limits. The lab uses full `kubectl` commands so each block can be copied into a non-interactive shell or runbook.
 
 ### Prerequisites
 
-You need:
-
-- A Kubernetes cluster running version 1.35 or newer.
-- At least one schedulable NVIDIA GPU node.
-- NVIDIA GPU Operator or equivalent GPU driver, device plugin, runtime, and monitoring setup.
-- `kubectl` configured for the target cluster.
-- Network access to the model source, or an internal mirror containing the same model.
-- Permission to create Deployments, Services, Secrets, and port-forwards in the target namespace.
-
-Confirm cluster access:
+You need a Kubernetes cluster with at least one schedulable NVIDIA GPU node, the NVIDIA GPU Operator or equivalent driver and device-plugin setup, `kubectl` configured for the target cluster, network access to the model source or an internal mirror, and permission to create Deployments, Services, Secrets, and port-forwards in the namespace. If your organization blocks public model downloads, use an approved internal model registry and adapt only the model reference, not the operational checks.
 
 ```bash
 kubectl version
 ```
-
-Confirm GPU capacity:
 
 ```bash
 kubectl get nodes
@@ -1642,11 +753,7 @@ kubectl get nodes
 kubectl describe nodes | grep -A5 -B2 "nvidia.com/gpu"
 ```
 
-If your shell has `k` configured as an alias for `kubectl`, you can use it from this point onward.
-
 ### Success Criteria
-
-Complete the lab when all of these are true:
 
 - [ ] The GPU node advertises `nvidia.com/gpu` capacity.
 - [ ] The vLLM Deployment is created successfully.
@@ -1659,16 +766,12 @@ Complete the lab when all of these are true:
 
 ### Step 1: Create an Optional Hugging Face Secret
 
-If your model requires a token, create a Secret.
-
-Skip this step for public models that do not require authentication.
+If your model requires a token, create a Secret and verify only the Secret object, not the token value. Skip this step for public models that do not require authentication, but keep the pattern in mind for production because model access is usually governed by license and approval rules.
 
 ```bash
 kubectl create secret generic hf-token-secret \
   --from-literal=token="$HUGGING_FACE_HUB_TOKEN"
 ```
-
-Verify the Secret exists without printing its value:
 
 ```bash
 kubectl get secret hf-token-secret
@@ -1676,7 +779,7 @@ kubectl get secret hf-token-secret
 
 ### Step 2: Create the vLLM Deployment
 
-Create a file named `vllm-deployment.yaml`.
+Create a file named `vllm-deployment.yaml` with the preserved deployment shape below. Before applying it, inspect the model identifier, quantization flag, GPU memory utilization, context cap, cache volume, and `/dev/shm` mount because each item maps to a failure mode you learned earlier.
 
 ```yaml
 apiVersion: apps/v1
@@ -1748,19 +851,15 @@ spec:
           sizeLimit: 2Gi
 ```
 
-Apply it:
+Apply the manifest and then watch rollout status. If the rollout takes time, inspect the pod and events instead of repeatedly changing the manifest, because model download and initialization can be slow while still healthy.
 
 ```bash
 kubectl apply -f vllm-deployment.yaml
 ```
 
-Watch rollout status:
-
 ```bash
 kubectl rollout status deployment/vllm-llama3-8b
 ```
-
-If the rollout takes time, inspect the pod:
 
 ```bash
 kubectl get pods -l app=vllm
@@ -1772,7 +871,7 @@ kubectl describe pod -l app=vllm
 
 ### Step 3: Create the Service
 
-Create `vllm-service.yaml`.
+Create `vllm-service.yaml`, apply it, and then verify that Service routing has backing endpoints. If endpoints are missing, compare the Service selector with the pod labels before investigating GPU or model logs, because a selector mismatch is a routing problem.
 
 ```yaml
 apiVersion: v1
@@ -1789,13 +888,9 @@ spec:
     targetPort: 8000
 ```
 
-Apply it:
-
 ```bash
 kubectl apply -f vllm-service.yaml
 ```
-
-Verify Service routing:
 
 ```bash
 kubectl get svc vllm-service
@@ -1805,13 +900,9 @@ kubectl get svc vllm-service
 kubectl get endpoints vllm-service
 ```
 
-If your cluster prefers EndpointSlices, use:
-
 ```bash
 kubectl get endpointslices -l kubernetes.io/service-name=vllm-service
 ```
-
-If there are no endpoints, compare the Service selector with the pod labels.
 
 ```bash
 kubectl get pod -l app=vllm --show-labels
@@ -1819,33 +910,21 @@ kubectl get pod -l app=vllm --show-labels
 
 ### Step 4: Inspect Startup Logs
 
-Downloading model weights can take time.
-
-Check logs:
+Downloading model weights can take time, so use logs to distinguish normal startup from authorization failure, unsupported quantization, CUDA out-of-memory, or runtime crashes. You are looking for evidence that the server started and is listening on `0.0.0.0:8000`, plus any warnings that explain degraded behavior.
 
 ```bash
 kubectl logs -f deployment/vllm-llama3-8b
 ```
 
-You are looking for evidence that the server started and is listening.
-
-A typical line may indicate that Uvicorn is running on `0.0.0.0:8000`.
-
-If logs show authorization failure, revisit the Secret and model license.
-
-If logs show CUDA out-of-memory during startup, lower `--gpu-memory-utilization` or choose a smaller model.
-
-If logs show unsupported quantization, confirm that the model artifact and engine support the selected format.
+If logs show authorization failure, revisit the Secret and model license. If logs show CUDA out-of-memory during startup, lower `--gpu-memory-utilization`, reduce `--max-model-len`, choose a smaller model, or move to a GPU with more VRAM. If logs show unsupported quantization, confirm that the model artifact and engine support the selected format.
 
 ### Step 5: Test the OpenAI-Compatible Endpoint
 
-Port-forward the Service:
+Port-forward the Service in one terminal, then send the chat completion request from another terminal. The exact response wording is not important; the validation is that the endpoint accepts the OpenAI-style request and returns generated assistant content in JSON.
 
 ```bash
 kubectl port-forward svc/vllm-service 8080:80
 ```
-
-In a second terminal, send a chat completion request:
 
 ```bash
 curl -s -X POST http://127.0.0.1:8080/v1/chat/completions \
@@ -1861,39 +940,19 @@ curl -s -X POST http://127.0.0.1:8080/v1/chat/completions \
   }'
 ```
 
-Expected result:
-
-The response is JSON.
-
-It contains an assistant message in a field such as `choices[0].message.content`.
-
-The exact wording may vary.
-
-The important validation is that the endpoint accepts the OpenAI-style request and returns generated text.
+Expected result: the response is JSON and contains an assistant message in a field such as `choices[0].message.content`. If the request fails, check the endpoint path, model name in the request body, port-forward state, and logs while the request is in flight.
 
 ### Step 6: Inspect Metrics
 
-While the port-forward is still running, request metrics:
+While the port-forward is still running, request metrics and identify at least one signal related to request activity, token activity, cache usage, or queue state. Do not choose a metric only because it exists; choose one that connects to user impact, such as TTFT and queue length for chat or tokens per second and error rate for batch summarization.
 
 ```bash
 curl -s http://127.0.0.1:8080/metrics | head -80
 ```
 
-Identify at least one metric related to request activity, token activity, cache usage, or queue state.
-
-Write down which metric you would alert on for early saturation.
-
-Do not choose a metric only because it exists.
-
-Choose one that connects to user impact.
-
-For chat, TTFT and queue length are strong candidates.
-
-For batch summarization, tokens per second and error rate may be more important.
-
 ### Step 7: Run a Context-Limit Experiment
 
-Send a request that asks for more output tokens than the smoke test.
+Send a request that asks for more output tokens than the smoke test, then reason about what would happen if many users submitted longer prompts at the same time. You do not need to overload the cluster; the goal is to connect request shape to cache pressure and to practice predicting which metrics would move first.
 
 ```bash
 curl -s -X POST http://127.0.0.1:8080/v1/chat/completions \
@@ -1908,39 +967,19 @@ curl -s -X POST http://127.0.0.1:8080/v1/chat/completions \
   }'
 ```
 
-Observe whether the endpoint still responds promptly.
-
-Now reason about what would happen if many users submitted much longer prompts.
-
-You do not need to overload your cluster.
-
-The goal is to connect request shape to cache pressure.
-
 ### Troubleshooting the Lab
 
-**Pod stuck in `Pending`:**
-
-The cluster may not have an available GPU.
-
-Check events:
+If the pod is stuck in `Pending`, the cluster may not have an available GPU or the node labels and taints may not match the workload. Check events for insufficient `nvidia.com/gpu`, then confirm that the device plugin or GPU operator components are running before changing model flags.
 
 ```bash
 kubectl describe pod -l app=vllm
 ```
 
-Look for messages about insufficient `nvidia.com/gpu`.
-
-Also confirm the device plugin is running.
-
 ```bash
 kubectl get pods -A | grep -i nvidia
 ```
 
-**Container restarts with OOMKilled:**
-
-This may be system RAM pressure or GPU initialization failure.
-
-Check pod events and logs.
+If the container restarts with `OOMKilled`, separate system RAM pressure from GPU initialization failure by reading pod events and previous logs. Try lowering `--gpu-memory-utilization` to `0.75`, reducing context length, choosing a smaller model, or moving to a larger GPU class if the model still fails.
 
 ```bash
 kubectl describe pod -l app=vllm
@@ -1950,31 +989,7 @@ kubectl describe pod -l app=vllm
 kubectl logs deployment/vllm-llama3-8b --previous
 ```
 
-Try lowering `--gpu-memory-utilization` to `0.75`.
-
-If the model still fails, use a smaller model or a GPU with more VRAM.
-
-**CUDA out-of-memory during model load:**
-
-The model plus runtime overhead does not fit with current settings.
-
-Reduce GPU memory utilization.
-
-Reduce max model length.
-
-Use a smaller or more aggressively quantized model.
-
-Verify no other workload is using the same GPU if the node is shared.
-
-**Hugging Face unauthorized error:**
-
-For gated models, create the Secret and ensure the account has accepted the model license.
-
-Use an internal model registry when production environments cannot reach public hubs.
-
-**Service does not route:**
-
-Check labels and selectors.
+If the Service does not route, check labels and selectors before changing the Deployment. A Service selector must match the pod labels exactly, and EndpointSlice output is often the fastest way to confirm whether routing has a backend.
 
 ```bash
 kubectl get pods --show-labels
@@ -1984,74 +999,26 @@ kubectl get pods --show-labels
 kubectl describe svc vllm-service
 ```
 
-The Service selector must match the pod labels.
+If multi-GPU experiments show NCCL errors, confirm `/dev/shm` is mounted, inspect GPU topology, and look for CPU contention before changing timeout variables. Environment-variable tuning can hide a symptom, but shared memory and topology are the first evidence to collect.
 
-**Port-forward works but the request fails:**
+## Sources
 
-Check the endpoint path and model name in the request body.
-
-Some engines require the `model` field to match the loaded model identifier.
-
-Check logs while sending the request.
-
-**NCCL errors in multi-GPU experiments:**
-
-Confirm `/dev/shm` is mounted.
-
-Check GPU topology.
-
-Consider NCCL timeout environment variables only after validating basic shared memory and topology.
-
-## Practitioner Gotchas
-
-### 1. The NCCL Timeout Crash
-
-**Context:** When scaling vLLM across multiple GPUs using `--tensor-parallel-size > 1`, the NVIDIA Collective Communications Library is used to synchronize GPU work.
-
-**Gotcha:** If shared memory is too small, topology is poor, or CPU contention delays synchronization, NCCL can time out and crash the pod.
-
-**Fix:** Mount a memory-backed `emptyDir` to `/dev/shm`, validate GPU topology, and tune NCCL timeout settings only with evidence from logs and load tests.
-
-### 2. Context Length OOMs
-
-**Context:** A model may advertise a very large theoretical context length.
-
-**Gotcha:** A user can submit a prompt large enough to consume a damaging amount of KV cache, even if normal smoke tests work.
-
-**Fix:** Set `--max-model-len` for the endpoint's workload. Do not treat the model maximum as the production policy.
-
-### 3. Starving the CPU Scheduler
-
-**Context:** GPU inference still depends on CPU-side tokenization, request handling, and scheduling.
-
-**Gotcha:** A pod with a powerful GPU and too little CPU can underfeed the GPU.
-
-**Fix:** Benchmark CPU requests and limits. Watch tokenization pressure, event-loop latency, and GPU utilization together.
-
-### 4. Head-of-Line Blocking with Mixed Workloads
-
-**Context:** Real-time chat and background summarization have different request shapes.
-
-**Gotcha:** Long requests can consume batch slots and cache pages, making short requests wait.
-
-**Fix:** Separate workloads by SLO. Use different context limits, output caps, replicas, and routing policies.
-
-### 5. Silent Model Drift
-
-**Context:** A manifest references a model name without a pinned revision.
-
-**Gotcha:** A future rollout may pull different weights or tokenizer files.
-
-**Fix:** Pin revisions or serve approved artifacts from an internal registry.
-
-### 6. Treating the Demo as the Load Test
-
-**Context:** One successful curl request proves the model can answer.
-
-**Gotcha:** It does not prove the endpoint can serve concurrent users, long prompts, or failure recovery.
-
-**Fix:** Test representative prompt lengths, output lengths, concurrency, and rollout scenarios before declaring production readiness.
+- https://docs.vllm.ai/en/v0.7.2/serving/openai_compatible_server.html
+- https://docs.vllm.ai/en/v0.4.2/
+- https://docs.vllm.ai/en/v0.7.2/features/quantization/
+- https://huggingface.co/docs/text-generation-inference/en/index
+- https://huggingface.co/docs/text-generation-inference/en/conceptual/quantization
+- https://huggingface.co/docs/text-generation-inference/en/reference/metrics
+- https://huggingface.co/docs/text-generation-inference/en/reference/launcher
+- https://kserve.github.io/website/docs/concepts/resources
+- https://kserve.github.io/website/docs/model-serving/node-scheduling/isvc-node-scheduling
+- https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/
+- https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#extended-resources
+- https://knative.dev/docs/serving/autoscaling/
+- https://knative.dev/docs/serving/autoscaling/concurrency/
+- https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/index.html
+- https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/overview.html
 
 ## Next Module
 
-Next: [Module 9.4: GPU Observability and Cost Control](./module-9.4-gpu-observability-cost-control/)
+Next: [Module 9.4: Private MLOps Platform](./module-9.4-private-mlops-platform/) introduces model registry, approval, rollout, and lifecycle practices for private AI platforms.


### PR DESCRIPTION
## Summary

Rewrites `src/content/docs/on-premises/ai-ml-infrastructure/module-9.3-private-llm-serving.md` for the #388 density and structure gates, clears `revision_pending: false`, removes the duplicate source H1, preserves the original serving concepts, code examples, diagrams, tables, and local endpoint examples, and adds a primary/vendor `Sources` section.

## Verifier

Verifier summary: tier T0; body_words=5495, mean_wpp=65.4, median_wpp=67.0, short_rate=0.012, max_run=1, mean_sentence_length=22.9; all density+structure+alignment+anti_leak+protected_assets gates passed; source reachability skipped per dispatch.

Protected assets preserved with counts: code blocks 57 before / 58 after, ASCII diagrams 0 before / 0 after per verifier, Mermaid diagrams 1 before / 1 after, tables 8 before / 11 after. Original local endpoint URLs were retained as runnable examples, and 15 source URLs were added under `## Sources`.

Commit SHA: dbfea1f1

## Checks

- `../../.venv/bin/python scripts/quality/verify_module.py --glob src/content/docs/on-premises/ai-ml-infrastructure/module-9.3-private-llm-serving.md --skip-source-check --summary --quiet` - T0 / passed
- `git diff --check -- src/content/docs/on-premises/ai-ml-infrastructure/module-9.3-private-llm-serving.md` - passed
- `../../.venv/bin/python scripts/test_pipeline.py` - 166 tests passed
- `npm run build` from this worktree - failed with the documented Astro worktree node_modules resolution issue: `Could not resolve "../../node_modules/@astrojs/starlight/style/layers.css" from "src/layouts/Homepage.astro"`. Primary checkout was left on `main` and not modified.
