### PR TITLE
feat(agents): integrate DeepSeek V4 (Pro + Flash, hermes API-key) as full peer agent

### DIFF
--- a/scripts/agent_runtime/adapters/deepseek.py
+++ b/scripts/agent_runtime/adapters/deepseek.py
@@ -1,0 +1,235 @@
+"""DeepSeekAdapter — wraps ``hermes -z`` (deepseek provider) for the agent runtime.
+
+Fourth production adapter. Brings deepseek-v4 Pro (and successors) online as a
+peer to codex / claude / gemini for code review, deliberation, and fix lanes.
+
+Key design points:
+
+- **Transport:** ``hermes`` CLI in oneshot mode (``-z -`` reads prompt
+  from stdin). Hermes proxies to DeepSeek via the ``deepseek`` provider.
+- **Modes:** All three (read-only / workspace-write / danger) supported.
+  Mode → hermes toolset mapping is conservative for read-only (no
+  terminal/file tools), permissive for workspace-write and danger.
+- **Project context:** hermes injects KubeDojo project state via its
+  ``memory`` + ``skills`` toolsets unless suppressed. We keep this on for
+  review/code work (gives DeepSeek situational awareness) but disable via
+  ``--ignore-user-config --ignore-rules`` when the caller passes
+  ``tool_config={"isolated": True}`` (used for benchmark / calibration).
+- **No session resume.** ``resume_policy=never`` in the registry — hermes
+  has session semantics but cross-worktree contamination would mirror the
+  Codex footgun. Defensively ignored even if passed.
+- **Liveness:** hermes streams output to stdout, so the runner's stdout
+  watchdog handles liveness. ``liveness_signal_paths()`` returns ``()``.
+
+Calibration (2026-05-17): Pro tied 5/5 with claude on content review; gold-tier
+reviewer. Hallucination rate 3/4 on code — caller should not promote a DS Pro
+claim to Green without independent verification (curl+pdftotext+grep) for
+factual claims (mirrors gemini hallucination policy per
+[[feedback_gemini_hallucinates_anchors]]). Flash is 3× faster than Pro;
+suited for plan / architect / UK translation lanes.
+
+Status flagged for the user:
+- DeepSeek adds a second cheap/fast lane (V4 Flash) while preserving Pro for
+  high-value review roles.
+"""
+from __future__ import annotations
+
+import os
+import re
+import shutil
+from pathlib import Path
+from typing import Any
+
+from ..result import ParseResult
+from .base import InvocationPlan
+
+# Rate-limit patterns. DeepSeek follows Hermes transport patterns, including
+# standard 429 signaling.
+_RATE_LIMIT_PATTERNS = (
+    r"rate limit",
+    r"rate_limit",
+    r"usage limit",
+    r"quota exceeded",
+    r"too many requests",
+    r"\bHTTP 429\b",
+    r"\bstatus 429\b",
+    r"\b429\b",
+)
+_RATE_LIMIT_RE = re.compile("|".join(_RATE_LIMIT_PATTERNS), re.IGNORECASE)
+
+# Hermes startup warnings we strip before declaring success.
+_HERMES_BANNER_RE = re.compile(
+    r"^(💡 Python project detected\..*|hermes -z:.*)$",
+    re.MULTILINE,
+)
+
+# Toolsets per mode. Hermes built-in toolsets are documented under
+# `hermes tools list`. We deliberately exclude memory / skills from
+# read-only to keep calibration runs reproducible; they're great for
+# real review/code work though.
+_TOOLSETS_READ_ONLY = "web"
+_TOOLSETS_WORKSPACE = "web,file,terminal,code_execution,todo"
+_TOOLSETS_DANGER = "web,file,terminal,code_execution,todo,memory,skills"
+
+
+class DeepSeekAdapter:
+    """Adapter for ``hermes -z`` with the deepseek provider."""
+
+    name: str = "deepseek"
+    # deepseek-v4-pro is the canonical model identifier for hermes via
+    # the deepseek provider.
+    # User may override via env (e.g. when deepseek-v4-flash is needed for
+    # a cheap planner/architect lane).
+    default_model: str = os.environ.get("AB_DEEPSEEK_MODEL", "deepseek-v4-pro")
+    supported_modes: frozenset[str] = frozenset({"read-only", "workspace-write", "danger"})
+
+    def build_invocation(
+        self,
+        *,
+        prompt: str,
+        mode: str,
+        cwd: Path,
+        model: str | None,
+        task_id: str | None,
+        session_id: str | None,
+        tool_config: dict | None,
+    ) -> InvocationPlan:
+        """Build the hermes oneshot invocation.
+
+        ``tool_config`` keys honored:
+            - ``isolated: bool`` — if True, pass ``--ignore-user-config
+              --ignore-rules`` to bypass hermes's project-context
+              injection. Default False (project context is feature, not
+              bug, for review/code work).
+            - ``toolsets: str`` — comma-separated override for ``-t``.
+              Wins over the mode-default mapping.
+            - ``provider: str`` — override hermes provider. Default
+              ``deepseek``.
+            - ``effort: str`` — reasoning effort label. Hermes does not
+              expose this as a flag today; we forward it via prompt
+              prefix when ``"xhigh"`` is requested. Tracking issue: see
+              ``project_hermes_model_inventory.md``.
+            - ``yolo: bool`` — pass ``--yolo`` (auto-accept tool calls).
+              Default True for write modes, False for read-only.
+            - ``accept_hooks: bool`` — pass ``--accept-hooks``. Default
+              False; opt-in for callers that want project hooks to fire.
+        """
+        if mode not in self.supported_modes:
+            raise ValueError(f"DeepSeekAdapter: unsupported mode {mode!r}")
+
+        tc: dict[str, Any] = tool_config or {}
+
+        binary = shutil.which("hermes") or "hermes"
+        cmd: list[str] = [binary]
+
+        # Reasoning effort hint applied first so the final prompt string is
+        # the argv positional we pass to -z.
+        effort = tc.get("effort")
+        final_prompt = prompt
+        if effort and effort != "default":
+            final_prompt = f"[Reasoning effort hint: {effort}]\n\n{prompt}"
+
+        # Oneshot mode. Pass the prompt as argv positional, NOT stdin.
+        # ``hermes -z -`` (stdin marker) is interpreted as "no prompt
+        # provided, run in project-introspection mode" — the prompt
+        # piped on stdin is ignored. ARG_MAX is ~1 MB on macOS so the
+        # ~10 KB review prompts fit comfortably; if a caller needs to
+        # pass a multi-megabyte prompt, write it to a temp file and use
+        # a different transport (not the runtime's concern today).
+        cmd.extend(["-z", final_prompt])
+
+        # Model
+        cmd.extend(["-m", model or self.default_model])
+
+        # Provider — deepseek is the canonical KubeDojo path (Hermes API key).
+        provider = tc.get("provider", "deepseek")
+        cmd.extend(["--provider", provider])
+
+        # Toolset selection — caller override wins, else mode default.
+        toolsets = tc.get("toolsets")
+        if not toolsets:
+            if mode == "read-only":
+                toolsets = _TOOLSETS_READ_ONLY
+            elif mode == "workspace-write":
+                toolsets = _TOOLSETS_WORKSPACE
+            else:  # danger
+                toolsets = _TOOLSETS_DANGER
+        cmd.extend(["-t", toolsets])
+
+        # Auto-accept tool calls. Required for non-interactive runs that
+        # do file edits or shell ops. Read-only stays prompt-only by
+        # default so we don't accidentally grant network egress through
+        # the web tool's confirm step.
+        yolo_default = mode in ("workspace-write", "danger")
+        if bool(tc.get("yolo", yolo_default)):
+            cmd.append("--yolo")
+
+        if bool(tc.get("accept_hooks", False)):
+            cmd.append("--accept-hooks")
+
+        # Isolation: bypass user config + project rules. Used for
+        # calibration / benchmark runs where deterministic output is
+        # more important than context awareness.
+        if bool(tc.get("isolated", False)):
+            cmd.extend(["--ignore-user-config", "--ignore-rules"])
+
+        # Defensively drop session_id — resume_policy=never.
+        _ = session_id
+        _ = task_id
+
+        return InvocationPlan(
+            cmd=cmd,
+            cwd=cwd,
+            stdin_payload="",  # prompt is in argv; stdin must be empty
+            output_file=None,
+            env_overrides={},
+            liveness_paths=(),
+        )
+
+    def parse_response(
+        self,
+        *,
+        stdout: str,
+        stderr: str,
+        returncode: int,
+        output_file: Path | None,
+        plan: InvocationPlan | None = None,
+        call_start_time: float | None = None,
+    ) -> ParseResult:
+        """Parse hermes -z output.
+
+        Hermes prints the final assistant message to stdout. Diagnostic
+        warnings ("💡 Python project detected.", argument errors) appear
+        in stdout/stderr depending on how hermes was invoked.
+        """
+        _ = output_file
+        _ = plan
+        _ = call_start_time
+
+        # Strip hermes banners that aren't part of the response.
+        clean_stdout = _HERMES_BANNER_RE.sub("", stdout or "").strip()
+
+        combined = f"{clean_stdout}\n{stderr or ''}"
+        rate_limited = bool(_RATE_LIMIT_RE.search(combined))
+
+        ok = returncode == 0 and bool(clean_stdout) and not rate_limited
+        response = clean_stdout if ok else ""
+
+        stderr_excerpt: str | None = None
+        if not ok:
+            excerpt_source = (stderr or "").strip() or (stdout or "").strip()
+            stderr_excerpt = excerpt_source[:500] or None
+
+        return ParseResult(
+            ok=ok,
+            response=response,
+            stderr_excerpt=stderr_excerpt,
+            rate_limited=rate_limited,
+            session_id=None,
+            tokens=None,
+        )
+
+    def liveness_signal_paths(self, plan: InvocationPlan) -> tuple[Path, ...]:
+        """Hermes streams to stdout; the runner's stdout watchdog covers liveness."""
+        _ = plan
+        return ()

--- a/scripts/agent_runtime/registry.py
+++ b/scripts/agent_runtime/registry.py
@@ -67,6 +67,21 @@ AGENTS: dict[str, AgentEntry] = {
         "cli_available": True,
         "resume_policy": "bridge_only",
     },
+    "deepseek": {
+        "adapter": "scripts.agent_runtime.adapters.deepseek:DeepSeekAdapter",
+        "default_model": os.environ.get("AB_DEEPSEEK_MODEL", "deepseek-v4-pro"),
+        "cost_tier": "low",
+        "capabilities": frozenset({
+            "code_review",
+            "content_review",
+            "adversarial_review",
+            "research",
+            "deliberation",
+            "architecture",
+        }),
+        "cli_available": True,
+        "resume_policy": "never",
+    },
     "gemini": {
         "adapter": "scripts.agent_runtime.adapters.gemini:GeminiAdapter",
         "default_model": GEMINI_WRITER_MODEL,

--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -59,6 +59,7 @@ _DISCUSSION_CLARIFICATION_MODES = {
     "claude": "bypass",
     "gemini": "yolo",
     "codex": "danger",
+    "deepseek": "yolo",
     "grok": "yolo",
 }
 
@@ -66,6 +67,7 @@ _DISCUSSION_RUNTIME_MODES = {
     "claude": "read-only",
     "gemini": "workspace-write",
     "codex": "danger",
+    "deepseek": "workspace-write",
     "grok": "workspace-write",
 }
 
@@ -169,6 +171,12 @@ def _agent_runtime_mode(agent_name: str, sandbox_mode: str | None) -> str:
         if sandbox_mode == "read-only":
             return "read-only"
         return "workspace-write"
+    if agent_name == "deepseek":
+        # DeepSeek via hermes accepts workspace-write; sandbox is enforced by
+        # toolset selection (see _agent_tool_config), not a mode flag.
+        if sandbox_mode == "read-only":
+            return "read-only"
+        return "workspace-write"
     if sandbox_mode == "read-only":
         return "read-only"
     return "workspace-write"
@@ -226,6 +234,26 @@ def _agent_tool_config(
                 "yolo": True,
             }
         return grok_tc
+    if agent_name == "deepseek":
+        # Sandbox enforcement for deepseek is via toolset selection (hermes has
+        # no CLI sandbox flag). DeepSeekAdapter.build_invocation honors caller
+        # overrides for toolsets/yolo over its mode defaults, so we MUST
+        # gate write-capable tools (file/terminal/code_execution) and --yolo
+        # on sandbox_mode here.
+        if sandbox_mode == "read-only":
+            deepseek_tc: dict[str, object] = {
+                "toolsets": "web",
+                "yolo": False,
+            }
+        else:
+            # workspace-write / yolo / bypass / None → grant the full
+            # deliberation toolset so DeepSeek can inspect repo state and
+            # execute tool calls.
+            deepseek_tc = {
+                "toolsets": "web,file,terminal,code_execution,todo",
+                "yolo": True,
+            }
+        return deepseek_tc
     return None
 
 

--- a/src/content/docs/changelog.md
+++ b/src/content/docs/changelog.md
@@ -8,6 +8,12 @@ sidebar:
 
 ## May 2026
 
+- **Agent runtime expanded.** DeepSeek V4 Pro and Flash are now integrated as
+  production peer agents via ``hermes --provider deepseek`` with a dedicated adapter,
+  registry entry, and bridge-mode tool/mode wiring. Pro defaults to
+  ``deepseek-v4-pro`` and Flash can be selected through ``AB_DEEPSEEK_MODEL``,
+  including dispatch coverage for review, research, and code lanes.
+
 - **On-prem multi-cluster track complete.** Four new modules in [On-Premises Multi-Cluster](/on-premises/multi-cluster/): [Gardener](/on-premises/multi-cluster/module-5.6-gardener/) (open-source Kubernetes-as-a-Service with a three-tier Gardens/Seeds/Shoots architecture), [Karmada + Liqo + kube-vip](/on-premises/multi-cluster/module-5.7-multi-cluster-on-prem/) (federation and virtual-IP advertisement for on-prem clusters), [OpenStack on Kubernetes](/on-premises/multi-cluster/module-5.8-openstack-on-kubernetes/) (running OpenStack's own control plane as Kubernetes workloads), and [VMware Tanzu](/on-premises/multi-cluster/module-5.9-vmware-tanzu/) (the full Tanzu portfolio — TKG, vSphere with Tanzu, TMC, TAP — plus an honest look at enterprise decisions after the Broadcom acquisition).
 
 - **ML model-serving toolkit.** [KServe](/platform/toolkits/data-ai-platforms/ml-platforms/module-9.8-kserve/), [Seldon Core](/platform/toolkits/data-ai-platforms/ml-platforms/module-9.9-seldon-core/), and [BentoML](/platform/toolkits/data-ai-platforms/ml-platforms/module-9.10-bentoml/) now have full modules — covering inference graphs, A/B experiments, and Python-first model packaging. The new [bare-metal MLOps capstone](/platform/toolkits/data-ai-platforms/ml-platforms/module-9.11-bare-metal-mlops/) shows how to wire all three into a complete production stack on your own hardware, from GPU scheduling and storage through to observability.

--- a/tests/test_deepseek_adapter.py
+++ b/tests/test_deepseek_adapter.py
@@ -1,0 +1,117 @@
+"""Unit tests for the ``DeepSeekAdapter`` Hermes integration."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent_runtime.adapters.deepseek import DeepSeekAdapter
+
+
+def test_build_invocation_read_only(monkeypatch) -> None:
+    monkeypatch.setattr("agent_runtime.adapters.deepseek.shutil.which", lambda _: "hermes")
+    adapter = DeepSeekAdapter()
+    plan = adapter.build_invocation(
+        prompt="p",
+        mode="read-only",
+        cwd=Path("/tmp"),
+        model=None,
+        task_id=None,
+        session_id=None,
+        tool_config=None,
+    )
+
+    cmd = plan.cmd
+    assert cmd == [
+        "hermes",
+        "-z",
+        "p",
+        "-m",
+        "deepseek-v4-pro",
+        "--provider",
+        "deepseek",
+        "-t",
+        "web",
+    ]
+    assert "--yolo" not in cmd
+
+
+def test_build_invocation_workspace_write(monkeypatch) -> None:
+    monkeypatch.setattr("agent_runtime.adapters.deepseek.shutil.which", lambda _: "hermes")
+    adapter = DeepSeekAdapter()
+    plan = adapter.build_invocation(
+        prompt="p",
+        mode="workspace-write",
+        cwd=Path("/tmp"),
+        model=None,
+        task_id=None,
+        session_id=None,
+        tool_config=None,
+    )
+
+    cmd = plan.cmd
+    assert "--yolo" in cmd
+    toolsets = cmd[cmd.index("-t") + 1]
+    assert toolsets == "web,file,terminal,code_execution,todo"
+
+
+def test_build_invocation_danger(monkeypatch) -> None:
+    monkeypatch.setattr("agent_runtime.adapters.deepseek.shutil.which", lambda _: "hermes")
+    adapter = DeepSeekAdapter()
+    plan = adapter.build_invocation(
+        prompt="p",
+        mode="danger",
+        cwd=Path("/tmp"),
+        model=None,
+        task_id=None,
+        session_id=None,
+        tool_config=None,
+    )
+
+    toolsets = plan.cmd[plan.cmd.index("-t") + 1]
+    assert "memory" in toolsets
+    assert "skills" in toolsets
+
+
+def test_model_override(monkeypatch) -> None:
+    monkeypatch.setattr("agent_runtime.adapters.deepseek.shutil.which", lambda _: "hermes")
+    adapter = DeepSeekAdapter()
+    plan = adapter.build_invocation(
+        prompt="p",
+        mode="read-only",
+        cwd=Path("/tmp"),
+        model="deepseek-v4-flash",
+        task_id=None,
+        session_id=None,
+        tool_config=None,
+    )
+
+    assert plan.cmd[plan.cmd.index("-m") + 1] == "deepseek-v4-flash"
+
+
+def test_parse_response_strips_hermes_banner() -> None:
+    adapter = DeepSeekAdapter()
+    result = adapter.parse_response(
+        stdout="💡 Python project detected. Run with hermes -z.\n\nAnswer",
+        stderr="",
+        returncode=0,
+        output_file=None,
+        plan=None,
+        call_start_time=None,
+    )
+
+    assert result.ok is True
+    assert result.response == "Answer"
+
+
+def test_parse_response_detects_rate_limit() -> None:
+    adapter = DeepSeekAdapter()
+    result = adapter.parse_response(
+        stdout="",
+        stderr="rate limit exceeded",
+        returncode=1,
+        output_file=None,
+        plan=None,
+        call_start_time=None,
+    )
+
+    assert result.rate_limited is True
+    assert result.ok is False


### PR DESCRIPTION
## Summary
- Added new `scripts/agent_runtime/adapters/deepseek.py` adapter using `hermes -z` with `--provider deepseek`, default model `deepseek-v4-pro`, `resume_policy=never`, DeepSeek-specific calibration footnote, and full parity with Grok tool mapping/parse logic.
- Added `deepseek` entry to `scripts/agent_runtime/registry.py` (alphabetically before `gemini`) with `AB_DEEPSEEK_MODEL`, low cost tier, and full peer capabilities.
- Wired `deepseek` into `scripts/ai_agent_bridge/_channels_cli.py` for discuss clarification/runtime modes and sandbox-aware tool config (`web` read-only, write toolset + `--yolo` for workspace-write, memory/skills included for danger).
- Added `tests/test_deepseek_adapter.py` covering invocation construction, model override, danger toolset, banner stripping, and rate-limit parsing.
- Added changelog note in `src/content/docs/changelog.md`.

## Validation
- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/pytest tests/test_agent_runtime_runner.py tests/test_quality_dispatchers.py tests/test_deepseek_adapter.py -q`
- registry smoke check:
```bash
/Users/krisztiankoos/projects/kubedojo/.venv/bin/python -c "from scripts.agent_runtime.registry import AGENTS, available_agents; assert 'deepseek' in AGENTS, 'deepseek not registered'; assert AGENTS['deepseek']['cli_available']; print('registered:', sorted(available_agents()))"
```
- live smoke:
```bash
timeout 30 hermes -z 'Respond with exactly one word: PONG' -m deepseek-v4-pro --provider deepseek
timeout 30 hermes -z 'Respond with exactly one word: PONG' -m deepseek-v4-flash --provider deepseek
```

Both smoke responses were exactly `PONG`.

```bash
registered: ['claude', 'codex', 'deepseek', 'gemini', 'grok']
PONG
PONG
```

## Notes
- Not closing any issue directly.
- No memory files updated.
