### PR TITLE
fix(runner): skip push-verify when danger-mode dispatch is a no-op (#1143)

### DIFF
--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -68,6 +68,24 @@ _POLL_INTERVAL_S = 1.0
 _ADAPTER_CACHE: dict[str, AgentAdapter] = {}
 
 
+def _git_head_sha(cwd: Path) -> str | None:
+    """Return the current HEAD SHA of ``cwd``, or None on failure."""
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+        if proc.returncode == 0:
+            return proc.stdout.strip()
+    except (subprocess.SubprocessError, OSError):
+        pass
+    return None
+
+
 def _load_adapter(name: str) -> AgentAdapter:
     """Import the adapter class for ``name`` and cache the instance.
 
@@ -372,6 +390,7 @@ def invoke(
     env = build_agent_env(provider=agent_name, overrides=plan.env_overrides)
 
     # ---------- 7–9. Run the subprocess with watchdog ----------
+    head_before = _git_head_sha(effective_cwd) if mode == "danger" else None
     start_time = time.monotonic()
     proc: subprocess.Popen | None = None
     watchdog_state: WatchdogState | None = None
@@ -617,13 +636,19 @@ def invoke(
 
         push_verify_error: str | None = None
         if mode == "danger" and parse.ok:
-            # Defense in depth: any agent in danger mode that lands commits
-            # could silent-fail-push (e.g., sandbox env issue). Codex was the
-            # original observed case (PR #907 round-2), but the verify is
-            # cheap (one git ls-remote) and applies to all agents.
-            push_ok, push_verify_error = verify_current_branch_pushed(effective_cwd)
-            if not push_ok:
-                outcome = "error"
+            head_after = _git_head_sha(effective_cwd)
+            if not (
+                head_before is not None
+                and head_after is not None
+                and head_before == head_after
+            ):
+                # Defense in depth: any agent in danger mode that lands commits
+                # could silent-fail-push (e.g., sandbox env issue). Codex was the
+                # original observed case (PR #907 round-2), but the verify is
+                # cheap (one git ls-remote) and applies to all agents.
+                push_ok, push_verify_error = verify_current_branch_pushed(effective_cwd)
+                if not push_ok:
+                    outcome = "error"
 
         record = _build_usage_record(
             agent=agent_name,

--- a/scripts/test_pipeline.py
+++ b/scripts/test_pipeline.py
@@ -188,6 +188,7 @@ class TestCodexPushVerification(unittest.TestCase):
              patch.object(runner, "start_watchdog", return_value=(FakeWatchdogState(), [])), \
              patch.object(runner, "stop_watchdog"), \
              patch.object(runner, "write_record"), \
+             patch.object(runner, "_git_head_sha", side_effect=["old", "new"]), \
              patch.object(runner, "verify_current_branch_pushed", return_value=(False, stale_error)):
             result = runner.invoke(
                 "codex",

--- a/tests/test_agent_runtime_runner.py
+++ b/tests/test_agent_runtime_runner.py
@@ -2,12 +2,78 @@ from __future__ import annotations
 
 from pathlib import Path
 import sys
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 from agent_runtime import runner
+from agent_runtime.adapters.base import InvocationPlan
+from agent_runtime.result import ParseResult
+
+
+@pytest.mark.parametrize(
+    ("head_shas", "verify_called"),
+    [
+        (["same", "same"], False),
+        (["before", "after"], True),
+        ([None, "after"], True),
+    ],
+    ids=[
+        "noop-danger-dispatch-skips-push-verify",
+        "commit-landing-danger-dispatch-runs-push-verify",
+        "git-head-failure-falls-back-to-push-verify",
+    ],
+)
+def test_danger_push_verify_depends_on_head_movement(head_shas, verify_called):
+    adapter = SimpleNamespace(
+        default_model="gpt-test",
+        supported_modes=frozenset({"danger"}),
+        build_invocation=lambda **kw: InvocationPlan(
+            cmd=["fake-agent"],
+            cwd=kw["cwd"],
+        ),
+        liveness_signal_paths=lambda _plan: (),
+        parse_response=lambda **_kw: ParseResult(ok=True, response="done"),
+    )
+    proc = SimpleNamespace(
+        returncode=0,
+        stdin=None,
+        poll=lambda: 0,
+        kill=lambda: None,
+        wait=lambda timeout=None: 0,
+    )
+    state = SimpleNamespace(stdout_lines=["done"], stderr_lines=[])
+
+    with (
+        patch.object(runner, "_load_adapter", return_value=adapter),
+        patch.object(runner, "has_headroom", return_value=(True, "")),
+        patch.object(runner, "build_agent_env", return_value={}),
+        patch.object(runner.subprocess, "Popen", return_value=proc),
+        patch.object(runner, "start_watchdog", return_value=(state, [])),
+        patch.object(runner, "stop_watchdog"),
+        patch.object(runner, "write_record"),
+        patch.object(runner, "_git_head_sha", side_effect=head_shas),
+        patch.object(
+            runner,
+            "verify_current_branch_pushed",
+            return_value=(True, None),
+        ) as verify_pushed,
+    ):
+        result = runner.invoke(
+            "codex",
+            "consult only",
+            mode="danger",
+            cwd=Path("/tmp"),
+            model="gpt-test",
+            skip_headroom_check=True,
+        )
+
+    assert result.ok
+    assert result.usage_record["stderr_excerpt"] is None
+    assert verify_pushed.called is verify_called
 
 
 def test_build_usage_record_session_mode_new():


### PR DESCRIPTION
## Summary

- Capture the danger-mode worktree HEAD before launching the agent subprocess.
- After a successful parse, skip `verify_current_branch_pushed` when HEAD is unchanged because the dispatch landed no commits.
- Preserve the existing push-verify fallback when HEAD lookup fails or HEAD moved, and update the legacy stale-origin test to simulate commit movement explicitly.

## Tests

- `.venv/bin/ruff check scripts/agent_runtime/runner.py tests/test_agent_runtime_runner.py scripts/test_pipeline.py`
- `.venv/bin/pytest tests/test_agent_runtime_runner.py`
- `.venv/bin/python scripts/test_pipeline.py`
- `env -u KUBEDOJO_GEMINI_SUBSCRIPTION PYTHONPATH=. .venv/bin/pytest tests/` fails only at `tests/test_local_api.py::test_quality_scores_live_repo_no_citations_force_critical`: current repo content scores `CKA 0.1: Cluster Setup` as `excellent`, while the test expects `critical`.

Skipped `npm run build` because this PR changes only Python test/runtime code, not `src/content/docs/` or Astro config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>