### PR TITLE
chore(deps): bump devalue → 5.8.1 (CVE: high)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4156,9 +4156,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
-      "integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "license": "MIT"
     },
     "node_modules/devlop": {


### PR DESCRIPTION
## Summary
- Bumps `devalue` from 5.6.4 → 5.8.1 (patched version)
- Closes Dependabot alert #15 (high severity): Svelte devalue DoS via sparse array deserialization
- Transitive dep via `astro@6.3.2` — `package-lock.json` only, no `package.json` change needed

## Verification
- `npm update devalue` clean
- `npm ls devalue` → resolves to 5.8.1 (was 5.6.4, vulnerable range `>=5.6.3,<=5.8.0`)
- `npm audit --omit=dev` → 0 vulnerabilities
- `npm run build` → 2023 pages built in 105s, no errors

## Test plan
- [x] Build passes
- [x] npm audit clean
- [ ] Merge ⇒ Dependabot alert closes automatically