### PR TITLE
feat(prompts): image-binary citation + writer cheat-sheet (#388 audit item 3)

### DIFF
--- a/scripts/prompts/module-rewriter-388.md
+++ b/scripts/prompts/module-rewriter-388.md
@@ -63,6 +63,27 @@ The {{BODY_WORDS_TARGET}}-7,000 target is a depth budget, not a quota. If a topi
 
 Do NOT rely on shell aliases in runnable Bash examples. Specifically: do NOT write `alias k=kubectl` or use `k <subcommand>` (e.g., `k get`, `k describe`) inside fenced ```bash / ```sh / ```shell / ```zsh blocks. Aliases do not expand in non-interactive shells, so a learner who copies the block into a script will see `command not found`. Always use the full `kubectl` binary name in copy-paste examples. Prose like "many engineers alias kubectl to k for interactive use" is fine; running `k <cmd>` in a code block is not.
 
+## Image-binary compatibility (lab-runnability contract)
+
+Every `kubectl exec POD -- BIN` you write must satisfy BIN ∈ POD's image binary set. The verifier (`scripts/quality/verify_module.py` → `lab_runnability_metrics`) enforces this deterministically with an allowlist; the reviewer (LAB RUNNABILITY dimension (a)) checks it with citation.
+
+Common image cheat-sheet (verified against Docker Hub overview pages):
+
+| Image | Has wget | Has curl | Has bash | Notes |
+|---|---|---|---|---|
+| `nginx` (= `nginx:latest`, debian-slim) | ✗ | ✗ | ✗ | has `sh`, `cat`, `head`, `tail`, `grep`, `nginx` |
+| `nginx:alpine` | ✓ (busybox) | ✗ | ✗ | alpine base; busybox provides wget by default |
+| `busybox` | ✓ | ✗ | ✗ | wget, sh, ash, ls, cat, grep, find, nc |
+| `alpine` | ✓ (busybox) | ✗ | ✗ | + `apk` package manager |
+| `curlimages/curl` | ✗ | ✓ | ✗ | purpose-built — `curl`, `sh` |
+| `debian:bookworm-slim` | ✗ | ✗ | ✓ | bash present; wget/curl require `apt install` |
+| `nicolaka/netshoot` | ✓ | ✓ | ✓ | network debugging toolkit — wget, curl, dig, tcpdump |
+| `python:3.12-slim` | ✗ | ✗ | ✓ | `python3`, `pip` |
+
+If your lab needs `kubectl exec POD -- wget ...`, choose `nginx:alpine` over `nginx`. If your lab needs `kubectl exec POD -- curl ...` and the pod should also serve HTTP, choose `nginx:alpine` (no curl) + use `wget` instead, or use `curlimages/curl` + `--command -- sleep 3600` if the pod doesn't need to serve. Never write `--image=nginx` followed by an exec wget/curl — this is the exact bug #1257 shipped with and #1229 precedent.
+
+Reference: `audit/2026-05-18-grok-primary-calibration/REPORT.html` § 4 (the #1257 anatomy).
+
 Do NOT invent business incidents, client stories, anonymized companies, or "war story" anecdotes. A scenario is allowed only if (a) it is clearly labeled hypothetical with a `Hypothetical scenario:` or `Exercise scenario:` prefix, OR (b) it is a sourced real incident with enough specific detail to verify against the cited source. Do not imply an event happened with phrasing like "a payments company once...", "a team I worked with...", "a customer reported...", "War story:..." unless the incident is real and sourced. The incident-dedup gate only catches catalog matches; this rule catches the rest.
 
 For practice-question / mock-exam modules, preserve exam-style MCQ structure. Each question must include four visible answer options labeled `1-4` or `A-D` (visible in the rendered question, NOT hidden in `<details>`), followed by answer reasoning that explains why the correct option is correct AND why each distractor is wrong. The reasoning may live in `<details>` blocks; the numbered options must remain visible.

--- a/scripts/quality/dispatch_388_pilot.py
+++ b/scripts/quality/dispatch_388_pilot.py
@@ -294,10 +294,16 @@ Inspect with `gh pr view {pr_num}` and `gh pr diff {pr_num}`. Then evaluate:
 4. PROTECTED ASSETS — Code blocks, ASCII/mermaid diagrams, tables, source URLs preserved across the rewrite (counts in PR body should match).
 5. SOURCES — Each source actually reaches a primary/vendor doc, not marketing fluff. Flag dead/redirect URLs if you can spot any.
 6. LAB RUNNABILITY — Walk every lab step and drill in order. For each `kubectl exec`, `kubectl run`, `kubectl edit`, `kubectl delete`, or container-shell command the lab tells the learner to run, check:
-   (a) Container binaries: does the image actually contain the binary the step uses? `image: nginx` lacks `kubectl`; `image: busybox` lacks `bash`; `image: alpine` lacks `curl` by default. Flag any binary-vs-image mismatch.
+   (a) Container binaries — citation-forced check. For EACH `kubectl exec POD -- BIN [args]` in the module:
+       (i)   Quote the line that establishes POD's image. This is either a `kubectl run POD --image=IMAGE` line earlier in the module, or an inline YAML manifest `name: POD` followed by `image: IMAGE`. Include the line as-is in your review.
+       (ii)  State the EXACT image tag from (i), including the tag suffix. `nginx` is debian-slim (no wget, no curl). `nginx:alpine` is alpine + busybox (has wget). `busybox` has wget. `curlimages/curl` has curl. Do NOT confuse `nginx` with `nginx:alpine` — they are different images with different binary inventories.
+       (iii) Cite a primary source for the binary presence: the Docker Hub image overview page, the upstream Dockerfile, or a known reference (e.g. "alpine busybox ships wget by default" — link the busybox project page). A confident assertion without a citation is NOT acceptable — flag NEEDS CHANGES on any uncited binary claim.
+       (iv)  If the binary is NOT in the image and there is no alternative path (an init container that installs it, a sidecar with the binary, a `kubectl cp` of a static binary), this is a blocking LAB RUNNABILITY failure. Cite #1229 and #1257 as precedents — both shipped because this check was performed without citation.
    (b) Role / ClusterRole verbs vs operations: does the Role grant ALL the verbs the lab actually exercises? `kubectl edit` needs `get,list,update`; `kubectl delete` needs `get,list,delete`; `kubectl exec` needs `get` on pods + `create` on pods/exec. Cross-reference every `--verb=...` line in the YAML against every operation the lab/drill performs.
    (c) Resource scope mismatch: namespaced operations attempted with cluster-scoped permissions (or vice versa).
    (d) Order of operations: lab steps that reference prior state (a pod, secret, configmap) that wasn't actually created in an earlier step.
+
+   (e) Hallucination self-check. After completing (a)-(d), re-read your own LAB RUNNABILITY paragraph. For every factual claim about an image's binary inventory, ensure you quoted the image tag verbatim from the module AND cited a source. Claims like "nginx ships wget" without a paired image-tag quote and source citation are exactly the pattern that produced the #1257 false-approval. Strike any uncited claim from your review.
 
    This dimension catches the bug class that lets lab-breaking PRs through content review (#1229 shipped with nginx-image-vs-kubectl and missing-verb bugs because no review dimension explicitly probed it).
 


### PR DESCRIPTION
## Summary

Audit action item 3 from [the 2026-05-18 grok-primary-reviewer audit](../blob/main/audit/2026-05-18-grok-primary-calibration/REPORT.html).

- **Reviewer (`gemini_review_prompt` in `scripts/quality/dispatch_388_pilot.py`)** — LAB RUNNABILITY dimension (a) now requires reviewers to (i) quote the exact `--image=` line, (ii) name the tag including suffix (`nginx` vs `nginx:alpine`), (iii) cite a primary source for any binary-presence claim, (iv) flag NEEDS CHANGES on any uncited claim. Adds a Hallucination self-check at the end of LAB RUNNABILITY.
- **Writer (`scripts/prompts/module-rewriter-388.md`)** — adds an Image-binary compatibility cheat-sheet section listing wget/curl/bash availability for the 8 most common images.

Three-way rule agreement (per `[[feedback_three_way_rule_agreement]]`):

| Surface | Change |
|---|---|
| Writer | This PR — cheat-sheet in `module-rewriter-388.md` |
| Reviewer | This PR — citation-forced LAB RUNNABILITY (a) + hallucination self-check |
| Verifier | Companion PR on `codex/audit-2-image-binary-preflight` — deterministic `lab_runnability_metrics` + `lab_image_binary_match` gate |

## Motivation

PR #1257 (CKAD 5.3 NetworkPolicies) shipped because the grok-as-primary review stated *"nginx ships wget"* as the load-bearing rationale for APPROVE. The image is debian-slim and ships no wget. The lab was broken on main until PR #1275 (post-audit fix).

## Test plan

- [x] `gemini_review_prompt` smoke-tested in worktree — contains `citation-forced check` + `Hallucination self-check`.
- [x] `codex_prompt` smoke-tested — embeds the new writer cheat-sheet.
- [x] `/Users/krisztiankoos/projects/kubedojo/.venv/bin/ruff check scripts/quality/dispatch_388_pilot.py`.
- [x] `git diff --check`.
- [ ] `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/test_pipeline.py` currently fails on unrelated existing content: `k8s/ckad/part1-design-build/module-1.3-multi-container-pods` has 0 inline active learning prompts (needs >= 2). This PR does not touch content or verifier logic.
- [ ] First production review using the new reviewer prompt should explicitly quote the image-tag line in its LAB RUNNABILITY paragraph (acceptance criterion for the prompt change).
