### PR TITLE
feat(dispatch): add agy to #388-pilot reviewer cascade (#1350 Phase 1)

### DIFF
--- a/scripts/quality/dispatch_388_pilot.py
+++ b/scripts/quality/dispatch_388_pilot.py
@@ -451,6 +451,44 @@ def dispatch_deepseek_review(pr_num: int, module_path: str, slug: str):
     return text, classify_verdict(text)
 
 
+def dispatch_agy_review(pr_num: int, module_path: str, slug: str):
+    """Cross-family review via Agy (Antigravity CLI — Google).
+
+    Agy is the gemini-cli replacement for Google One / unpaid tier; rolls out
+    fully on 2026-06-18 per #1350. Run-time:
+    - mode=danger required (dispatch_smart enforces this for agy)
+    - no `model=` arg — agy picks model via its TUI panel (env override:
+      KUBEDOJO_AGY_MODEL; adapter default gemini-3.5-flash-high)
+    - rate-limit signature is distinct from gemini-cli (separate counter),
+      so agy can run as a peer reviewer alongside gemini without sharing
+      the OAuth quota.
+
+    Failure shapes (session 39):
+    - Quota-exhausted: ok=False, elapsed~3s, response_chars=0, stderr=null
+    - OAuth-expired: ok=True, elapsed~32s, body is auth-prompt URL +
+      "authentication timed out"
+    Both surface as ERROR/UNCLEAR via classify_verdict — the cascade
+    fallback handles either case transparently.
+    """
+    log({"event": "agy_review_start", "pr": pr_num, "module": module_path})
+    try:
+        result = invoke(
+            agent_name="agy",
+            prompt=gemini_review_prompt(pr_num, module_path),  # reuse same prompt
+            mode="danger",  # required for agy in headless dispatch
+            cwd=REPO,
+            task_id=f"388-pilot-review-agy-{slug}",
+            entrypoint="dispatch",
+            hard_timeout=900,
+        )
+    except Exception as e:  # noqa: BLE001
+        log({"event": "agy_review_error", "pr": pr_num, "error": repr(e)})
+        return None, "ERROR"
+    text = result.response or ""
+    log({"event": "agy_review_done", "pr": pr_num, "ok": result.ok, "response_excerpt": text[-2000:]})
+    return text, classify_verdict(text)
+
+
 def classify_verdict(text: str) -> str:
     """Classify a gemini review into APPROVE / APPROVE_WITH_NITS / NEEDS CHANGES / UNCLEAR.
 
@@ -504,6 +542,15 @@ def build_reviewer_cascade(primary_reviewer: str) -> list[tuple[str, Callable]]:
             ("qwen", dispatch_qwen_review),
             ("gemini", dispatch_gemini_review),
             ("claude", dispatch_claude_review),
+        ]
+    if primary_reviewer == "agy":
+        # agy → claude → qwen. Gemini is on a SHARED Google OAuth pool with
+        # agy pre-2026-06-18 (separate counter on Google side but auth-flow
+        # collisions can still happen) — fall to claude first.
+        return [
+            ("agy", dispatch_agy_review),
+            ("claude", dispatch_claude_review),
+            ("qwen", dispatch_qwen_review),
         ]
     # default: gemini
     return [
@@ -634,7 +681,7 @@ def main(argv: list[str] | None = None) -> int:
                 log({"event": "module_skip", "module": module_path, "reason": "pr_creation_failed"})
                 continue
         # Reviewer cascade. Primary defaults to claude; override via
-        # KUBEDOJO_388_PRIMARY_REVIEWER (gemini | claude | qwen | deepseek).
+        # KUBEDOJO_388_PRIMARY_REVIEWER (gemini | claude | qwen | deepseek | agy).
         # Cascade order is always primary → claude → qwen/deepseek fallback
         # depending on the configured primary.
         primary = os.environ.get("KUBEDOJO_388_PRIMARY_REVIEWER", "claude").lower()

--- a/scripts/quality/dispatch_388_pilot.py
+++ b/scripts/quality/dispatch_388_pilot.py
@@ -463,12 +463,16 @@ def dispatch_agy_review(pr_num: int, module_path: str, slug: str):
       so agy can run as a peer reviewer alongside gemini without sharing
       the OAuth quota.
 
-    Failure shapes (session 39):
-    - Quota-exhausted: ok=False, elapsed~3s, response_chars=0, stderr=null
-    - OAuth-expired: ok=True, elapsed~32s, body is auth-prompt URL +
-      "authentication timed out"
-    Both surface as ERROR/UNCLEAR via classify_verdict — the cascade
-    fallback handles either case transparently.
+    Failure shapes and how they surface to the cascade:
+    - Quota-exhausted: invoke returns ok=False, response="" — this function
+      returns ("", "UNCLEAR") (classify_verdict on the empty string).
+    - OAuth-expired: invoke returns ok=True with body containing the
+      auth-prompt URL and "authentication timed out" — classify_verdict
+      finds no VERDICT line, returns "UNCLEAR".
+    - Exception inside invoke (network/transport failure, adapter crash):
+      caught below, returns (None, "ERROR").
+    All three cases let the cascade fall to the next reviewer; the
+    distinction matters only when reading dispatch logs after a failure.
     """
     log({"event": "agy_review_start", "pr": pr_num, "module": module_path})
     try:

--- a/tests/test_dispatch_388_pilot.py
+++ b/tests/test_dispatch_388_pilot.py
@@ -218,8 +218,42 @@ def test_dispatch_backfill_sha_regex_parses_ok_line():
         ("qwen", ["qwen", "gemini", "claude"]),
         ("deepseek", ["deepseek", "claude", "qwen"]),
         ("gemini", ["gemini", "claude", "qwen"]),
+        # #1350 Phase 1 carryover: agy is a peer-Google adapter post-2026-06-18
+        # and a viable primary reviewer; cascade skips gemini (shared OAuth)
+        # and falls to claude → qwen.
+        ("agy", ["agy", "claude", "qwen"]),
     ],
 )
 def test_reviewer_cascade_selection(primary: str, expected: list[str]) -> None:
     cascade = pilot.build_reviewer_cascade(primary)
     assert [name for name, _fn in cascade] == expected
+
+
+def test_dispatch_agy_review_uses_danger_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The agy adapter requires mode='danger' in headless dispatch — verify
+    dispatch_agy_review passes it and uses the correct agent_name."""
+    from types import SimpleNamespace
+
+    calls: list[dict] = []
+
+    def fake_invoke(**kwargs):
+        calls.append(kwargs)
+        return SimpleNamespace(
+            ok=True,
+            response="VERDICT: APPROVE\nlooks good",
+            stderr_excerpt=None,
+        )
+
+    monkeypatch.setattr(pilot, "invoke", fake_invoke)
+    monkeypatch.setattr(pilot, "log", lambda _event: None)
+    monkeypatch.setattr(pilot, "gemini_review_prompt", lambda *_a, **_kw: "test prompt")
+
+    text, verdict = pilot.dispatch_agy_review(pr_num=1234, module_path="x.md", slug="agy-test")
+
+    assert verdict == "APPROVE"
+    assert text == "VERDICT: APPROVE\nlooks good"
+    assert len(calls) == 1
+    assert calls[0]["agent_name"] == "agy"
+    assert calls[0]["mode"] == "danger"
+    assert calls[0]["entrypoint"] == "dispatch"
+    assert "model" not in calls[0]  # agy uses TUI-picker, no model= arg

--- a/tests/test_dispatch_388_pilot.py
+++ b/tests/test_dispatch_388_pilot.py
@@ -257,3 +257,66 @@ def test_dispatch_agy_review_uses_danger_mode(monkeypatch: pytest.MonkeyPatch) -
     assert calls[0]["mode"] == "danger"
     assert calls[0]["entrypoint"] == "dispatch"
     assert "model" not in calls[0]  # agy uses TUI-picker, no model= arg
+
+
+@pytest.mark.parametrize(
+    ("ok", "response", "expected_verdict", "expected_text"),
+    [
+        # Quota-exhausted: invoke returns ok=False with empty body.
+        (False, "", "UNCLEAR", ""),
+        # OAuth-expired: invoke returns ok=True but body is the auth-prompt
+        # URL plus a timed-out message; no VERDICT line present.
+        (
+            True,
+            "Authentication required. Please visit the URL to log in: "
+            "https://accounts.google.com/o/oauth2/auth?...\n"
+            "Error: authentication timed out.",
+            "UNCLEAR",
+            "Authentication required. Please visit the URL to log in: "
+            "https://accounts.google.com/o/oauth2/auth?...\n"
+            "Error: authentication timed out.",
+        ),
+    ],
+)
+def test_dispatch_agy_review_failure_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    ok: bool,
+    response: str,
+    expected_verdict: str,
+    expected_text: str,
+) -> None:
+    """Sonnet PR #1395 review: confirm the two documented agy failure
+    shapes (quota-exhaust + OAuth-expiry) surface as UNCLEAR — not ERROR —
+    so the cascade falls through transparently."""
+    from types import SimpleNamespace
+
+    def fake_invoke(**_kwargs):
+        return SimpleNamespace(ok=ok, response=response, stderr_excerpt=None)
+
+    monkeypatch.setattr(pilot, "invoke", fake_invoke)
+    monkeypatch.setattr(pilot, "log", lambda _event: None)
+    monkeypatch.setattr(pilot, "gemini_review_prompt", lambda *_a, **_kw: "test prompt")
+
+    text, verdict = pilot.dispatch_agy_review(pr_num=1234, module_path="x.md", slug="agy-fail")
+
+    assert verdict == expected_verdict
+    assert text == expected_text
+
+
+def test_dispatch_agy_review_invoke_exception_returns_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exception inside invoke() should bubble up as (None, 'ERROR') —
+    distinct from quota-exhaust (which is ok=False with empty body)."""
+
+    def fake_invoke(**_kwargs):
+        raise RuntimeError("transport failure")
+
+    monkeypatch.setattr(pilot, "invoke", fake_invoke)
+    monkeypatch.setattr(pilot, "log", lambda _event: None)
+    monkeypatch.setattr(pilot, "gemini_review_prompt", lambda *_a, **_kw: "test prompt")
+
+    text, verdict = pilot.dispatch_agy_review(pr_num=1234, module_path="x.md", slug="agy-exc")
+
+    assert text is None
+    assert verdict == "ERROR"


### PR DESCRIPTION
## Summary
- New `dispatch_agy_review(pr_num, module_path, slug)` function in `scripts/quality/dispatch_388_pilot.py`. Modeled on `dispatch_gemini_review`; uses `mode=\"danger\"` (agy adapter requirement in headless dispatch) and omits `model=` (agy uses TUI-panel state; `KUBEDOJO_AGY_MODEL` env-var drives adapter default).
- `build_reviewer_cascade(\"agy\")` returns `agy → claude → qwen`. Skips gemini in the cascade because it shares Google OAuth pre-cutover.
- Existing parametrized cascade test extended with the agy case + 1 new test verifying the danger-mode / no-model invocation shape.

Completes the Phase 1 cascade-extension item from #1350.

## Background
PR #1392 (just merged) added the ab-CLI surface for agy (`ab ask-agy`, plus parity for qwen / deepseek). This PR wires agy into the #388 dispatch loop so an operator can run:

```bash
KUBEDOJO_388_PRIMARY_REVIEWER=agy python -m scripts.quality.dispatch_388_pilot ...
```

…and get agy as the first-pass reviewer with claude / qwen as transparent fallbacks if agy quota-exhausts or OAuth-expires (both failure shapes are captured in `feedback_agy_rate_limit_detection.md`).

## Test plan
- [x] `pytest tests/test_dispatch_388_pilot.py -q` → all pass (5 cascade-selection params + 1 new agy-mode test).
- [x] `ruff check` → clean.
- [ ] Live smoke: dispatch a real review via `KUBEDOJO_388_PRIMARY_REVIEWER=agy` on next CKS module rewrite (5.4 codex dispatch currently in flight).

## Refs
- Issue #1350 (gemini-cli → agy migration deadline 2026-06-18)
- Memory: `feedback_agy_rate_limit_detection.md` (failure shape detection)
- Predecessor: PR #1392 (bridge integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)