### PR TITLE
feat(hooks): auto-inject --mode danger for codex git/gh dispatches (5/5 of #1175) (#1191)

### DIFF
--- a/.claude/hooks/inject-codex-danger-mode.sh
+++ b/.claude/hooks/inject-codex-danger-mode.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# Hook: PreToolUse (Bash) — Inject --mode danger for codex exec prompts that contain git push / gh pr create.
+source "${BASH_SOURCE[0]%/*}/_lib.sh"
+set -euo pipefail
+
+RAW_PAYLOAD=$(cat)
+
+TOOL_NAME=$(jq -r '.tool_name // ""' <<<"$RAW_PAYLOAD" 2>/dev/null || true)
+if [ "$TOOL_NAME" != "Bash" ]; then
+  exit 0
+fi
+
+COMMAND=$(jq -r '.tool_input.command // ""' <<<"$RAW_PAYLOAD" 2>/dev/null || true)
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+PARSE_RESULT=$(python3 - "$COMMAND" <<'PY'
+import shlex
+import sys
+
+command = sys.argv[1]
+
+try:
+    tokens = shlex.split(command)
+except ValueError as exc:
+    print(f"FAIL_OPEN\tcould not parse shell command ({exc})")
+    raise SystemExit
+
+codex_index = None
+for index in range(len(tokens) - 1):
+    if tokens[index] == "codex" and tokens[index + 1] == "exec":
+        codex_index = index
+        break
+
+if codex_index is None:
+    print("NO_CHANGE")
+    raise SystemExit
+
+args_start = codex_index + 2
+args = tokens[args_start:]
+i = 0
+prompt_seen = False
+prompt = None
+mode_token_index = None
+mode_value = None
+
+while i < len(args):
+    token = args[i]
+
+    if token == "--":
+        i += 1
+        if i >= len(args):
+            break
+        prompt = args[i]
+        prompt_seen = True
+        break
+
+    if token == "-":
+        print("FAIL_OPEN\tprompt source not statically visible")
+        raise SystemExit
+
+    if token == "<":
+        print("FAIL_OPEN\tprompt source not statically visible")
+        raise SystemExit
+
+    if token in {"-f", "--file"}:
+        print("FAIL_OPEN\tprompt source not statically visible")
+        raise SystemExit
+
+    if token.startswith("--file="):
+        print("FAIL_OPEN\tprompt source not statically visible")
+        raise SystemExit
+
+    if token == "--mode":
+        if i + 1 >= len(args):
+            print("NO_CHANGE")
+            raise SystemExit
+        mode_token_index = args_start + i
+        mode_value = args[i + 1]
+        i += 2
+        continue
+
+    if token.startswith("--mode="):
+        mode_token_index = args_start + i
+        mode_value = token.split("=", 1)[1]
+        i += 1
+        continue
+
+    if token.startswith("-") and token != "-":
+        i += 1
+        continue
+
+    prompt = token
+    prompt_seen = True
+    break
+
+if not prompt_seen or prompt is None:
+    print("NO_CHANGE")
+    raise SystemExit
+
+if "git push" not in prompt and "gh pr create" not in prompt:
+    print("NO_CHANGE")
+    raise SystemExit
+
+if mode_token_index is not None:
+    if mode_value == "danger":
+        print("NO_CHANGE")
+        raise SystemExit
+
+    if tokens[mode_token_index].startswith("--mode="):
+        tokens[mode_token_index] = "--mode=danger"
+    elif mode_token_index + 1 < len(tokens):
+        tokens[mode_token_index + 1] = "danger"
+    print("UPDATE\t" + shlex.join(tokens))
+    raise SystemExit
+
+insert_at = args_start
+tokens.insert(insert_at, "--mode")
+tokens.insert(insert_at + 1, "danger")
+print("UPDATE\t" + shlex.join(tokens))
+PY
+) || true
+
+if [ -z "$PARSE_RESULT" ]; then
+  exit 0
+fi
+
+PARSE_KIND=${PARSE_RESULT%%$'\t'*}
+
+if [ "$PARSE_KIND" = "UPDATE" ]; then
+  UPDATED_COMMAND=${PARSE_RESULT#*$'\t'}
+  printf '{
+    "hookSpecificOutput": {
+      "hookEventName": "PreToolUse",
+      "permissionDecision": "allow",
+      "updatedInput": {"command": %s}
+    }
+  }\n' "$(printf '%s' "$UPDATED_COMMAND" | jq -Rs '.')"
+  exit 0
+fi
+
+if [ "$PARSE_KIND" = "FAIL_OPEN" ]; then
+  printf '%s\n' "$PARSE_RESULT" >&2
+  exit 0
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,7 +11,8 @@
         "hooks": [
           {"type": "command", "command": ".claude/hooks/enforce-venv.sh"},
           {"type": "command", "command": ".claude/hooks/block-branch-create-in-primary.sh"},
-          {"type": "command", "command": ".claude/hooks/block-direct-commit-on-main.sh"}
+          {"type": "command", "command": ".claude/hooks/block-direct-commit-on-main.sh"},
+          {"type": "command", "command": ".claude/hooks/inject-codex-danger-mode.sh"}
         ]
       },
       {

--- a/tests/test_hook_inject_codex_danger_mode.py
+++ b/tests/test_hook_inject_codex_danger_mode.py
@@ -1,0 +1,156 @@
+import json
+import os
+import shlex
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOOK = REPO_ROOT / ".claude" / "hooks" / "inject-codex-danger-mode.sh"
+BASH = "/bin/bash"
+
+
+def run_hook_payload(
+    payload: dict[str, object],
+    primary: Path,
+    *,
+    env_overrides: dict[str, str] | None = None,
+    executable: str = "/bin/bash",
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["CLAUDE_PROJECT_DIR"] = str(primary)
+    if env_overrides:
+        env.update(env_overrides)
+    return subprocess.run(
+        [executable, str(HOOK)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+        cwd=primary,
+    )
+
+
+def run_hook(command: str, primary: Path) -> subprocess.CompletedProcess[str]:
+    return run_hook_payload({"tool_name": "Bash", "tool_input": {"command": command}}, primary)
+
+
+def assert_injected_mode(result: subprocess.CompletedProcess[str], expected_prompt: str) -> None:
+    assert result.returncode == 0
+    assert result.stdout != ""
+    payload = json.loads(result.stdout)
+    updated = payload["hookSpecificOutput"]["updatedInput"]["command"]
+    tokens = shlex.split(updated)
+    assert tokens[:4] == ["codex", "exec", "--mode", "danger"]
+    assert " ".join(tokens[4:]) == expected_prompt
+
+
+def test_codex_exec_with_git_push_in_prompt_no_mode_injects_danger(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+    prompt = "do work then git push origin main"
+    result = run_hook(f'codex exec "{prompt}"', primary)
+
+    assert result.returncode == 0
+    assert_injected_mode(result, prompt)
+
+
+def test_codex_exec_with_gh_pr_create_in_prompt_no_mode_injects_danger(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+    prompt = "draft fix, then gh pr create --title 'x'"
+    result = run_hook(f'codex exec "{prompt}"', primary)
+
+    assert result.returncode == 0
+    assert_injected_mode(result, prompt)
+
+
+def test_codex_exec_with_workspace_write_mode_and_git_push_in_prompt_upgrades_to_danger(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+    command = 'codex exec --mode workspace-write "git push origin main"'
+    result = run_hook(command, primary)
+    assert result.returncode == 0
+    assert result.stdout != ""
+    payload = json.loads(result.stdout)
+    updated = payload["hookSpecificOutput"]["updatedInput"]["command"]
+    tokens = shlex.split(updated)
+    assert tokens[:4] == ["codex", "exec", "--mode", "danger"]
+    assert " ".join(tokens[4:]) == "git push origin main"
+
+
+def test_codex_exec_with_danger_mode_already_set_no_change(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+    result = run_hook('codex exec --mode danger "git push origin main"', primary)
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_codex_exec_without_git_or_gh_in_prompt_no_inject(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+    command = "codex exec \"analyze the codebase\""
+    result = run_hook(command, primary)
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_codex_exec_via_stdin_dash_fail_open_no_inject(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+    result = run_hook("cat /tmp/brief.md | codex exec -", primary)
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+    assert "FAIL_OPEN\tprompt source not statically visible" in result.stderr
+
+
+def test_codex_exec_via_file_substitution_fail_open(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+    result = run_hook("codex exec - < /tmp/brief.md", primary)
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+    assert "FAIL_OPEN\tprompt source not statically visible" in result.stderr
+
+
+def test_non_codex_bash_command_ignored(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+    result = run_hook("python scripts/test_pipeline.py git push", primary)
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_codex_via_python_dispatch_wrapper_ignored(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+    result = run_hook('python scripts/dispatch_smart.py edit --agent codex --mode danger "..."', primary)
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_malformed_json_payload_fails_open(tmp_path: Path) -> None:
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+    env = os.environ.copy()
+    env["CLAUDE_PROJECT_DIR"] = str(primary)
+    result = subprocess.run(
+        [BASH, str(HOOK)],
+        input="this is not JSON",
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+        cwd=primary,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == ""


### PR DESCRIPTION
PreToolUse hook for Bash.

- Adds .claude/hooks/inject-codex-danger-mode.sh and registers it after existing hook 1-3 in .claude/settings.json.
- Detects bare `codex exec` calls whose prompt contains `git push` or `gh pr create`.
- Injects `--mode danger` when missing or replaces existing non-danger `--mode` values.
- Fail-open when prompt content is not statically visible (`-`, `<`, `--file`, `-f`, malformed JSON payload).
- Adds tests/test_hook_inject_codex_danger_mode.py with 10 required cases.

Verification:
- ".venv/bin/python -m pytest tests/test_hook_inject_codex_danger_mode.py -v" passed
- ".venv/bin/python -m pytest tests/test_hook_block_direct_commit_on_main.py tests/test_hook_block_orchestrator_content_edits.py tests/test_hook_block_branch_create_in_primary.py -v" passed with `KUBEDOJO_DISPATCHED=0` (denied/allowed matrix expected).

Note: this worktree does not contain `tests/test_hook_block_agent_worktree_isolation.py`.

Closes #1191.
