### PR TITLE
feat(388): rewrite module-1.4-ai-storage (#388 pilot)

### DIFF
--- a/src/content/docs/platform/disciplines/data-ai/ai-infrastructure/module-1.4-ai-storage.md
+++ b/src/content/docs/platform/disciplines/data-ai/ai-infrastructure/module-1.4-ai-storage.md
@@ -3,16 +3,13 @@ title: "Module 1.4: High-Performance Storage for AI"
 slug: platform/disciplines/data-ai/ai-infrastructure/module-1.4-ai-storage
 sidebar:
   order: 5
+revision_pending: false
 ---
-> **Discipline Module** | Complexity: `[MEDIUM]` | Time: 3 hours
-
-## Prerequisites
-
-Before starting this module:
-- **Required**: Kubernetes storage fundamentals (PersistentVolumes, PersistentVolumeClaims, StorageClasses, CSI drivers)
-- **Required**: Basic understanding of ML training data pipelines (datasets, batches, data loaders)
-- **Recommended**: [Module 1.1: GPU Provisioning](../module-1.1-gpu-provisioning/) — GPU workload basics
-- **Recommended**: Experience with object storage (S3, GCS, MinIO)
+> **Complexity**: MEDIUM
+>
+> **Time to Complete**: 3 hours
+>
+> **Prerequisites**: Kubernetes storage fundamentals, including PersistentVolumes, PersistentVolumeClaims, StorageClasses, and CSI drivers; basic understanding of ML training data pipelines, including datasets, batches, and data loaders; recommended completion of [Module 1.1: GPU Provisioning](../module-1.1-gpu-provisioning/); and practical familiarity with object storage such as S3, GCS, or MinIO.
 
 ---
 
@@ -20,51 +17,48 @@ Before starting this module:
 
 After completing this module, you will be able to:
 
-- **Design high-throughput storage architectures for AI workloads — training data, checkpoints, and model artifacts**
-- **Implement storage solutions using CSI drivers, NFS, and object storage optimized for large-scale data access**
-- **Configure caching layers that reduce data loading bottlenecks during distributed training**
-- **Evaluate storage options — local NVMe, network-attached, cloud object stores — against AI workload I/O patterns**
+- **Design** high-throughput storage architectures for AI workloads that separate training data, checkpoints, and model artifacts by access pattern.
+- **Implement** Kubernetes storage solutions using CSI drivers, local NVMe, distributed filesystems, and object-backed filesystems without breaking scheduler placement.
+- **Configure** caching layers that reduce data loading bottlenecks during repeated and distributed training runs.
+- **Evaluate** local NVMe, network-attached filesystems, cloud object stores, and dataset caches against measurable AI workload I/O profiles.
+- **Diagnose** whether a slow training job is compute-bound, CPU-bound, or storage-bound using GPU utilization, data-loader timing, and storage benchmarks.
 
 ## Why This Module Matters
 
-You spent months building a beautiful GPU platform. The GPUs are provisioned, shared efficiently, connected by InfiniBand. Then your ML team starts training and reports this:
+Hypothetical scenario: your platform team has just delivered a clean GPU pool for the machine learning group. The nodes have modern accelerators, the scheduler can place GPU jobs, and the team has confidence in quota enforcement because earlier modules covered provisioning and sharing. Then the first serious image-training job lands, eight GPUs light up for a few seconds, and the utilization graph flattens around forty percent because the workers spend most of each step waiting for the next batch to arrive from storage.
 
-> "Our 8-GPU job only uses 40% GPU utilization. The GPUs are waiting for data."
+That situation is frustrating because it looks like a GPU problem from a distance, but it is usually a data path problem. A training loop cannot compute on examples it has not loaded, decoded, shuffled, transferred, and staged, so storage design directly determines how much expensive accelerator time turns into useful gradient updates. If the platform exposes only a generic network filesystem or a direct object-store mount, the job may be correct yet still waste more money than a scheduling bug would.
 
-This is the **IO bottleneck** — the most common and most underestimated performance killer in AI infrastructure. Your $300,000 DGX node is sitting idle 60% of the time because the storage system cannot feed data to the GPUs fast enough.
+This module teaches storage as an operational design problem rather than a shopping list of tools. You will start by recognizing the I/O shape of different AI workloads, then build up the storage tiers that Kubernetes can expose: local NVMe for hot data, distributed filesystems for shared warm data, object storage for durable cold data, and caching systems that move bytes closer to the GPUs. The goal is not to memorize one preferred product; the goal is to choose a path that matches the dataset, checkpoint cadence, fault-tolerance needs, and Kubernetes scheduling constraints in front of you.
 
-The numbers are stark:
+The performance gap explains why the storage layer deserves its own module. GPU memory and GPU compute move at speeds that storage systems cannot approach, so the platform has to hide latency through locality, batching, prefetching, and parallelism. The exact numbers vary by hardware and cloud provider, but the relative order is stable enough to use as a design compass.
 
 | Component | Throughput | Latency |
 |-----------|-----------|---------|
 | GPU compute (A100 BF16) | 312 TFLOPS | nanoseconds |
 | GPU memory (HBM3) | 2 TB/s | nanoseconds |
-| NVMe SSD (local) | 7 GB/s | 10-100 μs |
+| NVMe SSD (local) | 7 GB/s | 10-100 us |
 | Network storage (CephFS) | 1-5 GB/s | 0.5-5 ms |
 | Object storage (S3) | 100-500 MB/s | 10-100 ms |
 
-There is a **1,000x gap** between GPU memory speed and network storage speed. Bridging this gap is what this module is about.
+The table is not a promise that every NVMe disk, CephFS cluster, or S3 bucket will hit those values. It is a reminder that storage sits far away from the compute unit in both latency and throughput, especially when the training workload issues millions of small reads. A platform that ignores this gap can buy more GPUs and still deliver slower training, while a platform that respects the gap can improve utilization with a cache, a packaging change, or a different checkpoint strategy.
 
----
+## The I/O Bottleneck in ML Workloads
 
-## The IO Bottleneck in ML Workloads
-
-### Where IO Happens
-
-Every training step involves IO at multiple stages:
+Every training step contains a small pipeline, and the slowest stage controls the useful pace of the whole job. The framework asks a data loader for a batch, the data loader reads files or records, CPU workers decode and transform the examples, the host transfers tensors to GPU memory, and only then does the forward and backward pass run. When storage is slow, GPU utilization appears low even if the model, CUDA libraries, and GPU scheduling are healthy.
 
 ```mermaid
 flowchart LR
     subgraph Training_Loop ["Training Loop (This dominates when storage is slow)"]
         direction LR
-        A["1. Load batch\nRead from storage\n(IO bound)\n100ms - 5s"] --> B["2. Transfer to GPU\nCPU RAM → GPU VRAM\n(PCIe bound)\n1-10ms"]
+        A["1. Load batch\nRead from storage\n(IO bound)\n100ms - 5s"] --> B["2. Transfer to GPU\nCPU RAM -> GPU VRAM\n(PCIe bound)\n1-10ms"]
         B --> C["3. Compute\nForward + Backward\n(compute)\n10-100ms"]
     end
 ```
 
-### Workload IO Profiles
+The diagram deliberately separates storage reads from GPU transfer because they fail in different ways. A PCIe transfer bottleneck often shows up after the batch is already resident in host memory, while a storage bottleneck shows up before the CPU workers can produce the batch. That distinction matters when you decide whether to tune `DataLoader` workers, pre-stage data onto local disks, package small files into larger records, or change the filesystem entirely.
 
-Different ML workloads have radically different IO characteristics:
+Different ML workloads have radically different I/O profiles, and platform teams get into trouble when they treat all training jobs as if they were the same. Image training often reads a huge count of tiny objects in random order, which punishes object storage and metadata-heavy network filesystems. Tokenized language-model training is usually friendlier because it can read larger sequential shards, but the required throughput may be much higher because the GPUs consume tokens quickly.
 
 | Workload | Data Size | Access Pattern | Read Size | Throughput Need |
 |----------|-----------|---------------|-----------|-----------------|
@@ -75,13 +69,11 @@ Different ML workloads have radically different IO characteristics:
 | LLM fine-tuning (tokenized) | 10-100 GB | Sequential | 1-10 MB | 1-5 GB/s |
 | Checkpoint save | 1-50 GB per save | Sequential write | Full model | 5-20 GB/s burst |
 
-The key insight: **image training** does millions of small random reads (hard for network storage), while **LLM training** does large sequential reads (easier to cache).
+The key design move is to translate the workload into read size, randomness, concurrency, and write burst requirements before choosing storage. Image classification against millions of JPEG files may need local caching or dataset repackaging even when the total dataset is modest. Video training may tolerate higher latency per file because each read is large, but it can saturate network links if several jobs stream at once. Checkpointing flips the problem from reads to writes, and a fast read cache does not automatically make checkpoint saves safe or durable.
 
-> **Pause and predict**: If you are training a large language model vs an image classification model, how will the I/O read patterns differ?
+Pause and predict: if a large language model and an image classifier both report low GPU utilization, which one would you expect to benefit more from packing data into larger sequential shards, and which one would you inspect first for metadata or small-file overhead? Write down the hypothesis before looking at metrics, because the habit of predicting forces you to connect symptoms to the workload shape rather than reaching for a favorite storage product.
 
-### Profiling IO Bottlenecks
-
-Before optimizing, measure. Run your training job with GPU utilization monitoring:
+Before optimizing, measure the job that is actually slow. GPU utilization tells you whether accelerators are waiting, but it does not prove storage is the cause by itself. Correlate that signal with data-loader timing, CPU saturation, network throughput, filesystem latency, and pod placement, because a CPU-heavy augmentation pipeline can look similar to an I/O bottleneck from the GPU side.
 
 ```bash
 # Monitor GPU utilization during training
@@ -100,20 +92,18 @@ kubectl exec -it training-pod -- watch -n 1 'nvidia-smi --query-gpu=utilization.
 #     load_start = time.time()
 ```
 
-> **Stop and think**: If your GPU utilization is at 40%, what metrics would you check to confirm it's an I/O bottleneck rather than a CPU compute bottleneck?
+The command is intentionally simple because the first measurement should be easy enough to run during an incident. If the GPU is below target utilization and the data loader repeatedly spends longer than the compute step, storage and preprocessing deserve immediate attention. If the data loader is fast but GPU memory utilization is high, you may be facing a model-memory or batch-size issue instead; the important skill is to avoid tuning storage when the evidence points somewhere else.
 
----
+Stop and think: if GPU utilization is around forty percent, what three metrics would you check before blaming the storage backend? A strong answer includes at least one GPU-side metric, one application-side timing signal, and one infrastructure-side signal such as filesystem latency, node network throughput, or cache hit rate.
 
 ## Storage Tiers for AI
 
-### The Storage Pyramid
-
-AI workloads need a multi-tier storage architecture:
+AI platforms usually need multiple storage tiers because no single tier gives perfect cost, latency, throughput, durability, and sharing semantics. Local disks are fast and close to the training process, but they disappear with the node and cannot be mounted by every pod at once. Distributed filesystems can provide shared POSIX access, but their metadata services and network paths create latency that small-file workloads feel immediately. Object storage is durable and cheap at scale, but it exposes a request-oriented API rather than the low-latency filesystem behavior most training scripts expect.
 
 ```mermaid
 flowchart TD
-    A["GPU VRAM (training)\n2 TB/s, μs latency\nManaged by framework"]
-    B["Local NVMe (hot cache)\n3-14 GB/s, 10-100 μs\nTopoLVM, OpenEBS LVM"]
+    A["GPU VRAM (training)\n2 TB/s, us latency\nManaged by framework"]
+    B["Local NVMe (hot cache)\n3-14 GB/s, 10-100 us\nTopoLVM, OpenEBS LVM"]
     C["Distributed FS (warm)\n1-10 GB/s, 0.5-5 ms\nCephFS, GlusterFS, JuiceFS"]
     D["Object Storage (cold)\n100 MB-5 GB/s, 10-100 ms\nS3, GCS, MinIO"]
     E["Tape/Archive\nArchival\nGlacier, Coldline"]
@@ -124,21 +114,13 @@ flowchart TD
     D -->|"Cost $$$$, Speed $"| E
 ```
 
-The platform team's job is to build infrastructure that automatically moves data between tiers based on access patterns.
+Think of the pyramid as a map of distance from the GPU. The farther data sits from the accelerator, the more the platform must compensate with prefetching, caching, batching, or careful scheduling. The closer data sits to the accelerator, the more the platform must compensate for durability, capacity, and scheduling restrictions. A good architecture does not try to put every byte on the fastest tier; it puts the active working set on the fastest tier while keeping the canonical dataset in a durable tier that can survive node loss.
 
----
+The platform team's job is to make movement between tiers predictable. For example, a training pod can read a canonical dataset from object storage, stage the current shard set onto local NVMe, and write durable checkpoints to a shared filesystem or object-backed layer. That flow gives the job a fast hot path during the epoch while still allowing the team to rebuild state after rescheduling. Kubernetes storage objects are the contract that lets you expose those choices without hard-coding node paths into every training script.
 
-## Local NVMe Caching
+Local NVMe matters because a modern SSD can serve sequential reads at several gigabytes per second and can handle random I/O far better than a remote object store. The practical strategy is to keep the active dataset, or a cache of it, on local NVMe while the canonical copy lives in object storage. This is especially effective for repeated experiments over the same data, where the first run warms the cache and later runs avoid most remote reads.
 
-### Why Local Storage Matters
-
-A modern NVMe SSD delivers 3-7 GB/s sequential read and 500K-1M IOPS random read. This is 10-50x faster than network storage for the random small-file reads that image training demands.
-
-The strategy: keep the active dataset (or a cache of it) on local NVMe while the canonical copy lives in object storage.
-
-### TopoLVM: Topology-Aware Local Volumes
-
-TopoLVM is a CSI driver that provisions PersistentVolumes from local LVM volume groups, with **topology awareness** — it ensures Pods are scheduled on nodes that have available local storage.
+TopoLVM is a CSI driver that provisions PersistentVolumes from local LVM volume groups with topology awareness. The topology part is essential: a local volume only exists on the node where its backing device exists, so Kubernetes must delay binding until it knows where the pod will run. Without that scheduler coordination, a PVC can bind to storage on one node while the GPU pod lands on another node, which leaves the job pending or forces manual repair.
 
 ```bash
 # Install TopoLVM
@@ -152,7 +134,7 @@ helm install topolvm topolvm/topolvm \
   --set node.volumeGroup.name=nvme-vg    # LVM VG name on each node
 ```
 
-Create a StorageClass:
+The StorageClass is where the scheduling intent becomes visible. `volumeBindingMode: WaitForFirstConsumer` tells Kubernetes not to bind the PVC until a pod actually needs it, which gives the scheduler a chance to consider both GPU availability and local storage availability. `allowVolumeExpansion` is useful for training caches because dataset working sets often grow after the first successful experiment.
 
 ```yaml
 apiVersion: storage.k8s.io/v1
@@ -167,7 +149,7 @@ allowVolumeExpansion: true
 reclaimPolicy: Delete
 ```
 
-Use in a training Pod:
+The training pod mounts a cache PVC exactly like it would mount any other Kubernetes volume, which is the point of using CSI rather than hand-managed host paths. The application sees a normal directory at `/data/cache`, while the platform keeps the placement and allocation logic inside Kubernetes. In a production environment, you would also constrain the pod to nodes with the right GPU type and local disk pool, but the storage pattern remains the same.
 
 ```yaml
 apiVersion: v1
@@ -209,9 +191,7 @@ spec:
         claimName: imagenet-s3
 ```
 
-### OpenEBS LVM Local PV
-
-OpenEBS provides a simpler alternative for local NVMe provisioning:
+OpenEBS LVM LocalPV offers a similar local-volume pattern with a different operational footprint. It is attractive when you want a simpler local-provisioning story and already manage node volume groups outside the storage driver. As with TopoLVM, the key is not the product name but the combination of local disk performance, CSI lifecycle management, and delayed binding so the scheduler does not make impossible placement decisions.
 
 ```bash
 # Install OpenEBS LVM LocalPV
@@ -238,9 +218,7 @@ parameters:
 volumeBindingMode: WaitForFirstConsumer
 ```
 
-### Init Container Pattern for Data Staging
-
-A common pattern: use an init container to stage data from object storage to local NVMe before training begins:
+An init container is the simplest cache warmer because it makes the data movement explicit and keeps the training container focused on training. The job starts, the init container copies the selected dataset from object storage to the cache volume, and the main container runs only after staging completes. This pattern is not perfect for multi-terabyte datasets or highly shared caches, but it is reliable, easy to debug, and often sufficient for medium-sized datasets.
 
 ```yaml
 apiVersion: batch/v1
@@ -288,24 +266,15 @@ spec:
       restartPolicy: OnFailure
 ```
 
----
+Before running a staged-training pattern in production, decide how cache freshness will be enforced. A copied dataset is fast, but it can become stale if the canonical object-store prefix changes after the cache was populated. Some teams solve that with immutable dataset versions, such as `imagenet-v3` rather than `latest`; others include a manifest checksum in the job and refuse to train if the local cache does not match it. Either approach is better than silently training against a mixture of old and new files.
 
-## Distributed Filesystems
+## Distributed Filesystems and Object-Backed POSIX
 
-### CephFS
+Distributed filesystems solve a different problem than local NVMe. They provide shared access, larger aggregate capacity, and sometimes stronger durability, which makes them useful for multi-node training, shared datasets, and checkpoint directories. The tradeoff is that each metadata lookup and data read crosses a network path, so the system has to be sized, tuned, and measured under the same access pattern the AI job will use.
 
-Ceph is the most widely deployed distributed storage system in Kubernetes. CephFS provides a POSIX-compatible filesystem backed by the Ceph cluster.
+CephFS is widely deployed in Kubernetes through Rook because it gives applications POSIX-compatible filesystem semantics backed by a Ceph cluster. That POSIX behavior matters because many training scripts expect files, directories, renames, and ordinary path traversal rather than object-store APIs. CephFS can be a good shared warm tier, but it is still not a magic replacement for local caching when a workload performs millions of tiny random reads.
 
-**Strengths for AI**:
-- POSIX semantics (training frameworks expect filesystem APIs)
-- Scalable metadata server (can handle millions of small files)
-- Multi-reader access (ReadWriteMany) for data-parallel training
-- Integrated with Rook for Kubernetes-native deployment
-
-**Weaknesses for AI**:
-- Latency: 0.5-5ms per operation (100-1000x slower than local NVMe)
-- Throughput ceiling: limited by network and OSD count
-- Small file performance: poor for millions of tiny files (image datasets)
+The strengths and weaknesses for AI workloads are practical rather than ideological. CephFS supports ReadWriteMany access, can scale with more OSDs and metadata servers, and integrates cleanly with Kubernetes. At the same time, metadata latency, network saturation, and small-file overhead can dominate image workloads unless the dataset is packed, cached, or prewarmed. The correct response is not to reject CephFS; it is to place it where shared semantics matter and avoid asking it to behave like GPU-local memory.
 
 ```yaml
 # Rook-Ceph CephFS StorageClass
@@ -327,9 +296,9 @@ mountOptions:
   - nodiratime
 ```
 
-### JuiceFS
+The `noatime` and `nodiratime` options are small settings with large consequences for read-heavy training. Traditional access-time updates create metadata writes when files are read, which means an apparently read-only workload can still pressure the metadata path. Disabling those updates is usually safe for datasets and checkpoint inputs because training jobs rarely depend on access times for correctness.
 
-JuiceFS is a cloud-native distributed filesystem purpose-built for the gap between object storage and high-performance compute. It separates metadata (stored in Redis, PostgreSQL, or TiKV) from data (stored in any object storage).
+JuiceFS targets the awkward space between object storage and filesystem expectations. It presents a POSIX client through FUSE and CSI, stores metadata in a separate engine such as Redis or PostgreSQL, stores data in object storage, and caches reads locally. That architecture lets a team keep the durable copy in S3-compatible storage while giving training code a familiar path-based interface.
 
 ```mermaid
 flowchart LR
@@ -343,14 +312,7 @@ flowchart LR
     Client <-->|"Local caching"| Cache
 ```
 
-**Why JuiceFS excels for AI**:
-1. **Transparent caching**: Reads are cached on local NVMe. Second read of same file is at NVMe speed.
-2. **POSIX compatible**: Drop-in replacement for local filesystem in training scripts.
-3. **Any object store backend**: S3, GCS, Azure Blob, MinIO — your data stays where it is.
-4. **Metadata engine flexibility**: Redis for speed, PostgreSQL for durability, TiKV for scale.
-5. **Kubernetes-native**: CSI driver with dynamic provisioning.
-
-### Installing JuiceFS CSI Driver
+The separation of metadata, object data, and local cache creates both power and responsibility. A warm JuiceFS cache can make repeated reads approach local-disk behavior, but the metadata engine is now part of the critical path and must be monitored like any other stateful service. Object storage remains the durable backend, so network reliability, bucket policies, and request rates still matter even when most hot reads are served locally.
 
 ```bash
 # Install JuiceFS CSI Driver
@@ -370,7 +332,7 @@ helm install juicefs-csi juicefs/juicefs-csi-driver \
   --set storageClasses[0].cachePVC=juicefs-cache
 ```
 
-### JuiceFS StorageClass with Caching
+Treat the command as a shape, not a production secret-management pattern. In a real cluster, backend credentials should come from Kubernetes Secrets or an external secret operator, the metadata engine should have backups and access controls, and the cache should be sized from observed working sets. The important storage lesson is that the CSI driver turns the object-backed filesystem into a normal PVC interface that training teams can consume without rewriting every data loader.
 
 ```yaml
 apiVersion: storage.k8s.io/v1
@@ -393,39 +355,37 @@ reclaimPolicy: Retain
 volumeBindingMode: Immediate
 ```
 
----
+The mount options show where performance choices become explicit. A larger cache can reduce repeat reads but competes with other workloads for local disk. A larger read-ahead buffer can improve sequential scans but may waste bandwidth when the access pattern is random. `Retain` protects the filesystem from accidental PVC deletion, which is often appropriate when the volume represents a durable dataset namespace rather than a disposable scratch cache.
 
-## Dataset Caching: Fluid and Alluxio
+Which approach would you choose here and why: a ReadWriteMany CephFS volume for a multi-node training job whose dataset changes daily, or a JuiceFS object-backed mount with local cache for many repeated experiments over immutable dataset versions? A defensible answer names the workload's sharing requirement, update pattern, cache reuse opportunity, and durability expectations.
 
-### The Caching Problem
+## Dataset Caching and Data-Aware Scheduling
 
-Consider this scenario: 50 ML engineers share a 500GB ImageNet dataset stored in S3. Without caching:
+Caching becomes most valuable when the same data is read repeatedly by many jobs. Without a cache, each run pays the object-store request latency and network transfer cost again, even if another pod on the same node just read the same files. With a cache, the first read is still cold, but later reads can be served from local disk or memory, and the platform can stop treating every training run as a brand-new download.
 
-```
-Engineer 1 training job: Downloads 500GB from S3 → 30 min
-Engineer 2 training job: Downloads 500GB from S3 → 30 min
+```text
+Engineer 1 training job: Downloads 500GB from S3 -> 30 min
+Engineer 2 training job: Downloads 500GB from S3 -> 30 min
 ...
-Engineer 50 training job: Downloads 500GB from S3 → 30 min
+Engineer 50 training job: Downloads 500GB from S3 -> 30 min
 
 Total: 25 TB downloaded, 25 hours of wait time, $50+ in S3 egress
 ```
 
-With a caching layer:
-
-```
-Engineer 1 training job: Downloads 500GB from S3 → 30 min (cold)
-Engineer 2 training job: Reads from cache → 2 min (warm)
+```text
+Engineer 1 training job: Downloads 500GB from S3 -> 30 min (cold)
+Engineer 2 training job: Reads from cache -> 2 min (warm)
 ...
-Engineer 50 training job: Reads from cache → 2 min (warm)
+Engineer 50 training job: Reads from cache -> 2 min (warm)
 
 Total: 500GB downloaded, 2 hours total wait, $1 in S3 egress
 ```
 
-> **Stop and think**: How much money could you save in cloud egress costs if 50 engineers are constantly downloading a 500GB dataset from S3 every day, and you switch to local caching?
+Those numbers are illustrative, but the direction is real: repeated reads turn network traffic into local traffic when the cache is warm. The hard part is keeping the cache close to the jobs that need it. If Kubernetes schedules a pod on a node with no cached data, the pod experiences a cold read even though another node in the cluster has the dataset ready. That is why storage design and scheduling design cannot be separated for AI workloads.
 
-### Fluid: Kubernetes-Native Dataset Orchestration
+Stop and think: if fifty engineers repeatedly train against the same five-hundred-gigabyte dataset every day, what costs would you include in the cache business case besides object-store egress? A complete answer includes GPU idle time, experiment turnaround, network contention, cache disk cost, operational overhead, and the risk of stale data.
 
-Fluid is a CNCF sandbox project that brings dataset-aware scheduling to Kubernetes. It manages datasets as first-class resources and uses cache engines (Alluxio, JuiceFS, JindoFS) under the hood.
+Fluid is a CNCF sandbox project that brings dataset-aware scheduling to Kubernetes. Instead of treating a dataset as just another PVC, Fluid models the dataset as a resource and coordinates cache engines such as Alluxio, JuiceFS, or JindoFS under the hood. That resource model lets the platform track cache placement and influence pod scheduling so jobs prefer nodes where the needed data is already warm.
 
 ```bash
 # Install Fluid
@@ -437,7 +397,7 @@ helm install fluid fluid/fluid \
   --create-namespace
 ```
 
-Define a dataset and its caching runtime:
+The Dataset resource describes the canonical location, while the runtime describes how the cache should be built and maintained. In the following example, the dataset points at an S3 path, and the Alluxio runtime gives each cache worker both memory and SSD tiers. That combination is useful because metadata and small hot objects can live in memory while larger cached blocks can live on SSD.
 
 ```yaml
 apiVersion: data.fluid.io/v1alpha1
@@ -485,7 +445,7 @@ spec:
     alluxio.user.streaming.data.timeout: "300sec"
 ```
 
-Use the dataset in a training Pod:
+The training pod consumes the dataset through the PVC Fluid creates. From the application perspective, this is still a mounted path, which is exactly what you want for adoption. From the scheduler perspective, the dataset now carries locality information that ordinary PVCs do not express. That is the difference between "mount this shared volume somewhere" and "place this job where the data is already warm if the cluster has a reasonable option."
 
 ```yaml
 apiVersion: batch/v1
@@ -514,9 +474,7 @@ spec:
       restartPolicy: OnFailure
 ```
 
-### Fluid's Data-Aware Scheduling
-
-Fluid tracks where cached data resides and preferentially schedules Pods on nodes that already have the data cached:
+Fluid also supports explicit warmup through a DataLoad resource. Prewarming is useful when benchmark correctness matters, because a cold first epoch can make one storage design look worse than it will be during steady-state training. It is also useful before scheduled training windows, where the platform can move data during a quieter period and reserve GPU time for compute rather than downloads.
 
 ```yaml
 # Fluid automatically injects scheduling hints
@@ -539,9 +497,7 @@ spec:
       replicas: 2    # Cache 2 copies for fault tolerance
 ```
 
-### Alluxio Standalone (without Fluid)
-
-For teams that want more control, Alluxio can be deployed independently:
+Alluxio can also be deployed independently when a team wants more control over the cache layer. That may be appropriate in an environment with multiple compute platforms or a mature storage team that already operates Alluxio outside Kubernetes. The cost is that you now own more of the integration and scheduling behavior yourself, so the operational model should be chosen deliberately rather than by habit.
 
 ```bash
 helm repo add alluxio https://alluxio-charts.storage.googleapis.com/openSource
@@ -564,32 +520,30 @@ helm install alluxio alluxio/alluxio \
   --set properties."alluxio.underfs.s3.region"=us-east-1
 ```
 
----
+The most common caching failure is celebrating a fast second read without asking whether the third job will land on the same node. Cache hit rate is partly a storage metric and partly a scheduling metric. If you scale the GPU pool, add autoscaling, or mix many datasets, you need to watch whether hot data is distributed across the nodes where future jobs will actually run.
 
-## Checkpoint Storage
+## Checkpoint Storage and Benchmarking
 
-### Why Checkpoint IO Matters
+Training data is mostly a read problem, but checkpointing is a write problem with correctness consequences. A checkpoint may include model parameters, optimizer state, random seeds, scheduler state, and training metadata. If it is slow, GPUs wait; if it is corrupt, the team may lose days of progress; if it is stored only on a failed node, recovery may be impossible.
 
-During training, checkpoints must be saved periodically. A checkpoint for a 70B parameter model is:
-
-```
-Model parameters:   70B × 2 bytes (BF16)  = 140 GB
-Optimizer state:    70B × 8 bytes (Adam)   = 560 GB
+```text
+Model parameters:   70B x 2 bytes (BF16)  = 140 GB
+Optimizer state:    70B x 8 bytes (Adam)   = 560 GB
 Total:              ~700 GB per checkpoint
 ```
 
-If your storage can write at 2 GB/s, saving one checkpoint takes **350 seconds** — almost 6 minutes. During this time, GPUs are either idle (synchronous checkpoint) or must continue while carefully not overwriting the in-flight checkpoint (asynchronous).
+If a storage target writes at two gigabytes per second, saving a checkpoint of that size takes about three hundred and fifty seconds before accounting for metadata, serialization, network contention, and filesystem behavior. That delay is not just annoying; it creates an expensive idle window on every checkpoint interval when checkpointing is synchronous. As model size grows, checkpoint design becomes part of the training architecture rather than an afterthought.
 
-### Strategies for Fast Checkpointing
+The simplest checkpoint is synchronous and monolithic, which is easy to reason about but expensive. The training process stops, writes one state file, and resumes when the write completes. This is acceptable for small models, infrequent checkpoints, or early experiments, but it can waste a meaningful share of accelerator time in large distributed jobs.
 
-**Synchronous (simple, slow)**:
 ```python
 # Training pauses during save
 torch.save(model.state_dict(), "/checkpoints/latest.pt")
 # 6 minutes of idle GPUs
 ```
 
-**Asynchronous with background thread**:
+Asynchronous checkpointing reduces the visible pause by copying state to CPU memory and writing in the background. The tradeoff is that the system must protect the in-flight checkpoint from process failure, node failure, and mutation of tensors that training continues to update. In practice, teams use temporary paths, atomic renames, completion markers, and checkpoint validation so a partially written checkpoint is never mistaken for a recoverable one.
+
 ```python
 import threading
 
@@ -603,7 +557,8 @@ thread.start()
 # Training continues immediately
 ```
 
-**Sharded checkpoints** (PyTorch FSDP / DeepSpeed):
+Sharded checkpoints match the distributed shape of modern training. Instead of one worker writing the entire model state, each rank writes its own shard in parallel, which reduces wall-clock save time and avoids funneling every byte through one process. The storage target must still handle the aggregate write burst, so sharding helps most when the filesystem or object-backed layer can accept parallel writes without turning metadata into the next bottleneck.
+
 ```python
 # Each GPU saves its own shard in parallel
 # 8 GPUs writing 87.5 GB each at 2 GB/s = 44 seconds (vs 350 seconds serial)
@@ -611,9 +566,7 @@ from torch.distributed.checkpoint import save
 save(model.state_dict(), checkpoint_id=f"/checkpoints/step_{step}")
 ```
 
-> **Pause and predict**: What is the risk of using asynchronous checkpointing if the node crashes exactly while the background thread is writing the checkpoint?
-
-### Recommended Checkpoint Storage
+Pause and predict: what is the risk of using asynchronous checkpointing if the node crashes exactly while the background thread is writing the checkpoint? The correct instinct is to think beyond speed: a fast checkpoint strategy must also make incomplete writes detectable, make restore points unambiguous, and decide which storage tier becomes the source of truth after failure.
 
 | Storage Type | Write Speed | Best For |
 |-------------|-------------|----------|
@@ -622,11 +575,9 @@ save(model.state_dict(), checkpoint_id=f"/checkpoints/step_{step}")
 | JuiceFS (NVMe cache + S3) | 3-7 GB/s local, async to S3 | Best of both: fast writes, durable storage |
 | NFS | 0.5-2 GB/s | Simple, widely available; potential bottleneck |
 
----
+The table is a decision aid, not a universal ranking. Local NVMe may be the right first landing zone for very frequent checkpoints if a separate process quickly copies completed checkpoints to durable storage. A shared filesystem may be better when many ranks need a common path and the platform can provision enough throughput. NFS remains useful for small teams and modest jobs, but it should be benchmarked under checkpoint-like writes before it becomes the default for large models.
 
-## Try This: Measure Your Storage Performance
-
-Run this inside a Pod on your cluster to understand your storage baseline:
+Benchmark storage from inside a pod because the pod path includes the same CSI driver, mount options, node network, security context, and filesystem behavior the workload will experience. A benchmark from the node shell can hide container-level constraints, while a cloud-provider dashboard can miss application-visible latency. The goal is not to produce a perfect storage benchmark; it is to collect a baseline that is close enough to the training job to guide decisions.
 
 ```bash
 # Create a test pod with your storage class
@@ -676,106 +627,113 @@ fio --name=seq-write --rw=write --bs=1M --size=10G \
   --runtime=60 --time_based --group_reporting
 ```
 
----
+Read the benchmark as three separate stories. Sequential read approximates shard streaming, random read approximates image or small-record training, and sequential write approximates checkpoint bursts. If random read collapses while sequential read looks fine, the storage system may still be acceptable for tokenized LLM data and unacceptable for small-file image training. If sequential write is weak, a read cache will not fix checkpoint stalls.
+
+## Patterns & Anti-Patterns
+
+Pattern: keep the canonical dataset durable and cache only the active working set near the GPU. This works because object storage or a distributed filesystem can remain the source of truth while local NVMe absorbs repeated hot reads. The scaling constraint is cache capacity and placement; when dataset versions multiply, you need eviction rules, quotas, and monitoring so one team does not fill every node cache with stale experiments.
+
+Pattern: use delayed binding for local storage classes. `WaitForFirstConsumer` aligns the PVC with the pod that will consume it, which allows the scheduler to consider node-local disk and GPU availability in the same placement decision. The scaling constraint is fragmentation: if each node has different free disk capacity, the scheduler may need labels, quotas, or separate storage classes to avoid stranding GPUs behind full local volumes.
+
+Pattern: package small files into larger records when the training framework supports it. This works because fewer larger reads reduce metadata pressure, object-store request overhead, and per-file latency. The scaling constraint is data-preparation discipline; once teams adopt shard formats, they need versioned manifests and validation so a corrupt shard does not silently poison a training run.
+
+Pattern: write checkpoints in shards and promote completed checkpoints atomically. This works because distributed training already partitions state across ranks, and the storage layer can often process parallel writes more efficiently than one large serial write. The scaling constraint is restore complexity; the platform should document how to find a complete checkpoint, validate every shard, and clean up failed partial saves.
+
+Anti-pattern: mounting object storage directly through a generic FUSE layer for every training job. Teams fall into this because the path looks like a filesystem and the setup is quick, but random reads can pay remote request latency for every small file. A better alternative is to use a cache-aware filesystem, pre-stage the working set, or convert the dataset into larger sequential shards.
+
+Anti-pattern: using one shared network filesystem for data, checkpoints, logs, and scratch space without classifying access patterns. It feels simple because every job gets one path, but a checkpoint burst can interfere with data loading and logging can create metadata noise. A better alternative is to separate hot cache, shared read-only datasets, durable checkpoint destinations, and disposable scratch volumes.
+
+Anti-pattern: benchmarking only a warm cache and presenting the result as storage performance. Teams do this because the second run looks good, but production jobs experience cold starts, evictions, and rescheduling. A better alternative is to report cold-cache, warm-cache, and post-eviction results, then tie those results to scheduler behavior and expected reuse.
+
+Anti-pattern: treating asynchronous checkpointing as safe just because training resumes quickly. The background write may still fail, produce a partial checkpoint, or fall behind future checkpoints under load. A better alternative is to use temporary directories, completion markers, atomic promotion, restore tests, and metrics that show checkpoint lag.
+
+## Decision Framework
+
+Start the decision with the workload, not the storage brand. If the workload is dominated by random small-file reads and repeated experiments, prioritize locality, cache hit rate, and dataset packaging. If the workload streams large token or video shards, prioritize aggregate sequential throughput and network capacity. If the workload is checkpoint-heavy, prioritize write bandwidth, atomic completion, and restore reliability.
+
+Choose local NVMe when the active working set fits on node-local disks, the data can be reconstructed from a durable source, and pod placement can be controlled with topology-aware provisioning. Choose a distributed filesystem when multiple nodes need shared POSIX access, the dataset or checkpoint directory must outlive any one node, and the storage team can provision enough metadata and network capacity. Choose object-backed POSIX systems when you want object storage durability with filesystem compatibility and a cache layer that makes repeated reads practical.
+
+Use dataset-aware caching when repeated jobs access the same dataset and scheduler placement is a major factor in performance. Fluid with Alluxio is compelling when the platform wants Kubernetes-native dataset resources and cache-aware placement. JuiceFS is compelling when a team wants a POSIX namespace backed by object storage with transparent local caching. An init-container staging pattern is compelling when the dataset slice is small enough to copy, freshness can be validated, and operational simplicity matters more than dynamic cache orchestration.
+
+For checkpoints, decide where a completed checkpoint becomes durable before deciding where it is first written. A common design is to land the checkpoint quickly on local or cache-backed storage, verify completion, then copy or flush it to a durable shared tier. Another design writes shards directly to a shared filesystem when the filesystem can handle the burst. The wrong design is to write quickly to ephemeral storage and call the job protected without a tested promotion path.
+
+Finally, require evidence before standardizing the storage class. A storage architecture should come with expected I/O profiles, a benchmark command, cache hit-rate metrics, and a restore test for checkpoints. Without those artifacts, the team has a storage preference rather than an operational decision. Kubernetes 1.35+ gives you the storage API surface, but it does not choose the right tier or prove the path is fast enough for your models.
+
+Make the decision review repeatable so storage choices survive staff changes and workload growth. Record the dataset size, file-count shape, expected reuse rate, checkpoint interval, restore objective, and acceptable cold-start time next to the StorageClass or platform template that teams will consume. That record gives future reviewers a way to see whether a new workload still matches the original assumptions or whether it needs a different tier, cache size, or checkpoint destination.
 
 ## Did You Know?
 
-1. **ImageNet, the dataset that launched the deep learning revolution, contains 14 million images totaling about 150GB**. But the images are tiny JPEG files (average ~10KB each). This means loading ImageNet requires 14 million random reads — a worst case for any storage system. This is why ImageNet training was one of the first workloads to expose storage bottlenecks in GPU clusters.
+1. **ImageNet contains more than fourteen million images and is often described as roughly one hundred fifty gigabytes in common training setups.** The total size is manageable, but the file count creates a small-read problem that punishes object stores, metadata services, and uncached network filesystems. This is why a dataset can be "small" by capacity planning standards and still be difficult for training throughput.
 
-2. **The concept of "data gravity" is literal in AI infrastructure**. Moving a 10TB dataset across the internet takes hours to days, but computing on it takes seconds to minutes. This is why cloud providers offer "data import" services where they physically ship hard drives. Google's Transfer Appliance can hold 1 PB and ships via FedEx — sometimes the highest-bandwidth network is a truck full of disks.
+2. **A single large checkpoint can be bigger than the full dataset used for many classic image tasks.** A seventy-billion-parameter model with Adam optimizer state can produce a checkpoint on the order of hundreds of gigabytes, which turns checkpoint storage into a first-class design concern. The write path must be tested, not assumed, because a slow checkpoint cadence can erase the benefit of faster GPUs.
 
-3. **Meta reported that during Llama 3 training, their storage system served 240 PB of data over the 54-day run** — roughly 4.4 PB per day, or 51 GB per second sustained. This required a custom distributed filesystem (Tectonic) because no off-the-shelf system could handle this throughput at this scale.
+3. **The fastest path is not always the safest path.** Local NVMe can make training reads and checkpoint landing zones extremely fast, but data on a node-local disk is not durable when the node fails. Production designs often pair a fast first hop with a durable promotion step so speed and recovery are both addressed.
 
----
-
-## War Story: The Cache That Saved $200K
-
-A medical imaging startup trained models on a 2TB dataset of CT scans stored in Google Cloud Storage (GCS). They had 20 GPU nodes, each running training jobs that loaded the full dataset.
-
-**Before caching**: Each job downloaded 2TB from GCS at ~500 MB/s = 67 minutes startup time. With 20 nodes running 3 jobs/day each, they downloaded **120 TB/day** from GCS.
-
-- GCS egress cost: $0.12/GB × 120,000 GB/day = $14,400/day = **$432,000/month**
-- GPU idle time during downloads: 20 nodes × 3 jobs × 67 min = 67 GPU-hours/day wasted
-
-**After JuiceFS with NVMe cache**: First job on each node downloads from GCS (cold cache). Subsequent jobs read from local NVMe cache at 5 GB/s = 7 minutes.
-
-- GCS egress: 20 nodes × 2TB × 1 download/week = 40TB/week = **$19,200/month**
-- GPU idle time: negligible (7 min cached vs 67 min uncached)
-
-**Monthly savings**: $432,000 - $19,200 = **$412,800/month**. The caching infrastructure (JuiceFS + NVMe on each node) cost $3,000/month.
-
-**Lesson**: In AI infrastructure, the most impactful optimization is often the simplest: cache the dataset close to the GPUs.
-
----
+4. **Kubernetes `WaitForFirstConsumer` is a storage performance feature as much as a scheduling feature.** It prevents local volumes from binding before the consuming pod is scheduled, which helps the scheduler align GPU availability and local-disk availability. Without that alignment, a technically valid PVC can still create an impossible training placement.
 
 ## Common Mistakes
 
-| Mistake | Problem | Solution |
-|---------|---------|----------|
-| Using S3 FUSE mounts for training | FUSE adds 2-10x latency overhead per IO operation | Use JuiceFS or Alluxio with local NVMe cache; or download to local disk first |
-| Network storage for ImageNet-style training | Millions of small random reads kill network storage | Cache dataset on local NVMe; or use WebDataset/TFRecord for sequential access |
-| Synchronous checkpoints on slow storage | GPUs idle for minutes during each checkpoint save | Use async checkpointing or sharded distributed checkpoints |
-| No `noatime` mount option | Every file read triggers a metadata write (access time update) | Always mount with `noatime,nodiratime` for training volumes |
-| RWO volumes for multi-node training | ReadWriteOnce cannot be mounted on multiple nodes | Use RWX storage (CephFS, NFS, JuiceFS) or local cache per node |
-| Ignoring storage class `volumeBindingMode` | PVC binds to wrong node before Pod is scheduled | Always use `WaitForFirstConsumer` for local storage |
-| Not pre-warming cache before training | First epoch runs at cold-cache speed, skewing benchmark results | Use Fluid's `DataLoad` CRD or an init container to warm cache |
-| Using ext4 for large files | ext4 fragments large sequential writes | Use XFS for datasets and checkpoint volumes; it handles large files better |
+| Mistake | Why It Happens | How to Fix It |
+|---------|----------------|---------------|
+| Using S3 FUSE mounts for training | FUSE adds 2-10x latency overhead per I/O operation, and object storage is request-oriented rather than small-read oriented | Use JuiceFS or Alluxio with local NVMe cache, or download the working set to local disk first |
+| Network storage for ImageNet-style training | Millions of small random reads overload metadata paths and expose network latency | Cache the dataset on local NVMe, or use WebDataset, TFRecord, or another sequential shard format |
+| Synchronous checkpoints on slow storage | GPUs idle for minutes during each checkpoint save while the training loop blocks | Use asynchronous checkpointing, sharded distributed checkpoints, or a faster first-hop checkpoint target |
+| No `noatime` mount option | Every file read can trigger unnecessary metadata updates on the filesystem | Mount read-heavy training volumes with `noatime,nodiratime` when application semantics allow it |
+| RWO volumes for multi-node training | ReadWriteOnce volumes cannot be mounted by pods on multiple nodes for shared training data | Use RWX storage such as CephFS, NFS, or JuiceFS, or provide a local cache per node |
+| Ignoring storage class `volumeBindingMode` | PVCs can bind to local storage on the wrong node before the scheduler sees the pod | Use `WaitForFirstConsumer` for local storage and test pod placement with real GPU constraints |
+| Not pre-warming cache before training | The first epoch runs at cold-cache speed, which skews benchmarks and wastes GPU time | Use Fluid's `DataLoad` CRD, an init container, or a scheduled warmup job before critical runs |
+| Using ext4 for large-file checkpoint workloads by default | The default filesystem choice may not match large sequential writes or the team's operational tuning | Benchmark XFS and ext4 under checkpoint-like writes, then standardize the filesystem and mount options |
 
----
-
-## Quiz: Check Your Understanding
-
-### Question 1
-*Scenario*: Your ML team wants to train a new ResNet model directly against a 150GB S3 bucket containing 14 million individual JPEG files. They've mounted the bucket using an S3 FUSE driver. They report that the training is exceptionally slow, even though the total dataset is relatively small. What underlying characteristics of object storage make this architecture problematic for this specific workload?
+## Quiz
 
 <details>
-<summary>Show Answer</summary>
+<summary>Question 1: Your ML team trains a ResNet model directly against an S3 bucket containing millions of individual JPEG files through a generic FUSE mount. GPUs stay under target utilization even though the dataset is not large. What should you change first, and why?</summary>
 
-Three compounding issues explain why this approach fails. First, object storage systems like S3 exhibit high per-request latency (10-100ms); when multiplied across 14 million independent image reads, this cumulative latency becomes the primary bottleneck. Second, S3 is optimized for high throughput on large files, not high IOPS for tiny 10KB files, meaning the HTTP/TLS protocol overhead for each GET request often exceeds the time taken to transfer the actual image data. Finally, object stores lack sequential prefetching logic, so they cannot anticipate and stream the next files the way a local filesystem or advanced caching layer would. To solve this, the team should either pack the files into sequential archives (like WebDataset) or introduce a caching layer like JuiceFS with a local NVMe tier.
+The first change should address the small-random-read pattern rather than the total dataset size. Object storage has meaningful per-request latency, and a FUSE layer adds more overhead before each tiny file reaches the data loader. A local cache, a cache-aware filesystem such as JuiceFS or Alluxio, or a shard format such as WebDataset reduces the number of remote requests and makes reads more sequential. Increasing GPU count would likely make the problem worse because more workers would issue more small reads against the same slow path.
 </details>
-
-### Question 2
-*Scenario*: Your infrastructure team needs to improve data loading times for a 5TB training dataset. Engineer A proposes installing JuiceFS, while Engineer B argues for deploying Alluxio with Fluid. In what architectural scenarios would you choose JuiceFS over Alluxio, and why?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Question 2: A platform engineer creates a local NVMe StorageClass but leaves `volumeBindingMode` at the default. Some GPU jobs remain pending even though nodes have free GPUs and free local disk. What is the likely storage scheduling mistake?</summary>
 
-JuiceFS and Alluxio take fundamentally different architectural approaches to solving the data caching problem. JuiceFS is designed as a complete POSIX-compliant distributed filesystem that happens to use object storage as its data backend and Redis/SQL for metadata, making it an excellent drop-in replacement when you need simple, robust filesystem semantics with transparent local NVMe caching. Alluxio, on the other hand, acts as a pure caching middleware layer that sits between your compute and existing storage systems (like HDFS or S3), without storing the canonical data itself. You would choose JuiceFS for its operational simplicity and seamless POSIX integration. Conversely, you would choose Alluxio (especially paired with Fluid) when you require advanced dataset-aware scheduling, multi-tier caching (RAM+SSD), or need to unify multiple disparate storage backends under a single namespace.
+The likely mistake is binding the PVC before Kubernetes knows which pod will consume it. For local storage, early binding can attach the claim to a volume on a node that does not match the eventual GPU placement, leaving the scheduler with incompatible requirements. `WaitForFirstConsumer` delays binding until pod scheduling, which lets Kubernetes consider local disk topology and GPU availability together. The fix is to update the StorageClass and recreate affected PVCs because existing claims may already be bound.
 </details>
-
-### Question 3
-*Scenario*: You are observing a massive 70B parameter LLM training job. Every 1000 steps (which take about 2 seconds each), the job halts for 350 seconds to save a 700GB checkpoint to a standard NFS share. The ML team is complaining about lost compute time. Quantify the GPU time wasted by this synchronous operation and propose a multi-faceted solution to minimize it.
 
 <details>
-<summary>Show Answer</summary>
+<summary>Question 3: A team reports that a JuiceFS-backed dataset is fast on the second run but slow whenever jobs move to newly added GPU nodes. What metric and operational behavior should you investigate?</summary>
 
-Currently, the training job spends 2000 seconds on compute and 350 seconds blocked on I/O, meaning nearly 15% of your expensive GPU time is entirely wasted waiting for storage. This synchronous checkpointing creates a severe bottleneck because all compute must halt while the single node writes out the monolithic 700GB state to a slow NFS target. To drastically reduce this waste, you should first implement sharded distributed checkpoints, allowing each GPU to write only its own portion of the model state in parallel. Second, transition to asynchronous checkpointing, where the state is quickly copied to host CPU RAM (taking only seconds) and then written to disk in a background thread. Finally, upgrading the storage target from slow NFS to a high-throughput local NVMe cache or parallel filesystem (like CephFS) ensures those background writes complete rapidly without saturating the network.
+Investigate cache hit rate by node and pod placement relative to cached data. A fast second run proves that the cache can help on a warm node, but it does not prove that the scheduler consistently places future jobs near the warm cache. You should check whether autoscaling or random placement is sending jobs to nodes with cold caches, then consider Fluid-style data-aware scheduling, prewarming, or node-affinity rules. Also verify that cache size and eviction policy are not discarding the dataset between runs.
 </details>
-
-### Question 4
-*Scenario*: Your cluster runs multiple ML training pods that access a shared 10TB dataset. When you use standard PersistentVolumeClaims (PVCs) backed by a network filesystem, the pods are scheduled randomly across your 50 nodes, and each node constantly fetches data from the remote storage. If you implement Fluid, how does its data-aware scheduling fundamentally change this behavior?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Question 4: A seventy-billion-parameter training job pauses for several minutes every checkpoint because one rank writes a monolithic file to NFS. What design changes reduce idle GPU time without sacrificing recoverability?</summary>
 
-Standard Kubernetes scheduling with regular PVCs has no awareness of data locality, meaning a pod will be scheduled on any node that meets its CPU/GPU requirements, completely ignoring whether that node has the required data cached locally. This leads to severe "cold cache" penalties as each new node must pull data from remote storage. Fluid fundamentally changes this by orchestrating the datasets as first-class citizens and actively tracking which nodes have cached portions of the data via engines like Alluxio. Fluid then automatically injects scheduling hints (like node affinities) into your training pods, ensuring the Kubernetes scheduler preferentially places them on nodes where the data is already warm. This data-aware placement drastically reduces network I/O, lowers object storage egress costs, and accelerates training startup times.
+Use sharded distributed checkpoints so multiple ranks write their own state in parallel, and consider asynchronous checkpointing so training does not block on the full storage write. To preserve recoverability, write to temporary paths, validate all shards, and promote the checkpoint only after completion markers confirm that every shard is present. The storage target should be benchmarked for aggregate sequential writes because parallel checkpointing can expose metadata and network limits. A fast local landing zone is acceptable only if completed checkpoints are copied or flushed to durable storage before older restore points are deleted.
 </details>
 
----
+<details>
+<summary>Question 5: Two teams ask for a shared dataset platform. Team A repeatedly trains on immutable dataset versions, while Team B updates a shared dataset daily and requires POSIX semantics across many pods. How would you compare JuiceFS caching and CephFS for these teams?</summary>
+
+Team A is a strong fit for object-backed caching because immutable versions make cache freshness easier to reason about and repeated reads can hit local NVMe after the first run. JuiceFS can expose a POSIX-like path while keeping object storage as the durable backend. Team B may be a better fit for a shared distributed filesystem such as CephFS if daily updates and multi-pod POSIX semantics are central requirements. The final decision should still be benchmarked under each team's read sizes, concurrency, and update pattern.
+</details>
+
+<details>
+<summary>Question 6: A benchmark shows excellent sequential read throughput but poor random-read throughput on the same storage class. Which AI workloads can still use this storage safely, and which need another design?</summary>
+
+Large-shard workloads such as tokenized LLM pretraining, video reads, or packed record formats may still perform well because they mostly issue sequential reads. Image datasets with millions of small files are risky because random reads and metadata operations dominate their data path. The better design for small-file workloads is to introduce local caching, use a dataset-aware cache, or repackage files into larger shards. The benchmark result should be documented with workload guidance so teams do not treat one throughput number as universal.
+</details>
 
 ## Hands-On Exercise: JuiceFS Cache Over S3 with Latency Measurement
 
-### Objective
+In this exercise you will deploy a small S3-compatible object store, place a test dataset in it, expose that dataset through JuiceFS, and measure the difference between cold-cache and warm-cache reads. The exercise uses MinIO and Redis so it can run in a test cluster without cloud credentials. The goal is not to build a production JuiceFS deployment; the goal is to see the shape of the performance difference and connect it to the cache architecture discussed in the module.
 
-Deploy JuiceFS with a local NVMe cache backed by S3-compatible object storage, load a dataset, and measure the difference between cold-cache and warm-cache read performance.
+Use a Kubernetes 1.35+ test cluster with permission to create namespaces, Deployments, Services, Secrets, StorageClasses, PVCs, and Pods. EmptyDir-backed MinIO storage is acceptable for the exercise because the dataset is disposable. If your cluster already has a locked-down default namespace or restricted Pod Security settings, create a dedicated lab cluster or adjust the manifests to match your local policy before running the commands.
 
-### Environment
+### Step 1: Deploy MinIO
 
-- Kubernetes cluster with at least one node
-- MinIO or any S3-compatible storage (we will deploy MinIO for this exercise)
-- A node with local storage available (emptyDir is acceptable for the exercise)
+Create a local S3-compatible endpoint that will act as the slow durable tier for the lab. In production, this layer would usually be cloud object storage, an enterprise object store, or a managed MinIO deployment with real credentials and durable disks. For the exercise, the object store is intentionally small and disposable.
 
-### Step 1: Deploy MinIO (S3-compatible Object Store)
+<details>
+<summary>Solution</summary>
 
 ```bash
 # Install MinIO for local S3-compatible storage
@@ -837,7 +795,14 @@ EOF
 kubectl -n storage wait --for=condition=Ready pod -l app=minio --timeout=120s
 ```
 
-### Step 2: Create a Test Dataset in MinIO
+</details>
+
+### Step 2: Create a Test Dataset
+
+Now create a bucket and upload a small dataset made of many equal-sized files. This shape is useful because it gives the cache enough objects to show a visible warm-read effect without requiring a large cluster. In a real AI platform, the equivalent step would be publishing a versioned training dataset and recording its manifest.
+
+<details>
+<summary>Solution</summary>
 
 ```bash
 # Create a bucket and upload test data
@@ -859,7 +824,14 @@ kubectl -n storage run mc --rm -it --restart=Never \
 '
 ```
 
-### Step 3: Deploy Redis (JuiceFS Metadata Engine)
+</details>
+
+### Step 3: Deploy Redis for Metadata
+
+JuiceFS separates metadata from object data, so the lab needs a metadata engine. Redis is convenient for a short exercise because it starts quickly and has a simple service endpoint. A production deployment should make a deliberate metadata-engine choice, then back it up and monitor it as a critical dependency.
+
+<details>
+<summary>Solution</summary>
 
 ```bash
 cat <<'EOF' | kubectl apply -f -
@@ -897,7 +869,14 @@ spec:
 EOF
 ```
 
-### Step 4: Install JuiceFS CSI Driver
+</details>
+
+### Step 4: Install the JuiceFS CSI Driver
+
+The CSI driver is what makes the object-backed filesystem consumable through Kubernetes PVCs. Notice that the lab Secret contains example credentials for the disposable MinIO deployment, not production secrets. In a real environment, use your organization's secret-management pattern and restrict access to the bucket that contains the relevant dataset.
+
+<details>
+<summary>Solution</summary>
 
 ```bash
 helm repo add juicefs https://juicedata.github.io/charts/
@@ -926,7 +905,14 @@ helm install juicefs-csi juicefs/juicefs-csi-driver \
   --version v0.24.8
 ```
 
-### Step 5: Create JuiceFS StorageClass and PVC
+</details>
+
+### Step 5: Create the StorageClass and PVC
+
+This StorageClass exposes JuiceFS to pods and sets a modest cache size so the lab can run on small clusters. The PVC uses ReadWriteMany because the filesystem can be mounted by more than one pod, which is a common requirement for shared training data. The cache settings are intentionally small; production settings should come from observed working-set size and node disk capacity.
+
+<details>
+<summary>Solution</summary>
 
 ```bash
 cat <<'EOF' | kubectl apply -f -
@@ -959,7 +945,14 @@ spec:
 EOF
 ```
 
-### Step 6: Measure Cold vs Warm Cache Performance
+</details>
+
+### Step 6: Measure Cold and Warm Reads
+
+The benchmark pod reads every test file once, then reads the same files again. The first pass should fetch data from the object backend through JuiceFS, while the second pass should benefit from the local cache. Do not treat the exact seconds as portable across clusters; focus on the relative behavior and the reason the second read changes.
+
+<details>
+<summary>Solution</summary>
 
 ```bash
 cat <<'BENCHEOF' | kubectl apply -f -
@@ -1029,68 +1022,53 @@ sleep 60
 kubectl -n storage logs cache-benchmark
 ```
 
+</details>
+
 ### Step 7: Cleanup
+
+Cleanup removes the disposable object store, Redis metadata engine, benchmark pod, and lab PVCs. If you want to inspect the namespace after the benchmark, run the cleanup only after you have captured logs and compared cold and warm read results. Leaving the namespace around is fine for a short investigation, but it should not become hidden state in a shared cluster.
+
+<details>
+<summary>Solution</summary>
 
 ```bash
 kubectl delete namespace storage
 ```
 
+</details>
+
 ### Success Criteria
 
 You have completed this exercise when:
-- [ ] MinIO is running and contains a 1GB test dataset (256 files)
-- [ ] Redis metadata engine is running
-- [ ] JuiceFS CSI driver is installed and StorageClass is created
-- [ ] PVC is bound and mountable
-- [ ] Cold cache read time is measured (expect: 30-120 seconds for 1GB)
-- [ ] Warm cache read time is measured (expect: 2-10 seconds for 1GB)
-- [ ] Warm cache read is at least 3x faster than cold cache read
-- [ ] You can explain why the speedup occurs (local NVMe/memory vs S3 network round-trip)
 
----
+- [ ] MinIO is running and contains a 1GB test dataset with 256 files.
+- [ ] Redis metadata engine is running.
+- [ ] JuiceFS CSI driver is installed and the StorageClass is created.
+- [ ] PVC is bound and mountable.
+- [ ] Cold cache read time is measured.
+- [ ] Warm cache read time is measured.
+- [ ] Warm cache read is at least three times faster than cold cache read.
+- [ ] You can explain why the speedup occurs: local cache reads avoid repeated object-store network round trips.
 
-## Key Takeaways
+## Sources
 
-1. **IO is the most common bottleneck in GPU training** — if GPU utilization is below 80%, investigate storage first
-2. **Local NVMe is 10-50x faster than network storage** for the random small-file reads that image training demands
-3. **JuiceFS bridges the gap** between object storage (cheap, durable, slow) and local NVMe (fast, ephemeral)
-4. **Fluid/Alluxio add data-aware scheduling** — Pods prefer nodes that already have their dataset cached
-5. **Checkpointing must be fast** — synchronous saves to slow storage can waste 15%+ of GPU time; use sharded async checkpoints
-6. **Mount with `noatime`** — a one-line fix that eliminates unnecessary metadata writes on every file read
-7. **Measure before optimizing** — use `fio` to benchmark your storage and `nvidia-smi` to correlate with GPU utilization
-8. **The init container pattern** for data staging is simple, reliable, and often sufficient for datasets under 1TB
-
----
-
-## Further Reading
-
-**Documentation**:
-- **JuiceFS**: juicefs.com/docs/
-- **Fluid**: github.com/fluid-cloudnative/fluid
-- **Alluxio**: docs.alluxio.io
-- **TopoLVM**: github.com/topolvm/topolvm
-- **Rook-Ceph**: rook.io/docs/rook/latest/
-
-**Papers**:
-- **"Analyzing and Mitigating Data Stalls in DNN Training"** — Jayaram et al. (IO bottleneck analysis)
-- **"CoorDL: Coordinated and Progressive Data Loading for Deep Learning"** — Mohan et al.
-
-**Talks**:
-- **"Building a Petabyte-Scale AI Data Platform on Kubernetes"** — KubeCon EU 2024
-- **"JuiceFS: A Cloud-Native Distributed File System for AI Workloads"** — CNCF Webinar
-
----
-
-## Summary
-
-Storage is the hidden bottleneck that prevents expensive GPUs from reaching their potential. A multi-tier approach — local NVMe for hot data, distributed filesystem for warm data, object storage for cold data — combined with intelligent caching (JuiceFS, Fluid/Alluxio) bridges the 1,000x performance gap between GPU memory and network storage. Fast checkpoint storage with async and sharded writes minimizes GPU idle time during saves. Measure, cache, and measure again.
-
----
+- [Kubernetes StorageClasses](https://kubernetes.io/docs/concepts/storage/storage-classes/)
+- [Kubernetes Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
+- [Kubernetes Volumes](https://kubernetes.io/docs/concepts/storage/volumes/)
+- [Container Storage Interface documentation](https://kubernetes-csi.github.io/docs/)
+- [TopoLVM documentation](https://topolvm.github.io/topolvm)
+- [TopoLVM GitHub repository](https://github.com/topolvm/topolvm)
+- [OpenEBS Local PV LVM installation](https://openebs.io/docs/user-guides/local-storage-user-guide/local-pv-lvm/lvm-installation)
+- [Rook CephFS filesystem storage](https://rook.io/docs/rook/latest/Storage-Configuration/Shared-Filesystem-CephFS/filesystem-storage/)
+- [JuiceFS CSI Driver introduction](https://juicefs.com/docs/csi/introduction/)
+- [JuiceFS Helm charts](https://juicedata.github.io/charts/)
+- [Fluid with Alluxio user guide](https://fluid-cloudnative.github.io/docs/userguide/how_to_use_fluid_with_alluxio/)
+- [Fluid GitHub repository](https://github.com/fluid-cloudnative/fluid)
+- [Alluxio on Kubernetes](https://docs.alluxio.io/os/user/stable/en/kubernetes/Running-Alluxio-On-Kubernetes.html)
+- [Alluxio open source Helm chart repository](https://alluxio-charts.storage.googleapis.com/openSource)
+- [PyTorch distributed checkpoint API](https://pytorch.org/docs/stable/distributed.checkpoint.html)
+- [MinIO Kubernetes documentation](https://min.io/docs/minio/kubernetes/upstream/index.html)
 
 ## Next Module
 
-Continue to [Module 1.5: Serving LLMs at Scale](../module-1.5-llm-serving/) to learn how to deploy large language models for inference with vLLM, continuous batching, and KEDA autoscaling.
-
----
-
-*"Data is the new oil, but storage is the pipeline. A clogged pipeline makes the oil worthless."* — Anonymous infrastructure engineer
+Continue to [Module 1.5: Serving LLMs at Scale](../module-1.5-llm-serving/) to learn how inference platforms use vLLM, continuous batching, autoscaling, and model-serving storage patterns after training artifacts are ready to serve.

--- a/src/content/docs/platform/disciplines/data-ai/ai-infrastructure/module-1.4-ai-storage.md
+++ b/src/content/docs/platform/disciplines/data-ai/ai-infrastructure/module-1.4-ai-storage.md
@@ -27,6 +27,8 @@ After completing this module, you will be able to:
 
 Hypothetical scenario: your platform team has just delivered a clean GPU pool for the machine learning group. The nodes have modern accelerators, the scheduler can place GPU jobs, and the team has confidence in quota enforcement because earlier modules covered provisioning and sharing. Then the first serious image-training job lands, eight GPUs light up for a few seconds, and the utilization graph flattens around forty percent because the workers spend most of each step waiting for the next batch to arrive from storage.
 
+Meta's Llama 3 training run is the same lesson at industrial scale. Meta reported that its storage system served **240 PB over 54 days**, which works out to about **4.4 PB per day** or **51 GB/s sustained**. That number is memorable because it is not a burst benchmark; it is the rate a training platform had to keep feeding the job for weeks so the accelerators did not starve.
+
 That situation is frustrating because it looks like a GPU problem from a distance, but it is usually a data path problem. A training loop cannot compute on examples it has not loaded, decoded, shuffled, transferred, and staged, so storage design directly determines how much expensive accelerator time turns into useful gradient updates. If the platform exposes only a generic network filesystem or a direct object-store mount, the job may be correct yet still waste more money than a scheduling bug would.
 
 This module teaches storage as an operational design problem rather than a shopping list of tools. You will start by recognizing the I/O shape of different AI workloads, then build up the storage tiers that Kubernetes can expose: local NVMe for hot data, distributed filesystems for shared warm data, object storage for durable cold data, and caching systems that move bytes closer to the GPUs. The goal is not to memorize one preferred product; the goal is to choose a path that matches the dataset, checkpoint cadence, fault-tolerance needs, and Kubernetes scheduling constraints in front of you.
@@ -71,7 +73,9 @@ Different ML workloads have radically different I/O profiles, and platform teams
 
 The key design move is to translate the workload into read size, randomness, concurrency, and write burst requirements before choosing storage. Image classification against millions of JPEG files may need local caching or dataset repackaging even when the total dataset is modest. Video training may tolerate higher latency per file because each read is large, but it can saturate network links if several jobs stream at once. Checkpointing flips the problem from reads to writes, and a fast read cache does not automatically make checkpoint saves safe or durable.
 
-Pause and predict: if a large language model and an image classifier both report low GPU utilization, which one would you expect to benefit more from packing data into larger sequential shards, and which one would you inspect first for metadata or small-file overhead? Write down the hypothesis before looking at metrics, because the habit of predicting forces you to connect symptoms to the workload shape rather than reaching for a favorite storage product.
+> **Pause and predict:** If a large language model and an image classifier both report low GPU utilization, which one would you expect to benefit more from packing data into larger sequential shards, and which one would you inspect first for metadata or small-file overhead?
+>
+> **Answer:** The image classifier usually benefits most from packing because millions of small random reads create metadata and request overhead; the LLM workload is more likely to need aggregate sequential throughput across already-sharded data.
 
 Before optimizing, measure the job that is actually slow. GPU utilization tells you whether accelerators are waiting, but it does not prove storage is the cause by itself. Correlate that signal with data-loader timing, CPU saturation, network throughput, filesystem latency, and pod placement, because a CPU-heavy augmentation pipeline can look similar to an I/O bottleneck from the GPU side.
 
@@ -94,7 +98,9 @@ kubectl exec -it training-pod -- watch -n 1 'nvidia-smi --query-gpu=utilization.
 
 The command is intentionally simple because the first measurement should be easy enough to run during an incident. If the GPU is below target utilization and the data loader repeatedly spends longer than the compute step, storage and preprocessing deserve immediate attention. If the data loader is fast but GPU memory utilization is high, you may be facing a model-memory or batch-size issue instead; the important skill is to avoid tuning storage when the evidence points somewhere else.
 
-Stop and think: if GPU utilization is around forty percent, what three metrics would you check before blaming the storage backend? A strong answer includes at least one GPU-side metric, one application-side timing signal, and one infrastructure-side signal such as filesystem latency, node network throughput, or cache hit rate.
+> **Stop and think:** If GPU utilization is around forty percent, what three metrics would you check before blaming the storage backend?
+>
+> **Answer:** Check GPU utilization and memory pressure, data-loader wait time per batch, and an infrastructure signal such as filesystem latency, node network throughput, or cache hit rate.
 
 ## Storage Tiers for AI
 
@@ -298,6 +304,12 @@ mountOptions:
 
 The `noatime` and `nodiratime` options are small settings with large consequences for read-heavy training. Traditional access-time updates create metadata writes when files are read, which means an apparently read-only workload can still pressure the metadata path. Disabling those updates is usually safe for datasets and checkpoint inputs because training jobs rarely depend on access times for correctness.
 
+RDMA-capable storage networks such as InfiniBand or RoCE can also help by reducing network latency and CPU overhead, but they cannot rescue a workload that turns every example into a serialized metadata operation. The storage path still has to match the workload shape.
+
+> **Stop and think:** Why can `noatime` or RDMA matter even when a storage benchmark shows acceptable sequential throughput?
+>
+> **Answer:** `noatime` removes metadata writes from read-heavy paths, while RDMA reduces network overhead; both matter because training bottlenecks often come from latency and metadata pressure rather than headline sequential bandwidth.
+
 JuiceFS targets the awkward space between object storage and filesystem expectations. It presents a POSIX client through FUSE and CSI, stores metadata in a separate engine such as Redis or PostgreSQL, stores data in object storage, and caches reads locally. That architecture lets a team keep the durable copy in S3-compatible storage while giving training code a familiar path-based interface.
 
 ```mermaid
@@ -357,7 +369,9 @@ volumeBindingMode: Immediate
 
 The mount options show where performance choices become explicit. A larger cache can reduce repeat reads but competes with other workloads for local disk. A larger read-ahead buffer can improve sequential scans but may waste bandwidth when the access pattern is random. `Retain` protects the filesystem from accidental PVC deletion, which is often appropriate when the volume represents a durable dataset namespace rather than a disposable scratch cache.
 
-Which approach would you choose here and why: a ReadWriteMany CephFS volume for a multi-node training job whose dataset changes daily, or a JuiceFS object-backed mount with local cache for many repeated experiments over immutable dataset versions? A defensible answer names the workload's sharing requirement, update pattern, cache reuse opportunity, and durability expectations.
+> **Pause and predict:** Which approach would you choose here and why: a ReadWriteMany CephFS volume for a multi-node training job whose dataset changes daily, or a JuiceFS object-backed mount with local cache for many repeated experiments over immutable dataset versions?
+>
+> **Answer:** CephFS is the better default for frequently updated shared POSIX data, while JuiceFS is stronger for immutable versions with repeated reads because the cache can turn object-backed storage into a fast warm path.
 
 ## Dataset Caching and Data-Aware Scheduling
 
@@ -383,7 +397,9 @@ Total: 500GB downloaded, 2 hours total wait, $1 in S3 egress
 
 Those numbers are illustrative, but the direction is real: repeated reads turn network traffic into local traffic when the cache is warm. The hard part is keeping the cache close to the jobs that need it. If Kubernetes schedules a pod on a node with no cached data, the pod experiences a cold read even though another node in the cluster has the dataset ready. That is why storage design and scheduling design cannot be separated for AI workloads.
 
-Stop and think: if fifty engineers repeatedly train against the same five-hundred-gigabyte dataset every day, what costs would you include in the cache business case besides object-store egress? A complete answer includes GPU idle time, experiment turnaround, network contention, cache disk cost, operational overhead, and the risk of stale data.
+> **Stop and think:** If fifty engineers repeatedly train against the same five-hundred-gigabyte dataset every day, what costs would you include in the cache business case besides object-store egress?
+>
+> **Answer:** Include GPU idle time, experiment turnaround, network contention, cache disk cost, operational overhead, and the risk of stale data.
 
 Fluid is a CNCF sandbox project that brings dataset-aware scheduling to Kubernetes. Instead of treating a dataset as just another PVC, Fluid models the dataset as a resource and coordinates cache engines such as Alluxio, JuiceFS, or JindoFS under the hood. That resource model lets the platform track cache placement and influence pod scheduling so jobs prefer nodes where the needed data is already warm.
 
@@ -566,7 +582,9 @@ from torch.distributed.checkpoint import save
 save(model.state_dict(), checkpoint_id=f"/checkpoints/step_{step}")
 ```
 
-Pause and predict: what is the risk of using asynchronous checkpointing if the node crashes exactly while the background thread is writing the checkpoint? The correct instinct is to think beyond speed: a fast checkpoint strategy must also make incomplete writes detectable, make restore points unambiguous, and decide which storage tier becomes the source of truth after failure.
+> **Pause and predict:** What is the risk of using asynchronous checkpointing if the node crashes exactly while the background thread is writing the checkpoint?
+>
+> **Answer:** The write may leave a partial or corrupt checkpoint that looks usable unless the design uses temporary paths, completion markers, atomic promotion, validation, and a durable source of truth.
 
 | Storage Type | Write Speed | Best For |
 |-------------|-------------|----------|
@@ -1068,6 +1086,14 @@ You have completed this exercise when:
 - [Alluxio open source Helm chart repository](https://alluxio-charts.storage.googleapis.com/openSource)
 - [PyTorch distributed checkpoint API](https://pytorch.org/docs/stable/distributed.checkpoint.html)
 - [MinIO Kubernetes documentation](https://min.io/docs/minio/kubernetes/upstream/index.html)
+
+## Key Takeaways
+
+- AI workloads are often bottlenecked by data-pipeline throughput before they are bottlenecked by GPU compute.
+- Storage choices must follow the workload shape: random small-file reads, sequential shard reads, and checkpoint writes need different paths.
+- Topology-aware storage placement matters as much as topology-aware GPU placement when local NVMe or warm caches are involved.
+- Cache designs need freshness rules, hit-rate metrics, and scheduler behavior, not just fast second-run benchmarks.
+- Checkpoint storage is a recoverability system, so speed only counts when incomplete writes are detectable and completed checkpoints are durable.
 
 ## Next Module
 


### PR DESCRIPTION
Summary:
- Rewrote src/content/docs/platform/disciplines/data-ai/ai-infrastructure/module-1.4-ai-storage.md for #388 density, structure, alignment, anti-leak, and protected-asset gates.
- Cleared revision_pending: false.

Verifier summary:
- .venv fallback: used /Users/krisztiankoos/projects/kubedojo/.venv/bin/python because this worktree has no local .venv.
- Command: scripts/quality/verify_module.py --glob src/content/docs/platform/disciplines/data-ai/ai-infrastructure/module-1.4-ai-storage.md --skip-source-check --summary --quiet
- Result: tier T0, passed=true; body_words=5028, mean_wpp=66.2, median_wpp=66.5, short_rate=0.026, max_run=1, mean_sentence_length=22.3.
- Sources gate: 16 URLs counted; reachability skipped per --skip-source-check.

Protected assets:
- Preserved counts before/after: code_blocks 32/32, mermaid_diagrams 3/3, tables 4/4, ascii_diagrams 0/0.

Additional checks:
- git diff --check clean for the changed module.
- npm run build not run: primary checkout is on main but has unrelated untracked state, and I did not mutate primary or create build artifacts outside the allowed module path.

Commit SHA: da6a78aa64a8faa755d9974fd3a2804de12878c8