### PR TITLE
fix(local_api): decision-card filter + FTS cache + pending-card thread summary (#1290 + #1291 + #1292)

### DIFF
--- a/scripts/local_api/routes/channels.py
+++ b/scripts/local_api/routes/channels.py
@@ -11,12 +11,14 @@ from typing import Any, Callable
 from urllib.parse import parse_qs, unquote
 
 try:
+    from local_api.routes.decisions import _is_decision_card
     from local_api.routes.ui_fragments import (
         AFK_NOTIFY_CSS,
         render_afk_notify_markup,
         render_search_widget,
     )
 except ModuleNotFoundError:
+    from scripts.local_api.routes.decisions import _is_decision_card
     from scripts.local_api.routes.ui_fragments import (
         AFK_NOTIFY_CSS,
         render_afk_notify_markup,
@@ -146,9 +148,15 @@ def find_decision_id_for_thread(repo_root: Path, thread_id: str) -> str | None:
     decisions_dir = repo_root / "docs" / "decisions"
     if not thread_id or not decisions_dir.exists():
         return None
-    for path in sorted(decisions_dir.glob("*.md")):
+    decision_paths = [
+        path
+        for pattern in ("*.md", "pending/*.md")
+        for path in sorted(decisions_dir.glob(pattern))
+        if _is_decision_card(path)
+    ]
+    for path in decision_paths:
         if thread_id in _decision_frontmatter_or_first_section(path):
-            return path.relative_to(repo_root).as_posix()
+            return path.relative_to(decisions_dir).as_posix()
     return None
 
 

--- a/scripts/local_api/routes/decisions.py
+++ b/scripts/local_api/routes/decisions.py
@@ -37,6 +37,7 @@ _PR_RE = _re.compile(r"\(#(\d+)\)")
 _ISSUE_REF_RE = _re.compile(r"#(\d+)")
 _PHASE_CELL_RE = _re.compile(r"^\|\s*(D\d+)\s*\|")
 _SAFE_DECISION_FILENAME_RE = _re.compile(r"^[A-Za-z0-9._-]+\.md$")
+_DECISION_CARD_RE = _re.compile(r"^\d{4}-\d{2}-\d{2}-.+\.md$")
 _STALE_SECONDS = 24 * 3600
 _CACHE_VERSION = 6
 _CACHE_LOCK = threading.Lock()
@@ -176,6 +177,10 @@ def _status_for_path(rel_path: str, mtime: float) -> str:
     return "decided"
 
 
+def _is_decision_card(path: Path) -> bool:
+    return bool(_DECISION_CARD_RE.match(path.name))
+
+
 def _lineage_from_commits(commits: list[dict[str, str]]) -> dict[str, list[dict[str, str]]]:
     prs: dict[str, dict[str, str]] = {}
     for commit in commits:
@@ -273,10 +278,10 @@ def _decision_files(repo_root: Path) -> list[Path]:
     decisions_dir = repo_root / "docs" / "decisions"
     files: list[Path] = []
     if decisions_dir.exists():
-        files.extend(sorted(decisions_dir.glob("*.md")))
+        files.extend(path for path in sorted(decisions_dir.glob("*.md")) if _is_decision_card(path))
     pending_dir = decisions_dir / "pending"
     if pending_dir.exists():
-        files.extend(sorted(pending_dir.glob("*.md")))
+        files.extend(path for path in sorted(pending_dir.glob("*.md")) if _is_decision_card(path))
     return files
 
 
@@ -338,7 +343,7 @@ def _refresh_decisions_fts(
                 except OSError:
                     continue
                 filename = path.name
-                if meta.get(filename) == mtime:
+                if meta.get(filename) == mtime and filename in existing_names:
                     continue
                 try:
                     body = path.read_text(encoding="utf-8")
@@ -419,6 +424,8 @@ def build_pending_decisions(repo_root: Path) -> dict[str, Any]:
     pending = 0
     if pending_dir.exists():
         for path in sorted(pending_dir.glob("*.md")):
+            if not _is_decision_card(path):
+                continue
             try:
                 rel = path.relative_to(repo_root).as_posix()
                 mtime = path.stat().st_mtime

--- a/tests/test_channel_summary_parse_votes.py
+++ b/tests/test_channel_summary_parse_votes.py
@@ -41,3 +41,18 @@ def test_vote_regex_extracts_last_structured_vote() -> None:
 
     for body, expected in cases:
         assert channels_route.extract_thread_vote(body) == expected
+
+
+def test_channel_summary_includes_pending_decision_link(tmp_path: Path) -> None:
+    pending_card = tmp_path / "docs/decisions/pending/2026-05-17-test.md"
+    pending_card.parent.mkdir(parents=True, exist_ok=True)
+    pending_card.write_text("**Thread:** ab-discuss-test-123\n# pending card", encoding="utf-8")
+
+    payload = channels_route.build_channel_thread_summary(
+        tmp_path,
+        "ab-discuss-test-123",
+        resolve_bridge_db_path_fn=lambda repo_root: repo_root / ".bridge" / "messages.db",
+        query_sqlite_rows_fn=lambda *args, **kwargs: [],
+    )
+
+    assert payload["decision_id"] == "pending/2026-05-17-test.md"

--- a/tests/test_decision_stale_detection.py
+++ b/tests/test_decision_stale_detection.py
@@ -35,7 +35,7 @@ def test_missing_pending_dir_returns_zero_counts(tmp_path: Path) -> None:
 def test_pending_decision_older_than_24h_is_stale(tmp_path: Path) -> None:
     pending_dir = tmp_path / "docs" / "decisions" / "pending"
     pending_dir.mkdir(parents=True)
-    decision = pending_dir / "test.md"
+    decision = pending_dir / "2026-05-17-test.md"
     decision.write_text("# Pending\n\n**Thread:** `a82ab60b4ce1457aa450f18dac7e8a54`\n", encoding="utf-8")
     old = time.time() - (25 * 3600)
     os.utime(decision, (old, old))
@@ -50,7 +50,7 @@ def test_pending_decision_older_than_24h_is_stale(tmp_path: Path) -> None:
 
     status, lineage, _ = decisions.route_decision_api_request(
         tmp_path,
-        "/api/decision/test.md/lineage",
+        "/api/decision/2026-05-17-test.md/lineage",
     )
     assert status == 200
     assert lineage["status"] == "stale"
@@ -59,7 +59,7 @@ def test_pending_decision_older_than_24h_is_stale(tmp_path: Path) -> None:
 def test_decisions_index_shows_banner_for_stale_pending_file(tmp_path: Path) -> None:
     pending_dir = tmp_path / "docs" / "decisions" / "pending"
     pending_dir.mkdir(parents=True)
-    decision = pending_dir / "test.md"
+    decision = pending_dir / "2026-05-17-test.md"
     decision.write_text("# Pending\n", encoding="utf-8")
     old = time.time() - (25 * 3600)
     os.utime(decision, (old, old))

--- a/tests/test_search_fts_decisions.py
+++ b/tests/test_search_fts_decisions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sqlite3
 import sys
 import time
 from pathlib import Path
@@ -15,15 +16,15 @@ def test_decisions_fts_indexes_and_refreshes_only_touched_file(tmp_path: Path) -
     decisions_dir = tmp_path / "docs" / "decisions"
     pending_dir = decisions_dir / "pending"
     pending_dir.mkdir(parents=True)
-    first = decisions_dir / "first.md"
-    second = pending_dir / "second.md"
+    first = decisions_dir / "2026-05-17-first.md"
+    second = pending_dir / "2026-05-17-second.md"
     first.write_text("# First Decision\n\nsharedterm alpha\n", encoding="utf-8")
     second.write_text("# Second Decision\n\nsharedterm beta\n", encoding="utf-8")
 
     decisions._DECISIONS_FTS_META.clear()
     refreshed = decisions._refresh_decisions_fts(tmp_path, db_path=db_path)
     assert refreshed["scanned"] == 2
-    assert set(refreshed["updated"]) == {"first.md", "second.md"}
+    assert set(refreshed["updated"]) == {"2026-05-17-first.md", "2026-05-17-second.md"}
 
     status, payload, _ = search_route.build_search_payload(
         tmp_path,
@@ -31,13 +32,16 @@ def test_decisions_fts_indexes_and_refreshes_only_touched_file(tmp_path: Path) -
         bridge_db_path=db_path,
     )
     assert status == 200
-    assert {item["filename"] for item in payload["results"]} == {"first.md", "second.md"}
+    assert {item["filename"] for item in payload["results"]} == {
+        "2026-05-17-first.md",
+        "2026-05-17-second.md",
+    }
 
     first.write_text("# First Decision Updated\n\nsharedterm updatedunique\n", encoding="utf-8")
     new_mtime = time.time() + 10
     os.utime(first, (new_mtime, new_mtime))
     refreshed = decisions._refresh_decisions_fts(tmp_path, db_path=db_path)
-    assert refreshed["updated"] == ["first.md"]
+    assert refreshed["updated"] == ["2026-05-17-first.md"]
     assert refreshed["deleted"] == []
 
     status, payload, _ = search_route.build_search_payload(
@@ -46,5 +50,74 @@ def test_decisions_fts_indexes_and_refreshes_only_touched_file(tmp_path: Path) -
         bridge_db_path=db_path,
     )
     assert status == 200
-    assert [item["filename"] for item in payload["results"]] == ["first.md"]
+    assert [item["filename"] for item in payload["results"]] == ["2026-05-17-first.md"]
     assert payload["results"][0]["title"] == "First Decision Updated"
+
+
+def test_decision_scanners_ignore_sidecar_readme_and_template(tmp_path: Path, monkeypatch) -> None:
+    decisions_dir = tmp_path / "docs" / "decisions"
+    pending = decisions_dir / "pending"
+    pending.mkdir(parents=True)
+    (decisions_dir / "README.md").write_text("sidecartoken not a card", encoding="utf-8")
+    (decisions_dir / "_template.md").write_text("sidecartoken not a card", encoding="utf-8")
+    (decisions_dir / "2026-05-17-real-card.md").write_text("# real card", encoding="utf-8")
+    (pending / "README.md").write_text("sidecartoken not a card", encoding="utf-8")
+    (pending / "2026-05-17-pending-card.md").write_text("# pending", encoding="utf-8")
+
+    pending_result = decisions.build_pending_decisions(tmp_path)
+    index_result = decisions.build_decisions_index(tmp_path)
+
+    pending_names = {Path(f["decision_path"]).name for f in pending_result["files"]}
+    assert "README.md" not in pending_names
+    assert "_template.md" not in pending_names
+    assert pending_names == {"2026-05-17-pending-card.md"}
+
+    index_names = {item["filename"] for item in index_result["decisions"]}
+    assert index_names == {"2026-05-17-real-card.md", "2026-05-17-pending-card.md"}
+
+    db_path = tmp_path / "messages.db"
+    decisions._DECISIONS_FTS_META.clear()
+    decisions._refresh_decisions_fts(tmp_path, db_path=db_path)
+    status, payload, _ = search_route.build_search_payload(
+        tmp_path,
+        {"q": ["sidecartoken"], "kind": ["decisions"], "limit": ["10"]},
+        bridge_db_path=db_path,
+    )
+    assert status == 200
+    assert payload["results"] == []
+
+
+def test_refresh_decisions_fts_repopulates_after_db_recreated(tmp_path: Path) -> None:
+    db_path = tmp_path / "messages.db"
+    decisions_dir = tmp_path / "docs" / "decisions"
+    decisions_dir.mkdir(parents=True)
+    card = decisions_dir / "2026-05-17-cache-card.md"
+    card.write_text("# Cache Card\n\ncardtoken survives db recreation\n", encoding="utf-8")
+
+    decisions._DECISIONS_FTS_META.clear()
+    decisions._refresh_decisions_fts(tmp_path, db_path=db_path)
+    status, payload, _ = search_route.build_search_payload(
+        tmp_path,
+        {"q": ["cardtoken"], "kind": ["decisions"], "limit": ["10"]},
+        bridge_db_path=db_path,
+    )
+    assert status == 200
+    assert payload["results"] != []
+
+    db_path.unlink()
+    db_path.touch()
+    conn = sqlite3.connect(db_path)
+    try:
+        decisions.setup_decisions_fts(conn)
+        conn.commit()
+    finally:
+        conn.close()
+
+    decisions._refresh_decisions_fts(tmp_path, db_path=db_path)
+    status, payload, _ = search_route.build_search_payload(
+        tmp_path,
+        {"q": ["cardtoken"], "kind": ["decisions"], "limit": ["10"]},
+        bridge_db_path=db_path,
+    )
+    assert status == 200
+    assert payload["results"] != []

--- a/tests/test_search_kind_filter.py
+++ b/tests/test_search_kind_filter.py
@@ -13,7 +13,7 @@ from local_api.routes import decisions, search as search_route
 def _seed_search_corpus(repo_root: Path, db_path: Path) -> None:
     decisions_dir = repo_root / "docs" / "decisions"
     decisions_dir.mkdir(parents=True)
-    (decisions_dir / "choice.md").write_text(
+    (decisions_dir / "2026-05-17-choice.md").write_text(
         "# Searchable Decision\n\nfiltertoken in decision body\n",
         encoding="utf-8",
     )


### PR DESCRIPTION
Closes #1290, closes #1291, closes #1292.

Fixes:
- #1290: filters live decision-card scanners to date-slug markdown cards only, excluding README/_template sidecars from pending/index/FTS. Regression: test_decision_scanners_ignore_sidecar_readme_and_template.
- #1291: refreshes a cached decision FTS file when its row is missing from the current SQLite database after DB recreation. Regression: test_refresh_decisions_fts_repopulates_after_db_recreated.
- #1292: includes pending decision cards when resolving channel thread summaries and returns docs/decisions-relative IDs. Regression: test_channel_summary_includes_pending_decision_link.

Verification:
- ../../.venv/bin/python -m pytest tests/ -k "decision" -x
- ../../.venv/bin/python -m ruff check scripts/local_api/routes/decisions.py scripts/local_api/routes/channels.py
- ../../.venv/bin/python -m ruff check scripts/local_api/routes/decisions.py scripts/local_api/routes/channels.py tests/test_channel_summary_parse_votes.py tests/test_decision_stale_detection.py tests/test_search_fts_decisions.py tests/test_search_kind_filter.py
- ../../.venv/bin/python scripts/test_pipeline.py
- git diff --check