### PR TITLE
fix(adapters): guard _RATE_LIMIT_RE behind call-failed in claude/deepseek/qwen

### DIFF
--- a/scripts/agent_runtime/adapters/_template.py
+++ b/scripts/agent_runtime/adapters/_template.py
@@ -54,10 +54,23 @@ Issue: #1184
 from __future__ import annotations
 
 import shutil
+import re
 from pathlib import Path
 
 from ..result import ParseResult
 from .base import InvocationPlan
+
+_RATE_LIMIT_PATTERNS = (
+    r"rate limit",
+    r"rate_limit",
+    r"usage limit",
+    r"quota exceeded",
+    r"too many requests",
+    r"\bHTTP 429\b",
+    r"\bstatus 429\b",
+    r"\b429\b",
+)
+_RATE_LIMIT_RE = re.compile("|".join(_RATE_LIMIT_PATTERNS), re.IGNORECASE)
 
 
 class TemplateAdapter:
@@ -141,15 +154,15 @@ class TemplateAdapter:
 
         Template: replace with real output parsing.
         """
-        # 1. Detect rate-limiting. Use word-boundary patterns to avoid
-        #    URL false positives (e.g. "\\b429\\b" not bare "429").
-        rate_limited = any(
-            pattern in (stderr or "").lower()
-            for pattern in ("rate limit", "quota exceeded", "usage limit")
-        )
+        # 1. Detect rate-limiting only when output indicates an actual
+        #    CLI failure; pattern matches alone are not sufficient.
+        combined = f"{stdout}\n{stderr}"
+        pattern_hit = bool(_RATE_LIMIT_RE.search(combined))
+        call_failed = returncode != 0 or not stdout.strip()
+        rate_limited = pattern_hit and call_failed
 
         # 2. Classify success. Adjust the criteria to match your CLI.
-        ok = returncode == 0 and not rate_limited
+        ok = returncode == 0 and bool(stdout.strip()) and not rate_limited
 
         # 3. Build the response. Read from output_file if you used one,
         #    otherwise use stdout.

--- a/scripts/agent_runtime/adapters/claude.py
+++ b/scripts/agent_runtime/adapters/claude.py
@@ -216,7 +216,9 @@ class ClaudeAdapter:
 
         # Rate-limit detection across both streams
         combined = f"{stdout}\n{stderr}"
-        rate_limited = bool(_RATE_LIMIT_RE.search(combined))
+        pattern_hit = bool(_RATE_LIMIT_RE.search(combined))
+        call_failed = returncode != 0 or not stdout.strip()
+        rate_limited = pattern_hit and call_failed
 
         # Success classification
         ok = returncode == 0 and bool(stdout.strip()) and not rate_limited

--- a/scripts/agent_runtime/adapters/deepseek.py
+++ b/scripts/agent_runtime/adapters/deepseek.py
@@ -236,7 +236,9 @@ class DeepSeekAdapter:
             )
 
         combined = f"{clean_stdout}\n{stderr or ''}"
-        rate_limited = bool(_RATE_LIMIT_RE.search(combined))
+        pattern_hit = bool(_RATE_LIMIT_RE.search(combined))
+        call_failed = returncode != 0 or not bool(clean_stdout)
+        rate_limited = pattern_hit and call_failed
 
         ok = returncode == 0 and bool(clean_stdout) and not rate_limited
         response = clean_stdout if ok else ""

--- a/scripts/agent_runtime/adapters/qwen.py
+++ b/scripts/agent_runtime/adapters/qwen.py
@@ -233,7 +233,9 @@ class QwenAdapter:
             )
 
         combined = f"{clean_stdout}\n{stderr or ''}"
-        rate_limited = bool(_RATE_LIMIT_RE.search(combined))
+        pattern_hit = bool(_RATE_LIMIT_RE.search(combined))
+        call_failed = returncode != 0 or not bool(clean_stdout)
+        rate_limited = pattern_hit and call_failed
 
         ok = returncode == 0 and bool(clean_stdout) and not rate_limited
         response = clean_stdout if ok else ""

--- a/tests/test_adapter_rate_limit_guards.py
+++ b/tests/test_adapter_rate_limit_guards.py
@@ -1,0 +1,76 @@
+"""Rate-limit parser guard coverage for adapter dispatch responses."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+
+from agent_runtime.adapters.claude import ClaudeAdapter
+from agent_runtime.adapters.deepseek import DeepSeekAdapter
+from agent_runtime.adapters.qwen import QwenAdapter
+
+
+AdapterFactory = Callable[[], object]
+
+
+def _parse_success_case(
+    adapter_factory: AdapterFactory,
+    *,
+    stdout: str,
+    stderr: str,
+    returncode: int = 0,
+) -> None:
+    adapter = adapter_factory()
+    result = adapter.parse_response(
+        stdout=stdout,
+        stderr=stderr,
+        returncode=returncode,
+        output_file=None,
+    )
+    assert result.ok is True
+    assert result.rate_limited is False
+    assert result.response == stdout.strip() or result.response
+
+
+@pytest.mark.parametrize(
+    ("adapter_factory", "stdout", "stderr"),
+    [
+        (ClaudeAdapter, "In this answer we discuss rate limit tradeoffs for APIs.", ""),
+        (DeepSeekAdapter, "The response explains rate limit policy and mitigation patterns.", ""),
+        (QwenAdapter, "Clarification: rate limit handling is part of this summary.", ""),
+    ],
+    ids=["claude", "deepseek", "qwen"],
+)
+def test_adapter_parses_rate_limit_phrase_as_success_on_success_exit(
+    adapter_factory: AdapterFactory,
+    stdout: str,
+    stderr: str,
+) -> None:
+    _parse_success_case(adapter_factory, stdout=stdout, stderr=stderr, returncode=0)
+
+
+@pytest.mark.parametrize(
+    ("adapter_factory", "stdout", "stderr"),
+    [
+        (ClaudeAdapter, "", "HTTP 429: too many requests"),
+        (DeepSeekAdapter, "", "rate limit reached"),
+        (QwenAdapter, "", "rate limit reached"),
+    ],
+    ids=["claude", "deepseek", "qwen"],
+)
+def test_adapter_marks_rate_limited_when_call_fails(
+    adapter_factory: AdapterFactory,
+    stdout: str,
+    stderr: str,
+) -> None:
+    adapter = adapter_factory()
+    result = adapter.parse_response(
+        stdout=stdout,
+        stderr=stderr,
+        returncode=1,
+        output_file=None,
+    )
+    assert result.ok is False
+    assert result.rate_limited is True
+    assert result.response == ""


### PR DESCRIPTION
Session 30 calibration (2026-05-19) discovered ``_RATE_LIMIT_RE`` matched the phrase \"rate limit\" inside successful model responses, falsely marking 4/25 dispatches as ``rate_limited``. The fix follows the precedent already shipped in ``codex.py`` + ``gemini.py``: ``rate_limited`` is true ONLY when the pattern matches AND the call also failed (non-zero returncode or empty output).

## Adapters fixed

- ``claude.py`` — pattern + call_failed guard
- ``deepseek.py`` — pattern + call_failed guard
- ``qwen.py`` — pattern + call_failed guard
- ``_template.py`` — canonical guarded pattern for future adapters

## Tests

``tests/test_adapter_rate_limit_guards.py`` adds parametrized cases for each adapter:
- Success path: ``returncode=0`` + stdout contains the phrase \"rate limit\" → ``ok=True``, ``rate_limited=False``
- True 429 path: ``returncode!=0`` + empty stdout + 429/rate-limit stderr → ``ok=False``, ``rate_limited=True``

Validation: ``26 passed`` on focused suite, ``42 passed`` on broader ``rate_limit|adapter`` selector.

## Source

``docs/session-state/2026-05-19-session-30-five-way-calibration.html`` § dispatch_smart parser bug.

## Test plan
- [x] ``pytest tests/test_quality_dispatchers.py tests/test_qwen_adapter.py tests/test_adapter_rate_limit_guards.py -x -q`` → 26 passed
- [x] ``pytest tests/ -x -q -k \"rate_limit or adapter\" --maxfail=3`` → 42 passed
- [ ] CI: full pytest suite passes
- [ ] CI: ruff/lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)