### PR TITLE
fix(citation_backfill): skip inline wrap when phrase already lives inside existing markdown link (#1216)

### DIFF
--- a/scripts/citation_backfill.py
+++ b/scripts/citation_backfill.py
@@ -1512,6 +1512,11 @@ def apply_inject_plan(body: str, plan: dict[str, Any], seed: dict[str, Any]) -> 
         else:
             phrase_idx_in_target = target.find(phrase)
             abs_phrase_idx = idx + phrase_idx_in_target
+        if _is_inside_existing_markdown_link(new_body, abs_phrase_idx):
+            applied.append({"claim_id": ins.get("claim_id"), "kind": "inline",
+                            "status": "applied",
+                            "note": "already_cited_in_body"})
+            continue
         new_body = new_body[:abs_phrase_idx] + replace + new_body[abs_phrase_idx + len(phrase):]
         applied.append({"claim_id": ins.get("claim_id"), "kind": "inline",
                         "status": "applied",
@@ -1530,6 +1535,45 @@ def apply_inject_plan(body: str, plan: dict[str, Any], seed: dict[str, Any]) -> 
         sources = _sanitize_sources_section_urls(sources)
         new_body = _merge_sources_section(new_body, sources)
     return new_body, applied
+
+
+def _is_inside_existing_markdown_link(body: str, idx: int) -> bool:
+    """Return True when ``idx`` falls inside a markdown link in ``body``."""
+    if idx < 0:
+        return False
+
+    i = 0
+    n = len(body)
+    while i < n:
+        lb = body.find("](", i)
+        if lb < 0:
+            return False
+        lbr = body.rfind("[", i, lb)
+        if lbr < 0:
+            i = lb + 2
+            continue
+        # Parse URL: balance-aware until the matching ")" at depth 0.
+        url_start = lb + 2
+        depth = 0
+        j = url_start
+        while j < n:
+            ch = body[j]
+            if ch == "(":
+                depth += 1
+            elif ch == ")":
+                if depth == 0:
+                    break
+                depth -= 1
+            elif ch.isspace():
+                break
+            j += 1
+        if j >= n or body[j] != ")":
+            i = lb + 2
+            continue
+        if lbr <= idx <= j:
+            return True
+        i = j + 1
+    return False
 
 
 def _sanitize_sources_section_urls(text: str) -> str:
@@ -1816,8 +1860,8 @@ def _verify_diff_is_additive(original: str, modified: str,
     if unauthorized:
         sample_lines: list[str] = []
         for old_line, new_line in unauthorized[:5]:
-            sample_lines.append(f"-{old_line[:140]}")
-            sample_lines.append(f"+{new_line[:140]}")
+            sample_lines.append(f"-{old_line[:800]}")
+            sample_lines.append(f"+{new_line[:800]}")
         issues.append("unauthorized_prose_change:\n" + "\n".join(sample_lines))
     return issues
 

--- a/tests/test_citation_backfill.py
+++ b/tests/test_citation_backfill.py
@@ -286,6 +286,32 @@ def test_apply_inject_plan_skips_rewrite_disposition_claims() -> None:
     } in applied
 
 
+def test_apply_inject_plan_skips_overlapping_wrap_when_phrase_already_cited() -> None:
+    """Regression test for #1216 (Pattern B): inject must not double-wrap a phrase
+    that already lives inside an existing [label](url) region. The claim should
+    be recorded as applied with note='already_cited_in_body' so the coverage
+    gate in run_inject treats it as addressed."""
+    body = "Lead.\\n\\n[Kubernetes](https://kubernetes.io/) is a container orchestrator.\\n"
+    plan = {
+        "inline_insertions": [
+            {
+                "claim_id": "k8s-orchestrator",
+                "target_line": "[Kubernetes](https://kubernetes.io/) is a container orchestrator.",
+                "original_phrase": "Kubernetes",
+                "replace_with": "[Kubernetes](https://kubernetes.io/)",
+            }
+        ],
+        "skipped_claims": [],
+    }
+    seed = {"claims": [{"claim_id": "k8s-orchestrator", "disposition": "supported"}]}
+    new_body, applied = citation_backfill.apply_inject_plan(body, plan, seed)
+    assert new_body == body, "body must not be mutated when phrase already cited"
+    matching = [a for a in applied if a.get("claim_id") == "k8s-orchestrator"]
+    assert len(matching) == 1
+    assert matching[0]["status"] == "applied"
+    assert matching[0]["note"] == "already_cited_in_body"
+
+
 def test_apply_inject_plan_preserves_next_module_after_sources() -> None:
     body = (
         "Body text.\n\n"


### PR DESCRIPTION
## Summary
- Widened `_verify_diff_is_additive` diff-sample diagnostics from 140 to 800 characters to preserve full malformed regions for easier triage.
- Added overlap detection in `apply_inject_plan` so a proposed inline citation replacement is skipped when the anchor sits inside an already-present markdown link.
- Added regression coverage for Pattern B to record skipped inline claims as `applied` with note `already_cited_in_body`, preserving idempotency for re-runs.

## Test plan
- `.venv/bin/pytest tests/test_citation_backfill.py -q`

Regression test: tests/test_citation_backfill.py::test_apply_inject_plan_skips_overlapping_wrap_when_phrase_already_cited

Fixes #1216
