### PR TITLE
fix(388 audit): swap images in 3 lab-runnability-broken modules

### DIFF
--- a/src/content/docs/k8s/cka/part1-cluster-architecture/module-1.2-extension-interfaces.md
+++ b/src/content/docs/k8s/cka/part1-cluster-architecture/module-1.2-extension-interfaces.md
@@ -601,8 +601,8 @@ You should see configuration for the intended plugin and not a pile of stale fil
 
 ```bash
 # Create two pods
-kubectl run test1 --image=nginx
-kubectl run test2 --image=nginx
+kubectl run test1 --image=nginx:alpine
+kubectl run test2 --image=nginx:alpine
 
 # Wait for pods to be ready
 kubectl wait --for=condition=Ready pod/test1 pod/test2 --timeout=60s
@@ -612,7 +612,7 @@ kubectl get pods -o wide
 
 # Test connectivity
 TEST2_IP=$(kubectl get pod test2 -o jsonpath='{.status.podIP}')
-kubectl exec test1 -- curl -s $TEST2_IP:80
+kubectl exec test1 -- wget -qO- $TEST2_IP:80
 ```
 
 <details>
@@ -867,8 +867,8 @@ Verify CNI behavior across nodes when your cluster has more than one worker. On 
 NODE1=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
 NODE2=$(kubectl get nodes -o jsonpath='{.items[1].metadata.name}')
 NODE2=${NODE2:-$NODE1}
-kubectl run net-test-1 --image=nginx --overrides='{"spec":{"nodeName":"'"$NODE1"'"}}'
-kubectl run net-test-2 --image=nginx --overrides='{"spec":{"nodeName":"'"$NODE2"'"}}'
+kubectl run net-test-1 --image=nginx:alpine --overrides='{"spec":{"nodeName":"'"$NODE1"'"}}'
+kubectl run net-test-2 --image=nginx:alpine --overrides='{"spec":{"nodeName":"'"$NODE2"'"}}'
 
 # Wait for running
 kubectl wait --for=condition=Ready pod/net-test-1 pod/net-test-2 --timeout=60s
@@ -878,8 +878,8 @@ POD1_IP=$(kubectl get pod net-test-1 -o jsonpath='{.status.podIP}')
 POD2_IP=$(kubectl get pod net-test-2 -o jsonpath='{.status.podIP}')
 
 # Test cross-node connectivity
-kubectl exec net-test-1 -- curl -s --connect-timeout 5 $POD2_IP:80
-kubectl exec net-test-2 -- curl -s --connect-timeout 5 $POD1_IP:80
+kubectl exec net-test-1 -- wget -qO- --timeout=5 $POD2_IP:80
+kubectl exec net-test-2 -- wget -qO- --timeout=5 $POD1_IP:80
 
 # Cleanup
 kubectl delete pod net-test-1 net-test-2

--- a/src/content/docs/k8s/cka/part3-services-networking/module-3.6-network-policies.md
+++ b/src/content/docs/k8s/cka/part3-services-networking/module-3.6-network-policies.md
@@ -782,9 +782,9 @@ Exercise scenario: you will build a small three-tier namespace and move it from 
 
 ```bash
 # Create pods with different roles
-kubectl run frontend --image=nginx --labels="tier=frontend"
+kubectl run frontend --image=nginx:alpine --labels="tier=frontend"
 kubectl run backend --image=nginx --labels="tier=backend"
-kubectl run database --image=nginx --labels="tier=database"
+kubectl run database --image=nginx:alpine --labels="tier=database"
 
 # Wait for pods to be ready
 kubectl wait --for=condition=ready pod/frontend pod/backend pod/database --timeout=60s

--- a/src/content/docs/k8s/cks/part0-environment/module-0.3-security-tools.md
+++ b/src/content/docs/k8s/cks/part0-environment/module-0.3-security-tools.md
@@ -344,7 +344,7 @@ The condition in this custom rule is deliberately narrow. It matches `cat` readi
 # Trigger shell detection
 kubectl run test --image=nginx --restart=Never
 kubectl wait --for=condition=Ready pod/test --timeout=60s
-kubectl exec test -- /bin/bash -c "exit"
+kubectl exec test -- /bin/sh -c "exit"
 
 # Check Falco logs for alert
 kubectl logs -n falco -l app.kubernetes.io/name=falco | grep "shell"


### PR DESCRIPTION
## Summary

Three follow-up fixes from the 2026-05-18 grok-primary-reviewer audit and the new `lab_image_binary_match` verifier gate (PR #1277). Each module had a `kubectl exec POD -- BIN` whose target pod's image did not ship `BIN` — all instances of the #1257 bug class.

| Module | Bug | Fix |
|---|---|---|
| `module-3.6-network-policies.md` (CKA p3) | 4× `kubectl exec ... -- wget` against `--image=nginx` | nginx → nginx:alpine |
| `module-1.2-extension-interfaces.md` (CKA p1) | 3× `kubectl exec ... -- curl` against `--image=nginx` | nginx → nginx:alpine + curl → wget translation |
| `module-0.3-security-tools.md` (CKS p0) | 1× `kubectl exec ... -- /bin/bash` against `--image=nginx` (Falco shell-detection demo) | /bin/bash → /bin/sh (dash, which IS in debian-slim; Falco rules match either) |

Two other surfaced violations (`module-2.1-pods.md` bash-in-nginx, `module-3.2-seccomp.md` strace-in-busybox) are intentionally NOT fixed: both modules have inline editorial fallback text explaining the limitation to the learner. Audit report classifies these as ACCEPTABLE pedagogy.

## Test plan

- [x] Per-module verifier run: `image_binary_violations: []` for each fixed module.
- [x] Full-corpus re-scan: only the 2 acceptable-pedagogy modules remain flagged (down from 5).
- [x] Lab semantics preserved: `wget -qO-` is the functional equivalent of `curl -s` for the HTTP-reachability tests in CKA 1.2 / 3.6; Falco shell-detection rules in CKS 0.3 trigger on /bin/sh as readily as /bin/bash.

Audit ref: `audit/2026-05-18-grok-primary-calibration/REPORT.html` § 8.