### PR TITLE
feat(cks): rewrite module 4.3 Secrets Management — T3 → T0

### DIFF
--- a/src/content/docs/k8s/cks/part4-microservice-vulnerabilities/module-4.3-secrets-management.md
+++ b/src/content/docs/k8s/cks/part4-microservice-vulnerabilities/module-4.3-secrets-management.md
@@ -135,7 +135,7 @@ resources:
       - identity: {}
 ```
 
-The local providers have different tradeoffs. `aescbc` is the common local provider for clusters that cannot integrate with an external KMS yet, and it requires a base64-encoded 32-byte key. `aesgcm` provides authenticated encryption, but it is sensitive to nonce limits and demands stricter operational rotation discipline. `secretbox` uses a NaCl secretbox construction and also requires a 32-byte key. `identity` performs no encryption and should normally appear only as a temporary fallback for reading old plaintext values during migration, because placing it first means new writes stay unencrypted.
+The local providers have different tradeoffs. `aescbc` is the common local provider for clusters that cannot integrate with an external KMS yet, and it requires a base64-encoded 32-byte key. `aesgcm` is faster than `aescbc` because GCM authentication and decryption are accelerated on modern x86_64 chips, but it imposes a hard upper bound on writes per key. With a random 96-bit nonce, the birthday-bound for collisions starts to matter at roughly 2^32 (~4 billion) writes per key, after which an attacker observing collisions could derive plaintext. The Kubernetes documentation recommends `secretbox` over `aesgcm` for new clusters because secretbox's XSalsa20-Poly1305 construction uses a 192-bit nonce and dodges this constraint entirely. `secretbox` uses a NaCl secretbox construction and also requires a 32-byte key. `identity` performs no encryption and should normally appear only as a temporary fallback for reading old plaintext values during migration, because placing it first means new writes stay unencrypted.
 
 ```yaml
 apiVersion: apiserver.config.k8s.io/v1
@@ -156,11 +156,44 @@ resources:
 
 Enabling the file is only half of the work. The kube-apiserver must receive `--encryption-provider-config`, and a static Pod control plane must mount the host path containing that file into the API server container. A common exam failure is to create a valid file on the node and forget the `volumeMounts` and `volumes` entries, causing the API server to restart into a path-not-found error. After the API server is healthy, newly written Secrets use the first provider, but existing Secrets remain in their previous storage form until they are rewritten through the API.
 
+### Wiring the config file into kube-apiserver
+
+Edit `/etc/kubernetes/manifests/kube-apiserver.yaml` on the control plane node so the static Pod can see the encryption config file. Kubelet watches this manifest directory and restarts the static Pod after a valid edit, so the API server will pick up the new command/volume wiring automatically. The most common mistake is to create a correct `encryption-config.yaml` but forget to mount it into the kube-apiserver container.
+
+```yaml
+# /etc/kubernetes/manifests/kube-apiserver.yaml
+# In spec.containers[0].command, add:
+- --encryption-provider-config=/etc/kubernetes/enc/encryption-config.yaml
+
+# In spec.containers[0].volumeMounts, add:
+- name: enc-config
+  mountPath: /etc/kubernetes/enc
+  readOnly: true
+
+# In spec.volumes, add:
+- name: enc-config
+  hostPath:
+    path: /etc/kubernetes/enc
+    type: DirectoryOrCreate
+```
+
+All three pieces — the flag, mount, and volume — must be present; if one is missing, the API server does not load the config and falls back to identity (plaintext) writes silently.
+
 ```bash
 kubectl get secrets --all-namespaces -o json | kubectl replace -f -
 ```
 
 Verification should prove both configuration and data transformation. The API server flag proves the process knows where the provider file is, but it does not prove older records were rewritten. A storage-level sample should show the encrypted storage prefix for a newly written Secret, while ordinary `kubectl get secret` should still return a usable object because decryption happens transparently on API reads. If a compliance check only asks whether the flag exists, it is checking intent rather than outcome. If it only checks one newly created Secret, it may miss historical plaintext data.
+
+```bash
+ETCDCTL_API=3 etcdctl \
+  --cacert=/etc/kubernetes/pki/etcd/ca.crt \
+  --cert=/etc/kubernetes/pki/etcd/server.crt \
+  --key=/etc/kubernetes/pki/etcd/server.key \
+  get /registry/secrets/secrets-lab/app-db | strings | head -5
+```
+
+After encryption is enabled, the value should start with `k8s:enc:aescbc:v1:` (or `:aesgcm:v1:` / `:secretbox:v1:` / `:kms:v2:` depending on provider). Before encryption, or when `identity` is used for write paths, plaintext fields are still visible and no such prefix appears. This is the canonical proof step: the verifier is authoritative when you can read the raw etcd value and see the `k8s:enc:...` prefix, because that is the storage format the API server writes when encryption is active.
 
 Key rotation is a provider-ordering exercise, not a one-line replacement. Add the new key above the old key, restart or reload the API server according to your control-plane model, rewrite the protected resources, verify that new storage records reference the new key, and only then remove the old key from the provider list. Removing an old key too early can make older stored objects unreadable. Leaving retired keys forever weakens the purpose of rotation because a leaked old key remains useful for any object that was never rewritten.
 
@@ -236,11 +269,13 @@ spec:
     name: payment-db
     creationPolicy: Owner
   data:
-    - secretKey: password
-      remoteRef:
-        key: payments/database
-        property: password
+      - secretKey: password
+        remoteRef:
+          key: payments/database
+          property: password
 ```
+
+Note: ExternalSecret moved from `external-secrets.io/v1beta1` to `external-secrets.io/v1` in ESO 0.10. Clusters running ESO 0.9.x still use `v1beta1` — replace the `apiVersion` field accordingly.
 
 The `SecretStore` versus `ClusterSecretStore` decision is a governance decision. A `SecretStore` lives in one namespace and is usually owned by the team that owns the workloads there. A `ClusterSecretStore` is cluster-scoped and useful when a platform team wants one provider configuration shared by many namespaces. The cluster-scoped option is powerful, so pair it with admission policy, namespace allowlists, and provider-side authorization. Otherwise, a namespace owner may gain a clean Kubernetes API path to remote secrets they should never reach.
 
@@ -255,6 +290,26 @@ ESO templating is useful when the provider stores atomic values but the applicat
 Sealed Secrets is a different GitOps-centered pattern. The `kubeseal` client encrypts a Secret using the controller's public key, producing a `SealedSecret` custom resource safe to commit to Git for the target cluster and scope. The controller inside the cluster holds the private key and decrypts the resource into a native Secret. This fits teams that want pull-based GitOps and do not have, or do not want, a runtime dependency on a cloud secret manager for every application. It does not fit secrets that need dynamic issuance, short leases, or centralized provider audit trails across many clusters.
 
 Sealed Secrets scope is a security feature that should be understood before moving encrypted YAML between environments. A sealed value can be bound to a name and namespace, which prevents someone from taking a ciphertext meant for one Secret and replaying it under a more privileged name elsewhere. That protection is useful, but it also means renaming or moving a Secret may require resealing. Back up the controller private key carefully, because losing it can make committed SealedSecret resources undecryptable during cluster recovery.
+
+Sealed Secrets keys rotate automatically every 30 days when the controller flag `--key-renew-period=720h` (the default) is set, but older keys are kept indefinitely so existing SealedSecret resources continue to decrypt. To force a manual rotation, create a new key Secret in `kube-system` with the `sealedsecrets.bitnami.com/sealed-secrets-key: active` label and the controller will use it for new seals on its next reconcile; the existing SealedSecret resources do not need to be re-sealed because each carries the encryption-key fingerprint in its annotations. The controller decrypts using whichever key the fingerprint points at, even after rotation.
+
+```yaml
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: app-db
+  namespace: production
+spec:
+  encryptedData:
+    password: AgBy3i4OJSWK+...g8VPo3vP
+  template:
+    metadata:
+      name: app-db
+      namespace: production
+    type: Opaque
+```
+
+`encryptedData` values are sealed against the controller's public key (via `kubeseal`); the controller in `kube-system` decrypts them at apply time and creates the matching plain Secret.
 
 ```text
 +------------------+      public key       +-------------------+
@@ -298,6 +353,20 @@ spec:
 ```
 
 Hypothetical scenario: a critical service starts without its expected Vault-rendered file because an injection annotation was copied to the Deployment template but the ServiceAccount was not bound to the Vault role. The container image is healthy, Kubernetes scheduling is healthy, and the application error looks like an ordinary missing-file problem. The security lesson is that injector-based delivery creates an admission-time dependency and a runtime file contract. Your readiness probe should fail if the rendered file is absent, and your deployment pipeline should validate both annotations and ServiceAccount-to-Vault-role bindings before traffic moves.
+
+```bash
+# One-time setup inside the Vault pod (after vault is unsealed):
+kubectl exec -n vault vault-0 -- /bin/sh -c '
+  vault auth enable kubernetes
+  vault write auth/kubernetes/config \
+    kubernetes_host="https://kubernetes.default.svc.cluster.local:443" \
+    kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+    token_reviewer_jwt=@/var/run/secrets/kubernetes.io/serviceaccount/token \
+    issuer="https://kubernetes.default.svc.cluster.local"
+'
+```
+
+In this setup, `token_reviewer_jwt` is the ServiceAccount JWT Vault uses when calling Kubernetes TokenReview to validate client Pod service account tokens. The `issuer` must match the cluster's JWT issuer configured on the API server via `--service-account-issuer`, otherwise token validation requests are rejected.
 
 The Secrets Store CSI Driver occupies the middle ground between native Kubernetes Secret consumption and direct application calls to an external provider. The kubelet mounts provider data into a Pod as a CSI volume, and optional sync features can also create a Kubernetes Secret when a workload or chart requires one. This is attractive when you want rotation to appear as file updates and when you want the external provider to remain the real store. The driver runs node components, provider plugins, and SecretProviderClass configuration, so operational ownership must include node coverage, provider credentials, and application reload behavior.
 
@@ -477,7 +546,7 @@ The cost decision follows the same path. Native Secrets add little direct cloud 
 
 ## Did You Know?
 
-- **KMS v2 became stable in Kubernetes 1.29.** That graduation matters because KMS v1 is deprecated and disabled by default in newer Kubernetes releases, making v2 the preferred provider path for external key management.
+- **KMS v2 became stable in Kubernetes 1.29.** KMS v1 is marked deprecated as of Kubernetes 1.28 but remains functional and configurable through 1.30+. KMS v2 (GA in 1.29) is strongly preferred for new deployments because the v1 plugin protocol's gRPC-streaming design has known performance and partition-failure issues that v2's request/response model resolves.
 - **Immutable Secrets became stable in Kubernetes 1.21.** They are not just a security guardrail; they also reduce kubelet watch load for clusters with many mounted Secret and ConfigMap objects.
 - **A ServiceAccount token can be requested for a specific audience and expiration.** That is the modern alternative to treating a long-lived token Secret as a reusable password for every internal service.
 - **A Secret read logged at `RequestResponse` level can expose the payload in the audit backend.** For most Secret access monitoring, `Metadata` level gives the actor, verb, resource, namespace, and timestamp without copying the sensitive value.
@@ -573,6 +642,8 @@ The decoded output should match the literal value you provided. That proves the 
 
 Generate a key in the lab and create a configuration file that encrypts only Secrets. Keep `identity` last so old plaintext records can still be read during migration.
 
+If your lab exposes the control-plane filesystem, also wire the manifest edit from “Wiring the config file into kube-apiserver” into `/etc/kubernetes/manifests/kube-apiserver.yaml`, then wait for kubelet to restart the static API server Pod.
+
 ```bash
 mkdir -p /tmp/cks-4-3
 head -c 32 /dev/urandom | base64 > /tmp/cks-4-3/aescbc.key
@@ -591,6 +662,21 @@ resources:
               secret: ${ENC_KEY}
       - identity: {}
 EOF
+
+sudo mkdir -p /etc/kubernetes/enc
+sudo cp /tmp/cks-4-3/encryption-config.yaml /etc/kubernetes/enc/encryption-config.yaml
+
+# Edit /etc/kubernetes/manifests/kube-apiserver.yaml to mount and pass the new config:
+# --encryption-provider-config, matching volumeMount, and volume entries.
+# Then verify the static Pod has restarted.
+
+kubectl get secrets --all-namespaces -o json | kubectl replace -f -
+
+ETCDCTL_API=3 etcdctl \
+  --cacert=/etc/kubernetes/pki/etcd/ca.crt \
+  --cert=/etc/kubernetes/pki/etcd/server.crt \
+  --key=/etc/kubernetes/pki/etcd/server.key \
+  get /registry/secrets/secrets-lab/app-db | strings | head -5
 ```
 
 <details>

--- a/src/content/docs/k8s/cks/part4-microservice-vulnerabilities/module-4.3-secrets-management.md
+++ b/src/content/docs/k8s/cks/part4-microservice-vulnerabilities/module-4.3-secrets-management.md
@@ -22,845 +22,563 @@ lab:
 
 After completing this module, you will be able to:
 
-1. **Diagnose** the security posture of existing Kubernetes Secrets by auditing etcd storage mechanisms and application consumption patterns.
-2. **Implement** encryption at rest for etcd using AES-CBC to secure sensitive data against infrastructure-level theft and unauthorized control-plane reads.
-3. **Implement** external secrets management using the External Secrets Operator to synchronize credentials securely from cloud provider secret stores (e.g., AWS Secrets Manager, HashiCorp Vault).
-4. **Design** least-privilege RBAC policies utilizing `resourceNames` to strictly govern pod and user access to specific secret payloads.
-5. **Evaluate** runtime secret consumption methods, comparing the attack surface of environment variables versus memory-backed volume mounts.
-
----
+1. **Diagnose** default Kubernetes Secret exposure by tracing where values appear in manifests, Pod specs, environment variables, kubelet-managed volumes, etcd, and audit records.
+2. **Implement** `EncryptionConfiguration` for Secrets at rest, including local providers, KMS v2, provider ordering, verification, and key rotation.
+3. **Compare** External Secrets Operator, Sealed Secrets, HashiCorp Vault, and the Secrets Store CSI Driver for different operational and GitOps secret-delivery models.
+4. **Design** least-privilege controls for Secret access using RBAC, projected ServiceAccount tokens, audit policies, immutable Secrets, and application-level rotation workflows.
 
 ## Why This Module Matters
 
-In September 2022, Uber suffered a catastrophic system-wide breach. The attackers didn't use a highly sophisticated zero-day exploit; they found a hardcoded administrator password inside an internal network share. In the Kubernetes ecosystem, an equivalent disaster happens every day when engineering teams mistakenly assume that Kubernetes Secrets are natively secure. When attackers gain initial access to a cluster, or even just compromise a poorly secured backup of the etcd database, unencrypted base64 strings act as an immediate skeleton key to your entire infrastructure. Databases, third-party APIs, and TLS private keys are laid bare.
+Hypothetical scenario: a payment API goes down during an ordinary rollout because the new Pod cannot authenticate to its database. The Secret object exists, the Deployment references the correct key, and the application image did not change. The root cause is less dramatic and more common: an operator rotated a database password in the cloud secret manager, the Kubernetes Secret stayed stale, the Pod consumed the old value through an environment variable, and the application had no reload path short of a restart. Nothing was exploited, yet the outage came from the same design weakness an attacker would use: the team did not know which component was the source of truth for the credential.
 
-The illusion of security provided by default Kubernetes Secrets is one of the most dangerous operational anti-patterns in cloud-native engineering. Kubernetes was architected for orchestration, not cryptographic credential management. Out of the box, it stores your most sensitive data in plain text inside its backing store. This makes the data incredibly vulnerable to anyone with direct node access, unencrypted backup access, or broad RBAC permissions that allow them to query the API server.
+Kubernetes Secrets are useful, but they are not a complete secrets-management system by themselves. A Secret gives you an API object for small sensitive values, a way to mount those values into Pods, and a type system for common payloads such as TLS keys and registry credentials. By default, however, the value is base64-encoded rather than encrypted, stored in the API server's backing store unless you configure encryption at rest, and readable by any subject with enough RBAC or indirect Pod-creation power in the namespace. That combination is easy to misunderstand because the object is called `Secret`, yet the default guarantees are closer to "separate this value from the image and Pod template" than to "cryptographically protect this value against cluster administrators, backups, and broad readers."
 
-For the Certified Kubernetes Security Specialist (CKS) exam—and for any production-grade deployment running Kubernetes v1.35 or higher—mastering Secrets management is non-negotiable. You must be able to recognize the operational risks of default secrets, implement robust encryption at rest to protect the etcd data store, and understand how to integrate enterprise-grade external secret managers. Failing to secure secrets effectively turns a minor pod compromise into a catastrophic, unrecoverable total-system breach.
+The CKS exam expects you to reason about that distinction under time pressure. You may need to inspect a Pod that leaks a password through an environment variable, restrict a Role that grants `list` on every Secret in a namespace, configure `--encryption-provider-config` for the API server, or explain why a projected ServiceAccount token is safer than a long-lived token Secret. Production work adds another layer: cost, rotation, audit volume, and failure modes. A secure design is not the tool with the strongest marketing page; it is the design where the storage boundary, decryption boundary, runtime delivery path, and human access path all match the risk you are trying to reduce.
 
----
+## Diagnosing Default Secret Exposure
 
-## The Reality of Default Kubernetes Secrets
+A Kubernetes Secret is an API object whose `data` fields are base64 strings. Base64 is an encoding format that lets arbitrary bytes travel safely through YAML, JSON, and HTTP APIs; it is not encryption because there is no key and no access decision during decoding. If someone can read the object, they can decode the value locally, and the API server will not know that decoding happened. The first diagnostic move is therefore to separate "who can read the Secret object" from "who can decode the bytes after reading it."
 
-Before we secure our secrets, we must understand how Kubernetes handles them by default. A Kubernetes `Secret` object is simply a specialized `ConfigMap` designed to hold sensitive data. By default, it applies a basic base64 encoding to the payloads to ensure binary data doesn't break JSON/YAML parsers. 
+```bash
+kubectl create namespace secrets-lab
+kubectl -n secrets-lab create secret generic app-db \
+  --from-literal=username=app_user \
+  --from-literal=password=example-password
 
-**Base64 encoding provides zero cryptographic security.**
+kubectl -n secrets-lab get secret app-db -o jsonpath='{.data.password}'
+printf '\n'
+kubectl -n secrets-lab get secret app-db -o jsonpath='{.data.password}' | base64 --decode
+printf '\n'
+```
+
+That demonstration is intentionally plain because the exam often tests whether you notice the obvious exposure path before reaching for a larger tool. The API response contains encoded bytes, not ciphertext. If the cluster has no encryption provider configured, the API server also persists the object into etcd without envelope encryption. That means etcd snapshots, direct etcd access, and poorly protected control-plane backups can expose sensitive values even when normal `kubectl get secret` access is locked down. RBAC protects API reads; at-rest encryption protects the storage layer; neither replaces the other.
 
 ```text
-┌─────────────────────────────────────────────────────────────┐
-│              DEFAULT SECRETS SECURITY                       │
-├─────────────────────────────────────────────────────────────┤
-│                                                             │
-│  ⚠️  Base64 is NOT encryption!                             │
-│  ─────────────────────────────────────────────────────────  │
-│  $ echo "mysecretpassword" | base64                        │
-│  bXlzZWNyZXRwYXNzd29yZAo=                                  │
-│                                                             │
-│  $ echo "bXlzZWNyZXRwYXNzd29yZAo=" | base64 -d            │
-│  mysecretpassword                                          │
-│                                                             │
-│  Problems with default secrets:                            │
-│  ├── Stored unencrypted in etcd                           │
-│  ├── Visible to anyone with get secrets permission         │
-│  ├── Appear in pod specs (kubectl describe)               │
-│  ├── May be logged in audit logs                          │
-│  └── Mounted as plain text files in containers            │
-│                                                             │
-└─────────────────────────────────────────────────────────────┘
++-------------------+       +--------------------+       +------------------+
+| Secret manifest   | ----> | kube-apiserver     | ----> | etcd storage     |
+| data: base64 text |       | admission + RBAC   |       | plaintext unless |
+| stringData: input |       | optional encryptor |       | configured       |
++-------------------+       +--------------------+       +------------------+
+          |                            |
+          |                            v
+          |                  +--------------------+
+          |                  | kubelet on node    |
+          |                  | projects as files  |
+          |                  | or env variables   |
+          |                  +--------------------+
+          v
++-------------------+
+| kubectl output    |
+| logs, Git, chats  |
+| copied snippets   |
++-------------------+
 ```
 
-For clarity, here is the modern architectural view of these vulnerabilities:
-
-```mermaid
-graph TD
-    A[Default Kubernetes Secrets] --> B[Base64 Encoding Only]
-    B --> C[Stored Plaintext in etcd]
-    B --> D[Visible via Broad RBAC]
-    B --> E[Leaked in Pod Specs]
-    B --> F[Captured in Audit Logs]
-    B --> G[Exposed in Container Filesystems]
-
-    classDef danger fill:#fee,stroke:#c00,stroke-width:2px;
-    class A,B,C,D,E,F,G danger;
-```
-
-> **Stop and think**: You've perfectly configured RBAC so no unauthorized users can run `kubectl get secrets`. However, considering how Kubernetes natively stores and distributes these base64-encoded values, what underlying operational processes (like disaster recovery backups, centralized logging, or node administration) could still expose your plaintext passwords to an attacker who has zero API access?
-
----
-
-## Creating and Consuming Secrets
-
-Kubernetes supports multiple types of secrets to handle different authentication patterns natively.
-
-### Generic Secret
-
-You can create generic Opaque secrets from literal strings, files, or environment files.
-
-```bash
-# From literal values
-kubectl create secret generic db-creds \
-  --from-literal=username=admin \
-  --from-literal=password=secretpass123
-
-# From files
-kubectl create secret generic ssh-key \
-  --from-file=id_rsa=/path/to/id_rsa \
-  --from-file=id_rsa.pub=/path/to/id_rsa.pub
-
-# From env file
-kubectl create secret generic app-config \
-  --from-env-file=secrets.env
-```
-
-### TLS Secret
-
-TLS secrets specifically expect `tls.crt` and `tls.key` data fields, which ingress controllers and web servers natively look for.
-
-```bash
-# Create TLS secret
-kubectl create secret tls web-tls \
-  --cert=server.crt \
-  --key=server.key
-```
-
-### Docker Registry Secret
-
-When pulling images from private registries, kubelets require specialized credentials formatted as a Docker config JSON.
-
-```bash
-# Create registry credential
-kubectl create secret docker-registry regcred \
-  --docker-server=registry.example.com \
-  --docker-username=user \
-  --docker-password=password \
-  --docker-email=user@example.com
-```
-
----
-
-## Using Secrets in Pods: Environment Variables vs Volume Mounts
-
-Once a secret exists, applications need to consume it. There are two primary methods: Environment Variables and Volume Mounts. From a security perspective, they are not equal.
-
-### Environment Variables
-
-Injecting secrets as environment variables is the most common, yet most dangerous, pattern.
+The runtime path matters just as much as storage. When a container receives a Secret through `env.valueFrom.secretKeyRef`, the value becomes part of the process environment. It can show up in debugging output, crash reports, accidental `printenv` dumps, and child processes. When a container receives a Secret through a volume, the kubelet writes files into a memory-backed volume and can update those files after the Secret changes, although applications still need to reopen or watch the files. A volume is not magic secrecy, but it gives you file permissions, a narrower read path, and a better rotation story than environment variables.
 
 ```yaml
 apiVersion: v1
 kind: Pod
 metadata:
-  name: secret-env-pod
+  name: env-leak-demo
+  namespace: secrets-lab
 spec:
   containers:
-  - name: app
-    image: nginx
-    env:
-    - name: DB_USERNAME
-      valueFrom:
-        secretKeyRef:
-          name: db-creds
-          key: username
-    - name: DB_PASSWORD
-      valueFrom:
-        secretKeyRef:
-          name: db-creds
-          key: password
+    - name: app
+      image: busybox
+      command: ["sh", "-c", "sleep 3600"]
+      env:
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: app-db
+              key: password
 ```
 
-### Volume Mounts (Preferred)
+Pause and predict: if a user cannot run `kubectl get secret app-db`, but can create Pods in `secrets-lab`, what could they do with the Pod above? The important gotcha is that Pod creation can become indirect Secret read access. A subject that can create a Pod in a namespace can usually mount or inject any Secret in that namespace into a container it controls, then read the value from inside the container. That is why Secret RBAC cannot be reviewed in isolation from workload-creation permissions.
 
-Mounting secrets as volumes attaches the secret to the pod as a file system construct. Kubernetes backs these specific mounts with `tmpfs`, meaning they exist only in RAM and are never written to the worker node's physical disk.
+Secret types add validation and convention, not universal confidentiality. `Opaque` is the generic type for arbitrary key-value pairs. `kubernetes.io/dockerconfigjson` stores registry pull credentials in the `.dockerconfigjson` key so kubelet image pulls can use them. `kubernetes.io/tls` expects `tls.crt` and `tls.key`, which ingress controllers and workloads commonly understand. `kubernetes.io/service-account-token` is a legacy long-lived ServiceAccount token Secret type that should usually be replaced by projected, bound tokens. Bootstrap token Secrets, using the `bootstrap.kubernetes.io/token` type, support kubelet TLS bootstrapping and should be treated as short-lived cluster-join credentials rather than application secrets.
+
+| Secret type | Typical payload | Main risk to check |
+|---|---|---|
+| `Opaque` | Application credentials and API keys | Values are arbitrary, so naming and rotation conventions must come from your team. |
+| `kubernetes.io/dockerconfigjson` | Registry authentication JSON | A stolen value may grant image-pull access across environments or registries. |
+| `kubernetes.io/tls` | `tls.crt` and `tls.key` | The private key is high impact and should not be stored in ConfigMaps or logs. |
+| `kubernetes.io/service-account-token` | Long-lived API bearer token | Prefer projected, audience-bound, time-bound tokens for modern workloads. |
+| `bootstrap.kubernetes.io/token` | Node bootstrap token data | Expire and scope tightly because it participates in node trust establishment. |
+
+Hypothetical scenario: during an outage, an engineer runs `kubectl describe pod payment-api` in a shared terminal recording and captures environment variable names showing exactly which Secret keys the container consumes. The output does not print the Secret value, but it reveals the credential map, the Secret object names, and enough structure for an attacker with later namespace access to know where to look. The fix is not to ban debugging; it is to consume high-value values as files, avoid dumping environments, restrict Pod creation, and keep audit logging focused on who read or changed Secret objects.
+
+`stringData` is another place where naming can mislead learners. It is a write-friendly input field that lets you submit clear text in a manifest or command output, and the API server stores the resulting value under `data` as base64. That makes `stringData` convenient for ad hoc creation but risky for Git and chat transcripts because the submitted manifest contains the raw value. In reviewed configuration, prefer generator or encryption workflows that keep the clear text out of the repository before the Kubernetes API ever sees it.
+
+The node boundary is also part of the exposure map. The kubelet retrieves Secret data for Pods scheduled to its node and writes projected files for those Pods, so a compromised node can become a credential collection point for the workloads running there. This is one reason Pod Security Admission, node hardening, hostPath restrictions, and runtime isolation still matter in a module about Secrets. A cluster can have perfect API RBAC and encrypted etcd snapshots while a privileged container on a node reads mounted credentials from neighboring workloads through host access.
+
+Registry pull credentials deserve separate review because they often outlive the workload that used them. A `kubernetes.io/dockerconfigjson` Secret may grant access to a whole registry namespace, not just one image, and that access can enable supply-chain movement if an attacker can pull private images or inspect layers. Treat image pull Secrets as deployment credentials with their own rotation calendar, provider-side scoping, and namespace boundaries. If a workload only needs public images, removing the pull Secret is simpler than protecting a credential that should not exist.
+
+On the exam, a fast Secret diagnosis can follow a consistent path: inspect how the Pod consumes the value, inspect who can read or indirectly mount the Secret, inspect whether the API server has encryption configured, and inspect whether logs or audit policy copy sensitive payloads. That sequence keeps you from overfocusing on one layer. A Pod using file mounts can still be unsafe if the Role grants `list secrets`; a cluster with encrypted etcd can still leak through environment dumps; and an external manager can still sync a native Secret that broad readers can decode.
+
+## Implementing EncryptionConfiguration and KMS v2
+
+At-rest encryption is configured on the kube-apiserver because the API server is the component that serializes API objects into etcd. The configuration file tells the API server which resources to encrypt and which providers to try. The first provider in the list is used for new writes, and each listed provider may be used to decrypt older data. This ordering rule is the heart of rotation: add the new key first, keep old keys below it for reads, rewrite the objects, verify, and only then remove retired keys.
 
 ```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: secret-volume-pod
-spec:
-  containers:
-  - name: app
-    image: nginx
-    volumeMounts:
-    - name: secrets
-      mountPath: /etc/secrets
-      readOnly: true
-  volumes:
-  - name: secrets
-    secret:
-      secretName: db-creds
-      # Optional: set specific permissions
-      defaultMode: 0400
-```
-
-### Why Volume Mounts Are Better
-
-```text
-┌─────────────────────────────────────────────────────────────┐
-│              ENV VARS vs VOLUME MOUNTS                      │
-├─────────────────────────────────────────────────────────────┤
-│                                                             │
-│  Environment Variables:                                     │
-│  ├── Visible in /proc/<pid>/environ                        │
-│  ├── May leak to child processes                           │
-│  ├── Often logged by applications                          │
-│  └── Visible in 'docker inspect'                           │
-│                                                             │
-│  Volume Mounts:                                             │
-│  ├── Files with restricted permissions                     │
-│  ├── tmpfs (in-memory, not written to disk)               │
-│  ├── Auto-updated when secret changes                      │
-│  └── Controlled access via file permissions               │
-│                                                             │
-│  Best Practice: Always use volume mounts                   │
-│                                                             │
-└─────────────────────────────────────────────────────────────┘
-```
-
-Visualized as a comparative flow:
-
-```mermaid
-graph TD
-    A[Secret Consumption] --> B[Environment Variables]
-    A --> C[Volume Mounts]
-    
-    B --> B1[Exposed in /proc/pid/environ]
-    B --> B2[Leaks in Crash Dumps]
-    B --> B3[Captured by APM Loggers]
-    
-    C --> C1[Stored in RAM via tmpfs]
-    C --> C2[Restricted by UNIX chmod]
-    C --> C3[Dynamically Updates without Restart]
-    
-    classDef danger fill:#fee,stroke:#c00,stroke-width:2px;
-    classDef safe fill:#efe,stroke:#090,stroke-width:2px;
-    class B,B1,B2,B3 danger;
-    class C,C1,C2,C3 safe;
-```
-
-> **Pause and predict**: You mount a secret as an environment variable (`env.valueFrom.secretKeyRef`) and the application crashes. The crash dump includes environment variables and gets logged to your centralized logging system. Who can now see the secret?
-
----
-
-## Securing Secrets at Rest (etcd Encryption)
-
-To mitigate the risk of etcd backups or raw disk access exposing secrets, Kubernetes allows you to configure encryption at rest. This ensures that before the API server writes a secret to etcd, it encrypts the payload cryptographically.
-
-### Check Current Encryption Status
-
-First, you must determine if your cluster currently encrypts data.
-
-```bash
-# Check API server configuration
-ps aux | grep kube-apiserver | grep encryption-provider-config
-
-# Or check the manifest
-cat /etc/kubernetes/manifests/kube-apiserver.yaml | grep encryption
-```
-
-### Encryption Providers
-
-Kubernetes supports multiple cryptographic providers for at-rest encryption.
-
-```text
-┌─────────────────────────────────────────────────────────────┐
-│              ENCRYPTION PROVIDERS                           │
-├─────────────────────────────────────────────────────────────┤
-│                                                             │
-│  identity (default)                                        │
-│  └── No encryption, plain storage                          │
-│                                                             │
-│  aescbc (recommended)                                      │
-│  └── AES-CBC with PKCS#7 padding                          │
-│      Strong, widely supported                              │
-│                                                             │
-│  aesgcm                                                    │
-│  └── AES-GCM authenticated encryption                     │
-│      Faster, must rotate keys every 200K writes           │
-│                                                             │
-│  kms                                                       │
-│  └── External KMS provider (AWS KMS, Azure Key Vault)     │
-│      Best for production, keys never touch etcd           │
-│                                                             │
-│  secretbox                                                 │
-│  └── XSalsa20 + Poly1305                                  │
-│      Strong, fixed nonce size                              │
-│                                                             │
-│  Order matters: First provider encrypts new secrets        │
-│  All listed providers can decrypt                          │
-│                                                             │
-└─────────────────────────────────────────────────────────────┘
-```
-
-A hierarchical breakdown of providers:
-
-```mermaid
-flowchart LR
-    A[Encryption Providers] --> B(identity)
-    A --> C(aescbc)
-    A --> D(aesgcm)
-    A --> E(kms v2)
-    
-    B -.-> B1[Default: Plaintext]
-    C -.-> C1[Standard: Strong padding]
-    D -.-> D1[Fast: Needs heavy rotation]
-    E -.-> E1[Enterprise: Keys outside K8s]
-```
-
-### Enable etcd Encryption
-
-We implement encryption by writing an `EncryptionConfiguration` file to the control plane.
-
-```yaml
-# /etc/kubernetes/enc/encryption-config.yaml
 apiVersion: apiserver.config.k8s.io/v1
 kind: EncryptionConfiguration
 resources:
   - resources:
       - secrets
     providers:
-      # aescbc - recommended for production
       - aescbc:
           keys:
-            - name: key1
-              secret: <base64-encoded-32-byte-key>
-      # identity is the fallback (unencrypted)
+            - name: key-2026-05
+              secret: REPLACE_WITH_32_BYTE_BASE64_KEY
       - identity: {}
 ```
 
-### Generate Encryption Key
-
-You must generate a cryptographically secure key for AES-CBC.
-
-```bash
-# Generate random 32-byte key
-head -c 32 /dev/urandom | base64
-
-# Example output (use your own!):
-# K8sSecretEncryptionKey1234567890ABCDEF==
-```
-
-### Configure API Server
-
-Mount the configuration into the static pod manifest. 
+The local providers have different tradeoffs. `aescbc` is the common local provider for clusters that cannot integrate with an external KMS yet, and it requires a base64-encoded 32-byte key. `aesgcm` provides authenticated encryption, but it is sensitive to nonce limits and demands stricter operational rotation discipline. `secretbox` uses a NaCl secretbox construction and also requires a 32-byte key. `identity` performs no encryption and should normally appear only as a temporary fallback for reading old plaintext values during migration, because placing it first means new writes stay unencrypted.
 
 ```yaml
-# /etc/kubernetes/manifests/kube-apiserver.yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: kube-apiserver
-spec:
-  containers:
-  - command:
-    - kube-apiserver
-    # Add this flag
-    - --encryption-provider-config=/etc/kubernetes/enc/encryption-config.yaml
-    volumeMounts:
-    # Mount the encryption config
-    - mountPath: /etc/kubernetes/enc
-      name: enc
-      readOnly: true
-  volumes:
-  - hostPath:
-      path: /etc/kubernetes/enc
-      type: DirectoryOrCreate
-    name: enc
+apiVersion: apiserver.config.k8s.io/v1
+kind: EncryptionConfiguration
+resources:
+  - resources:
+      - secrets
+      - configmaps
+    providers:
+      - aescbc:
+          keys:
+            - name: key-2026-06
+              secret: REPLACE_WITH_NEW_32_BYTE_BASE64_KEY
+            - name: key-2026-05
+              secret: REPLACE_WITH_OLD_32_BYTE_BASE64_KEY
+      - identity: {}
 ```
 
-### Verify Encryption Works
-
-We can query etcd directly to prove the bytes on disk are no longer readable.
+Enabling the file is only half of the work. The kube-apiserver must receive `--encryption-provider-config`, and a static Pod control plane must mount the host path containing that file into the API server container. A common exam failure is to create a valid file on the node and forget the `volumeMounts` and `volumes` entries, causing the API server to restart into a path-not-found error. After the API server is healthy, newly written Secrets use the first provider, but existing Secrets remain in their previous storage form until they are rewritten through the API.
 
 ```bash
-# Create a test secret
-kubectl create secret generic test-encryption --from-literal=mykey=myvalue
-
-# Read directly from etcd (on control plane)
-ETCDCTL_API=3 etcdctl get /registry/secrets/default/test-encryption \
-  --endpoints=https://127.0.0.1:2379 \
-  --cacert=/etc/kubernetes/pki/etcd/ca.crt \
-  --cert=/etc/kubernetes/pki/etcd/server.crt \
-  --key=/etc/kubernetes/pki/etcd/server.key | hexdump -C
-
-# If encrypted: You'll see random bytes, not readable text
-# If NOT encrypted: You'll see "mykey" and "myvalue" in plain text
+kubectl get secrets --all-namespaces -o json | kubectl replace -f -
 ```
 
-### Re-encrypt Existing Secrets
+Verification should prove both configuration and data transformation. The API server flag proves the process knows where the provider file is, but it does not prove older records were rewritten. A storage-level sample should show the encrypted storage prefix for a newly written Secret, while ordinary `kubectl get secret` should still return a usable object because decryption happens transparently on API reads. If a compliance check only asks whether the flag exists, it is checking intent rather than outcome. If it only checks one newly created Secret, it may miss historical plaintext data.
 
-Because the API server only encrypts data *upon write*, old secrets remain exposed until forcefully rewritten.
+Key rotation is a provider-ordering exercise, not a one-line replacement. Add the new key above the old key, restart or reload the API server according to your control-plane model, rewrite the protected resources, verify that new storage records reference the new key, and only then remove the old key from the provider list. Removing an old key too early can make older stored objects unreadable. Leaving retired keys forever weakens the purpose of rotation because a leaked old key remains useful for any object that was never rewritten.
 
-```bash
-# After enabling encryption, re-encrypt all existing secrets
-kubectl get secrets -A -o json | kubectl replace -f -
-```
+Managed Kubernetes changes who performs the mechanical step, not the concept you need to understand. Some managed services expose a checkbox or API for secret envelope encryption, while self-managed clusters require direct kube-apiserver configuration. For CKS, you should still understand the file format because the exam environment commonly resembles a kubeadm-style control plane. In production, ask whether the managed service encrypts only Secrets or all API resources, whether customer-managed keys are supported, and what operational event re-encrypts historical objects after a key change.
 
-> **Pause and predict**: You enable encryption at rest for secrets using `aescbc`. You then use `etcdctl get` to read a secret directly from etcd. Will you see the plain text or encrypted data? What about secrets that were created *before* you enabled encryption?
+KMS v2 is the production-grade version of this pattern when you want the root encryption key outside the cluster. In envelope encryption, Kubernetes encrypts each stored object with a data encryption key, then asks an external KMS plugin to encrypt or decrypt that data key with a key encryption key managed by AWS KMS, Google Cloud KMS, Azure Key Vault, Vault, or another provider. The API server talks to the plugin over a local Unix domain socket using the KMS provider protocol. The plugin boundary lets the cluster use a managed HSM-backed key without teaching the API server every cloud-specific authentication method.
 
----
-
-## Implementing External Secrets Management
-
-While etcd encryption protects data at rest, managing secret lifecycle, rotation, and cross-cluster synchronization natively in Kubernetes is difficult. The industry standard is to delegate secret storage to external Key Management Systems (KMS) and inject them dynamically.
-
-```text
-┌─────────────────────────────────────────────────────────────┐
-│              EXTERNAL SECRETS SOLUTIONS                     │
-├─────────────────────────────────────────────────────────────┤
-│                                                             │
-│  HashiCorp Vault                                           │
-│  └── Industry standard, rich features                      │
-│      Vault Agent Injector for Kubernetes                   │
-│                                                             │
-│  AWS Secrets Manager + External Secrets Operator           │
-│  └── Native AWS integration                                │
-│      Syncs AWS secrets to Kubernetes                       │
-│                                                             │
-│  Azure Key Vault                                           │
-│  └── Azure-native solution                                 │
-│      CSI driver available                                  │
-│                                                             │
-│  Sealed Secrets (Bitnami)                                  │
-│  └── Encrypt secrets for Git storage                       │
-│      Only cluster can decrypt                              │
-│                                                             │
-│  Note: External solutions are NOT on CKS exam              │
-│  but understanding them shows security maturity            │
-│                                                             │
-└─────────────────────────────────────────────────────────────┘
-```
-
-The architectural pattern relies on Kubernetes Operators acting as a bridge:
-
-```mermaid
-sequenceDiagram
-    participant AWS as AWS Secrets Manager
-    participant ESO as External Secrets Operator
-    participant API as Kubernetes API Server
-    participant Pod as Application Pod
-
-    ESO->>AWS: 1. Authenticate via IAM/OIDC
-    AWS-->>ESO: 2. Return secure payload
-    ESO->>API: 3. Create native K8s Secret
-    API-->>Pod: 4. Mount Secret via tmpfs
-```
-
-### Implementing External Secrets Operator (ESO)
-
-To implement external secrets securely, we must define two Custom Resources: a `SecretStore` (which holds authentication details to talk to the cloud provider) and an `ExternalSecret` (which dictates what specific secret to fetch).
-
-**Step 1: Define the SecretStore (Connecting to AWS)**
 ```yaml
-apiVersion: external-secrets.io/v1beta1
+apiVersion: apiserver.config.k8s.io/v1
+kind: EncryptionConfiguration
+resources:
+  - resources:
+      - secrets
+    providers:
+      - kms:
+          name: cloud-kms-v2
+          apiVersion: v2
+          endpoint: unix:///var/run/kmsplugin/socket.sock
+          timeout: 3s
+      - aescbc:
+          keys:
+            - name: emergency-local-key
+              secret: REPLACE_WITH_32_BYTE_BASE64_KEY
+      - identity: {}
+```
+
+KMS v2 became stable in Kubernetes 1.29 and is preferred over the older KMS v1 provider. The v2 protocol improves health reporting, observability, key version handling, and performance characteristics so the API server can tell whether the plugin is ready and which key version protected a value. That does not remove operational responsibility. If the plugin is slow, unavailable, or misconfigured during writes and decrypts, the API server path that handles encrypted resources can become slow or fail. Treat the KMS plugin as a control-plane dependency, monitor its latency and error rate, and test what happens when the external KMS throttles or rotates keys.
+
+The KMS plugin identity is part of the trust boundary. On a cloud platform, the plugin or control-plane integration needs permission to use a specific key, and that permission should be narrower than general secret-manager administration. On self-managed clusters, the socket file path and plugin process need filesystem protection because the API server depends on that local endpoint for encryption operations. A compromised plugin host or overpowered cloud identity can undermine the benefit of moving the root key out of etcd.
+
+Key versioning is the practical reason KMS v2 discussions mention observability so often. A provider can rotate the external key encryption key while Kubernetes continues to read older objects, but operators need to know which key version is active, which objects have been rewritten, and whether decrypt failures are increasing. Without that signal, rotation becomes a leap of faith. A healthy runbook records the external key version before rotation, rewrites a small namespace first, checks API server and plugin metrics, and only then runs the broader migration.
+
+Disaster recovery deserves a dry run before a real incident. An encrypted etcd snapshot is not useful if the restore cluster cannot reach the same KMS, cannot authenticate as the plugin identity, or has lost the local provider keys. For local `aescbc`, back up the encryption config separately from etcd with strong access control, because the config contains the key needed to decrypt the data. For KMS v2, document how to restore the plugin, socket path, cloud identity, and key permissions before declaring the backup strategy complete.
+
+Cloud KMS integration changes the cost model as well as the threat model. Managed KMS and secret-manager services usually bill for stored keys or secrets, API calls, and sometimes cross-region or log-ingestion side effects. KMS v2 reduces unnecessary external calls compared with less efficient designs, but short cache lifetimes, frequent rewrites, many clusters, and aggressive audit policies can still create visible monthly cost. External Secrets Operator adds another billable pattern because every refresh interval can call a cloud secret API, while audit logging Secret reads at high volume can shift the cost into your logging backend. Cost control comes from longer refresh intervals where safe, narrow resource selection, local plugin health, and clear ownership of which clusters actually need each external secret.
+
+Before running this in a real cluster, what output do you expect from `kubectl get --raw /readyz?verbose` immediately after a control-plane manifest change? The expected answer is not "it always succeeds." Static Pod restarts create a short window where the API server is unavailable, and a bad encryption config can extend that window until the manifest is fixed. On the exam, make one controlled change, preserve a backup of the manifest, and verify API health before rewriting every Secret.
+
+## Comparing External Secret Delivery Models
+
+External Secrets Operator, usually shortened to ESO, solves a source-of-truth problem rather than an at-rest encryption problem. The operator watches `ExternalSecret` resources, reads values from external providers such as Vault, AWS Secrets Manager, AWS Systems Manager Parameter Store, Google Secret Manager, Azure Key Vault, 1Password, and other supported backends, then writes ordinary Kubernetes Secret objects for workloads to consume. That compatibility is the main benefit: existing Helm charts and applications can keep referencing native Secrets while the sensitive value is authored and rotated outside the cluster.
+
+```yaml
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
-  name: aws-backend
-  namespace: production
+  name: team-vault
+  namespace: payments
 spec:
   provider:
-    aws:
-      service: SecretsManager
-      region: us-east-1
+    vault:
+      server: https://vault.example.com
+      path: kv
+      version: v2
       auth:
-        jwt:
-          # Uses IAM Roles for Service Accounts (IRSA)
+        kubernetes:
+          mountPath: kubernetes
+          role: payments-reader
           serviceAccountRef:
-            name: eso-auth-sa
-```
-
-**Step 2: Define the ExternalSecret (Fetching the Payload)**
-```yaml
-apiVersion: external-secrets.io/v1beta1
+            name: eso-payments
+---
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: db-credentials-sync
-  namespace: production
+  name: payment-db
+  namespace: payments
 spec:
-  refreshInterval: "1h" # Auto-rotate every hour
+  refreshInterval: 1h
   secretStoreRef:
-    name: aws-backend
+    name: team-vault
     kind: SecretStore
   target:
-    name: native-db-creds # The name of the resulting K8s Secret
+    name: payment-db
     creationPolicy: Owner
   data:
-  - secretKey: password
-    remoteRef:
-      key: rds/production/master
-      property: password
+    - secretKey: password
+      remoteRef:
+        key: payments/database
+        property: password
 ```
 
-By using ESO, your source code repositories never touch the secrets, and developers cannot `kubectl get` the master keys unless granted explicit permission to the AWS backend.
+The `SecretStore` versus `ClusterSecretStore` decision is a governance decision. A `SecretStore` lives in one namespace and is usually owned by the team that owns the workloads there. A `ClusterSecretStore` is cluster-scoped and useful when a platform team wants one provider configuration shared by many namespaces. The cluster-scoped option is powerful, so pair it with admission policy, namespace allowlists, and provider-side authorization. Otherwise, a namespace owner may gain a clean Kubernetes API path to remote secrets they should never reach.
 
----
+Provider identity is where ESO designs often succeed or fail. In AWS, the operator might use IAM Roles for Service Accounts; in Google Cloud, it might use Workload Identity; in Azure, it might use a managed identity path; and with Vault, it often authenticates through the Kubernetes auth method. Those provider identities should be scoped to the exact secret paths or names the operator must read. If the ESO controller has wildcard read access to a whole provider account, Kubernetes namespace boundaries become less meaningful because one compromised ExternalSecret definition can request far more than the workload owns.
 
-## Access Control and RBAC for Secrets
+Refresh intervals are not just freshness settings. A very short interval reduces the time between provider rotation and Kubernetes synchronization, but it also increases provider API calls, controller work, audit events, and the chance that a provider outage becomes visible as constant reconcile noise. A long interval lowers cost and noise but can leave a rotated credential stale until the next sync. For high-impact credentials, pair the interval with an explicit rotation event or manual reconcile process so rotation is deliberate instead of waiting for a polling loop to notice.
 
-Even with etcd encryption and external managers, if your RBAC allows a compromised frontend pod to read the backend database secret, you lose.
+ESO still creates Kubernetes Secret objects, so it does not eliminate the need for etcd encryption, RBAC, runtime controls, or audit policies. Its value is that rotation and authoring happen in a managed external system, not in Git or ad hoc `kubectl create secret` commands. The tradeoff is controller dependency: if ESO loses provider access, the last synchronized Kubernetes Secret may remain usable while new values stop arriving. That can be exactly what you want for availability, but it can also hide failed rotations until a password expires. Monitor `ExternalSecret` conditions and provider errors as production signals, not as optional operator noise.
 
-### Restrict Secret Access
+ESO templating is useful when the provider stores atomic values but the application needs a specific file or Secret type. For example, a provider may store a certificate, a private key, and a CA bundle as separate properties while the workload expects a `kubernetes.io/tls` Secret or a single configuration file. Templating should be kept small and reviewable because it becomes a translation layer between provider data and runtime behavior. Complex transformations are better handled in the application or a dedicated provisioning pipeline than hidden inside Secret synchronization.
 
-Always lock down access to exact `resourceNames`.
+Sealed Secrets is a different GitOps-centered pattern. The `kubeseal` client encrypts a Secret using the controller's public key, producing a `SealedSecret` custom resource safe to commit to Git for the target cluster and scope. The controller inside the cluster holds the private key and decrypts the resource into a native Secret. This fits teams that want pull-based GitOps and do not have, or do not want, a runtime dependency on a cloud secret manager for every application. It does not fit secrets that need dynamic issuance, short leases, or centralized provider audit trails across many clusters.
+
+Sealed Secrets scope is a security feature that should be understood before moving encrypted YAML between environments. A sealed value can be bound to a name and namespace, which prevents someone from taking a ciphertext meant for one Secret and replaying it under a more privileged name elsewhere. That protection is useful, but it also means renaming or moving a Secret may require resealing. Back up the controller private key carefully, because losing it can make committed SealedSecret resources undecryptable during cluster recovery.
+
+```text
++------------------+      public key       +-------------------+
+| developer laptop | --------------------> | SealedSecret YAML |
+| kubeseal client  |                       | committed to Git  |
++------------------+                       +-------------------+
+                                                    |
+                                                    v
+                                          +--------------------+
+                                          | cluster controller |
+                                          | private key holder |
+                                          +--------------------+
+                                                    |
+                                                    v
+                                          +--------------------+
+                                          | native Secret      |
+                                          | consumed by Pods   |
+                                          +--------------------+
+```
+
+HashiCorp Vault on Kubernetes gives you a richer runtime security model when you need dynamic secrets, leasing, renewal, and revocation. The Vault Agent injector mutating webhook can add an agent sidecar or init container that authenticates with Vault using the workload's Kubernetes identity, renders secrets into a shared volume, and renews leases where the secret type supports renewal. The Vault CSI provider and Secrets Store CSI Driver can mount values as volumes without first creating native Kubernetes Secrets, depending on configuration. These patterns reduce static credential lifetime, but they require the application or sidecar to handle file reads, renewal timing, and failure behavior when Vault is unavailable.
+
+Dynamic database credentials are the clearest reason to accept Vault's complexity. Instead of storing one shared database password for months, Vault can create a database user with a lease for the workload, renew it while the workload is healthy, and revoke it when the lease ends. That model shrinks the value of a stolen credential, but it also changes incident response. You need to know how to revoke leases, how to drain old connections, and how the application behaves if renewal fails while traffic is still flowing.
 
 ```yaml
-# Only allow access to specific secrets
+apiVersion: v1
+kind: Pod
+metadata:
+  name: vault-agent-demo
+  namespace: payments
+  annotations:
+    vault.hashicorp.com/agent-inject: "true"
+    vault.hashicorp.com/role: "payments-reader"
+    vault.hashicorp.com/agent-inject-secret-db.txt: "database/creds/payments"
+spec:
+  serviceAccountName: payments-api
+  containers:
+    - name: app
+      image: busybox
+      command: ["sh", "-c", "while true; do cat /vault/secrets/db.txt >/dev/null; sleep 30; done"]
+```
+
+Hypothetical scenario: a critical service starts without its expected Vault-rendered file because an injection annotation was copied to the Deployment template but the ServiceAccount was not bound to the Vault role. The container image is healthy, Kubernetes scheduling is healthy, and the application error looks like an ordinary missing-file problem. The security lesson is that injector-based delivery creates an admission-time dependency and a runtime file contract. Your readiness probe should fail if the rendered file is absent, and your deployment pipeline should validate both annotations and ServiceAccount-to-Vault-role bindings before traffic moves.
+
+The Secrets Store CSI Driver occupies the middle ground between native Kubernetes Secret consumption and direct application calls to an external provider. The kubelet mounts provider data into a Pod as a CSI volume, and optional sync features can also create a Kubernetes Secret when a workload or chart requires one. This is attractive when you want rotation to appear as file updates and when you want the external provider to remain the real store. The driver runs node components, provider plugins, and SecretProviderClass configuration, so operational ownership must include node coverage, provider credentials, and application reload behavior.
+
+Direct application calls to a cloud secret API are sometimes the right answer, but they move the Kubernetes control plane out of the delivery path and put more responsibility into application code. That can be excellent for a platform with strong workload identity and libraries that cache, refresh, and report errors consistently. It can be poor for heterogeneous teams where every service invents a different secret client. Kubernetes-native delivery is less pure from a zero-copy perspective, but it centralizes patterns that reviewers, operators, and exam graders can inspect.
+
+| Model | Best fit | Main tradeoff |
+|---|---|---|
+| Native Secret plus encryption | Small clusters, exam tasks, simple apps | Kubernetes remains the storage and RBAC boundary. |
+| External Secrets Operator | Apps expect native Secrets, provider is external | Synced Secret still exists in etcd and must be protected. |
+| Sealed Secrets | GitOps with encrypted manifests per cluster | Static payloads, controller private-key backup, resealing workflow. |
+| Vault injector or agent | Dynamic credentials, lease renewal, templating | Runtime dependency, app reload needs, Vault operational cost. |
+| Secrets Store CSI Driver | File-based mounts from external providers | Node plugin dependency and volume rotation semantics. |
+
+## Designing RBAC, ServiceAccount Tokens, Audit Logging, and Rotation
+
+Secret RBAC should be read as a blast-radius document. `get` on a named Secret is a narrow read. `list` on Secrets is a bulk exfiltration permission because the response can include every object in the namespace. `watch` is continuous exfiltration because it streams future changes. `create` Pods can become indirect read access, as discussed earlier. `update` or `patch` on Secrets can be as dangerous as read access because a malicious subject can replace credentials, inject trusted certificates, or change registry pull credentials to point workloads at attacker-controlled images.
+
+```yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: secret-reader
-  namespace: production
+  name: payment-api-secret-reader
+  namespace: payments
 rules:
-- apiGroups: [""]
-  resources: ["secrets"]
-  resourceNames: ["app-config", "db-creds"]  # Specific secrets only
-  verbs: ["get"]
-```
-
-### Dangerous RBAC Patterns
-
-```yaml
-# DON'T DO THIS - grants access to ALL secrets
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["payment-db"]
+    verbs: ["get"]
+---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: RoleBinding
 metadata:
-  name: dangerous-role
-rules:
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get", "list", "watch"]  # Can read ALL secrets cluster-wide!
+  name: payment-api-secret-reader
+  namespace: payments
+subjects:
+  - kind: ServiceAccount
+    name: payment-api
+    namespace: payments
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: payment-api-secret-reader
 ```
 
-### Audit Secret Access
+That Role is intentionally narrow, but it is not the whole policy. If the same ServiceAccount can create arbitrary Pods, exec into sibling Pods, or read every Secret through another binding, the narrow Role does not help much. `resourceNames` is useful for `get`, `update`, and `patch`, but broad `list` and `watch` permissions need separate scrutiny because they are often granted to controllers for convenience. A controller that truly needs to watch Secrets should run in a narrow namespace, use a dedicated ServiceAccount, and have an operational reason documented in the Role name or owner annotation.
 
-Use `can-i` to verify restrictions programmatically.
+Admission control is the companion to RBAC when the risk is indirect access. A Role can say who may create Pods, while an admission policy can say which Secrets those Pods may mount, whether `env.valueFrom.secretKeyRef` is allowed for high-value namespaces, and whether default ServiceAccount token automounting is permitted. This is especially useful in multi-tenant clusters where namespace administrators legitimately create workloads but should not be able to turn every Secret into a readable file. CKS focuses on built-in controls, yet the production lesson is to block dangerous Secret consumption paths before they become workload specs.
 
-```bash
-# Find who can access secrets
-kubectl auth can-i get secrets --as=system:serviceaccount:default:default
-kubectl auth can-i list secrets --as=system:serviceaccount:kube-system:default
+ServiceAccount tokens deserve special attention because Kubernetes historically represented them as long-lived Secret objects. Modern clusters use projected ServiceAccount tokens through the TokenRequest API. These tokens are time-bound, audience-bound, and mounted as projected volumes, which means a token intended for the Kubernetes API is not automatically valid for every external service and does not need to live forever as a Secret. Set `automountServiceAccountToken: false` for Pods that do not call the API, and request explicit projected tokens with a narrow audience when the workload needs an identity token for a specific recipient.
 
-# List all roles that can access secrets
-kubectl get clusterroles -o json | jq '.items[] | select(.rules[]?.resources[]? == "secrets") | .metadata.name'
-```
-
----
-
-## Preventing Secret Exposure
-
-Finally, minimize the attack surface of the pod itself.
-
-### Disable Secret Auto-mount
-
-Every pod automatically mounts a ServiceAccount token containing API credentials. If the pod doesn't talk to the Kubernetes API, disable it.
+Audience choice is a security decision, not a label. A token minted for `https://kubernetes.default.svc` is meant for the Kubernetes API, while a token minted for Vault or an internal identity broker should be accepted only by that recipient. If a service accepts any Kubernetes-issued token without checking audience and expiry, it recreates the old bearer-token problem with newer mechanics. In reviews, ask which component validates the token, what audience it expects, and whether token lifetime is shorter than the likely detection and response window for a compromised Pod.
 
 ```yaml
 apiVersion: v1
 kind: Pod
 metadata:
-  name: no-automount-pod
+  name: projected-token-demo
+  namespace: payments
 spec:
-  automountServiceAccountToken: false  # Don't mount SA token
+  serviceAccountName: payment-api
+  automountServiceAccountToken: false
   containers:
-  - name: app
-    image: nginx
+    - name: app
+      image: busybox
+      command: ["sh", "-c", "sleep 3600"]
+      volumeMounts:
+        - name: api-token
+          mountPath: /var/run/secrets/tokens
+          readOnly: true
+  volumes:
+    - name: api-token
+      projected:
+        sources:
+          - serviceAccountToken:
+              path: api-token
+              audience: https://kubernetes.default.svc
+              expirationSeconds: 3600
 ```
 
-### Use Read-Only Mounts
+Audit logging is how you answer the question "who read the Secret?" after the fact, but it must be configured carefully because audit logs can become another place where sensitive data leaks. For Secret reads, use `Metadata` level in most cases, because `RequestResponse` can record response bodies for API requests and that is the last thing you want for a Secret. The policy below logs read-style verbs against Secret resources without capturing the Secret payload. In a static Pod control plane, the audit policy and log path must be mounted into the kube-apiserver container just like the encryption configuration file.
 
-When mounting files, enforce `readOnly` flags and restrictive `defaultMode` permissions to prevent file tampering.
+```yaml
+apiVersion: audit.k8s.io/v1
+kind: Policy
+omitStages:
+  - RequestReceived
+rules:
+  - level: Metadata
+    verbs: ["get", "list", "watch"]
+    resources:
+      - group: ""
+        resources: ["secrets"]
+  - level: Metadata
+    verbs: ["create", "update", "patch", "delete"]
+    resources:
+      - group: ""
+        resources: ["secrets"]
+  - level: None
+    nonResourceURLs:
+      - /healthz*
+      - /readyz*
+      - /livez*
+```
+
+Audit analysis should distinguish normal controllers from surprising humans or workloads. ESO, cert-manager, ingress controllers, and image automation may legitimately read or update certain Secrets, but those accesses should come from predictable ServiceAccounts in predictable namespaces. A human user running `get secrets` in production, a CI account listing every Secret, or a workload ServiceAccount watching Secrets outside its namespace is a different signal. Build allowlists from expected controller identities and investigate the outliers rather than treating every Secret audit event as equally urgent.
+
+Rotation is the design area where many technically correct secrets systems fail in production. A Kubernetes Secret mounted as a volume can update in the container filesystem after the object changes, but an environment variable does not update until the container restarts. A Secret mounted with `subPath` also does not receive live updates through the usual projected volume mechanism. Immutable Secrets, stable since Kubernetes 1.21, improve safety and kubelet performance for values that should not change in place, but they force a create-new-name-and-rollout pattern for rotation. That is a feature when you want deliberate rollouts and a problem when you expected silent replacement.
 
 ```yaml
 apiVersion: v1
-kind: Pod
+kind: Secret
 metadata:
-  name: readonly-secrets
-spec:
-  containers:
-  - name: app
-    image: nginx
-    volumeMounts:
-    - name: secrets
-      mountPath: /etc/secrets
-      readOnly: true  # Prevent modification
-  volumes:
-  - name: secrets
-    secret:
-      secretName: app-secrets
-      defaultMode: 0400  # Read-only for owner
+  name: payment-db-2026-05
+  namespace: payments
+type: Opaque
+immutable: true
+stringData:
+  username: app_user
+  password: example-password
 ```
 
----
+Application behavior completes the rotation story. If the credential is a database password, the application may need a connection-pool drain, a file watcher, a `SIGHUP`, an HTTP reload endpoint, or a Deployment restart. If the credential is a TLS certificate, the server process may need to reload its listener and clients may need trust-bundle propagation. If the credential is dynamic Vault material with a lease, the application must be able to replace it before expiry or tolerate the sidecar doing that on disk. A good Secret design names the storage system, the delivery mechanism, the reload trigger, the rollback path, and the audit signal.
 
-## Real Exam Scenarios
+A practical rotation runbook has two clocks. The first clock is the secret store clock: when the provider value changes, when the old value stops working, and when rollback becomes impossible. The second clock is the workload clock: when Pods receive the new value, when processes reopen or reload it, and when health checks prove the new credential is actually in use. Align those clocks before the change window. If the provider invalidates the old password before Pods reload the new one, the outage is self-inflicted even though every individual tool behaved as documented.
 
-### Scenario 1: Enable etcd Encryption (Conceptual vs Automated)
+## CKS Exam Pattern Walkthroughs
 
-Many guides show how to edit the API server manually. While educational, **this will fail automated laboratory checks and is dangerous in CI/CD environments.** 
+When the exam asks you to identify an exposed Secret in a Pod spec, start with consumption mode and permissions rather than tool names. Look for `env.valueFrom.secretKeyRef`, broad `envFrom` imports, `subPath` Secret mounts that will not update, and default ServiceAccount tokens on Pods that do not need API access. Then check the namespace Roles for `list` and `watch` on Secrets, and remember that Pod creation can be an indirect read path. The answer is often a small YAML edit plus a short explanation of blast radius.
 
-Here is the conceptual flow:
+When the exam asks for `EncryptionConfiguration`, write the smallest valid configuration first and expand only if the task requires more resources. The common passing shape is `apiVersion: apiserver.config.k8s.io/v1`, `kind: EncryptionConfiguration`, `resources: ["secrets"]`, an encrypting provider such as `aescbc`, and `identity` last. The API server flag and static Pod volume mount are part of the answer because a file on the host is invisible to the container until mounted. After the API server recovers, create a new Secret and rewrite an old one to prove the migration path.
 
-```bash
-# Step 1: Create encryption config directory
-sudo mkdir -p /etc/kubernetes/enc
+When the exam asks you to restrict Secret access with RBAC, avoid namespace-wide read permissions unless the question explicitly describes a controller that needs them. A named `get` rule with `resourceNames` is usually the right primitive for one workload reading one Secret. Validate with `kubectl auth can-i` using the full ServiceAccount subject string, then test the negative case for `list secrets`. If the same account can create arbitrary Pods, mention that workload creation must also be constrained, because otherwise the named read rule is not the only path to the value.
 
-# Step 2: Generate encryption key
-ENCRYPTION_KEY=$(head -c 32 /dev/urandom | base64)
+When the exam gives you audit logs, focus on verb, user, namespace, resource, and response status. A successful `get` or `list` against Secrets by an unexpected user is more important than a denied request from a scanner. A repeated watch from an unknown ServiceAccount may indicate a controller compromise or a copied ClusterRoleBinding. Do not recommend `RequestResponse` logging for Secret reads as a reflex, because it can copy the protected value into the log backend. Metadata-level audit records are usually the safer evidence source.
 
-# Step 3: Create encryption config
-sudo tee /etc/kubernetes/enc/encryption-config.yaml << EOF
-apiVersion: apiserver.config.k8s.io/v1
-kind: EncryptionConfiguration
-resources:
-  - resources:
-      - secrets
-    providers:
-      - aescbc:
-          keys:
-            - name: key1
-              secret: ${ENCRYPTION_KEY}
-      - identity: {}
-EOF
+When the exam scenario includes external secret tooling, name the remaining native Kubernetes risk. ESO synchronizes a provider value into a Kubernetes Secret, so etcd encryption and RBAC still apply. Sealed Secrets protects Git storage but produces a native Secret after decryption. Vault injection and CSI mounts may avoid a synced native Secret, but they add runtime dependencies and application reload requirements. This comparison is how you avoid the common wrong answer that installing a tool automatically solves every layer of secrets management.
 
-# Step 4: Edit API server manifest
-sudo vi /etc/kubernetes/manifests/kube-apiserver.yaml
+A final exam habit is to write down the credential lifecycle in one sentence before changing YAML. For example: "The password originates in Vault, ESO syncs it to a native Secret hourly, the Pod mounts it as a file, the app reloads on rollout, and audit logs record Secret reads at metadata level." That sentence exposes missing links quickly. If you cannot name the source, delivery mechanism, runtime consumer, reload trigger, and audit point, you do not yet have a complete answer. In production, the same sentence becomes the basis for a runbook and a reviewer checklist.
 
-# Add to command:
-# - --encryption-provider-config=/etc/kubernetes/enc/encryption-config.yaml
+## Patterns & Anti-Patterns
 
-# Add volume mount:
-# volumeMounts:
-# - mountPath: /etc/kubernetes/enc
-#   name: enc
-#   readOnly: true
+| Pattern | When to Use | Why It Works |
+|---|---|---|
+| Encrypt native Secrets at rest and restrict read verbs | Any cluster that stores Kubernetes Secrets | It separates API authorization from storage compromise and backup exposure. |
+| Use ESO for provider-owned secrets consumed by ordinary charts | Teams already use AWS Secrets Manager, GCP Secret Manager, Azure Key Vault, Vault, or 1Password | It preserves native Secret compatibility while moving authoring, rotation, and provider audit outside the cluster. |
+| Use projected ServiceAccount tokens with explicit audiences | Pods that need API or identity tokens | Short-lived, audience-bound tokens reduce the value of token theft compared with legacy token Secrets. |
+| Use immutable versioned Secrets for deliberate rollouts | Credentials that rotate through controlled deployment waves | A new Secret name makes rollout state visible and avoids accidental in-place mutation. |
 
-# Add volume:
-# volumes:
-# - hostPath:
-#     path: /etc/kubernetes/enc
-#     type: DirectoryOrCreate
-#   name: enc
+| Anti-pattern | Why Teams Fall Into It | Better Alternative |
+|---|---|---|
+| Granting `list` and `watch` on Secrets to human troubleshooting groups | It feels like a convenient read-only permission | Grant named `get` only where possible and create break-glass access with audit review. |
+| Storing base64 Secret manifests directly in Git | The encoded value looks less obvious than plaintext | Use Sealed Secrets, SOPS, ESO, or provider references rather than raw Secret values. |
+| Assuming ESO removes the need for etcd encryption | The source of truth moved out of Kubernetes | ESO still writes native Secret objects unless you choose a mount-only design. |
+| Rotating a Secret without restarting or reloading the application | The object update succeeded, so the rollout is assumed complete | Test the application reload path and include success probes that prove the new credential is in use. |
 
-# Step 5: Wait for API server to restart
-kubectl get nodes  # Wait until this works
+## Decision Framework
 
-# Step 6: Re-encrypt existing secrets
-kubectl get secrets -A -o json | kubectl replace -f -
+Choose native Kubernetes Secrets with at-rest encryption when the cluster is the right operational boundary, the values are simple, and your risk model is mostly about namespace isolation, backup protection, and exam-style hardening. Choose ESO when another system is already the source of truth and workloads still need native Secret objects. Choose Sealed Secrets when Git must carry encrypted declarative manifests and the secrets are static enough that resealing is acceptable. Choose Vault or CSI-based runtime delivery when short-lived credentials, leases, revocation, or avoiding synced native Secrets are worth the extra control-plane and application complexity.
+
+```text
+Start
+  |
+  v
+Do applications already require native Kubernetes Secret objects?
+  |-- yes --> Is the source of truth outside the cluster?
+  |             |-- yes --> Use ESO, then protect synced Secrets.
+  |             |-- no  --> Use native Secrets with encryption and RBAC.
+  |
+  |-- no  --> Do you need dynamic leased credentials?
+                |-- yes --> Use Vault Agent, Vault CSI, or provider CSI.
+                |-- no  --> Is Git the delivery system?
+                              |-- yes --> Use Sealed Secrets or SOPS.
+                              |-- no  --> Use CSI mount or direct provider SDK.
 ```
 
-**The Modern Automated Approach (Non-Interactive)**
-
-To safely update `kube-apiserver.yaml` without breaking automation scripts, utilize stream editors (`sed`) or robust YAML parsers (`yq`).
-
-```bash
-# 1. Safely backup first
-sudo cp /etc/kubernetes/manifests/kube-apiserver.yaml /tmp/kube-apiserver.yaml.bak
-
-# 2. Inject the flag into the container command
-sudo sed -i '/- kube-apiserver/a\    - --encryption-provider-config=/etc/kubernetes/enc/encryption-config.yaml' /etc/kubernetes/manifests/kube-apiserver.yaml
-
-# 3. Inject the volumeMount safely
-sudo sed -i '/volumeMounts:/a\    - mountPath: /etc/kubernetes/enc\n      name: enc\n      readOnly: true' /etc/kubernetes/manifests/kube-apiserver.yaml
-
-# 4. Inject the hostPath volume
-sudo sed -i '/volumes:/a\  - hostPath:\n      path: /etc/kubernetes/enc\n      type: DirectoryOrCreate\n    name: enc' /etc/kubernetes/manifests/kube-apiserver.yaml
-```
-
-### Scenario 2: Fix Secret RBAC
-
-```bash
-# Find ServiceAccount with too much secret access
-kubectl get rolebindings,clusterrolebindings -A -o json | \
-  jq -r '.items[] | select(.roleRef.name | contains("secret")) |
-         "\(.metadata.namespace // "cluster")/\(.metadata.name) -> \(.roleRef.name)"'
-
-# Create restrictive role
-cat <<EOF | kubectl apply -f -
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: app-secret-reader
-  namespace: default
-rules:
-- apiGroups: [""]
-  resources: ["secrets"]
-  resourceNames: ["app-config"]  # Only this secret
-  verbs: ["get"]
-EOF
-```
-
-### Scenario 3: Create Secret from File
-
-```bash
-# Create secret containing certificate
-kubectl create secret generic tls-cert \
-  --from-file=tls.crt=./server.crt \
-  --from-file=tls.key=./server.key \
-  -n production
-
-# Use in pod with volume mount
-cat <<EOF | kubectl apply -f -
-apiVersion: v1
-kind: Pod
-metadata:
-  name: secure-app
-  namespace: production
-spec:
-  containers:
-  - name: app
-    image: nginx
-    volumeMounts:
-    - name: tls
-      mountPath: /etc/tls
-      readOnly: true
-  volumes:
-  - name: tls
-    secret:
-      secretName: tls-cert
-      defaultMode: 0400
-EOF
-```
-
----
+The cost decision follows the same path. Native Secrets add little direct cloud cost but increase the importance of etcd backup protection and audit storage. ESO and CSI designs add provider API calls, controller or node components, and logs. Vault adds storage, unseal, HA, backup, and operational staffing cost in exchange for dynamic secrets and stronger central control. A design that is too expensive or fragile will be bypassed, so the secure answer is the one your team can operate during rotation, outage, and incident response.
 
 ## Did You Know?
 
-- **In September 2022**, the monumental Uber breach highlighted the dangers of hardcoded credentials. Attackers utilized a plaintext password discovered on a network share to compromise Thycotic (their PAM solution) and subsequently AWS, Duo, and Google Workspace.
-- **Kubernetes v1.13 (released December 2018)** graduated etcd encryption at rest to a stable feature, yet an estimated 40% of standard non-managed clusters still operate without it enabled today.
-- **AES-GCM requires key rotation every 200,000 writes** to maintain its cryptographic integrity safely. Because this imposes massive operational overhead, `aescbc` remains the recommended provider for local encryption.
-- **The External Secrets Operator** was officially accepted as a Cloud Native Computing Foundation (CNCF) Sandbox project in July 2022, rapidly becoming the industry standard over proprietary, vendor-locked sync mechanisms.
-
----
+- **KMS v2 became stable in Kubernetes 1.29.** That graduation matters because KMS v1 is deprecated and disabled by default in newer Kubernetes releases, making v2 the preferred provider path for external key management.
+- **Immutable Secrets became stable in Kubernetes 1.21.** They are not just a security guardrail; they also reduce kubelet watch load for clusters with many mounted Secret and ConfigMap objects.
+- **A ServiceAccount token can be requested for a specific audience and expiration.** That is the modern alternative to treating a long-lived token Secret as a reusable password for every internal service.
+- **A Secret read logged at `RequestResponse` level can expose the payload in the audit backend.** For most Secret access monitoring, `Metadata` level gives the actor, verb, resource, namespace, and timestamp without copying the sensitive value.
 
 ## Common Mistakes
 
-| Mistake | Why It Hurts | Solution |
-|---------|--------------|----------|
-| Thinking base64 is secure | Data exposed immediately | Enable encryption at rest in etcd |
-| Using env vars for secrets | Leaks to logs and `/proc` | Use tmpfs volume mounts |
-| Broad RBAC for secrets | Any pod/user can read all keys | Scope RBAC utilizing `resourceNames` |
-| Not re-encrypting after enabling | Old secrets remain unencrypted | Run `kubectl replace -f -` across secrets |
-| Secrets stored directly in Git | Permanent, un-erasable exposure | Use External Secrets or Sealed Secrets |
-| Default SA automounting | Attackers get free API access tokens | Set `automountServiceAccountToken: false` |
-| Storing TLS certs in ConfigMaps | No API-level protection for raw keys | Use `kubernetes.io/tls` Secret types |
-
----
+| Mistake | Why It Happens | How to Fix It |
+|---|---|---|
+| Treating base64 as encryption | The YAML looks transformed, so reviewers assume a cryptographic boundary exists. | Decode one value during review, explain the difference, and enable at-rest encryption for persisted objects. |
+| Putting `identity` first in `EncryptionConfiguration` | Operators add it as a fallback but miss provider ordering semantics. | Put the encrypting provider first and keep `identity` last only while old plaintext data must be readable. |
+| Granting `list` on Secrets for troubleshooting | Read-only roles are copied from broad templates. | Grant named `get` with `resourceNames`, use temporary break-glass bindings, and audit every access. |
+| Using environment variables for rotating credentials | Framework examples often show simple `env` injection. | Prefer file mounts for sensitive values and implement reload or rollout logic for rotations. |
+| Assuming ESO means Kubernetes stores no secret data | The external provider is visible in the architecture diagram. | Remember ESO materializes native Secret objects unless a mount-only pattern is chosen. |
+| Leaving default ServiceAccount tokens mounted everywhere | The default is convenient and many Pods never call the API. | Set `automountServiceAccountToken: false` by default and add projected tokens only where needed. |
+| Enabling audit logs at payload level for Secret reads | Teams want maximum forensic detail during an incident. | Log Secret reads at `Metadata` level and protect audit log retention, access, and export pipelines. |
 
 ## Quiz
 
-1. **A junior developer commits a Kubernetes Secret manifest to Git. The manifest contains `data: password: bXlwYXNzd29yZA==`. They say "it's fine, the password is encrypted." Why is this a security incident, and what's the immediate remediation?**
+1. **Your verifier finds that a Secret named `api-token` is stored as `YXBpLXRva2Vu` in a manifest committed to Git. The developer says no one can read it because it is encoded. What do you do first, and what design change prevents the repeat?**
+
    <details>
    <summary>Answer</summary>
-   Base64 is encoding, not encryption -- anyone can decode it (`echo "bXlwYXNzd29yZA==" | base64 -d` reveals "mypassword"). This is a credential leak. Immediate remediation: (1) Rotate the compromised password immediately. (2) Remove the secret from Git history (not just the latest commit -- use `git filter-branch` or BFG Repo Cleaner). (3) Consider the password permanently compromised since Git history persists in forks and caches. Prevention: use SealedSecrets or SOPS to encrypt secrets before committing, or use external secret managers (Vault, AWS Secrets Manager) that store references rather than values.
+   Treat it as a credential exposure because base64 is reversible without a key. The immediate action is to rotate the underlying credential, remove the raw value from future commits, and assume any clone or fork may retain the old value. The design change depends on workflow: use Sealed Secrets or SOPS for Git-encrypted manifests, or use ESO so Git contains a reference to the external provider path rather than the payload. This maps to the diagnostic outcome because the issue is not Kubernetes decoding; it is human and repository access to the encoded value.
    </details>
 
-2. **During a security audit, you discover that application pods use `env.valueFrom.secretKeyRef` to inject database passwords. The auditor flags this as a risk. The developer says "environment variables are standard practice." Who is right, and what's the concrete attack scenario?**
+2. **You enabled an `aescbc` encryption provider and created a new Secret. A direct etcd inspection shows the new Secret is encrypted, but an older Secret still appears readable. Is encryption broken?**
+
    <details>
    <summary>Answer</summary>
-   The auditor is right. Environment variables are visible in `/proc/<pid>/environ`, can leak to child processes, appear in crash dumps, and are often captured in logging systems and error reporting tools. Concrete attack: if the application crashes and the error handler logs environment variables (common in frameworks like Django, Rails), the database password ends up in the logging system accessible to anyone with log access. Volume mounts are preferred because they're stored in tmpfs (memory-only), respect file permissions, auto-update when secrets change, and don't leak through `/proc` or crash dumps. Mount secrets as files and read them at runtime.
+   Encryption is probably not broken; enabling an encryption provider affects new writes and updates, not historical etcd records. Existing Secrets must be rewritten through the API server, commonly with `kubectl get secrets --all-namespaces -o json | kubectl replace -f -`, so the first configured provider can transform them. Keep older providers or `identity` available until the rewrite and verification are complete. This is a key exam pattern because provider configuration and data migration are separate steps.
    </details>
 
-3. **You enable encryption at rest for secrets with the `aescbc` provider. A compliance auditor asks you to prove all secrets are encrypted in etcd. You run `etcdctl get /registry/secrets/default/db-password` and see encrypted data. But when you check `/registry/secrets/kube-system/coredns-token`, you see plain text. What happened?**
+3. **A platform team wants to use AWS KMS, Google Cloud KMS, or Azure Key Vault as the root key boundary for Kubernetes Secret encryption. Which Kubernetes provider path should they evaluate, and what operational dependency does it introduce?**
+
    <details>
    <summary>Answer</summary>
-   Enabling encryption at rest only affects newly created or updated secrets. Existing secrets created before encryption was enabled remain stored in plain text. The `db-password` was created after encryption, so it's encrypted. The `coredns-token` existed before and was never re-written. Fix: re-encrypt all existing secrets by reading and replacing them: `kubectl get secrets -A -o json | kubectl replace -f -`. This forces each secret to be re-written through the API server, which now encrypts them. Always verify with `etcdctl` after re-encryption. The `identity` provider in the encryption config serves as a fallback to read these old unencrypted secrets.
+   They should evaluate the KMS v2 provider, which lets the API server call a local plugin that integrates with the external KMS. The operational dependency is that encrypted-resource reads and writes now depend on a healthy plugin, valid cloud identity, reasonable latency, and external KMS availability. KMS v2 improves health, key version, and observability behavior compared with older provider paths, but it still belongs in control-plane monitoring and disaster recovery tests. A provider outage can become an API-server symptom, not just a secret-manager symptom.
    </details>
 
-4. **Your cluster stores database credentials, API keys, and TLS certificates as Kubernetes Secrets. An attacker gains `get secrets` RBAC permission in the `production` namespace. What is the blast radius, and what layers of defense should have limited it?**
+4. **An application team asks whether ESO or Sealed Secrets is the better fit for its GitOps repository. Their credentials already live in Azure Key Vault, rotate monthly, and must be available to an off-the-shelf Helm chart that reads native Kubernetes Secrets. Which option do you choose and why?**
+
    <details>
    <summary>Answer</summary>
-   Blast radius: the attacker can read every secret in the `production` namespace -- all database passwords, API keys, and TLS private keys. They can decode base64 values instantly. Defense layers that should have limited this: (1) Use `resourceNames` in RBAC to restrict access to specific secrets, not all secrets in the namespace. (2) Enable encryption at rest so secrets are encrypted in etcd backups. (3) Use an external secrets manager (Vault, AWS Secrets Manager) so Kubernetes only stores references, not actual values. (4) Mount secrets as volumes (not env vars) to limit exposure paths. (5) Audit secret access with audit logging to detect unauthorized reads. No single layer is sufficient -- secrets management requires defense in depth.
+   ESO is the better fit because the source of truth already lives in an external provider and the Helm chart expects native Kubernetes Secret objects. ESO can synchronize the provider value into the cluster while preserving the chart interface, and the refresh interval can be aligned with the rotation process. Sealed Secrets would move encrypted static payloads into Git, which duplicates the provider source of truth and adds resealing work after each rotation. The synced Secret still needs RBAC and at-rest encryption because ESO does not remove native Secret storage.
    </details>
 
-5. **You are implementing the External Secrets Operator. You created a `SecretStore` but the dependent `ExternalSecret` is stuck in `Status: SecretSyncedError`. You check the ESO pod logs and see a "403 Access Denied" error from your cloud provider. What architectural component is missing?**
+5. **A namespace Role grants a CI ServiceAccount `create` on Pods but no Secret verbs. The security reviewer still says the account may be able to read application Secrets. What is the reviewer noticing?**
+
    <details>
    <summary>Answer</summary>
-   The External Secrets Operator pod itself lacks the proper IAM role or cloud provider identity required to read the secret from the remote backend (e.g., AWS Secrets Manager, GCP Secret Manager). ESO needs an authenticated identity, typically configured via IAM Roles for Service Accounts (IRSA) in AWS or Workload Identity in GCP, so it can securely pull the remote payload before constructing the native Kubernetes Secret.
+   The reviewer is noticing indirect Secret access through Pod creation. If the ServiceAccount can create a Pod in the namespace, it may create a container that mounts or injects a Secret, then read the value from inside that container. Removing `get secrets` is not sufficient when workload creation remains broad. The fix is to scope Pod creation, use admission policy, separate CI namespaces from runtime namespaces, and review Secret access together with workload permissions.
    </details>
 
-6. **An administrator uses a script to inject the `--encryption-provider-config` flag into the `kube-apiserver.yaml` manifest. After the kubelet restarts the static pod, the API server crashes continually with a "no such file or directory" error in `/var/log/pods`. What critical configuration step was omitted?**
+6. **Your audit backend is growing quickly after you add Secret monitoring, and a sample event includes response data for a Secret read. What should change in the audit policy?**
+
    <details>
    <summary>Answer</summary>
-   The administrator forgot to configure the necessary `volumeMounts` and `volumes` in the static pod manifest. Even if the encryption configuration file exists perfectly on the control plane host at `/etc/kubernetes/enc/encryption-config.yaml`, the API server container runs in isolation and cannot see host files unless they are explicitly mounted into the container via a `hostPath` volume.
+   Secret read rules should usually log at `Metadata` level, not `RequestResponse`, because the response body can contain the sensitive payload. Metadata still records who made the request, which verb was used, which namespace and resource were touched, and when it happened. You should also restrict the rule to Secret verbs and resources instead of raising the audit level globally. That reduces both leakage risk and log-ingestion cost while preserving the forensic signal needed for access review.
    </details>
 
----
+7. **A database password rotates in Vault, the CSI-mounted file updates in the Pod, but the application keeps failing authentication with the old password. Which layer is most likely missing?**
+
+   <details>
+   <summary>Answer</summary>
+   The missing layer is application reload behavior. Updating a mounted file does not guarantee the process rereads the file or recreates database connections. The fix might be a file watcher, a `SIGHUP`, an HTTP reload endpoint, a connection-pool drain, or a controlled rollout triggered after rotation. Secret delivery and application consumption are separate responsibilities, and a complete rotation plan includes both.
+   </details>
 
 ## Hands-On Exercise
 
-**Task**: Safely enable encryption at rest for an active cluster and verify the cryptographic transformation, utilizing non-interactive automation techniques designed for CI/CD environments.
+This exercise is designed for a disposable lab cluster where you control the API server configuration. You will diagnose default exposure, write a safe `EncryptionConfiguration`, tighten one Secret read path, and reason through rotation. If your lab provider does not expose the control-plane filesystem, complete the static Pod manifest edits as review tasks rather than applying them to a managed control plane.
+
+### Task 1: Prove base64 is not encryption
+
+Create a namespace and Secret, then decode the stored value from the API response. The goal is to make the default boundary visible before adding tools.
+
+```bash
+kubectl create namespace secrets-lab
+kubectl -n secrets-lab create secret generic app-db \
+  --from-literal=username=app_user \
+  --from-literal=password=example-password
+
+kubectl -n secrets-lab get secret app-db -o jsonpath='{.data.password}' | base64 --decode
+printf '\n'
+```
 
 <details>
-<summary>View Legacy Interactive Solution (Reference Only)</summary>
+<summary>Solution notes</summary>
 
-```bash
-# Step 1: Check current encryption status
-ps aux | grep kube-apiserver | grep encryption-provider-config || echo "Not configured"
-
-# Step 2: Create test secret BEFORE encryption
-kubectl create secret generic pre-encryption --from-literal=test=beforeencryption
-
-# Step 3: Create encryption config (on control plane node)
-sudo mkdir -p /etc/kubernetes/enc
-
-ENCRYPTION_KEY=$(head -c 32 /dev/urandom | base64)
-sudo tee /etc/kubernetes/enc/encryption-config.yaml << EOF
-apiVersion: apiserver.config.k8s.io/v1
-kind: EncryptionConfiguration
-resources:
-  - resources:
-      - secrets
-    providers:
-      - aescbc:
-          keys:
-            - name: key1
-              secret: ${ENCRYPTION_KEY}
-      - identity: {}
-EOF
-
-# Step 4: Backup API server manifest
-sudo cp /etc/kubernetes/manifests/kube-apiserver.yaml /tmp/kube-apiserver.yaml.bak
-
-# Step 5: Edit API server manifest (add encryption config)
-# Add: --encryption-provider-config=/etc/kubernetes/enc/encryption-config.yaml
-# Add volume and volumeMount for /etc/kubernetes/enc
-
-# Step 6: Wait for API server restart
-sleep 30
-kubectl get nodes
-
-# Step 7: Create test secret AFTER encryption
-kubectl create secret generic post-encryption --from-literal=test=afterencryption
-
-# Step 8: Re-encrypt pre-existing secret
-kubectl get secret pre-encryption -o json | kubectl replace -f -
-
-# Step 9: Verify in etcd (if you have access)
-# Encrypted secrets show random bytes, not plain text
-
-# Cleanup
-kubectl delete secret pre-encryption post-encryption
-```
+The decoded output should match the literal value you provided. That proves the API object is merely encoded for transport and storage representation. If you can read the Secret object, you can decode its values outside Kubernetes without another permission check. This is the reason RBAC, at-rest encryption, and runtime delivery choices must all be reviewed.
 </details>
 
-<details open>
-<summary>Automated Non-Interactive Solution (Lab Standard)</summary>
+### Task 2: Draft an encryption provider configuration
 
-**Step 1: Check Status and Create Baseline Secret**
+Generate a key in the lab and create a configuration file that encrypts only Secrets. Keep `identity` last so old plaintext records can still be read during migration.
+
 ```bash
-# Verify no encryption exists currently
-ps aux | grep kube-apiserver | grep encryption-provider-config || echo "Encryption disabled."
+mkdir -p /tmp/cks-4-3
+head -c 32 /dev/urandom | base64 > /tmp/cks-4-3/aescbc.key
+ENC_KEY="$(cat /tmp/cks-4-3/aescbc.key)"
 
-# Create an unencrypted secret
-kubectl create secret generic legacy-secret --from-literal=status=unencrypted
-```
-
-**Step 2: Generate Config and Keys Non-Interactively**
-```bash
-sudo mkdir -p /etc/kubernetes/enc
-export ENC_KEY=$(head -c 32 /dev/urandom | base64)
-
-cat <<EOF | sudo tee /etc/kubernetes/enc/encryption-config.yaml
+cat > /tmp/cks-4-3/encryption-config.yaml <<EOF
 apiVersion: apiserver.config.k8s.io/v1
 kind: EncryptionConfiguration
 resources:
@@ -869,74 +587,158 @@ resources:
     providers:
       - aescbc:
           keys:
-            - name: primary-key
+            - name: key-2026-05
               secret: ${ENC_KEY}
       - identity: {}
 EOF
 ```
 
-**Step 3: Patch the API Server Manifest using `sed`**
-```bash
-sudo cp /etc/kubernetes/manifests/kube-apiserver.yaml /tmp/backup.yaml
+<details>
+<summary>Solution notes</summary>
 
-# Safely inject the provider flag
-sudo sed -i '/- kube-apiserver/a\    - --encryption-provider-config=/etc/kubernetes/enc/encryption-config.yaml' /etc/kubernetes/manifests/kube-apiserver.yaml
-
-# Inject VolumeMount
-sudo sed -i '/volumeMounts:/a\    - mountPath: /etc/kubernetes/enc\n      name: enc\n      readOnly: true' /etc/kubernetes/manifests/kube-apiserver.yaml
-
-# Inject Volume
-sudo sed -i '/volumes:/a\  - hostPath:\n      path: /etc/kubernetes/enc\n      type: DirectoryOrCreate\n    name: enc' /etc/kubernetes/manifests/kube-apiserver.yaml
-```
-
-**Step 4: Verify Restart and Re-Encrypt**
-```bash
-# Wait for the control plane to stabilize
-sleep 30
-kubectl wait --for=condition=Ready node --all --timeout=60s
-
-# Generate a new secret to prove encryption works immediately
-kubectl create secret generic modern-secret --from-literal=status=encrypted
-
-# Re-encrypt the legacy secret via replace
-kubectl get secrets legacy-secret -o json | kubectl replace -f -
-```
-
+The important checks are API version, resource name, provider ordering, and key length. New writes use the first provider, so `aescbc` must appear before `identity`. The `identity` fallback is acceptable during migration because it lets the API server read older unencrypted records, but it should not be the first provider. In a real static Pod control plane, this file must be mounted into the API server container and referenced with `--encryption-provider-config`.
 </details>
 
-**Success Checklist**:
-- [ ] API server restarts successfully with the `--encryption-provider-config` flag active.
-- [ ] New secrets generated after the restart are written securely.
-- [ ] `kubectl replace` successfully cycles old plaintext data into AES-CBC ciphertexts.
+### Task 3: Write a narrow Secret reader Role
 
+Create a ServiceAccount that can read only the `app-db` Secret by name. Do not grant `list` or `watch`.
+
+```bash
+kubectl -n secrets-lab create serviceaccount app-reader
+
+cat <<'EOF' | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: app-db-reader
+  namespace: secrets-lab
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["app-db"]
+    verbs: ["get"]
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: app-db-reader
+  namespace: secrets-lab
+subjects:
+  - kind: ServiceAccount
+    name: app-reader
+    namespace: secrets-lab
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: app-db-reader
+EOF
 
-## Summary
+kubectl auth can-i get secret/app-db \
+  --as=system:serviceaccount:secrets-lab:app-reader \
+  -n secrets-lab
 
-**Secret Security Problems**:
-- Base64 is NOT encryption; it is simply encoding.
-- etcd stores plain text by default, exposing data to node and backup breaches.
-- Environment variables leak highly sensitive data into `/proc`, crash dumps, and APM systems.
+kubectl auth can-i list secrets \
+  --as=system:serviceaccount:secrets-lab:app-reader \
+  -n secrets-lab
+```
 
-**Best Practices**:
-- Enable encryption at rest utilizing `aescbc`.
-- Emphasize tmpfs volume mounts over environment variable injection.
-- Restrict RBAC explicitly with `resourceNames`.
-- Remember to re-encrypt existing keys after enabling provider encryption.
-- Adopt External Secrets Operator (ESO) for production, multi-cloud architectures.
+<details>
+<summary>Solution notes</summary>
 
-**Encryption Setup**:
-- Construct the `EncryptionConfiguration` file carefully.
-- Patch the API server flag, volume, and volume mount.
-- Execute a cluster-wide `replace` operation.
+The first authorization check should return `yes`, and the second should return `no`. That is the difference between a named read and a namespace-wide inventory. In a real review, you would also check whether the same ServiceAccount can create Pods, exec into Pods, or obtain Secret access through a different RoleBinding. RBAC is cumulative, so one narrow Role does not cancel a broader one.
+</details>
 
-**Exam Tips**:
-- Know the exact encryption config YAML format—you must be able to write it from memory or documentation.
-- Understand provider priority order: the first provider encrypts, all listed providers attempt to decrypt.
-- Be thoroughly prepared to automate file edits under pressure using `sed` or `yq`.
+### Task 4: Compare env and volume consumption
 
----
+Run a Pod that mounts the Secret as a file, then read the mounted value. This task uses `busybox`, which includes `sh` and `cat`, so the exec command matches the image binary set.
+
+```bash
+cat <<'EOF' | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: secret-reader
+  namespace: secrets-lab
+spec:
+  containers:
+    - name: app
+      image: busybox
+      command: ["sh", "-c", "sleep 3600"]
+      volumeMounts:
+        - name: db
+          mountPath: /etc/db
+          readOnly: true
+  volumes:
+    - name: db
+      secret:
+        secretName: app-db
+        defaultMode: 0400
+EOF
+
+kubectl -n secrets-lab wait --for=condition=Ready pod/secret-reader --timeout=60s
+kubectl -n secrets-lab exec secret-reader -- cat /etc/db/password
+```
+
+<details>
+<summary>Solution notes</summary>
+
+The mounted file should contain the decoded password value. A file mount gives you file permissions and a better rotation path than an environment variable, but the running process can still read the value. If you patch the Secret, the projected volume may update, but the application must reopen the file or reload its configuration. A process that cached the value at startup can continue using the old credential.
+</details>
+
+### Task 5: Review an audit policy for Secret reads
+
+Create a policy snippet that records Secret reads at metadata level. You do not need to apply it unless your lab exposes the control-plane static Pod manifest.
+
+```bash
+cat > /tmp/cks-4-3/audit-policy.yaml <<'EOF'
+apiVersion: audit.k8s.io/v1
+kind: Policy
+omitStages:
+  - RequestReceived
+rules:
+  - level: Metadata
+    verbs: ["get", "list", "watch"]
+    resources:
+      - group: ""
+        resources: ["secrets"]
+EOF
+```
+
+<details>
+<summary>Solution notes</summary>
+
+This policy captures who read or watched Secret resources without logging response bodies. If you used `RequestResponse` for `get secrets`, the audit backend could receive the Secret payload and become another sensitive data store. In a kubeadm-style static Pod control plane, remember that both the audit policy path and audit log path must be mounted into the API server container. Also plan log retention, because Secret-heavy controllers can generate many audit events.
+</details>
+
+### Success Criteria
+
+- [ ] You decoded a Secret value from the API response and can explain why that is not encryption.
+- [ ] Your `EncryptionConfiguration` places an encrypting provider before `identity`.
+- [ ] Your RBAC check allows named `get` on one Secret and denies namespace-wide `list`.
+- [ ] Your runtime example mounts the Secret as a file and uses an image that contains the executed binary.
+- [ ] Your audit policy logs Secret access at `Metadata` level rather than copying payloads into logs.
+
+## Sources
+
+- [Kubernetes Secrets](https://kubernetes.io/docs/concepts/configuration/secret/)
+- [Good practices for Kubernetes Secrets](https://kubernetes.io/docs/concepts/security/secrets-good-practices/)
+- [Encrypting Confidential Data at Rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/)
+- [Using a KMS provider for data encryption](https://kubernetes.io/docs/tasks/administer-cluster/kms-provider/)
+- [Kubernetes v1.29 release notes: KMS v2 stable](https://kubernetes.io/blog/2023/12/13/kubernetes-v1-29-release/)
+- [Configure Service Accounts for Pods](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/)
+- [Kubernetes Service Accounts](https://kubernetes.io/docs/concepts/security/service-accounts/)
+- [Kubelet TLS bootstrapping](https://kubernetes.io/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/)
+- [Kubernetes RBAC reference](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
+- [Kubernetes Auditing](https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/)
+- [External Secrets Operator documentation](https://external-secrets.io/latest/)
+- [External Secrets Operator SecretStore API](https://external-secrets.io/latest/api/secretstore/)
+- [External Secrets Operator ClusterSecretStore API](https://external-secrets.io/latest/api/clustersecretstore/)
+- [Bitnami Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets)
+- [HashiCorp Vault on Kubernetes](https://developer.hashicorp.com/vault/docs/deploy/kubernetes)
+- [Vault Agent Injector](https://developer.hashicorp.com/vault/docs/deploy/kubernetes/injector)
+- [Secrets Store CSI Driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver)
+- [Secrets Store CSI Driver documentation](https://secrets-store-csi-driver.sigs.k8s.io/)
 
 ## Next Module
 
-[Module 4.4: Runtime Sandboxing](../module-4.4-runtime-sandboxing/) - Secure your pods beyond RBAC by learning how gVisor and Kata Containers build aggressive, kernel-level isolation layers to trap attackers.
+[Module 4.4: Runtime Sandboxing](../module-4.4-runtime-sandboxing/) - Secure your pods beyond RBAC by learning how gVisor and Kata Containers add stronger workload isolation boundaries.


### PR DESCRIPTION
## Summary

**Second production module of the 160-module rewrite pivot.** CKS 4.3 Secrets Management rewritten from T3 (rubric 1.5, 0 sources, ~942 lines but mean_wpp ≪ 30) → **T0** (5517 body words, mean_wpp 84.9, 18 reachable sources, 7 quiz items, 7 mistakes, 5 hands-on checkboxes).

Topic coverage at CKS exam depth:
- Why Secrets aren't really secret (base64 ≠ encryption, etcd plaintext, env-var visibility in `kubectl describe`)
- `EncryptionConfiguration` + `--encryption-provider-config` + kube-apiserver static Pod manifest wiring + `etcdctl` verification
- KMS v2 (1.29 GA) deep dive: gRPC over Unix socket, plugin protocol, vs v1 deprecation
- External Secrets Operator: ClusterSecretStore vs SecretStore, provider catalog
- Sealed Secrets: controller architecture, key rotation, vs ESO decision framework
- HashiCorp Vault: vault-injector sidecar + vault auth enable kubernetes setup + token reviewer JWT
- Secret types: Opaque, dockerconfigjson, tls, service-account-token, bootstrap-token-secrets
- Projected ServiceAccount tokens (audience-bound, time-bound, vs long-lived SA Secrets)
- Audit policy for Secret access (Metadata level to avoid payload leakage)
- Immutable secrets (1.21+), rotation strategies, CSI driver mount rotation

Regression test: src/content/docs/k8s/cks/part4-microservice-vulnerabilities/module-4.3-secrets-management.md

## Verification

Before:
- T3, rubric 1.5, sources=0, fails density gates

After:
- **T0**, body_words=5517, mean_wpp=84.9, median_wpp=88, short_paragraph_rate=1.5%, sources=18 (all reachable), quiz=7, mistakes=7, hands_on=5
- `npm run build` → pass

## Learner check

> All three pieces — the flag, mount, and volume — must be present; if one is missing, the API server does not load the config and falls back to identity (plaintext) writes silently.

## Review chain

- Writer: codex (gpt-5.5 architect, danger mode, --search)
- Reviewer A: **claude-sonnet-4-6** — NEEDS_CHANGES (2 blockers: missing kube-apiserver manifest snippet, missing etcdctl verification) + 3 nits (aesgcm risk, Sealed Secrets rotation, ESO v1 vs v1beta1)
- Reviewer B: **agy / Gemini 3.5 Flash (High)** — APPROVE_WITH_NITS (3 nits: KMS v1 status, missing SealedSecret YAML, missing Vault auth setup)
- Fixup: codex (gpt-5.3-codex-spark) — addressed all 7 findings in commit `50740ca3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)