### PR TITLE
feat(chain): add citation backfill step to per-module loop (A^4 prereq #2)

### DIFF
--- a/scripts/quality/dispatch_388_pilot.py
+++ b/scripts/quality/dispatch_388_pilot.py
@@ -27,10 +27,12 @@ from pathlib import Path
 # checkout (primary OR a worktree) without a hard-coded absolute path.
 # scripts/quality/dispatch_388_pilot.py -> repo root is parents[2].
 REPO = Path(__file__).resolve().parents[2]
+PRIMARY_REPO = REPO.parent.parent if REPO.parent.name == ".worktrees" else REPO
 PILOT_FILE = REPO / "scripts/quality/pilot-2026-05-02.txt"
 LOG = REPO / "logs/388_pilot_2026-05-02.jsonl"
 BRIEF = REPO / "scripts/prompts/module-rewriter-388.md"
 WRITER_BRIEF = REPO / "scripts/prompts/module-writer.md"
+VENV_PYTHON = PRIMARY_REPO / ".venv" / "bin" / "python"
 
 sys.path.insert(0, str(REPO / "scripts"))
 from agent_runtime.runner import invoke  # noqa: E402
@@ -40,6 +42,27 @@ from agent_runtime.errors import (  # noqa: E402
     RateLimitedError,
 )
 from lib.pr_merge import PrMergeError, merge_when_green  # noqa: E402
+
+
+def module_slug_for_pipeline(module_path: str) -> str:
+    module = Path(module_path)
+    if not module.is_absolute():
+        module = REPO / module
+    try:
+        relative = module.relative_to(PRIMARY_REPO / "src" / "content" / "docs")
+    except ValueError:
+        rel = module.as_posix()
+        prefix_parts = rel.split("/src/content/docs/", 1)
+        if len(prefix_parts) == 2:
+            rel = prefix_parts[1]
+        elif rel.startswith("src/content/docs/"):
+            rel = rel[len("src/content/docs/"):]
+        else:
+            rel = rel.removeprefix(f"{REPO.as_posix().removesuffix('/')}/")
+            rel = rel.removeprefix(f"{PRIMARY_REPO.as_posix().removesuffix('/')}/")
+            rel = rel.removeprefix("/src/content/docs/")
+        return rel.removesuffix(".md").replace("/", "-")
+    return relative.as_posix().removesuffix(".md").replace("/", "-")
 
 
 def log(event: dict) -> None:
@@ -283,6 +306,58 @@ def merge_pr(pr_num: int) -> str | None:
         return None
 
 
+def dispatch_backfill(slug: str, module_path: str) -> bool:
+    log({"event": "backfill_start", "slug": slug, "module_path": module_path})
+    pipeline_slug = module_slug_for_pipeline(module_path)
+    pull = subprocess.run(
+        ["git", "pull", "--ff-only", "origin", "main"],
+        cwd=PRIMARY_REPO,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if pull.returncode != 0:
+        log({
+            "event": "backfill_failed",
+            "slug": slug,
+            "reason": f"git pull failed: {pull.stderr or pull.stdout}".strip()[-500:],
+        })
+        return False
+    backfill = subprocess.run(
+        [str(VENV_PYTHON), "-m", "scripts.quality.pipeline", "backfill-pending", "--module", pipeline_slug],
+        cwd=PRIMARY_REPO,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if backfill.returncode != 0:
+        log({
+            "event": "backfill_failed",
+            "slug": slug,
+            "reason": f"pipeline failed: {backfill.stderr or backfill.stdout}".strip()[-500:],
+        })
+        return False
+    push = subprocess.run(
+        ["git", "push", "origin", "main"],
+        cwd=PRIMARY_REPO,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if push.returncode != 0:
+        log({
+            "event": "backfill_failed",
+            "slug": slug,
+            "reason": f"git push failed: {push.stderr or push.stdout}".strip()[-500:],
+        })
+        return False
+
+    match = re.search(rf"^\[ok\]\s+{re.escape(pipeline_slug)}:\s+([0-9a-f]+)", backfill.stdout, re.MULTILINE)
+    sha = match.group(1) if match else None
+    log({"event": "backfill_done", "slug": slug, "sha": sha})
+    return True
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p = argparse.ArgumentParser(description="#388 volume-run dispatcher")
     p.add_argument(
@@ -348,6 +423,7 @@ def main(argv: list[str] | None = None) -> int:
             merge_sha = merge_pr(pr_num)
             if merge_sha:
                 log({"event": "merged", "pr": pr_num, "module": module_path, "merge_sha": merge_sha})
+                dispatch_backfill(slug, module_path)
             else:
                 log({"event": "merge_held", "pr": pr_num, "module": module_path, "verdict": "MERGE_FAILED"})
         elif verdict == "APPROVE_WITH_NITS":

--- a/scripts/quality/dispatch_388_pilot.py
+++ b/scripts/quality/dispatch_388_pilot.py
@@ -320,7 +320,8 @@ def dispatch_backfill(slug: str, module_path: str) -> bool:
         log({
             "event": "backfill_failed",
             "slug": slug,
-            "reason": f"git pull failed: {pull.stderr or pull.stdout}".strip()[-500:],
+            "reason": "pull_failed",
+            "detail": f"{pull.stderr or pull.stdout}".strip()[-500:],
         })
         return False
     backfill = subprocess.run(
@@ -334,9 +335,16 @@ def dispatch_backfill(slug: str, module_path: str) -> bool:
         log({
             "event": "backfill_failed",
             "slug": slug,
-            "reason": f"pipeline failed: {backfill.stderr or backfill.stdout}".strip()[-500:],
+            "reason": "pipeline_failed",
+            "detail": f"{backfill.stderr or backfill.stdout}".strip()[-500:],
         })
         return False
+
+    made_commit = any(line.startswith("[ok]") for line in backfill.stdout.splitlines())
+    if not made_commit:
+        log({"event": "backfill_skipped_noop", "slug": slug})
+        return True
+
     push = subprocess.run(
         ["git", "push", "origin", "main"],
         cwd=PRIMARY_REPO,
@@ -346,9 +354,11 @@ def dispatch_backfill(slug: str, module_path: str) -> bool:
     )
     if push.returncode != 0:
         log({
-            "event": "backfill_failed",
+            "event": "push_failed",
             "slug": slug,
-            "reason": f"git push failed: {push.stderr or push.stdout}".strip()[-500:],
+            "reason": "push_failed",
+            "rc": push.returncode,
+            "detail": f"{push.stderr or push.stdout}".strip()[-500:],
         })
         return False
 
@@ -423,6 +433,7 @@ def main(argv: list[str] | None = None) -> int:
             merge_sha = merge_pr(pr_num)
             if merge_sha:
                 log({"event": "merged", "pr": pr_num, "module": module_path, "merge_sha": merge_sha})
+                # dispatch_backfill is best-effort and must never block the merge chain.
                 dispatch_backfill(slug, module_path)
             else:
                 log({"event": "merge_held", "pr": pr_num, "module": module_path, "verdict": "MERGE_FAILED"})

--- a/scripts/quality/pipeline.py
+++ b/scripts/quality/pipeline.py
@@ -519,7 +519,10 @@ def cmd_backfill_pending(args: argparse.Namespace) -> int:
         print(f"missing dependency: {_CITATION_BACKFILL_SCRIPT}")
         return 1
 
-    candidates = iter_states(args.only or None)
+    filters = list(args.only or [])
+    if args.module:
+        filters.extend(args.module)
+    candidates = iter_states(filters or None)
     pending = [
         st for st in candidates
         if st["stage"] == "COMMITTED" and not (st.get("backfill") or {}).get("done")
@@ -812,6 +815,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     p_backfill.add_argument("--limit", type=int, default=None)
     p_backfill.add_argument("--only", nargs="*", help="filter by slug(s)")
+    p_backfill.add_argument("--module", action="append", default=[], help="filter by a single slug (repeatable)")
     p_backfill.add_argument(
         "--agent",
         choices=("codex", "gemini"),

--- a/tests/test_dispatch_388_pilot.py
+++ b/tests/test_dispatch_388_pilot.py
@@ -43,6 +43,57 @@ def test_dispatch_backfill_happy_path_runs_pipeline_and_push(tmp_path):
     assert mock_run.call_args_list[2].args[0] == ["git", "push", "origin", "main"]
 
 
+def test_dispatch_backfill_pull_failure_skips_backfill_and_push():
+    module_path = "src/content/docs/k8s/cka/module-3.md"
+    with patch("scripts.quality.dispatch_388_pilot.subprocess.run", side_effect=[
+        _mock_run(1, stderr="network down"),
+    ]) as mock_run, patch("scripts.quality.dispatch_388_pilot.log") as mock_log:
+        assert pilot.dispatch_backfill("my-slug", module_path) is False
+
+    events = [c.args[0]["event"] for c in mock_log.call_args_list]
+    assert events == ["backfill_start", "backfill_failed"]
+    failure = next(c.args[0] for c in mock_log.call_args_list if c.args[0]["event"] == "backfill_failed")
+    assert failure["slug"] == "my-slug"
+    assert failure["reason"] == "pull_failed"
+    assert mock_run.call_count == 1
+
+
+def test_dispatch_backfill_noop_skips_push(tmp_path):
+    module_path = "src/content/docs/k8s/cka/module-4.md"
+    with patch("scripts.quality.dispatch_388_pilot.subprocess.run", side_effect=[
+        _mock_run(0, stdout="Already up to date."),
+        _mock_run(0, stdout="[no-op]  module: nothing to inject"),
+    ]) as mock_run, patch("scripts.quality.dispatch_388_pilot.log") as mock_log:
+        assert pilot.dispatch_backfill("my-slug", module_path)
+
+    events = [c.args[0]["event"] for c in mock_log.call_args_list]
+    assert events == ["backfill_start", "backfill_skipped_noop"]
+    assert not any(c.args[0]["event"] == "backfill_done" for c in mock_log.call_args_list)
+    assert mock_run.call_count == 2
+
+
+def test_dispatch_backfill_push_failure_logs_push_failed():
+    module_path = "src/content/docs/k8s/cka/module-5.md"
+    module_slug = pilot.module_slug_for_pipeline(module_path)
+    with patch("scripts.quality.dispatch_388_pilot.subprocess.run", side_effect=[
+        _mock_run(0, stdout="Already up to date."),
+        _mock_run(0, stdout=f"[ok]    {module_slug}: deadbeef12"),
+        _mock_run(1, stderr="push failed"),
+    ]) as mock_run, patch("scripts.quality.dispatch_388_pilot.log") as mock_log:
+        assert pilot.dispatch_backfill("my-slug", module_path) is False
+
+    events = [call.args[0]["event"] for call in mock_log.call_args_list]
+    assert events == ["backfill_start", "push_failed"]
+    push_fail = next(
+        call.args[0]
+        for call in mock_log.call_args_list
+        if call.args[0]["event"] == "push_failed"
+    )
+    assert push_fail["slug"] == "my-slug"
+    assert push_fail["reason"] == "push_failed"
+    assert mock_run.call_count == 3
+
+
 def test_dispatch_backfill_backfill_failure_logs_and_continues():
     module_path = "src/content/docs/k8s/cka/module-2.md"
     with patch("scripts.quality.dispatch_388_pilot.subprocess.run", side_effect=[
@@ -55,7 +106,7 @@ def test_dispatch_backfill_backfill_failure_logs_and_continues():
     assert "backfill_failed" in events
     failed = next(c.args[0] for c in mock_log.call_args_list if c.args[0]["event"] == "backfill_failed")
     assert failed["slug"] == "my-slug"
-    assert "pipeline failed" in failed["reason"]
+    assert failed["reason"] == "pipeline_failed"
 
 
 def test_main_chain_calls_backfill_after_merge_and_continues_on_failure(tmp_path):
@@ -81,6 +132,10 @@ def test_main_chain_calls_backfill_after_merge_and_continues_on_failure(tmp_path
         rc = pilot.main(["--input", str(queue)])
 
     assert rc == 0
+    expected_slug_1 = pilot.slugify("src/content/docs/k8s/cka/module-1.md")
+    expected_slug_2 = pilot.slugify("src/content/docs/k8s/cka/module-2.md")
+    mock_backfill.assert_any_call(expected_slug_1, "src/content/docs/k8s/cka/module-1.md")
+    mock_backfill.assert_any_call(expected_slug_2, "src/content/docs/k8s/cka/module-2.md")
     assert mock_backfill.call_count == 2
     events = [c.args[0]["event"] for c in mock_log.call_args_list]
     assert events.count("merged") == 2

--- a/tests/test_dispatch_388_pilot.py
+++ b/tests/test_dispatch_388_pilot.py
@@ -1,0 +1,99 @@
+"""Tests for dispatch_388 backfill integration."""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.quality import dispatch_388_pilot as pilot
+
+
+def _mock_run(returncode: int, stdout: str = "", stderr: str = ""):
+    result = MagicMock()
+    result.returncode = returncode
+    result.stdout = stdout
+    result.stderr = stderr
+    return result
+
+
+def test_dispatch_backfill_happy_path_runs_pipeline_and_push(tmp_path):
+    module_path = "src/content/docs/k8s/cka/module-1.md"
+    module_slug = pilot.module_slug_for_pipeline(module_path)
+
+    with patch("scripts.quality.dispatch_388_pilot.subprocess.run", side_effect=[
+        _mock_run(0, stdout="Already up to date."),
+        _mock_run(0, stdout=f"[ok]    {module_slug}: deadbeef12"),
+        _mock_run(0, stdout="To github.com:repo.git"),
+    ]) as mock_run, patch("scripts.quality.dispatch_388_pilot.log") as mock_log:
+        assert pilot.dispatch_backfill("my-slug", module_path)
+
+    events = [c.args[0]["event"] for c in mock_log.call_args_list]
+    assert "backfill_start" in events
+    assert "backfill_done" in events
+    done = next(c.args[0] for c in mock_log.call_args_list if c.args[0]["event"] == "backfill_done")
+    assert done["slug"] == "my-slug"
+    assert done["sha"] == "deadbeef12"
+    assert mock_run.call_args_list[1].args[0] == [
+        str(pilot.VENV_PYTHON),
+        "-m", "scripts.quality.pipeline", "backfill-pending", "--module", module_slug,
+    ]
+    assert mock_run.call_args_list[2].args[0] == ["git", "push", "origin", "main"]
+
+
+def test_dispatch_backfill_backfill_failure_logs_and_continues():
+    module_path = "src/content/docs/k8s/cka/module-2.md"
+    with patch("scripts.quality.dispatch_388_pilot.subprocess.run", side_effect=[
+        _mock_run(0, stdout="Already up to date."),
+        _mock_run(1, stderr="pipeline failed"),
+    ]) as _, patch("scripts.quality.dispatch_388_pilot.log") as mock_log:
+        assert pilot.dispatch_backfill("my-slug", module_path) is False
+
+    events = [c.args[0]["event"] for c in mock_log.call_args_list]
+    assert "backfill_failed" in events
+    failed = next(c.args[0] for c in mock_log.call_args_list if c.args[0]["event"] == "backfill_failed")
+    assert failed["slug"] == "my-slug"
+    assert "pipeline failed" in failed["reason"]
+
+
+def test_main_chain_calls_backfill_after_merge_and_continues_on_failure(tmp_path):
+    queue = tmp_path / "queue.txt"
+    queue.write_text(
+        "\n".join(
+            [
+                "src/content/docs/k8s/cka/module-1.md",
+                "src/content/docs/k8s/cka/module-2.md",
+            ]
+        )
+    )
+    codex_result = MagicMock(ok=True, response="Opened PR: https://github.com/org/repo/pull/42")
+
+    with patch("scripts.quality.dispatch_388_pilot.make_worktree", return_value=tmp_path), \
+         patch("scripts.quality.dispatch_388_pilot.dispatch_codex", return_value=codex_result), \
+         patch("scripts.quality.dispatch_388_pilot.dispatch_gemini_review", return_value=("VERDICT: APPROVE", "APPROVE")), \
+         patch("scripts.quality.dispatch_388_pilot.merge_pr", return_value="abc123"), \
+         patch("scripts.quality.dispatch_388_pilot.dispatch_backfill", side_effect=[False, True]) as mock_backfill, \
+         patch("scripts.quality.dispatch_388_pilot.post_review_comment"), \
+         patch("scripts.quality.dispatch_388_pilot.time.sleep"), \
+         patch("scripts.quality.dispatch_388_pilot.log") as mock_log:
+        rc = pilot.main(["--input", str(queue)])
+
+    assert rc == 0
+    assert mock_backfill.call_count == 2
+    events = [c.args[0]["event"] for c in mock_log.call_args_list]
+    assert events.count("merged") == 2
+
+
+def test_dispatch_backfill_sha_regex_parses_ok_line():
+    output = "\n".join(
+        [
+            "[no-op] k8s-cka-module-9: already clean",
+            "[ok]    k8s-cka-module-8: deadbeef12",
+            "[ok]    k8s-cka-module-9: c0ffee99",
+        ]
+    )
+    match = re.search(r"^\[ok\]\s+k8s-cka-module-8:\s+([0-9a-f]+)", output, re.MULTILINE)
+    assert match is not None
+    assert match.group(1) == "deadbeef12"

--- a/tests/test_quality_stages.py
+++ b/tests/test_quality_stages.py
@@ -1566,6 +1566,19 @@ def test_backfill_pending_happy_path_records_done_and_commits(fake_repo, monkeyp
     assert rc2 == 0
 
 
+def test_backfill_pending_cli_accepts_module_filter(monkeypatch):
+    seen_filters = []
+
+    def fake_iter_states(filters=None):
+        seen_filters.append(list(filters) if filters is not None else None)
+        return []
+
+    monkeypatch.setattr(pipeline, "iter_states", fake_iter_states)
+    rc = pipeline.main(["backfill-pending", "--module", "k8s-cka-module-1.1-pods"])
+    assert rc == 0
+    assert seen_filters == [["k8s-cka-module-1.1-pods"]]
+
+
 def test_backfill_pending_research_failure_records_error_no_commit(fake_repo, monkeypatch):
     """Research subcommand failure must record stage_failed=research, leave
     state.backfill.done=False, and NOT touch the working tree. Repeating


### PR DESCRIPTION
## Summary
- Adds `dispatch_backfill()` to `scripts/quality/dispatch_388_pilot.py` that runs `python -m scripts.quality.pipeline backfill-pending --module <slug>` on the primary checkout after `merge_pr` success
- Wires the call into `main()` per-module loop: codex → review → merge → **backfill → push** → next module
- Adds `--module` (repeatable) flag to `pipeline.py backfill-pending` CLI
- Failure handling: backfill failure logs `backfill_failed` and continues to next module — does NOT abort the chain (task #6 catchup will sweep)

## Why
A^4 readiness API rewrite requires `fm.get("citations_verified") is True` to count a module as cleared. PR #1153 added the helper; this PR ensures every chain-merged module runs backfill (and writes `citations_verified: true`) before counting as done.

## Throughput cost
+2–5 min per module (per handoff, expected and accepted).

## Test plan
- [x] `ruff` on touched files passes
- [x] `pytest tests/test_dispatch_388_pilot.py -v` — 4 tests passed
- [x] Dry-run smoke on single-module queue with mocked chain steps — `main_rc=0, backfill_calls=1`
- [ ] Cross-family review (Gemini or Claude — reviewer to be assigned)

## New telemetry events
- `backfill_start` (slug, module_path)
- `backfill_done` (slug, sha)
- `backfill_failed` (slug, reason)

🤖 Generated with [Claude Code](https://claude.com/claude-code)