### PR TITLE
feat(388): rewrite module-0.6-git-basics (#388 pilot)

### DIFF
--- a/src/content/docs/prerequisites/zero-to-terminal/module-0.6-git-basics.md
+++ b/src/content/docs/prerequisites/zero-to-terminal/module-0.6-git-basics.md
@@ -1,50 +1,52 @@
 ---
 title: "Module 0.6: Git Basics — Track Your Work"
 slug: prerequisites/zero-to-terminal/module-0.6-git-basics
+revision_pending: false
 sidebar:
   order: 7
 ---
 
-# Module 0.6: Git Basics — Track Your Work
+> **Complexity**: [BEGINNER]
+>
+> **Time to Complete**: 60 minutes
+>
+> **Prerequisites**: Module 0.5 (Editing Files)
 
-**Complexity**: [BEGINNER]
-**Time to Complete**: 45 minutes
-**Prerequisites**: Module 0.5 (Editing Files)
+---
 
-## Learning Outcomes
+## What You'll Be Able to Do
 
 After completing this module, you will be able to:
-- Initialize local Git repositories and configure user identities for accurate commit attribution.
-- Construct a logical commit history by selectively staging file modifications using `git add` and `git commit`.
-- Diagnose unexpected repository states by analyzing `git status`, `git log`, and `git diff` outputs.
-- Synchronize local repositories with remote servers using `git push` and `git pull`.
-- Formulate a `.gitignore` file to prevent sensitive data or generated artifacts from being tracked.
+
+- Diagnose repository state by interpreting `git status`, `git diff`, and `git log` output instead of guessing what Git will save.
+- Construct focused commits by moving selected file changes from the working directory into the staging area and then into repository history.
+- Implement a safe local Git setup with accurate author identity, a new repository, and an ignore policy for generated files and secrets.
+- Compare local and remote repository timelines so you can choose when to clone, push, pull, fetch, or pause for conflict resolution.
+- Design a small Git workflow for Kubernetes configuration files that produces reviewable history without leaking credentials or generated artifacts.
 
 ## Why This Module Matters
 
-Teams that manage infrastructure files on a shared drive without version control can easily change the wrong environment by mistake and have no reliable audit trail when something breaks.
+Hypothetical scenario: an operations group keeps Kubernetes manifests on a shared drive because everyone can open the folder quickly, edit YAML, and copy the latest files into a deployment script. One morning the production namespace changes in a way nobody expected, the cluster accepts the update, and the team cannot tell whether the current file is the intended version, a half-finished experiment, or a copy of an older configuration. The outage investigation is slow not because Kubernetes is mysterious, but because the team has no trustworthy timeline for the text files that describe its infrastructure.
 
-When the system failed, the team could see only the current broken file state. Without version control, they had to reconstruct the previous configuration manually, which slowed recovery and made the incident more damaging.
+Git solves that operational problem by turning ordinary files into a deliberate, reviewable history. It records snapshots, authors, messages, and parent relationships, so a team can compare what changed, why it changed, and when the change entered the shared record. That matters for source code, but it matters just as much for cloud-native work: a Deployment, a Namespace, a Terraform module, or a CI pipeline definition can all change production behavior when automation trusts the repository as the source of truth.
 
-Version control prevents this exact scenario. [Git, the industry standard for version control](https://en.wikipedia.org/wiki/Git), acts as an unbreakable time machine for your code and configuration. It records every change, identifies exactly who made it, and usually allows you to quickly return to a previous committed state. In the modern cloud-native world, infrastructure is defined as code. If you cannot track, review, and revert your infrastructure code with absolute certainty, you are operating a disaster waiting to happen. Mastering Git is not optional for platform engineers; it is the foundational skill upon which all reliable automation and collaboration is built. 
+This module starts with local Git because local confidence comes before collaboration. You will initialize a repository, configure identity, stage changes intentionally, read diffs before committing, and use a `.gitignore` file to keep noise out of history. By the end, you should not merely remember a list of commands; you should be able to diagnose what Git is about to do and explain whether the next action should be `git add`, `git commit`, `git pull`, `git push`, or no action at all.
 
-Modern CI/CD pipelines rely on a version-controlled source of truth, and Git is the system most teams use for that job. The entire premise of automated deployments relies on a single, trusted source of truth that triggers automation whenever a new, approved change is detected. If you do not understand Git, you cannot understand modern software delivery.
+That diagnostic mindset is what separates a useful Git user from someone who only knows a happy-path recipe. A recipe works when every file is exactly where the tutorial expects it to be, but engineering work rarely stays that neat. You may have half-finished edits, generated logs, a teammate's new remote commits, or a local file that must never leave your machine. Git gives you precise tools for each case, and this module teaches you to choose among them based on observed state.
 
-## Section 1: The Concept of Version Control and Git's Architecture
+## How Git Thinks About Your Files
 
-Before typing any commands, you must understand how Git thinks about your files. Many beginners struggle with Git because they treat it like a simple backup tool (like Dropbox or Google Drive). Git is entirely different. Git does not just sync files continuously in the background; it takes deliberate, immutable snapshots of your project at specific points in time, but only when you explicitly command it to do so.
+Git is often described as version control, but beginners sometimes hear that phrase and imagine a cloud backup tool that continuously syncs the latest file contents. That model leads to mistakes, because Git is not trying to mirror every keystroke to a server. Git records deliberate snapshots when you ask it to, keeps those snapshots in a local database, and lets you decide exactly which changes belong together before they become part of the project history.
 
-Think of Git like a video game with manual save points. You can play the game, make mistakes, take damage, and explore dead ends. As long as you explicitly create a "save point" before trying a dangerous boss fight, you can always reload that exact state if things go wrong. Git works the same way, but for your text files.
+Think of Git like a manual save system in a strategy game. You can explore, make a risky move, inspect the result, and decide whether that state deserves a save point. If you save at thoughtful moments, later decisions become easier because you can compare states and explain how you moved from one state to the next. If you save everything randomly, the history exists, but it does not help you reason during a review or incident.
 
-### Centralized vs. Distributed Version Control
+Historically, many version control systems were centralized. A central server held the authoritative history, and clients depended on that server to inspect history or create new commits. Git is distributed: when you clone a repository, you receive a full local history, not just the latest files. That means you can inspect commits, compare versions, and create local commits while offline, then synchronize with a remote server when connectivity and team coordination are available.
 
-Historically, version control systems like Subversion (SVN) or Team Foundation Server (TFS) were centralized. There was one master server that held the history. If you wanted to view the history or make a commit, you had to be connected to the internet to talk to that server. If the server went down, nobody could work.
+The practical result is that Git has two personalities. Locally, it is a fast database and comparison engine for your files. Collaboratively, it is a synchronization protocol that lets multiple people exchange histories through a remote such as GitHub, GitLab, or Bitbucket. Good Git habits come from respecting both personalities: make clean local commits first, then share them only after you have checked what they contain.
 
-Git is a **distributed** version control system. When you use Git, you do not just download the latest files; you download the entire history of the project. Your local laptop becomes a fully functioning repository. You can view history, compare versions, and make commits while completely offline on an airplane. You only need the internet when you want to synchronize your history with someone else's.
+This local-first design is especially helpful in cloud-native work because many infrastructure changes need careful review before they touch a cluster. You can edit manifests, compare the patch, commit a narrow change, and ask another engineer to review the branch without applying anything to Kubernetes yet. Git does not validate the cluster behavior for you, but it gives the team a stable object to discuss. A reviewer can point to a line, a commit, or a branch instead of relying on a vague description of what changed.
 
-### The Three Trees of Git
-
-Git manages your files by moving them through three distinct logical areas, often called "trees." Understanding this pipeline is the key to diagnosing almost any Git problem.
+Git manages your files through three logical areas. The names matter because most confusing Git messages are simply Git telling you which area contains a change. Your working directory is where your editor writes files, the staging area is where you assemble the next snapshot, and the repository is the saved history inside the hidden `.git` database. The staging area is the piece many beginners skip, but it is what lets you turn messy work into a clean commit.
 
 ```text
 +---------------------+       +---------------------+       +---------------------+
@@ -64,35 +66,31 @@ Git manages your files by moving them through three distinct logical areas, ofte
                                3. Restore old versions
 ```
 
-1. **The Working Directory**: This is your current workspace on your computer. It contains the actual files you are editing, deleting, or creating. When you open a file in Vim or VS Code, you are modifying the Working Directory. Git sees these changes but has not saved them yet.
-2. **The Staging Area (Index)**: This is a crucial intermediate step unique to Git. Think of it as a loading dock or a staging area for a photoshoot. Before you take the final snapshot, you choose exactly which modified files to place on the stage. You can stage some files while leaving others behind. This allows you to craft highly focused, logical commits even if you modified fifty files at once.
-3. **The Repository (Commit History)**: This is the permanent database where Git stores your snapshots (called commits). Once files are committed here, they are safely recorded in history with an author name, a timestamp, and a descriptive message. A commit is mathematically sealed; it cannot be secretly altered without changing its unique identifier.
+The working directory is the current project folder on disk. When you edit `namespace.yaml`, create a README, or delete a temporary file, you are changing the working directory. Git can detect that tracked files differ from the last commit, and it can also notice new untracked files, but it will not automatically decide that those changes belong in the next snapshot. This is why `git status` is the first diagnostic command to learn.
 
-### Active Learning: Pause and Predict
-> **Pause and predict**: You have just finished a long debugging session. You fixed a database connection bug in `db.py`, but while hunting for the bug, you also added temporary print statements to `auth.py` and `api.py` that you don't want to save permanently. How does Git's Three Trees architecture allow you to create a clean history in this scenario without losing your temporary debug code in the working directory?
->
-> *Prediction check: The Three Trees architecture decouples your working files from what gets saved. You can use the Staging Area to selectively stage only `db.py` for the next commit. The temporary print statements in `auth.py` and `api.py` remain safely in your Working Directory for you to continue using or delete later, without ever polluting the permanent Repository history.*
+The staging area, also called the index, is a deliberate selection of what the next commit will contain. You can stage one file while leaving another modified file unstaged, or even stage only some hunks from a file with more advanced commands later. That separation is valuable when real work is messy. A debugging session might touch authentication, deployment YAML, and local notes, but the commit should capture one coherent reason for change.
 
-## Section 2: Setting the Stage: Installation and Configuration
+The repository is the permanent local database, stored inside `.git`, where commits live. A commit records file contents, author metadata, a message, a timestamp, and a pointer to its parent commit. In common repositories, each commit is named by a hash such as a SHA-1 object identifier, and newer Git versions can also support SHA-256 repositories. The important beginner idea is simpler than the cryptography: if the content or metadata changes, the identifier changes too.
 
-Git is a command-line tool at its core. While graphical interfaces exist, learning the terminal commands is mandatory for platform engineering, as you will often be using Git on remote servers without graphical capabilities. Most modern Linux distributions and macOS come with Git pre-installed, or it can be easily added via a standard package manager like `apt`, `yum`, or `brew`.
+Pause and predict: you fixed a database connection bug in `db.py`, but while searching for it you also added temporary print statements to `auth.py` and `api.py`. Which part of Git lets you save only the real fix while keeping the temporary debug code on disk? The answer is the staging area, because it decouples the files you are still editing from the files you are ready to save as the next snapshot.
 
-To verify your installation, open your terminal and check the version:
+## Configure Git and Create a Repository
+
+Git is a command-line tool at its core, even when teams use graphical clients or web interfaces around it. Platform engineers must be comfortable with the terminal version because many workflows happen over SSH, inside automation logs, or on machines where a graphical client is unavailable. The goal is not to memorize every option. The goal is to become fluent enough that repository state is visible instead of mysterious.
+
+Start by checking that Git is installed. Your exact version may differ from the example, and that is fine. The version number matters when you troubleshoot features, but the basic commands in this module have been stable for years. If this command fails, install Git through your operating system package manager before continuing, then reopen the terminal so the executable is available on your `PATH`.
 
 ```bash
 git --version
 ```
 
-Expected output:
+Expected output should include the Git version installed on your machine; the exact number may differ from this example.
+
 ```text
 git version 2.39.2
 ```
 
-### Identity Configuration
-
-Git records author and committer identity in each commit, and in normal day-to-day use you should configure `user.name` and `user.email` so your commits are attributed correctly. This is critical for accountability—if an infrastructure change brings down production, the team needs to know who to ask about the rationale behind the change.
-
-You configure this using the `git config` command. The `--global` flag applies these settings to all repositories on your current computer by writing them to a hidden file in your home directory (`~/.gitconfig`).
+Before creating commits, configure the identity Git will place into commit metadata. This is not the same thing as authenticating to GitHub during a push. The name and email configured here answer the question, "Who authored this snapshot?" Remote authentication answers a different question: "Is this person allowed to upload to that server?" Keeping those concepts separate prevents confusion when a commit succeeds locally but a push later asks for credentials.
 
 ```bash
 # Set your name (use your real name, this appears in the history)
@@ -102,15 +100,13 @@ git config --global user.name "Alex Chen"
 git config --global user.email "alex.chen@example.com"
 ```
 
-You can verify your configuration at any time by asking Git to list all its current settings:
+The `--global` flag writes to configuration associated with your user account on this computer, usually in `~/.gitconfig`. You can also set repository-specific configuration without `--global`, which is useful when one laptop contributes to both personal and work repositories. For now, a global beginner setup is enough, and you can inspect it with a command that prints the settings Git sees.
 
 ```bash
 git config --list
 ```
 
-### Initializing a Repository: git init
-
-To tell Git to start tracking a project, you must initialize a repository in the root directory of your project. Let us create a new directory for a hypothetical Kubernetes project and initialize Git within it.
+Now create a small project directory for the examples. The project uses Kubernetes-flavored filenames because infrastructure configuration is where Git habits quickly become operational habits. The commands below make a directory, enter it, and initialize a repository. Run them in a practice location such as your home directory or a temporary folder, not inside a real work repository.
 
 ```bash
 # Create a new directory
@@ -121,21 +117,21 @@ cd k8s-webapp
 git init
 ```
 
-Expected output:
+Expected output should confirm that Git created an empty repository database in a hidden `.git` directory.
+
 ```text
 Initialized empty Git repository in /home/alex/k8s-webapp/.git/
 ```
 
-What exactly did `git init` do? It did not magically scan your hard drive. It simply created a hidden directory named `.git` inside your `k8s-webapp` folder. This hidden `.git` directory is the actual "Repository" from our Three Trees model. It is where Git stores all the internal database objects, the compressed file contents, the commit history graph, and the local configuration for this specific project. 
-
-If you delete the `.git` directory, you delete all version history for the project, though your current working files will remain untouched on the disk.
+What exactly changed? Git created a hidden `.git` directory inside `k8s-webapp`. That hidden directory is not decorative; it is the repository database for this project. It contains objects, references, local configuration, and the machinery Git uses to know which branch you are on. If you delete `.git`, your current files may remain on disk, but the local history, branches, and repository identity are gone.
 
 ```bash
 # List all files, including hidden ones
 ls -la
 ```
 
-Expected output:
+Expected output should show the hidden `.git` directory beside the normal current and parent directory entries.
+
 ```text
 total 12
 drwxr-xr-x 3 alex alex 4096 Oct 12 10:00 .
@@ -143,15 +139,15 @@ drwxr-xr-x 5 alex alex 4096 Oct 12 09:59 ..
 drwxr-xr-x 7 alex alex 4096 Oct 12 10:00 .git
 ```
 
-With your repository successfully initialized and your identity configured, you have laid the essential groundwork. Next, we will explore how to populate this repository by deliberately moving files through Git's lifecycle to create your first committed snapshots.
+Before running the next command in any new repository, make a habit of asking what state you expect Git to report. In a brand-new repository with no tracked files and no commits, `git status` should tell you that there are no commits yet and that Git has nothing staged. That prediction habit is more valuable than it sounds, because every later Git recovery task starts by comparing expected state with observed state.
 
-## Section 3: The Snapshot Lifecycle: Add, Commit, and Status
+## Build Commits Deliberately
 
-Now that we have an active repository, let us walk through the daily workflow of tracking files. The command you will use more than any other—hundreds of times a day—is `git status`. It acts as your compass, telling you exactly where your files are within the Three Trees.
+The command you will use most often is `git status`, because it is the safest way to ask Git what it sees. It does not change files, create commits, or contact a remote. It simply reports which branch you are on, whether the working directory has modified files, which changes are staged, and which files are untracked. Treat it as your compass before every staging, committing, pulling, or pushing decision.
 
-### Step 1: Modifying the Working Directory
+There is another subtle reason `git status` matters: it teaches you Git's vocabulary in context. "Untracked" means Git sees a file but has no committed baseline for it. "Changes not staged" means Git tracks the file but the current working copy differs from the last commit. "Changes to be committed" means the staging area already contains content for the next snapshot. Those messages are not noise; they are a compact state machine report.
 
-Let us create our first file, a basic Kubernetes namespace configuration.
+Create the first file in the practice repository. This file defines a Kubernetes Namespace, which is a simple object that lets us focus on Git behavior without needing a running cluster. The content is valid YAML, but the point is the workflow: write a file, inspect repository state, stage the file, and commit the staged snapshot with a message that explains the intent.
 
 ```bash
 cat << 'EOF' > namespace.yaml
@@ -162,13 +158,14 @@ metadata:
 EOF
 ```
 
-Run `git status` to see what Git thinks about this newly created file:
+Run `git status` immediately. New learners often skip this because they believe they already know what changed, but memory is a weak audit system. Git's report is the objective state. In production work, that objectivity is what keeps temporary notes, generated files, and secret material from entering history by accident.
 
 ```bash
 git status
 ```
 
-Output:
+The output should classify the new file as untracked because it exists on disk but is not part of the next snapshot.
+
 ```text
 On branch main
 
@@ -181,23 +178,22 @@ Untracked files:
 nothing added to commit but untracked files present (use "git add" to track)
 ```
 
-Git recognizes that a file exists in the Working Directory, but it lists it as "Untracked." This means Git is not currently tracking this file. It is not monitoring it for changes, and it will not automatically back it up. Git only tracks what you explicitly tell it to track.
+The file is untracked, which means Git sees it in the working directory but has not been told to include it in version control. Untracked files are not part of the next commit, and Git will not compare future edits to them until you stage and commit them. This behavior is intentional. A directory often contains notes, generated artifacts, or local test files that should not automatically become project history.
 
-### Step 2: Moving to the Staging Area (git add)
-
-To tell Git we want to include this file in our very first snapshot, we must move it to the Staging Area (the loading dock) using the `git add` command.
+Move the file into the staging area with `git add`. This command is easy to underestimate because it sounds like you are adding a file to Git forever. More precisely, you are adding the current content of that file to the staging area for the next commit. If you edit the file again after staging, the new edit will be unstaged until you add it too.
 
 ```bash
 git add namespace.yaml
 ```
 
-Run `git status` again to observe the state change:
+Run `git status` again and compare the wording. The file has moved from "Untracked files" to "Changes to be committed." That wording tells you the next commit will include the file as it existed when you staged it. Nothing has been permanently saved yet; you have only prepared the next snapshot.
 
 ```bash
 git status
 ```
 
-Output:
+The output should now show the file under changes to be committed, which means it is staged.
+
 ```text
 On branch main
 
@@ -208,52 +204,38 @@ Changes to be committed:
 	new file:   namespace.yaml
 ```
 
-The file has moved. It is now categorized under "Changes to be committed". It is sitting on the loading dock, waiting for the photographer to take the picture.
-
-### Step 3: Taking the Snapshot (git commit)
-
-To permanently save the staged changes into the Repository, we use `git commit`. Every commit requires a commit message explaining *why* the change was made. Writing good commit messages is a core professional skill. A good message explains the intent and context, not just what lines changed.
+Commit the staged change. The message should explain the reason for the snapshot at a level useful to a future reviewer. A message like "update" forces people to inspect the diff just to understand the intent. A message like "feat: add production namespace definition" gives the reader a quick summary and still lets them open the diff for detail when needed.
 
 ```bash
 git commit -m "feat: add production namespace definition"
 ```
 
-Output:
+The output should report the root commit, the commit subject, and the number of inserted lines.
+
 ```text
 [main (root-commit) a1b2c3d] feat: add production namespace definition
  1 file changed, 4 insertions(+)
  create mode 100644 namespace.yaml
 ```
 
-Let us check `git status` one more time to see the final result of our workflow:
+Check status after the commit. A clean working tree means the tracked files in your working directory match the latest committed snapshot and nothing is staged for the next commit. Clean does not mean the project is correct, secure, or ready for production. It only means Git has no uncommitted tracked changes to report.
 
 ```bash
 git status
 ```
 
-Output:
+The output should now report a clean working tree because the staged content has been committed.
+
 ```text
 On branch main
 nothing to commit, working tree clean
 ```
 
-Your Working Directory is now described as "clean." This means every tracked file currently sitting in your Working Directory matches the latest snapshot stored in the `.git` database. There are no pending changes.
+Exercise scenario: while testing locally, a learner places a real access token into a YAML file, sees the application start, and then runs a broad staging command without reading the diff. The operational lesson is direct: a commit is not a private scratchpad once it is shared, and deleting a secret in a later commit does not remove it from earlier history. Always inspect state and diffs before committing, especially around configuration files that may contain credentials.
 
-### War Story: The Accidental Secret Commit
+The safer professional habit is to make each commit earn its place in history. Before staging, ask whether the patch has one reason that a reviewer can evaluate. Before committing, ask whether the staged content is the exact content you want attached to the message. Before pushing, ask whether the branch contains only work you are ready to share. These questions slow you down by seconds and can save hours of cleanup when a repository becomes the input to deployment automation.
 
-A junior developer was testing an application locally that required an AWS access key. For convenience, they hardcoded the key directly into their `deployment.yaml` file just to see if the pods would start. It worked. Excited, they ran `git add .` (a command which indiscriminately stages every changed file in the entire directory) and then ran `git commit -m "fix deployment"`.
-
-They then pushed the code to a public repository. Exposed cloud credentials in public repositories can be discovered quickly by automated scanners and abused to create expensive resources before a team notices.
-
-**The Lesson**: Never blindly use `git add .` unless you are absolutely certain what you have changed. Always run `git status` and `git diff` before staging to ensure you are not accidentally committing passwords, API keys, private ssh keys, or temporary debugging files.
-
-Now that you know how to safely construct snapshots, you will inevitably need to inspect past snapshots or review the exact modifications made to individual files over time. In the next section, we will delve into the commands that allow you to analyze your commit history and examine precise file differences.
-
-## Section 4: Traveling Through Time: Log and Diff
-
-Once you have made multiple commits, you need robust ways to view the history timeline and understand exactly what has changed between different points in time. 
-
-Let us make another change to our project. We will update the namespace file to add a label, a common task in Kubernetes for organizational purposes.
+Now modify the Namespace by adding a label. This is a realistic kind of infrastructure edit because labels help teams organize objects, select resources, and drive automation. The Git workflow, however, remains the same: make the change, inspect the difference, stage only the intended content, and commit a focused snapshot.
 
 ```bash
 cat << 'EOF' > namespace.yaml
@@ -266,15 +248,14 @@ metadata:
 EOF
 ```
 
-### Seeing What Changed: git diff
-
-Before you ever stage or commit a file, you should always verify exactly what lines you modified. Memory is fallible; the diff is objective. The `git diff` command compares your current Working Directory against the last snapshot you took.
+Before staging, read the diff. `git diff` compares the working directory against the last committed snapshot for unstaged changes. This is one of the most protective commands in your toolbox because it shows the exact lines that would surprise a reviewer if you committed without checking. It also trains you to think in patches, which is the unit of review in most professional Git workflows.
 
 ```bash
 git diff
 ```
 
-Output:
+The output should show only the new label lines as additions, with surrounding unchanged YAML for context.
+
 ```text
 diff --git a/namespace.yaml b/namespace.yaml
 index e46b825..8394c41 100644
@@ -288,44 +269,41 @@ index e46b825..8394c41 100644
 +    environment: production
 ```
 
-**How to decipher a diff output:**
-- The `--- a/namespace.yaml` and `+++ b/namespace.yaml` headers show the two versions of the files being compared (old vs new).
-- `@@ -2,3 +2,5 @@` is a chunk header. It provides context to the system about roughly where in the file the changes occurred.
-- Lines starting with a space character are unchanged context lines. Git shows them to help you orient yourself.
-- Lines starting with a `+` (usually highlighted in green) are entirely new additions.
-- Lines starting with a `-` (usually highlighted in red) are deletions. If you changed a line, Git represents it as deleting the old line and adding the new line.
+Diff output has a compact grammar. The `---` and `+++` lines name the old and new sides of the comparison. The chunk header beginning with `@@` tells Git and the reader where in the file the change appears. Lines that begin with a space are context, lines beginning with `+` are additions, and lines beginning with `-` are removals. A modified line is represented as one removal and one addition, which is why line-by-line review is more precise than "I changed the file."
 
-### Active Learning: Diff Reading
-> **Pause and predict**: Imagine you ran `git diff` on a deployment file and saw the following output:
->
-> ```text
-> @@ -10,3 +10,3 @@
->  spec:
->    replicas: 3
-> -  image: nginx:1.14
-> +  image: nginx:1.24
-> ```
->
-> Before reading further, what exactly did the engineer do in this file? Be specific.
->
-> *Prediction check: The engineer did not add a completely new structural element. They modified an existing line. They deleted the line specifying the Nginx container version 1.14 and replaced it with a line specifying version 1.24. This represents a container image version upgrade.*
+When you review a diff for infrastructure files, read it like a deployment plan, not like a spelling check. A one-line image tag change can move workloads to a different binary. A replica count change can alter cost, availability, and load on dependencies. A namespace or label change can affect automation that selects objects by metadata. Git's diff format is simple, but the operational interpretation of those lines requires attention to what the changed fields control.
 
-Now that we have verified our changes are correct and contain no secrets, let us stage and commit our label addition:
+Pause and predict: imagine the next diff appears in a Deployment file. Before reading the answer, decide whether this is a new field, a deleted field, or a changed value, and describe the operational effect in plain language.
+
+```text
+@@ -10,3 +10,3 @@
+ spec:
+   replicas: 3
+-  image: nginx:1.14
++  image: nginx:1.24
+```
+
+The engineer changed an existing image value from `nginx:1.14` to `nginx:1.24`. That is not merely a formatting update; it changes which container image Kubernetes will try to run. In a real review, you would ask whether this version jump is intentional, whether the tag exists, and whether the application was tested against that version.
+
+After confirming the label change is the intended change, stage and commit it. Notice that the commit message is specific to the label. It does not say "fix stuff" or "update namespace" because those messages decay quickly when someone is scanning history during an incident. A commit message is a tiny piece of operational documentation attached to the exact patch it describes.
 
 ```bash
 git add namespace.yaml
 git commit -m "chore: add environment label to namespace"
 ```
 
-### Viewing History: git log
+## Inspect History and Diagnose State
 
-To see the timeline of your snapshots, use the `git log` command. This opens a pager (usually `less`) showing your history in reverse chronological order (newest first).
+Once a repository has more than one commit, history becomes a diagnostic tool. `git log` shows the timeline of snapshots, newest first by default, including commit identifiers, author information, dates, and messages. During troubleshooting, this lets you answer who changed something recently and what explanation they left. During code review, it lets you assess whether the branch history tells a coherent story.
+
+History is most useful when commits are small enough to inspect and messages are specific enough to search. If a branch contains one giant commit that changes namespaces, deployments, scripts, and documentation together, reverting or reviewing it becomes risky because every concern is tangled. If the branch contains focused commits, you can inspect the deployment change separately from the documentation change. Git does not force that discipline, but it rewards it every time you need to reason under pressure.
 
 ```bash
 git log
 ```
 
-Output:
+The output should show the most recent commit first, followed by the earlier root commit.
+
 ```text
 commit 9f8e7d6c5b4a39281716151413121110abcdef12 (HEAD -> main)
 Author: Alex Chen <alex.chen@example.com>
@@ -340,33 +318,32 @@ Date:   Wed Oct 12 10:15:30 2023 -0400
     feat: add production namespace definition
 ```
 
-Notice the 40-character hexadecimal strings shown above. In most repositories, this is the commit hash generated with SHA-1. It is a mathematically generated unique identifier for that specific snapshot and reflects the file contents, author, date, and parent commit. You can use this hash to inspect or restore that exact point in history. Newer repositories can also be configured to use SHA-256, but the examples in this module use the common SHA-1 format.
+The long hexadecimal strings are commit identifiers. In many repositories they are SHA-1 object names, commonly displayed as long hashes and shortened in user interfaces when the short prefix is unambiguous. You do not need to calculate the hash yourself, but you should recognize it as a precise handle for a snapshot. Saying "the namespace label commit" is helpful in conversation; using the commit identifier is how tools inspect or compare the exact commit.
 
-For a more compact view, which is especially useful when you are investigating a repository with thousands of commits over several years, use the `--oneline` flag:
+For daily use, the compact log format is easier to scan. The `--oneline` option shows abbreviated commit identifiers and subjects on one line each. This is often enough when you want to verify that the expected commits exist in the expected order before pushing a branch or asking someone for review.
 
 ```bash
 git log --oneline
 ```
 
-Output:
+The compact output should preserve the same order while reducing each commit to a short identifier and subject.
+
 ```text
 9f8e7d6 chore: add environment label to namespace
 a1b2c3d feat: add production namespace definition
 ```
 
-You can also use `git log -p` to see the actual diffs introduced by every single commit in history, allowing you to see not just *that* a commit happened, but exactly *what lines* were altered by it.
+You can also use `git log -p` to inspect the patch introduced by each commit. That is useful when the question is not only "When did this change?" but "What exact lines did this commit add or remove?" As repositories grow, you will learn more targeted history tools, but `status`, `diff`, and `log` already give you a strong diagnostic loop: current state, uncommitted line changes, and committed timeline.
 
-Mastering the ability to navigate your local timeline provides immense confidence when experimenting with infrastructure code. However, modern engineering is a team effort; the next section will introduce how to safely share your local history with remote servers to collaborate seamlessly with others.
+Use that loop before assuming Git is broken. If a commit seems to be missing, check whether the change was ever staged and committed. If a file seems to be ignored, check whether it is already tracked or whether the ignore pattern actually matches. If a push is rejected, check whether the remote moved ahead of your local branch. Most beginner Git problems become ordinary state questions once you slow down and collect the evidence in the right order.
 
-## Section 5: Collaborating with the World: Remotes, Push, and Pull
+The most important habit is to read these commands as a set. If `git status` says a file is modified, `git diff` explains the unstaged modification. If the working tree is clean but behavior changed recently, `git log` tells you which commits to inspect. If a file is untracked, no amount of `git commit` will include it until you stage it. The tool is consistent; confusion usually comes from asking the wrong tree the right question.
 
-Up until this point, everything we have done exists entirely on your local laptop's hard drive. If your computer crashes, or if you drop a cup of coffee on it, your entire project history is permanently gone. Furthermore, nobody else on your team can see your work. 
+Before running this in your own practice repository, what output do you expect from `git status` after the second commit? If you have not edited anything since the commit, it should report a clean working tree. If it does not, pause and inspect the remaining changes rather than making another commit immediately, because the mismatch is telling you there is still state you have not accounted for.
 
-To collaborate with others and back up your work, you must connect your local repository to a remote server, such as GitHub, GitLab, or Bitbucket.
+## Work With Remotes Without Losing the Plot
 
-### What is a Remote?
-
-A "remote" is simply another Git repository hosted on a network or the internet. Because Git is decentralized, everyone has a full, standalone copy of the history. "Pushing" and "Pulling" are the explicit actions we take to synchronize our local timeline with the remote timeline. 
+Everything so far has happened on your local machine. That is enough to practice Git, but it is not enough for team work or backup. A remote is another repository reachable over a network, usually hosted by a service such as GitHub, GitLab, or Bitbucket. Because Git is distributed, the remote is not magic; it is another copy of the repository history that your local repository can fetch from and push to when the histories are compatible.
 
 ```text
 +-----------------------+                    +-----------------------+
@@ -381,57 +358,42 @@ A "remote" is simply another Git repository hosted on a network or the internet.
 +-----------------------+                    +-----------------------+
 ```
 
-### Connecting to a Remote
-
-When you create an empty repository on a platform like GitHub, the platform provides you with a connection URL (usually HTTPS or SSH). You tell your local Git installation to connect to this URL using the `git remote add` command. 
-
-By industry convention, the primary, default remote server is almost always named `origin`.
+When you create an empty repository on a hosting platform, the platform gives you a URL. You connect your local repository to that URL with `git remote add`. By convention, the first and primary remote is named `origin`, but the name is just a local nickname. The URL is where data goes; the remote name is how you refer to that URL in commands.
 
 ```bash
 # Example command (do not run unless you have a real repository URL prepared)
 git remote add origin https://github.com/yourusername/k8s-webapp.git
 ```
 
-If you join a company and want to download an existing project, you do not use `git init` and `git remote add`. Instead, you use `git clone <url>`. Cloning automatically initializes a local repository, adds the remote as `origin`, and downloads all the history and files in one step.
+If the repository already exists on the server, do not create a new local repository and try to glue the histories together. Use `git clone <url>` instead. Cloning initializes the local `.git` directory, downloads the repository history, checks out a working tree, and records the remote as `origin`. Most professional work starts from cloning because the team history already exists before you arrive.
 
-### Pushing Changes (git push)
-
-To upload your locally created commits to the remote server, you "push" them. You must specify the remote name (usually `origin`) and the branch name you are pushing (often `main` or `master`).
+Pushing uploads your local commits to the remote branch. The first push of a new branch often includes `-u`, which sets an upstream tracking relationship so future `git push` and `git pull` commands can infer the remote branch. This convenience is useful, but only after you understand what is being tracked. If the branch relationship is wrong, Git may push somewhere unexpected or ask you to be more explicit.
 
 ```bash
 # Push your main branch to the origin remote for the first time
 git push -u origin main
 ```
 
-The `-u` flag stands for "upstream." You only need to use it the very first time you push a new branch. It creates a persistent tracking link between your local `main` branch and the remote `main` branch. In the future, you can simply type `git push` without any arguments, and Git will know exactly where to send the data.
-
-### Pulling Changes (git pull)
-
-If a teammate makes changes, commits them locally, and pushes them to GitHub, your local repository will *not* update automatically. Git will never change your local files without your explicit permission. You must actively reach out to the server, download their new commits, and integrate them into your local history using `git pull`.
+Pulling downloads remote commits and integrates them into your current branch. Conceptually, `git pull` is `git fetch` followed by an integration step such as merge or rebase, depending on configuration. Beginners can treat it as "bring the remote branch into my local branch," but it is worth remembering the two-part nature because `git fetch` alone is safer when you only want to inspect remote changes before modifying your working branch.
 
 ```bash
 # Fetch changes from the remote and merge them into your local branch
 git pull origin main
 ```
 
-Under the hood, `git pull` is actually a macro that runs two distinct commands in sequence: `git fetch` (which safely downloads the new commits from the remote without modifying your working files) and `git merge` (which attempts to seamlessly combine the downloaded changes with your current working directory).
+Pause and predict: you made two local commits while offline, and a colleague pushed three commits to the same remote branch before you reconnected. What happens if you try `git push origin main` immediately? The likely result is a rejected push, because the remote contains commits your local branch does not yet contain. Git refuses to let your push overwrite the remote timeline by accident, so you must fetch or pull, inspect the combined history, resolve conflicts if needed, and then push.
 
-### Active Learning: Remote Synchronization
-> **Pause and predict**: You spent the morning working offline and made two local commits. Meanwhile, your teammate pushed three commits to the same branch on the remote server. What will happen if you blindly run `git push origin main` when you reconnect to the internet?
-> 
-> *Prediction check: The push will be rejected by the remote server. Git will recognize that the remote branch has commits that your local branch lacks, preventing you from unintentionally overwriting your teammate's work. You must run `git pull` to fetch and integrate their changes into your local history before you can successfully push your combined timeline.*
+This protection is one reason Git is safer than copying files over a shared folder, but it is not a substitute for communication. If two people edit the same line in the same file, Git can detect a conflict, but it cannot decide the correct business or operational outcome. In Kubernetes manifests, that may mean choosing the correct replica count, image tag, namespace, or resource limit. The human decision still matters; Git simply prevents silent overwrites.
 
-## Section 6: Ignoring the Noise: .gitignore
+There is also a difference between remote synchronization and deployment. Pushing a manifest to a repository shares code with the team and may trigger automation if the project has CI/CD configured, but Git itself is not Kubernetes and does not apply resources to a cluster. That boundary is important. A clean Git history makes deployment automation auditable, yet you still need separate checks, reviews, and cluster feedback to know whether the infrastructure change is safe.
 
-In any real-world software or infrastructure project, there are numerous files that you **never** want to commit to version control. These include:
-- Compiled binaries, executable files, or build artifacts (e.g., `.exe`, `.jar`, `/dist/` directories).
-- Log files generated by your application during testing.
-- Operating system hidden files (e.g., `.DS_Store` generated by macOS Finder).
-- **Secrets, API keys, database passwords, and local environment variables** (e.g., `.env` files).
+## Ignore Noise and Protect Secrets
 
-If you accidentally commit these, you bloat the repository size or, worse, cause a severe security breach. To tell Git to pretend these files do not exist entirely, you create a plain text file named `.gitignore` in the root folder of your project.
+Real projects generate files that do not belong in version control. Build directories, logs, local cache files, operating system metadata, editor swap files, downloaded dependencies, Terraform state, and private environment files can all appear beside source files. If those files enter Git history, they create different kinds of damage: large binaries bloat the repository, generated files cause noisy reviews, and secrets create immediate security incidents.
 
-Let us create a `.gitignore` tailored for our cloud-native environment.
+Git handles this with `.gitignore`, a plain text file usually stored at the repository root. Each line is a pattern for files Git should ignore when they are untracked. The "untracked" part is crucial. `.gitignore` prevents new matching files from being noticed as candidates for staging, but it does not make Git forget a file that is already tracked in history. If a secret was committed, you must treat the secret as compromised and rotate it, not merely add it to `.gitignore`.
+
+Create an ignore file for the practice repository. The exact patterns below are intentionally small so you can reason about them. They show operating system noise, local secrets, a local kubeconfig-style file, and Terraform state. In a production repository, you would adapt patterns to the tools actually used by the project and review them just like any other infrastructure policy.
 
 ```bash
 cat << 'EOF' > .gitignore
@@ -451,79 +413,124 @@ kubeconfig-local
 EOF
 ```
 
-Git reads this file top-to-bottom. Any untracked file that matches a pattern listed in the `.gitignore` will normally not show up in `git status` as untracked. This makes it much less likely that you will accidentally stage it with a wildcard command like `git add .`.
+Git reads ignore patterns and normally hides matching untracked files from `git status`. That reduces the chance of a broad staging command pulling in local-only files. It does not eliminate the need to read `git status` and `git diff`, because ignore files can be incomplete and because tracked files remain tracked even if their names later match an ignore rule.
 
-### Active Learning: Pattern Matching
-> **Pause and predict**: Given the `.gitignore` file above, which of the following three newly created files would still show up as "Untracked" when you run `git status`? 1) `main.tfstate`, 2) `secret-keys.yaml`, 3) `secret-keys.txt`.
->
-> *Prediction check: Only `secret-keys.txt` will show up as untracked. `main.tfstate` is ignored by the `*.tfstate` wildcard rule, and `secret-keys.yaml` is explicitly ignored by name. `secret-keys.txt` does not match any ignore pattern, so Git will continue to flag it as an untracked file.*
+Pause and predict: with the ignore file above, which of these new files would still show up as untracked: `main.tfstate`, `secret-keys.yaml`, or `secret-keys.txt`? Only `secret-keys.txt` should appear, because `main.tfstate` matches the `*.tfstate` wildcard and `secret-keys.yaml` matches an exact pattern. The `.txt` file does not match a listed pattern, so Git still reports it.
 
-### Active Learning: The Late Ignore
-> **Pause and predict**: You have a file named `database-creds.txt` that you created last week. You committed it to Git a few days ago. Today, you realize your mistake and add `database-creds.txt` to your `.gitignore` file. You modify the credentials file, and run `git status`. Will Git ignore the changes?
->
-> *Prediction check: No, Git will not ignore the changes. The `.gitignore` file only prevents **untracked** files from being added to the database. Once a file is tracked (committed), Git will continue tracking it regardless of what the `.gitignore` says. You must explicitly remove it from tracking using `git rm --cached database-creds.txt` before the ignore rule takes effect.*
+Now consider a late ignore rule. You committed `database-creds.txt` last week, then today you add that filename to `.gitignore` and edit the file. Git will still report the modification because the file is already tracked. To stop tracking the file while keeping the local copy, you would need a command such as `git rm --cached database-creds.txt`, followed by a commit, and you would still rotate any credential that was ever committed.
+
+This is why a strong Git workflow is both technical and behavioral. The technical controls are `.gitignore`, `git status`, `git diff`, and secret scanning on the server side. The behavior is slower and more deliberate: do not stage blindly, do not store real credentials in practice manifests, and do not assume a later cleanup commit erases exposure. Git history is useful because it remembers, and that same remembering makes leaked secrets persistent.
+
+For Kubernetes and cloud projects, a useful `.gitignore` policy usually appears before the first serious commit. Local kubeconfig files, generated manifests, temporary logs, Terraform working directories, and downloaded tool caches can all accumulate quickly. Some of those files are harmless noise, while others may contain credentials or environment-specific state. Ignoring them early keeps reviews focused on source files and reduces the chance that a local workstation detail becomes part of the team's permanent history.
+
+## Patterns & Anti-Patterns
+
+Git patterns are useful when they make history easier to review and safer to automate. The common thread is intentionality: stage intentionally, commit one coherent change at a time, and keep generated or sensitive files out of the repository. The anti-patterns below usually come from speed pressure, but they create slower recovery later because the history stops answering operational questions.
+
+| Pattern or Anti-Pattern | When It Appears | Why It Matters | Better Habit |
+| :--- | :--- | :--- | :--- |
+| Pattern: inspect before staging | Any change to code, YAML, scripts, or docs | You catch accidental edits, debug output, and secrets before they enter history. | Run `git status`, then `git diff`, then stage named files. |
+| Pattern: focused commits | A task touches several files for different reasons | Reviewers can understand and revert one logical change without dragging unrelated work along. | Commit the namespace change separately from README edits or local experiments. |
+| Pattern: repository-root `.gitignore` | A project has generated files, logs, state files, or local credentials | Shared ignore policy prevents common local noise from appearing for every contributor. | Review ignore patterns with the same care as build or deployment configuration. |
+| Anti-pattern: broad staging by reflex | A learner types `git add .` after every edit | Git may stage files the learner forgot existed, including generated files or local configuration. | Use named files first; use broad staging only after reading status and diff carefully. |
+| Anti-pattern: vague commit messages | A branch has messages such as "update" or "fix" | Incident review becomes slower because history no longer explains intent. | Write a short subject that names the operational reason for the snapshot. |
+| Anti-pattern: treating pull as harmless | A local branch has uncommitted work and the remote moved | Pull may create conflicts or merge commits before the learner understands local state. | Start with `git status`; commit, stash, or discard local work deliberately before integrating remote history. |
+
+## Decision Framework
+
+When Git feels confusing, choose the next command based on the state you need to inspect or change, not based on a memorized sequence. The same repository may need different commands depending on whether the problem is untracked files, unstaged edits, staged changes, missing remote commits, or a branch that has not been pushed before. This table gives you a beginner decision path that is conservative enough for infrastructure work.
+
+| Situation | Safer First Question | Command to Start With | What You Do Next |
+| :--- | :--- | :--- | :--- |
+| You edited files and want to know what Git sees | Which tree contains the change? | `git status` | Read whether files are untracked, unstaged, or staged. |
+| You want to review exact line changes | What would surprise a reviewer? | `git diff` | Stage only the intended files after reading the patch. |
+| You already staged changes but want to inspect staged content | What is in the next snapshot? | `git diff --staged` | Commit if it is correct, or unstage and revise. |
+| You want a local save point | Does the staged change have one coherent reason? | `git commit -m "message"` | Write a message that explains intent, not just mechanics. |
+| You need work from the remote | Has my local branch got uncommitted work? | `git status` then `git pull` | Pull only when the local state is understood and ready. |
+| You need to share local commits | Does the remote have work I lack? | `git push` or explicit `git push -u origin main` | If rejected, fetch or pull, integrate, and push again. |
+
+Use `git init` when you are starting a brand-new local repository in a directory that does not already have history. Use `git clone` when the project already exists somewhere else and you want your local copy to share that existing history. Use `.gitignore` before local files pile up, especially when a project touches credentials or generated artifacts. Use `git log` when behavior changed and you need a timeline, not when you are trying to inspect uncommitted edits.
+
+The decision framework also helps you avoid destructive commands early in your Git journey. There are commands that rewrite history, discard changes, or remove files from the index, and you will learn some of them later. At this stage, prefer observation commands first. A clean diagnosis with `status`, `diff`, and `log` makes recovery commands safer because you know exactly which state you are trying to change.
 
 ## Did You Know?
 
-1. **Git was built in two weeks.** In 2005, the Linux kernel project lost its free BitKeeper arrangement, which pushed Linus Torvalds and the community to create Git quickly as a replacement.
-2. **The name is a self-deprecating insult.** Torvalds, known for his abrasive humor, named the system ["Git" (British slang for a stubborn, unpleasant, or incompetent person)](https://en.wikipedia.org/wiki/Git). He famously joked at a conference, "I'm an egotistical bastard, and I name all my projects after myself. First Linux, now Git."
-3. **Git does not track empty directories.** Git does not track empty directories on their own. If a team wants an otherwise empty directory to exist in the repository, it usually adds a small placeholder file inside it.
-4. **Colossal collision resistance.** Historically, Git has identified objects with 40-character SHA-1 values. Accidental collisions are extremely unlikely in normal use, but SHA-1 is no longer considered strong enough for long-term cryptographic collision resistance, which is one reason newer Git work supports SHA-256.
+1. **Git was built in 2005 under intense pressure.** The Linux kernel project lost its free BitKeeper arrangement, which pushed Linus Torvalds and contributors to create a replacement quickly for a very large distributed project.
+2. **The name is intentionally cheeky.** Torvalds has joked about the name ["Git" in public talks and interviews](https://en.wikipedia.org/wiki/Git), and the name stuck because the tool solved a real collaboration problem better than the alternatives available to the kernel community.
+3. **Git does not track empty directories.** Git tracks file content, so teams that need an otherwise empty directory usually add a small placeholder file such as `.gitkeep` by convention.
+4. **Object identifiers are part of Git's integrity model.** Many repositories still display 40-character SHA-1 object names, while modern Git also includes support for SHA-256 repositories for stronger long-term collision resistance.
 
 ## Common Mistakes
 
 | Mistake | Why It Happens | How to Fix It |
 | :--- | :--- | :--- |
-| **Accidentally committing a password/secret** | Using the indiscriminate `git add .` command without reviewing `git status` first, accidentally dragging a `.env` file into the staging area. | If unpushed: `git reset HEAD~1` to undo the commit locally. If pushed, **the secret is compromised**. You must promptly revoke or rotate the credential in AWS/GCP. Do not just delete it in a new commit; the history is permanent. |
-| **"fatal: refusing to merge unrelated histories"** | You initialized a repository locally, and initialized a separate repository on GitHub with a default README, then tried to pull. Git thinks they are two completely different, unrelated projects. | Run `git pull origin main --allow-unrelated-histories` to forcefully instruct Git to combine the two distinct timelines into one. |
-| **"Updates were rejected because the remote contains work that you do not have locally"** | A teammate pushed new commits to the GitHub server while you were working offline. Git refuses to let you push and overwrite their work. | Run `git pull` first to download and integrate their changes into your local branch. Resolve any potential merge conflicts, then run `git push`. |
-| **Empty or meaningless commit messages** | Rushing the job. Using vague messages like `git commit -m "update"` or `git commit -m "fixed stuff"`. | Use `git commit --amend -m "new better message"` if you haven't pushed yet. Develop a professional habit of writing "Why" not just "What". |
-| **Forgetting to stage files before committing** | Running `git commit -m "message"` while your changes are still sitting in the Working Directory, entirely bypassing the Staging Area. | Run `git status` to see what is unstaged. Run `git add <file>` to move the changes to the stage, then retry the `git commit` command. |
-| **Committing massive binary files** | Accidentally adding compiled artifacts, database memory dumps, or large videos to the repository. Git is designed for text tracking, not large binaries. | Remove the file from the tracking database with `git rm --cached <file>`, commit the removal, and immediately add the file type to your `.gitignore`. |
+| Accidentally committing a password or secret | The learner stages broadly without reading `git status` and `git diff`, so a local `.env` or credential file enters the commit. | If it was pushed, rotate the credential immediately and follow the repository's secret-removal process. If it was only local, remove it from history before sharing and add an ignore rule. |
+| Seeing "fatal: refusing to merge unrelated histories" | A repository was initialized locally, while the hosting service also created its own first commit such as a README. | Prefer cloning an existing remote. If combining histories is truly intended, use the explicit unrelated-histories option only after reviewing why the histories differ. |
+| Getting "updates were rejected" during push | The remote branch has commits that the local branch lacks, often because someone pushed while you were offline. | Fetch or pull the remote work, resolve any conflicts, verify the combined history, and push again only after the local branch includes the remote commits. |
+| Writing empty or meaningless commit messages | The learner treats commits as checkpoints for themselves rather than messages to future maintainers. | Amend an unpushed commit message when needed and practice explaining the operational reason for each snapshot. |
+| Forgetting to stage files before committing | The working directory contains changes, but the staging area is empty when `git commit` runs. | Run `git status`, stage the intended files with `git add <file>`, inspect again, and retry the commit. |
+| Committing generated or binary artifacts | Build outputs and logs sit beside source files, and the repository has no ignore policy yet. | Remove accidental tracked artifacts with the appropriate Git command, commit the cleanup, and add patterns to `.gitignore` before more work continues. |
+| Adding an ignore rule after a file is already tracked | The learner expects `.gitignore` to override history for files already committed. | Remove the file from tracking with an index-only removal such as `git rm --cached <file>`, commit that change, and rotate secrets if sensitive content was ever committed. |
 
 ## Quiz
 
 <details>
-<summary>1. Your team just deployed a new Kubernetes configuration, and the cluster immediately crashed. You need to quickly see who made the last change and what their commit message was. Which command do you run?</summary>
-You should run `git log` or `git log --oneline`. This command displays the commit history in reverse chronological order, showing the author, the timestamp, and the commit message for each snapshot. By analyzing this output, you can instantly identify who made the recent changes and read their explanation for why the change was necessary. This rapid historical visibility is exactly why version control is critical during a production incident.
+<summary>1. Your team deployed a Kubernetes configuration and behavior changed immediately. You need to identify the recent commits, authors, and messages before deciding what to inspect next. Which Git command gives you the timeline, and why is it the right starting point?</summary>
+
+Use `git log`, or `git log --oneline` when you need a compact scan. The log shows committed history in reverse chronological order, so it answers who created recent snapshots and what messages they left. `git status` would only describe uncommitted local state, and `git diff` would only show unstaged line changes. During incident triage, the timeline narrows the search before you inspect individual patches.
+
 </details>
 
 <details>
-<summary>2. You have modified a `service.yaml` file on your laptop to expose a new port. You type `git commit -m "expose port 8080"`, but Git returns a message saying "nothing added to commit but untracked files present". What did you forget to do?</summary>
-You forgot to move the file from the Working Directory to the Staging Area using the `git add` command. Git's architecture requires you to explicitly select which files should be included in the next snapshot. Because you bypassed the Staging Area, Git saw your modified file but refused to automatically include it in the repository. You must run `git add service.yaml` before you attempt to commit again.
+<summary>2. You modified `service.yaml` and ran `git commit -m "expose port 8080"`, but Git said nothing was added to commit. What state did you forget to change, and how should you recover?</summary>
+
+The file was still in the working directory and had not been moved into the staging area. Git does not automatically include every modified file in a commit, because the staging area is where you choose the next snapshot's contents. Run `git status` to confirm the file state, then `git add service.yaml`, inspect status again, and rerun the commit. This preserves the deliberate two-step model that keeps unrelated edits out of history.
+
 </details>
 
 <details>
-<summary>3. You are about to stage `configMap.yaml`, but you cannot remember if you set the database password to the testing password or left the production password in there. What command should you run to inspect the exact lines you changed before staging?</summary>
-You should run `git diff` to view the exact line-by-line changes. This command compares your current Working Directory against the last saved snapshot in the repository. It will display the removed lines in red and the added lines in green, allowing you to objectively verify the contents of the file. Relying on this command prevents you from accidentally committing production secrets into the permanent history graph.
+<summary>3. You are about to stage `configMap.yaml`, but you are unsure whether a real database password is still present in the edited lines. What should you inspect before staging, and what decision should follow?</summary>
+
+Run `git diff` before staging so you can inspect the exact unstaged line changes. If the diff contains a real password, do not stage or commit it; remove the secret, replace it with a safe placeholder or external reference, and verify the diff again. `git log` would not help because the risky content is not committed yet. The safest decision is to make the patch clean before it enters the staging area.
+
 </details>
 
 <details>
-<summary>4. You just joined a new project. You clone the repository and discover Git does not know your `user.name` and `user.email`, so it tells you to run `git config` before committing. Why is this necessary, and how is that different from the authentication prompts you might see during `git push`?</summary>
-Git requires an author identity when you create a commit, so `user.name` and `user.email` must be configured before `git commit` can record who authored the snapshot. That identity is stored in the commit metadata for accountability and traceability. By contrast, prompts during `git push` are usually remote authentication checks from the hosting service, such as an HTTPS credential helper, a personal access token, or SSH keys. In short: commit identity is local metadata for `git commit`; push-time authentication proves you are allowed to upload to the remote.
+<summary>4. You cloned a repository and Git asks you to configure `user.name` and `user.email` before committing. Later, `git push` asks for remote credentials. Why are these two prompts different?</summary>
+
+`user.name` and `user.email` are local commit metadata that identify the author recorded inside new commits. Remote credentials prove to the hosting service that you are allowed to upload commits to that repository. The first setting affects the saved snapshot's attribution, while the second controls network access. Confusing them leads learners to think a successful local commit means the remote will also accept a push, which is not guaranteed.
+
 </details>
 
 <details>
-<summary>5. You created a file named `aws-credentials.json` on your local machine to test a script. You never want this file to be committed to the company repository. What exactly should you do to ensure it is ignored forever?</summary>
-You must create a plain text file named `.gitignore` in the root of your repository if one does not already exist. Inside this file, you need to add the exact filename `aws-credentials.json` on a new line. Git reads this configuration file top-to-bottom and will automatically filter out any matching files from its tracking radar. This ensures the credentials file is much less likely to be accidentally staged or committed, helping prevent a severe security breach.
+<summary>5. You created `aws-credentials.json` for a local test and never want it committed. What should you do before staging other work, and what limitation must you remember?</summary>
+
+Add `aws-credentials.json` to the repository's `.gitignore` file before broad staging, then run `git status` to confirm the file no longer appears as an untracked candidate. The limitation is that `.gitignore` only applies to untracked files. If the file was already committed, Git will continue tracking it until you explicitly remove it from the index, and any real secret inside should be considered exposed. The safer workflow is to prevent tracking before the file ever reaches a commit.
+
 </details>
 
 <details>
-<summary>6. A junior developer is trying to "reset" a broken project to start over. They open their file explorer, delete the hidden `.git` folder, and then type `git status` in their terminal, expecting Git to realize the project was reset and show an empty history. What actually happens, and why?</summary>
-When the developer types `git status`, the terminal will return a "fatal: not a git repository" error because they have completely destroyed the version control system for that folder. The hidden `.git` directory is not just a configuration file; it is the entire actual repository database containing all commits, branches, and historical snapshots. By deleting it, they did not reset the history—they permanently erased it locally, turning their project back into a normal, untracked folder on their operating system. The working files on their disk remain untouched, but Git no longer manages them.
+<summary>6. A learner deletes the hidden `.git` directory to "reset" a broken project, then runs `git status`. What happens, and why is this not a safe recovery method?</summary>
+
+Git reports that the directory is not a Git repository, because the `.git` directory contained the repository database, branches, references, and local history. Deleting it does not create a clean Git history; it destroys the local repository metadata while leaving ordinary working files behind. A safer recovery starts with observation commands and a clear goal, such as unstaging a file or reverting a commit. Removing `.git` should not be treated as a normal troubleshooting step.
+
 </details>
 
 <details>
-<summary>7. You and a colleague are both modifying the same `nginx-deployment.yaml` file. They push a change that sets `replicas: 5` while you are offline. You locally change the same line to `replicas: 2` and attempt to push. Git rejects your push, so you run `git pull`. What happens next, and how do you resolve it?</summary>
-Git will attempt to automatically merge the changes, but because you both modified the exact same line, it will pause and declare a merge conflict. It cannot safely guess whether the deployment should have 5 replicas or 2, so it leaves the decision to a human. To resolve the conflict, you must open the file in your editor and locate the conflict markers (which look like `<<<<<<< HEAD` and `>>>>>>>`). After manually editing the file to the desired state and removing the markers, you must use `git add` and `git commit` to finalize the merge before pushing.
+<summary>7. You and a colleague both changed the same `replicas` line in `nginx-deployment.yaml`. Their change reached the remote first, your push is rejected, and then you pull. What should you expect and how do you resolve it?</summary>
+
+Git may stop with a merge conflict because two histories changed the same line differently, and it cannot know which replica count is operationally correct. Open the file, read the conflict markers, choose or combine the intended value, and remove the markers. Then stage the resolved file and complete the merge commit before pushing. The important point is that Git detects the unsafe overlap, but a human still owns the infrastructure decision.
+
 </details>
 
 ## Hands-On Exercise
 
-In this exercise, you will create a local repository from scratch, simulate a standard engineering workflow by making multiple logical commits, and observe the resulting history. We will use dummy Kubernetes configuration files to simulate a real infrastructure workflow.
+In this exercise, you will create a local repository from scratch, simulate a standard engineering workflow by making multiple logical commits, and observe the resulting history. The files are small Kubernetes-style examples so you can focus on Git's state transitions rather than cluster behavior. Work in a disposable directory, read `git status` after each meaningful step, and do not use real credentials anywhere in the practice files.
 
 ### Task 1: Initialization
-Create a new directory named `dojo-k8s-project` and navigate into it. Initialize an empty Git repository.
+
+Create a new directory named `dojo-k8s-project`, navigate into it, and initialize an empty Git repository so you can observe the first status report from a clean practice workspace.
+
 - [ ] Directory created and navigated into.
 - [ ] Git repository initialized.
 
@@ -536,10 +543,13 @@ cd dojo-k8s-project
 git init
 git status
 ```
+
 </details>
 
 ### Task 2: The Initial Commit
-Create a `README.md` file with the text "# KubeDojo Project". Stage the file and commit it with the message "docs: add initial readme".
+
+Create a `README.md` file with the text "# KubeDojo Project". Stage the file and commit it with the message "docs: add initial readme". This task checks that you can move a new file through the working directory, staging area, and repository history without skipping the state checks.
+
 - [ ] File created with correct content.
 - [ ] File added to staging area.
 - [ ] Commit successfully created.
@@ -554,17 +564,22 @@ git add README.md
 git status
 git commit -m "docs: add initial readme"
 ```
+
 </details>
 
 ### Task 3: Simulating Infrastructure Development
-Create a file named `deployment.yaml` and add the following dummy content:
+
+Create a file named `deployment.yaml` and add the following dummy content so the repository has an infrastructure-style file to track:
+
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: web
 ```
-Stage and commit this file with the message "feat: add web deployment skeleton".
+
+Stage and commit this file with the message "feat: add web deployment skeleton" after confirming that Git reports the file as untracked.
+
 - [ ] File created.
 - [ ] Commit successfully created with correct message.
 
@@ -583,10 +598,13 @@ git status
 git add deployment.yaml
 git commit -m "feat: add web deployment skeleton"
 ```
+
 </details>
 
 ### Task 4: Modifying Existing Files
-Open `deployment.yaml` and add `replicas: 3` under a `spec:` block, so it looks like this:
+
+Open `deployment.yaml` and add `replicas: 3` under a `spec:` block, then inspect the resulting line change before you stage it:
+
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -595,7 +613,9 @@ metadata:
 spec:
   replicas: 3
 ```
+
 Use a command to view the exact differences before staging. Then, stage and commit the change with the message "fix: set deployment replicas to 3".
+
 - [ ] File modified.
 - [ ] Diff viewed successfully.
 - [ ] Change staged and committed.
@@ -621,10 +641,13 @@ git diff
 git add deployment.yaml
 git commit -m "fix: set deployment replicas to 3"
 ```
+
 </details>
 
 ### Task 5: Reviewing the Timeline
-Run a command to view your complete commit history in a compact, single-line format. Verify that all three of your commits are present in chronological order.
+
+Run a command to view your complete commit history in a compact, single-line format. Verify that all three of your commits are present in chronological order. If a commit is missing, use `git status` to determine whether the change is still unstaged, staged, or never created.
+
 - [ ] History command executed.
 - [ ] Three distinct commits visible in the output.
 
@@ -634,17 +657,21 @@ Run a command to view your complete commit history in a compact, single-line for
 ```bash
 git log --oneline
 ```
+
 Output should look similar to:
+
 ```text
 3b2a1c4 fix: set deployment replicas to 3
 9f8e7d6 feat: add web deployment skeleton
 1a2b3c4 docs: add initial readme
 ```
+
 </details>
 
 ### Task 6: Bonus Challenge — Advanced Ignore Rules
-You are working on a new application that generates numerous log files ending in `.log` across various directories. You want Git to ignore all of them to save space, but you must ensure that one specific file named `audit-trail.log` in the root directory is always tracked for compliance reasons.
-Create a `.gitignore` file that achieves this exact configuration. Verify your solution by creating dummy files (e.g., `app.log`, `database.log`, and `audit-trail.log`) and checking `git status` to ensure only `audit-trail.log` is ready to be tracked.
+
+You are working on a new application that generates numerous log files ending in `.log` across various directories. You want Git to ignore all of them to save space, but you must ensure that one specific file named `audit-trail.log` in the root directory is always tracked for compliance reasons. Create a `.gitignore` file that achieves this exact configuration, then verify the result with dummy files and `git status`.
+
 - [ ] `.gitignore` file created with appropriate wildcard and exclusion rules.
 - [ ] Dummy files created to test the rules.
 - [ ] `git status` confirms only the required file is untracked.
@@ -667,16 +694,36 @@ touch audit-trail.log
 # Check status
 git status
 ```
+
 Git will show `.gitignore` and `audit-trail.log` as untracked files. The other `.log` files will be successfully ignored.
+
 </details>
 
----
+### Success Criteria
 
-**Next Module**: [Module 0.7: What is Networking?](../module-0.7-what-is-networking/) — Now that you can track files, it is time to understand how computers actually talk to each other across the wires.
+- [ ] You can explain the difference between the working directory, staging area, and repository history using your own practice files.
+- [ ] You created at least three focused commits with meaningful messages.
+- [ ] You inspected a diff before staging a Kubernetes-style YAML change.
+- [ ] You used `git log --oneline` to verify the resulting history.
+- [ ] You created and tested a `.gitignore` rule that ignores a broad pattern while allowing one exception.
 
 ## Sources
 
-- [Git](https://en.wikipedia.org/wiki/Git) — Overview of Git, including its history and naming background.
-- [Git Guide](https://github.com/git-guides) — A concise beginner-friendly overview of Git concepts, commands, and workflow.
-- [Git Guides: git pull](https://github.com/git-guides/git-pull) — Explains remote synchronization in the same beginner-friendly register as this module.
-- [github/gitignore](https://github.com/github/gitignore) — Provides practical `.gitignore` examples learners can reuse immediately.
+- [Git documentation](https://git-scm.com/docs)
+- [Git book: Getting Started](https://git-scm.com/book/en/v2/Getting-Started-About-Version-Control)
+- [Git book: Git Basics](https://git-scm.com/book/en/v2/Git-Basics-Getting-a-Git-Repository)
+- [Git documentation: git-init](https://git-scm.com/docs/git-init)
+- [Git documentation: git-config](https://git-scm.com/docs/git-config)
+- [Git documentation: git-status](https://git-scm.com/docs/git-status)
+- [Git documentation: git-add](https://git-scm.com/docs/git-add)
+- [Git documentation: git-commit](https://git-scm.com/docs/git-commit)
+- [Git documentation: git-diff](https://git-scm.com/docs/git-diff)
+- [Git documentation: git-log](https://git-scm.com/docs/git-log)
+- [Git documentation: gitignore](https://git-scm.com/docs/gitignore)
+- [GitHub Git Guide](https://github.com/git-guides)
+- [GitHub Git Guide: git pull](https://github.com/git-guides/git-pull)
+- [GitHub gitignore templates](https://github.com/github/gitignore)
+
+## Next Module
+
+[Module 0.7: What is Networking?](../module-0.7-what-is-networking/) — Now that you can track files, it is time to understand how computers talk to each other across networks.


### PR DESCRIPTION
## Summary
- Rewrote `src/content/docs/prerequisites/zero-to-terminal/module-0.6-git-basics.md` for #388 density, structure, alignment, and anti-leak gates.
- Cleared `revision_pending` to `false`.
- Commit: `ffd88daf41c26313cfce2a0b518d49ba5f2c8691`.

## Verifier
- `verify_module.py --skip-source-check`: tier T0; body_words=5179, mean_wpp=58.9, median_wpp=66.0, short_rate=0.091, max_run=1, mean_sentence_length=19.2.
- Sources reachability was intentionally skipped per dispatch; Sources section has 14 counted URLs.

## Protected Assets
- Code blocks preserved: 42 before / 42 after.
- ASCII diagrams preserved: 0 before / 0 after; mermaid diagrams: 0 before / 0 after.
- Tables preserved/expanded: 1 before / 3 after.
- Original URLs retained: 5 before / 5 retained, with additional primary/vendor docs added under Sources.

## Checks
- `../../.venv/bin/python scripts/quality/verify_module.py --glob src/content/docs/prerequisites/zero-to-terminal/module-0.6-git-basics.md --skip-source-check --summary --quiet` passed T0.
- `../../.venv/bin/python scripts/test_pipeline.py` passed: 170 tests.
- `git diff --check -- src/content/docs/prerequisites/zero-to-terminal/module-0.6-git-basics.md` clean.
- Forbidden-token / kubectl-alias scan clean.
- `npm run build` was attempted in the worktree and failed with the known Astro worktree node_modules resolution issue: cannot resolve `../../node_modules/@astrojs/starlight/style/layers.css` from `src/layouts/Homepage.astro`.