### PR TITLE
fix(tests): hermetic hook 3 tests — drop inherited KUBEDOJO_DISPATCHED (#1204)

### DIFF
--- a/tests/test_hook_block_orchestrator_content_edits.py
+++ b/tests/test_hook_block_orchestrator_content_edits.py
@@ -16,6 +16,7 @@ def run_hook_payload(
     env_overrides: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
+    env.pop("KUBEDOJO_DISPATCHED", None)
     env["CLAUDE_PROJECT_DIR"] = str(primary)
     if env_overrides:
         env.update(env_overrides)
@@ -145,6 +146,7 @@ def test_edit_malformed_payload_fails_open(tmp_path: Path) -> None:
     primary = tmp_path / "kubedojo"
     primary.mkdir()
     env = os.environ.copy()
+    env.pop("KUBEDOJO_DISPATCHED", None)
     env["CLAUDE_PROJECT_DIR"] = str(primary)
     result = subprocess.run(
         [BASH, str(HOOK)],


### PR DESCRIPTION
## Summary

- Pop `KUBEDOJO_DISPATCHED` from inherited env in `run_hook_payload` + the inline malformed-payload test so hook-3 tests stay hermetic regardless of parent-env state.
- Surfaced last session when codex (dispatched, so `KUBEDOJO_DISPATCHED=1`) reported "3 failed, 999 passed" running pytest from inside a dispatched worktree; CI was green because GH Actions env doesn't set the var. Filed as #1204 by the user.

## Acceptance (from #1204)

```
KUBEDOJO_DISPATCHED=1 .venv/bin/python -m pytest tests/test_hook_block_orchestrator_content_edits.py -v
```

shows 9/9 pass.

Verified locally:

```
========================= 9 passed in 0.13s ==========================
```

## Test plan

- [x] `KUBEDOJO_DISPATCHED=1 pytest tests/test_hook_block_orchestrator_content_edits.py` → 9/9 pass
- [x] Unset env pytest → 9/9 pass (was already green)
- [x] "Allowed when dispatched" tests still pass — they re-add `KUBEDOJO_DISPATCHED=1` via `env_overrides`

Closes #1204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)