### PR TITLE
fix(388-reviewer): drop gemini-flash fallback + add LAB RUNNABILITY review dimension

### DIFF
--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -629,16 +629,19 @@ def _handle_ask_gemini(args):
     content = sys.stdin.read() if args.content == "-" else args.content
     content = build_review_message(content) if args.review else content
     model = args.model or (GEMINI_REVIEW_MODEL if args.review else GEMINI_DEFAULT_MODEL)
-    ask_gemini(content, args.task_id, args.type, data, model,
-               getattr(args, 'from_model', None),
-               getattr(args, 'async_mode', False),
-               getattr(args, 'stdout_only', False),
-               getattr(args, 'output_path', None),
-               getattr(args, 'extract', None),
-               getattr(args, 'skip_model_check', False),
-               getattr(args, 'allow_write', False),
-               getattr(args, 'delimiters', None),
-               getattr(args, 'no_github', False))
+    result = ask_gemini(content, args.task_id, args.type, data, model,
+                        getattr(args, 'from_model', None),
+                        getattr(args, 'async_mode', False),
+                        getattr(args, 'stdout_only', False),
+                        getattr(args, 'output_path', None),
+                        getattr(args, 'extract', None),
+                        getattr(args, 'skip_model_check', False),
+                        getattr(args, 'allow_write', False),
+                        getattr(args, 'delimiters', None),
+                        getattr(args, 'no_github', False),
+                        not args.review)
+    if result is None:
+        sys.exit(1)
 
 
 def main():

--- a/scripts/ai_agent_bridge/_gemini.py
+++ b/scripts/ai_agent_bridge/_gemini.py
@@ -132,7 +132,7 @@ def ask_gemini(content: str, task_id: str | None = None, msg_type: str = "query"
                stdout_only: bool = False, output_path: str | None = None,
                extract_tags: list | None = None, skip_model_check: bool = False,
                allow_write: bool = False, delimiters: str | None = None,
-               skip_github: bool = False):
+               skip_github: bool = False, allow_fallback: bool = True):
     """Send message to Gemini AND optionally invoke Gemini to process it."""
     # Model cache management
     if skip_model_check and model in _MODEL_CACHE:
@@ -146,6 +146,14 @@ def ask_gemini(content: str, task_id: str | None = None, msg_type: str = "query"
                     print(f"❌ Model '{model}' was unavailable {int(age)}s ago (cached). Skipping.")
                     print("💡 To switch accounts: run 'gemini auth login' or ask the user to switch.")
                     print("   To retry: --skip-model-check (clears cache)")
+                    return None
+                if not allow_fallback:
+                    print(
+                        f"Gemini model '{model}' was unavailable {int(age)}s ago "
+                        "(cached) — no gemini fallback configured for review path; "
+                        "returning failure so caller can fall through to cross-family review.",
+                        file=sys.stderr,
+                    )
                     return None
                 print(
                     f"⚠️  Model '{model}' was unavailable {int(age)}s ago "
@@ -161,7 +169,11 @@ def ask_gemini(content: str, task_id: str | None = None, msg_type: str = "query"
     # Warn if handoff message is too long
     _warn_long_handoff(content, msg_type, task_id)
 
-    model = _resolve_gemini_model(model, async_mode, skip_model_check)
+    model = _resolve_gemini_model(
+        model, async_mode, skip_model_check, allow_fallback=allow_fallback,
+    )
+    if model is None:
+        return None
 
     # Send the message
     msg_id = _send_gemini_message(content, task_id, msg_type, data, from_model, model,
@@ -186,12 +198,25 @@ def ask_gemini(content: str, task_id: str | None = None, msg_type: str = "query"
     return msg_id
 
 
-def _resolve_gemini_model(model: str, async_mode: bool, skip_model_check: bool) -> str:
+def _resolve_gemini_model(
+    model: str,
+    async_mode: bool,
+    skip_model_check: bool,
+    allow_fallback: bool = True,
+) -> str | None:
     """Return an available Gemini model, falling back before sync invocation."""
     if async_mode or skip_model_check or model == GEMINI_FALLBACK_MODEL:
         return model
     if check_model(model):
         return model
+    if not allow_fallback:
+        print(
+            f"Gemini model '{model}' is unavailable — no gemini fallback configured "
+            "for review path; returning failure so caller can fall through to "
+            "cross-family review.",
+            file=sys.stderr,
+        )
+        return None
     print(
         f"⚠️  Gemini model '{model}' is unavailable; "
         f"falling back to '{GEMINI_FALLBACK_MODEL}'."

--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -91,12 +91,21 @@ GEMINI_WRITER_MODEL = "gemini-3.1-pro-preview"
 GEMINI_DEFAULT_MODEL = "gemini-3-flash-preview"
 GEMINI_REVIEW_MODEL = "gemini-3.1-pro-preview"  # Pro for reviews — hallucinations on Flash cost real iteration time
 GEMINI_FALLBACK_MODEL = "auto"
-# Last-ditch fallback when the review model is rate-limited on every tier.
-# Pinned to gemini-3-flash-preview rather than "auto" because auto can pick
-# gemini-2.5-flash which hallucinates on review tasks (per memory
-# feedback_gemini_models.md). Flash-3 misses some Pro nuance but is the agreed
-# "good enough to publish a verdict" floor when Pro is capacity-out.
-GEMINI_REVIEW_FALLBACK_MODEL = "gemini-3-flash-preview"
+# Reviews: NO gemini-family fallback. When the review model (gemini-3.1-pro-preview)
+# is rate-limited / capacity-out on every tier, return failure so the upstream
+# caller (e.g. scripts/quality/dispatch_388_pilot.py:dispatch_gemini_review)
+# can fall through to the cross-family claude-sonnet-4-6 path via
+# dispatch_claude_review.
+#
+# Why None instead of "gemini-3-flash-preview" (which was the value pre-2026-05-16):
+# the 2026-05-16 multi-model calibration sweep (audit/2026-05-16-grok-4.3-kubedojo-calibration/)
+# measured gemini-3-flash-preview at 0/2 lab-bug-catch on PR #1229 (NEEDS CHANGES
+# bugs both shipped to main) and 0/2 on PR #1230 N=2 replication — flash
+# reliably rubber-stamps lab-breaking PRs with APPROVE. Falling back to flash
+# silently downgraded the gate. Per session-14 user-approved option 1, the
+# correct fallback path is cross-family (claude-sonnet-4-6), not same-family
+# cheaper-tier.
+GEMINI_REVIEW_FALLBACK_MODEL: str | None = None
 CLAUDE_DEFAULT_MODEL = "claude-sonnet-4-6"
 CODEX_DEFAULT_MODEL = "codex"  # lets codex CLI pick the default model
 CODEX_REVIEW_DEFAULT_MODEL = "codex"
@@ -454,18 +463,24 @@ def dispatch_gemini_with_retry(prompt: str, model: str = GEMINI_DEFAULT_MODEL,
                 time.sleep(delay)
                 continue
             # All retries exhausted on the primary model — last-ditch try the
-            # fallback model on subscription. If gemini-3.1-pro-preview is
-            # capacity-out, gemini-3-flash-preview often still answers.
-            # Reviews use GEMINI_REVIEW_FALLBACK_MODEL (explicit, never "auto")
-            # to avoid silently picking gemini-2.5-flash for verdicts.
+            # fallback model on subscription. For non-review writer/translator
+            # calls, gemini-3-flash-preview still serves as a cheap fallback
+            # (writer-side hallucinations are caught downstream by the verifier
+            # and cross-family review). For reviews, GEMINI_REVIEW_FALLBACK_MODEL
+            # is None — see the comment on its definition: flash rubber-stamps
+            # lab-breaking PRs, so we return failure here and let the upstream
+            # caller fall through to the cross-family claude-sonnet path.
             fallback = GEMINI_REVIEW_FALLBACK_MODEL if review else GEMINI_FALLBACK_MODEL
-            if model != fallback:
+            if fallback is not None and model != fallback:
                 print(f"Rate-limit retries exhausted on {model} — last-ditch on fallback model {fallback} (subscription)",
                       file=sys.stderr)
                 ok, output = dispatch_gemini(prompt, fallback, review, timeout, mcp,
                                              use_subscription=True)
                 if ok:
                     return True, output
+            elif fallback is None:
+                print(f"Rate-limit retries exhausted on {model} — no gemini fallback configured for review path; returning failure so caller can fall through to cross-family review.",
+                      file=sys.stderr)
             return False, output
 
         # Timeout — don't retry, just fail (Gemini is slow, not broken)
@@ -473,10 +488,12 @@ def dispatch_gemini_with_retry(prompt: str, model: str = GEMINI_DEFAULT_MODEL,
             return False, output
 
         # Non-rate-limit, non-timeout failure — try fallback model once.
-        # Reviews use the explicit GEMINI_REVIEW_FALLBACK_MODEL pin to avoid
-        # silently routing verdicts through "auto" (which can pick 2.5-flash).
+        # Reviews: GEMINI_REVIEW_FALLBACK_MODEL is None (see its definition);
+        # we return failure and let the upstream caller fall through to the
+        # cross-family claude-sonnet path. Writers/translators still get the
+        # "auto" fallback.
         nrl_fallback = GEMINI_REVIEW_FALLBACK_MODEL if review else GEMINI_FALLBACK_MODEL
-        if model != nrl_fallback:
+        if nrl_fallback is not None and model != nrl_fallback:
             print(f"Retrying with fallback model: {nrl_fallback}", file=sys.stderr)
             return dispatch_gemini(prompt, nrl_fallback, review, timeout, mcp,
                                    use_subscription=use_subscription)

--- a/scripts/quality/dispatch_388_pilot.py
+++ b/scripts/quality/dispatch_388_pilot.py
@@ -291,13 +291,20 @@ Inspect with `gh pr view {pr_num}` and `gh pr diff {pr_num}`. Then evaluate:
 3. DENSITY DOES NOT EQUAL TEACHING — The deterministic verifier already gates on density. You must judge whether the prose is genuinely teaching or just padded to clear gates. Flag any padded paragraphs you find.
 4. PROTECTED ASSETS — Code blocks, ASCII/mermaid diagrams, tables, source URLs preserved across the rewrite (counts in PR body should match).
 5. SOURCES — Each source actually reaches a primary/vendor doc, not marketing fluff. Flag dead/redirect URLs if you can spot any.
+6. LAB RUNNABILITY — Walk every lab step and drill in order. For each `kubectl exec`, `kubectl run`, `kubectl edit`, `kubectl delete`, or container-shell command the lab tells the learner to run, check:
+   (a) Container binaries: does the image actually contain the binary the step uses? `image: nginx` lacks `kubectl`; `image: busybox` lacks `bash`; `image: alpine` lacks `curl` by default. Flag any binary-vs-image mismatch.
+   (b) Role / ClusterRole verbs vs operations: does the Role grant ALL the verbs the lab actually exercises? `kubectl edit` needs `get,list,update`; `kubectl delete` needs `get,list,delete`; `kubectl exec` needs `get` on pods + `create` on pods/exec. Cross-reference every `--verb=...` line in the YAML against every operation the lab/drill performs.
+   (c) Resource scope mismatch: namespaced operations attempted with cluster-scoped permissions (or vice versa).
+   (d) Order of operations: lab steps that reference prior state (a pod, secret, configmap) that wasn't actually created in an earlier step.
+
+   This dimension catches the bug class that lets lab-breaking PRs through content review (#1229 shipped with nginx-image-vs-kubectl and missing-verb bugs because no review dimension explicitly probed it).
 
 End your review with EXACTLY ONE of:
   VERDICT: APPROVE
   VERDICT: APPROVE WITH NITS
   VERDICT: NEEDS CHANGES
 
-Keep the review under 600 words.
+Keep the review under 700 words. If any LAB RUNNABILITY check fails, the floor is NEEDS CHANGES — lab bugs are blocking, not nits.
 """
 
 

--- a/tests/test_bridge_gemini_models.py
+++ b/tests/test_bridge_gemini_models.py
@@ -34,22 +34,34 @@ def _ask_args(*, model: str | None = None, review: bool = False) -> SimpleNamesp
 
 def test_ask_gemini_review_defaults_to_review_model(monkeypatch):
     calls: list[tuple] = []
-    monkeypatch.setattr(_cli, "ask_gemini", lambda *args: calls.append(args))
+
+    def fake_ask_gemini(*args):
+        calls.append(args)
+        return 123
+
+    monkeypatch.setattr(_cli, "ask_gemini", fake_ask_gemini)
 
     _cli._handle_ask_gemini(_ask_args(review=True))
 
     assert calls
     assert calls[0][4] == _cli.GEMINI_REVIEW_MODEL
+    assert calls[0][-1] is False
 
 
 def test_ask_gemini_non_review_defaults_to_default_model(monkeypatch):
     calls: list[tuple] = []
-    monkeypatch.setattr(_cli, "ask_gemini", lambda *args: calls.append(args))
+
+    def fake_ask_gemini(*args):
+        calls.append(args)
+        return 123
+
+    monkeypatch.setattr(_cli, "ask_gemini", fake_ask_gemini)
 
     _cli._handle_ask_gemini(_ask_args())
 
     assert calls
     assert calls[0][4] == _cli.GEMINI_DEFAULT_MODEL
+    assert calls[0][-1] is True
 
 
 def test_resolve_gemini_model_uses_requested_model_when_available(monkeypatch):
@@ -64,7 +76,7 @@ def test_resolve_gemini_model_uses_requested_model_when_available(monkeypatch):
     assert resolved == _gemini.GEMINI_DEFAULT_MODEL
 
 
-def test_resolve_gemini_model_falls_back_when_requested_model_unavailable(
+def test_resolve_gemini_model_does_not_fallback_when_disallowed(
     monkeypatch,
 ):
     monkeypatch.setattr(_gemini, "check_model", lambda model: False)
@@ -73,6 +85,23 @@ def test_resolve_gemini_model_falls_back_when_requested_model_unavailable(
         _cli.GEMINI_REVIEW_MODEL,
         async_mode=False,
         skip_model_check=False,
+        allow_fallback=False,
+    )
+
+    assert resolved is None
+    assert resolved != _gemini.GEMINI_FALLBACK_MODEL
+
+
+def test_resolve_gemini_model_falls_back_when_requested_model_unavailable(
+    monkeypatch,
+):
+    monkeypatch.setattr(_gemini, "check_model", lambda model: False)
+
+    resolved = _gemini._resolve_gemini_model(
+        _gemini.GEMINI_DEFAULT_MODEL,
+        async_mode=False,
+        skip_model_check=False,
+        allow_fallback=True,
     )
 
     assert resolved == _gemini.GEMINI_FALLBACK_MODEL
@@ -159,6 +188,37 @@ def test_ask_gemini_cached_unavailable_model_uses_fallback(monkeypatch):
         _gemini._MODEL_CACHE.clear()
 
     assert seen_models == [_gemini.GEMINI_FALLBACK_MODEL]
+
+
+def test_ask_gemini_cached_unavailable_model_returns_none_without_fallback(
+    monkeypatch,
+):
+    _gemini._MODEL_CACHE.clear()
+    _gemini._MODEL_CACHE[_cli.GEMINI_REVIEW_MODEL] = (False, _gemini.time.time())
+
+    def fail_send(*_args):
+        raise AssertionError("unavailable review model should fail before sending")
+
+    monkeypatch.setattr(_gemini, "_send_gemini_message", fail_send)
+    monkeypatch.setattr(
+        _gemini,
+        "check_model",
+        lambda _model: (_ for _ in ()).throw(
+            AssertionError("cached unavailable model should not be rechecked")
+        ),
+    )
+
+    try:
+        result = _gemini.ask_gemini(
+            "please review",
+            task_id="task-1",
+            model=_cli.GEMINI_REVIEW_MODEL,
+            allow_fallback=False,
+        )
+    finally:
+        _gemini._MODEL_CACHE.clear()
+
+    assert result is None
 
 
 def test_launch_gemini_background_uses_configured_python(monkeypatch, tmp_path):

--- a/tests/test_dispatch_gemini_timeout.py
+++ b/tests/test_dispatch_gemini_timeout.py
@@ -223,19 +223,25 @@ def test_gemini_with_retry_double_429_falls_back_to_subscription_backoff():
     sleep_mock.assert_called_once()  # exactly one backoff between the two subscription attempts
 
 
-def test_gemini_with_retry_falls_back_to_review_fallback_model_on_exhaust():
-    """When every retry on the primary review model returns rate-limit, the
-    last-ditch dispatch must hit GEMINI_REVIEW_FALLBACK_MODEL on subscription
-    once before giving up. This covers the gemini-3.1-pro-preview capacity-out
-    case from PR #891 / #892 (2026-05-05)."""
+def test_gemini_with_retry_review_no_gemini_fallback_on_exhaust():
+    """When every retry on the primary review model rate-limits, the function
+    must return failure WITHOUT dispatching to any gemini fallback model.
+
+    Pre-2026-05-16 behavior was: fall back to gemini-3-flash-preview. Post the
+    2026-05-16 multi-model calibration sweep (which measured flash at 0/2 lab
+    bug-catch on PR #1229 + 0/2 on PR #1230 N=2 replication), reviews never
+    fall back to a same-family cheaper-tier model. Instead, this function
+    returns False so the upstream caller (dispatch_388_pilot.dispatch_gemini_review)
+    can fall through to dispatch_claude_review (cross-family). See
+    GEMINI_REVIEW_FALLBACK_MODEL docstring for full rationale."""
+    assert dispatch.GEMINI_REVIEW_FALLBACK_MODEL is None, \
+        "Reviews must not have a gemini fallback (cross-family is the fallback)."
+
     calls: list[dict] = []
 
     def fake_dispatch(prompt, model, review, timeout, mcp, use_subscription=None):
         calls.append({"model": model, "review": review,
                       "use_subscription": use_subscription})
-        # Every primary-model attempt rate-limits; the fallback model succeeds.
-        if model == dispatch.GEMINI_REVIEW_FALLBACK_MODEL:
-            return True, "fallback-model verdict"
         return False, "429 rate limit"
 
     with patch("dispatch.dispatch_gemini", side_effect=fake_dispatch), \
@@ -247,12 +253,12 @@ def test_gemini_with_retry_falls_back_to_review_fallback_model_on_exhaust():
             review=True, max_retries=2,
         )
 
-    assert ok is True
-    assert output == "fallback-model verdict"
-    # Final call must be the review fallback model on subscription.
-    assert calls[-1]["model"] == dispatch.GEMINI_REVIEW_FALLBACK_MODEL
-    assert calls[-1]["use_subscription"] is True
-    assert calls[-1]["review"] is True
+    assert ok is False
+    assert "429" in output
+    # Every dispatch call must stay on the primary review model — no fallback
+    # to a different gemini variant fired.
+    assert all(c["model"] == dispatch.GEMINI_REVIEW_MODEL for c in calls)
+    assert all(c["review"] is True for c in calls)
 
 
 def test_gemini_with_retry_no_fallback_when_already_on_fallback_model():
@@ -284,41 +290,13 @@ def test_gemini_with_retry_no_fallback_when_already_on_fallback_model():
     assert all(c["model"] == dispatch.GEMINI_FALLBACK_MODEL for c in calls)
 
 
-def test_gemini_with_retry_no_fallback_when_review_already_on_review_fallback():
-    """Recursion guard, review variant: if a review caller is already on
-    GEMINI_REVIEW_FALLBACK_MODEL and every retry rate-limits, no extra
-    dispatch must fire. Mirrors the writer-side guard test but on the
-    review path so the explicit-pin branch is also exercised.
-
-    Patches GEMINI_DEFAULT_MODEL to a synthetic value so dispatch.py:423's
-    auto-promote-to-Pro doesn't silently swap our test model: the real
-    GEMINI_DEFAULT_MODEL and GEMINI_REVIEW_FALLBACK_MODEL are both
-    "gemini-3-flash-preview", so passing the latter as the explicit
-    starting model would otherwise trigger the auto-promote branch.
-    """
-    calls: list[dict] = []
-
-    def fake_dispatch(prompt, model, review, timeout, mcp, use_subscription=None):
-        calls.append({"model": model, "review": review,
-                      "use_subscription": use_subscription})
-        return False, "429 rate limit"
-
-    with patch("dispatch.dispatch_gemini", side_effect=fake_dispatch), \
-         patch("dispatch.dispatch_gemini_rest", return_value=(False, "REST not used in this test")), \
-         patch("dispatch.time.sleep"), \
-         patch.object(dispatch, "_FORCE_GEMINI_SUBSCRIPTION", False), \
-         patch.object(dispatch, "GEMINI_DEFAULT_MODEL", "_synthetic-default-not-real"):
-        ok, output = dispatch.dispatch_gemini_with_retry(
-            "review this", model=dispatch.GEMINI_REVIEW_FALLBACK_MODEL,
-            review=True, max_retries=2,
-        )
-
-    assert ok is False
-    assert "429" in output
-    # Every dispatch call stays on the review fallback model — no double-burn
-    # on a different model after exhausting retries.
-    assert all(c["model"] == dispatch.GEMINI_REVIEW_FALLBACK_MODEL for c in calls)
-    assert all(c["review"] is True for c in calls)
+# NOTE: The pre-2026-05-16 test
+# `test_gemini_with_retry_no_fallback_when_review_already_on_review_fallback`
+# was removed when GEMINI_REVIEW_FALLBACK_MODEL was retired (set to None).
+# That test exercised a recursion guard against double-dispatching on the
+# flash fallback model; with no gemini fallback on the review path, the
+# guard is moot. The new contract is covered by
+# test_gemini_with_retry_review_no_gemini_fallback_on_exhaust above.
 
 
 def test_gemini_with_retry_non_review_uses_auto_fallback():


### PR DESCRIPTION
## Summary

Applies session-14 user-approved option 1 reviewer reassignment, anchored to the 2026-05-16 multi-model calibration sweep + phase-2 N=2 replication.

**The data:**
- `gemini-3-flash-preview` as production reviewer: **0/2 lab bugs caught on PR #1229** (both shipped to main) and 0/2 on PR #1230 N=2 replication. Verdict was APPROVE on both PRs despite real lab-runnability bugs.
- `gemini-3.1-pro-preview`: 2/2 + NEEDS CHANGES on both PRs.
- `claude-sonnet-4-6`: 1/2 on PR #1229 + NEEDS CHANGES on PR #1230 (best claude variant; beats opus at any effort).
- `claude-opus-4-7 --effort max`: 0/2 (same as default). Effort knob does NOT unlock claude reviewer bug-catch.

## Changes

- **`scripts/dispatch.py:99`** — `GEMINI_REVIEW_FALLBACK_MODEL` set to `None` (was `"gemini-3-flash-preview"`). The two callers at lines 461 and 478 now skip the gemini fallback when it's `None`, returning failure so the upstream caller can fall through to cross-family review via `dispatch_388_pilot.dispatch_claude_review` (claude-sonnet-4-6). **Writer/translator paths unchanged** — they still use `GEMINI_FALLBACK_MODEL = "auto"`; only the review path loses the gemini-flash safety net.
- **`scripts/quality/dispatch_388_pilot.py:gemini_review_prompt`** — adds a 6th `LAB RUNNABILITY` dimension that explicitly probes:
  - (a) Container binary vs image mismatch (nginx vs kubectl, alpine vs curl, etc.)
  - (b) Role/ClusterRole verbs vs operations (`kubectl edit` needs `get,list,update`; `kubectl exec` needs `get` on pods + `create` on `pods/exec`)
  - (c) Resource scope (namespaced vs cluster-scoped)
  - (d) Order of operations (steps that reference state not yet created)
  
  This dimension is the one that catches the bug class that let PR #1229's lab-breaking bugs through (nginx image vs kubectl reference; missing `get,list` verbs on the dm-edit Role). Floor for any failing lab check is NEEDS CHANGES.
- **`tests/test_dispatch_gemini_timeout.py`** — rewrote the falls-back-on-exhaust test to assert the new contract (no gemini fallback on review exhaust; failure returned so upstream can cross-family). Removed the now-moot recursion-guard test for the review path.

## Test plan

- [x] \`pytest tests/test_dispatch_gemini_timeout.py\` — 16 passed
- [x] \`pytest\` of all 5 dispatcher-adjacent test files — 135 passed (\`test_quality_dispatchers\`, \`test_citation_residuals\`, \`test_quality_stages\`, \`test_citation_backfill\`, \`test_claude_dispatch_special_chars\`)
- [x] \`ruff check\` on all 3 changed files — clean
- [ ] Smoke: re-review PR #1230 (CKA 1.7 kubeadm, currently MERGE_HELD) via the new prompt + reviewer config, see if it catches anything that gemini-3-flash missed in the original review.
- [ ] Cross-family review of this PR itself: codex gpt-5.5 high (since the change touches review dispatch infrastructure).

## Risk + rollback

- **Risk**: when gemini-3.1-pro is capacity-out, reviews now fail instead of silently falling to flash. The upstream `dispatch_388_pilot.dispatch_gemini_review` returns ERROR, and the caller invokes `dispatch_claude_review` (which already existed at line 324). Net: failure mode shifts from "silent flash rubber-stamp" to "explicit cross-family fallback" — strictly better for the gate, slightly more latency when gemini-pro is out.
- **Rollback**: revert this commit; the two-line constant change is the load-bearing piece.

## References

- Session 14 handoff: \`docs/session-state/2026-05-16-session-14-model-calibration-and-canary-bugs.html\`
- Calibration phase-2 report: \`audit/2026-05-16-grok-4.3-kubedojo-calibration/REPORT-PHASE2.md\`
- Memory: \`feedback_never_flash_for_code_review.md\` (the calibrated rule this PR encodes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)