### PR TITLE
fix(hooks): narrow bugfix gate to fix: title prefix only (#1387)

### DIFF
--- a/.claude/hooks/_lib_pr_check.py
+++ b/.claude/hooks/_lib_pr_check.py
@@ -132,6 +132,9 @@ def check_regression_test(pr_json: str, fixture_dir: str) -> tuple[str, str]:
     body = pr.get("body") or ""
 
     is_fix_title = bool(re.match(r"^fix(\([^)]+\))?:", title, re.IGNORECASE))
+    if not is_fix_title:
+        return ("PASS", "not a bugfix PR (title does not start with 'fix:')")
+
     issue_refs: set[str] = set()
     for match in re.finditer(
         r"(?:fix(?:es|ed)?|close[sd]?|resolve[sd]?)\s*(?:issue\s*)?[:#]?\s*#(\d+)",
@@ -141,9 +144,6 @@ def check_regression_test(pr_json: str, fixture_dir: str) -> tuple[str, str]:
         issue_refs.add(match.group(1))
     for match in re.finditer(r"\(#(\d+)\)", title):
         issue_refs.add(match.group(1))
-
-    if not is_fix_title and not issue_refs:
-        return ("PASS", "not a bugfix PR (no fix: title, no Fixes/Closes ref)")
 
     test_paths: list[str] = []
     for raw in body.splitlines():

--- a/tests/test_hook_block_bugfix_merge_without_regression_test.py
+++ b/tests/test_hook_block_bugfix_merge_without_regression_test.py
@@ -288,10 +288,11 @@ def test_fix_pr_with_test_in_files_but_unreadable_is_denied(tmp_path: Path) -> N
     assert "Could not read regression test file" in result.stderr
 
 
-def test_fix_pr_with_fixes_issue_keyword_recognized(tmp_path: Path) -> None:
-    # GitHub-recognized closing keywords include `Fixes issue #N` patterns
-    # — the issue ref regex should match this so the hook treats it as a
-    # bugfix PR.
+def test_non_fix_title_with_fixes_keyword_in_body_is_allowed(tmp_path: Path) -> None:
+    # Issue #1387: the body-keyword path used to trigger the hook on any PR
+    # containing "Fixes #N" / "Closes #N", which blocked feat:/chore:/docs:
+    # PRs that close feature-request issues. The trigger is now narrowed to
+    # `fix:` title prefix only; body keywords no longer trigger.
     pr = {
         "body": (
             "Fixes issue #1212 — restores the seed JSON on inject failure.\n"
@@ -307,8 +308,49 @@ def test_fix_pr_with_fixes_issue_keyword_recognized(tmp_path: Path) -> None:
         fixture_files=None,
         tmp_path=tmp_path,
     )
-    assert result.returncode == 2
-    assert "missing a 'Regression test:' line" in result.stderr
+    assert result.returncode == 0, result.stderr
+
+
+def test_feat_pr_with_paren_issue_ref_in_title_is_allowed(tmp_path: Path) -> None:
+    # Issue #1387 regression: a `feat:` PR that closes a feature-request
+    # issue via the squash-merge `(#N)` convention used to trigger the
+    # bugfix-hook because the title-`(#N)` regex populated `issue_refs`
+    # which alone activated the gate. Now only `fix:` titles trigger.
+    pr = {
+        "body": "Adds Module 1.6 GPU Memory Hierarchy and Bandwidth Math.\n",
+        "files": [
+            {"path": "src/content/docs/platform/llm-inference/module-1.6-gpu-memory.md"},
+        ],
+        "headRefOid": "abc123",
+        "title": "feat: Module 1.6 GPU Memory Hierarchy and Bandwidth Math (#1377)",
+        "number": 9111,
+    }
+    result = run_hook(
+        "gh pr merge 9111 --squash",
+        pr_json=pr,
+        fixture_files=None,
+        tmp_path=tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_feat_pr_with_closes_in_body_is_allowed(tmp_path: Path) -> None:
+    # Issue #1387 regression: `feat:` PR closing a feature-request issue
+    # with `Closes #N` in body used to trigger the gate. Now allowed.
+    pr = {
+        "body": "Adds a new helper.\n\nCloses #1377.\n",
+        "files": [{"path": "scripts/helper.py"}],
+        "headRefOid": "abc123",
+        "title": "feat: add helper",
+        "number": 9112,
+    }
+    result = run_hook(
+        "gh pr merge 9112 --squash",
+        pr_json=pr,
+        fixture_files=None,
+        tmp_path=tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
 
 
 def test_git_show_fallback_exercises_subprocess_when_no_fixture(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Narrows `.claude/hooks/block-bugfix-merge-without-regression-test.sh` (via `_lib_pr_check.py:check_regression_test`) to trigger ONLY on `fix:` / `fix(scope):` title prefixes.
- Body keywords (`Fixes #N` / `Closes #N`) and title `(#N)` references no longer activate the gate — they remain in use for downstream regression-test validation only.
- Resolves #1387: `feat:` PRs that close feature-request issues were being denied merge.

Regression test: tests/test_hook_block_bugfix_merge_without_regression_test.py

## Behavior change
| PR shape | Before | After |
|---|---|---|
| \`fix: ...\` title (any body) | gated | gated (unchanged) |
| \`feat: ... (#N)\` title | gated (false-positive) | allowed |
| \`feat: ...\` body with \`Closes #N\` | gated (false-positive) | allowed |
| \`chore:\` body with \`Fixes issue #N\` | gated | allowed |

## Test plan
- [x] \`pytest tests/test_hook_block_bugfix_merge_without_regression_test.py -v\` → 18 passed (15 existing + 3 new false-positive regression tests).
- [x] \`ruff check\` → clean.
- [x] Sonnet R1 review APPROVE_WITH_NITS.

## New regression tests
- \`test_non_fix_title_with_fixes_keyword_in_body_is_allowed\`
- \`test_feat_pr_with_paren_issue_ref_in_title_is_allowed\`
- \`test_feat_pr_with_closes_in_body_is_allowed\`

Closes #1387.

🤖 Generated with [Claude Code](https://claude.com/claude-code)