### PR TITLE
feat(api): /api/orient — punch-line orientation endpoint (T2.2)

### DIFF
--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -5076,6 +5076,12 @@ def build_state_manifest() -> dict[str, Any]:
                         "purpose": "Machine-readable index of local API routes and query conventions.",
                         "type": "api",
                     },
+                    {
+                        "name": "Orientation punch-line",
+                        "path": "/api/orient",
+                        "purpose": "Single primary action + up to 3 alternatives + blockers/alerts. Maximum signal-to-token.",
+                        "type": "api",
+                    },
                 ],
             },
             {
@@ -7744,6 +7750,56 @@ def _compact_briefing(briefing: dict[str, Any]) -> dict[str, Any]:
     return compact
 
 
+def build_orient(repo_root: Path) -> dict[str, Any]:
+    """Maximum-signal, minimum-token orientation: what to do RIGHT NOW.
+
+    Projects the session briefing into a single ``primary`` action +
+    up to 3 ``alternatives`` + raw ``blockers`` / ``alerts``. Reach for
+    ``/api/briefing/session?compact=1`` when the full snapshot is needed.
+    """
+    briefing, freshness = get_or_build_session_briefing(repo_root)
+    rows = briefing.get("action_rows") or []
+    blockers = briefing.get("blockers") or []
+    alerts = briefing.get("alerts") or []
+    workspace = briefing.get("workspace") or {}
+    snapshot = briefing.get("snapshot") or {}
+
+    def _row_to_action(row: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "action": row.get("bucket") or "next",
+            "headline": row.get("label"),
+            "module_key": row.get("module_key"),
+            "endpoint": row.get("endpoint"),
+            "reason": row.get("reason"),
+            "phase": row.get("phase"),
+        }
+
+    if rows:
+        primary = _row_to_action(rows[0])
+        alternatives = [_row_to_action(r) for r in rows[1:4]]
+    else:
+        primary = {
+            "action": "idle",
+            "headline": "queue empty — propose work or check blockers for unblock candidates",
+            "module_key": None,
+            "endpoint": None,
+            "reason": None,
+            "phase": None,
+        }
+        alternatives = []
+
+    return {
+        "version": 1,
+        "primary": primary,
+        "alternatives": alternatives,
+        "blockers": blockers,
+        "alerts": alerts,
+        "workspace_dirty": bool(workspace.get("dirty")),
+        "freshness_state": (freshness or {}).get("freshness_state"),
+        "generated_at": snapshot.get("generated_at"),
+    }
+
+
 # Registry keyed by resolved ``repo_root`` so multiple repos sharing one
 # Python process (test suite, multi-repo servers) never cross-contaminate.
 _SESSION_BRIEFING_SNAPSHOTS: dict[str, BackgroundSnapshot] = {}
@@ -7805,6 +7861,11 @@ def build_api_schema() -> dict[str, Any]:
             {
                 "path": "/api/state/manifest",
                 "desc": "Pointer-only cold-start state index grouped by purpose",
+                "content_type": "application/json",
+            },
+            {
+                "path": "/api/orient",
+                "desc": "Single primary action + up to 3 alternatives + blockers/alerts. Punch-line orientation derived from the session briefing.",
                 "content_type": "application/json",
             },
             {"path": "/api/artifacts", "desc": "JSON index of HTML and Markdown artifacts served by /artifacts"},
@@ -8246,6 +8307,8 @@ def route_request(repo_root: Path, raw_path: str) -> tuple[int, Any, str]:
         if compact:
             briefing = _compact_briefing(briefing)
         return 200, briefing, "application/json; charset=utf-8"
+    if path == "/api/orient":
+        return 200, build_orient(repo_root), "application/json; charset=utf-8"
     if path == "/api/session/current":
         return 200, build_current_session(repo_root), "application/json; charset=utf-8"
     if path == "/api/briefing/book":
@@ -8495,6 +8558,7 @@ CACHE_POLICY: dict[str, tuple[float, Callable[[Path], tuple] | None]] = {
     "/api/git/worktrees": (5.0, None),
     "/api/git/cleanup": (10.0, None),
     "/api/briefing/session": (5.0, None),  # background-refreshed; TTL just caps rebuild rate
+    "/api/orient": (5.0, None),  # cheap projection over the same background-refreshed briefing
 }
 
 


### PR DESCRIPTION
## Summary

Implements `/api/orient` — a token-light orientation endpoint that returns "what to do RIGHT NOW" in ~1.3 KB rather than the full briefing's ~14 KB.

**Output shape:**
```json
{
  "version": 1,
  "primary": { "action", "headline", "module_key", "endpoint", "reason", "phase" },
  "alternatives": [ ...up to 3 of the same shape... ],
  "blockers": [...],
  "alerts": [...],
  "workspace_dirty": bool,
  "freshness_state": "fresh|stale|refreshing",
  "generated_at": float
}
```

Pure projection over the existing background-refreshed session briefing — no new compute cost or worker thread. Uses `action_rows` as the sole input. `primary` is `action_rows[0]`; `alternatives` is `action_rows[1:4]`. When `action_rows` is empty, `primary.action == "idle"`.

## Why

Matches the learn-ukrainian Monitor protocol's `/api/orient` endpoint (per `feedback_briefing_first_handoff_on_demand.md` + the cold-start protocol parity track T2.2). Cold-start agents that just need the punch-line can hit `/api/orient` instead of parsing the full briefing.

Also registers the endpoint in `/api/state/manifest` (cold_start category) and `/api/schema` for self-discovery.

## Test plan

- [x] Ruff clean (`ruff check scripts/local_api.py` → "All checks passed!")
- [x] Server boots on isolated port 8769 against this worktree
- [x] `/api/orient` returns primary + 3 alternatives + blockers/alerts/workspace_dirty/freshness
- [x] `/api/state/manifest` cold_start lists "Orientation punch-line"
- [x] `/api/schema` includes `/api/orient` entry
- [ ] Production API restart picks up the new code (operator action after merge)

## Remaining T2.2 follow-up

Two endpoints still missing for full parity with learn-ukrainian:
- `/api/rules?format=markdown` — concatenate `.claude/rules/*.md` over HTTP
- `/api/comms/inbox?agent=X` — surface `.bridge/messages.db` rows for the named agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)