### PR TITLE
docs(research): deprecation banners on legacy gap docs

### DIFF
--- a/docs/research/content-gaps-2026-05.md
+++ b/docs/research/content-gaps-2026-05.md
@@ -1,6 +1,13 @@
 # KubeDojo content gap inventory — 2026-05-12
 
-> **Status**: Stage 0 in the gap-planning workflow. Captures candidate gaps;
+> **DEPRECATED — see [`gap-plan-2026-05-17.html`](./gap-plan-2026-05-17.html) instead.**
+> This Stage-0 inventory was superseded on 2026-05-17 by the deepseek+grok triangulation
+> synthesis (`gap-plan-2026-05-17.html`), which became the authoritative gap source. Most
+> items here either landed (T2-10 / T2-11 / T2-14 / T2-17 / T2-18 / T2-19 / T2-20 / T2-23
+> via Wave 2 of #1304), got de-scoped via [`docs/decisions/2026-05-17-gap-fill-decisions.md`](../decisions/2026-05-17-gap-fill-decisions.md),
+> or live as open Wave 3+ items in #1304. Kept for archival traceability; do not edit.
+
+> **Status (historical)**: Stage 0 in the gap-planning workflow. Captures candidate gaps;
 > per-gap research briefs (Stage 1) live as separate files in
 > `docs/research/gap-*.md`. Gap unlocks for drafting only after Stage 2
 > (`ab discuss` pressure-test), Stage 3 (parent epic + child issues),

--- a/docs/research/gap-triangulation-roadmap-2026-05.html
+++ b/docs/research/gap-triangulation-roadmap-2026-05.html
@@ -62,6 +62,17 @@
 <main>
 
 <h1>KubeDojo gap triangulation roadmap</h1>
+
+<div class="tldr" style="border-left-color: var(--gap); background: #fff5f5;">
+  <strong>DEPRECATED &mdash; see <a href="./gap-plan-2026-05-17.html"><code>gap-plan-2026-05-17.html</code></a> instead.</strong>
+  This Step-4 roadmap was superseded on 2026-05-17 by the deepseek+grok triangulation
+  synthesis (<code>gap-plan-2026-05-17.html</code>), which became the authoritative gap source.
+  Most items here either landed (Wave 2 of #1304 closed T2-10 / T2-11 / T2-14 / T2-17 / T2-18 /
+  T2-19 / T2-20 / T2-23 as PRs), got de-scoped via
+  <a href="../decisions/2026-05-17-gap-fill-decisions.md"><code>2026-05-17-gap-fill-decisions.md</code></a>,
+  or live as open Wave 3+ items in #1304. Kept for archival traceability; do not edit.
+</div>
+
 <p class="meta">
   Captured 2026-05. Scope: Step 4 of the gap-analysis pipeline. This is a
   planning artifact only; it does not authorize module drafting.


### PR DESCRIPTION
## Summary

Adds deprecation banners to two legacy gap-planning docs pointing readers to the current authoritative source.

| File | Banner type |
|---|---|
| ``docs/research/content-gaps-2026-05.md`` | markdown blockquote at top |
| ``docs/research/gap-triangulation-roadmap-2026-05.html`` | red-tinted ``.tldr`` div near top |

Both banners point to ``docs/research/gap-plan-2026-05-17.html`` (the deepseek+grok triangulation synthesis that became authoritative on 2026-05-17). Wave 2 of #1304 closed 8 of 9 items these docs tracked; the rest are de-scoped per ``docs/decisions/2026-05-17-gap-fill-decisions.md`` or open as Wave 3+ items in #1304.

Files kept for archival traceability; not deleted.

## Why

Carryover from session 28's NEXT SESSION list (item g): *deprecation banners on legacy gap docs*. Prevents future readers from mistaking these for the current gap source.

## Test plan
- [x] Markdown lints clean (no broken refs)
- [x] HTML banner uses existing CSS vars (``var(--gap)``) — no new style
- [ ] CI: full build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)