### PR TITLE
feat(388): rewrite module-0.4-exam-strategy (#388 pilot)

### DIFF
--- a/src/content/docs/k8s/cks/part0-environment/module-0.4-exam-strategy.md
+++ b/src/content/docs/k8s/cks/part0-environment/module-0.4-exam-strategy.md
@@ -1,5 +1,5 @@
 ---
-revision_pending: true
+revision_pending: false
 title: "Module 0.4: CKS Exam Strategy"
 slug: k8s/cks/part0-environment/module-0.4-exam-strategy
 sidebar:
@@ -28,17 +28,64 @@ After completing this module, you will be able to:
 3. **Design** a time budget that maximizes points across all CKS domains
 4. **Create** a personal exam-day checklist covering environment setup and kubectl shortcuts
 
----
-
 ## Why This Module Matters
 
-The CKS exam is 2 hours, ~15-20 tasks, 67% to pass. Time pressure is real. Many candidates who know the material fail because they manage time poorly or get stuck on complex tasks.
+Hypothetical scenario: you begin the CKS exam with confidence because you have practiced NetworkPolicy, RBAC, security contexts, Trivy, Falco, kube-bench, seccomp, AppArmor, and Pod Security Admission. The first prompt asks for a custom Falco rule, the syntax looks almost familiar, and you spend the next 18 minutes chasing a condition that still does not match. Nothing about Kubernetes security is conceptually new in that moment, but the exam has shifted from technical knowledge to portfolio management, where each minute has to be invested where it can still buy points.
 
-This module adapts the three-pass strategy for security-specific challenges.
+The CKS exam gives you 2 hours for a hands-on set of roughly 15 to 20 tasks, and the passing score is 67%. That shape matters because it means the winning strategy is not perfection; it is controlled execution across many independent scoring opportunities. A candidate who solves every familiar quick task, verifies each result, and leaves one hard investigation unfinished is often in a better position than a candidate who proves deep expertise on one difficult task while leaving several simpler tasks unseen.
 
----
+This module turns the final part of your environment preparation into an operating plan for exam day. You will build a security-specific three-pass strategy, practice classifying tasks in seconds, design a time budget that protects the passing score, and create a personal checklist for environment setup and verification. The commands and examples assume Kubernetes 1.35 or newer behavior where relevant, but the larger lesson is version-independent: in a performance exam, your workflow must be as practiced as your YAML.
+
+## Design a Time Budget From Points and Risk
+
+The first mistake many prepared candidates make is treating the exam like a normal troubleshooting session. In production, you may stay with the highest-risk issue until you understand the root cause, because an unresolved security problem can keep hurting users. In the exam, the scoring model is different: each task is a separate asset, and you need enough completed assets to cross the passing line before the clock expires. That does not make the exam shallow; it makes time management part of the assessed skill.
+
+The useful mental model is a scoreboard rather than a checklist. A checklist asks, "Have I done the next item?" A scoreboard asks, "How many points have I protected, how much time remains, and which task has the best return now?" When you think this way, skipping is not panic or avoidance. Skipping is an intentional decision to leave a low-confidence investment until after you have captured the faster returns that are still available.
+
+The 67% passing threshold should lower your stress, not your standards. If the exam has 17 tasks of uneven value, you do not need to finish every task; you need to avoid trading six quick completions for one heroic partial. Security tasks especially tempt you into that trade because they often involve interesting tools and realistic failure modes. Falco conditions, kube-bench remediation, seccomp profile paths, and NetworkPolicy selectors can each consume time without showing obvious progress if you start them cold.
+
+The budget below preserves the original three windows from the short version of this module. Do not treat the exact minute marks as sacred, because the number and weight of tasks can vary. Treat them as guardrails that prevent one hard task from silently taking over the whole exam. If your first pass finishes early, you have bought flexibility; if it runs late, you need to be more aggressive about deferring anything that is not already close to done.
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│              120 MINUTE TIME BUDGET                         │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│  0:00  ─────── Pass 1 Start ───────                        │
+│  │                                                          │
+│  │     Quick wins: RBAC, basic NetworkPolicy,              │
+│  │     securityContext, AppArmor annotations               │
+│  │                                                          │
+│  0:50  ─────── Pass 2 Start ───────                        │
+│  │                                                          │
+│  │     Tool tasks: seccomp, PSA, kube-bench fixes,        │
+│  │     complex NetworkPolicies, ServiceAccount hardening   │
+│  │                                                          │
+│  1:40  ─────── Pass 3 Start ───────                        │
+│  │                                                          │
+│  │     Complex: Falco rules, incident investigation,       │
+│  │     multi-step hardening                                │
+│  │                                                          │
+│  2:00  ─────── Exam End ───────                            │
+│                                                             │
+│  Reserve 5 min at end for verification!                    │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+The important hidden feature in this budget is the end reserve. Five minutes feels small while you are practicing, but it can rescue several mistakes when the grading script cares about final cluster state. A namespace typo, an unmatched label selector, or a RoleBinding subject in the wrong namespace can turn a mostly correct answer into a zero for that task. The reserve is not a luxury review period; it is part of the implementation cost of any solution you want counted.
+
+Pause and predict: you have completed Pass 1 in 45 minutes and scored an estimated 35%. You have 75 minutes left. Before reading further, decide whether that is on track to pass or whether you should be worried, and explain your reasoning in terms of points still available rather than tasks remaining.
+
+That situation is usually healthy because the fastest third of the score has been captured while more than half of the clock remains. The danger is not the 35%; the danger is becoming too relaxed and spending the next half hour on one complex item. At that moment, your plan should shift from broad scanning to deliberate Pass 2 execution, choosing medium tasks that have predictable mechanics and clear verification commands.
+
+The opposite situation is more dangerous than it feels. If you spend 20 minutes on a complex Falco rule during Pass 1 and get it partially working, the partial progress can make the sunk cost feel valuable. In exam terms, the unvisited quick tasks are now competing against an unfinished rule that might still fail final validation. A strong candidate notices the sunk cost, writes down the task number, leaves any useful partial file in place, and returns only after faster tasks have been handled.
 
 ## The Security Three-Pass Strategy
+
+The three-pass strategy is simple: sweep the exam first for quick security wins, then handle predictable tool-based tasks, then spend the remaining time on complex scenarios. Its value comes from reducing decision fatigue. You do not want to invent a new priority system under exam stress, and you do not want a difficult first task to define the rhythm of the whole session. The pass structure gives you a default answer when the next prompt is ambiguous.
+
+The security version differs from a general Kubernetes exam strategy because CKS tasks often have more environmental friction. A simple-looking question might require you to find a profile path on a node, interpret a scanner output, or remember whether a setting belongs in a Pod spec, a namespace label, or a control plane manifest. The three passes below group tasks by expected uncertainty rather than by topic alone. A NetworkPolicy can be quick or complex depending on selectors, namespaces, DNS, and egress requirements.
 
 ```text
 ┌─────────────────────────────────────────────────────────────┐
@@ -75,15 +122,23 @@ This module adapts the three-pass strategy for security-specific challenges.
 └─────────────────────────────────────────────────────────────┘
 ```
 
----
+Pass 1 is where you capture tasks that look almost mechanical once the requirement is understood. The work might still be important security work, but the execution path is short: edit a securityContext, create a Role and RoleBinding, label a namespace for Pod Security Admission, apply an existing AppArmor profile, or run a scanner and report a direct finding. The key test is whether you can name the verification command before you start typing the solution.
 
-> **Stop and think**: You open the CKS exam and the first task asks you to write a custom Falco rule to detect cryptomining. It's worth 7% of the total score. Do you tackle it immediately or skip it? Why?
+Pass 2 is for tasks that are predictable but involve more moving pieces. Creating a seccomp profile from scratch is not conceptually hard if you have practiced it, but it includes writing JSON, placing it where the kubelet expects it, referencing it correctly, and confirming the Pod actually uses it. A kube-bench task may be straightforward when the output names the failing check, but the fix can require editing a manifest and waiting for a static Pod to restart. These tasks deserve time, but they should not interrupt the first sweep.
 
-## Task Classification
+Pass 3 is where you place tasks with investigative uncertainty. A custom Falco rule might require careful condition syntax, a runtime incident might involve multiple logs and containers, and a multi-step hardening prompt might require you to infer the expected final state from several clues. You can still score these tasks, and you should practice them seriously. The strategic point is that they have a wider time distribution, so they belong after the predictable points have been protected.
 
-Learn to recognize task complexity in seconds:
+Stop and think: you open the CKS exam and the first task asks you to write a custom Falco rule to detect cryptomining. It is worth 7% of the total score. Do you tackle it immediately or skip it, and what evidence would change that decision after your first scan?
 
-### Pass 1 Tasks (Quick)
+The answer depends on your practiced speed, but the default is to flag it and continue scanning. Seven percent is meaningful, yet a hard 7% can block several easier tasks that collectively matter more. You would only take it immediately if the rule pattern is one you have rehearsed recently, the prompt gives a narrow condition, and you can see a direct way to validate the event. Otherwise, keep the task visible and return when the first pass has shown what else is available.
+
+The three-pass strategy also protects your attention. In the CKS exam, context switching is expensive because each topic uses a different vocabulary: RBAC verbs and subjects, NetworkPolicy selectors, image vulnerability severities, syscall profiles, audit stages, and runtime event fields. If you let the exam order dictate your mental order, you pay that switching cost repeatedly. Grouping work by complexity gives you a calmer rhythm: quick edits first, tool mechanics second, investigations last.
+
+## Classify and Evaluate Task Complexity
+
+Classification is the skill that makes the strategy usable. You do not need a perfect estimate; you need a fast estimate that is good enough to prevent bad early investments. In the first 30 seconds, look for three signals: how many objects are involved, whether the task requires an external tool or node-level file, and whether success can be verified with one command. A task with one namespace, one object, and one obvious check is usually a Pass 1 candidate.
+
+Quick tasks often use familiar verbs and narrow scopes. "Set runAsNonRoot" tells you the field family, the object, and the expected state. "Grant permission to list pods" tells you the RBAC verb and resource. "Create a NetworkPolicy to allow traffic from app A to app B" may still need care, but if both workloads are in one namespace and the labels are visible, you can implement and verify quickly. These are the tasks you should be hungry to find early.
 
 | Pattern | Example | Time |
 |---------|---------|------|
@@ -93,7 +148,9 @@ Learn to recognize task complexity in seconds:
 | "Apply AppArmor profile" | Add annotation | 1-2 min |
 | "Scan image with Trivy" | Run command, report findings | 2-3 min |
 
-### Pass 2 Tasks (Medium)
+The quick table is not telling you to rush blindly. It is telling you that the task shape has low uncertainty if you have practiced the pattern. You still read the prompt twice, identify the namespace, and verify the final behavior. The difference is that you do not open three documentation pages before starting, because the correct response is likely a small adaptation of a pattern you already know.
+
+Medium tasks usually have one extra layer of translation. The prompt might describe a policy goal, but you must convert that goal into labels, profile paths, a ServiceAccount reference, or a tool-specific remediation. This is where many candidates lose time by treating every medium task as a quick task. If the solution requires creating a file, restarting a component, interpreting multi-line tool output, or testing both allowed and denied behavior, it belongs in Pass 2 unless the rest of the exam is already scanned.
 
 | Pattern | Example | Time |
 |---------|---------|------|
@@ -103,7 +160,9 @@ Learn to recognize task complexity in seconds:
 | "Restrict ServiceAccount" | RBAC + automount settings | 4-5 min |
 | "NetworkPolicy with multiple rules" | Ingress + egress | 5-6 min |
 
-### Pass 3 Tasks (Complex)
+The time values are training estimates, not promises. A practiced seccomp task can be faster, and a messy RBAC task can be slower if the subject name is unclear. Use the table to notice when a prompt has crossed from "edit the object" into "coordinate several objects." Coordination is where mistakes multiply, so the classification should include verification time as part of the expected cost.
+
+Complex tasks contain uncertainty that cannot be removed by memorizing one YAML shape. A runtime investigation might require reading events, container logs, audit logs, and process clues before you know what to fix. A custom Falco rule might fail because of field names, macros, condition precedence, or the test event itself. A multi-namespace isolation task might look like a NetworkPolicy exercise but require careful reasoning about DNS, default deny behavior, and namespace selectors.
 
 | Pattern | Example | Time |
 |---------|---------|------|
@@ -112,42 +171,15 @@ Learn to recognize task complexity in seconds:
 | "Harden cluster based on..." | Multiple components | 10-15 min |
 | "Isolate compromised pod" | NetworkPolicy + analysis | 8-10 min |
 
----
+Before running this, what output do you expect from your classification pass: a clean list of every answer, or a rough map of which tasks are safe to solve now? The correct output is the rough map. You are not trying to understand every task during the first scan; you are trying to prevent one uncertain task from capturing time before you know the rest of the opportunity set.
 
-## Time Budget
+A practical classification note should be small enough to write without breaking flow. Use the exam interface flagging feature when available, and keep a scratch list such as "Q3 seccomp, Q8 Falco, Q11 multi-ns netpol." The list does not need full sentences. Its job is to help you return to the right tasks in the right phase without rereading every prompt from scratch.
 
-```text
-┌─────────────────────────────────────────────────────────────┐
-│              120 MINUTE TIME BUDGET                         │
-├─────────────────────────────────────────────────────────────┤
-│                                                             │
-│  0:00  ─────── Pass 1 Start ───────                        │
-│  │                                                          │
-│  │     Quick wins: RBAC, basic NetworkPolicy,              │
-│  │     securityContext, AppArmor annotations               │
-│  │                                                          │
-│  0:50  ─────── Pass 2 Start ───────                        │
-│  │                                                          │
-│  │     Tool tasks: seccomp, PSA, kube-bench fixes,        │
-│  │     complex NetworkPolicies, ServiceAccount hardening   │
-│  │                                                          │
-│  1:40  ─────── Pass 3 Start ───────                        │
-│  │                                                          │
-│  │     Complex: Falco rules, incident investigation,       │
-│  │     multi-step hardening                                │
-│  │                                                          │
-│  2:00  ─────── Exam End ───────                            │
-│                                                             │
-│  Reserve 5 min at end for verification!                    │
-│                                                             │
-└─────────────────────────────────────────────────────────────┘
-```
+## Use Documentation and Tool Templates Without Losing Flow
 
----
+The exam is open book, but open book does not mean slow book. Documentation is most useful when you already know the concept and need exact syntax, field names, or an example shape to adapt. It is least useful when you are trying to learn a topic from the beginning while the timer is running. Your preparation should make the official Kubernetes and tool documentation feel like a parts shelf, not a textbook you are opening for the first time.
 
-## Security-Specific Tips
-
-### 1. Know Your Documentation
+The original module listed the bookmark targets that matter most for this strategy. Preserve them in your personal browser routine, and practice navigating to the relevant subsection instead of just recognizing the top-level page. For Kubernetes 1.35 and newer, pay particular attention to the current shape of Pod Security Standards, seccomp references, AppArmor documentation, and NetworkPolicy semantics, because older notes can contain outdated annotations or assumptions.
 
 ```bash
 # Bookmark these in exam browser:
@@ -171,7 +203,9 @@ aquasecurity.github.io/trivy/
 falco.org/docs/
 ```
 
-### 2. Template Commands Ready
+Bookmarking alone does not create speed. The speed comes from knowing why you opened a page before it loads. If you open NetworkPolicy docs, you should already know whether you need a podSelector example, a namespaceSelector example, an egress example, or a reminder about default deny behavior. If you open the seccomp tutorial, you should already know whether the missing piece is profile placement or the Pod spec reference.
+
+The same principle applies to tool commands. You should know the difference between "run the tool and copy the finding" and "run the tool, interpret the finding, and change cluster state." Trivy often gives a direct image vulnerability signal. kube-bench frequently gives a benchmark check that you must map to a component configuration. Falco may be running already, or it may require you to test rule behavior. Each tool has a different verification habit, so do not put them all in one mental bucket.
 
 ```bash
 # Trivy scan
@@ -190,7 +224,9 @@ grep SECCOMP /boot/config-$(uname -r)
 /var/log/kubernetes/audit.log
 ```
 
-### 3. Common Security Context Fields
+The template commands are useful because they keep you from wasting time on spelling and option recall. They are not a substitute for reading the prompt. If the prompt asks for critical vulnerabilities only, the Trivy severity filter matters. If it asks for a kube-bench finding on worker nodes, a control-plane target is the wrong target. A copied command that answers a slightly different question is still wrong.
+
+Security context fields are a classic quick-win area because the desired state is often visible in the prompt. The trap is that several fields live at different levels of the Pod spec, and some images need specific users or writable paths to start. In a real cluster, you would test application behavior carefully; in the exam, you at least verify that the final manifest contains the requested fields and that the Pod reaches the expected state.
 
 ```yaml
 # Memorize this pattern
@@ -203,7 +239,9 @@ securityContext:
     drop: ["ALL"]
 ```
 
-### 4. NetworkPolicy Patterns
+This pattern is intentionally conservative, but it is not universally safe. Dropping all capabilities can break software that needs a specific capability, and readOnlyRootFilesystem can break images that write to paths without mounted volumes. The exam prompt usually tells you what behavior matters, so use the template as a starting point and then adapt it to the exact requirement. A senior-looking answer that ignores the application constraint can lose the same points as a missing field.
+
+NetworkPolicy patterns are another area where templates help but do not replace reasoning. A default deny policy is a namespace-level safety net only for the selected pods and selected traffic direction. An allow policy works only when its selectors match the intended source and destination labels. If you do not check labels before writing YAML, you are guessing, and guessing is especially expensive because an applied NetworkPolicy with a bad selector can look successful while protecting nothing.
 
 ```yaml
 # Default deny all ingress
@@ -234,11 +272,15 @@ spec:
     - port: 80
 ```
 
----
+Which approach would you choose here and why: write the NetworkPolicy from memory first, or inspect the live Pod labels before drafting? The safer answer is to inspect labels first, because a policy is judged by what it selects, not by whether the YAML looks like a familiar example. If you already have the template memorized, label inspection is a small upfront cost that prevents a silent zero.
 
-## Exam Environment Tips
+## Create the Exam-Day Checklist and Verification Loop
 
-### Security Tool Locations
+An exam-day checklist is not a motivational note; it is a compact operating procedure that reduces avoidable errors. The checklist should cover the browser and terminal setup you can control, the command habits you want to use consistently, and the verification loop you will run before leaving each task. It should be short enough to memorize, because you will not want to manage a long checklist while the timer is running.
+
+Start by checking the environment details the prompt gives you. Identify the target cluster or context if the exam uses more than one, note the namespace, and read the task until you can state the requested final state without looking back. Many wrong answers are not caused by Kubernetes misunderstanding; they are caused by applying a correct object to the wrong namespace or solving only half of a multi-clause requirement.
+
+Security tool locations can vary by exam environment and task setup, so treat the table as a recognition aid rather than a guarantee. The useful habit is to quickly determine whether a tool is already installed, provided as a manifest, or expected to be downloaded from a documented source. If the tool is not immediately available and the task is not quick, that is a classification signal for Pass 2 or Pass 3.
 
 | Tool | Location in Exam |
 |------|------------------|
@@ -247,7 +289,7 @@ spec:
 | kube-bench | Download or job manifest |
 | kubesec | May need to download |
 
-### File Locations
+File locations are similar. Some paths are common enough that you should recognize them immediately, but the actual prompt still decides what you touch. Static Pod manifests, kubelet configuration, audit policies, seccomp profiles, and AppArmor profiles each have different reload or restart implications. If a task asks for control plane configuration, factor the restart and verification time into the classification before editing.
 
 | File | Path |
 |------|------|
@@ -257,26 +299,13 @@ spec:
 | seccomp profiles | `/var/lib/kubelet/seccomp/` |
 | AppArmor profiles | `/etc/apparmor.d/` |
 
----
+The skip rule should be explicit before the exam starts. Skip immediately if the task requires a tool you have never used, a complex Falco rule with unfamiliar syntax, or a multi-namespace NetworkPolicy where the requirements are unclear after a short read. Come back if time permits, and leave any partial work in a state that will not break other tasks. Partial credit may be possible, but partial work that damages the cluster can cost more than it earns.
 
-> **Pause and predict**: You've completed Pass 1 in 45 minutes and scored an estimated 35%. You have 75 minutes left. Is that on track to pass, or should you be worried?
+Stop and think: you spend 20 minutes on a complex Falco rule task during Pass 1, get it partially working, but now have only 55 minutes for the remaining 12 tasks. Calculate your likely final score versus the 67% passing threshold before deciding whether to continue.
 
-> **Stop and think**: You spend 20 minutes on a complex Falco rule task during Pass 1, get it partially working, but now have only 55 minutes for the remaining 12 tasks. Calculate your likely final score versus the 67% passing threshold.
+The calculation is uncomfortable by design. If the remaining 12 tasks include several quick wins, staying with the Falco rule risks trading many likely completions for one uncertain result. Your next action should be to save the file, note what remains broken, and return to the broader task list. The discipline is not abandoning hard security work; it is delaying uncertain work until the score is no longer fragile.
 
-## When to Skip
-
-**Skip immediately if**:
-- Task requires tool you've never used
-- Complex Falco rule with unfamiliar syntax
-- Multi-namespace NetworkPolicy with unclear requirements
-
-**Come back if time permits**. Partial credit exists—submit something.
-
----
-
-## Verification Checklist
-
-Before moving to next task:
+Verification is the other half of the checklist. An applied manifest is not a verified solution, and a successful command exit is not the same as the requested final behavior. For each task, ask what the grader is likely to observe: object existence, effective authorization, selected pods, scanner output, running status, or a configuration field. Then run the smallest command that checks that observable state.
 
 ```bash
 # For pods/deployments
@@ -295,60 +324,155 @@ kubectl get pod <name> -o yaml | grep -A 10 securityContext
 trivy image <image>  # Scans correctly?
 ```
 
----
+The best verification commands are fast and specific. For RBAC, `kubectl auth can-i` is better than rereading the Role because it asks the authorization layer the question the task cares about. For a securityContext, the rendered Pod spec is better than your editor buffer because admission and defaults can change what actually exists. For NetworkPolicy, a describe command is a start, but a real connectivity test is stronger when time permits.
+
+Your personal checklist should also include command style. Use full `kubectl` in saved snippets and runnable scripts, even if you use a short alias interactively while practicing. Aliases are convenient in a terminal, but they do not reliably expand in non-interactive contexts, and copying alias-dependent commands into a script can fail at the worst time. The exam rewards repeatable commands, so make repeatability your default.
+
+## Run a First-Scan Worked Example
+
+Exercise scenario: imagine the first scan reveals eight visible tasks before you have solved anything. The prompts are not dependent on each other, and the exam interface lets you flag tasks for return. Your goal during this scan is not to finish any task immediately. Your goal is to build a triage board that tells you which tasks deserve immediate implementation, which tasks need a controlled second-pass time box, and which tasks should wait until the score is less fragile.
+
+The scan begins with task A, an RBAC prompt asking a ServiceAccount to list Pods in one namespace. You can name the likely objects, the namespace check, and the verification command before opening an editor, so it is Pass 1. Task B asks for `runAsNonRoot` and a numeric user on an existing Pod template, which is also Pass 1 if the image constraint is clear. Task C asks for a custom Falco rule with a condition you have not practiced recently, so it becomes Pass 3 even if the point value looks attractive.
+
+| Task | First-scan signal | Pass | Verification idea |
+|------|-------------------|------|-------------------|
+| A | One ServiceAccount, one verb, one resource | Pass 1 | `kubectl auth can-i` |
+| B | Two securityContext fields on one workload | Pass 1 | Rendered Pod spec and running state |
+| C | Custom Falco condition with unfamiliar field | Pass 3 | Trigger event and Falco output |
+| D | Trivy image scan with severity requirement | Pass 1 | Scanner output contains requested severity |
+| E | seccomp profile from scratch | Pass 2 | Pod references profile and starts |
+| F | kube-bench check with static Pod edit | Pass 2 | Finding disappears after component restart |
+| G | Multi-namespace NetworkPolicy with DNS egress | Pass 3 | Positive and negative connectivity tests |
+| H | Pod Security Admission label and test workload | Pass 2 | Namespace labels and admission behavior |
+
+Task D looks like a quick win only if Trivy is already available and the prompt asks for direct interpretation. If the task also asks you to remediate the image, rebuild, or compare multiple images, the classification changes because the work is no longer a simple scan. This is why classification must read the whole prompt, not just the first familiar word. A task that contains "Trivy" can be a one-command answer or a longer supply-chain decision.
+
+Task E is the kind of prompt that exposes weak practice habits. If you have rehearsed seccomp profile placement and Pod references recently, it is a normal Pass 2 task. If you only remember the concept but not the file shape or reference syntax, it behaves like Pass 3 for you personally. The classification table is allowed to be personal because the exam measures your execution speed, not an abstract average candidate's speed.
+
+Task F has a different kind of uncertainty. kube-bench output can be very direct, but the remediation may touch a static Pod manifest or kubelet configuration and require waiting for the component to settle. That waiting time belongs in the estimate. A candidate who edits quickly but forgets restart and verification cost will repeatedly underestimate benchmark tasks, which creates pressure later when the clock has already absorbed the hidden cost.
+
+Task G is classified as complex because multi-namespace NetworkPolicy work has several silent failure modes. A namespaceSelector can match the wrong namespace, a podSelector can match no Pods, an egress rule can block DNS, and a default deny policy can change unrelated traffic if the selector is too broad. None of those mistakes necessarily produce a syntax error. The task may still be worth solving, but it deserves a later slot where you can test both allowed and denied paths.
+
+Task H is a useful middle case. Pod Security Admission labeling is often quick, but a good answer includes testing admission behavior with a workload that should pass or fail under the selected level. If you can perform that test quickly, it is a strong Pass 2 candidate. If you do not remember the label keys or profile levels, the documentation lookup is still narrow enough that it should not be pushed all the way to Pass 3.
+
+After this scan, a reasonable scratch note might read: "A RBAC, B context, D Trivy first; H PSA, E seccomp, F bench second; C Falco, G netpol last." That note is short, but it contains enough structure to prevent the exam order from taking over. It also gives you a recovery plan if a quick task unexpectedly stalls: stop after one verification failure, flag the task, and take the next quick item rather than turning the first pass into a debugging session.
+
+The worked example also shows why point value is only one input. A 7% task that you can finish and verify in three minutes is excellent. A 7% task that can absorb 15 minutes without a working final state is dangerous early. The pass decision combines value, confidence, estimated time, and verification clarity. When those signals disagree, choose the action that keeps the most future options open.
+
+Use this same exercise after practice exams. Take the tasks you actually faced, classify them again after the run, and compare the estimate to the real time. If your Pass 1 tasks routinely take five minutes, you need more template practice or faster verification habits. If your Pass 3 tasks sometimes finish in two minutes, you may be over-skipping familiar topics because they sound intimidating. Strategy improves when you measure the estimate, not just the final answer.
+
+When a quick task stalls, use a checkpoint rather than a feeling. After one failed verification, ask whether the error is mechanical, such as a namespace typo or a missing label, or structural, such as realizing the prompt needs a different control than you first assumed. Mechanical errors deserve one fast repair attempt. Structural surprises should usually be flagged and moved later, because the task has changed categories while the clock kept moving.
+
+This checkpoint habit is also useful when the first scan finds fewer quick wins than expected. Do not respond by lowering your verification standard; respond by tightening the time boxes on medium tasks. A medium task that is 80% complete but unverified is not banked score, so it should not consume the reserve meant for final checks. The right adaptation is to finish fewer tasks cleanly rather than leave many tasks in ambiguous partial states.
+
+Protect the final reserve even when the middle of the exam feels calm. Candidates often spend the reserve early because they believe they will remember which tasks need review later, but exam stress makes that memory unreliable. A written flag plus a preserved five-minute window is stronger than confidence, especially when the final mistake is a namespace, selector, or subject typo.
+
+## Patterns & Anti-Patterns
+
+The patterns below are not generic study advice; they are exam behaviors that change the score outcome. Use a pattern when it gives you a concrete decision or verification step. Reject an anti-pattern when it creates false progress, such as editing a manifest without proving that the resulting cluster state matches the prompt.
+
+| Type | Behavior | When It Helps | Risk If Ignored |
+|------|----------|---------------|-----------------|
+| Pattern | Classify before solving | First scan and after any long task | Hard prompts consume the easy score first |
+| Pattern | Verify the grader-visible state | Before leaving every completed task | Correct-looking YAML may still select nothing |
+| Pattern | Use docs for syntax, not learning | When a known pattern needs exact fields | Documentation search becomes the main task |
+| Anti-pattern | Treat task order as priority order | Whenever the first prompt is complex | The exam sequence controls your score strategy |
+| Anti-pattern | Continue because of sunk cost | After ten minutes without a verified state | One partial task blocks multiple complete tasks |
+| Anti-pattern | Apply templates without inspecting labels | NetworkPolicy and RBAC tasks | The object exists but affects the wrong target |
+
+The strongest pattern is "verify the observable," because it applies across every CKS domain. RBAC, NetworkPolicy, security contexts, scanner reports, audit logging, and runtime rules each have different syntax, but each has some observable result. If you cannot name the observable result, you probably have not read the prompt carefully enough to start. This is why the first scan should include the verification idea, not just the implementation idea.
+
+The most seductive anti-pattern is sunk cost. Security work often feels close to working because each failed attempt teaches you something. In the exam, that learning is expensive if it happens before you have protected the predictable points. When you notice yourself saying "just one more edit," convert that thought into a time-box: one more edit, one verification attempt, then flag and move on unless the result is clearly working.
+
+## When You'd Use This vs Alternatives
+
+Use the three-pass strategy when the exam contains many independent hands-on tasks, the passing threshold is below perfect, and task complexity varies widely. That is the CKS shape. Use a straight sequential approach only when tasks are strictly dependent on each other or when the environment forces a single order. Use a deep-debug approach only after you have enough completed score that the remaining value justifies the time risk.
+
+| Situation | Better Approach | Reason |
+|-----------|-----------------|--------|
+| First complete scan of the exam | Three-pass strategy | Finds quick wins before hard tasks bias your time |
+| One task blocks several later tasks | Sequential dependency handling | Shared prerequisites change the normal skip rule |
+| Final minutes with one unfinished high-value task | Deep debug or partial submission | No unseen quick tasks remain to protect |
+| Tool syntax is known but exact field is forgotten | Documentation-assisted implementation | Docs answer the narrow syntax question quickly |
+| Requirement is unclear after a short read | Flag and return | Ambiguity is a time risk until other points are safe |
+
+The decision framework can be compressed into four questions. Can I name the final observable state? Can I implement most of it from practiced patterns? Can I verify it in under a minute? Will this task still be worth doing if it takes twice my estimate? If the first three answers are yes, solve it now. If one answer is no, classify it as Pass 2. If two or more answers are no, flag it for Pass 3 unless the task has unusually high value and no quick alternatives remain.
+
+This framework also helps during practice. After each timed drill, review not only whether the YAML was correct but whether the classification was correct. A task finished in 90 seconds that you had postponed as complex is a sign that you overestimated it. A task that took 12 minutes after you called it quick is a sign that you missed a complexity signal. Improving those estimates is one of the fastest ways to turn technical preparation into exam readiness.
 
 ## Did You Know?
 
-- **67% pass rate means you can miss ~5-6 tasks** out of 15-20 and still pass. Don't panic if you skip some.
-- **Partial credit is possible.** Even incomplete answers may score points. Always submit something.
-- **The exam is open book.** Your challenge is finding information fast, not memorizing everything.
-- **Security tasks often have multiple valid approaches.** The exam checks the result, not the exact method.
-
----
+- **67% pass score means perfection is not required.** Your plan should maximize verified points, not emotional satisfaction from solving every hard task.
+- **The CKS exam duration is 2 hours.** A ten-minute detour can consume the same time as several quick RBAC, securityContext, or scan tasks.
+- **Open-book access changes the skill being tested.** The exam rewards fast navigation to exact vendor documentation, not slow first-time learning.
+- **Security tasks often have multiple valid implementations.** The final cluster behavior matters more than matching a memorized command sequence.
 
 ## Common Mistakes
 
-| Mistake | Why It Hurts | Solution |
-|---------|--------------|----------|
-| Starting with complex tasks | Time wasted, confidence lost | Three-pass strategy |
-| Not reading task completely | Missing requirements | Read twice before typing |
-| Forgetting namespace | Changes in wrong namespace | Always `-n namespace` |
-| Not verifying | Partial solutions | Check before moving on |
-| Over-engineering | Simple solution was enough | Match requirements exactly |
-
----
+| Mistake | Why It Happens | How to Fix It |
+|---------|----------------|---------------|
+| Starting with complex tasks | The first prompt feels like the required priority | Scan first, flag complex tasks, and protect quick wins before deep work |
+| Not reading task completely | Familiar keywords make the solution feel obvious too early | Restate the final state, namespace, and verification command before typing |
+| Forgetting namespace | Practice clusters often use defaults, but exam tasks rarely do | Put `-n namespace` into every relevant command and verify object location |
+| Not verifying | Applying YAML gives a false sense of completion | Check the grader-visible behavior before moving to the next task |
+| Over-engineering | Security instincts push toward the strongest control, not the requested control | Match the prompt exactly, then add only what is needed for the stated outcome |
+| Using documentation as a tutorial | Open-book access feels like a safety net | Practice common patterns until docs are only for syntax confirmation |
+| Letting aliases leak into scripts | Interactive shortcuts feel faster during practice | Use full `kubectl` in runnable snippets, saved notes, and exam scripts |
 
 ## Quiz
 
-1. **You are exactly 30 minutes into the CKS exam and have just completed your 6th task (a mix of RBAC fixes, basic NetworkPolicies, and Trivy scans). The next task asks you to create a custom seccomp profile from scratch and apply it to a deployment. What is your immediate next action?**
-   <details>
-   <summary>Answer</summary>
-   You should immediately flag this task and return to scanning the remaining questions for quick Pass 1 tasks. Creating a seccomp profile from scratch requires writing JSON and referencing it correctly in the pod spec, which typically takes 4-5 minutes, placing it firmly in Pass 2. By getting bogged down in a medium-complexity task this early, you risk running out of time for the 1-2 minute tasks that guarantee easy points. Your primary goal in the first hour is to maximize your point accumulation rate, so you must aggressively defer anything that requires deeper thought or file creation.
-   </details>
+<details><summary>Question 1: You are exactly 30 minutes into the CKS exam and have completed six tasks: two RBAC fixes, two basic NetworkPolicies, one securityContext change, and one Trivy scan. The next task asks you to create a custom seccomp profile from scratch and apply it to a deployment. How should you implement the three-pass strategy at this moment?</summary>
 
-2. **The exam timer shows 30 minutes remaining. You have completed 12 out of 17 tasks, leaving a custom Falco rule, a runtime incident investigation, a multi-namespace NetworkPolicy, a kube-bench remediation, and a Pod Security Admission setup. How do you prioritize these final tasks?**
-   <details>
-   <summary>Answer</summary>
-   You must prioritize the Pod Security Admission and kube-bench remediation tasks first because they offer the highest points-per-minute return. These are standard Pass 2 tasks that rely on predictable labeling or following direct tool outputs, taking about 4-5 minutes each. Conversely, Falco rules and incident investigations are complex Pass 3 tasks that can easily swallow 10-15 minutes troubleshooting syntax errors or parsing logs. Tackling the predictable tasks first cements your passing score, while leaving the high-risk, time-consuming tasks for the very end ensures you do not sacrifice guaranteed points.
-   </details>
+Flag the seccomp task and continue scanning for remaining Pass 1 work. Creating a seccomp profile from scratch is predictable if practiced, but it usually involves writing a profile, placing or referencing it correctly, updating the workload, and verifying the runtime result. That makes it a Pass 2 task, not a first-sweep task. The correct strategy is to protect the remaining quick points first, then return to seccomp with a clear time budget.
+</details>
 
-3. **You apply a NetworkPolicy for a task worth 6% of your total score, assume it works because the YAML applied without syntax errors, and immediately move to the next question. During your final 5-minute review, you realize the pod selector label was misspelled. What was the true cost of skipping verification?**
-   <details>
-   <summary>Answer</summary>
-   You lost the entire 6% value of the task because a NetworkPolicy that does not select the intended pods effectively does nothing, and the exam grading script only checks the final cluster behavior. This catastrophic point loss occurred because you skipped the crucial 30-second verification step of checking effective pod selection. If you had run a quick `kubectl describe networkpolicy` or tested access via `kubectl exec`, you would have caught the typo instantly. The time cost of not verifying is always higher than the time spent running a quick check, as unverified tasks often yield zero points despite your upfront effort.
-   </details>
+<details><summary>Question 2: The exam timer shows 30 minutes remaining. You have completed 12 out of 17 tasks, leaving a custom Falco rule, a runtime incident investigation, a multi-namespace NetworkPolicy, a kube-bench remediation, and a Pod Security Admission setup. How do you evaluate task complexity and prioritize the final stretch?</summary>
 
-4. **A colleague preparing for the CKS exam decides not to memorize any YAML structures or tool commands, reasoning that they can just search the official Kubernetes and tool documentation for everything during the test. Why is this strategy almost guaranteed to fail?**
-   <details>
-   <summary>Answer</summary>
-   Your colleague will almost certainly fail due to severe time starvation caused by constant context switching and searching. With an average of 6 to 8 minutes available per task, spending 2 to 3 minutes just locating, reading, and adapting documentation for every single question consumes over half the exam time. While the exam is open-book, the documentation should only be used as a reference for specific syntax edge cases or forgotten arguments, not as a primary tutorial. You must have common security context fields, tool commands, and NetworkPolicy patterns committed to muscle memory to maintain the speed required to pass.
-   </details>
+Prioritize Pod Security Admission and kube-bench remediation first if you have practiced both patterns, because they are more predictable than the Falco rule or open-ended incident investigation. The multi-namespace NetworkPolicy may be worthwhile if the labels and requirements are clear, but it should be time-boxed because selector mistakes can be silent. Falco and incident response should wait until the predictable tasks are either done or clearly blocked. The goal is not to avoid hard work; it is to choose the best points-per-minute return with the time left.
+</details>
 
----
+<details><summary>Question 3: You apply a NetworkPolicy for a task worth 6% of the total score, assume it works because the YAML applied without syntax errors, and immediately move on. During final review, you discover the pod selector label was misspelled. What was the cost of skipping verification?</summary>
+
+The likely cost is the full value of that task, because a NetworkPolicy that selects no intended pods does not enforce the requested behavior. The YAML parser only confirmed syntax, not security effect. A fast verification command such as `kubectl describe networkpolicy` plus a label check would have exposed the mismatch before you moved on. This is why verification time must be included in the task budget rather than treated as optional review.
+</details>
+
+<details><summary>Question 4: A practice partner plans to design their time budget by spending exactly the same number of minutes on every task. Why is that weaker than the three-pass strategy for CKS?</summary>
+
+Equal time per task ignores the uneven complexity of security work. A basic securityContext edit and a runtime investigation should not receive the same initial investment, because their uncertainty and verification costs are different. The three-pass strategy adapts the budget to task risk: fast, familiar work first; predictable tool work second; uncertain investigations last. That structure maximizes verified points while still leaving room for hard tasks after the passing score is less fragile.
+</details>
+
+<details><summary>Question 5: You need to create a personal exam-day checklist before your final practice exam. Which items should be on it, and which items should stay out?</summary>
+
+Include actions that prevent common execution errors: check context and namespace, restate the final requested state, choose a classification pass, use full `kubectl` in runnable commands, and verify the grader-visible behavior before leaving the task. Keep the checklist short enough to remember under pressure. Do not fill it with long tutorials or every field you might need, because that turns the checklist into another document to search. Detailed syntax belongs in practiced templates and official documentation, not in the exam-day operating loop.
+</details>
+
+<details><summary>Question 6: A task asks you to restrict a workload with a securityContext, and you remember a hardened template that drops all capabilities and sets readOnlyRootFilesystem. The prompt only asks for runAsNonRoot and a specific runAsUser. What should you do?</summary>
+
+Apply exactly the requested controls unless the prompt also requires the stronger hardening fields. Extra restrictions can break the workload and produce a failing final state even if they look more secure. In the exam, the safest answer is the one that satisfies the stated requirement and remains verifiable. You can use the broader template as a reminder, but you must adapt it to the task rather than applying it blindly.
+</details>
+
+<details><summary>Question 7: During practice, a kube-bench remediation takes you 13 minutes even though you classified it as a medium Pass 2 task. How should you adjust your strategy before the real exam?</summary>
+
+Review why the estimate was wrong. If the delay came from not knowing where the relevant manifest or config file lived, add that path to your recognition practice and keep kube-bench in Pass 2. If the delay came from interpreting unfamiliar output or restarting components safely, classify similar tasks as late Pass 2 or Pass 3 until your practice time improves. The point is to calibrate your personal estimates, not memorize someone else's timing table.
+</details>
 
 ## Hands-On Exercise
 
-**Task**: Practice time management with sample tasks.
+Exercise scenario: you are using the lab environment or a local Kubernetes practice cluster to rehearse the exam strategy, not to learn new security controls from scratch. The goal is to finish a small sequence of familiar tasks, verify each one, and notice where your timing estimate differs from reality. Use the script as a compact drill, then repeat the same classification habit on your own custom task set.
+
+Before starting, set a visible 15-minute timer and decide how you will record skipped work. If a command or tool is unavailable in your environment, mark that as an environment finding rather than silently pretending the task was done. In the real exam, unavailable tools are part of the prompt design; in practice, they help you learn how quickly you can distinguish a tool problem from a knowledge problem.
+
+- [ ] Classify each drill item as Pass 1, Pass 2, or Pass 3 before running the command.
+- [ ] Complete at least four of the five timed tasks within 15 minutes.
+- [ ] Verify every completed task with a command that checks final cluster state.
+- [ ] Record any task that exceeded your estimate by more than 2 minutes.
+- [ ] Create a personal exam-day checklist covering environment setup and kubectl shortcuts.
+- [ ] Design a time budget for your next full practice run based on the timing results.
+
+<details><summary>Suggested solution approach for the timing drill</summary>
+
+Treat tasks 1, 2, and 3 as Pass 1 work because they are narrow object edits with direct verification. Treat task 4 as Pass 1 only if Trivy is installed and familiar; otherwise mark it as a tool availability finding and continue. Treat task 5 as Pass 1 if the AppArmor profile is already available and the prompt only asks for annotation, but move it to Pass 2 in an environment where profile loading or node inspection is required.
+</details>
 
 ```bash
 # Simulate exam conditions:
@@ -459,34 +583,30 @@ kubectl get networkpolicy,pods,role,rolebinding,sa -n secure
 kubectl delete namespace secure
 ```
 
-**Success criteria**: Complete at least 4/5 tasks in 15 minutes.
+<details><summary>How to interpret your result</summary>
 
----
+If you finished at least four tasks with verification, your Pass 1 mechanics are in usable shape. If you finished fewer tasks, inspect the delay instead of judging the score emotionally. A delay caused by typing YAML slowly needs template practice, a delay caused by labels needs better inspection habits, and a delay caused by missing tools needs environment setup practice. Your next drill should target the specific delay category.
+</details>
 
-## Summary
+Success criteria for this exercise are intentionally behavior-focused. You are not only checking whether the objects exist; you are checking whether your strategy survived time pressure. A clean run should leave you with completed objects, verification output, a short list of timing surprises, and one concrete adjustment to your exam-day checklist. That adjustment is the learning artifact you should carry into the next full practice exam.
 
-**Three-pass strategy for CKS**:
-- Pass 1 (50 min): Quick wins—RBAC, basic NetworkPolicy, securityContext
-- Pass 2 (50 min): Tool tasks—seccomp, PSA, kube-bench
-- Pass 3 (20 min): Complex—Falco rules, incident response
+## Sources
 
-**Key principles**:
-- Earn points early with quick wins
-- Skip unfamiliar tasks, return later
-- Verify every solution
-- Use documentation efficiently
-- Reserve time for verification
+- https://killercoda.com/kubedojo/scenario/cks-0.4-exam-strategy
+- https://www.cncf.io/training/certification/cks/
+- https://training.linuxfoundation.org/certification/certified-kubernetes-security-specialist/
+- https://docs.linuxfoundation.org/tc-docs/certification/lf-candidate-handbook
+- https://kubernetes.io/docs/concepts/services-networking/network-policies/
+- https://kubernetes.io/docs/concepts/security/pod-security-standards/
+- https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+- https://kubernetes.io/docs/reference/kubectl/generated/kubectl_auth/kubectl_auth_can-i/
+- https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/
+- https://kubernetes.io/docs/tutorials/security/seccomp/
+- https://kubernetes.io/docs/tutorials/security/apparmor/
+- https://aquasecurity.github.io/trivy/
+- https://github.com/aquasecurity/kube-bench
+- https://falco.org/docs/
 
-**Remember**: 67% to pass. You can skip some tasks and still succeed.
+## Next Module
 
----
-
-## Part 0 Complete!
-
-You've finished the **Environment Setup** section. You now have:
-- Understanding of CKS exam format and domains
-- Security lab with essential tools
-- Proficiency with Trivy, Falco, kube-bench
-- Exam strategy for security tasks
-
-**Next Part**: [Part 1: Cluster Setup](/k8s/cks/part1-cluster-setup/module-1.1-network-policies/) - Deep dive into network security.
+[Module 1.1: Network Policies](../part1-cluster-setup/module-1.1-network-policies/) - Start Part 1 by turning the exam strategy into concrete network isolation skills.


### PR DESCRIPTION
## Summary

Rewrites `src/content/docs/k8s/cks/part0-environment/module-0.4-exam-strategy.md` for #388 density, structure, alignment, anti-leak, and protected-asset gates. Clears `revision_pending: false`.

## Verifier

`verify_module.py --skip-source-check`: T3 -> T0; body_words=5036, mean_wpp=71.9, median_wpp=73.0, short_rate=0.029, max_run=1, mean_sentence_length=20.0. Sources reachability was intentionally skipped per dispatch; Sources section contains 14 counted URLs.

## Protected Assets

Preserved protected assets from the original module: code blocks 8 -> 8, original text diagrams 2 -> 2 inside fenced code blocks, markdown tables 6 -> 9, mermaid diagrams 0 -> 0. Original lab URL and original Kubernetes/Trivy/Falco documentation references are retained.

## Commit

9ddbf28816ddec4942cdf0e33e72cad66eda4b95