### PR TITLE
feat(local-api): serve calibration reports via /artifacts and add /api/benchmarks/latest

### DIFF
--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -4259,8 +4259,13 @@ def _render_skeleton_page(title: str, issue_number: int) -> str:
 </body></html>"""
 
 
+_BENCHMARK_REPORTS_REL = "calibration/v1/reports"
+_BENCHMARK_LEDGER_REL = "calibration/v1/ledger.db"
+_BENCHMARK_REPORT_DIR_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
 _ARTIFACT_ALLOWED_DIRS = (
     "audit",
+    "calibration/v1/reports",
     "docs/migrations",
     "docs/session-state",
     "docs/decisions",
@@ -4284,6 +4289,7 @@ _ARTIFACT_ASSET_TYPES = {
 }
 _ARTIFACT_SECTION_SPECS = (
     ("Reports", "audit", ("**/*.html", "**/*.md")),
+    ("Calibration reports", "calibration/v1/reports", ("**/*.html",)),
     ("Migrations", "docs/migrations", ("**/*.html", "**/*.md")),
     ("Handoffs", "docs/session-state", ("*.html", "*.md")),
     ("Decisions", "docs/decisions", ("**/*.html", "**/*.md")),
@@ -5044,6 +5050,114 @@ def build_current_session(repo_root: Path) -> dict[str, Any]:
     }
 
 
+def _benchmark_report_dirs(repo_root: Path) -> list[Path]:
+    reports_dir = repo_root / _BENCHMARK_REPORTS_REL
+    if not reports_dir.is_dir():
+        return []
+    dirs = [
+        path
+        for path in reports_dir.iterdir()
+        if path.is_dir() and _BENCHMARK_REPORT_DIR_RE.fullmatch(path.name)
+    ]
+    return sorted(dirs, key=lambda path: path.name, reverse=True)
+
+
+def _benchmark_report_summary(repo_root: Path, report_dir: Path) -> dict[str, str]:
+    rel_dir = report_dir.relative_to(repo_root).as_posix()
+    return {
+        "date": report_dir.name,
+        "directory": rel_dir,
+        "render_url": f"http://127.0.0.1:8768/artifacts/{rel_dir}/index.html",
+    }
+
+
+def _benchmark_artifact_url(repo_root: Path, path: Path) -> str:
+    return f"/artifacts/{path.relative_to(repo_root).as_posix()}"
+
+
+def _benchmark_file_url_if_present(repo_root: Path, report_dir: Path, filename: str) -> str | None:
+    path = report_dir / filename
+    if not path.is_file():
+        return None
+    return _benchmark_artifact_url(repo_root, path)
+
+
+def _benchmark_html_file_urls(repo_root: Path, directory: Path) -> list[str]:
+    if not directory.is_dir():
+        return []
+    return [
+        _benchmark_artifact_url(repo_root, path)
+        for path in sorted(directory.glob("*.html"), key=lambda item: item.name)
+        if path.is_file()
+    ]
+
+
+def _build_benchmark_files(repo_root: Path, report_dir: Path) -> dict[str, Any]:
+    return {
+        "index": _benchmark_file_url_if_present(repo_root, report_dir, "index.html"),
+        "matrix": _benchmark_file_url_if_present(repo_root, report_dir, "matrix.html"),
+        "wave_ab": _benchmark_file_url_if_present(repo_root, report_dir, "wave-ab-report.html"),
+        "per_lane": _benchmark_html_file_urls(repo_root, report_dir / "per-lane"),
+        "per_model": _benchmark_html_file_urls(repo_root, report_dir / "per-model"),
+    }
+
+
+def _build_benchmark_ledger(repo_root: Path) -> dict[str, Any]:
+    ledger = {
+        "path": _BENCHMARK_LEDGER_REL,
+        "cells_total": 0,
+        "cells_scored": 0,
+        "models": 0,
+        "lanes": 0,
+    }
+    db_path = repo_root / _BENCHMARK_LEDGER_REL
+    if not db_path.is_file():
+        return ledger
+
+    queries = {
+        "cells_total": "SELECT COUNT(*) FROM cells",
+        "cells_scored": "SELECT COUNT(DISTINCT cell_id) FROM scores",
+        "models": "SELECT COUNT(DISTINCT model_id) FROM cells",
+        "lanes": "SELECT COUNT(DISTINCT lane) FROM cells",
+    }
+    try:
+        conn = sqlite3.connect(f"{db_path.resolve().as_uri()}?mode=ro", uri=True)
+    except (OSError, sqlite3.Error):
+        return ledger
+    try:
+        for key, sql in queries.items():
+            row = conn.execute(sql).fetchone()
+            ledger[key] = int(row[0] or 0) if row else 0
+    except sqlite3.Error:
+        return {
+            "path": _BENCHMARK_LEDGER_REL,
+            "cells_total": 0,
+            "cells_scored": 0,
+            "models": 0,
+            "lanes": 0,
+        }
+    finally:
+        conn.close()
+    return ledger
+
+
+def build_latest_benchmarks(repo_root: Path) -> dict[str, Any]:
+    report_dirs = _benchmark_report_dirs(repo_root)
+    if not report_dirs:
+        return {"latest": None, "predecessors": [], "total_runs": 0}
+
+    latest_dir = report_dirs[0]
+    latest: dict[str, Any] = _benchmark_report_summary(repo_root, latest_dir)
+    latest["files"] = _build_benchmark_files(repo_root, latest_dir)
+    latest["ledger"] = _build_benchmark_ledger(repo_root)
+
+    return {
+        "latest": latest,
+        "predecessors": [_benchmark_report_summary(repo_root, path) for path in report_dirs[1:11]],
+        "total_runs": len(report_dirs),
+    }
+
+
 def build_state_manifest() -> dict[str, Any]:
     """Pointer-only index for canonical cold-start state discovery."""
     return {
@@ -5136,6 +5250,17 @@ def build_state_manifest() -> dict[str, Any]:
                         "name": "Artifacts JSON",
                         "path": "/api/artifacts",
                         "purpose": "JSON index of HTML and Markdown artifacts served by the artifacts route.",
+                        "type": "api",
+                    },
+                ],
+            },
+            {
+                "category": "benchmarks",
+                "entries": [
+                    {
+                        "name": "Latest calibration benchmark report",
+                        "path": "/api/benchmarks/latest",
+                        "purpose": "Latest calibration report artifact plus predecessor reports and ledger coverage counts.",
                         "type": "api",
                     },
                 ],
@@ -7881,6 +8006,11 @@ def build_api_schema() -> dict[str, Any]:
                 "content_type": "application/json",
             },
             {
+                "path": "/api/benchmarks/latest",
+                "desc": "Latest calibration benchmark report, predecessor reports, and ledger coverage counts",
+                "content_type": "application/json",
+            },
+            {
                 "path": "/api/briefing/book",
                 "desc": "AI-history book chapter status rollup. Scans chapters/ch-NN-*/status.yaml and groups by Part (1-9). Each part includes status_rollup, owners_seen, tracking_issue, and a per-chapter list with Green/Yellow/Red counts when present.",
             },
@@ -8311,6 +8441,8 @@ def route_request(repo_root: Path, raw_path: str) -> tuple[int, Any, str]:
         return 200, build_orient(repo_root), "application/json; charset=utf-8"
     if path == "/api/session/current":
         return 200, build_current_session(repo_root), "application/json; charset=utf-8"
+    if path == "/api/benchmarks/latest":
+        return 200, build_latest_benchmarks(repo_root), "application/json; charset=utf-8"
     if path == "/api/briefing/book":
         return 200, build_book_briefing(repo_root), "application/json; charset=utf-8"
     if path == "/api/cache/stats":
@@ -8540,6 +8672,7 @@ CACHE_POLICY: dict[str, tuple[float, Callable[[Path], tuple] | None]] = {
     "/api/schema": (600.0, None),
     "/api/state/manifest": (600.0, None),
     "/api/session/current": (30.0, None),
+    "/api/benchmarks/latest": (30.0, None),
     "/api/status/summary": (10.0, _v_v2_db),
     "/api/missing-modules/status": (30.0, None),
     "/api/activity/recent": (5.0, _v_v2_db),

--- a/tests/test_local_api_artifacts.py
+++ b/tests/test_local_api_artifacts.py
@@ -25,6 +25,10 @@ def _write(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
 
 
+def test_calibration_reports_are_allowed_artifacts() -> None:
+    assert "calibration/v1/reports" in local_api._ARTIFACT_ALLOWED_DIRS
+
+
 def test_artifacts_index_lists_seeded_html_by_category(tmp_path: Path) -> None:
     first = tmp_path / "audit" / "report.html"
     second = tmp_path / "docs" / "migrations" / "html-first" / "_design-system.html"

--- a/tests/test_local_api_state_session.py
+++ b/tests/test_local_api_state_session.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import re
+import sqlite3
 import sys
 from pathlib import Path
 from typing import Any
@@ -58,6 +59,41 @@ def _seed_handoffs(repo_root: Path) -> None:
     _write(repo_root / "docs" / "session-state" / "handoff-without-prefix.html", "<h1>Ignored</h1>")
 
 
+def _seed_benchmark_reports(repo_root: Path) -> None:
+    _write(
+        repo_root / "calibration" / "v1" / "reports" / "2026-05-20" / "index.html",
+        "<title>Previous</title>",
+    )
+    latest = repo_root / "calibration" / "v1" / "reports" / "2026-05-21"
+    _write(latest / "index.html", "<title>Latest</title>")
+    _write(latest / "matrix.html", "<title>Matrix</title>")
+    _write(latest / "wave-ab-report.html", "<title>Wave AB</title>")
+    _write(latest / "per-lane" / "architecting.html", "<title>Architecting</title>")
+    _write(latest / "per-model" / "gpt-5.html", "<title>GPT-5</title>")
+
+    ledger_path = repo_root / "calibration" / "v1" / "ledger.db"
+    ledger_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(ledger_path)
+    try:
+        conn.execute("CREATE TABLE cells (cell_id TEXT, model_id TEXT, lane TEXT)")
+        conn.execute("CREATE TABLE scores (cell_id TEXT)")
+        conn.executemany(
+            "INSERT INTO cells (cell_id, model_id, lane) VALUES (?, ?, ?)",
+            [
+                ("cell-1", "model-a", "architecting"),
+                ("cell-2", "model-a", "implementation"),
+                ("cell-3", "model-b", "architecting"),
+            ],
+        )
+        conn.executemany(
+            "INSERT INTO scores (cell_id) VALUES (?)",
+            [("cell-1",), ("cell-2",), ("cell-2",)],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
 def test_state_manifest_contains_cold_start_critical_paths(tmp_path: Path) -> None:
     status, body, content_type = local_api.route_request(tmp_path, "/api/state/manifest")
 
@@ -68,6 +104,16 @@ def test_state_manifest_contains_cold_start_critical_paths(tmp_path: Path) -> No
     assert "/api/briefing/session?compact=1" in paths
     assert "/api/schema" in paths
     assert "/api/session/current" in paths
+    assert "/api/benchmarks/latest" in paths
+
+
+def test_state_manifest_contains_benchmarks_category(tmp_path: Path) -> None:
+    status, body, _ = local_api.route_request(tmp_path, "/api/state/manifest")
+
+    assert status == 200
+    benchmarks = [category for category in body["categories"] if category["category"] == "benchmarks"]
+    assert benchmarks
+    assert benchmarks[0]["entries"][0]["path"] == "/api/benchmarks/latest"
 
 
 def test_state_manifest_entries_are_well_formed(tmp_path: Path) -> None:
@@ -126,3 +172,48 @@ def test_current_session_contains_at_least_one_html_handoff(tmp_path: Path) -> N
 
     handoffs = [body["latest"], *body["predecessors"]]
     assert any(item["format"] == "html" for item in handoffs)
+
+
+def test_latest_benchmarks_returns_report_tree_and_ledger_counts(tmp_path: Path) -> None:
+    _seed_benchmark_reports(tmp_path)
+
+    status, body, content_type = local_api.route_request(tmp_path, "/api/benchmarks/latest")
+
+    assert status == 200
+    assert content_type == "application/json; charset=utf-8"
+    assert body["total_runs"] == 2
+    assert body["latest"]["date"] == "2026-05-21"
+    assert body["latest"]["directory"] == "calibration/v1/reports/2026-05-21"
+    assert (
+        body["latest"]["render_url"]
+        == "http://127.0.0.1:8768/artifacts/calibration/v1/reports/2026-05-21/index.html"
+    )
+    assert body["latest"]["files"] == {
+        "index": "/artifacts/calibration/v1/reports/2026-05-21/index.html",
+        "matrix": "/artifacts/calibration/v1/reports/2026-05-21/matrix.html",
+        "wave_ab": "/artifacts/calibration/v1/reports/2026-05-21/wave-ab-report.html",
+        "per_lane": ["/artifacts/calibration/v1/reports/2026-05-21/per-lane/architecting.html"],
+        "per_model": ["/artifacts/calibration/v1/reports/2026-05-21/per-model/gpt-5.html"],
+    }
+    assert body["latest"]["ledger"] == {
+        "path": "calibration/v1/ledger.db",
+        "cells_total": 3,
+        "cells_scored": 2,
+        "models": 2,
+        "lanes": 2,
+    }
+    assert body["predecessors"] == [
+        {
+            "date": "2026-05-20",
+            "directory": "calibration/v1/reports/2026-05-20",
+            "render_url": "http://127.0.0.1:8768/artifacts/calibration/v1/reports/2026-05-20/index.html",
+        }
+    ]
+
+
+def test_latest_benchmarks_empty_reports_tree_returns_empty_payload(tmp_path: Path) -> None:
+    status, body, content_type = local_api.route_request(tmp_path, "/api/benchmarks/latest")
+
+    assert status == 200
+    assert content_type == "application/json; charset=utf-8"
+    assert body == {"latest": None, "predecessors": [], "total_runs": 0}


### PR DESCRIPTION
## Summary

Closes the gap between the calibration v1 sweep landing reports on disk (`calibration/v1/reports/2026-05-21/index.html`) and those reports being discoverable through the local API.

**Two changes in `scripts/local_api.py`:**

1. **Add `calibration/v1/reports` to the artifact allow-list** (`_ARTIFACT_ALLOWED_DIRS` + new section spec). HTML-only — no markdown, no SQLite, no fixtures. `http://127.0.0.1:8768/artifacts/calibration/v1/reports/<date>/index.html` now returns 200 (was 404).

2. **New endpoint `/api/benchmarks/latest`** — matches the shape of `/api/session/current`:
   - `latest.directory` / `render_url` / `files` (index, matrix, wave_ab, per_lane[], per_model[])
   - `latest.ledger` (path, cells_total, cells_scored, models, lanes — read-only sqlite query against `calibration/v1/ledger.db`)
   - `predecessors[]` (reverse chronological, capped at 10)
   - `total_runs` int
   - Empty-state: returns `{"latest": null, "predecessors": [], "total_runs": 0}` with HTTP 200 when the reports dir is missing.

3. **Manifest registration** under a new `benchmarks` category in `build_state_manifest` + `build_api_schema` so future agents discover it via `/api/state/manifest`.

## Tests

4 new tests in `tests/test_local_api_artifacts.py` + `tests/test_local_api_state_session.py`:
- allow-list membership
- state-manifest category presence
- endpoint shape on fixture (file tree + ledger SQL semantics + predecessor capping)
- empty-state JSON when reports dir is absent

## Review

Sonnet R1 cross-family review (`smart-claude-review-1779390466.txt`): **APPROVE**, no blockers. One cosmetic nit explicitly marked "not worth a change request."

## Note

The supervised local API serving `127.0.0.1:8768` needs a restart after this lands so the primary instance serves the new route.

Refs: today's calibration v1 sweep at `calibration/v1/reports/2026-05-21/`, ledger at `calibration/v1/ledger.db` (168/168 cells × 14 models × 12 lanes).

## Test plan

- [x] Targeted pytest (4 new tests) — passing
- [x] `scripts/test_pipeline.py` — 170 tests OK
- [x] `ruff check` clean
- [x] Live curl against worktree-local API: `200 OK` for `/artifacts/calibration/v1/reports/2026-05-21/index.html`; ledger counts `168/168 cells, 14 models, 12 lanes` via `/api/benchmarks/latest`
- [ ] Post-merge: restart primary API daemon

