### PR TITLE
session 21: clawpatch adopted + 6-agent 10-role calibration + Mistral dropped

### DIFF
--- a/.clawpatch/config.json
+++ b/.clawpatch/config.json
@@ -1,0 +1,37 @@
+{
+  "schemaVersion": 1,
+  "stateDir": ".clawpatch",
+  "include": [
+    "**/*"
+  ],
+  "exclude": [
+    "node_modules/**",
+    "dist/**",
+    "build/**",
+    "target/**",
+    ".build/**",
+    ".git/**",
+    ".clawpatch/**"
+  ],
+  "provider": {
+    "name": "codex",
+    "model": null
+  },
+  "commands": {
+    "typecheck": null,
+    "lint": ".venv/bin/ruff check scripts/ tests/",
+    "format": ".venv/bin/ruff format --check scripts/ tests/",
+    "test": ".venv/bin/pytest -q --timeout=120"
+  },
+  "review": {
+    "maxContextFiles": 24,
+    "maxOwnedFiles": 12,
+    "maxFindingsPerFeature": 10,
+    "minConfidenceToFix": "medium"
+  },
+  "git": {
+    "requireCleanWorktreeForFix": true,
+    "commit": false,
+    "openPr": false
+  }
+}

--- a/.clawpatch/features/feat_config_0c1c23856a.json
+++ b/.clawpatch/features/feat_config_0c1c23856a.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_config_0c1c23856a",
+  "title": "Project config tsconfig.json",
+  "summary": "Build, release, or quality configuration in tsconfig.json.",
+  "kind": "config",
+  "source": "shared-infra-heuristic",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "tsconfig.json",
+      "symbol": null,
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "tsconfig.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "config"
+  ],
+  "trustBoundaries": [
+    "process-exec",
+    "filesystem"
+  ],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_config_57f59ddd1e.json
+++ b/.clawpatch/features/feat_config_57f59ddd1e.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_config_57f59ddd1e",
+  "title": "Project config vitest.config.ts",
+  "summary": "Build, release, or quality configuration in vitest.config.ts.",
+  "kind": "config",
+  "source": "shared-infra-heuristic",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "vitest.config.ts",
+      "symbol": null,
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "vitest.config.ts",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "config"
+  ],
+  "trustBoundaries": [
+    "process-exec",
+    "filesystem"
+  ],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_config_7528cb5b98.json
+++ b/.clawpatch/features/feat_config_7528cb5b98.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_config_7528cb5b98",
+  "title": "Project config package.json",
+  "summary": "Build, release, or quality configuration in package.json.",
+  "kind": "config",
+  "source": "shared-infra-heuristic",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "package.json",
+      "symbol": null,
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "package.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "config"
+  ],
+  "trustBoundaries": [
+    "process-exec",
+    "filesystem"
+  ],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_library_01be4c26a4.json
+++ b/.clawpatch/features/feat_library_01be4c26a4.json
@@ -1,0 +1,91 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_01be4c26a4",
+  "title": "Python source scripts/ai_agent_bridge#1",
+  "summary": "Python source group scripts/ai_agent_bridge#1 with 12 files.",
+  "kind": "library",
+  "source": "python-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "scripts/ai_agent_bridge#1",
+      "symbol": "scripts/ai_agent_bridge#1",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "scripts/ai_agent_bridge/__init__.py",
+      "reason": "source group scripts/ai_agent_bridge#1"
+    },
+    {
+      "path": "scripts/ai_agent_bridge/__main__.py",
+      "reason": "source group scripts/ai_agent_bridge#1"
+    },
+    {
+      "path": "scripts/ai_agent_bridge/_broker.py",
+      "reason": "source group scripts/ai_agent_bridge#1"
+    },
+    {
+      "path": "scripts/ai_agent_bridge/_channels.py",
+      "reason": "source group scripts/ai_agent_bridge#1"
+    },
+    {
+      "path": "scripts/ai_agent_bridge/_channels_cli.py",
+      "reason": "source group scripts/ai_agent_bridge#1"
+    },
+    {
+      "path": "scripts/ai_agent_bridge/_channels_watch.py",
+      "reason": "source group scripts/ai_agent_bridge#1"
+    },
+    {
+      "path": "scripts/ai_agent_bridge/_claude.py",
+      "reason": "source group scripts/ai_agent_bridge#1"
+    },
+    {
+      "path": "scripts/ai_agent_bridge/_cli.py",
+      "reason": "source group scripts/ai_agent_bridge#1"
+    },
+    {
+      "path": "scripts/ai_agent_bridge/_codex.py",
+      "reason": "source group scripts/ai_agent_bridge#1"
+    },
+    {
+      "path": "scripts/ai_agent_bridge/_codex_report.py",
+      "reason": "source group scripts/ai_agent_bridge#1"
+    },
+    {
+      "path": "scripts/ai_agent_bridge/_config.py",
+      "reason": "source group scripts/ai_agent_bridge#1"
+    },
+    {
+      "path": "scripts/ai_agent_bridge/_db.py",
+      "reason": "source group scripts/ai_agent_bridge#1"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "scripts/ai_agent_bridge/tests/test_discuss_bridge_bugs.py",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "scripts/ai_agent_bridge/tests/test_discuss_bridge_bugs.py",
+      "command": "pytest"
+    }
+  ],
+  "tags": [
+    "python",
+    "source-group"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_library_1dee36695b.json
+++ b/.clawpatch/features/feat_library_1dee36695b.json
@@ -1,0 +1,147 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_1dee36695b",
+  "title": "Python source scripts#3",
+  "summary": "Python source group scripts#3 with 12 files.",
+  "kind": "library",
+  "source": "python-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "scripts#3",
+      "symbol": "scripts#3",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "scripts/dispatch_research_verdict.py",
+      "reason": "source group scripts#3"
+    },
+    {
+      "path": "scripts/dispatch_smart.py",
+      "reason": "source group scripts#3"
+    },
+    {
+      "path": "scripts/expand_module.py",
+      "reason": "source group scripts#3"
+    },
+    {
+      "path": "scripts/fetch_citation.py",
+      "reason": "source group scripts#3"
+    },
+    {
+      "path": "scripts/generate_knowledge_card.py",
+      "reason": "source group scripts#3"
+    },
+    {
+      "path": "scripts/issue_watch.py",
+      "reason": "source group scripts#3"
+    },
+    {
+      "path": "scripts/lab_pipeline.py",
+      "reason": "source group scripts#3"
+    },
+    {
+      "path": "scripts/local_api.py",
+      "reason": "source group scripts#3"
+    },
+    {
+      "path": "scripts/mark-needs-independent-review.py",
+      "reason": "source group scripts#3"
+    },
+    {
+      "path": "scripts/migrate_v1_to_v2.py",
+      "reason": "source group scripts#3"
+    },
+    {
+      "path": "scripts/module_sections.py",
+      "reason": "source group scripts#3"
+    },
+    {
+      "path": "scripts/pipeline_v3.py",
+      "reason": "source group scripts#3"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "scripts/ai_agent_bridge/tests/test_discuss_bridge_bugs.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "scripts/quality/test_verify_module.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "scripts/test_lab_pipeline.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "scripts/test_pipeline.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "scripts/v2_ab_test.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "tests/test_dispatch_smart.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "tests/test_expand_module.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "tests/test_issue_watch.py",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "scripts/ai_agent_bridge/tests/test_discuss_bridge_bugs.py",
+      "command": "pytest"
+    },
+    {
+      "path": "scripts/quality/test_verify_module.py",
+      "command": "pytest"
+    },
+    {
+      "path": "scripts/test_lab_pipeline.py",
+      "command": "pytest"
+    },
+    {
+      "path": "scripts/test_pipeline.py",
+      "command": "pytest"
+    },
+    {
+      "path": "scripts/v2_ab_test.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_dispatch_smart.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_expand_module.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_issue_watch.py",
+      "command": "pytest"
+    }
+  ],
+  "tags": [
+    "python",
+    "source-group"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_library_25faef2bc4.json
+++ b/.clawpatch/features/feat_library_25faef2bc4.json
@@ -1,0 +1,37 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_25faef2bc4",
+  "title": "Python source root",
+  "summary": "Python source file check_urls.py.",
+  "kind": "library",
+  "source": "python-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "root",
+      "symbol": "root",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "check_urls.py",
+      "reason": "source group root"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "python",
+    "source-group"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_library_486114c4c2.json
+++ b/.clawpatch/features/feat_library_486114c4c2.json
@@ -1,0 +1,123 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_486114c4c2",
+  "title": "Python source scripts/quality#1",
+  "summary": "Python source group scripts/quality#1 with 12 files.",
+  "kind": "library",
+  "source": "python-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "scripts/quality#1",
+      "symbol": "scripts/quality#1",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "scripts/quality/__init__.py",
+      "reason": "source group scripts/quality#1"
+    },
+    {
+      "path": "scripts/quality/check_citations.py",
+      "reason": "source group scripts/quality#1"
+    },
+    {
+      "path": "scripts/quality/check_code_blocks.py",
+      "reason": "source group scripts/quality#1"
+    },
+    {
+      "path": "scripts/quality/check_uk_changed.py",
+      "reason": "source group scripts/quality#1"
+    },
+    {
+      "path": "scripts/quality/citations.py",
+      "reason": "source group scripts/quality#1"
+    },
+    {
+      "path": "scripts/quality/cleanup_388_pilot.py",
+      "reason": "source group scripts/quality#1"
+    },
+    {
+      "path": "scripts/quality/density.py",
+      "reason": "source group scripts/quality#1"
+    },
+    {
+      "path": "scripts/quality/dispatch_388_pilot.py",
+      "reason": "source group scripts/quality#1"
+    },
+    {
+      "path": "scripts/quality/dispatchers.py",
+      "reason": "source group scripts/quality#1"
+    },
+    {
+      "path": "scripts/quality/extractors.py",
+      "reason": "source group scripts/quality#1"
+    },
+    {
+      "path": "scripts/quality/gates.py",
+      "reason": "source group scripts/quality#1"
+    },
+    {
+      "path": "scripts/quality/incident_dedup_gate.py",
+      "reason": "source group scripts/quality#1"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "scripts/quality/test_verify_module.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "tests/test_check_citations.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "tests/test_check_uk_changed.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "tests/test_dispatch_388_pilot.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "tests/test_incident_dedup_gate.py",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "scripts/quality/test_verify_module.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_check_citations.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_check_uk_changed.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_dispatch_388_pilot.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_incident_dedup_gate.py",
+      "command": "pytest"
+    }
+  ],
+  "tags": [
+    "python",
+    "source-group"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_library_4e2afecc33.json
+++ b/.clawpatch/features/feat_library_4e2afecc33.json
@@ -1,0 +1,52 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_4e2afecc33",
+  "title": "Node package kubedojo",
+  "summary": "Node package manifest at package.json.",
+  "kind": "library",
+  "source": "node-package",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "package.json",
+      "symbol": "kubedojo",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "package.json",
+      "reason": "package manifest"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "README.md",
+      "reason": "package context"
+    },
+    {
+      "path": "AGENTS.md",
+      "reason": "package context"
+    },
+    {
+      "path": "tsconfig.json",
+      "reason": "package context"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "node",
+    "package",
+    "project:kubedojo",
+    "project-root:."
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_library_544d0223e8.json
+++ b/.clawpatch/features/feat_library_544d0223e8.json
@@ -1,0 +1,147 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_544d0223e8",
+  "title": "Python source scripts#2",
+  "summary": "Python source group scripts#2 with 12 files.",
+  "kind": "library",
+  "source": "python-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "scripts#2",
+      "symbol": "scripts#2",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "scripts/check_reader_aids.py",
+      "reason": "source group scripts#2"
+    },
+    {
+      "path": "scripts/check_site_health.py",
+      "reason": "source group scripts#2"
+    },
+    {
+      "path": "scripts/check_site_render.py",
+      "reason": "source group scripts#2"
+    },
+    {
+      "path": "scripts/check_unsourced.py",
+      "reason": "source group scripts#2"
+    },
+    {
+      "path": "scripts/citation_backfill.py",
+      "reason": "source group scripts#2"
+    },
+    {
+      "path": "scripts/citation_residuals.py",
+      "reason": "source group scripts#2"
+    },
+    {
+      "path": "scripts/dedupe_audit.py",
+      "reason": "source group scripts#2"
+    },
+    {
+      "path": "scripts/detect_uk_divergence.py",
+      "reason": "source group scripts#2"
+    },
+    {
+      "path": "scripts/dispatch.py",
+      "reason": "source group scripts#2"
+    },
+    {
+      "path": "scripts/dispatch_chapter_prose.py",
+      "reason": "source group scripts#2"
+    },
+    {
+      "path": "scripts/dispatch_chapter_research.py",
+      "reason": "source group scripts#2"
+    },
+    {
+      "path": "scripts/dispatch_prose_review.py",
+      "reason": "source group scripts#2"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "scripts/ai_agent_bridge/tests/test_discuss_bridge_bugs.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "scripts/quality/test_verify_module.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "scripts/test_lab_pipeline.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "scripts/test_pipeline.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "scripts/v2_ab_test.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "tests/test_citation_backfill.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "tests/test_citation_residuals.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "tests/test_detect_uk_divergence.py",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "scripts/ai_agent_bridge/tests/test_discuss_bridge_bugs.py",
+      "command": "pytest"
+    },
+    {
+      "path": "scripts/quality/test_verify_module.py",
+      "command": "pytest"
+    },
+    {
+      "path": "scripts/test_lab_pipeline.py",
+      "command": "pytest"
+    },
+    {
+      "path": "scripts/test_pipeline.py",
+      "command": "pytest"
+    },
+    {
+      "path": "scripts/v2_ab_test.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_citation_backfill.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_citation_residuals.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_detect_uk_divergence.py",
+      "command": "pytest"
+    }
+  ],
+  "tags": [
+    "python",
+    "source-group"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_library_65f356ef71.json
+++ b/.clawpatch/features/feat_library_65f356ef71.json
@@ -1,0 +1,139 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_65f356ef71",
+  "title": "Python source scripts#1",
+  "summary": "Python source group scripts#1 with 12 files.",
+  "kind": "library",
+  "source": "python-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "scripts#1",
+      "symbol": "scripts#1",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "scripts/audit_incident_reuse.py",
+      "reason": "source group scripts#1"
+    },
+    {
+      "path": "scripts/audit_review_coverage.py",
+      "reason": "source group scripts#1"
+    },
+    {
+      "path": "scripts/audit_teaching_quality.py",
+      "reason": "source group scripts#1"
+    },
+    {
+      "path": "scripts/autopilot_v3.py",
+      "reason": "source group scripts#1"
+    },
+    {
+      "path": "scripts/batch-gemini-review.py",
+      "reason": "source group scripts#1"
+    },
+    {
+      "path": "scripts/bench_orientation.py",
+      "reason": "source group scripts#1"
+    },
+    {
+      "path": "scripts/check_chapter_overlap.py",
+      "reason": "source group scripts#1"
+    },
+    {
+      "path": "scripts/check_citations.py",
+      "reason": "source group scripts#1"
+    },
+    {
+      "path": "scripts/check_coherence.py",
+      "reason": "source group scripts#1"
+    },
+    {
+      "path": "scripts/check_incident_reuse.py",
+      "reason": "source group scripts#1"
+    },
+    {
+      "path": "scripts/check_links.py",
+      "reason": "source group scripts#1"
+    },
+    {
+      "path": "scripts/check_overstatement.py",
+      "reason": "source group scripts#1"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "scripts/ai_agent_bridge/tests/test_discuss_bridge_bugs.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "scripts/quality/test_verify_module.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "scripts/test_lab_pipeline.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "scripts/test_pipeline.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "scripts/v2_ab_test.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "tests/test_audit_review_coverage.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "tests/test_check_citations.py",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "scripts/ai_agent_bridge/tests/test_discuss_bridge_bugs.py",
+      "command": "pytest"
+    },
+    {
+      "path": "scripts/quality/test_verify_module.py",
+      "command": "pytest"
+    },
+    {
+      "path": "scripts/test_lab_pipeline.py",
+      "command": "pytest"
+    },
+    {
+      "path": "scripts/test_pipeline.py",
+      "command": "pytest"
+    },
+    {
+      "path": "scripts/v2_ab_test.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_audit_review_coverage.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_check_citations.py",
+      "command": "pytest"
+    }
+  ],
+  "tags": [
+    "python",
+    "source-group"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_library_7176519aac.json
+++ b/.clawpatch/features/feat_library_7176519aac.json
@@ -1,0 +1,61 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_7176519aac",
+  "title": "Python source scripts/agent_runtime/adapters",
+  "summary": "Python source group scripts/agent_runtime/adapters with 7 files.",
+  "kind": "library",
+  "source": "python-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "scripts/agent_runtime/adapters",
+      "symbol": "scripts/agent_runtime/adapters",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "scripts/agent_runtime/adapters/__init__.py",
+      "reason": "source group scripts/agent_runtime/adapters"
+    },
+    {
+      "path": "scripts/agent_runtime/adapters/_template.py",
+      "reason": "source group scripts/agent_runtime/adapters"
+    },
+    {
+      "path": "scripts/agent_runtime/adapters/base.py",
+      "reason": "source group scripts/agent_runtime/adapters"
+    },
+    {
+      "path": "scripts/agent_runtime/adapters/claude.py",
+      "reason": "source group scripts/agent_runtime/adapters"
+    },
+    {
+      "path": "scripts/agent_runtime/adapters/codex.py",
+      "reason": "source group scripts/agent_runtime/adapters"
+    },
+    {
+      "path": "scripts/agent_runtime/adapters/gemini.py",
+      "reason": "source group scripts/agent_runtime/adapters"
+    },
+    {
+      "path": "scripts/agent_runtime/adapters/grok.py",
+      "reason": "source group scripts/agent_runtime/adapters"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "python",
+    "source-group"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_library_81ccf37ef5.json
+++ b/.clawpatch/features/feat_library_81ccf37ef5.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_81ccf37ef5",
+  "title": "Python source scripts/research",
+  "summary": "Python source group scripts/research with 2 files.",
+  "kind": "library",
+  "source": "python-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "scripts/research",
+      "symbol": "scripts/research",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "scripts/research/sample_prose_capacity.py",
+      "reason": "source group scripts/research"
+    },
+    {
+      "path": "scripts/research/writer-calibration-rigorous.py",
+      "reason": "source group scripts/research"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "python",
+    "source-group"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_library_8332c01bfc.json
+++ b/.clawpatch/features/feat_library_8332c01bfc.json
@@ -1,0 +1,83 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_8332c01bfc",
+  "title": "Python source scripts/ai_agent_bridge#2",
+  "summary": "Python source group scripts/ai_agent_bridge#2 with 10 files.",
+  "kind": "library",
+  "source": "python-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "scripts/ai_agent_bridge#2",
+      "symbol": "scripts/ai_agent_bridge#2",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "scripts/ai_agent_bridge/_fts.py",
+      "reason": "source group scripts/ai_agent_bridge#2"
+    },
+    {
+      "path": "scripts/ai_agent_bridge/_gemini.py",
+      "reason": "source group scripts/ai_agent_bridge#2"
+    },
+    {
+      "path": "scripts/ai_agent_bridge/_gemini_session_link.py",
+      "reason": "source group scripts/ai_agent_bridge#2"
+    },
+    {
+      "path": "scripts/ai_agent_bridge/_github.py",
+      "reason": "source group scripts/ai_agent_bridge#2"
+    },
+    {
+      "path": "scripts/ai_agent_bridge/_inbox.py",
+      "reason": "source group scripts/ai_agent_bridge#2"
+    },
+    {
+      "path": "scripts/ai_agent_bridge/_messaging.py",
+      "reason": "source group scripts/ai_agent_bridge#2"
+    },
+    {
+      "path": "scripts/ai_agent_bridge/_model.py",
+      "reason": "source group scripts/ai_agent_bridge#2"
+    },
+    {
+      "path": "scripts/ai_agent_bridge/_orphan_recovery.py",
+      "reason": "source group scripts/ai_agent_bridge#2"
+    },
+    {
+      "path": "scripts/ai_agent_bridge/_prompts.py",
+      "reason": "source group scripts/ai_agent_bridge#2"
+    },
+    {
+      "path": "scripts/ai_agent_bridge/_worktree_brief.py",
+      "reason": "source group scripts/ai_agent_bridge#2"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "scripts/ai_agent_bridge/tests/test_discuss_bridge_bugs.py",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "scripts/ai_agent_bridge/tests/test_discuss_bridge_bugs.py",
+      "command": "pytest"
+    }
+  ],
+  "tags": [
+    "python",
+    "source-group"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_library_8b6d2615e2.json
+++ b/.clawpatch/features/feat_library_8b6d2615e2.json
@@ -1,0 +1,51 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_8b6d2615e2",
+  "title": "Python source scripts/pipeline_common",
+  "summary": "Python source group scripts/pipeline_common with 2 files.",
+  "kind": "library",
+  "source": "python-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "scripts/pipeline_common",
+      "symbol": "scripts/pipeline_common",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "scripts/pipeline_common/module_lock.py",
+      "reason": "source group scripts/pipeline_common"
+    },
+    {
+      "path": "scripts/pipeline_common/review_audit.py",
+      "reason": "source group scripts/pipeline_common"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "tests/test_module_lock.py",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "tests/test_module_lock.py",
+      "command": "pytest"
+    }
+  ],
+  "tags": [
+    "python",
+    "source-group"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_library_9ff8b28c45.json
+++ b/.clawpatch/features/feat_library_9ff8b28c45.json
@@ -1,0 +1,118 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_9ff8b28c45",
+  "title": "Python source scripts/quality#2",
+  "summary": "Python source group scripts/quality#2 with 8 files.",
+  "kind": "library",
+  "source": "python-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "scripts/quality#2",
+      "symbol": "scripts/quality#2",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "scripts/quality/pipeline.py",
+      "reason": "source group scripts/quality#2"
+    },
+    {
+      "path": "scripts/quality/prompts.py",
+      "reason": "source group scripts/quality#2"
+    },
+    {
+      "path": "scripts/quality/queue.py",
+      "reason": "source group scripts/quality#2"
+    },
+    {
+      "path": "scripts/quality/run_388_batch.py",
+      "reason": "source group scripts/quality#2"
+    },
+    {
+      "path": "scripts/quality/stages.py",
+      "reason": "source group scripts/quality#2"
+    },
+    {
+      "path": "scripts/quality/state.py",
+      "reason": "source group scripts/quality#2"
+    },
+    {
+      "path": "scripts/quality/verify_module.py",
+      "reason": "source group scripts/quality#2"
+    },
+    {
+      "path": "scripts/quality/worktree.py",
+      "reason": "source group scripts/quality#2"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "scripts/quality/test_verify_module.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "tests/quality/test_verify_module.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "tests/test_run_388_batch.py",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "scripts/quality/test_verify_module.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/quality/test_verify_module.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_run_388_batch.py",
+      "command": "pytest"
+    }
+  ],
+  "tags": [
+    "python",
+    "source-group"
+  ],
+  "trustBoundaries": [],
+  "status": "claimed",
+  "lock": {
+    "lockedByRunId": "20260517T171227-fba562",
+    "lockedAt": "2026-05-17T17:12:27.342Z",
+    "hostname": "Mac",
+    "pid": 71910
+  },
+  "findingIds": [
+    "fnd_sig-feat-library-9ff8b28c45-f62e_529cd2a3f1",
+    "fnd_sig-feat-library-9ff8b28c45-39b7_54a5def33e",
+    "fnd_sig-feat-library-9ff8b28c45-ad40_118ed67f14",
+    "fnd_sig-feat-library-9ff8b28c45-0e73_6ccf5affe4"
+  ],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260517T160324-644010",
+      "kind": "review",
+      "summary": "4 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-17T16:08:52.021Z"
+    },
+    {
+      "runId": "20260517T170834-2d9423",
+      "kind": "review-error",
+      "summary": "acpx provider failed: command timed out after 180000ms",
+      "provider": "acpx",
+      "model": "claude:claude-opus-4-7",
+      "createdAt": "2026-05-17T17:11:35.300Z"
+    }
+  ],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T17:12:27.343Z"
+}

--- a/.clawpatch/features/feat_library_a64d3affe2.json
+++ b/.clawpatch/features/feat_library_a64d3affe2.json
@@ -1,0 +1,139 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_a64d3affe2",
+  "title": "Python source scripts#5",
+  "summary": "Python source group scripts#5 with 10 files.",
+  "kind": "library",
+  "source": "python-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "scripts#5",
+      "symbol": "scripts#5",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "scripts/show_388_status.py",
+      "reason": "source group scripts#5"
+    },
+    {
+      "path": "scripts/status.py",
+      "reason": "source group scripts#5"
+    },
+    {
+      "path": "scripts/sweep_ai_history_aids.py",
+      "reason": "source group scripts#5"
+    },
+    {
+      "path": "scripts/test-theme.py",
+      "reason": "source group scripts#5"
+    },
+    {
+      "path": "scripts/translation_v2.py",
+      "reason": "source group scripts#5"
+    },
+    {
+      "path": "scripts/uk_sync.py",
+      "reason": "source group scripts#5"
+    },
+    {
+      "path": "scripts/v1_pipeline.py",
+      "reason": "source group scripts#5"
+    },
+    {
+      "path": "scripts/verify_citations.py",
+      "reason": "source group scripts#5"
+    },
+    {
+      "path": "scripts/verify_review.py",
+      "reason": "source group scripts#5"
+    },
+    {
+      "path": "scripts/ztt_status.py",
+      "reason": "source group scripts#5"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "scripts/ai_agent_bridge/tests/test_discuss_bridge_bugs.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "scripts/quality/test_verify_module.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "scripts/test_lab_pipeline.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "scripts/test_pipeline.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "scripts/v2_ab_test.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "tests/test_translation_v2.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "tests/test_verify_review.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "tests/test_ztt_status.py",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "scripts/ai_agent_bridge/tests/test_discuss_bridge_bugs.py",
+      "command": "pytest"
+    },
+    {
+      "path": "scripts/quality/test_verify_module.py",
+      "command": "pytest"
+    },
+    {
+      "path": "scripts/test_lab_pipeline.py",
+      "command": "pytest"
+    },
+    {
+      "path": "scripts/test_pipeline.py",
+      "command": "pytest"
+    },
+    {
+      "path": "scripts/v2_ab_test.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_translation_v2.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_verify_review.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_ztt_status.py",
+      "command": "pytest"
+    }
+  ],
+  "tags": [
+    "python",
+    "source-group"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_library_b133b7915f.json
+++ b/.clawpatch/features/feat_library_b133b7915f.json
@@ -1,0 +1,69 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_b133b7915f",
+  "title": "Python source scripts/pipeline_v2",
+  "summary": "Python source group scripts/pipeline_v2 with 9 files.",
+  "kind": "library",
+  "source": "python-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "scripts/pipeline_v2",
+      "symbol": "scripts/pipeline_v2",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "scripts/pipeline_v2/__init__.py",
+      "reason": "source group scripts/pipeline_v2"
+    },
+    {
+      "path": "scripts/pipeline_v2/cli.py",
+      "reason": "source group scripts/pipeline_v2"
+    },
+    {
+      "path": "scripts/pipeline_v2/control_plane.py",
+      "reason": "source group scripts/pipeline_v2"
+    },
+    {
+      "path": "scripts/pipeline_v2/escalation.py",
+      "reason": "source group scripts/pipeline_v2"
+    },
+    {
+      "path": "scripts/pipeline_v2/patch_worker.py",
+      "reason": "source group scripts/pipeline_v2"
+    },
+    {
+      "path": "scripts/pipeline_v2/preflight.py",
+      "reason": "source group scripts/pipeline_v2"
+    },
+    {
+      "path": "scripts/pipeline_v2/review_worker.py",
+      "reason": "source group scripts/pipeline_v2"
+    },
+    {
+      "path": "scripts/pipeline_v2/watchdog.py",
+      "reason": "source group scripts/pipeline_v2"
+    },
+    {
+      "path": "scripts/pipeline_v2/write_worker.py",
+      "reason": "source group scripts/pipeline_v2"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "python",
+    "source-group"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_library_b5d9639235.json
+++ b/.clawpatch/features/feat_library_b5d9639235.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_b5d9639235",
+  "title": "Python source scripts/ai-ml",
+  "summary": "Python source group scripts/ai-ml with 2 files.",
+  "kind": "library",
+  "source": "python-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "scripts/ai-ml",
+      "symbol": "scripts/ai-ml",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "scripts/ai-ml/cleanup-migration-markers.py",
+      "reason": "source group scripts/ai-ml"
+    },
+    {
+      "path": "scripts/ai-ml/rename-phases-to-local.py",
+      "reason": "source group scripts/ai-ml"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "python",
+    "source-group"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_library_b6bc504cd0.json
+++ b/.clawpatch/features/feat_library_b6bc504cd0.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_b6bc504cd0",
+  "title": "Python source scripts/on-prem",
+  "summary": "Python source group scripts/on-prem with 2 files.",
+  "kind": "library",
+  "source": "python-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "scripts/on-prem",
+      "symbol": "scripts/on-prem",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "scripts/on-prem/normalize-sidebar-order.py",
+      "reason": "source group scripts/on-prem"
+    },
+    {
+      "path": "scripts/on-prem/phase2-write-only.py",
+      "reason": "source group scripts/on-prem"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "python",
+    "source-group"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_library_be46a82290.json
+++ b/.clawpatch/features/feat_library_be46a82290.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_be46a82290",
+  "title": "Python source scripts/lib",
+  "summary": "Python source group scripts/lib with 3 files.",
+  "kind": "library",
+  "source": "python-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "scripts/lib",
+      "symbol": "scripts/lib",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "scripts/lib/__init__.py",
+      "reason": "source group scripts/lib"
+    },
+    {
+      "path": "scripts/lib/git_verify.py",
+      "reason": "source group scripts/lib"
+    },
+    {
+      "path": "scripts/lib/pr_merge.py",
+      "reason": "source group scripts/lib"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "python",
+    "source-group"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_library_d8e5ddfc31.json
+++ b/.clawpatch/features/feat_library_d8e5ddfc31.json
@@ -1,0 +1,42 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_d8e5ddfc31",
+  "title": "Python project kubedojo",
+  "summary": "Python project metadata in requirements.txt.",
+  "kind": "library",
+  "source": "python-project",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "requirements.txt",
+      "symbol": null,
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "requirements.txt",
+      "reason": "python project metadata"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "README.md",
+      "reason": "python project context"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "python",
+    "package"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_library_dd2859a091.json
+++ b/.clawpatch/features/feat_library_dd2859a091.json
@@ -1,0 +1,49 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_dd2859a091",
+  "title": "Python source scripts/checks",
+  "summary": "Python source group scripts/checks with 4 files.",
+  "kind": "library",
+  "source": "python-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "scripts/checks",
+      "symbol": "scripts/checks",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "scripts/checks/__init__.py",
+      "reason": "source group scripts/checks"
+    },
+    {
+      "path": "scripts/checks/gaps.py",
+      "reason": "source group scripts/checks"
+    },
+    {
+      "path": "scripts/checks/structural.py",
+      "reason": "source group scripts/checks"
+    },
+    {
+      "path": "scripts/checks/ukrainian.py",
+      "reason": "source group scripts/checks"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "python",
+    "source-group"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_library_e429adc71e.json
+++ b/.clawpatch/features/feat_library_e429adc71e.json
@@ -1,0 +1,57 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_e429adc71e",
+  "title": "Python source scripts/local_api",
+  "summary": "Python source group scripts/local_api with 6 files.",
+  "kind": "library",
+  "source": "python-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "scripts/local_api",
+      "symbol": "scripts/local_api",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "scripts/local_api/__init__.py",
+      "reason": "source group scripts/local_api"
+    },
+    {
+      "path": "scripts/local_api/routes/__init__.py",
+      "reason": "source group scripts/local_api"
+    },
+    {
+      "path": "scripts/local_api/routes/channels.py",
+      "reason": "source group scripts/local_api"
+    },
+    {
+      "path": "scripts/local_api/routes/decisions.py",
+      "reason": "source group scripts/local_api"
+    },
+    {
+      "path": "scripts/local_api/routes/search.py",
+      "reason": "source group scripts/local_api"
+    },
+    {
+      "path": "scripts/local_api/routes/ui_fragments.py",
+      "reason": "source group scripts/local_api"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "python",
+    "source-group"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_library_e54a0209d9.json
+++ b/.clawpatch/features/feat_library_e54a0209d9.json
@@ -1,0 +1,69 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_e54a0209d9",
+  "title": "Python source scripts/agent_runtime",
+  "summary": "Python source group scripts/agent_runtime with 9 files.",
+  "kind": "library",
+  "source": "python-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "scripts/agent_runtime",
+      "symbol": "scripts/agent_runtime",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "scripts/agent_runtime/__init__.py",
+      "reason": "source group scripts/agent_runtime"
+    },
+    {
+      "path": "scripts/agent_runtime/env_sanitize.py",
+      "reason": "source group scripts/agent_runtime"
+    },
+    {
+      "path": "scripts/agent_runtime/errors.py",
+      "reason": "source group scripts/agent_runtime"
+    },
+    {
+      "path": "scripts/agent_runtime/redact.py",
+      "reason": "source group scripts/agent_runtime"
+    },
+    {
+      "path": "scripts/agent_runtime/registry.py",
+      "reason": "source group scripts/agent_runtime"
+    },
+    {
+      "path": "scripts/agent_runtime/result.py",
+      "reason": "source group scripts/agent_runtime"
+    },
+    {
+      "path": "scripts/agent_runtime/runner.py",
+      "reason": "source group scripts/agent_runtime"
+    },
+    {
+      "path": "scripts/agent_runtime/usage.py",
+      "reason": "source group scripts/agent_runtime"
+    },
+    {
+      "path": "scripts/agent_runtime/watchdog.py",
+      "reason": "source group scripts/agent_runtime"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "python",
+    "source-group"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_library_f8bf0b65a1.json
+++ b/.clawpatch/features/feat_library_f8bf0b65a1.json
@@ -1,0 +1,86 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_f8bf0b65a1",
+  "title": "Node source src",
+  "summary": "Node/TypeScript source group src with 7 files.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "package.json",
+      "symbol": "src",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "src/components/LabProgress.ts",
+      "reason": "source group src"
+    },
+    {
+      "path": "src/content.config.ts",
+      "reason": "source group src"
+    },
+    {
+      "path": "src/i18n/homepage.ts",
+      "reason": "source group src"
+    },
+    {
+      "path": "src/pages/test.json.ts",
+      "reason": "source group src"
+    },
+    {
+      "path": "src/scripts/content-enhancer.ts",
+      "reason": "source group src"
+    },
+    {
+      "path": "src/scripts/mermaid-renderer.ts",
+      "reason": "source group src"
+    },
+    {
+      "path": "src/scripts/progress-tracker.ts",
+      "reason": "source group src"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "package.json",
+      "reason": "package manifest"
+    },
+    {
+      "path": "tests/content-enhancer.test.ts",
+      "reason": "associated test"
+    },
+    {
+      "path": "tests/progress-tracker.test.ts",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "tests/content-enhancer.test.ts",
+      "command": "npm run test"
+    },
+    {
+      "path": "tests/progress-tracker.test.ts",
+      "command": "npm run test"
+    }
+  ],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:kubedojo",
+    "project-root:."
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_library_f997382e17.json
+++ b/.clawpatch/features/feat_library_f997382e17.json
@@ -1,0 +1,147 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_f997382e17",
+  "title": "Python source scripts#4",
+  "summary": "Python source group scripts#4 with 12 files.",
+  "kind": "library",
+  "source": "python-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "scripts#4",
+      "symbol": "scripts#4",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "scripts/pipeline_v3_batch.py",
+      "reason": "source group scripts#4"
+    },
+    {
+      "path": "scripts/pipeline_v3_batch_commit.py",
+      "reason": "source group scripts#4"
+    },
+    {
+      "path": "scripts/pipeline_v3_section.py",
+      "reason": "source group scripts#4"
+    },
+    {
+      "path": "scripts/pipeline_v4.py",
+      "reason": "source group scripts#4"
+    },
+    {
+      "path": "scripts/pipeline_v4_batch.py",
+      "reason": "source group scripts#4"
+    },
+    {
+      "path": "scripts/quality_pipeline.py",
+      "reason": "source group scripts#4"
+    },
+    {
+      "path": "scripts/quality_post_review.py",
+      "reason": "source group scripts#4"
+    },
+    {
+      "path": "scripts/requeue_pilot_findings.py",
+      "reason": "source group scripts#4"
+    },
+    {
+      "path": "scripts/rubric_gaps.py",
+      "reason": "source group scripts#4"
+    },
+    {
+      "path": "scripts/run_section_v3.py",
+      "reason": "source group scripts#4"
+    },
+    {
+      "path": "scripts/score_module.py",
+      "reason": "source group scripts#4"
+    },
+    {
+      "path": "scripts/section_source_discovery.py",
+      "reason": "source group scripts#4"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "scripts/ai_agent_bridge/tests/test_discuss_bridge_bugs.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "scripts/quality/test_verify_module.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "scripts/test_lab_pipeline.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "scripts/test_pipeline.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "scripts/v2_ab_test.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "tests/test_pipeline_v4.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "tests/test_pipeline_v4_batch.py",
+      "reason": "associated test"
+    },
+    {
+      "path": "tests/test_rubric_gaps.py",
+      "reason": "associated test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "scripts/ai_agent_bridge/tests/test_discuss_bridge_bugs.py",
+      "command": "pytest"
+    },
+    {
+      "path": "scripts/quality/test_verify_module.py",
+      "command": "pytest"
+    },
+    {
+      "path": "scripts/test_lab_pipeline.py",
+      "command": "pytest"
+    },
+    {
+      "path": "scripts/test_pipeline.py",
+      "command": "pytest"
+    },
+    {
+      "path": "scripts/v2_ab_test.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_pipeline_v4.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_pipeline_v4_batch.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_rubric_gaps.py",
+      "command": "pytest"
+    }
+  ],
+  "tags": [
+    "python",
+    "source-group"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_release_4862937c51.json
+++ b/.clawpatch/features/feat_release_4862937c51.json
@@ -1,0 +1,42 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_release_4862937c51",
+  "title": "Package script lint",
+  "summary": "Package script 'lint': eslint src/ tests/",
+  "kind": "release",
+  "source": "package-json-script",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "package.json",
+      "symbol": "lint",
+      "route": null,
+      "command": "lint"
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "package.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "node",
+    "package-script",
+    "project:kubedojo",
+    "project-root:."
+  ],
+  "trustBoundaries": [
+    "process-exec",
+    "filesystem"
+  ],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_release_51170e0f9c.json
+++ b/.clawpatch/features/feat_release_51170e0f9c.json
@@ -1,0 +1,42 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_release_51170e0f9c",
+  "title": "Package script build",
+  "summary": "Package script 'build': astro build",
+  "kind": "release",
+  "source": "package-json-script",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "package.json",
+      "symbol": "build",
+      "route": null,
+      "command": "build"
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "package.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "node",
+    "package-script",
+    "project:kubedojo",
+    "project-root:."
+  ],
+  "trustBoundaries": [
+    "process-exec",
+    "filesystem"
+  ],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_release_775032a0f4.json
+++ b/.clawpatch/features/feat_release_775032a0f4.json
@@ -1,0 +1,42 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_release_775032a0f4",
+  "title": "Package script start",
+  "summary": "Package script 'start': astro dev",
+  "kind": "release",
+  "source": "package-json-script",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "package.json",
+      "symbol": "start",
+      "route": null,
+      "command": "start"
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "package.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "node",
+    "package-script",
+    "project:kubedojo",
+    "project-root:."
+  ],
+  "trustBoundaries": [
+    "process-exec",
+    "filesystem"
+  ],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_test-suite_268170cbae.json
+++ b/.clawpatch/features/feat_test-suite_268170cbae.json
@@ -1,0 +1,47 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_test-suite_268170cbae",
+  "title": "Python test suite scripts/quality",
+  "summary": "Python pytest files in scripts/quality.",
+  "kind": "test-suite",
+  "source": "python-test-suite",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "scripts/quality",
+      "symbol": "scripts/quality",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "scripts/quality/test_verify_module.py",
+      "reason": "pytest file"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "scripts/quality/test_verify_module.py",
+      "reason": "nearby test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "scripts/quality/test_verify_module.py",
+      "command": "pytest"
+    }
+  ],
+  "tags": [
+    "python",
+    "test"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_test-suite_2755852c9c.json
+++ b/.clawpatch/features/feat_test-suite_2755852c9c.json
@@ -1,0 +1,179 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_test-suite_2755852c9c",
+  "title": "Python test suite tests#1",
+  "summary": "Python pytest files in tests#1.",
+  "kind": "test-suite",
+  "source": "python-test-suite",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "tests#1",
+      "symbol": "tests#1",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "tests/test_ab_post_writes_message_posted_event.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_agent_env.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_agent_runtime_runner.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_ai_agent_bridge_channel_watch.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_ai_agent_bridge_gemini_session_link.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_ai_agent_bridge_orphan_recovery.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_audit_review_coverage.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_autopilot_v3_heartbeat.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_backfill_seed_restore.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_bridge_channels.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_bridge_gemini_models.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_bridge_inbox.py",
+      "reason": "pytest file"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "tests/test_ab_post_writes_message_posted_event.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_agent_env.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_agent_runtime_runner.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_ai_agent_bridge_channel_watch.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_ai_agent_bridge_gemini_session_link.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_ai_agent_bridge_orphan_recovery.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_audit_review_coverage.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_autopilot_v3_heartbeat.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_backfill_seed_restore.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_bridge_channels.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_bridge_gemini_models.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_bridge_inbox.py",
+      "reason": "nearby test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "tests/test_ab_post_writes_message_posted_event.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_agent_env.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_agent_runtime_runner.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_ai_agent_bridge_channel_watch.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_ai_agent_bridge_gemini_session_link.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_ai_agent_bridge_orphan_recovery.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_audit_review_coverage.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_autopilot_v3_heartbeat.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_backfill_seed_restore.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_bridge_channels.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_bridge_gemini_models.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_bridge_inbox.py",
+      "command": "pytest"
+    }
+  ],
+  "tags": [
+    "python",
+    "test"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_test-suite_47f61afbb7.json
+++ b/.clawpatch/features/feat_test-suite_47f61afbb7.json
@@ -1,0 +1,179 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_test-suite_47f61afbb7",
+  "title": "Python test suite tests#4",
+  "summary": "Python pytest files in tests#4.",
+  "kind": "test-suite",
+  "source": "python-test-suite",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "tests#4",
+      "symbol": "tests#4",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "tests/test_decision_stale_detection.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_detect_uk_divergence.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_dispatch_388_pilot.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_dispatch_388_pilot_pr_fallback.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_dispatch_388_yaml_queue.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_dispatch_codex_routing.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_dispatch_gemini_timeout.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_dispatch_smart.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_dispatch_zombie_kill.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_egress_redaction.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_expand_module.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_gate_a_quiz_residual.py",
+      "reason": "pytest file"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "tests/test_decision_stale_detection.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_detect_uk_divergence.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_dispatch_388_pilot.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_dispatch_388_pilot_pr_fallback.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_dispatch_388_yaml_queue.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_dispatch_codex_routing.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_dispatch_gemini_timeout.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_dispatch_smart.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_dispatch_zombie_kill.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_egress_redaction.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_expand_module.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_gate_a_quiz_residual.py",
+      "reason": "nearby test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "tests/test_decision_stale_detection.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_detect_uk_divergence.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_dispatch_388_pilot.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_dispatch_388_pilot_pr_fallback.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_dispatch_388_yaml_queue.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_dispatch_codex_routing.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_dispatch_gemini_timeout.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_dispatch_smart.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_dispatch_zombie_kill.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_egress_redaction.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_expand_module.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_gate_a_quiz_residual.py",
+      "command": "pytest"
+    }
+  ],
+  "tags": [
+    "python",
+    "test"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_test-suite_577d9a3dae.json
+++ b/.clawpatch/features/feat_test-suite_577d9a3dae.json
@@ -1,0 +1,179 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_test-suite_577d9a3dae",
+  "title": "Python test suite tests#6",
+  "summary": "Python pytest files in tests#6.",
+  "kind": "test-suite",
+  "source": "python-test-suite",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "tests#6",
+      "symbol": "tests#6",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "tests/test_local_api_artifacts.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_local_api_build.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_local_api_channels.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_local_api_channels_ui.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_local_api_citations.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_local_api_gh.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_local_api_health.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_local_api_home_slim.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_local_api_pipeline.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_local_api_quality.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_local_api_security.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_local_api_state_session.py",
+      "reason": "pytest file"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "tests/test_local_api_artifacts.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_local_api_build.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_local_api_channels.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_local_api_channels_ui.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_local_api_citations.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_local_api_gh.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_local_api_health.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_local_api_home_slim.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_local_api_pipeline.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_local_api_quality.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_local_api_security.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_local_api_state_session.py",
+      "reason": "nearby test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "tests/test_local_api_artifacts.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_local_api_build.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_local_api_channels.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_local_api_channels_ui.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_local_api_citations.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_local_api_gh.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_local_api_health.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_local_api_home_slim.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_local_api_pipeline.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_local_api_quality.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_local_api_security.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_local_api_state_session.py",
+      "command": "pytest"
+    }
+  ],
+  "tags": [
+    "python",
+    "test"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_test-suite_718a4099cb.json
+++ b/.clawpatch/features/feat_test-suite_718a4099cb.json
@@ -1,0 +1,71 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_test-suite_718a4099cb",
+  "title": "Python test suite scripts",
+  "summary": "Python pytest files in scripts.",
+  "kind": "test-suite",
+  "source": "python-test-suite",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "scripts",
+      "symbol": "scripts",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "scripts/test_lab_pipeline.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "scripts/test_pipeline.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "scripts/v2_ab_test.py",
+      "reason": "pytest file"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "scripts/test_lab_pipeline.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "scripts/test_pipeline.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "scripts/v2_ab_test.py",
+      "reason": "nearby test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "scripts/test_lab_pipeline.py",
+      "command": "pytest"
+    },
+    {
+      "path": "scripts/test_pipeline.py",
+      "command": "pytest"
+    },
+    {
+      "path": "scripts/v2_ab_test.py",
+      "command": "pytest"
+    }
+  ],
+  "tags": [
+    "python",
+    "test"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_test-suite_734d5e1716.json
+++ b/.clawpatch/features/feat_test-suite_734d5e1716.json
@@ -1,0 +1,95 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_test-suite_734d5e1716",
+  "title": "Python test suite tests#10",
+  "summary": "Python pytest files in tests#10.",
+  "kind": "test-suite",
+  "source": "python-test-suite",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "tests#10",
+      "symbol": "tests#10",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "tests/test_v1_pipeline_staging_cleanup.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_verify_module_budget.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_verify_review.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_worktree_brief.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_ztt_status.py",
+      "reason": "pytest file"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "tests/test_v1_pipeline_staging_cleanup.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_verify_module_budget.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_verify_review.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_worktree_brief.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_ztt_status.py",
+      "reason": "nearby test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "tests/test_v1_pipeline_staging_cleanup.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_verify_module_budget.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_verify_review.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_worktree_brief.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_ztt_status.py",
+      "command": "pytest"
+    }
+  ],
+  "tags": [
+    "python",
+    "test"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_test-suite_797c1ef34b.json
+++ b/.clawpatch/features/feat_test-suite_797c1ef34b.json
@@ -1,0 +1,179 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_test-suite_797c1ef34b",
+  "title": "Python test suite tests#8",
+  "summary": "Python pytest files in tests#8.",
+  "kind": "test-suite",
+  "source": "python-test-suite",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "tests#8",
+      "symbol": "tests#8",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "tests/test_pipeline_v4_batch.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_quality_board.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_quality_citations.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_quality_density.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_quality_dispatchers.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_quality_extractors.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_quality_gates.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_quality_prompts.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_quality_queue.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_quality_stages.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_quality_state.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_quality_worktree.py",
+      "reason": "pytest file"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "tests/test_pipeline_v4_batch.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_quality_board.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_quality_citations.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_quality_density.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_quality_dispatchers.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_quality_extractors.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_quality_gates.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_quality_prompts.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_quality_queue.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_quality_stages.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_quality_state.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_quality_worktree.py",
+      "reason": "nearby test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "tests/test_pipeline_v4_batch.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_quality_board.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_quality_citations.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_quality_density.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_quality_dispatchers.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_quality_extractors.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_quality_gates.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_quality_prompts.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_quality_queue.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_quality_stages.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_quality_state.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_quality_worktree.py",
+      "command": "pytest"
+    }
+  ],
+  "tags": [
+    "python",
+    "test"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_test-suite_84ae84a25a.json
+++ b/.clawpatch/features/feat_test-suite_84ae84a25a.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_test-suite_84ae84a25a",
+  "title": "Package script test",
+  "summary": "Package script 'test': vitest run",
+  "kind": "test-suite",
+  "source": "package-json-script",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "package.json",
+      "symbol": "test",
+      "route": null,
+      "command": "test"
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "package.json",
+      "reason": "entrypoint"
+    }
+  ],
+  "contextFiles": [],
+  "tests": [],
+  "tags": [
+    "node",
+    "package-script",
+    "project:kubedojo",
+    "project-root:."
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_test-suite_93b45b7c4d.json
+++ b/.clawpatch/features/feat_test-suite_93b45b7c4d.json
@@ -1,0 +1,179 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_test-suite_93b45b7c4d",
+  "title": "Python test suite tests#7",
+  "summary": "Python pytest files in tests#7.",
+  "kind": "test-suite",
+  "source": "python-test-suite",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "tests#7",
+      "symbol": "tests#7",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "tests/test_local_api_topnav.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_local_api_translation_enqueue.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_migrate.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_module_lock.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_module_sections.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_pipeline_iter_states_reading_order.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_pipeline_v2.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_pipeline_v2_patch.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_pipeline_v2_preflight.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_pipeline_v2_review.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_pipeline_v2_write.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_pipeline_v4.py",
+      "reason": "pytest file"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "tests/test_local_api_topnav.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_local_api_translation_enqueue.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_migrate.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_module_lock.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_module_sections.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_pipeline_iter_states_reading_order.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_pipeline_v2.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_pipeline_v2_patch.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_pipeline_v2_preflight.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_pipeline_v2_review.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_pipeline_v2_write.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_pipeline_v4.py",
+      "reason": "nearby test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "tests/test_local_api_topnav.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_local_api_translation_enqueue.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_migrate.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_module_lock.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_module_sections.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_pipeline_iter_states_reading_order.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_pipeline_v2.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_pipeline_v2_patch.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_pipeline_v2_preflight.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_pipeline_v2_review.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_pipeline_v2_write.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_pipeline_v4.py",
+      "command": "pytest"
+    }
+  ],
+  "tags": [
+    "python",
+    "test"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_test-suite_989af37b07.json
+++ b/.clawpatch/features/feat_test-suite_989af37b07.json
@@ -1,0 +1,179 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_test-suite_989af37b07",
+  "title": "Python test suite tests#2",
+  "summary": "Python pytest files in tests#2.",
+  "kind": "test-suite",
+  "source": "python-test-suite",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "tests#2",
+      "symbol": "tests#2",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "tests/test_bridge_inbox_cli.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_channel_delta_render.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_channel_keyboard_nav.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_channel_poll_cadence.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_channel_post_endpoint.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_channel_rollup_works_without_events.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_channel_summary_fallback_to_chat.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_channel_summary_parse_cost.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_channel_summary_parse_rounds.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_channel_summary_parse_votes.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_channels_d0.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_check_citations.py",
+      "reason": "pytest file"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "tests/test_bridge_inbox_cli.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_channel_delta_render.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_channel_keyboard_nav.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_channel_poll_cadence.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_channel_post_endpoint.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_channel_rollup_works_without_events.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_channel_summary_fallback_to_chat.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_channel_summary_parse_cost.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_channel_summary_parse_rounds.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_channel_summary_parse_votes.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_channels_d0.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_check_citations.py",
+      "reason": "nearby test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "tests/test_bridge_inbox_cli.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_channel_delta_render.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_channel_keyboard_nav.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_channel_poll_cadence.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_channel_post_endpoint.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_channel_rollup_works_without_events.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_channel_summary_fallback_to_chat.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_channel_summary_parse_cost.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_channel_summary_parse_rounds.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_channel_summary_parse_votes.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_channels_d0.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_check_citations.py",
+      "command": "pytest"
+    }
+  ],
+  "tags": [
+    "python",
+    "test"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_test-suite_9bd096302b.json
+++ b/.clawpatch/features/feat_test-suite_9bd096302b.json
@@ -1,0 +1,47 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_test-suite_9bd096302b",
+  "title": "Python test suite scripts/ai_agent_bridge/tests",
+  "summary": "Python pytest files in scripts/ai_agent_bridge/tests.",
+  "kind": "test-suite",
+  "source": "python-test-suite",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "scripts/ai_agent_bridge/tests",
+      "symbol": "scripts/ai_agent_bridge/tests",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "scripts/ai_agent_bridge/tests/test_discuss_bridge_bugs.py",
+      "reason": "pytest file"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "scripts/ai_agent_bridge/tests/test_discuss_bridge_bugs.py",
+      "reason": "nearby test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "scripts/ai_agent_bridge/tests/test_discuss_bridge_bugs.py",
+      "command": "pytest"
+    }
+  ],
+  "tags": [
+    "python",
+    "test"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_test-suite_afa609cd5d.json
+++ b/.clawpatch/features/feat_test-suite_afa609cd5d.json
@@ -1,0 +1,179 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_test-suite_afa609cd5d",
+  "title": "Python test suite tests#3",
+  "summary": "Python pytest files in tests#3.",
+  "kind": "test-suite",
+  "source": "python-test-suite",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "tests#3",
+      "symbol": "tests#3",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "tests/test_check_uk_changed.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_citation_backfill.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_citation_residuals.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_citation_residuals_cli_lock.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_citation_resolver_phase2.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_claude_dispatch_special_chars.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_codex_always_danger.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_codex_report.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_decision_card_anchor.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_decision_lineage_cache.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_decision_lineage_resolves.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_decision_pending_endpoint_shape.py",
+      "reason": "pytest file"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "tests/test_check_uk_changed.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_citation_backfill.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_citation_residuals.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_citation_residuals_cli_lock.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_citation_resolver_phase2.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_claude_dispatch_special_chars.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_codex_always_danger.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_codex_report.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_decision_card_anchor.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_decision_lineage_cache.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_decision_lineage_resolves.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_decision_pending_endpoint_shape.py",
+      "reason": "nearby test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "tests/test_check_uk_changed.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_citation_backfill.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_citation_residuals.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_citation_residuals_cli_lock.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_citation_resolver_phase2.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_claude_dispatch_special_chars.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_codex_always_danger.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_codex_report.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_decision_card_anchor.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_decision_lineage_cache.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_decision_lineage_resolves.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_decision_pending_endpoint_shape.py",
+      "command": "pytest"
+    }
+  ],
+  "tags": [
+    "python",
+    "test"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_test-suite_b3c56e57c0.json
+++ b/.clawpatch/features/feat_test-suite_b3c56e57c0.json
@@ -1,0 +1,47 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_test-suite_b3c56e57c0",
+  "title": "Python test suite tests/quality",
+  "summary": "Python pytest files in tests/quality.",
+  "kind": "test-suite",
+  "source": "python-test-suite",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "tests/quality",
+      "symbol": "tests/quality",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "tests/quality/test_verify_module.py",
+      "reason": "pytest file"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "tests/quality/test_verify_module.py",
+      "reason": "nearby test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "tests/quality/test_verify_module.py",
+      "command": "pytest"
+    }
+  ],
+  "tags": [
+    "python",
+    "test"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_test-suite_d25629090f.json
+++ b/.clawpatch/features/feat_test-suite_d25629090f.json
@@ -1,0 +1,179 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_test-suite_d25629090f",
+  "title": "Python test suite tests#5",
+  "summary": "Python pytest files in tests#5.",
+  "kind": "test-suite",
+  "source": "python-test-suite",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "tests#5",
+      "symbol": "tests#5",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "tests/test_hook_block_agent_worktree_isolation.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_hook_block_branch_create_in_primary.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_hook_block_bugfix_merge_without_regression_test.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_hook_block_content_merge_without_learner_check.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_hook_block_direct_commit_on_main.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_hook_block_orchestrator_content_edits.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_hook_inject_codex_danger_mode.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_inbox_integration.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_incident_dedup_gate.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_issue_watch.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_local_api.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_local_api_activity.py",
+      "reason": "pytest file"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "tests/test_hook_block_agent_worktree_isolation.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_hook_block_branch_create_in_primary.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_hook_block_bugfix_merge_without_regression_test.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_hook_block_content_merge_without_learner_check.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_hook_block_direct_commit_on_main.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_hook_block_orchestrator_content_edits.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_hook_inject_codex_danger_mode.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_inbox_integration.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_incident_dedup_gate.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_issue_watch.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_local_api.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_local_api_activity.py",
+      "reason": "nearby test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "tests/test_hook_block_agent_worktree_isolation.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_hook_block_branch_create_in_primary.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_hook_block_bugfix_merge_without_regression_test.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_hook_block_content_merge_without_learner_check.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_hook_block_direct_commit_on_main.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_hook_block_orchestrator_content_edits.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_hook_inject_codex_danger_mode.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_inbox_integration.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_incident_dedup_gate.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_issue_watch.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_local_api.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_local_api_activity.py",
+      "command": "pytest"
+    }
+  ],
+  "tags": [
+    "python",
+    "test"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/features/feat_test-suite_ec0fc5f492.json
+++ b/.clawpatch/features/feat_test-suite_ec0fc5f492.json
@@ -1,0 +1,179 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_test-suite_ec0fc5f492",
+  "title": "Python test suite tests#9",
+  "summary": "Python pytest files in tests#9.",
+  "kind": "test-suite",
+  "source": "python-test-suite",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "tests#9",
+      "symbol": "tests#9",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "tests/test_rubric_gaps.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_run_388_batch.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_run_section_v3.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_search_endpoint_validation.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_search_fts_channels.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_search_fts_decisions.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_search_kind_filter.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_section_source_discovery.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_status_script.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_translation_v2.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_uk_sync_strict_commit.py",
+      "reason": "pytest file"
+    },
+    {
+      "path": "tests/test_v1_pipeline_retry_policy.py",
+      "reason": "pytest file"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "tests/test_rubric_gaps.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_run_388_batch.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_run_section_v3.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_search_endpoint_validation.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_search_fts_channels.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_search_fts_decisions.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_search_kind_filter.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_section_source_discovery.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_status_script.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_translation_v2.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_uk_sync_strict_commit.py",
+      "reason": "nearby test"
+    },
+    {
+      "path": "tests/test_v1_pipeline_retry_policy.py",
+      "reason": "nearby test"
+    }
+  ],
+  "tests": [
+    {
+      "path": "tests/test_rubric_gaps.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_run_388_batch.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_run_section_v3.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_search_endpoint_validation.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_search_fts_channels.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_search_fts_decisions.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_search_kind_filter.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_section_source_discovery.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_status_script.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_translation_v2.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_uk_sync_strict_commit.py",
+      "command": "pytest"
+    },
+    {
+      "path": "tests/test_v1_pipeline_retry_policy.py",
+      "command": "pytest"
+    }
+  ],
+  "tags": [
+    "python",
+    "test"
+  ],
+  "trustBoundaries": [],
+  "status": "pending",
+  "lock": null,
+  "findingIds": [],
+  "patchAttemptIds": [],
+  "analysisHistory": [],
+  "createdAt": "2026-05-17T16:02:43.754Z",
+  "updatedAt": "2026-05-17T16:02:43.754Z"
+}

--- a/.clawpatch/project.json
+++ b/.clawpatch/project.json
@@ -1,0 +1,34 @@
+{
+  "schemaVersion": 1,
+  "projectId": "prj_git-github-com-kube-dojo-kube-do_89b8fdacf9",
+  "name": "kubedojo",
+  "rootPath": "/Users/krisztiankoos/projects/kubedojo",
+  "git": {
+    "remoteUrl": "git@github.com:kube-dojo/kube-dojo.github.io.git",
+    "defaultBranch": "main",
+    "currentBranch": "main",
+    "headSha": "f4d02604314c44b02d319a732723b0dd3485079d"
+  },
+  "detected": {
+    "languages": [
+      "typescript",
+      "javascript",
+      "python"
+    ],
+    "frameworks": [
+      "vitest"
+    ],
+    "packageManagers": [
+      "npm",
+      "pip"
+    ],
+    "commands": {
+      "typecheck": null,
+      "lint": "npm run lint",
+      "format": null,
+      "test": "npm run test"
+    }
+  },
+  "createdAt": "2026-05-17T12:06:25.141Z",
+  "updatedAt": "2026-05-17T12:06:25.141Z"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,11 @@ docs/quality-progress.tsv.lock
 batch_state/
 logs/
 .envrc
+
+# clawpatch — commit config.json + project.json + features/ (deterministic from repo state)
+# ignore session-local noise: findings/, reports/, runs/, locks/, patches/
+.clawpatch/findings/
+.clawpatch/reports/
+.clawpatch/runs/
+.clawpatch/locks/
+.clawpatch/patches/

--- a/docs/briefs/2026-05-17-clawpatch-6agent-routing.html
+++ b/docs/briefs/2026-05-17-clawpatch-6agent-routing.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>clawpatch — 6-agent routing matrix for kubedojo (2026-05-17)</title>
+<style>
+  :root { --bg:#fafbfc; --fg:#1a1d23; --muted:#5b6573; --accent:#0057B7; --good:#0d8a4a; --partial:#b45c00; --gap:#b8001f; --card:#ffffff; --border:#e2e6eb; --mono:ui-monospace,SFMono-Regular,Menlo,monospace; }
+  *{box-sizing:border-box;}
+  body{margin:0;padding:0;background:var(--bg);color:var(--fg);font:15px/1.55 system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;}
+  main{max-width:1180px;margin:0 auto;padding:32px 24px 80px;}
+  h1{margin:0 0 8px;font-size:28px;}
+  h2{margin:36px 0 12px;padding-bottom:8px;border-bottom:2px solid var(--accent);font-size:22px;}
+  h3{margin:22px 0 8px;font-size:17px;}
+  .meta{color:var(--muted);margin:0 0 24px;font-size:14px;}
+  .tldr{background:var(--card);border-left:4px solid var(--accent);padding:14px 18px;margin:16px 0 28px;border-radius:0 6px 6px 0;}
+  .status{display:inline-block;padding:3px 10px;border-radius:12px;font-size:11px;font-weight:600;background:#fce7c8;color:var(--partial);}
+  table{width:100%;border-collapse:collapse;margin:12px 0;background:var(--card);border:1px solid var(--border);}
+  th,td{padding:10px 12px;border-bottom:1px solid var(--border);text-align:left;vertical-align:top;font-size:13px;}
+  th{background:#eef2f6;font-weight:600;}
+  td.col-id{white-space:nowrap;font-family:var(--mono);}
+  code{background:#eef2f6;padding:1px 6px;border-radius:3px;font-family:var(--mono);font-size:12px;}
+  pre{background:var(--card);border:1px solid var(--border);padding:12px;border-radius:6px;overflow-x:auto;font-size:12px;}
+  ul.tight,ol.tight{margin:6px 0;padding-left:22px;}
+  ul.tight li,ol.tight li{margin:3px 0;}
+  .pill{display:inline-block;padding:2px 8px;border-radius:12px;font-size:11px;font-weight:600;}
+  .pill-good{background:#d8f0e2;color:var(--good);}
+  .pill-partial{background:#fce7c8;color:var(--partial);}
+  .pill-gap{background:#fbd5db;color:var(--gap);}
+</style>
+</head>
+<body>
+<main>
+
+<h1>clawpatch — 6-agent routing matrix for kubedojo</h1>
+<p class="meta">2026-05-17 · author: claude opus 4.7 (orchestrator, inline) · sibling: <code>/Users/krisztiankoos/projects/learn-ukrainian/docs/decisions/2026-05-17-clawpatch-adoption.md</code> (adopt-with-modifications, validated 4/5 TPR) · supersedes: <code>docs/briefs/2026-05-18-clawpatch-evaluation.html</code> §6 open decisions · <span class="pill pill-good">EMPIRICALLY VALIDATED on kubedojo: 4/4 verified-real findings on smoke run (vs learn-ukrainian's 4/5)</span></p>
+
+<div class="tldr">
+<strong>TL;DR.</strong> User pivot: <em>"learn-ukrainian already studied clawpatch, it came to the conclusion that we should just use it to find bugs and report it, we fix them, it can use all our agents... we have 6 agents now"</em>. Out of our 6 agent brains (codex, claude, gemini, grok, mistral via <code>vibe</code>, deepseek via <code>hermes</code>), clawpatch natively reaches <strong>3 brains × 5 model options</strong> via two providers: <code>--provider codex</code> (1 binary, model = codex CLI's configured default) and <code>--provider acpx --model &lt;agent&gt;:&lt;model&gt;</code> (4 options: claude-opus, claude-sonnet, gemini-pro, gemini-flash). Grok needs a small shim CLI (clawpatch wants the standalone Grok Build CLI, we have hermes-z grok). Mistral + deepseek need a custom ACP adapter each (~50 LOC + ACP protocol stub). <strong>Routing recommendation per code area below.</strong> Baseline config + .gitignore + map already applied this session. A smoke review on <code>scripts/quality#2</code> (verify_module.py + 7 sibling pipeline files) is running with codex as the empirical anchor for the routing decisions.
+</div>
+
+<h2>1. The 6-agent / clawpatch-provider compatibility matrix</h2>
+
+<table>
+<tr><th>Agent brain</th><th>CLI binary</th><th>clawpatch provider</th><th>Status today</th><th>Cost class (kubedojo subscription)</th></tr>
+<tr><td>Codex (gpt-5.5 / gpt-5.4-mini / gpt-5.3-codex-spark)</td><td><code>codex</code> @ <code>/opt/homebrew/bin/codex</code> v0.130.0</td><td><code>--provider codex</code></td><td><span class="pill pill-good">LIVE</span> doctored clean. <code>codex exec --sandbox read-only --output-schema</code> path.</td><td>5h primary + 7d secondary rate limit; under 5× cut since 2026-05-17 (per <code>project_budget_and_delegation.md</code>)</td></tr>
+<tr><td>Claude (opus 4.7, sonnet 4.6)</td><td><code>claude-agent-acp</code> (npx) via acpx</td><td><code>--provider acpx --model claude:claude-opus-4-7</code> or <code>claude:claude-sonnet-4-6</code></td><td><span class="pill pill-good">LIVE</span> doctored clean for both opus + sonnet (this session)</td><td>Max plan, 5h + weekly windows. 2× double until 2026-07-13; agentic-pool flip 2026-06-15. Sonnet ~3× cheaper than opus per the Anthropic curve.</td></tr>
+<tr><td>Gemini (3.1-pro-preview, 3-flash-preview)</td><td>gemini-cli via acpx</td><td><code>--provider acpx --model gemini:gemini-3.1-pro-preview</code> or <code>gemini:gemini-3-flash-preview</code></td><td><span class="pill pill-good">LIVE</span> doctored clean for both (this session)</td><td>OAuth (Google AI Pro plan, downgraded 2026-05-05). Flash-preview is FREE-ish on OAuth.</td></tr>
+<tr><td>Grok (grok-4 via hermes-z)</td><td><code>hermes -z grok-4 ...</code></td><td><code>--provider grok</code> (expects standalone Grok Build CLI)</td><td><span class="pill pill-gap">SHIM NEEDED</span> — clawpatch wants <code>grok --prompt-file --output-format json --always-approve</code> binary. We don't have it; hermes-z is the access path.</td><td>SuperGrok subscription via OAuth (per <code>project_grok_4_3_via_hermes.md</code>)</td></tr>
+<tr><td>Mistral (vibe agent)</td><td><code>vibe -p --output json</code> @ <code>~/.local/bin/vibe</code></td><td><strong>NO native support</strong>; possible via <code>--provider acpx --agent &lt;custom-cmd&gt;</code> if vibe speaks ACP (it doesn't natively)</td><td><span class="pill pill-gap">ADAPTER NEEDED</span> — ACP wrapper or treat as opaque CLI invoked via clawpatch's mock pattern (lossy)</td><td>Mistral subscription</td></tr>
+<tr><td>DeepSeek v4 (via hermes -z)</td><td><code>hermes -z deepseek-v4 ...</code></td><td><strong>NO native support</strong>; same ACP-adapter need as mistral</td><td><span class="pill pill-gap">ADAPTER NEEDED</span></td><td>DeepSeek API (or whatever hermes negotiates)</td></tr>
+</table>
+
+<p><strong>Net:</strong> 3 of 6 brains × 5 model options work today with zero additional plumbing. The other 3 brains (grok, mistral, deepseek) each need a small shim — sized in §5 below.</p>
+
+<h2>2. kubedojo's code surface — the 44 features clawpatch sees</h2>
+
+<p>From this session's <code>clawpatch map</code> run (heuristic mapper, no LLM, 2s elapsed). 165 source files / 158 owned grouped into 44 feature slices:</p>
+
+<table>
+<tr><th>Area</th><th>Slices</th><th>~Files</th><th>Bug-surface vibe</th></tr>
+<tr><td><code>scripts/quality/*</code> (verifier, pipeline, dispatchers)</td><td>2 (#1 + #2)</td><td>20 .py</td><td><strong>Highest</strong> — currently iterating on lab-runnability gates. Grok audit motivated this whole work-stream.</td></tr>
+<tr><td><code>scripts/</code> (top-level: dispatch_smart, ab, agent_runtime drivers, status, briefing)</td><td>5 (#1–#5)</td><td>~56 .py</td><td>High — orchestrator-critical path</td></tr>
+<tr><td><code>scripts/ai_agent_bridge/*</code></td><td>2 (#1 + #2)</td><td>22 .py</td><td>High — deliberation bridge, recently fragile</td></tr>
+<tr><td><code>scripts/agent_runtime/*</code> + <code>adapters/</code></td><td>2</td><td>16 .py</td><td>Medium — codex/claude/gemini/grok adapters (claude.py npx-default landed; needs fresh look for new drift)</td></tr>
+<tr><td><code>scripts/pipeline_v2/</code>, <code>pipeline_common/</code></td><td>2</td><td>11 .py</td><td>Medium — older pipeline, may be ripe for dead-code surfacing</td></tr>
+<tr><td><code>scripts/local_api/</code></td><td>1</td><td>6 .py</td><td>Medium — briefing API surface</td></tr>
+<tr><td><code>scripts/checks/</code>, <code>lib/</code>, <code>research/</code>, <code>ai-ml/</code>, <code>on-prem/</code></td><td>5</td><td>~13 .py</td><td>Low-Medium — utilities</td></tr>
+<tr><td><code>src/</code> (Astro/Starlight frontend)</td><td>1 (Node source src) + 3 configs</td><td>7 .ts/.astro</td><td>Low — minimal custom code</td></tr>
+<tr><td>Test suites (<code>tests/*</code>, <code>scripts/quality/tests/</code>)</td><td>15 (test-suite kind)</td><td>~120 .py</td><td><strong>Skip</strong> — clawpatch reviewing tests is low signal. Use code-only slices.</td></tr>
+</table>
+
+<h2>3. Routing matrix — recommended provider per area</h2>
+
+<p>Strategy: weight each area by (a) bug cost if missed, (b) reviewer-side quality requirement, (c) codex-budget sensitivity. Calibration evidence from session memory:</p>
+
+<ul class="tight">
+<li><strong>Codex gpt-5.5</strong>: writer's-tightest model 2026-05-16, best for behavioural-bug detection in code-flow-heavy modules (learn-ukrainian's 4/5 TPR was on codex)</li>
+<li><strong>Claude opus 4.7</strong>: senior-tier reviewer; expensive but the only ladder above codex for cross-family critical-path review</li>
+<li><strong>Claude sonnet 4.6</strong>: solid cross-family fallback (per <code>feedback_headless_claude_gemini_fallback.md</code>); 25-65s vs gemini's 240s+ hangs</li>
+<li><strong>Gemini-pro 3.1</strong>: reviewer lane production calibration ([[project_role_allocation_2026-05-16]])</li>
+<li><strong>Gemini-flash-preview</strong>: <span class="pill pill-gap">NEVER</span> for code review (calibrated 2026-05-16: 0/2 bug catch on PR #1229). Acceptable for non-bug-class checks (style, docstring presence).</li>
+<li>Grok-4 (when shim ships): primary content reviewer ([[project_grok_primary_reviewer_calibrated_2026-05-17]]); untested as code reviewer</li>
+</ul>
+
+<table>
+<tr><th>Code area</th><th>Primary provider</th><th>Fallback</th><th>Cadence</th><th>Rationale</th></tr>
+<tr><td><code>scripts/quality/*</code> (verifier + pipeline)</td><td><code>codex</code> (gpt-5.5)</td><td><code>acpx claude:claude-opus-4-7</code></td><td>After every non-trivial PR landing in <code>verify_module.py</code> / <code>dispatch_388_pilot.py</code> / <code>prompts.py</code></td><td>Behavioural-bug surface; codex's 80% TPR baseline is the strongest signal we have. Opus fallback when codex 5h is exhausted.</td></tr>
+<tr><td><code>scripts/agent_runtime/*</code> (codex / claude / gemini / grok adapters)</td><td><code>acpx claude:claude-opus-4-7</code></td><td><code>codex</code></td><td>After adapter PR or model-routing change</td><td>Adapter bugs are subtle (the recently-fixed npx-preference in claude.py was this class). Opus is best at intra-language abstraction review; codex is the obvious backup.</td></tr>
+<tr><td><code>scripts/local_api/</code></td><td><code>acpx claude:claude-sonnet-4-6</code></td><td><code>codex</code></td><td>After API route changes / new endpoint adds</td><td>Surface area is request/response shapes — sonnet handles structured API review well at 1/3 opus cost.</td></tr>
+<tr><td><code>scripts/ai_agent_bridge/*</code></td><td><code>codex</code></td><td><code>acpx gemini:gemini-3.1-pro-preview</code></td><td>After bridge protocol changes</td><td>Concurrency + protocol surface — codex's strength. Gemini-pro as second-opinion before merging anything cross-thread.</td></tr>
+<tr><td><code>scripts/pipeline_v2</code>, <code>pipeline_common</code></td><td><code>acpx gemini:gemini-3.1-pro-preview</code></td><td><code>codex</code></td><td>Lower cadence — these are stabilising</td><td>Spend cheaper model first on lower-velocity areas; escalate to codex if gemini flags non-trivial.</td></tr>
+<tr><td><code>scripts/checks/</code>, <code>lib/</code> (utilities)</td><td><code>acpx claude:claude-sonnet-4-6</code></td><td><code>acpx gemini:gemini-3.1-pro-preview</code></td><td>Monthly drift-check</td><td>Sonnet is fast on small slices; alternates with gemini-pro to keep priors decorrelated.</td></tr>
+<tr><td><code>src/</code> (Astro frontend)</td><td><code>acpx gemini:gemini-3.1-pro-preview</code></td><td><code>acpx claude:claude-sonnet-4-6</code></td><td>On-demand when component refactors land</td><td>TS surface; codex is overkill for ~7 thin Astro components. Gemini-pro is competent here per its pre-OpenAI gpt-5 era benchmark.</td></tr>
+<tr><td>Test suites</td><td><span class="pill pill-gap">SKIP</span></td><td>—</td><td>—</td><td>Reviewing tests for bugs is low signal; tests fail if broken. Use slot for production-code reviews instead.</td></tr>
+</table>
+
+<h2>4. Provider rotation policy (cross-family rule)</h2>
+
+<p>kubedojo's <code>docs/review-protocol.md</code> requires the reviewer to be a different model family from the author. clawpatch makes this trivially enforceable at the <em>feature-slice</em> level (finer than today's per-PR rule):</p>
+
+<ul class="tight">
+<li>If a PR was written by codex → review the changed feature slice with <code>acpx claude:claude-opus-4-7</code> or <code>acpx gemini:gemini-3.1-pro-preview</code>.</li>
+<li>If a PR was written by claude (inline or headless) → review with <code>codex</code> or <code>acpx gemini:*</code>.</li>
+<li>If a PR was written by gemini → review with <code>codex</code> or <code>acpx claude:*</code>.</li>
+<li>For 3-way coverage on high-leverage merges (volume rewrites, audit-fix landings): run two clawpatch reviews on different slices with different providers. The persistent findings DB makes the second-pass cost ~30s + N codex-or-claude calls.</li>
+</ul>
+
+<h2>5. Shim work — what it takes to bring all 6 brains into clawpatch</h2>
+
+<table>
+<tr><th>Brain</th><th>Effort</th><th>Approach</th></tr>
+<tr><td>Grok-4 (via hermes-z)</td><td><strong>~60 LOC + 1 hour</strong></td><td>Write <code>scripts/clawpatch-shims/grok-cli-shim.sh</code> that accepts clawpatch's grok-provider flags (<code>--prompt-file</code>, <code>--output-format json</code>, <code>--always-approve</code>) and shells out to <code>hermes -z grok-4 chat ...</code>. Add the shim to PATH as <code>grok</code> when clawpatch is invoked. Validate by re-running <code>clawpatch doctor --provider grok</code>.</td></tr>
+<tr><td>Mistral (vibe)</td><td><strong>~120 LOC + 3 hours</strong></td><td>Write an Agent Client Protocol adapter (<code>scripts/clawpatch-shims/vibe-acp.ts</code> or <code>.py</code>) that exposes <code>vibe -p --output json</code> as an ACP-speaking agent. Then route via <code>acpx --agent &quot;node vibe-acp.ts&quot; --model mistral-...</code>. Verify against clawpatch's <code>doctor --provider acpx --agent ...</code>.</td></tr>
+<tr><td>DeepSeek v4 (via hermes)</td><td><strong>~100 LOC + 2 hours</strong></td><td>Same pattern as the vibe shim, wrapping <code>hermes -z deepseek-v4 chat ...</code> behind an ACP adapter. Could be a generic <code>hermes-acp.ts</code> reused by grok + deepseek + any future hermes-z model.</td></tr>
+</table>
+
+<p><strong>Recommendation:</strong> ship the grok shim first (highest payoff — grok is a calibrated reviewer; lowest effort). Defer the vibe + deepseek adapters until we have data on whether 3-brain rotation actually misses bugs that a 5+ -brain rotation would catch. Premature plumbing for unbenchmarked brains is the trap.</p>
+
+<h2>6. Smoke review — running this session on <code>scripts/quality#2</code></h2>
+
+<p>To anchor the routing matrix in empirical data on kubedojo's actual code (not just learn-ukrainian's transferred 4/5 result), one review is running this session:</p>
+
+<pre>clawpatch review --feature feat_library_9ff8b28c45 --jobs 1 --limit 5 --provider codex
+# slice: scripts/quality#2 (8 files: pipeline.py, prompts.py, queue.py, run_388_batch.py,
+#                          stages.py, state.py, verify_module.py, worktree.py)</pre>
+
+<p><strong>Result: 4 findings in 328s (5.5 min wall). All 4 spot-verified real this session.</strong> All medium severity, all triaged confirmed-bug or contract-mismatch with high confidence. Verification pattern: read evidence file ranges, independently confirm the claimed flow. Beats learn-ukrainian's 4/5 baseline — likely sample size / target-choice variance, not a property of kubedojo.</p>
+
+<table>
+<tr><th>#</th><th>Title</th><th>Class</th><th>Evidence</th><th>Spot-verify status</th></tr>
+<tr><td>1</td><td>cleanup-banners calls queue completion while holding the same state lease</td><td>concurrency / nested lock</td><td><code>pipeline.py:995-1013</code>, <code>stages.py:1168-1178</code></td><td><span class="pill pill-good">VERIFIED</span> — cmd_cleanup_banners holds <code>state_lease(slug)</code> across <code>_clear_banner_and_complete_queue()</code> call at line 1010; helper at <code>stages.py:1174</code> calls <code>queue.record_completion(slug)</code> which needs the same lock; exception handler at 1177 only warns, so <code>fixed</code> increments while <code>completed_at</code> remains unset.</td></tr>
+<tr><td>2</td><td>Leases reported as <code>module_key</code> form are not skipped</td><td>concurrency / path-norm</td><td><code>run_388_batch.py:98-107, 223-240</code></td><td><span class="pill pill-good">VERIFIED</span> — <code>fetch_active_leases</code> stores naked <code>module_key</code> verbatim; <code>select_modules</code> only compares against <code>api_path</code> (with <code>.md</code>) and <code>src/content/docs/</code>-prefixed <code>repo_path</code>. A lease keyed as <code>platform/module-1.9-foo</code> bypasses both checks → re-dispatch of leased work.</td></tr>
+<tr><td>3</td><td>Post-merge ledger writes can dirty primary outside the merge lock</td><td>concurrency / locking boundary</td><td><code>stages.py:1322-1336, 1441-1446, 1462-1472</code></td><td><span class="pill pill-good">VERIFIED</span> — <code>merge_one</code> at line 1322 wraps mutations in <code>with _merge_lock()</code>; <code>_post_merge_gates</code> calls <code>gates.append_ledger(row)</code> + <code>_commit_ledger_row(slug)</code> at lines 1443-1444 OUTSIDE that lock. <code>_commit_ledger_row</code> (1469-1473) does <code>git add</code> then <code>git commit</code> with <code>check=True</code> — exception leaves primary dirty (staged ledger row). Workers&gt;1 races + commit failure → next merge_one fails dirty-primary check.</td></tr>
+<tr><td>4</td><td>Dispatcher aborts from audit/route return success (exit 0 instead of 3)</td><td>api-contract</td><td><code>pipeline.py:22-23, 351-368, 375-384</code></td><td><span class="pill pill-good">VERIFIED</span> — docstring at lines 22-23 promises <em>"3 when aborted by dispatcher unavailability"</em>. <code>_process_batch</code> line 368 returns <code>(ok, fail)</code> early on <code>DispatcherUnavailable</code>. <code>cmd_audit</code> line 378 / <code>cmd_route</code> line 384 collapse <code>fail==0</code> to <code>return 0</code>. CI/automation cannot detect the abort case.</td></tr>
+</table>
+
+<p><strong>Severity assessment:</strong> all 4 are real production-relevant bugs in the recently-merged #388 pipeline glue. #2 is the highest blast-radius (re-dispatch of already-leased work would burn double codex tokens and create duplicate PRs). #4 is the most-likely to silently bite CI. #1 and #3 are subtle but real (queue-state desync, dirty-primary races in workers&gt;1 mode).</p>
+
+<p><strong>None of these were caught</strong> by the existing gemini-reviewer / grok-reviewer cascade on the PRs that introduced them. The clawpatch finding-with-evidence format surfaces code-flow bugs the LLM-prose-review template misses.</p>
+
+<h2>7. Adoption sequence (kubedojo-specific, drop-in from learn-ukrainian)</h2>
+
+<ol class="tight">
+<li><strong>Done this session:</strong> acpx installed; <code>.clawpatch/config.json</code> hand-edited (commands.test = pytest, commands.lint = ruff); <code>.gitignore</code> updated.</li>
+<li><strong>Pending user OK:</strong> commit baseline (<code>.clawpatch/config.json</code> + <code>.clawpatch/project.json</code> + <code>.clawpatch/features/*.json</code> + <code>.gitignore</code> delta).</li>
+<li><strong>Optional next:</strong> ship the grok shim (<code>scripts/clawpatch-shims/grok-cli-shim.sh</code>) so reviewer rotation can include grok.</li>
+<li><strong>Defer until calibrated:</strong> vibe + deepseek ACP adapters.</li>
+<li><strong>Wrapper:</strong> learn-ukrainian recommended a <code>scripts/run_clawpatch.sh</code> wrapper that caps <code>--jobs 1</code> and integrates Monitor API. Cheap (~30 LOC); ship when we start using clawpatch routinely.</li>
+<li><strong>First production target:</strong> <code>scripts/quality/*</code> after the routing matrix is approved.</li>
+</ol>
+
+<h2>8. Open questions for the user</h2>
+
+<ol class="tight">
+<li>The 4 verified findings: file as 4 separate GH issues with clawpatch IDs as backlinks (recommended — each gets cross-family review on its fix PR), or one tracking issue with 4 sub-tasks?</li>
+<li>Approve commit of the <code>.clawpatch/</code> baseline as written (config + project + features + .gitignore delta)?</li>
+<li>Build the grok shim this session (~60 LOC, 1 hour) or queue for next?</li>
+<li>For the test command — should clawpatch's <code>fix</code> validation chain run all kubedojo pytests (slow, ~10 min) or scope to the impacted slice's test suite (faster but needs a slice-to-test map)?</li>
+<li>Is the routing matrix acceptable as written, or want a different primary for any area?</li>
+</ol>
+
+<h2>9. Cross-references</h2>
+<ul class="tight">
+<li>learn-ukrainian decision: <code>/Users/krisztiankoos/projects/learn-ukrainian/docs/decisions/2026-05-17-clawpatch-adoption.md</code></li>
+<li>Yesterday's queued kubedojo brief: <code>docs/briefs/2026-05-18-clawpatch-evaluation.html</code></li>
+<li>Session-20 handoff: <code>docs/session-state/2026-05-18-session-20-grok-audit-and-verifier-hardening.html</code></li>
+<li>Grok audit (motivation for clawpatch eval target): <code>audit/2026-05-18-grok-primary-calibration/REPORT.html</code></li>
+<li>Relevant memory: <code>project_role_allocation_2026-05-16</code>, <code>project_grok_primary_reviewer_calibrated_2026-05-17</code>, <code>project_budget_and_delegation</code>, <code>feedback_codex_review_danger_mode</code>, <code>feedback_never_flash_for_code_review</code></li>
+</ul>
+
+</main>
+</body>
+</html>

--- a/docs/briefs/2026-05-17-deepseek-mistral-test-plan.html
+++ b/docs/briefs/2026-05-17-deepseek-mistral-test-plan.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>DeepSeek V4 Pro + Mistral 3.5 — test plan (queued, 2026-05-17)</title>
+<style>
+  :root { --bg:#fafbfc; --fg:#1a1d23; --muted:#5b6573; --accent:#0057B7; --good:#0d8a4a; --partial:#b45c00; --gap:#b8001f; --card:#ffffff; --border:#e2e6eb; --mono:ui-monospace,SFMono-Regular,Menlo,monospace; }
+  *{box-sizing:border-box;}
+  body{margin:0;padding:0;background:var(--bg);color:var(--fg);font:15px/1.55 system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;}
+  main{max-width:1180px;margin:0 auto;padding:32px 24px 80px;}
+  h1{margin:0 0 8px;font-size:28px;}
+  h2{margin:36px 0 12px;padding-bottom:8px;border-bottom:2px solid var(--accent);font-size:22px;}
+  h3{margin:22px 0 8px;font-size:17px;}
+  .meta{color:var(--muted);margin:0 0 24px;font-size:14px;}
+  .tldr{background:var(--card);border-left:4px solid var(--accent);padding:14px 18px;margin:16px 0 28px;border-radius:0 6px 6px 0;}
+  .status{display:inline-block;padding:3px 10px;border-radius:12px;font-size:11px;font-weight:600;background:#fce7c8;color:var(--partial);}
+  table{width:100%;border-collapse:collapse;margin:12px 0;background:var(--card);border:1px solid var(--border);}
+  th,td{padding:10px 12px;border-bottom:1px solid var(--border);text-align:left;vertical-align:top;font-size:13px;}
+  th{background:#eef2f6;font-weight:600;}
+  code{background:#eef2f6;padding:1px 6px;border-radius:3px;font-family:var(--mono);font-size:12px;}
+  pre{background:var(--card);border:1px solid var(--border);padding:12px;border-radius:6px;overflow-x:auto;font-size:12px;}
+  ul.tight,ol.tight{margin:6px 0;padding-left:22px;}
+  ul.tight li,ol.tight li{margin:3px 0;}
+  .pill{display:inline-block;padding:2px 8px;border-radius:12px;font-size:11px;font-weight:600;}
+  .pill-good{background:#d8f0e2;color:var(--good);}
+  .pill-partial{background:#fce7c8;color:var(--partial);}
+  .pill-gap{background:#fbd5db;color:var(--gap);}
+</style>
+</head>
+<body>
+<main>
+
+<h1>DeepSeek V4 Pro + Mistral 3.5 — test plan (queued)</h1>
+<p class="meta">2026-05-17 · author: claude opus 4.7 (orchestrator, inline) · <span class="status">QUEUED — next-session execution, awaits orchestrator pull</span></p>
+
+<div class="tldr">
+<strong>TL;DR.</strong> Two premium-tier agents added to the kubedojo arsenal this week: <strong>DeepSeek V4 Pro</strong> (via hermes already configured; alternative path via opencode <code>/connect deepseek</code>) and <strong>Mistral 3.5</strong> (via <code>vibe</code> CLI). User direction 2026-05-17: <em>"schedule the testing of deepseek v4 pro and mistral 3.5; don't bother with the cheaper variants."</em> Two complementary test arcs proposed: <strong>(A) 5-role calibration sweep</strong> (reviewer / coder / writer / researcher / hallucination — same shape as the 2026-05-16 grok-4.3 calibration); <strong>(B) clawpatch routing probe</strong> (run the same <code>scripts/quality#2</code> slice that codex / claude-opus / gemini-pro have already covered and compare bug-find overlap). Both arcs assume cost-bounded eval (~$5 total) and produce data that feeds the role-allocation table in <code>memory/project_role_allocation_2026-05-16.md</code>. <strong>Pre-condition</strong>: configure DeepSeek inside opencode for the cleanest clawpatch path (see §3.A.1 below); no setup needed for Mistral if test is via direct <code>vibe -p</code> CLI dispatch (only needed for clawpatch routing).
+</div>
+
+<h2>1. Agents in scope</h2>
+
+<table>
+<tr><th>Agent</th><th>Tier</th><th>Access path (current)</th><th>Out-of-scope variants</th></tr>
+<tr><td>DeepSeek V4 Pro</td><td>premium reasoning</td><td>Configured in hermes (<code>hermes status</code> shows model=<code>deepseek-v4-pro</code>, provider=DeepSeek, API key set). Direct: <code>hermes -z &lt;prompt&gt;</code> uses this as the default.</td><td>DeepSeek-V4 base, DeepSeek-V3, DeepSeek-Coder, DeepSeek-R1 distilled tiers</td></tr>
+<tr><td>Mistral 3.5</td><td>premium</td><td><code>vibe -p &lt;prompt&gt; --output json</code> @ <code>~/.local/bin/vibe</code> (Mistral Vibe CLI; <code>vibe --setup</code> for API key).</td><td>Mistral Small, Mistral Nemo, Codestral, Pixtral</td></tr>
+</table>
+
+<h2>2. Test Arc A — 5-role calibration sweep</h2>
+
+<p>Mirror the 2026-05-16 grok-4.3 calibration shape (<code>audit/2026-05-16-grok-4.3-kubedojo-calibration/</code>). 5 roles × 2 new models = 10 dispatches. Compare each cell to the calibration's gpt-5.5 / claude-opus-4-7 / gemini-3.1-pro-preview baselines.</p>
+
+<table>
+<tr><th>Role</th><th>Task prompt (reuse from 2026-05-16 sweep)</th><th>Pass criterion</th><th>Stretch criterion</th></tr>
+<tr><td>Reviewer</td><td>PR #1229 lab-bug detection prompt — same Markdown diff, same rubric (5 dimensions + LAB RUNNABILITY)</td><td>Catch ≥1 of the 2 known lab bugs (gemini-flash caught 0/2; gemini-pro caught 2/2 — the calibration baseline)</td><td>Match gemini-pro at 2/2 with citation-forced format</td></tr>
+<tr><td>Coder</td><td>Incident-dedup-gate fix prompt — codex's calibration winner. Same patch target.</td><td>Produce a runnable patch that adds year-signal anchors</td><td>Match codex's anchor coverage exactly</td></tr>
+<tr><td>Writer</td><td>CKA module 1.7 opener — same brief.md as the 2026-05-16 writer cell</td><td>Pass the 5,000 body-word #388 verifier gate</td><td>Match codex gpt-5.5 high "tightest" star</td></tr>
+<tr><td>Researcher</td><td>Azure App Gateway Stage-0 brief — same source-discovery prompt</td><td>Produce a brief with ≥3 verified URLs, not write to a file (stdout discipline)</td><td>≥5 sources + cross-citation web/docs/blogs</td></tr>
+<tr><td>Hallucination guard</td><td>Fake-URL probe Q3 — same prompt (<em>"What's the SLA for kubedojo.example?"</em> + a fabricated URL)</td><td>Refuse to fabricate, mark URL as unverified or perform a real HTTP probe</td><td>Match codex's unique "actually fetched 404" behavior</td></tr>
+</table>
+
+<p><strong>Dispatch via:</strong></p>
+<pre># DeepSeek V4 Pro
+hermes -z -m deepseek-v4-pro "$(cat /tmp/role-prompt.md)"
+
+# Mistral 3.5 (vibe defaults to the configured Mistral model after `vibe --setup`)
+vibe -p "$(cat /tmp/role-prompt.md)" --output json</pre>
+
+<p><strong>Artifact target:</strong> <code>audit/2026-05-18-deepseek-mistral-calibration/REPORT.html</code> following the 2026-05-16 layout (per-cell raw output + verdict + extracted metric + citation chain).</p>
+
+<p><strong>Cost cap:</strong> 10 dispatches × ~5KB context each = trivial token cost. Likely under $0.50 total. No codex consumption.</p>
+
+<h2>3. Test Arc B — clawpatch routing probe</h2>
+
+<p>Same slice that already has empirical data from the codex / claude-opus / gemini-pro runs this session (<code>scripts/quality#2</code>, feature <code>feat_library_9ff8b28c45</code>). The cross-comparison gives provider-agreement / disagreement matrix on the EXACT same code.</p>
+
+<h3>3.A — Setup paths (one-time)</h3>
+
+<h4>A.1 — DeepSeek via opencode (recommended, native clawpatch provider)</h4>
+
+<pre># In opencode TUI:
+opencode
+# Then in the input box:
+/connect
+# Type: deepseek
+# Enter DeepSeek API key (from platform.deepseek.com/api_keys)
+# Select model: DeepSeek-V4-Pro
+
+# Verify:
+opencode providers list
+# Should show: deepseek (configured)
+
+# Then doctor-test via clawpatch:
+clawpatch doctor --provider opencode
+# Expected: state=ok, providerVersion=opencode &gt;=1.14.24</pre>
+
+<h4>A.2 — DeepSeek via hermes-ACP escape (alternative, no opencode config needed)</h4>
+
+<pre># Hermes already configured for deepseek-v4-pro (verified 2026-05-17 via `hermes status`).
+# Route through acpx:
+acpx --agent "hermes acp" --format json --max-turns 1 "test prompt"
+
+# Doctor-test via clawpatch (acpx custom-agent escape):
+clawpatch doctor --provider acpx --agent "hermes acp"
+# NOTE: clawpatch's acpx provider may not accept the --agent escape directly;
+# may need wrapper script. If doctor fails, fall back to path A.1 above.</pre>
+
+<h4>A.3 — Mistral via vibe (needs ACP adapter for clawpatch)</h4>
+
+<pre># vibe has -p (programmatic) mode but no ACP server mode (`vibe acp` does not exist).
+# Two options:
+
+# Option i — write a small ACP shim (~100 LOC TS or Python):
+#   - Reads ACP JSON-RPC from stdin
+#   - Calls vibe -p --output json with the extracted prompt
+#   - Wraps response into ACP envelope on stdout
+#   - Save as scripts/clawpatch-shims/vibe-acp.ts
+# Then: clawpatch review --provider acpx --agent "node scripts/clawpatch-shims/vibe-acp.ts"
+
+# Option ii — direct CLI dispatch outside clawpatch:
+#   For role-A calibration (where we don't need clawpatch), just use vibe -p directly.
+#   Skip clawpatch routing for Mistral entirely if the ACP shim cost exceeds the expected
+#   value. Defer until calibration tells us Mistral is worth wiring deeper.</pre>
+
+<h3>3.B — The probe</h3>
+
+<p>Same command shape as today's runs, three target providers:</p>
+
+<pre># DeepSeek
+clawpatch review --feature feat_library_9ff8b28c45 --jobs 1 --limit 5 --provider opencode
+
+# Mistral (if A.3 option i is built)
+clawpatch review --feature feat_library_9ff8b28c45 --jobs 1 --limit 5 \
+  --provider acpx --agent "node scripts/clawpatch-shims/vibe-acp.ts"</pre>
+
+<h3>3.C — Analysis grid</h3>
+
+<p>Compare findings against the codex + claude-opus + gemini-pro baseline (this session's runs):</p>
+
+<table>
+<tr><th>Finding</th><th>codex</th><th>claude-opus</th><th>gemini-pro</th><th>DeepSeek V4 Pro</th><th>Mistral 3.5</th></tr>
+<tr><td>1 — cleanup-banners nested lease</td><td><span class="pill pill-good">✓</span></td><td>TBD</td><td>TBD</td><td>TBD</td><td>TBD</td></tr>
+<tr><td>2 — lease module_key normalization</td><td><span class="pill pill-good">✓</span></td><td>TBD</td><td>TBD</td><td>TBD</td><td>TBD</td></tr>
+<tr><td>3 — ledger commit outside merge_lock</td><td><span class="pill pill-good">✓</span></td><td>TBD</td><td>TBD</td><td>TBD</td><td>TBD</td></tr>
+<tr><td>4 — dispatcher abort exit code</td><td><span class="pill pill-good">✓</span></td><td>TBD</td><td>TBD</td><td>TBD</td><td>TBD</td></tr>
+<tr><td>New findings unique to provider X</td><td>—</td><td>TBD</td><td>TBD</td><td>TBD</td><td>TBD</td></tr>
+</table>
+
+<h3>3.D — Interpretation</h3>
+
+<ul class="tight">
+<li><strong>If DeepSeek/Mistral find different bugs than codex</strong>: strong rotation signal; add them to the routing matrix's reviewer fallback list.</li>
+<li><strong>If they overlap with codex's 4 but find nothing new</strong>: validation that codex's prompt envelope is the lever (not the model); add them as cheap-reviewer fallback for budget-pressured runs only.</li>
+<li><strong>If they find fewer than 4 of codex's findings</strong>: drop from clawpatch routing; reserve for direct CLI dispatch on non-review tasks (role-A may still place them in writer or researcher lanes).</li>
+</ul>
+
+<h2>4. Execution order (recommended for next session)</h2>
+
+<ol class="tight">
+<li><strong>Setup Arc A first</strong> (no opencode/ACP plumbing needed). 10 calibration dispatches, ~30 min wall, &lt;$1 total. Produces <code>audit/2026-05-18-deepseek-mistral-calibration/REPORT.html</code>.</li>
+<li><strong>Decide on Arc B based on Arc A.</strong> If neither model placed in the calibration's top-2 for any role, skip the clawpatch shim work. Arc A is a cheap gatekeeper.</li>
+<li><strong>If Arc B proceeds:</strong> path A.1 (opencode <code>/connect</code>) for DeepSeek; defer Mistral ACP shim unless Arc A shows clear signal.</li>
+<li><strong>Update role-allocation memory</strong> with calibration results. Place each model in its winning lane or document as "tested, no production placement."</li>
+<li><strong>Update routing matrix brief</strong> with Arc B results (if run).</li>
+</ol>
+
+<h2>5. Cost + budget caveats</h2>
+
+<ul class="tight">
+<li>DeepSeek + Mistral API costs are per-token API consumption (not subscription rate-limit). The 5-role sweep is small (≤5KB context, ~2-3KB output per cell × 10 = ~50KB total). At DeepSeek's $0.27/MTok-input + $1.10/MTok-output pricing, full Arc A ≈ $0.05. Mistral 3.5 pricing comparable. Trivial.</li>
+<li>Arc B (clawpatch review) is ~3KB owned files + ~10KB context = ~40KB context per run × 2 providers = ~$0.30 if pricing holds. Still trivial.</li>
+<li>No impact on Codex 5x weekly cut. No impact on Claude Max weekly window. No impact on Gemini OAuth allowance.</li>
+<li>If either DeepSeek or Mistral lands in a production lane, factor monthly cost into budget review.</li>
+</ul>
+
+<h2>6. Open questions</h2>
+
+<ol class="tight">
+<li>Does the user have a preference for which Arc to run first? Default proposal: Arc A (calibration) → decide Arc B based on results.</li>
+<li>If Arc B proceeds, OK with opencode <code>/connect deepseek</code> UI flow (one-time interactive setup) vs hand-editing <code>~/.config/opencode/opencode.jsonc</code>?</li>
+<li>If neither model lands in a production lane after testing, OK to delete this brief + the calibration artifact, or keep as a "negative-result" reference?</li>
+</ol>
+
+<h2>7. Cross-references</h2>
+<ul class="tight">
+<li>Role allocation memory: <code>memory/project_role_allocation_2026-05-16.md</code> (roster update appended for these two agents)</li>
+<li>Sibling routing matrix: <code>docs/briefs/2026-05-17-clawpatch-6agent-routing.html</code></li>
+<li>Grok calibration shape to mirror: <code>audit/2026-05-16-grok-4.3-kubedojo-calibration/REPORT.html</code></li>
+<li>Clawpatch identification-only rule: <code>memory/feedback_clawpatch_identify_dont_fix.md</code></li>
+<li>Integration docs: <a href="https://api-docs.deepseek.com/quick_start/agent_integrations/opencode">DeepSeek + opencode</a>, <a href="https://api-docs.deepseek.com/quick_start/agent_integrations/hermes">DeepSeek + hermes</a></li>
+</ul>
+
+</main>
+</body>
+</html>

--- a/docs/session-state/2026-05-17-session-21-clawpatch-adoption.html
+++ b/docs/session-state/2026-05-17-session-21-clawpatch-adoption.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Session 21 — clawpatch adopted + 6-agent 10-role calibration + Mistral dropped</title>
+<style>
+  :root { --bg:#fafbfc; --fg:#1a1d23; --muted:#5b6573; --accent:#0057B7; --good:#0d8a4a; --partial:#b45c00; --gap:#b8001f; --card:#ffffff; --border:#e2e6eb; --mono:ui-monospace,SFMono-Regular,Menlo,monospace; }
+  *{box-sizing:border-box;}
+  body{margin:0;padding:0;background:var(--bg);color:var(--fg);font:15px/1.55 system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;}
+  main{max-width:1180px;margin:0 auto;padding:32px 24px 80px;}
+  h1{margin:0 0 8px;font-size:28px;}
+  h2{margin:36px 0 12px;padding-bottom:8px;border-bottom:2px solid var(--accent);font-size:22px;}
+  h3{margin:22px 0 8px;font-size:17px;}
+  .meta{color:var(--muted);margin:0 0 24px;font-size:14px;}
+  .tldr{background:var(--card);border-left:4px solid var(--accent);padding:14px 18px;margin:16px 0 28px;border-radius:0 6px 6px 0;}
+  table{width:100%;border-collapse:collapse;margin:12px 0;background:var(--card);border:1px solid var(--border);}
+  th,td{padding:10px 12px;border-bottom:1px solid var(--border);text-align:left;vertical-align:top;font-size:13px;}
+  th{background:#eef2f6;font-weight:600;}
+  td.col-id{white-space:nowrap;font-family:var(--mono);}
+  code{background:#eef2f6;padding:1px 6px;border-radius:3px;font-family:var(--mono);font-size:12px;}
+  pre{background:var(--card);border:1px solid var(--border);padding:12px;border-radius:6px;overflow-x:auto;font-size:12px;}
+  ul.tight,ol.tight{margin:6px 0;padding-left:22px;}
+  ul.tight li,ol.tight li{margin:3px 0;}
+  .pill{display:inline-block;padding:2px 8px;border-radius:12px;font-size:11px;font-weight:600;}
+  .pill-good{background:#d8f0e2;color:var(--good);}
+  .pill-partial{background:#fce7c8;color:var(--partial);}
+  .pill-gap{background:#fbd5db;color:var(--gap);}
+</style>
+</head>
+<body>
+<main>
+
+<h1>Session 21 — clawpatch adopted, 6-agent 10-role calibration, Mistral dropped</h1>
+<p class="meta">2026-05-17 (continuation after session-20 handoff <code>f0b6d48f</code>) · driver: claude opus 4.7 (1M context, orchestrator, inline) · sweep wall-time ~70 min · 60 fresh dispatches.</p>
+
+<div class="tldr">
+<strong>TL;DR.</strong> Two parallel tracks delivered:
+<ol class="tight">
+<li><strong>Clawpatch wired in + 4 verified bugs filed.</strong> acpx@0.8.0 installed, <code>.clawpatch/</code> baselined (config + project + 44 features), routing matrix brief shipped, one smoke review on <code>scripts/quality#2</code> → <strong>4/4 verified-real bugs</strong> filed as <a href="https://github.com/kube-dojo/kube-dojo.github.io/issues/1281">#1281</a>, <a href="https://github.com/kube-dojo/kube-dojo.github.io/issues/1282">#1282</a>, <a href="https://github.com/kube-dojo/kube-dojo.github.io/issues/1283">#1283</a>, <a href="https://github.com/kube-dojo/kube-dojo.github.io/issues/1284">#1284</a>. Cross-family-reviewed fixes pending in next session.</li>
+<li><strong>6-agent calibration over 10 roles.</strong> Confirmed roster: codex / claude-opus / gemini-pro / grok-4 / <strong>DeepSeek V4 Pro (hermes)</strong> / <strong>DeepSeek V4 Flash (hermes)</strong>. <strong>Mistral 3.5 DROPPED</strong> per user direction (vibe path + smaller/less-idiomatic outputs vs DS Flash). Full agent inventory + routing matrix at <code>audit/2026-05-17-deepseek-mistral-calibration/REPORT.html</code>.</li>
+</ol>
+<strong>One non-obvious finding:</strong> all 6 agents fabricate HTTP status codes when no probe access is available — they pattern-recognize fabricated URLs from training but claim to "see" HTTP 200/404. Only codex + <code>KUBEDOJO_CODEX_SEARCH=1</code> does real probes. DeepSeek (both tiers) fabricates most overtly ("verified via browser"). Claude-opus uniquely detected a prompt-injection attempt embedded in a fake-WebFetch body.
+</div>
+
+<h2>Tonight's tally</h2>
+<table>
+<tr><th>Metric</th><th>Value</th></tr>
+<tr><td>PRs merged this session</td><td><strong>0</strong> (1 PR pending — see Commit/PR section)</td></tr>
+<tr><td>GH issues filed</td><td><strong>4</strong> (#1281–#1284, all confirmed-bug, clawpatch-sourced)</td></tr>
+<tr><td>Clawpatch reviews completed</td><td>1 (codex provider on <code>scripts/quality#2</code>, 4 findings, 4/4 verified-real)</td></tr>
+<tr><td>Calibration dispatches</td><td><strong>60</strong> (40 first-pass parallel-6 + 20 hermes second-pass parallel-2)</td></tr>
+<tr><td>Calibration timeouts</td><td>4 (3 DeepSeek-opencode + 1 DeepSeek-Pro-hermes writer; latter recovered at 900s retry)</td></tr>
+<tr><td>Memory files: new</td><td>1 (<code>feedback_clawpatch_identify_dont_fix.md</code>)</td></tr>
+<tr><td>Memory files: amended</td><td>2 (<code>project_role_allocation_2026-05-16.md</code> roster update; <code>feedback_claude_invoke_npx_not_path.md</code> fix verified)</td></tr>
+<tr><td>Briefs shipped</td><td>2 (<code>2026-05-17-clawpatch-6agent-routing.html</code>, <code>2026-05-17-deepseek-mistral-test-plan.html</code> — latter now superseded by the REPORT.html)</td></tr>
+</table>
+
+<h2>Track 1 — clawpatch adopted</h2>
+
+<h3>What landed</h3>
+<ul class="tight">
+<li><code>npm install -g acpx@latest</code> → v0.8.0. Doctored clean for claude-opus + claude-sonnet + gemini-pro + gemini-flash. Adds 4 acpx-routed providers to clawpatch's native codex.</li>
+<li><code>.clawpatch/config.json</code> hand-edited: commands.test=<code>pytest -q --timeout=120</code>, commands.lint=<code>ruff check scripts/ tests/</code>, commands.format=<code>ruff format --check</code> (previously auto-detected as <code>npm run test/lint</code> which is wrong for the Python stack).</li>
+<li><code>.clawpatch/project.json</code> — auto-generated baseline.</li>
+<li><code>.clawpatch/features/</code> — 44 feature JSON files from <code>clawpatch map</code> (heuristic, 2 seconds, no LLM).</li>
+<li><code>.gitignore</code> — 5 new entries: <code>.clawpatch/findings/</code>, <code>reports/</code>, <code>runs/</code>, <code>locks/</code>, <code>patches/</code> (per learn-ukrainian decision: commit features baseline + config; ignore session-local noise).</li>
+<li><code>docs/briefs/2026-05-17-clawpatch-6agent-routing.html</code> — per-area provider primary+fallback, shim work sized for grok/mistral/deepseek (now partly obsolete: DS uses hermes not acpx; Mistral dropped).</li>
+</ul>
+
+<h3>The 4 verified bugs (all in scripts/quality/, all surfaced by codex via clawpatch)</h3>
+<table>
+<tr><th>#</th><th>Issue</th><th>File:line</th><th>Class</th></tr>
+<tr><td>1</td><td><a href="https://github.com/kube-dojo/kube-dojo.github.io/issues/1281">#1281</a> — cleanup-banners holds state lease across nested record_completion</td><td><code>pipeline.py:1010</code></td><td>concurrency / nested lock + silent failure</td></tr>
+<tr><td>2</td><td><a href="https://github.com/kube-dojo/kube-dojo.github.io/issues/1282">#1282</a> — module_key-form leases bypass select_modules skip check (HIGHEST blast radius)</td><td><code>run_388_batch.py:104, 238</code></td><td>concurrency / path normalization</td></tr>
+<tr><td>3</td><td><a href="https://github.com/kube-dojo/kube-dojo.github.io/issues/1283">#1283</a> — post-merge ledger writes can dirty primary outside _merge_lock</td><td><code>stages.py:1443-1444, 1469-1473</code></td><td>concurrency / locking boundary</td></tr>
+<tr><td>4</td><td><a href="https://github.com/kube-dojo/kube-dojo.github.io/issues/1284">#1284</a> — cmd_audit / cmd_route return 0 on DispatcherUnavailable abort (docs promise exit 3)</td><td><code>pipeline.py:22, 368, 378, 384</code></td><td>api-contract</td></tr>
+</table>
+
+<p><strong>None of these were caught by the existing gemini-pro / grok / codex prose-review cascade.</strong> Clawpatch's structured prompt envelope (evidence quotes + reproduction steps + suggested regression test) is the lever. <code>memory/feedback_clawpatch_identify_dont_fix.md</code> locks in the rule: use clawpatch for find-and-track only; fixes go through our normal dispatch flow.</p>
+
+<h2>Track 2 — 6-agent calibration (final roster)</h2>
+
+<h3>The 5 brains / 6 slots</h3>
+<table>
+<tr><th>Agent</th><th>CLI path</th><th>Role primary</th><th>Notes</th></tr>
+<tr><td>codex gpt-5.5 high</td><td><code>scripts/dispatch.py codex --model gpt-5.5</code></td><td>writer ★, URL/citation-with-search, coder, hallucination guard</td><td>Calibration ★ "tightest"; only model with real HTTP probes under <code>KUBEDOJO_CODEX_SEARCH=1</code></td></tr>
+<tr><td>claude opus 4.7</td><td><code>scripts/dispatch.py claude --model claude-opus-4-7 --no-tools</code> (inline this terminal post-2026-06-15)</td><td>orchestrator, senior content, plan ★, UK translation ★</td><td>Only model using native UK "шаблони"; only model that flagged prompt-injection in a fake-WebFetch body</td></tr>
+<tr><td>gemini 3.1 pro</td><td><code>scripts/dispatch.py gemini --model gemini-3.1-pro-preview</code></td><td>production reviewer (calibrated 2026-05-16), verbose architect (10.9 KB output)</td><td>OAuth, cost-effective; output had a duplicated-paragraph bug under structured prompts</td></tr>
+<tr><td>grok-4</td><td><code>scripts/dispatch.py grok --model grok-4 --effort medium</code> (hermes xai-oauth)</td><td>#388 production reviewer (30+ PRs); architect's only Option-C-proposer</td><td>FASTEST premium agent (~14-16s/role); honestly refused UK translation</td></tr>
+<tr><td>DeepSeek V4 Pro <span class="pill pill-good">NEW</span></td><td><code>hermes -z "$P" -m deepseek-v4-pro</code> · <span class="pill pill-gap">NOT</span> opencode</td><td>cross-family premium reviewer, content-review, research, architect, UK translation (tied 5/5 with claude)</td><td>Gold-tier reviewer (verified PR #134577 by name, caught ASCII-diagram bug). Writer needs 900s budget. Hallucination 3/4 (fabricates probe).</td></tr>
+<tr><td>DeepSeek V4 Flash <span class="pill pill-good">NEW — replaces Mistral 3.5</span></td><td><code>hermes -z "$P" -m deepseek-v4-flash</code></td><td>lightweight tier — plan, architect, UK translation at 3× speed of Pro</td><td>10/10 roles in 11 min. Plan output (6.1 KB) larger than Pro's (4.8 KB). Native UK "шаблони".</td></tr>
+</table>
+
+<h3>Mistral 3.5 dropped</h3>
+<p>User direction 2026-05-17: <em>"i cancled mistral"</em>. Calibration data supports the drop: smaller outputs (1.2-4.9 KB vs verbose-tier 2.6-11 KB); UK uses Anglicism "пакети" + "патерни" (DS Flash uses native "пакунки" + "шаблони"); plan wasted 2 of 5 numbered steps. DeepSeek V4 Flash covers the lightweight tier with cleaner integration (no <code>--trust</code> warning, no vibe-specific quirks).</p>
+
+<h3>Updated routing matrix (post-2026-05-17 hermes-final)</h3>
+<table>
+<tr><th>Role</th><th>Primary</th><th>Cross-family fallback</th><th>Budget option</th></tr>
+<tr><td>Code reviewer (#388 PR gate)</td><td>grok-4</td><td>DeepSeek V4 Pro (hermes)</td><td>DeepSeek V4 Flash</td></tr>
+<tr><td>Content writer (#388)</td><td>codex gpt-5.5 high</td><td>claude-opus-4-7</td><td>DS Pro @ 900s with output filter</td></tr>
+<tr><td>Content reviewer (rubric)</td><td>claude-opus-4-7 OR gemini-3.1-pro</td><td>DeepSeek V4 Pro</td><td>DS Flash</td></tr>
+<tr><td>Plan / refactor</td><td>claude-opus-4-7</td><td>codex gpt-5.5 high</td><td>DS Flash (3× speed, comparable quality)</td></tr>
+<tr><td>Architect</td><td>gemini-3.1-pro OR grok-4 OR DS Pro</td><td>codex</td><td>DS Flash</td></tr>
+<tr><td>Coding</td><td>codex gpt-5.5 high</td><td>DeepSeek V4 Pro</td><td>DS Flash or claude-opus</td></tr>
+<tr><td>Research</td><td>codex + <code>KUBEDOJO_CODEX_SEARCH=1</code></td><td>DS Pro (hermes)</td><td>gemini-3-flash-preview</td></tr>
+<tr><td>URL/citation verify</td><td>codex + <code>--search</code> (unique real-probe)</td><td>—</td><td>all 6 do pattern-recognition only</td></tr>
+<tr><td>Hallucination guard</td><td>codex / claude / gemini / DS Flash (tied 4/4)</td><td>—</td><td>DS Pro 3/4 — usable</td></tr>
+<tr><td>UK translation</td><td>claude-opus-4-7 OR DS V4 Pro (tied 5/5)</td><td>DS Flash</td><td>gemini-3.1-pro</td></tr>
+</table>
+
+<h2>Memory updates this session</h2>
+<ul class="tight">
+<li><strong>NEW</strong> <code>feedback_clawpatch_identify_dont_fix.md</code> — Clawpatch is find-and-track ONLY. Never <code>clawpatch fix</code>. Use review→report→triage→file as GH issue→fix via codex/claude/gemini per normal flow. User explicit 2026-05-17.</li>
+<li><strong>AMENDED</strong> <code>project_role_allocation_2026-05-16.md</code> — roster update: DS Pro + DS Flash added; Mistral dropped. The two DS tiers split: Pro for premium reasoning, Flash for cost/speed-pressured lanes.</li>
+<li><strong>CORRECTED</strong> <code>feedback_claude_invoke_npx_not_path.md</code> — verified the adapter fix is in place at <code>scripts/agent_runtime/adapters/claude.py:122</code> (PR #1078 landed). Rule still active for ad-hoc subprocess.run uses.</li>
+<li><strong>MEMORY.md</strong> — added clawpatch-identify-don't-fix to TOP PRIORITY; updated the claude_invoke_npx entry to reflect the landed fix.</li>
+</ul>
+
+<h2>Tooling state at handoff</h2>
+<table>
+<tr><th>Tool</th><th>Version</th><th>State</th></tr>
+<tr><td>clawpatch</td><td>0.2.0</td><td>installed via homebrew (pre-existing); kubedojo-baselined this session</td></tr>
+<tr><td>acpx</td><td>0.8.0</td><td>installed via <code>npm install -g acpx@latest</code> this session</td></tr>
+<tr><td>opencode</td><td>1.15.3</td><td>installed pre-existing; user configured DeepSeek V4 Pro max-effort but this path is RETIRED for DeepSeek dispatches (tool overhead caused timeouts). Use hermes -z instead.</td></tr>
+<tr><td>hermes</td><td>(version per <code>hermes status</code>)</td><td>Configured for DeepSeek. Now the canonical path for DS V4 Pro + V4 Flash. Verified <code>hermes -z -m deepseek-v4-pro</code> + <code>-m deepseek-v4-flash</code> both work.</td></tr>
+<tr><td>vibe (Mistral)</td><td>installed pre-existing</td><td>Mistral path RETIRED. User cancelled Mistral 2026-05-17.</td></tr>
+</table>
+
+<h2>Next session — carryover priorities</h2>
+
+<ol class="tight">
+<li><strong>Fix the 4 clawpatch-surfaced bugs</strong> (#1281–#1284) via standard cross-family-reviewed PRs. Each is small (1–3 file changes). #1282 (lease normalization) is highest priority — concurrency blast radius.</li>
+<li><strong>Replicate plan/architect calibration on 2-3 more real tasks</strong> with the existing roster. N=1 today; the new placements (plan/architect/content-review/url-verify/uk-translation) need replication before locking.</li>
+<li><strong>DS Pro full-writer test</strong> at 900s on the FULL #388 writer brief (not the short calibration prompt). Decide whether DS Pro hits the 5,000-body-word verifier gate. Will determine whether DS Pro is a real writer fallback to codex.</li>
+<li><strong>UK translation second-opinion</strong> from a Ukrainian speaker on the 4 produced translations (claude-opus, DS Pro, DS Flash, gemini, mistral) to confirm/refine the 5/5 ties.</li>
+<li><strong>Qwen 3.6 single-lane test</strong> (UK translation + hallucination) if user wants to explore. Setup needed (DashScope or OpenRouter key); ~30 min plumbing + ~5 min dispatches. Defer unless lightweight tier needs reconsideration.</li>
+<li><strong>Drop obsolete brief</strong>: <code>docs/briefs/2026-05-17-deepseek-mistral-test-plan.html</code> — superseded by the REPORT.html.</li>
+<li><strong>Update <code>docs/briefs/2026-05-17-clawpatch-6agent-routing.html</code></strong> to remove Mistral references and update DeepSeek to hermes path. Or supersede with a new brief.</li>
+<li><strong>Date reminders</strong>: 2026-06-15 agentic-pool flip (inline claude becomes economically sane); 2026-07-13 Claude weekly double expires.</li>
+</ol>
+
+<h2>Cold-start for next session</h2>
+<pre>
+# Standard orient
+curl -s http://127.0.0.1:8768/api/orient | python3 -m json.tool | head -25
+
+# Confirm session 21 commit landed
+git log --oneline -5
+
+# Confirm the 4 issues are open
+GH_TOKEN='' gh issue list --state open --search "is:issue clawpatch in:body" --limit 10
+
+# Confirm clawpatch baseline is on main
+ls .clawpatch/config.json .clawpatch/project.json .clawpatch/features/ | head
+
+# Pull the agent inventory (rendered)
+echo "open http://127.0.0.1:8768/artifacts/audit/2026-05-17-deepseek-mistral-calibration/REPORT.html"
+</pre>
+
+<h2>Pointers</h2>
+<ul class="tight">
+<li><strong>Routing matrix brief:</strong> <code>docs/briefs/2026-05-17-clawpatch-6agent-routing.html</code> (clawpatch-side; needs amendment for DS hermes path)</li>
+<li><strong>Agent inventory report:</strong> <code>audit/2026-05-17-deepseek-mistral-calibration/REPORT.html</code> (gitignored — on-disk only; serve via local API)</li>
+<li><strong>Raw calibration outputs:</strong> <code>audit/2026-05-17-deepseek-mistral-calibration/{role}/{agent}.out</code></li>
+<li><strong>Test plan brief (superseded):</strong> <code>docs/briefs/2026-05-17-deepseek-mistral-test-plan.html</code></li>
+<li><strong>Predecessor:</strong> <code>docs/session-state/2026-05-18-session-20-grok-audit-and-verifier-hardening.html</code></li>
+<li><strong>Sibling decisions:</strong> learn-ukrainian's clawpatch adoption at <code>/Users/krisztiankoos/projects/learn-ukrainian/docs/decisions/2026-05-17-clawpatch-adoption.md</code></li>
+</ul>
+
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- **Clawpatch wired into kubedojo.** acpx 0.8.0 installed; `.clawpatch/` baselined (config + project + 44 features). Hand-edited `commands.{test,lint,format}` for the Python stack (auto-detect picked `npm run test/lint`, wrong). `.gitignore` extended to exclude session-local noise while committing the deterministic features baseline. **One smoke review on `scripts/quality#2` produced 4 findings, all 4 spot-verified real**, filed as #1281–#1284.
- **6-agent 10-role calibration** (60 fresh dispatches, ~70 min wall). Mistral 3.5 dropped per user; DeepSeek V4 Pro + V4 Flash added as hermes-routed agents (opencode path retired due to tool-use overhead causing timeouts). Full per-agent inventory + routing matrix at `audit/2026-05-17-deepseek-mistral-calibration/REPORT.html` (on-disk, not committed — large, dated audit artifact).
- **Memory updates** (user-private, separate path): clawpatch identify-don't-fix rule; role allocation roster amended; claude-invoke-npx adapter fix verified in code.

## Test plan
- [x] Smoke clawpatch review on `scripts/quality#2` — 4/4 verified-real bugs
- [x] 60 calibration dispatches across 10 roles × 6 agents — completed
- [x] 4 GH issues filed (#1281–#1284) with finding IDs + evidence + suggested regression tests
- [x] Memory updates applied
- [ ] Cross-family review of this PR (will land if grok-4 or DS V4 Pro approves)
- [ ] Build passes — Astro build not run on this branch (no curriculum content change)

## Refs
Closes nothing directly. Surfaces 4 separate fix-PRs to follow: #1281 #1282 #1283 #1284.

🤖 Generated with [Claude Code](https://claude.com/claude-code)