### PR TITLE
fix(git): verify gh merge and codex push helpers

### DIFF
--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -53,6 +53,10 @@ from .watchdog import (
     stop_watchdog,
     tail_liveness_file_for_debug,
 )
+try:
+    from scripts.lib.git_verify import verify_current_branch_pushed
+except ImportError:  # pragma: no cover - depends on invocation style
+    from lib.git_verify import verify_current_branch_pushed
 
 # Poll interval while waiting on subprocess + watchdog. 1s is a good balance:
 # fast enough that stall detection fires within 1s of the threshold, slow
@@ -611,6 +615,12 @@ def invoke(
         else:
             outcome = "error"
 
+        push_verify_error: str | None = None
+        if agent_name == "codex" and mode == "danger" and parse.ok:
+            push_ok, push_verify_error = verify_current_branch_pushed(effective_cwd)
+            if not push_ok:
+                outcome = "error"
+
         record = _build_usage_record(
             agent=agent_name,
             entrypoint=entrypoint,
@@ -627,7 +637,7 @@ def invoke(
             outcome=outcome,
             rate_limited=parse.rate_limited,
             stalled=False,
-            stderr_excerpt=parse.stderr_excerpt,
+            stderr_excerpt=push_verify_error or parse.stderr_excerpt,
             tokens=parse.tokens,
         )
         write_record(record)
@@ -640,12 +650,12 @@ def invoke(
             )
 
         return Result(
-            ok=parse.ok,
+            ok=parse.ok and push_verify_error is None,
             agent=agent_name,
             model=effective_model,
             mode=mode,
             response=parse.response,
-            stderr_excerpt=parse.stderr_excerpt,
+            stderr_excerpt=push_verify_error or parse.stderr_excerpt,
             duration_s=duration_s,
             session_id=parse.session_id,
             rate_limited=parse.rate_limited,

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -616,7 +616,11 @@ def invoke(
             outcome = "error"
 
         push_verify_error: str | None = None
-        if agent_name == "codex" and mode == "danger" and parse.ok:
+        if mode == "danger" and parse.ok:
+            # Defense in depth: any agent in danger mode that lands commits
+            # could silent-fail-push (e.g., sandbox env issue). Codex was the
+            # original observed case (PR #907 round-2), but the verify is
+            # cheap (one git ls-remote) and applies to all agents.
             push_ok, push_verify_error = verify_current_branch_pushed(effective_cwd)
             if not push_ok:
                 outcome = "error"

--- a/scripts/dispatch_smart.py
+++ b/scripts/dispatch_smart.py
@@ -57,7 +57,7 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
-REPO = Path("/Users/krisztiankoos/projects/kubedojo")
+REPO = Path(__file__).resolve().parents[1]
 LOG_PATH = REPO / "logs" / "smart_dispatch.jsonl"
 
 

--- a/scripts/lib/__init__.py
+++ b/scripts/lib/__init__.py
@@ -1,0 +1,2 @@
+"""Shared helper modules for repo-local orchestration scripts."""
+

--- a/scripts/lib/git_verify.py
+++ b/scripts/lib/git_verify.py
@@ -1,0 +1,91 @@
+"""Git remote verification helpers for agent-orchestrated pushes."""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def verify_pushed_to_remote(
+    branch_name: str,
+    expected_local_sha: str,
+    *,
+    repo: Path | None = None,
+) -> tuple[bool, str | None, str | None]:
+    """Return whether ``origin/<branch_name>`` points at ``expected_local_sha``."""
+    cwd = repo or Path.cwd()
+    result = subprocess.run(
+        ["git", "ls-remote", "origin", branch_name],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return False, None, (result.stderr or result.stdout or "git ls-remote failed").strip()
+
+    remote_sha: str | None = None
+    expected_ref = f"refs/heads/{branch_name}"
+    for line in result.stdout.splitlines():
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        sha, ref = parts[0], parts[1]
+        if ref == expected_ref or ref.endswith(f"/{branch_name}"):
+            remote_sha = sha
+            break
+
+    if remote_sha is None:
+        return False, None, f"origin has no branch named {branch_name!r}"
+    if remote_sha != expected_local_sha:
+        return (
+            False,
+            remote_sha,
+            f"origin/{branch_name} is {remote_sha[:12]}, expected {expected_local_sha[:12]}",
+        )
+    return True, remote_sha, None
+
+
+def verify_current_branch_pushed(repo: Path) -> tuple[bool, str | None]:
+    """Verify the checked-out branch in ``repo`` is present at the same SHA on origin."""
+    branch = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if branch.returncode != 0:
+        return False, f"could not read current branch: {branch.stderr.strip()}"
+    branch_name = branch.stdout.strip()
+    if not branch_name or branch_name == "HEAD":
+        return False, "worktree is detached; cannot verify remote branch push"
+
+    local = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if local.returncode != 0:
+        return False, f"could not read local HEAD: {local.stderr.strip()}"
+    local_sha = local.stdout.strip()
+    ok, remote_sha, error = verify_pushed_to_remote(branch_name, local_sha, repo=repo)
+    if ok:
+        return True, None
+    if remote_sha is None:
+        on_origin_main = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", "HEAD", "origin/main"],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if on_origin_main.returncode == 0:
+            return True, None
+    remote_label = remote_sha[:12] if remote_sha else "missing"
+    return (
+        False,
+        "Codex danger-mode dispatch left origin stale: "
+        f"branch={branch_name} local={local_sha[:12]} remote={remote_label}; {error}",
+    )

--- a/scripts/lib/pr_merge.py
+++ b/scripts/lib/pr_merge.py
@@ -1,0 +1,140 @@
+"""Safe GitHub PR merge helpers.
+
+GitHub's auto-merge queue can capture an old squash payload before later
+branch commits land. These helpers wait for green checks first, then run a
+direct squash merge so GitHub merges the live branch tip.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+
+class PrMergeError(RuntimeError):
+    """Raised when a PR cannot be safely merged."""
+
+
+@dataclass(frozen=True)
+class CheckSummary:
+    pending: int
+    failed: int
+    total: int
+
+
+def _run_gh(args: list[str], repo: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["gh", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _check_value(item: dict[str, Any], *names: str) -> str:
+    for name in names:
+        value = item.get(name)
+        if isinstance(value, str) and value:
+            return value.upper()
+    return ""
+
+
+def _summarize_checks(status_check_rollup: list[dict[str, Any]]) -> CheckSummary:
+    pending = 0
+    failed = 0
+    total = 0
+    for item in status_check_rollup:
+        if not isinstance(item, dict):
+            continue
+        total += 1
+        conclusion = _check_value(item, "conclusion", "state")
+        status = _check_value(item, "status")
+        if conclusion in {"FAILURE", "FAILED", "ERROR", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED"}:
+            failed += 1
+        elif conclusion in {"SUCCESS", "NEUTRAL", "SKIPPED"} or status == "COMPLETED":
+            continue
+        else:
+            pending += 1
+    return CheckSummary(pending=pending, failed=failed, total=total)
+
+
+def _merge_sha(pr_number: int, repo: Path) -> str:
+    view = _run_gh(["pr", "view", str(pr_number), "--json", "mergeCommit"], repo)
+    if view.returncode != 0:
+        raise PrMergeError(f"merged PR #{pr_number}, but merge SHA lookup failed: {view.stderr.strip()}")
+    try:
+        payload = json.loads(view.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise PrMergeError(f"merged PR #{pr_number}, but merge SHA JSON was invalid") from exc
+    merge_commit = payload.get("mergeCommit") or {}
+    sha = merge_commit.get("oid") if isinstance(merge_commit, dict) else None
+    if not sha:
+        raise PrMergeError(f"merged PR #{pr_number}, but GitHub did not return mergeCommit.oid")
+    return sha
+
+
+def merge_when_green(
+    pr_number: int,
+    *,
+    poll_interval: int = 8,
+    timeout: int = 900,
+    repo: Path | None = None,
+    sleep_fn: Callable[[float], None] = time.sleep,
+) -> str:
+    """Wait for all PR checks to pass, then direct squash-merge the live tip.
+
+    Raises:
+        PrMergeError: If any check fails, the PR closes before merge, the
+            timeout expires, or the direct merge command fails.
+
+    Returns:
+        The merge commit SHA.
+    """
+    repo_root = repo or Path.cwd()
+    deadline = time.monotonic() + timeout
+    last_summary = CheckSummary(pending=0, failed=0, total=0)
+
+    while True:
+        view = _run_gh(
+            ["pr", "view", str(pr_number), "--json", "state,statusCheckRollup"],
+            repo_root,
+        )
+        if view.returncode != 0:
+            raise PrMergeError(f"gh pr view failed for PR #{pr_number}: {view.stderr.strip()}")
+        try:
+            payload = json.loads(view.stdout or "{}")
+        except json.JSONDecodeError as exc:
+            raise PrMergeError(f"gh pr view returned invalid JSON for PR #{pr_number}") from exc
+
+        state = str(payload.get("state") or "").upper()
+        if state and state != "OPEN":
+            raise PrMergeError(f"PR #{pr_number} is {state}, not open")
+
+        rollup = payload.get("statusCheckRollup") or []
+        if not isinstance(rollup, list):
+            raise PrMergeError(f"PR #{pr_number} statusCheckRollup was not a list")
+        last_summary = _summarize_checks(rollup)
+        if last_summary.failed:
+            raise PrMergeError(f"PR #{pr_number} has {last_summary.failed} failing check(s)")
+        if last_summary.pending == 0:
+            break
+
+        if time.monotonic() >= deadline:
+            raise PrMergeError(
+                f"timed out waiting for PR #{pr_number} checks: "
+                f"{last_summary.pending} pending of {last_summary.total}"
+            )
+        sleep_fn(poll_interval)
+
+    merge = _run_gh(
+        ["pr", "merge", str(pr_number), "--squash", "--delete-branch"],
+        repo_root,
+    )
+    if merge.returncode != 0:
+        raise PrMergeError(f"direct squash merge failed for PR #{pr_number}: {merge.stderr.strip()}")
+    return _merge_sha(pr_number, repo_root)
+

--- a/scripts/quality/dispatch_388_pilot.py
+++ b/scripts/quality/dispatch_388_pilot.py
@@ -39,6 +39,7 @@ from agent_runtime.errors import (  # noqa: E402
     AgentUnavailableError,
     RateLimitedError,
 )
+from lib.pr_merge import PrMergeError, merge_when_green  # noqa: E402
 
 
 def log(event: dict) -> None:
@@ -274,11 +275,12 @@ def post_review_comment(pr_num: int, body: str) -> None:
     )
 
 
-def merge_pr(pr_num: int) -> None:
-    subprocess.run(
-        ["gh", "pr", "merge", str(pr_num), "--squash", "--delete-branch"],
-        cwd=REPO, check=False,
-    )
+def merge_pr(pr_num: int) -> str | None:
+    try:
+        return merge_when_green(pr_num, repo=REPO)
+    except PrMergeError as exc:
+        log({"event": "merge_failed", "pr": pr_num, "error": str(exc)})
+        return None
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -343,8 +345,11 @@ def main(argv: list[str] | None = None) -> int:
         if review_text:
             post_review_comment(pr_num, review_text)
         if verdict == "APPROVE":
-            merge_pr(pr_num)
-            log({"event": "merged", "pr": pr_num, "module": module_path})
+            merge_sha = merge_pr(pr_num)
+            if merge_sha:
+                log({"event": "merged", "pr": pr_num, "module": module_path, "merge_sha": merge_sha})
+            else:
+                log({"event": "merge_held", "pr": pr_num, "module": module_path, "verdict": "MERGE_FAILED"})
         elif verdict == "APPROVE_WITH_NITS":
             # C3 fix-up lane: orchestrator triages inline (trivial nits) or
             # re-dispatches codex (semantic). Do NOT auto-merge — the

--- a/scripts/test_pipeline.py
+++ b/scripts/test_pipeline.py
@@ -56,6 +56,153 @@ def sample_fact_ledger() -> dict:
     }
 
 
+class TestPrMergeHelper(unittest.TestCase):
+    def test_merge_when_green_waits_then_direct_squash_merges(self):
+        from lib import pr_merge
+
+        calls = []
+
+        def fake_run_gh(args, repo):
+            calls.append(args)
+            if args[:3] == ["pr", "view", "123"] and "statusCheckRollup" in args[-1]:
+                if len([c for c in calls if c[:3] == ["pr", "view", "123"]]) == 1:
+                    payload = {
+                        "state": "OPEN",
+                        "statusCheckRollup": [{"status": "IN_PROGRESS"}],
+                    }
+                else:
+                    payload = {
+                        "state": "OPEN",
+                        "statusCheckRollup": [{"conclusion": "SUCCESS"}],
+                    }
+                return subprocess.CompletedProcess(args, 0, json.dumps(payload), "")
+            if args == ["pr", "merge", "123", "--squash", "--delete-branch"]:
+                return subprocess.CompletedProcess(args, 0, "", "")
+            if args == ["pr", "view", "123", "--json", "mergeCommit"]:
+                payload = {"mergeCommit": {"oid": "abc123"}}
+                return subprocess.CompletedProcess(args, 0, json.dumps(payload), "")
+            raise AssertionError(f"unexpected gh call: {args}")
+
+        sleeps = []
+        with patch.object(pr_merge, "_run_gh", side_effect=fake_run_gh):
+            sha = pr_merge.merge_when_green(
+                123,
+                repo=REPO_ROOT,
+                poll_interval=1,
+                sleep_fn=sleeps.append,
+            )
+
+        self.assertEqual(sha, "abc123")
+        self.assertEqual(sleeps, [1])
+        self.assertIn(["pr", "merge", "123", "--squash", "--delete-branch"], calls)
+        self.assertNotIn("--auto", " ".join(" ".join(call) for call in calls))
+
+
+class TestGitVerifyHelper(unittest.TestCase):
+    def test_verify_pushed_to_remote_accepts_matching_sha(self):
+        from lib.git_verify import verify_pushed_to_remote
+
+        def fake_run(_cmd, **_kwargs):
+            return subprocess.CompletedProcess(
+                _cmd,
+                0,
+                "abc123\trefs/heads/feature/test\n",
+                "",
+            )
+
+        with patch("lib.git_verify.subprocess.run", side_effect=fake_run):
+            ok, remote_sha, error = verify_pushed_to_remote(
+                "feature/test",
+                "abc123",
+                repo=REPO_ROOT,
+            )
+
+        self.assertTrue(ok)
+        self.assertEqual(remote_sha, "abc123")
+        self.assertIsNone(error)
+
+    def test_verify_pushed_to_remote_rejects_stale_sha(self):
+        from lib.git_verify import verify_pushed_to_remote
+
+        def fake_run(_cmd, **_kwargs):
+            return subprocess.CompletedProcess(
+                _cmd,
+                0,
+                "old456\trefs/heads/feature/test\n",
+                "",
+            )
+
+        with patch("lib.git_verify.subprocess.run", side_effect=fake_run):
+            ok, remote_sha, error = verify_pushed_to_remote(
+                "feature/test",
+                "new123",
+                repo=REPO_ROOT,
+            )
+
+        self.assertFalse(ok)
+        self.assertEqual(remote_sha, "old456")
+        self.assertIn("expected new123", error or "")
+
+
+class TestCodexPushVerification(unittest.TestCase):
+    def test_runner_marks_codex_danger_success_failed_when_origin_stale(self):
+        from agent_runtime import runner
+        from agent_runtime.adapters.base import InvocationPlan
+        from agent_runtime.result import ParseResult
+
+        class FakeAdapter:
+            default_model = "gpt-test"
+            supported_modes = frozenset({"danger"})
+
+            def build_invocation(self, **kwargs):
+                return InvocationPlan(cmd=["fake-codex"], cwd=kwargs["cwd"])
+
+            def liveness_signal_paths(self, _plan):
+                return ()
+
+            def parse_response(self, **_kwargs):
+                return ParseResult(ok=True, response="push: done")
+
+        class FakeProc:
+            returncode = 0
+            stdin = None
+
+            def poll(self):
+                return 0
+
+            def kill(self):
+                return None
+
+            def wait(self, timeout=None):
+                return 0
+
+        class FakeWatchdogState:
+            stdout_lines = ["push: done"]
+            stderr_lines = []
+
+        stale_error = "Codex danger-mode dispatch left origin stale"
+        with patch.object(runner, "_load_adapter", return_value=FakeAdapter()), \
+             patch.object(runner, "has_headroom", return_value=(True, "")), \
+             patch.object(runner, "build_agent_env", return_value={}), \
+             patch.object(runner.subprocess, "Popen", return_value=FakeProc()), \
+             patch.object(runner, "start_watchdog", return_value=(FakeWatchdogState(), [])), \
+             patch.object(runner, "stop_watchdog"), \
+             patch.object(runner, "write_record"), \
+             patch.object(runner, "verify_current_branch_pushed", return_value=(False, stale_error)):
+            result = runner.invoke(
+                "codex",
+                "commit and push",
+                mode="danger",
+                cwd=REPO_ROOT,
+                model="gpt-test",
+                skip_headroom_check=True,
+            )
+
+        self.assertFalse(result.ok)
+        self.assertIn(stale_error, result.stderr_excerpt or "")
+        self.assertEqual(result.usage_record["outcome"], "error")
+
+
 # ---------------------------------------------------------------------------
 # Fixtures: known-good and known-bad module content
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- add scripts/lib/pr_merge.py::merge_when_green to poll PR checks and direct squash-merge only after green checks
- route the #388 dispatcher merge path through the wait-then-direct helper
- add scripts/lib/git_verify.py::verify_pushed_to_remote and fail Codex danger-mode runner results when origin is stale
- derive dispatch_smart.py repo root from the script location instead of a machine-specific absolute path

## Tests

- ../../.venv/bin/ruff check scripts/lib/pr_merge.py scripts/lib/git_verify.py scripts/agent_runtime/runner.py scripts/dispatch_smart.py scripts/quality/dispatch_388_pilot.py scripts/test_pipeline.py
- ../../.venv/bin/python -m unittest scripts.test_pipeline.TestPrMergeHelper scripts.test_pipeline.TestGitVerifyHelper scripts.test_pipeline.TestCodexPushVerification -v
- ../../.venv/bin/python scripts/test_pipeline.py
- git diff --check
- rg -n 'pr merge.*--auto|--auto.*--squash|--squash.*--auto' scripts  # zero hits

## Notes

No Astro/content changes; npm build skipped per repo checklist.