### PR TITLE
feat(388): rewrite module-2-advanced-merging (#388 pilot)

### DIFF
--- a/src/content/docs/prerequisites/git-deep-dive/module-2-advanced-merging.md
+++ b/src/content/docs/prerequisites/git-deep-dive/module-2-advanced-merging.md
@@ -10,9 +10,13 @@ nextModule: "[Module 3: History as a Choice](../module-3-interactive-rebasing/)"
 revision_pending: false
 ---
 
-# Module 2: The Art of the Branch — Advanced Merging
+> **Complexity**: MEDIUM
+>
+> **Time to Complete**: 75 minutes
+>
+> **Prerequisites**: Module 1, Git Internals. This module assumes you can read a commit graph, create branches, and commit small changes, but it does not assume you have already handled a production-grade Kubernetes merge conflict under pressure.
 
-**Complexity:** MEDIUM. **Time to complete:** 75 minutes. **Prerequisites:** Module 1, Git Internals. This module assumes you can read a commit graph, create branches, and commit small changes, but it does not assume you have already handled a production-grade Kubernetes merge conflict under pressure.
+---
 
 ## Learning Outcomes
 - **Diagnose** the root cause of complex merge conflicts within Kubernetes manifest files by analyzing the merge base and divergent commit histories.
@@ -24,6 +28,8 @@ revision_pending: false
 ## Why This Module Matters
 
 On October 21, 2018, routine optical hardware maintenance disconnected GitHub's US-East hub from its primary database for 43 seconds. An automated failover promoted the US-West hub to primary, but the US-East hub continued to accept writes. Both sites held authoritative-looking records for the same rows. Recovery required 24 hours of manual reconciliation between two diverged timelines, and approximately 200,000 webhook payloads were permanently dropped. The incident demonstrated that divergent timelines can each appear correct in isolation while creating massive conflict at infrastructure scale. The same problem exists in source control every time long-lived branches are reconciled. Advanced Git merging is the practiced skill that keeps that reconciliation from becoming an outage.
+
+For Kubernetes platform work, merging is more than a repository housekeeping task because the merged text often becomes a desired-state contract consumed by controllers, admission policies, scanners, and deployment automation. A clean-looking merge can still leave a selector pointing at the wrong labels, a generated Secret missing from a Kustomize overlay, or a release branch carrying assumptions that are no longer true for Kubernetes 1.35 clusters. This module treats merging as an operational design skill: you will inspect graph shape, choose the right integration method, resolve conflicts by synthesizing intent, and validate that the resulting manifests still describe a coherent system.
 
 ## Core Content
 
@@ -66,6 +72,8 @@ Fast-forward
 Because the `main` branch had not diverged—meaning no new commits were added to `main` while the `feature/add-metadata` branch was being actively developed—Git simply moved the `main` pointer forward to catch up. 
 
 If you want to force Git to create a merge commit anyway (often done to preserve the historical context that a specific feature branch existed at all), you can use the `git merge --no-ff` flag, which always creates a merge commit even when a fast-forward would be perfectly possible. Conversely, running `git merge --ff-only` succeeds only if a clean fast-forward is mathematically possible; otherwise, it exits immediately with a non-zero status and refuses to merge. It is also worth noting a specific edge case: a fast-forward merge is automatically suppressed, and Git behaves as if `--no-ff` was passed, when merging an annotated tag that is not stored within the standard `refs/tags/` hierarchy.
+
+This distinction matters in automation because a protected branch can use `--ff-only` as a guardrail rather than as a style preference. If a pipeline expects a deployment branch to be a strict descendant of a reviewed release branch, a failed fast-forward tells you the graph no longer matches the release process you thought you were following. That failure is useful evidence. It says that someone introduced independent history and that the team now needs a deliberate integration decision instead of a silent pointer move.
 
 > **Pause and predict**: Before running `git log --oneline --graph` after this merge, sketch out what you think the history graph will look like. Will there be a fork and a merge commit? 
 > 
@@ -248,16 +256,16 @@ Always comprehensively validate the structural integrity of your infrastructure-
 After finalizing a complex merge, you or a reviewer may need to isolate and review only the specific manual conflict resolutions you made, without the noise of unrelated feature changes. You can achieve this by inspecting the merge commit with `git show <merge-commit-hash>`, which displays a specialized "combined diff" that intelligently filters the output to highlight only the lines modified differently from both parent branches.
 
 ```bash
-# We will use 'k' as an alias for kubectl going forward
-alias k=kubectl
-kustomize build . | k apply -f - --dry-run=client
+kustomize build . | kubectl apply -f - --dry-run=client
 
 # If successful:
 git add redis-deployment.yaml kustomization.yaml
 git commit -m "Merge redis-auth, resolving multi-file replicas, image, and secret generator conflicts"
 ```
 
-**War Story:** A junior DevOps engineer once attempted to resolve a shockingly similar multi-file conflict. They perfectly fixed the core Deployment YAML file manually but, feeling overwhelmed, accidentally ran `git checkout --ours kustomization.yaml` to blindly bypass the second, more confusing conflict. Git accepted this command and completed the merge. As a result, the Deployment strictly expected a password secret that the Kustomization file was no longer generating. The Redis pods crash-looped instantly upon deployment in production, causing a complete and total loss of cache availability for the entire user base. You must always resolve and thoroughly validate multi-file infrastructure conflicts holistically.
+Hypothetical scenario: a platform engineer resolves the core Deployment YAML manually but, feeling overwhelmed, runs `git checkout --ours kustomization.yaml` to bypass the second conflict. Git accepts the command and allows the merge to finish, yet the Deployment now expects a password Secret that the Kustomization file no longer generates. In a GitOps flow, that kind of text-level success can become a runtime failure as soon as the controller applies the reconciled tree. The lesson is not that `--ours` is forbidden; it is that whole-file conflict shortcuts must be justified against the complete resource graph, not against the file that looks most annoying in the editor.
+
+When you review this kind of merge, read the final configuration as a set of relationships rather than as two independent files. The Deployment's `env` block refers to a Secret by name, the Kustomization file decides whether that Secret is produced, and the image tag choice can alter runtime assumptions about authentication behavior. A good resolution preserves the useful intent from both branches and then proves that the references still connect. That is why the validation command comes before `git add`: once you stage the result, it becomes easy to treat the merge as finished even though the platform object has not yet been checked.
 
 To aid in visualizing these complex situations, you can utilize `git mergetool`, which launches a specialized external visual diffing tool presenting the BASE, LOCAL, and REMOTE versions side-by-side, and then automatically writes your final resolved result directly to the MERGED file. You can also significantly alter how Git presents conflicts natively in your editor. Three distinct merge conflict styles are available via the `merge.conflictStyle` configuration: `merge` shows only the two diverging sides, `diff3` adds a `|||||||` block showing the original ancestor code to provide critical context on why the conflict happened, and `zdiff3` is functionally identical to diff3 but trims matching, unchanged lines from the outer edges of the conflict block to reduce visual noise. The highly efficient `zdiff3` conflict style was introduced in Git 2.35.0.
 
@@ -267,11 +275,10 @@ If your team constantly encounters the exact same identical conflicts repeatedly
 
 To deeply understand how Git's context windows operate, it is highly instructive to look at a legacy exercise. In earlier versions of this course, students were given the following exact sequence of commands to intentionally create a merge conflict.
 
-The first part of the legacy exercise created a tiny repository and a Kubernetes Deployment that was deliberately small enough for students to inspect by eye. Notice that the `k` alias is introduced before any Kubernetes validation commands appear; the rest of this module uses `k` as shorthand for `kubectl`, which matches the convention used throughout KubeDojo.
+The first part of the legacy exercise created a tiny repository and a Kubernetes Deployment that was deliberately small enough for students to inspect by eye. Older classroom versions sometimes used a short interactive alias for Kubernetes validation, but the runnable examples here keep the full `kubectl` command so every block can be copied into a non-interactive shell or CI job without relying on local shell setup.
 ```bash
 mkdir k8s-merge-lab && cd k8s-merge-lab
 git init --initial-branch=main
-alias k=kubectl
 ```
 ```yaml
 apiVersion: apps/v1
@@ -378,7 +385,7 @@ spec:
 
 The exercise then required validation before committing, because a syntactically broken Deployment is still a failed merge even when the Git conflict markers have been removed:
 ```bash
-k apply -f deployment.yaml --dry-run=client
+kubectl apply -f deployment.yaml --dry-run=client
 # Expect output: deployment.apps/api-server created (dry run)
 ```
 ```bash
@@ -474,7 +481,7 @@ spec:
 
 **Task 5: Validate the YAML**
 ```bash
-k apply -f deployment.yaml --dry-run=client
+kubectl apply -f deployment.yaml --dry-run=client
 # Expect output: deployment.apps/api-server created (dry run)
 ```
 
@@ -487,6 +494,8 @@ git commit -m "Merge branch 'feature/update-image' into feature/scale-up resolvi
 </details>
 
 However, if you attempt to run this legacy exercise today using a modern Git version equipped with the highly optimized `ort` strategy, it seamlessly auto-merges without generating any conflict whatsoever. This fascinating phenomenon occurs because the modifications to `replicas` (line 6) and `image` (line 17) are separated by exactly ten unchanged lines. This gap provides Git's internal algorithms with just enough unambiguous textual context to safely apply both discrete hunks independently. The "overlapping context illusion" in older tutorials often fails to account for the increasing sophistication of modern Git diff engines.
+
+That does not make the legacy exercise useless; it makes it a useful warning about relying on intuition instead of observing the actual merge engine. Older teaching material often describes conflicts as if nearby conceptual changes must collide, but Git's decision is based on the diff hunks it can derive from the merge base and both tips. Two changes may feel related to a human because they live inside one Kubernetes object, yet still be mechanically independent enough for `ort` to combine them without asking. The opposite is also true: two changes that look harmless in separate reviews can collide if they alter the same small YAML region, especially when generated blocks or repeated keys reduce context.
 
 ### The Octopus Merge: Taming Multiple Branches
 
@@ -593,7 +602,7 @@ Advanced merging becomes safer when a team treats every integration as a design 
 
 The most reliable pattern is small, frequent integration against a protected trunk. A developer can still use a short-lived branch for review, but the branch should be measured in hours or a small number of days rather than weeks. This cadence keeps the merge base close to current reality, which means Git compares each branch against a recent ancestor and produces smaller, more intelligible conflict regions. For Kubernetes manifests, that difference is practical rather than aesthetic: a small conflict might ask whether `replicas` should be three or five, while a stale branch may force the resolver to reconcile probes, selectors, container names, generated Secrets, and network policy labels all at once.
 
-Another durable pattern is schema-aware validation immediately after conflict resolution. Git knows that two lines of YAML text differ, but it does not know whether a `secretKeyRef` points at a Secret that Kustomize still generates, whether a selector matches the labels inside a Pod template, or whether an API field is valid in Kubernetes 1.35. The resolver therefore has to move from text reconciliation to platform reconciliation. Running `k apply --dry-run=client`, `kustomize build`, or an admission-style validation tool is the engineering step that converts "Git accepted the file" into "this configuration still represents a coherent cluster object."
+Another durable pattern is schema-aware validation immediately after conflict resolution. Git knows that two lines of YAML text differ, but it does not know whether a `secretKeyRef` points at a Secret that Kustomize still generates, whether a selector matches the labels inside a Pod template, or whether an API field is valid in Kubernetes 1.35. The resolver therefore has to move from text reconciliation to platform reconciliation. Running `kubectl apply --dry-run=client`, `kustomize build`, or an admission-style validation tool is the engineering step that converts "Git accepted the file" into "this configuration still represents a coherent cluster object."
 
 A third pattern is reviewable merge commits. When a merge commit exists only because two timelines were joined, it should contain only the conflict synthesis required to join them. That discipline makes `git show <merge-commit>` useful during review because the combined diff can focus on the lines changed differently from both parents. If the resolver also folds in refactors, formatting changes, or unrelated policy edits, the merge commit becomes an opaque bundle, and reviewers lose the ability to distinguish conflict resolution from opportunistic feature work. This is how teams accidentally bless an "evil merge" that introduces behavior neither parent branch intended.
 
@@ -622,7 +631,7 @@ Use the following decision matrix as a practical guide when you are under pressu
 | :--- | :--- | :--- | :--- |
 | Current branch is behind and has no unique commits | `git merge --ff-only incoming` | The branch pointer can move without creating a synthetic merge commit. | Run the relevant tests or render manifests if the incoming branch was not already validated. |
 | Two fresh branches touched different files | Normal three-way merge with `ort` | Git can synthesize independent file changes cleanly while preserving both parents. | Review the merge commit and run targeted CI for changed areas. |
-| Two branches touched the same Kubernetes manifest | Manual conflict resolution with schema validation | Human intent matters more than text adjacency when selectors, probes, and generated resources interact. | Run `k apply --dry-run=client`, `kustomize build`, and any policy checks your repo requires. |
+| Two branches touched the same Kubernetes manifest | Manual conflict resolution with schema validation | Human intent matters more than text adjacency when selectors, probes, and generated resources interact. | Run `kubectl apply --dry-run=client`, `kustomize build`, and any policy checks your repo requires. |
 | Several independent branches need one release branch | Octopus merge only if conflicts are unlikely | The history stays compact, but the operation refuses manual conflicts. | Pre-merge each branch against trunk and retry only when every pair is clean. |
 | Old branch has a stale merge base | Recreate from current `main` and cherry-pick intent | The old graph encodes obsolete assumptions about the platform. | Test each selected commit after replay, especially migrations and API changes. |
 | Pull request contains noisy local commits | Interactive rebase before review | Reviewers see a coherent story instead of temporary savepoints. | Re-run tests after rewriting and force-push only to branches you own. |
@@ -687,13 +696,13 @@ Attempting a direct three-way merge with a year-old base is extremely dangerous,
 
 In this lab you will create a small Kubernetes manifest repository, force a real conflict that modern Git cannot safely auto-merge, inspect the merge base, resolve the conflict by synthesizing intent, and validate the final object before committing. The exercise uses a Deployment and a ConfigMap because they reveal the two failure modes you will see in platform work: one conflict is about competing runtime behavior, while the other is about a dependency between files. The goal is not to memorize conflict markers; the goal is to practice slowing down enough to identify what each branch was trying to accomplish.
 
-Work in a scratch directory outside any production repository. The commands below assume a Unix-like shell and Git with the default `ort` merge engine. They also assume `kubectl` is installed; the lab defines `alias k=kubectl` and uses `k` for validation so the command style matches the rest of the module. If you do not have a live cluster context, `--dry-run=client` still validates local object structure, which is enough for this exercise.
+Work in a scratch directory outside any production repository. The commands below assume a Unix-like shell and Git with the default `ort` merge engine. They also assume `kubectl` is installed and available on your `PATH`. If you do not have a live cluster context, `--dry-run=client` still validates local object structure, which is enough for this exercise because the point is to catch broken YAML and object references before committing the merge.
 
 - [ ] Create the repository, add the baseline Deployment and ConfigMap, and commit the initial state.
 - [ ] Create `feature/harden-api` to add a health probe and stricter ConfigMap setting.
 - [ ] Create `feature/scale-api` to change replicas and a competing ConfigMap setting.
 - [ ] Merge `feature/scale-api` into `feature/harden-api`, inspect the merge base, and resolve both conflicted files.
-- [ ] Validate the resolved manifests with `k apply --dry-run=client` before committing the merge.
+- [ ] Validate the resolved manifests with `kubectl apply --dry-run=client` before committing the merge.
 - [ ] Inspect the final merge commit with `git show` and explain which lines were human conflict resolutions.
 
 <details>
@@ -705,7 +714,6 @@ Create the repository and baseline files:
 mkdir k8s-advanced-merge-lab
 cd k8s-advanced-merge-lab
 git init --initial-branch=main
-alias k=kubectl
 ```
 
 ```yaml
@@ -826,8 +834,8 @@ data:
 Validate and commit:
 
 ```bash
-k apply -f configmap.yaml --dry-run=client
-k apply -f deployment.yaml --dry-run=client
+kubectl apply -f configmap.yaml --dry-run=client
+kubectl apply -f deployment.yaml --dry-run=client
 git add configmap.yaml deployment.yaml
 git commit -m "Merge scale-api into harden-api resolving replicas and feature mode"
 git show --stat --summary HEAD


### PR DESCRIPTION
## Summary
- Rewrites `src/content/docs/prerequisites/git-deep-dive/module-2-advanced-merging.md` for #388 density/structure gates.
- Removes duplicate source H1, replaces runnable `k` alias usage with full `kubectl`, and converts the unsourced war-story framing into a labeled hypothetical scenario.
- Keeps `revision_pending: false`.

## Verifier
- `verify_module.py --skip-source-check`: T0; body_words=5324, mean_wpp=64.9, median_wpp=62.5, short_rate=0.061, max_run=2.
- Protected assets preserved: code blocks 43 -> 43, mermaid diagrams 4 -> 4, ASCII diagrams 1 -> 1, tables 4 -> 4, source URLs 11 -> 11.
- Commit SHA: 4cc6bbf2b60015ddaeb1f9e2fae506c87f9531b3.

## Checks
- `git diff --check -- src/content/docs/prerequisites/git-deep-dive/module-2-advanced-merging.md`
- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/quality/verify_module.py --glob src/content/docs/prerequisites/git-deep-dive/module-2-advanced-merging.md --skip-source-check --summary --quiet`
- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/test_pipeline.py` (170 tests passed)
- `npm run build` from primary checkout