### PR TITLE
feat(388): add NO RESTATEMENT rule to writer contract (Option C)

### DIFF
--- a/scripts/prompts/module-rewriter-388.md
+++ b/scripts/prompts/module-rewriter-388.md
@@ -29,6 +29,18 @@ Write body sections as flowing instructional prose, not punchy note blocks. Most
 
 Do not create sequences of standalone transition lines, thesis lines, warning lines, or recap lines. If two adjacent paragraphs are under 18 words, merge them into the surrounding explanation unless one is a heading, table row, list item, quiz option, code comment, or source entry.
 
+## NO RESTATEMENT ACROSS H2 SECTIONS
+
+Every core `## ` body section must contribute a **net-new** mechanism, example, comparison, or decision rule. Later sections may not restate the same thesis in different prose. If a section can be deleted without losing a concrete artifact (a command, a YAML, a worked decision-rule, an ASCII diagram, a table comparison, a quiz scenario), it is restatement padding — cut it before finalizing.
+
+Specifically:
+
+- **`Patterns & Anti-Patterns`, `Decision Framework`, `Senior Judgment`, `From Beginner to Senior`, `Worked Example` synthesis tails, and "best practices" closings** are allowed only if they introduce net-new criteria or examples not in the earlier teaching sections. If they would just rephrase the prior sections in more philosophical language, omit them.
+- **Worked Example tails:** end the worked example at the first complete walked-through outcome. Do not append a paragraph or three of "stepping back, the lesson here is..." synthesis prose. The reader either understood the example or did not — the synthesis adds words, not understanding.
+- **Theme rehashing:** scan every body paragraph before finalizing. If you find a paragraph that repeats the same engineering point made in an earlier section using different vocabulary, delete the later occurrence. The point is made; the reader does not need it again.
+
+This rule does not ban legitimate conceptual build-up. The section is valid only if it teaches a thing the reader did not already know from the prior section. If it only paraphrases or re-emphasizes, remove it.
+
 ## SYNTHESIZE COVERAGE BULLETS
 
 The topic coverage bullets in the dispatch brief are inputs, not an outline. Do not create one section or one paragraph per bullet. Combine related bullets into a coherent teaching arc with cause, consequence, tradeoff, and operational decision-making in the same paragraphs.
@@ -44,6 +56,7 @@ Before finalizing, scan every consecutive body-prose paragraph. If three paragra
 ## DEPTH TARGET (REPLACES "600+ CONTENT LINES")
 
 Target substantial depth: 5,000-7,000 words of original instructional content. Do not satisfy depth by adding short lines, fragmented paragraphs, or decorative structure. Word count is the floor; density gates are the ceiling on how those words can be packaged.
+The 5,000-7,000 target is a depth budget, not a quota. If a topic naturally fits in 4,500 words of substantive teaching, write 4,500 words. Padding to hit 5,000 with restated content is a hard failure of this contract (see NO RESTATEMENT ACROSS H2 SECTIONS above).
 
 ## RUNNABILITY, FABRICATION, AND PRACTICE QUESTIONS
 


### PR DESCRIPTION
## Summary
This PR updates `scripts/prompts/module-rewriter-388.md` to add an explicit anti-restatement constraint for #388 rewrites and clarifies the 5,000-7,000 word target as a depth budget.

## Failure mode addressed
A3 rounds of `ab discuss` and subsequent review surfaced that #388 modules could satisfy density gates while still being weak on instructional value by repeating the same engineering thesis across multiple core H2 sections. The closed PRs (#1147, #1149, #1156) failed because `Patterns & Anti-Patterns`, `Decision Framework`, and `Senior Judgment` materially rehashed prior points in different prose.

## Changes
- Adds `## NO RESTATEMENT ACROSS H2 SECTIONS` with explicit acceptance criteria:
  - each core H2 must add a net-new mechanism/example/comparison/decision rule,
  - named sections are allowed only when they introduce new criteria/examples,
  - worked-example synthesis tails should stop after the first complete outcome,
  - duplicate theme rehash in later body paragraphs should be deleted.
- Appends depth guidance in `## DEPTH TARGET (REPLACES "600+ CONTENT LINES")`:
  - the 5,000-7,000 target is explicitly a depth budget, not a quota,
  - restating to hit the floor is treated as a hard failure tied to the no-restatement rule.

## Validation performed
- Required sanity check passed:
  - `../../.venv/bin/python -c "from pathlib import Path; text = Path('scripts/prompts/module-rewriter-388.md').read_text(); assert 'NO RESTATEMENT ACROSS H2 SECTIONS' in text, 'missing new section'; assert 'depth budget, not a quota' in text, 'missing depth-budget clause'; print('ok')"`
- Integrity scan for existing prompt-file assertions was run: `rg -n "module-rewriter-388" tests scripts`.
  - No test under `tests/` asserts section headings/line counts for this prompt.

## Decision context
In `ab discuss padding-constraint-tightening-2026-05-12` (3 rounds, 2026-05-12), codex and gemini converged on this Option C prose-only constraint.

Option D (deterministic overlap gate) was rejected because lexical overlap is too noisy at similar Jaccard values for clean and padded modules.
Option F (Prose Capacity Plans) was deferred to a later pipeline PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
