### PR TITLE
fix(bridge): repair ab discuss fallback and delivery ack

### DIFF
--- a/scripts/ai_agent_bridge/_channels.py
+++ b/scripts/ai_agent_bridge/_channels.py
@@ -1220,6 +1220,54 @@ def mark_delivery_delivered(
         conn.close()
 
 
+def mark_message_delivery_delivered(
+    message_id: str,
+    to_agent: str,
+    reply_message_id: str,
+    *,
+    now: str | None = None,
+) -> int:
+    """Mark a message delivery to one agent as terminally delivered.
+
+    ``ab discuss`` invokes agents inline instead of through the inbox
+    worker, so it has a reply message but no claimed delivery id. This
+    bridges that path without changing the delivery schema.
+    """
+    _validate_agent(to_agent)
+    now = now or _now_iso()
+    conn = get_db()
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+
+        # reply_message_id is the caller's evidence that the delivery
+        # produced a channel reply. The schema still has no reply linkage
+        # column, so keep the argument for API symmetry with
+        # mark_delivery_delivered() and future migration compatibility.
+        _ = reply_message_id
+        cursor = conn.execute(
+            """
+            UPDATE deliveries
+            SET status='delivered',
+                delivered_at=?,
+                error=NULL,
+                lease_until=NULL,
+                retry_after=NULL,
+                last_error_kind=NULL
+            WHERE message_id=?
+              AND to_agent=?
+              AND status NOT IN ('delivered', 'failed')
+            """,
+            (now, message_id, to_agent),
+        )
+        conn.commit()
+        return cursor.rowcount
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
 def mark_delivery_failed(
     delivery_id: str,
     error_kind: str,

--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -899,6 +899,10 @@ def _handle_discuss(args) -> int:
         )
         from agent_runtime.runner import invoke as runtime_invoke
         from ._db import get_session as _get_session, set_session as _set_session
+        from ._gemini import (
+            _should_switch_after_rate_limit_exception,
+            _should_switch_to_subscription,
+        )
     except ImportError as e:
         print(f"❌ agent_runtime unavailable: {e}", file=sys.stderr)
         print(
@@ -1029,6 +1033,8 @@ def _handle_discuss(args) -> int:
         print(f"   root message: {root_id[:12]} / thread {correlation_id[:12]}")
         print()
 
+    gemini_use_subscription_auth = os.environ.get("KUBEDOJO_GEMINI_SUBSCRIPTION") == "1"
+
     def _invoke_one(
         agent_name: str, prompt_text: str, round_idx: int
     ) -> tuple[str, str, bool]:
@@ -1039,6 +1045,8 @@ def _handle_discuss(args) -> int:
         row in a 4-round discussion would collide on the same task_id
         and the dashboard couldn't tell them apart.
         """
+        nonlocal gemini_use_subscription_auth
+
         # Codex.supported_modes drops read-only (PR #981 — codex always
         # runs in danger mode; read-only starves codex of network/spawn
         # and produces garbage). Other agents stay read-only because they
@@ -1057,19 +1065,58 @@ def _handle_discuss(args) -> int:
             # Codex is intentionally never resumable under registry policy;
             # never read stale codex rows even if present.
             session_id = None
-        try:
-            result = runtime_invoke(
+
+        def _invoke_runtime(*, use_subscription_auth: bool = False):
+            tool_config = None
+            skip_headroom_check = False
+            if agent_name == "gemini" and use_subscription_auth:
+                tool_config = {"use_subscription_auth": True}
+                skip_headroom_check = True
+            return runtime_invoke(
                 agent_name,
                 prompt_text,
                 mode=agent_mode,
                 cwd=agent_cwd,
                 task_id=f"discuss-{correlation_id[:8]}-r{round_idx}-{agent_name}",
                 session_id=session_id,
+                tool_config=tool_config,
                 entrypoint="bridge",
                 hard_timeout=900,
+                skip_headroom_check=skip_headroom_check,
+            )
+
+        try:
+            result = _invoke_runtime(
+                use_subscription_auth=gemini_use_subscription_auth,
             )
         except RateLimitedError as exc:
-            return (agent_name, f"[rate-limited: {exc}]", False)
+            if (
+                agent_name == "gemini"
+                and _should_switch_after_rate_limit_exception(
+                    gemini_use_subscription_auth,
+                )
+            ):
+                gemini_use_subscription_auth = True
+                print(
+                    "   🔁 gemini API-key quota exhausted — retrying via OAuth/subscription.",
+                    flush=True,
+                )
+                try:
+                    result = _invoke_runtime(use_subscription_auth=True)
+                except RateLimitedError as retry_exc:
+                    return (agent_name, f"[rate-limited: {retry_exc}]", False)
+                except (AgentStalledError, AgentTimeoutError) as retry_exc:
+                    return (agent_name, f"[timeout: {retry_exc}]", False)
+                except AgentUnavailableError as retry_exc:
+                    return (agent_name, f"[unavailable: {retry_exc}]", False)
+                except Exception as retry_exc:
+                    return (
+                        agent_name,
+                        f"[error: {type(retry_exc).__name__}: {retry_exc}]",
+                        False,
+                    )
+            else:
+                return (agent_name, f"[rate-limited: {exc}]", False)
         except (AgentStalledError, AgentTimeoutError) as exc:
             return (agent_name, f"[timeout: {exc}]", False)
         except AgentUnavailableError as exc:
@@ -1079,6 +1126,34 @@ def _handle_discuss(args) -> int:
             # is BaseException, not Exception, so Ctrl+C still bubbles
             # up to the pool-shutdown branch in the main loop.
             return (agent_name, f"[error: {type(exc).__name__}: {exc}]", False)
+
+        if (
+            agent_name == "gemini"
+            and not result.ok
+            and _should_switch_to_subscription(
+                result.stderr_excerpt or "",
+                gemini_use_subscription_auth,
+            )
+        ):
+            gemini_use_subscription_auth = True
+            print(
+                "   🔁 gemini API-key quota exhausted — retrying via OAuth/subscription.",
+                flush=True,
+            )
+            try:
+                result = _invoke_runtime(use_subscription_auth=True)
+            except RateLimitedError as exc:
+                return (agent_name, f"[rate-limited: {exc}]", False)
+            except (AgentStalledError, AgentTimeoutError) as exc:
+                return (agent_name, f"[timeout: {exc}]", False)
+            except AgentUnavailableError as exc:
+                return (agent_name, f"[unavailable: {exc}]", False)
+            except Exception as exc:
+                return (
+                    agent_name,
+                    f"[error: {type(exc).__name__}: {exc}]",
+                    False,
+                )
 
         if not result.ok:
             return (
@@ -1228,7 +1303,7 @@ def _handle_discuss(args) -> int:
             text, ok = responses[agent]
             reply_recipients = [name for name in with_agents if name != agent]
             try:
-                _channels.post(
+                reply = _channels.post(
                     args.channel,
                     agent,
                     text,
@@ -1238,6 +1313,11 @@ def _handle_discuss(args) -> int:
                     kind="reply",
                     auto_snapshot=False,
                     pre_delivered=True,
+                )
+                _channels.mark_message_delivery_delivered(
+                    root_id,
+                    agent,
+                    reply["message_id"],
                 )
             except ValueError as e:
                 print(

--- a/scripts/ai_agent_bridge/_gemini.py
+++ b/scripts/ai_agent_bridge/_gemini.py
@@ -82,9 +82,12 @@ def _gemini_rate_limited_text(text: str) -> bool:
 def _should_switch_to_subscription(text: str, use_subscription_auth: bool) -> bool:
     """Return True when an API-key quota hit should retry through OAuth.
 
-    Durable auth rule: Gemini bridge calls use API-key auth first. Only when
-    that path hits quota/rate-limit do we strip GEMINI_API_KEY/GOOGLE_API_KEY
-    for the retry, which makes the Gemini CLI fall through to OAuth creds.
+    Durable auth rule: Gemini bridge calls use API-key auth first. The legacy
+    ask/process path calls this from ``_run_gemini_attempt`` after a structured
+    runtime failure; ``ab discuss`` calls it after its direct runtime invocation
+    returns a failed Gemini result. Only when that path hits quota/rate-limit
+    do we strip GEMINI_API_KEY/GOOGLE_API_KEY for the retry, which makes the
+    Gemini CLI fall through to OAuth creds.
     """
     if use_subscription_auth or _force_gemini_subscription():
         return False

--- a/scripts/ai_agent_bridge/tests/test_discuss_bridge_bugs.py
+++ b/scripts/ai_agent_bridge/tests/test_discuss_bridge_bugs.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import os
+import shlex
+import sqlite3
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def _drop_bridge_modules() -> None:
+    for name in list(sys.modules):
+        if name == "ai_agent_bridge" or name.startswith("ai_agent_bridge."):
+            del sys.modules[name]
+
+
+def _load_bridge(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setenv("AB_DB_PATH", str(tmp_path / "messages.db"))
+    monkeypatch.setenv("AB_REPO_ROOT", str(REPO_ROOT))
+    _drop_bridge_modules()
+
+    from ai_agent_bridge import _channels, _channels_cli
+
+    _channels.create_channel("test-discuss")
+    return _channels, _channels_cli
+
+
+def _discuss_args(agent: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        channel="test-discuss",
+        body="test",
+        with_agents=agent,
+        max_rounds=1,
+        resume_thread=None,
+    )
+
+
+def _root_delivery_statuses(db_path: Path) -> list[str]:
+    db = sqlite3.connect(db_path)
+    try:
+        rows = db.execute(
+            """
+            SELECT d.status
+            FROM deliveries d
+            JOIN channel_messages cm ON cm.message_id = d.message_id
+            WHERE cm.parent_id IS NULL
+            ORDER BY d.to_agent
+            """
+        ).fetchall()
+    finally:
+        db.close()
+    return [row[0] for row in rows]
+
+
+def test_discuss_gemini_retries_quota_failure_without_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _channels, channels_cli = _load_bridge(monkeypatch, tmp_path)
+    _ = _channels
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    count_file = tmp_path / "gemini-count"
+    env_log = tmp_path / "gemini-env.log"
+    gemini = fake_bin / "gemini"
+    gemini.write_text(
+        "\n".join(
+            [
+                "#!/bin/sh",
+                f"count_file={shlex.quote(str(count_file))}",
+                f"env_log={shlex.quote(str(env_log))}",
+                'count="$(cat "$count_file" 2>/dev/null || printf 0)"',
+                'count=$((count + 1))',
+                'printf "%s" "$count" > "$count_file"',
+                'api_key="${GEMINI_API_KEY-<unset>}"',
+                'printf "%s:GEMINI_API_KEY=%s\\n" "$count" "$api_key" >> "$env_log"',
+                "cat >/dev/null",
+                'if [ "$count" -eq 1 ]; then',
+                '  echo "TerminalQuotaError: You have exhausted your capacity on this model. Your quota will reset after 1h." >&2',
+                "  exit 1",
+                "fi",
+                'echo "Gemini retry succeeded. [AGREE]"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    gemini.chmod(0o755)
+
+    monkeypatch.setenv("PATH", f"{fake_bin}:{SCRIPTS_DIR}:{os.environ.get('PATH', '')}")
+    monkeypatch.setenv("GEMINI_API_KEY", "api-key-from-test")
+    monkeypatch.delenv("KUBEDOJO_GEMINI_SUBSCRIPTION", raising=False)
+
+    import agent_runtime.runner as runner
+
+    monkeypatch.setattr(runner, "has_headroom", lambda _agent, _model: (True, ""))
+    monkeypatch.setattr(runner, "write_record", lambda _record: None)
+
+    assert channels_cli._handle_discuss(_discuss_args("gemini")) == 0
+
+    env_lines = env_log.read_text(encoding="utf-8").splitlines()
+    assert env_lines[0] == "1:GEMINI_API_KEY=api-key-from-test"
+    assert env_lines[1] == "2:GEMINI_API_KEY=<unset>"
+    assert env_lines[2] == "3:GEMINI_API_KEY=<unset>"
+
+
+def test_discuss_marks_root_delivery_delivered(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _channels, channels_cli = _load_bridge(monkeypatch, tmp_path)
+    _ = _channels
+
+    import agent_runtime.runner as runner
+
+    def fake_invoke(*_args, **_kwargs):
+        return SimpleNamespace(
+            ok=True,
+            response="Claude response. [AGREE]",
+            stderr_excerpt=None,
+            session_id="claude-session",
+        )
+
+    monkeypatch.setattr(runner, "invoke", fake_invoke)
+
+    assert channels_cli._handle_discuss(_discuss_args("claude")) == 0
+    assert _root_delivery_statuses(tmp_path / "messages.db") == ["delivered"]


### PR DESCRIPTION
## Summary
- add Gemini OAuth/subscription retry plumbing to the direct `ab discuss` runtime path when API-key quota exhaustion is detected
- keep the subscription fallback active for the remainder of the discussion once triggered, and honor `KUBEDOJO_GEMINI_SUBSCRIPTION=1` from the first call
- mark the root channel delivery delivered after each discussion participant reply is stored
- add regression tests for stripped Gemini env on retry and delivered root deliveries

## Tests
- `../../.venv/bin/ruff check scripts/ai_agent_bridge/_channels.py scripts/ai_agent_bridge/_channels_cli.py scripts/ai_agent_bridge/_gemini.py scripts/ai_agent_bridge/tests/test_discuss_bridge_bugs.py`
- `../../.venv/bin/python -m pytest scripts/ai_agent_bridge/tests/test_discuss_bridge_bugs.py`
- `../../.venv/bin/python scripts/test_pipeline.py` (166 tests OK)

## Scope
- 4 files changed
- no content or Astro config changes, so `npm run build` skipped

Cross-family review not triggered by this PR author; orchestrator should trigger it.