### PR TITLE
fix(ab-discuss): clarify max_rounds terminator on parallel within-round visibility lag

### DIFF
--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -1482,6 +1482,7 @@ def _handle_discuss(args) -> int:
         return (agent_name, result.response.strip(), True)
 
     completed_rounds = 0
+    round_history: list[dict[str, tuple[str, bool, bool]]] = []
     try:
         for round_idx in range(1, max_rounds + 1):
             completed_rounds = round_idx
@@ -1659,6 +1660,12 @@ def _handle_discuss(args) -> int:
             # without any cross-agent comparison. Hallucination would have
             # shipped to curriculum if the transcript were taken at face
             # value. Ported from learn-ukrainian commit 872d8376b0.
+            round_history.append(
+                {
+                    agent: (text, ok, text.strip().endswith("[AGREE]"))
+                    for agent, (text, ok) in responses.items()
+                }
+            )
             all_ok = all(ok for (_, ok) in responses.values())
             all_agreed = all_ok and all(
                 text.strip().endswith("[AGREE]") for (text, _) in responses.values()
@@ -1676,24 +1683,72 @@ def _handle_discuss(args) -> int:
                 )
 
             if round_idx == max_rounds:
-                # Tell the caller WHY we stopped so escalation is obvious.
-                # Same strict endswith check as convergence — substring
-                # match would false-positive on "I don't [AGREE] with
-                # that. [DISAGREE]" and report no disagreements.
-                disagreeing = [
+                # Tell the caller WHY we stopped. Use the same strict
+                # endswith check as convergence — substring match would
+                # false-positive on "I don't [AGREE] with that. [DISAGREE]".
+                agreed_final = [
+                    a for a, (t, _) in responses.items() if t.strip().endswith("[AGREE]")
+                ]
+                disagreed_final = [
                     a
                     for a, (t, _) in responses.items()
                     if not t.strip().endswith("[AGREE]")
                 ]
+                final_tokens = []
+                for agent in with_agents:
+                    text, _ = responses[agent]
+                    tail = text.strip()
+                    if tail.endswith("[AGREE]"):
+                        token = "[AGREE]"
+                    elif tail.endswith("[DISAGREE]"):
+                        token = "[DISAGREE]"
+                    else:
+                        token = "[NO_TOKEN]"
+                    final_tokens.append(f"{agent}={token}")
+
+                ever_agreed = {agent: False for agent in with_agents}
+                flipped_agree_to_disagree = False
+                for history_round in round_history:
+                    for agent in with_agents:
+                        text, _ok, ends_with_agree = history_round[agent]
+                        if ever_agreed[agent] and text.strip().endswith("[DISAGREE]"):
+                            flipped_agree_to_disagree = True
+                        if ends_with_agree:
+                            ever_agreed[agent] = True
+
+                parallel_lag_likely = (
+                    len(agreed_final) >= 1
+                    and len(disagreed_final) >= 1
+                    and not flipped_agree_to_disagree
+                )
                 print()
                 print(
-                    f"⚠️  hit max_rounds={max_rounds} without convergence. "
-                    f"Still disagreeing: {', '.join(disagreeing) or '(none? see errors)'}"
+                    f"⚠️  hit max_rounds={max_rounds} without unanimous [AGREE] "
+                    "sign-off."
                 )
-                print(
-                    "   Escalate to a human or re-open the discussion with a "
-                    "tighter brief."
-                )
+                print(f"   Final-round tokens: {'  '.join(final_tokens)}")
+                if parallel_lag_likely:
+                    print(
+                        "   Caveat: agents respond in parallel within a round, so an agent"
+                    )
+                    print(
+                        "   signing [DISAGREE] may not have seen concurrent [AGREE] "
+                        "responses"
+                    )
+                    print(
+                        "   from peers in the same round. Substance may have converged "
+                        "even if"
+                    )
+                    print(
+                        "   tokens did not. Inspect transcript before treating as actual"
+                    )
+                    print("   disagreement.")
+                else:
+                    disagreeing_text = ", ".join(disagreed_final) or "(none? see errors)"
+                    print(
+                        f"   Persistent disagreement on {disagreeing_text}. Escalate to "
+                        "a human or re-open the discussion with a tighter brief."
+                    )
     finally:
         for temp_mcp_path in mcp_cleanup_paths:
             try:

--- a/tests/test_bridge_inbox_cli.py
+++ b/tests/test_bridge_inbox_cli.py
@@ -230,6 +230,61 @@ def test_discuss_max_rounds_one_clamps_to_two(mock_invoke, monkeypatch, capsys):
 
 
 @patch("agent_runtime.runner.invoke")
+def test_discuss_max_rounds_partial_convergence_message(
+    mock_invoke, monkeypatch, capsys
+):
+    _channels.create_channel("shared")
+    monkeypatch.setattr(_channels, "fetch_monitor_state", lambda: None)
+
+    responses = {
+        "claude": ["[DISAGREE]", "[AGREE]", "[AGREE]"],
+        "codex": ["[DISAGREE]", "[DISAGREE]", "[AGREE]"],
+        "gemini": ["[DISAGREE]", "[DISAGREE]", "[DISAGREE]"],
+    }
+    call_counts = dict.fromkeys(responses, 0)
+
+    def _discuss_result(agent: str, *_args, **_kwargs) -> Result:
+        idx = call_counts[agent]
+        call_counts[agent] += 1
+        return Result(
+            ok=True,
+            agent=agent,
+            model="test-model",
+            mode="read-only",
+            response=f"{agent} discuss reply {responses[agent][idx]}",
+            stderr_excerpt=None,
+            duration_s=0.1,
+            session_id=None,
+            rate_limited=False,
+            stalled=False,
+            returncode=0,
+            usage_record={},
+        )
+
+    mock_invoke.side_effect = _discuss_result
+
+    exit_code = _run_cli(
+        [
+            "discuss",
+            "shared",
+            "topic",
+            "--with",
+            "claude,codex,gemini",
+            "--max-rounds",
+            "3",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "without unanimous [AGREE] sign-off" in captured.out
+    assert "Final-round tokens:" in captured.out
+    assert "Caveat" in captured.out
+    assert "parallel" in captured.out
+    assert "Escalate to a human" not in captured.out
+
+
+@patch("agent_runtime.runner.invoke")
 def test_discuss_claude_round1_round2_session_resume(mock_invoke, monkeypatch, capsys):
     _channels.create_channel("discuss-resume")
     monkeypatch.setattr(_channels, "fetch_monitor_state", lambda: None)


### PR DESCRIPTION
## Summary

Fixes the `ab discuss` max-rounds terminator wording when final-round tokens are mixed but the mixed state is plausibly caused by parallel within-round visibility lag, not live substantive disagreement.

## Motivation

Session 7 incident: channel `gap-tier12-pressure-test-2026-05-13`, thread `db4c0a1451bd4bf9b53c22e8c70d1cd1`.

Final round tokens were:

- `claude=[DISAGREE]`
- `codex=[DISAGREE]`
- `gemini=[AGREE]`

Gemini conceded the disputed points in the final round, so the substance had converged. But claude and codex responded in parallel and did not see Gemini's concurrent `[AGREE]`, so the old terminator printed a misleading "Still disagreeing" escalation.

## Before

```text
⚠️  hit max_rounds=N without convergence. Still disagreeing: codex, claude
   Escalate to a human or re-open the discussion with a tighter brief.
```

## After

```text
⚠️  hit max_rounds=N without unanimous [AGREE] sign-off.
   Final-round tokens: claude=[DISAGREE]  codex=[DISAGREE]  gemini=[AGREE]
   Caveat: agents respond in parallel within a round, so an agent
   signing [DISAGREE] may not have seen concurrent [AGREE] responses
   from peers in the same round. Substance may have converged even if
   tokens did not. Inspect transcript before treating as actual
   disagreement.
```

When there is an actual agree-to-disagree flip, the warning still reports persistent disagreement and keeps the human-escalation wording.

## Tests

- `.venv/bin/python -m pytest tests/test_bridge_inbox_cli.py -v -k discuss_max_rounds`
- `.venv/bin/python -m pytest scripts/ai_agent_bridge/tests/ -v`
- `.venv/bin/ruff check scripts/ai_agent_bridge/_channels_cli.py tests/test_bridge_inbox_cli.py`
- `.venv/bin/python scripts/test_pipeline.py` (170 tests OK)
- `git diff --check`
