### PR TITLE
feat(388): rewrite module-1.7-kubeadm (#388 pilot)

### DIFF
--- a/src/content/docs/k8s/cka/part1-cluster-architecture/module-1.7-kubeadm.md
+++ b/src/content/docs/k8s/cka/part1-cluster-architecture/module-1.7-kubeadm.md
@@ -1,5 +1,5 @@
 ---
-revision_pending: true
+revision_pending: false
 title: "Module 1.7: kubeadm Basics - Cluster Bootstrap"
 slug: k8s/cka/part1-cluster-architecture/module-1.7-kubeadm
 sidebar:
@@ -13,7 +13,7 @@ lab:
 ---
 > **Complexity**: `[MEDIUM]` - Essential cluster management
 >
-> **Time to Complete**: 35-45 minutes
+> **Time to Complete**: 60-75 minutes
 >
 > **Prerequisites**: Module 1.1 (Control Plane), Module 1.2 (Extension Interfaces)
 
@@ -22,49 +22,32 @@ lab:
 ## What You'll Be Able to Do
 
 After this module, you will be able to:
-- **Upgrade** a kubeadm cluster safely (control plane first, then workers, one at a time)
-- **Backup** and restore etcd snapshots for disaster recovery
-- **Manage** kubeadm certificates (check expiry, renew, rotate)
-- **Troubleshoot** kubeadm upgrade failures by reading component logs and checking version compatibility
+- **Design** a kubeadm bootstrap sequence that covers preflight checks, `kubeadm init`, CNI installation, and worker join tokens.
+- **Diagnose** static pod and kubelet failures by using local logs, manifests, and container runtime tools when the API server is unavailable.
+- **Evaluate** certificate and etcd maintenance risk by checking expiry, planning renewal, and protecting snapshots before disruptive work.
+- **Implement** safe node maintenance with cordon, drain, uncordon, and kubeadm reset workflows.
 
 ---
 
 ## Why This Module Matters
 
-kubeadm is the official tool for creating Kubernetes clusters. The CKA exam environment uses kubeadm-based clusters, and you'll need to understand how they work.
+Hypothetical scenario: you inherit a small kubeadm cluster that runs an internal platform team service, and the control plane is healthy until a routine node reboot exposes a forgotten bootstrap detail. New pods stop receiving IP addresses, a replacement worker cannot join, and `kubectl` works from one administrator laptop but not from another. Nothing about the incident requires exotic Kubernetes knowledge, yet the cluster remains stuck because the team only knows managed-cluster abstractions and has never looked at `/etc/kubernetes`, kubelet static pod manifests, bootstrap tokens, or the certificates kubeadm creates during initialization.
 
-While the 2025 curriculum **deprioritizes cluster upgrades**, you still need to know:
-- How clusters are bootstrapped
-- How to join nodes
-- Where control plane components live
-- Basic cluster maintenance tasks
+kubeadm matters because it is deliberately close to the machinery. Managed services hide most of this machinery until something underneath them leaks, but the CKA exam expects you to reason from first principles when a node will not join, a static pod keeps returning after deletion, a certificate is close to expiry, or a drained node remains unschedulable after maintenance. The point of this module is not to memorize every kubeadm subcommand. The point is to connect each file, certificate, token, and node operation to the control-plane behavior you already studied in earlier modules.
 
-Understanding kubeadm helps you troubleshoot cluster issues and understand what's happening under the hood.
+Think of kubeadm like a construction foreman with blueprints. When you run `kubeadm init`, it does not become the building, and it does not keep managing every brick after the cluster exists. It lays the foundation by generating certificates and kubeconfigs, places the control plane into static pod manifests, asks kubelet to keep those pods running, and prints a join instruction for future workers. Once that foundation exists, your operational job changes from "run the installer" to "protect the files and processes that installer created."
 
-> **The Construction Blueprint Analogy**
->
-> Think of kubeadm like a construction foreman with blueprints. When you say "init," it follows the blueprints to build the control plane—laying the foundation (certificates), erecting the framework (static pods), and connecting utilities (networking). When workers (nodes) arrive, it gives them instructions to join the team. The foreman doesn't build the house alone; it orchestrates the process.
+This module rewrites the old quick reference into a working mental model. You will first map the bootstrap sequence, then practice the commands that initialize a control plane, install networking, join nodes, inspect static pods, protect certificates and etcd data, and perform node maintenance. By the end, a kubeadm cluster should feel less like a magic script and more like a set of inspectable contracts between kubeadm, kubelet, the container runtime, the API server, and the files on disk.
 
 ---
 
-## What You'll Learn
+## Bootstrap Anatomy: What kubeadm Builds
 
-By the end of this module, you'll be able to:
-- Understand what kubeadm does during cluster creation
-- Bootstrap a control plane node
-- Join worker nodes to a cluster
-- Understand static pods and manifests
-- Perform basic node management
+kubeadm is best understood as a bootstrap coordinator rather than a full cluster lifecycle platform. It validates the host, writes certificate material, creates kubeconfig files, renders static pod manifests, and arranges enough cluster add-ons for the API server to become usable. It does not install your container runtime, decide your cloud load balancer design, pick your CNI plugin, or keep editing your operating system after the cluster is initialized. That boundary is useful because it keeps kubeadm predictable, but it also means a broken prerequisite remains your responsibility.
 
----
+The first practical lesson is that kubeadm creates a Kubernetes control plane by asking kubelet to run static pods. That design feels indirect at first: instead of starting `kube-apiserver` with systemd, kubeadm writes a YAML file into a watched directory, and kubelet starts the container from that manifest. This is why a kubeadm control plane can recover its API server container even when the API server itself is temporarily unavailable. The local kubelet is the supervisor for the control-plane containers, so file-level diagnosis remains possible when API-level diagnosis is not.
 
-## Part 1: kubeadm Overview
-
-### 1.1 What kubeadm Does
-
-kubeadm automates cluster setup:
-
-```
+```text
 ┌────────────────────────────────────────────────────────────────┐
 │                    kubeadm init Process                         │
 │                                                                 │
@@ -95,17 +78,11 @@ kubeadm automates cluster setup:
 └────────────────────────────────────────────────────────────────┘
 ```
 
-### 1.2 What kubeadm Does NOT Do
+The sequence above gives you a reliable troubleshooting order. If `kubeadm init` fails before certificates are written, you look at preflight checks, swap, host identity, ports, and the container runtime. If certificates and kubeconfigs exist but the API server is unavailable, you inspect kubelet logs and static pod containers. If the API server is reachable but CoreDNS is pending, you check whether a CNI plugin was installed and whether its pod CIDR matches the cluster configuration. Each failure point narrows the search space because kubeadm leaves visible artifacts behind.
 
-- **Install container runtime** (containerd) - you do this first
-- **Install kubelet/kubectl** - you install these first
-- **Install CNI plugin** - you apply this after init
-- **Configure load balancers** - that's your infrastructure
-- **Set up HA** - requires additional configuration
+kubeadm also has deliberate non-goals, and those non-goals are exam-relevant. It does not install containerd, kubelet, kubeadm, or kubectl for you. It does not install a CNI plugin during `init`, because CNI choice depends on the networking model you want. It does not build an external load balancer for an HA control plane, because that belongs to your infrastructure layer. It can help add extra control-plane nodes, but a production HA design still needs a stable endpoint in front of the API servers.
 
-### 1.3 Prerequisites
-
-Before running kubeadm:
+Before running kubeadm on a fresh host, treat prerequisites as part of the bootstrap plan rather than as a footnote. A missing container runtime socket, enabled swap, duplicate host identity, or blocked API server port causes failures that look like "Kubernetes is broken" when the real problem is the node preparation contract. Pause and predict: if kubelet is installed but the container runtime is stopped, which step in the diagram can still complete, and which step must fail when kubelet tries to start static pod containers?
 
 ```bash
 # Required on ALL nodes:
@@ -118,11 +95,17 @@ Before running kubeadm:
 # 7. Unique hostname, MAC, product_uuid
 ```
 
+The kubeadm phase model is useful when a failure lands in the middle of initialization. `kubeadm init` is not one opaque action; it is a sequence of phases that can be inspected, skipped, or rerun in controlled ways by experienced operators. For CKA work you rarely need custom phase execution, but knowing the phases exist helps you read error output. A failure during certificate generation, kubeconfig generation, static pod rendering, or add-on installation has a different repair path than a failure during host preflight checks.
+
+You can see this design in the command output as kubeadm reports each major step. That output is evidence, so keep it when a lab or real cluster fails. If the preflight phase complains about swap, fix swap. If static pod manifest generation succeeds but the API server never becomes reachable, move down the stack to kubelet and the runtime. The discipline is similar to reading a compiler error: the first meaningful failure usually gives you a better lead than the cascade of later symptoms.
+
+On the CKA exam, kubeadm questions are usually less about building a production cluster from an empty VM and more about recognizing where kubeadm placed the moving parts. Still, the bootstrap model pays off outside the exam as well. If you know that certificates live under `/etc/kubernetes/pki`, that control-plane pod manifests live under `/etc/kubernetes/manifests`, and that the kubelet is the local supervisor, you can diagnose failures even when the cluster API is temporarily unreachable.
+
 ---
 
-## Part 2: Initializing a Cluster
+## Initialize the Control Plane and Install Networking
 
-### 2.1 Basic kubeadm init
+The `kubeadm init` command starts the control plane, but the flags you choose encode assumptions that will keep affecting the cluster. A pod network CIDR must match the CNI plugin you plan to install. An API server advertise address must be reachable by the nodes that will join. A Kubernetes version pin controls the control-plane image versions and should line up with the packages you installed on the host. These are not decorative flags; they are the first durable decisions in the cluster.
 
 ```bash
 # Initialize control plane
@@ -138,9 +121,32 @@ sudo kubeadm init --apiserver-advertise-address=192.168.1.10
 sudo kubeadm init --kubernetes-version=v1.35.0
 ```
 
-> **Pause and predict**: After running `kubeadm init`, you immediately try `kubectl get nodes` as a regular user and it fails. Why can't you use kubectl yet, even though the cluster is initialized?
+The simplest command is useful in a lab, but real troubleshooting often begins with the more explicit variants. If a node joins but pods cannot communicate, the pod CIDR and CNI configuration are early suspects. If a worker receives a join command containing an address it cannot route to, the advertise address or control-plane endpoint choice is suspect. If packages and control-plane images are from different minor versions, version-skew rules matter before you assume the network is at fault.
 
-### 2.2 After init - Setup kubectl Access
+For repeatable clusters, a kubeadm configuration file is safer than a long command line copied from a notes page. The file records cluster settings such as the Kubernetes version, pod subnet, service subnet, image repository, API server endpoint, and certificate subject alternative names in one reviewable artifact. That matters in teams because another operator can inspect the intended bootstrap values before the command runs. It also matters during rebuilds because the second control plane should not be initialized from someone's memory of the first one.
+
+```bash
+# Generate a starting point for a reviewed kubeadm configuration
+kubeadm config print init-defaults
+```
+
+```yaml
+apiVersion: kubeadm.k8s.io/v1beta4
+kind: ClusterConfiguration
+kubernetesVersion: v1.35.0
+controlPlaneEndpoint: "192.168.1.10:6443"
+networking:
+  podSubnet: 10.244.0.0/16
+```
+
+When you use a configuration file, the command becomes simpler and the review becomes clearer. You can compare the chosen pod subnet to the CNI documentation, confirm the control-plane endpoint before workers join, and keep the file in an internal runbook without storing bootstrap tokens. The file does not eliminate the need to prepare hosts, but it reduces the chance that a critical bootstrap choice is hidden in a shell history entry.
+
+```bash
+# Initialize from a reviewed configuration file
+sudo kubeadm init --config kubeadm-config.yaml
+```
+
+After initialization, kubeadm writes an admin kubeconfig, but it does not copy that file into every user's home directory. This is why a freshly initialized cluster can exist while `kubectl get nodes` fails for a normal shell user. The API server may be running, but `kubectl` still needs credentials and cluster connection data. Before running this, what output do you expect from `kubectl get nodes` before the kubeconfig copy, and what changes after `$HOME/.kube/config` points at `admin.conf`?
 
 ```bash
 # For regular user (recommended)
@@ -152,7 +158,7 @@ sudo chown $(id -u):$(id -g) $HOME/.kube/config
 export KUBECONFIG=/etc/kubernetes/admin.conf
 ```
 
-### 2.3 Install CNI Plugin
+The next step is CNI installation. Without a CNI plugin, kubelet can run the static control-plane pods, but ordinary pods cannot receive routable pod IPs, and CoreDNS commonly remains pending or not ready. That distinction is important: a kubeadm cluster can look partially alive before networking is installed. The API server may answer requests, yet workloads remain unable to communicate because the networking layer has not fulfilled its part of the cluster contract.
 
 ```bash
 # Without CNI, pods won't get IPs and CoreDNS won't start
@@ -167,7 +173,7 @@ kubectl apply -f https://raw.githubusercontent.com/flannel-io/flannel/master/Doc
 cilium install
 ```
 
-### 2.4 Verify Cluster
+Those CNI examples are lab-oriented examples, not a recommendation to pin production networking to an old manifest URL without reading the vendor's current installation guide. The protected lesson is the sequence: initialize the control plane, configure `kubectl`, install one CNI that matches the pod network choice, and then verify system pods. Mixing multiple CNIs because "more networking should help" creates conflicting agents that fight over pod networking and makes diagnosis harder.
 
 ```bash
 # Check nodes
@@ -181,17 +187,22 @@ kubectl get pods -n kube-system
 #             kube-proxy, kube-scheduler, CNI pods
 ```
 
-> **Did You Know?**
->
-> The `kubeadm init` output includes a `kubeadm join` command with a token. This token expires in 24 hours by default. Save it, or you'll need to generate a new one.
+Verification should be interpreted rather than treated as a pass-or-fail ritual. A single control-plane node can report `Ready` while CoreDNS is still starting, and a newly installed CNI may need a short window to create its DaemonSet pods. The pattern you want is convergence: the node becomes ready, kube-system pods stop crash-looping, CoreDNS gains running replicas, and the CNI pods land on the nodes that need pod networking. If the cluster stalls, map the symptom back to the bootstrap sequence instead of rerunning `kubeadm init` blindly.
+
+A useful worked example is a control-plane host where `kubeadm init --pod-network-cidr=10.244.0.0/16` succeeds, `kubectl get nodes` works after copying the kubeconfig, but CoreDNS remains pending. The next command is not `kubeadm reset`; it is `kubectl get pods -n kube-system -o wide` to see whether a CNI DaemonSet exists and where pods are scheduled. If no CNI pods exist, install the intended CNI. If CNI pods exist but are crash-looping, inspect their logs and verify that the pod CIDR and kernel/network prerequisites match the plugin.
+
+kubeadm also stores cluster configuration in the cluster after initialization, which gives you another way to inspect what was intended. The `kubeadm-config` ConfigMap in `kube-system` records settings that future kubeadm operations, especially upgrades, can consult. This is not a replacement for your runbook, because a broken API server can make the ConfigMap unreachable, but it is valuable when the cluster is healthy enough for API inspection. If the stored configuration and your assumptions disagree, trust the evidence and update the runbook.
+
+```bash
+# Inspect kubeadm's stored cluster configuration
+kubectl -n kube-system get configmap kubeadm-config -o yaml
+```
 
 ---
 
-## Part 3: Joining Worker Nodes
+## Join Nodes and Protect Bootstrap Trust
 
-### 3.1 The Join Command
-
-After `kubeadm init`, you get a join command:
+Worker joins are easy to copy and easy to misunderstand. The join command contains a bootstrap token that authenticates the new node for its initial registration, and it contains a CA certificate hash that lets the node verify it is talking to the intended control plane. The token answers "am I allowed to start joining?" while the CA hash answers "am I joining the right cluster?" Both pieces matter because node bootstrap happens before the node has its long-lived kubelet client certificate.
 
 ```bash
 # Example output from kubeadm init
@@ -199,7 +210,7 @@ kubeadm join 192.168.1.10:6443 --token abcdef.0123456789abcdef \
   --discovery-token-ca-cert-hash sha256:abc123...
 ```
 
-Run this on worker nodes:
+Run the join command on a worker node after the runtime, kubelet, and kubeadm are installed there. The worker needs network reachability to the API server endpoint, matching time sufficiently for certificate validation, a working container runtime, and a token that has not expired. A failed join is often a local node preparation problem, not a control-plane problem, so the first logs to read are usually on the joining worker.
 
 ```bash
 # On worker node (as root)
@@ -208,9 +219,7 @@ sudo kubeadm join 192.168.1.10:6443 \
   --discovery-token-ca-cert-hash sha256:abc123...
 ```
 
-### 3.2 Regenerating Join Tokens
-
-If the token expired:
+Bootstrap tokens expire by default, and that is a feature rather than an inconvenience. A join command pasted into a ticket, chat thread, or shell history should not authorize new nodes forever. The operational habit is to generate a fresh command when needed, use it during a controlled maintenance window, and delete or allow old tokens to expire. Which approach would you choose here and why: a long-lived token for convenience, or short-lived tokens generated as part of each node-addition runbook?
 
 ```bash
 # On control plane - create new token
@@ -230,7 +239,7 @@ kubeadm join <control-plane-ip>:6443 --token <new-token> \
   --discovery-token-ca-cert-hash sha256:<hash>
 ```
 
-### 3.3 List and Manage Tokens
+The manual flow is worth learning even if `--print-join-command` is faster, because it exposes the trust model. The hash is derived from the cluster CA public key, not from the short-lived token. If the token expires, you create a new token; if the CA hash is wrong, the node should refuse to trust the endpoint. When a worker cannot join, reading the exact error matters because "token invalid", "x509", "connection refused", and "timed out" point to different layers.
 
 ```bash
 # List existing tokens
@@ -243,13 +252,15 @@ kubeadm token delete <token>
 kubeadm token create --ttl 2h
 ```
 
+Treat token management as part of cluster hygiene. In a tiny lab cluster, expired tokens are mostly a speed bump. In a shared environment, forgotten bootstrap tokens become confusing operational state and may widen the window during which an unintended host can attempt to register. The fix is not elaborate: list tokens before a join, create a token with a sensible TTL, document which node used it, and remove tokens that are no longer needed.
+
+Exercise scenario: a worker was provisioned from the same image as an existing node, but `kubeadm join` fails with an error about the node already existing. That is a signal to check host identity and old kubelet state before blaming the token. A cloned VM can carry stale `/var/lib/kubelet` data, duplicate machine identity, or a hostname that conflicts with an existing node object. Reset and clean the node, fix the hostname, and rerun join with a fresh command rather than forcing the API server to accept ambiguous identity.
+
 ---
 
-## Part 4: Understanding Static Pods
+## Static Pods, Files, Certificates, and etcd
 
-### 4.1 What Are Static Pods?
-
-Static pods are managed directly by kubelet, not the API server. Control plane components run as static pods in kubeadm clusters.
+Static pods are the key to kubeadm control-plane diagnosis. A normal Deployment is reconciled by controllers through the API server; a static pod is read directly from a file by kubelet. kubeadm uses static pods for `kube-apiserver`, `kube-controller-manager`, `kube-scheduler`, and local etcd because those components must exist before higher-level controllers can manage anything. This is the bootstrap loop: kubelet starts the API server, and only then can the API server expose mirror pods that make the static pods visible through `kubectl`.
 
 ```bash
 # Static pod manifests location
@@ -260,11 +271,9 @@ ls /etc/kubernetes/manifests/
 # kube-scheduler.yaml
 ```
 
-> **What would happen if**: You run `kubectl delete pod kube-apiserver-controlplane -n kube-system`. Does the API server go down? Does the pod come back? Who recreates it — the Deployment controller, the ReplicaSet controller, or something else entirely?
+The API server shows mirror pods for visibility, but it does not own the source of truth for static pods. If you delete the mirror pod with `kubectl`, kubelet notices that the manifest file still exists and recreates the container and mirror representation. That behavior is surprising only if you assume every pod seen through the API is controlled through the API. Pause and predict: if you run `kubectl delete pod kube-apiserver-controlplane -n kube-system`, who recreates it, and what file decides the answer?
 
-### 4.2 How Static Pods Work
-
-```
+```text
 ┌────────────────────────────────────────────────────────────────┐
 │                    Static Pod Lifecycle                         │
 │                                                                 │
@@ -293,7 +302,7 @@ ls /etc/kubernetes/manifests/
 └────────────────────────────────────────────────────────────────┘
 ```
 
-### 4.3 Working with Static Pods
+Editing static pod manifests is powerful and risky because kubelet applies the result automatically. A valid edit restarts the component with the new flags; an invalid edit can stop the API server, scheduler, controller manager, or etcd. The safest habit is to make a timestamped copy, change one thing, keep a root shell open on the control-plane node, and use local logs if the API disappears. For exam practice, the key distinction is simple: `kubectl` can show a static pod, but the manifest file controls it.
 
 ```bash
 # View static pod manifests
@@ -312,17 +321,9 @@ sudo mv /tmp/kube-scheduler.yaml /etc/kubernetes/manifests/
 # kubelet starts the pod again
 ```
 
-> **Gotcha: kubectl delete Won't Work**
->
-> You can't delete static pods with `kubectl delete pod`. They're recreated immediately because kubelet manages them. To stop a static pod, remove or rename its manifest file.
+The directory layout is the map you use when API-level tools stop working. `/etc/kubernetes/admin.conf` is the administrative kubeconfig. `/etc/kubernetes/manifests` holds static pod definitions. `/etc/kubernetes/pki` holds the cluster CA, API server certificates, service account signing keys, front-proxy material, and etcd certificates. When you know these paths, "control plane down" stops being a vague panic and becomes a file-and-process investigation.
 
----
-
-## Part 5: Cluster Directory Structure
-
-### 5.1 Key Directories
-
-```
+```text
 /etc/kubernetes/
 ├── admin.conf               # kubectl config for admin
 ├── controller-manager.conf  # kubeconfig for controller-manager
@@ -347,7 +348,11 @@ sudo mv /tmp/kube-scheduler.yaml /etc/kubernetes/manifests/
         └── ...
 ```
 
-### 5.2 Certificate Locations
+The kubeconfig files in this directory are also worth naming carefully. `admin.conf` is for cluster administration, while `kubelet.conf`, `controller-manager.conf`, and `scheduler.conf` are client credentials for components that talk to the API server. If an administrator copies the wrong file into `$HOME/.kube/config`, the resulting authorization behavior may be confusing. If a component kubeconfig is stale or unreadable, the component may start but fail to authenticate to the API server, so certificate and kubeconfig diagnosis often happen together.
+
+File permissions are part of the security model, not just a Linux housekeeping detail. The CA private key, service account signing key, and etcd private keys can authorize or sign highly sensitive cluster behavior. A good backup captures what is needed for recovery, but a careless copy into a shared directory creates a different incident. When you inspect these files, use the minimum necessary access, keep copies protected, and remove temporary diagnostic copies after the maintenance window.
+
+Certificate management is where kubeadm's convenience and your responsibility meet. kubeadm can check certificate expiration and renew certificates it manages, but renewed files do not matter until the affected components reload them. Static pod components usually reload by being restarted, which can be done by moving manifests out and back, letting kubelet recreate containers, or by restarting kubelet in a planned maintenance window. You should also know which kubeconfig files need to be recopied after admin credentials are renewed.
 
 ```bash
 # Cluster CA
@@ -366,11 +371,50 @@ sudo mv /tmp/kube-scheduler.yaml /etc/kubernetes/manifests/
 kubeadm certs check-expiration
 ```
 
+etcd deserves separate attention because it stores cluster state. Backing up etcd before disruptive control-plane maintenance is not optional in a serious environment, even when the exam only asks you to demonstrate the mechanics. A snapshot command must use the etcd endpoint and the correct client certificates, and a restore must be planned carefully because it replaces the state the API server will read. A backup you have never validated is closer to a hope than a recovery plan.
+
+```bash
+# Save an etcd snapshot on a stacked-control-plane kubeadm node
+sudo ETCDCTL_API=3 etcdctl \
+  --endpoints=https://127.0.0.1:2379 \
+  --cacert=/etc/kubernetes/pki/etcd/ca.crt \
+  --cert=/etc/kubernetes/pki/etcd/server.crt \
+  --key=/etc/kubernetes/pki/etcd/server.key \
+  snapshot save /var/backups/etcd-snapshot.db
+
+# Inspect the snapshot before trusting it
+sudo ETCDCTL_API=3 etcdctl snapshot status /var/backups/etcd-snapshot.db --write-out=table
+```
+
+Restoring etcd is a disruptive recovery action, not a casual maintenance command. In a single-node stacked etcd lab, the restore pattern is to stop the control plane, restore the snapshot to a new data directory, update the etcd static pod manifest to point at that directory if needed, and then let kubelet restart etcd and the API server. In a multi-member etcd topology, the procedure must respect quorum and member identity, so do not generalize a single-node lab recipe into a production runbook.
+
+```bash
+# Example lab restore target; plan production restores from the official etcd guidance
+sudo ETCDCTL_API=3 etcdctl snapshot restore /var/backups/etcd-snapshot.db \
+  --data-dir=/var/lib/etcd-from-backup
+```
+
+Upgrades fit into the same risk model. kubeadm can plan and apply a control-plane upgrade, but you still drain nodes, respect version skew, upgrade kubelet and kubectl packages, and verify each step before moving on. The safe order is control plane first, then workers one at a time, with a rollback and backup plan that exists before you touch the first component. For CKA purposes, know the shape of the workflow and the commands you use to inspect the plan.
+
+```bash
+# Control plane planning step
+sudo kubeadm upgrade plan
+
+# Example control plane apply step for a patch release in the same minor line
+sudo kubeadm upgrade apply v1.35.1
+
+# Restart kubelet after package changes on the upgraded node
+sudo systemctl daemon-reload
+sudo systemctl restart kubelet
+```
+
+The important connection is that certificates, etcd snapshots, static pod manifests, and upgrades are not separate topics. They are all maintenance operations around the same set of kubeadm-created assets. If you can read the file layout and explain which local process consumes each file, you can reason about renewal, restore, restart, and upgrade behavior without relying on a memorized script.
+
 ---
 
-## Part 6: Node Management
+## Node Maintenance, Reset, and Recovery
 
-### 6.1 Viewing Nodes
+Node maintenance starts with scheduling intent. Cordon says "do not place new pods here"; drain says "evict the pods that can safely move away." That difference matters because a cordoned node can still be running existing workloads, and a reboot can still interrupt them. Drain uses the eviction API for managed pods, respects many availability controls, and leaves DaemonSet pods alone unless you use additional flags. The right command depends on whether you are preventing future placement or preparing for disruptive work.
 
 ```bash
 # List nodes
@@ -383,11 +427,7 @@ kubectl get nodes -o wide
 kubectl describe node <node-name>
 ```
 
-> **Stop and think**: What's the difference between `kubectl cordon` and `kubectl drain`? If you only cordon a node before maintenance, what risk remains that drain would have handled?
-
-### 6.2 Draining a Node
-
-Before maintenance, drain the node to safely evict pods:
+Good node diagnosis starts by separating desired scheduling state from health state. A node can be `Ready,SchedulingDisabled`, which means kubelet is healthy but the scheduler is not allowed to place new pods there. A node can be `NotReady`, which means the control plane has not received healthy status from kubelet or related components. Those states imply different next moves. Stop and think: if you only cordon a node before kernel maintenance, what risk remains that drain would have handled?
 
 ```bash
 # Drain node (evict pods, mark unschedulable)
@@ -400,7 +440,7 @@ kubectl drain <node-name> --ignore-daemonsets --delete-emptydir-data
 kubectl drain <node-name> --ignore-daemonsets --force
 ```
 
-### 6.3 Cordoning and Uncordoning
+Drain flags should make you pause because each one encodes a tradeoff. `--ignore-daemonsets` is normal because DaemonSet pods are expected to live on the node and cannot be drained in the same way as Deployment pods. `--delete-emptydir-data` acknowledges that data in `emptyDir` volumes is node-local and will be removed with the pod. `--force` is a stronger statement: you are willing to remove pods that do not have a controller to recreate them. Use it deliberately, not as muscle memory.
 
 ```bash
 # Mark node unschedulable (no new pods)
@@ -416,7 +456,7 @@ kubectl get nodes
 # node2   Ready,SchedulingDisabled   worker   10d   v1.35.0  # cordoned
 ```
 
-### 6.4 Removing a Node
+Recovery after maintenance is not finished when the node reboots. You verify that kubelet is running, the node returns to `Ready`, critical DaemonSets are healthy, and the node is uncordoned if it should receive workloads. A common operational miss is to perform the maintenance correctly and then leave the node cordoned for days. The cluster keeps working, but capacity is lower, autoscaling signals become confusing, and future drains have less room to move pods.
 
 ```bash
 # 1. Drain the node first
@@ -434,18 +474,7 @@ sudo rm -rf /var/lib/kubelet/
 sudo rm -rf /var/lib/etcd/
 ```
 
----
-
-## Part 7: kubeadm reset
-
-### 7.1 When to Use Reset
-
-Use `kubeadm reset` to:
-- Remove a node from the cluster
-- Start fresh after failed init
-- Completely tear down a cluster
-
-### 7.2 Reset Process
+Removing a node is more final than draining it. Deleting the Node object tells the cluster to stop tracking that host, while `kubeadm reset` cleans local kubeadm state on the host. The cleanup commands are intentionally destructive, so they belong in a lab, a decommissioning runbook, or a controlled rebuild, not in a casual troubleshooting loop. If you only need to restart kubelet or fix a CNI config file, resetting the node throws away useful evidence and creates extra work.
 
 ```bash
 # On the node to reset
@@ -464,11 +493,13 @@ sudo rm -rf $HOME/.kube/config
 sudo iptables -F && sudo iptables -t nat -F
 ```
 
+Reset also has an exam trap: it does not magically erase every possible networking or runtime artifact in every environment. CNI configuration files, iptables rules, IPVS state, container images, and runtime data may need separate cleanup depending on how the node was prepared. That is why the kubeadm reset output tells you what it did and what you may still need to clean. Read the output instead of assuming reset means "factory new."
+
 ---
 
-## Part 8: Common Troubleshooting
+## Troubleshooting Without a Working API Server
 
-### 8.1 kubelet Not Starting
+The fastest kubeadm troubleshooting habit is to choose the tool that still works at the failed layer. If the API server is healthy, `kubectl` is convenient and expressive. If the API server is down, `kubectl` may hang, but kubelet logs, systemd status, container runtime tools, and static pod manifests are still available on the node. If kubelet itself is stopped, even static pod recovery depends on fixing the local service first. This layered approach prevents the common mistake of repeatedly running an API client against a dead API.
 
 ```bash
 # Check kubelet status
@@ -483,7 +514,9 @@ journalctl -u kubelet -f
 # - Wrong container runtime socket
 ```
 
-### 8.2 Control Plane Not Starting
+When you collect evidence, capture both the command and the node where you ran it. A kubelet log from a worker that cannot join tells a different story than a kubelet log from the control-plane node that cannot start the API server. Likewise, a `crictl ps` result from the wrong host can send you chasing missing containers that were never supposed to run there. Labeling evidence by node name, role, and time keeps a small incident from becoming a pile of disconnected snippets.
+
+When kubelet is not starting, the investigation is local and mechanical. Check whether the service is enabled and running, whether its configuration file references a valid container runtime endpoint, and whether the runtime itself can start containers. Kubelet log messages usually name the missing socket, invalid flag, cgroup mismatch, or certificate issue. Do not start by deleting cluster objects; the node agent must be healthy before the control plane can receive useful status.
 
 ```bash
 # Check container runtime
@@ -496,7 +529,7 @@ crictl logs <container-id>
 sudo cat /var/log/pods/kube-system_kube-apiserver-*/kube-apiserver/*.log
 ```
 
-### 8.3 Node Not Joining
+When the control plane is not starting, the local container runtime becomes your window into the failure. `crictl ps` tells you whether static pod containers exist, whether they are restarting, and which container ID to inspect. Container logs can reveal an invalid API server flag, an unreadable certificate, an etcd connection failure, or a YAML syntax error in a manifest. If the API server is unavailable, the fix often happens in `/etc/kubernetes/manifests` rather than through `kubectl`.
 
 ```bash
 # On the node, check logs
@@ -509,7 +542,7 @@ journalctl -u kubelet | tail -50
 # - Firewall blocking port 6443
 ```
 
-### 8.4 Certificates Expired
+Node join failures require you to decide whether the worker cannot reach the API server, cannot trust it, or cannot complete local bootstrap. A timeout points toward routing, firewall, endpoint, or API server availability. A CA hash or x509 error points toward trust material. A kubelet or runtime error points back to node preparation. Those categories are more useful than memorizing one "node not joining" fix because the same symptom at the dashboard level can come from several different layers.
 
 ```bash
 # Check expiration
@@ -522,11 +555,9 @@ kubeadm certs renew all
 # (just move manifests and wait)
 ```
 
----
+Certificate failures are especially easy to misread because they often surface as generic connection errors. The renewal command writes new certificate files, but running it is not the same thing as proving the control plane has reloaded them. Check expiration before and after, restart or cycle the relevant static pods, and verify client kubeconfigs where necessary. If etcd certificates are involved, be careful to distinguish API server serving certificates from etcd peer and client certificates because they are consumed by different processes.
 
-## Part 9: Exam-Relevant Commands
-
-### 9.1 Quick Reference
+The exam-relevant command set is short enough to practice until it becomes fluent, but fluency should include context. `kubeadm token create --print-join-command` is for bootstrap trust, not for fixing a broken CNI. `kubectl drain` is for moving workloads before maintenance, not for removing the node's local kubeadm state. `kubeadm reset` is for teardown or rebuild, not for every kubelet warning. Use the command that matches the failed contract.
 
 ```bash
 # Initialize cluster
@@ -551,84 +582,194 @@ kubectl uncordon <node>
 kubeadm reset
 ```
 
+Worked example: an administrator edits `/etc/kubernetes/manifests/kube-apiserver.yaml` to add an admission flag but leaves a YAML indentation error. `kubectl get nodes` now returns connection refused, which is expected because the API server container cannot start. The recovery path is to SSH to the control-plane node, inspect `journalctl -u kubelet`, inspect the failed API server container logs through `crictl`, fix the manifest with a local editor, and wait for kubelet to recreate the static pod. The lesson is concrete: when the API server is the broken component, local node tools replace API tools until the static pod is healthy again.
+
+Another useful scenario is a worker that reports `NotReady` after a reboot even though the control plane is healthy. Start with `kubectl describe node` if the API is reachable, then move to the worker and inspect kubelet, the container runtime, CNI configuration, and recent logs. If kubelet cannot authenticate, compare `/etc/kubernetes/kubelet.conf` and certificates; if pods cannot create sandboxes, inspect the CNI files and runtime errors. The node object gives you the symptom, but the worker's local evidence usually gives you the cause.
+
+---
+
+## Patterns & Anti-Patterns
+
+The patterns below are not generic "best practices"; they are decision habits that keep kubeadm operations reversible and diagnosable. A kubeadm cluster is transparent enough that you can inspect nearly every important artifact, but that transparency only helps if you make one change at a time and preserve evidence before destructive actions. In small labs, skipping that discipline costs minutes. In a shared cluster, it can turn an ordinary maintenance task into a recovery exercise.
+
+| Pattern | When to Use It | Why It Works | Scaling Consideration |
+|---------|----------------|--------------|-----------------------|
+| Bootstrap with explicit inputs | Use when initializing or rebuilding a control plane | Pod CIDR, advertise address, and version pins make later symptoms easier to explain | Store the chosen values in a runbook or kubeadm config file for repeatability |
+| Diagnose from the surviving layer | Use when `kubectl` hangs or the API server is unavailable | kubelet, systemd, crictl, and manifest files remain available locally | Train operators to SSH to the right node and collect local logs before resetting |
+| Protect state before disruption | Use before upgrades, certificate rotations, or static pod edits | etcd snapshots and copied manifests provide rollback evidence | Automate backup validation and keep restore procedures separate for single-node and HA etcd |
+| Drain before host maintenance | Use before rebooting, patching, or removing a node | Workloads move through the Kubernetes eviction path instead of dying abruptly | Capacity and PodDisruptionBudgets determine whether drain can complete quickly |
+
+The matching anti-patterns are tempting because they appear faster in the moment. Rerunning `kubeadm init` feels decisive, forcing a drain seems to clear a blocker, and deleting a static pod through `kubectl` looks natural because the pod is visible through the API. Each shortcut ignores ownership. kubeadm owns bootstrap artifacts, kubelet owns static pod execution, the scheduler owns new placement, controllers own replacement pods, and etcd owns cluster state.
+
+| Anti-Pattern | What Goes Wrong | Better Alternative |
+|--------------|-----------------|--------------------|
+| Rerunning `kubeadm init` on a half-working control plane | You risk overwriting evidence and creating conflicting local state | Read kubelet logs, static pod logs, and kubeadm output to identify the failed phase |
+| Treating `kubectl delete pod` as static pod removal | kubelet recreates the mirror pod because the manifest still exists | Move, edit, or restore the manifest in `/etc/kubernetes/manifests/` |
+| Keeping long-lived join tokens for convenience | Old tokens make node admission state harder to reason about | Generate short-lived tokens and delete unused ones after the join window |
+| Using `kubeadm reset` as a first troubleshooting step | You remove local state before understanding the failure | Reset only for teardown, rebuild, or a documented rejoin procedure |
+
+The scaling point is that kubeadm does not remove the need for operational design. A single-node lab can tolerate manual commands and brief outages, while a production-like cluster needs external API endpoints, tested backups, planned upgrade waves, and enough spare capacity for drains. The command names stay the same, but the risk surrounding each command changes with cluster size, workload criticality, and recovery requirements.
+
+---
+
+## Decision Framework
+
+Use the framework below when you face a kubeadm cluster symptom and need to choose the next action. The goal is to avoid jumping straight to the most dramatic command. Start by identifying which layer is still trustworthy, then pick the least destructive action that can prove or repair the suspected contract. This is the same mental move you practiced in earlier architecture modules: locate ownership before applying a fix.
+
+```text
+Symptom observed
+      |
+      v
+Can kubectl reach the API server?
+      |
+      +-- yes --> Is this a scheduling or workload-placement issue?
+      |              |
+      |              +-- yes --> inspect nodes, cordon/drain/uncordon, events
+      |              |
+      |              +-- no  --> inspect kube-system pods, CNI, certificates, joins
+      |
+      +-- no  --> Can you SSH to the affected control-plane node?
+                     |
+                     +-- yes --> inspect kubelet, crictl, static pod manifests, local logs
+                     |
+                     +-- no  --> fix host/network access before Kubernetes diagnosis
+```
+
+| Situation | First Check | Likely Command Family | Avoid Until You Know More |
+|-----------|-------------|-----------------------|---------------------------|
+| Fresh cluster has `NotReady` node and pending CoreDNS | CNI pods and pod CIDR | `kubectl get pods -n kube-system`, CNI install command | `kubeadm reset` |
+| Worker join fails immediately | Token, CA hash, API reachability, kubelet logs | `kubeadm token create --print-join-command`, `journalctl -u kubelet` | Reinitializing the control plane |
+| API server unavailable after manifest edit | kubelet and static pod logs | `journalctl`, `crictl logs`, edit manifest | `kubectl delete pod` |
+| Planned node reboot | Workload controllers and disruption policy | `kubectl cordon`, `kubectl drain`, `kubectl uncordon` | Power cycling without drain |
+| Certificates near expiry | `kubeadm certs check-expiration` output | `kubeadm certs renew`, static pod restart | Assuming renewal reloads every process automatically |
+| Disruptive control-plane maintenance | Recent etcd snapshot and restore plan | `etcdctl snapshot save`, `kubeadm upgrade plan` | Upgrading without state protection |
+
+Two rules keep this framework practical. First, do not use a cluster-level command to fix a node-local prerequisite until the node-local evidence says Kubernetes is ready for that command. Second, do not use a destructive local command to fix a cluster-level scheduling condition until you have checked the API view. That separation is what prevents a simple cordon oversight from turning into a reset, and it prevents a dead API server from wasting your time with repeated `kubectl` calls.
+
 ---
 
 ## Did You Know?
 
-- **kubeadm doesn't manage kubelet**. kubelet runs as a systemd service. kubeadm generates the config, but systemctl manages the service.
-
-- **Static pods have mirror pods**. The API server shows "mirror" pods for static pods so you can see them with kubectl. But you can't manage them through the API.
-
-- **HA control planes** require external load balancers. kubeadm can init additional control plane nodes, but you need to set up load balancing yourself.
+- Bootstrap tokens created by kubeadm expire after 24 hours by default, which is why `kubeadm token create --print-join-command` is a normal operational command rather than a rare recovery trick.
+- kubeadm control-plane components run as static pods, so kubelet watches `/etc/kubernetes/manifests/` and can restart the API server container even when the API server cannot answer `kubectl`.
+- The default secure Kubernetes API server port is 6443, and a worker that cannot reach that endpoint cannot complete `kubeadm join` no matter how many times you regenerate the token.
+- kubeadm-managed certificates can be checked with `kubeadm certs check-expiration`, but renewed certificate files must still be loaded by the relevant control-plane components before clients see the change.
 
 ---
 
 ## Common Mistakes
 
-| Mistake | Problem | Solution |
-|---------|---------|----------|
-| Running init with swap enabled | Init fails | `swapoff -a` and remove from /etc/fstab |
-| Forgetting CNI after init | Pods stay Pending | Install CNI immediately after init |
-| Token expired | Can't join nodes | `kubeadm token create --print-join-command` |
-| Using kubectl delete on static pods | Pods keep coming back | Edit/remove manifests in /etc/kubernetes/manifests/ |
-| Not draining before maintenance | Pod disruption | Always `kubectl drain` first |
+| Mistake | Why It Happens | How to Fix It |
+|---------|----------------|---------------|
+| Running init with swap enabled | kubeadm preflight checks reject a host that violates kubelet requirements | Disable swap with `swapoff -a`, remove persistent swap entries from `/etc/fstab`, and rerun preflight checks |
+| Forgetting CNI after init | The API server works, so the cluster looks "installed" even though pod networking is missing | Install exactly one intended CNI plugin and verify CNI pods plus CoreDNS in `kube-system` |
+| Token expired | The original join command was copied from old init output or stale notes | Run `kubeadm token create --print-join-command` and use the fresh command during the join window |
+| Using kubectl delete on static pods | Mirror pods appear in the API, so they look like normal API-managed pods | Edit, move, or restore files in `/etc/kubernetes/manifests/` because kubelet owns static pod lifecycle |
+| Not draining before maintenance | Cordon and drain are treated as interchangeable node commands | Cordon to stop new placement, drain to evict movable workloads, then uncordon after maintenance |
+| Renewing certificates without restarting components | The command writes files, but running processes may still hold old certificate data | Restart or cycle the affected static pods and verify expiration again after reload |
+| Resetting before collecting local evidence | Reset feels like a clean fix when kubelet or join behavior is confusing | Capture kubelet logs, `crictl` output, manifests, and kubeadm errors before using `kubeadm reset` |
 
 ---
 
 ## Quiz
 
-1. **It's 2 AM and your monitoring alerts that the API server certificate expires in 12 hours. You SSH into the control plane node. What commands do you run to check the certificate status and renew it, and what must happen after renewal for the new certificate to take effect?**
-   <details>
-   <summary>Answer</summary>
-   First, verify the expiration: `kubeadm certs check-expiration` shows all certificate expiry dates. Then renew: `kubeadm certs renew all` regenerates all certificates (or `kubeadm certs renew apiserver` for just the API server cert). After renewal, the control plane static pods must restart to load the new certificates. Since they're managed by kubelet via manifests in `/etc/kubernetes/manifests/`, you can trigger a restart by temporarily moving and restoring the manifests, or simply restarting kubelet with `systemctl restart kubelet`. Verify the new certificate: `openssl x509 -in /etc/kubernetes/pki/apiserver.crt -text -noout | grep "Not After"`. Also update your kubeconfig if the admin certificate was renewed: copy the new `/etc/kubernetes/admin.conf` to `$HOME/.kube/config`.
-   </details>
+<details>
+<summary>Question 1: Your team initializes a control plane with `kubeadm init`, copies `admin.conf`, and sees the node, but CoreDNS remains pending. What do you check before rerunning kubeadm?</summary>
 
-2. **A new worker node was set up last week, but the engineer who did it left the company and didn't document the join command. The original bootstrap token has expired. How do you generate a new join command, and what two pieces of information does the worker node need to securely join the cluster?**
-   <details>
-   <summary>Answer</summary>
-   On the control plane, run `kubeadm token create --print-join-command`. This generates a complete join command with both required pieces: (1) a bootstrap token for initial authentication — this is a short-lived shared secret that proves the node is authorized to join, and (2) a CA certificate hash (`--discovery-token-ca-cert-hash`) that the joining node uses to verify it's connecting to the legitimate API server, preventing man-in-the-middle attacks. The token expires in 24 hours by default (configurable with `--ttl`). You can list existing tokens with `kubeadm token list` and delete old ones with `kubeadm token delete <token>`. The CA cert hash doesn't change unless you rotate the cluster CA.
-   </details>
+Check whether a CNI plugin has been installed and whether its configuration matches the pod CIDR used during `kubeadm init`. The API server can be reachable before pod networking is ready, so pending CoreDNS is often a networking bootstrap symptom rather than a failed control-plane install. Inspect `kubectl get pods -n kube-system -o wide`, look for CNI DaemonSet pods, and read their logs if they exist. Rerunning kubeadm would be the wrong first move because it ignores the missing or unhealthy networking layer.
 
-3. **You need to perform kernel maintenance on a worker node running production pods managed by Deployments. A junior admin suggests just rebooting the node. What's the correct procedure, and what could go wrong if you skip the drain step?**
-   <details>
-   <summary>Answer</summary>
-   The correct procedure is: (1) `kubectl cordon <node>` to prevent new pods from being scheduled, (2) `kubectl drain <node> --ignore-daemonsets --delete-emptydir-data` to gracefully evict all pods — the Deployment controllers will recreate them on other nodes, (3) perform maintenance and reboot, (4) `kubectl uncordon <node>` to allow scheduling again. If you skip drain and just reboot, all pods on that node die abruptly without graceful shutdown. Pods with long-running requests or in-flight transactions will be interrupted. While Deployments will eventually recreate pods elsewhere (after the node's kubelet stops reporting and the node controller marks it NotReady, which takes ~5 minutes by default), there's an unnecessary outage window. Pods with `PodDisruptionBudgets` won't be respected either, potentially violating availability guarantees.
-   </details>
+</details>
 
-4. **You added a custom flag to `/etc/kubernetes/manifests/kube-apiserver.yaml` but made a YAML syntax error. Now `kubectl` commands hang and return connection refused. You can't use kubectl to diagnose the problem. How do you investigate and fix this?**
-   <details>
-   <summary>Answer</summary>
-   Since the API server is down, kubectl is useless — you must troubleshoot directly on the control plane node. SSH in and check: (1) `crictl ps` to see if the API server container is running or crash-looping, (2) `crictl logs <container-id>` or check `/var/log/pods/kube-system_kube-apiserver-*/` for error messages that will point to the YAML issue, (3) `journalctl -u kubelet -f` to see kubelet's attempts to start the static pod. To fix, edit the manifest directly: `sudo vi /etc/kubernetes/manifests/kube-apiserver.yaml` and correct the syntax error. Kubelet will automatically detect the file change and restart the API server. Pro tip: always run `kubectl apply --dry-run=client -f` on manifest changes before editing static pod files, or keep a backup: `sudo cp kube-apiserver.yaml kube-apiserver.yaml.bak` before making changes.
-   </details>
+<details>
+<summary>Question 2: A worker join command from yesterday fails, and the error mentions bootstrap token validation. What should you do, and why is the CA hash still part of the command?</summary>
+
+Generate a fresh join command on the control plane with `kubeadm token create --print-join-command`, then run that command on the prepared worker. The token is short-lived authentication material, so an old command can expire even though the cluster is healthy. The CA hash remains necessary because the worker must verify that the API server endpoint belongs to the intended cluster before trusting it. If the new token still fails, separate token errors from network reachability and kubelet preparation errors.
+
+</details>
+
+<details>
+<summary>Question 3: You delete `kube-apiserver-controlplane` with `kubectl`, and it comes back almost immediately. What does that tell you about ownership?</summary>
+
+It tells you the visible pod is a mirror of a static pod, not a normal pod owned by a Deployment or ReplicaSet. kubelet is watching `/etc/kubernetes/manifests/kube-apiserver.yaml` and recreates the container because the manifest still exists. To intentionally stop or change that static pod, you must edit or move the manifest on the control-plane node. This is also why local node access matters when the API server is the component you are troubleshooting.
+
+</details>
+
+<details>
+<summary>Question 4: During planned kernel maintenance, a junior admin suggests `kubectl cordon` and an immediate reboot. What safer workflow do you implement?</summary>
+
+Cordon the node first to prevent new pods from landing there, then drain it with the appropriate flags so managed pods are evicted before the reboot. After maintenance, verify kubelet health, confirm the node returns to `Ready`, and uncordon it so scheduling can resume. Cordon alone does not move existing pods, so rebooting immediately can interrupt workloads that could have been gracefully rescheduled. The exact drain flags depend on DaemonSets, local `emptyDir` data, and unmanaged pods.
+
+</details>
+
+<details>
+<summary>Question 5: You renew kubeadm certificates because the API server certificate is close to expiry, but clients still report the old date. What did you likely miss?</summary>
+
+You likely wrote new certificate files but did not restart or cycle the component that loads them. kubeadm renewal changes files under `/etc/kubernetes/pki`, while static pod processes need to reload those files before clients observe the new certificate. Check expiration with `kubeadm certs check-expiration`, restart or cycle the relevant static pod, and verify with an openssl inspection of the serving certificate. If admin client credentials were renewed, also update the kubeconfig used by the administrator shell.
+
+</details>
+
+<details>
+<summary>Question 6: After editing `kube-apiserver.yaml`, every `kubectl` command hangs. Which tools do you use next?</summary>
+
+Switch to local node tools because the API server may be the broken component. SSH to the control-plane node, check `journalctl -u kubelet`, list containers with `crictl ps`, and inspect API server container logs with `crictl logs` or files under `/var/log/pods`. Then fix the manifest directly in `/etc/kubernetes/manifests/` and let kubelet restart the static pod. Repeated `kubectl` retries do not help when the API server cannot start.
+
+</details>
+
+<details>
+<summary>Question 7: Before a kubeadm control-plane upgrade, what state protection do you want in place, and how does it change your risk?</summary>
+
+You want a recent etcd snapshot that has been inspected, plus copied static pod manifests and a clear restore plan that matches the cluster topology. The snapshot protects cluster state, while manifest copies help reverse accidental flag or path changes. This does not make an upgrade risk-free, but it changes failure handling from improvisation to a practiced recovery path. You should still run `kubeadm upgrade plan`, respect version skew, and upgrade one node at a time.
+
+</details>
 
 ---
 
 ## Hands-On Exercise
 
-**Task**: Practice node management operations.
+This exercise is designed for a lab kubeadm cluster with at least one worker node. If you are using kind or minikube, some static pod paths and node maintenance behaviors may differ because the "nodes" are containers or local VM abstractions rather than ordinary Linux hosts. The learning goal is still the same: connect each command to the layer it changes, then verify the result before moving to the next step.
 
-> **Note**: This exercise requires a cluster with at least one worker node. If using minikube or kind, some operations may differ.
+Exercise scenario: you are preparing a kubeadm cluster for routine maintenance and need to prove that you can inspect bootstrap artifacts, generate a join command, protect state, drain a node, and recover scheduling afterward. Do not run destructive reset commands against a cluster you care about unless the lab explicitly gives you disposable nodes. When a task says "on the control plane," run it from a shell on the control-plane host rather than from a random workstation.
 
-**Steps**:
+### Task 1: View and classify nodes
 
-1. **View cluster nodes**:
+Run the node inspection commands, then write down which node is the control plane, which node is a worker, and whether any node is already cordoned. The output should let you distinguish health from scheduling state before you perform maintenance.
+
 ```bash
 kubectl get nodes -o wide
 ```
 
-2. **Examine a node**:
 ```bash
 kubectl describe node <node-name> | head -50
 ```
 
-3. **Check static pod manifests** (on control plane):
+<details>
+<summary>Solution notes</summary>
+
+The first command gives a compact view of roles, versions, internal IPs, and readiness. The second command gives conditions, addresses, capacity, allocatable resources, taints, and recent node events. A node that shows `SchedulingDisabled` is cordoned, while a node that shows `NotReady` has a health or communication problem that should be diagnosed before maintenance.
+
+</details>
+
+### Task 2: Inspect control-plane static pod files
+
+On the control-plane node, inspect the manifest directory and read the beginning of the API server manifest. Do not edit anything yet; the point is to locate the source files that kubelet watches.
+
 ```bash
 # If you have SSH access to control plane
 ls /etc/kubernetes/manifests/
 cat /etc/kubernetes/manifests/kube-apiserver.yaml | head -30
 ```
 
-4. **Practice cordon/uncordon**:
+<details>
+<summary>Solution notes</summary>
+
+You should see manifests such as `kube-apiserver.yaml`, `kube-controller-manager.yaml`, `kube-scheduler.yaml`, and often `etcd.yaml` on a stacked control-plane node. If those files are present, kubelet is the local supervisor for those components. If `kubectl` fails later because the API server is down, this directory remains one of your primary recovery locations.
+
+</details>
+
+### Task 3: Practice cordon and uncordon
+
+Cordon a worker node, verify that scheduling is disabled, create a test pod, and check where it lands. Then uncordon the worker and verify that the scheduling state returns to normal.
+
 ```bash
 # Cordon a worker node
 kubectl cordon <worker-node>
@@ -647,7 +788,17 @@ kubectl uncordon <worker-node>
 kubectl get nodes
 ```
 
-5. **Practice drain** (careful in production!):
+<details>
+<summary>Solution notes</summary>
+
+The cordoned node should show `SchedulingDisabled`, and the test pod should land on a different schedulable node if capacity exists. If you only have one worker, the pod may remain pending until the node is uncordoned. That result is still useful because it proves cordon changes scheduler placement without proving anything about kubelet health.
+
+</details>
+
+### Task 4: Practice drain with a disposable deployment
+
+Create a small deployment, observe pod placement, drain a node that hosts one of the replicas, and verify that replacement pods move elsewhere. Use a lab cluster with enough capacity, and do not force production workloads unless your runbook explicitly allows it.
+
 ```bash
 # Create a deployment first
 kubectl create deployment drain-test --image=nginx --replicas=2
@@ -665,36 +816,55 @@ kubectl get pods -o wide
 kubectl uncordon <node-name>
 ```
 
-6. **Check certificates** (on control plane):
+<details>
+<summary>Solution notes</summary>
+
+The deployment controller should create replacement pods on schedulable nodes after the drain evicts the originals. If the drain blocks, read the message instead of adding flags blindly; it may be warning you about unmanaged pods or local data. After the test, uncordon the node so it can receive workloads again.
+
+</details>
+
+### Task 5: Check certificates and generate a join command
+
+On the control-plane node, inspect certificate expiration and generate a fresh join command. Do not run the join command unless you have a prepared worker node that should join the cluster.
+
 ```bash
 # If you have access to control plane
 kubeadm certs check-expiration
 ```
 
-7. **Generate join command**:
 ```bash
 # On control plane
 kubeadm token create --print-join-command
 ```
 
-8. **Cleanup**:
+<details>
+<summary>Solution notes</summary>
+
+The certificate command should show expiration dates for kubeadm-managed certificates, which helps you plan renewal before an outage. The token command should print a complete `kubeadm join` command containing a token and CA hash. Treat that output as temporary bootstrap material and avoid storing it in long-lived shared notes.
+
+</details>
+
+### Task 6: Cleanup lab resources
+
+Remove the disposable deployment and pod created during the exercise. Then recheck nodes to confirm that no lab node was left cordoned by mistake.
+
 ```bash
 kubectl delete deployment drain-test
 kubectl delete pod test-pod
 ```
 
-**Success Criteria**:
-- [ ] Can view and describe nodes
-- [ ] Understand cordon vs drain
-- [ ] Know where static pod manifests are stored
-- [ ] Can generate new join tokens
-- [ ] Understand the kubeadm init process
+<details>
+<summary>Solution notes</summary>
 
----
+Cleanup should remove the workload objects you created and leave nodes in the expected scheduling state. Run `kubectl get nodes` afterward and look for accidental `SchedulingDisabled` status. If you practiced drain, also confirm the drained node is uncordoned before ending the lab.
 
-## Practice Drills
+</details>
 
-### Drill 1: Node Management Commands (Target: 3 minutes)
+### Practice Drills
+
+Use these timed drills after the guided tasks. They preserve the original command practice from this module, but treat the targets as approximate lab pacing rather than a reason to rush through output you do not understand.
+
+#### Drill 1: Node Management Commands (Target: 3 minutes)
 
 ```bash
 # List nodes with details
@@ -713,7 +883,7 @@ kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.c
 kubectl describe node <node-name> | grep -A10 "Allocated resources"
 ```
 
-### Drill 2: Cordon and Uncordon (Target: 5 minutes)
+#### Drill 2: Cordon and Uncordon (Target: 5 minutes)
 
 ```bash
 # Cordon a node (prevent new pods)
@@ -734,7 +904,7 @@ kubectl get nodes  # Back to Ready
 kubectl delete pod cordon-test
 ```
 
-### Drill 3: Drain and Recover (Target: 5 minutes)
+#### Drill 3: Drain and Recover (Target: 5 minutes)
 
 ```bash
 # Create test deployment
@@ -757,7 +927,7 @@ kubectl uncordon <worker-node>
 kubectl delete deployment drain-test
 ```
 
-### Drill 4: kubeadm Token Management (Target: 3 minutes)
+#### Drill 4: kubeadm Token Management (Target: 3 minutes)
 
 ```bash
 # List existing tokens
@@ -776,7 +946,7 @@ kubeadm token create --print-join-command
 kubeadm token delete <token-id>
 ```
 
-### Drill 5: Static Pod Exploration (Target: 5 minutes)
+#### Drill 5: Static Pod Exploration (Target: 5 minutes)
 
 ```bash
 # Find static pod manifest directory
@@ -812,7 +982,7 @@ kubectl get pods | grep my-static-pod
 sudo rm /etc/kubernetes/manifests/my-static-pod.yaml
 ```
 
-### Drill 6: Certificate Inspection (Target: 5 minutes)
+#### Drill 6: Certificate Inspection (Target: 5 minutes)
 
 ```bash
 # Check certificate expiration (on control plane)
@@ -828,7 +998,7 @@ ls -la /etc/kubernetes/pki/
 openssl x509 -in /etc/kubernetes/pki/ca.crt -text -noout | grep -E "Subject:|Issuer:|Not"
 ```
 
-### Drill 7: Troubleshooting - Node NotReady (Target: 5 minutes)
+#### Drill 7: Troubleshooting - Node NotReady (Target: 5 minutes)
 
 ```bash
 # Simulate: Stop kubelet on a worker
@@ -849,13 +1019,13 @@ sudo systemctl start kubelet
 kubectl get nodes -w
 ```
 
-### Drill 8: Challenge - Node Maintenance Workflow
+#### Drill 8: Challenge - Node Maintenance Workflow
 
 Perform a complete maintenance workflow:
 
 1. Cordon the node
 2. Drain all workloads
-3. Simulate maintenance (wait 30s)
+3. Simulate maintenance by waiting 30 seconds
 4. Uncordon the node
 5. Verify pods can be scheduled again
 
@@ -899,20 +1069,35 @@ kubectl delete deployment maint-test
 
 </details>
 
+### Success Criteria
+
+- [ ] Design a kubeadm bootstrap sequence that includes preflight checks, `kubeadm init`, kubeconfig setup, CNI installation, and worker join tokens.
+- [ ] Diagnose static pod and kubelet failures with `/etc/kubernetes/manifests/`, `journalctl`, `crictl`, and local control-plane logs.
+- [ ] Evaluate certificate and etcd maintenance risk by checking expiry, saving an etcd snapshot, and planning component restarts.
+- [ ] Implement safe node maintenance with `kubectl cordon`, `kubectl drain`, `kubectl uncordon`, and a clear cleanup step.
+- [ ] Explain when `kubeadm reset` is appropriate and why it should not be the first response to every kubeadm problem.
+
 ---
 
-## Summary: Part 1 Complete!
+## Sources
 
-Congratulations! You've completed **Part 1: Cluster Architecture, Installation & Configuration**.
+- [Creating a cluster with kubeadm](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/)
+- [kubeadm reference](https://kubernetes.io/docs/reference/setup-tools/kubeadm/)
+- [kubeadm init reference](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/)
+- [kubeadm join reference](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-join/)
+- [kubeadm reset reference](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-reset/)
+- [kubeadm token reference](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-token/)
+- [Certificate management with kubeadm](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-certs/)
+- [Upgrading kubeadm clusters](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/)
+- [Safely drain a node](https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/)
+- [Static Pods](https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/)
+- [Operating etcd clusters for Kubernetes](https://kubernetes.io/docs/tasks/administer-cluster/configure-upgrade-etcd/)
 
-You now understand:
-- ✅ Control plane components and how they interact
-- ✅ Extension interfaces: CNI, CSI, CRI
-- ✅ Helm for package management
-- ✅ Kustomize for configuration management
-- ✅ CRDs and Operators for extending Kubernetes
-- ✅ RBAC for access control
-- ✅ kubeadm for cluster management
+---
+
+## Next Module
+
+Continue to [Part 2: Workloads & Scheduling](/k8s/cka/part2-workloads-scheduling/) to learn how Kubernetes places and runs application workloads after the cluster foundation exists.
 
 ### Part 1 Module Index
 
@@ -927,13 +1112,3 @@ Quick links for review:
 | [1.5](../module-1.5-crds-operators/) | CRDs & Operators | Create CRDs, manage custom resources |
 | [1.6](../module-1.6-rbac/) | RBAC | Roles, bindings, ServiceAccounts, `can-i` |
 | [1.7](../module-1.7-kubeadm/) | kubeadm Basics | Init, join, cordon, drain, tokens |
-
-📝 **Before moving on**: Complete the [Part 1 Cumulative Quiz](../part1-cumulative-quiz/) to test your retention.
-
----
-
-## Next Steps
-
-Continue to [Part 2: Workloads & Scheduling](/k8s/cka/part2-workloads-scheduling/) - Learn how to deploy and manage applications.
-
-This covers 15% of the exam and builds directly on what you've learned about cluster architecture.

--- a/src/content/docs/k8s/cka/part1-cluster-architecture/module-1.7-kubeadm.md
+++ b/src/content/docs/k8s/cka/part1-cluster-architecture/module-1.7-kubeadm.md
@@ -271,7 +271,7 @@ ls /etc/kubernetes/manifests/
 # kube-scheduler.yaml
 ```
 
-The API server shows mirror pods for visibility, but it does not own the source of truth for static pods. If you delete the mirror pod with `kubectl`, kubelet notices that the manifest file still exists and recreates the container and mirror representation. That behavior is surprising only if you assume every pod seen through the API is controlled through the API. Pause and predict: if you run `kubectl delete pod kube-apiserver-controlplane -n kube-system`, who recreates it, and what file decides the answer?
+The API server shows mirror pods for visibility, but it does not own the source of truth for static pods. If you delete the mirror pod with `kubectl`, kubelet notices that the manifest file still exists and recreates the mirror pod object in the API. The underlying container is NOT restarted by this — kubelet does not remove the manifest, so the static pod process keeps running uninterrupted. This is a classic CKA gotcha: deleting a mirror pod with `kubectl` does not restart a stuck control-plane component, because the API operation never reaches the runtime. That behavior is surprising only if you assume every pod seen through the API is controlled through the API. Pause and predict: if you run `kubectl delete pod kube-apiserver-controlplane -n kube-system`, what changes (and what does not) at the container-runtime level, and what file decides the answer?
 
 ```text
 ┌────────────────────────────────────────────────────────────────┐
@@ -397,13 +397,20 @@ sudo ETCDCTL_API=3 etcdctl snapshot restore /var/backups/etcd-snapshot.db \
 Upgrades fit into the same risk model. kubeadm can plan and apply a control-plane upgrade, but you still drain nodes, respect version skew, upgrade kubelet and kubectl packages, and verify each step before moving on. The safe order is control plane first, then workers one at a time, with a rollback and backup plan that exists before you touch the first component. For CKA purposes, know the shape of the workflow and the commands you use to inspect the plan.
 
 ```bash
-# Control plane planning step
+# Step 1: upgrade the kubeadm binary itself to the target version FIRST.
+# `kubeadm upgrade apply` validates that the running kubeadm matches the
+# target version, so skipping this step fails immediately. Exact package
+# string varies by distro and repo (apt example shown).
+sudo apt-get update && sudo apt-get install -y --allow-change-held-packages kubeadm=1.35.1-1.1
+
+# Step 2: control-plane planning step (read-only, safe to re-run)
 sudo kubeadm upgrade plan
 
-# Example control plane apply step for a patch release in the same minor line
+# Step 3: control-plane apply for a patch release in the same minor line
 sudo kubeadm upgrade apply v1.35.1
 
-# Restart kubelet after package changes on the upgraded node
+# Step 4: upgrade kubelet and kubectl packages, then restart kubelet
+sudo apt-get install -y --allow-change-held-packages kubelet=1.35.1-1.1 kubectl=1.35.1-1.1
 sudo systemctl daemon-reload
 sudo systemctl restart kubelet
 ```
@@ -690,7 +697,7 @@ Generate a fresh join command on the control plane with `kubeadm token create --
 <details>
 <summary>Question 3: You delete `kube-apiserver-controlplane` with `kubectl`, and it comes back almost immediately. What does that tell you about ownership?</summary>
 
-It tells you the visible pod is a mirror of a static pod, not a normal pod owned by a Deployment or ReplicaSet. kubelet is watching `/etc/kubernetes/manifests/kube-apiserver.yaml` and recreates the container because the manifest still exists. To intentionally stop or change that static pod, you must edit or move the manifest on the control-plane node. This is also why local node access matters when the API server is the component you are troubleshooting.
+It tells you the visible pod is a mirror of a static pod, not a normal pod owned by a Deployment or ReplicaSet. kubelet is watching `/etc/kubernetes/manifests/kube-apiserver.yaml`, so when you delete the mirror pod through the API, kubelet recreates the mirror pod object — but the underlying container is never restarted, because kubelet has not been instructed to remove the manifest. The static pod process keeps running across the `kubectl delete` operation. To intentionally stop or change that static pod, you must edit or move the manifest on the control-plane node. This is also why local node access matters when the API server is the component you are troubleshooting.
 
 </details>
 


### PR DESCRIPTION
## Summary
- Rewrote `module-1.7-kubeadm.md` in place for the #388 density, structure, alignment, anti-leak, and protected-asset gates.
- Cleared `revision_pending: false` and preserved the original kubeadm bootstrap, join, static pod, certificate, node maintenance, reset, troubleshooting, and drill command coverage.

## Verifier
- `verify_module.py --skip-source-check`: baseline T3 -> final T0; body_words=5114, mean_wpp=71.0, median_wpp=79.0, short_rate=0.042, max_run=1, mean_sentence_length=21.9; sources=11 counted, reachability skipped per dispatch command.

## Protected Assets
- Preserved counts: code blocks 42 -> 50, ASCII diagrams 3 -> 3, Mermaid diagrams 0 -> 0, tables 2 -> 5, original source URLs 3 -> 3 preserved, Sources section now has 11 unique URLs.

## Checks
- `git diff --check -- src/content/docs/k8s/cka/part1-cluster-architecture/module-1.7-kubeadm.md`
- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/quality/verify_module.py --glob src/content/docs/k8s/cka/part1-cluster-architecture/module-1.7-kubeadm.md --skip-source-check --summary --quiet`
- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/test_pipeline.py` (170 tests OK)
- `npm run build` from primary checkout at commit SHA, then primary returned to `main`

Commit SHA: `3b25fafc96d2425c171cca53827f504732ecd956`