### PR TITLE
refactor(hooks): extract _lib.sh + retroactive nits on hook 1 (pre-req for #1175 hook 2)

### DIFF
--- a/.claude/hooks/_lib.sh
+++ b/.claude/hooks/_lib.sh
@@ -1,0 +1,72 @@
+set -euo pipefail
+
+detect_primary_dir() {
+  local lib_dir primary project_dir
+
+  primary=$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {sub(/^worktree /, ""); print; exit}' 2>/dev/null || true)
+  if [ -n "$primary" ]; then
+    printf '%s\n' "$primary"
+    return 0
+  fi
+
+  project_dir="${CLAUDE_PROJECT_DIR:-}"
+  if [ -n "$project_dir" ] && [ -d "$project_dir" ]; then
+    printf '%s\n' "$project_dir"
+    return 0
+  fi
+
+  if lib_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd -P); then
+    if project_dir=$(cd "$lib_dir/../.." 2>/dev/null && pwd -P); then
+      printf '%s\n' "$project_dir"
+      return 0
+    fi
+  fi
+}
+
+normalize_path() {
+  local path
+  path=$1
+
+  (cd "$path" 2>/dev/null && pwd -P) || printf '%s\n' "$path"
+}
+
+is_inside_primary() {
+  local cwd primary
+  cwd=$(normalize_path "$1")
+  primary=$(normalize_path "$PRIMARY_DIR")
+
+  case "$cwd/" in
+    "$primary/.worktrees/"*)
+      return 1
+      ;;
+  esac
+
+  if [ "$cwd" = "$primary" ]; then
+    return 0
+  fi
+
+  case "$cwd/" in
+    "$primary/"*)
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
+read_tool_payload() {
+  jq -er '[(.tool_input.command // ""), (.tool_input.cwd // .cwd // env.PWD)] | @tsv'
+}
+
+deny() {
+  local allowlist_hint memory_ref rule_name
+  rule_name=$1
+  allowlist_hint=$2
+  memory_ref=$3
+
+  printf '[hook denied] %s\n  allowlist: %s\n  see: memory/%s\n' \
+    "$rule_name" \
+    "$allowlist_hint" \
+    "$memory_ref" >&2
+  exit 2
+}

--- a/.claude/hooks/block-branch-create-in-primary.sh
+++ b/.claude/hooks/block-branch-create-in-primary.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
+source "${BASH_SOURCE[0]%/*}/_lib.sh"
+set -euo pipefail
+
 # Hook: PreToolUse (Bash) — Block branch creation in the primary repo dir.
 
-INPUT=$(cat)
+PAYLOAD=$(read_tool_payload)
+COMMAND=${PAYLOAD%%$'\t'*}
+CWD=${PAYLOAD#*$'\t'}
 
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 if [ -z "$COMMAND" ]; then
   exit 0
 fi
@@ -12,42 +16,14 @@ if ! echo "$COMMAND" | grep -Eq '(^|[;&|[:space:]])git[[:space:]]+checkout([^;&|
   exit 0
 fi
 
-normalize_path() {
-  if [ -d "$1" ]; then
-    (cd "$1" && pwd -P)
-  else
-    printf '%s\n' "$1"
-  fi
-}
-
-PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
-PRIMARY_DIR=$(git -C "$PROJECT_DIR" worktree list --porcelain 2>/dev/null | awk '/^worktree / {sub(/^worktree /, ""); print; exit}')
-if [ -z "$PRIMARY_DIR" ]; then
-  PRIMARY_DIR="$PROJECT_DIR"
-fi
-
-CWD=$(echo "$INPUT" | jq -r '.tool_input.cwd // .tool_input.workdir // .cwd // empty' 2>/dev/null)
-if [ -z "$CWD" ]; then
-  CWD="$PWD"
-fi
-
-PRIMARY_DIR=$(normalize_path "$PRIMARY_DIR")
+PRIMARY_DIR=$(normalize_path "$(detect_primary_dir)")
 CWD=$(normalize_path "$CWD")
 
-case "$CWD/" in
-  "$PRIMARY_DIR/.worktrees/"*)
-    exit 0
-    ;;
-esac
-
-case "$CWD/" in
-  "$PRIMARY_DIR" | "$PRIMARY_DIR/"*)
-    printf '%s\n' \
-      "branch creation in the primary repo dir is blocked." \
-      "Use a worktree under \`.worktrees/\` instead." \
-      "See feedback_never_branch_in_primary_dir.md." >&2
-    exit 2
-    ;;
-esac
+if is_inside_primary "$CWD"; then
+  deny \
+    "branch creation in the primary repo dir is blocked." \
+    "Use a worktree under \`.worktrees/\` instead." \
+    "feedback_never_branch_in_primary_dir.md"
+fi
 
 exit 0

--- a/tests/test_hook_block_branch_create_in_primary.py
+++ b/tests/test_hook_block_branch_create_in_primary.py
@@ -8,6 +8,28 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 HOOK = REPO_ROOT / ".claude" / "hooks" / "block-branch-create-in-primary.sh"
 
 
+def run_hook_payload(
+    payload: dict[str, object],
+    primary: Path,
+    *,
+    env_overrides: dict[str, str] | None = None,
+    executable: str = "bash",
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["CLAUDE_PROJECT_DIR"] = str(primary)
+    if env_overrides:
+        env.update(env_overrides)
+    return subprocess.run(
+        [executable, str(HOOK)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+        cwd=primary,
+    )
+
+
 def run_hook(command: str, cwd: Path, primary: Path) -> subprocess.CompletedProcess[str]:
     payload = {
         "tool_name": "Bash",
@@ -16,17 +38,7 @@ def run_hook(command: str, cwd: Path, primary: Path) -> subprocess.CompletedProc
             "cwd": str(cwd),
         },
     }
-    env = os.environ.copy()
-    env["CLAUDE_PROJECT_DIR"] = str(primary)
-    return subprocess.run(
-        ["bash", str(HOOK)],
-        input=json.dumps(payload),
-        text=True,
-        capture_output=True,
-        check=False,
-        env=env,
-        cwd=primary,
-    )
+    return run_hook_payload(payload, primary)
 
 
 def test_primary_checkout_b_denied(tmp_path: Path) -> None:
@@ -88,3 +100,61 @@ def test_primary_switch_existing_branch_allowed(tmp_path: Path) -> None:
 
     assert result.returncode == 0
     assert result.stderr == ""
+
+
+def test_capital_b_flag_denied(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+
+    result = run_hook("git checkout -B foo", primary, primary)
+
+    assert result.returncode != 0
+    assert "branch creation in the primary repo dir is blocked" in result.stderr
+
+
+def test_capital_c_flag_denied(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+
+    result = run_hook("git switch -C foo", primary, primary)
+
+    assert result.returncode != 0
+    assert "branch creation in the primary repo dir is blocked" in result.stderr
+
+
+def test_real_harness_payload_shape_top_level_cwd(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+    payload = {
+        "tool_name": "Bash",
+        "cwd": str(primary),
+        "tool_input": {
+            "command": "git checkout -b foo",
+        },
+    }
+
+    result = run_hook_payload(payload, primary)
+
+    assert result.returncode != 0
+    assert "branch creation in the primary repo dir is blocked" in result.stderr
+
+
+def test_payload_without_jq_fails_closed(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+    payload = {
+        "tool_name": "Bash",
+        "tool_input": {
+            "command": "git checkout -b foo",
+            "cwd": str(primary),
+        },
+    }
+
+    result = run_hook_payload(
+        payload,
+        primary,
+        env_overrides={"PATH": str(tmp_path / "no-jq")},
+        executable="/bin/bash",
+    )
+
+    assert result.returncode != 0


### PR DESCRIPTION
## Summary
- Closes #1178 as the pre-req cleanup for #1175 hooks 2-5.
- Extracts shared hook helpers into source-only `.claude/hooks/_lib.sh`.
- Retrofitted hook 1 to use the shared primary-dir/CWD/payload/deny helpers while keeping its regex local.
- Addresses PR #1177 reviewer nits: strict mode, `-B`/`-C` coverage, and top-level `cwd` payload shape.

## Tests
- `bash -n .claude/hooks/_lib.sh`
- `bash -n .claude/hooks/block-branch-create-in-primary.sh`
- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python -m json.tool < .claude/settings.json`
- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/ruff check tests/test_hook_block_branch_create_in_primary.py`
- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python -m pytest tests/test_hook_block_branch_create_in_primary.py -x`
- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/test_pipeline.py`
- manual smoke: primary denial returns new three-line `[hook denied]` block; worktree payload exits 0

No `.claude/settings.json` wiring changes. Do not merge before cross-family review.