### PR TITLE
feat(388): rewrite module-1.3-multi-container-pods (#388 pilot)

### DIFF
--- a/src/content/docs/k8s/ckad/part1-design-build/module-1.3-multi-container-pods.md
+++ b/src/content/docs/k8s/ckad/part1-design-build/module-1.3-multi-container-pods.md
@@ -3,6 +3,7 @@ title: "Module 1.3: Multi-Container Pods"
 slug: k8s/ckad/part1-design-build/module-1.3-multi-container-pods
 sidebar:
   order: 3
+revision_pending: false
 lab:
   id: ckad-1.3-multi-container-pods
   url: https://killercoda.com/kubedojo/scenario/ckad-1.3-multi-container-pods
@@ -21,30 +22,41 @@ lab:
 ## Learning Outcomes
 
 After completing this module, you will be able to:
-- **Design** multi-container pod architectures utilizing sidecar, init, ambassador, and adapter patterns to decouple application concerns.
-- **Diagnose** pod lifecycle failures, including init container crash loops and shared-volume communication bottlenecks.
-- **Implement** a sidecar logging pattern that reliably ships logs from a main application container.
-- **Evaluate** the trade-offs between localhost network sharing and shared volumes for inter-container communication.
+
+- **Design** multi-container Pod architectures that apply init, sidecar, ambassador, and adapter patterns without mixing unrelated responsibilities into one image.
+- **Diagnose** multi-container Pod lifecycle failures, including init container retry loops, sidecar readiness problems, and shared-volume communication gaps.
+- **Implement** a sidecar logging pattern that uses a shared volume to ship output from a main application container while preserving application image simplicity.
+- **Evaluate** when containers in one Pod should communicate through localhost networking, shared volumes, or process namespace sharing.
 
 ---
 
 ## Why This Module Matters
 
-In October 2021, Roblox suffered a 73-hour global outage that wiped out an estimated $1.5 billion in market capitalization. The root cause involved a subtle bug in their backend services where service discovery and proxy routing became overwhelmed under massive load. If they had isolated their proxy logic into strictly resource-limited sidecar containers with explicit lifecycle controls, the blast radius could have been drastically contained, preventing a localized bottleneck from taking down the entire platform.
+Hypothetical scenario: your team owns a small web service that starts cleanly in development, then stalls in the cluster because it needs a generated configuration file, a reachable database endpoint, and a log shipper before it can safely receive traffic. The first instinct is often to add shell tools, retry loops, and log forwarding into the application image. That feels convenient for the first release, but it also means every operational concern now ships at the same pace as the app, shares the same failure domain inside the process, and requires the application team to own code that is not really application logic.
 
-While Roblox's specific outage involved a different orchestrator, the architectural lesson applies directly to Kubernetes. A Pod is a group of one or more containers, with shared storage and network resources, and a specification for how to run the containers. The one-container-per-Pod model is the most common Kubernetes use case, but when systems reach real-world scale, you must distribute responsibilities. Placing all functionality into a single monolithic container leads to cascading failures, resource starvation, and deployment bottlenecks. 
+Kubernetes gives you a more precise boundary: the Pod. A Pod is not just a wrapper around one container; it is the smallest schedulable unit that can hold multiple cooperating containers with shared storage and network resources. Multi-container Pods let you say, "this process is the application, this process prepares the filesystem, this process tails logs, and this process translates a local request into an external connection." The containers stay separately packaged, but the kubelet starts, stops, observes, and reports them as one unit.
 
-This module covers the four essential multi-container patterns: Init, Sidecar, Ambassador, and Adapter. Mastering these patterns is critical for the CKAD exam and for preventing catastrophic failures in production by decoupling initialization, logging, proxying, and data translation from your core business logic.
+For CKAD work, this topic matters because many exam tasks are not about inventing a new workload type. They are about recognizing which responsibility belongs in `initContainers`, which belongs beside the app for the lifetime of the Pod, and which communication path should join the containers together. In production, the same skill protects deployment speed and operational clarity. A clean multi-container design can make failure easier to isolate, logs easier to collect, and startup dependencies easier to reason about without turning the main image into a toolbox.
 
-> **The Food Truck Analogy**
->
-> A pod is like a food truck. The main container is the chef—they cook the food. But a successful food truck needs more: someone to prep the kitchen before opening (init), someone to take orders (sidecar), a cashier window facing customers differently (ambassador), and someone translating foreign currency to local currency (adapter). They all share the same truck (pod), share the counter space (filesystem), and work together—but each has a distinct, isolated role.
+---
+
+## The Pod Boundary You Are Designing
+
+The most important idea in this module is that a multi-container Pod is a deliberate coupling choice. Containers inside one Pod are scheduled to the same node, share the same Pod IP address, and can share volumes declared in the Pod spec. That makes the Pod an excellent place for tightly coupled helper processes, but a poor place for independent services that should scale, roll out, or fail separately. If two processes do not need the same fate, same node, or same local resources, they usually belong in separate Pods behind a Service instead.
+
+Think of a Pod like a small food truck rather than a whole restaurant. The main container is the cook preparing the menu, but the truck may also need someone to stock the counter before opening, someone to watch the order printer, someone to translate card payments, and someone to keep the work area observable. They share the same truck, utilities, and service window, so they must coordinate carefully. They are still different jobs, and that separation is what keeps the cook from becoming responsible for every operational chore.
+
+That analogy has a practical limit. Kubernetes does not give each helper an independent Service identity, independent scheduling decision, or independent rollout timeline when it lives in the same Pod. The whole Pod becomes Ready only when the required containers are Ready, and a restart of the Pod restarts the whole local arrangement. Use that constraint as a design signal: multi-container Pods are for local collaboration, not for building a miniature distributed system inside a single YAML object.
+
+The four patterns in this module describe common reasons to share a Pod boundary. Init containers handle blocking setup that must finish before the app starts. Sidecars run alongside the app to provide continuous support such as logging or synchronization. Ambassadors proxy local application traffic to something outside the Pod, usually hiding connection details. Adapters translate one local format into another format that outside systems expect. These names are not Kubernetes object kinds; they are design patterns expressed with normal Pod fields.
+
+Pause and predict: if a Pod must wait for a database name to resolve, serve web traffic, and continuously ship access logs to another system, which responsibilities should run before startup and which should run for the lifetime of the app? Write down the container names you would choose before reading the YAML examples, because the CKAD exam often tests this recognition step more than it tests memorized definitions.
 
 ---
 
 ## The Four Patterns You Must Know
 
-To properly design distributed systems in Kubernetes, you must understand the four primary patterns for multi-container pods. These patterns dictate how auxiliary containers interact with the main application logic.
+The patterns are easiest to learn when you separate time from communication. Init containers are defined by time: they run before app containers and must complete successfully. Sidecar, ambassador, and adapter containers are defined by ongoing communication with the main container or the outside world. They may share files, speak over localhost, or expose a translated interface, but they are expected to keep running while the application is useful.
 
 ```mermaid
 flowchart TD
@@ -73,25 +85,21 @@ flowchart TD
     end
 ```
 
-> **Pause and predict**: You have a pod that needs to (a) wait for a database to be ready, (b) run a web server, and (c) continuously ship logs to Elasticsearch. Which of the three patterns -- init, sidecar, or ambassador -- would you use for each task? Decide before reading the details below.
+The diagram shows why "multi-container" is not a single technique. An init container is not a weaker sidecar; it is a different lifecycle contract. An ambassador is not just "another helper"; it has a network-facing job that changes how the application reaches dependencies. An adapter may never be called by the app at all, because its job can be to read local output and present it in a standard shape to a monitoring system.
+
+This distinction keeps your YAML honest. If a container must finish and exit, do not make it a regular container with `sleep` just to keep the Pod alive. If a container must provide a local proxy while requests are in flight, do not hide that dependency inside an init script that stops before traffic arrives. If a container only transforms files or metrics, do not force the main application to learn that external format when a local adapter can own the translation.
+
+The CKAD version of this skill is often a quick design decision under time pressure. You may be given a pod that needs a generated file, a second container that tails logs, and a command that has to target one specific container. The correct answer is usually not a new controller or a custom resource. It is a Pod spec that uses the right field, a shared volume or localhost path, and explicit `kubectl` flags that remove ambiguity.
 
 ---
 
-## Init Containers
+## Init Containers: Blocking Work That Must Finish
 
-Init containers run **before** application containers start. They are specifically designed for setup scripts and initialization logic that you do not want to bundle inside your main application image.
+Init containers run before application containers start, and Kubernetes runs regular init containers sequentially. The kubelet starts the first init container, waits for it to exit successfully, starts the next one, and only starts the app containers after all init containers have completed. That gives you a clean place for setup work that should not remain running, such as waiting for DNS, preparing a directory, rendering a configuration file, or changing permissions on a mounted volume.
 
-Init containers run sequentially to completion, and each must succeed before the next begins. If a Pod's `restartPolicy` is not `Never` and an init container fails, the kubelet repeatedly restarts that init container until it succeeds. Because of their sequential, blocking nature, regular init containers (non-sidecar) do not support the `lifecycle`, `livenessProbe`, `readinessProbe`, or `startupProbe` fields.
+The key design benefit is image separation. Your application image can stay small and focused while an init container uses a different image that contains tools such as `nslookup`, `git`, or a database client. That does not make the setup unimportant; it makes the setup explicit. Anyone reading the Pod spec can see which steps must complete before the app exists, and anyone diagnosing the Pod can inspect init container status separately from application container readiness.
 
-### Use Cases
-
-- Wait for a backend service or database to be ready.
-- Clone a git repository or download remote assets.
-- Generate dynamic configuration files.
-- Run database migrations prior to application startup.
-- Modify file permissions on shared volumes.
-
-### Init Container YAML
+Failure behavior is strict by design. If a regular init container exits non-zero and the Pod restart policy allows retries, the kubelet retries that init container until it succeeds. The main containers do not start, because Kubernetes treats incomplete initialization as a reason the Pod is not ready to run the workload. This is exactly what you want for required setup, but it is a bad fit for optional background work or long-running watchers.
 
 ```yaml
 apiVersion: v1
@@ -120,7 +128,9 @@ spec:
     emptyDir: {}
 ```
 
-### Key Properties
+In this example, `init-wait` blocks startup until `myservice` resolves, and `init-setup` writes a file into an `emptyDir` volume that the nginx container later mounts. The two init containers do not need the nginx image, and nginx does not need DNS troubleshooting tools or setup scripts. The shared volume is the handoff point, while the sequential init lifecycle is the ordering guarantee.
+
+Regular init containers also have different API rules from app containers. They are expected to finish, so Kubernetes does not allow the usual health probe fields on regular init containers. Native sidecar containers are the exception, but they are defined with a different contract that you will see in the sidecar section. For ordinary init work, the success signal is simple: the command exits with status zero, then Kubernetes moves to the next step.
 
 | Property | Behavior |
 |----------|----------|
@@ -130,37 +140,32 @@ spec:
 | Resources | Can have different resource limits than app containers |
 | Probes | No liveness/readiness probes (they just need to exit 0) |
 
-### Init Container Status
+The table is worth reading as an operational checklist. "Sequential" means a later init container never races an earlier one. "Failure" means a bad setup command can hold the entire Pod in an init state. "Resources" means an init container can request enough CPU or memory for a heavy startup task without forcing the application container to keep those same requests for its whole lifetime. The CKAD exam can test any of these properties through status output or a broken YAML snippet.
 
 ```bash
 # Check init container status
-k get pod init-demo
+kubectl get pod init-demo
 
 # Detailed status
-k describe pod init-demo | grep -A10 "Init Containers"
+kubectl describe pod init-demo | grep -A10 "Init Containers"
 
 # Init container logs
-k logs init-demo -c init-wait
+kubectl logs init-demo -c init-wait
 ```
+
+When a Pod is stuck in `Init:0/1` or `Init:1/2`, start with `kubectl describe pod` and the logs for the active init container. The describe output shows image pull failures, command failures, restart counts, and event messages. The logs show what the setup command printed before it exited or retried. Do not debug the main container first, because the main container may not exist yet.
+
+What would happen if an init container accidentally ran `sleep 3600` instead of completing? The Pod would remain blocked in an init state, and the correct diagnosis would focus on init container logs, command arguments, and Events rather than nginx readiness. That question is simple, but it captures the main design rule: init containers are for work that ends.
 
 ---
 
-## Sidecar Containers
+## Sidecar Containers: Continuous Help Beside the App
 
-The sidecar pattern describes a secondary container that extends or enhances a primary container's functionality without modifying its code (e.g., logging, monitoring, security). Sidecars run **alongside** the main container for the pod's lifetime.
+The sidecar pattern describes a helper container that runs alongside the main container for the useful life of the Pod. A sidecar extends the workload without changing the application image, which is why the pattern is common for log shipping, local synchronization, telemetry collection, and security helpers. The app writes files, exposes local endpoints, or emits signals in its normal way, while the sidecar handles a cross-cutting concern that would otherwise bloat the app image.
 
-Historically, sidecars were just regular containers running next to the main application. However, this caused severe lifecycle race conditions during startup and shutdown. To fix this, the SidecarContainers feature was introduced as alpha in Kubernetes v1.28, graduated to beta (and enabled by default) in Kubernetes v1.29, and officially graduated to stable (GA) in Kubernetes v1.33.
+Historically, many Kubernetes sidecars were simply additional entries under `spec.containers`. That classic form is still common in examples and works well when both containers can start and stop without special ordering requirements. Kubernetes also supports native sidecar containers in v1.35 through init containers with `restartPolicy: Always`. Native sidecars start before ordinary app containers, remain running, support probes, and are terminated after the app containers, which solves important startup and shutdown ordering problems.
 
-Native sidecar containers are defined under `spec.initContainers` with `restartPolicy: Always` — not under `spec.containers`. Sidecar containers start before app containers and remain running throughout the Pod's lifetime. Sidecar containers (unlike regular init containers) support `livenessProbe`, `readinessProbe`, and `startupProbe` fields. Upon Pod termination, the kubelet postpones terminating sidecar containers until the main application containers have fully stopped. Finally, sidecar containers are shut down in the reverse order of their appearance in the Pod spec.
-
-### Use Cases
-
-- Log aggregation (shipping local files to an external system).
-- Monitoring and telemetry collection agents.
-- Real-time configuration synchronization.
-- Cache population and invalidation.
-
-### Sidecar YAML
+The distinction matters because a sidecar is not just "a second container." If the helper must be available before the app starts accepting traffic, native sidecar lifecycle semantics may be the right tool. If the helper only tails a file and can tolerate ordinary app-container lifecycle behavior, the classic pattern is often enough for a CKAD exercise. In both cases, the helper must run a foreground process. A command that exits immediately turns a sidecar into a restart problem.
 
 ```yaml
 apiVersion: v1
@@ -185,52 +190,55 @@ spec:
     emptyDir: {}
 ```
 
-> **Stop and think**: Two containers in the same pod need to communicate. One approach is shared volumes; another is localhost networking. When would you choose one over the other? What kind of data flows better through files vs network calls?
+This classic sidecar example uses a shared `emptyDir` volume as the contract between nginx and the log shipper. Nginx writes access logs under `/var/log/nginx`, and the busybox helper tails the same path. The main image does not need a log forwarding binary, credentials, or a second process supervisor. The sidecar owns the log stream, and the application owns serving HTTP content.
+
+That separation has a cost. The Pod readiness view includes multiple containers, so a broken sidecar can keep the whole Pod from becoming Ready even if the main process is healthy. That is often desirable when the sidecar is required for safe service, such as a proxy or security agent, but it can surprise teams that treat log shipping as optional. You need to decide whether the helper is part of the serving contract or merely part of observability, then set readiness behavior accordingly.
+
+Sidecars also compete for node resources inside the same Pod. If the log shipper has no CPU or memory limit, it can interfere with the main container during bursts. If it has limits that are too tight, it may crash or lag behind the file it reads. The clean architecture is not complete until the helper has realistic resource requests, a foreground command, and a failure mode that matches how important the helper is to the workload.
+
+Stop and think: two containers in the same Pod need to communicate, and you can choose between a shared volume and localhost networking. Which approach would you choose for append-only logs, and which would you choose for a request that needs a response before the app can continue? The answer should depend on the shape of the data, not on which example you memorized most recently.
 
 ---
 
-## Inter-Container Communication
+## Inter-Container Communication: Files, Localhost, and Processes
 
-All containers in a Pod share the same network namespace, including the same IP address and network port space. Containers in the same Pod communicate with each other via localhost. Additionally, containers in a Pod can share storage via Volumes, with each container mounting the volume at its own distinct path.
+Containers in the same Pod share the same network namespace, including the same Pod IP address and the same localhost interface. If one container listens on port `8080`, another container in the same Pod can reach it through `localhost:8080`, assuming the port is not already occupied by another container. This is useful for proxying, metrics endpoints, local API calls, and other request-response flows where a network protocol is already the natural interface.
 
-**Design Rationale**: Choose Volumes for persistent data streams, state files, or static assets (e.g., a log file written by the main app and read by a sidecar shipper). Choose localhost Networking for real-time request/response proxying (e.g., an app sending database queries through an ambassador). 
+Shared volumes solve a different problem. They provide a filesystem handoff between containers, which works well for generated configuration, static assets, logs, cache files, and other data that does not require an immediate network response. A volume also lets containers mount the same storage at different paths, so the producer can write to a convenient location while the consumer reads from the path its image expects. That flexibility is one reason `emptyDir` is so common in CKAD multi-container tasks.
 
-Containers in a pod can share:
+The decision is not about which mechanism is more Kubernetes-native. It is about the contract between processes. Files are good when data can be written, observed, retried, or tailed over time. Localhost is good when the app needs a live service with request ordering, connection handling, or protocol behavior. Process namespace sharing is narrower and should be used only when one container needs to inspect or signal processes in another container for debugging or specialized supervision.
 
-1. **Volumes** (most common for state and logging)
 ```yaml
 volumes:
 - name: shared
   emptyDir: {}
 ```
 
-2. **Network** (same localhost namespace)
+The `emptyDir` volume is created when the Pod is assigned to a node and exists as long as that Pod instance exists on the node. It is a clean fit for data that can be recreated, such as generated HTML, copied assets, or a log stream. It is not a replacement for durable storage. If the Pod is deleted and recreated, the new Pod receives a new empty directory.
+
 ```yaml
 # Main container exposes :8080
 # Sidecar can access localhost:8080
 ```
 
-3. **Process namespace** (allows containers to see and signal each other's processes)
+Localhost communication has a different failure mode from file sharing. If the target process is not listening yet, the client receives connection errors. If two containers try to bind the same port, one of them fails. This is why an ambassador proxy and the main app need an explicit port plan. The containers share the network namespace, so port conflicts are real even though the containers have separate filesystems.
+
 ```yaml
 spec:
   shareProcessNamespace: true
 ```
-Setting `shareProcessNamespace: true` allows containers in a Pod to view the process table of other containers, which is critical for specialized debugging or signaling tools.
+
+Setting `shareProcessNamespace: true` allows containers in the Pod to view processes from other containers. That can be valuable when a debug or helper container needs to inspect process IDs, send signals, or use tools that depend on a shared process table. It also weakens isolation, because process visibility crosses container boundaries inside the Pod. Treat it as a targeted diagnostic or supervision tool rather than a default setting for ordinary sidecar designs.
+
+Before running a shared-volume Pod, predict the first observable proof that the volume is working. You might look for the reader container printing content written by the writer, or for nginx serving a file created by an init container. Making that success signal explicit helps you avoid a common debugging trap: staring at Pod phase while the actual contract between containers is a missing file, an empty directory, or a wrong mount path.
 
 ---
 
-## Ambassador Pattern
+## Ambassador, Adapter, and Ephemeral Debugging
 
-The ambassador pattern describes a container that acts as a proxy between the application container and external services, handling concerns like service discovery, TLS, and circuit breaking. It shields the main application from the complexity of the outside network.
+The ambassador pattern uses a helper container as a local representative for something outside the Pod. The main application connects to `localhost` or another local address, and the ambassador handles the real external endpoint, TLS behavior, connection pooling, routing, or retry policy. This keeps external networking logic out of the application image, but it also makes the ambassador part of the request path. If the ambassador is down, slow, or misconfigured, the app may be healthy yet unable to reach its dependency.
 
-### Use Cases
-
-- Database connection pooling (e.g., PgBouncer).
-- TLS termination or outbound encryption (mTLS).
-- Transparent service discovery and routing.
-- Rate limiting and retry logic abstraction.
-
-### Ambassador YAML
+Ambassadors are useful when the application should not know the real destination. A database proxy can let the app connect to `localhost:5432` while the proxy owns the actual database host, pool settings, and outbound TLS. A service mesh sidecar is a more automated version of the same local-proxy idea, but the CKAD exam usually presents the pattern as an explicit second container. The important recognition point is that the main container talks locally while the helper handles the outside network.
 
 ```yaml
 apiVersion: v1
@@ -257,74 +265,33 @@ spec:
     - containerPort: 5432   # Listens on localhost:5432 for main
 ```
 
----
+The adapter pattern points in a different direction. Instead of hiding an external dependency from the app, an adapter translates the app's local output for another system. A legacy process might write custom metrics, plain text logs, or a vendor-specific status file. The adapter reads that local format and exposes a standard interface, such as Prometheus metrics or structured JSON, without forcing a source-code change in the main application.
 
-## Adapter Pattern
+Adapters are especially useful when the main image is owned by another team, frozen for compliance reasons, or simply not worth changing for a monitoring integration. The adapter lets the Pod speak two languages locally: the application's native language on one side and the platform's expected language on the other. The tradeoff is that the translation logic now has to be deployed, monitored, and versioned as part of the Pod contract.
 
-The adapter pattern describes a container that translates data formats, protocols, or APIs between the main application container and external services. It acts as an impedance matcher, standardizing disparate outputs into a unified format.
+Ephemeral containers are not one of the four architecture patterns, but they matter when debugging multi-container Pods. They are added to an existing Pod through the `ephemeralcontainers` subresource and are intended for interactive troubleshooting, especially when production images do not include tools such as a shell or network client. In Kubernetes v1.35, ephemeral containers remain a debugging feature rather than a normal way to run application helpers.
 
-### Use Cases
+The restrictions are intentional. Ephemeral containers do not support fields such as `ports`, ordinary probes, or resource declarations in the same way app containers do, and once an ephemeral container is added, it cannot be changed or removed from that Pod. If you make a typo in an ephemeral debug command, you add another ephemeral container with a new name. That permanence makes them useful for investigation, not for planned application behavior.
 
-- Translating legacy application log files into structured JSON for modern aggregators.
-- Reading JMX metrics from a Java application and exposing them as a Prometheus endpoint.
-- Normalizing custom API responses to match an organizational standard.
-
-The adapter pattern ensures that the main container can continue operating with its native or legacy outputs without requiring expensive code rewrites, while still integrating perfectly into modern cloud-native observability stacks.
+The practical boundary is simple: if the container is part of the workload design, put it in the Pod spec as an init container, regular app container, or native sidecar. If the container is a temporary tool for inspecting a live Pod, use an ephemeral container. Mixing those purposes creates confusing YAML, unclear ownership, and unreliable exam answers.
 
 ---
 
-## Ephemeral Containers
+## Lifecycle and Exam-Speed Construction
 
-When you need to debug a running Pod—especially one deployed with minimal base images that lack tools like `curl` or `sh`—you can use Ephemeral Containers. Ephemeral containers became stable (GA) in Kubernetes v1.25. 
+A Pod with multiple containers still has the standard Pod phases: `Pending`, `Running`, `Succeeded`, `Failed`, and `Unknown`. Those phases describe the whole Pod, not each individual container. To diagnose a multi-container Pod, you need container-level status as well as Pod-level phase. A Pod can be `Running` while one container is not Ready, and it can be stuck in an init status before any application container has started.
 
-They are designed purely for interactive troubleshooting. As such, ephemeral containers do not support the `ports`, `livenessProbe`, `readinessProbe`, or `resources` fields. They are added to a running Pod via a special `ephemeralcontainers` API subresource, not via a standard Pod spec update using `kubectl edit`. Once an ephemeral container is added to a Pod, it cannot be changed or removed. Furthermore, ephemeral containers are not supported in static Pods.
+Restart policy is also a Pod-level setting with container-level effects. The values are `Always`, `OnFailure`, and `Never`. Regular init containers must complete successfully before app containers run, and failed init containers are retried according to the Pod restart policy rules. Ordinary app containers may restart independently within the Pod, but the Pod readiness result still depends on the readiness of the containers that participate in the serving contract.
 
----
+Resource accounting is another lifecycle concern that shows up in real clusters. App container requests are summed because those containers run together. Regular init containers run one at a time, so Kubernetes uses the largest init container request when comparing init requirements to the app-container total for Pod scheduling. The scheduler must reserve enough capacity for both the startup peak and the steady-state app workload, which is one reason init containers can be tuned differently from the main application.
 
-## Pod Lifecycle, Restart Policies, and Boundaries
-
-Understanding the overall lifecycle of a Pod is critical when orchestrating multiple containers. Container restart policy has three possible values: `Always`, `OnFailure`, and `Never`. Pod phases are exactly: `Pending`, `Running`, `Succeeded`, `Failed`, and `Unknown`.
-
-When designing resource allocations for multi-container pods, be mindful of unverified boundaries. While it is generally understood that the effective Pod-level resource request when init containers are present is the maximum of the highest single init container's request and the sum of all app container requests, official documentation on the exact calculation formula is currently sparse. Additionally, while the network namespace is shared by default, it is unverified if the IPC namespace is shared by default between all containers in a Pod without explicit configuration. Finally, there is no documented hard maximum on the number of containers per Pod in the Kubernetes API, though practical node resource limits and etcd object size limits apply.
-
----
-
-## Pattern Recognition
-
-When do you use each pattern? 
-
-| Scenario | Pattern | Why |
-|----------|---------|-----|
-| Wait for database before starting | Init | One-time dependency check |
-| Ship logs to Elasticsearch | Sidecar | Continuous operation |
-| Download config before app starts | Init | Setup task |
-| Watch config file for changes | Sidecar | Continuous operation |
-| Proxy database connections | Ambassador | Abstraction layer |
-| Run database migrations | Init | One-time operation |
-| Add TLS to non-TLS app | Ambassador | Protocol handling |
-| Collect Prometheus metrics | Sidecar | Continuous operation |
-| Translate legacy logs to JSON | Adapter | Data format translation |
-| Expose JMX as Prometheus metrics | Adapter | API protocol translation |
-
----
-
-> **What would happen if**: An init container has a bug and runs `sleep 3600` instead of completing. What state would the pod be stuck in, and how would you diagnose it?
-
----
-
-## Creating Multi-Container Pods Quickly
-
-You cannot create multi-container pods purely imperatively using one-liners. Instead, rely on the generate-and-edit pattern for speed during the CKAD exam:
-
-### Step 1: Generate Base
+You cannot create a complete multi-container Pod purely with a single imperative command. During the CKAD exam, the fast path is usually generate, edit, apply, and verify. Generate a starter Pod manifest with `--dry-run=client -o yaml`, edit the containers and volumes, then apply the file. This gives you valid scaffolding while leaving room to add the extra containers that imperative `kubectl run` does not express well.
 
 ```bash
-k run multi --image=nginx --dry-run=client -o yaml > multi.yaml
+kubectl run multi --image=nginx --dry-run=client -o yaml > multi.yaml
 ```
 
-### Step 2: Add Containers
-
-Edit `multi.yaml`:
+After generating the base manifest, edit the YAML instead of trying to force everything into flags. Add a second container under `spec.containers` when it should run for the lifetime of the Pod. Add an `initContainers` section when the work must happen before app startup. Add volumes only when there is an actual file contract between containers, and mount each volume at the path each image expects.
 
 ```yaml
 apiVersion: v1
@@ -340,7 +307,7 @@ spec:
     command: ["sleep", "3600"]  # ADD THIS
 ```
 
-### Step 3: Add Init Containers (if needed)
+This generated-and-edited manifest is intentionally plain. It proves the shape of a multi-container Pod before you add more complex behavior. A `sleep` command can be useful for a quick exam scaffold when you need a container to remain running, but it is not a production sidecar design. In real workloads, the sidecar should run the actual foreground helper process, such as a proxy, collector, file watcher, or log shipper.
 
 ```yaml
 apiVersion: v1
@@ -360,36 +327,36 @@ spec:
     command: ["sleep", "3600"]
 ```
 
+When you combine init containers and sidecars, read the manifest from top to bottom as a timeline. Init containers complete before app containers, regular app containers run together, and shared volumes are the places where data moves between those steps. That timeline mental model will catch most YAML mistakes before you even apply the file, including a long-running command placed in the init section or a setup command placed beside the app where it can race startup.
+
 ---
 
 ## Debugging Multi-Container Pods
 
-When working with multiple containers, standard commands require extra specificity to target the correct container boundary.
-
-### Specify Container
+Debugging gets more specific when a Pod has multiple containers. Commands that were unambiguous for a single-container Pod now need a container name. `kubectl logs` needs `-c` when Kubernetes cannot infer the target, and `kubectl exec` should name the container so you open a shell in the process environment you actually intend to inspect. This is not just exam ceremony; it prevents you from reading the wrong logs and fixing the wrong container.
 
 ```bash
 # Logs from specific container
-k logs multi -c sidecar
+kubectl logs multi -c sidecar
 
 # Exec into specific container
-k exec -it multi -c sidecar -- sh
+kubectl exec -it multi -c sidecar -- sh
 
 # Describe shows all containers
-k describe pod multi
+kubectl describe pod multi
 ```
 
-### Check Container Status
+`kubectl describe pod` remains the broadest first look because it shows init containers, app containers, restart counts, state transitions, readiness, mounts, and Events in one place. Use it to identify which container is failing, then narrow the investigation with logs or exec. If the Pod is stuck before app startup, use the init container logs. If the Pod is `1/2 Ready`, check the non-ready app or sidecar container.
 
 ```bash
 # All container statuses
-k get pod multi -o jsonpath='{.status.containerStatuses[*].name}'
+kubectl get pod multi -o jsonpath='{.status.containerStatuses[*].name}'
 
 # Check if ready
-k get pod multi -o jsonpath='{range .status.containerStatuses[*]}{.name}{"\t"}{.ready}{"\n"}{end}'
+kubectl get pod multi -o jsonpath='{range .status.containerStatuses[*]}{.name}{"\t"}{.ready}{"\n"}{end}'
 ```
 
-### Common Issues
+JSONPath is a useful CKAD tool because it gives quick answers without scrolling through a long describe output. The first command prints the app container names from status, while the second prints each container and its readiness value. If you need init container status, inspect `.status.initContainerStatuses` instead. The habit is the same: ask Kubernetes for the specific container boundary you are debugging.
 
 | Symptom | Cause | Solution |
 |---------|-------|----------|
@@ -398,94 +365,139 @@ k get pod multi -o jsonpath='{range .status.containerStatuses[*]}{.name}{"\t"}{.
 | Containers can't share data | No shared volume | Add `emptyDir` volume |
 | Main can't reach sidecar | Network misconfiguration | Use `localhost:port` |
 
+The table captures the first branch of the debugging tree. Init states point toward init logs, crash loops point toward command or image behavior, missing shared data points toward volumes and mounts, and connection failures point toward localhost ports or process readiness. The mistake is treating every multi-container failure like a generic Pod failure. You need to ask which boundary is broken: lifecycle, filesystem, network, or command targeting.
+
+Before you reach for an ephemeral container, decide what evidence you cannot get from normal status, logs, and describe output. Ephemeral containers are valuable when the target image lacks tools, but they should not replace basic diagnosis. If the issue is a bad mount path, `kubectl describe pod` will often show it. If the issue is a sidecar command that exits immediately, the sidecar logs are usually enough.
+
+---
+
+## Patterns & Anti-Patterns
+
+**Pattern: keep setup separate from serving.** Use regular init containers for work that must happen once and finish before the application starts. This works when the setup output is a file, directory, permission change, schema check, or dependency probe that has a clear success condition. It scales operationally because the app image stays small while startup logic remains visible in the Pod spec.
+
+**Pattern: share files only when files are the contract.** A sidecar that tails a log file or an init container that writes generated content is easy to reason about because the shared volume is the handoff. This works best for append-only or replaceable data that can be recreated when the Pod is recreated. It becomes fragile when the file format is undocumented or when two containers write to the same path without ownership rules.
+
+**Pattern: use localhost for live request paths.** An ambassador proxy, local metrics endpoint, or in-Pod API call should usually use the shared network namespace rather than a shared file. The request-response shape gives the caller immediate success or failure, and the proxy can own protocol behavior that the application should not implement. The scaling limit is that the proxy is now part of every request, so it needs resources, readiness, and logs.
+
+**Anti-pattern: turning init containers into background services.** A regular init container that runs forever blocks the app containers forever. Teams fall into this when they copy a long-running shell loop into the wrong field because it looks like the easiest place to add helper work. The fix is to move continuous behavior to a sidecar, or to use native sidecar semantics when startup and shutdown ordering are part of the requirement.
+
+**Anti-pattern: using one Pod as a small cluster.** If two containers should scale independently, roll out independently, or survive each other's failures independently, placing them in one Pod hides real architecture behind a local convenience. Teams often do this to avoid Services or Deployments early in a project. The better design is separate Pods with a Service boundary, leaving multi-container Pods for helpers that truly share a lifecycle.
+
+**Anti-pattern: omitting the container name during diagnosis.** In a multi-container Pod, commands without `-c` can fail or send you toward the wrong evidence. This happens because the single-container habit is strong and because `kubectl describe pod` shows a lot of information at once. The fix is to list container names early, then use explicit container targeting for logs, exec, and mental ownership of each process.
+
+**Anti-pattern: treating observability helpers as free.** A log shipper, adapter, or metrics sidecar consumes CPU, memory, network, and failure budget inside the Pod. Teams fall into this because helpers look smaller than the main app and are often copied from examples. The fix is to define resource requests, confirm the helper runs a foreground process, and decide whether helper failure should remove the Pod from Service endpoints.
+
+---
+
+## Decision Framework
+
+Choose the pattern by asking three questions in order. First, does the work need to finish before the application starts? If yes, it is init work unless it must remain running as a native sidecar. Second, does the work need to run continuously beside the app? If yes, decide whether it enhances the app, proxies external traffic, or translates output. Third, what is the communication contract: a file, a local network call, or process visibility?
+
+This order prevents a common design shortcut. Many helper requirements sound similar at first because they all involve "another container." The lifecycle question separates setup from runtime. The responsibility question separates sidecar, ambassador, and adapter. The communication question decides whether you need a volume, a port plan, or `shareProcessNamespace`. You can apply this framework quickly during the exam and more deliberately during production review.
+
+| Scenario | Pattern | Why |
+|----------|---------|-----|
+| Wait for database before starting | Init | One-time dependency check |
+| Ship logs to Elasticsearch | Sidecar | Continuous operation |
+| Download config before app starts | Init | Setup task |
+| Watch config file for changes | Sidecar | Continuous operation |
+| Proxy database connections | Ambassador | Abstraction layer |
+| Run database migrations | Init | One-time operation |
+| Add TLS to non-TLS app | Ambassador | Protocol handling |
+| Collect Prometheus metrics | Sidecar | Continuous operation |
+| Translate legacy logs to JSON | Adapter | Data format translation |
+| Expose JMX as Prometheus metrics | Adapter | API protocol translation |
+
+Use the table as a pattern-recognition drill, but do not stop at the middle column. The "Why" column is what keeps the answer transferable. Database waiting and migrations are init work because they must complete before startup. Log shipping and config watching are sidecar work because they continue while the app runs. TLS proxying is ambassador work because the app talks locally while the helper handles protocol concerns outside the Pod.
+
+There are edge cases. A database migration might be better as a Job when it must run once per release rather than once per Pod replica. A config watcher might be unnecessary when a ConfigMap reload mechanism or rollout is enough. A service mesh might replace a hand-written ambassador container in a production platform. Those alternatives do not weaken the multi-container patterns; they remind you to choose the smallest Kubernetes primitive that matches lifecycle, ownership, and failure behavior.
+
+For CKAD purposes, keep one practical sequence in mind. Generate a starter manifest, edit the correct container section, add volumes only when there is a file handoff, and verify with container-specific commands. If a task asks for a Pod, answer with a Pod. If it asks for a one-time cluster operation, consider whether a Job is more appropriate, but do not overbuild the solution when the requirement is clearly local to one Pod.
+
 ---
 
 ## Did You Know?
 
-- **Init containers can have different images than app containers.** Use specialized tools (like `git`, database clients) in init containers without bloating your app image.
-- **The ambassador pattern predates service meshes.** Before Istio and Linkerd, developers used ambassador containers to handle cross-cutting concerns. Now service meshes automate sidecar injection.
-- The SidecarContainers feature was introduced as alpha in Kubernetes v1.28 on August 25, 2023, and officially graduated to stable (GA) in v1.33 on April 23, 2025.
-- Ephemeral containers, heavily relied upon for debugging stripped-down multi-container pods, became a stable (GA) feature in Kubernetes v1.25.
-- In *Infrastructure as Code*, the canonical Knight Capital 2012 <!-- incident-xref: knight-capital-2012 --> cross-reference shows why lifecycle controls are essential when partial rollout and execution ordering become coupled to operational speed and reliability.
-- Kubernetes v1.29 enabled native sidecar containers by default, definitively solving the infamous race condition where a proxy sidecar would shut down before the main application had finished processing its final in-flight requests.
+- **Init containers can use different images from app containers.** This lets you run setup tools such as DNS utilities, Git clients, or database clients without permanently adding those tools to the application image.
+- **The SidecarContainers feature reached stable status in Kubernetes v1.33 on April 23, 2025.** In Kubernetes v1.35, native sidecars are expressed as init containers with `restartPolicy: Always`.
+- **Ephemeral containers became stable in Kubernetes v1.25.** They are designed for debugging running Pods and are added through a special API subresource rather than ordinary Pod spec editing.
+- **A Pod has exactly five documented phase names.** They are `Pending`, `Running`, `Succeeded`, `Failed`, and `Unknown`, while detailed container state lives under container status fields.
 
 ---
 
 ## Common Mistakes
 
-| Mistake | Why It Hurts | Solution |
-|---------|--------------|----------|
-| Forgetting `-c container` | Wrong container logs | Always specify `-c container-name` in multi-container pods |
-| Init container with `sleep` | Pod never starts | Ensure init commands exit 0; do not use long sleeps |
-| No shared volume | Containers can't communicate via files | Add an `emptyDir` volume mounted in both containers |
-| Sidecar exits immediately | Pod keeps restarting | Add `sleep infinity` or run an actual foreground service |
-| Wrong port in localhost | Connection refused | Verify port mappings match the ambassador/main container |
-| Modifying Ephemeral container | API Rejection | Ephemeral containers cannot be changed or removed once added |
-| Missing `shareProcessNamespace` | Can't signal processes | Set `shareProcessNamespace: true` to allow inter-container signaling |
-| Using livenessProbe on regular init | Validation Error | Regular init containers do not support liveness probes |
+| Mistake | Why It Happens | How to Fix It |
+|---------|----------------|---------------|
+| Forgetting `-c container` | Single-container habits carry over, so logs or exec commands target no clear container | Always specify `-c container-name` when inspecting multi-container Pods |
+| Init container with `sleep` | A long-running helper is accidentally placed in the blocking init lifecycle | Ensure init commands exit zero, and move continuous work to a sidecar |
+| No shared volume | The producer writes a file into its own filesystem, while the consumer reads a different filesystem | Add an `emptyDir` volume and mount it into both containers at the required paths |
+| Sidecar exits immediately | The helper command performs one action and exits instead of running a foreground service | Run a real foreground helper process, or use a deliberate long-running command only for exam scaffolding |
+| Wrong port in localhost | Containers share one network namespace, so port assumptions and conflicts are easy to miss | Verify the listening port and have the caller use `localhost:port` consistently |
+| Modifying an ephemeral container | Ephemeral containers feel like normal spec entries, but the API treats them as append-only debug entries | Add a new ephemeral container with a new name if the first debug attempt was wrong |
+| Missing `shareProcessNamespace` | A debug or helper container expects to see another container's process IDs by default | Set `shareProcessNamespace: true` only when cross-container process visibility is required |
+| Using livenessProbe on a regular init container | Probe fields are copied from app containers into a lifecycle that only needs an exit status | Remove app-style probes from regular init containers and make the command return the correct status |
 
 ---
 
 ## Quiz
 
-1. **Your pod has two init containers: `init-db` (waits for database) and `init-config` (downloads configuration). The pod is stuck showing `Init:1/2`. Which init container succeeded and which is still running? How do you find out what's wrong?**
-   <details>
-   <summary>Answer</summary>
-   `Init:1/2` means the first init container (`init-db`) completed successfully, but the second (`init-config`) is still running or failing. Init containers run sequentially -- `init-config` can't start until `init-db` exits 0. Diagnose with `kubectl logs <pod> -c init-config` to see its output, and `kubectl describe pod <pod>` to check Events for errors like image pull failures or command errors. If `init-config` is stuck in a retry loop (e.g., downloading from an unreachable URL), fix the URL or the network issue.
-   </details>
+<details>
+<summary>Question 1: Your Pod has two init containers, `init-db` and `init-config`, and status shows `Init:1/2`. Which container has completed, which one is blocking startup, and what evidence should you collect first?</summary>
 
-2. **A microservice team deploys their API with a sidecar that ships logs to Elasticsearch. After deployment, `kubectl get pod api-pod` shows `1/2 Ready`. The main container is fine but the sidecar keeps crashing. What are the most likely causes, and does this affect the main application?**
-   <details>
-   <summary>Answer</summary>
-   The sidecar is likely crashing because its process is exiting prematurely, which can happen if the command isn't a long-running daemon (like `tail -F`), if the Elasticsearch endpoint is unreachable, or if there is no shared volume preventing log access. You can diagnose the exact root cause by running `kubectl logs api-pod -c log-shipper` to view the crash output. Although the main application container continues to run perfectly fine, the overall pod Ready status will remain `1/2`. Because the pod is not fully ready, Kubernetes will stop routing Service traffic to it, essentially taking the pod out of rotation until the sidecar stabilizes.
-   </details>
+`Init:1/2` means the first init container has completed successfully and the second init container is still running, failing, or retrying. Because init containers run sequentially, the application containers have not started yet, so debugging nginx or the main app would waste time. Start with `kubectl describe pod` to inspect Events and init state, then read `kubectl logs <pod> -c init-config` to see the active init container output. If the logs show an unreachable URL, bad command, or endless wait loop, fix that setup step so it exits zero.
 
-3. **You're building an application that needs to: (1) clone a git repository before starting, (2) serve the repo content via nginx, and (3) have a background process that pulls git updates every 60 seconds. Which multi-container pattern(s) do you use, and how do the containers share the git data?**
-   <details>
-   <summary>Answer</summary>
-   Use an init container for the initial git clone (one-time setup task), nginx as the main container to serve content, and a sidecar for the periodic git pull (continuous background operation). All three share an `emptyDir` volume mounted at the same path. The init container clones into `/data`, nginx serves from `/data`, and the sidecar runs `git pull` in `/data` every 60 seconds. This is a classic combination of init + sidecar patterns working together through shared volumes.
-   </details>
+</details>
 
-4. **During the CKAD exam, you need to add a sidecar container to an existing pod. You run `kubectl logs mypod` and get an error asking you to specify a container name. Why does this happen, and what's the fastest way to find the container names?**
-   <details>
-   <summary>Answer</summary>
-   When a pod has multiple containers, `kubectl logs` doesn't know which container's logs you want and requires the `-c` flag. The fastest way to find container names is `kubectl get pod mypod -o jsonpath='{.spec.containers[*].name}'`, which prints all container names on one line. Alternatively, `kubectl describe pod mypod` shows containers under the "Containers:" section. Once you have the name, use `kubectl logs mypod -c container-name`. In the exam, always use `-c` for multi-container pods to avoid wasting time on this error.
-   </details>
+<details>
+<summary>Question 2: A web API runs with a log-shipper sidecar. The main container is healthy, but the Pod shows `1/2 Ready` because the sidecar keeps crashing. What are the likely causes, and why can this affect Service traffic?</summary>
 
-5. **You need to integrate an older legacy application that outputs proprietary telemetry data into a modern Prometheus monitoring stack. You cannot modify the legacy application's source code. Which multi-container pattern is best suited for this, and why?**
-   <details>
-   <summary>Answer</summary>
-   The Adapter pattern is the correct choice for this scenario. This pattern is explicitly designed to translate disparate data formats, protocols, or APIs between a main application container and external monitoring services. By deploying an adapter container alongside the legacy application, it can ingest the proprietary telemetry locally. It then exposes a standard `/metrics` endpoint in the Prometheus format, entirely avoiding any risky modifications to the legacy source code.
-   </details>
+The sidecar may be exiting immediately, failing to read the shared log path, or failing when it tries to connect to the external log destination. The main process can still be healthy because containers have separate processes, but Pod readiness reflects the containers that Kubernetes considers part of the ready workload. If the sidecar has a readiness requirement and remains unready, the Pod may be removed from Service endpoints even though the main container can answer locally. Diagnose the sidecar with container-specific logs and confirm the shared volume mount before changing the application.
 
-6. **Your application requires a sidecar container to securely proxy requests to an external API (the Ambassador pattern). However, during pod termination, the sidecar shuts down before the main container finishes processing in-flight requests, causing errors. How does Kubernetes v1.33+ solve this?**
-   <details>
-   <summary>Answer</summary>
-   Starting with Kubernetes v1.29 (beta) and fully stable in v1.33, the native SidecarContainers feature solves this race condition natively. By defining the sidecar under the `spec.initContainers` array with `restartPolicy: Always`, Kubernetes treats it as a true sidecar rather than a standard init container. When the pod receives a termination signal, the kubelet deliberately postpones terminating these native sidecar containers until the main application containers have completely shut down. This guaranteed shutdown order ensures the proxy remains fully available to handle and route all remaining in-flight requests during the pod's graceful termination phase.
-   </details>
+</details>
 
-7. **You added an ephemeral container to a running Pod to capture network packets, but you made a typo in the command. The ephemeral container immediately exits. You try to use `kubectl edit pod` to fix the typo in the ephemeral container's spec. What happens, and how do you resolve the situation?**
-   <details>
-   <summary>Answer</summary>
-   The API will reject the edit. Ephemeral containers cannot be changed or removed once they are added to a Pod. They are inserted via the `ephemeralcontainers` subresource, not standard pod spec updates. To resolve this, you must add a brand new ephemeral container with a different name and the corrected command, leaving the failed one in a terminated state.
-   </details>
+<details>
+<summary>Question 3: You need to clone content before nginx starts, serve that content, and refresh it every 60 seconds. Which patterns should you combine, and how should the containers share data?</summary>
 
-8. **A pod's `restartPolicy` is set to `OnFailure`. An init container fails to download a required configuration file and exits with a non-zero status. What will the kubelet do in response to this failure?**
-   <details>
-   <summary>Answer</summary>
-   Because the pod's overall `restartPolicy` is set to `OnFailure` (or `Always`), the kubelet will repeatedly restart the failed init container until it eventually succeeds. Kubernetes enforces a strict execution order where init containers must run sequentially and exit successfully before progressing. Therefore, the main application containers will remain blocked and will not start until this failing init container completes with a zero exit code. You would need to inspect the logs and fix the underlying issue (such as correcting the URL or fixing network permissions) so the container can break out of its crash loop.
-   </details>
+Use an init container for the initial clone because the first copy must exist before nginx starts. Use nginx as the main container and a sidecar for the continuing refresh loop because periodic updates are runtime behavior. All three containers should share an `emptyDir` volume, with the init container writing the initial content, nginx serving the mounted directory, and the sidecar updating the same directory. This combines lifecycle ordering with a file-based communication contract.
+
+</details>
+
+<details>
+<summary>Question 4: During an exam task, `kubectl logs mypod` returns an error asking for a container name. What does that tell you, and what is the fastest safe next step?</summary>
+
+The error tells you the Pod has multiple containers and Kubernetes cannot infer which log stream you want. The safe next step is to list or inspect container names, for example with JSONPath or `kubectl describe pod`, then rerun logs with `-c container-name`. Guessing the name wastes time and can hide the real failing container. The broader lesson is that multi-container debugging should always name the container boundary explicitly.
+
+</details>
+
+<details>
+<summary>Question 5: A legacy application writes proprietary telemetry locally, and you cannot modify its source code. Which pattern should you use to expose Prometheus-style metrics, and what tradeoff does that introduce?</summary>
+
+Use the adapter pattern because the helper container can read the legacy output and expose a standard metrics endpoint. This keeps the main application unchanged while allowing the platform's monitoring stack to scrape a familiar format. The tradeoff is that the translation logic becomes part of the Pod's operational contract, so the adapter needs resources, logs, and version ownership. If the adapter fails, monitoring may break even when the application still serves user traffic.
+
+</details>
+
+<details>
+<summary>Question 6: Your application talks to a database through `localhost:5432`, and a second container owns the real database endpoint and TLS details. Which pattern is this, and what failure mode should you watch during rollout?</summary>
+
+This is the ambassador pattern because the application talks locally while the helper represents an external service. The most important failure mode is that the main app can be healthy while the local proxy is unavailable or misconfigured. During rollout, verify that the ambassador is listening on the expected local port, has the correct external target, and becomes ready before the app receives traffic. If native sidecar ordering is required, use Kubernetes v1.35 sidecar semantics rather than relying on accidental startup timing.
+
+</details>
+
+<details>
+<summary>Question 7: You add an ephemeral container for debugging, but the command has a typo and exits immediately. Why can you not simply edit it, and how do you continue the investigation?</summary>
+
+Ephemeral containers are appended to a running Pod through the ephemeral containers subresource and cannot be changed or removed after they are added. That restriction keeps the debugging history attached to the Pod but means mistakes remain visible in terminated state. Continue by adding a new ephemeral container with a different name and the corrected command. If you need planned helper behavior rather than temporary debugging, change the Pod template instead of using ephemeral containers.
+
+</details>
 
 ---
 
 ## Hands-On Exercise
 
-**Task**: Build a pod with init, sidecar, and main containers.
+In this exercise you will build the local collaboration pattern that appears repeatedly in CKAD tasks: an init container writes content into a shared volume, nginx serves the content, and a sidecar observes the same file over time. The important part is not the sample message. The important part is proving that each container has a distinct responsibility and that the volume is the only handoff point between them.
 
-**Scenario**: Create an app that:
-1. Init: Downloads config from a URL (simulated)
-2. Main: Runs nginx serving the config
-3. Sidecar: Monitors and logs changes
+Create a file named `full-pattern.yaml` with the manifest below. The init container simulates a configuration download by writing an HTML file. The main container serves the file through nginx, and the monitor sidecar reads the same file every ten seconds. This is intentionally small enough to run in a practice cluster, but it exercises init ordering, shared volumes, container-specific logs, and cleanup.
 
 ```yaml
 apiVersion: v1
@@ -519,46 +531,46 @@ spec:
     emptyDir: {}
 ```
 
-**Verification:**
+Run the verification commands in order and pause after each one to state what evidence it should produce. You are looking for four proofs: the Pod becomes Ready, the init container completed, nginx serves the generated file, and the monitor sidecar can read the same content. If one proof is missing, diagnose that boundary before changing unrelated YAML.
+
 ```bash
 # Apply
-k apply -f full-pattern.yaml
+kubectl apply -f full-pattern.yaml
 
 # View current state
-k get pod full-pattern
+kubectl get pod full-pattern
 
 # Wait for ready
-k wait --for=condition=Ready pod/full-pattern --timeout=60s
+kubectl wait --for=condition=Ready pod/full-pattern --timeout=60s
 
 # Check init completed
-k describe pod full-pattern | grep -A5 "Init Containers"
+kubectl describe pod full-pattern | grep -A5 "Init Containers"
 
 # Check nginx serves content
-k exec full-pattern -c nginx -- curl localhost
+kubectl exec full-pattern -c nginx -- curl localhost
 
 # Check monitor logs
-k logs full-pattern -c monitor
+kubectl logs full-pattern -c monitor
 
 # Cleanup
-k delete pod full-pattern
+kubectl delete pod full-pattern
 ```
 
-**Success Checklist:**
+Success criteria should be evidence-based rather than hope-based. A Pod phase alone is not enough, because the learning target is the relationship between containers. Use the checklist below as the minimum evidence set, then repeat the drills until the commands feel automatic.
+
 - [ ] Pod reaches the `Running` state successfully.
 - [ ] Init container logs show the configuration was written.
 - [ ] Nginx container successfully serves the content on localhost.
 - [ ] Monitor sidecar continuously logs the configuration content.
 - [ ] Pod initialization transitions were clearly observed using `kubectl get pod -w`.
 
----
-
-## Practice Drills
-
 ### Drill 1: Basic Init Container (Target: 3 minutes)
+
+This drill isolates startup ordering. The init container prints a message, sleeps briefly, and exits before nginx starts. After the Pod becomes Ready, inspect the init logs to confirm that the completed setup step remains observable even though the init container is no longer running.
 
 ```bash
 # Create pod with init container
-cat << 'EOF' | k apply -f -
+cat << 'EOF' | kubectl apply -f -
 apiVersion: v1
 kind: Pod
 metadata:
@@ -574,23 +586,25 @@ spec:
 EOF
 
 # View current state
-k get pod init-pod
+kubectl get pod init-pod
 
 # Watch pod start
-k wait --for=condition=Ready pod/init-pod --timeout=60s
+kubectl wait --for=condition=Ready pod/init-pod --timeout=60s
 
 # Check init logs
-k logs init-pod -c init
+kubectl logs init-pod -c init
 
 # Cleanup
-k delete pod init-pod
+kubectl delete pod init-pod
 ```
 
 ### Drill 2: Basic Sidecar (Target: 3 minutes)
 
+This drill isolates the runtime helper pattern. The sidecar has no useful production purpose, but it proves that two app containers can run together and that you need container-specific logs. If the sidecar exits, the example stops teaching the intended lifecycle, so keep the loop running until cleanup.
+
 ```bash
 # Create pod with sidecar
-cat << 'EOF' | k apply -f -
+cat << 'EOF' | kubectl apply -f -
 apiVersion: v1
 kind: Pod
 metadata:
@@ -605,23 +619,25 @@ spec:
 EOF
 
 # Verify both containers
-k get pod sidecar-pod -o jsonpath='{.spec.containers[*].name}'
+kubectl get pod sidecar-pod -o jsonpath='{.spec.containers[*].name}'
 
 # Wait for pod to be ready
-k wait --for=condition=Ready pod/sidecar-pod --timeout=60s
+kubectl wait --for=condition=Ready pod/sidecar-pod --timeout=60s
 
 # Check sidecar logs
-k logs sidecar-pod -c sidecar
+kubectl logs sidecar-pod -c sidecar
 
 # Cleanup
-k delete pod sidecar-pod
+kubectl delete pod sidecar-pod
 ```
 
 ### Drill 3: Shared Volume (Target: 4 minutes)
 
+This drill proves file-based communication. The writer appends timestamps to a file, and the reader tails that file from the same `emptyDir` volume. If the reader logs remain empty, the likely causes are a missing volume, a mount path mismatch, or a writer command that never created the expected file.
+
 ```bash
 # Create pod with shared volume
-cat << 'EOF' | k apply -f -
+cat << 'EOF' | kubectl apply -f -
 apiVersion: v1
 kind: Pod
 metadata:
@@ -646,23 +662,25 @@ spec:
 EOF
 
 # Wait for pod to be ready
-k wait --for=condition=Ready pod/shared-vol --timeout=60s
+kubectl wait --for=condition=Ready pod/shared-vol --timeout=60s
 
 # Check reader sees writer's data
-k logs shared-vol -c reader
+kubectl logs shared-vol -c reader
 
 # Cleanup
-k delete pod shared-vol
+kubectl delete pod shared-vol
 ```
 
 ### Drill 4: Init Waiting for Service (Target: 5 minutes)
 
+This drill practices a dependency gate. The Service is created first so the init container has a DNS name to resolve, and the main container starts only after the lookup succeeds. If you remove the Service or change the name, the Pod should remain in an init state, which is exactly the behavior required dependency checks should produce.
+
 ```bash
 # Create a service first
-k create svc clusterip wait-svc --tcp=80:80
+kubectl create svc clusterip wait-svc --tcp=80:80
 
 # Create pod that waits for service
-cat << 'EOF' | k apply -f -
+cat << 'EOF' | kubectl apply -f -
 apiVersion: v1
 kind: Pod
 metadata:
@@ -678,18 +696,20 @@ spec:
 EOF
 
 # Check init status
-k describe pod wait-pod | grep -A3 "Init Containers"
+kubectl describe pod wait-pod | grep -A3 "Init Containers"
 
 # Cleanup
-k delete pod wait-pod
-k delete svc wait-svc
+kubectl delete pod wait-pod
+kubectl delete svc wait-svc
 ```
 
 ### Drill 5: Ambassador Pattern (Target: 5 minutes)
 
+This drill shows the local proxy shape. The main container repeatedly calls `localhost:80`, and the proxy container owns the listener. In a real ambassador design the proxy would forward to an external dependency, but the local nginx proxy is enough to prove the shared network namespace and the need for a clear port plan.
+
 ```bash
 # Create pod with ambassador proxy
-cat << 'EOF' | k apply -f -
+cat << 'EOF' | kubectl apply -f -
 apiVersion: v1
 kind: Pod
 metadata:
@@ -706,28 +726,18 @@ spec:
 EOF
 
 # Wait for pod to be ready
-k wait --for=condition=Ready pod/ambassador-pod --timeout=60s
+kubectl wait --for=condition=Ready pod/ambassador-pod --timeout=60s
 
 # Main accesses proxy via localhost
-k logs ambassador-pod -c main
+kubectl logs ambassador-pod -c main
 
 # Cleanup
-k delete pod ambassador-pod
+kubectl delete pod ambassador-pod
 ```
 
 ### Drill 6: Complete Multi-Container Challenge (Target: 8 minutes)
 
-**No hints—build from memory:**
-
-Create a pod named `app-complete` with:
-1. Init container: Creates `/data/config.txt` with "Config loaded"
-2. Main container (nginx): Serves `/data` directory
-3. Sidecar: Monitors `/data/config.txt` every 5 seconds
-
-After creating, verify:
-- Pod is Running
-- Init completed successfully
-- Sidecar shows config content
+Exercise scenario: create a Pod named `app-complete` with an init container that writes `/data/config.txt`, an nginx container that serves the mounted data directory, and a sidecar that reads the config file every five seconds. Build it from memory first, then compare your work with the solution. The success signal is not only that the Pod runs; it is that each container proves its role through observable output.
 
 <details>
 <summary>Solution</summary>
@@ -763,17 +773,32 @@ spec:
 ```
 
 ```bash
-k apply -f app-complete.yaml
-k get pod app-complete
-k wait --for=condition=Ready pod/app-complete --timeout=60s
-k logs app-complete -c init
-k logs app-complete -c monitor
-k delete pod app-complete
+kubectl apply -f app-complete.yaml
+kubectl get pod app-complete
+kubectl wait --for=condition=Ready pod/app-complete --timeout=60s
+kubectl logs app-complete -c init
+kubectl logs app-complete -c monitor
+kubectl delete pod app-complete
 ```
 
 </details>
 
 ---
+
+## Sources
+
+- https://kubernetes.io/docs/concepts/workloads/pods/
+- https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+- https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/
+- https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/
+- https://kubernetes.io/docs/concepts/workloads/pods/ephemeral-containers/
+- https://kubernetes.io/docs/concepts/storage/volumes/#emptydir
+- https://kubernetes.io/docs/tasks/debug/debug-application/debug-running-pod/
+- https://kubernetes.io/docs/tasks/debug/debug-application/debug-running-pod/#ephemeral-container
+- https://kubernetes.io/docs/reference/kubectl/generated/kubectl_logs/
+- https://kubernetes.io/docs/reference/kubectl/generated/kubectl_exec/
+- https://kubernetes.io/docs/reference/kubectl/generated/kubectl_wait/
+- https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#pod-v1-core
 
 ## Next Module
 

--- a/src/content/docs/k8s/ckad/part1-design-build/module-1.3-multi-container-pods.md
+++ b/src/content/docs/k8s/ckad/part1-design-build/module-1.3-multi-container-pods.md
@@ -531,7 +531,7 @@ spec:
     emptyDir: {}
 ```
 
-Run the verification commands in order and pause after each one to state what evidence it should produce. You are looking for four proofs: the Pod becomes Ready, the init container completed, nginx serves the generated file, and the monitor sidecar can read the same content. If one proof is missing, diagnose that boundary before changing unrelated YAML.
+Run the verification commands in order and pause after each one to state what evidence it should produce. You are looking for four proofs: the Pod becomes Ready, the init container completed, the monitor sidecar can read the shared file directly, and the monitor logs show the same content over time. If one proof is missing, diagnose that boundary before changing unrelated YAML.
 
 ```bash
 # Apply
@@ -546,8 +546,8 @@ kubectl wait --for=condition=Ready pod/full-pattern --timeout=60s
 # Check init completed
 kubectl describe pod full-pattern | grep -A5 "Init Containers"
 
-# Check nginx serves content
-kubectl exec full-pattern -c nginx -- curl localhost
+# Check monitor reads shared content
+kubectl exec full-pattern -c monitor -- cat /data/index.html
 
 # Check monitor logs
 kubectl logs full-pattern -c monitor
@@ -560,7 +560,7 @@ Success criteria should be evidence-based rather than hope-based. A Pod phase al
 
 - [ ] Pod reaches the `Running` state successfully.
 - [ ] Init container logs show the configuration was written.
-- [ ] Nginx container successfully serves the content on localhost.
+- [ ] Monitor sidecar can read the shared file from `/data/index.html`.
 - [ ] Monitor sidecar continuously logs the configuration content.
 - [ ] Pod initialization transitions were clearly observed using `kubectl get pod -w`.
 


### PR DESCRIPTION
## Summary

Rewrites `src/content/docs/k8s/ckad/part1-design-build/module-1.3-multi-container-pods.md` to clear the #388 verifier gates and clears `revision_pending: false`.

## Verification

Verifier: T0; body_words=5322, mean_wpp=69.1, median_wpp=71, short_rate=0.026, max_run=1; all density, structure, alignment, anti_leak, runnable-shell, and sources_min_10 gates pass. Source reachability was skipped per the requested verifier command; sources_count=12.

Protected assets preserved: code_blocks 22 -> 22, mermaid_diagrams 1 -> 1, tables 4 -> 4, ascii_diagrams 0 -> 0. Existing lab URL and next-module link were preserved.

Commit SHA: 0f98125d2c62a2ce27ec48013b31969cd0835c5f

## Commands Run

- `../../.venv/bin/python scripts/quality/verify_module.py --glob src/content/docs/k8s/ckad/part1-design-build/module-1.3-multi-container-pods.md --skip-source-check --summary --quiet`
- `git diff --check -- src/content/docs/k8s/ckad/part1-design-build/module-1.3-multi-container-pods.md`