### PR TITLE
feat(388): rewrite module-1.3-cicd-pipelines (#388 pilot)

### DIFF
--- a/src/content/docs/prerequisites/modern-devops/module-1.3-cicd-pipelines.md
+++ b/src/content/docs/prerequisites/modern-devops/module-1.3-cicd-pipelines.md
@@ -6,11 +6,13 @@ sidebar:
   order: 4
 ---
 
-# Module 1.3: CI/CD Pipelines
+> **Complexity:** [MEDIUM]
+>
+> **Time to Complete:** 60-75 minutes
+>
+> **Prerequisites:** [Module 1.1: Infrastructure as Code](/prerequisites/modern-devops/module-1.1-infrastructure-as-code/), basic Git knowledge
 
-**Complexity:** [MEDIUM]<br>
-**Time to Complete:** 60-75 minutes<br>
-**Prerequisites:** [Module 1.1: Infrastructure as Code](/prerequisites/modern-devops/module-1.1-infrastructure-as-code/), basic Git knowledge
+---
 
 ## Learning Outcomes
 
@@ -30,7 +32,7 @@ In 2020, attackers compromised the SolarWinds Orion build environment and insert
 
 Think of CI/CD as the automated assembly line for software. Source code enters as raw material, moves through quality stations, becomes a container image, receives a label and signature, and is promoted only if each station records a clean result. A team can still choose when a release reaches users, but the release should never depend on someone remembering which commands to run on which host. Kubernetes 1.35+ assumes this world: applications arrive as versioned container images, rollout controllers converge toward desired state, and platform teams rely on repeatable automation rather than personal deployment folklore.
 
-This module turns that assembly line into a design skill. You will separate CI from the two meanings of CD, model pipelines as stages and jobs, connect Infrastructure as Code to delivery gates, secure container artifacts with scans and provenance, compare common CI/CD tools, and choose rollout strategies that fit the risk of the change. When later Kubernetes modules use `k` as the kubectl alias, read it as `alias k=kubectl`; for example, a rollout check would be written as `k rollout status deployment/myapp` after the alias is configured in your shell.
+This module turns that assembly line into a design skill. You will separate CI from the two meanings of CD, model pipelines as stages and jobs, connect Infrastructure as Code to delivery gates, secure container artifacts with scans and provenance, compare common CI/CD tools, and choose rollout strategies that fit the risk of the change. Later Kubernetes modules may mention interactive shell shorthand for `kubectl`, but every runnable command in this module uses the full `kubectl` binary name so copied examples behave the same way in scripts and CI jobs.
 
 ## Core Concepts: CI, Delivery, and Deployment
 

--- a/src/content/docs/prerequisites/modern-devops/module-1.3-cicd-pipelines.md
+++ b/src/content/docs/prerequisites/modern-devops/module-1.3-cicd-pipelines.md
@@ -449,7 +449,7 @@ Append this step to your `build-and-test` job:
 
 ```yaml
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@v0.36.0
       with:
         image-ref: 'kubedojo-app:test'
         format: 'table'
@@ -553,7 +553,7 @@ jobs:
       run: docker build -t kubedojo-app:test .
 
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@v0.36.0
       with:
         image-ref: 'kubedojo-app:test'
         format: 'table'


### PR DESCRIPTION
## Summary
- Cleared the duplicate source H1 and restored the module metadata blockquote structure while preserving the existing CI/CD teaching flow.
- Kept `revision_pending: false` in frontmatter.

## Verifier
- `verify_module.py --skip-source-check`: T0; body_words=5009, mean_wpp=77.1, median_wpp=81, short_rate=0.031, max_run=1; all density+structure+alignment+anti_leak+protected_assets gates pass.
- Protected assets preserved: code blocks 12 -> 12, mermaid diagrams 2 -> 2, ASCII diagrams 0 -> 0, tables 7 -> 7, source URLs 12 -> 12.
- Commit SHA: 54177bd3

## Checks
- `git diff --check -- src/content/docs/prerequisites/modern-devops/module-1.3-cicd-pipelines.md`: pass.
- Forbidden token grep for alias shorthand, number 47, and emoji: no matches.
- Full source reachability check was not required by the dispatch; with source checking enabled, 8 URLs returned 200, 3 redirected, and the preserved Sigstore Cosign URL returned 404.
- `npm run build`: attempted from the worktree and failed with the known worktree-only `../../node_modules/@astrojs/starlight/style/layers.css` resolution issue in `src/layouts/Homepage.astro`.