### PR TITLE
fix(citation_backfill): soft-skip cited claims codex drops from inline_insertions (#1218)

### DIFF
--- a/scripts/citation_backfill.py
+++ b/scripts/citation_backfill.py
@@ -1260,6 +1260,21 @@ Two kinds of edits land in the module:
   `skipped_claims` with reason `awaiting_allowlist_review`. Do not
   edit the module; do not add a citation.
 
+## Completeness contract (CRITICAL)
+
+Every cited-disposition claim (supported, weak_anchor) from the seed
+MUST appear in EXACTLY ONE of:
+
+- `inline_insertions[]` with a valid wrap, OR
+- `skipped_claims[]` with a reason like `span_in_code_block`,
+  `span_not_wrappable`, `inside_quoted_block`, or `claim_text_not_found_in_body`.
+
+Omitting a cited claim from BOTH arrays is a CONTRACT VIOLATION. The
+orchestrator will detect this and soft-skip the missing claim — your
+hard work on the other claims still lands, but the dropped claim
+becomes a manual-review item in the sidecar log. Aim for zero
+contract violations.
+
 ## Edit discipline
 
 1. `target_line` MUST be a verbatim single line copied from the module
@@ -1959,9 +1974,14 @@ def run_inject(module_key: str, *, agent: str = "codex", dry_run: bool = False) 
     }
     missing_cited = expected_cited_ids - applied_inline_ids - skipped_ids
     if missing_cited:
-        diff_issues.append(
-            f"cited_dispositions_not_addressed: {sorted(missing_cited)[:5]}"
-        )
+        for cid in sorted(missing_cited):
+            applied.append({
+                "claim_id": cid,
+                "kind": "inline",
+                "status": "skipped",
+                "reason": "not_addressed_by_agent",
+            })
+    codex_dropped_count = len(missing_cited)
 
     # Only write to disk on a clean diff. A failed diff lint means
     # Codex made an unauthorized prose change or skipped required
@@ -1974,9 +1994,10 @@ def run_inject(module_key: str, *, agent: str = "codex", dry_run: bool = False) 
     # the full list. Rewrites are applied in-place; no revision record
     # needed for them any more.
     deferred_record_path = None
-    if deferred:
+    if deferred or missing_cited:
         rp = REPO_ROOT / ".pipeline" / "citation-revisions" / f"{normalized_key.replace('/', '-')}.json"
         rp.parent.mkdir(parents=True, exist_ok=True)
+        missing_lookup = set(str(cid) for cid in missing_cited)
         rp.write_text(
             json.dumps({
                 "module_key": normalized_key,
@@ -1992,6 +2013,17 @@ def run_inject(module_key: str, *, agent: str = "codex", dry_run: bool = False) 
                     }
                     for c in deferred
                 ],
+                "codex_dropped": [
+                    {
+                        "claim_id": c.get("claim_id"),
+                        "claim_text": c.get("claim_text"),
+                        "span_hint": c.get("span_hint"),
+                        "proposed_url": c.get("proposed_url"),
+                        "disposition": c.get("disposition"),
+                    }
+                    for c in seed.get("claims") or []
+                    if str(c.get("claim_id")) in missing_lookup
+                ],
             }, indent=2, ensure_ascii=False) + "\n",
             encoding="utf-8",
         )
@@ -2000,6 +2032,7 @@ def run_inject(module_key: str, *, agent: str = "codex", dry_run: bool = False) 
     return {
         "module_key": normalized_key, "ok": len(diff_issues) == 0,
         "module_path": str(module_path.relative_to(REPO_ROOT)),
+        "codex_dropped_count": codex_dropped_count,
         "inline_applied": sum(1 for a in applied if a.get("kind") == "inline" and a.get("status") == "applied"),
         "rewrite_applied": sum(1 for a in applied if a.get("kind") == "prose_rewrite" and a.get("status") == "applied"),
         "rejected_count": sum(1 for a in applied if a.get("status") == "rejected"),

--- a/tests/test_citation_backfill.py
+++ b/tests/test_citation_backfill.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -371,3 +372,106 @@ def test_apply_inject_plan_sources_merge_dedupes_by_url() -> None:
     assert "- [A](https://x.com/a)" in new_body
     assert "Different A" not in new_body
     assert "- [B](https://y.com/b)" in new_body
+
+
+def test_run_inject_soft_skips_codex_dropped_cited_claims(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Use an isolated fake repo, so this test can run in parallel with
+    # other citation fixtures without touching actual source files.
+    monkeypatch.setattr(citation_backfill, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(citation_backfill, "DOCS_ROOT", tmp_path / "src" / "content" / "docs")
+    monkeypatch.setattr(citation_backfill, "SEED_DIR", tmp_path / "docs" / "citation-seeds")
+
+    module_key = "platform/cluster-api-demo"
+    module_path = tmp_path / "src" / "content" / "docs" / "platform" / "cluster-api-demo.md"
+    module_path.parent.mkdir(parents=True, exist_ok=True)
+    module_body = (
+        "Cluster API bootstraps nodes for production use.\n"
+        "The operator reviews cluster events and scales workloads.\n"
+        "Kubernetes handles control-plane scheduling automatically.\n"
+    )
+    module_path.write_text(module_body, encoding="utf-8")
+
+    seed = {
+        "claims": [
+            {
+                "claim_id": "C001",
+                "disposition": "supported",
+                "claim_text": "Cluster API bootstraps nodes for production use.",
+                "span_hint": "line 1",
+                "proposed_url": "https://kubernetes.io/docs/concepts/overview/",
+            },
+            {
+                "claim_id": "C002",
+                "disposition": "supported",
+                "claim_text": "The operator reviews cluster events and scales workloads.",
+                "span_hint": "line 2",
+                "proposed_url": "https://kubernetes.io/docs/concepts/architecture/control-plane-node-communication/",
+            },
+            {
+                "claim_id": "C003",
+                "disposition": "supported",
+                "claim_text": "Kubernetes handles control-plane scheduling automatically.",
+                "span_hint": "line 3",
+                "proposed_url": "https://kubernetes.io/docs/concepts/scheduling-eviction/",
+            },
+        ]
+    }
+    citation_backfill.seed_path_for(module_key).write_text(
+        json.dumps(seed, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+    plan = {
+        "inline_insertions": [
+            {
+                "claim_id": "C001",
+                "target_line": "Cluster API bootstraps nodes for production use.",
+                "original_phrase": "Cluster API",
+                "replace_with": "[Cluster API](https://kubernetes.io/docs/concepts/overview/)",
+            },
+            {
+                "claim_id": "C002",
+                "target_line": "The operator reviews cluster events and scales workloads.",
+                "original_phrase": "scales workloads",
+                "replace_with": "[scales workloads](https://kubernetes.io/docs/concepts/architecture/control-plane-node-communication/)",
+            },
+        ],
+        "skipped_claims": [],
+    }
+
+    def _fake_dispatch(
+        _prompt: str,
+        *,
+        task_id: str | None = None,
+        timeout: int = 900,
+    ) -> tuple[bool, str]:
+        del _prompt, task_id, timeout
+        return True, json.dumps(plan, ensure_ascii=False)
+
+    monkeypatch.setattr(citation_backfill, "dispatch_codex", _fake_dispatch)
+
+    result = citation_backfill.run_inject(module_key, agent="codex")
+
+    assert result["ok"] is True
+    assert not any(
+        "cited_dispositions_not_addressed" in str(item)
+        for item in result["diff_issues"]
+    )
+    assert result["codex_dropped_count"] == 1
+
+    revision_rel = result["deferred_record"]
+    assert isinstance(revision_rel, str)
+    revision_path = tmp_path / revision_rel
+    assert revision_path.exists()
+    revision = json.loads(revision_path.read_text(encoding="utf-8"))
+    dropped = revision.get("codex_dropped") or []
+    assert len(dropped) == 1
+    assert dropped[0]["claim_id"] == "C003"
+
+    c003 = [entry for entry in result["applied"] if entry.get("claim_id") == "C003"]
+    assert len(c003) == 1
+    assert c003[0]["kind"] == "inline"
+    assert c003[0]["status"] == "skipped"
+    assert c003[0]["reason"] == "not_addressed_by_agent"


### PR DESCRIPTION
## Summary
- Implement Pattern C soft-skip behavior in run_inject when cited-disposition claims are omitted from Codex inline insertions and skipped claims.
- Extend inject sidecar logging with a new codex_dropped array so dropped cites are preserved for manual review.
- Add codex_dropped_count to inject result payloads and strengthen the inject prompt with a cited-completeness contract section.

## Test plan
- /Users/krisztiankoos/projects/kubedojo/.venv/bin/pytest tests/test_citation_backfill.py -q

Regression test: tests/test_citation_backfill.py::test_run_inject_soft_skips_codex_dropped_cited_claims

Fixes #1218
