### PR TITLE
feat(388): rewrite module-1.6-ai-cost (#388 pilot)

### DIFF
--- a/src/content/docs/platform/disciplines/data-ai/ai-infrastructure/module-1.6-ai-cost.md
+++ b/src/content/docs/platform/disciplines/data-ai/ai-infrastructure/module-1.6-ai-cost.md
@@ -3,16 +3,13 @@ title: "Module 1.6: Cost & Capacity Planning for AI"
 slug: platform/disciplines/data-ai/ai-infrastructure/module-1.6-ai-cost
 sidebar:
   order: 7
+revision_pending: false
 ---
-> **Discipline Module** | Complexity: `[MEDIUM]` | Time: 3 hours
-
-## Prerequisites
-
-Before starting this module:
-- **Required**: [Module 1.1: GPU Provisioning & Device Plugins](../module-1.1-gpu-provisioning/) — GPU resources, DCGM metrics
-- **Required**: [Module 1.5: Serving LLMs at Scale](../module-1.5-llm-serving/) — Inference workload patterns
-- **Recommended**: Kubernetes autoscaling concepts (HPA, VPA, Cluster Autoscaler)
-- **Recommended**: Experience with cloud billing (AWS, GCP, or Azure cost explorer)
+> **Complexity**: `[MEDIUM]`
+>
+> **Time to Complete**: 3 hours
+>
+> **Prerequisites**: [Module 1.1: GPU Provisioning & Device Plugins](../module-1.1-gpu-provisioning/), [Module 1.5: Serving LLMs at Scale](../module-1.5-llm-serving/), Kubernetes autoscaling concepts, and basic cloud billing familiarity
 
 ---
 
@@ -21,11 +18,17 @@ Before starting this module:
 After completing this module, you will be able to:
 
 - **Implement GPU cost tracking and attribution across teams, projects, and workload types**
-- **Design spot/preemptible instance strategies that reduce AI training costs by 60-80%**
-- **Build cost optimization workflows — right-sizing, scheduling, auto-shutdown — for GPU clusters**
-- **Evaluate reserved capacity versus on-demand pricing models for predictable AI infrastructure budgets**
+- **Design spot and preemptible instance strategies that reduce AI training cost while preserving recoverability**
+- **Build cost optimization workflows for right-sizing, scheduling, preemption, and auto-shutdown in GPU clusters**
+- **Evaluate reserved, on-demand, and interruptible capacity models for predictable AI infrastructure budgets**
 
 ## Why This Module Matters
+
+Hypothetical scenario: your platform team opens the monthly cloud bill and finds that GPU spending has become larger than every other Kubernetes cost combined. The data science organization is not doing anything obviously reckless: training jobs are important, inference services have real users, and notebooks are part of daily development. The problem is that GPU infrastructure punishes small operational gaps. A few idle notebooks, a training cluster left warm between runs, and inference replicas sized for peak traffic can quietly turn into a budget line that grows faster than the business value it supports.
+
+AI cost management is difficult because a GPU is both an expensive accelerator and a scarce scheduling resource. A CPU-heavy service can often be overprovisioned by a modest amount without changing the annual budget very much, but an eight-GPU node running around the clock can cost as much as a small engineering team. That is why this module treats cost as an engineering property rather than a finance afterthought. You will connect unit economics, workload interruption tolerance, Kubernetes scheduling, Karpenter provisioning, Kueue batch admission, and chargeback dashboards into one operating model.
+
+The goal is not to make every workload cheap. Production inference may justify on-demand capacity, and a critical training run may deserve a reserved allocation during a launch window. The skill is knowing which workloads need that reliability, which can safely use spot capacity, which should wait in a queue, and which should disappear when nobody is using them. By the end, you should be able to explain a GPU bill in terms that both finance and engineering can act on: cost per epoch, cost per thousand requests, idle GPU-hours, spot ratio, queue wait time, and protected capacity for service-level commitments.
 
 AI infrastructure is the most expensive line item in many organizations' cloud bills. The numbers are staggering:
 
@@ -36,17 +39,15 @@ AI infrastructure is the most expensive line item in many organizations' cloud b
 | GCP a3-megagpu-8g (8x H100) | $101.22/hr | $886,688 |
 | Azure ND96amsr_A100_v4 (8x A100) | $32.77/hr | $287,069 |
 
-A 32-node training cluster of H100s costs **$3.1 million per year** at on-demand prices. And here is the painful part: most organizations waste 40-70% of this spending through a combination of idle GPUs, over-provisioning, lack of spot/preemptible usage, and no queuing discipline.
-
-This module teaches you the tools and techniques to cut GPU costs by 50-80% without sacrificing capability: spot instances for interruptible workloads, Karpenter for intelligent GPU node provisioning, Kueue for batch job scheduling and preemption, and the metrics framework to know exactly where every GPU-dollar goes.
-
----
+A 32-node training cluster of H100s costs roughly $3.1 million per year at on-demand prices. The painful part is that much of this spend is not attached to useful model progress or reliable user traffic. Idle GPUs, over-provisioned replicas, failed experiments, unbounded notebooks, and poor queuing discipline can waste a large share of total spend while still leaving teams frustrated because the cluster feels full. That combination is the signal that capacity planning is missing a control loop.
 
 ## The Cost Anatomy of AI Workloads
 
-> **Stop and think**: Before looking at the breakdown below, what percentage of your organization's GPU spend do you estimate is actively performing computations versus sitting idle?
+The first step in AI cost planning is to stop treating a GPU-hour as the only unit that matters. A GPU-hour is the raw ingredient, but platform decisions are made around business and engineering outcomes: one training epoch, one experiment, one batch inference job, one thousand online requests, or one developer notebook session. When you translate infrastructure into units of work, a vague request such as "we need sixteen GPUs for a week" becomes a concrete question about whether an experiment is worth the budget it consumes and whether a smaller design would answer the same research question.
 
-### Where Money Goes
+Cost anatomy also exposes why utilization alone is not enough. A production inference service with twenty percent average GPU utilization may be correctly sized if it absorbs bursts without violating latency objectives, while a notebook with the same utilization is probably wasteful because nobody notices when it waits a minute for a GPU to start. The platform team must therefore separate workload classes before applying optimization. Training wants recoverability and throughput, inference wants latency and availability, development wants convenience with guardrails, and batch preprocessing wants cheap idempotent execution.
+
+Pause and predict: if your dashboard shows low GPU utilization across the fleet, what extra label would you need before deciding whether to terminate nodes, reduce replicas, or move jobs to spot capacity? The useful answer is usually a workload label such as `training`, `inference`, or `development`, because the same metric means different things under different service expectations. A cost dashboard without workload identity is like a power meter without room labels: it tells you electricity is being used, but not whether the refrigerator, the heater, or a forgotten lamp is responsible.
 
 Break down a typical AI team's GPU spending:
 
@@ -70,9 +71,9 @@ graph TD
     Dev --> D3["Forgotten pods: 10% (stale notebooks nobody uses)"]
 ```
 
-### Cost Per Unit of Work
+This diagram is not a claim about every organization; it is a model for reasoning about where controls belong. Training waste is often solved with checkpointing, spot capacity, and a queue that prevents jobs from holding resources while waiting for peers. Inference waste is usually solved with autoscaling, model sharing, batching, and clear latency targets. Development waste is solved with auto-shutdown, quota, and a user experience that makes releasing GPUs normal rather than punitive. Treating all three classes the same creates either brittle production service or expensive research convenience.
 
-Think in **cost per unit of work**, not cost per GPU-hour:
+Think in cost per unit of work, not cost per GPU-hour:
 
 | Metric | Formula | Example |
 |--------|---------|---------|
@@ -81,26 +82,30 @@ Think in **cost per unit of work**, not cost per GPU-hour:
 | Cost per experiment | (GPU-hours x $/hr) | 1 A100 x $3/hr x 2hr = $6/experiment |
 | Cost per idle hour (waste) | (Idle GPUs x $/hr) | 4 idle A100 x $3/hr = $12/hr waste |
 
-Track these metrics in dashboards. When a scientist says "I need 16 GPUs for a week," translate that to **$8,064** (16 x $3/hr x 168hr) and ask: "Is this experiment worth $8,064?"
+The table gives you the vocabulary for a better conversation with model owners. A researcher may not know whether a week of sixteen GPUs is a large request in cloud terms, but they can usually explain what they expect from an experiment and how much accuracy improvement would justify it. An inference owner may not care about GPU-hours, but they can reason about cost per thousand requests against product margin or internal budget. Once you express costs this way, optimization stops being a generic mandate to spend less and becomes a choice between explicit tradeoffs.
 
----
+Track these metrics in dashboards and reviews. When a scientist says "I need 16 GPUs for a week," translate that to $8,064 at $3 per GPU-hour and ask whether the experiment is worth that spend, whether a smaller pilot could reject the idea earlier, and whether spot capacity with checkpoints would reduce the risk. The point is not to interrogate every request. The point is to make invisible opportunity cost visible before the infrastructure platform silently accepts the most expensive possible version of the plan.
 
 ## Spot Instances for Interruptible Workloads
 
-> **Pause and predict**: If spot instances can be terminated with only a 30-120 second warning, what specific application architecture pattern is required to train a deep learning model over several days on spot capacity?
+Spot and preemptible instances are the largest single lever for many AI platforms because training, hyperparameter search, batch inference, and data preprocessing are often interruption-tolerant when designed correctly. The cloud provider sells unused capacity at a discount, and your application accepts the risk that the capacity can be reclaimed. This is not free money; it is a contract. The workload must checkpoint, tolerate eviction, re-enter a queue, and avoid corrupting shared state when it is terminated.
 
-### The Opportunity
+The basic economic question is whether the cost of lost work is smaller than the savings from discounted capacity. For a well-checkpointed training job, the lost work after an interruption is usually half the checkpoint interval on average. If the job checkpoints every thirty minutes, an interruption wastes about fifteen minutes of computation, not the entire run. That is why checkpoint cadence is not merely a reliability setting. It is a cost-control parameter that determines how much of the spot discount you actually keep.
 
-Cloud providers sell excess GPU capacity at 60-90% discount as "spot" (AWS), "preemptible" (GCP), or "spot" (Azure). The catch: they can be reclaimed with 30-120 seconds notice.
+Pause and predict: if spot instances can be terminated with only a short warning, what specific training behavior makes a multi-day run economically safe on spot capacity? The answer is frequent, validated checkpointing to durable storage, combined with job logic that resumes from the newest complete checkpoint after eviction. Without that behavior, spot pricing turns into a gamble. With it, spot pricing becomes a controlled interruption model where lost work is bounded and measurable.
+
+Cloud providers sell excess GPU capacity at large discounts as spot instances, preemptible VMs, or equivalent discounted capacity. The catch is that they can reclaim the instance with limited notice, and availability varies by region, zone, instance type, and time. For cost planning, this means you should diversify instance types where the workload allows it, keep capacity requirements flexible, and reserve on-demand fallback for workloads that cannot safely wait.
 
 | Provider | GPU Instance | On-Demand | Spot Price | Savings |
 |----------|-------------|-----------|------------|---------|
 | AWS | p4d.24xlarge (8x A100) | $32.77/hr | $12.50/hr | 62% |
 | AWS | g5.xlarge (1x A10G) | $1.01/hr | $0.35/hr | 65% |
 | GCP | a2-highgpu-8g (8x A100) | $29.39/hr | $8.82/hr | 70% |
-| Azure | NC24ads_A100_v4 (1x A100) | $3.67/hr | $1.47/hr | 60% |
+| Azure | NC24ads_A100_v4 (1x A100) | $3.67/hr | $1.46/hr | 60% |
 
-### Which Workloads Can Use Spot
+The exact prices in this table should be replaced with the rates in your own region and contract, but the design lesson remains stable. The deeper discount belongs to workloads that can be interrupted, restarted, or delayed without user-visible harm. A training job with a clean checkpoint path is a strong candidate. A public inference endpoint with strict latency commitments is usually not, unless you have enough redundancy and fallback to absorb node loss without errors.
+
+One practical way to de-risk spot adoption is to create a short approval checklist for each workload class. Training owners should show where checkpoints are stored, how restore is tested, and how many minutes of work the team is willing to lose. Batch inference owners should show idempotent input partitions and retry behavior. Development notebook owners should acknowledge that convenience is lower priority than preventing forgotten accelerators from running all weekend.
 
 | Workload | Spot-Friendly? | Why |
 |----------|---------------|-----|
@@ -111,16 +116,7 @@ Cloud providers sell excess GPU capacity at 60-90% discount as "spot" (AWS), "pr
 | Interactive inference (serving) | No | Interruptions = user-facing errors |
 | Jupyter notebooks | Risky | Users lose unsaved work |
 
-### Handling Spot Interruptions
-
-When a spot instance is reclaimed:
-
-1. **Cloud provider sends termination notice** (2 min on AWS, 30s on GCP)
-2. **Kubernetes detects node termination** and marks node as unschedulable
-3. **Pods are evicted** — they receive SIGTERM
-4. **Cluster autoscaler/Karpenter** provisions replacement nodes
-
-For training jobs, the key is **checkpoint frequency** vs **interruption frequency**:
+For training jobs, the key is checkpoint frequency versus interruption frequency:
 
 ```
 Interruption rate: ~1 per 4 hours (average for GPU spot on AWS)
@@ -132,7 +128,9 @@ Savings from spot: 8 A100 x ($32.77 - $12.50) x 4hr = $648.64 per period
 Net savings: $648.64 - $3.12 = $645.52 per 4-hour period (99.5% of potential savings captured)
 ```
 
-### Node Termination Handler
+The calculation demonstrates why interruption fear is often larger than interruption cost. If checkpointing is reliable, the wasted compute is a small adjustment to the effective hourly price. If checkpointing is unreliable, the calculation collapses because you may lose hours of progress, corrupt a run, or require manual cleanup. Before moving a training platform to spot, test checkpoint restore as a normal path, not as an emergency procedure that nobody rehearses.
+
+When a spot instance is reclaimed, the cloud provider sends a termination notice, Kubernetes marks the node unschedulable or begins eviction, Pods receive termination signals, and the autoscaling layer must provision replacement capacity. The details differ by provider, but the platform pattern is consistent: detect interruption early, drain gracefully, write or preserve checkpoint state, and return work to the scheduler. A node termination handler does not make an unsafe workload safe by itself, but it gives safe workloads the time and signal they need to exit cleanly.
 
 Install a handler that gracefully manages spot interruptions:
 
@@ -148,27 +146,20 @@ helm install aws-node-termination-handler eks/aws-node-termination-handler \
 
 ```bash
 # GCP: Uses native node auto-repair + preemptible handling
-# No separate handler needed — GKE handles it natively
+# No separate handler needed -- GKE handles it natively
 ```
 
----
+The operational guardrail is to keep spot and on-demand expectations explicit in scheduling labels, queues, and dashboards. A team should not discover during an incident that its inference Pod landed on interruptible capacity because a generic node selector matched more than intended. Conversely, a training job should not silently fall back to expensive on-demand nodes just because spot capacity was temporarily unavailable, unless the owner made that budget choice in advance. Cost safety depends on scheduling intent being visible.
 
 ## Karpenter: Intelligent GPU Node Provisioning
 
-> **Stop and think**: The traditional Cluster Autoscaler scales predefined node groups. Why would relying on fixed node groups be particularly inefficient and costly when managing a diverse fleet of expensive GPU instances?
+Karpenter is valuable for GPU cost planning because it provisions nodes for pending Pods rather than scaling only predefined groups. Traditional node groups work well when most workloads fit a small set of instance shapes, but GPU fleets are rarely that tidy. One team may need an A100 with large memory, another may need a cheaper L4-class device for inference, and a batch queue may be able to use any of several spot pools. If those choices are encoded as rigid node groups, capacity planning becomes a guessing game that either strands expensive nodes or blocks useful work.
 
-### Why Karpenter Over Cluster Autoscaler
+The cost advantage comes from matching the node to the Pod at scheduling time. Karpenter can consider instance type, zone, capacity type, taints, labels, and NodePool limits before creating a node. That lets you express policy as constraints: training may prefer spot A100 or H100 capacity across several zones, inference may require on-demand nodes, and development may have a hard GPU ceiling. The autoscaler is no longer merely making an existing pool bigger. It is selecting the cheapest acceptable shape for the work waiting in the queue.
 
-The Cluster Autoscaler (CA) scales **node groups** — predefined pools of identical instances. This works poorly for GPUs because:
+Stop and think: the traditional Cluster Autoscaler scales predefined node groups, so why is that especially inefficient for a diverse fleet of expensive GPU instances? The answer is that every node group is a bet made before the workload arrives. If the bet is too small, jobs wait. If it is too large, the team pays for idle accelerators. If it is too narrow, a temporary capacity shortage in one instance type blocks work even when a compatible alternative exists.
 
-1. **GPU instance diversity**: You need different GPU types for different workloads (T4 for inference, A100 for training)
-2. **Slow scaling**: CA checks every 10-30 seconds, then takes 5-10 minutes to provision cloud instances
-3. **Inefficient packing**: CA can't mix instance types within a node group
-4. **No spot fallback**: If spot capacity is unavailable, CA just waits
-
-Karpenter provisions **individual nodes** based on Pod requirements, choosing the optimal instance type, zone, and capacity type (on-demand vs spot) in real-time.
-
-### Karpenter Architecture for GPU
+The Cluster Autoscaler scales node groups, which are predefined pools of identical or similar instances. This model has several GPU-specific weaknesses: you often need different GPU types for different workloads, scale-up can be slower than the user expects, packing across instance choices is limited, and spot fallback requires careful group design. Karpenter provisions individual nodes based on Pod requirements and NodePool policy, which makes it better suited to cost-aware AI infrastructure where workload shape changes throughout the day.
 
 ```mermaid
 graph TD
@@ -189,7 +180,9 @@ graph TD
     end
 ```
 
-### NodePool for GPU Spot Instances
+The architecture in the diagram is simple, but the policy choices require care. For GPU training, aggressive consolidation can be harmful because moving a running job usually means terminating it and relying on checkpoint recovery. For development nodes, fast consolidation is desirable because forgotten notebooks are a common source of waste. For production inference, consolidation must respect disruption budgets and latency objectives. The same autoscaler feature can be a cost saver or an outage trigger depending on workload class.
+
+The following NodePool expresses an intentionally narrow training pool. It allows only spot capacity, only selected high-end GPU instance types, and only specific zones. The taints prevent ordinary Pods from landing on expensive GPU nodes, while the pool-level GPU limit prevents a runaway queue or bad deployment from creating unbounded spend. Notice that the disruption policy uses `WhenEmpty`, which favors cost recovery after jobs finish without attempting to reshuffle live training workloads.
 
 ```yaml
 apiVersion: karpenter.sh/v1
@@ -237,7 +230,7 @@ spec:
   weight: 10                              # Prefer this pool (spot) over on-demand
 ```
 
-### NodePool for GPU On-Demand (Fallback)
+Inference deserves a different pool because user-facing services should not be optimized with the same interruption assumptions as batch training. This example uses on-demand capacity and smaller GPU shapes that are more appropriate for serving workloads. The consolidation policy is more aggressive than the training pool, but it still needs to be paired with workload-level disruption controls, readiness gates, and replica design. The autoscaler can remove waste only after the application has enough redundancy to tolerate change.
 
 ```yaml
 apiVersion: karpenter.sh/v1
@@ -279,7 +272,7 @@ spec:
     nvidia.com/gpu: "32"
 ```
 
-### EC2NodeClass for GPU Nodes
+The NodeClass separates cloud-provider details from the scheduling policy. That boundary matters because cost and reliability decisions live in both places. The NodePool decides which jobs are allowed to create GPU nodes and how many GPUs they can create. The NodeClass decides how those nodes are built, which subnets and security groups they use, how much boot and data volume capacity they get, and how quickly they can become useful after launch.
 
 ```yaml
 apiVersion: karpenter.k8s.aws/v1
@@ -314,42 +307,38 @@ spec:
     # GPU Operator handles this, but pre-baked AMIs are faster
 ```
 
-### Scale to Zero with Karpenter
-
-Karpenter naturally scales to zero: when no unschedulable Pods need GPUs, no GPU nodes exist. When a GPU Pod is created, Karpenter provisions a node within 1-3 minutes.
-
-This is transformative for cost:
+Karpenter naturally enables scale-to-zero because GPU nodes do not need to exist before GPU Pods need them. This changes the budget conversation for development and batch training. Instead of asking whether a team should be trusted with a standing pool, you can ask whether their workloads have enough startup tolerance to wait for nodes. The tradeoff is cold-start time: saving money by deleting idle nodes means someone waits when work resumes, so the platform should document expected provisioning delays and keep production paths separate.
 
 ```
 Without scale-to-zero:
   8 A100 nodes running 24/7 for training
   Active training: 10 hours/day
   Idle: 14 hours/day
-  Monthly cost: 8 × $32.77/hr × 730hr = $191,376
+  Monthly cost: 8 x $32.77/hr x 730hr = $191,376
   Effective cost: $191,376 (100%)
 
 With Karpenter scale-to-zero:
   8 A100 nodes provisioned only during training
-  Active: 10 hours/day × 30 days = 300 hours
-  Monthly cost: 8 × $32.77/hr × 300hr = $78,648
+  Active: 10 hours/day x 30 days = 300 hours
+  Monthly cost: 8 x $32.77/hr x 300hr = $78,648
   Savings: $112,728 (59%)
 
 With Karpenter + spot:
   Active: 300 hours, spot price $12.50/hr
-  Monthly cost: 8 × $12.50/hr × 300hr = $30,000
+  Monthly cost: 8 x $12.50/hr x 300hr = $30,000
   Savings: $161,376 (84% vs always-on on-demand!)
 ```
 
----
+Before running this in a real cluster, predict which number in the example will change most in your environment: hourly price, active hours, idle hours, or spot discount. Most teams discover that active and idle hours matter as much as the advertised GPU rate. A modest hourly discount is useful, but eliminating fourteen idle hours per day is often the cleaner win because it removes consumption entirely rather than making waste cheaper.
 
-## Priority Classes and Preemption
+## Priority, Queues, and Fair GPU Sharing
 
-### GPU Priority Hierarchy
+Priority classes and Kueue solve different layers of the same problem. Kubernetes priority tells the scheduler which Pods are more important when capacity is scarce, while Kueue adds batch-aware admission, quota, borrowing, and orderly preemption. Native priority by itself can protect production inference from casual experiments, but it does not give research teams a fair queue or a clear way to borrow unused capacity. Kueue turns scarce GPU capacity into a managed shared resource instead of a race between whoever submits first.
 
-Not all GPU workloads are equally important. Define a priority hierarchy:
+Not all GPU workloads are equally important, so define a priority hierarchy before the cluster is full. Production inference should outrank training because users experience errors when serving fails. Training should outrank development because an organized run is usually more valuable than an idle notebook. Best-effort work should be explicitly marked as unable to preempt anything, which prevents low-value jobs from causing avoidable disruption while still allowing them to use spare capacity.
 
 ```yaml
-# Critical production inference — never preempted
+# Critical production inference -- never preempted
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
@@ -357,9 +346,9 @@ metadata:
 value: 1000000
 globalDefault: false
 preemptionPolicy: PreemptLowerPriority
-description: "Production inference services — highest GPU priority"
+description: "Production inference services -- highest GPU priority"
 ---
-# Training jobs — can preempt dev but not production
+# Training jobs -- can preempt dev but not production
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
@@ -367,9 +356,9 @@ metadata:
 value: 100000
 globalDefault: false
 preemptionPolicy: PreemptLowerPriority
-description: "Training jobs — preemptable by production only"
+description: "Training jobs -- preemptable by production only"
 ---
-# Development and experimentation — lowest priority
+# Development and experimentation -- lowest priority
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
@@ -377,9 +366,9 @@ metadata:
 value: 10000
 globalDefault: false
 preemptionPolicy: PreemptLowerPriority
-description: "Development workloads — preempted by training and production"
+description: "Development workloads -- preempted by training and production"
 ---
-# Best-effort — preempted by everything
+# Best-effort -- preempted by everything
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
@@ -387,7 +376,7 @@ metadata:
 value: 1000
 globalDefault: false
 preemptionPolicy: Never         # Cannot preempt anything
-description: "Best-effort GPU access — runs only when capacity is free"
+description: "Best-effort GPU access -- runs only when capacity is free"
 ```
 
 Use in Pods:
@@ -398,7 +387,7 @@ kind: Pod
 metadata:
   name: experiment-42
 spec:
-  priorityClassName: gpu-development   # Low priority — can be preempted
+  priorityClassName: gpu-development   # Low priority -- can be preempted
   containers:
     - name: experiment
       image: nvcr.io/nvidia/pytorch:24.09-py3
@@ -407,30 +396,16 @@ spec:
           nvidia.com/gpu: 1
 ```
 
----
+Priority alone is not enough for AI batch work because a pending Pod is not the same as an admitted job with a fair place in line. Training jobs often need a gang of workers, and starting only half of them can waste capacity or cause failures. Multiple teams may share one cluster, and each team needs a guaranteed share plus the ability to borrow idle capacity. These requirements are closer to high-performance computing schedulers than to ordinary web-service scheduling.
 
-## Kueue: Batch Job Queuing and Scheduling
+Stop and think: if a high-priority production job needs GPUs but the cluster is full of low-priority experiments, how should the system decide which experiments to terminate while ensuring resources are allocated fairly among research teams? The answer needs more information than Pod priority. It needs ownership, quota, queue order, borrowing policy, and a definition of which resources each workload can use. Kueue provides those concepts as Kubernetes-native APIs.
 
-> **Stop and think**: If a high-priority production job needs GPUs but the cluster is full of low-priority experiments, how should the system decide which experiments to terminate while ensuring resources are allocated fairly among different research teams?
-
-### Why Kueue
-
-Kubernetes schedulers are designed for **services** (run forever, maintain N replicas). AI training jobs are **batch** workloads that need:
-
-- **Queuing**: 50 training jobs submitted, but only 16 GPUs available
-- **Fair sharing**: Team A and Team B each get 50% of GPU capacity
-- **Preemption**: High-priority jobs can bump low-priority ones
-- **Resource quotas**: Team A can use at most 32 GPUs
-- **Borrowing**: Team A can use Team B's idle GPUs (and give them back when needed)
-
-Kueue (Kubernetes Queue) provides all of this.
-
-### Kueue Architecture
+Kueue is designed for batch workloads that need queuing, fair sharing, preemption, quotas, and borrowing. Kubernetes services are usually meant to run forever and maintain replicas. AI training jobs are different: they enter the system, wait until enough resources are available, run to completion, and then leave. A platform that lacks admission control often lets jobs create Pods immediately, which fills the cluster with pending objects and gives users little insight into when their work will start.
 
 ```mermaid
 flowchart LR
     subgraph Kueue Architecture
-        Workload["Workload<br/>(submitted Job/Pod)<br/>Pending → Admitted → Running"]
+        Workload["Workload<br/>(submitted Job/Pod)<br/>Pending -> Admitted -> Running"]
         LocalQueue["LocalQueue<br/>(per team)<br/>Team A queue<br/>Team B queue<br/>Team C queue"]
         ClusterQueue["ClusterQueue<br/>Defines GPU capacity +<br/>fair share policies"]
         
@@ -442,7 +417,9 @@ flowchart LR
     Cohorts["Cohorts: Groups of ClusterQueues that can borrow"]
 ```
 
-### Installing Kueue
+The architecture introduces three operational handles. A `ResourceFlavor` describes the kind of capacity, such as A100 spot or A100 on-demand. A `ClusterQueue` describes quota, borrowing, and preemption policy for a shared pool. A `LocalQueue` gives a namespace or team a place to submit work. This separation keeps team workflows simple while allowing the platform team to manage scarce resources centrally.
+
+Install Kueue:
 
 ```bash
 kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.9.1/manifests.yaml
@@ -451,9 +428,7 @@ kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases
 kubectl -n kueue-system get pods
 ```
 
-### Configuring Kueue for GPU Workloads
-
-**Step 1: Define ResourceFlavors** (what kinds of GPUs exist)
+The first configuration step is to define resource flavors. These labels must line up with node labels produced by your GPU device plugin, cloud provider integration, or autoscaler. If labels are wrong, Kueue can admit a workload to capacity that Kubernetes cannot actually provide. Treat label design as part of your cost model because it determines whether a job uses spot, on-demand, A100, T4, or another accelerator class.
 
 ```yaml
 apiVersion: kueue.x-k8s.io/v1beta1
@@ -484,7 +459,7 @@ spec:
     karpenter.sh/capacity-type: spot
 ```
 
-**Step 2: Define ClusterQueue** (total GPU budget and fair sharing)
+The ClusterQueue is where budget policy becomes scheduling behavior. In this example, spot A100 capacity has a large nominal quota and a borrowing limit, on-demand A100 capacity is smaller and protected, and T4 spot capacity is available for workloads that can use it. Borrowing lets one team use another team's idle share, but preemption policies make sure borrowed resources can be reclaimed when the owner needs them back. This is how a shared GPU platform can be both efficient and fair.
 
 ```yaml
 apiVersion: kueue.x-k8s.io/v1beta1
@@ -532,7 +507,7 @@ spec:
     weight: 1
 ```
 
-**Step 3: Define LocalQueues** (per-team queues)
+LocalQueues keep team submission paths clean. A research namespace submits to its local queue, a platform namespace submits to its queue, and production has its own queue. The platform team can change the backing ClusterQueue policy without forcing every training script to learn the entire cluster budget. That is important for adoption because cost controls fail when they require every user to become a scheduler expert.
 
 ```yaml
 apiVersion: kueue.x-k8s.io/v1beta1
@@ -560,7 +535,7 @@ spec:
   clusterQueue: gpu-cluster-queue
 ```
 
-**Step 4: Submit Jobs to Kueue**
+A submitted job identifies its queue using a label, then declares the GPUs, CPU, and memory it needs. Requests and limits should be deliberate here. If a job requests two GPUs per worker and four workers, the queue must account for eight GPUs before admitting it. This prevents the cluster from starting partial work that cannot complete, and it gives users a visible reason when a job is waiting.
 
 ```yaml
 apiVersion: batch/v1
@@ -591,7 +566,7 @@ spec:
       restartPolicy: OnFailure
 ```
 
-### Kueue in Action: Queue Status
+Queue status should be part of the normal operating dashboard. Pending work is not automatically a problem; it may mean the platform is enforcing fair use and avoiding waste. The problem is unexplained or excessive wait time, especially when expensive nodes are idle or when production work waits behind development work. Queue metrics let you distinguish intentional backpressure from broken scheduling.
 
 ```bash
 # View queue status
@@ -606,15 +581,13 @@ kubectl -n ml-research get workloads
 # NAME                 QUEUE              ADMITTED  FINISHED  AGE
 # training-run-82      ml-research-queue  True                2h
 # training-run-83      ml-research-queue  True                1h
-# experiment-99        ml-research-queue  False               10m  ← queued
+# experiment-99        ml-research-queue  False               10m  <- queued
 ```
-
-### Preemption Flow
 
 When a high-priority job arrives and no GPUs are free:
 
 ```
-1. Job "critical-inference" (priority: 1000000) submitted → needs 4 GPUs
+1. Job "critical-inference" (priority: 1000000) submitted -> needs 4 GPUs
 2. All 32 GPUs are busy with "experiment-*" jobs (priority: 10000)
 3. Kueue identifies 4 GPUs occupied by lowest-priority workloads
 4. Kueue evicts experiment-72, experiment-73 (freeing 4 GPUs)
@@ -623,11 +596,13 @@ When a high-priority job arrives and no GPUs are free:
 7. When GPUs become available, experiments resume
 ```
 
----
+The preemption flow should be communicated before users experience it. If researchers know that low-priority experiments may be suspended and returned to the queue, they can design runs with checkpoints and choose the right priority class. If preemption feels arbitrary, users will hoard resources, inflate priorities, or avoid the shared platform. Fairness is both a technical policy and a trust-building practice.
 
-## Utilization Profiling and Cost Dashboards
+## Utilization Profiling, Quotas, and Chargeback
 
-### Essential Metrics
+Cost visibility is the feedback loop that tells you whether scheduling policy is working. Without telemetry, spot adoption can look successful while teams quietly rerun failed jobs, scale-to-zero can look aggressive while cold starts harm productivity, and quotas can look fair while one namespace pays for most idle capacity. A useful dashboard connects Kubernetes labels, DCGM GPU metrics, Kueue queue state, node capacity type, and cloud pricing. It should answer who used capacity, what kind they used, whether it was busy, and what unit of work it produced.
+
+Start with essential metrics and refine them over time. GPU utilization by namespace shows whether allocated devices are doing work. Allocated-versus-used comparisons reveal waste from idle notebooks or blocked training workers. Cost per namespace turns usage into budget language. Queue wait time tells you whether budget limits are constraining throughput. Spot ratio shows whether interruptible workloads are actually landing on the cheaper fleet rather than leaking into on-demand capacity.
 
 Build a GPU cost dashboard with these Prometheus queries:
 
@@ -662,7 +637,7 @@ count(kube_node_labels{label_karpenter_sh_capacity_type="spot"})
 count(kube_node_labels{label_nvidia_com_gpu_present="true"})
 ```
 
-### Cost Alerting
+Alerting should focus on actionable waste and scheduling pressure, not every fluctuation. An on-demand GPU idle for an hour is worth investigating because the burn rate is high and the owner can usually release it. Long queue waits may be acceptable during known budget caps, but they should be visible so platform owners can decide whether to buy capacity, adjust quotas, or steer jobs to cheaper shapes. A low spot ratio is a signal to check availability, labels, or fallback behavior.
 
 ```yaml
 apiVersion: monitoring.coreos.com/v1
@@ -683,7 +658,7 @@ spec:
           labels:
             severity: warning
           annotations:
-            summary: "On-demand GPU {{ $labels.gpu }} on {{ $labels.node }} idle for 1h — costing $3/hr"
+            summary: "On-demand GPU {{ $labels.gpu }} on {{ $labels.node }} idle for 1h -- costing $3/hr"
             runbook: "Check if workload is stuck or notebook is abandoned. Consider scaling down."
 
         - alert: HighQueueWaitTime
@@ -693,7 +668,7 @@ spec:
           labels:
             severity: info
           annotations:
-            summary: "Jobs waiting >1hr in GPU queue — consider increasing GPU budget"
+            summary: "Jobs waiting >1hr in GPU queue -- consider increasing GPU budget"
 
         - alert: SpotCapacityLow
           expr: |
@@ -705,22 +680,22 @@ spec:
           labels:
             severity: info
           annotations:
-            summary: "Spot GPUs are <40% of fleet — check spot availability in your AZs"
+            summary: "Spot GPUs are <40% of fleet -- check spot availability in your AZs"
 ```
 
-### The GPU Chargeback Model
+Chargeback does not have to mean internal billing. In many organizations, a monthly report is enough to change behavior because it gives teams a mirror. The report should avoid shaming and focus on useful facts: GPU-hours by type, idle cost, efficiency score, spot ratio, and top consumers. When users see that one abandoned notebook costs more than several completed experiments, cleanup becomes a normal engineering habit rather than a finance complaint.
 
 Implement chargeback so teams understand their spending:
 
 ```
-Monthly GPU Report — ML Research Team
+Monthly GPU Report -- ML Research Team
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-GPU-hours consumed:      2,847 hrs
-  ├── A100 on-demand:      312 hrs × $3.06 =   $954.72
-  ├── A100 spot:         1,935 hrs × $1.17 = $2,263.95
-  └── T4 spot:             600 hrs × $0.35 =   $210.00
+GPU-hours consumed:      2,846 hrs
+  ├── A100 on-demand:      312 hrs x $3.06 =   $954.72
+  ├── A100 spot:         1,934 hrs x $1.17 = $2,262.78
+  └── T4 spot:             600 hrs x $0.35 =   $210.00
                                              ──────────
-Total:                                        $3,428.67
+Total:                                        $3,427.50
 
 Waste analysis:
   Idle GPU-hours:          423 hrs (14.9%)
@@ -732,14 +707,10 @@ Spot ratio: 89.1% (target: >70%)
 Top consumers:
   1. training-llama-ft-v3:   1,200 GPU-hrs  ($1,404.00)
   2. hyperparameter-sweep:     800 GPU-hrs  ($280.00)
-  3. jupyter-alice:            400 GPU-hrs  ($140.00) ← 82% idle
+  3. jupyter-alice:            400 GPU-hrs  ($140.00) <- 82% idle
 ```
 
----
-
-## Resource Quotas for GPU
-
-### Namespace-Level Quotas
+Resource quotas are the hard boundary behind friendly reports. A quota prevents one namespace from monopolizing the cluster, and it protects the budget from accidental expansion. Quotas should reflect an agreed operating model: guaranteed team capacity, maximum burst, and a separate path for requesting exceptional capacity. They are not a substitute for Kueue, because quotas do not provide fair batch admission by themselves, but they are an important layer of defense.
 
 Prevent any single team from monopolizing GPUs:
 
@@ -756,7 +727,7 @@ spec:
     pods: "50"                         # Max 50 pods (prevent notebook sprawl)
 ```
 
-### LimitRange for Default GPU Requests
+LimitRanges set defaults and maximums for containers in a namespace. They are useful when users submit ad hoc Pods or notebooks, because a missing request can produce confusing scheduling behavior and an oversized limit can consume scarce GPUs unnecessarily. For serious training pipelines, prefer explicit resource requests in job templates. Defaults are guardrails for humans, not a replacement for deliberate workload specifications.
 
 Prevent users from accidentally requesting too many GPUs:
 
@@ -777,131 +748,157 @@ spec:
         nvidia.com/gpu: "1"
 ```
 
----
+Which approach would you choose here and why: a hard namespace quota, a Kueue borrowing policy, or a monthly chargeback report? A mature platform usually needs all three, but each solves a different problem. The quota prevents runaway allocation, Kueue makes scarce capacity fair and efficient, and the report changes behavior by making cost legible. If you use only one, you will either block useful work, allow waste, or leave users confused about the consequences of their choices.
+
+## Patterns & Anti-Patterns
+
+Patterns are reusable operating choices, not magic defaults. The right pattern depends on whether the workload is interruptible, whether users experience latency, whether startup time is acceptable, and whether the organization values predictable budgets over opportunistic throughput. Use these patterns as a menu for designing a platform contract that teams can understand before they submit work.
+
+| Pattern | When to Use | Why It Works | Scaling Consideration |
+|---------|-------------|--------------|-----------------------|
+| Spot-first training queue | Checkpointed training, hyperparameter search, and batch inference | Captures the largest discount while bounding lost work through checkpoint restore | Diversify instance types and zones, then monitor interruption-driven retry cost |
+| On-demand inference pool | User-facing endpoints with latency or availability commitments | Separates reliability-sensitive serving from interruptible batch capacity | Pair with autoscaling, batching, and disruption budgets so on-demand spend stays justified |
+| Scale-to-zero development GPUs | Notebooks, experiments, and sporadic exploratory work | Deletes idle accelerators instead of making forgotten sessions cheaper | Provide clear startup expectations and auto-save guidance for users |
+| Queue-based fair sharing | Multi-team clusters with more demand than GPUs | Converts contention into visible admission, borrowing, and preemption policy | Review quota weights regularly as teams and priorities change |
+
+Anti-patterns are common because they feel simpler at first. A standing all-purpose GPU pool avoids early scheduler design, but it hides cost until the bill arrives. Letting every team choose any priority avoids difficult policy conversations, but it turns incidents into political arguments. Moving everything to spot reduces the bill for a while, but the first serving interruption will teach users not to trust the platform. Cost design has to be explicit enough that users know what reliability they bought.
+
+| Anti-Pattern | What Goes Wrong | Better Alternative |
+|--------------|-----------------|--------------------|
+| One shared GPU pool for every workload | Production, training, and notebooks compete with no visible reliability contract | Separate NodePools, labels, taints, and queues by workload class |
+| Spot capacity without restore testing | Interruptions lose hours or require manual cleanup, erasing the discount | Make checkpoint restore part of normal CI or scheduled drills |
+| Aggressive consolidation for live training | Autoscaler terminates useful work because the node looks underutilized | Use `WhenEmpty` for training pools and tune disruption by workload class |
+| Chargeback without ownership labels | Reports show spend but cannot identify teams, projects, or services | Require namespace, team, workload type, and project labels at admission |
+
+The safest way to adopt these patterns is to start with one workload class and one measurable outcome. For example, move checkpointed nightly training to a spot-first Kueue queue, measure effective cost per completed run for two weeks, and compare queue wait time against the old platform. Then expand the pattern to related workloads. This incremental rollout gives users proof that the system works and gives platform owners data before they change production or high-priority research paths.
+
+## Decision Framework
+
+A decision framework helps prevent every cost discussion from becoming an argument about the most recent incident. Instead of asking whether spot is good or bad in general, classify the workload by interruption tolerance, latency sensitivity, startup tolerance, and budget predictability. These questions map naturally to Kubernetes controls: capacity type, NodePool, queue, priority, quota, and dashboard. The framework should be written down because the cheapest option is not always the correct option.
+
+Start with interruption tolerance. If the workload cannot tolerate interruption, use on-demand or reserved capacity and focus on right-sizing. If it can tolerate interruption and can restore automatically, use spot or preemptible capacity. If it can tolerate delay but not partial execution, put it behind Kueue so it waits until the full resource request is available. If it is interactive and sporadic, prioritize scale-to-zero and user experience because idle time dominates the cost curve.
+
+```
+Workload asks for GPUs
+        |
+        v
+Can users tolerate interruption?
+        |
+   +----+----+
+   |         |
+  No        Yes
+   |         |
+Use on-   Can it restore from
+demand    durable checkpoints?
+or reserved      |
+capacity   +-----+-----+
+           |           |
+          No          Yes
+           |           |
+   Fix resilience   Use spot or
+   before spot      preemptible
+                    capacity
+                         |
+                         v
+              Does it need fair sharing?
+                         |
+                  +------+------+
+                  |             |
+                 No            Yes
+                  |             |
+          Karpenter only   Kueue + quotas
+```
+
+| Decision Question | Choose This | Avoid This | Reasoning |
+|-------------------|-------------|------------|-----------|
+| Is the workload user-facing with strict latency? | On-demand or reserved inference pool | Spot-only serving | User-visible errors cost more than the discount |
+| Is the workload checkpointed and batch-oriented? | Spot-first Kueue queue | Always-on on-demand pool | Lost work is bounded and queueing improves utilization |
+| Is usage sporadic and interactive? | Scale-to-zero development pool | Permanent notebook GPUs | Idle time dominates notebook cost |
+| Does the team need guaranteed capacity? | Nominal quota plus borrowing policy | Informal first-come scheduling | Guarantees and borrowing make fairness explicit |
+| Is monthly spend predictable and steady? | Reserved or committed capacity for the baseline | Buying all capacity on demand | Commitments can reduce known baseline cost while burst stays flexible |
+
+Reserved capacity belongs in the framework, but it should not be the default answer. A commitment makes sense for a stable baseline that you expect to run regardless of queue behavior, such as production inference or a recurring training schedule with clear utilization. It is a poor fit for exploratory workloads whose demand may disappear, change GPU type, or shift region. A practical budget model often combines reserved or committed capacity for the predictable floor, on-demand for reliability-sensitive burst, and spot for recoverable batch work.
+
+When you present this framework to stakeholders, lead with risk rather than discount. Finance needs to know which spend is committed, variable, and avoidable. Researchers need to know when work may wait or be preempted. Service owners need to know which capacity is protected. A good platform design makes those contracts visible in Kubernetes objects and cost reports instead of burying them in tribal knowledge.
+
+The review cadence matters as much as the first decision. GPU prices, model architectures, queue pressure, and team priorities change over time, so a capacity plan should be revisited after meaningful usage shifts rather than treated as a one-time procurement answer. A monthly review can compare reserved baseline utilization, spot interruption cost, queue wait time, and idle spend. If the baseline is consistently full, increase committed capacity deliberately; if it is consistently idle, move that budget back to flexible capacity.
 
 ## Did You Know?
 
-1. **Spot GPU interruption rates vary wildly by instance type and region**. AWS p4d.24xlarge (8x A100) in us-east-1 has a spot interruption rate of about 5-15% (meaning roughly 1 in 7-20 spot instances gets interrupted per hour), while g5.xlarge (1x A10G) has a rate under 5%. Diversifying across instance types and availability zones significantly reduces interruption frequency.
+1. **A single eight-H100 on-demand node can cost more than $860,000 per year before storage, networking, or operational overhead.** That number is why GPU scale-to-zero deserves serious engineering attention even when the cluster feels small.
 
-2. **Kueue was created at Google specifically for AI/ML workloads on GKE**. The Google Kubernetes team realized that the standard Kubernetes scheduler had no concept of "wait in line" — if resources aren't available, a Pod is just Pending forever with no ordering guarantee. Kueue adds the queuing, fair sharing, and preemption semantics that HPC and ML batch systems have had for decades (think SLURM, PBS).
+2. **Kueue brings queue semantics to Kubernetes batch workloads instead of making every training job compete as ordinary Pods.** That distinction matters because fair sharing, borrowing, and admission are scheduling features, not just dashboard labels.
 
-3. **The biggest hidden cost in AI infrastructure is often egress, not compute**. A team downloading a 100GB model from Hugging Face Hub to 50 nodes pays for 5TB of egress. If they do this daily (CI/CD pipeline rebuilds), that is 150TB/month. At $0.09/GB, that is **$13,500/month in bandwidth alone**. Caching model weights on a shared PVC eliminates this entirely.
+3. **Egress can rival compute waste when every Pod downloads the same large model or dataset.** Caching model weights and datasets near the cluster often reduces both startup time and avoidable network spend.
 
----
-
-## War Story: The Team That Saved 73% by Doing Nothing Differently
-
-A startup spending $180,000/month on GPU infrastructure asked for a cost review. Their workloads:
-
-- 3 always-on inference services (needed on-demand for SLA)
-- 15-20 training jobs per day (interruptible, checkpoint every 20 minutes)
-- 30+ Jupyter notebooks (mostly idle)
-
-**Changes made**:
-
-1. **Karpenter + spot for training**: Training jobs moved to spot instances. Cost reduction: 62% on training compute.
-
-2. **Karpenter scale-to-zero for notebooks**: Notebooks got GPU only when running a cell. Idle notebooks lost their GPU after 15 minutes. Cost reduction: 90% on notebook GPUs (from $30K/month to $3K/month).
-
-3. **Kueue for fairness**: Instead of every team hoarding GPUs "just in case," Kueue managed a shared pool. Teams that finished early released GPUs for others. Utilization went from 35% to 78%.
-
-4. **Time-slicing for inference**: Small inference models shared GPUs instead of getting dedicated ones. 3 inference services went from 6 GPUs to 2 GPUs.
-
-**Result**:
-
-| Category | Before | After | Savings |
-|----------|--------|-------|---------|
-| Training | $81,000 | $25,000 | 69% |
-| Inference | $52,500 | $18,000 | 66% |
-| Development | $30,000 | $3,000 | 90% |
-| Networking/egress | $16,500 | $2,500 | 85% |
-| **Total** | **$180,000** | **$48,500** | **73%** |
-
-The ML team did not change a single line of training code. Every optimization was at the platform level.
-
-**Lesson**: The platform team has more leverage over AI costs than the ML team does. Invest in infrastructure efficiency.
-
----
+4. **Checkpoint frequency is a cost parameter as much as a reliability parameter.** Halving the checkpoint interval can reduce lost spot work, but it may also increase storage writes, so the best value is workload-specific.
 
 ## Common Mistakes
 
-| Mistake | Problem | Solution |
-|---------|---------|----------|
-| Running all GPU workloads on-demand | Paying 3x more than necessary for interruptible work | Use spot for training, hyperparameter search, batch inference |
-| No scale-to-zero for dev GPUs | Notebooks hold GPUs 24/7, used 10% of the time | Karpenter `consolidateAfter: 15m` or KEDA scale-to-zero |
-| No resource quotas | One team monopolizes all GPUs; others wait indefinitely | Per-namespace ResourceQuotas + Kueue ClusterQueue fair sharing |
-| Checkpoint too infrequently on spot | Spot interruption loses 2+ hours of training | Checkpoint every 15-30 minutes; cost of wasted work is pennies |
-| Same priority for all workloads | Production inference and casual experiments compete equally | PriorityClasses: production (1M), training (100K), dev (10K), best-effort (1K) |
-| Ignoring egress costs | Downloading models/datasets on every Pod start | Cache on shared PVCs; use JuiceFS for datasets |
-| No cost visibility | Teams have no idea what their GPU usage costs | Build chargeback dashboards with per-namespace cost tracking |
-| Karpenter without GPU limits | Bug or runaway job provisions 100 GPU nodes | Set `limits.nvidia.com/gpu` on every NodePool |
+| Mistake | Why It Happens | How to Fix It |
+|---------|----------------|---------------|
+| Running all GPU workloads on-demand | Teams optimize for reliability by default because interruption behavior is unclear | Use on-demand for serving, spot for checkpointed batch, and document the reliability contract |
+| No scale-to-zero for development GPUs | Notebooks feel interactive, so teams leave accelerators attached for convenience | Use Karpenter consolidation, idle shutdown, and user-visible save behavior for notebooks |
+| No resource quotas | A busy team can consume the entire cluster before anyone notices | Set namespace quotas and Kueue ClusterQueue limits that match agreed capacity shares |
+| Checkpointing too infrequently on spot | Training code treats checkpointing as disaster recovery instead of normal control flow | Checkpoint often enough that expected lost work is small compared with the spot discount |
+| Same priority for all workloads | It avoids early policy decisions but creates conflict during scarcity | Define production, training, development, and best-effort PriorityClasses with clear rules |
+| Ignoring model and dataset transfer cost | Compute dominates attention while repeated downloads happen quietly | Cache shared artifacts on durable storage and include egress in cost dashboards |
+| No ownership labels on GPU Pods | Metrics cannot connect spend to teams, services, or experiments | Enforce labels for team, project, workload type, and environment at admission |
+| Karpenter NodePools without GPU limits | A broken queue or deployment can provision far more GPUs than planned | Set `limits.nvidia.com/gpu` and alert on rapid node creation |
 
----
-
-## Quiz: Check Your Understanding
-
-### Question 1
-You are architecting a training pipeline for a new LLM. The data science team has implemented checkpointing every 30 minutes. The finance team points out that spot instances cost $12/hr compared to the $32/hr on-demand price, but the data scientists are worried about lost work since spot interruptions occur on average once every 3 hours. How do you calculate the effective hourly cost to prove to the data science team that spot instances are still the right choice?
+## Quiz
 
 <details>
-<summary>Show Answer</summary>
+<summary>Question 1: Your team wants to move a three-day training job to spot capacity. The model checkpoints every thirty minutes, and spot interruptions are expected several times during the run. What do you check before approving the move?</summary>
 
-The effective hourly cost is calculated by adding the base spot price to the cost of wasted compute time. Since the spot instance costs $12/hr and interruptions occur on average every 3 hours, you can expect one interruption per 3-hour window. With a 30-minute checkpoint interval, an interruption will destroy an average of 15 minutes of work (half the interval). This 15 minutes of lost work costs $3 ($12/hr × 0.25 hrs), which amortizes to a waste cost of $1/hr over the 3-hour period. Therefore, the effective cost is $13/hr, which still yields a massive 59% savings compared to the $32/hr on-demand price, definitively proving that spot instances are the more economical choice despite the interruptions.
+Check that the job can restore automatically from the newest complete checkpoint, that checkpoints are written to durable storage outside the interrupted node, and that the queue resubmits or resumes work without manual cleanup. The spot discount is only useful when lost work is bounded by the checkpoint interval. You should also estimate expected waste as roughly half a checkpoint interval per interruption and compare that cost with the on-demand premium. If restore has not been tested, the correct fix is to validate resilience before changing capacity type.
 </details>
-
-### Question 2
-Your organization currently relies on native Kubernetes PriorityClasses to ensure production inference services preempt batch experiments. However, the machine learning researchers complain that when preemption happens, their jobs fail completely and their quotas get messed up. You are proposing Kueue to solve this. How would you explain the operational difference between Kueue's preemption and native Kubernetes preemption to the research team?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Question 2: Production inference and low-priority experiments are sharing one GPU pool. During a traffic spike, inference Pods wait behind experiments. What platform changes would you make first?</summary>
 
-Native Kubernetes preemption is a blunt tool operated by the scheduler that simply evicts lower-priority pods to make room, forcing them back into a pending state with no queuing order or quota awareness. In contrast, Kueue's preemption is managed by a sophisticated admission controller designed for multi-tenant batch workloads. Kueue respects fair sharing and cohort borrowing policies, ensuring that one team's high-priority job cannot aggressively evict workloads from another team's guaranteed quota unless borrowing limits are exceeded. When Kueue preempts a workload, it suspends it and returns it to an ordered queue, preserving its position so it can seamlessly resume once capacity frees up. This makes Kueue significantly safer and fairer for research teams sharing a cluster.
+Separate the workload classes with labels, taints, PriorityClasses, and preferably distinct NodePools so inference has protected on-demand capacity. Kueue can manage batch experiments, but production serving should not rely on casual queue behavior during a spike. The experiments should use lower priority and interruption-tolerant design, while inference should have autoscaling and disruption controls. This fixes the core problem: the platform failed to encode different reliability contracts for different workloads.
 </details>
-
-### Question 3
-The computer vision team (Team A) and the NLP team (Team B) each have a strict quota of 16 A100 GPUs in your 32-GPU cluster. The vision team is currently only running experiments that use 8 GPUs. The NLP team has a massive backlog and needs 24 GPUs to meet a deadline. Using Kueue, how can you configure the system so the NLP team can utilize the vision team's idle GPUs without permanently depriving the vision team of their guaranteed capacity when they need it back?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Question 3: Two research teams each have a nominal quota of sixteen A100 GPUs. Team A is idle, and Team B has a deadline requiring more than its share. How can Kueue improve utilization without stealing Team A's guarantee?</summary>
 
-Kueue solves this resource-sharing challenge through the use of cohorts and temporary borrowing. By placing both the computer vision and NLP teams' ClusterQueues into the same cohort, you establish a shared resource pool. You would configure the NLP team's queue with a `nominalQuota` of 16 and a `borrowingLimit` of at least 8, allowing them to dynamically borrow the vision team's unused GPUs and scale up to 24 GPUs. Crucially, because the vision team's queue maintains its `nominalQuota` of 16 and Kueue is configured with `reclaimWithinCohort: Any`, Kueue will gracefully preempt the NLP team's lowest-priority borrowed workloads the moment the vision team submits new jobs. This guarantees the vision team immediate access to their dedicated capacity while maximizing overall cluster utilization.
+Put the teams' ClusterQueues into a cohort and allow borrowing with an explicit borrowing limit and reclaim policy. Team B can temporarily use Team A's idle quota, which raises utilization while the capacity would otherwise sit unused. When Team A submits work again, Kueue can reclaim borrowed resources by preempting lower-priority borrowed workloads according to policy. This preserves the guarantee while avoiding the waste of rigid, unused partitions.
 </details>
-
-### Question 4
-You are configuring Karpenter NodePools for a new GPU training cluster. A junior platform engineer suggests using `consolidationPolicy: WhenEmptyOrUnderutilized` to maximize cost savings by packing pods tightly and terminating underutilized nodes. You know this is a bad idea for GPU training workloads. How do you explain to the engineer why `WhenEmpty` is the safer and more appropriate choice?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Question 4: A platform engineer proposes `WhenEmptyOrUnderutilized` consolidation for long-running distributed training nodes. Why might you reject that policy for the training pool?</summary>
 
-Using the `WhenEmptyOrUnderutilized` policy on GPU nodes is highly disruptive because moving a running GPU training pod involves terminating it, losing uncheckpointed progress, and enduring a lengthy cold-start process to reload large model weights. Furthermore, Karpenter's utilization metrics might interpret a node as "underutilized" if only 1 out of 4 GPUs is active, even though the remaining GPUs might be required momentarily for the next phase of a distributed training job. `WhenEmpty` is the much safer alternative because it only terminates a node when zero GPU pods are running on it. This configuration entirely avoids the risk of destructive mid-training migrations while still aggressively scaling the cluster down to zero when the nodes are genuinely idle, perfectly balancing cost savings with workload stability.
+Long-running GPU training jobs are expensive to interrupt because a move usually means terminating the worker, loading data and model state again, and relying on checkpoint recovery. A node can look underutilized during a phase of the training loop even though disrupting it would waste useful progress. For training pools, `WhenEmpty` is often the safer default because it still scales down after jobs finish without treating live workers as movable web replicas. More aggressive consolidation can be reserved for development or serving pools that have appropriate redundancy.
 </details>
-
-### Question 5
-You have been hired as a FinOps consultant for a startup struggling with a $156,750/month AWS bill for AI workloads. They currently run 40 inference pods (1 GPU each, 15% avg utilization), 20 daily training jobs (4 GPUs for 2 hours each), and 25 always-on Jupyter notebooks (1 GPU each). Everything runs on on-demand A100s at $3/hr without sharing. You plan to implement time-slicing (4 pods/GPU) for inference, Kueue with spot instances ($1.17/hr) for training, and Karpenter scale-to-zero (active 10% of time) for notebooks. Calculate the projected monthly savings and explain how these three mechanisms achieve the reduction.
 
 <details>
-<summary>Show Answer</summary>
+<summary>Question 5: A chargeback dashboard shows high GPU-hours for a namespace, but the team argues the spend was necessary. What extra measurements help decide whether the cost is justified?</summary>
 
-The optimized monthly cost will be $29,652, resulting in a dramatic savings of $127,098 (an 81% reduction) compared to the original $156,750 bill. Time-slicing achieves the first major reduction by packing four 15%-utilized inference pods onto a single GPU, dropping the required always-on inference GPUs from 40 down to just 10. For training, transitioning to spot instances slashes the compute rate by 62%, while Kueue ensures these batch jobs execute efficiently without idle wait times or quota conflicts. Finally, applying Karpenter's scale-to-zero capabilities to the Jupyter notebooks eliminates the massive waste of 24/7 on-demand allocation, ensuring the cluster only spins up spot GPUs for the 10% of the time the data scientists are actively running code. These three strategies combined transform the infrastructure from a static, over-provisioned liability into a dynamic, workload-driven architecture.
+Add utilization, workload type, cost per unit of work, idle GPU-hours, queue wait time, and top consumer labels. High GPU-hours alone do not prove waste because a valuable training run or busy inference service may legitimately consume capacity. Cost per epoch, cost per thousand requests, or completed experiments ties spend to output. Idle percentage and workload ownership show whether the team is buying useful work or paying for abandoned allocations.
 </details>
 
----
+<details>
+<summary>Question 6: A notebook platform keeps one GPU attached to every user's server so notebooks open instantly. The monthly report shows most notebook GPUs are idle. What design would reduce cost while keeping the workflow usable?</summary>
 
-## Hands-On Exercise: Karpenter GPU Spot NodePool + Kueue Batch Jobs + Preemption
+Use scale-to-zero or detach-on-idle behavior for development GPUs, paired with clear user messaging and autosave expectations. Karpenter can provision GPU nodes when notebooks actually run GPU cells, and consolidation can remove nodes after the idle window expires. The tradeoff is startup delay, so the platform should document expected wait time and perhaps keep a small warm pool if productivity requires it. The key is to stop paying for accelerators during long periods when users are away.
+</details>
 
-### Objective
+<details>
+<summary>Question 7: Finance asks whether the platform should buy reserved GPU capacity for the next year. What workload evidence would support a reserved baseline instead of spot or pure on-demand?</summary>
 
-Configure Karpenter to provision GPU spot nodes, deploy Kueue for batch job scheduling, submit jobs with different priorities, and observe preemption behavior.
+Reserved or committed capacity is reasonable when there is a predictable baseline with high utilization, stable GPU type requirements, and reliability needs that justify capacity guarantees. Production inference with steady traffic is a stronger candidate than exploratory research that changes shape every month. The platform should compare the committed baseline against actual historical usage, then keep bursty or recoverable work on on-demand or spot capacity. This avoids locking the organization into expensive resources that do not match future demand.
+</details>
 
-### Environment
+## Hands-On Exercise
 
-- EKS cluster with Karpenter installed (or GKE with equivalent; adapt NodePool syntax)
-- At least one GPU instance type available in your region (g5.xlarge or similar)
-- kubectl and Helm installed
+In this exercise, you configure Karpenter to provision GPU spot nodes, deploy Kueue for batch job scheduling, submit jobs with different priorities, and observe preemption behavior. The manifests assume an AWS EKS cluster with Karpenter and Kubernetes 1.35 or newer, but the scheduling concepts transfer to GKE and AKS with provider-specific NodeClass changes. Use a non-production environment because the exercise intentionally creates and preempts GPU workloads.
 
-> **Note**: This exercise is designed for AWS EKS with Karpenter. If using GKE or AKS, adapt the NodePool/NodeClass definitions to your provider's syntax. The Kueue concepts are identical across providers.
+Before you start, confirm that your cluster can provision at least one small GPU instance type, that `kubectl` points to the correct cluster, and that Helm is installed for the optional AWS interruption handler path earlier in the module. Replace placeholder cluster names and IAM role names before applying the Karpenter resources. If your cloud account does not have GPU quota, read through the commands and compare them with your platform's existing NodePools and Kueue queues instead of applying them.
 
 ### Step 1: Create GPU NodePool in Karpenter
+
+This task creates a small spot-only GPU NodePool with a hard cap of four GPUs. The low limit is intentional: it protects the exercise from accidental spend while still giving Kueue enough capacity to demonstrate admission and preemption. The NodeClass contains placeholders for your cluster discovery tags and node role, so do not apply it unchanged to a shared environment.
 
 ```bash
 cat <<'EOF' | kubectl apply -f -
@@ -957,14 +954,30 @@ spec:
 EOF
 ```
 
+<details>
+<summary>Solution notes for Step 1</summary>
+
+After applying the manifests, inspect the NodePool and NodeClass with `kubectl get nodepool gpu-spot-exercise -o yaml` and `kubectl get ec2nodeclass gpu-exercise -o yaml`. You should see spot capacity requirements, the GPU taint, and the four-GPU limit. If Karpenter rejects the resource, check whether your installed Karpenter version supports the `karpenter.sh/v1` API and whether the AWS-specific NodeClass group matches your installation.
+</details>
+
 ### Step 2: Install Kueue
+
+Kueue provides the admission controller and queue APIs used by the rest of the lab. The exercise uses the preserved upstream manifest URL from the original module, so review compatibility with your cluster policy before applying it in a managed environment. In production, you would pin versions through your normal deployment system rather than applying directly from a release URL.
 
 ```bash
 kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.9.1/manifests.yaml
 kubectl -n kueue-system wait --for=condition=Ready pods --all --timeout=120s
 ```
 
+<details>
+<summary>Solution notes for Step 2</summary>
+
+The wait command should finish only after Kueue controller Pods are ready. If it times out, inspect `kubectl -n kueue-system get pods` and `kubectl -n kueue-system describe pod` for image pull, admission webhook, or permission problems. Do not continue to the queue configuration until the controller is healthy, because workloads may otherwise be created without the expected admission behavior.
+</details>
+
 ### Step 3: Configure Kueue Resources
+
+This step creates two team namespaces, two priority classes, one ResourceFlavor, one ClusterQueue, and two LocalQueues. The nominal GPU quota is four, matching the Karpenter NodePool limit. That alignment is deliberate: Kueue should not admit more GPU work than the autoscaler is allowed to create for the exercise.
 
 ```bash
 # Create namespaces
@@ -1043,7 +1056,15 @@ spec:
 EOF
 ```
 
-### Step 4: Submit Low-Priority Jobs (fill the queue)
+<details>
+<summary>Solution notes for Step 3</summary>
+
+Run `kubectl get clusterqueue gpu-exercise-queue -o wide` and confirm that the queue exists with the expected resource groups. Then check `kubectl -n team-alpha get localqueue` and `kubectl -n team-beta get localqueue`. If workloads later remain pending even when quota appears available, compare the ResourceFlavor node labels with labels on the nodes Karpenter creates.
+</details>
+
+### Step 4: Submit Low-Priority Jobs
+
+The first workload batch fills the exercise queue with low-priority GPU jobs. Each job asks for one GPU, so four jobs consume the whole nominal quota. This creates the condition needed to observe preemption when a higher-priority job arrives from another namespace.
 
 ```bash
 # Submit 4 low-priority jobs (will fill all 4 GPU slots)
@@ -1089,7 +1110,15 @@ kubectl -n team-alpha get jobs
 kubectl get nodes -l exercise=ai-cost
 ```
 
-### Step 5: Submit a High-Priority Job (trigger preemption)
+<details>
+<summary>Solution notes for Step 4</summary>
+
+You should see Team Alpha jobs created, admitted by Kueue, and eventually scheduled onto nodes labeled for the exercise. If jobs are admitted but Pods stay pending, inspect the Pod events for taint, quota, or instance availability errors. If Karpenter does not create nodes, verify that the NodePool requirements match instance types available in your region and account quota.
+</details>
+
+### Step 5: Submit a High-Priority Job
+
+The second workload submits a higher-priority job from Team Beta. Because the queue is already full, Kueue should choose lower-priority work to preempt according to the ClusterQueue policy. This is the moment where fair sharing becomes visible: the high-priority job gets capacity, and the preempted lower-priority work returns to the queue instead of disappearing from the system.
 
 ```bash
 # Submit a high-priority job from Team Beta
@@ -1144,7 +1173,15 @@ echo "=== All pods ==="
 kubectl get pods -n team-alpha -n team-beta
 ```
 
+<details>
+<summary>Solution notes for Step 5</summary>
+
+Expect at least one Team Alpha workload to lose admission or return to pending while the Team Beta workload becomes admitted. Depending on timing and Kueue version, the visible state may move quickly, so use events and workload descriptions if a watch misses the transition. The important result is that priority changes admission in a controlled way rather than relying on users to manually delete lower-value work.
+</details>
+
 ### Step 6: Verify and Observe
+
+The verification commands connect Kueue behavior, Pod events, ClusterQueue state, and Karpenter logs. This is how you debug a real GPU scheduling issue: start from queue admission, then move to Pod scheduling, then node provisioning. Avoid jumping straight to cloud console capacity errors before you know whether Kubernetes admitted the workload in the first place.
 
 ```bash
 # Check Kueue events
@@ -1158,7 +1195,15 @@ kubectl get clusterqueue gpu-exercise-queue -o yaml | grep -A 10 "status:"
 kubectl -n kube-system logs -l app.kubernetes.io/name=karpenter --tail=50 | grep -i "gpu\|provisioned\|terminated"
 ```
 
+<details>
+<summary>Solution notes for Step 6</summary>
+
+Healthy output shows queue admission events, ClusterQueue status reflecting admitted and pending workloads, and Karpenter logs that explain node provisioning or termination decisions. If the queue admits work but Karpenter fails to provision, the likely problem is cloud capacity, quota, or NodePool requirements. If Kueue never admits the work, inspect ClusterQueue quota, ResourceFlavor matching, and workload labels.
+</details>
+
 ### Step 7: Cleanup
+
+Clean up promptly because the exercise creates cloud resources that can cost real money. The cleanup removes namespaces, Karpenter resources, Kueue queue objects, and priority classes. Confirm that GPU nodes terminate after workloads are gone, and check your cloud console if nodes remain.
 
 ```bash
 kubectl delete namespace team-alpha team-beta
@@ -1169,64 +1214,42 @@ kubectl delete resourceflavor gpu-spot
 kubectl delete priorityclass high-priority-gpu low-priority-gpu
 ```
 
+<details>
+<summary>Solution notes for Step 7</summary>
+
+After cleanup, run `kubectl get nodes -l exercise=ai-cost` and confirm that exercise nodes disappear. If nodes remain, inspect finalizers, Karpenter logs, and cloud provider instance state. In a shared cluster, also verify that deleting the exercise PriorityClasses does not affect other workloads before running the command unchanged.
+</details>
+
 ### Success Criteria
 
 You have completed this exercise when:
+
 - [ ] Karpenter provisions spot GPU nodes in response to pending Pods
-- [ ] 4 low-priority jobs are running on spot GPU nodes
+- [ ] Four low-priority jobs are running on spot GPU nodes
 - [ ] High-priority job submission triggers Kueue preemption of a low-priority job
-- [ ] Preempted job returns to the queue (visible as Pending workload)
+- [ ] Preempted job returns to the queue and is visible as a pending workload
 - [ ] High-priority job runs to completion
-- [ ] After all jobs complete, Karpenter terminates idle GPU nodes (scale-to-zero)
-- [ ] You can explain the cost advantage: spot pricing + scale-to-zero + preemption
+- [ ] After all jobs complete, Karpenter terminates idle GPU nodes through scale-to-zero behavior
+- [ ] You can explain the cost advantage of spot pricing, scale-to-zero, and preemption using cost per unit of work
 
----
+## Sources
 
-## Key Takeaways
+- [AWS EKS charts for AWS Node Termination Handler](https://aws.github.io/eks-charts)
+- [Kueue release manifest used in the exercise](https://github.com/kubernetes-sigs/kueue/releases/download/v0.9.1/manifests.yaml)
+- [Karpenter documentation](https://karpenter.sh/docs/)
+- [Karpenter NodePools](https://karpenter.sh/docs/concepts/nodepools/)
+- [Karpenter NodeClasses](https://karpenter.sh/docs/concepts/nodeclasses/)
+- [Karpenter disruption controls](https://karpenter.sh/docs/concepts/disruption/)
+- [AWS EC2 Spot Instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-spot-instances.html)
+- [AWS Spot Instance interruption notices](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-instance-termination-notices.html)
+- [Google Kubernetes Engine Spot VMs](https://cloud.google.com/kubernetes-engine/docs/concepts/spot-vms)
+- [Azure Spot Virtual Machines in scale sets](https://learn.microsoft.com/en-us/azure/virtual-machine-scale-sets/use-spot)
+- [Kueue documentation](https://kueue.sigs.k8s.io/docs/)
+- [Kueue ClusterQueue concept](https://kueue.sigs.k8s.io/docs/concepts/cluster_queue/)
+- [NVIDIA DCGM Exporter documentation](https://docs.nvidia.com/datacenter/cloud-native/gpu-telemetry/latest/dcgm-exporter.html)
+- [Kubernetes Pod priority and preemption](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/)
+- [Kubernetes ResourceQuota](https://kubernetes.io/docs/concepts/policy/resource-quotas/)
 
-1. **Spot instances save 60-90% on interruptible GPU workloads** — training, hyperparameter search, and batch inference all qualify
-2. **Karpenter provisions optimal GPU nodes dynamically** — right instance type, right zone, spot with on-demand fallback, and scale-to-zero when idle
-3. **Priority classes create a GPU hierarchy** — production inference should never be disrupted by experiments
-4. **Kueue brings HPC-grade batch scheduling to Kubernetes** — queuing, fair sharing, borrowing, and preemption for multi-tenant GPU clusters
-5. **Cost visibility is prerequisite to cost optimization** — you cannot reduce what you cannot measure; build per-team chargeback dashboards
-6. **The platform team has the most leverage on AI costs** — spot migration, scale-to-zero, sharing, and queuing save more than any ML code optimization
-7. **Think in cost per unit of work** (cost per epoch, cost per 1K inferences) not cost per GPU-hour
+## Next Module
 
----
-
-## Further Reading
-
-**Documentation**:
-- **Kueue**: kueue.sigs.k8s.io/docs/
-- **Karpenter**: karpenter.sh/docs/
-- **AWS Spot Instances**: docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-spot-instances.html
-- **GKE Spot VMs**: cloud.google.com/kubernetes-engine/docs/concepts/spot-vms
-
-**Talks**:
-- **"Kueue: Job Queueing for Kubernetes"** — Aldo Culquicondor, KubeCon NA 2024
-- **"Cost-Optimizing AI Workloads at Scale"** — AWS re:Invent 2024
-- **"GPU Cost Optimization with Karpenter"** — Rajdeep Saha, KubeCon EU 2024
-
-**Books**:
-- **"Cloud FinOps"** — J.R. Storment & Mike Fuller (O'Reilly) — general cloud cost optimization principles
-
----
-
-## Summary
-
-AI infrastructure cost optimization is a multi-layered discipline: spot instances for interruptible workloads, Karpenter for intelligent node provisioning and scale-to-zero, priority classes and Kueue for multi-tenant GPU sharing with preemption, and comprehensive metrics dashboards for cost visibility and chargeback. Applied together, these techniques typically reduce GPU spending by 50-80% — often without any changes to ML training or inference code. The platform team's cost optimization work frequently delivers more ROI than the models it supports.
-
----
-
-## What's Next
-
-You have completed the AI/GPU Infrastructure discipline. From here:
-
-- **Build on this foundation** with the [Platform Engineering](/platform/disciplines/core-platform/platform-engineering/) discipline for internal developer platforms
-- **Deepen your observability** with the [SRE](/platform/disciplines/core-platform/sre/) discipline for GPU cluster reliability
-- **Explore MLOps** with the [MLOps](/platform/disciplines/data-ai/mlops/) discipline for model lifecycle management
-- **Review** all modules in this discipline and build a production GPU platform integrating all six modules
-
----
-
-*"The cheapest GPU is the one you don't provision. The second cheapest is the spot instance you terminate when you're done."* — FinOps for AI
+You have completed the AI/GPU Infrastructure sequence; continue into [Platform Engineering](/platform/disciplines/core-platform/platform-engineering/) to design the internal platforms that make these GPU cost controls usable by product and research teams.


### PR DESCRIPTION
Rewrites `src/content/docs/platform/disciplines/data-ai/ai-infrastructure/module-1.6-ai-cost.md` to clear #388 verifier gates and clears `revision_pending: false`.

Verifier summary: tier T0; body_words=5007; mean_wpp=62.6; median_wpp=72.0; short_rate=0.175; max_run=1; mean_sentence_length=19.5; failure_gates={}; sources check skipped per dispatch.

Protected assets preserved: before code_blocks=31, mermaid_diagrams=3, tables=6, source URLs=2; after code_blocks=32, mermaid_diagrams=3, tables=8, Sources URLs=15. Original Kueue manifest and AWS EKS chart URLs are preserved.

Validation:
- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/quality/verify_module.py --glob src/content/docs/platform/disciplines/data-ai/ai-infrastructure/module-1.6-ai-cost.md --skip-source-check --summary --quiet` -> T0, all gates pass
- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/test_pipeline.py` -> 166 tests OK
- `npm run build` from primary checkout -> passed, 2015 pages built
- `git diff --check` -> clean

Commit SHA: 6ddac3bde70aa48fa0231f4ad02bced2283e8592