### PR TITLE
docs(decisions): adopt Decision Card convention (#740)

### DIFF
--- a/.claude/rules/decision-card.md
+++ b/.claude/rules/decision-card.md
@@ -69,5 +69,5 @@ Future cold-start agents must scan `docs/decisions/pending/` for outstanding dec
 ## References
 
 - Issue: kube-dojo/kube-dojo.github.io#740
-- Memory: `~/.claude/projects/-Users-krisztiankoos-projects-kubedojo/memory/feedback_ab_discuss_for_decisions.md`
+- Memory key: `feedback_ab_discuss_for_decisions.md`
 - Convention source: Claude on the learn-ukrainian project (2026-05-02). KubeDojo imports rather than reinvents.

--- a/STATUS.md
+++ b/STATUS.md
@@ -16,10 +16,11 @@
 ## Cold-start protocol
 
 1. Hit `curl -s http://127.0.0.1:8768/api/briefing/session?compact=1` (the API parses the `## TODO` and `## Blockers` sections of this file).
-2. Read the row in **Latest handoff** below — that's the only file you need for current state.
-3. Skim **Cross-thread notes (still active)** for stuff that spans sessions.
-4. If picking up a long-running thread, click into the relevant **Predecessor chain** row.
-5. Pre-2026-04-28 sessions (29 of them, going back to session 1) live in [`docs/session-state/archive-pre-2026-04-28.md`](./docs/session-state/archive-pre-2026-04-28.md) — kept for spelunking only, not actively maintained.
+2. Scan [`docs/decisions/pending/`](./docs/decisions/pending/) for outstanding Decision Cards and surface any pending user decision before unrelated work.
+3. Read the row in **Latest handoff** below — that's the only file you need for current state.
+4. Skim **Cross-thread notes (still active)** for stuff that spans sessions.
+5. If picking up a long-running thread, click into the relevant **Predecessor chain** row.
+6. Pre-2026-04-28 sessions (29 of them, going back to session 1) live in [`docs/session-state/archive-pre-2026-04-28.md`](./docs/session-state/archive-pre-2026-04-28.md) — kept for spelunking only, not actively maintained.
 
 ## Latest handoff
 
@@ -259,7 +260,7 @@ Issue tracker shrunk 40 → 14 open via batch triage 2026-05-01 (session 4); the
 **Next session — 1-7 list (2026-05-09 evening handoff, "utilizing ALL agents"):**
 
 - [ ] 1. Pipeline Supervisor stopped — investigate `.pids/pipeline.pid` + logs, restart if appropriate.
-- [ ] 2. Close GH #740 (Decision Card pattern adopted: `.claude/rules/decision-card.md` + `html-migration-strategy` ab discuss thread).
+- [x] 2. Close GH #740 (Decision Card pattern adopted: `.claude/rules/decision-card.md`, `docs/decisions/` convention docs, `day3-388` and `html-migration-strategy` ab discuss threads).
 - [ ] 3. Rename `needs_human` → `residuals_filed` (GH #342, pipeline-v4 outcomes — mechanical change; codex dispatch + gemini review).
 - [ ] 4. Update stale memory `feedback_codex_review_danger_mode.md` (bug fixed by `dispatch_smart.py:270-279` codex auto-bump).
 - [ ] 5. GH #373 — composite K8s-style liveness probes for LLM-dispatch subprocesses (large EPIC; `ab discuss` first).

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,36 @@
+# Decision Records
+
+This directory holds durable records for high-leverage project decisions: architecture choices, threshold freezes, contested review outcomes, and strategic bets that affect many modules.
+
+Use `scripts/ab discuss <channel> --with claude,codex,gemini --max-rounds 3` when the decision benefits from multiple model-family perspectives. Treat the discussion as distributed deliberation, not quorum. LLM agents have correlated priors, so the goal is to expose disagreement and option space, not to manufacture a vote.
+
+## Decision Card Convention
+
+Decision Cards are emitted only when `ab discuss` surfaces disagreement or multiple viable options. If all agents converge with `[AGREE]`, no card is needed; the orchestrator records or proceeds with the converged decision.
+
+Use [`_template.md`](./_template.md) for cards that need user input. Use [`pending/`](./pending/) when the user is AFK and the decision must survive the session boundary.
+
+Surface protocol:
+
+- User online: emit the card inline in chat for immediate visibility.
+- User AFK: write the card to `docs/decisions/pending/{date}-{slug}.md`.
+- Multi-week or architecture-level decision: open a GitHub issue with the card body.
+- User decides: move the pending file to `docs/decisions/{date}-{slug}.md` and record the chosen option plus decision date.
+
+## Scope
+
+Use `ab discuss` for:
+
+- architecture choices
+- threshold freezes
+- contested NEEDS CHANGES outcomes
+- strategic bets affecting 100+ modules
+- major curriculum scope decisions
+
+Do not use it for per-PR review, one-line fixes, single-module choices, or decisions where the agents will obviously converge.
+
+## References
+
+- Canonical agent rule: [`.claude/rules/decision-card.md`](../../.claude/rules/decision-card.md)
+- Project memory: `~/.claude/projects/-Users-krisztiankoos-projects-kubedojo/memory/feedback_ab_discuss_for_decisions.md`
+- Adoption issue: [kube-dojo/kube-dojo.github.io#740](https://github.com/kube-dojo/kube-dojo.github.io/issues/740)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -32,5 +32,5 @@ Do not use it for per-PR review, one-line fixes, single-module choices, or decis
 ## References
 
 - Canonical agent rule: [`.claude/rules/decision-card.md`](../../.claude/rules/decision-card.md)
-- Project memory: `~/.claude/projects/-Users-krisztiankoos-projects-kubedojo/memory/feedback_ab_discuss_for_decisions.md`
+- Project memory key: `feedback_ab_discuss_for_decisions.md`
 - Adoption issue: [kube-dojo/kube-dojo.github.io#740](https://github.com/kube-dojo/kube-dojo.github.io/issues/740)

--- a/docs/decisions/_template.md
+++ b/docs/decisions/_template.md
@@ -1,0 +1,51 @@
+## DECISION REQUIRED — {question}
+
+**Date filed:** {YYYY-MM-DD}
+**Agents:** claude, gemini, codex ({R} rounds)
+**Channel:** `{ab-discuss-channel}`
+**Options:** A (proposed by {agent}), B (proposed by {agent}), C (proposed by {agent})
+**Votes:** claude→A {rationale}; gemini→B {rationale}; codex→A {rationale}
+
+## Context
+
+{Why this decision matters, what triggered it, and what scope it affects.}
+
+## Options
+
+**A. {option name}** — proposed by {agent}
+
+{1-3 lines of rationale and tradeoff.}
+
+**B. {option name}** — proposed by {agent}
+
+{1-3 lines of rationale and tradeoff.}
+
+**C. {option name}** — proposed by {agent}
+
+{1-3 lines of rationale and tradeoff.}
+
+## Votes
+
+- claude→{A|B|C|DEFER}: {rationale}
+- gemini→{A|B|C|DEFER}: {rationale}
+- codex→{A|B|C|DEFER}: {rationale}
+
+## Disagreement
+
+{What the agents actually differ on. Do not summarize convergence as disagreement.}
+
+## Orchestrator Recommendation
+
+{A|B|C} — {1-3 lines explaining why this is the recommended path.}
+
+## Awaiting
+
+User override or "go".
+
+## Decision
+
+**Chosen option:** TBD
+**Decision date:** TBD
+**Decided by:** TBD
+
+{Move this file from `docs/decisions/pending/` to `docs/decisions/` after the user decides.}

--- a/docs/decisions/pending/README.md
+++ b/docs/decisions/pending/README.md
@@ -1,0 +1,25 @@
+# Pending Decisions
+
+This directory holds Decision Cards that need user input and were created while the user was AFK.
+
+Cold-start agents must scan this directory before starting unrelated work. If any pending card exists, surface it to the user first with the question, options, disagreement, and orchestrator recommendation.
+
+## When to Write Here
+
+Write `docs/decisions/pending/{date}-{slug}.md` only when all of these are true:
+
+- a high-leverage `ab discuss` produced disagreement or multiple viable options
+- the decision needs user input before proceeding
+- the user is not available in chat
+
+Do not write a pending card when the agents converge with `[AGREE]`. In that case, record the outcome in the relevant handoff, issue, PR, or decision record and proceed.
+
+## Promotion
+
+When the user decides:
+
+1. Move the file to `docs/decisions/{date}-{slug}.md`.
+2. Fill in the `## Decision` section with the chosen option, decision date, and who decided.
+3. Link the final record from the related issue, PR, or handoff.
+
+For multi-week or architecture-level decisions, use a GitHub issue instead of relying only on a pending file.


### PR DESCRIPTION
## Summary
- add tracked `docs/decisions/` convention docs for Decision Cards
- add `docs/decisions/pending/README.md` so pending AFK decisions survive cold starts
- update STATUS cold-start protocol and mark #740 adoption complete

Closes #740.

## Checks
- `git diff --check`
- `../../.venv/bin/python scripts/test_pipeline.py` (170 tests, OK)
- ruff skipped: no Python files changed
- `npm run build` skipped: no `src/content/docs/` or Astro config changes

## Diff budget
4 files, 118 insertions, 5 deletions