### PR TITLE
refactor(scripts): _Results dataclass in check_site_health.py

### DIFF
--- a/scripts/check_site_health.py
+++ b/scripts/check_site_health.py
@@ -16,18 +16,26 @@ Checks:
   12. No orphaned modules (every module dir has index.md)
 """
 
-import json
 import re
 import sys
+from dataclasses import dataclass, field
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent.parent
 DOCS_DIR = REPO_ROOT / "src" / "content" / "docs"
 CONFIG_FILE = REPO_ROOT / "astro.config.mjs"
 
-errors = []
-warnings = []
-stats = {}
+
+@dataclass
+class _Results:
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    total_files: int = 0
+    module_count: int = 0
+    links_checked: int = 0
+
+
+_results = _Results()
 
 
 def _is_ignored_content_file(path: Path) -> bool:
@@ -36,24 +44,30 @@ def _is_ignored_content_file(path: Path) -> bool:
 
 def _iter_markdown_files():
     for md in DOCS_DIR.rglob("*.md"):
-        if _is_ignored_content_file(md):
-            continue
-        yield md
+        if not _is_ignored_content_file(md):
+            yield md
 
 
 def _iter_module_files():
     for md in DOCS_DIR.rglob("module-*.md"):
-        if _is_ignored_content_file(md):
-            continue
-        yield md
+        if not _is_ignored_content_file(md):
+            yield md
 
 
-def error(msg: str):
-    errors.append(msg)
+def error(msg: str) -> None:
+    _results.errors.append(msg)
 
 
-def warn(msg: str):
-    warnings.append(msg)
+def warn(msg: str) -> None:
+    _results.warnings.append(msg)
+
+
+def _read_frontmatter(content: str) -> str | None:
+    """Return the frontmatter block, or None if absent or malformed."""
+    if not content.startswith("---"):
+        return None
+    parts = content.split("---", 2)
+    return parts[1] if len(parts) >= 3 else None
 
 
 def get_all_slugs() -> set:
@@ -65,22 +79,16 @@ def get_all_slugs() -> set:
             continue
 
         content = md.read_text(errors="replace")
-        fm = content.split("---")[1] if content.startswith("---") and content.count("---") >= 2 else ""
+        fm = _read_frontmatter(content) or ""
 
-        # Use slug if present, otherwise derive from file path
         slug_match = re.search(r'^slug:\s*(.+)$', fm, re.MULTILINE)
         if slug_match:
             slug = slug_match.group(1).strip().strip('"').strip("'")
         else:
-            # Derive slug from file path
-            if md.name == "index.md":
-                slug = str(rel.parent)
-            else:
-                slug = str(rel.with_suffix(""))
+            slug = str(rel.parent if md.name == "index.md" else rel.with_suffix(""))
             slug = slug.replace("\\", "/")
 
         slugs.add(slug.rstrip("/"))
-        # Also add with trailing slash for matching
         slugs.add(slug.rstrip("/") + "/")
 
     return slugs
@@ -91,40 +99,28 @@ def get_all_slugs() -> set:
 def check_frontmatter():
     """Check all .md files have valid Starlight frontmatter."""
     print("\n 1. Frontmatter validation...")
-    missing_fm = 0
-    missing_title = 0
-    missing_order = 0
+    missing_fm = missing_title = missing_order = 0
 
     for md in sorted(_iter_markdown_files()):
+        _results.total_files += 1
         rel = str(md.relative_to(DOCS_DIR))
         content = md.read_text(errors="replace")
 
-        if not content.startswith("---"):
-            error(f"Missing frontmatter: {rel}")
+        fm = _read_frontmatter(content)
+        if fm is None:
+            label = "Malformed frontmatter" if content.startswith("---") else "Missing frontmatter"
+            error(f"{label}: {rel}")
             missing_fm += 1
             continue
-
-        parts = content.split("---", 2)
-        if len(parts) < 3:
-            error(f"Malformed frontmatter: {rel}")
-            missing_fm += 1
-            continue
-
-        fm = parts[1]
 
         if "title:" not in fm:
             error(f"Missing title: {rel}")
             missing_title += 1
-
-        # Module files should have sidebar.order
         if md.name.startswith("module-") and "order:" not in fm:
             warn(f"Missing sidebar.order: {rel}")
             missing_order += 1
 
-    total = len(list(_iter_markdown_files()))
-    ok = total - missing_fm
-    stats["total_files"] = total
-    print(f"    {ok}/{total} files have valid frontmatter")
+    print(f"    {_results.total_files - missing_fm}/{_results.total_files} files have valid frontmatter")
     if missing_title:
         print(f"    {missing_title} missing title")
     if missing_order:
@@ -139,16 +135,13 @@ def check_slugs():
     missing = 0
 
     for md in sorted(_iter_markdown_files()):
+        if "." not in md.stem:
+            continue
         rel = str(md.relative_to(DOCS_DIR))
-        name = md.stem  # filename without .md
-
-        # Check if filename has a dot (e.g., module-1.1-foo)
-        if "." in name:
-            content = md.read_text(errors="replace")
-            fm = content.split("---")[1] if content.startswith("---") and content.count("---") >= 2 else ""
-            if "slug:" not in fm:
-                error(f"Dotted filename without slug: {rel}")
-                missing += 1
+        fm = _read_frontmatter(md.read_text(errors="replace")) or ""
+        if "slug:" not in fm:
+            error(f"Dotted filename without slug: {rel}")
+            missing += 1
 
     if missing == 0:
         print("    All dotted filenames have slug fields")
@@ -171,67 +164,51 @@ def check_link_targets():
             continue
 
         content = md.read_text(errors="replace")
-        # Strip fenced code blocks
         content_clean = re.sub(r'```[^`]*```', '', content, flags=re.DOTALL)
 
-        # Find all markdown links
         for match in re.finditer(r'\[([^\]]*)\]\(([^)]+)\)', content_clean):
             link_text, link_path = match.group(1), match.group(2)
 
-            # Skip external links, anchors, images, mailto
             if any(link_path.startswith(p) for p in ("http", "#", "mailto:", "/")):
-                # For absolute internal links starting with /
                 if link_path.startswith("/") and not link_path.startswith("//"):
                     abs_path = link_path.lstrip("/").split("#")[0].rstrip("/")
                     checked += 1
                     if abs_path and abs_path not in all_slugs and abs_path + "/" not in all_slugs:
-                        # Check if the directory exists as a fallback
                         dir_path = DOCS_DIR / abs_path
                         if not dir_path.exists() and not (dir_path.parent / "index.md").exists():
                             warn(f"Possibly broken absolute link in {rel}: {link_path}")
                             broken += 1
                 continue
 
-            # Relative link — resolve against file's directory
             checked += 1
             target = link_path.split("#")[0].rstrip("/")
             if not target:
                 continue
 
-            # Resolve relative path against file's parent directory
-            base_dir = md.parent
-            resolved = (base_dir / target).resolve()
+            resolved = (md.parent / target).resolve()
 
-            # Check multiple ways the link could be valid:
-            # 1. Target is an existing directory (Astro serves index.md)
             if resolved.is_dir():
                 continue
-            # 2. Target exists as a file
             if resolved.exists():
                 continue
-            # 3. Target is a directory with /index.md
             if (resolved / "index.md").exists():
                 continue
-            # 4. Target matches a known slug (Astro slug routing)
             try:
                 rel_from_docs = str(resolved.relative_to(DOCS_DIR.resolve())).replace("\\", "/")
             except ValueError:
                 rel_from_docs = None
             if rel_from_docs and (rel_from_docs in all_slugs or rel_from_docs + "/" in all_slugs):
                 continue
-            # 5. Check if stripping trailing path component matches a slug
-            # (handles module-1.1-foo/ → slug: .../module-1.1-foo)
             if rel_from_docs:
                 slug_guess = rel_from_docs.rstrip("/")
                 if any(s.endswith(slug_guess) for s in all_slugs):
                     continue
 
-            # 6. Starlight URL model: non-index files are served as directories
+            # Starlight URL model: non-index files are served as directories
             # (foo/bar.md → URL foo/bar/), so relative links resolve from
             # foo/bar/ not foo/. Try this as a fallback.
             if md.name != "index.md":
-                starlight_base = md.parent / md.stem
-                starlight_resolved = (starlight_base / target).resolve()
+                starlight_resolved = (md.parent / md.stem / target).resolve()
                 try:
                     starlight_rel = str(starlight_resolved.relative_to(DOCS_DIR.resolve())).replace("\\", "/")
                 except ValueError:
@@ -242,15 +219,13 @@ def check_link_targets():
                     continue
                 if starlight_rel and (starlight_rel in all_slugs or starlight_rel + "/" in all_slugs):
                     continue
-                if starlight_rel:
-                    starlight_slug = starlight_rel.rstrip("/")
-                    if any(s.endswith(starlight_slug) for s in all_slugs):
-                        continue
+                if starlight_rel and any(s.endswith(starlight_rel.rstrip("/")) for s in all_slugs):
+                    continue
 
             warn(f"Broken relative link in {rel}: [{link_text[:30]}]({link_path})")
             broken += 1
 
-    stats["links_checked"] = checked
+    _results.links_checked = checked
     print(f"    {checked} links checked, {broken} potentially broken")
 
 
@@ -266,8 +241,7 @@ def check_no_md_links():
         if rel.startswith("uk/"):
             continue
 
-        content = md.read_text(errors="replace")
-        content_clean = re.sub(r'```[^`]*```', '', content, flags=re.DOTALL)
+        content_clean = re.sub(r'```[^`]*```', '', md.read_text(errors="replace"), flags=re.DOTALL)
 
         for match in re.finditer(r'\[([^\]]*)\]\(([^)]+\.md(?:#[^)]*)?)\)', content_clean):
             link_path = match.group(2)
@@ -288,8 +262,8 @@ def check_no_readme():
     """No README.md files should remain."""
     print("\n 5. No README.md files...")
     readmes = list(DOCS_DIR.rglob("README.md"))
-    for r in readmes:
-        error(f"README.md not renamed: {r.relative_to(DOCS_DIR)}")
+    for readme in readmes:
+        error(f"README.md not renamed: {readme.relative_to(DOCS_DIR)}")
     if not readmes:
         print("    All READMEs converted to index.md")
 
@@ -320,9 +294,11 @@ def check_module_count():
     m = re.search(r'\*\*(\d+)\*\*', status)
     if m:
         claimed = int(m.group(1))
-        actual = len([f for f in _iter_module_files()
-                      if not str(f.relative_to(DOCS_DIR)).startswith("uk/")])
-        stats["module_count"] = actual
+        actual = sum(
+            1 for f in _iter_module_files()
+            if not str(f.relative_to(DOCS_DIR)).startswith("uk/")
+        )
+        _results.module_count = actual
         if claimed != actual:
             warn(f"STATUS.md claims {claimed} modules but found {actual}")
         else:
@@ -343,17 +319,13 @@ def check_index_completeness():
         if rel.startswith("uk/"):
             continue
 
-        parent = index.parent
-        # Only check direct child modules (not in subdirectories)
-        modules = sorted(f for f in parent.glob("module-*.md") if not _is_ignored_content_file(f))
+        modules = sorted(f for f in index.parent.glob("module-*.md") if not _is_ignored_content_file(f))
         if not modules:
             continue
 
         content = index.read_text(errors="replace")
         for mod in modules:
-            # Check for slug-based reference or filename reference
-            slug_name = mod.stem  # e.g., module-1.1-foo
-            if slug_name not in content and mod.name not in content:
+            if mod.stem not in content and mod.name not in content:
                 warn(f"{rel} doesn't mention {mod.name}")
                 missing += 1
 
@@ -370,9 +342,7 @@ def check_naming_consistency():
     print("\n 9. Module naming consistency (X.Y format)...")
     inconsistent = 0
 
-    # Pattern: module-N-name (no dot) — these are the old format
     old_pattern = re.compile(r'^module-(\d+)-[a-z]')
-    # Pattern: module-X.Y-name (with dot) — this is the correct format
     new_pattern = re.compile(r'^module-(\d+\.\d+)-[a-z]')
 
     for md in sorted(_iter_module_files()):
@@ -380,12 +350,10 @@ def check_naming_consistency():
         if rel.startswith("uk/"):
             continue
         if rel.startswith("prerequisites/git-deep-dive/"):
-            # This subsection intentionally uses linear module-N naming
-            # because it is a single numbered Git course, not an X.Y tree.
+            # Intentionally linear module-N numbering (single Git course, not X.Y tree)
             continue
 
-        name = md.stem
-        if old_pattern.match(name) and not new_pattern.match(name):
+        if old_pattern.match(md.stem) and not new_pattern.match(md.stem):
             warn(f"Old naming format (module-N, not X.Y): {rel}")
             inconsistent += 1
 
@@ -428,8 +396,7 @@ def check_sidebar_dirs():
 
     for match in re.finditer(r"directory:\s*['\"]([^'\"]+)['\"]", config):
         dir_path = match.group(1)
-        full_path = DOCS_DIR / dir_path
-        if not full_path.is_dir():
+        if not (DOCS_DIR / dir_path).is_dir():
             error(f"Sidebar references missing directory: {dir_path}")
             missing += 1
 
@@ -477,16 +444,12 @@ def check_title_numbering():
         if rel.startswith("uk/"):
             continue
 
-        name = md.stem
-        # Extract number from filename: module-1.3-foo → 1.3
-        fn_match = re.match(r'module-(\d+\.?\d*)', name)
+        fn_match = re.match(r'module-(\d+\.?\d*)', md.stem)
         if not fn_match:
             continue
         fn_num = fn_match.group(1)
 
-        content = md.read_text(errors="replace")
-        fm = content.split("---")[1] if content.startswith("---") and content.count("---") >= 2 else ""
-
+        fm = _read_frontmatter(md.read_text(errors="replace")) or ""
         title_match = re.search(r'title:\s*["\']?(?:Module\s+)?(\d+\.?\d*)', fm)
         if title_match:
             title_num = title_match.group(1)
@@ -526,42 +489,44 @@ def main():
     check_title_numbering()
 
     print("\n" + "=" * 60)
-    e_count = len(errors)
-    w_count = len(warnings)
+    e_count = len(_results.errors)
+    w_count = len(_results.warnings)
     print(f"RESULTS: {e_count} errors, {w_count} warnings")
-    if stats:
-        parts = []
-        if "total_files" in stats:
-            parts.append(f"{stats['total_files']} files")
-        if "module_count" in stats:
-            parts.append(f"{stats['module_count']} modules")
-        if "links_checked" in stats:
-            parts.append(f"{stats['links_checked']} links checked")
+
+    parts = []
+    if _results.total_files:
+        parts.append(f"{_results.total_files} files")
+    if _results.module_count:
+        parts.append(f"{_results.module_count} modules")
+    if _results.links_checked:
+        parts.append(f"{_results.links_checked} links checked")
+    if parts:
         print(f"STATS:   {', '.join(parts)}")
+
     print("=" * 60)
 
-    if errors:
+    if _results.errors:
         print(f"\nERRORS ({e_count}):")
-        for e in errors[:30]:
+        for e in _results.errors[:30]:
             print(f"  ✗ {e}")
         if e_count > 30:
             print(f"  ... and {e_count - 30} more")
 
-    if warnings:
+    if _results.warnings:
         print(f"\nWARNINGS ({w_count}):")
-        for w in warnings[:50]:
+        for w in _results.warnings[:50]:
             print(f"  ⚠ {w}")
         if w_count > 50:
             print(f"  ... and {w_count - 50} more")
 
-    if not errors and not warnings:
+    if not _results.errors and not _results.warnings:
         print("\nAll checks passed.")
-    elif not errors:
+    elif not _results.errors:
         print("\nNo errors. Warnings are non-blocking.")
     else:
         print("\nFix errors before pushing.")
 
-    sys.exit(1 if errors else 0)
+    sys.exit(1 if _results.errors else 0)
 
 
 if __name__ == "__main__":

--- a/scripts/check_site_health.py
+++ b/scripts/check_site_health.py
@@ -20,6 +20,7 @@ import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Optional
 
 REPO_ROOT = Path(__file__).parent.parent
 DOCS_DIR = REPO_ROOT / "src" / "content" / "docs"
@@ -30,9 +31,9 @@ CONFIG_FILE = REPO_ROOT / "astro.config.mjs"
 class _Results:
     errors: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
-    total_files: int = 0
-    module_count: int = 0
-    links_checked: int = 0
+    total_files: Optional[int] = None
+    module_count: Optional[int] = None
+    links_checked: Optional[int] = None
 
 
 _results = _Results()
@@ -100,6 +101,7 @@ def check_frontmatter():
     """Check all .md files have valid Starlight frontmatter."""
     print("\n 1. Frontmatter validation...")
     missing_fm = missing_title = missing_order = 0
+    _results.total_files = 0
 
     for md in sorted(_iter_markdown_files()):
         _results.total_files += 1
@@ -494,11 +496,11 @@ def main():
     print(f"RESULTS: {e_count} errors, {w_count} warnings")
 
     parts = []
-    if _results.total_files:
+    if _results.total_files is not None:
         parts.append(f"{_results.total_files} files")
-    if _results.module_count:
+    if _results.module_count is not None:
         parts.append(f"{_results.module_count} modules")
-    if _results.links_checked:
+    if _results.links_checked is not None:
         parts.append(f"{_results.links_checked} links checked")
     if parts:
         print(f"STATS:   {', '.join(parts)}")


### PR DESCRIPTION
## Summary

Replace module-level `errors` / `warnings` / `stats` globals in `scripts/check_site_health.py` with a typed `_Results` dataclass. Extract `_read_frontmatter` helper (was inlined 4×). Drop unused `import json`. Collapse `if/continue` patterns into expression-form yields.

**No behavior change.** Same exit codes, same stdout. 0 errors / N warnings, same as before. Smoke-tested locally — runs to completion, prints the usual summary, exits 0.

## Why now

This refactor sat uncommitted in `.worktrees/check-site-health-refactor` for ~16 days (per session 36 carryover). Surfaced during session-39 git hygiene; user green-lit shipping it as a standalone PR rather than discarding the work.

The script is run by orchestrators after dispatch and by humans before push, so the module globals were load-bearing for the print summary. Dataclass surface is explicit, type-checkable, and easier to extend (e.g. a JSON output mode later if we want one).

## Test plan

- [x] ruff clean
- [x] `python scripts/check_site_health.py` runs to completion, exits 0
- [x] Output identical in shape to pre-refactor (errors / warnings sections, RESULTS line, STATS line)
- [ ] CI green (no new gates needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)