### PR TITLE
fix(388-5.3): nginx -> nginx:alpine for wget exec (#1257 post-audit fix)

### DIFF
--- a/src/content/docs/k8s/ckad/part5-networking/module-5.3-networkpolicies.md
+++ b/src/content/docs/k8s/ckad/part5-networking/module-5.3-networkpolicies.md
@@ -587,7 +587,7 @@ Run the lab slowly the first time and name the reason for every expected result.
 
 ### Task 1: Environment Setup
 
-Create a clean namespace and deploy three labeled pods with Services. These commands use `nginx` for every tier because the point is network reachability, not application behavior. Wait for readiness before testing so that a failed connection means policy behavior instead of a pod startup race.
+Create a clean namespace and deploy three labeled pods with Services. These commands use `nginx:alpine` for every tier because the alpine variant ships busybox wget, which the validation steps below use to test reachability. Wait for readiness before testing so that a failed connection means policy behavior instead of a pod startup race.
 
 The labels in this setup are intentionally simple because they become the identities used by the policies. If you change the labels, update the later policy manifests at the same time. A surprising number of policy failures are caused by a lab or deployment using labels that differ from the labels copied into the NetworkPolicy examples.
 
@@ -596,9 +596,9 @@ The labels in this setup are intentionally simple because they become the identi
 kubectl create ns netpol-demo
 
 # Create pods
-kubectl run frontend --image=nginx -n netpol-demo -l tier=frontend
-kubectl run backend --image=nginx -n netpol-demo -l tier=backend
-kubectl run database --image=nginx -n netpol-demo -l tier=database
+kubectl run frontend --image=nginx:alpine -n netpol-demo -l tier=frontend
+kubectl run backend --image=nginx:alpine -n netpol-demo -l tier=backend
+kubectl run database --image=nginx:alpine -n netpol-demo -l tier=database
 
 # Wait for pods
 kubectl wait --for=condition=Ready pod --all -n netpol-demo --timeout=60s


### PR DESCRIPTION
## Summary

Post-audit source: [audit/2026-05-18-grok-primary-calibration/REPORT.html](audit/2026-05-18-grok-primary-calibration/REPORT.html).

This applies the same wget-in-nginx fix class as #1249, #1253, and #1262 to the Module 5.3 NetworkPolicies lab. The lab validates reachability with `kubectl exec ... -- wget`, but `nginx:latest` is debian-slim and does not ship wget. Swapping only the three lab pods to `nginx:alpine` provides busybox wget while preserving nginx's default HTTP server behavior on port 80.

No Service definitions, NetworkPolicy manifests, learning outcomes, quiz items, or solution notes were changed.

## Verification

- `../../../.venv/bin/python scripts/quality/verify_module.py src/content/docs/k8s/ckad/part5-networking/module-5.3-networkpolicies.md` passed
- Verifier density metrics: `median_wpp=62`, `mean_wpp=61.4`, `short_paragraph_rate=0.011`
- `git diff --check` passed

## Test Plan

- Run the updated setup commands with `kubectl run frontend/backend/database --image=nginx:alpine`.
- Confirm `kubectl exec -n netpol-demo frontend -- wget -qO- --timeout=2 backend:80` succeeds before the default-deny policy.
- Confirm the later positive/negative `wget` checks reflect the intended NetworkPolicy behavior.
