### PR TITLE
ci(security): pin pip install zizmor to 1.25.2

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -30,7 +30,7 @@ jobs:
           persist-credentials: false
 
       - name: Install zizmor
-        run: pip install zizmor
+        run: pip install 'zizmor==1.25.2'
 
       - name: Run zizmor
         env:


### PR DESCRIPTION
## Summary

Follow-up to PR #1333. The calibration in PR #1335 surfaced a finding **codex missed** in the original review chain: `pip install zizmor` in `.github/workflows/zizmor.yml` was unpinned. 4 of 5 calibration candidates (qwen3.6-plus, qwen3.6-27b, moonshotai/kimi-k2.5, moonshotai/kimi-k2.6, z-ai/glm-5.1) flagged it; codex (gpt-5.5) approved PR #1333 without catching it.

## Risk if not fixed

PyPI takeover of the `zizmor` package would execute attacker code on every PR with workflow changes, with `GITHUB_TOKEN` in the env. Scoped to `contents: read`, but on a public repo that's still all source. **Same supply-chain attack class** PR #1333 was defending against — irony noted by 4 calibration models.

## Change

`pip install zizmor` → `pip install 'zizmor==1.25.2'` (released 2026-05-16).

When zizmor releases new versions, Dependabot will propose the bump as a normal versioned update — subject to the `cooldown` configured in `dependabot.yml` (PR #1333).

## Verification

\`\`\`
uvx zizmor --offline --strict-collection .github/
→ No findings to report. Good job! (6 suppressed)
\`\`\`

## Test plan

- [ ] CI: zizmor workflow runs green on this PR (validates the pinned version actually installs and scans)
- [ ] Future: when 1.25.3 / 1.26 lands on PyPI, Dependabot opens a PR that updates this single line — review per the github-actions Dependabot PR review checklist in `.claude/rules/github-actions-security.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)