### PR TITLE
feat(388): rewrite module-1.5-running-open-models-on-linux-boxes (#388 pilot)

### DIFF
--- a/src/content/docs/ai/open-models-local-inference/module-1.5-running-open-models-on-linux-boxes.md
+++ b/src/content/docs/ai/open-models-local-inference/module-1.5-running-open-models-on-linux-boxes.md
@@ -1,211 +1,429 @@
 ---
-revision_pending: true
 title: "Running Open Models on Linux Boxes"
 slug: ai/open-models-local-inference/module-1.5-running-open-models-on-linux-boxes
 sidebar:
   order: 5
+revision_pending: false
 ---
 
-> **Open Models & Local Inference** | Complexity: `[MEDIUM]` | Time: 45-60 min
+> **Complexity**: `[MEDIUM]`
+>
+> **Time to Complete**: 45-60 min
+>
+> **Prerequisites**: Comfort with Linux shell basics, basic awareness of open model hubs, and familiarity with local inference vocabulary from the previous modules
+
+---
+
+## Learning Outcomes
+
+- Diagnose CPU GPU CUDA constraints on a Linux inference box before selecting a runtime.
+- Compare CPU-first single-GPU workstation and home-lab server paths for open model inference.
+- Design a runtime and model profile for interactive experimentation or persistent service deployment.
+- Implement a repeatable Linux host profile that records hardware drivers memory storage and service goals.
+- Evaluate security monitoring and escalation tradeoffs before exposing a local model service to users.
 
 ## Why This Module Matters
 
-Linux remains a common learner path for people who want to move from local experimentation toward more direct control over AI systems.
+Hypothetical scenario: a learner inherits an old Linux workstation, sees that open models can run locally, and decides to turn the machine into a private assistant for code notes, document summaries, and retrieval experiments. The first install works for a small quantized model, then the same workflow collapses when they try a larger instruction model, add a web UI, and leave the service running overnight. Nothing mystical happened. The machine moved from "a box that can run one experiment" to "a host with memory pressure, storage growth, driver assumptions, network exposure, and service management responsibilities."
 
-But “Linux box” can mean very different things:
-- a CPU-only mini PC
-- a gaming desktop with one GPU
-- a recycled workstation
-- a small home server
+That transition is why Linux is such a valuable learning environment for local inference. A Linux box forces you to see the operating system boundary that a polished desktop app can hide: which device is present, which driver is loaded, which process owns memory, which user account runs the service, where model files live, which port is listening, and how a failed runtime will be restarted or stopped. The point is not that Linux is always better than a laptop workflow. The point is that Linux makes infrastructure consequences visible early, while the stakes are still small enough to learn from mistakes.
 
-If you treat all Linux setups as interchangeable, learners make poor decisions about runtimes, models, and expectations.
-
-## What You'll Learn
-
-- what kinds of Linux boxes learners actually use
-- how to think about CPU vs GPU paths
-- where CUDA fits into the Linux learner path
-- when a Linux box is better than a laptop path
-- what questions to answer before choosing a runtime
+This module teaches a disciplined way to profile a Linux host before you choose a runtime such as Transformers, llama.cpp, Ollama, text-generation-inference, or vLLM. You will classify the machine honestly, decide whether CPU-only inference is enough, identify when CUDA changes the operational path, and separate interactive experimentation from persistent service deployment. By the end, you should be able to explain what your Linux box can teach you, what it cannot reasonably do, and what evidence you need before offering local model access to anyone else.
 
 ## Start With The Machine You Actually Have
 
-The right learner question is not:
+The right learner question is not "What is the best Linux AI setup?" because that question hides the actual constraint. A small central processing unit only box, a gaming desktop with one NVIDIA card, a recycled workstation, and a small home-lab server can all run Linux, but they are not equivalent inference platforms. Good engineering starts by naming the machine in front of you, then matching the learning goal to that machine instead of forcing the machine to imitate a benchmark screenshot.
 
-> “What is the best Linux AI setup?”
+Treat the host profile like a travel itinerary rather than a wish list. You need to know where you are starting, how much capacity you can carry, and which route creates useful experience without stranding you halfway through the trip. For local inference, that means recording processor class, system memory, accelerator type, driver availability, storage speed, network exposure, and the intended style of use. Those facts do not make the decision for you, but they prevent decisions that ignore physics.
 
-It is:
+CPU-only boxes are not failed GPU boxes. They are excellent for learning model packaging, prompt flow, retrieval wiring, quantized formats, service supervision, logging, and the difference between a runtime that loads and a runtime that responds comfortably. The tradeoff is throughput. A central processing unit can be useful for a small model and a single learner, but it will not make a large model feel interactive just because the shell prompt accepts the command.
 
-> “What can this specific Linux box do well enough to teach me something useful?”
+Single-GPU workstations are the practical middle ground for many learners because they bring accelerator memory into reach without requiring a cluster. On Linux, that often means an NVIDIA card, a compatible driver, CUDA-aware frameworks, and a runtime that can actually use the device. This path teaches both local inference and the first layer of machine-learning infrastructure: device visibility, driver compatibility, container runtime support, and memory budgeting around key-value cache and concurrent requests.
 
-That leads to better decisions.
+Home-lab servers add a different lesson. A server is useful when you want persistent services, remote access, automated startup, logs, and repeatable deployment habits, but it can also conceal weak model selection behind operational ceremony. If the learner has not yet understood runtime behavior on one host, turning the model into a service can create more surface area than learning value. A server should make a working model more reliable; it should not be a way to postpone understanding the model.
 
-## Three Common Learner Linux Paths
+Pause and predict: if a Linux box has enough memory to load a quantized model once, does that prove it is ready for a persistent local assistant? The safer prediction is no. Loading is only the first boundary. A persistent assistant also needs memory headroom for longer prompts, simultaneous requests, log growth, model cache updates, operating system work, and a controlled shutdown path when the runtime misbehaves.
 
-### 1. CPU-first box
+The following inventory block is deliberately boring because boring inventory prevents exciting failures. Run commands like these from a normal terminal session and save the results in a note beside the model and runtime you are evaluating. The commands do not choose the runtime; they give you the evidence you need to choose with fewer guesses.
 
-Good for:
-- understanding runtimes
-- smaller models
-- quantized experiments
-- RAG prototypes
+```bash
+uname -a
+lscpu
+free -h
+lsblk -o NAME,SIZE,TYPE,FSTYPE,MOUNTPOINTS
+df -h
+```
 
-Weak for:
-- larger models
-- fast iteration
-- serious tuning
+If the machine has an NVIDIA GPU, the next check is whether the operating system can see the device through the installed driver. A card that appears in marketing material but not in the driver stack is not available to your runtime. When `nvidia-smi` works, read it as a snapshot of driver health, device memory, current processes, and CUDA compatibility clues, not as a guarantee that every framework build will work.
 
-### 2. Single-GPU workstation
+```bash
+nvidia-smi
+```
 
-Good for:
-- better local inference
-- embeddings
-- stronger experimentation
-- realistic local-first development
+If the machine has no supported GPU or no working accelerator driver, stay CPU-first and learn the runtime model. That advice can feel conservative, but it keeps learning moving. You can still compare quantized artifacts, measure prompt latency, build a retrieval prototype, study service supervision, and learn where the bottlenecks appear. The best beginner setup is the one that lets you iterate honestly rather than spend the whole week repairing a driver stack you do not yet understand.
 
-For many learners, this is a practical middle ground on Linux.
+## Compare The Three Linux Learner Paths
 
-For many learners, this also means:
-- NVIDIA GPU
-- CUDA-capable frameworks and runtimes
-- a more direct bridge into serious AI/ML engineering later
+The three common learner paths are CPU-first boxes, single-GPU workstations, and small servers or home-lab hosts. They overlap, but they optimize different lessons. A CPU-first box emphasizes mechanics and constraints. A single-GPU workstation emphasizes accelerator-aware inference and model selection. A small server emphasizes persistence, remote access, observability, and the discipline required when a tool stops being a private experiment.
 
-### 3. Small server or home-lab box
+| Linux path | Strong learning value | Main constraint | Better first runtime category |
+|---|---|---|---|
+| CPU-first box | Quantization, packaging, retrieval prototypes, service basics | Slow generation and limited model size | llama.cpp-style local runtime or small Transformers experiment |
+| Single-GPU workstation | CUDA-aware inference, embeddings, stronger experiments, memory budgeting | Driver and accelerator memory compatibility | Transformers, vLLM, TGI, or GPU-enabled local runtime |
+| Home-lab server | Persistent services, remote access, monitoring, operational habits | Security exposure and reliability expectations | A supervised service after interactive tests pass |
 
-Good for:
-- persistent services
-- self-hosted experimentation
-- learning operational concerns
+The CPU-first path is often underestimated because learners equate speed with seriousness. Speed matters, but it is not the only thing a local inference host can teach. A slower CPU workflow forces you to notice model size, prompt length, token rate, file formats, and the difference between acceptable batch processing and painful interactive use. Those are real engineering lessons, especially if you later move to GPU-backed serving and need to explain why the same prompt behaves differently.
 
-Weak if the learner has not yet built basic model/runtime understanding.
+The single-GPU path gives you a more realistic bridge into modern AI engineering because many production inference stacks assume accelerator awareness. You start encountering CUDA versions, framework wheels, container GPU access, device memory limits, and runtime choices that do not appear in a pure consumer workflow. This path is powerful, but it is also easier to misdiagnose. A failure might come from the model, the Python package, the driver, the container runtime, or the GPU memory budget, so disciplined evidence gathering matters.
 
-## Linux Is A Control Advantage
+The home-lab server path is valuable when the goal includes always-on access. A service that starts at boot, writes logs, exposes a local network endpoint, and survives a shell logout teaches a different set of habits than a notebook or one-off command. The risk is premature operationalization. If the model has not been evaluated interactively, service wrappers can make a weak setup look official while hiding the fact that the underlying model is too slow, too large, or too loosely secured.
 
-Linux matters because it gives learners stronger control over:
-- package environments
-- services
-- monitoring
-- runtime choices
-- automation
+Exercise scenario: you have a reused office desktop with thirty-two gigabytes of system memory, no discrete GPU, and a fast solid-state drive. The best first goal is not serving the largest model you can find. A better goal is to run a small quantized instruction model, measure token rate on representative prompts, build a tiny retrieval demo, and write down what latency feels acceptable for your own learning workflow. That result will teach more than a week spent chasing an accelerator path the hardware does not have.
 
-On GPU-backed Linux systems, it also becomes the main place where learners first encounter the real CUDA stack:
-- NVIDIA driver compatibility
-- framework builds that expect CUDA
-- runtime differences between CPU and GPU inference
-- the operational cost of mismatched environments
+The practical middle ground is to think in terms of "learning yield per hour." If your box lets you test prompts, observe resource usage, and change one variable at a time, it is teaching you. If your box traps you in unclear dependency failures before you can run a basic model, the learning yield is poor until you simplify the path. A modest CPU box can have high learning yield when the objective is runtime literacy, while a powerful workstation can have low learning yield when every failure is treated as random magic.
 
-That makes it a better bridge into infrastructure thinking than a pure consumer-device workflow.
+Before running your first model, ask which constraint you are testing. Are you testing whether the model can answer a domain question, whether the runtime can use a GPU, whether a quantized artifact still formats answers well, or whether a service can restart cleanly? These are different experiments. Combining them into one "install everything and see" session makes troubleshooting harder because any failure has too many possible causes.
 
-## What Linux Does Not Solve Automatically
+## Where CUDA Changes The Linux Path
 
-A Linux box does not solve:
-- weak model choice
-- bad evaluation
-- unclear runtime selection
-- poor security habits
+CUDA usually enters this module when a Linux learner uses an NVIDIA GPU for local inference. It is not a separate badge of seriousness; it is the layer that lets many machine-learning frameworks talk to the accelerator efficiently. Once CUDA is involved, the host profile needs to include driver compatibility, framework build compatibility, container runtime configuration if containers are used, and the memory envelope of the model under real prompt length. A working shell is not the same thing as a working accelerator stack.
 
-It gives you more control.
+The simplest operational rule is still useful. With no GPU or an unsupported GPU, stay CPU-first and learn the runtime model. With an NVIDIA GPU available, CUDA becomes part of the runtime decision. With serious local serving or fine-tuning ambitions, CUDA awareness becomes essential because model loading, batching, key-value cache behavior, and framework kernels all depend on the accelerator path being coherent. You do not need to master CUDA internals here, but you do need to know when CUDA is part of the problem.
 
-It does not guarantee better decisions.
+Driver compatibility is the first boundary because frameworks depend on what the installed driver can support. PyTorch, Transformers, vLLM, and text-generation-inference each publish installation paths that assume particular accelerator support. When the framework and driver expectations diverge, the failure may appear as an import error, a missing library, a runtime warning, or a silent fallback to central processor execution. Silent fallback is especially dangerous because the model still runs, just slowly enough to distort every performance conclusion.
 
-## A Good Beginner Linux Question Set
+```bash
+nvidia-smi --query-gpu=name,driver_version,memory.total --format=csv
+```
 
-Before choosing a local inference path, answer:
-- CPU only or GPU available?
-- if GPU exists, is it realistically a CUDA path?
-- interactive experimentation or persistent service?
-- one-user local setup or shared internal tool?
-- model exploration or production-style serving practice?
+The second boundary is memory. GPU memory is not the same as disk size or system memory, and an inference service needs more than raw weight storage. The model weights occupy memory, but so do runtime buffers, the key-value cache used for active context, batching overhead, and other processes sharing the device. A model that barely loads in an empty terminal can fail when prompts become longer or when a second request arrives. That is why "it loaded once" is weak evidence for service readiness.
 
-These questions matter more than brand loyalty to a particular runtime.
+Think of accelerator memory like a workbench, not a warehouse. Disk is where model files are stored, but GPU memory is the bench where active computation happens. If the bench is covered by the model itself, there is no room for prompt context, tools, logs, or a second job. You can own a large warehouse of model files and still have a tiny workbench for actual inference.
 
-## Where CUDA Actually Enters The Picture
+Containerized GPU workflows add another layer. A container image can include the user-space libraries needed by a runtime, but the host still provides the driver and device access. NVIDIA's container tooling exists because ordinary containers do not automatically make accelerators available inside the process namespace. If you use containers for local serving, the test is not merely "does Docker run?" The test is whether the container can see the device, allocate memory, and run the same framework path you validated outside the container.
 
-On Linux, CUDA often enters the picture when learners use NVIDIA GPUs for local inference.
+```bash
+docker run --rm --gpus all nvidia/cuda:12.6.0-base-ubuntu24.04 nvidia-smi
+```
 
-The practical rule is simple:
+Use that container check as a diagnostic, not as a universal prescription. Some learners should avoid containers until the native runtime path is clear. Others should use containers because they want repeatability and easier cleanup. The decision depends on the learning goal. If you are studying Python package compatibility, native virtual environments can be clearer. If you are studying service deployment, container boundaries may better match the operational shape you want to practice.
 
-- no GPU or unsupported GPU: stay CPU-first and learn the runtime model
-- [NVIDIA GPU available: CUDA becomes part of the runtime decision](https://huggingface.co/docs/transformers/en/installation)
-- serious local serving or fine-tuning ambitions: CUDA awareness becomes essential
+Before running this, what output do you expect if the host driver is missing but the container image includes CUDA libraries? The likely result is failure to access the GPU, because the container cannot manufacture the host driver. That prediction matters because it separates image contents from host capability. A container can package the runtime, but it cannot make unsupported hardware become supported.
 
-You do not need to master CUDA internals in this section.
+The CUDA path also affects which follow-on modules will matter most. If you plan to continue toward reproducible Python, CUDA, and ROCm environments, then driver and framework discipline becomes part of your learning path. If you plan to stay with a CPU-oriented local runtime, the same operational discipline applies, but the accelerator-specific dependency stack is less central. The point is to choose the next lesson based on the machine and goal rather than treating every local inference setup as one track.
 
-You do need to understand that GPU-backed Linux workflows often add system-level dependencies beyond a basic Python environment, for example:
-- driver compatibility
-- framework build compatibility
-- container/runtime choice
+## Design A Runtime And Model Profile
 
-That is why the deeper handoff later is:
-- [AI/ML Engineering: Reproducible Python, CUDA, and ROCm Environments](../../ai-ml-engineering/prerequisites/module-1.3-reproducible-python-cuda-rocm-environments/)
-- [AI/ML Engineering: Local Inference Stack for Learners](../../ai-ml-engineering/ai-infrastructure/module-1.4-local-inference-stack-for-learners/)
+A runtime is the program that loads the model, prepares inputs, executes inference, and returns generated tokens or embeddings. A model profile is the written contract that explains which model artifact, format, quantization level, context length, runtime, hardware path, and service mode you intend to use. Without that profile, learners tend to change two or three variables at once and then cannot explain why quality, speed, or reliability changed. The profile turns experimentation into engineering evidence.
 
-## Linux vs Mac Learner Tradeoff
+Start with the workload shape. Interactive experimentation rewards fast setup, visible errors, and simple cleanup. A persistent service rewards stable startup, predictable logs, controlled ports, resource limits, and repeatability. A shared internal tool adds user access, authentication boundaries, network placement, and escalation paths. The same Linux box can support each shape at different maturity levels, but it should not be treated as production-like simply because a web endpoint exists.
 
-Mac path:
-- smoother for Apple Silicon users
-- strong local-first path
-- less like production Linux operations
+The common runtime categories map to different strengths. Transformers is excellent for learning the model ecosystem directly because it exposes tokenizers, model classes, and framework installation choices. llama.cpp-style runtimes are excellent for quantized local inference and constrained devices. Ollama gives a smoother local service experience and model management workflow. vLLM and text-generation-inference are closer to high-throughput serving patterns, especially when accelerator-backed batching and production-style APIs matter.
 
-Linux path:
-- rougher at first
-- more operational control
-- better bridge to infrastructure work
+| Runtime category | Good fit | Watch carefully |
+|---|---|---|
+| Transformers | Learning model files, tokenizers, framework behavior, small custom scripts | Python dependency drift and accelerator wheel compatibility |
+| llama.cpp or GGUF runtime | CPU-first or constrained local inference with quantized models | Quality loss from quantization and runtime-specific model format support |
+| Ollama | Fast local service experiments and simple model lifecycle commands | Hidden defaults that can obscure resource use or prompt formatting details |
+| vLLM | GPU-backed serving, batching, OpenAI-compatible API experiments | CUDA path, accelerator memory, model support matrix, and operational tuning |
+| Text Generation Inference | Container-oriented GPU serving and production-like deployment practice | NVIDIA container setup, shard configuration, and hardware requirements |
 
-Neither is “the winner.”
+The model profile should name the artifact precisely. "A small open model" is not enough. Record the repository, revision or version when available, file format, quantization level, context length, tokenizer source, license review status, and the prompts used for evaluation. This may feel excessive during the first experiment, but it saves time when a later run behaves differently. Without the profile, you cannot tell whether the runtime improved, the model changed, or your prompt accidentally became easier.
 
-They serve different learner needs.
+The service profile should name the operating mode. If the model is only for private command-line experiments, a foreground process may be fine. If the model should survive a terminal closing, use a service manager such as systemd and define the user, working directory, environment file, restart policy, logs, and network bind address deliberately. Service management is where local inference starts to look like ordinary infrastructure, and ordinary infrastructure deserves ordinary hygiene.
 
-## Active Check
+```ini
+[Unit]
+Description=Local model runtime for learning experiments
+After=network.target
 
-If your current goal is to learn service management, runtime control, and repeatable local deployments, which path usually teaches more transferable operational habits?
+[Service]
+Type=simple
+User=localmodel
+WorkingDirectory=/srv/localmodel
+EnvironmentFile=/etc/localmodel/runtime.env
+ExecStart=/srv/localmodel/bin/start-runtime.sh
+Restart=on-failure
+RestartSec=5
 
-Usually the Linux path.
+[Install]
+WantedBy=multi-user.target
+```
+
+This service file is a template for thinking, not a command to paste blindly into every host. The important parts are explicit ownership and explicit restart behavior. A model service should not run as your everyday shell user if other people will access it. It should not bind to every network interface by accident. It should not restart forever without logs that explain the failure. Those are the same habits you would apply to any long-running service.
+
+Storage needs a line in the profile because model files are large and caches accumulate. A learner may download several variants of the same model while comparing formats, and each variant can occupy enough disk to distort backup, filesystem, and cleanup assumptions. Keep model artifacts in a predictable directory, record which ones are approved for current experiments, and remove failed candidates after the notes are complete. Disk clutter becomes a reliability problem when the next model download fails halfway through a lab.
+
+Security also belongs in the first profile, not in a later production checklist. Local inference often feels private because it runs on a machine you control, but a service bound to the wrong address can become reachable from a network you did not intend. A model endpoint can leak prompt data through logs, store sensitive documents in a retrieval index, or accept requests from people who do not understand the limitations. Security starts with a clear answer to "who can send prompts to this process?"
+
+Which approach would you choose here and why: a direct Python script that prints answers in your terminal, or a systemd-managed service listening on a local network address? If the goal is to learn model behavior and prompt shape, the script is usually the better first step. If the goal is to practice persistent service operation after the model already behaves acceptably, the managed service becomes the right next step. The difference is not prestige; it is whether the operational wrapper matches the learning question.
+
+## Implement A Repeatable Linux Host Profile
+
+A repeatable host profile is the document that lets you rerun the experiment next month and understand what changed. It should be small enough to maintain, but complete enough to explain performance, failures, and constraints. At minimum, record hardware class, CPU model, system memory, GPU model if present, GPU memory, driver version, operating system release, storage location for model files, runtime name, model artifact, model format, intended use, and whether the setup is interactive or persistent.
+
+You can keep the profile in markdown because the first audience is the learner, not an automation system. Later, you might turn the same fields into YAML, inventory data, or a deployment record, but plain text is enough to build the habit. The key is consistency. Every runtime experiment should update the same fields so comparisons are based on facts rather than memory. "It felt faster last week" is less useful than "the quantized model produced nine tokens per second on the same prompt."
+
+```markdown
+## Linux Inference Host Profile
+
+- Host role: interactive experiment or persistent service
+- CPU:
+- System memory:
+- GPU and GPU memory:
+- Driver version:
+- Operating system:
+- Runtime:
+- Model artifact and revision:
+- Model format or quantization:
+- Intended use:
+- Network binding:
+- Notes from evaluation:
+```
+
+The evaluation notes should include a short representative prompt set. Do not test only the cheerful path where the model answers a simple question in one sentence. Include a longer prompt, a domain-specific prompt, a refusal or uncertainty case, and a formatting case if your application expects JSON, markdown, or citations. Local inference is not just about making tokens appear. It is about learning whether a particular host, runtime, and model can support the behavior you actually need.
+
+Measurements should be simple at first. Time to first token, tokens per second, peak memory, startup time, and subjective usability are enough for a learner profile. If you later build a service, add request latency, error rate, restart count, and disk growth. Do not turn the first profile into a monitoring platform. The goal is to create enough evidence that the next decision can be argued clearly.
+
+```bash
+/usr/bin/time -v ./run-local-model.sh < prompts/smoke-test.txt
+```
+
+The exact command will depend on your runtime, but the habit transfers. Wrap your runtime command, feed it a repeatable prompt, and capture timing and memory observations. If you use an HTTP service, write a small script that sends the same request each time and records the response time. Repeatability beats precision at this stage. A rough measurement repeated consistently is more useful than a perfect measurement you never collect again.
+
+Monitoring starts with process and resource visibility. On a private learner host, ordinary tools such as `systemctl status`, `journalctl`, `ps`, `top`, `htop`, `free`, `df`, and `nvidia-smi` can answer many first questions. In Kubernetes 1.35+ environments, the same thinking expands into node labels, device plugins, resource requests, logs, metrics, and rollout health, but the single-host lesson comes first: know which process is running, what resource it is consuming, and how it fails.
+
+```bash
+systemctl status localmodel.service
+journalctl -u localmodel.service --since "30 minutes ago"
+```
+
+Escalation rules matter even for a solo learner because a local model can consume the whole machine. Decide when to stop the service, when to downgrade to a smaller model, when to reduce context length, and when to abandon the GPU path until the driver situation is clear. Good operators define stop conditions before frustration takes over. A service that makes the machine unusable is not a learning success just because it technically starts.
+
+The host profile should also state what the Linux box does not solve. Linux gives you control over packages, processes, monitoring, runtime choices, and automation. It does not choose a good model, create a valid evaluation set, protect sensitive prompts by default, or make a weak GPU behave like a high-end accelerator. Control is useful only when paired with judgment. The profile is where that judgment becomes visible.
+
+## From Local Box To Infrastructure Thinking
+
+Linux becomes especially valuable when you stop treating the box as a toy and start treating it as a tiny infrastructure environment. The same categories that matter on one host will matter later in Kubernetes 1.35+ or a larger platform: artifact provenance, hardware scheduling, runtime compatibility, service ownership, monitoring, network exposure, and rollback. A single Linux box is not a cluster, but it can teach the mental model that clusters make more formal.
+
+The most important transfer is resource honesty. In Kubernetes, an accelerator-backed workload needs device visibility, scheduling rules, runtime support, and capacity planning. On a single Linux box, those concerns appear as `nvidia-smi`, process ownership, memory headroom, and runtime selection. The vocabulary changes, but the discipline does not. You still ask what resource is required, who owns it, what happens when it is exhausted, and how the system reports the problem.
+
+Network exposure is the second transfer. A local service bound to `127.0.0.1` is available only on the local machine, while a service bound to `0.0.0.0` may listen on every interface. That difference is easy to miss when a web UI works in your browser. In larger infrastructure, the equivalent questions become service type, ingress, authentication, authorization, and audit logging. The habit begins with checking what your Linux process is actually listening on.
+
+```bash
+ss -ltnp
+```
+
+Secrets and prompt data deserve the same care. A local model service might not call an external API, but it can still store sensitive prompts in logs, shell history, retrieval indexes, or temporary files. If you test with private documents, the risk moves from vendor transmission to local handling. That is still a risk. Local inference narrows some boundaries and widens others, especially when the machine is shared, backed up, or reachable over a network.
+
+Reliability is the third transfer. A command-line demo can fail noisily and be restarted by hand. A service needs health checks, restart behavior, log retention, model artifact availability, and a rollback path to a smaller or safer model. On a Linux box, systemd and basic logs are enough to practice these concepts. In a platform environment, the same ideas become readiness probes, liveness probes, image rollbacks, persistent volumes, and resource policies.
+
+This is also where Mac and Linux paths diverge in useful ways. Apple Silicon gives many learners a smooth local-first path, especially through MLX-aware tooling, and that smoothness is valuable when the goal is application experimentation. Linux is rougher at first, but it exposes operating-system and service-management details that transfer more directly into infrastructure work. Neither path is the winner for every learner. Choose the path that teaches the next constraint you actually need to master.
+
+The final decision is about maturity, not identity. Use a CPU-first Linux box when you need runtime literacy and small experiments. Use a single-GPU workstation when accelerator-aware local inference is the real learning goal. Use a home-lab server when persistence, access control, and operational practice matter. Move toward Kubernetes only when the single-host profile has answered the model, runtime, and service questions clearly enough that orchestration will solve a real problem rather than hide an unresolved one.
+
+## Patterns & Anti-Patterns
+
+### Patterns
+
+Start with a host profile before installing the runtime. This pattern works because it separates facts from preferences and lets you compare experiments honestly. Record processor, memory, accelerator, driver, storage, operating system, model artifact, runtime, and service mode before changing packages. As your setup grows, the same profile becomes an intake document for platform review, capacity planning, and troubleshooting.
+
+Use CPU-first experiments to learn model mechanics even when you eventually plan to use a GPU. CPU-first work teaches file formats, quantization, prompt shape, model cache behavior, and service control without the extra uncertainty of accelerator dependencies. This pattern scales because the debugging vocabulary transfers. Once the GPU path is active, you can tell whether a failure is new accelerator complexity or a behavior you already saw in the simpler runtime.
+
+Promote a model from interactive command to persistent service only after a repeatable prompt set passes. This pattern prevents the operational wrapper from becoming a disguise for weak model behavior. A service should add reliability, logging, restart behavior, and access boundaries around a model that already fits the learning goal. If the model is too slow, too large, or too unreliable in a foreground session, systemd will make it more official but not more correct.
+
+Keep accelerator checks close to runtime checks. If a runtime is supposed to use CUDA, verify the device, driver, framework, and process placement during the same evaluation. This pattern works because GPU failures often masquerade as runtime or model problems. A model that silently falls back to central processor execution can appear functional while producing misleading latency evidence, so every GPU result should state how device usage was confirmed.
+
+### Anti-Patterns
+
+Do not treat any Linux box as server-grade just because it runs without a display. Teams and learners fall into this mistake because Linux has a strong association with servers. The better alternative is to classify the machine honestly by hardware, service expectations, and failure tolerance. A reused desktop can be a great learning host while still being a poor always-on shared service.
+
+Do not assume a GPU is mandatory for all useful learning. This mistake blocks progress for learners who could be studying runtimes, quantization, retrieval, prompt evaluation, and service management on CPU-only hardware. The better alternative is to match the lesson to the box. Use CPU paths for mechanics and constraints, then move to GPU-backed inference when the goal requires accelerator behavior.
+
+Do not optimize for cluster complexity before single-host understanding. Kubernetes, device plugins, and accelerator node pools are valuable once the workload shape is clear, but they add moving parts. The better alternative is to prove the model, runtime, memory budget, and service behavior on one host first. Orchestration should solve scheduling and rollout problems, not compensate for an unknown local setup.
+
+Do not confuse infrastructure ambition with infrastructure readiness. A learner may want production-style serving, but readiness comes from evidence: repeatable prompts, measured latency, known memory use, documented driver state, controlled network binding, and clear stop conditions. The better alternative is to earn complexity step by step. Each new layer should answer a question the previous layer could not answer.
+
+## Decision Framework
+
+Start by choosing the learning objective, then choose the runtime path. If the objective is to understand model loading, tokenizer behavior, and package mechanics, use a simple Transformers experiment or a small local runtime before introducing service supervision. If the objective is to learn constrained local inference, use a quantized model and measure quality loss against the task. If the objective is accelerator-backed serving, verify the CUDA path before comparing sophisticated runtime features.
+
+Next, classify the hardware. A CPU-only machine points toward smaller models, quantized formats, retrieval prototypes, and patient expectations. A single-GPU workstation points toward CUDA-aware runtimes, careful memory budgeting, and stronger local experiments. A home-lab server points toward service management, storage hygiene, network binding, and monitoring. A machine can fit more than one category, but one category should lead the first experiment so the scope remains clear.
+
+Then decide whether the model will be interactive or persistent. Interactive work favors commands that are easy to run, interrupt, and modify. Persistent work favors explicit users, directories, logs, restart policies, and bind addresses. Shared access adds security and support expectations. This decision should happen before installing a web UI because a convenient interface can make a casual experiment look like a service before the owner has accepted service responsibilities.
+
+Finally, write the exit criteria. A local inference path is ready for the next layer when the host profile is complete, the model artifact is named, the runtime is reproducible, the prompt set has been measured, and the failure modes are known. It is not ready when success depends on one fragile shell session, one unexplained driver state, or one model file nobody can identify. The decision framework should tell you when to proceed, when to simplify, and when to switch hardware.
+
+```text
++------------------------------+
+| Start with learning objective |
++---------------+--------------+
+                |
+                v
++------------------------------+
+| Classify Linux hardware       |
+| CPU-only, GPU, or server      |
++---------------+--------------+
+                |
+                v
++------------------------------+
+| Choose runtime category       |
+| mechanics, local, or serving  |
++---------------+--------------+
+                |
+                v
++------------------------------+
+| Measure repeatable prompt set |
+| latency, memory, quality      |
++---------------+--------------+
+                |
+                v
++------------------------------+
+| Promote only if evidence fits |
++------------------------------+
+```
+
+## Did You Know?
+
+- Did you know that a model can load successfully and still be a poor service candidate because key-value cache memory grows with active context and concurrent requests?
+- Did you know that `nvidia-smi` reports driver and device state, but framework compatibility still depends on the specific runtime build you install?
+- Did you know that binding a local model server to `127.0.0.1` and binding it to `0.0.0.0` can be the difference between private testing and network exposure?
+- Did you know that Apple Silicon MLX workflows can be smoother for local experimentation, while Linux workflows often teach service and infrastructure habits that transfer into Kubernetes 1.35+ environments?
 
 ## Common Mistakes
 
-| Mistake | Why It Hurts | Better Move |
+| Mistake | Why It Happens | How to Fix It |
 |---|---|---|
-| treating any Linux box as “server-grade” | hides real hardware limits | classify the machine honestly |
-| assuming GPU is mandatory for all learning | blocks useful experimentation | learn what CPU-only paths can still teach |
-| optimizing for cluster complexity too early | creates ops pain before understanding | master single-host local inference first |
-| confusing infra ambition with infra readiness | makes the learning path brittle | earn complexity step by step |
+| Treating any Linux box as server-grade | Linux feels like a server environment even when the hardware is a fragile desktop or recycled workstation. | Classify the machine honestly by CPU, memory, accelerator, storage, uptime expectation, and who will use it. |
+| Assuming GPU is mandatory for all learning | Learners equate fast generation with useful education and overlook what CPU-only paths can teach. | Use CPU-first experiments for runtime mechanics, quantized models, retrieval prototypes, and service basics before chasing accelerator complexity. |
+| Optimizing for cluster complexity too early | Kubernetes and service meshes can feel more serious than a single host, so learners add orchestration before understanding the workload. | Prove the model, runtime, memory behavior, and service profile on one Linux box before moving toward Kubernetes 1.35+ patterns. |
+| Confusing infrastructure ambition with infrastructure readiness | A desire to run production-style serving gets mistaken for evidence that the host is stable enough. | Require a host profile, repeatable prompt set, measured latency, controlled network binding, and known failure modes before sharing access. |
+| Ignoring CUDA driver and framework compatibility | The GPU is physically present, so the learner assumes every runtime can use it automatically. | Check device visibility, driver version, framework installation guidance, and actual GPU memory use during the same test. |
+| Leaving model caches and failed downloads unmanaged | Comparing models creates large files quickly, and cleanup feels less interesting than the next experiment. | Keep artifacts in a predictable directory, record approved candidates, and remove failed variants after notes are captured. |
+| Exposing a local service without access boundaries | A web UI that works locally makes it tempting to bind broadly for convenience. | Start with local-only binding, document who may connect, and add authentication or network controls before shared use. |
+| Testing only one cheerful prompt | A simple answer can hide weak formatting, poor domain behavior, or unacceptable latency on longer inputs. | Use a repeatable prompt set with short, long, domain-specific, refusal, and formatting cases before promoting the setup. |
 
-## Quick Quiz
+## Quiz
 
-1. **Why is “start with the machine you actually have” a better rule than chasing an ideal setup?**
-   <details>
-   <summary>Answer</summary>
-   Because real learning depends on iteration and control. A realistic, working setup teaches more than a theoretical perfect setup you cannot sustain.
-   </details>
+<details>
+<summary>Your CPU-only Linux mini PC can run a small quantized model, but generation is slow. What should you do before buying GPU hardware?</summary>
 
-2. **Why is Linux a strong bridge toward AI infrastructure work?**
-   <details>
-   <summary>Answer</summary>
-   Because it exposes learners to service control, package environments, automation, and operational patterns that transfer into more serious infrastructure work.
-   </details>
+First, decide what lesson the current box can still teach. A CPU-only host is useful for learning runtime mechanics, quantized formats, prompt measurement, retrieval prototypes, service supervision, and storage hygiene. Measure a repeatable prompt set and record the model format, memory use, and subjective latency before changing hardware. If the learning goal is accelerator behavior, a GPU may be justified, but the CPU experiment should still produce a baseline that makes the upgrade decision clearer.
+</details>
 
-3. **What should a learner decide before choosing a runtime?**
-   <details>
-   <summary>Answer</summary>
-   CPU vs GPU, interactive vs service use, local-only vs shared tool, and exploration vs production-style serving.
-   </details>
+<details>
+<summary>Your single-GPU workstation shows a model running, but responses are much slower than expected. What do you check first?</summary>
+
+Check whether the runtime is actually using the GPU rather than silently falling back to central processor execution. Use `nvidia-smi` during inference, confirm the framework installation matches the accelerator path, and verify that the selected model format is supported by the runtime. If the device is unused, the issue is likely driver, framework, container, or runtime configuration rather than model intelligence. Only compare model quality after the resource path is known.
+</details>
+
+<details>
+<summary>You want to turn an interactive local model command into a service for teammates. What evidence should exist before you do that?</summary>
+
+You should have a complete host profile, a named model artifact, a repeatable prompt set, latency and memory observations, and clear notes about failure modes. A service wrapper adds ownership, logs, restart behavior, and network exposure, so it should surround a model that already behaves acceptably in interactive tests. Also decide who may connect, what address the service binds to, and where prompt data appears in logs or indexes. Without that evidence, the service can make an immature experiment look reliable.
+</details>
+
+<details>
+<summary>A container image includes CUDA libraries, but the container cannot see the GPU. Why is that not surprising?</summary>
+
+The container image can package user-space libraries, but it still depends on the host driver and device access. If the host driver is missing, incompatible, or not exposed through the container runtime, the process inside the container cannot allocate the accelerator. The fix is to verify host device visibility first, then configure NVIDIA container tooling or another supported accelerator path. Do not treat a CUDA image tag as proof that the Linux host is GPU-ready.
+</details>
+
+<details>
+<summary>Your home-lab model service works from another room after you bind it to every interface. What risk should you evaluate immediately?</summary>
+
+Evaluate network exposure and access control. Binding to every interface can make a model endpoint reachable beyond the local machine, and possibly beyond the intended household or lab network depending on routing and firewall rules. Check the listening address, firewall policy, authentication boundary, and logs that may contain prompts. A convenient remote interface should not be treated as safe until you know who can reach it and what data it stores.
+</details>
+
+<details>
+<summary>You are choosing between a smoother Mac local path and a rougher Linux workstation path. Which should you pick for infrastructure learning?</summary>
+
+Pick the path that matches the next constraint you need to learn. Apple Silicon workflows can be excellent for fast local experimentation, especially when MLX-aware tooling fits the model. Linux is usually better when the goal is service management, driver visibility, automation, monitoring, and habits that transfer toward Kubernetes 1.35+ infrastructure. Neither path is universally superior; the correct answer depends on whether application iteration or operational control is the current lesson.
+</details>
+
+<details>
+<summary>Your Linux host profile says the model loaded once with little free memory remaining. Should you promote it to a persistent service?</summary>
+
+No, not without more evidence. A one-time load does not account for longer prompts, key-value cache growth, concurrent requests, logs, operating system work, or restart behavior. Test a representative prompt set, observe peak memory, reduce context length or model size if needed, and leave headroom before offering the endpoint to anyone else. A persistent service needs operating margin, not just a successful startup.
+</details>
 
 ## Hands-On Exercise
 
-Write a short profile of your Linux box:
+Exercise scenario: create a practical profile for a Linux box you already own or can access. You do not need to install a large model for this exercise. The goal is to produce the evidence that would let you choose a runtime responsibly, explain whether CPU or GPU inference is realistic, and decide whether the box should remain interactive or become a persistent service later.
 
-1. hardware class
-2. likely model size range
-3. whether you want interactive use or a persistent service
-4. which runtime category seems most appropriate and why
+### Task 1: Classify the Linux box
 
-## Next Module
+Run the host inventory commands from this module and write a short classification. Name the hardware class, system memory, storage location for model files, and whether an accelerator is present. If the box has an NVIDIA GPU, include the driver and memory output from `nvidia-smi`; if it does not, explicitly state that the first path is CPU-first.
 
-Continue to [Choosing Between Ollama, MLX, Transformers, and vLLM](./module-1.6-choosing-between-ollama-mlx-transformers-vllm/).
+<details>
+<summary>Solution guidance</summary>
+
+A strong answer names the machine as CPU-first, single-GPU workstation, or home-lab server, then supports that classification with evidence. It should not say "good enough for AI" without hardware facts. If the GPU check fails, record the failure honestly rather than assuming CUDA will work later. That honesty is the point of the task.
+</details>
+
+### Task 2: Choose an initial runtime category
+
+Use the runtime table to choose a first runtime category, not necessarily a final runtime. Explain whether your goal is model mechanics, constrained local inference, smooth local service experiments, GPU-backed serving, or production-style container practice. Tie the choice to your host profile rather than to runtime popularity.
+
+<details>
+<summary>Solution guidance</summary>
+
+A CPU-first learner might choose a GGUF-oriented local runtime to study quantized inference. A GPU workstation learner might choose Transformers, vLLM, or text-generation-inference depending on whether they want framework literacy or serving practice. A home-lab learner should still prove interactive behavior before choosing service tooling. The answer should explain the tradeoff, not merely name a tool.
+</details>
+
+### Task 3: Draft the model and service profile
+
+Fill in the markdown profile template with the model artifact you plan to test, the model format or quantization level, the intended use, and whether the setup is interactive or persistent. If you do not know the exact model yet, write the constraints the model must satisfy instead of inventing a candidate.
+
+<details>
+<summary>Solution guidance</summary>
+
+The profile should be specific enough that another learner could rerun the same experiment. For example, it should distinguish a small quantized instruction model from a full-precision GPU model, and it should state whether the endpoint is local-only or intended for shared access. Unknowns are acceptable when they are labeled as unknowns and turned into next questions.
+</details>
+
+### Task 4: Build a repeatable prompt set
+
+Write at least five prompts that represent the intended use. Include one short prompt, one long prompt, one domain-specific prompt, one uncertainty or refusal case, and one formatting case if you expect structured output. Record what acceptable behavior would look like for each prompt before running the model.
+
+<details>
+<summary>Solution guidance</summary>
+
+A useful prompt set tests the workload, not the model's ability to answer a trivia question. The expected behavior should include latency expectations, formatting requirements, and safety boundaries when relevant. If the model is for retrieval practice, include a prompt that should require retrieved context and a prompt that should be rejected when context is missing.
+</details>
+
+### Task 5: Decide whether the box is interactive-only or service-ready
+
+Use your evidence to decide whether the Linux box should remain an interactive learning environment or can responsibly host a persistent service. Include stop conditions such as unacceptable latency, memory pressure, broad network exposure, failed GPU visibility, or unclear model provenance.
+
+<details>
+<summary>Solution guidance</summary>
+
+The strongest answers are often conservative. A box can be excellent for learning and still not be ready for shared service use. Service-ready means the owner can explain the model artifact, runtime, resource use, logs, restart behavior, network binding, and escalation path. If those facts are missing, keep the setup interactive and continue measuring.
+</details>
+
+### Success Criteria
+
+- [ ] Diagnose CPU GPU CUDA constraints on a Linux inference box using recorded command output.
+- [ ] Compare CPU-first single-GPU workstation and home-lab server paths for your specific host.
+- [ ] Design a runtime and model profile that names the intended use, artifact constraints, and service mode.
+- [ ] Implement a repeatable Linux host profile with hardware drivers memory storage and runtime notes.
+- [ ] Evaluate security monitoring and escalation tradeoffs before exposing any local model service to users.
 
 ## Sources
 
-- [Transformers Installation](https://huggingface.co/docs/transformers/en/installation) — Shows the practical split between CPU-only installs and GPU-backed installs that require CUDA drivers.
-- [Using TGI with Nvidia GPUs](https://huggingface.co/docs/text-generation-inference/installation_nvidia) — Demonstrates the extra CUDA and container-tooling requirements that appear on Linux GPU serving paths.
-- [Using MLX at Hugging Face](https://huggingface.co/docs/hub/mlx) — Provides the Apple Silicon comparison point referenced in the module’s Linux-vs-Mac discussion.
+- [Transformers Installation](https://huggingface.co/docs/transformers/en/installation)
+- [Using TGI with Nvidia GPUs](https://huggingface.co/docs/text-generation-inference/installation_nvidia)
+- [Using MLX at Hugging Face](https://huggingface.co/docs/hub/mlx)
+- [NVIDIA CUDA Installation Guide for Linux](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)
+- [NVIDIA Container Toolkit Install Guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
+- [PyTorch Get Started Locally](https://pytorch.org/get-started/locally/)
+- [vLLM Installation](https://docs.vllm.ai/en/latest/getting_started/installation.html)
+- [llama.cpp Build Documentation](https://github.com/ggml-org/llama.cpp/blob/master/docs/build.md)
+- [Ollama API Documentation](https://github.com/ollama/ollama/blob/main/docs/api.md)
+- [Kubernetes Device Plugins](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/)
+- [Kubernetes Schedule GPUs](https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/)
+- [systemd Service Documentation](https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html)
+
+## Next Module
+
+Continue to [Choosing Between Ollama, MLX, Transformers, and vLLM](./module-1.6-choosing-between-ollama-mlx-transformers-vllm/) to turn your host profile into a runtime selection.


### PR DESCRIPTION
Summary
- Rewrote the Linux local inference module as a dense #388 T0 module and cleared revision_pending.
- Preserved original protected assets: original source URLs 3/3 retained; original mistake concepts retained in the expanded Common Mistakes table. Asset counts before: code_blocks=0, ascii_diagrams=0, mermaid_diagrams=0, tables=1, sources=3. Asset counts after: code_blocks=10, ascii_diagrams=0, mermaid_diagrams=0, tables=3, sources=12.
- Verifier summary: tier=T0; body_words=5116; mean_wpp=72.1; median_wpp=73; short_rate=0.0; max_run=0; paragraph_count=71; mean_sentence_length=18.3.
- Live source check: 11 URLs returned 200 and 1 redirected; no source fetch failures.
- Commit SHA: b4376463174cbeebd0ec3736a6ef807036843e14

Checks
- #388 verifier with skip-source-check: pass, T0.
- #388 verifier with live source check: pass, T0.
- git diff --check on changed module: clean.
- Forbidden-token grep: clean.

Note
- The worktree does not have a local .venv symlink, so verifier commands were run with the primary repo virtualenv path while keeping tracked edits limited to the module file.