### PR TITLE
feat(agents): integrate Grok-4 (xai-oauth via hermes) as full peer agent

### DIFF
--- a/scripts/agent_runtime/adapters/grok.py
+++ b/scripts/agent_runtime/adapters/grok.py
@@ -1,0 +1,236 @@
+"""GrokAdapter — wraps ``hermes -z`` (xai-oauth provider) for the agent runtime.
+
+Fourth production adapter. Brings grok-4 (and successors) online as a peer
+to codex / claude / gemini for code review, deliberation, and fix lanes.
+
+Key design points:
+
+- **Transport:** ``hermes`` CLI in oneshot mode (``-z -`` reads prompt
+  from stdin). Hermes proxies to xAI via the ``xai-oauth`` provider
+  (loopback PKCE OAuth set up via ``hermes login``). No API key required.
+- **Modes:** All three (read-only / workspace-write / danger) supported.
+  Mode → hermes toolset mapping is conservative for read-only (no
+  terminal/file tools), permissive for workspace-write and danger.
+- **Project context:** hermes injects KubeDojo project state via its
+  ``memory`` + ``skills`` toolsets unless suppressed. We keep this on for
+  review/code work (gives grok situational awareness) but disable via
+  ``--ignore-user-config --ignore-rules`` when the caller passes
+  ``tool_config={"isolated": True}`` (used for benchmark / calibration).
+- **No session resume.** ``resume_policy=never`` in the registry — hermes
+  has session semantics but cross-worktree contamination would mirror the
+  Codex footgun. Defensively ignored even if passed.
+- **Liveness:** hermes streams output to stdout, so the runner's stdout
+  watchdog handles liveness. ``liveness_signal_paths()`` returns ``()``.
+
+Status flagged for the user:
+- Grok writer DQ'd by the #388 deterministic verifier gate (see memory
+  ``project_grok_writer_word_cap_2026-05-16.md``). This adapter does NOT
+  unlock the writer lane — the verifier gate is the floor. It DOES unlock
+  reviewer, fixer, ab-discuss, and one-shot research lanes.
+
+Issue: #1184 (agent-runtime), #1235 (reviewer reassignment context).
+"""
+from __future__ import annotations
+
+import os
+import re
+import shutil
+from pathlib import Path
+from typing import Any
+
+from ..result import ParseResult
+from .base import InvocationPlan
+
+# Rate-limit patterns. xAI returns 429 like everyone else; hermes
+# surfaces rate-limit errors in stderr / stdout depending on transport.
+_RATE_LIMIT_PATTERNS = (
+    r"rate limit",
+    r"rate_limit",
+    r"usage limit",
+    r"quota exceeded",
+    r"too many requests",
+    r"\bHTTP 429\b",
+    r"\bstatus 429\b",
+    r"\b429\b",
+    r"xai.*rate",
+    r"x-ai.*rate",
+)
+_RATE_LIMIT_RE = re.compile("|".join(_RATE_LIMIT_PATTERNS), re.IGNORECASE)
+
+# Hermes startup warnings we strip before declaring success.
+_HERMES_BANNER_RE = re.compile(
+    r"^(💡 Python project detected\..*|hermes -z:.*)$",
+    re.MULTILINE,
+)
+
+# Toolsets per mode. Hermes built-in toolsets are documented under
+# `hermes tools list`. We deliberately exclude memory / skills from
+# read-only to keep calibration runs reproducible; they're great for
+# real review/code work though.
+_TOOLSETS_READ_ONLY = "web"
+_TOOLSETS_WORKSPACE = "web,file,terminal,code_execution,todo"
+_TOOLSETS_DANGER = "web,file,terminal,code_execution,todo,memory,skills"
+
+
+class GrokAdapter:
+    """Adapter for ``hermes -z`` with the xai-oauth provider."""
+
+    name: str = "grok"
+    # grok-4 is the canonical model identifier for hermes via xai-oauth.
+    # User may override via env (e.g. when xAI ships grok-4.3 under a new
+    # identifier or routes effort=xhigh via a separate slug).
+    default_model: str = os.environ.get("AB_GROK_MODEL", "grok-4")
+    supported_modes: frozenset[str] = frozenset({"read-only", "workspace-write", "danger"})
+
+    def build_invocation(
+        self,
+        *,
+        prompt: str,
+        mode: str,
+        cwd: Path,
+        model: str | None,
+        task_id: str | None,
+        session_id: str | None,
+        tool_config: dict | None,
+    ) -> InvocationPlan:
+        """Build the hermes oneshot invocation.
+
+        ``tool_config`` keys honored:
+            - ``isolated: bool`` — if True, pass ``--ignore-user-config
+              --ignore-rules`` to bypass hermes's project-context
+              injection. Default False (project context is feature, not
+              bug, for review/code work).
+            - ``toolsets: str`` — comma-separated override for ``-t``.
+              Wins over the mode-default mapping.
+            - ``provider: str`` — override hermes provider. Default
+              ``xai-oauth``. Useful for testing api-key transport once
+              ``xai`` provider gets re-auth'd.
+            - ``effort: str`` — reasoning effort label. Hermes does not
+              expose this as a flag today; we forward it via prompt
+              prefix when ``"xhigh"`` is requested. Tracking issue: see
+              ``project_hermes_model_inventory.md``.
+            - ``yolo: bool`` — pass ``--yolo`` (auto-accept tool calls).
+              Default True for write modes, False for read-only.
+            - ``accept_hooks: bool`` — pass ``--accept-hooks``. Default
+              False; opt-in for callers that want project hooks to fire.
+        """
+        if mode not in self.supported_modes:
+            raise ValueError(f"GrokAdapter: unsupported mode {mode!r}")
+
+        tc: dict[str, Any] = tool_config or {}
+
+        binary = shutil.which("hermes") or "hermes"
+        cmd: list[str] = [binary]
+
+        # Reasoning effort hint applied first so the final prompt string is
+        # the argv positional we pass to -z.
+        effort = tc.get("effort")
+        final_prompt = prompt
+        if effort and effort != "default":
+            final_prompt = f"[Reasoning effort hint: {effort}]\n\n{prompt}"
+
+        # Oneshot mode. Pass the prompt as argv positional, NOT stdin.
+        # ``hermes -z -`` (stdin marker) is interpreted as "no prompt
+        # provided, run in project-introspection mode" — the prompt
+        # piped on stdin is ignored. ARG_MAX is ~1 MB on macOS so the
+        # ~10 KB review prompts fit comfortably; if a caller needs to
+        # pass a multi-megabyte prompt, write it to a temp file and use
+        # a different transport (not the runtime's concern today).
+        cmd.extend(["-z", final_prompt])
+
+        # Model
+        cmd.extend(["-m", model or self.default_model])
+
+        # Provider — xai-oauth is the canonical KubeDojo path
+        # (loopback PKCE; no API key required).
+        provider = tc.get("provider", "xai-oauth")
+        cmd.extend(["--provider", provider])
+
+        # Toolset selection — caller override wins, else mode default.
+        toolsets = tc.get("toolsets")
+        if not toolsets:
+            if mode == "read-only":
+                toolsets = _TOOLSETS_READ_ONLY
+            elif mode == "workspace-write":
+                toolsets = _TOOLSETS_WORKSPACE
+            else:  # danger
+                toolsets = _TOOLSETS_DANGER
+        cmd.extend(["-t", toolsets])
+
+        # Auto-accept tool calls. Required for non-interactive runs that
+        # do file edits or shell ops. Read-only stays prompt-only by
+        # default so we don't accidentally grant network egress through
+        # the web tool's confirm step.
+        yolo_default = mode in ("workspace-write", "danger")
+        if bool(tc.get("yolo", yolo_default)):
+            cmd.append("--yolo")
+
+        if bool(tc.get("accept_hooks", False)):
+            cmd.append("--accept-hooks")
+
+        # Isolation: bypass user config + project rules. Used for
+        # calibration / benchmark runs where deterministic output is
+        # more important than context awareness.
+        if bool(tc.get("isolated", False)):
+            cmd.extend(["--ignore-user-config", "--ignore-rules"])
+
+        # Defensively drop session_id — resume_policy=never.
+        _ = session_id
+        _ = task_id
+
+        return InvocationPlan(
+            cmd=cmd,
+            cwd=cwd,
+            stdin_payload="",  # prompt is in argv; stdin must be empty
+            output_file=None,
+            env_overrides={},
+            liveness_paths=(),
+        )
+
+    def parse_response(
+        self,
+        *,
+        stdout: str,
+        stderr: str,
+        returncode: int,
+        output_file: Path | None,
+        plan: InvocationPlan | None = None,
+        call_start_time: float | None = None,
+    ) -> ParseResult:
+        """Parse hermes -z output.
+
+        Hermes prints the final assistant message to stdout. Diagnostic
+        warnings ("💡 Python project detected.", argument errors) appear
+        in stdout/stderr depending on how hermes was invoked.
+        """
+        _ = output_file
+        _ = plan
+        _ = call_start_time
+
+        # Strip hermes banners that aren't part of the response.
+        clean_stdout = _HERMES_BANNER_RE.sub("", stdout or "").strip()
+
+        combined = f"{clean_stdout}\n{stderr or ''}"
+        rate_limited = bool(_RATE_LIMIT_RE.search(combined))
+
+        ok = returncode == 0 and bool(clean_stdout) and not rate_limited
+        response = clean_stdout if ok else ""
+
+        stderr_excerpt: str | None = None
+        if not ok:
+            excerpt_source = (stderr or "").strip() or (stdout or "").strip()
+            stderr_excerpt = excerpt_source[:500] or None
+
+        return ParseResult(
+            ok=ok,
+            response=response,
+            stderr_excerpt=stderr_excerpt,
+            rate_limited=rate_limited,
+            session_id=None,
+            tokens=None,
+        )
+
+    def liveness_signal_paths(self, plan: InvocationPlan) -> tuple[Path, ...]:
+        """Hermes streams to stdout; the runner's stdout watchdog covers liveness."""
+        _ = plan
+        return ()

--- a/scripts/agent_runtime/registry.py
+++ b/scripts/agent_runtime/registry.py
@@ -81,10 +81,15 @@ AGENTS: dict[str, AgentEntry] = {
     },
     "grok": {
         "adapter": "scripts.agent_runtime.adapters.grok:GrokAdapter",
-        "default_model": None,
-        "cost_tier": "unknown",
-        "capabilities": frozenset(),
-        "cli_available": False,
+        "default_model": os.environ.get("AB_GROK_MODEL", "grok-4"),
+        "cost_tier": "medium",
+        "capabilities": frozenset({
+            "code_review",
+            "adversarial_review",
+            "debugging",
+            "deliberation",
+        }),
+        "cli_available": True,
         "resume_policy": "never",
     },
 }

--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -59,12 +59,14 @@ _DISCUSSION_CLARIFICATION_MODES = {
     "claude": "bypass",
     "gemini": "yolo",
     "codex": "danger",
+    "grok": "yolo",
 }
 
 _DISCUSSION_RUNTIME_MODES = {
     "claude": "read-only",
     "gemini": "workspace-write",
     "codex": "danger",
+    "grok": "workspace-write",
 }
 
 _DISCUSSION_MCP_EXCLUDE_TOKENS: tuple[str, ...] = (
@@ -161,6 +163,12 @@ def _agent_runtime_mode(agent_name: str, sandbox_mode: str | None) -> str:
     if agent_name == "claude":
         # Claude uses a permission-mode override, not a dedicated mode value.
         return "read-only"
+    if agent_name == "grok":
+        # Grok via hermes accepts workspace-write; sandbox is enforced by
+        # toolset selection (see _agent_tool_config), not a mode flag.
+        if sandbox_mode == "read-only":
+            return "read-only"
+        return "workspace-write"
     if sandbox_mode == "read-only":
         return "read-only"
     return "workspace-write"
@@ -195,6 +203,15 @@ def _agent_tool_config(
         return tc or None
     if agent_name == "codex":
         return {"enable_search": True}
+    if agent_name == "grok":
+        # Default discuss toolsets — give grok web + terminal + file so it
+        # can inspect repo state and curl primary sources during deliberation.
+        # Skills/memory are off to keep deliberation reproducible across runs.
+        grok_tc: dict[str, object] = {
+            "toolsets": "web,file,terminal,code_execution,todo",
+            "yolo": True,
+        }
+        return grok_tc
     return None
 
 

--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -204,13 +204,27 @@ def _agent_tool_config(
     if agent_name == "codex":
         return {"enable_search": True}
     if agent_name == "grok":
-        # Default discuss toolsets — give grok web + terminal + file so it
-        # can inspect repo state and curl primary sources during deliberation.
-        # Skills/memory are off to keep deliberation reproducible across runs.
-        grok_tc: dict[str, object] = {
-            "toolsets": "web,file,terminal,code_execution,todo",
-            "yolo": True,
-        }
+        # Sandbox enforcement for grok is via toolset selection (hermes has
+        # no CLI sandbox flag). GrokAdapter.build_invocation honors caller
+        # overrides for toolsets/yolo over its mode defaults, so we MUST
+        # gate write-capable tools (file/terminal/code_execution) and --yolo
+        # on sandbox_mode here. Gemini-pro adversarial review on PR #1245
+        # caught this — earlier revision hardcoded write tools regardless
+        # of mode, which would have let read-only bridge sessions execute
+        # arbitrary shell.
+        if sandbox_mode == "read-only":
+            grok_tc: dict[str, object] = {
+                "toolsets": "web",
+                "yolo": False,
+            }
+        else:
+            # workspace-write / yolo / bypass / None → grant the full
+            # deliberation toolset so grok can inspect repo state and curl
+            # primary sources. Skills/memory stay off for reproducibility.
+            grok_tc = {
+                "toolsets": "web,file,terminal,code_execution,todo",
+                "yolo": True,
+            }
         return grok_tc
     return None
 

--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -347,7 +347,7 @@ def _build_parser() -> argparse.ArgumentParser:
     # send
     send_parser = subparsers.add_parser("send", help="Send message to another agent")
     send_parser.add_argument("content", help="Message content")
-    send_parser.add_argument("--to", dest="to_llm", default="claude", choices=['claude', 'gemini', 'codex'],
+    send_parser.add_argument("--to", dest="to_llm", default="claude", choices=['claude', 'gemini', 'codex', 'grok'],
                             help="Target agent (default: claude)")
     send_parser.add_argument("--from", dest="from_llm", default="gemini",
                             help="Sender agent name (default: gemini)")
@@ -363,7 +363,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     # ack-all
     ack_all_parser = subparsers.add_parser("ack-all", help="Acknowledge ALL unread messages for an agent")
-    ack_all_parser.add_argument("agent", choices=['claude', 'gemini', 'codex'], help="Agent whose inbox to clear")
+    ack_all_parser.add_argument("agent", choices=['claude', 'gemini', 'codex', 'grok'], help="Agent whose inbox to clear")
 
     # conversation
     conv_parser = subparsers.add_parser("conversation", help="Get conversation history")

--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -110,6 +110,11 @@ CLAUDE_DEFAULT_MODEL = "claude-sonnet-4-6"
 CODEX_DEFAULT_MODEL = "codex"  # lets codex CLI pick the default model
 CODEX_REVIEW_DEFAULT_MODEL = "codex"
 CODEX_PATCH_DEFAULT_MODEL = "gpt-5.4"
+GROK_DEFAULT_MODEL = os.environ.get("AB_GROK_MODEL", "grok-4")
+GROK_PROVIDER = os.environ.get("AB_GROK_PROVIDER", "xai-oauth")
+# Grok via hermes -z toolsets. Match dispatch_smart task-class semantics:
+# review/research = web only; write paths can opt-in to terminal+file via env.
+GROK_DEFAULT_TOOLSETS = os.environ.get("AB_GROK_TOOLSETS", "web")
 
 # ---------------------------------------------------------------------------
 # Rate limit detection + pacing
@@ -731,6 +736,75 @@ def dispatch_codex_patch(prompt: str, model: str = CODEX_PATCH_DEFAULT_MODEL,
         return False, "TIMEOUT"
 
 
+def dispatch_grok(prompt: str, model: str = GROK_DEFAULT_MODEL,
+                  timeout: int = 900, toolsets: str | None = None,
+                  isolated: bool = False, yolo: bool | None = None,
+                  effort: str | None = None) -> tuple[bool, str]:
+    """Call Grok via ``hermes -z`` with the xai-oauth provider. Returns (success, output).
+
+    ``isolated=True`` adds ``--ignore-user-config --ignore-rules`` to bypass
+    hermes's project-context injection (used for calibration / benchmark
+    runs where deterministic output matters more than situational awareness).
+
+    ``yolo`` auto-accepts tool calls. Defaults to True when toolsets include
+    a write-capable lane (file / terminal / code_execution), False otherwise.
+
+    ``effort`` forwards a reasoning-effort hint as a prompt prefix. Hermes
+    has no direct flag for this today (see ``project_hermes_model_inventory.md``).
+    """
+    toolsets = toolsets or GROK_DEFAULT_TOOLSETS
+    write_lanes = {"file", "terminal", "code_execution"}
+    has_write_lane = any(t.strip() in write_lanes for t in toolsets.split(","))
+    if yolo is None:
+        yolo = has_write_lane
+
+    final_prompt = prompt
+    if effort and effort != "default":
+        final_prompt = f"[Reasoning effort hint: {effort}]\n\n{prompt}"
+
+    # IMPORTANT: pass prompt via argv, NOT stdin. `hermes -z -` is interpreted
+    # as "no prompt, project-introspection mode" — see comment in
+    # scripts/agent_runtime/adapters/grok.py for the empirical evidence.
+    cmd = [
+        "hermes", "-z", final_prompt,
+        "-m", model,
+        "--provider", GROK_PROVIDER,
+        "-t", toolsets,
+    ]
+    if yolo:
+        cmd.append("--yolo")
+    if isolated:
+        cmd.extend(["--ignore-user-config", "--ignore-rules"])
+
+    t0 = time.time()
+    try:
+        result = _run_with_process_group(
+            cmd, "", timeout, str(REPO_ROOT), _agent_env("grok")
+        )
+        elapsed = time.time() - t0
+        if result.returncode != 0:
+            print(f"Grok error (exit {result.returncode}): {redact_text(result.stderr)[:500]}", file=sys.stderr)
+            _log("grok", model, prompt, "", False, elapsed, result.stderr)
+            if _is_rate_limited(result.stderr) or _is_rate_limited(result.stdout):
+                # Grok via xai-oauth shares the OAuth-tier cap class — surface
+                # as a generic rate-limit error so callers can decide whether
+                # to fall back to claude-sonnet (per session-16 reviewer cascade).
+                print("Grok rate-limited (xai-oauth tier).", file=sys.stderr)
+            return False, redact_text(result.stderr)
+        output = result.stdout.strip()
+        _log("grok", model, prompt, output, True, elapsed)
+        return True, output
+    except FileNotFoundError:
+        _log("grok", model, prompt, "", False, time.time() - t0, "hermes CLI not found")
+        print("hermes CLI not found — install via 'pip install hermes-agent' "
+              "and authenticate with 'hermes login xai-oauth'.", file=sys.stderr)
+        return False, ""
+    except subprocess.TimeoutExpired:
+        _log("grok", model, prompt, "", False, time.time() - t0, "TIMEOUT")
+        print(f"Grok timed out after {timeout}s", file=sys.stderr)
+        return False, ""
+
+
 def post_to_github(issue_num: int, content: str, model: str) -> bool:
     """Post review content to a GitHub issue as comment(s)."""
     if not content:
@@ -959,6 +1033,22 @@ def main():
                          "Use for v2 quality writer/reviewer dispatches where stdout = full module text.")
     cp.add_argument("--timeout", type=int, default=600, help="Timeout in seconds (default: 600)")
 
+    # grok (via hermes -z xai-oauth)
+    rp = subparsers.add_parser("grok", help="Dispatch prompt to Grok via hermes -z (xai-oauth)")
+    rp.add_argument("prompt", help="Prompt text (use '-' to read from stdin)")
+    rp.add_argument("--model", default=GROK_DEFAULT_MODEL, help=f"Grok model (default: {GROK_DEFAULT_MODEL!r})")
+    rp.add_argument("--toolsets", default=None,
+                    help=f"Comma-separated hermes toolsets (default: {GROK_DEFAULT_TOOLSETS!r}; "
+                         "write paths typically use 'web,file,terminal,code_execution,todo').")
+    rp.add_argument("--isolated", action="store_true",
+                    help="Pass --ignore-user-config --ignore-rules (suppress project-context injection).")
+    rp.add_argument("--no-yolo", dest="no_yolo", action="store_true",
+                    help="Disable --yolo (default: auto-on when write-capable toolsets are enabled).")
+    rp.add_argument("--effort", default=None, choices=["default", "low", "medium", "high", "xhigh"],
+                    help="Reasoning-effort hint (forwarded as prompt prefix; hermes has no direct flag yet).")
+    rp.add_argument("--github", type=int, metavar="ISSUE", help="Post output to GitHub issue")
+    rp.add_argument("--timeout", type=int, default=900, help="Timeout in seconds (default: 900)")
+
     # codex
     xp = subparsers.add_parser("codex", help="Dispatch prompt to Codex CLI (codex exec)")
     xp.add_argument("prompt", help="Prompt text (use '-' to read from stdin)")
@@ -1008,6 +1098,20 @@ def main():
     elif args.agent == "codex":
         prompt = sys.stdin.read() if args.prompt == "-" else args.prompt
         ok, output = dispatch_codex(prompt, args.model, args.timeout)
+        if ok:
+            print(output)
+        sys.exit(0 if ok else 1)
+
+    elif args.agent == "grok":
+        prompt = sys.stdin.read() if args.prompt == "-" else args.prompt
+        yolo = None if not args.no_yolo else False
+        ok, output = dispatch_grok(
+            prompt, args.model, args.timeout,
+            toolsets=args.toolsets, isolated=args.isolated,
+            yolo=yolo, effort=args.effort,
+        )
+        if ok and args.github:
+            post_to_github(args.github, output, args.model)
         if ok:
             print(output)
         sys.exit(0 if ok else 1)

--- a/scripts/dispatch_smart.py
+++ b/scripts/dispatch_smart.py
@@ -72,7 +72,7 @@ def _primary_checkout_root(repo_root: Path) -> Path:
 PRIMARY_REPO = _primary_checkout_root(REPO)
 
 
-SUPPORTED_AGENTS = ("claude", "codex")
+SUPPORTED_AGENTS = ("claude", "codex", "grok")
 
 
 @dataclass(frozen=True)
@@ -89,6 +89,7 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
         models={
             "claude": "claude-haiku-4-5-20251001",
             "codex": "gpt-5.4-mini",
+            "grok": "grok-4",
         },
         default_mode="read-only",
         default_timeout_s=600,
@@ -99,6 +100,7 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
         models={
             "claude": "claude-sonnet-4-6",
             "codex": "gpt-5.3-codex-spark",
+            "grok": "grok-4",
         },
         default_mode="workspace-write",
         default_timeout_s=1800,
@@ -109,6 +111,7 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
         models={
             "claude": "claude-sonnet-4-6",
             "codex": "gpt-5.3-codex-spark",
+            "grok": "grok-4",
         },
         default_mode="workspace-write",
         default_timeout_s=3600,
@@ -119,6 +122,7 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
         models={
             "claude": "claude-sonnet-4-6",
             "codex": "gpt-5.5",
+            "grok": "grok-4",
         },
         default_mode="read-only",
         default_timeout_s=1800,
@@ -129,6 +133,7 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
         models={
             "claude": "claude-opus-4-7",
             "codex": "gpt-5.5",
+            "grok": "grok-4",
         },
         default_mode="workspace-write",
         default_timeout_s=3600,

--- a/scripts/quality/dispatch_388_pilot.py
+++ b/scripts/quality/dispatch_388_pilot.py
@@ -17,12 +17,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Callable
 
 import yaml
 
@@ -350,6 +352,45 @@ def dispatch_claude_review(pr_num: int, module_path: str, slug: str):
     return text, classify_verdict(text)
 
 
+def dispatch_grok_review(pr_num: int, module_path: str, slug: str):
+    """Cross-family review via Grok-4 (xai-oauth, hermes -z).
+
+    Grok is a peer cross-family reviewer alongside gemini-pro and claude-sonnet.
+    Uses the same prompt (gemini_review_prompt). Grok's strengths: independent
+    family (xAI), tool-using via hermes terminal/file toolsets so it can curl
+    URLs and inspect the diff itself.
+
+    Selection:
+        - Primary: set ``KUBEDOJO_388_PRIMARY_REVIEWER=grok`` to make this the
+          first-pass reviewer in the cascade.
+        - Tertiary: if gemini and claude both return ERROR/UNCLEAR, grok is
+          the third-line reviewer.
+        - Manual: callable directly from one-off review scripts (mirrors
+          dispatch_gemini_review / dispatch_claude_review shape).
+    """
+    log({"event": "grok_review_start", "pr": pr_num, "module": module_path})
+    try:
+        result = invoke(
+            agent_name="grok",
+            prompt=gemini_review_prompt(pr_num, module_path),  # reuse same prompt
+            mode="workspace-write",  # grok benefits from terminal+file tools (curl, gh pr diff)
+            cwd=REPO,
+            task_id=f"388-pilot-review-grok-{slug}",
+            entrypoint="dispatch",
+            hard_timeout=600,  # hermes startup + first-token latency tends to be higher than gemini-pro
+            tool_config={
+                "toolsets": "web,file,terminal,code_execution,todo",
+                "yolo": True,
+            },
+        )
+    except Exception as e:  # noqa: BLE001
+        log({"event": "grok_review_error", "pr": pr_num, "error": repr(e)})
+        return None, "ERROR"
+    text = result.response or ""
+    log({"event": "grok_review_done", "pr": pr_num, "ok": result.ok, "response_excerpt": text[-2000:]})
+    return text, classify_verdict(text)
+
+
 def classify_verdict(text: str) -> str:
     """Classify a gemini review into APPROVE / APPROVE_WITH_NITS / NEEDS CHANGES / UNCLEAR.
 
@@ -504,11 +545,28 @@ def main(argv: list[str] | None = None) -> int:
             if pr_num is None:
                 log({"event": "module_skip", "module": module_path, "reason": "pr_creation_failed"})
                 continue
-        review_text, verdict = dispatch_gemini_review(pr_num, module_path, slug)
-        if verdict in ("ERROR", "UNCLEAR"):
-            # Gemini hung or returned ambiguous output — fall back to Claude.
-            log({"event": "review_fallback_to_claude", "pr": pr_num, "module": module_path})
-            review_text, verdict = dispatch_claude_review(pr_num, module_path, slug)
+        # Reviewer cascade. Primary defaults to gemini-pro; override via
+        # KUBEDOJO_388_PRIMARY_REVIEWER (gemini | claude | grok).
+        # Cascade order is always primary → claude → grok (each only fires
+        # when the prior tier returned ERROR/UNCLEAR). The slot the primary
+        # occupies is skipped in the fallback chain.
+        primary = os.environ.get("KUBEDOJO_388_PRIMARY_REVIEWER", "gemini").lower()
+        cascade: list[tuple[str, Callable]] = []
+        if primary == "claude":
+            cascade = [("claude", dispatch_claude_review), ("gemini", dispatch_gemini_review), ("grok", dispatch_grok_review)]
+        elif primary == "grok":
+            cascade = [("grok", dispatch_grok_review), ("gemini", dispatch_gemini_review), ("claude", dispatch_claude_review)]
+        else:  # default: gemini
+            cascade = [("gemini", dispatch_gemini_review), ("claude", dispatch_claude_review), ("grok", dispatch_grok_review)]
+
+        review_text, verdict = (None, "ERROR")
+        for tier_name, tier_fn in cascade:
+            if review_text is not None and verdict not in ("ERROR", "UNCLEAR"):
+                break
+            if cascade.index((tier_name, tier_fn)) > 0:
+                log({"event": f"review_fallback_to_{tier_name}", "pr": pr_num, "module": module_path})
+            review_text, verdict = tier_fn(pr_num, module_path, slug)
+
         if review_text:
             post_review_comment(pr_num, review_text)
         if verdict == "APPROVE":


### PR DESCRIPTION
## Summary
Brings **grok-4 (xAI via hermes oauth)** online as a peer to codex / claude / gemini for cross-family review, ab-discuss deliberation, dispatch_smart routing, and one-off CLI dispatch.

**Writer lane stays DQ'd** by the #388 deterministic verifier gate (see `project_grok_writer_word_cap_2026-05-16` memory) — this PR does NOT unlock writer. It unlocks **reviewer + deliberation + fixer + research**.

## Wiring map

| Layer | File | Change |
|---|---|---|
| Runtime adapter | `scripts/agent_runtime/adapters/grok.py` | **NEW** — wraps `hermes -z <prompt> --provider xai-oauth -m grok-4 -t <toolsets>`. Supports all 3 modes via toolset selection. |
| Registry | `scripts/agent_runtime/registry.py` | Flips `cli_available=True`, sets capabilities + default_model. |
| Dispatch CLI | `scripts/dispatch.py` | Adds `dispatch_grok()` + `python scripts/dispatch.py grok "..."` subparser. |
| Smart dispatcher | `scripts/dispatch_smart.py` | Adds "grok" to `SUPPORTED_AGENTS` + every task_class (search/edit/draft/review/architect). |
| #388 pilot wrapper | `scripts/quality/dispatch_388_pilot.py` | Adds `dispatch_grok_review()`. Reviewer cascade configurable via `KUBEDOJO_388_PRIMARY_REVIEWER={gemini\|claude\|grok}`. |
| ab bridge | `scripts/ai_agent_bridge/_cli.py` + `_channels_cli.py` | Adds grok to `ab send --to`, `ab ack-all`, `ab discuss --with` defaults + tool_config. |

## Key technical detail (the bug that almost shipped)

`hermes -z -` (stdin marker) is interpreted as **"no prompt, project-introspection mode"** and *ignores* piped content. Empirical evidence (smoke test):
- `echo "Reply OK" | hermes -z - -m grok-4` → "Workspace: primary on... | pipelines v2: 567 modules"
- `hermes -z "Reply OK" -m grok-4` → "Reply OK" ✓

Fix: pass prompt via argv positional, not stdin. ARG_MAX is ~1 MB on macOS — fits review prompts (~10 KB) comfortably.

## Smoke tests (all passed)
- `runtime invoke('grok', ...)`: clean 8s round-trip
- `dispatch.py grok`: `GROK_ARGV_FIX_OK`
- `dispatch_smart.py review --agent grok`: 8s
- `dispatch_388_pilot.dispatch_grok_review(1240, ...)` against merged PR #1240 (module-2.2-helm): **produced full 6-dimension cross-family review** (PEDAGOGY/ACCURACY/DENSITY/PROTECTED ASSETS/SOURCES/LAB RUNNABILITY) in 13s, verdict APPROVE. Comparable depth + quality to gemini-pro.

## Test plan
- [ ] Cross-family review per `docs/review-protocol.md`
- [ ] Run `KUBEDOJO_388_PRIMARY_REVIEWER=grok .venv/bin/python scripts/quality/dispatch_388_pilot.py --input <queue.txt>` on the next T5 burn-down batch to validate grok-as-primary at production scale.
- [ ] Confirm `ab discuss --with claude,gemini,grok ...` ends each turn with `[AGREE]`/`[OPTION X]`/`[DEFER]` per `decision-card.md`.

## Notes
- `xai-oauth` is the canonical provider (loopback PKCE OAuth, no API key required). Confirmed via `hermes auth list`.
- Reasoning-effort hints (`xhigh`/`high`/`medium`/`low`) are forwarded as prompt prefix; hermes has no direct effort flag today.
- Hermes IS wired for grok despite earlier memory drift suggesting otherwise — see `project_hermes_model_inventory.md`.

Issue refs: #1184 (agent-runtime), #1235 (reviewer reassignment context).