### PR TITLE
feat(dispatch): add deepseek + gemini to dispatch_smart + GrokAdapter unit tests

### DIFF
--- a/scripts/dispatch_smart.py
+++ b/scripts/dispatch_smart.py
@@ -72,7 +72,7 @@ def _primary_checkout_root(repo_root: Path) -> Path:
 PRIMARY_REPO = _primary_checkout_root(REPO)
 
 
-SUPPORTED_AGENTS = ("claude", "codex", "grok")
+SUPPORTED_AGENTS = ("claude", "codex", "deepseek", "gemini", "grok")
 
 
 @dataclass(frozen=True)
@@ -89,6 +89,8 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
         models={
             "claude": "claude-haiku-4-5-20251001",
             "codex": "gpt-5.4-mini",
+            "deepseek": "deepseek-v4-flash",
+            "gemini": "gemini-3.1-flash-lite-preview",
             "grok": "grok-4",
         },
         default_mode="read-only",
@@ -100,6 +102,8 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
         models={
             "claude": "claude-sonnet-4-6",
             "codex": "gpt-5.3-codex-spark",
+            "deepseek": "deepseek-v4-pro",
+            "gemini": "gemini-3.1-pro-preview",
             "grok": "grok-4",
         },
         default_mode="workspace-write",
@@ -111,6 +115,8 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
         models={
             "claude": "claude-sonnet-4-6",
             "codex": "gpt-5.3-codex-spark",
+            "deepseek": "deepseek-v4-pro",
+            "gemini": "gemini-3.1-pro-preview",
             "grok": "grok-4",
         },
         default_mode="workspace-write",
@@ -122,6 +128,8 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
         models={
             "claude": "claude-sonnet-4-6",
             "codex": "gpt-5.5",
+            "deepseek": "deepseek-v4-pro",
+            "gemini": "gemini-3.1-pro-preview",
             "grok": "grok-4",
         },
         default_mode="read-only",
@@ -133,6 +141,8 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
         models={
             "claude": "claude-opus-4-7",
             "codex": "gpt-5.5",
+            "deepseek": "deepseek-v4-pro",
+            "gemini": "gemini-3.1-pro-preview",
             "grok": "grok-4",
         },
         default_mode="workspace-write",

--- a/tests/test_grok_adapter.py
+++ b/tests/test_grok_adapter.py
@@ -1,0 +1,117 @@
+"""Unit tests for the ``GrokAdapter`` Hermes integration."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent_runtime.adapters.grok import GrokAdapter
+
+
+def test_build_invocation_read_only(monkeypatch) -> None:
+    monkeypatch.setattr("agent_runtime.adapters.grok.shutil.which", lambda _: "hermes")
+    adapter = GrokAdapter()
+    plan = adapter.build_invocation(
+        prompt="p",
+        mode="read-only",
+        cwd=Path("/tmp"),
+        model=None,
+        task_id=None,
+        session_id=None,
+        tool_config=None,
+    )
+
+    cmd = plan.cmd
+    assert cmd == [
+        "hermes",
+        "-z",
+        "p",
+        "-m",
+        "grok-4",
+        "--provider",
+        "xai-oauth",
+        "-t",
+        "web",
+    ]
+    assert "--yolo" not in cmd
+
+
+def test_build_invocation_workspace_write(monkeypatch) -> None:
+    monkeypatch.setattr("agent_runtime.adapters.grok.shutil.which", lambda _: "hermes")
+    adapter = GrokAdapter()
+    plan = adapter.build_invocation(
+        prompt="p",
+        mode="workspace-write",
+        cwd=Path("/tmp"),
+        model=None,
+        task_id=None,
+        session_id=None,
+        tool_config=None,
+    )
+
+    cmd = plan.cmd
+    assert "--yolo" in cmd
+    toolsets = cmd[cmd.index("-t") + 1]
+    assert toolsets == "web,file,terminal,code_execution,todo"
+
+
+def test_build_invocation_danger(monkeypatch) -> None:
+    monkeypatch.setattr("agent_runtime.adapters.grok.shutil.which", lambda _: "hermes")
+    adapter = GrokAdapter()
+    plan = adapter.build_invocation(
+        prompt="p",
+        mode="danger",
+        cwd=Path("/tmp"),
+        model=None,
+        task_id=None,
+        session_id=None,
+        tool_config=None,
+    )
+
+    toolsets = plan.cmd[plan.cmd.index("-t") + 1]
+    assert "memory" in toolsets
+    assert "skills" in toolsets
+
+
+def test_model_override(monkeypatch) -> None:
+    monkeypatch.setattr("agent_runtime.adapters.grok.shutil.which", lambda _: "hermes")
+    adapter = GrokAdapter()
+    plan = adapter.build_invocation(
+        prompt="p",
+        mode="read-only",
+        cwd=Path("/tmp"),
+        model="grok-4-fast",
+        task_id=None,
+        session_id=None,
+        tool_config=None,
+    )
+
+    assert plan.cmd[plan.cmd.index("-m") + 1] == "grok-4-fast"
+
+
+def test_parse_response_strips_hermes_banner() -> None:
+    adapter = GrokAdapter()
+    result = adapter.parse_response(
+        stdout="💡 Python project detected. Run with hermes -z.\n\nAnswer",
+        stderr="",
+        returncode=0,
+        output_file=None,
+        plan=None,
+        call_start_time=None,
+    )
+
+    assert result.ok is True
+    assert result.response == "Answer"
+
+
+def test_parse_response_detects_rate_limit() -> None:
+    adapter = GrokAdapter()
+    result = adapter.parse_response(
+        stdout="",
+        stderr="rate limit exceeded",
+        returncode=1,
+        output_file=None,
+        plan=None,
+        call_start_time=None,
+    )
+
+    assert result.rate_limited is True
+    assert result.ok is False


### PR DESCRIPTION
## Changes
- Extend `scripts/dispatch_smart.py` `SUPPORTED_AGENTS` to include `deepseek` and `gemini`.
- Add default `deepseek`/`gemini` model mappings for `search`, `edit`, `draft`, `review`, `architect` task classes.
- Add `tests/test_grok_adapter.py` mirroring `tests/test_deepseek_adapter.py` with Grok-specific expectations.

## Smoke checks
- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/dispatch_smart.py review --agent deepseek --dry-run "test"` -> `model=deepseek-v4-pro`
- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/dispatch_smart.py search --agent gemini --dry-run "test"` -> `model=gemini-3.1-flash-lite-preview`

## Tests
- `PYTHONPATH=./scripts /Users/krisztiankoos/projects/kubedojo/.venv/bin/pytest tests/test_grok_adapter.py tests/test_deepseek_adapter.py tests/test_agent_runtime_runner.py tests/test_quality_dispatchers.py -q` (35 passed)
