### PR TITLE
chore(calibration): add explicit 'do not write to disk' to content-writing-long prompt (#1390)

### DIFF
--- a/scripts/calibration/prompts/v1/content-writing-long/kubedojo-rbac-module.md
+++ b/scripts/calibration/prompts/v1/content-writing-long/kubedojo-rbac-module.md
@@ -10,5 +10,12 @@ Constraints:
 - Include Bloom L3+ learning outcomes.
 - Keep the module focused on Kubernetes 1.35 operator practice.
 
-Return the full module Markdown.
+Return the full module Markdown INLINE in your response.
+
+CRITICAL — DO NOT write the module to disk. This is a calibration
+prompt evaluating your written output, not a real authoring task.
+Do NOT use Write/Edit tools, do NOT modify any file under
+src/content/docs/k8s/cka/, do NOT cite a file path as your answer.
+Return the raw module Markdown directly as your response text,
+starting with the frontmatter `---` line.
 


### PR DESCRIPTION
## Summary
- Adds explicit \"DO NOT write to disk / return Markdown INLINE\" instruction to `scripts/calibration/prompts/v1/content-writing-long/kubedojo-rbac-module.md`.
- Cheapest of the three fix options in #1390 (prompt-side / dispatch-tmp-sandbox / scorer-side gate). Dispatch + scorer hardening remain as follow-ups.

## Background
During the Wave A/B/C/D calibration runs (session 36 → session 39), two models interpreted \"Return the full module Markdown\" as an instruction to write to disk:

- **gpt-5.4-mini**: \"The full module is in [module-1.6-rbac.md](/Users/.../src/content/docs/k8s/cka/part1-cluster-architecture/module-1.6-rbac.md)\"
- **claude-sonnet-4-6**: \"The module is self-contained and drops directly into src/content/docs/k8s/cka/...\"

Both wrote to the real CKA module path. The scorer correctly penalized them (link-only responses fail verifier gates), but the side-effect was unsandboxed writes to the primary curriculum tree — root cause of:
- The orphan `src/content/docs/k8s/cka/rbac.md` flagged in session 36 carryover #7.
- The TTT-pedagogy modifications to `module-1.6-rbac.md` discovered during session 39 git hygiene.

## Test plan
- [x] No code changes; calibration runs on-demand, not in CI.
- [ ] Next calibration run should not produce sonnet/gpt-5.4-mini link-only responses for this fixture.
- [ ] Follow-ups: dispatch-tmp-sandbox + scorer-side `respected_inline_return` gate (filed for separate PRs).

## Other prompts surveyed
- `harness-following/inline-write-falco-module.md` is a deliberate trap (tests the rules harness). Safe.
- All other v1 prompts are for code-review / debugging / refactoring / fact-check lanes — no curriculum-write risk.

Closes #1390.

🤖 Generated with [Claude Code](https://claude.com/claude-code)