### PR TITLE
fix(quality): Russicism uppercase + CLI missing-path exit + prose-prefixed fence unwrap (#1293 + #1294 + #1295)

### DIFF
--- a/scripts/quality/check_citations.py
+++ b/scripts/quality/check_citations.py
@@ -233,7 +233,7 @@ def check_file(path: Path) -> list[CitationCheck]:
     return out
 
 
-def iter_target_files(args: argparse.Namespace) -> Iterable[Path]:
+def iter_target_files(args: argparse.Namespace, missing_paths: list[Path]) -> Iterable[Path]:
     if args.all_ml:
         for d in ML_DIRS:
             if not d.exists():
@@ -247,6 +247,7 @@ def iter_target_files(args: argparse.Namespace) -> Iterable[Path]:
         path = Path(p).resolve()
         if not path.exists():
             print(f"warning: {path} does not exist", file=sys.stderr)
+            missing_paths.append(path)
             continue
         yield path
 
@@ -270,8 +271,13 @@ def main(argv: list[str] | None = None) -> int:
     if not args.paths and not args.all_ml:
         parser.error("provide one or more paths, or pass --all-ml")
 
+    explicit_path_mode = bool(args.paths) and not args.all_ml
+    missing_paths: list[Path] = []
+    files_checked = 0
+
     all_results: list[CitationCheck] = []
-    for path in iter_target_files(args):
+    for path in iter_target_files(args, missing_paths):
+        files_checked += 1
         all_results.extend(check_file(path))
 
     if args.json_output:
@@ -303,6 +309,12 @@ def main(argv: list[str] | None = None) -> int:
     failures = [r for r in all_results if not r.ok]
     if failures:
         print(f"\n{len(failures)} citation(s) failed verification.", file=sys.stderr)
+        return 1
+    if explicit_path_mode and files_checked == 0:
+        print("\nNo existing files were checked.", file=sys.stderr)
+        return 1
+    if missing_paths:
+        print(f"\n{len(missing_paths)} provided path(s) were missing.", file=sys.stderr)
         return 1
     print(f"\nAll {len(all_results)} citation(s) verified.", file=sys.stderr)
     return 0

--- a/scripts/quality/check_code_blocks.py
+++ b/scripts/quality/check_code_blocks.py
@@ -175,11 +175,15 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     all_results: list[BlockCheck] = []
+    missing_paths: list[Path] = []
+    files_checked = 0
     for p in args.paths:
         path = Path(p).resolve()
         if not path.exists():
             print(f"warning: {path} does not exist", file=sys.stderr)
+            missing_paths.append(path)
             continue
+        files_checked += 1
         all_results.extend(check_file(path, args.imports_only))
 
     if args.json_output:
@@ -203,6 +207,12 @@ def main(argv: list[str] | None = None) -> int:
             f"\n{len(failures)} of {len(all_results)} block(s) failed.",
             file=sys.stderr,
         )
+        return 1
+    if files_checked == 0:
+        print("\nNo existing files were checked.", file=sys.stderr)
+        return 1
+    if missing_paths:
+        print(f"\n{len(missing_paths)} provided path(s) were missing.", file=sys.stderr)
         return 1
     print(
         f"\nAll {len(all_results)} python block(s) parsed cleanly.",

--- a/scripts/quality/check_uk_changed.py
+++ b/scripts/quality/check_uk_changed.py
@@ -7,6 +7,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import importlib
 import re
 import sys
 from pathlib import Path
@@ -15,9 +16,9 @@ SCRIPTS_DIR = Path(__file__).resolve().parents[1]
 if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
-from checks import ukrainian
+ukrainian = importlib.import_module("checks.ukrainian")
 
-RUSSIAN_ONLY_CHARS_RE = re.compile(r"[ыёъэ]")
+RUSSIAN_ONLY_CHARS_RE = re.compile(r"[ыёъэ]", re.IGNORECASE)
 
 
 def _check_file_for_russian_chars(path: Path) -> list[str]:

--- a/scripts/quality/extractors.py
+++ b/scripts/quality/extractors.py
@@ -123,30 +123,34 @@ def extract_module_markdown(raw: str) -> ModuleExtract:
 def _unwrap_outer_fence(raw: str) -> tuple[str, bool]:
     """Strip a surrounding ``` fence if the module is wholly inside one.
 
-    Heuristic: the first non-empty line after an optional prose prefix is
-    ``` or ```<lang>, and a matching ``` exists near the end of input.
-    Anything between them is the module. If no such fence structure is
-    present, returns the input unchanged.
+    Heuristic: skip optional prose, then unwrap the first ``` or ```markdown
+    fence whose body contains titled frontmatter. The closing fence is the
+    last ``` after the opener so fenced code blocks inside the module body do
+    not prematurely terminate the outer wrapper.
     """
     lines = raw.splitlines()
-    # Find first non-empty line — must be a fence to trigger unwrap.
-    i = 0
-    while i < len(lines) and not lines[i].strip():
-        i += 1
-    if i >= len(lines):
-        return raw, False
-    first = lines[i].strip()
-    if not first.startswith("```"):
-        return raw, False
-
-    # Find the last ``` in the input — paired with the opener if the
-    # interior contains the rest of the module. Naive: last non-empty
-    # line that is exactly ``` wins.
-    for j in range(len(lines) - 1, i, -1):
-        if lines[j].strip() == "```":
+    for i, line in enumerate(lines):
+        if line.strip().lower() not in {"```", "```markdown"}:
+            continue
+        for j in range(len(lines) - 1, i, -1):
+            if lines[j].strip() != "```":
+                continue
             inside = "\n".join(lines[i + 1 : j])
-            return inside, True
+            if _contains_titled_frontmatter(inside):
+                return inside, True
+            break
     return raw, False
+
+
+def _contains_titled_frontmatter(text: str) -> bool:
+    lines = text.splitlines()
+    start = _find_frontmatter_start(lines)
+    if start < 0:
+        return False
+    end = _find_frontmatter_end(lines, start)
+    if end < 0:
+        return False
+    return _extract_title(lines[start + 1 : end]) is not None
 
 
 def _find_frontmatter_start(lines: list[str]) -> int:

--- a/tests/test_check_citations.py
+++ b/tests/test_check_citations.py
@@ -13,8 +13,26 @@ def _load_check_citations():
     return module
 
 
+def _load_quality_check_citations():
+    module_path = (
+        Path(__file__).resolve().parent.parent
+        / "scripts"
+        / "quality"
+        / "check_citations.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "quality_check_citations_test", module_path
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
 check_citations = _load_check_citations()
 check_file = check_citations.check_file
+quality_check_citations = _load_quality_check_citations()
 
 
 def test_check_citations_passes_with_sources_and_war_story_source(tmp_path: Path) -> None:
@@ -61,3 +79,54 @@ def test_check_citations_fails_without_sources_section(tmp_path: Path) -> None:
     assert result["passes"] is False
     assert "missing_sources_section" in result["issues"]
     assert "war_story_missing_source_line" in result["issues"]
+
+
+def test_quality_check_citations_missing_explicit_path_returns_nonzero(
+    tmp_path: Path, capsys
+) -> None:
+    missing = tmp_path / "does-not-exist.md"
+
+    result = quality_check_citations.main([str(missing)])
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert f"warning: {missing.resolve()} does not exist" in captured.err
+    assert "No existing files were checked." in captured.err
+
+
+def test_quality_check_citations_mixed_valid_and_missing_returns_nonzero(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    valid = tmp_path / "module.md"
+    missing = tmp_path / "missing.md"
+    valid.write_text(
+        """# Demo
+
+## Sources
+
+- [Example](https://example.com/story)
+""",
+        encoding="utf-8",
+    )
+
+    def fake_check_url(url: str):
+        return quality_check_citations.CitationCheck(
+            file="",
+            url=url,
+            status=200,
+            final_url=url,
+            final_host="example.com",
+            original_host="example.com",
+            ok=True,
+            error=None,
+        )
+
+    monkeypatch.setattr(quality_check_citations, "check_url", fake_check_url)
+
+    result = quality_check_citations.main([str(valid), str(missing)])
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "OK" in captured.out
+    assert f"warning: {missing.resolve()} does not exist" in captured.err
+    assert "1 provided path(s) were missing." in captured.err

--- a/tests/test_check_code_blocks.py
+++ b/tests/test_check_code_blocks.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_check_code_blocks():
+    module_path = (
+        Path(__file__).resolve().parent.parent
+        / "scripts"
+        / "quality"
+        / "check_code_blocks.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "quality_check_code_blocks_test", module_path
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+check_code_blocks = _load_check_code_blocks()
+
+
+def test_check_code_blocks_missing_explicit_path_returns_nonzero(
+    tmp_path: Path, capsys
+) -> None:
+    missing = tmp_path / "does-not-exist.md"
+
+    result = check_code_blocks.main([str(missing)])
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert f"warning: {missing.resolve()} does not exist" in captured.err
+    assert "No existing files were checked." in captured.err
+
+
+def test_check_code_blocks_mixed_valid_and_missing_returns_nonzero(
+    tmp_path: Path, capsys
+) -> None:
+    valid = tmp_path / "module.md"
+    missing = tmp_path / "missing.md"
+    valid.write_text(
+        """# Demo
+
+```python
+print("hello")
+```
+""",
+        encoding="utf-8",
+    )
+
+    result = check_code_blocks.main([str(valid), str(missing)])
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "OK" in captured.out
+    assert f"warning: {missing.resolve()} does not exist" in captured.err
+    assert "1 provided path(s) were missing." in captured.err

--- a/tests/test_check_uk_changed.py
+++ b/tests/test_check_uk_changed.py
@@ -1,16 +1,38 @@
 from __future__ import annotations
 
+import importlib.util
 import subprocess
-import shutil
+import sys
 from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SCRIPT = REPO_ROOT / "scripts" / "quality" / "check_uk_changed.py"
-_PYTHON = REPO_ROOT / ".venv" / "bin" / "python"
-if not _PYTHON.exists():
-    _PYTHON = Path(shutil.which("python") or "python")
-PYTHON = _PYTHON
+
+
+def _venv_python() -> Path:
+    candidates = [REPO_ROOT / ".venv" / "bin" / "python"]
+    if REPO_ROOT.parent.name == ".worktrees":
+        candidates.append(REPO_ROOT.parent.parent / ".venv" / "bin" / "python")
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return candidates[0]
+
+
+PYTHON = _venv_python()
+
+
+def _load_check_uk_changed():
+    spec = importlib.util.spec_from_file_location("check_uk_changed_test", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+check_uk_changed = _load_check_uk_changed()
 
 
 def _run(paths: list[Path]) -> subprocess.CompletedProcess[str]:
@@ -52,6 +74,24 @@ def test_check_uk_changed_reports_russian_only_character_position(tmp_path: Path
     assert result.returncode == 1
     assert "forbidden Russian-only character" in result.stdout
     assert f"{path}:3:" in result.stdout
+
+
+def test_check_uk_changed_reports_uppercase_russian_only_character_position(
+    tmp_path: Path,
+) -> None:
+    assert check_uk_changed.RUSSIAN_ONLY_CHARS_RE.search("ЫЁЪЭ") is not None
+    path = tmp_path / "module.md"
+    path.write_text(
+        """# Переклад
+
+Ы тут не має проходити.
+""",
+        encoding="utf-8",
+    )
+
+    result = _run([path])
+    assert result.returncode == 1
+    assert f"{path}:3:1: forbidden Russian-only character 'Ы'" in result.stdout
 
 
 def test_check_uk_changed_clean_file_passes(tmp_path: Path) -> None:

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.quality.extractors import extract_module_markdown
+
+
+def test_extract_module_markdown_unwraps_prose_prefixed_fenced_module() -> None:
+    result = extract_module_markdown(
+        """Here is the rewritten module:
+
+```markdown
+---
+title: Demo
+---
+
+Body.
+```
+"""
+    )
+
+    assert result.unwrapped_code_fence is True
+    assert result.text == "---\ntitle: Demo\n---\n\nBody.\n"


### PR DESCRIPTION
## Summary
- Fixes #1293: make `RUSSIAN_ONLY_CHARS_RE` case-insensitive while preserving the matched character in diagnostics. Regression: `test_check_uk_changed_reports_uppercase_russian_only_character_position`.
- Fixes #1294: make explicit missing paths and zero-files-checked explicit-path runs return nonzero in citation/code-block CLIs. Regressions: `test_quality_check_citations_missing_explicit_path_returns_nonzero`, `test_quality_check_citations_mixed_valid_and_missing_returns_nonzero`, `test_check_code_blocks_missing_explicit_path_returns_nonzero`, `test_check_code_blocks_mixed_valid_and_missing_returns_nonzero`.
- Fixes #1295: unwrap prose-prefixed outer markdown fences when the fenced body contains titled frontmatter. Regression: `test_extract_module_markdown_unwraps_prose_prefixed_fenced_module`.

## Verification
- `../../.venv/bin/pytest tests/test_check_uk_changed.py tests/test_check_citations.py tests/test_check_code_blocks.py tests/test_extractors.py -x 2>&1 | tail -30` — 11 passed
- `../../.venv/bin/python -m ruff check scripts/quality/check_uk_changed.py scripts/quality/check_citations.py scripts/quality/check_code_blocks.py scripts/quality/extractors.py` — passed
- `../../.venv/bin/python -m ruff check scripts/quality/check_uk_changed.py scripts/quality/check_citations.py scripts/quality/check_code_blocks.py scripts/quality/extractors.py tests/test_check_uk_changed.py tests/test_check_citations.py tests/test_check_code_blocks.py tests/test_extractors.py` — passed
- `../../.venv/bin/pytest tests/test_quality_extractors.py -q` — 27 passed
- `../../.venv/bin/python scripts/test_pipeline.py` — 170 tests OK

## Notes
- `npm run build` skipped: no `src/content/docs/` or Astro config changes.
- Diff: 8 files, +253/-29; no generated artifacts staged.
