### PR TITLE
fix(docs): path reference + plan.html phase 5 nit (#1195, #1060)

### DIFF
--- a/.claude/rules/goal-driven-runs.md
+++ b/.claude/rules/goal-driven-runs.md
@@ -67,7 +67,7 @@ last_output, current_module, next_action.
 
 ```text
 /goal #388 batch: dispatch codex per module on briefing.actions.next,
-run scripts/verifier.py for density gates (median_wpp≥28, mean_wpp≥30,
+run scripts/quality/verify_module.py for density gates (median_wpp≥28, mean_wpp≥30,
 short-para-rate≤20%), paste the verifier output verbatim. Final line
 of each turn MUST be:
   GOAL_STATUS turn=N/40 blocked=X/3 no_progress=Y/3 module=<key> verifier=<pass|fail>

--- a/docs/migrations/html-first/plan.html
+++ b/docs/migrations/html-first/plan.html
@@ -259,7 +259,7 @@
   <div class="phase">
     <div class="num">Phase 5</div>
     <div class="name">Session handoffs</div>
-    <span class="status queued">REVISED</span>
+    <span class="status done">REVISED</span>
     <div class="when">Markdown by default (AI→AI)</div>
   </div>
 </div>
@@ -430,7 +430,7 @@
       <td><span class="heat h1"></span>low (agent pastes, not reads)</td>
       <td><span class="badge fail">Markdown (AI→AI)</span></td>
       <td>4 - REVISED</td>
-      <td>native markdown via /artifacts renderer (brief #2026-05-09)</td>
+      <td>native markdown via /artifacts renderer (see brief #2026-05-09 for pattern)</td>
     </tr>
     <tr>
       <td class="artifact">Session handoffs <span class="path">(docs/session-state/*.md)</span></td>
@@ -438,7 +438,7 @@
       <td><span class="heat h1"></span>low (next agent reads via Read tool)</td>
       <td><span class="badge fail">Markdown (AI→AI)</span></td>
       <td>5 - REVISED</td>
-      <td>native markdown via /artifacts renderer (brief #2026-05-09)</td>
+      <td>native markdown via /artifacts renderer (see brief #2026-05-09 for pattern)</td>
     </tr>
     <tr>
       <td class="artifact">STATUS.md <span class="path">(STATUS.md)</span></td>


### PR DESCRIPTION
## Summary

Two single-shot cosmetic nits surfaced in earlier cross-family reviews:

- **#1195** — \`.claude/rules/goal-driven-runs.md\` §4 Template 3 referenced \`scripts/verifier.py\` (doesn't exist). Now points to \`scripts/quality/verify_module.py\`.
- **#1060** — \`docs/migrations/html-first/plan.html\` Phase 5 chip carried \`class="status queued"\` while the meta block listed Phase 5 as REVISED/done. Flipped to \`class="status done"\` so the visual matches the meta. Also tightened the parenthetical brief reference on both matrix rows: \`(brief #2026-05-09)\` → \`(see brief #2026-05-09 for pattern)\`.

Phase 4 chip intentionally left as \`queued\` per orchestrator judgment (the optional nit-3 in #1060 was rejected at file-time; keeping the queued chip preserves visual continuity of phase numbering).

## Test plan

- [x] No code changes, only docs/rules text.
- [x] No test suite to run; rules file readable; HTML structure preserved.

Closes #1195, #1060.

🤖 Generated with [Claude Code](https://claude.com/claude-code)