### PR TITLE
fix(dispatch): persist full response body to logs/dispatch_responses/<task_id>.txt

### DIFF
--- a/scripts/dispatch_smart.py
+++ b/scripts/dispatch_smart.py
@@ -44,7 +44,17 @@ Task classes — model mapping per agent:
     architect   claude-opus-4-7              gpt-5.5
 
 Each dispatch is recorded to ``logs/smart_dispatch.jsonl`` for usage
-auditing. Reuse with --dry-run to print the chosen plan without firing.
+auditing. The FULL response body is also persisted to
+``logs/dispatch_responses/<task_id>.txt`` so callers that pipe stdout
+through ``tail``/``head`` (e.g. background bash tasks) can recover the
+body even if the live stream was truncated. The JSONL row's
+``response_path`` field is the canonical pointer. Pattern::
+
+    python scripts/dispatch_smart.py review --task-id review-foo ... | tail -N
+    # body may be truncated in stdout; recover from disk:
+    cat "$(jq -r 'select(.task_id == "review-foo") | .response_path' logs/smart_dispatch.jsonl)"
+
+Reuse with --dry-run to print the chosen plan without firing.
 """
 from __future__ import annotations
 
@@ -59,6 +69,7 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
 LOG_PATH = REPO / "logs" / "smart_dispatch.jsonl"
+RESPONSE_DIR = REPO / "logs" / "dispatch_responses"
 PRIMARY_REPO = REPO
 
 
@@ -184,6 +195,24 @@ def append_log(entry: dict) -> None:
         fp.write(json.dumps(entry) + "\n")
 
 
+def persist_response(task_id: str, response: str, stderr_excerpt: str) -> Path:
+    """Write the full response body (and stderr excerpt) to disk.
+
+    Returns the path of the response file. Callers that pipe dispatch output
+    through ``tail`` or similar truncation can still recover the full body
+    from this file. Prior to this, only ``response_chars`` was captured in
+    the JSONL row and the body lived solely in stdout, which got silently
+    dropped on ~3 of session-31's review dispatches.
+    """
+    RESPONSE_DIR.mkdir(parents=True, exist_ok=True)
+    response_path = RESPONSE_DIR / f"{task_id}.txt"
+    response_path.write_text(response or "")
+    if stderr_excerpt:
+        stderr_path = RESPONSE_DIR / f"{task_id}.stderr.txt"
+        stderr_path.write_text(stderr_excerpt)
+    return response_path
+
+
 def fire(*, agent: str, task_class: str, prompt: str, mode: str, model: str,
          worktree: Path | None, task_id: str, timeout_s: int) -> int:
     sys.path.insert(0, str(REPO / "scripts"))
@@ -196,6 +225,8 @@ def fire(*, agent: str, task_class: str, prompt: str, mode: str, model: str,
     print(f"[smart] task_id={task_id}")
 
     started = time.time()
+    previous_search: str | None = None
+    previous_dispatched: str | None = None
     try:
         previous_search = os.environ.get("KUBEDOJO_CODEX_SEARCH")
         previous_dispatched = os.environ.get("KUBEDOJO_DISPATCHED")
@@ -236,6 +267,8 @@ def fire(*, agent: str, task_class: str, prompt: str, mode: str, model: str,
             os.environ["KUBEDOJO_DISPATCHED"] = previous_dispatched
 
     elapsed = time.time() - started
+    response_path = persist_response(task_id, response, stderr_excerpt)
+    rel_response_path = str(response_path.relative_to(REPO))
     append_log({
         "ts": int(started),
         "elapsed_s": round(elapsed, 1),
@@ -248,12 +281,16 @@ def fire(*, agent: str, task_class: str, prompt: str, mode: str, model: str,
         "ok": ok,
         "session_id": session_id,
         "response_chars": len(response),
+        "response_path": rel_response_path,
         "stderr_excerpt": stderr_excerpt[:400] if stderr_excerpt else None,
     })
 
+    # Print response_path BEFORE the body so callers that truncate stdout
+    # (tail -N, head -N) still see the path and can `cat` the full file.
     print("=" * 70)
     print(f"OK: {ok}  |  elapsed: {elapsed:.0f}s  |  "
           f"resp_chars: {len(response)}")
+    print(f"response_path: {rel_response_path}")
     print("=" * 70)
     if response:
         print(response)

--- a/scripts/dispatch_smart.py
+++ b/scripts/dispatch_smart.py
@@ -68,9 +68,6 @@ from dataclasses import dataclass
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
-LOG_PATH = REPO / "logs" / "smart_dispatch.jsonl"
-RESPONSE_DIR = REPO / "logs" / "dispatch_responses"
-PRIMARY_REPO = REPO
 
 
 def _primary_checkout_root(repo_root: Path) -> Path:
@@ -81,6 +78,10 @@ def _primary_checkout_root(repo_root: Path) -> Path:
 
 
 PRIMARY_REPO = _primary_checkout_root(REPO)
+# Anchor logs to the primary checkout so worktree dispatches do not
+# fragment the audit trail across .worktrees/*/logs/.
+LOG_PATH = PRIMARY_REPO / "logs" / "smart_dispatch.jsonl"
+RESPONSE_DIR = PRIMARY_REPO / "logs" / "dispatch_responses"
 
 
 SUPPORTED_AGENTS = ("claude", "codex", "deepseek", "gemini", "qwen")
@@ -206,10 +207,10 @@ def persist_response(task_id: str, response: str, stderr_excerpt: str) -> Path:
     """
     RESPONSE_DIR.mkdir(parents=True, exist_ok=True)
     response_path = RESPONSE_DIR / f"{task_id}.txt"
-    response_path.write_text(response or "")
+    response_path.write_text(response or "", encoding="utf-8")
     if stderr_excerpt:
         stderr_path = RESPONSE_DIR / f"{task_id}.stderr.txt"
-        stderr_path.write_text(stderr_excerpt)
+        stderr_path.write_text(stderr_excerpt, encoding="utf-8")
     return response_path
 
 
@@ -268,7 +269,7 @@ def fire(*, agent: str, task_class: str, prompt: str, mode: str, model: str,
 
     elapsed = time.time() - started
     response_path = persist_response(task_id, response, stderr_excerpt)
-    rel_response_path = str(response_path.relative_to(REPO))
+    rel_response_path = str(response_path.relative_to(PRIMARY_REPO))
     append_log({
         "ts": int(started),
         "elapsed_s": round(elapsed, 1),


### PR DESCRIPTION
## Summary

- `dispatch_smart.py` previously only stored `response_chars` (count) in the JSONL row; the body lived solely in stdout via `print(response)`. Callers that piped through `tail -N` lost it.
- Persist the full response body to `logs/dispatch_responses/<task_id>.txt` (stderr excerpt to `.stderr.txt` if non-empty). Add `response_path` field to the JSONL row. Print the path on stdout before the body so even truncated callers can recover it.
- Init `previous_search` / `previous_dispatched` before the try block (cheap proactive fix for a pre-existing pyright warning while touching the file).

## Why

Session 31 lost the line-by-line findings of 3 claude-sonnet review dispatches because the body landed in stdout before the trailing verdict — and the caller piped through `tail -N` for "minimal captured output". The verdict survived; the actionable detail did not. This was flagged in the session-31 handoff under "Tech debt observed but not addressed":

> `logs/smart_dispatch.jsonl` stores `response_chars` but not the actual response text. For audit/replay, the response itself should be persisted next to the row (or referenced as a file path). Currently lost on shell pipe truncation, which bit me 3x this session.

## Recovery pattern for callers

```bash
python scripts/dispatch_smart.py review --task-id review-foo ... | tail -N
# body may be truncated in stdout; recover from disk:
cat "$(jq -r 'select(.task_id == \"review-foo\") | .response_path' logs/smart_dispatch.jsonl)"
```

`logs/` is gitignored so the new directory does not pollute git.

## Smoke tests run on this branch

Two claude-haiku search dispatches:
1. Prompt: `Reply with exactly the word PONG and nothing else.` → response file = `PONG\n` (4 chars, matches `response_chars: 4` in JSONL); JSONL row has `"response_path": "logs/dispatch_responses/smoke-test-response-persistence.txt"`.
2. Prompt: `Reply with exactly 'ALPHA BETA GAMMA DELTA' on one line.` piped through `head -3`. Stdout truncated before the body. Recovered the body from disk via `jq -r 'select(.task_id == "smoke-truncate-test") | .response_path' logs/smart_dispatch.jsonl | xargs cat` → got `ALPHA BETA GAMMA DELTA` cleanly.

## Test plan

- [x] argparse `--help` still parses cleanly
- [x] `python -c "import ast; ast.parse(open(file).read())"` passes
- [x] Live dispatch creates response file at expected path
- [x] JSONL row contains `response_path` field
- [x] Pipe-truncation recovery works via JSONL lookup
- [ ] (reviewer) confirm `RESPONSE_DIR` constant placement / naming is consistent with existing module conventions
- [ ] (reviewer) confirm the docstring example is correct

## Non-goals

- Did NOT touch the agent runner (`agent_runtime/runner.py`) — that returns the parsed `response` to dispatch_smart already; the bug was strictly at the dispatch_smart layer.
- Did NOT change the JSONL schema beyond adding one field — `response_chars` stays for backward compat with existing log readers.
- Did NOT add response-file rotation/cleanup — these accumulate in gitignored `logs/`. If volume becomes a concern, a separate PR can add a rotation step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)