### PR TITLE
fix(module-3.1): 3 deployment bugs caught by agy Cell 2

### DIFF
--- a/src/content/docs/ai-ml-engineering/synthesis-apps/module-3.1-llm-native-stack-k8s.md
+++ b/src/content/docs/ai-ml-engineering/synthesis-apps/module-3.1-llm-native-stack-k8s.md
@@ -192,10 +192,12 @@ spec:
     requests.memory: 32Gi
     limits.cpu: "12"
     limits.memory: 96Gi
-    requests.storage: 300Gi
+    requests.storage: 400Gi
     persistentvolumeclaims: "4"
     pods: "8"
 ```
+
+Keep the quota aligned with workload storage demands: verify that `sum(PVC requests) <= requests.storage` so namespace storage admission is predictable and not stuck by a manifest mismatch.
 
 This quota is intentionally conservative. It gives one inference pod enough
 room to load a modest instruction model and leaves space for Qdrant, monitoring
@@ -377,7 +379,16 @@ spec:
   resources:
     requests:
       storage: 120Gi
----
+```
+
+Llama-3.1-8B-Instruct is a gated model on HuggingFace; you must accept the licence on huggingface.co/meta-llama/Llama-3.1-8B-Instruct and create a Secret with your access token before the pod will start.
+
+```bash
+kubectl -n llm-system create secret generic huggingface-token \
+  --from-literal=token=$HF_TOKEN
+```
+
+```yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -424,6 +435,11 @@ spec:
           env:
             - name: HF_HOME
               value: /models/huggingface
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: huggingface-token
+                  key: token
           ports:
             - name: http
               containerPort: 8000
@@ -895,6 +911,7 @@ from `llm-apps` should succeed. The call from the outside namespace should time
 out or be rejected, depending on your CNI's enforcement behavior. A fast success
 from the outside namespace means the policy is not enforced or the namespace
 selector is too broad.
+A NetworkPolicy that successfully blocks traffic produces curl exit code 28 (timeout); a 4xx or 5xx response means the policy is not blocking — the traffic reached the server. Look specifically for exit 28 to confirm the policy works.
 
 ```bash
 kubectl create namespace outside-llm-test

--- a/src/content/docs/ai-ml-engineering/synthesis-apps/module-3.1-llm-native-stack-k8s.md
+++ b/src/content/docs/ai-ml-engineering/synthesis-apps/module-3.1-llm-native-stack-k8s.md
@@ -911,7 +911,8 @@ from `llm-apps` should succeed. The call from the outside namespace should time
 out or be rejected, depending on your CNI's enforcement behavior. A fast success
 from the outside namespace means the policy is not enforced or the namespace
 selector is too broad.
-A NetworkPolicy that successfully blocks traffic produces curl exit code 28 (timeout); a 4xx or 5xx response means the policy is not blocking — the traffic reached the server. Look specifically for exit 28 to confirm the policy works.
+
+Exit 28 (timeout) means packets are being silently dropped; exit 7 (connection refused) means the CNI is sending TCP RST. Both confirm the policy is enforced — the difference is purely a CNI implementation detail (Cilium and weave-net default to drop; Calico and eBPF data planes often default to RST). A 4xx/5xx HTTP response means the traffic reached the server and the NetworkPolicy is NOT blocking it.
 
 ```bash
 kubectl create namespace outside-llm-test


### PR DESCRIPTION
## Summary

Fixes three deployment-blocking bugs in `module-3.1-llm-native-stack-k8s.md` that the agy/Gemini 3.5 Flash (High) Cell 2 calibration re-run (session 34) caught against the pre-fix version of PR #1349:

1. **ResourceQuota storage mismatch** — quota was `requests.storage: 300Gi` but `vllm-model-cache` (120Gi) + Qdrant `persistence.size` (200Gi) = 320Gi → second PVC would stay `Pending` forever. Bumped to `400Gi` with an 80Gi safety margin and added a one-sentence sanity-check nudge after the ResourceQuota block.

2. **Missing HF_TOKEN for gated Llama model** — `meta-llama/Llama-3.1-8B-Instruct` is a gated HuggingFace model; the manifest had `HF_HOME` but no `HF_TOKEN`, so the pod would fail to download the weights and crash-loop. Added the prerequisite paragraph (accept licence + `kubectl create secret`) before the vLLM Deployment, and added the `HF_TOKEN` env-var with `secretKeyRef` matching the Secret name + key.

3. **NetworkPolicy verification ambiguity** — the `curl -fsS` verification commands had ambiguous exit-code semantics. Added a paragraph clarifying that exit 28 (timeout, Cilium/weave-net default) AND exit 7 (RST, Calico/eBPF default) both confirm enforcement, while 4xx/5xx means traffic reached the server.

The vLLM probe-path hallucination (`/health/live` + `/health/ready` vs the real `/health`) was already fixed in PR #1349's second commit (session 32). This PR closes the remaining gaps.

Regression test: src/content/docs/ai-ml-engineering/synthesis-apps/module-3.1-llm-native-stack-k8s.md

## Learner check

> Exit 28 (timeout) means packets are being silently dropped; exit 7 (connection refused) means the CNI is sending TCP RST. Both confirm the policy is enforced — the difference is purely a CNI implementation detail (Cilium and weave-net default to drop; Calico and eBPF data planes often default to RST). A 4xx/5xx HTTP response means the traffic reached the server and the NetworkPolicy is NOT blocking it.

## Review chain

- Source: agy/Gemini 3.5 Flash (High) Cell 2 re-calibration on pre-fix module 3.1 (session 34, 2026-05-20)
- Writer: codex (gpt-5.3-codex-spark, edit class) — 92355e91
- Fixup: codex (sonnet nits N1+N2) — 6f9e7be1
- Reviewer A: claude-sonnet-4-6 — APPROVE_WITH_NITS (verified all 3 bug fixes; N1+N2 addressed by fixup commit)
- Reviewer B: agy/Gemini 3.5 Flash (High) — APPROVE_WITH_NITS (independent verification; stale image-tag nit deferred to follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)