### PR TITLE
fix(bridge): capture codex session_id from "session id:" header line

### DIFF
--- a/scripts/agent_runtime/result.py
+++ b/scripts/agent_runtime/result.py
@@ -88,4 +88,5 @@ class Result:
     rate_limited: bool
     stalled: bool
     returncode: int | None
+    stderr: str | None = None
     usage_record: dict[str, Any] = field(default_factory=dict)

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -661,6 +661,7 @@ def invoke(
             response=parse.response,
             stderr_excerpt=push_verify_error or parse.stderr_excerpt,
             duration_s=duration_s,
+            stderr=stderr_text,
             session_id=parse.session_id,
             rate_limited=parse.rate_limited,
             stalled=False,

--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -35,6 +35,7 @@ commands handle the agent-calling side.
 from __future__ import annotations
 
 import json
+import re
 import tempfile
 import os
 import shlex
@@ -71,6 +72,11 @@ _DISCUSSION_MCP_EXCLUDE_TOKENS: tuple[str, ...] = (
     "calendar",
     "drive",
     "claude-in-chrome",
+)
+
+_CODEX_HEADER_SESSION_ID_RE = re.compile(
+    r"^session id:\s+([0-9a-f-]{36})",
+    re.MULTILINE,
 )
 
 
@@ -1449,10 +1455,24 @@ def _handle_discuss(args) -> int:
             )
 
         if result is not None:
+            persist_session_id = result.session_id
+            if agent_name == "codex" and not persist_session_id:
+                header_payload = getattr(result, "stdout", None) or getattr(
+                    result,
+                    "stderr",
+                    None,
+                )
+                if isinstance(header_payload, str):
+                    match = _CODEX_HEADER_SESSION_ID_RE.search(header_payload)
+                    if match is not None:
+                        persist_session_id = match.group(1)
+                if not persist_session_id:
+                    print("bridge: codex session id not in stdout header; not persisting")
+
             _set_session(
                 task_key,
                 agent=agent_name,
-                session_id=result.session_id or attempt_session,
+                session_id=persist_session_id or attempt_session,
                 **{
                     f"{agent_name}_cwd": str(attempt_cwd),
                     f"{agent_name}_sandbox_mode": attempt_sandbox_mode,

--- a/tests/test_bridge_inbox_cli.py
+++ b/tests/test_bridge_inbox_cli.py
@@ -5,6 +5,7 @@ import sqlite3
 import sys
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -314,6 +315,58 @@ def test_discuss_codex_round1_round2_session_resume(mock_invoke, monkeypatch, tm
     assert (
         _db.get_session("discuss:discuss-codex-0001")["codex_session_id"]
         == "codex-session-02"
+    )
+
+
+@patch("agent_runtime.runner.invoke")
+def test_discuss_codex_round1_persists_session_id_from_stdout_header(mock_invoke, monkeypatch):
+    _channels.create_channel("discuss-codex-header")
+    monkeypatch.setattr(_channels, "fetch_monitor_state", lambda: None)
+    ids = iter(range(1, 1000))
+    monkeypatch.setattr(
+        _channels,
+        "_new_id",
+        lambda: f"discuss-codex-header-{next(ids):04d}",
+    )
+
+    session_id = "019e192b-2c12-78f2-a97c-c684706891ff"
+    codex_stdout = (
+        "approval: never\n"
+        "sandbox: danger-full-access\n"
+        "reasoning effort: high\n"
+        "reasoning summaries: none\n"
+        f"session id: {session_id}\n"
+        "--------\n"
+        "user\n"
+    )
+
+    def _discuss_result(agent: str, *_, **kwargs) -> SimpleNamespace:
+        return SimpleNamespace(
+            ok=True,
+            agent=agent,
+            model="test-model",
+            mode="danger",
+            response="codex reply [AGREE]",
+            stderr_excerpt=None,
+            duration_s=0.1,
+            session_id=None,
+            rate_limited=False,
+            stalled=False,
+            returncode=0,
+            usage_record={},
+            stdout=codex_stdout,
+        )
+
+    mock_invoke.side_effect = _discuss_result
+
+    exit_code = _run_cli(
+        ["discuss", "discuss-codex-header", "topic", "--with", "codex", "--max-rounds", "2"]
+    )
+
+    assert exit_code == 0
+    assert (
+        _db.get_session("discuss:discuss-codex-header-0001")["codex_session_id"]
+        == session_id
     )
 
 


### PR DESCRIPTION
## Summary
PRs #1083 and #1084 failed to land codex session_id capture logic. This is the surgical fix.

Codex prints `session id: <UUID>` as a header line at the start of its output (on stderr when `-o` is used). This patch regex-parses that line and persists the UUID to `codex_session_id` in the bridge sessions table — same flow claude/gemini use.

Also makes a small runtime change to plumb stderr through `Result.stderr` so the channels CLI can parse it.

## Verification (real, just ran)
```
sqlite3 .bridge/messages.db "SELECT codex_session_id FROM sessions WHERE task_id LIKE 'discuss:%' ORDER BY updated_at DESC LIMIT 1;"
# 019e192e-9e50-7df3-bf4b-31ecd05d5bae
```

40 unit tests pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)