### PR TITLE
feat(388): rewrite module-1.6-using-ai-for-learning-writing-research-and-coding (#388 pilot)

### DIFF
--- a/src/content/docs/ai/foundations/module-1.6-using-ai-for-learning-writing-research-and-coding.md
+++ b/src/content/docs/ai/foundations/module-1.6-using-ai-for-learning-writing-research-and-coding.md
@@ -1,47 +1,40 @@
 ---
 title: "Using AI for Learning, Writing, Research, and Coding"
 slug: ai/foundations/module-1.6-using-ai-for-learning-writing-research-and-coding
+revision_pending: false
 sidebar:
   order: 6
 ---
 
-> **AI Foundations** | Complexity: `[MEDIUM]` | Time: 35-45 min
+> **Complexity**: `[MEDIUM]`
+>
+> **Time to Complete**: 45-60 min
+>
+> **Prerequisites**: Completion of the earlier AI Foundations modules, basic comfort with command-line examples, and a willingness to verify model output before trusting it.
+
+---
+
+## Learning Outcomes
+
+- Evaluate when AI assistance improves learning, writing, research, or coding without replacing human judgment.
+- Design verification checkpoints that connect AI claims, drafts, and code suggestions to primary sources, tests, and evidence.
+- Diagnose weak prompts and rewrite them into prompts that request decomposition, constraints, alternatives, and review criteria.
+- Implement a reusable four-workflow practice loop for AI-supported learning, writing, research, and coding tasks.
+- Compare patterns and anti-patterns for safe AI use in individual study, team documentation, and production engineering work.
 
 ## Why This Module Matters
 
-Most people will first experience AI through ordinary work:
-- learning
-- writing
-- research
-- coding
+Hypothetical scenario: you are preparing for a Kubernetes 1.35 platform review, and you need to learn a networking concept, clean up a rough design note, compare several source documents, and debug a manifest that an AI assistant helped draft. Each task feels ordinary, but together they create a professional risk: a tool that accelerates your work can also hide gaps in your understanding. If you accept a confident summary, polished paragraph, source claim, or YAML change without inspection, the work may look finished while the underlying reasoning is still weak.
 
-The question is not whether AI can help. The question is whether it helps without making your thinking weaker.
+Most people first meet AI through ordinary knowledge workflows: learning a concept, writing a draft, researching a decision, or coding a small change. Those workflows are not side activities around engineering; they are how engineering judgment is formed and expressed. A platform engineer who cannot explain a manifest, defend a tradeoff, or trace a claim back to evidence is not safer because a model produced the text quickly. The question is not whether AI can help, but whether it helps without making your thinking weaker.
 
-## What You'll Learn
+This module gives you a practical operating model for AI-assisted work. You will treat AI as a high-speed collaborator for decomposition, comparison, drafting, and review, while you keep ownership of truth, intent, and consequences. The central habit is simple: use AI to reduce friction, then add explicit checkpoints where a human verifies meaning, sources, security, and tests. That habit works across learning, writing, research, and coding because each workflow has the same failure mode: fluency can arrive before understanding.
 
-- good uses of AI in common knowledge workflows
-- where AI accelerates work without replacing judgment
-- how to avoid dependence and shallow understanding
-- how to keep yourself, not the model, as the real learner and author
+## Evaluate AI Assistance Without Replacing Judgment
 
-## The Main Principle
+AI should reduce friction, not replace thought. That sentence sounds simple until a deadline arrives and the generated answer looks cleaner than your own notes. In professional work, the useful question is not "Can AI do this?" but "Will using AI here make the work clearer, faster, and still trustworthy?" The first question measures capability; the second measures responsibility. A model can draft, summarize, compare, and suggest, but it cannot be accountable for the consequences of what you ship, cite, or teach.
 
-AI should reduce friction, not replace thought.
-
-The practical question is not:
-
-> “Can AI do this?”
-
-It is:
-
-> “Will using AI here make the work clearer, faster, and still trustworthy?”
-<!-- v4:generated type=thin model=gemini turn=1 -->
-
-In professional engineering, this manifests as the "Pilot vs. Autopilot" distinction. An autopilot maintains a steady state, but the pilot remains responsible for the flight path and reacting to anomalies. When you use AI to generate a Kubernetes manifest, the friction reduced is the manual lookup of YAML schema and API versions. However, the thought process must remain focused on the *implications* of that manifest: Are the resource limits appropriate for the cluster's node types? Is the `imagePullPolicy` optimized for cost? If you delegate these decisions to the model, you haven't just reduced friction; you've outsourced the engineering responsibility that justifies your role.
-
-Developing a "Human-in-the-Loop" workflow requires shifting from a consumer mindset to an editorial one. Instead of asking for a solution, ask for a decomposition. For example, when researching a new library or protocol, use the AI to generate a list of "unknown unknowns" or edge cases rather than a summary of the happy path. This forces the AI to serve your inquiry rather than leading it. In practice, this prevents the "hallucination trap" where a plausible-sounding but incorrect explanation is accepted because it aligns with a superficial understanding of the topic.
-
-Consider the difference in a typical coding or ops task where AI is used as a filter rather than a raw source:
+The clearest mental model is the difference between a pilot and an autopilot. An autopilot can maintain a steady course under known conditions, but the pilot remains responsible for route, weather, fuel, warnings, and exceptions. When you use AI to generate a Kubernetes manifest, the friction reduced is the lookup of YAML shape, field names, and API conventions. The engineering work remains in deciding whether the resource limits fit the node pool, whether the security posture is acceptable, and whether the generated change matches the operational intent.
 
 ```bash
 # Instead of: "Write a script to clean up my cluster"
@@ -53,48 +46,29 @@ Consider the difference in a typical coding or ops task where AI is used as a fi
 # suggested adding a 'securityContext'—is it strictly necessary for this use case?"
 ```
 
-This distinction matters because "AI-assisted technical debt" accumulates faster than manual debt. When code is written by a human, there is an implicit understanding of *why* certain trade-offs were made. When AI writes code without rigorous human review, the "why" is often missing, leaving future maintainers—or your future self—with a codebase that functions but remains fundamentally opaque. High-performing practitioners use AI to accelerate the "how" while strictly guarding the "why," ensuring that every line of generated text or code remains a deliberate choice rather than a convenient copy-paste.
+That original audit prompt is worth preserving because it changes the model's job from answer factory to reasoning assistant. A request for a cleanup script invites the model to optimize for completion, which can be dangerous when deletion, disruption, or authorization is involved. A request to analyze evidence and propose a safe strategy forces the output to mention conditions, constraints, and uncertainty. You still have to verify the response, but you have made verification easier because the model must expose its reasoning path.
 
-<!-- /v4:generated -->
-## Good Uses
+Pause and predict: if two learners ask AI about the same topic, and one asks for "the answer" while the other asks for assumptions, edge cases, and tests, who is more likely to notice a wrong but plausible response? The second learner has a better chance because the prompt creates places for disagreement. A model can still be wrong, but a structured answer gives you more handles to inspect. In technical work, those handles are often more valuable than the first answer.
 
-### Learning
+The four common workflows in this module share one boundary: AI may accelerate the how, but you must keep the why. In learning, that means the model can restate a concept, generate practice questions, and compare mental models, but you still need to explain the concept in your own words. In writing, it can tighten structure and tone, but the argument must be yours. In research, it can suggest search directions and gaps, but source authority remains external to the model. In coding, it can propose tests and drafts, but correctness belongs to inspection and execution.
 
-- explain a concept at different levels
-- generate practice questions
-- compare two mental models
+AI-assisted technical debt accumulates faster than manual technical debt because the output arrives with very little friction. When a human writes code slowly, the reasoning usually leaves traces in names, comments, commit history, and design notes. When a model produces code quickly, the "why" can vanish unless you deliberately add it back. Future maintainers then inherit something that may function today but feels opaque tomorrow. Your job is to keep every accepted output explainable enough that a teammate can review, test, and revise it without guessing.
 
-### Writing
+The practical self-check is direct: after using AI, can you explain the output in your own words, defend the decision without the model, and name what still needs verification? If the answer is no, you are probably outsourcing too much. That does not mean you must avoid AI; it means you should change the prompt, gather more evidence, or slow down before accepting the result. Strong AI use is not abstinence from assistance. It is disciplined assistance with visible human checkpoints.
 
-- rewrite for tone or clarity
-- compress long drafts
-- propose structure for messy ideas
+## Design Verification Checkpoints for Learning, Writing, Research, and Coding
 
-### Research
+Verification is not a separate cleanup step after AI use; it is the workflow design. A safe workflow creates checkpoints before the model's output becomes part of your knowledge, document, decision, or repository. The checkpoint can be a source link, a test run, a peer review, a comparison table, or a written explanation in your own words. What matters is that the model's fluency does not become the evidence. Evidence must come from primary sources, runnable behavior, or accountable human judgment.
 
-- generate search directions
-- summarize source material you already have
-- identify gaps or follow-up questions
+For learning, the first checkpoint is pre-work. Write what you already think before asking the model, even if your explanation is incomplete. This gives you a baseline to compare against, which prevents the model's wording from becoming your only mental representation. Then ask for simpler explanations, analogies, contrasting examples, and practice questions. The goal is not to memorize the generated answer. The goal is to expose where your model is fuzzy enough that a good question can improve it.
 
-### Coding
+For writing, the checkpoint is intent. A model is useful for structure, tone, concision, and transitions, but it cannot know what you truly mean unless you provide a rough claim, audience, constraints, and non-negotiable points. If you ask it to "write a proposal" before your argument exists, it may produce text that sounds informed while hiding the fact that you have not made a decision. Better writing prompts ask for alternatives, preserve meaning, and force a change log so you can accept or reject edits deliberately.
 
-- explain code
-- propose tests
-- suggest refactors
-- accelerate debugging hypotheses
+For research, the checkpoint is source separation. Treat AI-generated research directions as leads, not citations. The model can help you frame questions, discover terminology, compare documents you provide, and identify missing angles. It should not be the final authority for claims about standards, APIs, legal requirements, security controls, or incident facts. A useful research note distinguishes "model suggested this angle" from "source supports this claim" and "still needs checking." That distinction protects your credibility when the work becomes a decision.
 
-These are good uses because they:
-- help you move faster
-- expose more options
-- reduce blank-page friction
-- still leave judgment with you
-<!-- v4:generated type=thin model=gemini turn=2 -->
+For coding, the checkpoint is executable evidence. A generated snippet is not done when it compiles in the model's answer; it is done when you understand it, run it, test it, and review the failure modes. This is especially important for infrastructure, where a permissive RBAC rule, unsafe cleanup script, or unbounded resource setting can appear to solve the immediate problem while creating risk. Before running this, what output do you expect, and what output would prove the model misunderstood the task?
 
-Beyond simple explanations, AI excels at **epistemic stress-testing**. In practice, this means using the model to identify "missing tiles" in your mental map. Instead of asking "How does X work?", practitioners should prompt the AI to "Identify the three most common misconceptions experts have about X, and explain why a novice might fall into those traps." This forced perspective shift moves you from passive consumption to active synthesis. By treating the model as a Socratic interlocutor, you aren't just getting facts; you're building a structural understanding that is resilient to edge cases and real-world complexity.
-
-In software engineering, the most potent use case isn't writing the initial code, but **adversarial design review**. Before committing to a specific architectural pattern or library, you can use a Large Language Model (LLM) to simulate the failure modes of your proposed solution. This matters because it allows you to iterate on "software-defined infrastructure" at the speed of thought before you've even initialized a repository. By providing the model with your high-level constraints—such as high availability requirements, 200ms latency p99 targets, and strictly limited egress—you can ask it to generate a "pre-mortem" report. This identifies where your logic might break under load or during a network partition, saving hours of refactoring later in the development cycle.
-
-For instance, when debugging a complex Kubernetes deployment, rather than asking for a quick fix, ask for a **diagnostic decision tree**. This approach prioritizes your own technical growth by forcing you to follow the investigative path:
+The following preserved prompt shows a healthier debugging pattern because it asks for a decision tree rather than a magic fix. It keeps the learner in the investigation and requires the model to connect commands to observable outcomes. That is the right shape for many operational questions, especially when several causes can create the same symptom.
 
 ```markdown
 "I am seeing ImagePullBackOff on a private registry deployment.
@@ -105,22 +79,41 @@ network policy blocks, and DNS resolution issues.
 For each command, explain what 'success' vs 'failure' looks like."
 ```
 
-For research and documentation, the value lies in **semantic cross-referencing**. When you have a stack of disparate documents—perhaps a series of RFCs, post-mortems, and whitepapers—the AI acts as a "knowledge bridge." It can identify non-obvious correlations across different domain-specific languages (DSLs). This matters because it breaks down information silos within a project. You can ask the model to "Map the security constraints mentioned in Document A to the performance optimizations proposed in Document B," highlighting potential conflicts that a human might miss when reading the documents in isolation over several days. This transformational use of AI ensures that your research results in a cohesive strategy rather than a collection of disconnected notes.
+Notice what this prompt does not do. It does not ask the model to guess the secret, mutate the cluster, or skip straight to a patch. It asks for a diagnostic sequence that separates authentication, network policy, and DNS resolution. That makes the response reviewable because each suggested command has an expected interpretation. If a command is irrelevant, too broad, or unsafe, you can catch that before acting. A good AI prompt often looks less like a request for a result and more like a request for a map.
 
-<!-- /v4:generated -->
-## Bad Uses
+Verification also requires a record. In a personal learning session, that record may be a note that says which explanation you accepted and which part still felt unclear. In a team design document, it may be a source table with direct links to primary documentation. In code review, it may be a comment explaining why a generated change was narrowed, tested, or rejected. The record matters because it converts a private interaction with a model into reviewable engineering work.
 
-- replacing reading with summary-only learning
-- submitting unverified writing
-- trusting unsourced research claims
-- copying code you do not understand into production
+The verification standard should rise with risk. It is reasonable to use AI freely for brainstorming flashcards, drafting a first outline, or converting your own rough notes into a clearer structure. It is not reasonable to let a model invent citations, grant wildcard permissions, or change production automation without tests and review. The same tool can be safe or unsafe depending on the decision boundary you put around it. The boundary is not a vibe; it is a documented checkpoint.
 
-These uses feel efficient in the short term, but they often make you weaker over time.
-<!-- v4:generated type=thin model=gemini turn=3 -->
+## Diagnose and Improve Prompts
 
-Summary-only learning creates "knowledge islands" without the connecting bridges of context. In complex technical domains like Kubernetes networking, an LLM might accurately summarize that "Calico uses BGP," but by skipping the original documentation, you miss the underlying explanations of IP-in-IP encapsulation or MTU considerations. This leads to "brittle expertise"—you may pass a certification quiz, but you will fail during a high-pressure production outage because you lack the deep mental model required to troubleshoot components that interact under stress. The "productive struggle" of reading dense material is what actually builds long-term memory consolidation.
+Weak prompts usually fail because they hide the shape of the task. "Explain Kubernetes networking" is broad, so the model must guess your level, goal, and desired evidence. "Rewrite this proposal" is broad, so the model may optimize for polish instead of accuracy. "Fix this code" is broad, so the model may produce the smallest visible patch rather than a diagnosis. Prompt quality is not about clever wording; it is about making the task, constraints, context, and review criteria explicit enough that the output can be checked.
 
-Blindly copying code snippets introduces "silent technical debt" and significant security risks. LLMs frequently suggest patterns that are syntactically correct but architecturally disastrous, such as using deprecated API versions or ignoring error handling in concurrent Go routines. For instance, when generating a Kubernetes RBAC policy, an AI might provide a `ClusterRole` with broad wildcard permissions simply because it ensures the tool "just works," bypassing the Principle of Least Privilege.
+A stronger prompt starts with role only when role helps, then gives context, asks for a specific form of reasoning, and defines what must not happen. In learning, you might ask for two explanations, three misconceptions, and a self-quiz. In writing, you might ask for an outline before prose and require the model to preserve the original claims. In research, you might ask it to separate source-supported claims from hypotheses. In coding, you might ask for tests before implementation so the model cannot hide behind a plausible snippet.
+
+The most useful prompt pattern is "decompose, compare, constrain, verify." Decompose asks the model to break a problem into parts before solving. Compare asks for alternatives and tradeoffs, which reduces the chance that one confident path becomes the only path. Constrain tells the model what evidence, style, security boundary, or runtime environment matters. Verify asks for checks you can perform after the answer arrives. This pattern works because it turns a single opaque output into smaller claims that can be inspected.
+
+Which approach would you choose here and why: a prompt that asks "make this better," or a prompt that says "preserve the meaning, improve clarity for a beginner, list the edits, and flag any claims that require sources"? The second prompt is longer, but length is not the main benefit. The main benefit is that it defines success in a way a human can audit. A short prompt can be fine for low-risk brainstorming, but reviewable work needs reviewable instructions.
+
+When you ask AI to challenge your explanation, be specific about the kind of challenge you want. A model can find missing assumptions, produce counterexamples, suggest tests, or ask clarifying questions. If you simply ask "is this good," it may reassure you with shallow praise or rewrite your words without surfacing the real issue. Better prompts create productive friction. They ask for places where the idea fails, where terminology is ambiguous, where sources are missing, or where a reader might misinterpret the claim.
+
+There is also a failure mode in over-prompting. A very long prompt can become a policy document that still lacks the one concrete example the model needed. Instead of piling on instructions, include representative input and describe the acceptance criteria. For a coding helper, a failing test and expected behavior are often more valuable than paragraphs of style guidance. For a writing helper, the audience and one bad paragraph are often enough to produce a useful revision. Prompt discipline means giving the model the right evidence, not every thought you have.
+
+Good prompt diagnosis ends by looking at the output, not the prompt alone. If the answer invents facts, your prompt probably failed to demand source separation or the task lacked source material. If the answer is too generic, your prompt probably lacked context or constraints. If the answer changes your meaning, your prompt probably failed to protect intent. If the answer is hard to test, your prompt probably asked for a solution before asking for acceptance criteria. These observations become the next prompt revision.
+
+## Implement the Four-Workflow Practice Loop
+
+The practice loop in this module is deliberately small because the habit matters more than the tool. For any AI-assisted workflow, start with your own attempt, ask AI for targeted help, compare the result against your intent, verify the risky parts, and record what you accepted. This loop prevents the common slide from assistance into dependency. It also gives you a repeatable way to improve, because every pass leaves evidence of your baseline, the model's contribution, and your judgment.
+
+In learning, your own attempt should come before the model's explanation. Write a few sentences, draw a small diagram, or list the parts you think interact. Then ask AI to explain the same concept at multiple levels and to quiz you on weak spots. The comparison is where learning happens. If the model's explanation feels smoother than yours, do not simply replace your note. Ask what changed, which distinction became clearer, and which claim you still need to confirm in primary documentation.
+
+In writing, the loop begins with messy human intent. A rough paragraph is enough if it contains your actual claim. Ask AI to propose structure, reduce repetition, or adjust tone for a specific audience. Then compare the revision against the original meaning. Accept edits that clarify your claim and reject edits that add unsupported certainty, remove nuance, or make the text sound more authoritative than the evidence allows. Good AI-assisted writing still sounds like a responsible author, not a borrowed costume.
+
+In research, the loop treats the model as a question generator and cross-reference assistant. Give it the sources you already gathered when possible, and ask for tensions, missing angles, and terms to search next. Then mark which suggestions are supported by sources and which remain open. This is especially important when the topic involves standards, APIs, regulation, or security, where a plausible false claim can travel far. Your research note should make uncertainty visible instead of letting a polished summary flatten it.
+
+In coding, the loop starts with understanding the task and expected behavior before accepting a generated change. Ask AI to explain existing code, propose tests, or draft a small implementation, but read every line and run the relevant checks. If the model proposes a Kubernetes manifest, inspect API version, kind, namespace scope, RBAC permissions, resource requests, security context, and rollout impact. If the model proposes application code, inspect error handling, edge cases, dependency changes, and test coverage. You remain the reviewer of both syntax and intent.
+
+The following preserved example is intentionally dangerous because it shows how generated infrastructure can solve the visible problem while violating least privilege. The YAML is valid enough to look convincing, but broad wildcard permissions would grant cluster-wide control. A responsible workflow does not accept this because the rollout is blocked. It asks which verbs and resources are actually required, then narrows the policy and tests the workload under the least privilege that still satisfies the task.
 
 ```yaml
 # DANGEROUS: AI-generated "convenience" config often found in production
@@ -134,150 +127,191 @@ rules:
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ```
 
-This matters in practice because as an engineer, you are the ultimate authority for every line of code committed under your name. If an AI-generated script causes a cascading failure or a security breach, "the AI wrote it" is not a valid defense; it is an admission that you have abdicated your role as a gatekeeper. Verification is not a secondary task; it is the core of professional engineering.
+This example also shows why tests are necessary but not sufficient. A broad permission policy can make functional tests pass because the workload can do everything. The problem is that it can do too much. Security review asks a different question from functional review: not only "does the thing work," but "does it work with the smallest authority and blast radius that make sense?" AI helpers often optimize for the first question unless you explicitly ask for the second.
 
-Furthermore, trusting unsourced research claims can lead to the "Echo Chamber of Error," where AI-generated hallucinations are mistaken for fact and then re-indexed into future training sets. LLMs are known to fabricate citations, inventing plausible-sounding titles and authors for papers that do not exist. Using these in a technical proposal or strategic brief destroys your professional credibility instantly. Treat the AI as a high-speed intern who is prone to confident lying—you must act as the editor-in-chief who verifies every claim against a primary source before it reaches any stakeholder.
+The four-workflow practice loop should become muscle memory. For learning, compare your explanation against the model's explanation. For writing, compare your intent against the model's revision. For research, compare model-suggested claims against source-supported claims. For coding, compare generated changes against tests, least privilege, and operational impact. The loop is simple enough to use daily, but strong enough to prevent many failures that come from trusting fluency too early.
 
-<!-- /v4:generated -->
-## A Better Way To Use AI For Learning
+## Compare Patterns and Anti-Patterns
 
-Instead of asking for final answers immediately, ask AI to help you think:
-- explain this in simpler language
-- compare two concepts
-- quiz me on the material
-- show me what I am missing
-- challenge my explanation
+Safe AI use is not one behavior; it is a set of patterns that fit different levels of risk. In a private study session, you can let the model quiz you, explain analogies, or generate alternate examples with little downside. In a team document, the output affects shared understanding, so you need source links, change rationale, and human review. In production engineering, the output can affect systems and users, so you need tests, least privilege, staged rollout, and rollback thinking. The same model answer can be harmless in one context and reckless in another.
 
-That keeps you in the learning loop.
+| Pattern | When to Use It | Why It Works | Scaling Consideration |
+|---|---|---|---|
+| AI as tutor | Learning a concept, checking your explanation, or preparing practice questions | Keeps the learner active by asking for comparison, misconceptions, and quizzes | Require your own baseline explanation before using generated notes |
+| AI as editor | Improving drafts where the claim and audience are already clear | Separates human intent from mechanical polish and structure | Keep a change log of accepted and rejected edits for important documents |
+| AI as research scout | Finding terminology, angles, and gaps before source verification | Speeds exploration without making the model the source of truth | Track source-supported claims separately from model-suggested leads |
+| AI as diagnostic partner | Debugging with logs, symptoms, and constraints already available | Produces hypotheses and commands that a human can verify | Prefer decision trees and expected observations over direct mutation |
+| AI as code reviewer | Reviewing generated or human code for tests, edge cases, and security issues | Adds another inspection pass without replacing local execution | Require runnable checks and least-privilege review before merging |
 
-## A Better Way To Use AI For Writing
+Patterns become dangerous when the human role disappears. A tutor becomes a shortcut when you stop trying before asking. An editor becomes a ghostwriter when you accept claims you never formed. A research scout becomes a false authority when you cite generated text instead of sources. A diagnostic partner becomes a risky operator when you let it mutate systems without explaining the reason. A code reviewer becomes a rubber stamp when passing tests replace understanding. The difference is not the tool; it is the checkpoint.
 
-Good writing use cases:
-- improve clarity
-- propose structure
-- tighten tone
-- shorten repetition
+| Anti-Pattern | What Goes Wrong | Better Alternative |
+|---|---|---|
+| Summary-only learning | You gain vocabulary without the mental model needed for troubleshooting | Read important source material and use AI to quiz gaps afterward |
+| Polished but unsupported writing | The document sounds certain while hiding weak evidence | Draft the claim first, then ask AI to improve clarity and list source needs |
+| Citation laundering | Model-suggested references are treated as verified facts | Open primary sources and record only claims you can trace |
+| Copy-paste coding | Code runs without the author understanding behavior or edge cases | Ask for tests and explanations, then inspect and execute locally |
+| Permission by convenience | Broad access makes demos work while increasing blast radius | Start from least privilege and expand only when evidence requires it |
+| Prompt roulette | Repeated vague prompts produce random variations instead of progress | Diagnose output failures and add constraints, examples, and acceptance criteria |
 
-Weak writing use cases:
-- asking AI to generate final text for ideas you have not formed
-- accepting confident phrasing as if it were authority
-- using it to sound informed instead of becoming informed
+The most mature pattern is not "use AI less" or "use AI more." It is "use AI where speed helps, then add proof where trust matters." That framing lets you be pragmatic without being careless. It also prevents a false debate between manual purity and uncritical automation. The point is to put the model in the part of the workflow where it is strong: generating alternatives, restructuring text, summarizing provided material, proposing hypotheses, and drafting boilerplate. Keep humans in the part where accountability matters: selecting goals, checking evidence, accepting risk, and learning from mistakes.
 
-## A Better Way To Use AI For Research
+Teams should make these patterns visible. A personal checklist is enough for solo study, but shared engineering work benefits from conventions such as "AI-drafted code must include tests," "AI-supported research notes must link primary sources," or "AI-edited policy text must preserve a human-authored claim." These conventions are not bureaucracy for its own sake. They create a common expectation that generated work is welcome when it is reviewable. Reviewability is the bridge between individual productivity and team trust.
 
-AI can help with:
-- framing questions
-- suggesting search directions
-- comparing source material you already gathered
-- highlighting gaps in your notes
+## Decision Framework
 
-It should not replace:
-- checking primary sources
-- reading important material yourself
-- confirming whether a claim is actually supported
+Use this framework before you decide how much AI help to accept. The framework starts with risk, because risk determines the strength of verification. A low-risk brainstorming task can tolerate more exploratory prompting. A high-risk production, security, legal, or public communication task needs stricter evidence. The purpose is not to slow every task down. The purpose is to spend verification effort where a wrong answer would matter.
 
-## A Better Way To Use AI For Coding
+```text
++-----------------------------+
+| Start: What is the task?     |
++-----------------------------+
+              |
+              v
++-----------------------------+
+| Could bad output cause       |
+| security, money, data, or    |
+| reputation damage?           |
++-----------------------------+
+      | yes                         | no
+      v                             v
++-----------------------------+  +-----------------------------+
+| Use AI for decomposition,    |  | Use AI for drafting,        |
+| comparison, and checklists.  |  | practice, and exploration.  |
+| Require source/test review.  |  | Keep a human review pass.   |
++-----------------------------+  +-----------------------------+
+      |                             |
+      v                             v
++-----------------------------+  +-----------------------------+
+| Can you explain and verify   |  | Did the output improve      |
+| the accepted output?         |  | clarity or understanding?   |
++-----------------------------+  +-----------------------------+
+      | yes          | no           | yes          | no
+      v              v              v              v
++-----------+  +----------------+  +-----------+  +----------------+
+| Accept    |  | Revise prompt, |  | Keep with |  | Discard or     |
+| with      |  | gather proof,  |  | notes     |  | reprompt with  |
+| evidence  |  | or do manually |  |           |  | constraints    |
++-----------+  +----------------+  +-----------+  +----------------+
+```
 
-AI is especially useful for:
-- reading unfamiliar code
-- suggesting tests
-- summarizing stack traces
-- proposing refactors
-- generating first drafts of repetitive code
+This decision tree is intentionally conservative around high-impact tasks. It does not say that AI is forbidden for production engineering. It says that the model should help you create the reasoning artifacts that production work requires: hypotheses, alternatives, checklists, tests, and review questions. The more serious the outcome, the more the model should be used to expose uncertainty rather than hide it. A tool that helps you ask better questions is often safer than a tool that rushes to an answer.
 
-It becomes dangerous when you:
-- paste unknown code into production
-- stop reading what the code does
-- accept changes without running tests or verifying behavior
+| Task Type | Good AI Role | Required Human Checkpoint | Typical Evidence |
+|---|---|---|---|
+| Learning a concept | Tutor, quiz writer, analogy generator | Explain the concept without reading the model answer | Your own summary, quiz results, primary docs |
+| Writing a draft | Editor, organizer, tone adjuster | Confirm the revision preserves meaning and support | Original claim, change notes, source links |
+| Researching a decision | Search scout, comparison helper, gap finder | Verify claims against primary sources | Source table, quoted facts, unresolved questions |
+| Debugging a system | Diagnostic partner, hypothesis generator | Run commands safely and interpret observations | Logs, command output, test results |
+| Writing code | Test proposer, first-draft assistant, reviewer | Read, run, and review for security and maintainability | Tests, code review, least-privilege analysis |
 
-## A Healthy Rule
+The framework also helps you choose what not to ask. If a task requires current legal advice, sensitive personal data, secret credentials, or irreversible production changes, do not ask the model to decide or act. Ask it to help you prepare questions for an accountable expert, design a verification plan, or list information you need. That keeps the model useful while respecting the boundary between assistance and authority. Mature AI use is often defined by the requests you decline to make.
 
-Use AI to:
-- accelerate understanding
-- improve iteration
-- reduce blank-page friction
+One way to apply the framework is to name the artifact before you prompt. A learning artifact might be a personal explanation, a flashcard set, or a concept map. A writing artifact might be a proposal, status update, or tutorial. A research artifact might be a source table or decision memo. A coding artifact might be a test, manifest, or review note. Naming the artifact matters because different artifacts need different proof. A flashcard can tolerate a looser source trail than a production RBAC change.
 
-Do not use AI to:
-- skip comprehension
-- skip verification
-- skip responsibility
+Another practical move is to define the acceptance test before you ask for help. In learning, the acceptance test might be "I can explain this without reading the generated answer." In writing, it might be "the revision preserves the original claim and names unsupported additions." In research, it might be "each factual claim maps to a primary source." In coding, it might be "the change passes tests and I can explain the risk areas." This habit makes AI assistance measurable instead of vaguely helpful.
 
-## A Simple Self-Check
+The acceptance test also protects you from a subtle trap: changing the goal after the model produces something impressive. If you ask for a beginner explanation and the model returns an elegant advanced explanation, you may be tempted to keep it because it sounds smart. If your acceptance test was beginner clarity, the elegant answer still fails. The same applies to writing that sounds executive but loses nuance, research notes that sound complete but lack sources, and code that looks idiomatic but ignores the actual failure mode.
 
-After using AI on a task, ask:
-- can I explain this output in my own words?
-- could I defend this decision without the model?
-- do I know what still needs verification?
+Teams can turn individual checkpoints into shared review language. Instead of saying "AI wrote this," a pull request or design note can say "AI assisted with draft structure; source claims were verified against the linked docs; generated code was narrowed and tested locally." That sentence is not a confession or a badge. It is a review signal. It tells teammates where to inspect the work and what kind of evidence exists. The point is transparency about the workflow, not theater about the tool.
 
-If the answer is “no,” you are probably outsourcing too much of the work.
+There is a useful distinction between using AI before you know enough and using AI instead of knowing enough. Before you know enough, AI can help you form questions, translate jargon, and locate missing concepts. Instead of knowing enough, AI becomes a substitute for comprehension, and the output may pass through you without being examined. The same interaction can move in either direction. The difference is whether you end the session with better questions and a clearer mental model, or merely with prettier text.
 
-## Summary
+For learners, the best sign of good AI use is improved retrieval. After the model explains a topic, close the chat and write the explanation again. If the second version is clearer, more accurate, and more connected to examples, the tool probably helped. If you can only repeat the model's phrasing while looking at it, the tool has mostly provided borrowed fluency. Borrowed fluency feels productive because it fills the page, but it often disappears the moment you need to debug, teach, or adapt the idea.
 
-AI is most useful when it supports your thinking rather than replacing it.
+For writers, the best sign is stronger intent. A good AI edit makes your claim easier to follow without changing what you are willing to defend. A bad edit makes the paragraph smoother while quietly adding certainty, removing caveats, or shifting the audience. This is why an accepted and rejected edit note is so valuable. It forces you to read the revision as an author, not as a consumer of polished language. The note also helps reviewers understand what changed and why.
 
-For learning, writing, research, and coding, the best pattern is:
-- use AI to move faster
-- keep yourself responsible for truth, understanding, and judgment
+For researchers, the best sign is a cleaner evidence map. AI can help you notice that two sources use different terms for similar ideas, or that a standard answers one part of the question but not another. It can also help you create a list of claims to verify. The mistake is letting that list become the conclusion. A good evidence map keeps three categories separate: supported claims, plausible leads, and unresolved questions. That separation is the difference between research and summary-shaped speculation.
 
-<!-- v4:generated type=no_quiz model=codex turn=1 -->
+For coders, the best sign is smaller, more testable changes. A model may produce a large patch because it tries to be helpful across the whole problem. You do not have to accept that shape. Ask for the smallest change that demonstrates the idea, or ask for tests first, or ask for a review of your current patch instead of a replacement. The smaller the generated unit, the easier it is to inspect behavior, security, and maintainability. This is especially important in infrastructure code where side effects matter.
+
+Prompting for alternatives is one of the simplest ways to keep judgment active. If the model gives only one path, you may unconsciously treat it as the path. Asking for two or three approaches with tradeoffs turns the interaction into a comparison exercise. The human then chooses based on context: time, risk, reversibility, team familiarity, and evidence. Even when the first option is best, seeing alternatives helps you understand why. That understanding is what lets you defend the decision later.
+
+Prompting for failure modes is equally important. A model that drafts a study plan can tell you where the plan might leave gaps. A model that edits a document can identify which claims sound unsupported. A model that compares sources can list contradictions or missing definitions. A model that proposes code can name tests that would break the implementation. These requests do not make the model authoritative. They make the output more inspectable by forcing possible weaknesses into the open.
+
+You should also decide when not to use AI at all. If the main value of the task is memory practice, original reflection, or careful reading, using AI too early can remove the valuable difficulty. If the task involves private data that should not leave your environment, tool choice and data handling matter before prompting begins. If the work requires an accountable professional decision, AI may help prepare the context but should not make the decision. Knowing when to stop is part of competent tool use.
+
+The habit scales from one person to a team because it is observable. A teammate cannot see whether a private chat made you understand something, but they can see your baseline note, source table, test output, and review rationale. Those artifacts create shared confidence. They also make mistakes easier to catch. If a generated research lead is labeled as unverified, a reviewer can help verify it. If a generated permission is labeled as broad and temporary, a reviewer can push for least privilege before merge.
+
+When you mentor someone using AI, focus less on whether they used a tool and more on what happened to their thinking. Ask them to explain the accepted output, name an alternative they rejected, and show the evidence they used. Those questions are fair across learning, writing, research, and coding. They also avoid moral panic about the tool itself. The real concern is not that a model helped. The concern is that the learner, writer, researcher, or engineer stopped doing the accountable part of the work.
+
+Finally, remember that AI systems are probabilistic interfaces, not stable authorities. The same prompt may produce different wording, omit a detail, or emphasize another tradeoff on a later run. That variability is useful for brainstorming and review, but it is a poor foundation for truth. Your workflow should treat model output as a proposal that enters a verification process. Once verified, the useful part becomes your work product: a clearer explanation, a better paragraph, a sourced claim, or a tested change.
+
+The decision framework is therefore a discipline for preserving authorship. You can accept help without surrendering ownership. You can move faster without letting speed become the evidence. You can use generated suggestions without letting them become invisible assumptions. The module's rule stays constant across every workflow: AI may reduce friction, but the human must keep responsibility for truth, understanding, and judgment.
+
+## Did You Know?
+
+- In 2023, NIST published the AI Risk Management Framework 1.0, which gives teams a vocabulary for mapping, measuring, managing, and governing AI risks instead of treating trust as a vague feeling.
+- The OECD AI Principles were adopted in 2019 and later updated to address newer general-purpose AI risks, which shows that responsible AI guidance changes as systems and social use change.
+- Kubernetes RBAC supports namespace-scoped `Role` objects and cluster-scoped `ClusterRole` objects, so a model-generated permission choice can change blast radius even when the YAML looks routine.
+- OpenAI's evaluation guidance emphasizes test data, metrics, and continuous evaluation, which matches the practical rule in this module: generated output needs evidence before it becomes trusted work.
+
+## Common Mistakes
+
+| Mistake | Why It Happens | How to Fix It |
+|---|---|---|
+| Asking for the final answer before trying | The model removes the blank page so quickly that productive struggle disappears | Write a short baseline first, then ask AI to compare, quiz, or challenge it |
+| Treating polished prose as verified knowledge | Fluent wording feels like expertise, especially under deadline pressure | Separate wording quality from source support and mark unsupported claims clearly |
+| Letting AI citations pass unchecked | Generated references can look plausible even when they are wrong or irrelevant | Open primary sources, record URLs, and cite only claims you personally verified |
+| Copying generated code without reading it | The snippet appears to solve the visible task and tests may be absent | Explain each line, run checks, and add tests before accepting the change |
+| Accepting broad RBAC or security settings | Convenience patterns make examples work across many environments | Start from least privilege and require evidence for every permission or exception |
+| Re-prompting vaguely until the answer sounds right | Iteration feels productive even when the task definition is unstable | Diagnose the failure and add constraints, examples, and acceptance criteria |
+| Using AI edits to sound more certain than the evidence allows | Models often smooth uncertainty out of drafts | Preserve uncertainty, add source notes, and reject edits that overstate support |
+
 ## Quiz
 
-
-**Q1.** Your team is adopting a new Kubernetes networking concept, and a teammate wants to skip the docs and learn only from AI-generated summaries so they can move faster. Based on this module, what is the stronger approach?
-
 <details>
-<summary>Answer</summary>
-Use AI to explain the concept in simpler language, compare mental models, and quiz you on weak spots, but still read the important source material yourself. The module warns that summary-only learning creates shallow understanding and makes you weaker over time. AI should reduce friction, not replace the productive struggle that builds real comprehension.
+<summary>Question 1: Your team is adopting a new Kubernetes networking concept, and a teammate wants to skip the docs and learn only from AI-generated summaries so they can move faster. What is the stronger approach?</summary>
+
+Use AI to explain the concept in simpler language, compare mental models, and quiz weak spots, but still read the important source material yourself. The summary can reduce friction, yet it cannot replace the mental model built by tracing the original explanation and examples. This approach evaluates AI assistance without replacing human judgment because the learner remains responsible for explaining and verifying the concept. If the teammate cannot explain the topic without reading the model answer, the workflow has created dependency rather than learning.
+
 </details>
 
-**Q2.** You drafted an internal proposal, but the structure is messy and the tone is inconsistent. A coworker suggests asking AI to rewrite the whole thing and sending the result unchanged to leadership. What would the module recommend instead?
-
 <details>
-<summary>Answer</summary>
-Use AI to improve clarity, propose structure, tighten tone, and shorten repetition, but keep authorship and judgment with yourself. The module treats unverified final-text generation as a weak use because it can make you sound informed without actually becoming informed. You should review and own the final message rather than submit confident phrasing as if it were authority.
+<summary>Question 2: You drafted an internal proposal, but the structure is messy and the tone is inconsistent. A coworker suggests asking AI to rewrite the whole thing and sending the result unchanged to leadership. What should you do instead?</summary>
+
+Use AI as an editor, not as the author of an argument you have not formed or reviewed. Provide the rough claim, audience, constraints, and non-negotiable points, then ask for structure and clarity improvements while preserving meaning. The verification checkpoint is to compare the revision against your intent and mark any new claims that need sources. Sending the output unchanged would confuse polish with authority and would weaken your responsibility for the final message.
+
 </details>
 
-**Q3.** During research for a technical decision, AI gives your team several strong-sounding claims and even references papers you have not seen before. The deadline is tight, so someone wants to cite them directly in the proposal. What should you do?
-
 <details>
-<summary>Answer</summary>
-Do not trust the claims or citations until you verify them against primary sources. The module says AI is useful for framing questions, suggesting search directions, comparing material you already gathered, and highlighting gaps, but it should not replace checking whether a claim is actually supported. Unsourced or fabricated research claims can damage credibility and lead to bad decisions.
+<summary>Question 3: During research for a technical decision, AI gives your team several strong-sounding claims and references papers you have not seen before. The deadline is tight, so someone wants to cite them directly. What should happen next?</summary>
+
+Treat the model's claims as leads until primary sources confirm them. The correct checkpoint is to open the sources, verify that they exist, and record which claims are actually supported. AI is useful for framing questions, suggesting terminology, and finding missing angles, but it is not the evidence for a research claim. Citing unverified generated material can damage credibility and may push a decision toward a false premise.
+
 </details>
 
-**Q4.** You are debugging a private-registry deployment that shows `ImagePullBackOff`. One engineer asks AI for “the fix,” while another asks AI for a prioritized diagnostic decision tree with commands and what success or failure would mean. Which approach fits the module best, and why?
-
 <details>
-<summary>Answer</summary>
-The diagnostic decision tree is the better approach. The module recommends using AI to help you think and investigate, not just hand you final answers. Asking for prioritized diagnostic commands keeps you in the loop, strengthens your troubleshooting skills, and reduces the risk of applying a fix you do not understand.
+<summary>Question 4: You are debugging a private-registry deployment that shows `ImagePullBackOff`. One engineer asks AI for "the fix," while another asks for a prioritized diagnostic decision tree with commands and expected observations. Which approach fits this module best?</summary>
+
+The diagnostic decision tree fits the module best because it keeps the human in the investigation. `ImagePullBackOff` can come from authentication, registry reachability, image names, network policy, DNS, or other causes, so a direct fix may be a guess. A decision tree produces hypotheses and observations that can be tested safely. That design checkpoint connects AI suggestions to executable evidence instead of letting a fluent answer become the fix.
+
 </details>
 
-**Q5.** AI generates a Kubernetes RBAC policy that makes your deployment work immediately, but it uses wildcards for nearly every resource and verb. The rollout is blocked, and the team is tempted to merge it because “the model probably knows the standard pattern.” What is the correct response?
-
 <details>
-<summary>Answer</summary>
-Do not copy the policy into production without understanding and verifying it. The module explicitly warns against pasting unknown code into production and gives broad AI-generated RBAC as an example of dangerous convenience. You remain responsible for the security and behavior of what you ship, so you must review whether the permissions are actually necessary and align with least privilege.
+<summary>Question 5: AI generates a Kubernetes RBAC policy that makes a deployment work immediately, but it uses wildcards for nearly every resource and verb. The rollout is blocked, and the team is tempted to merge it because the model probably knows the standard pattern. What is the correct response?</summary>
+
+Do not merge the broad policy simply because it works. The generated YAML may pass a functional check while violating least privilege and increasing cluster-wide blast radius. The correct response is to identify the exact resources and verbs the workload needs, narrow the role, and test that narrower policy. This answer compares the pattern of AI as code assistant with the anti-pattern of permission by convenience.
+
 </details>
 
-**Q6.** You ask AI to generate a Kubernetes manifest for a service. It saves time on syntax and API details, but you are unsure about the resource limits and other operational settings. According to the module, what responsibility still belongs to you?
-
 <details>
-<summary>Answer</summary>
-You are still responsible for the engineering judgment behind the manifest, including whether the resource limits, policies, and trade-offs make sense for the real environment. The module frames this as “pilot vs. autopilot”: AI can help with the how, but you must retain the why. If you let the model make those decisions uncritically, you have outsourced responsibility rather than reduced friction.
+<summary>Question 6: A developer says, "The tests passed, so I do not need to understand the AI-generated change." How should they apply the module's self-check?</summary>
+
+They should ask whether they can explain the output in their own words, defend the decision without the model, and name what still needs verification. Passing tests are important, but tests may not cover maintainability, security scope, edge cases, or operational intent. If the developer cannot explain the change, they have not completed the human checkpoint. The right next step is to read the code, inspect risk areas, and add or adjust tests where the generated change is under-specified.
+
 </details>
 
-**Q7.** After using AI to help with a coding task, a developer says, “The tests passed, so I do not need to understand the output.” Using the module’s self-check, how should they evaluate whether they relied on AI appropriately?
-
 <details>
-<summary>Answer</summary>
-They should ask: Can I explain this output in my own words? Could I defend this decision without the model? Do I know what still needs verification? If the answer to those questions is no, they are outsourcing too much of the work. The module’s core rule is to use AI to accelerate understanding and iteration, not to skip comprehension, verification, or responsibility.
+<summary>Question 7: You want a reusable practice routine for AI-supported learning, writing, research, and coding. What loop should you implement, and why does it work across all four workflows?</summary>
+
+Implement a loop that starts with your own attempt, asks AI for targeted help, compares the output against your intent, verifies risky parts, and records what you accepted or rejected. It works across learning, writing, research, and coding because each workflow can fail when fluent output arrives before understanding or evidence. The baseline preserves your thinking, the targeted prompt focuses assistance, and the verification checkpoint keeps responsibility with you. Recording the decision makes the work reviewable later.
+
 </details>
 
-<!-- /v4:generated -->
-<!-- v4:generated type=no_exercise model=codex turn=1 -->
 ## Hands-On Exercise
 
-
-Goal: use AI in learning, writing, research, and coding without giving up comprehension, verification, or responsibility.
+The goal is to use AI in learning, writing, research, and coding without giving up comprehension, verification, or responsibility. This exercise intentionally uses small files so the workflow stays visible. You are not trying to produce a perfect essay, research report, or program. You are practicing the habit of creating a human baseline, asking for targeted assistance, comparing the result, and recording verification notes that another person could inspect.
 
 - [ ] Create a working folder for the exercise and add four files: `learning.md`, `writing.md`, `research.md`, and `coding.md`.
 ```bash
@@ -287,13 +321,38 @@ touch learning.md writing.md research.md coding.md
 ls -1
 ```
 
+<details>
+<summary>Solution guidance</summary>
+
+You should see the four file names listed in the working directory. The important part is not the directory itself, but the separation of workflows. Separate files make it easier to see whether you are using the same verification habit across different types of work.
+
+</details>
+
+Before asking AI for anything, choose one small technical topic that you can explain imperfectly. Containers, Kubernetes Pods, HTTP status codes, DNS lookups, or RBAC roles all work well. The topic should be small enough that you can gather two real sources and inspect a short code or command example. Starting with a manageable topic lets you focus on the workflow rather than fighting the size of the subject.
+
 - [ ] Choose one small technical topic you can explain in plain language, such as containers, Kubernetes Pods, or HTTP status codes, and write a 3-5 sentence explanation in `learning.md` before using AI.
 ```bash
 printf "Topic: \nMy explanation:\n" > learning.md
 sed -n '1,20p' learning.md
 ```
 
+<details>
+<summary>Solution guidance</summary>
+
+Fill in the topic and write your own explanation before opening an AI tool. The explanation can be incomplete or slightly wrong. Its purpose is to create a baseline you can compare against the model's explanation.
+
+</details>
+
 - [ ] Ask an AI tool to explain the same topic at two levels: one for a beginner and one for an intermediate learner. Add both versions to `learning.md`, then write your own short comparison of what the AI helped clarify and what still felt weak or unclear.
+
+<details>
+<summary>Solution guidance</summary>
+
+Ask for the two explanations in the same prompt and include a request for likely misconceptions. After pasting the result into `learning.md`, add your own comparison paragraph. Name at least one clarification and at least one point that still needs a primary source or hands-on check.
+
+</details>
+
+The writing step uses the same discipline, but the checkpoint changes from conceptual accuracy to intent preservation. You should be able to identify edits you accept because they clarify meaning and edits you reject because they add unsupported certainty or change the claim. This is where AI writing becomes a professional tool instead of a shortcut. A model can improve the mechanics, but you decide whether the revised text still says what you mean.
 
 - [ ] Write a rough paragraph about the same topic in `writing.md`, then ask AI to improve clarity and structure without changing the main meaning. Keep both the original and revised versions, and add one sentence naming the edits you accept and one sentence naming an edit you reject.
 ```bash
@@ -301,11 +360,29 @@ printf "Original draft:\n\nRevised with AI:\n\nAccepted changes:\nRejected chang
 grep -n "Accepted changes\|Rejected change" writing.md
 ```
 
+<details>
+<summary>Solution guidance</summary>
+
+Your accepted change might be a clearer topic sentence, a simpler phrase, or a better order for ideas. Your rejected change might be a stronger claim than your evidence supports, a missing caveat, or a voice that sounds less like you. Record both decisions so the AI edit remains reviewable.
+
+</details>
+
+The research step asks you to keep source-supported claims separate from model-suggested leads. This is the most important distinction in the exercise. AI can help you ask better questions, but sources carry the authority. If a suggestion is useful but not yet supported, label it that way. A good research note is honest about uncertainty, because honest uncertainty is safer than a confident unsupported claim.
+
 - [ ] Gather two real sources on the topic and record them in `research.md`. Ask AI for follow-up questions, missing angles, or possible contradictions between the sources. Add those suggestions, then mark which ones are actually supported by the sources and which ones still need checking.
 ```bash
 printf "Source 1:\nSource 2:\n\nAI follow-up questions:\n\nVerified:\nNeeds checking:\n" > research.md
 grep -n "Source\|Verified\|Needs checking" research.md
 ```
+
+<details>
+<summary>Solution guidance</summary>
+
+Use vendor or project documentation when possible. For example, a Kubernetes topic should use Kubernetes documentation before a blog post. In `research.md`, put supported claims under `Verified` only when you have checked the source directly. Put useful but unverified ideas under `Needs checking`.
+
+</details>
+
+The coding step should remain tiny. A short script, checklist generator, or data structure is enough. The goal is not to prove that AI can write code; you already know it can draft code. The goal is to prove that you can review generated code responsibly. Your notes should explain behavior, likely tests, and any edge cases that the first draft ignored.
 
 - [ ] Create a tiny coding task related to the topic, such as a shell script that prints a study checklist or a short Python script that stores quiz questions in a list. Ask AI for a first draft, then review it line by line and add comments in `coding.md` explaining what each part does and what you would test before using it.
 ```bash
@@ -313,29 +390,62 @@ printf "Code draft:\n\nReview notes:\n\nWhat I would test:\n" > coding.md
 sed -n '1,40p' coding.md
 ```
 
+<details>
+<summary>Solution guidance</summary>
+
+Keep the code small enough that you can explain every line. If the model adds a dependency, broad file access, network calls, or unexplained behavior, either reject that change or write down the verification you would need. Your review notes are the evidence that the code did not bypass comprehension.
+
+</details>
+
 - [ ] Perform a final self-check across all four files. For each workflow, answer these questions in one line: Can you explain the output in your own words? Could you defend it without the model? What still requires verification?
 ```bash
 for f in learning.md writing.md research.md coding.md; do echo "== $f =="; tail -n 6 "$f"; done
 ```
+
+<details>
+<summary>Solution guidance</summary>
+
+Add a short self-check section to each file before running the command. If one file has no unresolved verification item, look again. Even low-risk work usually has a caveat, such as a source to revisit, a test to run, or a wording choice to confirm with the audience.
+
+</details>
 
 - [ ] Compare your own original work with the AI-assisted versions and write a short conclusion: where AI reduced friction, where it risked replacing thought, and what guardrail you want to keep using in future work.
 ```bash
 wc -l learning.md writing.md research.md coding.md
 ```
 
+<details>
+<summary>Solution guidance</summary>
+
+Your conclusion should name one benefit and one risk from each workflow. For example, AI may have clarified vocabulary in learning, improved structure in writing, suggested a missing research angle, or produced a useful code draft. The risk might be shallow understanding, unsupported certainty, a fabricated lead, or code you were tempted to accept before reading.
+
+</details>
+
 Success criteria:
-- You produced your own explanation or draft before asking AI for help.
-- You used AI to improve understanding, structure, questions, or first-draft code rather than outsourcing judgment.
-- You recorded at least one point in each workflow that still needed human verification.
-- You kept evidence of your review process in the four files.
-- You can explain, in your own words, why the final outputs are trustworthy enough to keep or revise further.
 
-<!-- /v4:generated -->
-## Next Section
-
-Continue to [AI-Native Work](../ai-native-work/).
+- [ ] You produced your own explanation or draft before asking AI for help.
+- [ ] You used AI to improve understanding, structure, questions, or first-draft code rather than outsourcing judgment.
+- [ ] You recorded at least one point in each workflow that still needed human verification.
+- [ ] You kept evidence of your review process in the four files.
+- [ ] You can explain, in your own words, why the final outputs are trustworthy enough to keep or revise further.
+- [ ] You implemented a reusable four-workflow practice loop for AI-supported learning, writing, research, and coding tasks.
 
 ## Sources
 
-- [NIST AI RMF: Generative AI Profile](https://www.nist.gov/publications/artificial-intelligence-risk-management-framework-generative-artificial-intelligence) — A practical framework for trustworthy generative AI use, with emphasis on verification, risk, and human responsibility.
-- [OECD.AI: Generative AI Issues](https://oecd.ai/en/generative-ai-issues) — A beginner-friendly overview of common generative AI benefits, limitations, and risks that reinforces judgment-first usage.
+- [NIST AI Risk Management Framework: Generative AI Profile](https://www.nist.gov/publications/artificial-intelligence-risk-management-framework-generative-artificial-intelligence)
+- [NIST AI Risk Management Framework](https://www.nist.gov/itl/ai-risk-management-framework)
+- [OECD.AI: Generative AI Issues](https://oecd.ai/en/generative-ai-issues)
+- [OECD AI Principles](https://oecd.ai/en/ai-principles)
+- [OpenAI Evaluation Best Practices](https://developers.openai.com/api/docs/guides/evaluation-best-practices)
+- [OpenAI Optimizing LLM Accuracy](https://developers.openai.com/api/docs/guides/optimizing-llm-accuracy)
+- [OpenAI GPT-4.1 Prompting Guide](https://developers.openai.com/cookbook/examples/gpt4-1_prompting_guide)
+- [OpenAI Function Calling Guide](https://developers.openai.com/api/docs/guides/function-calling)
+- [Anthropic Prompt Engineering Overview](https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/overview)
+- [Google Gemini Prompting Strategies](https://ai.google.dev/gemini-api/docs/prompting-strategies)
+- [Kubernetes RBAC Authorization](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
+- [Kubernetes Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+- [Kubernetes Debug Pods](https://kubernetes.io/docs/tasks/debug/debug-application/debug-pods/)
+
+## Next Module
+
+Continue to [AI-Native Work](../ai-native-work/) to examine how workflows, tools, and team practices change when AI becomes a regular part of engineering delivery.


### PR DESCRIPTION
## Summary

Rewrites `src/content/docs/ai/foundations/module-1.6-using-ai-for-learning-writing-research-and-coding.md` to clear the #388 verifier gates and clears `revision_pending: false`.

## Verifier

`/Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/quality/verify_module.py --glob src/content/docs/ai/foundations/module-1.6-using-ai-for-learning-writing-research-and-coding.md --skip-source-check --summary --quiet`

Verifier summary: tier T0; body_words=5053, mean_wpp=79.0, median_wpp=82.0, short_rate=0.016, max_run=1, mean_sentence_length=16.7; all density, structure, alignment, anti_leak, anti_fabrication, runnable shell, and sources_min_10 gates pass. Sources reachability was skipped by verifier per dispatch; manual curl sweep returned HTTP 200 for all 13 source URLs, with the Anthropic docs URL resolving through a 200 redirect.

## Protected assets

Protected assets preserved: before code_blocks=10, ascii_diagrams=0, mermaid_diagrams=0, tables=0, sources=2; after code_blocks=11, ascii_diagrams=0, mermaid_diagrams=0, tables=4, sources=13. The original ten code blocks and both original source URLs are retained; one ASCII decision-tree code block and required tables/sources were added.

## Validation

- `git diff --check -- src/content/docs/ai/foundations/module-1.6-using-ai-for-learning-writing-research-and-coding.md` passed.
- Forbidden-token grep for `47`, `alias k=kubectl`, runnable `k <subcommand>`, leak placeholders, and AI refusal boilerplate returned no matches.
- `npm run build` was attempted in this worktree and failed with the documented `.worktrees/*` Astro/node_modules resolution issue: `Could not resolve "../../node_modules/@astrojs/starlight/style/layers.css" from "src/layouts/Homepage.astro"`. This is the known worktree build limitation described in AGENTS.md, not a module-specific error.

Commit SHA: d83e2813