### PR TITLE
feat(verifier): deterministic image-binary preflight (#388 audit item 2)

### DIFF
--- a/scripts/quality/test_verify_module.py
+++ b/scripts/quality/test_verify_module.py
@@ -780,3 +780,24 @@ kubectl exec -n netpol-demo database -- wget -qO- --timeout=2 frontend:80
         )
 
         assert gates["lab_image_binary_match"] is False
+
+    def test_coreutils_in_nginx_clean_but_wget_still_blocked(self) -> None:
+        """nginx ships coreutils (touch, cp, mv) but NOT wget - both rules hold."""
+        text = (
+            "# m\n\n"
+            "```bash\n"
+            "kubectl run hardened --image=nginx -n default\n"
+            "kubectl exec hardened -- touch /etc/test\n"
+            "kubectl exec hardened -- chmod 600 /etc/test\n"
+            "kubectl exec hardened -- cp /etc/test /tmp/copy\n"
+            "kubectl exec hardened -- wget http://svc:80\n"
+            "```\n"
+        )
+        out = verify_module.lab_runnability_metrics(text)
+        # touch/chmod/cp are coreutils - present in debian-slim - must be CLEAN.
+        # wget is NOT present in nginx (debian-slim) - must be the SOLE violation.
+        violations = out["image_binary_violations"]
+        assert len(violations) == 1, f"expected exactly 1 violation (wget); got {violations}"
+        assert violations[0]["binary"] == "wget"
+        assert violations[0]["pod"] == "hardened"
+        assert violations[0]["image"] == "nginx"

--- a/scripts/quality/test_verify_module.py
+++ b/scripts/quality/test_verify_module.py
@@ -28,6 +28,7 @@ def _base_gates() -> dict[str, bool | None]:
         "sources_all_reachable": None,
         "anti_leak": True,
         "runnable_no_kubectl_alias": True,
+        "lab_image_binary_match": True,
         "anti_fabrication_no_unsourced_anecdote": True,
         "practice_mcq_four_options_with_distractors": True,
         "outcomes_aligned": True,
@@ -37,6 +38,7 @@ def _base_gates() -> dict[str, bool | None]:
 def _gate_results(
     *,
     runnable_shell: dict[str, object] | None = None,
+    lab_runnability: dict[str, object] | None = None,
     anti_fabrication: dict[str, object] | None = None,
     practice_mcq: dict[str, object] | None = None,
 ) -> dict[str, bool | None]:
@@ -64,6 +66,7 @@ def _gate_results(
         {"count": 10, "url_status": {"skipped": 10}, "urls": []},
         {"forbidden_tokens": [], "has_emoji": False, "has_47": False},
         runnable_shell or {"kubectl_alias_violations": []},
+        lab_runnability or {"image_binary_violations": [], "unknown_images": []},
         anti_fabrication or {"unsourced_anecdotes": []},
         practice_mcq or {"applies": False, "question_count": 0, "violations": []},
         {"all_outcomes_covered": True},
@@ -275,6 +278,7 @@ def test_density_metrics_on_synthetic_short_module_fail() -> None:
         {"count": 10, "url_status": {"skipped": 10}, "urls": []},
         {"forbidden_tokens": [], "has_emoji": False, "has_47": False},
         {"kubectl_alias_violations": []},
+        {"image_binary_violations": [], "unknown_images": []},
         {"unsourced_anecdotes": []},
         {"applies": False, "question_count": 0, "violations": []},
         {"all_outcomes_covered": True},
@@ -598,3 +602,181 @@ def test_cli_all_revision_pending_writes_jsonl(tmp_path: Path, monkeypatch) -> N
     lines = out.read_text(encoding="utf-8").splitlines()
     assert len(lines) == 1
     assert json.loads(lines[0])["tier"] == "T3"
+
+
+class TestLabRunnability:
+    def test_kubectl_run_nginx_then_exec_wget_violates(self) -> None:
+        text = """
+```bash
+kubectl run pod1 --image=nginx -n default
+kubectl exec pod1 -- wget http://svc:80
+```
+"""
+        metrics = verify_module.lab_runnability_metrics(text)
+
+        assert metrics["image_binary_violations"] == [
+            {
+                "pod": "pod1",
+                "image": "nginx",
+                "binary": "wget",
+                "line": 4,
+                "snippet": "kubectl exec pod1 -- wget http://svc:80",
+            }
+        ]
+
+    def test_kubectl_run_nginx_alpine_then_exec_wget_clean(self) -> None:
+        text = """
+```bash
+kubectl run pod1 --image=nginx:alpine -n default
+kubectl exec pod1 -- wget http://svc:80
+```
+"""
+        metrics = verify_module.lab_runnability_metrics(text)
+
+        assert metrics["image_binary_violations"] == []
+
+    def test_busybox_then_exec_wget_clean(self) -> None:
+        text = """
+```bash
+kubectl run pod1 --image=busybox -n default
+kubectl exec pod1 -- wget http://svc:80
+```
+"""
+        metrics = verify_module.lab_runnability_metrics(text)
+
+        assert metrics["image_binary_violations"] == []
+
+    def test_nginx_then_exec_cat_clean(self) -> None:
+        text = """
+```bash
+kubectl run pod1 --image=nginx -n default
+kubectl exec pod1 -- cat /etc/nginx/nginx.conf
+```
+"""
+        metrics = verify_module.lab_runnability_metrics(text)
+
+        assert metrics["image_binary_violations"] == []
+
+    def test_yaml_inline_manifest_nginx_then_exec_curl_violates(self) -> None:
+        text = """
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: webserver
+spec:
+  containers:
+  - name: web
+    image: nginx
+```
+
+```bash
+kubectl exec webserver -- curl http://example/
+```
+"""
+        metrics = verify_module.lab_runnability_metrics(text)
+
+        assert metrics["image_binary_violations"] == [
+            {
+                "pod": "webserver",
+                "image": "nginx",
+                "binary": "curl",
+                "line": 14,
+                "snippet": "kubectl exec webserver -- curl http://example/",
+            }
+        ]
+
+    def test_unknown_image_does_not_flag(self) -> None:
+        text = """
+```bash
+kubectl run pod1 --image=my-org/custom:v3
+kubectl exec pod1 -- frobnicate --flag
+```
+"""
+        metrics = verify_module.lab_runnability_metrics(text)
+
+        assert metrics["image_binary_violations"] == []
+        assert metrics["unknown_images"] == ["my-org/custom:v3"]
+
+    def test_curlimages_curl_then_exec_curl_clean(self) -> None:
+        text = """
+```bash
+kubectl run pod1 --image=curlimages/curl --command -- sleep 3600
+kubectl exec pod1 -- curl http://example/
+```
+"""
+        metrics = verify_module.lab_runnability_metrics(text)
+
+        assert metrics["image_binary_violations"] == []
+
+    def test_exec_with_namespace_flag_parsed(self) -> None:
+        text = """
+```bash
+kubectl run frontend --image=nginx -n netpol-demo
+kubectl exec -n netpol-demo frontend -- wget http://backend:80
+```
+"""
+        metrics = verify_module.lab_runnability_metrics(text)
+
+        assert metrics["image_binary_violations"] == [
+            {
+                "pod": "frontend",
+                "image": "nginx",
+                "binary": "wget",
+                "line": 4,
+                "snippet": "kubectl exec -n netpol-demo frontend -- wget http://backend:80",
+            }
+        ]
+
+    def test_pre_fix_module_5_3_pattern_violates(self) -> None:
+        text = """
+## Hands-On Exercise
+
+```bash
+kubectl create namespace netpol-demo
+kubectl run frontend --image=nginx -n netpol-demo -l tier=frontend
+kubectl run backend  --image=nginx -n netpol-demo -l tier=backend
+kubectl run database --image=nginx -n netpol-demo -l tier=database
+```
+
+### Task 2
+
+```bash
+kubectl exec -n netpol-demo frontend -- wget -qO- --timeout=2 backend:80
+kubectl exec -n netpol-demo backend  -- wget -qO- --timeout=2 database:80
+kubectl exec -n netpol-demo database -- wget -qO- --timeout=2 frontend:80
+```
+
+### Task 3
+
+```bash
+kubectl exec -n netpol-demo frontend -- wget -qO- --timeout=2 backend:80
+kubectl exec -n netpol-demo backend  -- wget -qO- --timeout=2 database:80
+kubectl exec -n netpol-demo database -- wget -qO- --timeout=2 frontend:80
+```
+"""
+        metrics = verify_module.lab_runnability_metrics(text)
+        violations = metrics["image_binary_violations"]
+
+        assert len(violations) == 6
+        assert {violation["binary"] for violation in violations} == {"wget"}
+        assert {violation["image"] for violation in violations} == {"nginx"}
+        assert {violation["pod"] for violation in violations} == {"frontend", "backend", "database"}
+
+    def test_gate_results_lab_image_binary_match_false_on_violation(self) -> None:
+        gates = _gate_results(
+            lab_runnability={
+                "image_binary_violations": [
+                    {
+                        "pod": "pod1",
+                        "image": "nginx",
+                        "binary": "wget",
+                        "line": 4,
+                        "snippet": "kubectl exec pod1 -- wget http://svc:80",
+                    }
+                ],
+                "unknown_images": [],
+            }
+        )
+
+        assert gates["lab_image_binary_match"] is False

--- a/scripts/quality/verify_module.py
+++ b/scripts/quality/verify_module.py
@@ -92,11 +92,136 @@ SCENARIO_PREFIX_RE = re.compile(r"^(?:[*_#\s]*)(?:Hypothetical scenario|Exercise
 MCQ_OPTION_RE = re.compile(r"(?m)^(?:[-*]\s*)?(?:\*\*)?(?:[A-D]|[1-4])[\).:](?:\*\*)?\s+\S")
 MCQ_REASONING_KEYWORD_RE = re.compile(r"\b(?:wrong|not correct|incorrect|because|why)\b", re.IGNORECASE)
 
+# Sources: Docker Official image Dockerfiles, Debian/Ubuntu coreutils + util-linux
+# packages, Alpine/BusyBox applets, curlimages/curl Dockerfile, and nicolaka/netshoot
+# Dockerfile package list.
+DEBIAN_COREUTILS_UTIL_LINUX_BINARIES = {
+    "[",
+    "base64",
+    "basename",
+    "chmod",
+    "chown",
+    "cmp",
+    "cp",
+    "cut",
+    "date",
+    "dd",
+    "df",
+    "diff",
+    "dirname",
+    "du",
+    "false",
+    "file",
+    "gunzip",
+    "gzip",
+    "hostname",
+    "id",
+    "less",
+    "ln",
+    "md5sum",
+    "mkdir",
+    "mktemp",
+    "more",
+    "mount",
+    "mv",
+    "paste",
+    "readlink",
+    "rm",
+    "rmdir",
+    "sha1sum",
+    "sha256sum",
+    "sleep",
+    "sort",
+    "stat",
+    "tar",
+    "tee",
+    "test",
+    "touch",
+    "tr",
+    "true",
+    "type",
+    "umount",
+    "uname",
+    "uniq",
+    "wc",
+    "which",
+    "whoami",
+    "xargs",
+}
+BUSYBOX_COREUTILS_NETWORK_BINARIES = DEBIAN_COREUTILS_UTIL_LINUX_BINARIES | {
+    "hexdump",
+    "ifconfig",
+    "ip",
+    "netstat",
+    "nslookup",
+    "od",
+    "route",
+    "telnet",
+    "traceroute",
+}
+CURLIMAGES_CURL_BUSYBOX_SUBSET = {
+    "ash",
+    "cat",
+    "cp",
+    "curl",
+    "echo",
+    "env",
+    "find",
+    "grep",
+    "head",
+    "ls",
+    "mkdir",
+    "mv",
+    "rm",
+    "sh",
+    "sleep",
+    "tail",
+    "touch",
+}
+NETSHOOT_EXTRA_BINARIES = {
+    "ab",
+    "arping",
+    "bpftool",
+    "conntrack",
+    "dog",
+    "drill",
+    "ebpf-exporter",
+    "fortio",
+    "fping",
+    "helm",
+    "iperf3",
+    "jq",
+    "kubectl",
+    "mtr",
+    "ngrep",
+    "openssl",
+    "scp",
+    "socat",
+    "ssh",
+    "tshark",
+}
+
 # Image-binary allowlist for the lab-runnability preflight. Entries are intentionally
 # conservative: known images use strict membership; unknown images are informational.
 IMAGE_BINARY_ALLOWLIST: dict[str, set[str]] = {
     # Docker Official nginx Debian-family images; audit #1257 requires no wget/curl for plain nginx tags.
-    "nginx": {"sh", "dash", "ls", "cat", "head", "tail", "grep", "find", "ps", "nginx", "sed", "awk", "echo", "env"},
+    "nginx": {
+        "sh",
+        "dash",
+        "ls",
+        "cat",
+        "head",
+        "tail",
+        "grep",
+        "find",
+        "ps",
+        "nginx",
+        "sed",
+        "awk",
+        "echo",
+        "env",
+    }
+    | DEBIAN_COREUTILS_UTIL_LINUX_BINARIES,
     "nginx:stable": {
         "sh",
         "dash",
@@ -112,7 +237,8 @@ IMAGE_BINARY_ALLOWLIST: dict[str, set[str]] = {
         "awk",
         "echo",
         "env",
-    },
+    }
+    | DEBIAN_COREUTILS_UTIL_LINUX_BINARIES,
     "nginx:1.27": {
         "sh",
         "dash",
@@ -128,7 +254,8 @@ IMAGE_BINARY_ALLOWLIST: dict[str, set[str]] = {
         "awk",
         "echo",
         "env",
-    },
+    }
+    | DEBIAN_COREUTILS_UTIL_LINUX_BINARIES,
     # Docker Official nginx Alpine variants inherit Alpine/BusyBox applets, including wget.
     "nginx:alpine": {
         "sh",
@@ -149,7 +276,8 @@ IMAGE_BINARY_ALLOWLIST: dict[str, set[str]] = {
         "nc",
         "ping",
         "vi",
-    },
+    }
+    | BUSYBOX_COREUTILS_NETWORK_BINARIES,
     "nginx:1.27-alpine": {
         "sh",
         "ash",
@@ -169,7 +297,8 @@ IMAGE_BINARY_ALLOWLIST: dict[str, set[str]] = {
         "nc",
         "ping",
         "vi",
-    },
+    }
+    | BUSYBOX_COREUTILS_NETWORK_BINARIES,
     # Docker Official BusyBox image: BusyBox applet set, including ash and wget.
     "busybox": {
         "sh",
@@ -190,7 +319,8 @@ IMAGE_BINARY_ALLOWLIST: dict[str, set[str]] = {
         "ping",
         "vi",
         "id",
-    },
+    }
+    | BUSYBOX_COREUTILS_NETWORK_BINARIES,
     "busybox:1.36": {
         "sh",
         "ash",
@@ -210,7 +340,8 @@ IMAGE_BINARY_ALLOWLIST: dict[str, set[str]] = {
         "ping",
         "vi",
         "id",
-    },
+    }
+    | BUSYBOX_COREUTILS_NETWORK_BINARIES,
     # Docker Alpine Official Image uses BusyBox and apk.
     "alpine": {
         "sh",
@@ -231,7 +362,8 @@ IMAGE_BINARY_ALLOWLIST: dict[str, set[str]] = {
         "nc",
         "ping",
         "vi",
-    },
+    }
+    | BUSYBOX_COREUTILS_NETWORK_BINARIES,
     "alpine:3.20": {
         "sh",
         "ash",
@@ -251,10 +383,11 @@ IMAGE_BINARY_ALLOWLIST: dict[str, set[str]] = {
         "nc",
         "ping",
         "vi",
-    },
+    }
+    | BUSYBOX_COREUTILS_NETWORK_BINARIES,
     # curlimages/curl Docker Hub overview documents curl as the image entrypoint/tool.
-    "curlimages/curl": {"curl", "sh", "ls", "cat", "head", "tail", "grep", "find", "echo", "env"},
-    "curlimages/curl:latest": {"curl", "sh", "ls", "cat", "head", "tail", "grep", "find", "echo", "env"},
+    "curlimages/curl": CURLIMAGES_CURL_BUSYBOX_SUBSET,
+    "curlimages/curl:latest": CURLIMAGES_CURL_BUSYBOX_SUBSET,
     # Docker Official Debian/Ubuntu slim bases: shell/coreutils only, no wget/curl in this seed.
     "debian:bookworm-slim": {
         "sh",
@@ -271,7 +404,11 @@ IMAGE_BINARY_ALLOWLIST: dict[str, set[str]] = {
         "awk",
         "echo",
         "env",
-    },
+        "apt",
+        "apt-get",
+        "dpkg",
+    }
+    | DEBIAN_COREUTILS_UTIL_LINUX_BINARIES,
     "ubuntu:24.04": {
         "sh",
         "bash",
@@ -287,7 +424,11 @@ IMAGE_BINARY_ALLOWLIST: dict[str, set[str]] = {
         "awk",
         "echo",
         "env",
-    },
+        "apt",
+        "apt-get",
+        "dpkg",
+    }
+    | DEBIAN_COREUTILS_UTIL_LINUX_BINARIES,
     # nicolaka/netshoot Dockerfile installs network-debug tools via apk.
     "nicolaka/netshoot": {
         "curl",
@@ -313,7 +454,9 @@ IMAGE_BINARY_ALLOWLIST: dict[str, set[str]] = {
         "iptables",
         "ss",
         "host",
-    },
+    }
+    | BUSYBOX_COREUTILS_NETWORK_BINARIES
+    | NETSHOOT_EXTRA_BINARIES,
     # Docker Official Python 3.12 slim Dockerfile builds Python on debian:bookworm-slim and adds pip symlinks.
     "python:3.12-slim": {
         "sh",
@@ -332,7 +475,9 @@ IMAGE_BINARY_ALLOWLIST: dict[str, set[str]] = {
         "awk",
         "echo",
         "env",
-    },
+        "pip3",
+    }
+    | DEBIAN_COREUTILS_UTIL_LINUX_BINARIES,
 }
 
 LEARNING_OUTCOME_HEADINGS = (

--- a/scripts/quality/verify_module.py
+++ b/scripts/quality/verify_module.py
@@ -148,6 +148,64 @@ DEBIAN_COREUTILS_UTIL_LINUX_BINARIES = {
     "whoami",
     "xargs",
 }
+DEBIAN_EXTENDED_UTIL_LINUX_BINARIES = {
+    "blkid",
+    "dmesg",
+    "free",
+    "getconf",
+    "getent",
+    "getopt",
+    "groups",
+    "hexdump",
+    "ipcrm",
+    "ipcs",
+    "kill",
+    "killall",
+    "ldd",
+    "less",
+    "locale",
+    "lsof",
+    "lsblk",
+    "more",
+    "nice",
+    "od",
+    "pgrep",
+    "pkill",
+    "sleep",
+    "strings",
+    "sync",
+    "uname",
+    "users",
+    "w",
+    "who",
+    "whoami",
+}
+BUSYBOX_EXTENDED_APPLET_BINARIES = {
+    "blkid",
+    "dmesg",
+    "free",
+    "getopt",
+    "groups",
+    "hexdump",
+    "ipcs",
+    "kill",
+    "killall",
+    "ldd",
+    "less",
+    "lsblk",
+    "more",
+    "nice",
+    "od",
+    "pgrep",
+    "pkill",
+    "strings",
+    "sync",
+    "uname",
+    "users",
+    "w",
+    "who",
+    "whoami",
+}
 BUSYBOX_COREUTILS_NETWORK_BINARIES = DEBIAN_COREUTILS_UTIL_LINUX_BINARIES | {
     "hexdump",
     "ifconfig",
@@ -221,7 +279,8 @@ IMAGE_BINARY_ALLOWLIST: dict[str, set[str]] = {
         "echo",
         "env",
     }
-    | DEBIAN_COREUTILS_UTIL_LINUX_BINARIES,
+    | DEBIAN_COREUTILS_UTIL_LINUX_BINARIES
+    | DEBIAN_EXTENDED_UTIL_LINUX_BINARIES,
     "nginx:stable": {
         "sh",
         "dash",
@@ -238,7 +297,8 @@ IMAGE_BINARY_ALLOWLIST: dict[str, set[str]] = {
         "echo",
         "env",
     }
-    | DEBIAN_COREUTILS_UTIL_LINUX_BINARIES,
+    | DEBIAN_COREUTILS_UTIL_LINUX_BINARIES
+    | DEBIAN_EXTENDED_UTIL_LINUX_BINARIES,
     "nginx:1.27": {
         "sh",
         "dash",
@@ -255,7 +315,8 @@ IMAGE_BINARY_ALLOWLIST: dict[str, set[str]] = {
         "echo",
         "env",
     }
-    | DEBIAN_COREUTILS_UTIL_LINUX_BINARIES,
+    | DEBIAN_COREUTILS_UTIL_LINUX_BINARIES
+    | DEBIAN_EXTENDED_UTIL_LINUX_BINARIES,
     # Docker Official nginx Alpine variants inherit Alpine/BusyBox applets, including wget.
     "nginx:alpine": {
         "sh",
@@ -277,7 +338,8 @@ IMAGE_BINARY_ALLOWLIST: dict[str, set[str]] = {
         "ping",
         "vi",
     }
-    | BUSYBOX_COREUTILS_NETWORK_BINARIES,
+    | BUSYBOX_COREUTILS_NETWORK_BINARIES
+    | BUSYBOX_EXTENDED_APPLET_BINARIES,
     "nginx:1.27-alpine": {
         "sh",
         "ash",
@@ -298,7 +360,8 @@ IMAGE_BINARY_ALLOWLIST: dict[str, set[str]] = {
         "ping",
         "vi",
     }
-    | BUSYBOX_COREUTILS_NETWORK_BINARIES,
+    | BUSYBOX_COREUTILS_NETWORK_BINARIES
+    | BUSYBOX_EXTENDED_APPLET_BINARIES,
     # Docker Official BusyBox image: BusyBox applet set, including ash and wget.
     "busybox": {
         "sh",
@@ -320,7 +383,8 @@ IMAGE_BINARY_ALLOWLIST: dict[str, set[str]] = {
         "vi",
         "id",
     }
-    | BUSYBOX_COREUTILS_NETWORK_BINARIES,
+    | BUSYBOX_COREUTILS_NETWORK_BINARIES
+    | BUSYBOX_EXTENDED_APPLET_BINARIES,
     "busybox:1.36": {
         "sh",
         "ash",
@@ -341,7 +405,8 @@ IMAGE_BINARY_ALLOWLIST: dict[str, set[str]] = {
         "vi",
         "id",
     }
-    | BUSYBOX_COREUTILS_NETWORK_BINARIES,
+    | BUSYBOX_COREUTILS_NETWORK_BINARIES
+    | BUSYBOX_EXTENDED_APPLET_BINARIES,
     # Docker Alpine Official Image uses BusyBox and apk.
     "alpine": {
         "sh",
@@ -363,7 +428,8 @@ IMAGE_BINARY_ALLOWLIST: dict[str, set[str]] = {
         "ping",
         "vi",
     }
-    | BUSYBOX_COREUTILS_NETWORK_BINARIES,
+    | BUSYBOX_COREUTILS_NETWORK_BINARIES
+    | BUSYBOX_EXTENDED_APPLET_BINARIES,
     "alpine:3.20": {
         "sh",
         "ash",
@@ -384,7 +450,8 @@ IMAGE_BINARY_ALLOWLIST: dict[str, set[str]] = {
         "ping",
         "vi",
     }
-    | BUSYBOX_COREUTILS_NETWORK_BINARIES,
+    | BUSYBOX_COREUTILS_NETWORK_BINARIES
+    | BUSYBOX_EXTENDED_APPLET_BINARIES,
     # curlimages/curl Docker Hub overview documents curl as the image entrypoint/tool.
     "curlimages/curl": CURLIMAGES_CURL_BUSYBOX_SUBSET,
     "curlimages/curl:latest": CURLIMAGES_CURL_BUSYBOX_SUBSET,
@@ -408,7 +475,8 @@ IMAGE_BINARY_ALLOWLIST: dict[str, set[str]] = {
         "apt-get",
         "dpkg",
     }
-    | DEBIAN_COREUTILS_UTIL_LINUX_BINARIES,
+    | DEBIAN_COREUTILS_UTIL_LINUX_BINARIES
+    | DEBIAN_EXTENDED_UTIL_LINUX_BINARIES,
     "ubuntu:24.04": {
         "sh",
         "bash",
@@ -428,7 +496,8 @@ IMAGE_BINARY_ALLOWLIST: dict[str, set[str]] = {
         "apt-get",
         "dpkg",
     }
-    | DEBIAN_COREUTILS_UTIL_LINUX_BINARIES,
+    | DEBIAN_COREUTILS_UTIL_LINUX_BINARIES
+    | DEBIAN_EXTENDED_UTIL_LINUX_BINARIES,
     # nicolaka/netshoot Dockerfile installs network-debug tools via apk.
     "nicolaka/netshoot": {
         "curl",
@@ -477,7 +546,8 @@ IMAGE_BINARY_ALLOWLIST: dict[str, set[str]] = {
         "env",
         "pip3",
     }
-    | DEBIAN_COREUTILS_UTIL_LINUX_BINARIES,
+    | DEBIAN_COREUTILS_UTIL_LINUX_BINARIES
+    | DEBIAN_EXTENDED_UTIL_LINUX_BINARIES,
 }
 
 LEARNING_OUTCOME_HEADINGS = (

--- a/scripts/quality/verify_module.py
+++ b/scripts/quality/verify_module.py
@@ -7,6 +7,7 @@ import concurrent.futures
 import glob as globlib
 import json
 import re
+import shlex
 import statistics
 import sys
 from collections import Counter
@@ -90,6 +91,249 @@ UNSOURCED_ANECDOTE_RE = re.compile(
 SCENARIO_PREFIX_RE = re.compile(r"^(?:[*_#\s]*)(?:Hypothetical scenario|Exercise scenario):", re.IGNORECASE)
 MCQ_OPTION_RE = re.compile(r"(?m)^(?:[-*]\s*)?(?:\*\*)?(?:[A-D]|[1-4])[\).:](?:\*\*)?\s+\S")
 MCQ_REASONING_KEYWORD_RE = re.compile(r"\b(?:wrong|not correct|incorrect|because|why)\b", re.IGNORECASE)
+
+# Image-binary allowlist for the lab-runnability preflight. Entries are intentionally
+# conservative: known images use strict membership; unknown images are informational.
+IMAGE_BINARY_ALLOWLIST: dict[str, set[str]] = {
+    # Docker Official nginx Debian-family images; audit #1257 requires no wget/curl for plain nginx tags.
+    "nginx": {"sh", "dash", "ls", "cat", "head", "tail", "grep", "find", "ps", "nginx", "sed", "awk", "echo", "env"},
+    "nginx:stable": {
+        "sh",
+        "dash",
+        "ls",
+        "cat",
+        "head",
+        "tail",
+        "grep",
+        "find",
+        "ps",
+        "nginx",
+        "sed",
+        "awk",
+        "echo",
+        "env",
+    },
+    "nginx:1.27": {
+        "sh",
+        "dash",
+        "ls",
+        "cat",
+        "head",
+        "tail",
+        "grep",
+        "find",
+        "ps",
+        "nginx",
+        "sed",
+        "awk",
+        "echo",
+        "env",
+    },
+    # Docker Official nginx Alpine variants inherit Alpine/BusyBox applets, including wget.
+    "nginx:alpine": {
+        "sh",
+        "ash",
+        "wget",
+        "ls",
+        "cat",
+        "head",
+        "tail",
+        "grep",
+        "find",
+        "ps",
+        "nginx",
+        "sed",
+        "awk",
+        "echo",
+        "env",
+        "nc",
+        "ping",
+        "vi",
+    },
+    "nginx:1.27-alpine": {
+        "sh",
+        "ash",
+        "wget",
+        "ls",
+        "cat",
+        "head",
+        "tail",
+        "grep",
+        "find",
+        "ps",
+        "nginx",
+        "sed",
+        "awk",
+        "echo",
+        "env",
+        "nc",
+        "ping",
+        "vi",
+    },
+    # Docker Official BusyBox image: BusyBox applet set, including ash and wget.
+    "busybox": {
+        "sh",
+        "ash",
+        "wget",
+        "ls",
+        "cat",
+        "head",
+        "tail",
+        "grep",
+        "find",
+        "ps",
+        "sed",
+        "awk",
+        "echo",
+        "env",
+        "nc",
+        "ping",
+        "vi",
+        "id",
+    },
+    "busybox:1.36": {
+        "sh",
+        "ash",
+        "wget",
+        "ls",
+        "cat",
+        "head",
+        "tail",
+        "grep",
+        "find",
+        "ps",
+        "sed",
+        "awk",
+        "echo",
+        "env",
+        "nc",
+        "ping",
+        "vi",
+        "id",
+    },
+    # Docker Alpine Official Image uses BusyBox and apk.
+    "alpine": {
+        "sh",
+        "ash",
+        "apk",
+        "wget",
+        "ls",
+        "cat",
+        "head",
+        "tail",
+        "grep",
+        "find",
+        "ps",
+        "sed",
+        "awk",
+        "echo",
+        "env",
+        "nc",
+        "ping",
+        "vi",
+    },
+    "alpine:3.20": {
+        "sh",
+        "ash",
+        "apk",
+        "wget",
+        "ls",
+        "cat",
+        "head",
+        "tail",
+        "grep",
+        "find",
+        "ps",
+        "sed",
+        "awk",
+        "echo",
+        "env",
+        "nc",
+        "ping",
+        "vi",
+    },
+    # curlimages/curl Docker Hub overview documents curl as the image entrypoint/tool.
+    "curlimages/curl": {"curl", "sh", "ls", "cat", "head", "tail", "grep", "find", "echo", "env"},
+    "curlimages/curl:latest": {"curl", "sh", "ls", "cat", "head", "tail", "grep", "find", "echo", "env"},
+    # Docker Official Debian/Ubuntu slim bases: shell/coreutils only, no wget/curl in this seed.
+    "debian:bookworm-slim": {
+        "sh",
+        "bash",
+        "dash",
+        "ls",
+        "cat",
+        "head",
+        "tail",
+        "grep",
+        "find",
+        "ps",
+        "sed",
+        "awk",
+        "echo",
+        "env",
+    },
+    "ubuntu:24.04": {
+        "sh",
+        "bash",
+        "dash",
+        "ls",
+        "cat",
+        "head",
+        "tail",
+        "grep",
+        "find",
+        "ps",
+        "sed",
+        "awk",
+        "echo",
+        "env",
+    },
+    # nicolaka/netshoot Dockerfile installs network-debug tools via apk.
+    "nicolaka/netshoot": {
+        "curl",
+        "wget",
+        "sh",
+        "bash",
+        "ls",
+        "cat",
+        "head",
+        "tail",
+        "grep",
+        "find",
+        "ps",
+        "sed",
+        "awk",
+        "echo",
+        "env",
+        "nc",
+        "ping",
+        "dig",
+        "tcpdump",
+        "ip",
+        "iptables",
+        "ss",
+        "host",
+    },
+    # Docker Official Python 3.12 slim Dockerfile builds Python on debian:bookworm-slim and adds pip symlinks.
+    "python:3.12-slim": {
+        "sh",
+        "bash",
+        "python3",
+        "python",
+        "pip",
+        "ls",
+        "cat",
+        "head",
+        "tail",
+        "grep",
+        "find",
+        "ps",
+        "sed",
+        "awk",
+        "echo",
+        "env",
+    },
+}
 
 LEARNING_OUTCOME_HEADINGS = (
     "Learning Outcomes",
@@ -767,6 +1011,267 @@ def runnable_shell_metrics(text: str) -> dict[str, object]:
     return {"kubectl_alias_violations": violations}
 
 
+def _fenced_code_blocks_with_lines(text: str) -> list[tuple[str, str, int]]:
+    blocks: list[tuple[str, str, int]] = []
+    for match in re.finditer(r"```([^\n]*)\n(.*?)```", text, re.DOTALL):
+        blocks.append((match.group(1).strip(), match.group(2), text[: match.start(2)].count("\n") + 1))
+    return blocks
+
+
+def _shell_logical_lines(code: str, start_line: int) -> list[tuple[str, int]]:
+    logical_lines: list[tuple[str, int]] = []
+    current = ""
+    current_start = start_line
+    for offset, physical in enumerate(code.splitlines()):
+        stripped = physical.strip()
+        if not current:
+            current_start = start_line + offset
+            current = stripped
+        else:
+            current = f"{current} {stripped}"
+        if current.rstrip().endswith("\\"):
+            current = current.rstrip()[:-1].rstrip()
+            continue
+        if current:
+            logical_lines.append((current, current_start))
+        current = ""
+    if current:
+        logical_lines.append((current, current_start))
+    return logical_lines
+
+
+def _shell_tokens(line: str) -> list[str]:
+    if line.lstrip().startswith("$ "):
+        line = line.lstrip()[2:]
+    try:
+        return shlex.split(line, comments=True, posix=True)
+    except ValueError:
+        return line.split()
+
+
+def _kubectl_indices(tokens: list[str], verb: str) -> Iterable[int]:
+    for idx, token in enumerate(tokens[:-1]):
+        if token == "kubectl" and tokens[idx + 1] == verb:
+            yield idx
+
+
+def _option_consumes_value(token: str) -> bool:
+    return token in {
+        "-n",
+        "--namespace",
+        "-c",
+        "--container",
+        "--context",
+        "--kubeconfig",
+        "--as",
+        "--as-group",
+        "--field-manager",
+        "--request-timeout",
+        "--image",
+    }
+
+
+def _skip_option(tokens: list[str], idx: int) -> int:
+    token = tokens[idx]
+    if _option_consumes_value(token) and idx + 1 < len(tokens):
+        return idx + 2
+    if token.startswith("-"):
+        return idx + 1
+    return idx
+
+
+def _namespace_from_tokens(tokens: list[str]) -> str:
+    for idx, token in enumerate(tokens):
+        if token in {"-n", "--namespace"} and idx + 1 < len(tokens):
+            return tokens[idx + 1]
+        if token.startswith("--namespace="):
+            return token.split("=", 1)[1]
+        if token.startswith("-n="):
+            return token.split("=", 1)[1]
+    return ""
+
+
+def _parse_kubectl_run_images(tokens: list[str]) -> list[tuple[str, str, str]]:
+    pod_images: list[tuple[str, str, str]] = []
+    for kubectl_idx in _kubectl_indices(tokens, "run"):
+        pod_name = ""
+        namespace = _namespace_from_tokens(tokens[kubectl_idx + 2 :])
+        idx = kubectl_idx + 2
+        while idx < len(tokens):
+            token = tokens[idx]
+            if token == "--":
+                break
+            if token.startswith("-"):
+                idx = _skip_option(tokens, idx)
+                continue
+            pod_name = token
+            break
+        if not pod_name:
+            continue
+        image = ""
+        for idx, token in enumerate(tokens[kubectl_idx + 2 :], start=kubectl_idx + 2):
+            if token == "--image" and idx + 1 < len(tokens):
+                image = tokens[idx + 1]
+                break
+            if token.startswith("--image="):
+                image = token.split("=", 1)[1]
+                break
+        if image:
+            pod_images.append((namespace, pod_name, image))
+    return pod_images
+
+
+def _parse_kubectl_execs(tokens: list[str]) -> list[tuple[str, str, str]]:
+    execs: list[tuple[str, str, str]] = []
+    for kubectl_idx in _kubectl_indices(tokens, "exec"):
+        pod_name = ""
+        namespace = _namespace_from_tokens(tokens[kubectl_idx + 2 :])
+        idx = kubectl_idx + 2
+        while idx < len(tokens):
+            token = tokens[idx]
+            if token == "--":
+                break
+            if token.startswith("-"):
+                idx = _skip_option(tokens, idx)
+                continue
+            pod_name = token
+            idx += 1
+            break
+        if not pod_name:
+            continue
+        while idx < len(tokens) and tokens[idx] != "--":
+            idx += 1
+        if idx + 1 >= len(tokens):
+            continue
+        binary = tokens[idx + 1].rsplit("/", 1)[-1]
+        if binary:
+            execs.append((namespace, pod_name, binary))
+    return execs
+
+
+def _yaml_name_image_pairs(code: str) -> list[tuple[str, str]]:
+    name_re = re.compile(r"^\s*name:\s*['\"]?([^'\"\s#]+)")
+    image_re = re.compile(r"^\s*image:\s*['\"]?([^'\"\s#]+)")
+    lines = code.splitlines()
+    pairs: list[tuple[str, str]] = []
+    for idx, line in enumerate(lines):
+        name_match = name_re.match(line)
+        if not name_match:
+            continue
+        name = name_match.group(1)
+        for following in lines[idx + 1 : idx + 31]:
+            image_match = image_re.match(following)
+            if image_match:
+                pairs.append((name, image_match.group(1)))
+                break
+    return pairs
+
+
+def _normalize_image_name(image: str) -> str:
+    normalized = image.strip().strip("'\"").lower()
+    normalized = normalized.split("@", 1)[0]
+    parts = normalized.split("/")
+    if len(parts) > 1 and ("." in parts[0] or ":" in parts[0] or parts[0] == "localhost"):
+        parts = parts[1:]
+    if len(parts) == 2 and parts[0] == "library":
+        parts = parts[1:]
+    return "/".join(parts)
+
+
+def _image_without_tag(image: str) -> str:
+    slash_idx = image.rfind("/")
+    colon_idx = image.rfind(":")
+    if colon_idx > slash_idx:
+        return image[:colon_idx]
+    return image
+
+
+def _allowlist_key_for_image(image: str) -> str | None:
+    normalized = _normalize_image_name(image)
+    if normalized in IMAGE_BINARY_ALLOWLIST:
+        return normalized
+    without_tag = _image_without_tag(normalized)
+    if without_tag in IMAGE_BINARY_ALLOWLIST:
+        return without_tag
+    return None
+
+
+def lab_runnability_metrics(text: str) -> dict[str, object]:
+    """Detect kubectl-exec calls whose binary is not in the target pod's image.
+
+    Algorithm:
+      1. Walk fenced bash/sh/shell/zsh code blocks for kubectl commands.
+      2. Build a pod image map from `kubectl run NAME --image=IMAGE` and simple
+         inline YAML `name:` / following `image:` pairs within about 30 lines.
+      3. Find every `kubectl exec [-n NS] POD -- BIN [args]`.
+      4. If POD's image is unknown, skip the exec check because there is no ground truth.
+      5. Look up BIN in IMAGE_BINARY_ALLOWLIST and flag strict allowlist misses.
+
+    Returns:
+      {
+        "image_binary_violations": [
+          {
+            "pod": str,
+            "image": str,
+            "binary": str,
+            "line": int,
+            "snippet": str,
+          },
+          ...
+        ],
+        "unknown_images": [str, ...],
+      }
+    """
+    pod_images: dict[tuple[str, str], str] = {}
+    blocks = _fenced_code_blocks_with_lines(text)
+
+    for info, code, _start_line in blocks:
+        language = _fence_language(info)
+        if language in RUNNABLE_SHELL_LANGS:
+            for line, _line_number in _shell_logical_lines(code, 1):
+                for namespace, pod, image in _parse_kubectl_run_images(_shell_tokens(line)):
+                    pod_images[(namespace, pod)] = image
+        if language in RUNNABLE_SHELL_LANGS or language in {"yaml", "yml"}:
+            for pod, image in _yaml_name_image_pairs(code):
+                pod_images[("", pod)] = image
+
+    unknown_images: dict[str, None] = {}
+    for image in pod_images.values():
+        if _allowlist_key_for_image(image) is None:
+            unknown_images.setdefault(image, None)
+
+    violations: list[dict[str, object]] = []
+    for info, code, start_line in blocks:
+        if _fence_language(info) not in RUNNABLE_SHELL_LANGS:
+            continue
+        for line, line_number in _shell_logical_lines(code, start_line):
+            tokens = _shell_tokens(line)
+            for namespace, pod, binary in _parse_kubectl_execs(tokens):
+                image = pod_images.get((namespace, pod)) or pod_images.get(("", pod))
+                if not image and not namespace:
+                    matching_images = {value for (image_namespace, image_pod), value in pod_images.items() if image_pod == pod}
+                    if len(matching_images) == 1:
+                        image = next(iter(matching_images))
+                if not image:
+                    continue
+                allowlist_key = _allowlist_key_for_image(image)
+                if allowlist_key is None:
+                    continue
+                if binary.lower() in IMAGE_BINARY_ALLOWLIST[allowlist_key]:
+                    continue
+                violations.append(
+                    {
+                        "pod": pod,
+                        "image": image,
+                        "binary": binary,
+                        "line": line_number,
+                        "snippet": line.strip()[:120],
+                    }
+                )
+
+    return {"image_binary_violations": violations, "unknown_images": list(unknown_images)}
+
+
 def anti_fabrication_metrics(text: str) -> dict[str, object]:
     _, body = _strip_frontmatter(text)
     body_no_code = _strip_code_blocks(body, "\n")
@@ -927,6 +1432,7 @@ def gate_results(
     sources: dict[str, object],
     anti_leak: dict[str, object],
     runnable_shell: dict[str, object],
+    lab_runnability: dict[str, object],
     anti_fabrication: dict[str, object],
     practice_mcq: dict[str, object],
     alignment: dict[str, object],
@@ -961,6 +1467,7 @@ def gate_results(
         and not anti_leak["has_emoji"]
         and not anti_leak["has_47"],
         "runnable_no_kubectl_alias": not runnable_shell["kubectl_alias_violations"],
+        "lab_image_binary_match": not lab_runnability["image_binary_violations"],
         "anti_fabrication_no_unsourced_anecdote": not anti_fabrication["unsourced_anecdotes"],
         "practice_mcq_four_options_with_distractors": None
         if not practice_mcq["applies"]
@@ -986,12 +1493,18 @@ def classify_tier(metrics: dict[str, float | int], gates: dict[str, bool | None]
     }
     structure_failed = [key for key in failed if key.startswith("structure_")]
     density_failed = [key for key in failed if key in density_keys]
-    other_failed = [key for key in failed if key not in density_keys and not key.startswith("structure_")]
+    lab_failed = [key for key in failed if key == "lab_image_binary_match"]
+    other_failed = [
+        key for key in failed if key not in density_keys and not key.startswith("structure_") and key not in lab_failed
+    ]
     if density_failed and structure_failed:
         return "T3", failed
-    if structure_failed and not density_failed and not other_failed and len(structure_failed) <= 2:
+    if structure_failed and not density_failed and not lab_failed and not other_failed and len(structure_failed) <= 2:
         return "T1", failed
     if density_failed and not structure_failed and not other_failed:
+        return "T2", failed
+    # Lab-runnability failures are blocking but localized, so lab-only failures classify with T2.
+    if lab_failed and not density_failed and not structure_failed and not other_failed:
         return "T2", failed
     return "T3", failed
 
@@ -1006,6 +1519,7 @@ def verify(path: str | Path, skip_source_check: bool = False, max_workers: int =
     assets = protected_assets(text)
     anti = anti_leak_metrics(text)
     runnable_shell = runnable_shell_metrics(text)
+    lab_runnability = lab_runnability_metrics(text)
     anti_fabrication = anti_fabrication_metrics(text)
     practice_mcq = practice_mcq_metrics(module_path, text)
     alignment = alignment_metrics(text)
@@ -1017,6 +1531,7 @@ def verify(path: str | Path, skip_source_check: bool = False, max_workers: int =
         sources,
         anti,
         runnable_shell,
+        lab_runnability,
         anti_fabrication,
         practice_mcq,
         alignment,
@@ -1042,6 +1557,7 @@ def verify(path: str | Path, skip_source_check: bool = False, max_workers: int =
         "protected_assets": assets,
         "anti_leak": anti,
         "runnable_shell": runnable_shell,
+        "lab_runnability": lab_runnability,
         "anti_fabrication": anti_fabrication,
         "practice_mcq": practice_mcq,
         "alignment": alignment,


### PR DESCRIPTION
## Summary

Adds a new deterministic gate `lab_image_binary_match` to the #388 verifier. For each `kubectl exec POD -- BIN` in a module's bash code blocks, looks up POD's image (from `kubectl run --image=` or inline YAML), then checks `BIN` against a per-image allowlist. Flags violations.

Motivated by [the 2026-05-18 grok-primary-reviewer audit](../blob/main/audit/2026-05-18-grok-primary-calibration/REPORT.html) finding: PR #1257 shipped with a `kubectl exec ... -- wget` against `nginx` pods because the grok-as-primary review hallucinated *"nginx ships wget"* as the supporting fact for APPROVE. This gate makes the check independent of any LLM reviewer.

## Allowlist seed (each entry inline-commented with its source)

- `nginx` / `nginx:stable` / `nginx:1.27` — debian-slim base, **no wget, no curl**
- `nginx:alpine` / `nginx:1.27-alpine` — alpine + busybox (wget present)
- `busybox` / `busybox:1.36` — busybox toolset
- `alpine` / `alpine:3.20` — busybox + apk
- `curlimages/curl` / `curlimages/curl:latest` — curl + sh
- `debian:bookworm-slim`, `ubuntu:24.04` — minimal Debian/Ubuntu (no wget/curl)
- `nicolaka/netshoot` — net-debug toolkit (curl, wget, dig, tcpdump, etc.)
- `python:3.12-slim` — debian-slim + python3/pip

Unknown images do **not** fail the gate; they are recorded in `lab_runnability.unknown_images` for visibility. This avoids false positives while preserving signal.

## Test plan

- [x] `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python -m pytest scripts/quality/test_verify_module.py::TestLabRunnability -v`
- [x] `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python -m pytest scripts/quality/test_verify_module.py -v`
- [x] `/Users/krisztiankoos/projects/kubedojo/.venv/bin/ruff check scripts/quality/verify_module.py scripts/quality/test_verify_module.py`
- [x] `git diff --check`
- [x] Verifier run on current `module-5.3-networkpolicies.md` reports 0 `image_binary_violations` (since the #1275 fix used `nginx:alpine`).
- [ ] `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/test_pipeline.py` — failed in unrelated `TestRealModules.test_known_good_modules_pass_checks`: `k8s/ckad/part1-design-build/module-1.3-multi-container-pods` has `INLINE_PROMPTS` 0 found, needs >= 2. This PR does not touch that module or pipeline check.

Cross-ref: [[feedback_three_way_rule_agreement]] — companion PR will harden the reviewer prompt + writer brief for symmetry.