### PR TITLE
feat(pipeline): order iter_states() by learner reading order

### DIFF
--- a/scripts/quality/pipeline.py
+++ b/scripts/quality/pipeline.py
@@ -26,6 +26,7 @@ scripts can detect issues), 3 when aborted by dispatcher unavailability.
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 from collections import Counter
 from pathlib import Path
@@ -44,6 +45,210 @@ _CONTENT_ROOT = _REPO_ROOT / "src" / "content" / "docs"
 WORKER_CAP = 3
 """Hard cap per project memory ``feedback_batch_worker_cap.md`` —
 above 3, Gemini 429s and user's Mac lags."""
+
+
+_MODULE_NUMBER_RE = re.compile(r"-module-(\d+)\.(\d+)-")
+_LEGACY_MODULE_NUMBER_RE = re.compile(r"-module-(\d+)-")
+
+# Flattened from astro.config.mjs sidebar entries and src/content/docs/.
+# Unknown tracks/sections sort after the known learner path.
+_READING_ORDER_SECTIONS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "prerequisites",
+        (
+            "prerequisites-zero-to-terminal",
+            "linux-foundations-everyday-use",
+            "prerequisites-cloud-native-101",
+            "prerequisites-kubernetes-basics",
+            "prerequisites-git-deep-dive",
+            "prerequisites-philosophy-design",
+            "prerequisites-modern-devops",
+        ),
+    ),
+    (
+        "linux",
+        (
+            "linux-foundations-system-essentials",
+            "linux-foundations-container-primitives",
+            "linux-foundations-networking",
+            "linux-operations-shell-scripting",
+            "linux-operations-performance",
+            "linux-operations-troubleshooting",
+            "linux-operations",
+            "linux-security-hardening",
+            "k8s-lfcs",
+        ),
+    ),
+    (
+        "ai",
+        (
+            "ai-foundations",
+            "ai-ai-native-work",
+            "ai-ai-building",
+            "ai-open-models-local-inference",
+            "ai-ai-for-kubernetes-platform-work",
+            "ai-history",
+        ),
+    ),
+    (
+        "cloud",
+        (
+            "cloud-hyperscaler-rosetta-stone",
+            "cloud-aws-essentials",
+            "cloud-eks-deep-dive",
+            "cloud-gcp-essentials",
+            "cloud-gke-deep-dive",
+            "cloud-azure-essentials",
+            "cloud-aks-deep-dive",
+            "cloud-architecture-patterns",
+            "cloud-advanced-operations",
+            "cloud-managed-services",
+            "cloud-enterprise-hybrid",
+        ),
+    ),
+    (
+        "k8s",
+        (
+            "k8s-kcna",
+            "k8s-kcsa",
+            "k8s-cka",
+            "k8s-ckad",
+            "k8s-cks",
+            "k8s-extending",
+            "k8s-bridges",
+            "k8s-pca",
+            "k8s-ica",
+            "k8s-cca",
+            "k8s-cgoa",
+            "k8s-cba",
+            "k8s-otca",
+            "k8s-kca",
+            "k8s-capa",
+            "k8s-cnpe",
+            "k8s-cnpa",
+            "k8s-finops",
+        ),
+    ),
+    (
+        "platform",
+        (
+            "platform-foundations-advanced-networking",
+            "platform-foundations-distributed-systems",
+            "platform-foundations-engineering-leadership",
+            "platform-foundations-observability-theory",
+            "platform-foundations-reliability-engineering",
+            "platform-foundations-security-principles",
+            "platform-foundations-systems-thinking",
+            "platform-foundations",
+            "platform-disciplines-core-platform-sre",
+            "platform-disciplines-core-platform-platform-engineering",
+            "platform-disciplines-core-platform-leadership",
+            "platform-disciplines-delivery-automation-release-engineering",
+            "platform-disciplines-delivery-automation-gitops",
+            "platform-disciplines-delivery-automation-iac",
+            "platform-disciplines-reliability-security-networking",
+            "platform-disciplines-reliability-security-chaos-engineering",
+            "platform-disciplines-reliability-security-devsecops",
+            "platform-disciplines-data-ai-data-engineering",
+            "platform-disciplines-data-ai-mlops",
+            "platform-disciplines-data-ai-aiops",
+            "platform-disciplines-data-ai-ai-infrastructure",
+            "platform-disciplines-business-value-finops",
+            "platform-disciplines",
+            "platform-toolkits-cicd-delivery-ci-cd-pipelines",
+            "platform-toolkits-cicd-delivery-gitops-deployments",
+            "platform-toolkits-cicd-delivery-source-control",
+            "platform-toolkits-cicd-delivery-container-registries",
+            "platform-toolkits-observability-intelligence-observability",
+            "platform-toolkits-observability-intelligence-aiops-tools",
+            "platform-toolkits-infrastructure-networking-iac-tools",
+            "platform-toolkits-infrastructure-networking-k8s-distributions",
+            "platform-toolkits-infrastructure-networking-networking",
+            "platform-toolkits-infrastructure-networking-platforms",
+            "platform-toolkits-infrastructure-networking-storage",
+            "platform-toolkits-security-quality-security-tools",
+            "platform-toolkits-security-quality-code-quality",
+            "platform-toolkits-developer-experience-devex-tools",
+            "platform-toolkits-developer-experience-scaling-reliability",
+            "platform-toolkits-data-ai-platforms-ml-platforms",
+            "platform-toolkits-data-ai-platforms-cloud-native-databases",
+            "platform-toolkits",
+        ),
+    ),
+    (
+        "ai-ml-engineering",
+        (
+            "ai-ml-engineering-prerequisites",
+            "ai-ml-engineering-ai-native-development",
+            "ai-ml-engineering-generative-ai",
+            "ai-ml-engineering-vector-rag",
+            "ai-ml-engineering-frameworks-agents",
+            "ai-ml-engineering-mlops",
+            "ai-ml-engineering-ai-infrastructure",
+            "ai-ml-engineering-advanced-genai",
+            "ai-ml-engineering-multimodal-ai",
+            "ai-ml-engineering-deep-learning",
+            "ai-ml-engineering-machine-learning",
+            "ai-ml-engineering-reinforcement-learning",
+            "ai-ml-engineering-bridges",
+            "ai-ml-engineering-history",
+        ),
+    ),
+    (
+        "on-premises",
+        (
+            "on-premises-planning",
+            "on-premises-provisioning",
+            "on-premises-networking",
+            "on-premises-storage",
+            "on-premises-multi-cluster",
+            "on-premises-security",
+            "on-premises-operations",
+            "on-premises-resilience",
+            "on-premises-ai-ml-infrastructure",
+        ),
+    ),
+)
+
+
+def _slug_matches_prefix(slug: str, prefix: str) -> bool:
+    return slug == prefix or slug.startswith(f"{prefix}-")
+
+
+def _reading_order_position(slug: str) -> tuple[int, int]:
+    unknown_track_idx = len(_READING_ORDER_SECTIONS)
+    for track_idx, (track_prefix, sections) in enumerate(_READING_ORDER_SECTIONS):
+        for section_idx, section_prefix in enumerate(sections):
+            if _slug_matches_prefix(slug, section_prefix):
+                return track_idx, section_idx
+
+    fallback_matches = [
+        (len(track_prefix), track_idx, len(sections))
+        for track_idx, (track_prefix, sections) in enumerate(_READING_ORDER_SECTIONS)
+        if _slug_matches_prefix(slug, track_prefix)
+    ]
+    if fallback_matches:
+        _, track_idx, section_idx = max(fallback_matches, key=lambda item: item[0])
+        return track_idx, section_idx
+    return unknown_track_idx, 0
+
+
+def _module_number_key(slug: str) -> tuple[int, int]:
+    match = _MODULE_NUMBER_RE.search(slug)
+    if match is not None:
+        return int(match.group(1)), int(match.group(2))
+
+    legacy_match = _LEGACY_MODULE_NUMBER_RE.search(slug)
+    if legacy_match is not None:
+        return int(legacy_match.group(1)), 0
+
+    return 0, -1
+
+
+def _reading_order_key(slug: str) -> tuple[int, int, int, int, str]:
+    track_idx, section_idx = _reading_order_position(slug)
+    major, minor = _module_number_key(slug)
+    return track_idx, section_idx, major, minor, slug
 
 
 # ---- bootstrap --------------------------------------------------------
@@ -117,7 +322,7 @@ def iter_states(slug_filter: Iterable[str] | None = None) -> list[dict[str, Any]
         st = state.load_state(slug)
         if st is not None:
             out.append(st)
-    return out
+    return sorted(out, key=lambda st: _reading_order_key(st["slug"]))
 
 
 def cmd_status(args: argparse.Namespace) -> int:

--- a/scripts/quality/pipeline.py
+++ b/scripts/quality/pipeline.py
@@ -48,6 +48,7 @@ above 3, Gemini 429s and user's Mac lags."""
 
 
 _MODULE_NUMBER_RE = re.compile(r"-module-(\d+)\.(\d+)-")
+_CH_NUMBER_RE = re.compile(r"-ch-(\d+)-")
 _LEGACY_MODULE_NUMBER_RE = re.compile(r"-module-(\d+)-")
 
 # Flattened from astro.config.mjs sidebar entries and src/content/docs/.
@@ -91,22 +92,6 @@ _READING_ORDER_SECTIONS: tuple[tuple[str, tuple[str, ...]], ...] = (
         ),
     ),
     (
-        "cloud",
-        (
-            "cloud-hyperscaler-rosetta-stone",
-            "cloud-aws-essentials",
-            "cloud-eks-deep-dive",
-            "cloud-gcp-essentials",
-            "cloud-gke-deep-dive",
-            "cloud-azure-essentials",
-            "cloud-aks-deep-dive",
-            "cloud-architecture-patterns",
-            "cloud-advanced-operations",
-            "cloud-managed-services",
-            "cloud-enterprise-hybrid",
-        ),
-    ),
-    (
         "k8s",
         (
             "k8s-kcna",
@@ -127,6 +112,55 @@ _READING_ORDER_SECTIONS: tuple[tuple[str, tuple[str, ...]], ...] = (
             "k8s-cnpe",
             "k8s-cnpa",
             "k8s-finops",
+        ),
+    ),
+    (
+        "cloud",
+        (
+            "cloud-hyperscaler-rosetta-stone",
+            "cloud-aws-essentials",
+            "cloud-eks-deep-dive",
+            "cloud-gcp-essentials",
+            "cloud-gke-deep-dive",
+            "cloud-azure-essentials",
+            "cloud-aks-deep-dive",
+            "cloud-architecture-patterns",
+            "cloud-advanced-operations",
+            "cloud-managed-services",
+            "cloud-enterprise-hybrid",
+        ),
+    ),
+    (
+        "ai-ml-engineering",
+        (
+            "ai-ml-engineering-prerequisites",
+            "ai-ml-engineering-ai-native-development",
+            "ai-ml-engineering-generative-ai",
+            "ai-ml-engineering-vector-rag",
+            "ai-ml-engineering-frameworks-agents",
+            "ai-ml-engineering-mlops",
+            "ai-ml-engineering-ai-infrastructure",
+            "ai-ml-engineering-advanced-genai",
+            "ai-ml-engineering-multimodal-ai",
+            "ai-ml-engineering-deep-learning",
+            "ai-ml-engineering-machine-learning",
+            "ai-ml-engineering-reinforcement-learning",
+            "ai-ml-engineering-bridges",
+            "ai-ml-engineering-history",
+        ),
+    ),
+    (
+        "on-premises",
+        (
+            "on-premises-planning",
+            "on-premises-provisioning",
+            "on-premises-networking",
+            "on-premises-storage",
+            "on-premises-multi-cluster",
+            "on-premises-security",
+            "on-premises-operations",
+            "on-premises-resilience",
+            "on-premises-ai-ml-infrastructure",
         ),
     ),
     (
@@ -175,39 +209,6 @@ _READING_ORDER_SECTIONS: tuple[tuple[str, tuple[str, ...]], ...] = (
             "platform-toolkits",
         ),
     ),
-    (
-        "ai-ml-engineering",
-        (
-            "ai-ml-engineering-prerequisites",
-            "ai-ml-engineering-ai-native-development",
-            "ai-ml-engineering-generative-ai",
-            "ai-ml-engineering-vector-rag",
-            "ai-ml-engineering-frameworks-agents",
-            "ai-ml-engineering-mlops",
-            "ai-ml-engineering-ai-infrastructure",
-            "ai-ml-engineering-advanced-genai",
-            "ai-ml-engineering-multimodal-ai",
-            "ai-ml-engineering-deep-learning",
-            "ai-ml-engineering-machine-learning",
-            "ai-ml-engineering-reinforcement-learning",
-            "ai-ml-engineering-bridges",
-            "ai-ml-engineering-history",
-        ),
-    ),
-    (
-        "on-premises",
-        (
-            "on-premises-planning",
-            "on-premises-provisioning",
-            "on-premises-networking",
-            "on-premises-storage",
-            "on-premises-multi-cluster",
-            "on-premises-security",
-            "on-premises-operations",
-            "on-premises-resilience",
-            "on-premises-ai-ml-infrastructure",
-        ),
-    ),
 )
 
 
@@ -237,6 +238,10 @@ def _module_number_key(slug: str) -> tuple[int, int]:
     match = _MODULE_NUMBER_RE.search(slug)
     if match is not None:
         return int(match.group(1)), int(match.group(2))
+
+    chapter_match = _CH_NUMBER_RE.search(slug)
+    if chapter_match is not None:
+        return int(chapter_match.group(1)), 0
 
     legacy_match = _LEGACY_MODULE_NUMBER_RE.search(slug)
     if legacy_match is not None:

--- a/tests/test_pipeline_iter_states_reading_order.py
+++ b/tests/test_pipeline_iter_states_reading_order.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.quality import pipeline, state  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(state, "STATE_DIR", tmp_path / "state")
+    state.STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _write_states(slugs: list[str]) -> None:
+    for slug in slugs:
+        state.save_state(
+            {
+                "slug": slug,
+                "stage": "COMMITTED",
+                "history": [{"at": state.now_iso(), "stage": "COMMITTED"}],
+            }
+        )
+
+
+def _iter_state_slugs() -> list[str]:
+    return [st["slug"] for st in pipeline.iter_states()]
+
+
+def test_iter_states_orders_by_track_then_section_then_module_number() -> None:
+    _write_states(
+        [
+            "platform-toolkits-security-quality-security-tools-module-1.1-kyverno",
+            "cloud-aws-essentials-module-1.1-iam",
+            "platform-foundations-security-principles-module-1.1-security-mindset",
+            "prerequisites-zero-to-terminal-module-0.1-what-is-a-computer",
+        ]
+    )
+
+    assert _iter_state_slugs() == [
+        "prerequisites-zero-to-terminal-module-0.1-what-is-a-computer",
+        "cloud-aws-essentials-module-1.1-iam",
+        "platform-foundations-security-principles-module-1.1-security-mindset",
+        "platform-toolkits-security-quality-security-tools-module-1.1-kyverno",
+    ]
+
+
+def test_module_numbers_sort_numerically_not_lexicographically() -> None:
+    _write_states(
+        [
+            "cloud-aws-essentials-module-1.10-cloudwatch",
+            "cloud-aws-essentials-module-1.3-ec2",
+            "cloud-aws-essentials-module-1.2-vpc",
+        ]
+    )
+
+    assert _iter_state_slugs() == [
+        "cloud-aws-essentials-module-1.2-vpc",
+        "cloud-aws-essentials-module-1.3-ec2",
+        "cloud-aws-essentials-module-1.10-cloudwatch",
+    ]
+
+
+def test_index_modules_sort_before_numbered_modules_in_section() -> None:
+    _write_states(
+        [
+            "platform-foundations-security-principles-module-1.1-security-mindset",
+            "platform-foundations-security-principles",
+        ]
+    )
+
+    assert _iter_state_slugs() == [
+        "platform-foundations-security-principles",
+        "platform-foundations-security-principles-module-1.1-security-mindset",
+    ]
+
+
+def test_unknown_track_sorts_to_end() -> None:
+    _write_states(
+        [
+            "unknown-track-module-1.1-surprise",
+            "on-premises-planning-module-1.1-case-for-on-prem",
+            "prerequisites-zero-to-terminal-module-0.1-what-is-a-computer",
+        ]
+    )
+
+    assert _iter_state_slugs() == [
+        "prerequisites-zero-to-terminal-module-0.1-what-is-a-computer",
+        "on-premises-planning-module-1.1-case-for-on-prem",
+        "unknown-track-module-1.1-surprise",
+    ]

--- a/tests/test_pipeline_iter_states_reading_order.py
+++ b/tests/test_pipeline_iter_states_reading_order.py
@@ -49,6 +49,20 @@ def test_iter_states_orders_by_track_then_section_then_module_number() -> None:
     ]
 
 
+def test_k8s_certifications_sort_before_cloud_modules() -> None:
+    _write_states(
+        [
+            "cloud-aws-essentials-module-1.1-iam",
+            "k8s-cka-module-1.1-cluster-architecture",
+        ]
+    )
+
+    assert _iter_state_slugs() == [
+        "k8s-cka-module-1.1-cluster-architecture",
+        "cloud-aws-essentials-module-1.1-iam",
+    ]
+
+
 def test_module_numbers_sort_numerically_not_lexicographically() -> None:
     _write_states(
         [
@@ -62,6 +76,20 @@ def test_module_numbers_sort_numerically_not_lexicographically() -> None:
         "cloud-aws-essentials-module-1.2-vpc",
         "cloud-aws-essentials-module-1.3-ec2",
         "cloud-aws-essentials-module-1.10-cloudwatch",
+    ]
+
+
+def test_ai_history_chapters_sort_numerically_not_lexicographically() -> None:
+    _write_states(
+        [
+            "ai-history-ch-10-the-imitation-game",
+            "ai-history-ch-2-the-universal-machine",
+        ]
+    )
+
+    assert _iter_state_slugs() == [
+        "ai-history-ch-2-the-universal-machine",
+        "ai-history-ch-10-the-imitation-game",
     ]
 
 


### PR DESCRIPTION
## Summary

- Adds `_reading_order_key(slug)` returning `(track_idx, section_idx, major, minor, slug)` and sorts `iter_states()` by each loaded state's `slug` field.
- Track order follows the requested learner path: Fundamentals/prerequisite entries, Linux, AI, Cloud, Certifications/K8s, Platform, AI/ML Engineering, then On-Premises. Section order is flattened from `astro.config.mjs` sidebar `autogenerate.directory` entries, with directory-list fallback where the sidebar autogenerates a parent directory.
- Unknown tracks or sections sort after known learner-path content. Numbered modules parse `module-X.Y` numerically, legacy `module-X` slugs get numeric fallback ordering, and section/index states with no module number sort before numbered modules in the same section.

## Test plan

- [x] `test_iter_states_orders_by_track_then_section_then_module_number`
- [x] `test_module_numbers_sort_numerically_not_lexicographically`
- [x] `test_index_modules_sort_before_numbered_modules_in_section`
- [x] `test_unknown_track_sorts_to_end`
- [x] `.venv/bin/pytest tests/test_pipeline_iter_states_reading_order.py -v`
- [x] `.venv/bin/pytest tests/test_quality_stages.py -q`
- [x] `.venv/bin/python scripts/test_pipeline.py`
- [x] `.venv/bin/ruff check scripts/quality/pipeline.py tests/test_pipeline_iter_states_reading_order.py`
- [x] `git diff --check`

Note: this is `feat:`, not `fix:`, so `block-bugfix-merge-without-regression-test.sh` will not fire on merge.

`tests/test_pipeline.py` is not present in this checkout; the equivalent repository pipeline gate here is `scripts/test_pipeline.py`, which passed.
