### PR TITLE
docs(decisions): resolve readiness-signal redesign — A⁴ shipped

### DIFF
--- a/docs/decisions/2026-05-12-readiness-signal-redesign.md
+++ b/docs/decisions/2026-05-12-readiness-signal-redesign.md
@@ -136,3 +136,20 @@ Reusable helpers Codex identified:
 
 **Awaiting:** user override (D / different scope) or "go A⁴ now" /
 "defer A⁴ until chain done".
+
+---
+
+## Resolution — 2026-05-12
+
+**Chosen option:** GO A⁴.
+
+**Shipped on `main` via three PRs:**
+
+| PR | SHA | What |
+|---|---|---|
+| #1153 | `228c5786` | A⁴ prereq #1 — write `citations_verified` to frontmatter on backfill |
+| #1155 | `acf1c03f` | A⁴ prereq #2 — add citation backfill step to per-module loop |
+| #1157 | `f0fd5ea3` | A⁴ main — frontmatter-derived `/api/tracks/readiness` |
+
+Backfill backlog and one-time apparent regression were both flagged in
+the PRs; ongoing `quality.pipeline backfill-pending` walks the corpus.


### PR DESCRIPTION
## Summary

- Move `docs/decisions/pending/2026-05-12-readiness-signal-redesign.md` → `docs/decisions/2026-05-12-readiness-signal-redesign.md`.
- Append a Resolution footer recording the chosen option (**GO A⁴**) and the three PRs that landed it on `main`:
  - #1153 / `228c5786` — A⁴ prereq #1 (citations_verified frontmatter)
  - #1155 / `acf1c03f` — A⁴ prereq #2 (chain citation backfill step)
  - #1157 / `f0fd5ea3` — A⁴ main (frontmatter-derived readiness API)

Per `.claude/rules/decision-card.md` cold-start protocol, resolved decisions move out of `pending/` so cold-start agents don't re-surface them.

## Test plan

- [x] No code change — pure docs rename + 17-line footer.
- [x] `git mv` preserves history (rename score 92%).
- [ ] Cross-family review (Codex, since Claude orchestrated the move).

🤖 Generated with [Claude Code](https://claude.com/claude-code)