### PR TITLE
fix(services-up): always resolve REPO_ROOT to primary tree + kill orphan APIs

### DIFF
--- a/scripts/services-up
+++ b/scripts/services-up
@@ -4,9 +4,25 @@
 # every session.
 #
 # Usage: scripts/services-up [--api-only | --workers-only]
+#
+# REPO_ROOT always resolves to the primary working tree, even when this script
+# is invoked from inside a git worktree (`.worktrees/<name>/`). Otherwise the
+# API would start with cwd inside the worktree; removing the worktree would
+# orphan the API process with a dangling repo_root — manifested as /artifacts/*
+# returning 404 for every file. Recurring footgun; see session-24 handoff.
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GIT_COMMON_DIR="$(git -C "$SCRIPT_DIR" rev-parse --git-common-dir 2>/dev/null || echo "")"
+if [ -n "$GIT_COMMON_DIR" ]; then
+  case "$GIT_COMMON_DIR" in
+    /*) ABS_GIT_COMMON_DIR="$GIT_COMMON_DIR" ;;
+    *)  ABS_GIT_COMMON_DIR="$(cd "$SCRIPT_DIR" && cd "$GIT_COMMON_DIR" && pwd)" ;;
+  esac
+  REPO_ROOT="$(dirname "$ABS_GIT_COMMON_DIR")"
+else
+  REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+fi
 cd "$REPO_ROOT"
 
 VENV_PY="$REPO_ROOT/.venv/bin/python"
@@ -57,13 +73,55 @@ is_alive() {
   kill -0 "$pid" 2>/dev/null
 }
 
+# Detect and kill any API process that is NOT running with the primary repo
+# tree as cwd. Two recurring failure modes:
+#   1. Worktree orphan — started inside .worktrees/<name>, that worktree later
+#      removed, API kept running with a dangling repo_root that 404s
+#      /artifacts/* for everything.
+#   2. Wrong-tree orphan — started from a different project (e.g. inherited
+#      cwd from a sibling Claude Code session), serving stale state.
+# The recorded pid in .pids/api.pid may not point at the orphan (the pid file
+# gets clobbered when multiple worktrees ran services-up), so scan all python
+# processes that match the local_api.py argv signature.
+kill_orphan_api() {
+  local found=0
+  # Match on argv: local_api.py running --port 8768. Avoids killing a peer
+  # project's local_api.py on a different port.
+  for pid in $(pgrep -f "local_api.py.*--port 8768" 2>/dev/null); do
+    local cwd
+    cwd="$(lsof -p "$pid" -d cwd -Fn 2>/dev/null | awk '/^n/ {sub(/^n/,""); print; exit}')"
+    if [ -z "$cwd" ]; then
+      continue
+    fi
+    if [ "$cwd" != "$REPO_ROOT" ]; then
+      echo "api: orphan pid=$pid cwd=$cwd (expected $REPO_ROOT) — killing" >&2
+      kill "$pid" 2>/dev/null || true
+      found=1
+    fi
+  done
+  if [ "$found" -eq 1 ]; then
+    sleep 1
+  fi
+}
+
 start_api() {
+  kill_orphan_api
   if is_alive .pids/api.pid; then
-    echo "api: already running (pid $(cat .pids/api.pid))"
-    return
+    local recorded_pid
+    recorded_pid=$(cat .pids/api.pid 2>/dev/null || true)
+    local recorded_cwd
+    recorded_cwd="$(lsof -p "$recorded_pid" -d cwd -Fn 2>/dev/null | awk '/^n/ {sub(/^n/,""); print; exit}')"
+    if [ -n "$recorded_cwd" ] && [[ "$recorded_cwd" == *"/.worktrees/"* ]]; then
+      echo "api: recorded pid $recorded_pid is in worktree ($recorded_cwd) — killing + restarting" >&2
+      kill "$recorded_pid" 2>/dev/null || true
+      sleep 1
+    else
+      echo "api: already running (pid $recorded_pid)"
+      return
+    fi
   fi
   launch_detached .pids/api.pid logs/api.log \
-    "$VENV_PY" scripts/local_api.py --host 127.0.0.1 --port 8768
+    "$VENV_PY" scripts/local_api.py --host 127.0.0.1 --port 8768 --repo-root "$REPO_ROOT"
   sleep 1
   if is_alive .pids/api.pid; then
     echo "api: started (pid $(cat .pids/api.pid))"


### PR DESCRIPTION
## Summary

Recurring footgun: when `services-up` is invoked from a worktree (`.worktrees/<name>/scripts/services-up`), it computed `REPO_ROOT` from `dirname $0` and started the API with cwd inside the worktree. Removing the worktree later orphaned the API with a dangling `repo_root` → `/artifacts/*` returned 404 for every file even though `/api/orient` and `/api/briefing/session` kept working.

Hit again this morning (session 24): pid 3701 was orphaned with cwd at `.worktrees/gap-1300-cloud-custodian/` after that worktree was removed.

## Changes

1. **REPO_ROOT from `git rev-parse --git-common-dir`** — returns the primary `.git` regardless of which worktree the script lives in. Verified both primary and worktree invocations resolve to `/Users/krisztiankoos/projects/kubedojo`.
2. **`kill_orphan_api` helper** — `pgrep -f 'local_api.py.*--port 8768'` scans all matching processes, checks each one's cwd via lsof, kills any whose cwd ≠ `$REPO_ROOT`. Catches both worktree-orphans AND wrong-tree orphans (API inheriting cwd from a sibling Claude Code session in a peer project — also seen this morning, pid 19743 cwd=learn-ukrainian).
3. **`start_api` checks recorded pid's cwd** before trusting `.pids/api.pid` — kills + restarts if the recorded pid is in a worktree. Otherwise stale `.pids/api.pid` would prevent restart.
4. **`local_api.py --repo-root "$REPO_ROOT"` is now passed explicitly** so even if cwd somehow drifts, the artifact resolver locks to the primary tree.

## Verification

Tested end-to-end this session:
- Started two stale APIs from wrong cwds (pid 3701 cwd=removed-worktree; pid 19743 cwd=learn-ukrainian).
- Ran fixed `services-up --api-only` from `.worktrees/services-up-fix/`.
- Orphan-detection killed both stale APIs.
- New API started with cwd=primary, pid 31486, explicit `--repo-root /Users/krisztiankoos/projects/kubedojo`.
- `/artifacts/docs/session-state/2026-05-18-session-24-T1-three-merged.html` → HTTP 200, 17783 bytes.
- `/api/orient`, `/api/briefing/session`, `/artifacts` index all 200.

## Test plan

- [ ] Future cold-starts from any worktree should keep API rooted at primary.
- [ ] After `git worktree remove`, next services-up call kills the orphan automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)