### PR TITLE
feat(calibration): PR 1 — scripts/calibration/ foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,15 @@
 # Model-calibration sweeps (multi-model role outputs, REPORT.html, helper scripts).
 # Keep on disk for reference; never commit — outputs are large and time-stamped.
 audit/
+calibration/v1/ledger.db
+calibration/v1/ledger.db-wal
+calibration/v1/ledger.db-shm
+calibration/v1/*/results.db
+calibration/v1/*/results.db-wal
+calibration/v1/*/results.db-shm
+calibration/v1/*/results.jsonl
+calibration/v1/*/responses/
+calibration/v1/*/reports/
 
 # Python bytecode caches
 __pycache__/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pyyaml>=6.0.3
 psutil>=7.2.2
+jinja2>=3.1.6

--- a/scripts/calibration/__init__.py
+++ b/scripts/calibration/__init__.py
@@ -1,0 +1,6 @@
+"""Calibration framework foundation.
+
+The package is intentionally ledger-first: dispatches, scores, and reports all
+flow through the SQLite schema in ``schema.py``.
+"""
+

--- a/scripts/calibration/ground-truth/v1/architecting/kubedojo-review-override-rfc.yaml
+++ b/scripts/calibration/ground-truth/v1/architecting/kubedojo-review-override-rfc.yaml
@@ -1,0 +1,22 @@
+# Fixture source: v1.1 spec lane 6, KUBEDOJO_REVIEW_OVERRIDE RFC.
+fixture_id: kubedojo-review-override-rfc
+lane: architecting
+required_categories:
+  - "env-var format"
+  - "validation"
+  - "hermes invocation"
+  - "failure modes"
+  - "telemetry"
+  - "flow integration"
+  - "rollback"
+  - "rate-limit"
+  - "prompt-model mismatch"
+  - "worktree"
+novel_risk_terms:
+  - "prompt-model mismatch"
+  - "cost cap"
+  - "audit trail"
+llm_rubric: |
+  Return JSON: {"score": 0-10, "rationale": "..."}.
+  Reward concrete failure handling, typed telemetry, and a reversible rollout.
+

--- a/scripts/calibration/ground-truth/v1/code-review/pr-1333-security-yaml.yaml
+++ b/scripts/calibration/ground-truth/v1/code-review/pr-1333-security-yaml.yaml
@@ -1,0 +1,17 @@
+# Fixture source: v1.1 spec lane 2, PR #1333 security-YAML diff.
+fixture_id: pr-1333-security-yaml
+lane: code-review
+findings:
+  - id: F1
+    aliases: ["--strict-collection", "strict collection", "zizmor strict"]
+  - id: F2
+    aliases: [".github/actions", "reusable actions", "scan scope"]
+  - id: F3
+    aliases: ["cooldown", "default-days", "dependabot cooldown"]
+  - id: F4
+    aliases: ["pip install zizmor", "unpinned", "pin"]
+hallucination_terms:
+  - "secrets exposed"
+  - "pull_request_target"
+  - "write-all"
+

--- a/scripts/calibration/ground-truth/v1/code-writing/parse-dependabot-cooldown.yaml
+++ b/scripts/calibration/ground-truth/v1/code-writing/parse-dependabot-cooldown.yaml
@@ -1,0 +1,35 @@
+# Fixture source: v1.1 spec lane 1. Eight tests lock the expected parser behavior.
+fixture_id: parse-dependabot-cooldown
+lane: code-writing
+tests_py: |
+  import pytest
+  from solution import parse_dependabot_cooldown
+
+  def test_inline_mapping_returns_days():
+      assert parse_dependabot_cooldown("cooldown: { default-days: 7 }") == 7
+
+  def test_nested_mapping_returns_days():
+      assert parse_dependabot_cooldown("cooldown:\n  default-days: 14\n") == 14
+
+  def test_missing_cooldown_returns_none():
+      assert parse_dependabot_cooldown("version: 2\nupdates: []\n") is None
+
+  def test_empty_yaml_returns_none():
+      assert parse_dependabot_cooldown("") is None
+
+  def test_top_level_non_mapping_raises():
+      with pytest.raises(ValueError):
+          parse_dependabot_cooldown("- just\n- a\n- list\n")
+
+  def test_cooldown_non_mapping_raises():
+      with pytest.raises(ValueError):
+          parse_dependabot_cooldown("cooldown: 7\n")
+
+  def test_non_integer_days_raises():
+      with pytest.raises(ValueError):
+          parse_dependabot_cooldown("cooldown:\n  default-days: seven\n")
+
+  def test_bool_days_raises():
+      with pytest.raises(ValueError):
+          parse_dependabot_cooldown("cooldown:\n  default-days: true\n")
+

--- a/scripts/calibration/ground-truth/v1/content-review/flawed-module-rubric-review.yaml
+++ b/scripts/calibration/ground-truth/v1/content-review/flawed-module-rubric-review.yaml
@@ -1,0 +1,25 @@
+# Fixture source: v1.1 spec lane 4, deliberately flawed module.
+fixture_id: flawed-module-rubric-review
+lane: content-review
+planted_flaws:
+  - id: hallucinated-kubectl-flag
+    aliases: ["--remove-extra-permission", "hallucinated flag"]
+  - id: missing-ipa-tags
+    aliases: ["IPA", "instructional purpose", "missing ipa"]
+  - id: wrong-header-levels
+    aliases: ["duplicate H1", "header", "heading"]
+  - id: broken-citation
+    aliases: ["broken citation", "missing-page", "404"]
+  - id: off-by-one-bloom
+    aliases: ["Bloom", "understand", "know"]
+  - id: missing-diagram
+    aliases: ["diagram", "Mermaid"]
+  - id: duplicate-h1
+    aliases: ["duplicate H1", "# Kubernetes RBAC"]
+  - id: banned-simply
+    aliases: ["simply", "banned word"]
+hallucination_terms:
+  - "etcd encryption"
+  - "PSA labels"
+  - "container runtime"
+

--- a/scripts/calibration/ground-truth/v1/content-writing-long/kubedojo-rbac-module.yaml
+++ b/scripts/calibration/ground-truth/v1/content-writing-long/kubedojo-rbac-module.yaml
@@ -1,0 +1,11 @@
+# Fixture source: v1.1 spec lane 3, long RBAC module.
+fixture_id: kubedojo-rbac-module
+lane: content-writing-long
+accepted_verifier_tiers: ["T0", "T1"]
+bloom_l3_terms: ["analyze", "diagnose", "compare", "design", "troubleshoot"]
+llm_rubric: |
+  Return JSON: {"score": 0-10, "rationale": "..."}.
+  9-10: Teaches RBAC through operator decisions, misconceptions, and runnable checks.
+  7-8: Solid explanation with minor pedagogy gaps.
+  0-6: Mostly reference summary, shallow examples, or unclear learner checks.
+

--- a/scripts/calibration/ground-truth/v1/content-writing-long/kubedojo-rbac-module.yaml
+++ b/scripts/calibration/ground-truth/v1/content-writing-long/kubedojo-rbac-module.yaml
@@ -3,9 +3,9 @@ fixture_id: kubedojo-rbac-module
 lane: content-writing-long
 accepted_verifier_tiers: ["T0", "T1"]
 bloom_l3_terms: ["analyze", "diagnose", "compare", "design", "troubleshoot"]
+judge_instruction: "Score whether the module actually teaches Kubernetes RBAC with TTT pedagogy rather than paraphrasing upstream docs."
 llm_rubric: |
   Return JSON: {"score": 0-10, "rationale": "..."}.
   9-10: Teaches RBAC through operator decisions, misconceptions, and runnable checks.
   7-8: Solid explanation with minor pedagogy gaps.
   0-6: Mostly reference summary, shallow examples, or unclear learner checks.
-

--- a/scripts/calibration/ground-truth/v1/debugging/resourcequota-pvc-mismatch.yaml
+++ b/scripts/calibration/ground-truth/v1/debugging/resourcequota-pvc-mismatch.yaml
@@ -1,0 +1,16 @@
+# Fixture source: PR #1353 ResourceQuota PVC mismatch.
+# Choice: session-34 records agy caught requests.storage=300Gi while PVCs sum to 320Gi.
+fixture_id: resourcequota-pvc-mismatch
+lane: debugging
+root_cause_terms:
+  - "300Gi"
+  - "320Gi"
+  - "ResourceQuota"
+fix_terms:
+  - "requests.storage: 320Gi"
+  - "+    requests.storage: 320Gi"
+broad_rewrite_terms:
+  - "rewrite the module"
+  - "replace the manifest"
+pytest_command: []
+

--- a/scripts/calibration/ground-truth/v1/fact-check/k8s-1-35-claims.yaml
+++ b/scripts/calibration/ground-truth/v1/fact-check/k8s-1-35-claims.yaml
@@ -1,0 +1,15 @@
+# Fixture source: v1.1 spec lane 5. Claims are anchored to KubeDojo's 1.35 target.
+fixture_id: k8s-1-35-claims
+lane: fact-check
+min_citations: 3
+claims:
+  - claim_id: C1
+    verdict: VERIFIED
+  - claim_id: C2
+    verdict: VERIFIED
+  - claim_id: C3
+    verdict: VERIFIED
+  - claim_id: C4
+    verdict: "FALSE"
+  - claim_id: C5
+    verdict: "FALSE"

--- a/scripts/calibration/ground-truth/v1/orchestrating/multi-task-routing-brief.yaml
+++ b/scripts/calibration/ground-truth/v1/orchestrating/multi-task-routing-brief.yaml
@@ -1,0 +1,20 @@
+# Fixture source: v1.1 spec lane 7, orchestrating routing brief.
+fixture_id: multi-task-routing-brief
+lane: orchestrating
+expected_routes:
+  - subtask: "Python bug"
+    model_class: "codex"
+    lane: "debugging"
+  - subtask: "security regressions"
+    model_class: "claude"
+    lane: "code-review"
+  - subtask: "module handoff"
+    model_class: "cheap"
+    lane: "summarization"
+  - subtask: "fact-check"
+    model_class: "google"
+    lane: "fact-check"
+llm_rubric: |
+  Return JSON: {"score": 0-10, "rationale": "..."}.
+  Reward clear dependency boundaries, same-family serialization, and honest cost estimates.
+

--- a/scripts/calibration/ground-truth/v1/refactoring/check-site-health-refactor.yaml
+++ b/scripts/calibration/ground-truth/v1/refactoring/check-site-health-refactor.yaml
@@ -1,0 +1,12 @@
+# Fixture source: selected `scripts/check_site_health.py`.
+# The file has shared global errors/warnings/stats state and repeated counter logic.
+fixture_id: check-site-health-refactor
+lane: refactoring
+original_loc: 38
+behavior_terms:
+  - "Missing frontmatter"
+  - "Missing title"
+  - "Missing sidebar.order"
+test_command: []
+lint_command: []
+

--- a/scripts/calibration/ground-truth/v1/summarization/session-34-handoff.yaml
+++ b/scripts/calibration/ground-truth/v1/summarization/session-34-handoff.yaml
@@ -1,0 +1,20 @@
+# Fixture source: docs/session-state/2026-05-20-session-34-rewrite-pivot-launch-plus-calibration-framework.html
+fixture_id: session-34-handoff
+lane: summarization
+min_words: 180
+max_words: 220
+must_mentions:
+  - "CKS 4.2 PSA rewrite shipped as PR #1362"
+  - "CKS 4.3 Secrets Management shipped as PR #1363"
+  - "T2-13 Ansible arc decision archived"
+  - "Calibration framework v1 spec designed and shipped as PR #1364"
+  - "Module 7.12 Ansible Operator SDK shipped as PR #1354"
+  - "agy/Gemini 3.5 Flash High promoted to primary-tier reviewer"
+banned_hallucinations:
+  - "merged calibration PR 1"
+  - "no blockers remain"
+  - "translation lane shipped"
+llm_rubric: |
+  Return JSON: {"score": 0-10, "rationale": "..."}.
+  Reward concise sequencing, faithful status, and clear next-session handoff value.
+

--- a/scripts/calibration/models.py
+++ b/scripts/calibration/models.py
@@ -1,0 +1,216 @@
+"""Canonical calibration model registry for v1.1."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+Family = Literal["anthropic", "openai", "google", "deepseek", "alibaba", "xai"]
+ProviderCli = Literal["claude-cli", "codex-cli", "agy-cli", "gemini-cli", "hermes"]
+EffortMechanism = Literal[
+    "native_flag",
+    "cli_config",
+    "model_name_suffix",
+    "prompt_prefix_hint",
+    "none",
+]
+EffortConfidence = Literal["high", "medium", "low", "unknown"]
+Wave = Literal["A", "B", "C", "D"]
+
+
+@dataclass(frozen=True)
+class CalibrationModel:
+    family: Family
+    provider_cli: ProviderCli
+    model_id: str
+    version: str
+    effort_requested: str
+    effort_mechanism: EffortMechanism
+    effort_confidence: EffortConfidence
+    wave: Wave
+    canonical_string: str
+
+
+ANCHORS: tuple[CalibrationModel, ...] = (
+    CalibrationModel(
+        "anthropic",
+        "claude-cli",
+        "claude-opus",
+        "4-7",
+        "max",
+        "native_flag",
+        "high",
+        "A",
+        "claude-opus-4-7",
+    ),
+    CalibrationModel(
+        "openai",
+        "codex-cli",
+        "gpt-5",
+        "5.5",
+        "xhigh",
+        "cli_config",
+        "high",
+        "A",
+        "gpt-5.5",
+    ),
+    CalibrationModel(
+        "google",
+        "agy-cli",
+        "gemini-3.5-flash",
+        "3.5-flash",
+        "high",
+        "model_name_suffix",
+        "high",
+        "A",
+        "gemini-3.5-flash-high",
+    ),
+    CalibrationModel(
+        "deepseek",
+        "hermes",
+        "deepseek-v4-pro",
+        "v4-pro",
+        "xhigh",
+        "prompt_prefix_hint",
+        "low",
+        "A",
+        "deepseek-v4-pro",
+    ),
+    CalibrationModel(
+        "alibaba",
+        "hermes",
+        "qwen3.6-plus",
+        "3.6-plus",
+        "xhigh",
+        "prompt_prefix_hint",
+        "low",
+        "A",
+        "qwen3.6-plus",
+    ),
+    CalibrationModel(
+        "anthropic",
+        "claude-cli",
+        "claude-sonnet",
+        "4-6",
+        "max",
+        "native_flag",
+        "high",
+        "B",
+        "claude-sonnet-4-6",
+    ),
+    CalibrationModel(
+        "google",
+        "gemini-cli",
+        "gemini-3.1-pro",
+        "3.1-pro-preview",
+        "high",
+        "model_name_suffix",
+        "high",
+        "B",
+        "gemini-3.1-pro-preview",
+    ),
+    CalibrationModel(
+        "deepseek",
+        "hermes",
+        "deepseek-v4-flash",
+        "v4-flash",
+        "xhigh",
+        "prompt_prefix_hint",
+        "low",
+        "B",
+        "deepseek-v4-flash",
+    ),
+    CalibrationModel(
+        "xai",
+        "hermes",
+        "grok",
+        "4.3",
+        "xhigh",
+        "prompt_prefix_hint",
+        "unknown",
+        "C",
+        "grok-4.3",
+    ),
+    CalibrationModel(
+        "anthropic",
+        "claude-cli",
+        "claude-haiku",
+        "4-5",
+        "default",
+        "none",
+        "high",
+        "D",
+        "claude-haiku-4-5",
+    ),
+    CalibrationModel(
+        "openai",
+        "codex-cli",
+        "gpt-5-codex-spark",
+        "5.3",
+        "xhigh",
+        "cli_config",
+        "medium",
+        "D",
+        "gpt-5.3-codex-spark",
+    ),
+    CalibrationModel(
+        "openai",
+        "codex-cli",
+        "gpt-5-mini",
+        "5.4",
+        "xhigh",
+        "cli_config",
+        "low",
+        "D",
+        "gpt-5.4-mini",
+    ),
+    CalibrationModel(
+        "google",
+        "agy-cli",
+        "gemini-3.1-flash-lite",
+        "3.1-flash-lite-preview",
+        "high",
+        "model_name_suffix",
+        "low",
+        "D",
+        "gemini-3.1-flash-lite-preview",
+    ),
+    CalibrationModel(
+        "alibaba",
+        "hermes",
+        "qwen3.6",
+        "3.6",
+        "xhigh",
+        "prompt_prefix_hint",
+        "low",
+        "D",
+        "qwen3.6",
+    ),
+)
+
+LANES = (
+    "code-writing",
+    "code-review",
+    "content-writing-long",
+    "content-review",
+    "fact-check",
+    "architecting",
+    "orchestrating",
+    "debugging",
+    "refactoring",
+    "summarization",
+)
+
+
+def models_by_family() -> dict[Family, list[CalibrationModel]]:
+    grouped: dict[Family, list[CalibrationModel]] = {}
+    for model in ANCHORS:
+        grouped.setdefault(model.family, []).append(model)
+    return grouped
+
+
+def model_by_canonical(canonical_string: str) -> CalibrationModel:
+    for model in ANCHORS:
+        if model.canonical_string == canonical_string:
+            return model
+    raise KeyError(f"unknown calibration model: {canonical_string}")
+

--- a/scripts/calibration/models.py
+++ b/scripts/calibration/models.py
@@ -97,6 +97,11 @@ ANCHORS: tuple[CalibrationModel, ...] = (
         "B",
         "claude-sonnet-4-6",
     ),
+    # Wave B uses gemini-cli for gemini-3.1-pro-preview because agy-cli
+    # does not expose pro-preview models.
+    # After 2026-06-18 (gemini-cli cutover to agy), this row may need to
+    # migrate or be retired.
+    # Tracked in #1365.
     CalibrationModel(
         "google",
         "gemini-cli",
@@ -213,4 +218,3 @@ def model_by_canonical(canonical_string: str) -> CalibrationModel:
         if model.canonical_string == canonical_string:
             return model
     raise KeyError(f"unknown calibration model: {canonical_string}")
-

--- a/scripts/calibration/prompts/v1/architecting/kubedojo-review-override-rfc.md
+++ b/scripts/calibration/prompts/v1/architecting/kubedojo-review-override-rfc.md
@@ -1,0 +1,19 @@
+Design `KUBEDOJO_REVIEW_OVERRIDE`: an environment-variable hook that routes
+review-class dispatches to any OpenRouter model without registering it as a
+first-class agent.
+
+Output a 700-1500 word design RFC covering:
+
+1. env-var format
+2. validation
+3. hermes invocation
+4. failure modes
+5. telemetry
+6. flow integration
+7. rollback
+8. rate-limit behavior
+9. prompt-model mismatch
+10. worktree/mode safety
+
+Include any novel risks beyond the list if you find them.
+

--- a/scripts/calibration/prompts/v1/code-review/pr-1333-security-yaml.md
+++ b/scripts/calibration/prompts/v1/code-review/pr-1333-security-yaml.md
@@ -1,0 +1,39 @@
+Review this security-YAML diff from PR #1333.
+
+Output one finding per line with:
+
+- file:line citation
+- classification: `security`, `correctness`, or `style`
+- concise rationale grounded only in the diff
+
+Unsupported claims count as hallucinations. Do not claim a finding unless the
+diff directly supports it.
+
+```diff
+diff --git a/.github/workflows/security.yml b/.github/workflows/security.yml
+@@
+ name: security
+ on:
+   pull_request:
+ jobs:
+   lint-actions:
+     runs-on: ubuntu-latest
+     steps:
+       - uses: actions/checkout@v4
+       - name: Install zizmor
+-        run: pip install zizmor
++        run: pip install zizmor
+       - name: Scan workflows
+-        run: zizmor .github/workflows
++        run: zizmor .github/workflows
+
+diff --git a/.github/dependabot.yml b/.github/dependabot.yml
+@@
+ version: 2
+ updates:
+   - package-ecosystem: "github-actions"
+     directory: "/"
+     schedule:
+       interval: "weekly"
+```
+

--- a/scripts/calibration/prompts/v1/code-writing/parse-dependabot-cooldown.md
+++ b/scripts/calibration/prompts/v1/code-writing/parse-dependabot-cooldown.md
@@ -1,0 +1,20 @@
+Implement `parse_dependabot_cooldown(yaml_text: str) -> int | None`.
+
+The function returns the configured Dependabot cooldown days as an `int`, or
+`None` if no cooldown is configured.
+
+Constraints:
+
+- Use `yaml.safe_load`.
+- Handle malformed input by raising `ValueError`.
+- Do not use a bare `except`.
+- The output must be ruff-clean Python.
+- Return only the implementation code.
+
+Expected behavior:
+
+- `cooldown: { default-days: 7 }` returns `7`.
+- Missing `cooldown` returns `None`.
+- Non-mapping YAML, non-mapping `cooldown`, negative values, booleans, and
+  non-integer values raise `ValueError`.
+

--- a/scripts/calibration/prompts/v1/content-review/flawed-module-rubric-review.md
+++ b/scripts/calibration/prompts/v1/content-review/flawed-module-rubric-review.md
@@ -1,0 +1,45 @@
+Review this deliberately flawed module against `docs/quality-rubric.md`.
+
+Output a JSON list of failing rubric criteria with file:line evidence. Do not
+enumerate passing criteria.
+
+```markdown
+---
+title: Kubernetes RBAC Quick Guide
+sidebar:
+  order: 42
+---
+
+# Kubernetes RBAC Quick Guide
+
+RBAC is simply a way to give users permissions. This module explains the
+basics.
+
+## Learn outcomes
+
+- Understand RBAC
+- Know Roles
+
+## Lab
+
+Run:
+
+```bash
+kubectl auth reconcile --remove-extra-permission -f role.yaml
+```
+
+This command always removes every extra permission cluster-wide.
+
+## Diagram
+
+No diagram is needed because RBAC is intuitive.
+
+## Sources
+
+- Kubernetes RBAC docs: https://kubernetes.io/docs/reference/access-authn-authz/rbac-missing-page/
+```
+
+Known traps include a hallucinated kubectl flag, missing IPA tags, wrong header
+levels, broken citation, off-by-one Bloom level, missing diagram, duplicate H1,
+and banned wording.
+

--- a/scripts/calibration/prompts/v1/content-writing-long/kubedojo-rbac-module.md
+++ b/scripts/calibration/prompts/v1/content-writing-long/kubedojo-rbac-module.md
@@ -1,0 +1,14 @@
+Write a 5000-word KubeDojo module on Kubernetes RBAC.
+
+Constraints:
+
+- Use TTT pedagogy: telegraph, teach, test.
+- Include a Mermaid diagram showing subjects, Role/ClusterRole,
+  RoleBinding/ClusterRoleBinding, verbs, resources, and namespaces.
+- Hit the deterministic verifier at T0 or T1.
+- Do not use the word `simply`.
+- Include Bloom L3+ learning outcomes.
+- Keep the module focused on Kubernetes 1.35 operator practice.
+
+Return the full module Markdown.
+

--- a/scripts/calibration/prompts/v1/debugging/resourcequota-pvc-mismatch.md
+++ b/scripts/calibration/prompts/v1/debugging/resourcequota-pvc-mismatch.md
@@ -1,0 +1,47 @@
+Given the failing pytest output and relevant manifest excerpt, identify the
+root cause in one sentence and produce a minimal patch.
+
+Failing test:
+
+```text
+E   AssertionError: namespace ResourceQuota requests.storage=300Gi is lower
+E   than the PVC requests sum 320Gi, so the second PVC can remain Pending.
+```
+
+Relevant file excerpt from the Module 3.1 deployment fix path:
+
+```yaml
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: llm-stack-quota
+spec:
+  hard:
+    requests.cpu: "16"
+    requests.memory: 96Gi
+    requests.storage: 300Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vllm-cache
+spec:
+  resources:
+    requests:
+      storage: 300Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: qdrant-data
+spec:
+  resources:
+    requests:
+      storage: 20Gi
+```
+
+Return:
+
+- root cause: one sentence
+- patch: unified diff only for the minimal fix
+

--- a/scripts/calibration/prompts/v1/fact-check/k8s-1-35-claims.md
+++ b/scripts/calibration/prompts/v1/fact-check/k8s-1-35-claims.md
@@ -1,0 +1,23 @@
+Verify these five claims about Kubernetes 1.35.
+
+Output JSON exactly as:
+
+```json
+[
+  {"claim_id": "C1", "verdict": "VERIFIED|FALSE|UNVERIFIABLE|NONEXISTENT", "rationale": "..."}
+]
+```
+
+Do not guess. If you cannot find the claim in upstream docs, return
+`UNVERIFIABLE`.
+
+Claims:
+
+- C1: PodSecurityPolicy is not available in Kubernetes 1.35.
+- C2: `kubectl create secret generic` remains a supported way to create a
+  Secret from literal values.
+- C3: `ReadWriteOncePod` is a stable PersistentVolume access mode by the 1.35
+  target.
+- C4: Kubernetes 1.35 removed NetworkPolicy from the `networking.k8s.io` API.
+- C5: In Kubernetes 1.35, `Deployment.spec.replicas` must be a quoted string.
+

--- a/scripts/calibration/prompts/v1/orchestrating/multi-task-routing-brief.md
+++ b/scripts/calibration/prompts/v1/orchestrating/multi-task-routing-brief.md
@@ -1,0 +1,16 @@
+Given this multi-task brief, output:
+
+1. dispatch plan with model, effort, and lane per sub-task
+2. parallelization decisions
+3. decision-card draft if disagreement is plausible
+4. cost estimate
+
+Brief:
+
+We need to fix a small Python bug in `scripts/check_links.py`, review the PR
+for security regressions, write a concise module handoff for the CKS rewrite
+queue, and fact-check two Kubernetes API-version claims. The code fix and
+handoff can happen in parallel, but OpenAI/Codex tasks share one family queue.
+If reviewers disagree on whether to add an OpenRouter override, capture a
+decision card instead of forcing a merge.
+

--- a/scripts/calibration/prompts/v1/refactoring/check-site-health-refactor.md
+++ b/scripts/calibration/prompts/v1/refactoring/check-site-health-refactor.md
@@ -1,0 +1,52 @@
+Refactor the following script excerpt while preserving behavior.
+
+Goals:
+
+- remove duplicate global state mutations where practical
+- improve names so the data flow is clearer
+- keep all checks behaviorally equivalent
+- reduce LOC
+- keep the output ruff-clean
+
+Source: `scripts/check_site_health.py`, selected because it is an older
+procedural script with global `errors`, `warnings`, and `stats` state shared
+across many checks.
+
+```python
+errors = []
+warnings = []
+stats = {}
+
+def error(msg: str):
+    errors.append(msg)
+
+def warn(msg: str):
+    warnings.append(msg)
+
+def check_frontmatter():
+    missing_fm = 0
+    missing_title = 0
+    missing_order = 0
+    for md in sorted(_iter_markdown_files()):
+        rel = str(md.relative_to(DOCS_DIR))
+        content = md.read_text(errors="replace")
+        if not content.startswith("---"):
+            error(f"Missing frontmatter: {rel}")
+            missing_fm += 1
+            continue
+        parts = content.split("---", 2)
+        if len(parts) < 3:
+            error(f"Malformed frontmatter: {rel}")
+            missing_fm += 1
+            continue
+        fm = parts[1]
+        if "title:" not in fm:
+            error(f"Missing title: {rel}")
+            missing_title += 1
+        if md.name.startswith("module-") and "order:" not in fm:
+            warn(f"Missing sidebar.order: {rel}")
+            missing_order += 1
+```
+
+Return the refactored Python code only.
+

--- a/scripts/calibration/prompts/v1/summarization/session-34-handoff.md
+++ b/scripts/calibration/prompts/v1/summarization/session-34-handoff.md
@@ -1,0 +1,19 @@
+Given this raw session-34 source excerpt, write a 200-word handoff covering PRs
+merged, decisions made, and blockers. Stay within 180-220 words.
+
+Source file:
+`docs/session-state/2026-05-20-session-34-rewrite-pivot-launch-plus-calibration-framework.html`
+
+Excerpt:
+
+Session 34 shipped CKS 4.2 Pod Security Admission as PR #1362 and CKS 4.3
+Secrets Management as PR #1363. The session archived the T2-13 Ansible arc
+decision after Module 7.12 Ansible Operator SDK Fundamentals shipped as PR
+#1354. It promoted agy/Gemini 3.5 Flash High to a primary-tier reviewer after
+it caught real module 3.1 deployment bugs and useful review nits. The user asked
+for a model calibration framework; the team designed and shipped the v1 spec as
+PR #1364, with the build tracked as #1365. The remaining rewrite pivot has many
+critical-quality modules, with CKS 4.4 and CKS 5.x next in the queue.
+
+Return only the handoff paragraph.
+

--- a/scripts/calibration/report.py
+++ b/scripts/calibration/report.py
@@ -1,0 +1,265 @@
+"""Render HTML calibration reports from the SQLite ledger."""
+from __future__ import annotations
+
+import argparse
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+from . import schema
+from .models import ANCHORS, LANES
+from .run_cell import DEFAULT_DB_PATH, DEFAULT_OUTPUT_ROOT
+
+TEMPLATE_DIR = Path(__file__).resolve().parent / "reports" / "templates"
+
+
+@dataclass(frozen=True)
+class CellSummary:
+    cell_id: str
+    lane: str
+    canonical_string: str
+    run_date: str
+    family: str
+    effort_requested: str
+    effort_confidence: str
+    deterministic_score: float
+    llm_score: float | None
+    response_path: str | None
+
+
+def _env() -> Environment:
+    return Environment(
+        loader=FileSystemLoader(TEMPLATE_DIR),
+        autoescape=select_autoescape(("html", "xml")),
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+
+
+def _safe_filename(value: str) -> str:
+    return value.replace("/", "_").replace("@", "_")
+
+
+def load_summaries(db_path: Path) -> list[CellSummary]:
+    schema.init_db(db_path)
+    with schema.connect(db_path) as conn:
+        cells = conn.execute(
+            "SELECT * FROM cells ORDER BY run_date, lane, canonical_string"
+        ).fetchall()
+        scores = conn.execute(
+            "SELECT * FROM scores ORDER BY cell_id, gate_name, scorer"
+        ).fetchall()
+        dispatches = conn.execute(
+            """
+            SELECT cell_id, response_path
+            FROM dispatches
+            WHERE dispatch_id IN (
+              SELECT MAX(dispatch_id) FROM dispatches GROUP BY cell_id
+            )
+            """
+        ).fetchall()
+
+    score_rows: dict[str, list[Any]] = defaultdict(list)
+    for score in scores:
+        score_rows[str(score["cell_id"])].append(score)
+    response_paths = {
+        str(dispatch["cell_id"]): str(dispatch["response_path"])
+        for dispatch in dispatches
+    }
+
+    summaries: list[CellSummary] = []
+    for cell in cells:
+        cell_scores = score_rows[str(cell["cell_id"])]
+        deterministic = [
+            int(row["gate_pass"])
+            for row in cell_scores
+            if str(row["scorer"]) == "deterministic"
+            and str(row["gate_name"]) != "human_spot_check"
+        ]
+        llm = [
+            float(row["score_value"])
+            for row in cell_scores
+            if str(row["scorer"]).startswith("llm-judge:")
+            and row["score_value"] is not None
+        ]
+        deterministic_score = (
+            sum(deterministic) / len(deterministic) if deterministic else 0.0
+        )
+        llm_score = sum(llm) / len(llm) if llm else None
+        summaries.append(
+            CellSummary(
+                cell_id=str(cell["cell_id"]),
+                lane=str(cell["lane"]),
+                canonical_string=str(cell["canonical_string"]),
+                run_date=str(cell["run_date"]),
+                family=str(cell["family"]),
+                effort_requested=str(cell["effort_requested"]),
+                effort_confidence=str(cell["effort_confidence"]),
+                deterministic_score=deterministic_score,
+                llm_score=llm_score,
+                response_path=response_paths.get(str(cell["cell_id"])),
+            )
+        )
+    return summaries
+
+
+def _matrix_context(summaries: list[CellSummary]) -> dict[str, Any]:
+    models = [model.canonical_string for model in ANCHORS]
+    lanes = [lane for lane in LANES if any(cell.lane == lane for cell in summaries)]
+    by_key = {(cell.lane, cell.canonical_string): cell for cell in summaries}
+    rows = [
+        {
+            "lane": lane,
+            "cells": [by_key.get((lane, model)) for model in models],
+        }
+        for lane in lanes
+    ]
+    return {
+        "lanes": lanes,
+        "models": models,
+        "rows": rows,
+        "total_cells": len(summaries),
+    }
+
+
+def render_reports(
+    *,
+    db_path: Path = DEFAULT_DB_PATH,
+    out_dir: Path | None = None,
+) -> list[Path]:
+    summaries = load_summaries(db_path)
+    run_date = summaries[0].run_date if summaries else "latest"
+    out_dir = out_dir or DEFAULT_OUTPUT_ROOT / run_date / "reports"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "per-lane").mkdir(exist_ok=True)
+    (out_dir / "per-model").mkdir(exist_ok=True)
+
+    env = _env()
+    written: list[Path] = []
+
+    matrix_html = env.get_template("matrix.html.j2").render(
+        **_matrix_context(summaries),
+        run_date=run_date,
+    )
+    matrix_path = out_dir / "matrix.html"
+    matrix_path.write_text(matrix_html, encoding="utf-8")
+    written.append(matrix_path)
+
+    per_lane_template = env.get_template("per_lane.html.j2")
+    lanes = sorted({cell.lane for cell in summaries})
+    for lane in lanes:
+        lane_cells = sorted(
+            [cell for cell in summaries if cell.lane == lane],
+            key=lambda cell: (cell.deterministic_score, cell.llm_score or 0.0),
+            reverse=True,
+        )
+        path = out_dir / "per-lane" / f"{lane}.html"
+        path.write_text(
+            per_lane_template.render(
+                lane=lane,
+                cells=lane_cells,
+                run_date=run_date,
+            ),
+            encoding="utf-8",
+        )
+        written.append(path)
+
+    per_model_template = env.get_template("per_model.html.j2")
+    models = sorted({cell.canonical_string for cell in summaries})
+    for canonical_string in models:
+        model_cells = sorted(
+            [cell for cell in summaries if cell.canonical_string == canonical_string],
+            key=lambda cell: LANES.index(cell.lane),
+        )
+        path = out_dir / "per-model" / f"{_safe_filename(canonical_string)}.html"
+        path.write_text(
+            per_model_template.render(
+                canonical_string=canonical_string,
+                cells=model_cells,
+                run_date=run_date,
+            ),
+            encoding="utf-8",
+        )
+        written.append(path)
+
+    total_cost = _total_cost(db_path)
+    index_path = out_dir / "index.html"
+    index_path.write_text(
+        _render_index(
+            run_date=run_date,
+            total_cells=len(summaries),
+            total_cost=total_cost,
+            families=sorted({cell.family for cell in summaries}),
+            lanes=lanes,
+            models=models,
+        ),
+        encoding="utf-8",
+    )
+    written.append(index_path)
+    return written
+
+
+def _total_cost(db_path: Path) -> float:
+    with schema.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT COALESCE(SUM(cost_usd), 0.0) AS total_cost FROM dispatches"
+        ).fetchone()
+    return float(row["total_cost"])
+
+
+def _render_index(
+    *,
+    run_date: str,
+    total_cells: int,
+    total_cost: float,
+    families: list[str],
+    lanes: list[str],
+    models: list[str],
+) -> str:
+    family_list = ", ".join(families) if families else "none"
+    lane_links = "\n".join(
+        f'<li><a href="per-lane/{lane}.html">{lane}</a></li>' for lane in lanes
+    )
+    model_links = "\n".join(
+        f'<li><a href="per-model/{_safe_filename(model)}.html">{model}</a></li>'
+        for model in models
+    )
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Calibration reports — {run_date}</title>
+<link rel="stylesheet" href="../design-system.css">
+</head>
+<body>
+<h1>Calibration reports — {run_date}</h1>
+<p class="meta">cells={total_cells} · total_cost=${total_cost:.4f} · families={family_list}</p>
+<p><a href="matrix.html">Matrix heatmap</a></p>
+<h2>Per Lane</h2>
+<ul>{lane_links}</ul>
+<h2>Per Model</h2>
+<ul>{model_links}</ul>
+</body>
+</html>
+"""
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Render calibration reports")
+    parser.add_argument("--db-path", type=Path, default=DEFAULT_DB_PATH)
+    parser.add_argument("--out-dir", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    for path in render_reports(db_path=args.db_path, out_dir=args.out_dir):
+        print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/calibration/reports/templates/matrix.html.j2
+++ b/scripts/calibration/reports/templates/matrix.html.j2
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Calibration matrix — {{ run_date }}</title>
+<link rel="stylesheet" href="../design-system.css">
+<style>
+  body { max-width: 1100px; margin: 0 auto; padding: 1.5rem 1.25rem 3rem; }
+  h1 { margin-bottom: 0.25rem; }
+  p.meta { color: #555; font-size: 0.9rem; margin-top: 0.1rem; }
+  table { width:100%; border-collapse: collapse; margin: 0.75rem 0 1.25rem; }
+  th, td { border:1px solid #ddd; padding:0.35rem 0.55rem; font-size:0.88rem; vertical-align: top; }
+  th { background:#f3f5f7; text-align:left; }
+  .score { display:block; font-weight:700; }
+  .missing { color:#777; background:#f7f7f7; }
+  .heat-0 { background:#f8d7da; }
+  .heat-1 { background:#fff3cd; }
+  .heat-2 { background:#d1ecf1; }
+  .heat-3 { background:#d4edda; }
+  a { color:#0b5cad; }
+</style>
+</head>
+<body>
+<h1>Calibration matrix</h1>
+<p class="meta">run_date={{ run_date }} · cells={{ total_cells }}</p>
+<table>
+  <thead>
+    <tr>
+      <th>Lane</th>
+      {% for model in models %}
+      <th>{{ model }}</th>
+      {% endfor %}
+    </tr>
+  </thead>
+  <tbody>
+    {% for row in rows %}
+    <tr>
+      <th><a href="per-lane/{{ row.lane }}.html">{{ row.lane }}</a></th>
+      {% for cell in row.cells %}
+        {% if cell %}
+          {% set bucket = 3 if cell.deterministic_score >= 0.95 else 2 if cell.deterministic_score >= 0.75 else 1 if cell.deterministic_score > 0 else 0 %}
+          <td class="heat-{{ bucket }}" title="{{ cell.cell_id }}">
+            <a href="per-model/{{ cell.canonical_string | replace('/', '_') | replace('@', '_') }}.html">{{ cell.canonical_string }}</a>
+            <span class="score">{{ "%.0f"|format(cell.deterministic_score * 100) }}%</span>
+            {% if cell.llm_score is not none %}<span>judge {{ "%.1f"|format(cell.llm_score) }}</span>{% endif %}
+          </td>
+        {% else %}
+          <td class="missing">not run</td>
+        {% endif %}
+      {% endfor %}
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+</body>
+</html>

--- a/scripts/calibration/reports/templates/per_lane.html.j2
+++ b/scripts/calibration/reports/templates/per_lane.html.j2
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>{{ lane }} — calibration lane</title>
+<link rel="stylesheet" href="../../design-system.css">
+<style>
+  body { max-width: 1100px; margin: 0 auto; padding: 1.5rem 1.25rem 3rem; }
+  h1 { margin-bottom: 0.25rem; }
+  p.meta { color: #555; font-size: 0.9rem; margin-top: 0.1rem; }
+  table { width:100%; border-collapse: collapse; margin: 0.75rem 0 1.25rem; }
+  th, td { border:1px solid #ddd; padding:0.35rem 0.55rem; font-size:0.92rem; vertical-align: top; }
+  th { background:#f3f5f7; text-align:left; }
+  .pill { display:inline-block; padding:0.1rem 0.55rem; border-radius:0.35rem; font-size:0.78rem; font-weight:600; background:#e0e0ff; color:#1a1a8a; }
+</style>
+</head>
+<body>
+<h1>{{ lane }}</h1>
+<p class="meta">run_date={{ run_date }} · <a href="../matrix.html">matrix</a></p>
+<table>
+  <thead>
+    <tr><th>Model</th><th>Family</th><th>Effort</th><th>Deterministic</th><th>LLM judge</th><th>Response</th></tr>
+  </thead>
+  <tbody>
+    {% for cell in cells %}
+    <tr>
+      <td>{{ cell.canonical_string }}</td>
+      <td>{{ cell.family }}</td>
+      <td><span class="pill">{{ cell.effort_requested }} / {{ cell.effort_confidence }}</span></td>
+      <td>{{ "%.0f"|format(cell.deterministic_score * 100) }}%</td>
+      <td>{% if cell.llm_score is not none %}{{ "%.1f"|format(cell.llm_score) }}{% else %}n/a{% endif %}</td>
+      <td>{% if cell.response_path %}{{ cell.response_path }}{% else %}n/a{% endif %}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+</body>
+</html>
+

--- a/scripts/calibration/reports/templates/per_model.html.j2
+++ b/scripts/calibration/reports/templates/per_model.html.j2
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>{{ canonical_string }} — calibration model</title>
+<link rel="stylesheet" href="../../design-system.css">
+<style>
+  body { max-width: 1100px; margin: 0 auto; padding: 1.5rem 1.25rem 3rem; }
+  h1 { margin-bottom: 0.25rem; }
+  p.meta { color: #555; font-size: 0.9rem; margin-top: 0.1rem; }
+  table { width:100%; border-collapse: collapse; margin: 0.75rem 0 1.25rem; }
+  th, td { border:1px solid #ddd; padding:0.35rem 0.55rem; font-size:0.92rem; vertical-align: top; }
+  th { background:#f3f5f7; text-align:left; }
+  .confidence { font-weight:700; }
+</style>
+</head>
+<body>
+<h1>{{ canonical_string }}</h1>
+<p class="meta">run_date={{ run_date }} · <a href="../matrix.html">matrix</a></p>
+<table>
+  <thead>
+    <tr><th>Lane</th><th>Deterministic</th><th>LLM judge</th><th>Confidence vs actual</th><th>Cell</th></tr>
+  </thead>
+  <tbody>
+    {% for cell in cells %}
+    <tr>
+      <td><a href="../per-lane/{{ cell.lane }}.html">{{ cell.lane }}</a></td>
+      <td>{{ "%.0f"|format(cell.deterministic_score * 100) }}%</td>
+      <td>{% if cell.llm_score is not none %}{{ "%.1f"|format(cell.llm_score) }}{% else %}n/a{% endif %}</td>
+      <td><span class="confidence">{{ cell.effort_confidence }}</span> effort signal vs {{ "%.0f"|format(cell.deterministic_score * 100) }}% deterministic</td>
+      <td>{{ cell.cell_id }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+</body>
+</html>
+

--- a/scripts/calibration/run_cell.py
+++ b/scripts/calibration/run_cell.py
@@ -1,0 +1,332 @@
+"""Dispatch one calibration cell and persist the ledger rows."""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+from scripts.agent_runtime import runner
+from scripts.agent_runtime.errors import AgentTimeoutError
+
+from . import schema
+from .models import CalibrationModel, LANES, model_by_canonical
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROMPT_ROOT = REPO_ROOT / "scripts" / "calibration" / "prompts" / "v1"
+DEFAULT_DB_PATH = REPO_ROOT / "calibration" / "v1" / "ledger.db"
+DEFAULT_OUTPUT_ROOT = REPO_ROOT / "calibration" / "v1"
+
+
+@dataclass(frozen=True)
+class DispatchPlan:
+    kind: str
+    argv: tuple[str, ...] = ()
+    agent_name: str | None = None
+    mode: str = "read-only"
+    model: str | None = None
+    prompt_prefix: str = ""
+
+
+@dataclass(frozen=True)
+class DispatchResult:
+    response: str
+    task_id: str
+    latency_s: float
+    cost_usd: float | None = None
+    returncode: int | None = 0
+    stderr_excerpt: str | None = None
+
+
+DispatchFn = Callable[[CalibrationModel, str, Path, int], DispatchResult]
+
+
+def load_fixture_prompt(lane: str, fixture_id: str) -> str:
+    path = PROMPT_ROOT / lane / f"{fixture_id}.md"
+    if not path.exists():
+        raise FileNotFoundError(f"missing calibration fixture prompt: {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def build_dispatch_plan(model: CalibrationModel) -> DispatchPlan:
+    if model.provider_cli == "claude-cli" and model.effort_mechanism == "native_flag":
+        return DispatchPlan(
+            kind="subprocess",
+            argv=(
+                "claude",
+                "-p",
+                "--effort",
+                model.effort_requested,
+                "--model",
+                model.canonical_string,
+            ),
+        )
+    if model.provider_cli == "claude-cli" and model.effort_mechanism == "none":
+        return DispatchPlan(
+            kind="subprocess",
+            argv=("claude", "-p", "--model", model.canonical_string),
+        )
+    if model.provider_cli == "codex-cli" and model.effort_mechanism == "cli_config":
+        return DispatchPlan(
+            kind="subprocess",
+            argv=(
+                "codex",
+                "exec",
+                "--skip-git-repo-check",
+                "-C",
+                str(REPO_ROOT),
+                "--color",
+                "never",
+                "--model",
+                model.canonical_string,
+                "-c",
+                f"model_reasoning_effort={model.effort_requested}",
+                "-",
+            ),
+        )
+    if model.provider_cli == "agy-cli" and model.effort_mechanism == "model_name_suffix":
+        return DispatchPlan(
+            kind="runtime",
+            agent_name="agy",
+            mode="danger",
+            model=model.canonical_string,
+        )
+    if model.provider_cli == "gemini-cli" and model.effort_mechanism == "model_name_suffix":
+        return DispatchPlan(
+            kind="runtime",
+            agent_name="gemini",
+            mode="read-only",
+            model=model.canonical_string,
+        )
+    if model.provider_cli == "hermes" and model.effort_mechanism == "prompt_prefix_hint":
+        if model.family == "deepseek":
+            agent_name = "deepseek"
+        elif model.family == "alibaba":
+            agent_name = "qwen"
+        else:
+            raise NotImplementedError(
+                "hermes prompt-prefix dispatch is not implemented for "
+                f"family={model.family!r}, model={model.canonical_string!r}"
+            )
+        return DispatchPlan(
+            kind="runtime",
+            agent_name=agent_name,
+            mode="read-only",
+            model=model.canonical_string,
+            prompt_prefix=(
+                f"[Reasoning effort hint: {model.effort_requested}]\n\n"
+            ),
+        )
+    raise NotImplementedError(
+        "unsupported calibration dispatch combination: "
+        f"provider_cli={model.provider_cli}, "
+        f"effort_mechanism={model.effort_mechanism}"
+    )
+
+
+def dispatch_prompt(
+    model: CalibrationModel,
+    prompt: str,
+    cwd: Path,
+    timeout_s: int,
+) -> DispatchResult:
+    plan = build_dispatch_plan(model)
+    task_id = f"calibration-{model.canonical_string}-{int(time.time())}"
+    prompt = f"{plan.prompt_prefix}{prompt}"
+    start = time.monotonic()
+
+    if plan.kind == "subprocess":
+        proc = subprocess.run(
+            list(plan.argv),
+            input=prompt,
+            text=True,
+            capture_output=True,
+            cwd=cwd,
+            timeout=timeout_s,
+            check=False,
+        )
+        latency_s = time.monotonic() - start
+        response = (proc.stdout or "").strip()
+        stderr_excerpt = (proc.stderr or "").strip()[:500] or None
+        if proc.returncode != 0 or not response:
+            raise RuntimeError(
+                f"dispatch failed for {model.canonical_string} "
+                f"(rc={proc.returncode}): {stderr_excerpt or 'empty response'}"
+            )
+        return DispatchResult(
+            response=response,
+            task_id=task_id,
+            latency_s=latency_s,
+            returncode=proc.returncode,
+            stderr_excerpt=stderr_excerpt,
+        )
+
+    if plan.kind == "runtime" and plan.agent_name:
+        result = runner.invoke(
+            plan.agent_name,
+            prompt,
+            mode=plan.mode,
+            cwd=cwd,
+            model=plan.model,
+            task_id=task_id,
+            entrypoint="calibration",
+            hard_timeout=timeout_s,
+            tool_config={"isolated": True},
+        )
+        return DispatchResult(
+            response=result.response,
+            task_id=task_id,
+            latency_s=result.duration_s,
+            cost_usd=result.usage_record.get("cost_usd"),
+            returncode=result.returncode,
+            stderr_excerpt=result.stderr_excerpt,
+        )
+
+    raise NotImplementedError(f"unknown dispatch plan kind: {plan.kind}")
+
+
+def _paths_for_cell(
+    *,
+    output_root: Path,
+    run_date: str,
+    cell_id: str,
+) -> tuple[Path, Path]:
+    run_dir = output_root / run_date
+    response_dir = run_dir / "responses"
+    response_dir.mkdir(parents=True, exist_ok=True)
+    response_path = response_dir / f"{cell_id}.md"
+    results_path = run_dir / "results.jsonl"
+    return response_path, results_path
+
+
+def _append_jsonl(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fp:
+        fp.write(json.dumps(payload, sort_keys=True) + "\n")
+
+
+def run_cell(
+    *,
+    lane: str,
+    canonical_string: str,
+    fixture_id: str,
+    run_date: str | None = None,
+    db_path: Path = DEFAULT_DB_PATH,
+    output_root: Path = DEFAULT_OUTPUT_ROOT,
+    timeout_s: int = 3600,
+    dispatch_fn: DispatchFn = dispatch_prompt,
+) -> str:
+    if lane not in LANES:
+        raise ValueError(f"unknown calibration lane: {lane}")
+
+    run_date = run_date or schema.today_iso()
+    model = model_by_canonical(canonical_string)
+    prompt = load_fixture_prompt(lane, fixture_id)
+    cell_row = schema.build_cell_row(
+        lane=lane,
+        fixture_id=fixture_id,
+        model=model,
+        run_date=run_date,
+    )
+    cell_id = str(cell_row["cell_id"])
+
+    schema.init_db(db_path)
+    with schema.connect(db_path) as conn:
+        schema.insert_cell(conn, cell_row)
+
+    response_path, results_path = _paths_for_cell(
+        output_root=output_root,
+        run_date=run_date,
+        cell_id=cell_id,
+    )
+
+    try:
+        result = dispatch_fn(model, prompt, REPO_ROOT, timeout_s)
+    except subprocess.TimeoutExpired:
+        with schema.connect(db_path) as conn:
+            schema.insert_score(
+                conn,
+                cell_id=cell_id,
+                gate_name="dispatch_completed",
+                gate_pass=False,
+                score_value=0.0,
+            )
+        raise
+    except AgentTimeoutError:
+        with schema.connect(db_path) as conn:
+            schema.insert_score(
+                conn,
+                cell_id=cell_id,
+                gate_name="dispatch_completed",
+                gate_pass=False,
+                score_value=0.0,
+            )
+        raise
+
+    response_path.write_text(result.response, encoding="utf-8")
+    try:
+        relative_response_path = str(response_path.relative_to(REPO_ROOT))
+    except ValueError:
+        relative_response_path = str(response_path)
+    with schema.connect(db_path) as conn:
+        schema.insert_dispatch(
+            conn,
+            cell_id=cell_id,
+            task_id=result.task_id,
+            response_path=relative_response_path,
+            latency_s=result.latency_s,
+            cost_usd=result.cost_usd,
+            returncode=result.returncode,
+            stderr_excerpt=result.stderr_excerpt,
+        )
+
+    _append_jsonl(
+        results_path,
+        {
+            "cell_id": cell_id,
+            "lane": lane,
+            "fixture_id": fixture_id,
+            "canonical_string": canonical_string,
+            "effort_requested": model.effort_requested,
+            "run_date": run_date,
+            "task_id": result.task_id,
+            "response_path": relative_response_path,
+            "latency_s": result.latency_s,
+            "cost_usd": result.cost_usd,
+        },
+    )
+    return cell_id
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run one calibration cell")
+    parser.add_argument("--lane", required=True, choices=LANES)
+    parser.add_argument("--canonical-string", required=True)
+    parser.add_argument("--fixture-id", required=True)
+    parser.add_argument("--run-date")
+    parser.add_argument("--db-path", type=Path, default=DEFAULT_DB_PATH)
+    parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
+    parser.add_argument("--timeout-s", type=int, default=3600)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    cell_id = run_cell(
+        lane=args.lane,
+        canonical_string=args.canonical_string,
+        fixture_id=args.fixture_id,
+        run_date=args.run_date,
+        db_path=args.db_path,
+        output_root=args.output_root,
+        timeout_s=args.timeout_s,
+    )
+    print(cell_id)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/calibration/run_cell.py
+++ b/scripts/calibration/run_cell.py
@@ -106,6 +106,10 @@ def build_dispatch_plan(model: CalibrationModel) -> DispatchPlan:
             agent_name = "deepseek"
         elif model.family == "alibaba":
             agent_name = "qwen"
+        elif model.family == "xai":
+            # No dedicated grok adapter exists yet, so route Wave C xai traffic
+            # through the openrouter-backed hermes adapter.
+            agent_name = "qwen"
         else:
             raise NotImplementedError(
                 "hermes prompt-prefix dispatch is not implemented for "

--- a/scripts/calibration/scheduler.py
+++ b/scripts/calibration/scheduler.py
@@ -1,0 +1,50 @@
+"""Family-parallel scheduling helpers."""
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Iterable, Iterator
+
+from .models import CalibrationModel, Family
+
+Cell = tuple[str, str, CalibrationModel]
+
+
+class FamilyParallelScheduler:
+    """Max 1 inflight per family. Codex models share the openai queue."""
+
+    def __init__(self, models: Iterable[CalibrationModel]):
+        self.family_order: list[Family] = []
+        seen: set[Family] = set()
+        for model in models:
+            if model.family not in seen:
+                seen.add(model.family)
+                self.family_order.append(model.family)
+
+    def schedule(self, cells: list[Cell]) -> Iterator[Cell]:
+        """Yield cells in round-robin family order.
+
+        The caller owns actual concurrency. This stream avoids same-family
+        adjacency while any other family still has available cells.
+        """
+        queues: dict[Family, deque[Cell]] = {}
+        order = list(self.family_order)
+        seen: set[Family] = set(order)
+
+        for cell in cells:
+            family = cell[2].family
+            queues.setdefault(family, deque()).append(cell)
+            if family not in seen:
+                seen.add(family)
+                order.append(family)
+
+        while any(queues.values()):
+            emitted_this_round = False
+            for family in order:
+                queue = queues.get(family)
+                if not queue:
+                    continue
+                emitted_this_round = True
+                yield queue.popleft()
+            if not emitted_this_round:
+                break
+

--- a/scripts/calibration/schema.py
+++ b/scripts/calibration/schema.py
@@ -1,0 +1,329 @@
+"""SQLite schema and small persistence helpers for calibration v1."""
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterable
+from dataclasses import asdict
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any
+
+from .models import CalibrationModel
+
+DEFAULT_DOMAIN = "kubedojo"
+DEFAULT_FIXTURE_VERSION = "v1"
+DEFAULT_LEDGER_VERSION = "v1"
+
+SCHEMA_SQL = """
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS cells (
+  cell_id TEXT PRIMARY KEY,
+  domain TEXT NOT NULL,
+  lane TEXT NOT NULL,
+  fixture_id TEXT NOT NULL,
+  fixture_version TEXT NOT NULL,
+  family TEXT NOT NULL,
+  provider_cli TEXT NOT NULL,
+  model_id TEXT NOT NULL,
+  version TEXT NOT NULL,
+  canonical_string TEXT NOT NULL,
+  effort_requested TEXT NOT NULL,
+  effort_mechanism TEXT NOT NULL,
+  effort_confidence TEXT NOT NULL,
+  effort_effective TEXT,
+  run_date TEXT NOT NULL,
+  as_of_date TEXT NOT NULL,
+  ledger_version TEXT NOT NULL DEFAULT 'v1',
+  created_at TEXT NOT NULL,
+  UNIQUE (
+    domain,
+    lane,
+    fixture_id,
+    fixture_version,
+    family,
+    provider_cli,
+    model_id,
+    version,
+    effort_requested,
+    run_date
+  )
+);
+
+CREATE TABLE IF NOT EXISTS dispatches (
+  dispatch_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  cell_id TEXT NOT NULL REFERENCES cells(cell_id) ON DELETE CASCADE,
+  task_id TEXT NOT NULL,
+  dispatch_ts TEXT NOT NULL,
+  response_path TEXT NOT NULL,
+  latency_s REAL,
+  cost_usd REAL,
+  returncode INTEGER,
+  stderr_excerpt TEXT,
+  UNIQUE (cell_id, task_id)
+);
+
+CREATE TABLE IF NOT EXISTS scores (
+  cell_id TEXT NOT NULL REFERENCES cells(cell_id) ON DELETE CASCADE,
+  gate_name TEXT NOT NULL,
+  gate_pass INTEGER NOT NULL CHECK (gate_pass IN (0, 1)),
+  score_value REAL,
+  scorer TEXT NOT NULL,
+  scored_at TEXT NOT NULL,
+  PRIMARY KEY (cell_id, gate_name, scorer)
+);
+
+CREATE TABLE IF NOT EXISTS production_events (
+  event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  family TEXT NOT NULL,
+  provider_cli TEXT NOT NULL,
+  model_id TEXT NOT NULL,
+  version TEXT NOT NULL,
+  effort_requested TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  pr_number INTEGER,
+  occurred_at TEXT NOT NULL,
+  evidence_url TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_cells_lane ON cells (lane);
+CREATE INDEX IF NOT EXISTS idx_cells_canonical ON cells (canonical_string);
+CREATE INDEX IF NOT EXISTS idx_cells_family ON cells (family);
+CREATE INDEX IF NOT EXISTS idx_cells_run_date ON cells (run_date);
+CREATE INDEX IF NOT EXISTS idx_scores_cell ON scores (cell_id);
+"""
+
+
+def today_iso() -> str:
+    return date.today().isoformat()
+
+
+def utc_now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def make_cell_id(
+    *,
+    lane: str,
+    fixture_id: str,
+    canonical_string: str,
+    effort_requested: str,
+    run_date: str,
+) -> str:
+    return f"{lane}-{fixture_id}-{canonical_string}@{effort_requested}-{run_date}"
+
+
+def connect(db_path: Path | str) -> sqlite3.Connection:
+    db = Path(db_path)
+    db.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+def init_db(db_path: Path | str) -> None:
+    with connect(db_path) as conn:
+        conn.executescript(SCHEMA_SQL)
+
+
+def build_cell_row(
+    *,
+    lane: str,
+    fixture_id: str,
+    model: CalibrationModel,
+    run_date: str,
+    domain: str = DEFAULT_DOMAIN,
+    fixture_version: str = DEFAULT_FIXTURE_VERSION,
+    as_of_date: str | None = None,
+    ledger_version: str = DEFAULT_LEDGER_VERSION,
+    effort_effective: str | None = None,
+) -> dict[str, Any]:
+    model_row = asdict(model)
+    cell_id = make_cell_id(
+        lane=lane,
+        fixture_id=fixture_id,
+        canonical_string=model.canonical_string,
+        effort_requested=model.effort_requested,
+        run_date=run_date,
+    )
+    return {
+        "cell_id": cell_id,
+        "domain": domain,
+        "lane": lane,
+        "fixture_id": fixture_id,
+        "fixture_version": fixture_version,
+        "family": model_row["family"],
+        "provider_cli": model_row["provider_cli"],
+        "model_id": model_row["model_id"],
+        "version": model_row["version"],
+        "canonical_string": model_row["canonical_string"],
+        "effort_requested": model_row["effort_requested"],
+        "effort_mechanism": model_row["effort_mechanism"],
+        "effort_confidence": model_row["effort_confidence"],
+        "effort_effective": effort_effective,
+        "run_date": run_date,
+        "as_of_date": as_of_date or run_date,
+        "ledger_version": ledger_version,
+        "created_at": utc_now_iso(),
+    }
+
+
+def insert_cell(conn: sqlite3.Connection, row: dict[str, Any]) -> str:
+    columns = (
+        "cell_id",
+        "domain",
+        "lane",
+        "fixture_id",
+        "fixture_version",
+        "family",
+        "provider_cli",
+        "model_id",
+        "version",
+        "canonical_string",
+        "effort_requested",
+        "effort_mechanism",
+        "effort_confidence",
+        "effort_effective",
+        "run_date",
+        "as_of_date",
+        "ledger_version",
+        "created_at",
+    )
+    placeholders = ", ".join(f":{column}" for column in columns)
+    updates = ", ".join(
+        f"{column}=excluded.{column}"
+        for column in columns
+        if column not in {"cell_id", "created_at"}
+    )
+    conn.execute(
+        f"""
+        INSERT INTO cells ({", ".join(columns)})
+        VALUES ({placeholders})
+        ON CONFLICT(cell_id) DO UPDATE SET {updates}
+        """,
+        row,
+    )
+    return str(row["cell_id"])
+
+
+def insert_dispatch(
+    conn: sqlite3.Connection,
+    *,
+    cell_id: str,
+    task_id: str,
+    response_path: str,
+    latency_s: float | None = None,
+    cost_usd: float | None = None,
+    returncode: int | None = None,
+    stderr_excerpt: str | None = None,
+    dispatch_ts: str | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO dispatches (
+          cell_id, task_id, dispatch_ts, response_path, latency_s, cost_usd,
+          returncode, stderr_excerpt
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(cell_id, task_id) DO UPDATE SET
+          dispatch_ts=excluded.dispatch_ts,
+          response_path=excluded.response_path,
+          latency_s=excluded.latency_s,
+          cost_usd=excluded.cost_usd,
+          returncode=excluded.returncode,
+          stderr_excerpt=excluded.stderr_excerpt
+        """,
+        (
+            cell_id,
+            task_id,
+            dispatch_ts or utc_now_iso(),
+            response_path,
+            latency_s,
+            cost_usd,
+            returncode,
+            stderr_excerpt,
+        ),
+    )
+
+
+def insert_score(
+    conn: sqlite3.Connection,
+    *,
+    cell_id: str,
+    gate_name: str,
+    gate_pass: bool,
+    score_value: float | None = None,
+    scorer: str = "deterministic",
+    scored_at: str | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO scores (
+          cell_id, gate_name, gate_pass, score_value, scorer, scored_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT(cell_id, gate_name, scorer) DO UPDATE SET
+          gate_pass=excluded.gate_pass,
+          score_value=excluded.score_value,
+          scored_at=excluded.scored_at
+        """,
+        (
+            cell_id,
+            gate_name,
+            1 if gate_pass else 0,
+            score_value,
+            scorer,
+            scored_at or utc_now_iso(),
+        ),
+    )
+
+
+def insert_scores(
+    conn: sqlite3.Connection,
+    *,
+    cell_id: str,
+    gates: dict[str, bool],
+    scorer: str = "deterministic",
+) -> None:
+    for gate_name, gate_pass in gates.items():
+        insert_score(
+            conn,
+            cell_id=cell_id,
+            gate_name=gate_name,
+            gate_pass=gate_pass,
+            score_value=1.0 if gate_pass else 0.0,
+            scorer=scorer,
+        )
+
+
+def fetch_cell(conn: sqlite3.Connection, cell_id: str) -> sqlite3.Row:
+    row = conn.execute("SELECT * FROM cells WHERE cell_id = ?", (cell_id,)).fetchone()
+    if row is None:
+        raise KeyError(f"unknown calibration cell: {cell_id}")
+    return row
+
+
+def list_indexes(conn: sqlite3.Connection) -> set[str]:
+    rows = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'index'"
+    ).fetchall()
+    return {str(row["name"]) for row in rows}
+
+
+def bulk_insert_scores(
+    conn: sqlite3.Connection,
+    *,
+    cell_id: str,
+    rows: Iterable[tuple[str, bool, float | None, str]],
+) -> None:
+    for gate_name, gate_pass, score_value, scorer in rows:
+        insert_score(
+            conn,
+            cell_id=cell_id,
+            gate_name=gate_name,
+            gate_pass=gate_pass,
+            score_value=score_value,
+            scorer=scorer,
+        )
+

--- a/scripts/calibration/score_cell.py
+++ b/scripts/calibration/score_cell.py
@@ -158,11 +158,15 @@ class ContentWritingLongScorer:
         response: str,
         ground_truth: dict[str, Any],
     ) -> str | None:
+        default_instruction = (
+            "Score whether the module actually teaches the topic, not "
+            "just rephrases upstream docs."
+        )
+        instruction = ground_truth.get("judge_instruction", default_instruction)
         return _judge_prompt(
             "pedagogy",
             response,
-            "Score whether the module actually teaches Kubernetes RBAC "
-            "with TTT pedagogy rather than paraphrasing upstream docs.",
+            instruction,
             ground_truth,
         )
 

--- a/scripts/calibration/score_cell.py
+++ b/scripts/calibration/score_cell.py
@@ -1,0 +1,593 @@
+"""Per-lane deterministic scoring and optional LLM judge wiring."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Callable, Protocol
+
+import yaml
+
+from . import schema
+from .models import model_by_canonical
+from .run_cell import DEFAULT_DB_PATH, REPO_ROOT, dispatch_prompt
+
+GROUND_TRUTH_ROOT = REPO_ROOT / "scripts" / "calibration" / "ground-truth" / "v1"
+
+
+class LaneScorer(Protocol):
+    def deterministic_gates(
+        self,
+        response: str,
+        ground_truth: dict[str, Any],
+    ) -> dict[str, bool]:
+        ...
+
+    def llm_judge_prompt(
+        self,
+        response: str,
+        ground_truth: dict[str, Any],
+    ) -> str | None:
+        ...
+
+
+def _contains_all(text: str, terms: list[str]) -> bool:
+    lowered = text.lower()
+    return all(term.lower() in lowered for term in terms)
+
+
+def _contains_any(text: str, terms: list[str]) -> bool:
+    lowered = text.lower()
+    return any(term.lower() in lowered for term in terms)
+
+
+def _word_count(text: str) -> int:
+    return len(re.findall(r"\b[\w'-]+\b", text))
+
+
+def _extract_fenced_code(response: str, language: str = "python") -> str:
+    pattern = re.compile(
+        rf"```(?:{re.escape(language)})?\s*\n(.*?)```",
+        re.IGNORECASE | re.DOTALL,
+    )
+    match = pattern.search(response)
+    if match:
+        return match.group(1).strip() + "\n"
+    return response.strip() + "\n"
+
+
+def run_command(
+    args: list[str],
+    *,
+    cwd: Path,
+    timeout_s: int = 60,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=timeout_s,
+        check=False,
+    )
+
+
+class CodeWritingScorer:
+    def deterministic_gates(
+        self,
+        response: str,
+        ground_truth: dict[str, Any],
+    ) -> dict[str, bool]:
+        code = _extract_fenced_code(response)
+        tests_py = str(ground_truth["tests_py"])
+        with tempfile.TemporaryDirectory(prefix="calibration-code-writing-") as tmp:
+            tmp_path = Path(tmp)
+            (tmp_path / "solution.py").write_text(code, encoding="utf-8")
+            (tmp_path / "test_solution.py").write_text(tests_py, encoding="utf-8")
+            pytest_result = run_command(
+                [".venv/bin/python", "-m", "pytest", str(tmp_path / "test_solution.py")],
+                cwd=REPO_ROOT,
+            )
+            ruff_result = run_command(
+                [".venv/bin/ruff", "check", str(tmp_path / "solution.py")],
+                cwd=REPO_ROOT,
+            )
+        return {
+            "pytest_exit": pytest_result.returncode == 0,
+            "ruff_exit": ruff_result.returncode == 0,
+        }
+
+    def llm_judge_prompt(
+        self,
+        response: str,
+        ground_truth: dict[str, Any],
+    ) -> str | None:
+        return None
+
+
+class CodeReviewScorer:
+    def deterministic_gates(
+        self,
+        response: str,
+        ground_truth: dict[str, Any],
+    ) -> dict[str, bool]:
+        findings = ground_truth.get("findings", [])
+        found = [
+            finding
+            for finding in findings
+            if _contains_any(response, list(finding.get("aliases", [])))
+        ]
+        hallucination_terms = list(ground_truth.get("hallucination_terms", []))
+        return {
+            "ground_truth_findings": len(found) == len(findings),
+            "no_hallucinations": not _contains_any(response, hallucination_terms),
+        }
+
+    def llm_judge_prompt(
+        self,
+        response: str,
+        ground_truth: dict[str, Any],
+    ) -> str | None:
+        return None
+
+
+class ContentWritingLongScorer:
+    def deterministic_gates(
+        self,
+        response: str,
+        ground_truth: dict[str, Any],
+    ) -> dict[str, bool]:
+        tier = _verifier_tier(response)
+        accepted_tiers = set(ground_truth.get("accepted_verifier_tiers", ["T0", "T1"]))
+        mermaid_pattern = re.compile(r"```\s*mermaid\b.*?```", re.IGNORECASE | re.DOTALL)
+        return {
+            "verifier_t0_t1": tier in accepted_tiers,
+            "mermaid_block": bool(mermaid_pattern.search(response)),
+            "no_simply": not re.search(r"\bsimply\b", response, re.IGNORECASE),
+            "bloom_l3_outcomes": _contains_any(
+                response,
+                list(ground_truth.get("bloom_l3_terms", [])),
+            ),
+        }
+
+    def llm_judge_prompt(
+        self,
+        response: str,
+        ground_truth: dict[str, Any],
+    ) -> str | None:
+        return _judge_prompt(
+            "pedagogy",
+            response,
+            "Score whether the module actually teaches Kubernetes RBAC "
+            "with TTT pedagogy rather than paraphrasing upstream docs.",
+            ground_truth,
+        )
+
+
+class ContentReviewScorer:
+    def deterministic_gates(
+        self,
+        response: str,
+        ground_truth: dict[str, Any],
+    ) -> dict[str, bool]:
+        flaws = ground_truth.get("planted_flaws", [])
+        found = [
+            flaw
+            for flaw in flaws
+            if _contains_any(response, list(flaw.get("aliases", [])))
+        ]
+        hallucination_terms = list(ground_truth.get("hallucination_terms", []))
+        return {
+            "planted_flaw_recall": len(found) == len(flaws),
+            "review_precision": not _contains_any(response, hallucination_terms),
+        }
+
+    def llm_judge_prompt(
+        self,
+        response: str,
+        ground_truth: dict[str, Any],
+    ) -> str | None:
+        return None
+
+
+class FactCheckScorer:
+    def deterministic_gates(
+        self,
+        response: str,
+        ground_truth: dict[str, Any],
+    ) -> dict[str, bool]:
+        verdicts = _parse_json_response(response)
+        expected = {
+            claim["claim_id"]: claim["verdict"]
+            for claim in ground_truth.get("claims", [])
+        }
+        matched = 0
+        cited = 0
+        for item in verdicts:
+            claim_id = item.get("claim_id")
+            verdict = item.get("verdict")
+            rationale = str(item.get("rationale", ""))
+            if expected.get(claim_id) == verdict:
+                matched += 1
+            if "http://" in rationale or "https://" in rationale:
+                cited += 1
+        total = len(expected)
+        return {
+            "verdict_class_match": total > 0 and matched == total,
+            "citation_grounding": total > 0 and cited >= int(ground_truth.get("min_citations", 3)),
+        }
+
+    def llm_judge_prompt(
+        self,
+        response: str,
+        ground_truth: dict[str, Any],
+    ) -> str | None:
+        return None
+
+
+class ArchitectingScorer:
+    def deterministic_gates(
+        self,
+        response: str,
+        ground_truth: dict[str, Any],
+    ) -> dict[str, bool]:
+        required = list(ground_truth.get("required_categories", []))
+        covered = [category for category in required if _contains_any(response, [category])]
+        novel_terms = list(ground_truth.get("novel_risk_terms", []))
+        return {
+            "required_category_count": len(covered) >= len(required),
+            "novel_risk_bonus": _contains_any(response, novel_terms),
+        }
+
+    def llm_judge_prompt(
+        self,
+        response: str,
+        ground_truth: dict[str, Any],
+    ) -> str | None:
+        return _judge_prompt(
+            "architecture",
+            response,
+            "Score design clarity, failure-mode coverage, and operational fit.",
+            ground_truth,
+        )
+
+
+class OrchestratingScorer:
+    def deterministic_gates(
+        self,
+        response: str,
+        ground_truth: dict[str, Any],
+    ) -> dict[str, bool]:
+        routes = ground_truth.get("expected_routes", [])
+        route_hits = [
+            route
+            for route in routes
+            if _contains_all(
+                response,
+                [route["subtask"], route["model_class"], route["lane"]],
+            )
+        ]
+        return {
+            "routing_accuracy": len(route_hits) == len(routes),
+            "cost_awareness": _contains_any(response, ["cost", "$", "cheap", "budget"]),
+            "decision_card_discipline": _contains_any(
+                response,
+                ["decision card", "disagreement", "tradeoff"],
+            ),
+            "same_family_serialized": _contains_any(response, ["serialize", "same-family"]),
+        }
+
+    def llm_judge_prompt(
+        self,
+        response: str,
+        ground_truth: dict[str, Any],
+    ) -> str | None:
+        return _judge_prompt(
+            "orchestration",
+            response,
+            "Score plan coherence, parallelization discipline, and routing judgment.",
+            ground_truth,
+        )
+
+
+class DebuggingScorer:
+    def deterministic_gates(
+        self,
+        response: str,
+        ground_truth: dict[str, Any],
+    ) -> dict[str, bool]:
+        patch_ok = _contains_any(response, list(ground_truth.get("fix_terms", [])))
+        root_cause_ok = _contains_any(response, list(ground_truth.get("root_cause_terms", [])))
+        broad_rewrite = _contains_any(response, list(ground_truth.get("broad_rewrite_terms", [])))
+        test_result = _run_optional_command(ground_truth.get("pytest_command"))
+        return {
+            "root_cause_identified": root_cause_ok,
+            "patch_targets_bug": patch_ok,
+            "tests_pass": test_result,
+            "minimal_patch": not broad_rewrite,
+        }
+
+    def llm_judge_prompt(
+        self,
+        response: str,
+        ground_truth: dict[str, Any],
+    ) -> str | None:
+        return None
+
+
+class RefactoringScorer:
+    def deterministic_gates(
+        self,
+        response: str,
+        ground_truth: dict[str, Any],
+    ) -> dict[str, bool]:
+        original_loc = int(ground_truth.get("original_loc", 200))
+        response_loc = len(_extract_fenced_code(response).splitlines())
+        tests_pass = _run_optional_command(ground_truth.get("test_command"))
+        lint_clean = _run_optional_command(ground_truth.get("lint_command"))
+        return {
+            "tests_still_pass": tests_pass,
+            "loc_reduction": response_loc < original_loc,
+            "lint_clean": lint_clean,
+            "behavior_preserved": _contains_any(
+                response,
+                list(ground_truth.get("behavior_terms", [])),
+            ),
+        }
+
+    def llm_judge_prompt(
+        self,
+        response: str,
+        ground_truth: dict[str, Any],
+    ) -> str | None:
+        return None
+
+
+class SummarizationScorer:
+    def deterministic_gates(
+        self,
+        response: str,
+        ground_truth: dict[str, Any],
+    ) -> dict[str, bool]:
+        must_mentions = list(ground_truth.get("must_mentions", []))
+        banned = list(ground_truth.get("banned_hallucinations", []))
+        min_words = int(ground_truth.get("min_words", 180))
+        max_words = int(ground_truth.get("max_words", 220))
+        words = _word_count(response)
+        return {
+            "must_mention_recall": all(
+                mention.lower() in response.lower() for mention in must_mentions
+            ),
+            "length_compliance": min_words <= words <= max_words,
+            "no_hallucination": not _contains_any(response, banned),
+        }
+
+    def llm_judge_prompt(
+        self,
+        response: str,
+        ground_truth: dict[str, Any],
+    ) -> str | None:
+        return _judge_prompt(
+            "summary coherence",
+            response,
+            "Score whether the handoff is coherent, useful, and faithful.",
+            ground_truth,
+        )
+
+
+SCORERS: dict[str, LaneScorer] = {
+    "code-writing": CodeWritingScorer(),
+    "code-review": CodeReviewScorer(),
+    "content-writing-long": ContentWritingLongScorer(),
+    "content-review": ContentReviewScorer(),
+    "fact-check": FactCheckScorer(),
+    "architecting": ArchitectingScorer(),
+    "orchestrating": OrchestratingScorer(),
+    "debugging": DebuggingScorer(),
+    "refactoring": RefactoringScorer(),
+    "summarization": SummarizationScorer(),
+}
+
+
+def _parse_json_response(response: str) -> list[dict[str, Any]]:
+    try:
+        parsed = json.loads(response)
+    except json.JSONDecodeError:
+        match = re.search(r"```(?:json)?\s*(.*?)```", response, re.DOTALL | re.IGNORECASE)
+        if not match:
+            return []
+        try:
+            parsed = json.loads(match.group(1))
+        except json.JSONDecodeError:
+            return []
+    if isinstance(parsed, list):
+        return [item for item in parsed if isinstance(item, dict)]
+    if isinstance(parsed, dict) and isinstance(parsed.get("claims"), list):
+        return [item for item in parsed["claims"] if isinstance(item, dict)]
+    return []
+
+
+def _run_optional_command(command: object) -> bool:
+    if not command:
+        return True
+    if not isinstance(command, list) or not all(isinstance(part, str) for part in command):
+        return False
+    result = run_command(command, cwd=REPO_ROOT, timeout_s=120)
+    return result.returncode == 0
+
+
+def _verifier_tier(response: str) -> str:
+    """Return verify_module.py tier when response looks like a module.
+
+    Short unit-test snippets and malformed model outputs fall back to an
+    explicit ``T0``/``T1`` marker search so the scorer still records a gate
+    rather than crashing before the ledger write.
+    """
+    if response.lstrip().startswith("---"):
+        with tempfile.TemporaryDirectory(prefix="calibration-module-") as tmp:
+            module_path = Path(tmp) / "module.md"
+            module_path.write_text(response, encoding="utf-8")
+            result = run_command(
+                [
+                    ".venv/bin/python",
+                    "scripts/quality/verify_module.py",
+                    str(module_path),
+                    "--skip-source-check",
+                    "--tier-only",
+                ],
+                cwd=REPO_ROOT,
+                timeout_s=120,
+            )
+        if result.returncode == 0:
+            match = re.search(r"\bT[0-4]\b", result.stdout)
+            if match:
+                return match.group(0)
+    tier_match = re.search(r"\bT([0-4])\b", response)
+    return f"T{tier_match.group(1)}" if tier_match else ""
+
+
+def _judge_prompt(
+    dimension: str,
+    response: str,
+    instruction: str,
+    ground_truth: dict[str, Any],
+) -> str:
+    rubric = ground_truth.get("llm_rubric", "Return JSON: {\"score\": 0-10, \"rationale\": \"...\"}.")
+    return (
+        f"You are a calibration judge for {dimension}.\n\n"
+        f"{instruction}\n\n"
+        f"Rubric:\n{rubric}\n\n"
+        f"Model response:\n{response}\n"
+    )
+
+
+def load_ground_truth(lane: str, fixture_id: str) -> dict[str, Any]:
+    path = GROUND_TRUTH_ROOT / lane / f"{fixture_id}.yaml"
+    if not path.exists():
+        raise FileNotFoundError(f"missing calibration ground truth: {path}")
+    payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(payload, dict):
+        raise ValueError(f"ground truth must be a mapping: {path}")
+    return payload
+
+
+def _latest_response_path(conn: Any, cell_id: str) -> Path:
+    row = conn.execute(
+        """
+        SELECT response_path
+        FROM dispatches
+        WHERE cell_id = ?
+        ORDER BY dispatch_ts DESC
+        LIMIT 1
+        """,
+        (cell_id,),
+    ).fetchone()
+    if row is None:
+        raise FileNotFoundError(f"no dispatch response recorded for {cell_id}")
+    path = Path(row["response_path"])
+    if not path.is_absolute():
+        path = REPO_ROOT / path
+    return path
+
+
+def _parse_judge_score(response: str) -> float:
+    rows = _parse_json_response(response)
+    if rows and "score" in rows[0]:
+        return float(rows[0]["score"])
+    try:
+        parsed = json.loads(response)
+        if isinstance(parsed, dict) and "score" in parsed:
+            return float(parsed["score"])
+    except (json.JSONDecodeError, TypeError, ValueError):
+        pass
+    match = re.search(r"\b(?:score\s*[:=]\s*)?([0-9](?:\.[0-9])?|10)\b", response)
+    if not match:
+        raise ValueError(f"judge response does not contain a score: {response[:120]}")
+    return float(match.group(1))
+
+
+JudgeFn = Callable[[str, str], str]
+
+
+def dispatch_judge(judge_model: str, prompt: str) -> str:
+    model = model_by_canonical(judge_model)
+    result = dispatch_prompt(model, prompt, REPO_ROOT, 1800)
+    return result.response
+
+
+def score_cell(
+    *,
+    cell_id: str,
+    db_path: Path = DEFAULT_DB_PATH,
+    judge1: str = "claude-sonnet-4-6",
+    judge2: str = "gemini-3.5-flash-high",
+    judge_fn: JudgeFn = dispatch_judge,
+) -> dict[str, bool]:
+    schema.init_db(db_path)
+    with schema.connect(db_path) as conn:
+        cell = schema.fetch_cell(conn, cell_id)
+        response_path = _latest_response_path(conn, cell_id)
+        response = response_path.read_text(encoding="utf-8")
+        ground_truth = load_ground_truth(str(cell["lane"]), str(cell["fixture_id"]))
+        scorer = SCORERS[str(cell["lane"])]
+        gates = scorer.deterministic_gates(response, ground_truth)
+        schema.insert_scores(conn, cell_id=cell_id, gates=gates)
+
+        if not all(gates.values()):
+            return gates
+
+        prompt = scorer.llm_judge_prompt(response, ground_truth)
+        if prompt is None:
+            return gates
+
+        judge_scores: list[float] = []
+        for judge_model in (judge1, judge2):
+            judge_response = judge_fn(judge_model, prompt)
+            judge_score = _parse_judge_score(judge_response)
+            judge_scores.append(judge_score)
+            schema.insert_score(
+                conn,
+                cell_id=cell_id,
+                gate_name="llm_judge_score",
+                gate_pass=judge_score >= 7.0,
+                score_value=judge_score,
+                scorer=f"llm-judge:{judge_model}",
+            )
+        if len(judge_scores) == 2 and abs(judge_scores[0] - judge_scores[1]) > 1.0:
+            schema.insert_score(
+                conn,
+                cell_id=cell_id,
+                gate_name="human_spot_check",
+                gate_pass=False,
+                score_value=abs(judge_scores[0] - judge_scores[1]),
+                scorer="deterministic",
+            )
+    return gates
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Score one calibration cell")
+    parser.add_argument("--cell-id", required=True)
+    parser.add_argument("--db-path", type=Path, default=DEFAULT_DB_PATH)
+    parser.add_argument("--judge1", default="claude-sonnet-4-6")
+    parser.add_argument("--judge2", default="gemini-3.5-flash-high")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    gates = score_cell(
+        cell_id=args.cell_id,
+        db_path=args.db_path,
+        judge1=args.judge1,
+        judge2=args.judge2,
+    )
+    print(json.dumps(gates, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/calibration/selftest.py
+++ b/scripts/calibration/selftest.py
@@ -1,0 +1,87 @@
+"""End-to-end smoke test for the calibration harness."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from . import report, schema, score_cell
+from .run_cell import DEFAULT_OUTPUT_ROOT, run_cell
+
+
+def run_selftest(
+    *,
+    run_date: str | None = None,
+    output_root: Path = DEFAULT_OUTPUT_ROOT,
+    db_path: Path | None = None,
+) -> str:
+    run_date = run_date or schema.today_iso()
+    db_path = db_path or output_root / run_date / "results.db"
+    cell_id = run_cell(
+        lane="code-writing",
+        canonical_string="gpt-5.3-codex-spark",
+        fixture_id="parse-dependabot-cooldown",
+        run_date=run_date,
+        db_path=db_path,
+        output_root=output_root,
+    )
+    score_cell.score_cell(cell_id=cell_id, db_path=db_path)
+    reports = report.render_reports(
+        db_path=db_path,
+        out_dir=output_root / run_date / "reports",
+    )
+
+    with schema.connect(db_path) as conn:
+        cell_count = conn.execute(
+            "SELECT COUNT(*) AS count FROM cells WHERE cell_id = ?",
+            (cell_id,),
+        ).fetchone()["count"]
+        dispatch_count = conn.execute(
+            "SELECT COUNT(*) AS count FROM dispatches WHERE cell_id = ?",
+            (cell_id,),
+        ).fetchone()["count"]
+        score_count = conn.execute(
+            "SELECT COUNT(*) AS count FROM scores WHERE cell_id = ?",
+            (cell_id,),
+        ).fetchone()["count"]
+        response_row = conn.execute(
+            "SELECT response_path FROM dispatches WHERE cell_id = ?",
+            (cell_id,),
+        ).fetchone()
+
+    response_path = Path(response_row["response_path"])
+    if not response_path.is_absolute():
+        response_path = Path(__file__).resolve().parents[2] / response_path
+    matrix_path = output_root / run_date / "reports" / "matrix.html"
+
+    assert cell_count == 1
+    assert dispatch_count == 1
+    assert score_count >= 1
+    assert response_path.exists()
+    assert matrix_path in reports
+    assert cell_id in matrix_path.read_text(encoding="utf-8")
+    return cell_id
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the calibration self-test")
+    parser.add_argument("--run-date")
+    parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
+    parser.add_argument("--db-path", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    print(
+        run_selftest(
+            run_date=args.run_date,
+            output_root=args.output_root,
+            db_path=args.db_path,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/tests/calibration/conftest.py
+++ b/tests/calibration/conftest.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "requires_dispatch: requires a real model CLI dispatch",
+    )

--- a/tests/calibration/test_models.py
+++ b/tests/calibration/test_models.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from scripts.calibration.models import ANCHORS, LANES, model_by_canonical, models_by_family
+
+
+def test_anchor_registry_has_locked_models_and_lanes():
+    assert len(ANCHORS) == 14
+    assert len({model.canonical_string for model in ANCHORS}) == 14
+    assert len(LANES) == 10
+    assert model_by_canonical("claude-opus-4-7").effort_mechanism == "native_flag"
+    assert model_by_canonical("gpt-5.5").effort_requested == "xhigh"
+    assert model_by_canonical("grok-4.3").effort_confidence == "unknown"
+
+
+def test_models_by_family_groups_codex_under_openai():
+    grouped = models_by_family()
+    assert [model.canonical_string for model in grouped["openai"]] == [
+        "gpt-5.5",
+        "gpt-5.3-codex-spark",
+        "gpt-5.4-mini",
+    ]
+    assert set(grouped) == {"anthropic", "openai", "google", "deepseek", "alibaba", "xai"}
+

--- a/tests/calibration/test_report.py
+++ b/tests/calibration/test_report.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from scripts.calibration import report, schema
+from scripts.calibration.models import model_by_canonical
+
+
+def _insert_cell(db_path, lane, fixture_id, canonical, score):
+    model = model_by_canonical(canonical)
+    row = schema.build_cell_row(
+        lane=lane,
+        fixture_id=fixture_id,
+        model=model,
+        run_date="2026-05-21",
+    )
+    with schema.connect(db_path) as conn:
+        cell_id = schema.insert_cell(conn, row)
+        schema.insert_dispatch(
+            conn,
+            cell_id=cell_id,
+            task_id=f"task-{canonical}-{lane}",
+            response_path=f"calibration/v1/2026-05-21/responses/{cell_id}.md",
+            cost_usd=0.02,
+        )
+        schema.insert_score(
+            conn,
+            cell_id=cell_id,
+            gate_name="gate",
+            gate_pass=score == 1.0,
+            score_value=score,
+        )
+    return cell_id
+
+
+def test_report_renders_matrix_per_lane_and_per_model(tmp_path):
+    db_path = tmp_path / "ledger.db"
+    schema.init_db(db_path)
+    cell_id = _insert_cell(
+        db_path,
+        "code-writing",
+        "parse-dependabot-cooldown",
+        "gpt-5.5",
+        1.0,
+    )
+    _insert_cell(db_path, "code-writing", "parse-dependabot-cooldown", "claude-opus-4-7", 0.0)
+    _insert_cell(db_path, "fact-check", "k8s-1-35-claims", "gpt-5.5", 1.0)
+    _insert_cell(db_path, "fact-check", "k8s-1-35-claims", "claude-opus-4-7", 1.0)
+
+    out_dir = tmp_path / "reports"
+    written = report.render_reports(db_path=db_path, out_dir=out_dir)
+
+    matrix = (out_dir / "matrix.html").read_text(encoding="utf-8")
+    per_lane = (out_dir / "per-lane" / "code-writing.html").read_text(
+        encoding="utf-8",
+    )
+    per_model = (out_dir / "per-model" / "gpt-5.5.html").read_text(
+        encoding="utf-8",
+    )
+    index = (out_dir / "index.html").read_text(encoding="utf-8")
+
+    assert out_dir / "matrix.html" in written
+    assert cell_id in matrix
+    assert "code-writing" in matrix
+    assert "gpt-5.5" in per_lane
+    assert "confidence vs actual" in per_model.lower()
+    assert "total_cost=$0.0800" in index
+

--- a/tests/calibration/test_run_cell.py
+++ b/tests/calibration/test_run_cell.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scripts.calibration import run_cell, schema
+from scripts.calibration.models import model_by_canonical
+from scripts.calibration.run_cell import DispatchResult
+
+
+def test_build_dispatch_plan_for_codex_effort_config():
+    model = model_by_canonical("gpt-5.3-codex-spark")
+    plan = run_cell.build_dispatch_plan(model)
+    assert plan.kind == "subprocess"
+    assert "--model" in plan.argv
+    assert "gpt-5.3-codex-spark" in plan.argv
+    assert "model_reasoning_effort=xhigh" in plan.argv
+
+
+def test_run_cell_persists_cell_dispatch_response_and_jsonl(tmp_path):
+    db_path = tmp_path / "ledger.db"
+    output_root = tmp_path / "calibration" / "v1"
+
+    def fake_dispatch(model, prompt, cwd, timeout_s):
+        assert model.canonical_string == "gpt-5.3-codex-spark"
+        assert "parse_dependabot_cooldown" in prompt
+        assert cwd == run_cell.REPO_ROOT
+        assert timeout_s == 30
+        return DispatchResult(
+            response="def parse_dependabot_cooldown(yaml_text):\n    return None\n",
+            task_id="fake-task",
+            latency_s=0.01,
+        )
+
+    cell_id = run_cell.run_cell(
+        lane="code-writing",
+        canonical_string="gpt-5.3-codex-spark",
+        fixture_id="parse-dependabot-cooldown",
+        run_date="2026-05-21",
+        db_path=db_path,
+        output_root=output_root,
+        timeout_s=30,
+        dispatch_fn=fake_dispatch,
+    )
+
+    response_path = output_root / "2026-05-21" / "responses" / f"{cell_id}.md"
+    jsonl_path = output_root / "2026-05-21" / "results.jsonl"
+    assert response_path.exists()
+    row = json.loads(jsonl_path.read_text(encoding="utf-8").strip())
+    assert row["cell_id"] == cell_id
+    with schema.connect(db_path) as conn:
+        assert schema.fetch_cell(conn, cell_id)["family"] == "openai"
+        dispatch = conn.execute(
+            "SELECT * FROM dispatches WHERE cell_id = ?",
+            (cell_id,),
+        ).fetchone()
+    assert dispatch["task_id"] == "fake-task"
+    assert dispatch["response_path"] == str(response_path)
+
+
+def test_missing_fixture_raises_file_not_found(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        run_cell.run_cell(
+            lane="code-writing",
+            canonical_string="gpt-5.3-codex-spark",
+            fixture_id="missing-fixture",
+            db_path=tmp_path / "ledger.db",
+            output_root=tmp_path / "calibration",
+            dispatch_fn=lambda model, prompt, cwd, timeout_s: DispatchResult(
+                response="",
+                task_id="unused",
+                latency_s=0.0,
+            ),
+        )
+

--- a/tests/calibration/test_run_cell.py
+++ b/tests/calibration/test_run_cell.py
@@ -1,3 +1,11 @@
+"""Tests for scripts/calibration/run_cell.py — calibration framework v1 foundation.
+
+Tracking issue: #1365 (calibration framework v1.1 build).
+Regression guards:
+- test_haiku_4_5_omits_effort_flag: ensures claude-haiku-4-5 dispatch plan does NOT include the --effort flag (haiku does not support adaptive thinking per the v1.1 spec).
+- test_build_dispatch_plan_routes_grok_4_3_via_prompt_prefix_hint: ensures grok-4.3 builds a well-formed runtime dispatch plan.
+"""
+
 from __future__ import annotations
 
 import json

--- a/tests/calibration/test_run_cell.py
+++ b/tests/calibration/test_run_cell.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 
 import pytest
 
@@ -18,7 +19,69 @@ def test_build_dispatch_plan_for_codex_effort_config():
     assert "model_reasoning_effort=xhigh" in plan.argv
 
 
-def test_run_cell_persists_cell_dispatch_response_and_jsonl(tmp_path):
+def test_build_dispatch_plan_routes_grok_4_3_via_prompt_prefix_hint():
+    model = model_by_canonical("grok-4.3")
+    plan = run_cell.build_dispatch_plan(model)
+    assert plan.kind == "runtime"
+    assert plan.agent_name in {"grok", "qwen"}
+    assert plan.model == model.canonical_string
+    assert plan.prompt_prefix == f"[Reasoning effort hint: {model.effort_requested}]\n\n"
+    assert isinstance(plan.argv, tuple)
+
+
+def test_haiku_4_5_omits_effort_flag():
+    """Regression guard: claude-haiku-4-5 has effort_mechanism='none'; --effort must NOT appear in argv."""
+    plan = run_cell.build_dispatch_plan(model_by_canonical("claude-haiku-4-5"))
+    assert "--effort" not in plan.argv
+
+
+def test_run_cell_persists_cell_dispatch_response_and_jsonl_with_relative_output_root(tmp_path):
+    db_path = tmp_path / "ledger.db"
+    output_root = run_cell.DEFAULT_OUTPUT_ROOT / f"tmp-test-{tmp_path.name}"
+
+    try:
+
+        def fake_dispatch(model, prompt, cwd, timeout_s):
+            assert model.canonical_string == "gpt-5.3-codex-spark"
+            assert "parse_dependabot_cooldown" in prompt
+            assert cwd == run_cell.REPO_ROOT
+            assert timeout_s == 30
+            return DispatchResult(
+                response="def parse_dependabot_cooldown(yaml_text):\n    return None\n",
+                task_id="fake-task",
+                latency_s=0.01,
+            )
+
+        cell_id = run_cell.run_cell(
+            lane="code-writing",
+            canonical_string="gpt-5.3-codex-spark",
+            fixture_id="parse-dependabot-cooldown",
+            run_date="2026-05-21",
+            db_path=db_path,
+            output_root=output_root,
+            timeout_s=30,
+            dispatch_fn=fake_dispatch,
+        )
+
+        response_path = output_root / "2026-05-21" / "responses" / f"{cell_id}.md"
+        jsonl_path = output_root / "2026-05-21" / "results.jsonl"
+        assert response_path.exists()
+        row = json.loads(jsonl_path.read_text(encoding="utf-8").strip())
+        assert row["cell_id"] == cell_id
+        assert row["response_path"] == str(response_path.relative_to(run_cell.REPO_ROOT))
+        with schema.connect(db_path) as conn:
+            assert schema.fetch_cell(conn, cell_id)["family"] == "openai"
+            dispatch = conn.execute(
+                "SELECT * FROM dispatches WHERE cell_id = ?",
+                (cell_id,),
+            ).fetchone()
+        assert dispatch["task_id"] == "fake-task"
+        assert dispatch["response_path"] == str(response_path.relative_to(run_cell.REPO_ROOT))
+    finally:
+        shutil.rmtree(output_root, ignore_errors=True)
+
+
+def test_run_cell_persists_cell_dispatch_response_and_jsonl_with_absolute_output_root(tmp_path):
     db_path = tmp_path / "ledger.db"
     output_root = tmp_path / "calibration" / "v1"
 
@@ -73,4 +136,3 @@ def test_missing_fixture_raises_file_not_found(tmp_path):
                 latency_s=0.0,
             ),
         )
-

--- a/tests/calibration/test_scheduler.py
+++ b/tests/calibration/test_scheduler.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from scripts.calibration.models import model_by_canonical
+from scripts.calibration.scheduler import FamilyParallelScheduler
+
+
+def test_scheduler_interleaves_families_until_only_one_family_remains():
+    openai = model_by_canonical("gpt-5.5")
+    anthropic = model_by_canonical("claude-opus-4-7")
+    google = model_by_canonical("gemini-3.5-flash-high")
+    cells = [
+        ("code-writing", "f1", openai),
+        ("code-review", "f2", openai),
+        ("fact-check", "f3", openai),
+        ("code-writing", "f1", anthropic),
+        ("code-review", "f2", anthropic),
+        ("code-writing", "f1", google),
+    ]
+
+    scheduled = list(FamilyParallelScheduler([openai, anthropic, google]).schedule(cells))
+    families = [cell[2].family for cell in scheduled]
+
+    for index, family in enumerate(families[:-1]):
+        remaining_other_families = set(families[index + 1 :]) - {family}
+        if remaining_other_families:
+            assert families[index + 1] != family
+    assert sorted(families) == sorted(["openai", "openai", "openai", "anthropic", "anthropic", "google"])
+

--- a/tests/calibration/test_schema.py
+++ b/tests/calibration/test_schema.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from scripts.calibration import schema
+from scripts.calibration.models import model_by_canonical
+
+
+def test_schema_initializes_cells_dispatches_scores(tmp_path):
+    db_path = tmp_path / "ledger.db"
+    schema.init_db(db_path)
+    model = model_by_canonical("gpt-5.3-codex-spark")
+    row = schema.build_cell_row(
+        lane="code-writing",
+        fixture_id="parse-dependabot-cooldown",
+        model=model,
+        run_date="2026-05-21",
+    )
+
+    with schema.connect(db_path) as conn:
+        cell_id = schema.insert_cell(conn, row)
+        schema.insert_dispatch(
+            conn,
+            cell_id=cell_id,
+            task_id="task-1",
+            response_path="calibration/v1/2026-05-21/responses/cell.md",
+            latency_s=1.2,
+        )
+        schema.insert_score(
+            conn,
+            cell_id=cell_id,
+            gate_name="pytest_exit",
+            gate_pass=True,
+            score_value=1.0,
+        )
+        stored = schema.fetch_cell(conn, cell_id)
+        indexes = schema.list_indexes(conn)
+
+    assert cell_id == (
+        "code-writing-parse-dependabot-cooldown-"
+        "gpt-5.3-codex-spark@xhigh-2026-05-21"
+    )
+    assert stored["ledger_version"] == "v1"
+    assert stored["canonical_string"] == "gpt-5.3-codex-spark"
+    assert {
+        "idx_cells_lane",
+        "idx_cells_canonical",
+        "idx_cells_family",
+        "idx_cells_run_date",
+        "idx_scores_cell",
+    }.issubset(indexes)
+

--- a/tests/calibration/test_score_cell.py
+++ b/tests/calibration/test_score_cell.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import json
+import subprocess
+
+from scripts.calibration import schema, score_cell
+from scripts.calibration.models import model_by_canonical
+
+
+def _completed(returncode: int = 0) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout="", stderr="")
+
+
+def test_code_writing_scorer_happy_path(monkeypatch):
+    monkeypatch.setattr(score_cell, "run_command", lambda *args, **kwargs: _completed())
+    response = """
+```python
+import yaml
+
+def parse_dependabot_cooldown(yaml_text: str) -> int | None:
+    data = yaml.safe_load(yaml_text) if yaml_text else None
+    if data is None:
+        return None
+    if not isinstance(data, dict):
+        raise ValueError("top-level YAML must be a mapping")
+    cooldown = data.get("cooldown")
+    if cooldown is None:
+        return None
+    if not isinstance(cooldown, dict):
+        raise ValueError("cooldown must be a mapping")
+    days = cooldown.get("default-days")
+    if isinstance(days, bool) or not isinstance(days, int) or days < 0:
+        raise ValueError("default-days must be a non-negative integer")
+    return days
+```
+"""
+    ground_truth = score_cell.load_ground_truth("code-writing", "parse-dependabot-cooldown")
+    assert score_cell.SCORERS["code-writing"].deterministic_gates(response, ground_truth) == {
+        "pytest_exit": True,
+        "ruff_exit": True,
+    }
+
+
+def test_code_review_scorer_happy_path():
+    response = (
+        ".github/workflows/security.yml:10 security -- zizmor lacks "
+        "--strict-collection. .github/workflows/security.yml:11 correctness -- "
+        "scan scope misses .github/actions reusable actions. "
+        ".github/dependabot.yml:6 correctness -- missing cooldown default-days. "
+        ".github/workflows/security.yml:8 security -- pip install zizmor is unpinned."
+    )
+    ground_truth = score_cell.load_ground_truth("code-review", "pr-1333-security-yaml")
+    gates = score_cell.SCORERS["code-review"].deterministic_gates(response, ground_truth)
+    assert gates == {"ground_truth_findings": True, "no_hallucinations": True}
+
+
+def test_content_writing_long_scorer_happy_path():
+    response = """
+Verifier tier: T0
+Learning outcomes: analyze RBAC bindings and diagnose namespace escalation.
+```mermaid
+graph TD
+  User --> RoleBinding --> Role
+```
+"""
+    ground_truth = score_cell.load_ground_truth(
+        "content-writing-long",
+        "kubedojo-rbac-module",
+    )
+    gates = score_cell.SCORERS["content-writing-long"].deterministic_gates(
+        response,
+        ground_truth,
+    )
+    assert all(gates.values())
+
+
+def test_content_review_scorer_happy_path():
+    response = (
+        "hallucinated flag --remove-extra-permission; missing IPA; duplicate H1; "
+        "broken citation missing-page 404; Bloom outcomes only understand/know; "
+        "missing Mermaid diagram; source has # Kubernetes RBAC duplicate H1; "
+        "uses banned word simply."
+    )
+    ground_truth = score_cell.load_ground_truth(
+        "content-review",
+        "flawed-module-rubric-review",
+    )
+    gates = score_cell.SCORERS["content-review"].deterministic_gates(
+        response,
+        ground_truth,
+    )
+    assert gates == {"planted_flaw_recall": True, "review_precision": True}
+
+
+def test_fact_check_scorer_happy_path():
+    response = json.dumps(
+        [
+            {"claim_id": "C1", "verdict": "VERIFIED", "rationale": "https://kubernetes.io/docs/"},
+            {"claim_id": "C2", "verdict": "VERIFIED", "rationale": "https://kubernetes.io/docs/"},
+            {"claim_id": "C3", "verdict": "VERIFIED", "rationale": "https://kubernetes.io/docs/"},
+            {"claim_id": "C4", "verdict": "FALSE", "rationale": "NetworkPolicy remains."},
+            {"claim_id": "C5", "verdict": "FALSE", "rationale": "replicas is integer."},
+        ]
+    )
+    ground_truth = score_cell.load_ground_truth("fact-check", "k8s-1-35-claims")
+    gates = score_cell.SCORERS["fact-check"].deterministic_gates(response, ground_truth)
+    assert gates == {"verdict_class_match": True, "citation_grounding": True}
+
+
+def test_architecting_scorer_happy_path():
+    response = (
+        "env-var format, validation, hermes invocation, failure modes, telemetry, "
+        "flow integration, rollback, rate-limit behavior, prompt-model mismatch, "
+        "worktree safety, cost cap, audit trail."
+    )
+    ground_truth = score_cell.load_ground_truth(
+        "architecting",
+        "kubedojo-review-override-rfc",
+    )
+    gates = score_cell.SCORERS["architecting"].deterministic_gates(
+        response,
+        ground_truth,
+    )
+    assert gates == {"required_category_count": True, "novel_risk_bonus": True}
+
+
+def test_orchestrating_scorer_happy_path():
+    response = (
+        "Python bug -> codex -> debugging. security regressions -> claude -> "
+        "code-review. module handoff -> cheap -> summarization. fact-check -> "
+        "google -> fact-check. Serialize same-family Codex work, include a "
+        "cost estimate, and draft a decision card for the override disagreement."
+    )
+    ground_truth = score_cell.load_ground_truth(
+        "orchestrating",
+        "multi-task-routing-brief",
+    )
+    gates = score_cell.SCORERS["orchestrating"].deterministic_gates(
+        response,
+        ground_truth,
+    )
+    assert all(gates.values())
+
+
+def test_debugging_scorer_happy_path():
+    response = (
+        "Root cause: ResourceQuota requests.storage is 300Gi but PVCs sum to 320Gi.\n"
+        "```diff\n-    requests.storage: 300Gi\n+    requests.storage: 320Gi\n```"
+    )
+    ground_truth = score_cell.load_ground_truth("debugging", "resourcequota-pvc-mismatch")
+    gates = score_cell.SCORERS["debugging"].deterministic_gates(response, ground_truth)
+    assert all(gates.values())
+
+
+def test_refactoring_scorer_happy_path():
+    response = """
+```python
+def record_frontmatter_result(rel, content, report):
+    if not content.startswith("---"):
+        report.error(f"Missing frontmatter: {rel}")
+    if "title:" not in content:
+        report.error(f"Missing title: {rel}")
+    if "order:" not in content:
+        report.warn(f"Missing sidebar.order: {rel}")
+```
+"""
+    ground_truth = score_cell.load_ground_truth(
+        "refactoring",
+        "check-site-health-refactor",
+    )
+    gates = score_cell.SCORERS["refactoring"].deterministic_gates(response, ground_truth)
+    assert all(gates.values())
+
+
+def test_summarization_scorer_happy_path():
+    required = (
+        "CKS 4.2 PSA rewrite shipped as PR #1362. "
+        "CKS 4.3 Secrets Management shipped as PR #1363. "
+        "T2-13 Ansible arc decision archived. "
+        "Calibration framework v1 spec designed and shipped as PR #1364. "
+        "Module 7.12 Ansible Operator SDK shipped as PR #1354. "
+        "agy/Gemini 3.5 Flash High promoted to primary-tier reviewer. "
+    )
+    filler = (
+        "Next work should keep the rewrite queue moving, preserve dual review, "
+        "and treat the calibration build as the foundation for later model runs. "
+    )
+    response = required + " ".join([filler] * 7)
+    ground_truth = score_cell.load_ground_truth("summarization", "session-34-handoff")
+    gates = score_cell.SCORERS["summarization"].deterministic_gates(response, ground_truth)
+    assert all(gates.values())
+
+
+def test_score_cell_writes_deterministic_rows(tmp_path):
+    db_path = tmp_path / "ledger.db"
+    response_path = tmp_path / "response.md"
+    response_path.write_text(
+        ".github/workflows/security.yml:10 --strict-collection; "
+        ".github/actions reusable actions; dependabot cooldown default-days; "
+        "pip install zizmor unpinned.",
+        encoding="utf-8",
+    )
+    model = model_by_canonical("claude-opus-4-7")
+    row = schema.build_cell_row(
+        lane="code-review",
+        fixture_id="pr-1333-security-yaml",
+        model=model,
+        run_date="2026-05-21",
+    )
+    schema.init_db(db_path)
+    with schema.connect(db_path) as conn:
+        cell_id = schema.insert_cell(conn, row)
+        schema.insert_dispatch(
+            conn,
+            cell_id=cell_id,
+            task_id="task",
+            response_path=str(response_path),
+        )
+
+    gates = score_cell.score_cell(cell_id=cell_id, db_path=db_path)
+
+    assert all(gates.values())
+    with schema.connect(db_path) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) AS count FROM scores WHERE cell_id = ?",
+            (cell_id,),
+        ).fetchone()["count"]
+    assert count == 2
+

--- a/tests/calibration/test_selftest.py
+++ b/tests/calibration/test_selftest.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import pytest
+
+from scripts.calibration.selftest import run_selftest
+
+pytestmark = [
+    pytest.mark.requires_dispatch,
+    pytest.mark.skip(reason="requires a real Codex dispatch"),
+]
+
+
+def test_selftest_runs_one_real_codex_cell(tmp_path):
+    cell_id = run_selftest(
+        run_date="2026-05-21",
+        output_root=tmp_path / "calibration" / "v1",
+        db_path=tmp_path / "results.db",
+    )
+    assert "gpt-5.3-codex-spark@xhigh" in cell_id
+


### PR DESCRIPTION
## Summary
Foundation for the calibration framework per the merged v1.1 spec (#1367).

- Canonical 14-model registry across 6 families (Waves A-D)
- Ledger-first SQLite schema with effort_mechanism + effort_confidence + effort_effective dimensions
- Single-cell dispatcher (run_cell.py) honoring family-specific effort mechanisms
- 10 per-lane scorers with deterministic-gate + 2-judge-LLM 2-stage scoring
- Family-parallel scheduler (max 1 inflight per family; codex models serialize)
- HTML matrix + per-lane + per-model report drill-downs
- 10 fixture prompts + 10 ground-truth files

Closes #1365 (foundation phase). Next: PR 2 fires Wave A 50-cell seed run.

Regression test: tests/calibration/test_run_cell.py (test_haiku_4_5_omits_effort_flag + grok-4.3 dispatch plan coverage + split production/fallback branch tests)
