### PR TITLE
fix(deepseek): detect unfulfilled tool-use intent in parse_response (PR #1288 first-prod finding)

### DIFF
--- a/scripts/agent_runtime/adapters/deepseek.py
+++ b/scripts/agent_runtime/adapters/deepseek.py
@@ -28,6 +28,11 @@ factual claims (mirrors gemini hallucination policy per
 [[feedback_gemini_hallucinates_anchors]]). Flash is 3× faster than Pro;
 suited for plan / architect / UK translation lanes.
 
+In read-only mode, DeepSeek runs with a restricted Hermes toolset (web-only). If
+the model emits unfulfilled tool-use intent (e.g. ``<bash>`` blocks), the returned
+text is a non-executable stub and not a useful review. See
+``feedback_ds_pro_review_needs_workspace_write.md``.
+
 Status flagged for the user:
 - DeepSeek adds a second cheap/fast lane (V4 Flash) while preserving Pro for
   high-value review roles.
@@ -56,6 +61,10 @@ _RATE_LIMIT_PATTERNS = (
     r"\b429\b",
 )
 _RATE_LIMIT_RE = re.compile("|".join(_RATE_LIMIT_PATTERNS), re.IGNORECASE)
+_TOOL_USE_INTENT_RE = re.compile(
+    r"<\s*(bash|tool_use|tool|terminal|shell)\b[^>]*>",
+    re.IGNORECASE,
+)
 
 # Hermes startup warnings we strip before declaring success.
 _HERMES_BANNER_RE = re.compile(
@@ -208,6 +217,23 @@ class DeepSeekAdapter:
 
         # Strip hermes banners that aren't part of the response.
         clean_stdout = _HERMES_BANNER_RE.sub("", stdout or "").strip()
+        tool_use_unfulfilled = bool(_TOOL_USE_INTENT_RE.search(clean_stdout))
+
+        if tool_use_unfulfilled and len(clean_stdout) < 1000:
+            return ParseResult(
+                ok=False,
+                response="",
+                stderr_excerpt=(
+                    "DS Pro returned tool-use intent without execution "
+                    f"({len(clean_stdout)} chars). The hermes toolset for this mode "
+                    "doesn't include the requested tool. For DS Pro reviews, re-dispatch "
+                    "with --mode workspace-write (grants terminal/file tools), or fall "
+                    "back to grok/claude. Raw stub: " + clean_stdout[:200]
+                ),
+                rate_limited=False,
+                session_id=None,
+                tokens=None,
+            )
 
         combined = f"{clean_stdout}\n{stderr or ''}"
         rate_limited = bool(_RATE_LIMIT_RE.search(combined))

--- a/tests/test_deepseek_adapter.py
+++ b/tests/test_deepseek_adapter.py
@@ -115,3 +115,42 @@ def test_parse_response_detects_rate_limit() -> None:
 
     assert result.rate_limited is True
     assert result.ok is False
+
+
+def test_parse_response_detects_unfulfilled_tool_use_intent() -> None:
+    """DS Pro tool-use intent without execution → ok=False, helpful stderr."""
+    adapter = DeepSeekAdapter()
+    raw = (
+        "I'll verify the PR commits first and then systematically review the diff.\n"
+        "<bash>gh pr view 1288 --json commits</bash>"
+    )
+    result = adapter.parse_response(
+        stdout=raw,
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+
+    assert result.ok is False
+    assert result.response == ""
+    assert "tool-use intent" in (result.stderr_excerpt or "")
+    assert "workspace-write" in (result.stderr_excerpt or "")
+
+
+def test_parse_response_long_response_with_bash_codeblock_still_passes() -> None:
+    """A long real review that happens to quote <bash> in a code block must pass."""
+    adapter = DeepSeekAdapter()
+    raw = (
+        "VERDICT: APPROVE\n\n"
+        + "SUMMARY: All criteria met. " * 40
+        + "\n\nThe author also added the `<bash>` toolset gating which is correct."
+    )
+    result = adapter.parse_response(
+        stdout=raw,
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+
+    assert result.ok is True
+    assert result.response.startswith("VERDICT: APPROVE")


### PR DESCRIPTION
This patch implements Route A for DS Pro review degradation: when DeepSeek emits an unfulfilled tool-use stub (for example <bash> in read-only mode), DeepSeekAdapter.parse_response now detects the pattern and marks the result as unsuccessful with a clear stderr hint to re-dispatch with --mode workspace-write or fall back to grok/claude, instead of incorrectly returning a short pseudo-review. Tests include coverage for the new short-intent failure path and a long-review pass-through case that still tolerates <bash> mentions. This is based on PR #1288 first-prod-use evidence documented in feedback_ds_pro_review_needs_workspace_write.md.