### PR TITLE
feat(hooks): block direct commit on main without PR ref (2/5 of #1175)

### DIFF
--- a/.claude/hooks/block-direct-commit-on-main.sh
+++ b/.claude/hooks/block-direct-commit-on-main.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# shellcheck source=.claude/hooks/_lib.sh
+source "${BASH_SOURCE[0]%/*}/_lib.sh"
+set -euo pipefail
+
+# Hook: PreToolUse (Bash) — Block direct commits to main unless the subject is pipeline-owned or PR-backed.
+
+RAW_PAYLOAD=$(cat)
+
+TOOL_NAME=$(jq -r '.tool_name // ""' <<<"$RAW_PAYLOAD")
+if [ "$TOOL_NAME" != "Bash" ]; then
+  exit 0
+fi
+
+PAYLOAD=$(read_tool_payload <<<"$RAW_PAYLOAD")
+COMMAND=${PAYLOAD%%$'\t'*}
+CWD=${PAYLOAD#*$'\t'}
+
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+if ! echo "$COMMAND" | grep -Eq '(^|[;&|[:space:]])git[[:space:]]+commit([[:space:]]|$)'; then
+  exit 0
+fi
+
+BRANCH=$(git -C "$CWD" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+if [ "$BRANCH" != "main" ]; then
+  exit 0
+fi
+
+PARSE_RESULT=$(python3 -c '
+import shlex
+import sys
+
+command = sys.argv[1]
+
+try:
+    tokens = shlex.split(command)
+except ValueError as exc:
+    print(f"UNKNOWN\tcould not parse shell command ({exc})")
+    raise SystemExit
+
+args = None
+for index, token in enumerate(tokens[:-1]):
+    if token == "git" and tokens[index + 1] == "commit":
+        args = tokens[index + 2 :]
+        break
+
+if args is None:
+    print("UNKNOWN\tmatched git commit text, but could not locate argv")
+    raise SystemExit
+
+for index, token in enumerate(args):
+    if token in {"-F", "--file"}:
+        print("UNKNOWN\tcommit message comes from a file")
+        raise SystemExit
+    if token.startswith("-F") and token != "-F":
+        print("UNKNOWN\tcommit message comes from a file")
+        raise SystemExit
+    if token.startswith("--file="):
+        print("UNKNOWN\tcommit message comes from a file")
+        raise SystemExit
+
+subject = None
+for index, token in enumerate(args):
+    if token in {"-m", "--message"}:
+        if index + 1 >= len(args):
+            print("UNKNOWN\t-m was present without a statically visible message")
+            raise SystemExit
+        subject = args[index + 1]
+        break
+    if token.startswith("-m") and token != "-m":
+        subject = token[2:]
+        break
+    if token.startswith("--message="):
+        subject = token.split("=", 1)[1]
+        break
+
+if subject is None:
+    if "--amend" in args and "--no-edit" in args:
+        print("UNKNOWN\tcommit amend keeps the existing message")
+    else:
+        print("UNKNOWN\tno statically visible -m commit subject")
+    raise SystemExit
+
+if subject.startswith("$("):
+    print("UNKNOWN\tcommit subject is dynamically built with command substitution")
+    raise SystemExit
+
+print("SUBJECT\t" + (subject.splitlines()[0] if subject else ""))
+' "$COMMAND" || true)
+
+PARSE_KIND=${PARSE_RESULT%%$'\t'*}
+PARSE_VALUE=${PARSE_RESULT#*$'\t'}
+
+if [ "$PARSE_KIND" != "SUBJECT" ]; then
+  printf '[hook note] direct commit to main not introspected: %s; allowing.\n' "$PARSE_VALUE" >&2
+  exit 0
+fi
+
+SUBJECT=$PARSE_VALUE
+
+case "$SUBJECT" in
+  backfill* | handoff* | docs\(status\):*)
+    exit 0
+    ;;
+esac
+
+if printf '%s\n' "$SUBJECT" | grep -Eq '\(#[0-9]+\)'; then
+  exit 0
+fi
+
+deny \
+  "direct commit to main without PR ref is blocked." \
+  "subject must start with one of [backfill, handoff, docs(status):] OR contain (#N)." \
+  "feedback_no_direct_push_to_main.md"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,7 +10,8 @@
         "matcher": "Bash",
         "hooks": [
           {"type": "command", "command": ".claude/hooks/enforce-venv.sh"},
-          {"type": "command", "command": ".claude/hooks/block-branch-create-in-primary.sh"}
+          {"type": "command", "command": ".claude/hooks/block-branch-create-in-primary.sh"},
+          {"type": "command", "command": ".claude/hooks/block-direct-commit-on-main.sh"}
         ]
       }
     ],

--- a/tests/test_hook_block_direct_commit_on_main.py
+++ b/tests/test_hook_block_direct_commit_on_main.py
@@ -1,0 +1,185 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOOK = REPO_ROOT / ".claude" / "hooks" / "block-direct-commit-on-main.sh"
+BASH = "/bin/bash"
+
+
+def init_git_main(primary: Path) -> None:
+    subprocess.run(["git", "init", "-b", "main", str(primary)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "agent@example.test"],
+        cwd=primary,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Agent"],
+        cwd=primary,
+        check=True,
+        capture_output=True,
+    )
+    (primary / "README.md").write_text("test repo\n")
+    subprocess.run(["git", "add", "README.md"], cwd=primary, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "initial"],
+        cwd=primary,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(["git", "checkout", "main"], cwd=primary, check=True, capture_output=True)
+
+
+def run_hook_payload(
+    payload: dict[str, object],
+    primary: Path,
+    *,
+    cwd: Path | None = None,
+    env_overrides: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["CLAUDE_PROJECT_DIR"] = str(primary)
+    if env_overrides:
+        env.update(env_overrides)
+    return subprocess.run(
+        [BASH, str(HOOK)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+        cwd=cwd or primary,
+    )
+
+
+def run_hook(command: str, cwd: Path, primary: Path) -> subprocess.CompletedProcess[str]:
+    payload = {
+        "tool_name": "Bash",
+        "tool_input": {
+            "command": command,
+            "cwd": str(cwd),
+        },
+    }
+    return run_hook_payload(payload, primary, cwd=cwd)
+
+
+def test_main_commit_no_ref_denied(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    init_git_main(primary)
+
+    result = run_hook('git commit -m "fix: thing"', primary, primary)
+
+    assert result.returncode == 2
+    assert "direct commit to main without PR ref is blocked" in result.stderr
+    assert "feedback_no_direct_push_to_main.md" in result.stderr
+
+
+def test_main_commit_pr_ref_allowed(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    init_git_main(primary)
+
+    result = run_hook('git commit -m "feat(x): blah (#1234)"', primary, primary)
+
+    assert result.returncode == 0
+
+
+def test_main_commit_docs_status_allowed(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    init_git_main(primary)
+
+    result = run_hook('git commit -m "docs(status): handoff"', primary, primary)
+
+    assert result.returncode == 0
+
+
+def test_main_commit_handoff_prefix_allowed(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    init_git_main(primary)
+
+    result = run_hook('git commit -m "handoff: session-N"', primary, primary)
+
+    assert result.returncode == 0
+
+
+def test_main_commit_backfill_prefix_allowed(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    init_git_main(primary)
+
+    result = run_hook('git commit -m "backfill citations"', primary, primary)
+
+    assert result.returncode == 0
+
+
+def test_feature_branch_commit_allowed(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    init_git_main(primary)
+    subprocess.run(["git", "checkout", "-b", "feature"], cwd=primary, check=True, capture_output=True)
+
+    result = run_hook('git commit -m "fix: thing"', primary, primary)
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+
+
+def test_commit_amend_no_message_allowed(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    init_git_main(primary)
+
+    result = run_hook("git commit --amend --no-edit", primary, primary)
+
+    assert result.returncode == 0
+    assert "not introspected" in result.stderr
+
+
+def test_commit_F_file_allowed(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    init_git_main(primary)
+    message = tmp_path / "msg.txt"
+    message.write_text("fix: thing\n")
+
+    result = run_hook(f"git commit -F {message}", primary, primary)
+
+    assert result.returncode == 0
+    assert "not introspected" in result.stderr
+
+
+def test_commit_no_m_flag_allowed(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    init_git_main(primary)
+
+    result = run_hook("git commit", primary, primary)
+
+    assert result.returncode == 0
+    assert "not introspected" in result.stderr
+
+
+def test_non_commit_bash_command_allowed(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    init_git_main(primary)
+
+    result = run_hook("git log -3", primary, primary)
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+
+
+def test_detached_head_allowed(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    init_git_main(primary)
+    commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=primary,
+        text=True,
+        check=True,
+        capture_output=True,
+    ).stdout.strip()
+    subprocess.run(["git", "checkout", commit], cwd=primary, check=True, capture_output=True)
+
+    result = run_hook('git commit -m "fix: thing"', primary, primary)
+
+    assert result.returncode == 0
+    assert result.stderr == ""


### PR DESCRIPTION
## Summary

Implements hook 2 from #1175 item 2: block `git commit` while the resolved `tool_input.cwd` is on `main` unless the commit subject is pipeline-owned or PR-backed.

Changes:
- Adds executable `.claude/hooks/block-direct-commit-on-main.sh`, sourcing `_lib.sh` and using the shared `deny()` message shape.
- Wires the hook as the third Bash PreToolUse command after `enforce-venv.sh` and `block-branch-create-in-primary.sh`.
- Adds `tests/test_hook_block_direct_commit_on_main.py` covering deny, allowlist, feature branch, detached HEAD, and fail-open cases.

## Rationale

This encodes the `feedback_no_direct_push_to_main.md` memory as deterministic harness behavior after lapse `92e36e9e` on 2026-05-12. PR + rebase/squash merge is the floor for normal work; the hook preserves the pipeline-owned exception from `feedback_ai_gate_is_the_gate.md` for `docs(status):`, `handoff`, and `backfill` subjects, and recognizes squash-style PR refs like `(#1234)`.

Refs #1175 item 2.

## Manual smoke

From the primary worktree (`/Users/krisztiankoos/projects/kubedojo`, current branch `main`) via hook payloads that set `tool_input.cwd` to the primary checkout:

- `git commit -m "fix: my-thing" --allow-empty` -> denied, `rc=2`, stderr includes `direct commit to main without PR ref is blocked.`
- `git commit -m "docs(status): blah" --allow-empty` -> allowed, `rc=0`
- `git commit -m "merge PR (#1234)" --allow-empty` -> allowed, `rc=0`
- Primary checkout stayed clean on `main` after the smoke.

## Validation

- `../../.venv/bin/python -m pytest tests/test_hook_block_direct_commit_on_main.py -v` -> 11 passed
- `../../.venv/bin/python -m pytest tests/test_hook_block_branch_create_in_primary.py -v` -> 10 passed
- `../../.venv/bin/ruff check tests/test_hook_block_direct_commit_on_main.py` -> clean
- `/bin/bash -n .claude/hooks/block-direct-commit-on-main.sh` -> clean
- `jq . .claude/settings.json >/dev/null` -> valid JSON
- `../../.venv/bin/python scripts/test_pipeline.py` -> 170 tests, OK
- `git diff --cached --check` before commit -> clean
- `shellcheck .claude/hooks/block-direct-commit-on-main.sh` skipped locally: `shellcheck` is not installed

## Notes

No `npm run build`: this PR only changes hook/test/config files, not `src/content/docs/` or Astro config.
