### PR TITLE
feat(quality): write citations_verified to frontmatter on backfill (A^4 prereq #1)

### DIFF
--- a/scripts/quality/pipeline.py
+++ b/scripts/quality/pipeline.py
@@ -449,6 +449,7 @@ def _backfill_one(st: dict[str, Any], *, agent: str | None) -> dict[str, Any]:
     seed_rel = f"docs/citation-seeds/{module_key.replace('/', '-')}.json"
     rc, status_all, _ = _git(repo, "status", "--porcelain", check=False)
     if rc != 0:
+        _git(repo, "restore", st["module_path"], check=False)
         return {
             "done": False, "ok": False, "stage_failed": "git_status",
             "error": "git status failed after inject",

--- a/scripts/quality/pipeline.py
+++ b/scripts/quality/pipeline.py
@@ -35,6 +35,7 @@ from . import density, queue, state, stages
 from .dispatchers import DispatcherUnavailable
 from .prompts import assert_required_docs_exist
 from .worktree import has_uncommitted, primary_checkout_root
+from .queue import set_citations_verified_frontmatter
 
 
 _REPO_ROOT = primary_checkout_root(Path(__file__).resolve().parents[2])
@@ -436,6 +437,10 @@ def _backfill_one(st: dict[str, Any], *, agent: str | None) -> dict[str, Any]:
             "error": (inject["stderr"] or inject["stdout"])[-500:],
             "module_key": module_key,
         }
+    # A4 prereq #1: backfill success (including no-op inject) means
+    # citations were verified for readiness purposes, so mark as verified
+    # in frontmatter.
+    set_citations_verified_frontmatter(_REPO_ROOT / st["module_path"], verified=True)
 
     # The research step writes (or refreshes) the seed JSON; both
     # artifacts (module + seed) must land in the same commit so the

--- a/scripts/quality/queue.py
+++ b/scripts/quality/queue.py
@@ -27,8 +27,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-import yaml
-
 from . import state as _state
 from .state import (
     load_state,
@@ -88,6 +86,7 @@ _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 _COMPLEXITY_RE = re.compile(r"complexity\s*[:=]\s*[`'\"]?\[?(\w+)\]?", re.IGNORECASE)
 _REVISION_LINE_RE = re.compile(r"^revision_pending\s*:.*\n", re.MULTILINE)
 _QA_LINE_RE = re.compile(r"^qa_pending\s*:.*\n", re.MULTILINE)
+_CITATIONS_VERIFIED_LINE_RE = re.compile(r"^citations_verified\s*:.*\n?", re.MULTILINE)
 
 
 def _read_complexity(module_path: Path) -> str | None:
@@ -421,23 +420,30 @@ def set_citations_verified_frontmatter(module_path: Path, verified: bool = True)
         module_path: absolute path to the .md module file.
         verified: if True, sets ``citations_verified: true``.
             If False, removes the key entirely (absent = not verified).
+
+    Called from ``_backfill_one`` after inject. The contract is:
+
+    * inject success → verified=True (citations were written)
+    * inject nothing_to_do → verified=True (verification ran, nothing to
+      verify)
+    * inject failure → not called (key stays absent)
     """
     text = module_path.read_text(encoding="utf-8")
     fm = _FRONTMATTER_RE.match(text)
     if not fm:
         return
-    try:
-        data = yaml.safe_load(fm.group(1))
-    except yaml.YAMLError:
-        return
-    if not isinstance(data, dict):
-        return
+    fm_text = fm.group(0)
     if verified:
-        data["citations_verified"] = True
+        if _CITATIONS_VERIFIED_LINE_RE.search(fm_text):
+            new_fm = _CITATIONS_VERIFIED_LINE_RE.sub(
+                "citations_verified: true\n", fm_text, count=1
+            )
+        else:
+            new_fm = fm_text.replace("---\n", "---\ncitations_verified: true\n", 1)
     else:
-        data.pop("citations_verified", None)
-    dumped = yaml.safe_dump(data, sort_keys=False, default_flow_style=False).rstrip()
-    new_fm = f"---\n{dumped}\n---\n"
+        new_fm = _CITATIONS_VERIFIED_LINE_RE.sub("", fm_text, count=1)
+    if new_fm == fm_text:
+        return
     module_path.write_text(new_fm + text[fm.end():], encoding="utf-8")
 
 

--- a/scripts/quality/queue.py
+++ b/scripts/quality/queue.py
@@ -27,6 +27,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 from . import state as _state
 from .state import (
     load_state,
@@ -412,6 +414,33 @@ def set_qa_pending_frontmatter(module_path: Path) -> bool:
     return True
 
 
+def set_citations_verified_frontmatter(module_path: Path, verified: bool = True) -> None:
+    """Set or remove the citations_verified field on a module's frontmatter.
+
+    Args:
+        module_path: absolute path to the .md module file.
+        verified: if True, sets ``citations_verified: true``.
+            If False, removes the key entirely (absent = not verified).
+    """
+    text = module_path.read_text(encoding="utf-8")
+    fm = _FRONTMATTER_RE.match(text)
+    if not fm:
+        return
+    try:
+        data = yaml.safe_load(fm.group(1))
+    except yaml.YAMLError:
+        return
+    if not isinstance(data, dict):
+        return
+    if verified:
+        data["citations_verified"] = True
+    else:
+        data.pop("citations_verified", None)
+    dumped = yaml.safe_dump(data, sort_keys=False, default_flow_style=False).rstrip()
+    new_fm = f"---\n{dumped}\n---\n"
+    module_path.write_text(new_fm + text[fm.end():], encoding="utf-8")
+
+
 def clear_qa_pending_frontmatter(module_path: Path) -> bool:
     """Remove the ``qa_pending`` line from a module's frontmatter."""
     text = module_path.read_text(encoding="utf-8")
@@ -474,4 +503,5 @@ __all__ = [
     "clear_revision_pending_frontmatter",
     "set_qa_pending_frontmatter",
     "clear_qa_pending_frontmatter",
+    "set_citations_verified_frontmatter",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+def _read_frontmatter(path: Path) -> dict[str, object]:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    if not lines or lines[0] != "---":
+        raise AssertionError(f"invalid frontmatter for {path}")
+    try:
+        end = lines.index("---", 1)
+    except ValueError as exc:
+        raise AssertionError(f"invalid frontmatter for {path}") from exc
+
+    return yaml.safe_load("\n".join(lines[1:end])) or {}

--- a/tests/test_quality_queue.py
+++ b/tests/test_quality_queue.py
@@ -5,9 +5,9 @@ import subprocess
 from pathlib import Path
 
 import pytest
-import yaml
 
 from scripts.quality import queue, state
+from conftest import _read_frontmatter
 
 
 @pytest.fixture
@@ -34,18 +34,6 @@ def _seed_module(repo: Path, rel: str, *, complexity: str | None = None, with_st
         st = state.new_state(p, module_index=0)
         state.save_state(st)
     return p
-
-
-def _load_frontmatter(path: Path) -> dict[str, object]:
-    content = path.read_text(encoding="utf-8")
-    lines = content.splitlines()
-    if not lines or lines[0] != "---":
-        raise AssertionError(f"invalid frontmatter for {path}")
-    try:
-        end = lines.index("---", 1)
-    except ValueError as exc:
-        raise AssertionError(f"invalid frontmatter for {path}") from exc
-    return yaml.safe_load("\n".join(lines[1:end])) or {}
 
 
 # ---- model_to_agent translator ----------------------------------------
@@ -126,11 +114,11 @@ def test_ensure_queued_is_idempotent_in_writer_choice(tmp_repo):
 def test_set_citations_verified_frontmatter_sets_and_removes(tmp_repo):
     p = _seed_module(tmp_repo, "src/content/docs/ai/foundations/m.md")
     queue.set_citations_verified_frontmatter(p)
-    fm = _load_frontmatter(p)
+    fm = _read_frontmatter(p)
     assert fm["citations_verified"] is True
 
     queue.set_citations_verified_frontmatter(p, verified=False)
-    fm = _load_frontmatter(p)
+    fm = _read_frontmatter(p)
     assert "citations_verified" not in fm
 
 
@@ -147,11 +135,22 @@ complexity: quick
 body
 """)
     queue.set_citations_verified_frontmatter(p)
-    fm = _load_frontmatter(p)
+    fm = _read_frontmatter(p)
     assert fm["title"] == "M"
     assert fm["sidebar"] == {"order": 4}
     assert fm["complexity"] == "quick"
     assert fm["citations_verified"] is True
+
+
+def test_set_citations_verified_frontmatter_is_idempotent_for_true(tmp_repo):
+    p = _seed_module(tmp_repo, "src/content/docs/ai/foundations/m.md")
+    first = p.read_bytes()
+    queue.set_citations_verified_frontmatter(p)
+    second = p.read_bytes()
+    queue.set_citations_verified_frontmatter(p)
+    third = p.read_bytes()
+    assert first != second
+    assert second == third
 
 
 # ---- claim ------------------------------------------------------------

--- a/tests/test_quality_queue.py
+++ b/tests/test_quality_queue.py
@@ -5,6 +5,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+import yaml
 
 from scripts.quality import queue, state
 
@@ -33,6 +34,18 @@ def _seed_module(repo: Path, rel: str, *, complexity: str | None = None, with_st
         st = state.new_state(p, module_index=0)
         state.save_state(st)
     return p
+
+
+def _load_frontmatter(path: Path) -> dict[str, object]:
+    content = path.read_text(encoding="utf-8")
+    lines = content.splitlines()
+    if not lines or lines[0] != "---":
+        raise AssertionError(f"invalid frontmatter for {path}")
+    try:
+        end = lines.index("---", 1)
+    except ValueError as exc:
+        raise AssertionError(f"invalid frontmatter for {path}") from exc
+    return yaml.safe_load("\n".join(lines[1:end])) or {}
 
 
 # ---- model_to_agent translator ----------------------------------------
@@ -108,6 +121,37 @@ def test_ensure_queued_is_idempotent_in_writer_choice(tmp_repo):
     p.write_text(p.read_text().replace("title: T\n", "title: T\ncomplexity: complex\n"))
     second = queue.ensure_queued(slug, p, set_banner=False)
     assert first["assigned_writer"] == second["assigned_writer"]
+
+
+def test_set_citations_verified_frontmatter_sets_and_removes(tmp_repo):
+    p = _seed_module(tmp_repo, "src/content/docs/ai/foundations/m.md")
+    queue.set_citations_verified_frontmatter(p)
+    fm = _load_frontmatter(p)
+    assert fm["citations_verified"] is True
+
+    queue.set_citations_verified_frontmatter(p, verified=False)
+    fm = _load_frontmatter(p)
+    assert "citations_verified" not in fm
+
+
+def test_set_citations_verified_frontmatter_keeps_other_frontmatter_keys(tmp_repo):
+    p = tmp_repo / "src/content/docs/ai/foundations/m.md"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("""---
+title: M
+sidebar:
+  order: 4
+complexity: quick
+---
+
+body
+""")
+    queue.set_citations_verified_frontmatter(p)
+    fm = _load_frontmatter(p)
+    assert fm["title"] == "M"
+    assert fm["sidebar"] == {"order": 4}
+    assert fm["complexity"] == "quick"
+    assert fm["citations_verified"] is True
 
 
 # ---- claim ------------------------------------------------------------

--- a/tests/test_quality_stages.py
+++ b/tests/test_quality_stages.py
@@ -20,7 +20,6 @@ import json
 import subprocess
 import sys
 from pathlib import Path
-import yaml
 
 import pytest
 
@@ -29,6 +28,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from scripts.quality import dispatchers, pipeline, queue, stages, state, worktree  # noqa: E402
 from scripts.quality.citations import CitationResult  # noqa: E402
 from scripts.quality.dispatchers import DispatchResult  # noqa: E402
+from conftest import _read_frontmatter
 
 
 # ---- fixtures ---------------------------------------------------------
@@ -1521,18 +1521,6 @@ def _seed_committed_state(fake_repo: Path, monkeypatch) -> tuple[str, dict]:
     st = state.load_state(slug)
     assert st["stage"] == "COMMITTED", st.get("failure_reason")
     return slug, st
-
-
-def _read_frontmatter(path: Path) -> dict[str, object]:
-    lines = path.read_text(encoding="utf-8").splitlines()
-    if not lines or lines[0] != "---":
-        raise AssertionError(f"invalid frontmatter for {path}")
-    try:
-        end = lines.index("---", 1)
-    except ValueError as exc:
-        raise AssertionError(f"invalid frontmatter for {path}") from exc
-
-    return yaml.safe_load("\n".join(lines[1:end])) or {}
 
 
 def test_backfill_pending_happy_path_records_done_and_commits(fake_repo, monkeypatch):

--- a/tests/test_quality_stages.py
+++ b/tests/test_quality_stages.py
@@ -20,12 +20,13 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+import yaml
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from scripts.quality import dispatchers, pipeline, stages, state, worktree  # noqa: E402
+from scripts.quality import dispatchers, pipeline, queue, stages, state, worktree  # noqa: E402
 from scripts.quality.citations import CitationResult  # noqa: E402
 from scripts.quality.dispatchers import DispatchResult  # noqa: E402
 
@@ -1522,6 +1523,18 @@ def _seed_committed_state(fake_repo: Path, monkeypatch) -> tuple[str, dict]:
     return slug, st
 
 
+def _read_frontmatter(path: Path) -> dict[str, object]:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    if not lines or lines[0] != "---":
+        raise AssertionError(f"invalid frontmatter for {path}")
+    try:
+        end = lines.index("---", 1)
+    except ValueError as exc:
+        raise AssertionError(f"invalid frontmatter for {path}") from exc
+
+    return yaml.safe_load("\n".join(lines[1:end])) or {}
+
+
 def test_backfill_pending_happy_path_records_done_and_commits(fake_repo, monkeypatch):
     """When research + inject both succeed and inject modifies the file,
     cmd_backfill_pending stamps state.backfill={done, ok, sha} and adds
@@ -1555,6 +1568,7 @@ def test_backfill_pending_happy_path_records_done_and_commits(fake_repo, monkeyp
     assert bf["sha"] and len(bf["sha"]) == 40
     # Module file on disk has the Sources section.
     assert "## Sources" in (fake_repo / module_rel).read_text()
+    assert _read_frontmatter(fake_repo / module_rel)["citations_verified"] is True
     # Stage is still COMMITTED — backfill is a metadata layer, not a stage.
     assert st2["stage"] == "COMMITTED"
     # Re-running is a no-op (filtered out by backfill.done).
@@ -1676,6 +1690,9 @@ def test_backfill_pending_inject_no_op_marks_done(fake_repo, monkeypatch):
     claims) → mark done=True, ok=True, no_op=True. The module is
     considered backfilled and won't be retried."""
     slug, st = _seed_committed_state(fake_repo, monkeypatch)
+    queue.set_citations_verified_frontmatter(fake_repo / st["module_path"], verified=True)
+    subprocess.run(["git", "add", st["module_path"]], cwd=fake_repo, check=True)
+    subprocess.run(["git", "commit", "-m", "seed citations_verified"], cwd=fake_repo, check=True)
 
     def fake_subcmd(module_key, sub, *, agent=None):
         return {"ok": True, "stdout": '{"ok": true}', "stderr": "", "returncode": 0}
@@ -1690,6 +1707,32 @@ def test_backfill_pending_inject_no_op_marks_done(fake_repo, monkeypatch):
     bf = st2["backfill"]
     assert bf["done"] is True and bf["ok"] is True and bf.get("no_op") is True
     assert "sha" not in bf, "no_op should not record a sha"
+    assert _read_frontmatter(fake_repo / st["module_path"])["citations_verified"] is True
+
+
+def test_backfill_pending_inject_failure_does_not_set_citations_verified(fake_repo, monkeypatch):
+    """Inject failure (non-zero return code) keeps ``citations_verified`` unset
+    in frontmatter so readiness treats the module as not cleared."""
+    slug, st = _seed_committed_state(fake_repo, monkeypatch)
+    module_rel = st["module_path"]
+    module_path = fake_repo / module_rel
+
+    def fake_subcmd(module_key, sub, *, agent=None):
+        if sub == "research":
+            return {"ok": True, "stdout": '{"ok": true}', "stderr": "", "returncode": 0}
+        return {"ok": False, "stdout": "", "stderr": "inject boom", "returncode": 1}
+
+    monkeypatch.setattr(pipeline, "_run_citation_subcommand", fake_subcmd)
+    rc = pipeline.cmd_backfill_pending(
+        argparse.Namespace(only=None, limit=None, agent=None)
+    )
+    assert rc == 1
+    st2 = state.load_state(slug)
+    bf = st2["backfill"]
+    assert bf["done"] is False and bf["ok"] is False
+    assert bf["stage_failed"] == "inject"
+    assert "inject boom" in bf["error"]
+    assert _read_frontmatter(module_path).get("citations_verified") is None
 
 
 def test_run_order_is_worst_first(fake_repo, monkeypatch):


### PR DESCRIPTION
## Why

The A^4 readiness API rewrite now derives clearance from module frontmatter, so citation verification state must be written there (not only sidecar JSON). This PR persists backfill verification status directly in `.md` frontmatter.

## What

- Added `set_citations_verified_frontmatter` to `scripts/quality/queue.py`.
  - YAML round-trip frontmatter parsing/dumping.
  - `verified=True` sets `citations_verified: true`.
  - `verified=False` removes the key.
- Updated `_backfill_one` in `scripts/quality/pipeline.py`:
  - Calls helper after successful `inject`.
  - Marks `citations_verified: true` for both inject success and inject no-op outcomes.
  - Skips writing on inject failure / exceptions (field remains absent).
- Added tests:
  - `tests/test_quality_queue.py`: helper sets/removes the key and preserves unrelated frontmatter fields.
  - `tests/test_quality_stages.py`: backfill success, no-op, and inject failure outcomes with assertions on frontmatter state.

## Semantic decision

`inject` returning `nothing_to_do` is treated as `verified=True` because the backfill pipeline ran and completed with no actionable claims; this should clear readiness in A^4 semantics.

## Test plan

- [x] `/Users/krisztiankoos/projects/kubedojo/.venv/bin/ruff check scripts/quality/queue.py scripts/quality/pipeline.py tests/test_quality_queue.py tests/test_quality_stages.py`
- [x] `PYTHONPATH=. /Users/krisztiankoos/projects/kubedojo/.venv/bin/pytest tests/test_quality_queue.py tests/test_quality_stages.py -k "citations_verified or backfill_pending" -q`
- [x] `PYTHONPATH=. /Users/krisztiankoos/projects/kubedojo/.venv/bin/pytest $( [ -f tests/test_quality_pipeline.py ] && echo tests/test_quality_pipeline.py ) $( [ -f tests/test_quality_pipeline_citations_verified.py ] && echo tests/test_quality_pipeline_citations_verified.py ) tests/test_quality_queue.py tests/test_quality_stages.py -v`
- [x] Smoke check on one real module (`prerequisites-modern-devops-module-1.5-platform-engineering`) via backfill path with stubbed dispatch + safe git hooks; verified frontmatter gained `citations_verified: true`, then reverted module with `git checkout -- src/content/docs/prerequisites/modern-devops/module-1.5-platform-engineering.md`.
