### PR TITLE
fix(bridge): include -o/-m/mode flags on codex resume cmd

### DIFF
--- a/scripts/agent_runtime/adapters/codex.py
+++ b/scripts/agent_runtime/adapters/codex.py
@@ -180,19 +180,24 @@ class CodexAdapter:
             use_search = os.environ.get("KUBEDOJO_CODEX_SEARCH", "0") == "1"
         cmd: list[str] = [codex_bin]
         if session_id:
+            if use_search:
+                cmd.append("--search")
             cmd.extend(
                 [
                     "exec",
                     "resume",
                     session_id,
+                    "--skip-git-repo-check",
+                    "-o", str(output_path),
+                    "-m", model or self.default_model,
                 ]
             )
-            if prompt:
-                cmd.extend(["--", prompt])
+            cmd.extend(self._mode_flags(mode))
+            cmd.append("-")
             return InvocationPlan(
                 cmd=cmd,
                 cwd=cwd,
-                stdin_payload="",
+                stdin_payload=prompt,
                 output_file=output_path,
                 env_overrides={},
                 liveness_paths=(output_path,),

--- a/tests/test_codex_always_danger.py
+++ b/tests/test_codex_always_danger.py
@@ -120,6 +120,14 @@ def _codex_invocation_cmd(
     search_env: str | None,
     session_id: str | None = None,
 ) -> list[str]:
+    return _codex_invocation_plan(search_env=search_env, session_id=session_id).cmd
+
+
+def _codex_invocation_plan(
+    search_env: str | None,
+    session_id: str | None = None,
+    prompt: str = "x",
+):
     import os
 
     adapter_module = _load_codex_adapter()
@@ -132,14 +140,14 @@ def _codex_invocation_cmd(
         else:
             os.environ["KUBEDOJO_CODEX_SEARCH"] = search_env
         return adapter.build_invocation(
-            prompt="x",
+            prompt=prompt,
             mode="danger",
             cwd=REPO_ROOT,
             model=None,
             task_id=None,
             session_id=session_id,
             tool_config=None,
-        ).cmd
+        )
     finally:
         if old is None:
             os.environ.pop("KUBEDOJO_CODEX_SEARCH", None)
@@ -232,6 +240,41 @@ def test_codex_adapter_uses_resume_action():
     assert cmd[1] == "exec"
     assert cmd[2] == "resume"
     assert cmd[3] == "stored-codex-session"
+
+
+def test_codex_adapter_resume_includes_output_file():
+    cmd = _codex_invocation_cmd(None, session_id="stored-codex-session")
+    assert "-o" in cmd
+    output_index = cmd.index("-o")
+    assert output_index + 1 < len(cmd), (
+        f"Expected resume cmd include output path after -o, got: {cmd}"
+    )
+    assert cmd[output_index + 1], (
+        f"Expected non-empty output path after -o, got: {cmd[output_index + 1:]}"
+    )
+
+
+def test_codex_adapter_resume_includes_model_and_mode_flags():
+    cmd = _codex_invocation_cmd(None, session_id="stored-codex-session")
+    assert "-m" in cmd
+    assert "--dangerously-bypass-approvals-and-sandbox" in cmd
+
+
+def test_codex_adapter_resume_uses_stdin_for_prompt():
+    plan = _codex_invocation_plan(
+        None,
+        session_id="stored-codex-session",
+        prompt="x",
+    )
+    assert plan.cmd[-1] == "-"
+    assert plan.stdin_payload == "x"
+
+
+def test_codex_adapter_resume_search_flag_order():
+    cmd = _codex_invocation_cmd("1", session_id="stored-codex-session")
+    assert cmd[1] == "--search"
+    assert cmd[2] == "exec"
+    assert cmd[3] == "resume"
 
 
 def test_dispatch_smart_codex_sets_search_for_draft():


### PR DESCRIPTION
## Summary

- Resume branch of `CodexAdapter.build_invocation` built bare `codex exec resume <id>` with no `-o <output_path>`, `-m <model>`, `--skip-git-repo-check`, `--search`, or mode flags — so codex resumed correctly at the CLI level but wrote its answer to stdout instead of the file the runner reads. The runner classified the empty output file as a failure, and the bridge fell back to "start fresh" — silently spawning a new codex session every round of `ab discuss`.
- This completes the codex side of the 3/3 warm-resume goal (claude + gemini already working post #1083–#1086 + 92e36e9e).

## Test plan

Empirical reproduction via `runtime_invoke` (`agent_runtime.runner.invoke`) with stored round-1 session id:

- before: `ok=False`, `response=''`, bridge falls back to fresh session
- after:  `ok=True`, `response='`X`'`, same session id preserved (verified against rollout file)

- [x] `PYTHONPATH=<repo>/scripts .venv/bin/pytest tests/test_codex_always_danger.py -v` — 18/18 pass
- [x] `.venv/bin/ruff check scripts/agent_runtime/adapters/codex.py tests/test_codex_always_danger.py` — clean
- [x] End-to-end `runtime_invoke('codex', ..., session_id=<round1_id>, entrypoint='bridge')` returns `ok=True`
- [ ] Cross-family review (gemini) before merge
- [ ] After merge: re-run the smoketest from `docs/session-state/2026-05-12-bridge-warm-resume.md` and verify codex round-2 appends to round-1 rollout file (one file, not two)

## Notes

- `--color never` is NOT included in the resume cmd — `codex exec resume` rejects it (unlike `codex exec`). Verified empirically.
- `-C <cwd>` also omitted — not supported on the resume subcommand; cwd is set via the subprocess working directory (`InvocationPlan.cwd`).
- The fresh-session branch is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)