### PR TITLE
fix(pipeline-v4): rename outcome needs_human → residuals_filed (#342)

### DIFF
--- a/scripts/pipeline_v4.py
+++ b/scripts/pipeline_v4.py
@@ -44,7 +44,7 @@ STAGE_DONE = "DONE"
 
 OUTCOME_CLEAN = "clean"
 OUTCOME_SKIPPED = "skipped_already_stable"
-OUTCOME_NEEDS_HUMAN = "needs_human"
+OUTCOME_RESIDUALS_FILED = "residuals_filed"
 OUTCOME_FAILED = "failed"
 
 
@@ -410,7 +410,7 @@ def _run_pipeline_v4(
                 if result.retry_count >= max_rubric_retries:
                     return _fail_result(
                         result,
-                        outcome=OUTCOME_NEEDS_HUMAN,
+                        outcome=OUTCOME_RESIDUALS_FILED,
                         reason="rubric_stage_3_unmet",
                         score_after=score_after_expand,
                     )
@@ -508,10 +508,10 @@ def _run_pipeline_v4(
         result.stage_reached = STAGE_DONE
         # residuals_queued means pipeline_v3 ran cleanly but routed some
         # items to human review. Not a failure, not fully clean — flag
-        # as needs_human so batch summaries distinguish it from modules
-        # that closed out without operator follow-up.
+        # as residuals_filed so summaries distinguish it from modules
+        # that closed out without residual follow-up.
         if citation_status == "residuals_queued":
-            result.outcome = OUTCOME_NEEDS_HUMAN
+            result.outcome = OUTCOME_RESIDUALS_FILED
             result.reason = "citation_residuals_queued"
         else:
             result.outcome = OUTCOME_SKIPPED if stable_before_citation else OUTCOME_CLEAN

--- a/tests/test_pipeline_v4.py
+++ b/tests/test_pipeline_v4.py
@@ -308,7 +308,7 @@ def test_stage_3_retry_budget_exhausted(monkeypatch: pytest.MonkeyPatch, tmp_pat
 
     assert len(expand_calls) == 3
     assert result.retry_count == 2
-    assert result.outcome == "needs_human"
+    assert result.outcome == "residuals_filed"
     assert result.reason == "rubric_stage_3_unmet"
     assert result.stage_reached == "RUBRIC_RECHECK"
 
@@ -427,13 +427,13 @@ def test_generated_loc_threshold_is_deprecated(monkeypatch: pytest.MonkeyPatch, 
     assert result.stage_reached == "DONE"
 
 
-def test_citation_residuals_queued_is_needs_human(
+def test_citation_residuals_queued_is_residuals_filed(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """pipeline_v3 exits non-zero with status="residuals_queued" when
     it's audited the module and routed un-auto-fixable items to human
     review. That's a legitimate outcome, not a pipeline failure, so
-    pipeline_v4 should classify it as needs_human and still run the
+    pipeline_v4 should classify it as residuals_filed and still run the
     final rescore — not short-circuit out as failed."""
     _patch_roots(monkeypatch, tmp_path)
     _write_module(tmp_path)
@@ -463,7 +463,7 @@ def test_citation_residuals_queued_is_needs_human(
 
     result = pipeline_v4.run_pipeline_v4(MODULE_KEY)
 
-    assert result.outcome == "needs_human"
+    assert result.outcome == "residuals_filed"
     assert result.reason == "citation_residuals_queued"
     assert result.stage_reached == "DONE"
     assert result.citation_v3_exit == 1

--- a/tests/test_pipeline_v4_batch.py
+++ b/tests/test_pipeline_v4_batch.py
@@ -455,18 +455,18 @@ def test_audit_missing_sources_clean_module_without_sources_flagged(
 
 
 def test_audit_missing_sources_skips_non_clean_outcomes(tmp_path: Path) -> None:
-    """A module not marked `clean` (needs_human / failed / skipped_locked)
+    """A module not marked `clean` (residuals_filed / failed / skipped_locked)
     is out of audit scope — those are expected to be incomplete."""
     _write_module_351(
         tmp_path,
-        "ai/demo/module-1.0-needs-human",
+        "ai/demo/module-1.0-residuals-filed",
         "# Title\n\nNo sources.\n",
     )
     results = [
-        {"module_key": "ai/demo/module-1.0-needs-human", "outcome": "needs_human"},
-        {"module_key": "ai/demo/module-1.0-needs-human", "outcome": "failed"},
+        {"module_key": "ai/demo/module-1.0-residuals-filed", "outcome": "residuals_filed"},
+        {"module_key": "ai/demo/module-1.0-residuals-filed", "outcome": "failed"},
         {
-            "module_key": "ai/demo/module-1.0-needs-human",
+            "module_key": "ai/demo/module-1.0-residuals-filed",
             "outcome": pipeline_v4_batch.OUTCOME_SKIPPED_LOCKED,
         },
     ]


### PR DESCRIPTION
Closes #342.

Files touched:
- `scripts/pipeline_v4.py` — renames the v4 outcome constant/value to `residuals_filed` and updates residual follow-up wording.
- `tests/test_pipeline_v4.py` — updates the v4 outcome assertions and renames the residuals test.
- `tests/test_pipeline_v4_batch.py` — updates the non-clean outcome fixture/comment.

Grep proof:
- `rg -n '"needs_human"' scripts tests docs --glob '!docs/session-state/**' --glob '!docs/sessions/**' --glob '!docs/decisions/**' --glob '!memory/**'` → no output.\n- `rg -n 'needs_human' scripts/pipeline_v4.py tests/test_pipeline_v4.py tests/test_pipeline_v4_batch.py` → no output.\n\nValidation:\n- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/ruff check scripts/pipeline_v4.py`\n- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python -m pytest tests/test_pipeline_v4.py tests/test_pipeline_v4_batch.py` → 43 passed\n- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python -m pytest scripts/` → 212 passed\n- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/test_pipeline.py` → 170 tests OK\n- `git diff --check`\n\nBuild: skipped; no Astro/content/config changes.