### PR TITLE
fix(agent-runtime): default claude adapter to npx

### DIFF
--- a/scripts/agent_runtime/adapters/claude.py
+++ b/scripts/agent_runtime/adapters/claude.py
@@ -103,19 +103,25 @@ class ClaudeAdapter:
             - ``output_format: str`` — defaults to "text"
             - ``use_bare: bool`` — explicit opt-out of --bare (default: auto-enable
               when no session + ANTHROPIC_API_KEY is set)
+            - ``use_path_claude: bool`` — opt in to a PATH-resolved ``claude``
+              binary when available; otherwise npx stays the default
         """
         tc: dict[str, Any] = tool_config or {}
 
-        # Command prefix — respect both the packaged npx path and a local
-        # `claude` binary if present. The bridge uses CLAUDE_CMD=["npx", "@anthropic-ai/claude-code@latest"]
-        # as the canonical prefix; we default to the same. Callers can
-        # override by passing ``tool_config={"cmd_prefix": [...]}``.
+        # Command prefix — default to the packaged npx invocation so we
+        # avoid drift from stale PATH installs. PATH `claude` is only used
+        # when callers explicitly opt in via ``use_path_claude`` or
+        # ``KUBEDOJO_CLAUDE_USE_PATH=1``. Full prefix overrides still win via
+        # ``tool_config={"cmd_prefix": [...]}``.
         cmd_prefix = tc.get("cmd_prefix")
         if cmd_prefix:
-            cmd: list[str] = list(cmd_prefix)
+            prefix: list[str] = list(cmd_prefix)
         else:
-            claude_bin = shutil.which("claude")
-            cmd = [claude_bin] if claude_bin else ["npx", "@anthropic-ai/claude-code@latest"]
+            use_path_claude = bool(tc.get("use_path_claude")) or os.environ.get("KUBEDOJO_CLAUDE_USE_PATH") == "1"
+            claude_bin = shutil.which("claude") if use_path_claude else None
+            prefix = [claude_bin] if claude_bin else ["npx", "@anthropic-ai/claude-code@latest"]
+
+        cmd: list[str] = list(prefix)
 
         cmd.append("-p")
 
@@ -161,12 +167,9 @@ class ClaudeAdapter:
         # Cache-warmth optimization (CC 2.1.98+)
         try:
             from utils.claude_version import supports_exclude_dynamic_system_prompt_sections
-            # Probe the prefix we're about to run (matches the actual binary)
-            probe_prefix = tuple(cmd[:1]) if len(cmd) >= 1 else tuple(cmd[:2] or ["claude"])
-            if cmd_prefix:
-                probe_prefix = tuple(cmd_prefix)
-            elif not shutil.which("claude"):
-                probe_prefix = ("npx", "@anthropic-ai/claude-code@latest")
+            # Probe the same prefix we're about to run so version gating
+            # stays aligned with the selected command.
+            probe_prefix = tuple(prefix)
             if supports_exclude_dynamic_system_prompt_sections(probe_prefix):
                 cmd.append("--exclude-dynamic-system-prompt-sections")
         except ImportError:

--- a/tests/test_claude_dispatch_special_chars.py
+++ b/tests/test_claude_dispatch_special_chars.py
@@ -4,6 +4,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 from agent_runtime.adapters.claude import ClaudeAdapter
@@ -14,6 +16,7 @@ SPECIAL_PROMPT = """--monitor snapshot
 {"--foo": "bar", "note": "keep this out of argv"}
 Shell metacharacters: $(echo nope); `uname`; | & > < *
 """
+FAKE_CLAUDE_BIN = str(Path(__file__).resolve().parent / "mock-claude")
 
 
 def _completed_process(cmd: list[str], *, stdout: str = "ok", stderr: str = ""):
@@ -67,3 +70,47 @@ def test_claude_runtime_adapter_pipes_special_prompt_to_stdin(monkeypatch):
     assert SPECIAL_PROMPT not in plan.cmd
     assert not any('{"--foo": "bar"' in arg for arg in plan.cmd)
     assert not any("$(echo nope)" in arg for arg in plan.cmd)
+
+
+@pytest.mark.parametrize(
+    ("tool_config", "env_value", "expected_prefix"),
+    [
+        (
+            {"use_bare": False},
+            None,
+            ["npx", "@anthropic-ai/claude-code@latest"],
+        ),
+        (
+            {"use_bare": False, "use_path_claude": True},
+            None,
+            [FAKE_CLAUDE_BIN],
+        ),
+        (
+            {"use_bare": False},
+            "1",
+            [FAKE_CLAUDE_BIN],
+        ),
+    ],
+)
+def test_claude_runtime_adapter_prefix_selection(monkeypatch, tool_config, env_value, expected_prefix):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("KUBEDOJO_CLAUDE_USE_PATH", raising=False)
+    if env_value is not None:
+        monkeypatch.setenv("KUBEDOJO_CLAUDE_USE_PATH", env_value)
+    monkeypatch.setattr(
+        "agent_runtime.adapters.claude.shutil.which",
+        lambda name: FAKE_CLAUDE_BIN if name == "claude" else None,
+    )
+
+    plan = ClaudeAdapter().build_invocation(
+        prompt="hello",
+        mode="read-only",
+        cwd=Path.cwd(),
+        model=None,
+        task_id=None,
+        session_id=None,
+        tool_config=tool_config,
+    )
+
+    assert plan.cmd[: len(expected_prefix)] == expected_prefix
+    assert plan.cmd[len(expected_prefix)] == "-p"


### PR DESCRIPTION
Summary:\n- Default Claude adapter invocation to `npx @anthropic-ai/claude-code@latest` unless PATH Claude is explicitly opted in via `tool_config.use_path_claude` or `KUBEDOJO_CLAUDE_USE_PATH=1`.\n- Reuse the resolved prefix for the Claude version probe so the npx/path selection stays consistent.\n- Add hermetic tests for default npx and both PATH opt-in paths.\n\nValidation:\n- `git diff --check`\n- `../../.venv/bin/ruff check scripts/agent_runtime/adapters/claude.py tests/test_claude_dispatch_special_chars.py`\n- `../../.venv/bin/python -m pytest -q tests/test_claude_dispatch_special_chars.py`\n- `../../.venv/bin/python scripts/test_pipeline.py`\n- Smoke: `env -u KUBEDOJO_CLAUDE_USE_PATH ../../.venv/bin/python scripts/dispatch_smart.py search --agent claude --dry-run "prefix smoke"` and a direct adapter probe confirmed the default prefix is `['npx', '@anthropic-ai/claude-code@latest']`.