### PR TITLE
fix(docs): plan.html Phase 4 status chip consistency (#1060)

### DIFF
--- a/docs/migrations/html-first/plan.html
+++ b/docs/migrations/html-first/plan.html
@@ -252,7 +252,7 @@
   <div class="phase">
     <div class="num">Phase 4</div>
     <div class="name">Dispatch briefs</div>
-    <span class="status queued">REVISED</span>
+    <span class="status done">REVISED</span>
     <div class="when">Markdown by default (AI→AI)</div>
     <span class="arrow">→</span>
   </div>


### PR DESCRIPTION
## Summary

One-line CSS-class fix to plan.html. Phase 4 and Phase 5 both carry the REVISED label (both reclassified Markdown-by-default in 2026-05-09 consumer-direction-lens update), but Phase 4 was still using the gray \`queued\` chip while Phase 5 was already \`done\`. Aligns them.

## #1060 nit triage

| Nit | Status |
|---|---|
| 1. Phase status chip inconsistency | ✅ This PR fixes Phase 4 |
| 2. Brief-pattern reference wording | ✅ Already applied earlier (lines 433 + 441 already say \"see brief ... for pattern\") |
| 3. Remove Phase 4 arrow (optional) | ⏭️ Explicitly rejected per orchestrator-judgment in #1060 |

## Verification

\`\`\`
$ grep -c 'class=\"status done\">REVISED' docs/migrations/html-first/plan.html
2
\`\`\`

Both Phase 4 and Phase 5 now have matching \`status done\` chips.

Closes #1060.

🤖 Generated with [Claude Code](https://claude.com/claude-code)