### PR TITLE
feat(hooks): block Agent worktree isolation (4/5 of #1175) (#1190)

### DIFF
--- a/.claude/hooks/block-agent-worktree-isolation.sh
+++ b/.claude/hooks/block-agent-worktree-isolation.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# shellcheck source=.claude/hooks/_lib.sh
+source "${BASH_SOURCE[0]%/*}/_lib.sh"
+set -euo pipefail
+
+# Hook: PreToolUse (Agent) — block worktree isolation.
+
+RAW_PAYLOAD=$(cat)
+
+TOOL_NAME=$(jq -r '.tool_name // ""' <<<"$RAW_PAYLOAD" 2>/dev/null || true)
+if [ "$TOOL_NAME" != "Agent" ]; then
+  exit 0
+fi
+
+ISOLATION=$(jq -r '.tool_input.isolation // ""' <<<"$RAW_PAYLOAD" 2>/dev/null || true)
+
+if [ "$ISOLATION" = "worktree" ]; then
+  deny \
+    "Agent calls with isolation='worktree' are blocked — parallel agent worktree fan-out has a GC race that lost 5/8 agents on Part 5 night-2 (2026-04-30)." \
+    "Run agents inline/sequential instead. Recovery procedure if you've already cherry-picked work: see memory/reference_agent_worktree_recovery.md" \
+    "feedback_no_parallel_agent_fanout.md (TOP PRIORITY memory)"
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,6 +19,12 @@
         "hooks": [
           {"type": "command", "command": ".claude/hooks/block-orchestrator-content-edits.sh"}
         ]
+      },
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {"type": "command", "command": ".claude/hooks/block-agent-worktree-isolation.sh"}
+        ]
       }
     ],
     "PostToolUse": [

--- a/tests/test_hook_block_agent_worktree_isolation.py
+++ b/tests/test_hook_block_agent_worktree_isolation.py
@@ -1,0 +1,141 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOOK = REPO_ROOT / ".claude" / "hooks" / "block-agent-worktree-isolation.sh"
+BASH = "/bin/bash"
+
+
+def run_hook_payload(
+    payload: dict[str, object],
+    primary: Path,
+    *,
+    env_overrides: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["CLAUDE_PROJECT_DIR"] = str(primary)
+    if env_overrides:
+        env.update(env_overrides)
+    return subprocess.run(
+        [BASH, str(HOOK)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+        cwd=primary,
+    )
+
+
+def test_agent_with_worktree_isolation_denied(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+
+    result = run_hook_payload(
+        {
+            "tool_name": "Agent",
+            "tool_input": {
+                "isolation": "worktree",
+                "description": "x",
+                "prompt": "y",
+            },
+        },
+        primary,
+    )
+
+    assert result.returncode == 2
+    assert "blocked" in result.stderr
+
+
+def test_agent_without_isolation_allowed(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+
+    result = run_hook_payload(
+        {
+            "tool_name": "Agent",
+            "tool_input": {
+                "description": "x",
+                "prompt": "y",
+            },
+        },
+        primary,
+    )
+
+    assert result.returncode == 0
+
+
+def test_agent_with_empty_isolation_allowed(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+
+    result = run_hook_payload(
+        {
+            "tool_name": "Agent",
+            "tool_input": {
+                "isolation": "",
+                "description": "x",
+                "prompt": "y",
+            },
+        },
+        primary,
+    )
+
+    assert result.returncode == 0
+
+
+def test_agent_with_container_isolation_allowed(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+
+    result = run_hook_payload(
+        {
+            "tool_name": "Agent",
+            "tool_input": {
+                "isolation": "container",
+                "description": "x",
+                "prompt": "y",
+            },
+        },
+        primary,
+    )
+
+    assert result.returncode == 0
+
+
+def test_non_agent_tool_ignored(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+
+    result = run_hook_payload(
+        {
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": "parallel: use Agent with isolation=worktree",
+            },
+        },
+        primary,
+    )
+
+    assert result.returncode == 0
+
+
+def test_agent_malformed_payload_fails_open(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+    env = os.environ.copy()
+    env["CLAUDE_PROJECT_DIR"] = str(primary)
+    result = subprocess.run(
+        [BASH, str(HOOK)],
+        input="this is not JSON",
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+        cwd=primary,
+    )
+
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary
- Add .claude/hooks/block-agent-worktree-isolation.sh to deny PreToolUse Agent tool calls with tool_input.isolation == "worktree".
- Register a new PreToolUse matcher for Agent in .claude/settings.json.
- Add tests/test_hook_block_agent_worktree_isolation.py with 6 cases (1 deny, 4 allow, 1 fail-open malformed payload).

## Verification
- .venv/bin/pytest requested commands could not run because this worktree environment does not include .venv and pytest.
- Manual smoke check for hook:
  - Agent + worktree isolation => exit 2
  - Agent without isolation => exit 0

## Rule references
- feedback_no_parallel_agent_fanout.md (TOP PRIORITY)
- memory/reference_agent_worktree_recovery.md

Closes #1190.
