### PR TITLE
fix(dispatch_smart): agy danger carve-out + worktree node_modules symlink

### DIFF
--- a/scripts/dispatch_smart.py
+++ b/scripts/dispatch_smart.py
@@ -201,6 +201,10 @@ def ensure_worktree(worktree: Path, new_branch: str | None,
     worktree_venv = worktree / ".venv"
     if primary_venv.exists() and not worktree_venv.exists():
         worktree_venv.symlink_to(primary_venv)
+    primary_node_modules = PRIMARY_REPO / "node_modules"
+    worktree_node_modules = worktree / "node_modules"
+    if primary_node_modules.exists() and not worktree_node_modules.exists():
+        worktree_node_modules.symlink_to(primary_node_modules)
 
 
 def append_log(entry: dict) -> None:
@@ -391,7 +395,13 @@ def main() -> int:
         return 2
 
     if mode == "danger" and not args.worktree and not args.dry_run:
-        p.error("--mode danger requires --worktree (no override)")
+        # agy carve-out: agy under danger mode only suppresses interactive
+        # permission prompts (--dangerously-skip-permissions); it does not
+        # write files. Review-class agy dispatches don't need a worktree.
+        # Codex under danger mode DOES write — its worktree requirement
+        # stays as-is.
+        if args.agent != "agy":
+            p.error("--mode danger requires --worktree (no override)")
 
     worktree: Path | None = None
     if args.worktree:

--- a/scripts/dispatch_smart.py
+++ b/scripts/dispatch_smart.py
@@ -199,11 +199,15 @@ def ensure_worktree(worktree: Path, new_branch: str | None,
     subprocess.run(cmd, cwd=PRIMARY_REPO, check=True)
     primary_venv = PRIMARY_REPO / ".venv"
     worktree_venv = worktree / ".venv"
-    if primary_venv.exists() and not worktree_venv.exists():
+    if primary_venv.exists() and not (
+            worktree_venv.exists() or worktree_venv.is_symlink()
+    ):
         worktree_venv.symlink_to(primary_venv)
     primary_node_modules = PRIMARY_REPO / "node_modules"
     worktree_node_modules = worktree / "node_modules"
-    if primary_node_modules.exists() and not worktree_node_modules.exists():
+    if primary_node_modules.exists() and not (
+            worktree_node_modules.exists() or worktree_node_modules.is_symlink()
+    ):
         worktree_node_modules.symlink_to(primary_node_modules)
 
 
@@ -408,7 +412,7 @@ def main() -> int:
         worktree = Path(args.worktree)
         if not worktree.is_absolute():
             worktree = PRIMARY_REPO / worktree
-    elif mode != "read-only" and not args.dry_run:
+    elif mode != "read-only" and not args.dry_run and args.agent != "agy":
         sys.stderr.write(
             f"[smart] mode={mode} requires --worktree to avoid trampling "
             "the main checkout\n"

--- a/tests/test_dispatch_smart.py
+++ b/tests/test_dispatch_smart.py
@@ -31,3 +31,28 @@ def test_dispatch_smart_danger_allows_dry_run_with_worktree() -> None:
     assert result.returncode == 0
     assert "mode=danger" in result.stdout
     assert "[dry-run] task_id=" in result.stdout
+
+
+def test_dispatch_smart_agy_danger_no_worktree_ok() -> None:
+    """agy review-class dispatches don't write to disk under danger mode,
+    so the worktree requirement should not apply to --agent agy."""
+    result = _run_dispatch_smart(
+        ["review", "--agent", "agy", "--mode", "danger", "--dry-run", "x"]
+    )
+    # Should succeed (rc=0) — agy carve-out lets danger run without --worktree.
+    assert result.returncode == 0, (
+        f"agy danger-mode dry-run should not require --worktree. "
+        f"stderr={result.stderr!r}, stdout={result.stdout!r}"
+    )
+
+
+def test_dispatch_smart_codex_danger_still_requires_worktree() -> None:
+    """The agy carve-out must NOT loosen the requirement for codex,
+    which actually writes under danger mode."""
+    # Codex auto-forces mode=danger, so any codex dispatch without --worktree
+    # should hard-fail.
+    result = _run_dispatch_smart(["edit", "--agent", "codex", "x"])
+    merged_output = (result.stdout or "") + (result.stderr or "")
+    assert result.returncode != 0
+    assert "danger" in merged_output
+    assert "worktree" in merged_output

--- a/tests/test_dispatch_smart.py
+++ b/tests/test_dispatch_smart.py
@@ -33,16 +33,23 @@ def test_dispatch_smart_danger_allows_dry_run_with_worktree() -> None:
     assert "[dry-run] task_id=" in result.stdout
 
 
-def test_dispatch_smart_agy_danger_no_worktree_ok() -> None:
+def test_dispatch_smart_agy_danger_no_worktree_passes_guards() -> None:
     """agy review-class dispatches don't write to disk under danger mode,
-    so the worktree requirement should not apply to --agent agy."""
+    so neither worktree guard should fire. We don't dry-run (which would
+    bypass both guards trivially) — instead we assert the worktree-required
+    error strings do NOT appear. The dispatch will fail later (no agy
+    binary in CI, or agent_runtime import) but BOTH worktree-guards must
+    be passed before that downstream failure."""
     result = _run_dispatch_smart(
-        ["review", "--agent", "agy", "--mode", "danger", "--dry-run", "x"]
+        ["review", "--agent", "agy", "--mode", "danger", "x"]
     )
-    # Should succeed (rc=0) — agy carve-out lets danger run without --worktree.
-    assert result.returncode == 0, (
-        f"agy danger-mode dry-run should not require --worktree. "
-        f"stderr={result.stderr!r}, stdout={result.stdout!r}"
+    merged_output = (result.stdout or "") + (result.stderr or "")
+    # Neither worktree guard should fire for agy.
+    assert "--mode danger requires --worktree" not in merged_output, (
+        f"agy hit the line-397 guard. stderr={result.stderr!r}"
+    )
+    assert "requires --worktree to avoid trampling" not in merged_output, (
+        f"agy hit the line-411 guard. stderr={result.stderr!r}"
     )
 
 


### PR DESCRIPTION
## Summary

Two surgical fixes from the session 33 handoff (commit `39af451e`):

1. **agy danger carve-out** — `dispatch_smart.py` forces `--agent agy` to `mode=danger` (because agy hangs on interactive permission prompts without `--dangerously-skip-permissions`). The existing `if mode == "danger" and not args.worktree: error` guard then over-applied to review-class agy dispatches, which don't actually write to disk. The fix: agy is exempt from the worktree requirement on BOTH guards (line 397 if + line 411 elif); codex's requirement is preserved (codex DOES write under danger).

2. **node_modules symlink in worktrees** — `ensure_worktree()` now symlinks `node_modules` from the primary repo alongside the existing `.venv` symlink. Without this, orchestrator-side `npm run build` inside a worktree fails with `Could not resolve '../../node_modules/@astrojs/starlight/style/layers.css'` because Astro's import chain reaches outside the worktree.

Both items were filed as TODOs in the session 33 handoff. Each tripped real session-33 dispatches.

Regression test: tests/test_dispatch_smart.py

## Review chain

- Writer: codex (gpt-5.3-codex-spark, edit class)
- Reviewer: **agy / Gemini 3.5 Flash (High)** — first production code review on kubedojo. Returned NEEDS_CHANGES with B1+B2+N1+N2; round-2 fixup commit `aaf74f36` addresses all three. Caught two real blockers (line-411 elif guard + dry-run test bypass) the orchestrator missed.

## Test plan
- [x] `python -m py_compile scripts/dispatch_smart.py` — clean
- [x] `pytest tests/test_dispatch_smart.py -x -q` — 4 passed
- [x] Non-dry-run agy dispatch passes BOTH worktree guards
- [x] Codex without worktree still hard-fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)