### PR TITLE
fix(hooks): hook 2 nits — tighten allowlist + handle -am (#1193)

### DIFF
--- a/.claude/hooks/block-direct-commit-on-main.sh
+++ b/.claude/hooks/block-direct-commit-on-main.sh
@@ -51,6 +51,21 @@ if args is None:
     print("UNKNOWN\tmatched git commit text, but could not locate argv")
     raise SystemExit
 
+expanded_args = []
+for token in args:
+    if (
+        token.startswith("-")
+        and not token.startswith("--")
+        and len(token) > 2
+        and "m" in token
+        and token[-1] == "m"
+    ):
+        expanded_args.append(token[:-1])
+        expanded_args.append("-m")
+    else:
+        expanded_args.append(token)
+args = expanded_args
+
 for index, token in enumerate(args):
     if token in {"-F", "--file"}:
         print("UNKNOWN\tcommit message comes from a file")
@@ -102,7 +117,7 @@ fi
 SUBJECT=$PARSE_VALUE
 
 case "$SUBJECT" in
-  backfill* | handoff* | docs\(status\):*)
+  backfill:* | backfill\ * | handoff:* | handoff\ * | docs\(status\):*)
     exit 0
     ;;
 esac

--- a/tests/test_hook_block_direct_commit_on_main.py
+++ b/tests/test_hook_block_direct_commit_on_main.py
@@ -114,6 +114,44 @@ def test_main_commit_backfill_prefix_allowed(tmp_path: Path) -> None:
     assert result.returncode == 0
 
 
+def test_main_commit_backfill_false_positive_denied(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    init_git_main(primary)
+
+    result = run_hook('git commit -m "backfilling: not a pipeline commit"', primary, primary)
+
+    assert result.returncode == 2
+    assert "direct commit to main without PR ref is blocked" in result.stderr
+
+
+def test_main_commit_short_flag_cluster_am_denied(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    init_git_main(primary)
+
+    result = run_hook('git commit -am "fix: thing"', primary, primary)
+
+    assert result.returncode == 2
+    assert "direct commit to main without PR ref is blocked" in result.stderr
+
+
+def test_main_commit_backfill_prefix_allowed_with_colon(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    init_git_main(primary)
+
+    result = run_hook('git commit -m "backfill: real pipeline commit"', primary, primary)
+
+    assert result.returncode == 0
+
+
+def test_main_commit_short_flag_cluster_am_with_pr_ref_allowed(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    init_git_main(primary)
+
+    result = run_hook('git commit -am "fix: thing (#123)"', primary, primary)
+
+    assert result.returncode == 0
+
+
 def test_feature_branch_commit_allowed(tmp_path: Path) -> None:
     primary = tmp_path / "kubedojo"
     init_git_main(primary)


### PR DESCRIPTION
## Summary

Two non-blocking nits flagged during PR #1192 (hook 2) cross-family review by claude opus 4.7. Now fixed:

- **Allowlist tightening**: `backfill*` / `handoff*` patterns required no separator, so `backfilling: ...` and `handoffs everywhere` were fail-opens. Now requires `:` or whitespace.
- **-am decomposition**: `git commit -am "msg"` clusters short flags; the python parser only knew about bare `-m`. Cluster is now split (rule: `m` must be the cluster's last char per git's CLI grammar).

## Tests

Adds 3 new tests in `tests/test_hook_block_direct_commit_on_main.py`:
- `-m "backfilling: ..."` → DENY
- `-am "fix: ..."` → DENY
- `-m "backfill: ..."` → ALLOW (existing happy-path)

Existing 11 tests continue to pass.

## Test plan

- [x] `pytest tests/test_hook_block_direct_commit_on_main.py -v` all green
- [x] Manual smoke from a worktree on main confirms both new DENY paths

Closes #1193.

🤖 Generated with codex
