### PR TITLE
docs(claude): explicit cold-start curl sequence (T2.1, learn-ukrainian parity)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,27 +4,43 @@ KubeDojo — free, open-source cloud native curriculum.
 
 ## Agent Orientation (first call on a cold start)
 
-Before `cat`-ing `STATUS.md`, reading the latest `docs/session-state/*.{md,html}` handoff, or running `git log`, hit the local API — it returns the same orientation in ~65 % fewer tokens.
+The orientation sequence is API-first to reduce token use and get a complete cold-start picture (`actions`, blockers, leases, and top modules) before reading local handoff files.
 
+1. Pull compact briefing:
+```bash
+curl -s --max-time 2 http://127.0.0.1:8768/api/briefing/session?compact=1
 ```
-curl -s http://127.0.0.1:8768/api/briefing/session             # ~1.5K tokens, full
-curl -s http://127.0.0.1:8768/api/briefing/session?compact=1   # ~0.7K tokens, compact
-curl -s http://127.0.0.1:8768/api/schema                       # endpoint index
+If 200, parse and act from that payload. If timeout or non-200, record `API down` and skip to step 6.
+
+2. Run local working-tree awareness:
+```bash
+git status --short
 ```
 
-The briefing covers: current branch + dirty summary, all worktrees, runtime services, pipeline v2 queue head, **recent commits**, top TODO bullets, blockers, and alerts. It also returns the actionable triage triple — `actions.{active, blocked, next}` plus `top_modules[{module_key, phase, reason, endpoint}]` — so a fresh agent decides *what to touch* in the same call. Responses carry a weak ETag — send `If-None-Match` for 304 on repeat polls. If the API is down, fall back to reading `STATUS.md` + `CLAUDE.md`.
+3. Scan for blocking decisions:
+```bash
+ls docs/decisions/pending/
+```
+Respect `.claude/rules/decision-card.md` and only process what is declared blocking.
 
-**Cold-start ordering rule (do not regress):**
+4. Read the latest handoff at `docs/session-state/<date>-*.{md,html>` only when the briefing leaves a real narrative-why gap. Use the path from the `STATUS.md` row labeled `Latest handoff`.
 
-1. Briefing API first. It already covers `recent_commits`, `workspace.dirty`, `blockers`, `actions.{active,blocked,next}`, `focus`, `alerts`. **Do not redundantly run `git log -N` or read the latest handoff in full.**
-2. The handoff file at `docs/session-state/YYYY-MM-DD-*.{md,html}` is the *narrative-why* canonical record. The extension is whatever `STATUS.md` points at — could be `.md` or `.html` depending on the session. Read it only when the briefing leaves a real gap (e.g., needing the rationale behind a contract decision, or full PR-by-PR provenance for the prior session). Use `Read` with `limit:` to pull only the relevant section.
-3. `git status --short` is the only marginal-value supplement to the briefing — useful for spotting untracked-files state the briefing summarizes but doesn't enumerate.
-4. Only fall back to STATUS.md when the API is down.
+5. Optional situational check for recent orchestration context:
+```bash
+curl -s --max-time 2 "http://127.0.0.1:8768/api/activity?limit=30"
+```
 
-**Before you claim work**: `GET /api/pipeline/leases` (or `/api/module/{key}/lease`) to see if another worker already holds it — avoids concurrent re-writes.
-**Before you fix a module**: `GET /api/module/{key}/state` for the structured `diagnostics[]` (frontmatter, UK sync, rubric, lease, dead-letter).
-**Before you re-review**: `GET /api/reviews?module={key}` for the existing audit log.
-**For situational awareness**: `GET /api/tracks/readiness` (per-section cleared/in-flight/dead-letter/not-yet-enqueued) and `GET /api/activity?limit=30` (merged feed of commits + pipeline events + bridge messages, 24 h window by default). Both are also rendered in the Operator panel at the top of the dashboard (`http://127.0.0.1:8768/`).
+6. Fallback path if API is down:
+`STATUS.md` → latest handoff → `MEMORY.md` → `CLAUDE.md`.
+
+**Before you claim/fix/re-review work**:
+- `GET /api/pipeline/leases`
+- `GET /api/module/{key}/state`
+- `GET /api/reviews?module={key}`
+
+*Endpoints planned for protocol parity with learn-ukrainian Monitor API (not yet shipped):* `/api/state/manifest`, `/api/rules?format=markdown`, `/api/session/current`, `/api/orient`, `/api/comms/inbox?agent=X`. Tracked as T2.2 in the gap inventory.
+
+Standalone session = main orchestrator. Drive the queue; ask only on irreversible or ambiguous actions.
 
 Full agent recipe: [`scripts/agent_onboarding.md`](scripts/agent_onboarding.md).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,9 @@ The orientation sequence is API-first to reduce token use and get a complete col
 
 1. Pull compact briefing:
 ```bash
-curl -s --max-time 2 http://127.0.0.1:8768/api/briefing/session?compact=1
+curl -s --max-time 2 "http://127.0.0.1:8768/api/briefing/session?compact=1"
 ```
-If 200, parse and act from that payload. If timeout or non-200, record `API down` and skip to step 6.
+If 200, parse the payload and proceed. If timeout or non-200, record `API down` — still run steps 2 and 3 (local filesystem state is independent of the API), then fall back to step 6 instead of step 4.
 
 2. Run local working-tree awareness:
 ```bash
@@ -25,7 +25,7 @@ Respect `.claude/rules/decision-card.md` and only process what is declared block
 
 4. Pull the latest handoff via API (preferred) or fall back to the file:
 ```bash
-curl -s --max-time 2 http://127.0.0.1:8768/api/session/current
+curl -s --max-time 2 "http://127.0.0.1:8768/api/session/current"
 ```
 Returns the most recent handoff path plus predecessor chain. Only read the underlying `docs/session-state/<date>-*.{md,html}` file when the briefing leaves a real narrative-why gap; use the path from the API response or from STATUS.md's `Latest handoff` row.
 
@@ -44,7 +44,9 @@ curl -s --max-time 2 "http://127.0.0.1:8768/api/activity?limit=30"
 
 **Self-discovery**: `curl -s http://127.0.0.1:8768/api/state/manifest` returns the categorized route inventory (cold_start / dashboards / pipeline / etc.) — use this when uncertain which endpoint serves a given concern.
 
-*Endpoints planned for protocol parity with learn-ukrainian Monitor API (not yet shipped):* `/api/rules?format=markdown`, `/api/orient`, `/api/comms/inbox?agent=X`. Tracked as T2.2 in the gap inventory.
+**Orientation punch-line**: `curl -s --max-time 2 http://127.0.0.1:8768/api/orient` returns the single primary action + up to 3 alternatives + blockers/alerts in ~1.3 KB. Use this when the briefing is overkill.
+
+*Endpoints planned for protocol parity with learn-ukrainian Monitor API (not yet shipped):* `/api/rules?format=markdown`, `/api/comms/inbox?agent=X`. Tracked as T2.2 in the gap inventory.
 
 Standalone session = main orchestrator. Drive the queue; ask only on irreversible or ambiguous actions.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,11 @@ ls docs/decisions/pending/
 ```
 Respect `.claude/rules/decision-card.md` and only process what is declared blocking.
 
-4. Read the latest handoff at `docs/session-state/<date>-*.{md,html>` only when the briefing leaves a real narrative-why gap. Use the path from the `STATUS.md` row labeled `Latest handoff`.
+4. Pull the latest handoff via API (preferred) or fall back to the file:
+```bash
+curl -s --max-time 2 http://127.0.0.1:8768/api/session/current
+```
+Returns the most recent handoff path plus predecessor chain. Only read the underlying `docs/session-state/<date>-*.{md,html}` file when the briefing leaves a real narrative-why gap; use the path from the API response or from STATUS.md's `Latest handoff` row.
 
 5. Optional situational check for recent orchestration context:
 ```bash
@@ -38,7 +42,9 @@ curl -s --max-time 2 "http://127.0.0.1:8768/api/activity?limit=30"
 - `GET /api/module/{key}/state`
 - `GET /api/reviews?module={key}`
 
-*Endpoints planned for protocol parity with learn-ukrainian Monitor API (not yet shipped):* `/api/state/manifest`, `/api/rules?format=markdown`, `/api/session/current`, `/api/orient`, `/api/comms/inbox?agent=X`. Tracked as T2.2 in the gap inventory.
+**Self-discovery**: `curl -s http://127.0.0.1:8768/api/state/manifest` returns the categorized route inventory (cold_start / dashboards / pipeline / etc.) — use this when uncertain which endpoint serves a given concern.
+
+*Endpoints planned for protocol parity with learn-ukrainian Monitor API (not yet shipped):* `/api/rules?format=markdown`, `/api/orient`, `/api/comms/inbox?agent=X`. Tracked as T2.2 in the gap inventory.
 
 Standalone session = main orchestrator. Drive the queue; ask only on irreversible or ambiguous actions.
 


### PR DESCRIPTION
## Why
- Restructure Agent Orientation to a tight, explicit cold-start curl sequence mirroring learn-ukrainian operational style.
- Keeps API-first orientation first, adds explicit timeouts, fallback chain, and a required docs/decisions/pending scan step.

## Preserved guards retained
- /api/pipeline/leases
- /api/module/{key}/state
- /api/reviews?module={key}

## Endpoint gap follow-up
Tracked as T2.2 for protocol parity:
- /api/state/manifest
- /api/rules?format=markdown
- /api/session/current
- /api/orient
- /api/comms/inbox?agent=X

## Checks
- [x] curl verification: `GET /api/briefing/session?compact=1` -> 200
- [ ] ruff (n/a, docs-only)
- [ ] render check on edited section
