### PR TITLE
feat(388): rewrite module-1.2-hugging-face-for-learners (#388 pilot)

### DIFF
--- a/src/content/docs/ai/open-models-local-inference/module-1.2-hugging-face-for-learners.md
+++ b/src/content/docs/ai/open-models-local-inference/module-1.2-hugging-face-for-learners.md
@@ -1,178 +1,332 @@
 ---
-revision_pending: true
+revision_pending: false
 title: "Hugging Face for Learners"
 slug: ai/open-models-local-inference/module-1.2-hugging-face-for-learners
 sidebar:
   order: 2
 ---
 
-> **Open Models & Local Inference** | Complexity: `[QUICK]` | Time: 40-50 min
+> **Complexity**: `[QUICK]`
+>
+> **Time to Complete**: 40-50 min
+>
+> **Prerequisites**: Basic comfort with web documentation, model names, files, and the idea that local inference means running a model with software on your own machine or cluster.
+
+---
+
+## What You'll Be Able to Do
+
+- Evaluate Hugging Face model repositories by comparing the model card, license, intended use, limitations, and file list before downloading anything.
+- Differentiate model repositories, datasets, Spaces, and libraries so you choose the right documentation path for an inference task.
+- Diagnose beginner risk in community derivatives by tracing provenance, quantization, fine tuning, and compatibility notes.
+- Design a repeatable first-model selection checklist that prioritizes clarity, compatibility, and reproducibility over hype or parameter count.
 
 ## Why This Module Matters
 
-For many learners, Hugging Face is the first real encounter with the open-model ecosystem.
+Hypothetical scenario: you are learning local inference and someone sends you a Hugging Face link that looks impressive. The page has a polished name, a high download count, several unfamiliar files, a license line you do not recognize, and comments from people using it in different tools. If you treat the page as a simple download button, you may spend the next hour debugging the wrong runtime, accepting a license you did not inspect, or comparing results from a derivative whose changes were never explained.
 
-That first encounter often goes badly because the learner sees:
-- too many model names
-- too many repos
-- too many file formats
-- too much community noise
+That confusion is normal because Hugging Face is not one product with one path through it. It is a model hub, a dataset hub, a documentation ecosystem, a social publishing platform, and the home of libraries such as Transformers. The same search result page may show an original model, a fine-tuned model, a quantized package for a specific runtime, a dataset used for training, and a Space that demonstrates a user interface. A learner needs a map before a download, just as a traveler needs to know whether a sign points to a station, a ticket counter, a timetable, or a train.
 
-The result is confusion instead of progress.
-
-This module exists to make Hugging Face usable as a learning tool rather than an overwhelming catalog.
-
-## What You'll Learn
-
-- what Hugging Face is in practical terms
-- how to navigate model cards and repos
-- how to tell the difference between a model, a dataset, and a library
-- how to choose a sane first model repo
+This module turns Hugging Face from an overwhelming catalog into a practical learning tool. You will learn how to read model pages in a consistent order, separate model assets from software libraries, recognize when a community derivative is helpful or risky, and pick a first repository that teaches you more than it surprises you. The goal is not to make you an expert in every model family today. The goal is to give you a repeatable way to evaluate a Hugging Face model repository before you trust it as the basis for a local inference experiment.
 
 ## What Hugging Face Actually Is
 
-Hugging Face is not just one thing.
+The first mental shift is to stop thinking of Hugging Face as a single model or a single command. In practical terms, Hugging Face is a publishing and discovery layer for machine learning artifacts, wrapped with documentation and tooling. A model repository can store configuration files, tokenizer files, weights, metadata, examples, and a model card. The Hub can also host datasets, Spaces, discussions, pull requests, and organization-level collections, which means a search result is often an entry point into a broader ecosystem rather than the finished answer.
 
-Learners usually interact with it as:
-- a **model hub**
-- a **documentation ecosystem**
-- a set of **libraries** such as Transformers
-- a place where the open-model community publishes derivatives and tools
+For a beginner, the word "repo" is the safest anchor. A repository is the container that holds a specific asset and the surrounding metadata that explains how to use it. On GitHub, a repository usually centers on source code. On Hugging Face, a repository may center on model weights, dataset files, or an application demo. That difference matters because the page may look familiar while the contents behave very differently from a normal programming project.
 
-That means you should not think:
+The Hub exists because model work has more moving pieces than a single executable file. A text generation model usually needs weights, a configuration, tokenizer assets, and loading code that knows how those parts fit together. A vision model may need image preprocessing rules, label mappings, and task-specific examples. A dataset repository may need splits, schemas, and viewer metadata. Hugging Face gives all of those artifacts a common place to live, but the learner still has to inspect which kind of artifact they are looking at.
 
-> “Hugging Face equals one AI model.”
+Think of the ecosystem as a technical library where the shelves are close together. One shelf holds model repositories, another holds datasets, another holds library documentation, and another holds runnable demos. The signs are clear once you know how to read them, but they are easy to blur when you are moving quickly. A good learner workflow starts by asking, "Which shelf am I on?" before asking, "How do I run this?"
 
-Think:
+This distinction also protects you from a common false shortcut. A Hugging Face page with many downloads is not automatically the right page for your first local inference test. Popularity can signal usefulness, but it can also reflect a dependency pulled by another tool, a temporary trend, or a derivative used by a narrow community. For learning, the better question is whether the repo explains what it is, what it is for, what files it contains, and how a beginner can reproduce a simple result.
 
-> “[Hugging Face is a major ecosystem for discovering, understanding, and using open models.](https://huggingface.co/docs/hub/index)”
+Pause and predict: if two pages have similar names, one labeled as a model and one labeled as a dataset, what breaks when you try to load the dataset page as if it were model weights? The important answer is not just "the code fails." The deeper answer is that you started from the wrong kind of artifact, so every later debugging step becomes less informative. Correct classification saves time before any command runs.
 
-## The Three Things Learners Confuse Most
+The main Hugging Face categories a learner meets early are model repositories, dataset repositories, Spaces, and libraries. A model repository answers "what artifact can I load for a task?" A dataset repository answers "what data was published or can be inspected?" A Space answers "what demo or application can I try in a browser?" Library documentation answers "what software API loads, configures, or serves the artifact?" Mixing those questions is the fastest way to make a simple experiment feel mysterious.
 
-### 1. Model repo
+| Thing you opened | What it usually contains | Learner question it answers |
+|---|---|---|
+| Model repository | Weights, config, tokenizer assets, model card, examples | Can I load this model for my task? |
+| Dataset repository | Data files, splits, schema, dataset card, viewer | Is this the data source or evaluation input? |
+| Space | Demo app, interface code, hosted runtime metadata | Can I try a working interaction before building one? |
+| Library documentation | APIs, installation notes, examples, class references | Which software path loads or runs the artifact? |
 
-This is the thing that contains model files, configs, [tokenizer assets](https://huggingface.co/docs/transformers/main/main_classes/tokenizer), and a [model card](https://huggingface.co/docs/hub/en/models-uploading).
+This table is simple, but it is one of the most useful habits in open-model work. When a page confuses you, classify the page before judging the model. If the page is a library page, it will explain APIs rather than ownership of a specific model. If the page is a derivative model repo, it may explain a conversion or fine tune rather than the original training process. If the page is a Space, the visible interface may hide which model or runtime sits behind it.
 
-### 2. Library docs
+For local inference, this classification becomes operational. You might use the Hub to choose a model, Transformers documentation to understand loading behavior, a tokenizer page to understand preprocessing, and a separate runtime guide to run a quantized file. Those are not competing sources of truth; they answer different layers of the same workflow. Treating them as layers gives you a more stable map than treating every Hugging Face page as interchangeable.
 
-This is where you learn how to actually load or use the model with software such as [Transformers](https://huggingface.co/docs/transformers/main/en/index).
+## Reading A Model Repository Before Downloading
 
-### 3. Community derivatives
+The model page is where learners most often move too fast. A tempting workflow is to read the title, copy the first code snippet, and hope the rest becomes obvious. That works only when the repo is unusually polished and your environment matches the author's assumptions. A safer workflow scans the page in a deliberate order: model card summary, intended use, limitations, license, file list, and example inference path. This sequence keeps meaning ahead of mechanics.
 
-These are [fine-tuned, quantized, merged, or repackaged versions](https://huggingface.co/docs/hub/model-cards).
+Start with the model card because it is the human explanation attached to the artifact. A good model card tells you what the model is meant to do, what it should not be used for, what data or method shaped it, what limitations are known, and which license governs use. It is not just a courtesy note. It is the closest thing the repo has to a product label, safety note, and operating manual in one place.
 
-These can be useful, but they are not automatically better than the original source model.
+The intended-use section matters because a model name rarely tells the whole story. A model that appears useful for general chat may actually be tuned for instruction following, code generation, summarization, embeddings, translation, classification, or a benchmark-specific task. If you use a model outside its intended task, it may still produce output, but the output can be misleading. A machine that accepts your input is not the same as a machine designed for your purpose.
 
-## How To Read A Model Page
+Limitations are equally important because they tell you where trust should stop. A model card might describe language coverage, domain weakness, toxicity risk, factual unreliability, context length, evaluation caveats, or data constraints. Beginners sometimes skip this section because it feels negative, but limitations make experiments cleaner. When a weak result appears, you can compare it against known boundaries instead of assuming you made a runtime mistake.
 
-When you open a model page, scan it in this order:
+Licenses deserve slow reading even during learning. Some models are permissive, some require attribution, some restrict commercial use, and some have custom terms or gated access. Even if you are only experimenting locally, license awareness builds the habit you will need when models move into shared projects. A repository that is easy to run is not automatically easy to use in a product, classroom, company demo, or public tutorial.
 
-1. [model card summary](https://huggingface.co/docs/hub/model-cards)
-2. intended use
-3. limitations
-4. license
-5. file list
-6. example inference path
+The file list tells you whether the repo matches the runtime path you have in mind. You may see `config.json`, tokenizer files, safetensors weight shards, model index files, ONNX exports, GGUF files, adapter files, or auxiliary scripts. Those names are clues. If you plan to use Transformers, you want the repository to expose the assets that Transformers expects. If you plan to use a different local runtime, you need to confirm whether the published files fit that runtime instead of assuming every file format is interchangeable.
 
-This order matters because it keeps you from downloading first and understanding later.
+Before running this, what output do you expect from a repo whose model card says "text classification" but whose community comments discuss chat prompts? A careful learner should expect a mismatch between the task interface and the comments. The comments might describe a wrapper, a derivative, or a misunderstanding. The model card and file list should carry more weight than scattered enthusiasm because they are closer to the artifact's declared purpose.
 
-## Good First Learner Choices
+A simple inspection habit is to write down the model's task, source, license, limitations, and expected loader before downloading. This sounds slow, but it usually saves time because it turns debugging into comparison. If your note says "intended for embeddings" and your experiment tries open-ended chat, you have found a design error rather than a mysterious model failure. If your note says "requires gated access" and your download fails, authentication becomes the next obvious thing to check.
 
-A good first Hugging Face model repo usually has:
-- a clear model card
-- obvious task description
-- strong ecosystem support
-- recent maintenance
-- practical loading instructions
+| Scan step | What to look for | What it prevents |
+|---|---|---|
+| Model card summary | Task, family, source organization, high-level purpose | Mistaking a specialized model for a general one |
+| Intended use | Supported tasks, expected inputs, audience | Running the model against the wrong problem |
+| Limitations | Known weaknesses, safety notes, coverage gaps | Overtrusting output or misdiagnosing expected weakness |
+| License | Permission, restrictions, attribution requirements | Reusing a model in a context the terms do not allow |
+| File list | Config, tokenizer, weights, format, adapters | Choosing a runtime that cannot load the artifact |
+| Example path | Transformers, inference API, local runtime, demo | Copying instructions meant for a different environment |
 
-A bad first learner repo usually has:
-- cryptic description
-- unclear provenance
-- no limitations section
-- no practical inference notes
+This scan order also helps when a page is incomplete. If the model card lacks intended use, limitations, or license clarity, you have learned something important before touching your machine. Missing documentation does not always mean the model is bad, but it does mean the model is a weaker first learner choice. A first experiment should teach the ecosystem, not force you to reconstruct provenance from hints.
 
-## What Not To Optimize For Yet
+## From Model Card To Inference Path
 
-Do not optimize for:
-- biggest parameter count
-- trendiest ranking
-- most impressive benchmark screenshot
+Once you know what the model is, the next question is how the artifact becomes an inference run. A model card describes the artifact, while a library such as Transformers provides the software interface that loads it. The tokenizer prepares raw text or other inputs in the form the model expects. The configuration tells the library what architecture and behavior to assemble. The weight files contain learned parameters. If any layer is missing or incompatible, the repository may still look complete to a beginner while failing at runtime.
 
-At the learner stage, optimize for:
-- clarity
-- compatibility
-- repeatability
-- ability to understand what you are running
+The relationship between those parts is easier to see as a flow. You start with a human task, choose a model repository that matches that task, let a library read the config and tokenizer assets, load the weights, and then send inputs through the assembled pipeline. Hugging Face reduces friction by making many repositories follow predictable conventions, but the conventions do not remove the need to inspect the repository. They make inspection more useful because you know what each file is likely to mean.
 
-## Community Derivatives: Useful But Risky
+| Learner decision | Repository clue | Practical consequence |
+|---|---|---|
+| Which task am I solving? | Model card task label and examples | Determines whether chat, classification, embeddings, or another API fits |
+| Which loader can I use? | Config, architecture name, library tags | Determines whether Transformers or another runtime is the normal path |
+| Which inputs are valid? | Tokenizer files and example code | Determines how text is split, encoded, padded, or truncated |
+| Which environment is needed? | File size, format, dependencies, hardware notes | Determines whether local CPU, local GPU, or hosted inference is realistic |
 
-A derivative model might be:
-- quantized
-- fine-tuned
-- merged
-- repackaged for a specific runtime
+Tokenizer assets are especially easy to underestimate. A tokenizer is not a spell checker or a decorative helper; it is the bridge between human-readable input and model-readable numbers. Two models with similar names may use different tokenization rules, and those rules affect context length, truncation, special tokens, and input formatting. If you copy only the weight files while ignoring the tokenizer, you may produce errors or strange outputs that have nothing to do with model quality.
 
-That can be useful.
+The file format also changes the local inference path. Safetensors files are common in Transformers-oriented repositories because they store tensor data in a safer, predictable format. GGUF files are common in certain local inference runtimes that prioritize quantized execution on consumer machines. Adapter files may represent a small fine tune layered on top of a base model rather than a complete standalone model. A beginner does not need to memorize every format immediately, but they should learn to ask what the file format implies.
 
-But it also means you should ask:
-- who made this?
-- what changed?
-- what did they optimize for?
-- is this still aligned with the original intended use?
+Parameter count is another place where the path matters. Larger models can be more capable, but they are also more demanding. A bigger model can require more memory, slower downloads, longer startup times, or hardware you do not have. A smaller model with clear documentation may teach you more in a first lab than a larger model that barely loads. The early learning objective is controlled feedback, not maximum bragging rights.
 
-## Active Check
+Exercise scenario: you want a first local inference test on a laptop, and you find one repo with a concise model card, task examples, clear license, and files documented for Transformers. You also find a much larger derivative that claims better results but gives little explanation of what changed. The better learner choice is the documented repo because it gives you a stable baseline. Once you can run and explain the baseline, derivatives become easier to evaluate.
 
-You find two model repos:
-- one official, well-documented source model
-- one derivative with unclear notes but lots of hype
+This is also where "official" and "community" labels need nuance. An official source model from the original organization usually gives you stronger provenance, but it may not always be the easiest local file format. A community derivative may provide a convenient quantized package that runs on your hardware, but the derivative must explain what changed. The right question is not "official or community?" in isolation. The right question is "which repository gives me the clearest chain from task to files to runtime to expected behavior?"
 
-Which is the better first learner choice?
+When you read example inference instructions, check whether they are meant for local execution, hosted inference, or a demonstration environment. A browser demo may hide dependencies that your local system must install. A hosted inference snippet may rely on a service path rather than your machine. A Transformers snippet may assume Python packages and enough memory. Matching the example path to your intended environment prevents a lot of false debugging.
 
-The official, well-documented one.
+Kubernetes does not need to be part of this first module, but the same habit scales when local inference later moves into containers or Kubernetes 1.35+ clusters. You still inspect the artifact before deployment, then match model size, file format, tokenization, and runtime to the environment. The cluster only makes mistakes more expensive because a bad assumption can become a failed image build, a pending workload, or a service that returns poor results at scale.
+
+## Separating Models, Datasets, Libraries, And Spaces
+
+Many beginner mistakes come from treating every Hugging Face object as if it were a model. A dataset repository can look repo-shaped, contain a card, show file listings, and have community activity, but it is not something you load as model weights. A Space can look like the easiest way to use a model, but it is an application wrapper. A library page can show code, but it documents a software interface rather than owning a specific artifact. These boundaries are simple once named, yet they are hard to infer from search results alone.
+
+The Hub's strength is that related objects can link to each other. A model card may mention a training dataset. A dataset card may mention models trained from it. A Space may demonstrate a model hosted elsewhere. Transformers documentation may show a generic loading pattern that works across many model repos. The learner's job is to follow these links without losing the category of each page. Keep asking whether the page is the artifact, the data, the demo, or the tool.
+
+Datasets are especially important because they influence what a model has seen, how it is evaluated, and where it may fail. A beginner may not be ready to audit a training corpus deeply, but they can still notice whether a model card names data sources, evaluation data, or domain boundaries. If a model claims strong results for a specialized task while saying little about data or evaluation, that absence should lower your confidence. You are not rejecting the model; you are choosing a safer learning path.
+
+Libraries deserve the same separation. Transformers is a software library that knows how to load and run many kinds of models, but it is not the same thing as any particular model repository. The Auto classes in Transformers can infer architectures from repository configuration, which makes loading feel magical when everything is compatible. That convenience is useful, but it should not hide the underlying relationship: the library reads metadata and files from the repo, then constructs the runtime objects.
+
+Spaces are helpful for exploration because they give you a quick interface. You can try a model's behavior before setting up local software, and you can inspect the app if the author shared code. However, a Space is not proof that the model repo is appropriate for your environment. The Space may use a hosted GPU, a wrapper prompt, a private setting, or a different model revision. Treat a Space as a demonstration, not as a complete reproducibility guarantee.
+
+Pause and predict: if a Space gives great answers but the linked model repo has no local loading instructions, what should you verify before choosing it for a learner lab? You should verify the model identity, license, file formats, expected runtime, and whether the Space applies hidden preprocessing or prompting. The demo tells you that an interaction is possible; the repository inspection tells you whether you can reproduce it.
+
+This separation is also how you debug documentation confusion. If an installation page tells you to install Transformers, it is not telling you which model to choose. If a model card shows example code, it is not necessarily documenting every installation detail. If a dataset card explains columns and splits, it is not telling you how to serve inference. The pages cooperate, but they do not replace one another.
+
+For learners, a useful note format has four lines: artifact type, purpose, owner or publisher, and next documentation path. For a model repo, the next path may be the model card and Transformers loading docs. For a dataset, the next path may be dataset card details and viewer schema. For a Space, it may be the app code and linked model. For a library, it may be installation, model class documentation, and examples. Four lines can turn a confusing browser session into a traceable investigation.
+
+## Evaluating Community Derivatives Without Fear
+
+Community derivatives are one of the reasons the open-model ecosystem moves quickly. Someone may fine tune a base model for a specific style, merge several adapters, quantize weights into a smaller format, package files for a local runtime, or add instructions for a tool that the original publisher did not target. These derivatives can be extremely useful. They can also hide important tradeoffs if the page does not explain what changed.
+
+Fine tuning changes behavior by training the model further on additional data or instructions. That can make the model better for a target task, but it can also narrow behavior, introduce bias, reduce generality, or make evaluation results hard to compare with the base model. A good derivative page explains the base model, training data or method at an appropriate level, intended use, evaluation, and limitations. A weak derivative page says "better" without saying better for what.
+
+Quantization changes representation so the model can run with less memory or faster inference on certain hardware. That can be the difference between a practical laptop experiment and an impossible one. The tradeoff is that quantization may affect quality, compatibility, or supported runtimes. A quantized derivative should say which format it provides, what base model it came from, what quantization method or level was used, and which loader is expected.
+
+Merges and repackages deserve special care because their names can sound authoritative while their provenance is mixed. A merged model may combine behavior from multiple sources, and a repackaged model may exist only to fit a tool's file expectations. Neither category is automatically bad. The risk is opacity. If you cannot explain what changed, you cannot explain whether a surprising output came from the base model, the derivative process, the prompt, or your runtime.
+
+Beginners should use derivatives after establishing a baseline. First, run or at least evaluate an official or well-documented source model. Then compare the derivative against that baseline using the same prompt, task, and environment where possible. This turns derivative evaluation into a controlled experiment instead of a popularity contest. You learn more from a modest comparison than from chasing the most dramatic benchmark screenshot.
+
+Hypothetical scenario: a derivative page has many community likes, a short description, and a file format that your laptop runtime supports. The original model page has clearer intended use, limitations, and license text, but the files are too large for your current machine. A reasonable learner decision is to study the original page for provenance, then use the derivative only if it clearly states its base model, conversion method, and compatible runtime. Convenience is valuable, but it should not erase the source chain.
+
+The most useful derivative question is "what changed?" Ask it repeatedly. What changed in data? What changed in weights? What changed in precision? What changed in file format? What changed in prompt template? What changed in license obligations? A derivative that answers those questions can be a strong learning asset. A derivative that avoids them may still work, but it is a poor first teaching example because it makes cause and effect harder to see.
+
+There is also a social signal to read carefully. Comments, downloads, and likes can reveal whether people are successfully using a derivative, but they are not substitutes for documentation. Community activity may cluster around a tool, a temporary leaderboard, or a niche workflow. Use social signals as hints for further inspection, not as the main criterion. A beginner's best defense is a written checklist that privileges provenance and reproducibility.
+
+## Choosing A Sane First Model Repository
+
+A sane first model repository is not necessarily the most powerful model you can find. It is the repository that lets you connect concept, artifact, and runtime with the fewest hidden assumptions. You want a clear model card, an obvious task, a license you can read, a file list that matches a known loader, examples that fit your environment, and recent enough maintenance that the instructions are not obviously stale. That combination makes mistakes easier to diagnose.
+
+The learner-stage optimization target is clarity, compatibility, repeatability, and explainability. Clarity means the page tells you what the model is and what it is not. Compatibility means the files and examples match software you can actually use. Repeatability means you can run the same basic test again and get a comparable result. Explainability means you can describe why you chose the repo without saying "it looked popular."
+
+Do not optimize first for parameter count, trendiness, leaderboard rank, or the most impressive screenshot. Those signals have their place later, but they can distort early learning. A giant model that fails to load teaches you mostly about resource limits. A trending derivative with weak notes teaches you mostly about confusion. A smaller, well-documented repo teaches you how the ecosystem works, and that skill transfers to larger choices later.
+
+The first-model checklist should be written before you browse deeply, because browsing can pull you toward whatever looks exciting. Decide in advance that a good first repo needs a model card, intended use, limitations, license, file list, example path, and clear relationship to its source. Then use the checklist to compare candidates. This keeps evaluation grounded when names, badges, and community comments start competing for attention.
+
+Worked example: suppose you are choosing between two text models for a local summarization experiment. Repo A has an official publisher, a task label that matches summarization, a model card with limitations, clear license terms, and a Transformers snippet. Repo B is larger and popular, but the card mostly says it is "great" and the files target a runtime you have not installed. Repo A is the better first learner choice because it gives you a clean path from task to runtime.
+
+After you pick a repo, capture your assumptions in a small decision note. Write the artifact type, task, publisher, license, limitations, file format, runtime path, and one expected success criterion. This note makes your first run more meaningful. If the run fails, you can compare the failure with each assumption. If the run succeeds, you have a reusable pattern for evaluating the next model.
+
+Which approach would you choose here and why: a smaller model with excellent documentation and a known loader, or a larger derivative with unclear provenance but many likes? For a first learner experiment, choose the smaller documented model. That choice is not timid; it is disciplined. You are building the ability to inspect, run, and explain models, and those skills matter more than one impressive output.
+
+This selection habit also helps you talk with more experienced practitioners. Instead of asking whether a model is "good," you can ask whether it is good for a task, under a license, with a runtime, on a hardware budget, and with documented limitations. That phrasing invites better answers. It also reveals when someone else's recommendation assumes constraints that do not match your lab.
+
+## Patterns & Anti-Patterns
+
+The strongest beginner pattern is to evaluate before downloading. It feels slower because you spend several minutes reading, but it reduces wasted time by turning vague interest into a testable plan. Use this pattern when you are selecting a first model, comparing official and derivative repos, or preparing a tutorial for someone else. It scales because the same questions still apply when models become larger, workloads become shared, or inference moves into containers.
+
+Another useful pattern is baseline before derivative. Start with an official or well-documented source when possible, learn its intended behavior, and then compare a derivative against that reference. This pattern works because it gives you a control. Without a baseline, it is difficult to know whether a behavior difference comes from fine tuning, quantization, prompt format, runtime settings, or your own expectations.
+
+The third pattern is category labeling. Every time you open a Hugging Face page, label it as model, dataset, Space, or library documentation. This habit sounds almost too basic, but it prevents many beginner errors. It also scales to team settings because shared notes become clearer when each link carries its role. A list of unlabeled links becomes a maze; a list of typed links becomes a map.
+
+The most common anti-pattern is popularity-first selection. Teams fall into it because downloads, likes, and leaderboard claims are visible, while provenance and limitations require reading. The better alternative is documentation-first selection for the first lab, then performance comparison after you can reproduce a baseline. Popularity can help you find candidates, but it should not make the decision alone.
+
+Another anti-pattern is format-blind copying. A learner sees a model name, copies a file or snippet, and assumes any runtime will load it. This fails because file formats, tokenizer assets, adapter requirements, and configuration conventions are not interchangeable. The better alternative is to inspect the file list and example path before choosing a runtime. Inference begins with compatibility, not just enthusiasm.
+
+The third anti-pattern is derivative amnesia, where a learner forgets that a convenient repo may have changed the base model. This happens because derivative names often preserve the recognizable model family while adding suffixes that seem harmless. The fix is to trace the base model, conversion method, fine tune notes, license inheritance, and intended runtime. If the page does not make that chain clear, use it later rather than first.
+
+| Pattern or anti-pattern | When it appears | Better learner behavior |
+|---|---|---|
+| Evaluate before downloading | Choosing any first repo | Read card, license, limitations, files, and example path first |
+| Baseline before derivative | Comparing source and community versions | Run or study the source model before judging the derivative |
+| Category labeling | Browsing mixed Hub results | Mark each page as model, dataset, Space, or library docs |
+| Popularity-first selection | Sorting by hype, likes, or downloads | Use social signals only after documentation checks |
+| Format-blind copying | Moving files between runtimes | Match file format and tokenizer assets to the loader |
+| Derivative amnesia | Using quantized, merged, or fine-tuned repos | Trace provenance and changed assumptions before trusting results |
+
+These patterns are intentionally modest. They do not require advanced machine learning math, a GPU, or a production serving platform. They require careful reading and a repeatable decision process. That is exactly what learners need at this stage, because the open-model ecosystem changes quickly. A stable inspection method is more durable than memorizing whichever model name is fashionable this month.
+
+## When You'd Use This vs Alternatives
+
+Use Hugging Face as your first discovery and inspection path when you need to understand open-model artifacts in context. The Hub is useful when you want to compare model cards, licenses, file lists, datasets, demos, and library examples near one another. It is also useful when you want to learn community conventions, because many open-model projects publish or mirror their artifacts there. The tradeoff is that the catalog is broad, so you must filter deliberately.
+
+Use a vendor's own documentation when the original publisher maintains more detailed release notes, technical reports, safety guidance, or license explanations outside the Hub. Hugging Face pages are often concise, and they may link to external papers or project pages for deeper context. A learner should follow those links when the model card references them. The Hub page is the entry point, not always the whole documentation set.
+
+Use a runtime-specific registry or documentation when your main constraint is execution rather than discovery. If you already know you need a certain local runtime, model server, or file format, the runtime documentation may tell you exactly which artifacts are compatible. Hugging Face still helps with provenance, but the runtime guide may answer installation, memory, and serving questions more directly. The right workflow often uses both sources.
+
+Use a browser demo or Space when you want a quick behavioral preview before investing in setup. This is useful for building intuition, comparing prompts, or checking whether a task feels plausible. Do not stop there if your goal is local inference. A demo may hide runtime details, hardware assumptions, preprocessing, or model revisions. Treat it as a preview that points back to repositories and documentation.
+
+| If your immediate goal is... | Start with... | Then verify... |
+|---|---|---|
+| Learn what a model is for | Model card on Hugging Face | Intended use, limitations, license, file list |
+| Learn how to load it in Python | Transformers documentation | Config compatibility, tokenizer, package requirements |
+| Learn whether a dataset is relevant | Dataset card and viewer | Schema, splits, source, license, evaluation fit |
+| Try behavior quickly | Space or hosted demo | Linked model, hidden preprocessing, local reproducibility |
+| Run on constrained hardware | Runtime-specific format docs | Quantization method, file format, quality tradeoff |
+
+The decision framework is therefore a loop rather than a single page. Identify the artifact type, read the human explanation, inspect the files, match the runtime, and write down the assumption you are testing. If any step is unclear, choose a more documented candidate for the first lab. Once you can explain one clean path, you can return to harder repos with better questions.
+
+## Did You Know?
+
+- Hugging Face model cards are inspired by the broader "Model Cards for Model Reporting" idea introduced in 2019, which pushed model publishers to describe intended use, evaluation, and limitations rather than only sharing performance numbers.
+- Transformers grew from natural language processing tooling into a broad library for text, vision, audio, multimodal, and reinforcement learning workflows, so its documentation can describe software patterns that span many different repository types.
+- Hugging Face Spaces can run demos backed by frameworks such as Gradio or Streamlit, which means a learner may be seeing an application layer rather than the model repository itself.
+- Safetensors was designed as a safer tensor storage format than pickle-based weight loading, which matters because model files are executable-adjacent artifacts that learners should treat with care.
 
 ## Common Mistakes
 
-| Mistake | Why It Hurts | Better Move |
+| Mistake | Why It Happens | How to Fix It |
 |---|---|---|
-| treating every repo as equally trustworthy | provenance varies a lot | start with official or well-documented sources |
-| confusing a library page with a model page | breaks mental model of the ecosystem | separate model, docs, and runtime concerns |
-| picking by popularity alone | hides fit and clarity problems | choose for documentation and repeatability |
-| ignoring limitations | creates false trust | read intended use and known weaknesses first |
+| Treating every repo as equally trustworthy | The Hub gives many pages a similar visual shape, so weak documentation can look as official as strong documentation | Start with official or well-documented sources, then write down provenance before downloading |
+| Confusing a library page with a model page | Transformers examples and model cards both contain code, which blurs the difference between software and artifact | Label each page as model, dataset, Space, or library documentation before following instructions |
+| Picking by popularity alone | Downloads and likes are visible, while limitations and license terms require slower reading | Use popularity only as a discovery signal after the card, license, limitations, and file list pass inspection |
+| Ignoring limitations | Learners want to see success quickly and may treat caveats as optional background | Read intended use and known weaknesses before running prompts, then compare bad outputs with those caveats |
+| Downloading before checking file formats | Model names feel more important than repository contents when you are new to inference tooling | Inspect config, tokenizer, weights, adapters, and expected runtime before choosing a local path |
+| Trusting a derivative without tracing changes | Quantized or fine-tuned repos can feel convenient, especially when they target common laptop runtimes | Identify the base model, conversion method, fine-tune notes, license inheritance, and compatible loader |
+| Treating a Space as proof of local reproducibility | A demo hides hardware, dependencies, prompt templates, and sometimes the exact model revision | Use the Space to preview behavior, then verify the linked repo and local loading instructions separately |
 
-## Quick Quiz
+## Quiz
 
-1. **What is the difference between a model repo and a library like Transformers?**
-   <details>
-   <summary>Answer</summary>
-   A model repo contains assets and metadata for a specific model; a library provides the software interface used to load and run models.
-   </details>
+<details>
+<summary>Your teammate evaluates two Hugging Face model repositories for a first local inference lab. Repo A has a clear model card, license, limitations, file list, and Transformers example. Repo B is larger and more popular but does not explain its provenance. Which one should they choose first, and why?</summary>
 
-2. **Why are community derivatives useful but risky for beginners?**
-   <details>
-   <summary>Answer</summary>
-   Because they may be optimized for convenience or performance, but their provenance, tradeoffs, or limitations can be less clear than the original source model.
-   </details>
+Choose Repo A for the first learner lab. The goal is to evaluate model repositories in a way that makes the next mistake diagnosable, and Repo A provides the information needed to connect task, license, limitations, files, and runtime. Repo B might become useful later, but popularity and size do not replace provenance. Starting with the clearer repo creates a baseline that makes later comparisons with larger or derivative models more meaningful.
+</details>
 
-3. **What should a learner optimize for first on Hugging Face?**
-   <details>
-   <summary>Answer</summary>
-   Clarity, compatibility, documentation quality, and repeatability.
-   </details>
+<details>
+<summary>You open a Hugging Face page that has column names, splits, and a data viewer, but no model weight files. A beginner tries to load it as a text generation model and gets errors. What should you diagnose first?</summary>
+
+Diagnose the artifact category first because the page is likely a dataset repository, not a model repository. The right fix is not to change random loader arguments but to differentiate datasets, models, Spaces, and library documentation before choosing a path. A dataset can be related to training or evaluation, but it is not loaded as model weights. Once the category is clear, the learner can find the model repo or use dataset-specific documentation.
+</details>
+
+<details>
+<summary>A derivative repo says it is quantized for a laptop runtime, but the card does not name the base model or explain the quantization method. The files might run on your machine. What risk should you diagnose before using it as a teaching example?</summary>
+
+The main risk is opaque provenance. Quantization can be useful because it reduces resource requirements, but a learner still needs to know what changed, which base model was used, which file format is expected, and what quality tradeoffs may exist. If the derivative does not explain those points, failures or surprising outputs become hard to interpret. It is better to use that repo after studying a clearer source model or to choose a derivative with better notes.
+</details>
+
+<details>
+<summary>You find a Space that gives impressive answers for your prompt, and the page links to a model repo. Your goal is local inference. What should you verify before treating the Space result as reproducible?</summary>
+
+Verify the linked model identity, file formats, license, local loading path, and whether the Space applies hidden preprocessing, prompts, or runtime settings. A Space proves that an application interaction is possible, but it does not prove that your machine can reproduce the same path. The demo may use hosted hardware or a different revision. Treat the Space as a preview, then inspect the repository and library documentation for reproducibility.
+</details>
+
+<details>
+<summary>Your first model choice has a strong benchmark screenshot but no limitations section and no practical inference notes. Another smaller model has modest claims and detailed loading guidance. Which selection checklist principle applies?</summary>
+
+Prioritize clarity, compatibility, repeatability, and explainability over hype. A benchmark screenshot may be interesting, but it does not tell you whether the model fits your task, license, environment, or loader. The smaller documented model is usually a better first learner choice because it gives you a controlled path from inspection to execution. Once that path is clear, benchmark-driven comparisons become more useful.
+</details>
+
+<details>
+<summary>You copied a loading snippet from Transformers documentation but never inspected the model repository's tokenizer files or task label. The code runs, but outputs look strange for your task. What should you check next?</summary>
+
+Check whether the repository actually matches the task and whether its tokenizer and configuration fit the loading path you used. Transformers documentation explains software patterns, but the model repo declares the artifact's intended use and required assets. Strange output can come from a task mismatch, prompt format mismatch, tokenizer assumption, or using a derivative with different behavior. Return to the model card, file list, and examples before changing code blindly.
+</details>
+
+<details>
+<summary>You need to design a repeatable first-model selection checklist for a study group. Which items must be on it so the group can compare repositories consistently?</summary>
+
+Include artifact type, task, publisher or provenance, model card quality, intended use, limitations, license, file formats, tokenizer or required assets, example runtime path, and expected success criteria. These items make model selection comparable across learners instead of dependent on whoever found the most exciting link. The checklist also aligns the learning activity with the assessment: everyone can justify the repo they chose. A repeatable checklist is the difference between browsing and evaluation.
+</details>
 
 ## Hands-On Exercise
 
-Pick one official model repo and one derivative repo.
+Exercise scenario: choose one official or clearly documented Hugging Face model repository and one community derivative that appears related to the same model family or task. You do not need to download the files for this exercise. Your job is to inspect, compare, and decide which repository is the better first learner experiment for local inference.
 
-Compare:
-- provenance
-- documentation quality
-- intended use
-- limitations
-- whether you would trust each one as a first learner experiment
+Start by opening each repository in separate browser tabs and reading the model cards from top to bottom. Resist the urge to rank them immediately. Instead, collect evidence in a short note so your decision is based on the same fields for both repositories. If a field is missing, write "missing" rather than guessing. Missing information is itself part of the evaluation.
 
-## Next Module
+- [ ] Task 1: Differentiate each page as a model repository, dataset repository, Space, or library documentation page, then record the artifact type and intended task.
 
-Continue to [Quantization and Model Formats](./module-1.3-quantization-and-model-formats/).
+<details>
+<summary>Solution guidance for Task 1</summary>
+
+A model repository should expose model-oriented metadata, files, and a model card. If the page mainly shows data splits or a viewer, it is a dataset. If it runs an app in the browser, it is a Space. If it explains APIs rather than a specific artifact, it is library documentation. Your note should make the category explicit before you compare quality.
+</details>
+
+- [ ] Task 2: Evaluate the model card for each repository by recording intended use, limitations, license, publisher, and whether the page explains how to load or test the model.
+
+<details>
+<summary>Solution guidance for Task 2</summary>
+
+The stronger first learner repository usually names the task clearly, provides limitations, states the license, identifies the publisher or source chain, and includes practical loading guidance. If a repo omits several of these items, mark that as a risk rather than filling in the blank from memory. The goal is to compare documented evidence.
+</details>
+
+- [ ] Task 3: Diagnose derivative risk by tracing the base model, fine-tuning or quantization notes, file format, tokenizer expectations, and compatible runtime.
+
+<details>
+<summary>Solution guidance for Task 3</summary>
+
+For a derivative, look for the base model link, what changed, why it changed, and which runtime the files target. A useful derivative explains whether it is quantized, fine tuned, merged, or repackaged. If those notes are missing, the derivative may still run, but it is a weaker first teaching artifact because behavior and compatibility are harder to explain.
+</details>
+
+- [ ] Task 4: Design a repeatable first-model selection checklist with at least eight fields your future self could reuse for another repository comparison.
+
+<details>
+<summary>Solution guidance for Task 4</summary>
+
+A strong checklist includes artifact type, task, publisher, provenance, license, limitations, file formats, tokenizer assets, runtime path, example instructions, expected hardware fit, and success criteria. Keep it short enough to reuse but specific enough to guide decisions. The checklist should make clarity and reproducibility visible rather than relying on memory.
+</details>
+
+- [ ] Task 5: Choose the better first learner repository and write a five-sentence justification that mentions clarity, compatibility, reproducibility, and one risk in the rejected option.
+
+<details>
+<summary>Solution guidance for Task 5</summary>
+
+The best answer is evidence based, not hype based. A good justification says which repo you chose, what task it supports, why the model card and file list make it compatible with your planned runtime, and how the license and limitations affect your confidence. It should also name a concrete risk in the rejected option, such as missing provenance, unclear quantization notes, or poor loading guidance.
+</details>
+
+Success criteria:
+
+- [ ] You classified both Hugging Face pages correctly before comparing them.
+- [ ] You evaluated model repository evidence instead of relying on popularity or parameter count.
+- [ ] You differentiated model documentation from library, dataset, and Space documentation.
+- [ ] You diagnosed at least one community derivative risk using provenance, quantization, fine tuning, or compatibility notes.
+- [ ] You produced a reusable first-model selection checklist and a written decision.
 
 ## Sources
 
@@ -181,3 +335,16 @@ Continue to [Quantization and Model Formats](./module-1.3-quantization-and-model
 - [Tokenizer main classes](https://huggingface.co/docs/transformers/main/main_classes/tokenizer) — Documents tokenizer assets and related files used when preparing models for inference.
 - [Transformers Documentation](https://huggingface.co/docs/transformers/main/en/index) — Distinguishes the Transformers software library from model repositories and explains how models are loaded and used.
 - [Model Cards](https://huggingface.co/docs/hub/model-cards) — Describes the metadata and guidance model pages should include, such as intended use, limitations, and licensing.
+- [Hugging Face models documentation](https://huggingface.co/docs/hub/en/models)
+- [Hugging Face datasets documentation](https://huggingface.co/docs/hub/en/datasets)
+- [Hugging Face Spaces documentation](https://huggingface.co/docs/hub/en/spaces)
+- [Hugging Face repository documentation](https://huggingface.co/docs/hub/en/repositories)
+- [Hugging Face gated models documentation](https://huggingface.co/docs/hub/en/models-gated)
+- [Downloading models documentation](https://huggingface.co/docs/hub/en/models-downloading)
+- [Transformers Auto classes documentation](https://huggingface.co/docs/transformers/en/model_doc/auto)
+- [Transformers installation documentation](https://huggingface.co/docs/transformers/en/installation)
+- [Safetensors documentation](https://huggingface.co/docs/safetensors/index)
+
+## Next Module
+
+Continue to [Quantization and Model Formats](./module-1.3-quantization-and-model-formats/) to learn how file formats, precision, and runtime constraints shape local inference choices.


### PR DESCRIPTION
## Summary

Rewrites `src/content/docs/ai/open-models-local-inference/module-1.2-hugging-face-for-learners.md` to clear the #388 density, structure, alignment, anti-leak, and protected-assets gates while preserving the original topic coverage and source URLs.

## Verification

Verifier: T0; body_words=5083, mean_wpp=72.6, median_wpp=73.5, short_rate=0.014, max_run=1; failure_gates={}; source reachability skipped per command with --skip-source-check.

Protected assets preserved: before code_blocks=0, ascii_diagrams=0, mermaid_diagrams=0, tables=1, source_urls=5; after code_blocks=0, ascii_diagrams=0, mermaid_diagrams=0, tables=6, source_urls=14. All 5 original source URLs remain in the Sources section.

Command run: `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/quality/verify_module.py --glob src/content/docs/ai/open-models-local-inference/module-1.2-hugging-face-for-learners.md --skip-source-check --summary --quiet`

Commit: 2a311ec0