### PR TITLE
feat(hooks): block branch creation in primary repo dir (#1176)

### DIFF
--- a/.claude/hooks/block-branch-create-in-primary.sh
+++ b/.claude/hooks/block-branch-create-in-primary.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Hook: PreToolUse (Bash) — Block branch creation in the primary repo dir.
+
+INPUT=$(cat)
+
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+if ! echo "$COMMAND" | grep -Eq '(^|[;&|[:space:]])git[[:space:]]+checkout([^;&|]*)[[:space:]]+-[bB]([[:space:]]|$)|(^|[;&|[:space:]])git[[:space:]]+switch([^;&|]*)[[:space:]]+-[cC]([[:space:]]|$)'; then
+  exit 0
+fi
+
+normalize_path() {
+  if [ -d "$1" ]; then
+    (cd "$1" && pwd -P)
+  else
+    printf '%s\n' "$1"
+  fi
+}
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+PRIMARY_DIR=$(git -C "$PROJECT_DIR" worktree list --porcelain 2>/dev/null | awk '/^worktree / {sub(/^worktree /, ""); print; exit}')
+if [ -z "$PRIMARY_DIR" ]; then
+  PRIMARY_DIR="$PROJECT_DIR"
+fi
+
+CWD=$(echo "$INPUT" | jq -r '.tool_input.cwd // .tool_input.workdir // .cwd // empty' 2>/dev/null)
+if [ -z "$CWD" ]; then
+  CWD="$PWD"
+fi
+
+PRIMARY_DIR=$(normalize_path "$PRIMARY_DIR")
+CWD=$(normalize_path "$CWD")
+
+case "$CWD/" in
+  "$PRIMARY_DIR/.worktrees/"*)
+    exit 0
+    ;;
+esac
+
+case "$CWD/" in
+  "$PRIMARY_DIR" | "$PRIMARY_DIR/"*)
+    printf '%s\n' \
+      "branch creation in the primary repo dir is blocked." \
+      "Use a worktree under \`.worktrees/\` instead." \
+      "See feedback_never_branch_in_primary_dir.md." >&2
+    exit 2
+    ;;
+esac
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,7 +8,10 @@
     "PreToolUse": [
       {
         "matcher": "Bash",
-        "hooks": [{"type": "command", "command": ".claude/hooks/enforce-venv.sh"}]
+        "hooks": [
+          {"type": "command", "command": ".claude/hooks/enforce-venv.sh"},
+          {"type": "command", "command": ".claude/hooks/block-branch-create-in-primary.sh"}
+        ]
       }
     ],
     "PostToolUse": [

--- a/tests/test_hook_block_branch_create_in_primary.py
+++ b/tests/test_hook_block_branch_create_in_primary.py
@@ -1,0 +1,90 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOOK = REPO_ROOT / ".claude" / "hooks" / "block-branch-create-in-primary.sh"
+
+
+def run_hook(command: str, cwd: Path, primary: Path) -> subprocess.CompletedProcess[str]:
+    payload = {
+        "tool_name": "Bash",
+        "tool_input": {
+            "command": command,
+            "cwd": str(cwd),
+        },
+    }
+    env = os.environ.copy()
+    env["CLAUDE_PROJECT_DIR"] = str(primary)
+    return subprocess.run(
+        ["bash", str(HOOK)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+        cwd=primary,
+    )
+
+
+def test_primary_checkout_b_denied(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+
+    result = run_hook("git checkout -b foo", primary, primary)
+
+    assert result.returncode != 0
+    assert "branch creation in the primary repo dir is blocked" in result.stderr
+
+
+def test_worktree_checkout_b_allowed(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    worktree = primary / ".worktrees" / "whatever"
+    worktree.mkdir(parents=True)
+
+    result = run_hook("git checkout -b foo", worktree, primary)
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+
+
+def test_primary_checkout_existing_branch_allowed(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+
+    result = run_hook("git checkout main", primary, primary)
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+
+
+def test_primary_branch_create_without_switch_allowed(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+
+    result = run_hook("git branch foo", primary, primary)
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+
+
+def test_primary_switch_c_denied(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+
+    result = run_hook("git switch -c foo", primary, primary)
+
+    assert result.returncode != 0
+    assert "branch creation in the primary repo dir is blocked" in result.stderr
+
+
+def test_primary_switch_existing_branch_allowed(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+
+    result = run_hook("git switch main", primary, primary)
+
+    assert result.returncode == 0
+    assert result.stderr == ""


### PR DESCRIPTION
## Rule

Implements Hook 1/5 from #1175 for child issue #1176. The new PreToolUse Bash hook blocks `git checkout -b`, `git checkout -B`, `git switch -c`, and `git switch -C` when the Bash tool cwd is the primary kubedojo checkout. The denial message cites `feedback_never_branch_in_primary_dir.md` and tells agents to use `.worktrees/` instead.

## Allowlist

- CWD under `.worktrees/` is allowed.
- `git branch <name>` is allowed.
- `git checkout <existing-branch>` is allowed.
- `git switch <existing-branch>` is allowed.
- Other git subcommands are allowed.

## Tests

- `test_primary_checkout_b_denied`
- `test_worktree_checkout_b_allowed`
- `test_primary_checkout_existing_branch_allowed`
- `test_primary_branch_create_without_switch_allowed`
- `test_primary_switch_c_denied`
- `test_primary_switch_existing_branch_allowed`

## Validation

- `bash -n .claude/hooks/block-branch-create-in-primary.sh`
- `shellcheck .claude/hooks/block-branch-create-in-primary.sh` skipped: shellcheck is not installed in this environment.
- `../../.venv/bin/python -m json.tool < .claude/settings.json >/dev/null`
- `../../.venv/bin/ruff check tests/test_hook_block_branch_create_in_primary.py`
- `../../.venv/bin/python -m pytest tests/test_hook_block_branch_create_in_primary.py -x`
- `../../.venv/bin/python scripts/test_pipeline.py`
- Manual smoke: primary denial exits non-zero with rule message; `.worktrees/` allow exits 0 with empty stderr.

Do not merge until cross-family Claude Opus review is posted.