### PR TITLE
feat(388): rewrite module-1.5-monolith-to-microservices (#388 pilot)

### DIFF
--- a/src/content/docs/prerequisites/cloud-native-101/module-1.5-monolith-to-microservices.md
+++ b/src/content/docs/prerequisites/cloud-native-101/module-1.5-monolith-to-microservices.md
@@ -77,7 +77,7 @@ A good monolith is not a bad architecture waiting to be rescued. Shopify's long-
 
 For Kubernetes learners, a monolith also teaches a useful baseline. You can run a monolith in a container, deploy it with a Deployment, expose it with a Service, configure it with ConfigMaps and Secrets, and restart it with probes. Kubernetes does not require microservices; it manages containers and desired state, which can be useful before an application is decomposed.
 
-The first Kubernetes command you will eventually use in many modules is `kubectl`, and this curriculum uses the shorter alias `k` after introducing it once with `alias k=kubectl`. For example, when you later inspect workloads with `k get pods -A`, you are asking Kubernetes about runtime units, not asking it whether those units contain monolithic or microservice code.
+The first Kubernetes command you will eventually use in many modules is `kubectl`, and this curriculum writes commands with the full binary name so examples remain copy-paste safe in scripts and non-interactive shells. For example, when you later inspect workloads with `kubectl get pods -A`, you are asking Kubernetes about runtime units, not asking it whether those units contain monolithic or microservice code.
 
 ## The Microservices Approach
 
@@ -485,7 +485,7 @@ Separate data ownership is a strong long-term pattern, but immediate physical se
 
 ## Hands-On Exercise
 
-This module is architectural, so the exercise is a design review rather than a cluster lab. You will analyze a familiar application, choose boundaries, and connect each decision to Kubernetes runtime features. If you have a cluster available, you may also practice the inspection habit by setting `alias k=kubectl` and running `k get pods -A`, but the core deliverable is the reasoning document you create for yourself.
+This module is architectural, so the exercise is a design review rather than a cluster lab. You will analyze a familiar application, choose boundaries, and connect each decision to Kubernetes runtime features. If you have a cluster available, you may also practice the inspection habit by running `kubectl get pods -A`, but the core deliverable is the reasoning document you create for yourself.
 
 ### Setup
 


### PR DESCRIPTION
## Summary
- Updated the module to remove kubectl alias/shorthand guidance while preserving the #388 T0 rewrite structure.
- Kept frontmatter revision_pending: false.

## Verifier
- Tiers: T0=1; failure_gates={}; body_words=5036; mean_wpp=55.3; median_wpp=56; short_rate=0.022; max_run=1.

## Protected Assets
- Preserved counts: code_blocks=10, mermaid_diagrams=10, ascii_diagrams=3, tables=6, sources=12 URLs.

## Validation
- ../../.venv/bin/python scripts/quality/verify_module.py --glob src/content/docs/prerequisites/cloud-native-101/module-1.5-monolith-to-microservices.md --skip-source-check --summary --quiet
- ../../.venv/bin/python scripts/test_pipeline.py (170 tests passed)
- npm run build (primary checkout)
- git diff --check
- ruff: not run; no Python files changed.

Commit SHA: d49354607a0b2bf17a210bff4377292a71c4fb1d