### PR TITLE
fix: quote module 2.2 title with colon (#1221 follow-up)

### DIFF
--- a/src/content/docs/ai/ai-native-work/module-2.2-orchestrating-fleets-symphony.md
+++ b/src/content/docs/ai/ai-native-work/module-2.2-orchestrating-fleets-symphony.md
@@ -1,5 +1,5 @@
 ---
-title: Orchestrating Fleets: Symphony and Project-Management-as-Control-Plane
+title: "Orchestrating Fleets: Symphony and Project-Management-as-Control-Plane"
 slug: ai/ai-native-work/module-2.2-orchestrating-fleets-symphony
 description: Use issue-level contracts, lifecycle hooks, and explicit state machines to orchestrate autonomous coding fleets through PM states without losing ownership.
 sidebar:


### PR DESCRIPTION
## Summary

- One-line YAML frontmatter fix: wraps the `title:` value in double quotes so the colon inside `Orchestrating Fleets: Symphony and Project-Management-as-Control-Plane` no longer parses as a nested mapping separator.
- Symptom: `npx astro dev` crashed on every content-store rebuild with `bad indentation of a mapping entry` at `module-2.2-orchestrating-fleets-symphony.md:1:27`. Stack trace through `safeParseFrontmatter` → `js-yaml`.
- Follow-up to #1221 — the unquoted title shipped with the Symphony module merge.

## Test plan

- [x] `git diff` shows only the title-line quoting change
- [ ] `npx astro dev` starts without `safeParseFrontmatter` crash
- [ ] `npm run build` exits 0 with the module renderable

🤖 Generated with [Claude Code](https://claude.com/claude-code)