### PR TITLE
fix(bridge): strip exec-only flags when invoking codex resume

### DIFF
--- a/scripts/agent_runtime/adapters/codex.py
+++ b/scripts/agent_runtime/adapters/codex.py
@@ -179,18 +179,36 @@ class CodexAdapter:
         else:
             use_search = os.environ.get("KUBEDOJO_CODEX_SEARCH", "0") == "1"
         cmd: list[str] = [codex_bin]
+        if session_id:
+            cmd.extend(
+                [
+                    "resume",
+                    session_id,
+                ]
+            )
+            if prompt:
+                cmd.extend(["--", prompt])
+            return InvocationPlan(
+                cmd=cmd,
+                cwd=cwd,
+                stdin_payload="",
+                output_file=output_path,
+                env_overrides={},
+                liveness_paths=(output_path,),
+            )
+
         if use_search:
             cmd.append("--search")
-        base_action = "resume" if session_id else "exec"
-        cmd.extend([
-            base_action,
-            *( [session_id] if session_id else []),
-            "--skip-git-repo-check",
-            "-C", str(cwd),
-            "--color", "never",
-            "-o", str(output_path),
-            "-m", model or self.default_model,
-        ])
+        cmd.extend(
+            [
+                "exec",
+                "--skip-git-repo-check",
+                "-C", str(cwd),
+                "--color", "never",
+                "-o", str(output_path),
+                "-m", model or self.default_model,
+            ]
+        )
         cmd.extend(self._mode_flags(mode))
         cmd.append("-")  # Read prompt from stdin.
 


### PR DESCRIPTION
## Summary
Bridge was passing `--skip-git-repo-check`, `--sandbox`, `--search`, `-o`, `-m` to `codex resume <SESSION_ID>` — but `codex resume` only accepts `-c`, `--last`, `--all`, `--enable` per its --help. Resume was failing with "unexpected argument" before this fix.

After this fix, resume invocation is minimal: `codex resume <SESSION_ID> [-- <PROMPT>]`. Fresh codex invocations unchanged.

## Caveat (separate issue, not solvable in this PR)
Verified: `codex resume` requires a TTY (`Error: stdin is not a terminal`). The codex CLI's resume command is interactive-only and cannot be invoked headlessly. So even with this fix, the bridge's codex round-2 still falls back to fresh — but now via the right code path, not via an argument error.

Workarounds for full codex warm-resume (future work):
- pty wrapper (pexpect/unbuffer/script)
- Or accept codex stays cold per round (current behavior)

## Test plan
- [x] 40 unit tests pass, ruff clean
- [x] Real ab discuss verified: codex_session_id stored, no more flag-error in logs
- [ ] Codex actual warm-resume — blocked on TTY requirement, not on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)