### PR TITLE
feat(hooks): block orchestrator content edits (3/5 of #1175) (#1189)

### DIFF
--- a/.claude/hooks/block-orchestrator-content-edits.sh
+++ b/.claude/hooks/block-orchestrator-content-edits.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# shellcheck source=.claude/hooks/_lib.sh
+source "${BASH_SOURCE[0]%/*}/_lib.sh"
+set -euo pipefail
+
+# Hook: PreToolUse (Edit/Write) — block direct orchestrator edits to src/content/docs.
+
+RAW_PAYLOAD=$(cat)
+
+TOOL_NAME=$(jq -r '.tool_name // ""' <<<"$RAW_PAYLOAD" 2>/dev/null || true)
+if [ "$TOOL_NAME" != "Edit" ] && [ "$TOOL_NAME" != "Write" ]; then
+  exit 0
+fi
+
+FILE_PATH=$(jq -r '.tool_input.file_path // ""' <<<"$RAW_PAYLOAD" 2>/dev/null || true)
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+PROJECT_ROOT="${BASH_SOURCE[0]%/.claude/hooks/*}"
+if [ "${FILE_PATH:0:1}" = "/" ]; then
+  REL_PATH="${FILE_PATH#"$PROJECT_ROOT"/}"
+else
+  REL_PATH="$FILE_PATH"
+fi
+
+if [[ "$REL_PATH" == src/content/docs/* ]]; then
+  if [ "${KUBEDOJO_DISPATCHED:-0}" != "1" ]; then
+    deny \
+      "Edit/Write on src/content/docs/** from orchestrator is blocked; dispatch a codex/claude headless agent instead." \
+      "Use scripts/dispatch_smart.py edit --agent codex --worktree .worktrees/<task> --new-branch <branch>" \
+      "feedback_dispatch_codex_for_code_changes.md (TOP PRIORITY memory)"
+  fi
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,12 @@
           {"type": "command", "command": ".claude/hooks/block-branch-create-in-primary.sh"},
           {"type": "command", "command": ".claude/hooks/block-direct-commit-on-main.sh"}
         ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {"type": "command", "command": ".claude/hooks/block-orchestrator-content-edits.sh"}
+        ]
       }
     ],
     "PostToolUse": [

--- a/scripts/dispatch_smart.py
+++ b/scripts/dispatch_smart.py
@@ -168,9 +168,13 @@ def fire(*, agent: str, task_class: str, prompt: str, mode: str, model: str,
     started = time.time()
     try:
         previous_search = os.environ.get("KUBEDOJO_CODEX_SEARCH")
+        previous_dispatched = os.environ.get("KUBEDOJO_DISPATCHED")
         if agent == "codex":
             cfg = TASK_CLASSES[task_class]
             os.environ["KUBEDOJO_CODEX_SEARCH"] = "1" if cfg.codex_search else "0"
+        env = os.environ.copy()
+        env["KUBEDOJO_DISPATCHED"] = "1"
+        os.environ.update(env)
         result = invoke(
             agent,
             prompt,
@@ -196,6 +200,10 @@ def fire(*, agent: str, task_class: str, prompt: str, mode: str, model: str,
                 os.environ.pop("KUBEDOJO_CODEX_SEARCH", None)
             else:
                 os.environ["KUBEDOJO_CODEX_SEARCH"] = previous_search
+        if previous_dispatched is None:
+            os.environ.pop("KUBEDOJO_DISPATCHED", None)
+        else:
+            os.environ["KUBEDOJO_DISPATCHED"] = previous_dispatched
 
     elapsed = time.time() - started
     append_log({

--- a/tests/test_hook_block_orchestrator_content_edits.py
+++ b/tests/test_hook_block_orchestrator_content_edits.py
@@ -1,0 +1,159 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOOK = REPO_ROOT / ".claude" / "hooks" / "block-orchestrator-content-edits.sh"
+BASH = "/bin/bash"
+
+
+def run_hook_payload(
+    payload: dict[str, object],
+    primary: Path,
+    *,
+    env_overrides: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["CLAUDE_PROJECT_DIR"] = str(primary)
+    if env_overrides:
+        env.update(env_overrides)
+    return subprocess.run(
+        [BASH, str(HOOK)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+        cwd=primary,
+    )
+
+
+def run_edit_hook(
+    tool_name: str,
+    file_path: str,
+    primary: Path,
+    *,
+    env_overrides: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return run_hook_payload(
+        {
+            "tool_name": tool_name,
+            "tool_input": {
+                "file_path": file_path,
+            },
+        },
+        primary,
+        env_overrides=env_overrides,
+    )
+
+
+def test_edit_src_content_docs_denied_when_undispatched(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+
+    result = run_edit_hook("Edit", "src/content/docs/foo.md", primary)
+
+    assert result.returncode == 2
+    assert "blocked" in result.stderr
+
+
+def test_edit_src_content_docs_allowed_when_dispatched(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+
+    result = run_edit_hook(
+        "Edit",
+        "src/content/docs/foo.md",
+        primary,
+        env_overrides={"KUBEDOJO_DISPATCHED": "1"},
+    )
+
+    assert result.returncode == 0
+
+
+def test_write_src_content_docs_denied_when_undispatched(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+
+    result = run_edit_hook("Write", "src/content/docs/foo.md", primary)
+
+    assert result.returncode == 2
+    assert "blocked" in result.stderr
+
+
+def test_write_src_content_docs_allowed_when_dispatched(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+
+    result = run_edit_hook(
+        "Write",
+        "src/content/docs/foo.md",
+        primary,
+        env_overrides={"KUBEDOJO_DISPATCHED": "1"},
+    )
+
+    assert result.returncode == 0
+
+
+def test_edit_outside_src_content_docs_allowed(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+
+    result = run_edit_hook("Edit", "docs/research/foo.html", primary)
+    result_with_env = run_edit_hook(
+        "Edit",
+        "docs/research/foo.html",
+        primary,
+        env_overrides={"KUBEDOJO_DISPATCHED": "1"},
+    )
+
+    assert result.returncode == 0
+    assert result_with_env.returncode == 0
+
+
+def test_edit_status_md_allowed(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+
+    result = run_edit_hook("Edit", "STATUS.md", primary)
+
+    assert result.returncode == 0
+
+
+def test_bash_tool_call_ignored(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+
+    result = run_edit_hook("Bash", "src/content/docs/foo.md", primary)
+
+    assert result.returncode == 0
+
+
+def test_edit_with_absolute_path_to_src_content_docs_denied(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+
+    result = run_edit_hook("Edit", str(REPO_ROOT / "src/content/docs/foo.md"), primary)
+
+    assert result.returncode == 2
+    assert "blocked" in result.stderr
+
+
+def test_edit_malformed_payload_fails_open(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+    env = os.environ.copy()
+    env["CLAUDE_PROJECT_DIR"] = str(primary)
+    result = subprocess.run(
+        [BASH, str(HOOK)],
+        input="this is not JSON",
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+        cwd=primary,
+    )
+
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary

Hook 3 of the harness hardening epic (#1175). Mirrors PR #1192 (hook 2):

- New `.claude/hooks/block-orchestrator-content-edits.sh` — PreToolUse on Edit/Write; denies when `file_path` is under `src/content/docs/**` and `KUBEDOJO_DISPATCHED != "1"`.
- `scripts/dispatch_smart.py` now injects `KUBEDOJO_DISPATCHED=1` into agent subprocess env, so dispatched agents (codex/claude headless) bypass the deny.
- `.claude/settings.json` adds a new PreToolUse matcher for Edit|Write.
- 9 new tests in `tests/test_hook_block_orchestrator_content_edits.py` cover DENY/ALLOW, env toggling, path normalization, out-of-scope files, defensive fail-open.

## Test plan

- [x] `pytest tests/test_hook_block_orchestrator_content_edits.py -v` all green
- [x] `pytest tests/test_hook_block_direct_commit_on_main.py -v` no regression
- [x] Manual smoke confirms DENY without env, ALLOW with env

## Rule enforced

`memory/feedback_dispatch_codex_for_code_changes.md` (TOP PRIORITY): claude orchestrates ONLY; never inline-writes content under `src/content/docs/**`. The orchestrator has violated this repeatedly across sessions despite advisory text; mechanical enforcement is the fix.

Closes #1189.

🤖 Generated with codex
