### PR TITLE
feat(local-api): A^4 — frontmatter-derived readiness API

### DIFF
--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -3544,139 +3544,6 @@ def build_activity_feed(
 
 # ---- Phase D: per-section track readiness ----
 
-# Pipeline v2's ``jobs.queue_state`` is one of ``pending | leased |
-# completed | failed`` (control_plane.py:195-201). It is NOT the same
-# vocabulary as the status reducer's ``pending_write | pending_review |
-# pending_patch | in_progress | done | dead_letter`` (cli.py:536-560),
-# which is derived from a combination of job rows + events. Bucketing
-# naïvely off raw ``queue_state`` misclassifies dead-lettered modules
-# as in-flight. We reuse the pipeline's own reducer so this endpoint
-# stays in lock-step with ``/api/pipeline/v2/status``.
-_READINESS_BUCKET_FOR_STATUS: dict[str, str] = {
-    "done": "cleared",
-    "dead_letter": "dead_letter",
-    "in_progress": "in_flight",
-    "pending_write": "in_flight",
-    "pending_review": "in_flight",
-    "pending_patch": "in_flight",
-}
-
-
-def _readiness_bucket_for_status(status: str | None) -> str:
-    if not status:
-        return "not_yet_enqueued"
-    # Unknown statuses default to in_flight so a reducer extension
-    # doesn't silently mark new work cleared.
-    return _READINESS_BUCKET_FOR_STATUS.get(status, "in_flight")
-
-
-def _load_v2_module_statuses(repo_root: Path) -> dict[str, str]:
-    """Map ``module_key`` → reducer status from ``.pipeline/v2.db``.
-
-    Uses the same ``_module_status`` reducer as
-    ``pipeline_v2.cli._build_status_report`` so the readiness grid
-    agrees with ``/api/pipeline/v2/status`` row-for-row. Dead-letter
-    detection flows through ``_current_dead_letter_rows``.
-    """
-    db_path = repo_root / ".pipeline" / "v2.db"
-    if not db_path.exists():
-        return {}
-    # Import here so the module-level deferral pattern is preserved.
-    # Missing pipeline_v2 degrades to an empty map (same stance as
-    # ``build_pipeline_stuck`` around dead-letter rows).
-    try:
-        from pipeline_v2.cli import (
-            _current_dead_letter_rows,
-            _module_status,
-        )
-    except ModuleNotFoundError as exc:
-        if exc.name not in {"pipeline_v2", "pipeline_v2.cli"}:
-            raise
-        return {}
-
-    job_rows = _query_sqlite_rows(
-        db_path,
-        """
-        SELECT module_key, phase, queue_state
-        FROM jobs
-        WHERE module_key IS NOT NULL
-        ORDER BY id ASC
-        """,
-    )
-    event_rows = _query_sqlite_rows(
-        db_path,
-        """
-        SELECT id, module_key, type, payload_json, at
-        FROM events
-        WHERE module_key IS NOT NULL
-        ORDER BY id ASC
-        """,
-    )
-
-    modules: set[str] = set()
-    job_state_by_module: dict[str, dict[str, Any]] = {}
-    event_types_by_module: dict[str, set[str]] = {}
-    dead_letter_rows: list[dict[str, Any]] = []
-
-    for row in job_rows:
-        module_key = str(row.get("module_key") or "")
-        if not module_key:
-            continue
-        phase = str(row.get("phase") or "")
-        queue_state = str(row.get("queue_state") or "")
-        modules.add(module_key)
-        state = job_state_by_module.setdefault(
-            module_key,
-            {
-                "pending_phases": set(),
-                "has_leased": False,
-                "has_failed": False,
-                "has_completed": False,
-            },
-        )
-        if queue_state == "pending":
-            state["pending_phases"].add(phase)
-        elif queue_state == "leased":
-            state["has_leased"] = True
-        elif queue_state == "failed":
-            state["has_failed"] = True
-        elif queue_state == "completed":
-            state["has_completed"] = True
-
-    for row in event_rows:
-        module_key = str(row.get("module_key") or "")
-        if not module_key:
-            continue
-        event_type = str(row.get("type") or "")
-        modules.add(module_key)
-        event_types_by_module.setdefault(module_key, set()).add(event_type)
-        if event_type in {
-            "needs_human_intervention",
-            "module_dead_lettered",
-            "dead_letter_recovered",
-        }:
-            dead_letter_rows.append({
-                "module_key": module_key,
-                "id": int(row.get("id") or 0),
-                "type": event_type,
-                "payload_json": str(row.get("payload_json") or "{}"),
-                "at": int(row.get("at") or 0),
-            })
-
-    unresolved_dead_letters = {
-        r["module_key"] for r in _current_dead_letter_rows(dead_letter_rows)
-    }
-
-    statuses: dict[str, str] = {}
-    for module_key in modules:
-        status = _module_status(
-            job_state_by_module.get(module_key),
-            event_types_by_module.get(module_key, set()),
-            dead_lettered=module_key in unresolved_dead_letters,
-        )
-        statuses[module_key] = status
-    return statuses
-
 
 def _section_for_key(module_key: str) -> str:
     """Second path segment of a module key; ``_root`` for top-level modules.
@@ -4026,28 +3893,39 @@ def build_tracks_readiness(repo_root: Path) -> dict[str, Any]:
     """Per-track, per-section readiness grid for the operator dashboard.
 
     Buckets every English module on disk into one of:
-      - ``cleared`` — pipeline v2 latest state is ``done``/``completed``
-      - ``in_flight`` — pending_* / leased / running / in_progress
-      - ``dead_letter`` — pipeline gave up, needs human triage
-      - ``not_yet_enqueued`` — file exists but has no v2 job row
+      - ``cleared`` — frontmatter says ``revision_pending`` is not true and ``citations_verified`` is true
+      - ``not_yet_enqueued`` — every other state
 
     Readiness % = ``cleared / total``. Tracks come out in the canonical
     ``TRACK_ORDER``; within a track, sections are alphabetical so the
     grid layout is stable across calls.
     """
+    started_at = time.perf_counter()
     docs_root = repo_root / "src" / "content" / "docs"
-    from status import TRACK_ORDER, _iter_en_modules, _track_for_key
-    pipeline_status = _load_v2_module_statuses(repo_root)
+    from status import TRACK_ORDER, _extract_frontmatter, _iter_en_modules, _track_for_key
+
+    parse_errors = 0
 
     # track_slug -> section_slug -> counts
     grid: dict[str, dict[str, dict[str, int]]] = {}
+    # Keep the old buckets so downstream dashboards stay compatible.
+    # Unclear cases are represented as not-yet-enqueued until A^4 catchup.
+    # Track-level in_flight/dead_letter are always 0 under A^4.
 
     for path in _iter_en_modules(docs_root):
         rel = path.relative_to(docs_root).as_posix()
         module_key = rel[:-3] if rel.endswith(".md") else rel
+        frontmatter = _extract_frontmatter(path)
+        if not isinstance(frontmatter, dict):
+            parse_errors += 1
+            frontmatter = {}
+        cleared = (
+            frontmatter.get("revision_pending") is not True
+            and frontmatter.get("citations_verified") is True
+        )
         track = _track_for_key(module_key)
         section = _section_for_key(module_key)
-        bucket = _readiness_bucket_for_status(pipeline_status.get(module_key))
+        bucket = "cleared" if cleared else "not_yet_enqueued"
         t = grid.setdefault(track, {})
         s = t.setdefault(
             section,
@@ -4127,8 +4005,13 @@ def build_tracks_readiness(repo_root: Path) -> dict[str, Any]:
     grand["readiness_pct"] = (
         round(100.0 * grand["cleared"] / grand["total"], 1) if grand["total"] else 0.0
     )
+    errors: dict[str, int] = {}
+    if parse_errors:
+        errors["frontmatter_parse_errors"] = parse_errors
     return {
         "generated_at": int(time.time()),
+        "duration_ms": round(1000.0 * (time.perf_counter() - started_at), 3),
+        "errors": errors,
         "totals": grand,
         "tracks": out_tracks,
     }
@@ -8565,6 +8448,20 @@ def _v_quality_board(repo_root: Path) -> tuple:
     return ("quality-board", sig.hexdigest())
 
 
+def _v_docs_frontmatter(repo_root: Path) -> tuple:
+    docs_root = repo_root / "src" / "content" / "docs"
+    sig = hashlib.sha1()
+    for path in sorted(docs_root.glob("**/module-*.md")):
+        try:
+            rel = path.relative_to(repo_root).as_posix()
+            stat = path.stat()
+        except OSError:
+            continue
+        sig.update(rel.encode("utf-8"))
+        sig.update(f":{stat.st_mtime_ns}:{stat.st_size}".encode("utf-8"))
+    return ("docs-frontmatter", sig.hexdigest())
+
+
 # Map fixed paths (query-independent beyond ``?compact=1``) to policies.
 # (ttl_seconds, version_fn_or_None)
 CACHE_POLICY: dict[str, tuple[float, Callable[[Path], tuple] | None]] = {
@@ -8583,6 +8480,7 @@ CACHE_POLICY: dict[str, tuple[float, Callable[[Path], tuple] | None]] = {
     "/api/labs/status": (10.0, None),
     "/api/quality/board": (30.0, _v_quality_board),
     "/api/quality/upgrade-plan": (30.0, None),
+    "/api/tracks/readiness": (5.0, _v_docs_frontmatter),
     "/api/citations/status": (30.0, None),
     "/api/ztt/status": (30.0, None),
     "/api/git/worktree": (2.0, None),

--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -3904,7 +3904,7 @@ def build_tracks_readiness(repo_root: Path) -> dict[str, Any]:
     docs_root = repo_root / "src" / "content" / "docs"
     from status import TRACK_ORDER, _extract_frontmatter, _iter_en_modules, _track_for_key
 
-    parse_errors = 0
+    read_errors = 0
 
     # track_slug -> section_slug -> counts
     grid: dict[str, dict[str, dict[str, int]]] = {}
@@ -3915,10 +3915,16 @@ def build_tracks_readiness(repo_root: Path) -> dict[str, Any]:
     for path in _iter_en_modules(docs_root):
         rel = path.relative_to(docs_root).as_posix()
         module_key = rel[:-3] if rel.endswith(".md") else rel
+        try:
+            path.read_text(encoding="utf-8")
+        except OSError:
+            read_errors += 1
+            continue
         frontmatter = _extract_frontmatter(path)
-        if not isinstance(frontmatter, dict):
-            parse_errors += 1
-            frontmatter = {}
+        # Non-bool values produce spec-correct but surprising behavior:
+        #   revision_pending: "yes" → not True → counts as cleared
+        #   citations_verified: 1   → not True → counts as uncleared
+        # This is intentional: only literal True/False/absent are valid frontmatter states.
         cleared = (
             frontmatter.get("revision_pending") is not True
             and frontmatter.get("citations_verified") is True
@@ -4006,8 +4012,8 @@ def build_tracks_readiness(repo_root: Path) -> dict[str, Any]:
         round(100.0 * grand["cleared"] / grand["total"], 1) if grand["total"] else 0.0
     )
     errors: dict[str, int] = {}
-    if parse_errors:
-        errors["frontmatter_parse_errors"] = parse_errors
+    if read_errors:
+        errors["frontmatter_read_errors"] = read_errors
     return {
         "generated_at": int(time.time()),
         "duration_ms": round(1000.0 * (time.perf_counter() - started_at), 3),
@@ -8450,8 +8456,10 @@ def _v_quality_board(repo_root: Path) -> tuple:
 
 def _v_docs_frontmatter(repo_root: Path) -> tuple:
     docs_root = repo_root / "src" / "content" / "docs"
+    from status import _iter_en_modules
+
     sig = hashlib.sha1()
-    for path in sorted(docs_root.glob("**/module-*.md")):
+    for path in _iter_en_modules(docs_root):
         try:
             rel = path.relative_to(repo_root).as_posix()
             stat = path.stat()

--- a/tests/test_local_api.py
+++ b/tests/test_local_api.py
@@ -2920,14 +2920,23 @@ def test_activity_feed_accepts_iso_since(tmp_path: Path) -> None:
 # ---- Phase D: per-section track readiness ----
 
 
-def _seed_module(repo: Path, rel: str) -> None:
+def _seed_module(
+    repo: Path,
+    rel: str,
+    *,
+    frontmatter: dict[str, object] | None = None,
+) -> None:
     """Create a minimal ``module-*.md`` under ``src/content/docs/<rel>.md``.
 
     ``rel`` is the docs-relative path without the ``.md`` suffix, e.g.
     ``k8s/cka/module-1.1-foo``.
     """
     path = repo / "src" / "content" / "docs" / f"{rel}.md"
-    _write(path, "---\ntitle: t\n---\n\nbody\n")
+    fm: dict[str, object] = {"title": "t"}
+    if frontmatter:
+        fm.update(frontmatter)
+    payload = yaml.safe_dump(fm, sort_keys=False).strip()
+    _write(path, f"---\n{payload}\n---\n\nbody\n")
 
 
 def _seed_v2_job(
@@ -2999,7 +3008,7 @@ def _seed_v2_event(
 
 
 def test_tracks_readiness_empty_repo(tmp_path: Path) -> None:
-    """No docs directory, no v2.db — returns zeroed totals and no tracks."""
+    """No docs directory, no frontmatter-based readiness data — returns zeroed totals and no tracks."""
     _init_repo(tmp_path)
     result = local_api.build_tracks_readiness(tmp_path)
     assert result["tracks"] == []
@@ -3007,122 +3016,95 @@ def test_tracks_readiness_empty_repo(tmp_path: Path) -> None:
     assert result["totals"]["readiness_pct"] == 0.0
 
 
-def test_tracks_readiness_buckets_cleared_vs_notenq(tmp_path: Path) -> None:
-    """A module with a ``completed`` job (the pipeline's real state
-    vocabulary — not ``done``) is cleared; a module with no job at all
-    is ``not_yet_enqueued``. Readiness % = cleared / total."""
-    _init_repo(tmp_path)
-    _seed_module(tmp_path, "k8s/cka/module-1.1-foo")
-    _seed_module(tmp_path, "k8s/cka/module-1.2-bar")
+def test_tracks_readiness_frontmatter_predicate_cleared_states(tmp_path: Path) -> None:
+    """A module is cleared iff ``revision_pending`` is falsey and
+    ``citations_verified`` is true."""
+    cases = (
+        ("k8s/cka/module-1.1-foo", {"revision_pending": False, "citations_verified": True}, True),
+        ("k8s/cka/module-1.2-bar", {"revision_pending": True, "citations_verified": True}, False),
+        ("k8s/cka/module-1.3-baz", {"revision_pending": False}, False),
+        ("k8s/cka/module-1.4-qux", {"citations_verified": True}, True),
+        ("k8s/cka/module-1.5-quux", {}, False),
+        ("k8s/cka/module-1.6-quuz", {"revision_pending": True}, False),
+    )
+    for rel, frontmatter_data, should_clear in cases:
+        case_root = tmp_path / f"case-{rel.replace('/', '-')}"
+        case_root.mkdir(parents=True, exist_ok=True)
+        _init_repo(case_root)
+        _seed_module(case_root, rel, frontmatter=frontmatter_data)
+        result = local_api.build_tracks_readiness(case_root)
+        k8s = next(t for t in result["tracks"] if t["slug"] == "k8s")
+        cka = next(s for s in k8s["sections"] if s["slug"] == "cka")
+        assert cka["cleared"] == (1 if should_clear else 0)
+        assert cka["not_yet_enqueued"] == (0 if should_clear else 1)
 
-    db = tmp_path / ".pipeline" / "v2.db"
-    _init_v2_db(db, module_key="k8s/cka/seed")
-    _seed_v2_job(db, module_key="k8s/cka/module-1.1-foo", queue_state="completed")
+
+def test_tracks_readiness_frontmatter_aggregate_counts(tmp_path: Path) -> None:
+    """Three modules in one track/section aggregate with mixed states."""
+    _init_repo(tmp_path)
+    _seed_module(
+        tmp_path,
+        "k8s/cka/module-1.1-alpha",
+        frontmatter={"revision_pending": False, "citations_verified": True},
+    )
+    _seed_module(
+        tmp_path,
+        "k8s/cka/module-1.2-beta",
+        frontmatter={"revision_pending": True, "citations_verified": True},
+    )
+    _seed_module(
+        tmp_path,
+        "k8s/cka/module-1.3-gamma",
+        frontmatter={"revision_pending": False},
+    )
 
     result = local_api.build_tracks_readiness(tmp_path)
     k8s = next(t for t in result["tracks"] if t["slug"] == "k8s")
-    assert k8s["total"] == 2
+    cka = next(s for s in k8s["sections"] if s["slug"] == "cka")
+    assert k8s["total"] == 3
     assert k8s["cleared"] == 1
-    assert k8s["not_yet_enqueued"] == 1
-    assert k8s["readiness_pct"] == 50.0
-    cka = next(s for s in k8s["sections"] if s["slug"] == "cka")
-    assert cka["total"] == 2
-    assert cka["readiness_pct"] == 50.0
+    assert k8s["not_yet_enqueued"] == 2
+    assert cka["total"] == 3
+    assert cka["readiness_pct"] == 33.3
 
 
-def test_tracks_readiness_completed_plus_pending_counts_in_flight(tmp_path: Path) -> None:
-    """Codex Phase D review: the readiness grid must reuse the same
-    ``_module_status`` reducer as ``/api/pipeline/v2/status``. A module
-    that has BOTH a ``completed`` row and a fresh ``pending`` row must
-    count as in_flight (work has been re-enqueued), not cleared — that's
-    what the reducer says."""
+def test_tracks_readiness_cache_invalidation_from_frontmatter_change(tmp_path: Path) -> None:
+    """Changes to module frontmatter invalidate the readiness cache key."""
     _init_repo(tmp_path)
-    _seed_module(tmp_path, "k8s/ckad/module-2.1-quiz")
-
-    db = tmp_path / ".pipeline" / "v2.db"
-    _init_v2_db(db, module_key="k8s/ckad/seed")
-    _seed_v2_job(db, module_key="k8s/ckad/module-2.1-quiz",
-                 queue_state="completed", phase="write")
-    _seed_v2_job(db, module_key="k8s/ckad/module-2.1-quiz",
-                 queue_state="pending", phase="review")
-
-    result = local_api.build_tracks_readiness(tmp_path)
-    k8s = next(t for t in result["tracks"] if t["slug"] == "k8s")
-    ckad = next(s for s in k8s["sections"] if s["slug"] == "ckad")
-    assert ckad["cleared"] == 0
-    assert ckad["in_flight"] == 1
-
-
-def test_tracks_readiness_leased_job_counts_in_flight(tmp_path: Path) -> None:
-    """A ``leased`` job row (worker actively holding the module) must
-    bucket as in_flight via the reducer's ``in_progress`` status."""
-    _init_repo(tmp_path)
-    _seed_module(tmp_path, "k8s/cka/module-3.1-lease")
-
-    db = tmp_path / ".pipeline" / "v2.db"
-    _init_v2_db(db, module_key="k8s/cka/seed")
-    _seed_v2_job(
-        db,
-        module_key="k8s/cka/module-3.1-lease",
-        queue_state="leased",
-        phase="review",
-        lease_id="lease-abc",
-        leased_by="claude",
-        leased_at=1,
+    _seed_module(
+        tmp_path,
+        "k8s/cka/module-1.1-alpha",
+        frontmatter={"revision_pending": True, "citations_verified": True},
     )
-    result = local_api.build_tracks_readiness(tmp_path)
-    k8s = next(t for t in result["tracks"] if t["slug"] == "k8s")
-    cka = next(s for s in k8s["sections"] if s["slug"] == "cka")
-    assert cka["in_flight"] == 1
-    assert cka["cleared"] == 0
-
-
-def test_tracks_readiness_dead_letter_from_event(tmp_path: Path) -> None:
-    """Codex Phase D review: the live pipeline surfaces dead-letter
-    state via an EVENT (``module_dead_lettered``), not a ``queue_state``
-    row. A ``module_dead_lettered`` event with no later
-    ``dead_letter_recovered`` must bucket as dead_letter — not
-    in_flight — and a recovered one must revert."""
-    _init_repo(tmp_path)
-    _seed_module(tmp_path, "platform/foundations/module-1.1-zzz")
-    _seed_module(tmp_path, "platform/foundations/module-1.2-recovered")
-
-    db = tmp_path / ".pipeline" / "v2.db"
-    _init_v2_db(db, module_key="platform/foundations/seed")
-    # Unresolved dead-letter.
-    _seed_v2_event(
-        db,
-        module_key="platform/foundations/module-1.1-zzz",
-        event_type="module_dead_lettered",
-        at=10,
+    first_status, first_payload, _ = local_api.route_request(
+        tmp_path, "/api/tracks/readiness"
     )
-    # Dead-lettered then recovered -> should NOT count as dead_letter.
-    _seed_v2_event(
-        db,
-        module_key="platform/foundations/module-1.2-recovered",
-        event_type="module_dead_lettered",
-        at=20,
-    )
-    _seed_v2_event(
-        db,
-        module_key="platform/foundations/module-1.2-recovered",
-        event_type="dead_letter_recovered",
-        at=30,
-    )
+    assert first_status == 200
+    k8s_first = next(t for t in first_payload["tracks"] if t["slug"] == "k8s")
+    assert k8s_first["cleared"] == 0
 
-    result = local_api.build_tracks_readiness(tmp_path)
-    platform = next(t for t in result["tracks"] if t["slug"] == "platform")
-    assert platform["dead_letter"] == 1
-    # Recovered module falls back to "pending_write" via the reducer's
-    # default branch -> in_flight. Never dead_letter.
-    assert platform["in_flight"] >= 1
+    _seed_module(
+        tmp_path,
+        "k8s/cka/module-1.1-alpha",
+        frontmatter={"revision_pending": False, "citations_verified": True},
+    )
+    second_status, second_payload, _ = local_api.route_request(
+        tmp_path, "/api/tracks/readiness"
+    )
+    assert second_status == 200
+    k8s_second = next(t for t in second_payload["tracks"] if t["slug"] == "k8s")
+    assert k8s_second["cleared"] == 1
 
 
 def test_tracks_readiness_top_level_module_uses_root_section(tmp_path: Path) -> None:
     """``prerequisites/module-*.md`` has no intermediate section directory
     — it must land in a ``_root`` bucket rather than crashing."""
     _init_repo(tmp_path)
-    _seed_module(tmp_path, "prerequisites/module-0-welcome")
+    _seed_module(
+        tmp_path,
+        "prerequisites/module-0-welcome",
+        frontmatter={"revision_pending": False, "citations_verified": True},
+    )
     result = local_api.build_tracks_readiness(tmp_path)
     prereq = next(t for t in result["tracks"] if t["slug"] == "prerequisites")
     root = next(s for s in prereq["sections"] if s["slug"] == "_root")

--- a/tests/test_local_api.py
+++ b/tests/test_local_api.py
@@ -3068,6 +3068,33 @@ def test_tracks_readiness_frontmatter_aggregate_counts(tmp_path: Path) -> None:
     assert cka["readiness_pct"] == 33.3
 
 
+def test_v_docs_frontmatter_changes_on_module_edit(tmp_path: Path) -> None:
+    """The cache version key must change when ANY EN module's frontmatter changes."""
+    _init_repo(tmp_path)
+    _seed_module(
+        tmp_path,
+        "k8s/cka/module-1.1-alpha",
+        frontmatter={"revision_pending": False, "citations_verified": True},
+    )
+    v1 = local_api._v_docs_frontmatter(tmp_path)
+
+    _seed_module(
+        tmp_path,
+        "k8s/cka/module-1.1-alpha",
+        frontmatter={"revision_pending": True, "citations_verified": True},
+    )
+    v2 = local_api._v_docs_frontmatter(tmp_path)
+    assert v1 != v2, "version key must change when frontmatter changes"
+
+    _seed_module(
+        tmp_path,
+        "k8s/cka/module-1.2-beta",
+        frontmatter={"revision_pending": False, "citations_verified": True},
+    )
+    v3 = local_api._v_docs_frontmatter(tmp_path)
+    assert v2 != v3, "version key must change when a new module is added"
+
+
 def test_tracks_readiness_cache_invalidation_from_frontmatter_change(tmp_path: Path) -> None:
     """Changes to module frontmatter invalidate the readiness cache key."""
     _init_repo(tmp_path)


### PR DESCRIPTION
## Summary
Replaces v2.db-reducer-derived `/api/tracks/readiness` with FS-derived handler that parses module frontmatter. Aligns with [Decision Card 2026-05-12-readiness-signal-redesign](../blob/main/docs/decisions/pending/2026-05-12-readiness-signal-redesign.md).

**Predicate**:
```python
cleared := fm.get("revision_pending") is not True
       AND fm.get("citations_verified") is True
```

Asymmetry is intentional:
- `revision_pending` absent → cleared (not pending)
- `citations_verified` absent → uncleared (not verified)

## What changed

- Drops v2.db glue (~135 LOC at `scripts/local_api.py:3546-3680` area)
- New `build_tracks_readiness` parses frontmatter via `status._extract_frontmatter`
- Adds `_v_docs_frontmatter` cache version paralleling `_v_quality_board`
- Tests rewritten for 6 predicate combos + aggregate counts + cache invalidation
- Net: **+122 / -242 LOC** (simpler code)

## Caveat

45 chain-merged modules show as **uncleared** until task #6 (one-time backfill catchup) populates `citations_verified` on them. This is expected and correct per the design.

## Test plan
- [x] `ruff check scripts/local_api.py scripts/status.py tests/test_local_api.py` — clean
- [x] `PYTHONPATH=. pytest tests/test_local_api.py -v -k "readiness or tracks_readiness"` — 6 pass
- [x] Import smoke: `python -c "import scripts.local_api"`
- [x] Live API smoke: `GET /api/tracks/readiness` returns expected shape post-restart
- [ ] Cross-family review (claude/gemini — reviewer to be assigned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)