### PR TITLE
feat(agents): agy (Antigravity CLI) adapter — Phase 1 of #1350

### DIFF
--- a/scripts/agent_runtime/adapters/agy.py
+++ b/scripts/agent_runtime/adapters/agy.py
@@ -1,0 +1,148 @@
+"""AgyAdapter - wraps Antigravity CLI (``agy``) for the agent runtime.
+
+Phase 1 of the Antigravity migration keeps this adapter alongside the
+existing Gemini CLI adapter. ``agy`` model selection is controlled by the
+interactive TUI and persists across ``agy -p`` invocations; there is no CLI
+model flag today, so the runtime's model value is audit-only.
+
+Known behavioral facts as of issue #1350:
+
+- Headless prompt mode is ``agy -p "<prompt>"``. Stdin prompts are ignored.
+- Resume/new conversation is ``--conversation=<uuid>``.
+- Write-capable modes use ``--dangerously-skip-permissions``.
+- No known on-disk session or liveness file exists, so stdout is canonical.
+"""
+from __future__ import annotations
+
+import os
+import re
+import shutil
+from pathlib import Path
+
+from ..result import ParseResult
+from .base import InvocationPlan
+
+
+_MODEL_HINT_ENV = "KUBEDOJO_AGY_MODEL_HINT"
+
+# Defensive defaults borrowed from Gemini CLI. Agy is new enough that these
+# may need adjustment once we see real Antigravity rate-limit errors.
+_RATE_LIMIT_PATTERNS = (
+    r"RESOURCE_EXHAUSTED",
+    r"usage limit reached",
+    r"quota exceeded",
+    r"daily.{0,10}limit.{0,10}exceeded",
+)
+_RATE_LIMIT_RE = re.compile("|".join(_RATE_LIMIT_PATTERNS), re.IGNORECASE)
+
+
+class AgyAdapter:
+    """Adapter for the ``agy`` Antigravity CLI."""
+
+    name: str = "agy"
+    default_model: str = os.environ.get("KUBEDOJO_AGY_MODEL", "gemini-3.5-flash-high")
+    supported_modes: frozenset[str] = frozenset({"read-only", "workspace-write", "danger"})
+
+    def build_invocation(
+        self,
+        *,
+        prompt: str,
+        mode: str,
+        cwd: Path,
+        model: str | None,
+        task_id: str | None,
+        session_id: str | None,
+        tool_config: dict | None,
+    ) -> InvocationPlan:
+        """Build the ``agy`` print-mode invocation.
+
+        ``model`` is intentionally not mapped to a CLI flag. The active model
+        is whichever model the operator selected in the ``agy`` TUI panel.
+        """
+        if mode not in self.supported_modes:
+            raise ValueError(f"AgyAdapter: unsupported mode {mode!r}")
+
+        agy_bin = shutil.which("agy") or str(Path.home() / ".local/bin/agy")
+        cmd: list[str] = [agy_bin, "-p", prompt]
+
+        if session_id:
+            cmd.append(f"--conversation={session_id}")
+
+        if mode in ("workspace-write", "danger"):
+            cmd.append("--dangerously-skip-permissions")
+
+        # Phase 2 follow-up: agy uses `agy plugin` for MCP configuration,
+        # not a per-invocation CLI flag like gemini-cli.
+        _ = tool_config
+        _ = task_id
+
+        effective_model = model or self.default_model
+
+        return InvocationPlan(
+            cmd=cmd,
+            cwd=cwd,
+            stdin_payload=None,
+            output_file=None,
+            env_overrides={_MODEL_HINT_ENV: effective_model},
+            liveness_paths=(),
+        )
+
+    def parse_response(
+        self,
+        *,
+        stdout: str,
+        stderr: str,
+        returncode: int,
+        output_file: Path | None,
+        plan: InvocationPlan | None = None,
+        call_start_time: float | None = None,
+    ) -> ParseResult:
+        """Parse ``agy -p`` output.
+
+        Stdout is the only known canonical response source. We deliberately do
+        not attempt Gemini-style session-file recovery because no Antigravity
+        on-disk session location is known yet.
+        """
+        _ = output_file
+        _ = call_start_time
+
+        stdout_response = (stdout or "").strip()
+        stderr_text = (stderr or "").strip()
+        combined = f"{stdout_response}\n{stderr_text}"
+        hard_limit_hit = bool(_RATE_LIMIT_RE.search(combined))
+        call_failed = returncode != 0 or not bool(stdout_response)
+        rate_limited = hard_limit_hit and call_failed
+
+        ok = returncode == 0 and bool(stdout_response) and not rate_limited
+        response = stdout_response if ok else ""
+
+        stderr_excerpt: str | None = None
+        if not ok:
+            excerpt_source = stderr_text or stdout_response
+            stderr_excerpt = excerpt_source[:500] or None
+        elif stderr_text:
+            stderr_excerpt = stderr_text[:500]
+        else:
+            model_hint = self.default_model
+            if plan is not None:
+                hint = plan.env_overrides.get(_MODEL_HINT_ENV)
+                if isinstance(hint, str) and hint:
+                    model_hint = hint
+            stderr_excerpt = (
+                "agy active model: tracked in TUI panel; "
+                f"--model arg '{model_hint}' is informational"
+            )
+
+        return ParseResult(
+            ok=ok,
+            response=response,
+            stderr_excerpt=stderr_excerpt,
+            rate_limited=rate_limited,
+            session_id=None,
+            tokens=None,
+        )
+
+    def liveness_signal_paths(self, plan: InvocationPlan) -> tuple[Path, ...]:
+        """Agy has no known on-disk liveness signal; stdout is canonical."""
+        _ = plan
+        return ()

--- a/scripts/agent_runtime/adapters/agy.py
+++ b/scripts/agent_runtime/adapters/agy.py
@@ -35,8 +35,6 @@ from ..result import ParseResult
 from .base import InvocationPlan
 
 
-_MODEL_HINT_ENV = "KUBEDOJO_AGY_MODEL_HINT"
-
 # Defensive defaults borrowed from Gemini CLI. Agy is new enough that these
 # may need adjustment once we see real Antigravity rate-limit errors.
 _RATE_LIMIT_PATTERNS = (
@@ -75,27 +73,34 @@ class AgyAdapter:
             raise ValueError(f"AgyAdapter: unsupported mode {mode!r}")
 
         agy_bin = shutil.which("agy") or str(Path.home() / ".local/bin/agy")
-        cmd: list[str] = [agy_bin, "-p", prompt]
+        # `--dangerously-skip-permissions` is unconditional: any tool-using
+        # prompt (file read, shell call) triggers an interactive permission
+        # prompt that would hang a headless dispatch waiting for human input.
+        # The `mode` field is retained for runtime accounting + adapter-API
+        # parity, but agy has no finer-grained permission model than this
+        # single flag. dispatch_smart.py separately forces mode=danger for
+        # --agent agy so callers can't accidentally route around this.
+        cmd: list[str] = [agy_bin, "-p", prompt, "--dangerously-skip-permissions"]
 
         if session_id:
             cmd.append(f"--conversation={session_id}")
 
-        if mode in ("workspace-write", "danger"):
-            cmd.append("--dangerously-skip-permissions")
-
         # Phase 2 follow-up: agy uses `agy plugin` for MCP configuration,
         # not a per-invocation CLI flag like gemini-cli.
+        # `model` is intentionally unused — agy's model is TUI-selected and
+        # cannot be overridden per-invocation. The runtime records the
+        # caller-passed model in the JSONL audit row for informational
+        # provenance only.
         _ = tool_config
         _ = task_id
-
-        effective_model = model or self.default_model
+        _ = model
 
         return InvocationPlan(
             cmd=cmd,
             cwd=cwd,
             stdin_payload="",
             output_file=None,
-            env_overrides={_MODEL_HINT_ENV: effective_model},
+            env_overrides={},
             liveness_paths=(),
         )
 
@@ -117,6 +122,7 @@ class AgyAdapter:
         """
         _ = output_file
         _ = call_start_time
+        _ = plan
 
         stdout_response = (stdout or "").strip()
         stderr_text = (stderr or "").strip()
@@ -128,22 +134,17 @@ class AgyAdapter:
         ok = returncode == 0 and bool(stdout_response) and not rate_limited
         response = stdout_response if ok else ""
 
+        # `stderr_excerpt` follows the documented convention in result.py:
+        # populated only when there's diagnostic stderr or the call failed.
+        # The model hint is informational and lives in the JSONL audit row
+        # via env_overrides, not in stderr_excerpt (which is also used as
+        # an error-presence signal by some callers).
         stderr_excerpt: str | None = None
         if not ok:
             excerpt_source = stderr_text or stdout_response
             stderr_excerpt = excerpt_source[:500] or None
         elif stderr_text:
             stderr_excerpt = stderr_text[:500]
-        else:
-            model_hint = self.default_model
-            if plan is not None:
-                hint = plan.env_overrides.get(_MODEL_HINT_ENV)
-                if isinstance(hint, str) and hint:
-                    model_hint = hint
-            stderr_excerpt = (
-                "agy active model: tracked in TUI panel; "
-                f"--model arg '{model_hint}' is informational"
-            )
 
         return ParseResult(
             ok=ok,

--- a/scripts/agent_runtime/adapters/agy.py
+++ b/scripts/agent_runtime/adapters/agy.py
@@ -9,8 +9,20 @@ Known behavioral facts as of issue #1350:
 
 - Headless prompt mode is ``agy -p "<prompt>"``. Stdin prompts are ignored.
 - Resume/new conversation is ``--conversation=<uuid>``.
-- Write-capable modes use ``--dangerously-skip-permissions``.
+- Write-capable modes use ``--dangerously-skip-permissions``. In addition,
+  ``dispatch_smart.py`` forces ``mode="danger"`` for ``--agent agy``
+  unconditionally because read-only would otherwise hang on the CLI's
+  interactive permission prompts (same protection as ``--agent codex``).
 - No known on-disk session or liveness file exists, so stdout is canonical.
+
+MCP / plugin configuration is a Phase-2 follow-up. ``agy plugin`` only
+exposes ``import gemini|claude``, ``install <known-target>``, ``enable``,
+and ``disable``. The CLI has no plugin-marketplace browse surface as of
+1.0.0, and ``agy plugin import gemini`` is a no-op in a default install
+because gemini-cli ships no extensions out of the box. The adapter
+accepts ``tool_config["mcp_server_names"]`` for API parity with
+``GeminiAdapter`` but does not act on it today — wire ``agy plugin
+enable <name>`` here once we have concrete MCP servers to consume.
 """
 from __future__ import annotations
 
@@ -81,7 +93,7 @@ class AgyAdapter:
         return InvocationPlan(
             cmd=cmd,
             cwd=cwd,
-            stdin_payload=None,
+            stdin_payload="",
             output_file=None,
             env_overrides={_MODEL_HINT_ENV: effective_model},
             liveness_paths=(),

--- a/scripts/agent_runtime/registry.py
+++ b/scripts/agent_runtime/registry.py
@@ -41,6 +41,18 @@ class AgentEntry(TypedDict):
 
 
 AGENTS: dict[str, AgentEntry] = {
+    "agy": {
+        "adapter": "scripts.agent_runtime.adapters.agy:AgyAdapter",
+        "default_model": os.environ.get("KUBEDOJO_AGY_MODEL", "gemini-3.5-flash-high"),
+        "cost_tier": "low",
+        "capabilities": frozenset({
+            "content_writing",
+            "content_review",
+            "adversarial_review",
+        }),
+        "cli_available": True,
+        "resume_policy": "bridge_only",
+    },
     "codex": {
         "adapter": "scripts.agent_runtime.adapters.codex:CodexAdapter",
         "default_model": os.environ.get("AB_CODEX_MODEL", "gpt-5.5"),

--- a/scripts/agent_runtime/tests/test_agy_adapter.py
+++ b/scripts/agent_runtime/tests/test_agy_adapter.py
@@ -1,0 +1,115 @@
+"""Unit tests for the ``AgyAdapter`` Antigravity CLI integration."""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from agent_runtime.adapters.agy import AgyAdapter
+
+
+def _build(mode: str) -> list[str]:
+    adapter = AgyAdapter()
+    plan = adapter.build_invocation(
+        prompt="p",
+        mode=mode,
+        cwd=Path("/tmp"),
+        model="gemini-3.5-flash-high",
+        task_id=None,
+        session_id=None,
+        tool_config=None,
+    )
+    return plan.cmd
+
+
+def test_build_invocation_read_only(monkeypatch) -> None:
+    monkeypatch.setattr("agent_runtime.adapters.agy.shutil.which", lambda _: "agy")
+
+    cmd = _build("read-only")
+
+    assert cmd == ["agy", "-p", "p"]
+    assert "--dangerously-skip-permissions" not in cmd
+
+
+def test_build_invocation_workspace_write(monkeypatch) -> None:
+    monkeypatch.setattr("agent_runtime.adapters.agy.shutil.which", lambda _: "agy")
+
+    cmd = _build("workspace-write")
+
+    assert cmd == ["agy", "-p", "p", "--dangerously-skip-permissions"]
+
+
+def test_build_invocation_danger(monkeypatch) -> None:
+    monkeypatch.setattr("agent_runtime.adapters.agy.shutil.which", lambda _: "agy")
+
+    cmd = _build("danger")
+
+    assert cmd == ["agy", "-p", "p", "--dangerously-skip-permissions"]
+
+
+def test_build_invocation_with_session_id(monkeypatch) -> None:
+    monkeypatch.setattr("agent_runtime.adapters.agy.shutil.which", lambda _: "agy")
+    adapter = AgyAdapter()
+    session_id = "123e4567-e89b-12d3-a456-426614174000"
+
+    plan = adapter.build_invocation(
+        prompt="p",
+        mode="read-only",
+        cwd=Path("/tmp"),
+        model="gemini-3.5-flash-high",
+        task_id=None,
+        session_id=session_id,
+        tool_config=None,
+    )
+
+    assert f"--conversation={session_id}" in plan.cmd
+
+
+def test_build_invocation_uses_home_fallback(monkeypatch) -> None:
+    monkeypatch.setattr("agent_runtime.adapters.agy.shutil.which", lambda _: None)
+    adapter = AgyAdapter()
+
+    plan = adapter.build_invocation(
+        prompt="p",
+        mode="read-only",
+        cwd=Path("/tmp"),
+        model=None,
+        task_id=None,
+        session_id=None,
+        tool_config=None,
+    )
+
+    assert plan.cmd[0].endswith("/.local/bin/agy")
+    assert plan.stdin_payload is None
+
+
+def test_parse_response_happy_path() -> None:
+    adapter = AgyAdapter()
+    result = adapter.parse_response(
+        stdout="Answer\n",
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+
+    assert result.ok is True
+    assert result.response == "Answer"
+    assert result.rate_limited is False
+    assert result.session_id is None
+    assert result.tokens is None
+    assert "model" in (result.stderr_excerpt or "")
+
+
+def test_parse_response_detects_rate_limit() -> None:
+    adapter = AgyAdapter()
+    result = adapter.parse_response(
+        stdout="",
+        stderr="RESOURCE_EXHAUSTED: quota exceeded",
+        returncode=1,
+        output_file=None,
+    )
+
+    assert result.rate_limited is True
+    assert result.ok is False
+    assert result.response == ""

--- a/scripts/agent_runtime/tests/test_agy_adapter.py
+++ b/scripts/agent_runtime/tests/test_agy_adapter.py
@@ -81,7 +81,7 @@ def test_build_invocation_uses_home_fallback(monkeypatch) -> None:
     )
 
     assert plan.cmd[0].endswith("/.local/bin/agy")
-    assert plan.stdin_payload is None
+    assert plan.stdin_payload == ""
 
 
 def test_parse_response_happy_path() -> None:

--- a/scripts/agent_runtime/tests/test_agy_adapter.py
+++ b/scripts/agent_runtime/tests/test_agy_adapter.py
@@ -23,29 +23,23 @@ def _build(mode: str) -> list[str]:
     return plan.cmd
 
 
-def test_build_invocation_read_only(monkeypatch) -> None:
+def test_build_invocation_always_includes_dangerously_skip(monkeypatch) -> None:
+    """--dangerously-skip-permissions is unconditional across all modes.
+
+    Agy has no finer-grained permission model than this single flag, and
+    leaving it off causes interactive permission prompts that hang a
+    headless dispatch. dispatch_smart.py also forces mode=danger as a
+    second line of defense, but the adapter must hold the invariant on
+    its own so direct runner.invoke callers get the right behavior.
+    """
     monkeypatch.setattr("agent_runtime.adapters.agy.shutil.which", lambda _: "agy")
 
-    cmd = _build("read-only")
-
-    assert cmd == ["agy", "-p", "p"]
-    assert "--dangerously-skip-permissions" not in cmd
-
-
-def test_build_invocation_workspace_write(monkeypatch) -> None:
-    monkeypatch.setattr("agent_runtime.adapters.agy.shutil.which", lambda _: "agy")
-
-    cmd = _build("workspace-write")
-
-    assert cmd == ["agy", "-p", "p", "--dangerously-skip-permissions"]
-
-
-def test_build_invocation_danger(monkeypatch) -> None:
-    monkeypatch.setattr("agent_runtime.adapters.agy.shutil.which", lambda _: "agy")
-
-    cmd = _build("danger")
-
-    assert cmd == ["agy", "-p", "p", "--dangerously-skip-permissions"]
+    for mode in ("read-only", "workspace-write", "danger"):
+        cmd = _build(mode)
+        assert cmd == ["agy", "-p", "p", "--dangerously-skip-permissions"], (
+            f"mode={mode} must produce the same cmd because agy has no "
+            f"mode-specific permission flag"
+        )
 
 
 def test_build_invocation_with_session_id(monkeypatch) -> None:
@@ -98,7 +92,25 @@ def test_parse_response_happy_path() -> None:
     assert result.rate_limited is False
     assert result.session_id is None
     assert result.tokens is None
-    assert "model" in (result.stderr_excerpt or "")
+    # stderr_excerpt is documented as a diagnostic signal — None when no
+    # diagnostic output. Don't pollute it with informational notes.
+    assert result.stderr_excerpt is None
+
+
+def test_parse_response_empty_stdout_happy_returncode_fails() -> None:
+    """Successful exit + no stdout is not a successful call."""
+    adapter = AgyAdapter()
+    result = adapter.parse_response(
+        stdout="",
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+
+    assert result.ok is False
+    assert result.response == ""
+    assert result.rate_limited is False
+    assert result.stderr_excerpt is None
 
 
 def test_parse_response_detects_rate_limit() -> None:

--- a/scripts/dispatch_smart.py
+++ b/scripts/dispatch_smart.py
@@ -359,6 +359,21 @@ def main() -> int:
             )
         mode = "danger"
 
+    # Agy always runs in danger mode for the same reason — read-only would
+    # cause its tool-permission prompts to hang waiting for human input in
+    # a headless dispatch, since the runtime cannot answer the prompt.
+    # `--dangerously-skip-permissions` is the equivalent of codex's danger
+    # sandbox: auto-approve all tool calls. User direction 2026-05-19.
+    if args.agent == "agy" and mode != "danger":
+        if args.mode is not None and args.mode != "danger":
+            p.error(
+                f"--agent agy always runs in danger mode (you passed "
+                f"--mode {args.mode!r}). agy in headless dispatch needs "
+                f"--dangerously-skip-permissions to avoid hanging on "
+                f"interactive permission prompts. Drop --mode to use the default."
+            )
+        mode = "danger"
+
     if args.prompt is None:
         sys.stderr.write("[smart] no prompt — pass as arg or `-` for stdin\n")
         return 2

--- a/scripts/dispatch_smart.py
+++ b/scripts/dispatch_smart.py
@@ -96,10 +96,18 @@ class TaskClassConfig:
     codex_search: bool = False  # opt-in per class
 
 
+# Note on the "agy" model entries below: Antigravity CLI's model is selected
+# interactively in its TUI panel and cannot be overridden per-invocation
+# (no -m / --model flag as of agy 1.0.0). The string `tui-controlled`
+# is an informational placeholder — the actual model in flight is whatever
+# the operator last picked in `agy`'s panel and is reported in the model
+# self-identify probe (`agy -p 'what model are you?'`). The per-class
+# distinction is therefore meaningless for agy until Google adds a model
+# flag or config-file path.
 TASK_CLASSES: dict[str, TaskClassConfig] = {
     "search": TaskClassConfig(
         models={
-            "agy": "gemini-3.5-flash-high",
+            "agy": "tui-controlled",
             "claude": "claude-haiku-4-5-20251001",
             "codex": "gpt-5.4-mini",
             "deepseek": "deepseek-v4-flash",
@@ -113,7 +121,7 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
     ),
     "edit": TaskClassConfig(
         models={
-            "agy": "gemini-3.5-flash-high",
+            "agy": "tui-controlled",
             "claude": "claude-sonnet-4-6",
             "codex": "gpt-5.3-codex-spark",
             "deepseek": "deepseek-v4-pro",
@@ -127,7 +135,7 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
     ),
     "draft": TaskClassConfig(
         models={
-            "agy": "gemini-3.5-flash-high",
+            "agy": "tui-controlled",
             "claude": "claude-sonnet-4-6",
             "codex": "gpt-5.3-codex-spark",
             "deepseek": "deepseek-v4-pro",
@@ -141,7 +149,7 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
     ),
     "review": TaskClassConfig(
         models={
-            "agy": "gemini-3.5-flash-high",
+            "agy": "tui-controlled",
             "claude": "claude-sonnet-4-6",
             "codex": "gpt-5.5",
             "deepseek": "deepseek-v4-pro",
@@ -155,7 +163,7 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
     ),
     "architect": TaskClassConfig(
         models={
-            "agy": "gemini-3.5-flash-high",
+            "agy": "tui-controlled",
             "claude": "claude-opus-4-7",
             "codex": "gpt-5.5",
             "deepseek": "deepseek-v4-pro",

--- a/scripts/dispatch_smart.py
+++ b/scripts/dispatch_smart.py
@@ -84,7 +84,7 @@ LOG_PATH = PRIMARY_REPO / "logs" / "smart_dispatch.jsonl"
 RESPONSE_DIR = PRIMARY_REPO / "logs" / "dispatch_responses"
 
 
-SUPPORTED_AGENTS = ("claude", "codex", "deepseek", "gemini", "qwen")
+SUPPORTED_AGENTS = ("agy", "claude", "codex", "deepseek", "gemini", "qwen")
 
 
 @dataclass(frozen=True)
@@ -99,6 +99,7 @@ class TaskClassConfig:
 TASK_CLASSES: dict[str, TaskClassConfig] = {
     "search": TaskClassConfig(
         models={
+            "agy": "gemini-3.5-flash-high",
             "claude": "claude-haiku-4-5-20251001",
             "codex": "gpt-5.4-mini",
             "deepseek": "deepseek-v4-flash",
@@ -112,6 +113,7 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
     ),
     "edit": TaskClassConfig(
         models={
+            "agy": "gemini-3.5-flash-high",
             "claude": "claude-sonnet-4-6",
             "codex": "gpt-5.3-codex-spark",
             "deepseek": "deepseek-v4-pro",
@@ -125,6 +127,7 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
     ),
     "draft": TaskClassConfig(
         models={
+            "agy": "gemini-3.5-flash-high",
             "claude": "claude-sonnet-4-6",
             "codex": "gpt-5.3-codex-spark",
             "deepseek": "deepseek-v4-pro",
@@ -138,6 +141,7 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
     ),
     "review": TaskClassConfig(
         models={
+            "agy": "gemini-3.5-flash-high",
             "claude": "claude-sonnet-4-6",
             "codex": "gpt-5.5",
             "deepseek": "deepseek-v4-pro",
@@ -151,6 +155,7 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
     ),
     "architect": TaskClassConfig(
         models={
+            "agy": "gemini-3.5-flash-high",
             "claude": "claude-opus-4-7",
             "codex": "gpt-5.5",
             "deepseek": "deepseek-v4-pro",


### PR DESCRIPTION
## Summary

Phase 1 for #1350: add an `agy` (Antigravity CLI) adapter alongside the existing `gemini` adapter. This PR does not remove or modify `scripts/agent_runtime/adapters/gemini.py`.

Changes:
- Added `scripts/agent_runtime/adapters/agy.py` with stdout-only `agy -p <prompt>` invocation.
- Registered `agy` in `scripts/agent_runtime/registry.py` and `scripts/dispatch_smart.py`.
- Added focused adapter tests for mode flags, conversation IDs, stdout parsing, and defensive rate-limit detection.

## Notes

`--model` is informational only for `agy`: Antigravity currently uses the model last selected in the `agy` TUI panel. The runtime records the model string in dispatch/audit logs, but the adapter does not pass a model flag until Google adds one or we find a stable config-file path.

MCP plugin wiring is left for Phase 2 because `agy` uses plugin configuration rather than a per-invocation MCP CLI flag.

## Smoke Test: PR #1349 Review

Command run with the same prompt as the saved Claude Sonnet review:

```bash
.venv/bin/python scripts/dispatch_smart.py review --agent agy --task-id smoke-agy-pr1349 - < /tmp/review-1349-agy.txt
```

Prompt source was copied from `/tmp/review-1349-prompt.txt` and verified with `cmp -s`.

| Reviewer | Verdict line | vLLM `/health/live` + `/health/ready` factual error |
| --- | --- | --- |
| `claude-sonnet-4-6` | `Verdict: NEEDS_CHANGES` | Caught as blocking: stock `vllm/vllm-openai` exposes `/health`, not `/health/live` or `/health/ready`; required changing all probe and verification paths to `/health`. |
| `agy` / Gemini 3.5 Flash (High) | `One-line verdict: APPROVE_WITH_NITS` | Missed the blocker. It instead stated the module correctly identified the unified `/health` endpoint and only raised unrelated nits. |

Reviewer viability verdict: Gemini 3.5 Flash (High) through `agy` is useful as an extra low-cost reviewer, but this smoke test says it is not viable as the sole adversarial technical reviewer yet. It missed the exact factual probe-path error that Claude Sonnet caught.

Response paths:
- `logs/dispatch_responses/review-1349-claude-sonnet.txt`
- `logs/dispatch_responses/smoke-agy-pr1349.txt`

## Validation

- `.venv/bin/ruff check scripts/agent_runtime/adapters/agy.py scripts/agent_runtime/tests/test_agy_adapter.py scripts/agent_runtime/registry.py scripts/dispatch_smart.py`
- `.venv/bin/pytest scripts/agent_runtime/tests/test_agy_adapter.py`
- `.venv/bin/python scripts/dispatch_smart.py --dry-run search --agent agy test`
- `.venv/bin/python scripts/test_pipeline.py` (170 tests passed)
- `git diff --cached --check`

`npm run build` is N/A: this is a pure Python agent-runtime change.
