### PR TITLE
feat(bridge): ask-agy / ask-qwen / ask-deepseek parity in ab CLI

### DIFF
--- a/scripts/ai_agent_bridge/_agy.py
+++ b/scripts/ai_agent_bridge/_agy.py
@@ -1,0 +1,263 @@
+"""Agy interaction: ask_agy and process_for_agy."""
+
+from __future__ import annotations
+
+import json
+import os
+
+from agent_runtime import runner as agent_runner
+from agent_runtime.errors import (
+    AgentStalledError,
+    AgentTimeoutError,
+    AgentUnavailableError,
+    RateLimitedError,
+)
+from agent_runtime.registry import get_agent_entry
+
+from ._config import REPO_ROOT
+from ._db import get_db
+from ._messaging import acknowledge, send_message
+
+_AGENT_NAME = "agy"
+_AGENT_TITLE = "Agy"
+_DEFAULT_BRIDGE_TIMEOUT_SECONDS = 900
+_NO_TIMEOUT_BRIDGE_TIMEOUT_SECONDS = 24 * 60 * 60
+_DEFAULT_MODEL = str(
+    get_agent_entry(_AGENT_NAME)["default_model"] or "gemini-3.5-flash-high"
+)
+_TIMEOUT_ENV = "AGY_BRIDGE_TIMEOUT"
+
+
+def _resolve_bridge_timeout(no_timeout: bool = False) -> int:
+    """Resolve the hard timeout from CLI flag/env with a safe fallback."""
+    if no_timeout:
+        return _NO_TIMEOUT_BRIDGE_TIMEOUT_SECONDS
+
+    raw = os.environ.get(_TIMEOUT_ENV)
+    if raw is None:
+        return _DEFAULT_BRIDGE_TIMEOUT_SECONDS
+
+    value = raw.strip().lower()
+    if value in {"0", "none", "off", "false", "no"}:
+        return _NO_TIMEOUT_BRIDGE_TIMEOUT_SECONDS
+
+    try:
+        timeout = int(value)
+    except ValueError:
+        print(
+            f"⚠️  Invalid {_TIMEOUT_ENV}={raw!r} "
+            f"— falling back to {_DEFAULT_BRIDGE_TIMEOUT_SECONDS}s"
+        )
+        return _DEFAULT_BRIDGE_TIMEOUT_SECONDS
+
+    if timeout <= 0:
+        return _NO_TIMEOUT_BRIDGE_TIMEOUT_SECONDS
+    return timeout
+
+
+def ask_agy(
+    content: str,
+    task_id: str | None = None,
+    msg_type: str = "query",
+    data: str | None = None,
+    new_session: bool = False,
+    from_llm: str = "gemini",
+    from_model: str | None = None,
+    to_model: str | None = None,
+    no_timeout: bool = False,
+    review: bool = False,
+):
+    """Send a message to Agy and invoke it to process the message."""
+    msg_id = send_message(
+        content,
+        task_id,
+        msg_type,
+        data,
+        from_llm=from_llm,
+        to_llm=_AGENT_NAME,
+        from_model=from_model,
+        to_model=to_model,
+    )
+    print(f"\n🚀 Invoking {_AGENT_TITLE} to process message #{msg_id}...")
+    process_for_agy(msg_id, new_session, no_timeout, review=review)
+    return msg_id
+
+
+def process_for_agy(
+    message_id: int,
+    new_session: bool = False,
+    no_timeout: bool = False,
+    review: bool = False,
+):
+    """Read a message addressed to Agy, invoke the runtime, and reply."""
+    msg = _fetch_message(message_id)
+    if not msg:
+        return
+
+    _ = new_session  # The current Agy adapter starts fresh per bridge call.
+    timeout_val = _resolve_bridge_timeout(no_timeout)
+    model = _extract_target_model(msg) or _DEFAULT_MODEL
+    prompt = _build_prompt(msg, review)
+
+    print(f"📨 Message #{msg['id']}")
+    print(f"   From: {msg['from']} → To: {msg['to']}")
+    print(f"   Type: {msg['type']}")
+    print(f"   Task: {msg['task_id'] or 'N/A'}")
+    print(f"   Model: {model}")
+    if timeout_val == _NO_TIMEOUT_BRIDGE_TIMEOUT_SECONDS:
+        print("   Hard timeout: no-timeout requested (24h ceiling)")
+    else:
+        print(f"   Hard timeout: {timeout_val}s")
+
+    try:
+        result = agent_runner.invoke(
+            _AGENT_NAME,
+            prompt,
+            mode="read-only",
+            cwd=REPO_ROOT,
+            model=model,
+            task_id=msg["task_id"],
+            session_id=None,
+            tool_config=None,
+            entrypoint="bridge",
+            hard_timeout=timeout_val,
+            stall_timeout=min(600, timeout_val),
+        )
+    except RateLimitedError as exc:
+        _handle_error(msg, message_id, f"{_AGENT_TITLE} rate limited: {exc}")
+        return
+    except AgentStalledError as exc:
+        _handle_error(msg, message_id, f"{_AGENT_TITLE} stalled: {exc}")
+        return
+    except AgentTimeoutError as exc:
+        _handle_error(msg, message_id, f"{_AGENT_TITLE} hard timeout: {exc}")
+        return
+    except AgentUnavailableError as exc:
+        _handle_error(msg, message_id, f"{_AGENT_TITLE} unavailable: {exc}")
+        return
+
+    if not result.ok:
+        _handle_error(
+            msg,
+            message_id,
+            result.stderr_excerpt or f"{_AGENT_TITLE} returned no final message",
+        )
+        return
+
+    response = result.response
+    if not response:
+        _handle_error(msg, message_id, f"{_AGENT_TITLE} returned no final message")
+        return
+
+    print(f"\n✅ {_AGENT_TITLE} finished ({len(response)} chars)")
+    reply_id = send_message(
+        content=response,
+        task_id=msg["task_id"],
+        msg_type="response",
+        from_llm=_AGENT_NAME,
+        to_llm=msg["from"],
+    )
+    acknowledge(message_id)
+    acknowledge(reply_id)
+
+
+def _fetch_message(message_id: int) -> dict | None:
+    """Fetch a message addressed to this agent from the database."""
+    conn = get_db()
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        SELECT id, task_id, from_llm, to_llm, message_type, content, data, timestamp
+        FROM messages
+        WHERE id = ? AND to_llm = ?
+        """,
+        (message_id, _AGENT_NAME),
+    )
+    row = cursor.fetchone()
+    conn.close()
+
+    if not row:
+        print(
+            f"❌ Message {message_id} not found or not addressed to {_AGENT_TITLE}"
+        )
+        return None
+
+    return {
+        "id": row[0],
+        "task_id": row[1],
+        "from": row[2],
+        "to": row[3],
+        "type": row[4],
+        "content": row[5],
+        "data": row[6],
+        "timestamp": row[7],
+    }
+
+
+def _extract_target_model(msg: dict) -> str | None:
+    """Read optional to_model from message metadata JSON."""
+    data = msg.get("data")
+    if not data:
+        return None
+    try:
+        payload = json.loads(data)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    model = payload.get("to_model")
+    return str(model) if model else None
+
+
+def _build_prompt(msg: dict, review: bool = False) -> str:
+    """Build a direct one-shot bridge prompt."""
+    prompt = f"""You are {_AGENT_TITLE}, receiving a message from {msg['from'].title()} via the message broker.
+
+---
+Task ID: {msg['task_id'] or 'none'}
+Type: {msg['type']}
+From: {msg['from']}
+
+{msg['content']}
+"""
+    if msg["data"]:
+        prompt += f"""
+---
+Attached data:
+{msg['data']}
+"""
+    prompt += """
+
+---
+
+Standing rules for bridge Q&A:
+- Respond directly. Be concise. This bridge is for quick questioning
+  and short coordination, not long-running task execution.
+- Do NOT use broker or MCP messaging tools to send your response.
+  Output your response directly.
+"""
+    return _prepend_review_protocol(prompt, review)
+
+
+def _prepend_review_protocol(prompt: str, review: bool) -> str:
+    """Prepend docs/review-protocol.md when --review is requested."""
+    if not review:
+        return prompt
+    prefix = (REPO_ROOT / "docs" / "review-protocol.md").read_text(
+        encoding="utf-8"
+    ).rstrip()
+    return f"{prefix}\n\n{prompt}"
+
+
+def _handle_error(msg: dict, message_id: int, reason: str) -> None:
+    """Record an agent failure as an error response and acknowledge it."""
+    print(f"\n❌ {_AGENT_TITLE} error for message #{message_id}: {reason}")
+    reply_id = send_message(
+        content=f"[{_AGENT_TITLE} error] {reason}",
+        task_id=msg["task_id"],
+        msg_type="error",
+        from_llm=_AGENT_NAME,
+        to_llm=msg["from"],
+    )
+    acknowledge(message_id)
+    acknowledge(reply_id)

--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -1230,10 +1230,19 @@ def _handle_discuss(args) -> int:
         print(f"   root message: {root_id[:12]} / thread {correlation_id[:12]}")
         print()
 
-    session_field_map = {
+    # Session-less agents (agy / qwen / deepseek) map to all-None tuples;
+    # the per-agent branch at "if agent_name in {claude, gemini}" later
+    # in this function correctly skips session persistence for them, and
+    # `stored_session.get(None)` returns None which feeds the resume-skip
+    # path. Required to prevent KeyError when ab discuss --with picks
+    # one of these agents.
+    session_field_map: dict[str, tuple[str | None, str | None, str | None]] = {
         "claude": ("claude_session_id", "claude_cwd", "claude_sandbox_mode"),
         "gemini": ("gemini_session_id", "gemini_cwd", "gemini_sandbox_mode"),
         "codex": ("codex_session_id", "codex_cwd", "codex_sandbox_mode"),
+        "agy": (None, None, None),
+        "qwen": (None, None, None),
+        "deepseek": (None, None, None),
     }
     resume_thread_session: dict[str, str | None] = {}
     if args.resume_thread:

--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -56,6 +56,7 @@ from agent_runtime.result import Result
 # ── argparse registration ────────────────────────────────────────────
 
 _DISCUSSION_CLARIFICATION_MODES = {
+    "agy": "danger",
     "claude": "bypass",
     "gemini": "yolo",
     "codex": "danger",
@@ -64,6 +65,7 @@ _DISCUSSION_CLARIFICATION_MODES = {
 }
 
 _DISCUSSION_RUNTIME_MODES = {
+    "agy": "danger",
     "claude": "read-only",
     "gemini": "workspace-write",
     "codex": "danger",
@@ -160,6 +162,8 @@ def _agent_discuss_defaults(agent_name: str) -> tuple[str, str]:
 
 def _agent_runtime_mode(agent_name: str, sandbox_mode: str | None) -> str:
     """Map persisted `*_sandbox_mode` into runtime `mode`."""
+    if agent_name == "agy":
+        return "danger"
     if agent_name == "codex":
         return "danger"
     if agent_name == "claude":

--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -1250,7 +1250,7 @@ def _handle_discuss(args) -> int:
         missing_resumable: list[str] = []
         for agent_name in with_agents:
             session_field = session_field_map[agent_name][0]
-            if not resume_thread_session.get(session_field):
+            if session_field is None or not resume_thread_session.get(session_field):
                 missing_resumable.append(agent_name)
 
         if missing_resumable:

--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from agent_runtime import usage as runtime_usage
 
+from ._agy import ask_agy
 from ._broker import bridge_status, broker_cleanup
 from ._claude import ask_claude, process_for_claude
 from ._codex import (
@@ -18,6 +19,7 @@ from ._codex import (
 )
 from ._config import GEMINI_DEFAULT_MODEL, GEMINI_REVIEW_MODEL
 from ._db import get_db
+from ._deepseek import ask_deepseek
 from ._gemini import ask_gemini, converse_gemini, process_and_respond
 from ._messaging import (
     acknowledge,
@@ -29,6 +31,7 @@ from ._messaging import (
 )
 from ._model import check_model
 from ._prompts import build_review_message
+from ._qwen import ask_qwen
 
 try:
     from dispatch import GEMINI_WRITER_MODEL
@@ -337,7 +340,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     # inbox
     inbox_parser = subparsers.add_parser("inbox", help="Check inbox for messages")
-    inbox_parser.add_argument("--for", dest="for_llm", default="gemini", choices=['gemini', 'claude', 'codex'],
+    inbox_parser.add_argument("--for", dest="for_llm", default="gemini", choices=['gemini', 'claude', 'codex', 'qwen', 'agy', 'deepseek'],
                              help="Check inbox for which agent (default: gemini)")
 
     # read
@@ -347,7 +350,7 @@ def _build_parser() -> argparse.ArgumentParser:
     # send
     send_parser = subparsers.add_parser("send", help="Send message to another agent")
     send_parser.add_argument("content", help="Message content")
-    send_parser.add_argument("--to", dest="to_llm", default="claude", choices=['claude', 'gemini', 'codex', 'qwen'],
+    send_parser.add_argument("--to", dest="to_llm", default="claude", choices=['claude', 'gemini', 'codex', 'qwen', 'agy', 'deepseek'],
                             help="Target agent (default: claude)")
     send_parser.add_argument("--from", dest="from_llm", default="gemini",
                             help="Sender agent name (default: gemini)")
@@ -363,7 +366,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     # ack-all
     ack_all_parser = subparsers.add_parser("ack-all", help="Acknowledge ALL unread messages for an agent")
-    ack_all_parser.add_argument("agent", choices=['claude', 'gemini', 'codex', 'qwen'], help="Agent whose inbox to clear")
+    ack_all_parser.add_argument("agent", choices=['claude', 'gemini', 'codex', 'qwen', 'agy', 'deepseek'], help="Agent whose inbox to clear")
 
     # conversation
     conv_parser = subparsers.add_parser("conversation", help="Get conversation history")
@@ -464,6 +467,63 @@ def _build_parser() -> argparse.ArgumentParser:
                                    help="Skip auto-posting review to GitHub issue")
     ask_gemini_parser.add_argument("--review", action="store_true",
                                    help="Prepend canonical review protocol to the message")
+
+    # ask-agy
+    ask_agy_parser = subparsers.add_parser("ask-agy", help="Send message AND invoke Agy (one-step)")
+    ask_agy_parser.add_argument("content", help="Message content (use '-' to read from stdin)")
+    ask_agy_parser.add_argument("--task-id", help="Task ID for session tracking")
+    ask_agy_parser.add_argument("--type", default="query", help="Message type (default: query)")
+    ask_agy_parser.add_argument("--data", help="Path to data file to attach")
+    ask_agy_parser.add_argument("--new-session", dest="new_session", action="store_true",
+                                help="Force new session even if one exists")
+    ask_agy_parser.add_argument("--from", dest="from_llm", default="gemini",
+                                help="Sender agent family. Default: gemini")
+    ask_agy_parser.add_argument("--from-model", dest="from_model",
+                                help="Exact sender model ID")
+    ask_agy_parser.add_argument("--to-model", dest="to_model",
+                                help="Target model ID")
+    ask_agy_parser.add_argument("--no-timeout", dest="no_timeout", action="store_true",
+                                help="Run sync without timeout")
+    ask_agy_parser.add_argument("--review", action="store_true",
+                                help="Prepend docs/review-protocol.md")
+
+    # ask-qwen
+    ask_qwen_parser = subparsers.add_parser("ask-qwen", help="Send message AND invoke Qwen (one-step)")
+    ask_qwen_parser.add_argument("content", help="Message content (use '-' to read from stdin)")
+    ask_qwen_parser.add_argument("--task-id", help="Task ID for session tracking")
+    ask_qwen_parser.add_argument("--type", default="query", help="Message type (default: query)")
+    ask_qwen_parser.add_argument("--data", help="Path to data file to attach")
+    ask_qwen_parser.add_argument("--new-session", dest="new_session", action="store_true",
+                                 help="Force new session even if one exists")
+    ask_qwen_parser.add_argument("--from", dest="from_llm", default="gemini",
+                                 help="Sender agent family. Default: gemini")
+    ask_qwen_parser.add_argument("--from-model", dest="from_model",
+                                 help="Exact sender model ID")
+    ask_qwen_parser.add_argument("--to-model", dest="to_model",
+                                 help="Target model ID")
+    ask_qwen_parser.add_argument("--no-timeout", dest="no_timeout", action="store_true",
+                                 help="Run sync without timeout")
+    ask_qwen_parser.add_argument("--review", action="store_true",
+                                 help="Prepend docs/review-protocol.md")
+
+    # ask-deepseek
+    ask_deepseek_parser = subparsers.add_parser("ask-deepseek", help="Send message AND invoke DeepSeek (one-step)")
+    ask_deepseek_parser.add_argument("content", help="Message content (use '-' to read from stdin)")
+    ask_deepseek_parser.add_argument("--task-id", help="Task ID for session tracking")
+    ask_deepseek_parser.add_argument("--type", default="query", help="Message type (default: query)")
+    ask_deepseek_parser.add_argument("--data", help="Path to data file to attach")
+    ask_deepseek_parser.add_argument("--new-session", dest="new_session", action="store_true",
+                                     help="Force new session even if one exists")
+    ask_deepseek_parser.add_argument("--from", dest="from_llm", default="gemini",
+                                     help="Sender agent family. Default: gemini")
+    ask_deepseek_parser.add_argument("--from-model", dest="from_model",
+                                     help="Exact sender model ID")
+    ask_deepseek_parser.add_argument("--to-model", dest="to_model",
+                                     help="Target model ID")
+    ask_deepseek_parser.add_argument("--no-timeout", dest="no_timeout", action="store_true",
+                                     help="Run sync without timeout")
+    ask_deepseek_parser.add_argument("--review", action="store_true",
+                                     help="Prepend docs/review-protocol.md")
 
     # converse — multi-turn conversation with Gemini
     converse_parser = subparsers.add_parser("converse", help="Multi-turn conversation with Gemini (includes history)")
@@ -569,6 +629,12 @@ def _dispatch_command(args):
         _handle_ask_codex(args)
     elif args.command == "ask-gemini":
         _handle_ask_gemini(args)
+    elif args.command == "ask-agy":
+        _handle_ask_agy(args)
+    elif args.command == "ask-qwen":
+        _handle_ask_qwen(args)
+    elif args.command == "ask-deepseek":
+        _handle_ask_deepseek(args)
     elif args.command == "converse":
         content = sys.stdin.read() if args.content == "-" else args.content
         converse_gemini(content, args.task_id, args.model,
@@ -642,6 +708,39 @@ def _handle_ask_gemini(args):
                         not args.review)
     if result is None:
         sys.exit(1)
+
+
+def _handle_ask_agy(args):
+    """Handle ask-agy subcommand."""
+    data = None
+    if args.data:
+        data = Path(args.data).read_text()
+    content = sys.stdin.read() if args.content == "-" else args.content
+    ask_agy(content, args.task_id, args.type, data,
+            args.new_session, args.from_llm, args.from_model,
+            args.to_model, args.no_timeout, args.review)
+
+
+def _handle_ask_qwen(args):
+    """Handle ask-qwen subcommand."""
+    data = None
+    if args.data:
+        data = Path(args.data).read_text()
+    content = sys.stdin.read() if args.content == "-" else args.content
+    ask_qwen(content, args.task_id, args.type, data,
+             args.new_session, args.from_llm, args.from_model,
+             args.to_model, args.no_timeout, args.review)
+
+
+def _handle_ask_deepseek(args):
+    """Handle ask-deepseek subcommand."""
+    data = None
+    if args.data:
+        data = Path(args.data).read_text()
+    content = sys.stdin.read() if args.content == "-" else args.content
+    ask_deepseek(content, args.task_id, args.type, data,
+                 args.new_session, args.from_llm, args.from_model,
+                 args.to_model, args.no_timeout, args.review)
 
 
 def main():

--- a/scripts/ai_agent_bridge/_deepseek.py
+++ b/scripts/ai_agent_bridge/_deepseek.py
@@ -1,0 +1,263 @@
+"""DeepSeek interaction: ask_deepseek and process_for_deepseek."""
+
+from __future__ import annotations
+
+import json
+import os
+
+from agent_runtime import runner as agent_runner
+from agent_runtime.errors import (
+    AgentStalledError,
+    AgentTimeoutError,
+    AgentUnavailableError,
+    RateLimitedError,
+)
+from agent_runtime.registry import get_agent_entry
+
+from ._config import REPO_ROOT
+from ._db import get_db
+from ._messaging import acknowledge, send_message
+
+_AGENT_NAME = "deepseek"
+_AGENT_TITLE = "DeepSeek"
+_DEFAULT_BRIDGE_TIMEOUT_SECONDS = 900
+_NO_TIMEOUT_BRIDGE_TIMEOUT_SECONDS = 24 * 60 * 60
+_DEFAULT_MODEL = str(
+    get_agent_entry(_AGENT_NAME)["default_model"] or "deepseek-v4-pro"
+)
+_TIMEOUT_ENV = "DEEPSEEK_BRIDGE_TIMEOUT"
+
+
+def _resolve_bridge_timeout(no_timeout: bool = False) -> int:
+    """Resolve the hard timeout from CLI flag/env with a safe fallback."""
+    if no_timeout:
+        return _NO_TIMEOUT_BRIDGE_TIMEOUT_SECONDS
+
+    raw = os.environ.get(_TIMEOUT_ENV)
+    if raw is None:
+        return _DEFAULT_BRIDGE_TIMEOUT_SECONDS
+
+    value = raw.strip().lower()
+    if value in {"0", "none", "off", "false", "no"}:
+        return _NO_TIMEOUT_BRIDGE_TIMEOUT_SECONDS
+
+    try:
+        timeout = int(value)
+    except ValueError:
+        print(
+            f"⚠️  Invalid {_TIMEOUT_ENV}={raw!r} "
+            f"— falling back to {_DEFAULT_BRIDGE_TIMEOUT_SECONDS}s"
+        )
+        return _DEFAULT_BRIDGE_TIMEOUT_SECONDS
+
+    if timeout <= 0:
+        return _NO_TIMEOUT_BRIDGE_TIMEOUT_SECONDS
+    return timeout
+
+
+def ask_deepseek(
+    content: str,
+    task_id: str | None = None,
+    msg_type: str = "query",
+    data: str | None = None,
+    new_session: bool = False,
+    from_llm: str = "gemini",
+    from_model: str | None = None,
+    to_model: str | None = None,
+    no_timeout: bool = False,
+    review: bool = False,
+):
+    """Send a message to DeepSeek and invoke it to process the message."""
+    msg_id = send_message(
+        content,
+        task_id,
+        msg_type,
+        data,
+        from_llm=from_llm,
+        to_llm=_AGENT_NAME,
+        from_model=from_model,
+        to_model=to_model,
+    )
+    print(f"\n🚀 Invoking {_AGENT_TITLE} to process message #{msg_id}...")
+    process_for_deepseek(msg_id, new_session, no_timeout, review=review)
+    return msg_id
+
+
+def process_for_deepseek(
+    message_id: int,
+    new_session: bool = False,
+    no_timeout: bool = False,
+    review: bool = False,
+):
+    """Read a message addressed to DeepSeek, invoke the runtime, and reply."""
+    msg = _fetch_message(message_id)
+    if not msg:
+        return
+
+    _ = new_session  # DeepSeek's runtime registry uses fresh sessions.
+    timeout_val = _resolve_bridge_timeout(no_timeout)
+    model = _extract_target_model(msg) or _DEFAULT_MODEL
+    prompt = _build_prompt(msg, review)
+
+    print(f"📨 Message #{msg['id']}")
+    print(f"   From: {msg['from']} → To: {msg['to']}")
+    print(f"   Type: {msg['type']}")
+    print(f"   Task: {msg['task_id'] or 'N/A'}")
+    print(f"   Model: {model}")
+    if timeout_val == _NO_TIMEOUT_BRIDGE_TIMEOUT_SECONDS:
+        print("   Hard timeout: no-timeout requested (24h ceiling)")
+    else:
+        print(f"   Hard timeout: {timeout_val}s")
+
+    try:
+        result = agent_runner.invoke(
+            _AGENT_NAME,
+            prompt,
+            mode="read-only",
+            cwd=REPO_ROOT,
+            model=model,
+            task_id=msg["task_id"],
+            session_id=None,
+            tool_config=None,
+            entrypoint="bridge",
+            hard_timeout=timeout_val,
+            stall_timeout=min(600, timeout_val),
+        )
+    except RateLimitedError as exc:
+        _handle_error(msg, message_id, f"{_AGENT_TITLE} rate limited: {exc}")
+        return
+    except AgentStalledError as exc:
+        _handle_error(msg, message_id, f"{_AGENT_TITLE} stalled: {exc}")
+        return
+    except AgentTimeoutError as exc:
+        _handle_error(msg, message_id, f"{_AGENT_TITLE} hard timeout: {exc}")
+        return
+    except AgentUnavailableError as exc:
+        _handle_error(msg, message_id, f"{_AGENT_TITLE} unavailable: {exc}")
+        return
+
+    if not result.ok:
+        _handle_error(
+            msg,
+            message_id,
+            result.stderr_excerpt or f"{_AGENT_TITLE} returned no final message",
+        )
+        return
+
+    response = result.response
+    if not response:
+        _handle_error(msg, message_id, f"{_AGENT_TITLE} returned no final message")
+        return
+
+    print(f"\n✅ {_AGENT_TITLE} finished ({len(response)} chars)")
+    reply_id = send_message(
+        content=response,
+        task_id=msg["task_id"],
+        msg_type="response",
+        from_llm=_AGENT_NAME,
+        to_llm=msg["from"],
+    )
+    acknowledge(message_id)
+    acknowledge(reply_id)
+
+
+def _fetch_message(message_id: int) -> dict | None:
+    """Fetch a message addressed to this agent from the database."""
+    conn = get_db()
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        SELECT id, task_id, from_llm, to_llm, message_type, content, data, timestamp
+        FROM messages
+        WHERE id = ? AND to_llm = ?
+        """,
+        (message_id, _AGENT_NAME),
+    )
+    row = cursor.fetchone()
+    conn.close()
+
+    if not row:
+        print(
+            f"❌ Message {message_id} not found or not addressed to {_AGENT_TITLE}"
+        )
+        return None
+
+    return {
+        "id": row[0],
+        "task_id": row[1],
+        "from": row[2],
+        "to": row[3],
+        "type": row[4],
+        "content": row[5],
+        "data": row[6],
+        "timestamp": row[7],
+    }
+
+
+def _extract_target_model(msg: dict) -> str | None:
+    """Read optional to_model from message metadata JSON."""
+    data = msg.get("data")
+    if not data:
+        return None
+    try:
+        payload = json.loads(data)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    model = payload.get("to_model")
+    return str(model) if model else None
+
+
+def _build_prompt(msg: dict, review: bool = False) -> str:
+    """Build a direct one-shot bridge prompt."""
+    prompt = f"""You are {_AGENT_TITLE}, receiving a message from {msg['from'].title()} via the message broker.
+
+---
+Task ID: {msg['task_id'] or 'none'}
+Type: {msg['type']}
+From: {msg['from']}
+
+{msg['content']}
+"""
+    if msg["data"]:
+        prompt += f"""
+---
+Attached data:
+{msg['data']}
+"""
+    prompt += """
+
+---
+
+Standing rules for bridge Q&A:
+- Respond directly. Be concise. This bridge is for quick questioning
+  and short coordination, not long-running task execution.
+- Do NOT use broker or MCP messaging tools to send your response.
+  Output your response directly.
+"""
+    return _prepend_review_protocol(prompt, review)
+
+
+def _prepend_review_protocol(prompt: str, review: bool) -> str:
+    """Prepend docs/review-protocol.md when --review is requested."""
+    if not review:
+        return prompt
+    prefix = (REPO_ROOT / "docs" / "review-protocol.md").read_text(
+        encoding="utf-8"
+    ).rstrip()
+    return f"{prefix}\n\n{prompt}"
+
+
+def _handle_error(msg: dict, message_id: int, reason: str) -> None:
+    """Record an agent failure as an error response and acknowledge it."""
+    print(f"\n❌ {_AGENT_TITLE} error for message #{message_id}: {reason}")
+    reply_id = send_message(
+        content=f"[{_AGENT_TITLE} error] {reason}",
+        task_id=msg["task_id"],
+        msg_type="error",
+        from_llm=_AGENT_NAME,
+        to_llm=msg["from"],
+    )
+    acknowledge(message_id)
+    acknowledge(reply_id)

--- a/scripts/ai_agent_bridge/_qwen.py
+++ b/scripts/ai_agent_bridge/_qwen.py
@@ -1,0 +1,263 @@
+"""Qwen interaction: ask_qwen and process_for_qwen."""
+
+from __future__ import annotations
+
+import json
+import os
+
+from agent_runtime import runner as agent_runner
+from agent_runtime.errors import (
+    AgentStalledError,
+    AgentTimeoutError,
+    AgentUnavailableError,
+    RateLimitedError,
+)
+from agent_runtime.registry import get_agent_entry
+
+from ._config import REPO_ROOT
+from ._db import get_db
+from ._messaging import acknowledge, send_message
+
+_AGENT_NAME = "qwen"
+_AGENT_TITLE = "Qwen"
+_DEFAULT_BRIDGE_TIMEOUT_SECONDS = 900
+_NO_TIMEOUT_BRIDGE_TIMEOUT_SECONDS = 24 * 60 * 60
+_DEFAULT_MODEL = str(
+    get_agent_entry(_AGENT_NAME)["default_model"] or "qwen/qwen3.6-plus"
+)
+_TIMEOUT_ENV = "QWEN_BRIDGE_TIMEOUT"
+
+
+def _resolve_bridge_timeout(no_timeout: bool = False) -> int:
+    """Resolve the hard timeout from CLI flag/env with a safe fallback."""
+    if no_timeout:
+        return _NO_TIMEOUT_BRIDGE_TIMEOUT_SECONDS
+
+    raw = os.environ.get(_TIMEOUT_ENV)
+    if raw is None:
+        return _DEFAULT_BRIDGE_TIMEOUT_SECONDS
+
+    value = raw.strip().lower()
+    if value in {"0", "none", "off", "false", "no"}:
+        return _NO_TIMEOUT_BRIDGE_TIMEOUT_SECONDS
+
+    try:
+        timeout = int(value)
+    except ValueError:
+        print(
+            f"⚠️  Invalid {_TIMEOUT_ENV}={raw!r} "
+            f"— falling back to {_DEFAULT_BRIDGE_TIMEOUT_SECONDS}s"
+        )
+        return _DEFAULT_BRIDGE_TIMEOUT_SECONDS
+
+    if timeout <= 0:
+        return _NO_TIMEOUT_BRIDGE_TIMEOUT_SECONDS
+    return timeout
+
+
+def ask_qwen(
+    content: str,
+    task_id: str | None = None,
+    msg_type: str = "query",
+    data: str | None = None,
+    new_session: bool = False,
+    from_llm: str = "gemini",
+    from_model: str | None = None,
+    to_model: str | None = None,
+    no_timeout: bool = False,
+    review: bool = False,
+):
+    """Send a message to Qwen and invoke it to process the message."""
+    msg_id = send_message(
+        content,
+        task_id,
+        msg_type,
+        data,
+        from_llm=from_llm,
+        to_llm=_AGENT_NAME,
+        from_model=from_model,
+        to_model=to_model,
+    )
+    print(f"\n🚀 Invoking {_AGENT_TITLE} to process message #{msg_id}...")
+    process_for_qwen(msg_id, new_session, no_timeout, review=review)
+    return msg_id
+
+
+def process_for_qwen(
+    message_id: int,
+    new_session: bool = False,
+    no_timeout: bool = False,
+    review: bool = False,
+):
+    """Read a message addressed to Qwen, invoke the runtime, and reply."""
+    msg = _fetch_message(message_id)
+    if not msg:
+        return
+
+    _ = new_session  # Qwen's runtime registry uses fresh sessions.
+    timeout_val = _resolve_bridge_timeout(no_timeout)
+    model = _extract_target_model(msg) or _DEFAULT_MODEL
+    prompt = _build_prompt(msg, review)
+
+    print(f"📨 Message #{msg['id']}")
+    print(f"   From: {msg['from']} → To: {msg['to']}")
+    print(f"   Type: {msg['type']}")
+    print(f"   Task: {msg['task_id'] or 'N/A'}")
+    print(f"   Model: {model}")
+    if timeout_val == _NO_TIMEOUT_BRIDGE_TIMEOUT_SECONDS:
+        print("   Hard timeout: no-timeout requested (24h ceiling)")
+    else:
+        print(f"   Hard timeout: {timeout_val}s")
+
+    try:
+        result = agent_runner.invoke(
+            _AGENT_NAME,
+            prompt,
+            mode="read-only",
+            cwd=REPO_ROOT,
+            model=model,
+            task_id=msg["task_id"],
+            session_id=None,
+            tool_config=None,
+            entrypoint="bridge",
+            hard_timeout=timeout_val,
+            stall_timeout=min(600, timeout_val),
+        )
+    except RateLimitedError as exc:
+        _handle_error(msg, message_id, f"{_AGENT_TITLE} rate limited: {exc}")
+        return
+    except AgentStalledError as exc:
+        _handle_error(msg, message_id, f"{_AGENT_TITLE} stalled: {exc}")
+        return
+    except AgentTimeoutError as exc:
+        _handle_error(msg, message_id, f"{_AGENT_TITLE} hard timeout: {exc}")
+        return
+    except AgentUnavailableError as exc:
+        _handle_error(msg, message_id, f"{_AGENT_TITLE} unavailable: {exc}")
+        return
+
+    if not result.ok:
+        _handle_error(
+            msg,
+            message_id,
+            result.stderr_excerpt or f"{_AGENT_TITLE} returned no final message",
+        )
+        return
+
+    response = result.response
+    if not response:
+        _handle_error(msg, message_id, f"{_AGENT_TITLE} returned no final message")
+        return
+
+    print(f"\n✅ {_AGENT_TITLE} finished ({len(response)} chars)")
+    reply_id = send_message(
+        content=response,
+        task_id=msg["task_id"],
+        msg_type="response",
+        from_llm=_AGENT_NAME,
+        to_llm=msg["from"],
+    )
+    acknowledge(message_id)
+    acknowledge(reply_id)
+
+
+def _fetch_message(message_id: int) -> dict | None:
+    """Fetch a message addressed to this agent from the database."""
+    conn = get_db()
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        SELECT id, task_id, from_llm, to_llm, message_type, content, data, timestamp
+        FROM messages
+        WHERE id = ? AND to_llm = ?
+        """,
+        (message_id, _AGENT_NAME),
+    )
+    row = cursor.fetchone()
+    conn.close()
+
+    if not row:
+        print(
+            f"❌ Message {message_id} not found or not addressed to {_AGENT_TITLE}"
+        )
+        return None
+
+    return {
+        "id": row[0],
+        "task_id": row[1],
+        "from": row[2],
+        "to": row[3],
+        "type": row[4],
+        "content": row[5],
+        "data": row[6],
+        "timestamp": row[7],
+    }
+
+
+def _extract_target_model(msg: dict) -> str | None:
+    """Read optional to_model from message metadata JSON."""
+    data = msg.get("data")
+    if not data:
+        return None
+    try:
+        payload = json.loads(data)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    model = payload.get("to_model")
+    return str(model) if model else None
+
+
+def _build_prompt(msg: dict, review: bool = False) -> str:
+    """Build a direct one-shot bridge prompt."""
+    prompt = f"""You are {_AGENT_TITLE}, receiving a message from {msg['from'].title()} via the message broker.
+
+---
+Task ID: {msg['task_id'] or 'none'}
+Type: {msg['type']}
+From: {msg['from']}
+
+{msg['content']}
+"""
+    if msg["data"]:
+        prompt += f"""
+---
+Attached data:
+{msg['data']}
+"""
+    prompt += """
+
+---
+
+Standing rules for bridge Q&A:
+- Respond directly. Be concise. This bridge is for quick questioning
+  and short coordination, not long-running task execution.
+- Do NOT use broker or MCP messaging tools to send your response.
+  Output your response directly.
+"""
+    return _prepend_review_protocol(prompt, review)
+
+
+def _prepend_review_protocol(prompt: str, review: bool) -> str:
+    """Prepend docs/review-protocol.md when --review is requested."""
+    if not review:
+        return prompt
+    prefix = (REPO_ROOT / "docs" / "review-protocol.md").read_text(
+        encoding="utf-8"
+    ).rstrip()
+    return f"{prefix}\n\n{prompt}"
+
+
+def _handle_error(msg: dict, message_id: int, reason: str) -> None:
+    """Record an agent failure as an error response and acknowledge it."""
+    print(f"\n❌ {_AGENT_TITLE} error for message #{message_id}: {reason}")
+    reply_id = send_message(
+        content=f"[{_AGENT_TITLE} error] {reason}",
+        task_id=msg["task_id"],
+        msg_type="error",
+        from_llm=_AGENT_NAME,
+        to_llm=msg["from"],
+    )
+    acknowledge(message_id)
+    acknowledge(reply_id)

--- a/scripts/ai_agent_bridge/tests/test_new_agent_ask_commands.py
+++ b/scripts/ai_agent_bridge/tests/test_new_agent_ask_commands.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def _drop_bridge_modules() -> None:
+    for name in list(sys.modules):
+        if name == "ai_agent_bridge" or name.startswith("ai_agent_bridge."):
+            del sys.modules[name]
+
+
+def _load_cli(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setenv("AB_DB_PATH", str(tmp_path / "messages.db"))
+    monkeypatch.setenv("AB_REPO_ROOT", str(REPO_ROOT))
+    _drop_bridge_modules()
+
+    from ai_agent_bridge import _cli, _messaging
+
+    monkeypatch.setattr(
+        _messaging.subprocess,
+        "run",
+        lambda *_args, **_kwargs: None,
+    )
+    return _cli
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["ask-agy", "ask-qwen", "ask-deepseek"],
+)
+def test_new_ask_subparsers_register(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    command: str,
+) -> None:
+    cli = _load_cli(monkeypatch, tmp_path)
+
+    args = cli._build_parser().parse_args([command, "OK test"])
+
+    assert args.command == command
+    assert args.content == "OK test"
+    assert args.task_id is None
+    assert args.no_timeout is False
+    assert args.review is False
+
+
+@pytest.mark.parametrize(
+    ("command", "agent"),
+    [
+        ("ask-agy", "agy"),
+        ("ask-qwen", "qwen"),
+        ("ask-deepseek", "deepseek"),
+    ],
+)
+def test_new_ask_handlers_invoke_runtime_with_default_model(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    command: str,
+    agent: str,
+) -> None:
+    cli = _load_cli(monkeypatch, tmp_path)
+    calls: list[tuple[str, str, dict]] = []
+
+    from agent_runtime.registry import get_agent_entry
+    import agent_runtime.runner as runner
+
+    def fake_invoke(agent_name: str, prompt: str, **kwargs):
+        calls.append((agent_name, prompt, kwargs))
+        return SimpleNamespace(
+            ok=True,
+            response=f"{agent_name} response",
+            stderr_excerpt=None,
+            session_id=None,
+        )
+
+    monkeypatch.setattr(runner, "invoke", fake_invoke)
+
+    args = cli._build_parser().parse_args(
+        [command, "OK test", "--task-id", "bridge-test", "--from", "claude"]
+    )
+
+    assert cli._dispatch_command(args) is True
+    assert len(calls) == 1
+
+    agent_name, prompt, kwargs = calls[0]
+    expected_model = str(get_agent_entry(agent)["default_model"])
+    assert agent_name == agent
+    assert "OK test" in prompt
+    assert kwargs["mode"] == "read-only"
+    assert kwargs["model"] == expected_model
+    assert kwargs["task_id"] == "bridge-test"
+    assert kwargs["entrypoint"] == "bridge"
+    assert kwargs["hard_timeout"] == 900


### PR DESCRIPTION
Implements requirements from session-39 user request.

## Summary
- Adds `ask-agy`, `ask-qwen`, and `ask-deepseek` bridge modules that send through the broker, invoke `agent_runtime.runner.invoke`, and write responses/errors back to the broker.
- Wires the three new ask subcommands into `scripts/ab`, including `--task-id`, `--type`, `--data`, `--new-session`, `--from`, `--from-model`, `--to-model`, `--no-timeout`, and `--review`.
- Extends inbox/send/ack-all agent choices and adds `agy` to channel discussion policy defaults.
- Adds bridge tests for subparser registration and runtime invocation with registry default models.

Related: #1387

## Verification
- [x] `/Users/krisztiankoos/projects/kubedojo/.venv/bin/ruff check scripts/ai_agent_bridge/` — clean
- [x] `/Users/krisztiankoos/projects/kubedojo/.venv/bin/pytest scripts/ai_agent_bridge/` — 8 passed
- [x] `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/test_pipeline.py` — 170 passed
- [x] `scripts/ab --help` — shows `ask-agy`, `ask-qwen`, `ask-deepseek`
- [x] `AGY_BRIDGE_TIMEOUT=1 scripts/ab ask-agy 'OK test'` — argparse/bridge dispatch reached runtime; expected 1s hard-timeout error recorded cleanly
- [x] `git diff --check` — clean

## Diff Size
- 6 files changed
- 997 insertions, 3 deletions

Cross-family review is still required before merge.