### PR TITLE
feat(388): rewrite mlx-on-apple-silicon (#388 pilot)

### DIFF
--- a/src/content/docs/ai/open-models-local-inference/module-1.4-mlx-on-apple-silicon.md
+++ b/src/content/docs/ai/open-models-local-inference/module-1.4-mlx-on-apple-silicon.md
@@ -3,9 +3,16 @@ title: "MLX on Apple Silicon"
 slug: ai/open-models-local-inference/module-1.4-mlx-on-apple-silicon
 sidebar:
   order: 4
+revision_pending: false
 ---
 
-> **Open Models & Local Inference** | Complexity: `[MEDIUM]` | Time: 55-75 min | Prerequisites: Python virtual environments, basic terminal use, and the previous modules on local model runtimes
+> **Complexity**: `[MEDIUM]`
+>
+> **Time to Complete**: 55-75 min
+>
+> **Prerequisites**: Python virtual environments, basic terminal use, and the previous modules on local model runtimes
+
+---
 
 ## Learning Outcomes
 
@@ -19,13 +26,15 @@ By the end of this module, you will be able to:
 
 ## Why This Module Matters
 
-A learner opens a new MacBook, installs a popular local model tool, and quickly hits a confusing question: is the Mac a serious machine for open-model learning, or is it only a convenient terminal for cloud GPUs? The wrong answer pushes that learner toward unnecessary infrastructure before they understand the shape of local inference. The right answer is more useful: Apple Silicon has its own runtime lane, and MLX is the most direct way to study that lane without pretending the machine is a smaller CUDA workstation.
+Hypothetical scenario: a learner opens a new MacBook, installs a popular local model tool, and quickly hits a confusing question: is the Mac a serious machine for open-model learning, or is it only a convenient terminal for cloud GPUs? The wrong answer pushes that learner toward unnecessary infrastructure before they understand the shape of local inference. The right answer is more useful: Apple Silicon has its own runtime lane, and MLX is the most direct way to study that lane without pretending the machine is a smaller CUDA workstation.
 
 This matters because hardware shapes learning. A learner with an M-series Mac has unified memory, an integrated GPU, a neural engine, good battery life, and a mature desktop operating system. Those constraints are not the same constraints as a Linux server with an NVIDIA card. If the learner copies every command from a CUDA tutorial, they may learn a lot about installation pain and very little about model behavior, prompt latency, context windows, quantization trade-offs, or inference measurement.
 
 MLX changes the beginner conversation because it gives Apple Silicon learners a native framework to explore arrays, model loading, token generation, quantization, and local experimentation. It also changes the senior conversation because a native laptop workflow can become a fast prototyping lane for privacy-sensitive demos, evaluation scripts, model comparisons, and pre-production design discussions. The point is not that every production system should run on a laptop. The point is that a laptop can teach the core mechanics before infrastructure complexity becomes the main subject.
 
 The senior skill is knowing where the boundary sits. MLX is excellent when the machine, runtime, and learning goal line up. It is weaker when you need a shared service, multi-user scheduling, GPU fleet utilization, Kubernetes deployment, or compatibility with a production serving stack. A strong practitioner can use MLX without turning it into a religion. They can explain why it works, what it hides, where it breaks, and when another runtime is the better engineering choice.
+
+This module treats MLX as an engineering lens rather than a product endorsement. You will preserve the convenience of a laptop workflow, but you will also measure where that convenience stops being evidence. That balance matters because local AI work often starts as a personal experiment and then attracts organizational expectations. A prototype that rewrites one synthetic incident note can teach a team a lot about prompts, model behavior, and privacy constraints, yet it cannot prove capacity planning, access control, or fleet reliability.
 
 ## 1. Start With The Problem MLX Solves
 
@@ -60,6 +69,8 @@ Apple Silicon is different from the classic desktop GPU setup because CPU and GP
 The diagram shows the main teaching idea: the learner should see one coherent path from environment setup to model execution to measurement. MLX is useful because it reduces the number of unrelated problems in that path. Instead of debugging Docker images, CUDA drivers, or remote GPU billing before any model runs, the learner can focus on model selection, prompt shape, token generation, and resource use.
 
 **Active Learning Prompt:** Before reading further, decide which failure would teach you more about local inference: a model that cannot start because the Python environment is wrong, or a model that starts but becomes slow when the prompt grows. The second failure teaches more about inference behavior because it happens after the runtime is working; the first failure mostly teaches setup hygiene.
+
+That distinction is why the first local experiment should be intentionally modest. A small model, a short prompt, and a clean environment give you a trustworthy baseline that you can extend. If the baseline is noisy, every later conclusion becomes suspect because you cannot separate model quality from environment instability. Treat the first successful generation like the first passing health check of a service: useful, necessary, and still far from a complete readiness signal.
 
 ## 2. What MLX Is, And What It Is Not
 
@@ -102,6 +113,8 @@ A useful mental model is to separate the runtime layer from the model workflow l
 MLX is not a drop-in replacement for every local inference tool. Ollama is often easier for a quick chat server, GGUF-based tools are widely used across different machines, Hugging Face Transformers is a broad engineering ecosystem, and vLLM is built for high-throughput serving rather than laptop learning. MLX is best understood as a Mac-native technical lane that can be excellent for learning and prototyping, especially when the learner wants to see how a model is loaded and called from Python.
 
 That framing prevents two opposite mistakes. The first mistake is dismissing MLX because it is not the dominant production serving stack. The second mistake is overselling MLX as if every learner should use it for every local model task. Both mistakes flatten the decision. A strong practitioner asks: what is the machine, what is the goal, what model format is available, what operational behavior matters, and what will the learner need to transfer later?
+
+The runtime decision also affects what kind of evidence you collect. A chat-first tool may quickly show whether an idea feels promising, while a Python-first workflow makes it easier to record settings, repeat prompts, and compare output under controlled conditions. A server-first runtime may be the right tool when concurrency and operational metrics matter more than laptop ergonomics. MLX belongs in the second category for this module: it is a learning and prototyping workflow that exposes enough mechanics to make later comparisons more meaningful.
 
 | Runtime path | Best first use | Strength on Apple Silicon | Trade-off to evaluate |
 |---|---|---|---|
@@ -160,6 +173,8 @@ This diagnostic script is intentionally small and runnable. It does not prove ML
 
 **Active Learning Prompt:** Suppose `mlx_lm.generate` fails on a Mac that definitely has an M-series chip. What would you check first: model quality, Python architecture, or prompt wording? Check Python architecture first, because a model cannot demonstrate quality and a prompt cannot matter until the runtime is executing in the expected environment.
 
+Environment notes should be boring enough to repeat and specific enough to explain surprises. Record the macOS version, Python version, package version, model identifier, token limit, and whether the model was already downloaded. Those details make it possible to compare a first run with a later run, or one learner's MacBook Air with another learner's MacBook Pro. Without that context, "MLX felt fast" or "MLX felt broken" is only a diary entry, not engineering evidence.
+
 ## 4. Choose A Model Like An Engineer
 
 Model choice is where MLX becomes more than an installation exercise. A learner often asks, "What is the biggest model I can run?" A practitioner asks a better question: "What is the smallest model that can answer the question I am testing with acceptable behavior?" That shift matters because local inference is a constraints exercise. Model size, quantization, context length, memory pressure, latency, and task quality all move together.
@@ -213,6 +228,8 @@ mlx_lm.generate \
 
 After the first run, the team should not immediately declare success. They should ask whether the output preserves the important details, whether it invents facts, whether the latency is acceptable, and whether a repeated run is stable enough for the intended workflow. If the model drops the rollback detail or invents a root cause, the team can adjust the prompt, try another model, or conclude that this class of task needs stronger evaluation before adoption.
 
+Notice the order of those questions. Quality comes before enthusiasm, and the task definition comes before the tool preference. If the model produces a polished handoff that quietly removes the queue backlog, the output is not safe for the handoff workflow even if the runtime performed beautifully. If the model preserves facts but takes too long for repeated use, the runtime and model combination may still be useful for offline drafting. Local inference decisions are rarely binary; they are usually about matching a behavior to a workflow.
+
 Now compare that with a different scenario. A platform team wants to serve many users through an internal API with access controls, monitoring, queues, and throughput targets. MLX on a laptop can still be useful for early prompt experiments, but it is not the obvious final serving path. The team should evaluate server-oriented runtimes and deployment patterns once the problem moves from "can this model help?" to "can we operate this reliably for many users?"
 
 | Decision question | MLX-friendly answer | Move beyond MLX when |
@@ -224,6 +241,8 @@ Now compare that with a different scenario. A platform team wants to serve many 
 | How much control is needed? | Python-level model loading and generation are useful | A standardized API gateway or inference platform is required |
 
 The senior-level decision is not "MLX or not MLX." It is "MLX for which phase of the lifecycle?" A local MLX script can be the right tool for discovery, while a different runtime becomes the right tool for serving. Good engineering preserves what was learned in the prototype without confusing the prototype with the final architecture.
+
+A useful rule is to separate "model evidence" from "platform evidence." The prototype may show that a small instruction model can rewrite operational notes without sending text to an external API. That is model evidence and workflow evidence. It does not show that the team has solved authentication, audit logging, request isolation, upgrade strategy, or incident response for the assistant itself. Those are platform questions, and they require a different validation plan once the project moves beyond one local user.
 
 ## 5. Run And Inspect A Python Workflow
 
@@ -286,6 +305,8 @@ The script also demonstrates a serious local-inference habit: keep the model ide
 
 You can extend the script to test multiple prompts. The important design choice is to keep the prompts stable across runs. If both the prompt and the model change at the same time, you cannot tell which change caused the output difference. This is the same experimental discipline used in performance testing, debugging, and production incident analysis.
 
+The next habit is to separate the parts of the timing measurement. A learner who records only wall-clock time may accidentally combine model loading, prompt formatting, token generation, and terminal output into one vague number. Separating load time from generation time makes the result more useful because different fixes apply to each part. If load time dominates, caching and model reuse matter; if generation time dominates, model size, token budget, and prompt length are better places to look.
+
 ```bash
 cat > compare_prompts.py <<'PY'
 import time
@@ -322,6 +343,8 @@ python compare_prompts.py
 This is the first step toward evaluation. It does not score the model, but it makes comparison possible. A senior engineer would later add expected properties, failure labels, regression prompts, and perhaps human review. The beginner should first learn the simple discipline of changing one variable at a time.
 
 **Active Learning Prompt:** If the second script gives one excellent answer and two weak answers, should you immediately replace MLX with another runtime? Probably not. The first question is whether the weakness comes from the prompt, the model, the token limit, or the task itself; the runtime is only one part of the chain.
+
+When you later compare against another runtime, carry this same script discipline forward even if the command syntax changes. Keep the task examples stable, keep the token budget explicit, and decide before the run what counts as an acceptable answer. That habit prevents a common local-AI failure mode where teams chase whatever tool produced the most impressive single answer. Engineering evaluation is not a highlight reel; it is a repeatable method for discovering which behavior you can trust.
 
 ## 6. Debug MLX By Following The Failure Domain
 
@@ -389,6 +412,8 @@ Memory debugging requires a different mindset. If a model loads slowly, swaps he
 | Repeated runs differ too much | Sampling or prompt ambiguity | Control prompt wording and generation options | Declaring the model useless after one run |
 
 The debugging lesson is transferable beyond MLX. Every local runtime has layers, and every layer can fail in a different way. MLX gives Mac learners a clean place to practice that layered reasoning because the environment can be small enough to understand.
+
+The best debugging notes read like a decision tree, not like a list of commands attempted in frustration. Start with the symptom, name the layer, run one check, and then decide what evidence would move you to the next layer. That approach saves time because it avoids fixes that cannot possibly affect the failing layer. It also produces better team communication, because another engineer can see the path you followed and continue from the last proven fact instead of restarting from a guess.
 
 ## 7. Compare MLX With The Rest Of The Local Inference Map
 
@@ -460,6 +485,38 @@ The fourth senior question is user experience. A local model that works in a ter
 
 This boundary is the reason MLX belongs in a serious curriculum. It is not just a Mac convenience topic. It is a case study in matching runtime, hardware, and learning stage. When learners can explain that match, they become better at evaluating every other runtime too.
 
+The same boundary protects the learner from both underestimating and overestimating the Mac. Underestimation sends every experiment to remote infrastructure before the learner has a simple mental model. Overestimation turns a successful laptop script into an architecture claim it cannot support. The practical middle path is stronger: use MLX to learn quickly, document what you learn, and deliberately graduate to a different runtime when the problem statement changes.
+
+## Patterns & Anti-Patterns
+
+The strongest MLX pattern is the controlled local prototype. Use it when the learner has Apple Silicon, the data can stay on the machine, the task is small enough for repeated experiments, and the team needs to learn prompt behavior before designing a service. This pattern works because the feedback loop is short and the runtime exposes enough Python-level mechanics to support real notes, timing, and comparison. It scales intellectually before it scales operationally: the prompts, evaluation cases, and failure categories can move forward even if the final serving layer changes.
+
+Another strong pattern is the diagnostic ladder. Begin with the machine and Python environment, then package imports, then model access, then load behavior, then generation quality. This order mirrors the actual dependency chain, so it keeps the learner from changing prompts when the import is broken or changing runtimes when the model name is wrong. It also creates a reusable troubleshooting method that transfers cleanly to Ollama, Transformers, GGUF tools, and Linux GPU stacks.
+
+The third pattern is the evidence-preserving comparison. When you compare MLX with another local runtime, hold the task, prompt set, model family where possible, token budget, and evaluation criteria as steady as you can. This does not make the comparison perfect, because model formats and runtime defaults can still differ, but it makes the result honest enough to guide the next decision. The goal is not to prove that one tool is universally best; the goal is to learn which tool is best for the current constraint set.
+
+The main anti-pattern is laptop absolutism, where a working MLX script gets treated as proof that the final product should run on the same kind of machine in the same style. Teams fall into this because local success feels concrete, screenshots travel well, and a quick demo can be more persuasive than a careful architecture note. The better alternative is to label the prototype evidence precisely: it may validate task feasibility, prompt shape, and privacy-friendly experimentation, while leaving service reliability, access control, and shared capacity unproven.
+
+Another anti-pattern is model-size bravado. Learners often reach for the largest model they can almost run because the size feels like a shortcut to quality. That choice can slow every iteration, increase memory pressure, and hide the learning signal behind waiting and system instability. Start with a model that leaves headroom, then increase size only when the smaller model cannot meet a defined task criterion.
+
+The final anti-pattern is invisible evaluation. A learner runs one prompt, likes the answer, and concludes that the runtime is ready for the workflow. That skips the hard part: checking whether the model preserves required facts, avoids invented causes, handles variations, and remains usable across repeated runs. A better practice is to keep a small prompt set and write down what a good answer must contain before the model responds.
+
+## Decision Framework
+
+Use MLX first when the machine is Apple Silicon, the goal is learning or prototype discovery, and Python-level control is valuable. Use a chat-first local tool when the immediate goal is low-friction conversation or a simple local API. Use Hugging Face engineering workflows when the team needs broad model ecosystem compatibility, training or evaluation utilities, or portability across development environments. Use GGUF-oriented tools when cross-platform quantized local inference matters more than a Mac-native framework. Use a server-oriented runtime when many users, shared capacity, observability, and policy boundaries become part of the requirement.
+
+The decision should change when the constraint changes. A privacy-sensitive one-user experiment can reasonably start with MLX because local execution and quick iteration matter most. The same idea may need a server runtime after it becomes a shared internal assistant, not because MLX failed, but because the problem expanded. Engineers make better decisions when they revisit the constraint set instead of defending the first tool that worked.
+
+| Situation | Prefer MLX when | Prefer another path when |
+|---|---|---|
+| First Apple Silicon lab | You want to learn native Mac inference mechanics from Python | The learner only needs a packaged chat interface |
+| Prompt evaluation | You need repeatable scripts and timing notes on local data | The evaluation must match a Linux deployment stack from day one |
+| Privacy-sensitive prototype | Data should stay on one developer machine during exploration | Data governance requires a managed server-side workflow |
+| Model ecosystem work | An MLX-compatible model exists and Mac behavior is the lesson | The work depends on broad Transformers features or non-MLX formats |
+| Shared service planning | MLX is used only to validate task feasibility and prompts | Multiple users need quotas, monitoring, authentication, and uptime |
+
+Pause and predict: if a prototype moves from one engineer's laptop to a team-wide tool, which evidence from the MLX lab still matters and which evidence should you discard? Keep the prompt examples, failure categories, and task-quality notes because they describe the work the model must do. Discard laptop-specific latency and memory assumptions unless the final service will run on the same class of hardware under the same usage pattern.
+
 ## Did You Know?
 
 1. MLX is designed around Apple Silicon assumptions, which makes it a useful way to study local inference on the same class of machine many learners already use every day.
@@ -469,7 +526,7 @@ This boundary is the reason MLX belongs in a serious curriculum. It is not just 
 
 ## Common Mistakes
 
-| Mistake | Why It Hurts | Better Move |
+| Mistake | Why It Happens | How to Fix It |
 |---|---|---|
 | Assuming Macs are not serious learning machines | This blocks useful local experimentation before the learner has tested what the machine can actually do | Use the Apple Silicon hardware deliberately and measure small MLX experiments before escalating to remote infrastructure |
 | Treating MLX as a universal solution | This creates wrong expectations and leads teams to force laptop workflows into problems that need shared serving | Use MLX where Mac-native learning, local privacy, or Python prototyping is the real goal |
@@ -741,12 +798,21 @@ EOF
 - [ ] You diagnosed at least one likely failure by naming the failure domain before proposing fixes.
 - [ ] You wrote a runtime decision note that explains when MLX is appropriate and when another runtime would be better.
 
-## Next Module
-
-Continue to [Running Open Models on Linux Boxes](./module-1.5-running-open-models-on-linux-boxes/).
-
 ## Sources
 
 - [MLX](https://github.com/ml-explore/mlx) — Primary upstream source describing MLX as Apple's array framework for machine learning on Apple Silicon.
 - [MLX LM](https://github.com/ml-explore/mlx-lm) — Upstream package showing practical large language model inference workflows built on MLX for Apple Silicon.
 - [MLX Examples](https://github.com/ml-explore/mlx-examples) — Upstream example collection demonstrating MLX across text, image, audio, and multimodal workloads.
+- [MLX Swift](https://github.com/ml-explore/mlx-swift) — Apple MLX bindings for Swift, useful context for the broader Apple Silicon MLX ecosystem.
+- [Apple MLX documentation](https://ml-explore.github.io/mlx/build/html/index.html) — Upstream MLX documentation for arrays, transforms, modules, and runtime behavior.
+- [Apple MLX LM documentation](https://github.com/ml-explore/mlx-lm/tree/main/docs) — Upstream MLX LM usage documentation for generation, conversion, quantization, and serving helpers.
+- [Hugging Face MLX community models](https://huggingface.co/mlx-community) — Vendor-hosted collection of MLX-compatible model repositories used by many examples.
+- [Hugging Face Transformers documentation](https://huggingface.co/docs/transformers/index) — Primary documentation for the broader Transformers ecosystem compared in this module.
+- [Ollama documentation](https://github.com/ollama/ollama/tree/main/docs) — Upstream documentation for the local model runtime used as a comparison point.
+- [llama.cpp](https://github.com/ggerganov/llama.cpp) — Upstream GGUF-oriented local inference project used as a comparison point for cross-platform quantized models.
+- [vLLM documentation](https://docs.vllm.ai/en/latest/) — Primary documentation for a server-oriented inference runtime used to contrast laptop prototyping with production serving.
+- [Apple Platform Security](https://support.apple.com/guide/security/welcome/web) — Apple vendor documentation relevant to local data handling discussions on Apple hardware.
+
+## Next Module
+
+Continue to [Running Open Models on Linux Boxes](./module-1.5-running-open-models-on-linux-boxes/).


### PR DESCRIPTION
## Summary
- Rewrote the MLX on Apple Silicon module to clear #388 density, structure, alignment, anti-leak, and protected-asset gates.
- Cleared frontmatter revision_pending to false.
- Added primary/vendor sources and moved Sources before Next Module.

## Verifier
- verify_module: tier T0; body_words=5826, mean_wpp=63.3, median_wpp=66.5, short_rate=0.065, max_run=2; failure_gates={}

## Protected Assets
- Preserved protected assets: code blocks 20 -> 20, ASCII fences 6 -> 6, original tables preserved 4 -> 5, source URLs 3 -> 12 with all original source URLs retained.

## Validation
- git diff --check -- target module: pass
- /Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/quality/verify_module.py --glob src/content/docs/ai/open-models-local-inference/module-1.4-mlx-on-apple-silicon.md --skip-source-check --summary --quiet: pass, T0
- /Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/test_pipeline.py: pass, 170 tests OK
- npm run build: attempted in worktree and failed on known AGENTS.md node_modules path issue resolving ../../node_modules/@astrojs/starlight/style/layers.css from src/layouts/Homepage.astro; primary checkout remained on main and was not modified.

Commit: f99dd5f4e6684caa04749f3624b306429a142d1e