### PR TITLE
fix(pipeline): restore seed JSON on inject failure to prevent cascade (#1212)

### DIFF
--- a/scripts/quality/pipeline.py
+++ b/scripts/quality/pipeline.py
@@ -431,6 +431,7 @@ def _backfill_one(st: dict[str, Any], *, agent: str | None) -> dict[str, Any]:
 
     research = _run_citation_subcommand(module_key, "research", agent=agent)
     if not research["ok"]:
+        _restore_seed_json()
         return {
             "done": False, "ok": False, "stage_failed": "research",
             "error": (research["stderr"] or research["stdout"])[-500:],

--- a/scripts/quality/pipeline.py
+++ b/scripts/quality/pipeline.py
@@ -408,6 +408,15 @@ def _backfill_one(st: dict[str, Any], *, agent: str | None) -> dict[str, Any]:
     slug = st["slug"]
     module_key = _module_key_from_path(st["module_path"])
     repo = _REPO_ROOT
+    seed_rel = f"docs/citation-seeds/{module_key.replace('/', '-')}.json"
+
+    def _restore_seed_json() -> None:
+        # Research writes the seed before inject runs. `restore` handles
+        # tracked/staged seed edits; `clean` removes a brand-new untracked
+        # seed and ignores tracked files after they have been restored.
+        _git(repo, "restore", "--staged", seed_rel, check=False)
+        _git(repo, "restore", seed_rel, check=False)
+        _git(repo, "clean", "-f", "--", seed_rel, check=False)
 
     # Refuse to operate on a dirty primary — any pending edits must be
     # resolved before we mutate the same files. The pipeline never leaves
@@ -435,10 +444,10 @@ def _backfill_one(st: dict[str, Any], *, agent: str | None) -> dict[str, Any]:
         # path (frontmatter can still be marked verified).
         if inject.get("error") == "nothing_to_do" or "nothing_to_do" in (inject.get("stdout") or ""):
             set_citations_verified_frontmatter(_REPO_ROOT / st["module_path"], verified=True)
-            seed_rel = f"docs/citation-seeds/{module_key.replace('/', '-')}.json"
             rc, status_all, _ = _git(repo, "status", "--porcelain", check=False)
             if rc != 0:
                 _git(repo, "restore", st["module_path"], check=False)
+                _restore_seed_json()
                 return {
                     "done": False, "ok": False, "stage_failed": "git_status",
                     "error": "git status failed after no-op inject",
@@ -455,6 +464,7 @@ def _backfill_one(st: dict[str, Any], *, agent: str | None) -> dict[str, Any]:
                 # back no-op writes if someone else touched this checkout.
                 for p in backfill_paths:
                     _git(repo, "restore", p, check=False)
+                _restore_seed_json()
                 return {
                     "done": False, "ok": False, "stage_failed": "concurrent_edit",
                     "error": f"unexpected working-tree changes outside backfill scope: {sorted(foreign_paths)[:5]}",
@@ -472,6 +482,7 @@ def _backfill_one(st: dict[str, Any], *, agent: str | None) -> dict[str, Any]:
                 for p in backfill_paths:
                     _git(repo, "restore", "--staged", p, check=False)
                     _git(repo, "restore", p, check=False)
+                _restore_seed_json()
                 return {
                     "done": False, "ok": False, "stage_failed": "git_commit",
                     "error": stderr.strip()[-500:], "module_key": module_key,
@@ -484,6 +495,7 @@ def _backfill_one(st: dict[str, Any], *, agent: str | None) -> dict[str, Any]:
             }
         # Best-effort: discard any partial write so primary stays clean.
         _git(repo, "restore", st["module_path"], check=False)
+        _restore_seed_json()
         return {
             "done": False, "ok": False, "stage_failed": "inject",
             "error": (inject["stderr"] or inject["stdout"])[-500:],
@@ -498,10 +510,10 @@ def _backfill_one(st: dict[str, Any], *, agent: str | None) -> dict[str, Any]:
     # artifacts (module + seed) must land in the same commit so the
     # provenance is traceable in git history. ``git status --porcelain``
     # without a path lists every file we may need to stage.
-    seed_rel = f"docs/citation-seeds/{module_key.replace('/', '-')}.json"
     rc, status_all, _ = _git(repo, "status", "--porcelain", check=False)
     if rc != 0:
         _git(repo, "restore", st["module_path"], check=False)
+        _restore_seed_json()
         return {
             "done": False, "ok": False, "stage_failed": "git_status",
             "error": "git status failed after inject",
@@ -519,6 +531,7 @@ def _backfill_one(st: dict[str, Any], *, agent: str | None) -> dict[str, Any]:
         # citation_backfill wrote so primary stays clean for retry.
         for p in backfill_paths:
             _git(repo, "restore", p, check=False)
+        _restore_seed_json()
         return {
             "done": False, "ok": False, "stage_failed": "concurrent_edit",
             "error": f"unexpected working-tree changes outside backfill scope: {sorted(foreign_paths)[:5]}",
@@ -543,6 +556,7 @@ def _backfill_one(st: dict[str, Any], *, agent: str | None) -> dict[str, Any]:
         for p in backfill_paths:
             _git(repo, "restore", "--staged", p, check=False)
             _git(repo, "restore", p, check=False)
+        _restore_seed_json()
         return {
             "done": False, "ok": False, "stage_failed": "git_commit",
             "error": stderr.strip()[-500:], "module_key": module_key,

--- a/tests/test_backfill_seed_restore.py
+++ b/tests/test_backfill_seed_restore.py
@@ -88,3 +88,69 @@ def test_inject_failure_restores_seed_json_for_1212(
     assert outcome["ok"] is False
     assert outcome["stage_failed"] == "inject"
     assert _git(repo, "status", "--porcelain") == ""
+
+
+def test_research_failure_after_seed_write_restores_seed_for_1212(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for #1212: failed research may still leave a seed JSON behind."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+
+    module_rel = "src/content/docs/cloud/test/module-test.md"
+    module_path = repo / module_rel
+    module_path.parent.mkdir(parents=True, exist_ok=True)
+    module_path.write_text(
+        "---\n"
+        "title: Module Test\n"
+        "sidebar:\n"
+        "  order: 1\n"
+        "---\n\n"
+        "Original body.\n",
+        encoding="utf-8",
+    )
+    _git(repo, "add", module_rel)
+    _git(repo, "commit", "-m", "seed module")
+
+    monkeypatch.setattr(pipeline, "_REPO_ROOT", repo)
+    monkeypatch.setattr(pipeline, "_CONTENT_ROOT", repo / "src" / "content" / "docs")
+
+    module_key = "cloud/test/module-test"
+    seed_rel = f"docs/citation-seeds/{module_key.replace('/', '-')}.json"
+    seed_path = repo / seed_rel
+
+    def fake_subcommand(
+        module_key_arg: str,
+        sub: str,
+        *,
+        agent: str | None = None,
+    ) -> dict[str, Any]:
+        del agent
+        assert module_key_arg == module_key
+        if sub == "research":
+            # #1212: simulate citation_backfill writing the seed, then crashing.
+            seed_path.parent.mkdir(parents=True, exist_ok=True)
+            seed_path.write_text(
+                '{"module_key": "cloud/test/module-test", "claims": []}\n',
+                encoding="utf-8",
+            )
+            return {
+                "ok": False,
+                "stderr": "research crashed after seed write",
+                "stdout": "",
+                "returncode": 1,
+            }
+        raise AssertionError(f"unexpected subcommand: {sub}")
+
+    monkeypatch.setattr(pipeline, "_run_citation_subcommand", fake_subcommand)
+
+    outcome = _backfill_one({"slug": "module-test", "module_path": module_rel}, agent=None)
+
+    assert outcome["done"] is False
+    assert outcome["ok"] is False
+    assert outcome["stage_failed"] == "research"
+    assert _git(repo, "status", "--porcelain") == ""

--- a/tests/test_backfill_seed_restore.py
+++ b/tests/test_backfill_seed_restore.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.quality import pipeline  # noqa: E402
+from scripts.quality.pipeline import _backfill_one  # noqa: E402
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def test_inject_failure_restores_seed_json_for_1212(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for #1212: inject failure must not leave research seed JSON dirty."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+
+    module_rel = "src/content/docs/cloud/test/module-test.md"
+    module_path = repo / module_rel
+    module_path.parent.mkdir(parents=True, exist_ok=True)
+    module_path.write_text(
+        "---\n"
+        "title: Module Test\n"
+        "sidebar:\n"
+        "  order: 1\n"
+        "---\n\n"
+        "Original body.\n",
+        encoding="utf-8",
+    )
+    _git(repo, "add", module_rel)
+    _git(repo, "commit", "-m", "seed module")
+
+    monkeypatch.setattr(pipeline, "_REPO_ROOT", repo)
+    monkeypatch.setattr(pipeline, "_CONTENT_ROOT", repo / "src" / "content" / "docs")
+
+    module_key = "cloud/test/module-test"
+    seed_rel = f"docs/citation-seeds/{module_key.replace('/', '-')}.json"
+    seed_path = repo / seed_rel
+
+    def fake_subcommand(
+        module_key_arg: str,
+        sub: str,
+        *,
+        agent: str | None = None,
+    ) -> dict[str, Any]:
+        del agent
+        assert module_key_arg == module_key
+        if sub == "research":
+            seed_path.parent.mkdir(parents=True, exist_ok=True)
+            seed_path.write_text(
+                '{"module_key": "cloud/test/module-test", "claims": []}\n',
+                encoding="utf-8",
+            )
+            return {"ok": True, "stderr": "", "stdout": "", "returncode": 0}
+        if sub == "inject":
+            return {
+                "ok": False,
+                "stderr": "inject failed before writing module",
+                "stdout": "",
+                "returncode": 1,
+            }
+        raise AssertionError(f"unexpected subcommand: {sub}")
+
+    monkeypatch.setattr(pipeline, "_run_citation_subcommand", fake_subcommand)
+
+    outcome = _backfill_one({"slug": "module-test", "module_path": module_rel}, agent=None)
+
+    assert outcome["done"] is False
+    assert outcome["ok"] is False
+    assert outcome["stage_failed"] == "inject"
+    assert _git(repo, "status", "--porcelain") == ""


### PR DESCRIPTION
Fixes #1212

Regression test: tests/test_backfill_seed_restore.py

## Diagnosis

`research` is the subcommand that writes `docs/citation-seeds/<module_key>.json`. In `scripts/citation_backfill.py`, `run_research()` resolves `out_path = seed_path_for(normalized_key)` and writes it with `out_path.write_text(...)`. `inject` reads that same seed with `json.loads(seed_path.read_text(...))`; it writes the module markdown and, for deferred claims, `.pipeline/citation-revisions/...`, but it does not write the seed JSON.

In `_backfill_one`, the seed can be dirty after successful research on every failure return after inject begins. I patched the three production candidates called out in #1212 (`no-op inject` git-status failure, general inject failure, and post-inject git-status failure), plus the same cleanup on the adjacent `concurrent_edit` and `git_commit` failure exits in both the no-op and normal inject branches. The initial dirty-tree guard runs before research, and real `research` failure exits before `run_research()` writes the seed.

Cleanup uses `git restore --staged`, `git restore`, then `git clean -f -- <seed_rel>` for the seed path. `restore` handles tracked/staged seed edits; `clean` removes a brand-new untracked seed and ignores tracked files after restore.

## Failing test output before fix

```text
$ .venv/bin/pytest tests/test_backfill_seed_restore.py -v
============================= test session starts ==============================
platform darwin -- Python 3.14.5, pytest-9.0.3, pluggy-1.6.0 -- /Users/krisztiankoos/projects/kubedojo/.venv/bin/python3.14
cachedir: .pytest_cache
rootdir: /Users/krisztiankoos/projects/kubedojo/.worktrees/fix-1212-cascade-seed-restore
plugins: timeout-2.4.0
collecting ... collected 1 item

tests/test_backfill_seed_restore.py::test_inject_failure_restores_seed_json_for_1212 FAILED [100%]

=================================== FAILURES ===================================
_______________ test_inject_failure_restores_seed_json_for_1212 ________________

    outcome = _backfill_one({"slug": "module-test", "module_path": module_rel}, agent=None)

    assert outcome["done"] is False
    assert outcome["ok"] is False
    assert outcome["stage_failed"] == "inject"
>   assert _git(repo, "status", "--porcelain") == ""
E   AssertionError: assert '?? docs/\n' == ''
E
E     + ?? docs/

tests/test_backfill_seed_restore.py:90: AssertionError
=========================== short test summary info ============================
FAILED tests/test_backfill_seed_restore.py::test_inject_failure_restores_seed_json_for_1212
============================== 1 failed in 0.13s ===============================
```

## Passing output after fix

```text
$ .venv/bin/pytest tests/test_backfill_seed_restore.py -v
============================= test session starts ==============================
platform darwin -- Python 3.14.5, pytest-9.0.3, pluggy-1.6.0 -- /Users/krisztiankoos/projects/kubedojo/.venv/bin/python3.14
cachedir: .pytest_cache
rootdir: /Users/krisztiankoos/projects/kubedojo/.worktrees/fix-1212-cascade-seed-restore
plugins: timeout-2.4.0
collecting ... collected 1 item

tests/test_backfill_seed_restore.py::test_inject_failure_restores_seed_json_for_1212 PASSED [100%]

============================== 1 passed in 0.13s ===============================
```

## Verification

```text
$ .venv/bin/ruff check scripts/quality/pipeline.py tests/test_backfill_seed_restore.py
All checks passed!

$ git diff --check
# clean

$ .venv/bin/python scripts/test_pipeline.py
Ran 170 tests in 107.136s

OK

$ PYTHONPATH="$PWD" .venv/bin/pytest tests/ -k "pipeline or backfill" -x
collected 1031 items / 887 deselected / 144 selected
144 passed, 887 deselected in 7.32s
```

The literal required slice command without `PYTHONPATH` stopped during collection before selected tests ran on an existing import-path issue:

```text
$ .venv/bin/pytest tests/ -k "pipeline or backfill" -x
ERROR collecting tests/test_audit_review_coverage.py
ModuleNotFoundError: No module named 'scripts'
```

`npm run build` skipped: this PR only changes Python test/pipeline code, not `src/content/docs/` or Astro config.
