### PR TITLE
chore(cloud): rewrite Module 3.14 Azure App Service Operator Path to T0/T1 (#1369 ladder)

### DIFF
--- a/src/content/docs/cloud/azure-essentials/module-3.14-app-service.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.14-app-service.md
@@ -5,203 +5,92 @@ sidebar:
   order: 15
 ---
 **Complexity**: [COMPLEX] | **Time:** 90-120 min | **Prerequisites**: [3.7-aci-aca](../module-3.7-aci-aca/) (Container Apps), [3.8-functions](../module-3.8-functions/), [3.9-key-vault](../module-3.9-key-vault/), [3.10-monitor](../module-3.10-monitor/)
-## What You'll Be Able to Do (Debug, Design, Evaluate)
+
+## What You'll Be Able to Do
+
 After completing this module, you will be able to:
 
 - **Debug** App Service incidents by separating plan capacity, worker health, deployment slot state, networking path, identity permissions, and application logs.
 - **Design** a production Web App pattern with the right App Service Plan tier, deployment slots, managed identity, private networking, autoscale rules, and diagnostics.
 - **Evaluate** when App Service is the right default, when Azure Container Apps is a better fit, and when AKS is justified by platform control requirements.
 
-The focus is the operator path. You are not learning App Service as a portal wizard. You are learning it as a production hosting surface with shared compute, slots, warm-up behavior, identity, private access patterns, and scaling boundaries. By the end, you should be able to look at a web workload and answer:
+The focus is the operator path. You are not learning App Service as a portal wizard. You are learning it as a production hosting surface with shared compute, slots, warm-up behavior, identity, private access patterns, and scaling boundaries. By the end, you should be able to look at a web workload and answer these seven operator questions:
 
-- Which service should host it?
-- Which plan tier should run it?
-- Which settings must be sticky across swaps?
-- Which path does inbound traffic use?
-- Which path does outbound traffic use?
-- Which logs prove what happened?
-- Which rollback takes minutes instead of hours?
+> - Which service should host it?
+> - Which plan tier should run it?
+> - Which settings must be sticky across swaps?
+> - Which path does inbound traffic use?
+> - Which path does outbound traffic use?
+> - Which logs prove what happened?
+> - Which rollback takes minutes instead of hours?
 
 ## Why This Module Matters
 
-Azure App Service is one of the most useful services in Azure because it handles a boring but hard problem: running web applications without making every team become an operating-system, load-balancer, and patching team. It can host .NET, Java, Node.js, Python, PHP, Ruby, Go, and custom containers. It can terminate HTTPS, bind custom domains, integrate with Entra ID, use managed identity, pull secrets from Key Vault, attach to VNets, receive traffic over Private Link, autoscale, and ship logs to Azure Monitor. That convenience is why many enterprise applications land on App Service first. The risk is that App Service looks simple until the first production incident. A team deploys to the production slot and discovers that the app takes ninety seconds to warm up. A connection string swaps with the slot when the database setting should have stayed attached to production. The app can reach the public internet but cannot reach the private database because VNet integration was misunderstood. An autoscale rule adds workers but the App Service Plan is shared with three other apps, so the noisy app scales everyone and increases cost. A migration from Premium v2 to Premium v3 is planned as a quick scale-up, then the team learns that the existing deployment unit cannot support the desired Premium v3 SKU. App Service is not a toy service. It is a managed application platform with strong operational features and sharp edges. The biggest feature is deployment slots. Slots let you deploy a new release into a parallel environment, warm it up, validate it, and swap it into production with a fast rollback path. For many long-running web applications, that is the killer feature that keeps App Service relevant even when Container Apps and AKS are available. The second biggest decision is whether App Service should be used at all. [Azure Container Apps](../module-3.7-aci-aca/) often beats App Service for new event-driven microservices because it has revision traffic splitting, KEDA scaling, service-to-service patterns, and container-native operations. App Service often beats Container Apps for traditional web apps, enterprise .NET applications, slot-based release workflows, and teams that want a stable PaaS contract without Kubernetes concepts. AKS wins only when the platform needs Kubernetes-level control and is willing to operate Kubernetes-level complexity.
+Azure App Service is a managed platform for web applications, REST APIs, mobile back ends, and custom containers, and it supports mainstream stacks such as .NET, Java, Node.js, Python, PHP, and containerized workloads on Windows or Linux. The operational value is not that the service hides everything; the value is that the app team can operate at the app, plan, slot, identity, network, and telemetry layer instead of owning host patching and a full ingress platform. [Microsoft's overview](https://learn.microsoft.com/en-us/azure/app-service/overview) is deliberately broad, but the operator version is narrower: know which compute plan owns capacity, which release primitive moves traffic, which identity authorizes dependencies, and which network feature controls each traffic direction.
 
-> **Pause and predict:** A team has a public .NET monolith with predictable traffic, a SQL backend, and a strict requirement for pre-production validation plus instant rollback. Should your first candidate be App Service, Container Apps, or AKS? What feature drives that answer?
+The first production surprise is usually the App Service Plan. A plan defines the region, operating system, VM size, tier, and instance count, and every app, deployment slot, diagnostic job, backup, and WebJob in that plan consumes the same worker pool. Scaling the plan scales all apps inside it, so cost isolation and blast-radius isolation are plan decisions, not just tagging decisions. [The hosting-plan documentation](https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans) states this directly, and [the service-limits table](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#azure-app-service-limits) is the canonical place to check maximum instance counts, slot counts, storage, access restrictions, and networking feature availability before committing a design.
 
-## When App Service, When Container Apps, When AKS (THE decision mental model)
+The second surprise is that App Service has two different private-networking stories. Virtual Network Integration is outbound from the app into a VNet; it does not make the app privately reachable. Private Endpoint is inbound private access to the app; it does not route the app's outbound calls into the VNet. Hybrid Connections are a narrow outbound bridge to a single TCP host and port. Microsoft documents these boundaries separately for [VNet Integration](https://learn.microsoft.com/en-us/azure/app-service/overview-vnet-integration), [Private Endpoint](https://learn.microsoft.com/en-us/azure/app-service/overview-private-endpoint), and [Hybrid Connections](https://learn.microsoft.com/en-us/azure/app-service/app-service-hybrid-connections), so an incident runbook must always name inbound and outbound paths separately.
 
-Start with the shape of the workload, not the feature list. App Service is best when the unit of deployment is a web application. Container Apps is best when the unit of deployment is a containerized service or worker that benefits from revisions, event-driven scaling, and scale-to-zero economics. AKS is best when the unit of operation is a Kubernetes platform. Those are different ownership models.
+The third surprise is release behavior. Deployment slots let you deploy to a nonproduction slot, warm and validate it, swap it into production, and keep the previous production build in the other slot as a rollback target. The official slot guide also documents warm-up, slot-specific settings, swap with preview, and auto-swap caveats, including that auto swap is not supported for Linux web apps or Web App for Containers. [Deployment slots](https://learn.microsoft.com/en-us/azure/app-service/deploy-staging-slots) are therefore the feature that often makes App Service the correct choice for classic web applications even when Container Apps or AKS can also run the code.
 
-### The Fast Decision Sequence
+> **Pause and predict:** A public .NET monolith has predictable traffic, Azure SQL, Key Vault references, a custom domain, weekly releases, and a rollback target of under five minutes. App Service, Container Apps, and AKS can all run the workload. Which one is the first candidate, and which release primitive drives that answer?
 
-Use this sequence before drawing architecture boxes:
+## Did You Know
 
-1. If the workload is a traditional web app or API with a stable runtime, custom domain, TLS, managed identity, and release-slot workflow, evaluate App Service first.
-2. If the workload is a set of containerized microservices, event-driven workers, queue consumers, or services that should scale to zero, evaluate Container Apps first.
-3. If the workload needs Kubernetes APIs, custom controllers, service mesh, admission policy, advanced scheduling, or platform team ownership of clusters, evaluate AKS.
-4. If the workload is a short event handler, evaluate Azure Functions before all three.
-5. If the workload needs full VM control, App Service is probably the wrong abstraction.
+These four details explain many App Service incidents that look surprising only because the team learned the feature names without learning the boundaries. A slot is production-like because it runs on the same plan, but that also means capacity is shared. VNet Integration sounds bidirectional, but Microsoft defines it as outbound. Key Vault references remove secrets from app settings, but they still depend on identity, network access, and refresh behavior. Autoscale can add workers, but it cannot make a saturated SQL database accept more concurrent requests. The practical operator move is to turn each detail into a release checklist item and a dashboard signal, not a trivia note. [Hosting plans](https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans), [VNet Integration](https://learn.microsoft.com/en-us/azure/app-service/overview-vnet-integration), [Key Vault references](https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references), and [Azure Monitor autoscale](https://learn.microsoft.com/en-us/azure/azure-monitor/autoscale/autoscale-overview) are the source anchors.
 
-### Mental Model Table
+- **Did You Know:** An active deployment slot is an active app competing for resources in the same App Service Plan as production.
+- **Did You Know:** VNet Integration gives outbound access from the app into a VNet; it does not provide inbound private access to the app.
+- **Did You Know:** Versionless Key Vault references refresh automatically, but App Service caches resolved values and refetches on its documented cadence or after configuration changes.
+- **Did You Know:** Azure Monitor autoscale scales out when any scale-out rule is met, but scales in only when all scale-in rules are met.
+
+## Choosing the Hosting Surface
+
+Start with the ownership model. App Service is a web-app platform: the primary object is an app in a plan, and the release tool is a slot swap. Container Apps is a serverless container platform: the primary object is a container app revision, and the release tool is revision traffic management with HTTP, event, CPU, memory, and KEDA-supported scale rules. AKS is a managed Kubernetes service: the primary object is a cluster with node pools, Kubernetes APIs, workload controllers, ingress, storage, autoscalers, and platform governance. These are different operating models, not just three ways to start a container. [App Service](https://learn.microsoft.com/en-us/azure/app-service/overview), [Container Apps](https://learn.microsoft.com/en-us/azure/container-apps/overview), and [AKS](https://learn.microsoft.com/en-us/azure/aks/what-is-aks) each document a different contract.
 
 | Decision factor | App Service | Container Apps | AKS |
 |---|---|---|---|
-| Primary abstraction | Web app in an App Service Plan | Container app revision in a managed environment | Kubernetes workload in a cluster |
-| Best default for | Long-running web apps and APIs | New containerized services and workers | Platform-heavy systems |
-| Release strength | Deployment slots and swap rollback | Revisions and traffic splitting | Rollouts through Kubernetes controllers |
-| Scale-to-zero | No for dedicated App Service Plans | Yes for many workloads | No by default; possible with add-ons and careful design |
-| Event-driven scaling | Limited compared with KEDA | Strong through KEDA-style rules | Strong if you install and operate KEDA |
-| Operations surface | App, plan, slots, settings, diagnostics | App, revisions, environment, ingress, scale rules | Cluster, nodes, CNI, ingress, storage, policies, upgrades |
-| Team fit | App teams that want PaaS | App teams comfortable with containers | Platform teams ready to operate Kubernetes |
-| Common mistake | Treating the plan as per-app compute | Treating every web app as a microservice | Using Kubernetes because it is familiar |
+| Primary abstraction | Web app or API in an App Service Plan | Container app revision in a managed environment | Kubernetes workload in a cluster |
+| Best default for | Traditional web apps, enterprise APIs, slot-based releases | Microservices, workers, event-driven containers, scale-to-zero candidates | Platforms that need Kubernetes APIs, controllers, mesh, policy, or node control |
+| Release primitive | Deployment slots, swap, swap with preview, slot rollback | Immutable revisions, labels, traffic splitting, rollback to prior revision | Kubernetes rollouts, GitOps, controller-driven rollout and rollback |
+| Scaling primitive | Plan instances, Azure Monitor autoscale, or supported automatic scaling | Replica min/max, HTTP and KEDA-based triggers, many apps can scale to zero | Cluster autoscaler, horizontal pod autoscaler, node pools, workload controllers |
+| Operational surface | App, plan, slots, app settings, identity, networking, diagnostics | App, revisions, environment, ingress, secrets, scale rules | Cluster, nodes, CNI, ingress, storage, policy, upgrades, runtime add-ons |
+| Cost shape | Pay for plan instances except Free; shared plans can host multiple apps | Pay for replicas and environment profile behavior; inactive revisions are not charged | Pay for nodes and cluster dependencies; platform cost remains even when apps are idle |
+| First hesitation | Event-driven scale-to-zero services may fit better elsewhere | Classic apps may miss slot workflows and runtime conveniences | Normal web apps rarely justify cluster ownership |
 
-### App Service Wins When
+For a normal web app with a stable runtime, custom domain, managed identity, TLS, App Insights, and a release-slot workflow, evaluate App Service first because the service natively supports those app-platform concerns. For a new set of containerized APIs and queue workers that should scale by queue depth or HTTP concurrency, evaluate Container Apps first because its revision and KEDA model is built around that workload shape. For a shared developer platform that needs Kubernetes admission policy, CRDs, service mesh, node pools, DaemonSets, GPUs, or multi-cloud Kubernetes consistency, AKS can be justified because the organization is operating Kubernetes as the product. [Container Apps revisions](https://learn.microsoft.com/en-us/azure/container-apps/revisions), [Container Apps scaling](https://learn.microsoft.com/en-us/azure/container-apps/scale-app), and [AKS capabilities](https://learn.microsoft.com/en-us/azure/aks/what-is-aks) are the comparison anchors.
 
-- You need a managed web-hosting platform with minimal infrastructure ownership.
-- Deployment slots are central to your release and rollback strategy.
-- The app is a monolith or modular monolith with a conventional HTTP lifecycle.
-- The runtime is supported directly by App Service.
-- The organization already has App Service runbooks, policies, and cost models.
-- App teams need custom domains, TLS, auth integration, and diagnostics without owning ingress controllers.
+Total cost of ownership follows the same ownership model. App Service charges for plan compute resources, and dedicated plan instances are charged the same regardless of how many apps run on them, which can make plan sharing efficient or dangerous depending on ownership and traffic patterns. Container Apps can reduce idle cost for workloads that truly scale down, but revision, ingress, environment, and scale-rule behavior become the operator's release vocabulary. AKS puts more knobs in your hands, but the nodes, network, ingress, storage, upgrades, policy, and incident response all need owners. [App Service plan cost behavior](https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans), [Container Apps scale behavior](https://learn.microsoft.com/en-us/azure/container-apps/scale-app), and [AKS cluster operations](https://learn.microsoft.com/en-us/azure/aks/what-is-aks) should be reviewed before any "Kubernetes by default" decision.
 
-### Container Apps Wins When
+## App Service Plan Tiers and Capacity
 
-- The workload is already containerized and designed as a service or worker.
-- You need revision-based gradual rollout instead of slot swap.
-- Queue length, Kafka lag, Service Bus messages, or HTTP concurrency should drive scaling.
-- Scale to zero is a real cost requirement.
-- Dapr, internal service discovery, and microservice patterns matter.
-- You want less Kubernetes than AKS but more container-native behavior than App Service.
+An App Service Plan is the compute boundary. Free and Shared run on shared compute with CPU quotas and cannot scale out; Basic, Standard, Premium, and Isolated tiers run on dedicated workers, and only apps in the same plan share those dedicated workers. The higher tiers unlock more feature coverage and larger scale-out ceilings, while Isolated runs in an App Service Environment for network isolation on top of compute isolation. [Hosting-plan tiers](https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans) explain the model; [service limits](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#azure-app-service-limits) and the Microsoft pricing pages give the current shape of CPU, memory, storage, and scale ceilings.
 
-Container Apps is often the better answer for new microservices. That is not a criticism of App Service. It is a sign that the workload's natural unit is a container revision, not a web app slot.
+| Tier | Compute and size anchor | Scale-out limit | Production fit | Networking and release features to check |
+|---|---|---:|---|---|
+| Free | Shared compute, 1 GB RAM quota, 1 GB storage, 60 CPU minutes/day | 1 shared | No | No custom domains beyond `azurewebsites.net`; diagnostic logs and Kudu exist, but production features are intentionally limited |
+| Shared | Shared compute, 1 GB RAM per app, 1 GB storage, 240 CPU minutes/day | 1 shared | No | Custom domains are supported, but dedicated capacity, autoscale, slots, VNet Integration, and Private Endpoint are not the production story |
+| Basic | Dedicated workers; B1/B2/B3 are 1/2/4 cores with 1.75/3.5/7 GB RAM and 10 GB storage | 3 dedicated | Small internal apps, dev/test, minimum dedicated tier | Manual scale only; supports custom domains, TLS, access restrictions, diagnostics, and Kudu; no staging slots or autoscale |
+| Standard | Dedicated workers; S1/S2/S3 are 1/2/4 cores with 1.75/3.5/7 GB RAM and 50 GB storage | 10 dedicated | Baseline production tier | Adds autoscale and staging slots; supports VNet Integration, diagnostics, access restrictions, custom domains, and managed certificates where applicable |
+| Premium v3 | Dedicated workers; P0v3-P5mv3 range from 1 vCPU/4 GB to 32 vCPU/256 GB with 250 GB storage | 30 dedicated | Serious production default when headroom or networking matters | Stronger CPU/RAM options, slots, autoscale, Private Endpoint, VNet Integration, Always On, backups, and production networking patterns |
+| Isolated v2 | Dedicated workers in App Service Environment v3; I1v2-I6v2 and memory-optimized variants range from 2 cores/8 GB to 64 cores/256 GB with 1 TB storage | 100 dedicated by default, more by request | Compliance or network-isolated estate only | ASE v3 provides single-tenant environment isolation and supports internal load-balancer patterns; cost and platform ownership must be explicit |
 
-### AKS Wins When
+Use this matrix as a review prompt, not a substitute for the live SKU selector. Microsoft now highlights Premium v4 on the primary App Service pricing page, while Standard and Premium v2 sit under the legacy pricing page for existing customers, and SKU availability can vary by region, operating system, and deployment stamp. If a migration depends on Premium v3 or Isolated v2, test creation in the target region before the incident, because a "scale up" plan can become a migration plan if the current deployment unit cannot host the target SKU. [Current App Service pricing](https://azure.microsoft.com/en-us/pricing/details/app-service/windows/), [legacy App Service pricing](https://azure.microsoft.com/en-us/pricing/details/app-service/windows-previous/), and [service limits](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#azure-app-service-limits) are the current cross-checks.
 
-- You need Kubernetes APIs and ecosystem tools as the platform contract.
-- Teams require custom controllers, CRDs, admission policy, sidecars, or service mesh.
-- You need advanced workload placement, GPUs, DaemonSets, host networking, or node-level control.
-- The organization has a real platform team with cluster lifecycle ownership.
-- You are standardizing on Kubernetes across clouds or on-prem environments.
+Plan sharing is a cost optimization only when the apps have the same owner, same availability target, compatible traffic shape, and acceptable shared scale events. The hosting-plan guide states that apps and slots in the same plan share the same VM instances, and the same guide recommends isolating resource-intensive apps or apps that must scale independently into separate plans. A useful production rule is simple: if a noisy neighbor would trigger an incident bridge or a cost dispute, that app deserves its own plan. [App Service plan sharing](https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans) and [the density guidance in the plan documentation](https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans#decision-to-use-a-new-plan-or-an-existing-plan-for-an-app) support that review.
 
-AKS is a platform, not just a hosting option. If no one owns cluster upgrades, node images, ingress, CNI, policy, and incident response, AKS is usually the expensive answer to a simpler hosting problem.
+Scale up and scale out solve different problems. Scale up changes tier or worker size to unlock CPU, memory, storage, or features; scale out changes instance count and assumes the application can run horizontally without local session state or local-disk coordination. If session state, cache, uploaded files, or background jobs depend on one worker, more instances can create correctness bugs before they fix latency. The platform will scale the plan, but the operator still has to prove the app is stateless enough for plan-level scale. [Plan scaling behavior](https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans#considerations-for-running-and-scaling-an-app) and [Azure Monitor autoscale](https://learn.microsoft.com/en-us/azure/azure-monitor/autoscale/autoscale-overview) define the platform side of that decision.
 
-### Worked Example: Three Teams, Three Correct Answers
+## Production Baseline as Code
 
-Team A owns a .NET MVC app used by finance. It has predictable business-hours traffic, SQL Database, Key Vault secrets, custom domain, and change windows. App Service on a Standard or Premium v3 plan is a strong first candidate because slots, managed identity, Always On, and App Insights fit the work. Team B owns a set of small containerized fraud-scoring APIs and workers. Traffic is spiky, queues drive background processing, and each service releases independently. Container Apps is a strong first candidate because revisions, KEDA scale rules, and scale-to-zero economics match the system. Team C owns a shared internal developer platform with hundreds of services, network policy, service mesh, custom admission controls, and strong multi-tenant requirements. AKS is justified because the platform itself needs Kubernetes primitives.
-
-> **Stop and think:** If a workload can run on both App Service and Container Apps, which rollback model does the team understand better today: slot swap or revision traffic splitting? That answer often matters more than the feature checklist.
-
-## App Service Plans + SKU Tiers (table; Free/Shared/Basic/Standard/Premium v3/Isolated v2; when each makes sense)
-
-An App Service Plan is the compute boundary. Every Web App runs in a plan. The plan defines operating system, region, VM size, pricing tier, and instance count. Apps in the same plan share the plan's workers. Slots for those apps also share the same workers. Diagnostics, WebJobs, deployment activity, and background tasks consume resources from the same plan. This is the most important cost and capacity fact in App Service: **You scale the plan, not just one app.** If three production apps share one plan, scaling out the plan adds instances for all three. That can be efficient when apps have complementary traffic. It can also hide noisy-neighbor problems inside your own subscription.
-
-### SKU Decision Table
-
-| Tier | Compute model | Scale behavior | Production fit | When it makes sense |
-|---|---|---|---|---|
-| Free | Shared compute with quotas | No scale-out | No | Learning, tiny demos, throwaway tests. Expect limits and idle unloads. |
-| Shared | Shared compute with quota-based billing | No scale-out | No | Legacy dev/test only when cost is the only concern. Avoid for real environments. |
-| Basic | Dedicated plan workers | Manual scale-out; limited advanced features | Small internal apps only | Low-risk dev/test, simple internal apps, or private endpoint eligibility at minimum cost. |
-| Standard | Dedicated workers with production features | Manual and rule-based autoscale | Yes for many apps | Baseline production tier for slots, autoscale, backups, and Always On. |
-| Premium v3 | Dedicated workers with stronger CPU/memory options | Higher scale and performance headroom | Preferred for serious production | High-traffic apps, custom containers, private networking, memory pressure, and better performance per instance. |
-| Isolated v2 | Dedicated workers inside App Service Environment v3 | High scale in single-tenant environment | Only when justified | Network-isolated, compliance-heavy, high-scale single-tenant workloads where ASE cost is accepted. |
-
-### Scale Up vs Scale Out
-
-Scale up changes the worker size or tier. Examples:
-
-- Standard S1 to Standard S2
-- Standard to Premium v3
-- Premium v3 P1v3 to P2v3
-
-Scale up is useful when each instance needs more CPU, memory, disk throughput, or feature support. It is also the move when the current tier lacks a required feature, such as autoscale or deployment slots. Scale out changes the number of workers. Examples:
-
-- two workers to four workers;
-- autoscale from two to ten workers;
-- schedule-based scale-out during business hours.
-
-Scale out is useful when the app is horizontally scalable and requests can be distributed across instances. The app must be stateless or externalize session state to Redis, SQL, Storage, or another shared service. Local disk is not a durable coordination mechanism.
-
-### Plan Isolation Rules
-
-Use separate App Service Plans when:
-
-- apps have different availability requirements;
-- one app has unpredictable CPU or memory spikes;
-- one team must own cost independently;
-- deployment activity for one app should not affect another;
-- production and non-production should not share capacity;
-- the app needs a different OS, region, tier, or scale profile.
-
-Share a plan when:
-
-- apps are small and low-risk;
-- the same team owns all apps;
-- scaling them together is acceptable;
-- cost efficiency matters more than isolation;
-- the blast radius is understood.
-
-Worked example: a company runs a public catalog API, an internal admin portal, and a nightly report generator. Putting all three in one Premium v3 plan may look efficient. During month-end reporting, the report generator saturates CPU and the catalog slows down. The correct fix is not only "add more workers." It may be to isolate the report generator into its own plan so its background load cannot steal capacity from the customer-facing API.
-
-## Web App Provisioning (one azurerm Terraform + one Bicep snippet)
-
-Provision the plan and app as code. The operator goal is reviewability. You want the plan tier, worker count, runtime, identity, HTTPS setting, health check path, app settings, and diagnostics to be visible before deployment. This section uses a Linux Web App because Linux is common for modern runtimes and containers.
-
-### Terraform: App Service Plan + Linux Web App
-
-This example intentionally stays compact. It shows the production decisions an operator should review before adding domain binding, diagnostics, slots, and private networking.
-
-```hcl
-resource "azurerm_resource_group" "rg" {
-  name     = "rg-appsvc-prod-eus"
-  location = "eastus"
-}
-
-resource "azurerm_service_plan" "web" {
-  name                = "asp-orders-prod-eus"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
-  os_type             = "Linux"
-  sku_name            = "P1v3"
-  worker_count        = 2
-}
-
-resource "azurerm_linux_web_app" "orders" {
-  name                = "app-orders-prod-eus"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
-  service_plan_id     = azurerm_service_plan.web.id
-  https_only          = true
-
-  identity {
-    type = "SystemAssigned"
-  }
-
-  site_config {
-    always_on         = true
-    health_check_path = "/healthz"
-
-    application_stack {
-      node_version = "20-lts"
-    }
-  }
-
-  app_settings = {
-    "APP_ENV"                         = "production"
-    "WEBSITE_HEALTHCHECK_MAXPINGFAILURES" = "3"
-    "SCM_DO_BUILD_DURING_DEPLOYMENT"  = "true"
-  }
-}
-```
-
-Why these choices? `P1v3` is not a universal default, but it is a realistic production starting point for a serious app. Two workers avoid making one worker the only serving instance. `always_on` reduces idle cold-start behavior. The health check path gives App Service a real readiness signal instead of assuming the root path means the app is healthy. The system-assigned identity removes the need for application credentials when calling Key Vault, Storage, or SQL.
-
-### Bicep: Same Shape, Native Azure Resource Model
+Provisioning should make the operator decisions reviewable: plan tier, worker count, runtime, identity, HTTPS, health check, app settings, diagnostics, network integration, and slot behavior should be visible in code before the release. This Bicep skeleton keeps the app, plan, identity, and key runtime settings together, using resource types from the Microsoft.Web provider and operational settings documented in the App Service plan, managed identity, and app-setting references. [Hosting plans](https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans), [managed identity](https://learn.microsoft.com/en-us/azure/app-service/overview-managed-identity), and [app settings](https://learn.microsoft.com/en-us/azure/app-service/reference-app-settings) explain the underlying resources.
 
 ```bicep
 param location string = resourceGroup().location
 param appName string = 'app-orders-prod-eus'
 param planName string = 'asp-orders-prod-eus'
+param logAnalyticsWorkspaceId string
 
 resource plan 'Microsoft.Web/serverfarms@2023-12-01' = {
   name: planName
@@ -232,96 +121,76 @@ resource app 'Microsoft.Web/sites@2023-12-01' = {
       healthCheckPath: '/healthz'
       linuxFxVersion: 'NODE|20-lts'
       appSettings: [
-        {
-          name: 'APP_ENV'
-          value: 'production'
-        }
-        {
-          name: 'WEBSITE_HEALTHCHECK_MAXPINGFAILURES'
-          value: '3'
-        }
-        {
-          name: 'SCM_DO_BUILD_DURING_DEPLOYMENT'
-          value: 'true'
-        }
+        { name: 'APP_ENV'; value: 'production' }
+        { name: 'WEBSITE_HEALTHCHECK_MAXPINGFAILURES'; value: '3' }
+        { name: 'SCM_DO_BUILD_DURING_DEPLOYMENT'; value: 'true' }
+        { name: 'WEBSITE_SWAP_WARMUP_PING_PATH'; value: '/healthz/ready' }
+        { name: 'WEBSITE_SWAP_WARMUP_PING_STATUSES'; value: '200,202' }
       ]
     }
   }
 }
+
+resource logs 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: 'send-appservice-logs'
+  scope: app
+  properties: {
+    workspaceId: logAnalyticsWorkspaceId
+    logs: [
+      { category: 'AppServiceHTTPLogs'; enabled: true }
+      { category: 'AppServiceConsoleLogs'; enabled: true }
+    ]
+  }
+}
 ```
 
-The important part is that the app, plan, and identity are described together. If a pull request changes `capacity`, `sku`, `alwaysOn`, runtime, or health check behavior, the reviewer can see the operational impact before the release.
+After deployment, the first check is not whether the app page loads once. Confirm that the plan instance count, runtime, identity, diagnostic settings, and health endpoint match the intended operating model. The Azure CLI gives a repeatable review surface and avoids relying on portal screenshots. [Diagnostic settings for App Service](https://learn.microsoft.com/en-us/azure/app-service/tutorial-troubleshoot-monitor) show the `AppServiceHTTPLogs` and `AppServiceConsoleLogs` categories used here, and [App Service diagnostics](https://learn.microsoft.com/en-us/azure/app-service/overview-diagnostics) explains the built-in troubleshooting surface.
 
-### Provisioning Review Checklist
+```bash
+az appservice plan show -g rg-appsvc-prod-eus -n asp-orders-prod-eus \
+  --query '{sku:sku.name, tier:sku.tier, workers:sku.capacity, kind:kind}' -o table
 
-Before applying an App Service change, review:
+az webapp show -g rg-appsvc-prod-eus -n app-orders-prod-eus \
+  --query '{httpsOnly:httpsOnly, state:state, hostNames:enabledHostNames}' -o json
 
-- plan tier and worker count;
-- whether the plan is shared with other apps;
-- runtime and OS;
-- custom container image source if used;
-- `always_on` or `alwaysOn`;
-- health check path;
-- managed identity type;
-- app settings and slot settings;
-- VNet integration and private endpoint requirements;
-- diagnostic settings;
-- slot creation and swap plan;
-- rollback owner.
+az webapp identity show -g rg-appsvc-prod-eus -n app-orders-prod-eus \
+  --query '{principalId:principalId, tenantId:tenantId, type:type}' -o json
 
-## Deployment Slots + Slot Swap (concrete worked example: green→blue swap; config sync gotchas; pre-warming)
-
-Deployment slots are separate deployment targets for the same Web App. Each slot has its own hostname. Each slot can have its own app settings, connection strings, identity behavior, and deployed code. Slots run on the same App Service Plan as the production slot, so they consume the same plan capacity. That shared capacity is a feature and a cost. It means a staging slot can behave like production because it runs on the same worker class. It also means a staging load test can harm production if the plan is undersized.
-
-### Why Slots Matter
-
-Without slots, deployment rollback usually means redeploying an older artifact. That can be slow, brittle, and hard to perform during an incident. With slots, a release can follow this sequence:
-
-1. Deploy version N+1 to a non-production slot.
-2. Warm the slot.
-3. Validate health checks and smoke tests.
-4. Swap the warmed slot into production.
-5. Keep the previous production version in the old slot for rollback.
-
-This is why slots are the killer App Service feature. The rollback can be another swap, not a rebuild.
-
-### Worked Example: Green to Blue Swap
-
-Assume the production slot currently serves the blue version. The `green` slot will receive the new release. The intended flow is:
-
-```text
-before release:
-  production slot -> blue code -> users
-  green slot      -> old or empty code -> no users
-
-after deploy:
-  production slot -> blue code -> users
-  green slot      -> green code -> validation
-
-after swap:
-  production slot -> green code -> users
-  green slot      -> blue code -> rollback target
+az monitor diagnostic-settings list \
+  --resource "$(az webapp show -g rg-appsvc-prod-eus -n app-orders-prod-eus --query id -o tsv)" \
+  -o table
 ```
 
-Create a slot:
+## Deployment Slots and Swap Safety
+
+Deployment slots are separate deployment targets for the same app, with their own hostnames, configuration surface, and deployed content, but they run on the same App Service Plan workers as production. That means a staging slot can be realistic, but it also means a staging load test can consume production plan capacity. The slot guide documents validation before swap, warm-up of all slot instances, slot-specific settings, swap with preview, auto swap, and troubleshooting, while the plan guide documents that slots share the plan's VM instances. [Deployment slots](https://learn.microsoft.com/en-us/azure/app-service/deploy-staging-slots) and [hosting-plan slot sharing](https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans#considerations-for-running-and-scaling-an-app) should be read together.
+
+```mermaid
+stateDiagram-v2
+    [*] --> BlueServing: production slot serves version N
+    BlueServing --> DeployGreen: deploy version N+1 to green slot
+    DeployGreen --> WarmGreen: App Service warms source slot instances
+    WarmGreen --> ValidateGreen: smoke tests hit green hostname
+    ValidateGreen --> SwapPreview: optional swap with preview applies production config
+    ValidateGreen --> SwapNow: normal swap
+    SwapPreview --> SwapNow: complete swap after validation
+    SwapNow --> GreenServing: production slot serves version N+1
+    GreenServing --> RollbackSwap: rollback criteria violated
+    RollbackSwap --> BlueServing: swap green and production again
+    GreenServing --> [*]: release accepted
+```
+
+The safe runbook is to deploy the new artifact to `green`, warm it through a readiness endpoint, smoke-test the slot hostname, verify sticky settings, swap into production, and keep the old production build in `green` until the release is accepted. The rollback command is the same swap command because the old production code now lives in the nonproduction slot. This is why the release primitive is stronger than "redeploy the old package under stress." [The slot swap workflow](https://learn.microsoft.com/en-us/azure/app-service/deploy-staging-slots) is explicit about validating a nonproduction slot before swapping it into production.
 
 ```bash
 az webapp deployment slot create \
   --resource-group rg-appsvc-prod-eus \
   --name app-orders-prod-eus \
   --slot green
-```
 
-Deploy the new artifact to the `green` slot using your normal deployment system. For example, GitHub Actions, Azure DevOps, Zip Deploy, container image update, or an IaC-driven release. Then validate the slot hostname:
-
-```bash
-curl -fsS https://app-orders-prod-eus-green.azurewebsites.net/healthz
+curl -fsS https://app-orders-prod-eus-green.azurewebsites.net/healthz/ready
 curl -fsS https://app-orders-prod-eus-green.azurewebsites.net/version
-```
 
-Swap the slot into production:
-
-```bash
 az webapp deployment slot swap \
   --resource-group rg-appsvc-prod-eus \
   --name app-orders-prod-eus \
@@ -329,172 +198,32 @@ az webapp deployment slot swap \
   --target-slot production
 ```
 
-If the release fails after swap, swap back:
+Slot stickiness is the configuration trap. An app setting or connection string that is marked as a deployment-slot setting stays with the slot during swap; a setting that is not marked as slot-specific swaps with the content. Production database connection strings, Key Vault references, OAuth redirect settings, public callback URLs, and telemetry endpoints often need to stay attached to the production slot, while release-specific feature flags may intentionally move with the release. Microsoft documents the CLI form through `az webapp config appsettings set --slot-settings` and the equivalent connection-string command. [Slot-specific settings](https://learn.microsoft.com/en-us/azure/app-service/deploy-staging-slots#make-an-app-setting-unswappable) are not optional release hygiene.
+
+| Setting class | Swap behavior you usually want | Operator reason | Review command or artifact |
+|---|---|---|---|
+| Production database connection string | Sticky to production slot | Prevent production code from writing to staging data after swap | `az webapp config connection-string list --slot production` |
+| Key Vault reference for environment secret | Sticky per environment | Keep prod slot on prod vault and staging slot on staging vault | `az webapp config appsettings list --slot green` |
+| Telemetry connection string | Usually sticky | Keep release evidence in the right workspace or App Insights resource | Diagnostic setting plus app setting review |
+| OAuth redirect URI or callback base URL | Usually sticky | External identity providers and webhooks often bind to hostnames | Identity provider config and app setting review |
+| Feature flag for new code path | Usually swappable | The flag belongs to the release if rollback should disable the same code path | Release manifest or feature-flag system |
+| `WEBSITE_SWAP_WARMUP_PING_PATH` | Sticky or globally identical | Warm-up must reflect the slot's real readiness contract | App-setting definition in IaC |
+
+Warm-up needs a real readiness endpoint. App Service supports `WEBSITE_SWAP_WARMUP_PING_PATH`, and `WEBSITE_SWAP_WARMUP_PING_STATUSES` can stop the warm-up and swap if the response code is not in the allowed list. A shallow `/` check can return before caches, dependency connections, or container initialization are ready, so the readiness path should prove that the app can serve core traffic without doing destructive work. [The app-setting reference](https://learn.microsoft.com/en-us/azure/app-service/reference-app-settings) documents these swap warm-up settings, and [the slot guide](https://learn.microsoft.com/en-us/azure/app-service/deploy-staging-slots) explains how warm-up fits the swap operation.
+
+Auto swap belongs only in low-risk continuous deployment flows where pre-swap validation is not required, and it is not supported for Linux web apps or Web App for Containers. Swap with preview belongs in higher-risk releases because it applies destination settings to the source slot before completing the swap, letting you validate the would-be production configuration before traffic moves. A disciplined operator chooses normal swap, swap with preview, or no swap based on configuration risk, not on habit. [Auto swap and swap troubleshooting](https://learn.microsoft.com/en-us/azure/app-service/deploy-staging-slots#configure-auto-swap) define those caveats.
+
+## Managed Identity and Secretless Dependencies
+
+Managed identity gives the app an Entra ID identity that can request tokens for Azure services without storing client secrets in app settings. A system-assigned identity is enabled on the app or slot and is removed when that resource is removed; a user-assigned identity is its own Azure resource and can be attached to apps or slots when identity lifecycle must outlive a single app or when a deployment needs a stable principal before the app exists. Microsoft documents both identity types, the permissions needed to create and assign them, and the local token endpoint exposed through `IDENTITY_ENDPOINT` and `IDENTITY_HEADER`. [Managed identities for App Service](https://learn.microsoft.com/en-us/azure/app-service/overview-managed-identity) is the primary source.
 
 ```bash
-az webapp deployment slot swap \
-  --resource-group rg-appsvc-prod-eus \
-  --name app-orders-prod-eus \
-  --slot green \
-  --target-slot production
-```
-
-The command looks the same because the slot now contains the previous production code. The rollback operation swaps the old code back into production.
-
-### Swap with Preview
-
-For high-risk changes, use a two-phase swap with preview. The preview phase applies destination slot settings to the source slot before completing the swap. That lets you validate the source slot under the configuration it will have after swap. The decision point is simple:
-
-- use a normal swap for routine releases with low configuration risk;
-- use swap with preview when configuration and warm-up behavior are the main risk;
-- do not use slots as a substitute for real staging environments when external dependencies differ.
-
-### Pre-Warming
-
-Warm-up is not cosmetic. Many frameworks load dependencies, compile views, open connection pools, initialize caches, or perform migrations on first request. If the first real user request pays that cost, the swap looks successful but the user experience fails. Use a dedicated warm-up path. Set:
-
-```text
-WEBSITE_SWAP_WARMUP_PING_PATH=/healthz/ready
-WEBSITE_SWAP_WARMUP_PING_STATUSES=200,202
-```
-
-The warm-up path should exercise the parts of the app that must be ready to accept traffic. It should not perform destructive work. It should not depend on optional downstream systems that can be degraded while the app still serves a useful response.
-
-### Slot Setting Gotchas
-
-Some settings should move with code. Some settings should stay with the slot. Production database connection strings, production Key Vault references, monitoring connection strings, and public callback URLs often need to stay attached to the production slot. Feature flags, runtime settings, and version-specific toggles may need to move with the release. This is the configuration-sync problem. App Service lets you mark app settings and connection strings as slot settings. A slot setting stays with the slot during swap. A non-slot setting swaps with the code. That sentence is worth repeating: **Sticky settings stay with the slot; non-sticky settings move with the release.** The operational danger is that teams often set this once in the portal and forget it. Review slot stickiness in code or in a release checklist.
-
-### Settings That Deserve Extra Review
-
-Review these before every slot-based release:
-
-- database connection strings;
-- Key Vault reference settings;
-- storage account names and queues;
-- `APP_ENV` or environment-name flags;
-- telemetry connection strings;
-- external callback URLs;
-- payment provider keys;
-- OAuth redirect URIs;
-- `WEBSITE_SWAP_WARMUP_PING_PATH`;
-- framework environment variables such as `ASPNETCORE_ENVIRONMENT` or `NODE_ENV`.
-
-> **Pause and predict:** If the staging slot points to a staging database, and that connection string is not marked as a slot setting, what database might production use immediately after the swap?
-
-### Slot Runbook
-
-A usable slot runbook includes:
-
-1. Confirm the slot exists and is not serving production traffic.
-2. Deploy the release artifact to the slot.
-3. Confirm the slot has the expected code version.
-4. Confirm slot settings and connection strings.
-5. Warm the slot through the configured warm-up path.
-6. Run smoke tests against the slot hostname.
-7. Swap into production.
-8. Query production logs and metrics for errors and latency.
-9. Keep the previous production version in the old slot until the release is accepted.
-10. Swap back if the release violates rollback criteria.
-
-## Networking: Hybrid Connections vs VNet Integration vs Private Endpoint (decision table + when each)
-
-App Service networking is easier when you separate inbound and outbound paths. Inbound means clients reaching your app. Outbound means your app reaching dependencies. Hybrid Connections and VNet integration are outbound features. Private Endpoint is an inbound feature. Many production designs use both VNet integration and Private Endpoint.
-
-### Three Patterns
-
-| Pattern | Direction | What it solves | Best fit | What it does not solve |
-|---|---|---|---|---|
-| Hybrid Connections | Outbound from app to one TCP host:port | Reach a specific private or on-prem endpoint without full VNet integration | Quick access to one legacy dependency | It does not make the app private for inbound traffic; no UDP; no dynamic ports. |
-| VNet Integration | Outbound from app into a VNet | Reach private Azure resources, private DNS, peered networks, VPN, or ExpressRoute paths | Apps that need many private dependencies | It does not provide private inbound access to the app. |
-| Private Endpoint | Inbound from a VNet to the app | Let private clients reach the app over Private Link | Private apps, app-to-app private ingress, internal APIs | It does not route outbound app traffic into the VNet. |
-
-### Hybrid Connections
-
-Hybrid Connections are pragmatic. They let App Service reach a single TCP endpoint through Azure Relay and a Hybrid Connection Manager running where the endpoint is reachable. The App Service app and the on-prem relay agent both make outbound connections to Azure. That is why the pattern is attractive in locked-down networks. Use Hybrid Connections when:
-
-- one or two legacy TCP dependencies are needed;
-- the target is identified by host and port;
-- the network team will not approve full VPN or ExpressRoute work yet;
-- the app needs a bridge while a migration is in progress.
-
-Avoid Hybrid Connections when:
-
-- the app needs many dependencies;
-- the dependency uses UDP or dynamic ports;
-- DNS and private routing are central to the design;
-- the connection needs to look like normal VNet traffic;
-- you need inbound private access to the app.
-
-Worked example: an App Service app needs to call an on-prem license server at `license01.corp.example:443`. Hybrid Connection can be a low-friction bridge because the target is one TCP endpoint. It would be a poor fit for a whole estate of databases, file shares, LDAP, and service discovery.
-
-### VNet Integration
-
-VNet integration lets the app send outbound traffic into a delegated subnet. Use it when the app needs to call private Azure services, databases, internal APIs, or on-prem resources reachable through VPN or ExpressRoute. VNet integration is commonly paired with:
-
-- private DNS zones;
-- private endpoints for downstream services;
-- route tables;
-- NAT Gateway for controlled outbound IP;
-- network security review;
-- Azure Firewall or NVA egress patterns.
-
-VNet integration does not put the app itself inside your VNet for inbound traffic. That distinction prevents a common incident. An operator enables VNet integration and expects internal clients to reach the app privately. Nothing changes for inbound access because VNet integration is outbound. Private Endpoint is the inbound private access pattern.
-
-### Private Endpoint
-
-Private Endpoint gives the app a private IP address in a VNet through Azure Private Link. Clients inside the VNet, peered VNets, or connected on-prem networks can reach the app privately. Public network access can then be restricted or disabled depending on the design. Use Private Endpoint when:
-
-- the app is an internal API;
-- public exposure is not acceptable;
-- traffic should stay on private Azure networking;
-- Application Gateway or another private client should reach the app;
-- DNS can be managed correctly.
-
-Private Endpoint requires DNS discipline. The app's public hostname must resolve to the private endpoint IP from private clients. If DNS is wrong, clients may still resolve the public path and the incident will look like an application failure.
-
-### Combining Patterns
-
-A common production pattern:
-
-```text
-client in VNet
-  -> private DNS
-  -> App Service Private Endpoint
-  -> Web App
-  -> VNet Integration subnet
-  -> private endpoint for SQL / Storage / Key Vault
-```
-
-Inbound to the app uses Private Endpoint. Outbound from the app uses VNet integration. Private DNS ties the names to private addresses.
-
-### Decision Rules
-
-| Requirement | Pick first | Rationale |
-|---|---|---|
-| App must call one on-prem TCP service quickly | Hybrid Connection | It avoids full network integration for one host:port. |
-| App must call many private Azure services | VNet Integration | Outbound private routing and DNS become the main need. |
-| App must be reachable only from private networks | Private Endpoint | Inbound exposure is the main need. |
-| App-to-app private call between two Web Apps | Private Endpoint plus VNet Integration | The caller needs outbound private routing; the callee needs private inbound access. |
-| Internal App Gateway fronts App Service | Private Endpoint or documented App Gateway integration pattern | The gateway needs a private path to the app. |
-| Legacy dependency uses dynamic ports | Not Hybrid Connection | Hybrid Connections map to TCP host:port, not whole network protocols. |
-
-## Managed Identity for Backend Services (Key Vault secret rotation, Storage role assignment, SQL token auth)
-
-Managed identity gives an App Service app an Entra ID identity. The app can use that identity to request tokens for Azure services. That removes stored credentials from application settings. It also gives operators a normal RBAC and audit story. There are two types:
-
-- system-assigned identity, created with the app and deleted with the app;
-- user-assigned identity, created as its own resource and attached to one or more apps.
-
-System-assigned identity is simpler for one app. User-assigned identity is useful when identity lifecycle must outlive the app, several slots or apps need the same identity, or deployment ordering is easier with a stable principal.
-
-### Key Vault: Secret References and Rotation
-
-App Service can use Key Vault references in app settings. The app setting value points to a Key Vault secret instead of storing the secret directly. Example:
-
-```bash
-az webapp identity assign \
-  --resource-group rg-appsvc-prod-eus \
-  --name app-orders-prod-eus
+APP_PRINCIPAL_ID=$(
+  az webapp identity assign \
+    --resource-group rg-appsvc-prod-eus \
+    --name app-orders-prod-eus \
+    --query principalId -o tsv
+)
 
 az role assignment create \
   --assignee "$APP_PRINCIPAL_ID" \
@@ -504,597 +233,266 @@ az role assignment create \
 az webapp config appsettings set \
   --resource-group rg-appsvc-prod-eus \
   --name app-orders-prod-eus \
+  --slot-settings OrdersDbPassword \
   --settings "OrdersDbPassword=@Microsoft.KeyVault(SecretUri=https://kv-orders-prod.vault.azure.net/secrets/orders-db-password/)"
 ```
 
-Why this shape? The app setting name stays stable. The secret value rotates in Key Vault. The managed identity authorizes access. The application does not need a client secret to read the secret. Prefer versionless secret URIs when normal rotation should be picked up automatically. Use versioned secret URIs only when pinning is deliberate. Operational note: Key Vault references are convenient, but they are still secrets. If a downstream service supports Entra authentication directly, prefer token auth over a password stored in Key Vault.
+Key Vault references are useful when the application still needs a secret value, because an app setting can contain an `@Microsoft.KeyVault(...)` reference and the application reads it like any other setting. The reference uses the system-assigned identity by default, can be configured to use a user-assigned identity, and automatically picks up a newer version within 24 hours when the secret URI is versionless; a configuration change restarts the app and forces an immediate refetch. Microsoft also recommends marking most Key Vault references as slot settings because environments usually have separate vaults. [Key Vault references](https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references) document these behaviors and failure modes.
 
-### Storage: Role Assignment Instead of Account Keys
+Prefer direct Entra authentication when the downstream service supports it. For Azure SQL, the app identity must exist, the SQL server needs an Entra administrator, and the database must create a user for the identity and grant only the required roles. For Blob Storage, Azure RBAC data roles such as Storage Blob Data Contributor or Storage Blob Data Reader authorize data-plane access, and the role scope should be the narrowest useful container, account, resource group, or subscription scope. [App Service to Azure SQL with managed identity](https://learn.microsoft.com/en-us/azure/app-service/tutorial-connect-msi-sql-database) and [Blob access with Microsoft Entra ID](https://learn.microsoft.com/en-us/azure/storage/blobs/authorize-access-azure-active-directory) are the operator references.
 
-Storage account keys are broad secrets. Managed identity plus Azure RBAC is usually safer. For blob access:
+Identity incidents are usually grant-chain failures, not platform mysteries. Confirm the slot has the expected identity, confirm the app is requesting the right resource and the right user-assigned identity client ID when applicable, confirm the target resource has an RBAC role or access policy at the correct scope, wait for role propagation where documented, and verify that private networking is not blocking the dependency call. Key Vault reference diagnostics explicitly mention unresolved references caused by permissions, missing secrets, syntax, or network restrictions, and Blob RBAC documentation warns that role assignments can take time to propagate. [Key Vault reference troubleshooting](https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references#troubleshoot-key-vault-references) and [Storage RBAC propagation notes](https://learn.microsoft.com/en-us/azure/storage/blobs/authorize-access-azure-active-directory#assign-azure-roles-for-access-rights) keep the debug path concrete.
 
-```bash
-az role assignment create \
-  --assignee "$APP_PRINCIPAL_ID" \
-  --role "Storage Blob Data Contributor" \
-  --scope "$STORAGE_ACCOUNT_ID"
+## Networking: Inbound and Outbound Are Separate
+
+An App Service networking design must draw two paths. Inbound traffic is how clients reach the app; outbound traffic is how the app reaches dependencies. Private Endpoint is the usual private inbound pattern for multitenant App Service, access restrictions are front-end allow/deny rules for the public endpoint, VNet Integration sends outbound app traffic into a delegated subnet, and Hybrid Connections bridge outbound calls to a single TCP host and port through Azure Relay. Microsoft documents that VNet Integration is outbound only and that access restrictions or Private Endpoint control inbound access. [VNet Integration](https://learn.microsoft.com/en-us/azure/app-service/overview-vnet-integration), [Private Endpoint](https://learn.microsoft.com/en-us/azure/app-service/overview-private-endpoint), [access restrictions](https://learn.microsoft.com/en-us/azure/app-service/app-service-ip-restrictions), and [Hybrid Connections](https://learn.microsoft.com/en-us/azure/app-service/app-service-hybrid-connections) define the boundaries.
+
+```mermaid
+flowchart LR
+    Internet[Public clients] --> FrontEnd[App Service front ends]
+    FrontEnd --> Workers[App Service workers]
+    PrivateClient[Hub VNet or on-prem client] --> PrivateDNS[Private DNS zone]
+    PrivateDNS --> PE[Private Endpoint for app]
+    PE --> Workers
+    Workers -->|outbound through VNet Integration| IntSubnet[Delegated integration subnet]
+    IntSubnet --> SQLPE[Private endpoint: Azure SQL]
+    IntSubnet --> KVPE[Private endpoint: Key Vault]
+    IntSubnet --> StoragePE[Private endpoint: Storage]
+    Workers -->|Hybrid Connection| Relay[Azure Relay]
+    Relay --> OnPrem[On-prem TCP host:port]
 ```
 
-Then app code uses the Azure Identity SDK. For example, a Python app can use `DefaultAzureCredential`. Local developers authenticate with Azure CLI or developer credentials. The deployed app authenticates with managed identity. The code path stays similar. The operator decision is the scope. Assign at the smallest useful scope:
+| Requirement | First feature to evaluate | What it solves | What it does not solve |
+|---|---|---|---|
+| Public app should allow only Front Door or known corporate IPs | Access restrictions | Priority-ordered allow/deny rules at App Service front ends, including IP ranges and service tags | It does not move the app into a VNet |
+| Internal clients must reach the app privately | Private Endpoint | Private inbound access to the app through a VNet and private DNS | It does not route outbound calls to private dependencies |
+| App must call private Azure resources or on-prem networks | VNet Integration | Outbound calls from workers into a delegated subnet, peered VNets, Private Endpoints, VPN, or ExpressRoute paths | It does not make inbound access private |
+| App must reach one legacy host and port quickly | Hybrid Connection | Outbound TCP access to one host:port through Azure Relay and Hybrid Connection Manager | It does not support UDP, dynamic ports, or inbound access |
+| ASE-level single-tenant network isolation is required | App Service Environment v3 | Dedicated App Service environment deployed into a VNet with Isolated v2 plans | It is a platform and cost commitment, not a fix for one private app |
 
-- container scope when one app writes one container;
-- storage account scope when the app legitimately uses many containers;
-- resource group scope only when ownership is broad and documented.
+VNet Integration needs subnet planning. The feature requires a dedicated subnet, consumes addresses per plan instance, temporarily doubles address use during some scale operations, and Microsoft recommends enough address space for planned maximum scale plus platform operations. It can route private-only or all outbound traffic depending on routing configuration, and NSGs or route tables on the integration subnet apply only to traffic routed through the integration. If Key Vault, Storage, SQL, or image pulls use private endpoints, DNS must resolve those names to private endpoint addresses from the app's VNet path. [Subnet requirements and routing](https://learn.microsoft.com/en-us/azure/app-service/overview-vnet-integration#subnet-requirements) and [private endpoint DNS behavior for outbound calls](https://learn.microsoft.com/en-us/azure/app-service/overview-vnet-integration#private-endpoints) are the design guardrails.
 
-### SQL: Token Auth Instead of Password Auth
+Private Endpoint is configured per app slot, and a slot cannot share another slot's private endpoint. The official documentation states that each slot is configured separately, up to 100 private endpoints can be used per slot, and the private endpoint subnet cannot be the same subnet used for VNet Integration. That matters during release design: if a staging slot must be tested privately, it needs its own private endpoint and DNS story. [Private Endpoint for App Service](https://learn.microsoft.com/en-us/azure/app-service/overview-private-endpoint) and [VNet Integration subnet limitations](https://learn.microsoft.com/en-us/azure/app-service/overview-vnet-integration#limitations) make this a review item.
 
-Azure SQL can use Microsoft Entra authentication. For .NET applications, connection strings can use managed identity authentication. Example shape:
+Access restrictions are still useful even when Private Endpoint is planned. They provide priority-ordered allow and deny rules, support IP ranges, service tags, and selected VNet subnets through service endpoints, and can be applied separately to the SCM/Kudu site. If any allow or deny entries exist, an implicit deny exists at the end unless the unmatched rule action is changed. The service returns HTTP 403 when the source is not allowed, so a sudden 403 after a network change should send the operator to the access-restriction list before blaming application auth. [Access restrictions](https://learn.microsoft.com/en-us/azure/app-service/app-service-ip-restrictions) document the rule order, 512-rule limit, service tags, and SCM-site restrictions.
 
-```text
-Server=tcp:sql-orders-prod.database.windows.net,1433;
-Database=orders;
-Authentication=Active Directory Managed Identity;
-Encrypt=True;
-TrustServerCertificate=False;
-```
+## Autoscale Without Creating a Dependency Outage
 
-For a user-assigned identity, include the client ID when the driver requires it. The database must also know the identity. That normally means an Entra admin is configured for the SQL server and a database user is created for the managed identity. Then grant only the required database permissions. Do not grant `db_owner` because the app needed to read one table during a deployment crunch.
+App Service has manual scale, Azure Monitor autoscale, and a newer automatic scaling feature for supported Premium v2-v4 plans. Manual scale is Basic and up; Azure Monitor autoscale is Standard and up and uses metric or schedule rules at the plan level; automatic scaling is different because App Service handles HTTP-traffic-based scaling decisions and exposes always-ready, prewarmed, per-app limit, and burst controls. Microsoft explicitly says only one scaling method should be active for an App Service plan. [Automatic scaling](https://learn.microsoft.com/en-us/azure/app-service/manage-automatic-scaling) and [Azure Monitor autoscale](https://learn.microsoft.com/en-us/azure/azure-monitor/autoscale/autoscale-overview) define the difference.
 
-### Identity Debugging Checklist
+Azure Monitor autoscale is the usual regulated-production pattern because it has explicit profiles, default/minimum/maximum instance bounds, metric rules, schedule rules, cooldowns, and notifications. Autoscale can add resources when load increases and reduce them when load is low, and the rule engine scales out if any scale-out rule is met but scales in only if all scale-in rules are met. That OR-for-out, AND-for-in behavior prevents one quiet metric from shrinking the plan while another metric still shows pressure. [Autoscale rules and settings](https://learn.microsoft.com/en-us/azure/azure-monitor/autoscale/autoscale-overview#rules) are worth citing in design reviews.
 
-When managed identity access fails:
+| Rule type | Example | Operator use | Failure mode |
+|---|---|---|---|
+| Metric scale-out | CPU above 70% for 10 minutes, memory above 75%, or HTTP queue length above baseline | Add workers when sustained plan pressure is likely capacity-related | More workers can increase SQL, Storage, or downstream API pressure |
+| Metric scale-in | CPU below 35% and queue length low for 30 minutes | Remove idle workers slowly after demand falls | Fast scale-in can cause oscillation and cold workers |
+| Schedule | Weekdays 07:30 set min to 4; weekdays 19:00 set min to 2 | Prewarm for predictable business traffic before users arrive | Schedules drift from real traffic if never reviewed |
+| Maximum bound | Cap at 10 workers for a Standard plan or lower if downstreams cannot handle more | Limits cost and blast radius during runaway traffic | If max is too low, HTTP queue grows and users see latency |
+| Notification | Email, webhook, automation runbook, or Logic App action | Makes scale events visible during incidents | Silent scale events hide cost spikes and dependency saturation |
 
-1. Confirm the app or slot has the expected identity enabled.
-2. Confirm the target resource has a role assignment or access policy for that identity.
-3. Confirm the scope is correct.
-4. Confirm the application requests a token for the right resource.
-5. Confirm private networking is not blocking the target call.
-6. Remember that authorization changes can take time to propagate.
-7. Query application logs for the actual token or authorization error class, not just the HTTP status.
+The autoscale design must include dependency capacity. If the database is saturating, scaling the web tier can make the outage worse by increasing concurrent database calls. If Key Vault, Storage, or a private API is the bottleneck, more workers may only amplify retries. Use scale-out rules to address worker saturation, and use dashboards to detect when the bottleneck moved downstream. Azure Monitor supports metrics, Log Analytics, metric alerts, log alerts, and Application Insights telemetry, so the scale decision should be visible in the same evidence surface used for incident response. [Monitor App Service](https://learn.microsoft.com/en-us/azure/app-service/monitor-app-service) and [Azure Monitor autoscale actions](https://learn.microsoft.com/en-us/azure/azure-monitor/autoscale/autoscale-overview#actions-and-automation) support that pattern.
 
-> **Stop and think:** If a Web App receives `403` from Key Vault, is the first hypothesis "Key Vault is down" or "the app identity lacks permission or is using the wrong vault URI"? What evidence would distinguish those?
+## Diagnostics and Evidence
 
-## Autoscaling (per-plan rules; CPU/memory/HTTP queue; schedule-based; cool-down)
+App Service diagnostics are layered. App Service logs can capture application logs, web server logs, detailed errors, failed request traces, and deployment logs, with filesystem logging intended for temporary debugging in some cases and blob or Azure Monitor routing used for longer retention. Diagnostic settings can route `AppServiceHTTPLogs` and `AppServiceConsoleLogs` to Log Analytics, while Application Insights adds application exceptions, dependency telemetry, distributed traces, and application-level correlation. [Diagnostic logs](https://learn.microsoft.com/en-us/azure/app-service/troubleshoot-diagnostic-logs), [Azure Monitor troubleshooting](https://learn.microsoft.com/en-us/azure/app-service/tutorial-troubleshoot-monitor), and [Monitor App Service](https://learn.microsoft.com/en-us/azure/app-service/monitor-app-service) define the data paths.
 
-Autoscaling happens at the App Service Plan boundary. That means every app in the plan is affected. Before writing rules, list the apps in the plan and decide whether they should scale together. If not, separate them first.
-
-### Scale Rule Types
-
-Use three kinds of rules:
-
-- metric-based rules for real load;
-- schedule-based rules for predictable load;
-- manual scale changes for planned events and incident response.
-
-Common metric signals:
-
-- CPU percentage;
-- memory percentage;
-- HTTP queue length;
-- request count;
-- average response time;
-- HTTP 5xx count.
-
-CPU and memory rules are easy to understand. They are also blunt. HTTP queue length is often a better signal that requests are waiting for worker capacity. Response time and 5xx signals are user closer, but they may indicate application failures rather than capacity needs.
-
-### Example Autoscale Shape
-
-For a production API:
-
-| Rule | Direction | Why |
-|---|---|---|
-| CPU > 70% for 10 minutes | Scale out by 1 | Sustained CPU pressure suggests more workers may help. |
-| Memory > 75% for 10 minutes | Scale out by 1 | Memory pressure can cause GC churn, restarts, or slow requests. |
-| HTTP queue length > 100 for 5 minutes | Scale out by 2 | Waiting requests are a direct capacity symptom. |
-| CPU < 35% for 30 minutes and queue length low | Scale in by 1 | Avoid paying for idle workers after traffic falls. |
-| Weekdays 07:30 | Set minimum to 4 | Business traffic is predictable; warm capacity before users arrive. |
-| Weekdays 19:00 | Set minimum to 2 | Reduce baseline after peak hours. |
-
-### Cool-Down Matters
-
-Cool-down prevents oscillation. If a rule scales out and the metric drops immediately, scaling back in too quickly can restart the pressure cycle. Use longer scale-in cool-downs than scale-out cool-downs. A common pattern:
-
-- scale out cool-down: 5 to 10 minutes;
-- scale in cool-down: 20 to 30 minutes;
-- schedule change lead time: before traffic arrives, not after.
-
-### Per-Plan Rule Design
-
-Do not create autoscale rules in isolation from deployment slots. Slots consume plan resources. A staging slot warming up during a release can increase CPU and memory. If autoscale triggers during every release, that may be acceptable. If a staging performance test causes production cost spikes, the plan is too shared or the release process needs a dedicated test plan.
-
-### Automatic Scaling vs Azure Autoscale
-
-Azure has more than one scaling concept. App Service automatic scaling can handle some scaling decisions for supported tiers. Azure Monitor autoscale rules let you define metric and schedule-based scale behavior. The operator decision is whether you want Azure-managed scaling behavior or explicit rules that match your traffic model and change windows. For regulated production workloads, explicit rules are often easier to explain in review. For simpler workloads, automatic scaling may be enough.
-
-### Autoscale Review Checklist
-
-Before enabling autoscale:
-
-- confirm the app is stateless across workers;
-- externalize sessions if needed;
-- check downstream dependency capacity;
-- choose minimum capacity for normal traffic;
-- choose maximum capacity for cost and blast radius;
-- set alerts before max capacity is reached;
-- use cool-downs that avoid flapping;
-- load test the same runtime, slot, network path, and auth behavior used in production.
-
-Scaling out a web tier does not scale the database. If the database is the bottleneck, adding more workers can make the outage worse by increasing concurrent pressure.
-
-## Monitoring + Diagnostics (Log Analytics; ≥2 KQL queries on `AppServiceHTTPLogs` / `AppServiceConsoleLogs`; metric alerts)
-
-App Service should not go to production without diagnostics. At minimum, send HTTP logs, console logs, application logs, and relevant platform metrics to Azure Monitor and Log Analytics. Application Insights is also common for distributed tracing and application-level telemetry. The operator view needs both:
-
-- platform evidence from App Service and Azure Monitor;
-- application evidence from logs, traces, dependencies, and exceptions.
-
-### What to Enable
-
-Enable diagnostic settings for:
-
-- `AppServiceHTTPLogs`;
-- `AppServiceConsoleLogs`;
-- application logs where supported;
-- audit or platform logs relevant to the app;
-- metrics on the app and App Service Plan.
-
-Use Log Analytics retention deliberately. High-volume web apps can generate large log bills. Do not solve that by disabling logs during incidents. Instead, set retention, sampling, and table plans based on incident and compliance requirements.
-
-### KQL: 5xx Trend by App and Path
+Kudu is the companion SCM site for an App Service app, exposed at `https://<app-name>.scm.azurewebsites.net` for non-Isolated apps, and it powers deployment-related features and provides access to diagnostic files. It is not a public troubleshooting toy; lock down the SCM site with access restrictions when the main app has network restrictions, because Microsoft documents separate SCM restrictions and the ability to use the main-site rules. [Kudu overview](https://learn.microsoft.com/en-us/azure/app-service/resources-kudu) and [SCM access restrictions](https://learn.microsoft.com/en-us/azure/app-service/app-service-ip-restrictions#restrict-access-to-an-scm-site) give the control surface.
 
 ```kusto
 AppServiceHTTPLogs
 | where TimeGenerated > ago(2h)
 | where ScStatus >= 500
-| summarize
-    Requests = count(),
-    ExampleClient = any(CIp),
-    P95DurationMs = percentile(TimeTaken, 95)
+| summarize Requests=count(), P95DurationMs=percentile(TimeTaken, 95)
   by bin(TimeGenerated, 5m), _ResourceId, CsMethod, CsUriStem, ScStatus
 | order by TimeGenerated desc, Requests desc
 ```
 
-Use this when the symptom is "the app is returning errors." It groups failures by method, path, and status. That helps separate one broken endpoint from an app-wide failure.
-
-### KQL: Slow Requests Before Errors
+Use the first query when the symptom is "users see 5xx." It separates one broken endpoint from app-wide failure and gives a latency signal next to the status code. App Service monitoring examples use `AppServiceHTTPLogs` for HTTP 500 analysis, and the troubleshooting tutorial shows diagnostic settings that route those logs to Log Analytics. [Monitor App Service KQL](https://learn.microsoft.com/en-us/azure/app-service/monitor-app-service#kusto-queries) and [diagnostic setting examples](https://learn.microsoft.com/en-us/azure/app-service/tutorial-troubleshoot-monitor#create-a-diagnostic-setting) are the source anchors.
 
 ```kusto
 AppServiceHTTPLogs
 | where TimeGenerated > ago(6h)
-| summarize
-    Requests = count(),
-    P50Ms = percentile(TimeTaken, 50),
-    P95Ms = percentile(TimeTaken, 95),
-    P99Ms = percentile(TimeTaken, 99),
-    Errors = countif(ScStatus >= 500)
+| summarize Requests=count(),
+            P50Ms=percentile(TimeTaken, 50),
+            P95Ms=percentile(TimeTaken, 95),
+            P99Ms=percentile(TimeTaken, 99),
+            Errors=countif(ScStatus >= 500)
   by bin(TimeGenerated, 10m), _ResourceId
 | extend ErrorRate = todouble(Errors) / todouble(Requests)
 | order by TimeGenerated desc
 ```
 
-Use this when latency increased before the outage. Many incidents begin as saturation, not immediate failure.
-
-### KQL: Console Errors After a Slot Swap
+Use the second query when latency rose before errors. Many App Service incidents are saturation stories: CPU, memory, SNAT, connection pools, dependency latency, or cold initialization increases request time before the user-visible error rate climbs. The built-in Diagnose and solve problems blade groups availability, performance, application logs, CPU, memory, TCP connections, SNAT exhaustion, and application changes into diagnostic categories, so the log query should be paired with the diagnostic blade rather than treated as the only evidence. [App Service diagnostics](https://learn.microsoft.com/en-us/azure/app-service/overview-diagnostics) documents those categories.
 
 ```kusto
 AppServiceConsoleLogs
 | where TimeGenerated > ago(1h)
-| where Level in ("Error", "Warning") or ResultDescription has_any ("Exception", "ERROR", "Traceback")
+| where Level in ("Error", "Warning")
+   or ResultDescription has_any ("Exception", "ERROR", "Traceback", "Startup")
 | project TimeGenerated, _ResourceId, Host, Level, ResultDescription
 | order by TimeGenerated desc
 ```
 
-Use this right after deployment or swap. It finds application startup errors, dependency failures, and container logs that may not appear as clean HTTP status patterns yet.
+Use the third query immediately after a deployment or slot swap. Startup errors, dependency failures, container launch issues, and framework exceptions often appear in console or application logs before a clean HTTP pattern emerges. For Linux apps and custom containers, App Service stores console output under `/home/LogFiles`, and scaled-out diagnostic dumps contain logs for each instance, which is why instance-aware log review matters after a bad release. [Diagnostic log locations](https://learn.microsoft.com/en-us/azure/app-service/troubleshoot-diagnostic-logs#access-log-files) and [Log Analytics tooling](https://learn.microsoft.com/en-us/azure/app-service/monitor-app-service#azure-monitor-tools) document the workflow.
 
-### KQL: One Client or User Agent Dominates Traffic
+## Outage Playbook
 
-```kusto
-AppServiceHTTPLogs
-| where TimeGenerated > ago(30m)
-| summarize Requests = count(), Errors = countif(ScStatus >= 500)
-  by CIp, CsUserAgent, CsUriStem
-| top 20 by Requests desc
-```
+For a 502 or 503, first decide whether the platform has no healthy worker, the app process is failing, the slot swap exposed a cold or misconfigured app, or a dependency is causing startup failure. Check current slot and code version, plan CPU and memory, HTTP queue length, instance count, app restarts, console errors, deployment logs, and dependency telemetry. If the incident started immediately after swap, compare sticky settings, warm-up path, Key Vault reference resolution, and database target before scaling the plan. [Deployment slots](https://learn.microsoft.com/en-us/azure/app-service/deploy-staging-slots), [diagnostic logs](https://learn.microsoft.com/en-us/azure/app-service/troubleshoot-diagnostic-logs), and [App Service diagnostics](https://learn.microsoft.com/en-us/azure/app-service/overview-diagnostics) map directly to this first branch.
 
-Use this when a sudden traffic spike might be one client, one crawler, or one broken retry loop.
+For a slot-swap warm-up failure, read the warm-up settings and response codes before forcing traffic. `WEBSITE_SWAP_WARMUP_PING_PATH` should point to readiness, `WEBSITE_SWAP_WARMUP_PING_STATUSES` should reject unacceptable responses, and swap with preview should be used when production configuration is the main risk. If the source slot only passes `/` but fails a dependency-aware readiness check, fix the readiness contract or the dependency path before completing the swap. [Warm-up app settings](https://learn.microsoft.com/en-us/azure/app-service/reference-app-settings) and [swap with preview](https://learn.microsoft.com/en-us/azure/app-service/deploy-staging-slots#swap-with-preview) are the runbook references.
 
-### Metric Alerts
+For an identity failure, do not stop at the HTTP status. A Key Vault reference can fail because the reference syntax is wrong, the secret no longer exists, the identity lacks `get` permission or RBAC, the app uses the wrong user-assigned identity, role assignment has not propagated, or network-restricted vault access is not routed correctly. SQL and Storage add their own grant chain: SQL needs an Entra admin and database user; Blob access needs a data-plane role such as Storage Blob Data Reader or Contributor at the correct scope. [Key Vault reference troubleshooting](https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references#troubleshoot-key-vault-references), [SQL managed identity](https://learn.microsoft.com/en-us/azure/app-service/tutorial-connect-msi-sql-database), and [Storage RBAC](https://learn.microsoft.com/en-us/azure/storage/blobs/authorize-access-azure-active-directory) keep the debug path factual.
 
-Create alerts for:
+For a networking failure, draw the path and test the name resolution. If clients cannot reach a private app, confirm Private Endpoint, private DNS, public network access, and access restrictions. If the app cannot reach SQL, Storage, or Key Vault privately, confirm VNet Integration, route-all behavior when required, integration subnet sizing, private endpoint DNS, NSGs, UDRs, and target firewalls. If the app reaches one on-prem TCP endpoint through Hybrid Connections, confirm the host:port mapping and Hybrid Connection Manager, and do not expect UDP or dynamic ports. [VNet Integration routing](https://learn.microsoft.com/en-us/azure/app-service/overview-vnet-integration#routes), [Private Endpoint](https://learn.microsoft.com/en-us/azure/app-service/overview-private-endpoint), and [Hybrid Connections](https://learn.microsoft.com/en-us/azure/app-service/app-service-hybrid-connections) separate the evidence.
 
-- App Service Plan CPU percentage sustained high;
-- App Service Plan memory percentage sustained high;
-- HTTP queue length above baseline;
-- HTTP 5xx rate above baseline;
-- average response time or p95 response time above SLO;
-- worker restarts or app restarts;
-- slot swap failure events;
-- plan instance count approaching autoscale maximum;
-- Key Vault, SQL, or Storage dependency failures from Application Insights.
+For an autoscale storm, determine whether the rule is reacting to real worker pressure or to a bad release, retry loop, crawler, dependency timeout, or staging-slot load test. Check scale actions, instance count, HTTP queue, CPU, memory, response time, request paths, dependency metrics, and downstream throttling before raising the maximum bound. Autoscale can save a saturated stateless web tier, but it can also multiply downstream concurrency and cost. [Azure Monitor autoscale](https://learn.microsoft.com/en-us/azure/azure-monitor/autoscale/autoscale-overview) and [App Service plan sharing](https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans) explain why scale events are plan events.
 
-Alert thresholds should start from a baseline. If normal CPU is 55% during peak, a 60% alert is noise. If normal HTTP queue length is zero, a small nonzero sustained queue may be meaningful.
+## Common Mistakes
 
-### Deployment Dashboard
-
-A release dashboard should show:
-
-- current slot and code version;
-- request count;
-- 4xx and 5xx;
-- latency percentiles;
-- CPU and memory;
-- HTTP queue length;
-- dependency failures;
-- console errors;
-- active instance count;
-- last swap timestamp.
-
-The goal is not to create a beautiful dashboard. The goal is to answer one question quickly: **Should we keep the release, pause, or swap back?**
-
-## App Service Environment v3 (when ASE is justified — single-tenant pattern, IL stamps, cost tradeoff)
-
-App Service Environment v3 is a single-tenant App Service deployment inside your virtual network. It is not the default App Service choice. It is the expensive isolation choice. In multitenant App Service, your App Service Plan workers are dedicated to your plan, but the surrounding platform is shared. In an App Service Environment, the environment itself is dedicated to one customer and deployed into a VNet subnet. Apps run in Isolated v2 plans.
-
-### When ASE v3 Is Justified
-
-ASE v3 is justified when one or more of these are true:
-
-- compliance requires single-tenant App Service hosting;
-- inbound and outbound network isolation must be controlled at the environment boundary;
-- the app estate needs very high scale in App Service;
-- internal line-of-business apps need an internal virtual IP pattern;
-- the organization has a platform team ready to own the ASE lifecycle;
-- dedicated host isolation is specifically required and budgeted.
-
-ASE v3 is not justified because:
-
-- someone wants "more secure" without defining a requirement;
-- a single app needs one private endpoint;
-- the app only needs outbound access to SQL;
-- the team dislikes public DNS;
-- the app could use multitenant App Service with Private Endpoint and VNet integration.
-
-### Internal Load Balancer Pattern
-
-An internal App Service Environment uses an internal VIP. Apps are reachable through private networking instead of public internet exposure. A common pattern:
-
-```text
-corporate network / peered VNet
-  -> private DNS
-  -> internal Application Gateway
-  -> internal App Service Environment app
-  -> private downstream services
-```
-
-This pattern can satisfy enterprise network controls, but it also creates more platform ownership. DNS, certificates, gateway routing, ASE subnet sizing, route tables, and diagnostics all become platform responsibilities.
-
-### Cost Tradeoff
-
-ASE is a cost and commitment decision. Even an empty ASE can have baseline cost behavior. Isolated v2 workers are priced differently from multitenant App Service workers. Dedicated host options add more cost and constraints. Before approving ASE, compare it against:
-
-- Premium v3 App Service with Private Endpoint and VNet integration;
-- Container Apps environment with internal ingress;
-- AKS with private ingress;
-- a regional Application Gateway plus private App Service endpoints.
-
-The question is not "Is ASE powerful?" It is. The question is "Which requirement forces ASE instead of multitenant App Service?"
-
-## Production Gotchas (≥3 war stories: slot warm-up, app settings vs connection strings during swap, Premium v3 vs Premium v2 cold-migration)
-
-### War Story 1: The Swap Was Fast, the App Was Not
-
-A team deployed a new release to a staging slot and swapped immediately after the deployment completed. The swap itself finished quickly. For the next five minutes, users saw slow responses and intermittent `503` errors. The root cause was application warm-up. The app compiled templates, opened database pools, and built an in-memory cache on first request. The slot had passed a shallow `/` check that returned before the real dependencies were ready. The fix:
-
-- configure `WEBSITE_SWAP_WARMUP_PING_PATH` to a real readiness path;
-- make the readiness path prove the app can serve core traffic;
-- keep expensive cache warm-up bounded and observable;
-- run smoke tests against the slot before swap;
-- watch `AppServiceConsoleLogs` and p95 latency immediately after swap.
-
-The lesson: Slot swap changes routing. It does not magically make a cold app warm.
-
-### War Story 2: The Connection String Moved With the Code
-
-A staging slot used a staging database. Production used a production database. The team swapped a release and production immediately began writing to the staging database. The app code was fine. The slot setting model was wrong. The connection string was not sticky, so it moved with the release during swap. The fix:
-
-- mark environment-specific settings as slot settings;
-- review app settings and connection strings before every swap;
-- keep a script or IaC definition for stickiness;
-- use swap with preview for risky configuration changes;
-- add a startup log line that records the expected database name without leaking secrets.
-
-The lesson: Slots are safe only when configuration ownership is explicit.
-
-### War Story 3: Premium v3 Was Not a Button
-
-A team planned to scale from Premium v2 to Premium v3 during a performance incident. The desired Premium v3 SKU was not available for the existing app's deployment unit. The emergency "scale up" became a cold migration to a new plan and app in a different resource group or deployment stamp. That required DNS, custom domains, certificates, private endpoints, VNet integration, slot setup, diagnostics, and release validation. The fix:
-
-- check Premium v3 availability before the incident;
-- create new production plans in deployment units that support the desired v3 SKUs;
-- rehearse migration with a non-production app;
-- keep DNS TTL and rollback plans documented;
-- do not sell a tier migration as a zero-risk scale-up.
-
-The lesson: Scale-up can be a migration when the existing stamp cannot host the target tier.
-
-### War Story 4: The Plan Scaled, the Database Fell Over
-
-An autoscale rule added six workers during a traffic spike. HTTP queue length dropped for a few minutes. Then SQL throttling increased, API latency worsened, and 5xx errors climbed. The web tier was not the only bottleneck. Adding workers increased concurrent database pressure. The fix:
-
-- include dependency capacity in autoscale reviews;
-- add database metrics to the release dashboard;
-- use connection pool limits and backpressure;
-- load test the whole path, not only the web tier;
-- scale the database or reduce concurrency before increasing max workers.
-
-The lesson: Autoscale is not capacity planning for the whole system.
-
-### War Story 5: "Consumption-Style" Expectations Caused Cold Starts
-
-A team expected the app to behave like a serverless workload: cheap when idle and instantly fast when traffic returned. They used a low tier, disabled Always On, and accepted idle unload behavior. The first request after idle paid startup cost. Then new scale-out workers also had cold initialization under load. The fix:
-
-- use Basic or higher with Always On for long-running web apps;
-- use Premium v3 for serious production latency requirements;
-- move true scale-to-zero workloads to Container Apps or Functions;
-- warm new slots and new instances before routing critical traffic;
-- keep startup work small and observable.
-
-The lesson: App Service is a web app platform. If the requirement is scale-to-zero event economics, evaluate Container Apps or Functions instead of forcing App Service to behave like them.
-
-## Decision Framework (App Service vs Container Apps vs AKS table; SKU vs Plan vs ASE table)
-
-### App Service vs Container Apps vs AKS
-
-| Question | App Service | Container Apps | AKS |
-|---|---|---|---|
-| What is the deployment unit? | Web app or API | Container app revision | Kubernetes workload |
-| What is the strongest release primitive? | Deployment slots and swap | Revisions and traffic splitting | Deployment, StatefulSet, rollout controllers, GitOps |
-| What is the scaling model? | Plan workers and autoscale rules | HTTP/event/KEDA-style scaling, often scale-to-zero | Cluster and workload autoscaling |
-| Who owns the platform? | App team with light platform support | App team plus environment owners | Platform team |
-| What is the main operational risk? | Shared plan capacity and config swaps | Revision, ingress, and scale-rule behavior | Cluster complexity |
-| When is it the first pick? | Traditional web apps, enterprise APIs, slot rollback | New microservices, workers, event-driven containers | Kubernetes platform requirements |
-| When should you hesitate? | Event-driven scale-to-zero microservices | Classic apps needing slot workflows and simple PaaS | Small apps without platform staff |
-
-### SKU vs Plan vs ASE
-
-| Need | Choose | Why |
-|---|---|---|
-| Learning or demo | Free or Basic | Keep cost low; do not treat it as production. |
-| Small internal production app | Standard plan | Slots, Always On, and autoscale features become available. |
-| Serious production web app | Premium v3 plan | Better performance, private networking fit, and production headroom. |
-| Multiple low-risk apps with same owner | Shared Standard or Premium v3 plan | Cost-efficient if shared scaling is acceptable. |
-| Noisy or critical app | Dedicated plan for that app | Isolates cost, capacity, and deployment effects. |
-| Private inbound app | Private Endpoint on multitenant App Service | Usually enough without ASE. |
-| Strict single-tenant network-isolated estate | ASE v3 with Isolated v2 plans | Use only when isolation requirement justifies cost. |
-
-### Release Decision Checklist
-
-Before choosing App Service, write the answers:
-
-- What is the rollback mechanism?
-- Which settings are sticky?
-- What path warms the app?
-- What tier supports the required features?
-- Which apps share the plan?
-- What is the max scale-out and why?
-- Is inbound public, private, or both?
-- How does outbound traffic reach dependencies?
-- Which identity reads Key Vault, Storage, and SQL?
-- Which dashboard decides keep, pause, or rollback?
-
-## Did You Know? (3-5 bullets)
-
-- Deployment slots run on the same App Service Plan workers as production, so staging activity can consume production capacity.
-- VNet integration is outbound only; Private Endpoint is the usual private inbound pattern.
-- Key Vault references reduce secret sprawl, but direct Entra token auth is better when the downstream service supports it.
-- Premium v3 availability can depend on the app's existing deployment unit, so a scale-up can become a migration.
-- Container Apps often beats App Service for new event-driven microservices, even though App Service is excellent for traditional web apps.
-
-## Common Mistakes (5-7)
+Most App Service failures in mature environments are not caused by a missing feature; they are caused by applying the right feature at the wrong boundary. The table below translates the common operator failure into the review habit that prevents it. Read it as a pre-submit checklist for design documents and pull requests: every row asks whether the team has made capacity, release, identity, networking, autoscale, and evidence decisions explicit enough that an on-call engineer can debug without reconstructing the architecture from the portal. [App Service plans](https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans), [slots](https://learn.microsoft.com/en-us/azure/app-service/deploy-staging-slots), [networking](https://learn.microsoft.com/en-us/azure/app-service/overview-vnet-integration), and [diagnostics](https://learn.microsoft.com/en-us/azure/app-service/troubleshoot-diagnostic-logs) are the backing references.
 
 | Mistake | Why it happens | Better operator move |
 |---|---|---|
-| Putting every app in one App Service Plan | Sharing looks cheaper | Separate critical or noisy apps into their own plans. |
-| Treating VNet integration as private inbound access | The name sounds bidirectional | Use VNet integration for outbound and Private Endpoint for inbound. |
-| Swapping slots without reviewing sticky settings | The release process focuses on code | Review app settings and connection strings as part of the swap runbook. |
-| Using `/` as the warm-up path | It is easy to curl | Use a readiness path that proves the app can serve core traffic. |
-| Scaling out to fix every incident | More workers feel safe | Check database, storage, dependency, and queue pressure first. |
-| Choosing AKS for a normal web app | Kubernetes is familiar to platform teams | Use App Service unless Kubernetes primitives are required. |
-| Choosing App Service for every containerized microservice | Existing App Service knowledge is strong | Evaluate Container Apps when revisions, KEDA, and scale-to-zero matter. |
+| Putting every app in one plan | Shared compute looks cheaper in the estimate | Put critical or noisy apps in their own plan unless shared scaling is explicitly acceptable |
+| Treating slots as free staging capacity | The slot has a separate hostname and feels isolated | Remember slots share plan workers and include slot warm-up in capacity reviews |
+| Swapping without sticky-setting review | Release automation focuses on code, not configuration | Mark environment-specific settings and connection strings as slot settings and inspect them before swap |
+| Using VNet Integration for private inbound access | The feature name sounds bidirectional | Use Private Endpoint for inbound private access and VNet Integration for outbound private dependency calls |
+| Resolving every 403 as application authorization | Network and identity failures both surface as access failures | Check access restrictions, Key Vault permissions, identity selection, and private endpoint DNS before changing code |
+| Raising max autoscale during every outage | More workers feel like progress under pressure | Confirm the bottleneck is the web tier and not SQL, Storage, Key Vault, or a retry storm |
+| Leaving SCM/Kudu unrestricted | The main site received network rules, but the tool site was forgotten | Apply SCM access restrictions or main-site rules to the advanced tool site as part of the same network change |
 
-## Quiz (4 scenario questions with `<details>` answers; reasoning, not recall)
+## Quiz
 
 ### Question 1
 
-A team is building a new set of small containerized services. Each service releases independently. Workers scale from queue length. HTTP services should scale down aggressively outside business hours. The team does not need Kubernetes APIs. Which platform should be the first candidate?
+A team is building five small containerized services. Each service releases independently, queue workers should scale from queue length, HTTP services should scale down aggressively outside business hours, and the team does not need Kubernetes APIs. Which platform is the first candidate?
 
-A. App Service  
-B. Container Apps  
-C. AKS  
+A. App Service
+B. Container Apps
+C. AKS
 D. App Service Environment v3
 
 <details>
 <summary>Answer</summary>
 
-**Correct: B.** Container Apps matches container revisions, event-driven scaling, and scale-to-zero economics without requiring the team to operate AKS. App Service can run containers, but the workload shape is microservice and worker oriented rather than slot-oriented web app hosting.
+**Correct: B.** Container Apps matches the revision, traffic-splitting, event-driven scale, and scale-to-zero shape documented for serverless container apps. This is the Evaluate outcome: App Service can run containers, but this workload is revision and worker oriented rather than slot-oriented web hosting.
 
 </details>
 
 ### Question 2
 
-A production Web App uses a staging slot. The staging slot should use a staging database. Production should always use the production database. What must be true before swapping?
+A staging slot uses a staging database, and production must always use the production database after a swap. What must be true before the release?
 
-A. The database connection string must be marked as a slot setting.  
-B. The staging slot must run on a separate App Service Plan.  
-C. The app must use a Free tier plan.  
-D. VNet integration must be disabled.
+A. The database connection string is marked as a slot setting.
+B. The staging slot runs on a separate App Service Plan.
+C. The app uses Free tier.
+D. VNet Integration is disabled.
 
 <details>
 <summary>Answer</summary>
 
-**Correct: A.** Environment-specific connection strings should stay with the slot. If the setting is not sticky, it can move with the release during swap and production can point to the wrong database.
+**Correct: A.** Environment-specific connection strings should stay with the slot. This is part of the Design outcome because the production Web App pattern must define slot settings before the release, not during rollback.
 
 </details>
 
 ### Question 3
 
-An internal API must be reachable only from a hub VNet and on-prem networks connected through ExpressRoute. The same API must call a private SQL endpoint. Which networking combination best matches the requirement?
+An internal API must be reachable only from a hub VNet and on-prem networks connected through ExpressRoute, and the same API must call Azure SQL through a private endpoint. Which networking shape fits?
 
-A. Hybrid Connection only  
-B. VNet integration only  
-C. Private Endpoint for inbound plus VNet integration for outbound  
-D. Public access restriction only
+A. Hybrid Connection only
+B. VNet Integration only
+C. Private Endpoint for inbound plus VNet Integration for outbound
+D. Access restrictions only
 
 <details>
 <summary>Answer</summary>
 
-**Correct: C.** Private Endpoint gives private inbound access to the app. VNet integration gives the app outbound access into the VNet path for private dependencies. Hybrid Connection is useful for one TCP endpoint, but it is not private inbound access.
+**Correct: C.** Private Endpoint provides the private inbound path to the app, while VNet Integration provides the outbound path from the app to private dependencies. This reinforces the Design outcome because the architecture must name both paths.
 
 </details>
 
 ### Question 4
 
-During a traffic spike, an autoscale rule adds workers. CPU drops, but latency and 5xx errors increase. SQL metrics show throttling and connection pressure. What is the best reasoning?
+An autoscale rule adds workers during a traffic spike. CPU drops, but latency and 5xx errors increase, and SQL metrics show throttling and connection pressure. What is the best operator conclusion?
 
-A. Autoscale failed because workers cannot be added to App Service.  
-B. The bottleneck moved to SQL, and more web workers increased dependency pressure.  
-C. The app needs an App Service Environment v3 immediately.  
-D. The only fix is to disable HTTPS.
+A. App Service cannot add workers.
+B. The bottleneck moved to SQL, and more workers increased dependency pressure.
+C. The app must move to ASE v3 immediately.
+D. HTTPS should be disabled.
 
 <details>
 <summary>Answer</summary>
 
-**Correct: B.** Autoscaling the web tier can increase concurrent calls to downstream services. The operator should review database capacity, connection pooling, backpressure, and dependency metrics before raising max worker count further.
+**Correct: B.** Scaling the web tier can increase concurrent dependency calls. This is the Debug outcome: separate plan capacity from dependency saturation before changing autoscale bounds.
 
 </details>
 
-## Hands-On Exercise (Setup → 4-5 Tasks → Success Criteria; design exercises with Azure-sub note for actual provisioning)
+### Question 5
 
-This exercise is design-first. You can complete the architecture and runbook work without an Azure subscription. The optional provisioning steps require an Azure subscription and can create billable resources. Use a sandbox subscription only if you have permission.
+After a slot swap, users see intermittent 503 responses for five minutes. The release passed a `/` check, but console logs show startup work and connection-pool initialization. Which fix targets the release mechanism rather than the symptom?
 
-### Setup
+A. Set a real `WEBSITE_SWAP_WARMUP_PING_PATH` and allow only acceptable warm-up statuses.
+B. Remove the staging slot.
+C. Disable diagnostic logs.
+D. Move the app into the Shared tier.
 
-Create a working folder for your design notes:
+<details>
+<summary>Answer</summary>
 
-```bash
-mkdir -p app-service-operator-lab
-cd app-service-operator-lab
-```
+**Correct: A.** The swap should wait for a readiness path that proves the app can serve core traffic. This is a Debug and Design bridge: the failed release evidence points back to the warm-up contract.
 
-Create these files:
+</details>
 
-```text
-decision.md
-slots-runbook.md
-networking.md
-autoscale.md
-monitoring.kql
-```
+### Question 6
 
-Use this scenario:
+A Key Vault reference appears in the application as the literal `@Microsoft.KeyVault(...)` string, and the app throws a configuration error. Which first branch is most useful?
 
-```text
-Application: orders-api
-Runtime: Node.js or .NET
-Traffic: steady business traffic, 3x spike at 09:00 and 13:00
-Release: weekly, rollback must be under 5 minutes
-Dependencies: Azure SQL, Storage account, Key Vault
-Inbound: public today, private-only target in six months
-Team: app team owns code; platform team owns shared network and policies
-```
+A. Recreate the App Service Plan.
+B. Check reference syntax, secret existence, identity permission, and network-restricted vault access.
+C. Increase the autoscale maximum.
+D. Remove Application Insights.
 
-### Task 1: Choose the Hosting Platform
+<details>
+<summary>Answer</summary>
 
-In `decision.md`, compare App Service, Container Apps, and AKS. Write the decision in one paragraph. Include:
+**Correct: B.** Microsoft documents unresolved Key Vault references as usually caused by syntax, missing secrets, permission, or network access problems. This is the Debug outcome applied to the identity grant chain.
 
-- why App Service is or is not the first candidate;
-- what would make Container Apps better;
-- what would make AKS justified;
-- what rollback primitive the team will use.
+</details>
 
-### Task 2: Design the Plan and Slot Model
+## Hands-On Practice
 
-In `slots-runbook.md`, choose:
+Use this design scenario without provisioning paid Azure resources unless you have an approved sandbox subscription. The application is `orders-api`, a Node.js or .NET API with steady business traffic, 3x spikes at 09:00 and 13:00, weekly releases, rollback under five minutes, Azure SQL, Storage, Key Vault, public inbound today, private-only target in six months, and an app team that owns code while a platform team owns shared networking. Your deliverables are five short files: `decision.md`, `slots-runbook.md`, `networking.md`, `autoscale.md`, and `monitoring.kql`. The exercise deliberately asks you to Design the target App Service pattern, Evaluate the service choice against Container Apps and AKS, and Debug likely failure modes before any real resource exists.
 
-- plan tier;
-- minimum worker count;
-- whether the app shares a plan;
-- production slot;
-- staging slot name;
-- warm-up path;
-- rollback command;
-- sticky settings list.
+In `decision.md`, compare App Service, Container Apps, and AKS in one paragraph each, then pick the first candidate and name the release primitive that makes rollback credible. In `slots-runbook.md`, choose a plan tier, minimum workers, staging slot name, warm-up path, sticky settings, swap command, rollback command, and stop condition. In `networking.md`, draw inbound and outbound paths separately for the current public model and the private target model. In `autoscale.md`, set minimum, maximum, metric rules, schedule rules, cooldowns, and dependency stop conditions. In `monitoring.kql`, include one 5xx query, one latency-percentile query, and one console-error query adapted from this module. [The App Service plan](https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans), [slot](https://learn.microsoft.com/en-us/azure/app-service/deploy-staging-slots), [networking](https://learn.microsoft.com/en-us/azure/app-service/overview-vnet-integration), [autoscale](https://learn.microsoft.com/en-us/azure/azure-monitor/autoscale/autoscale-overview), and [diagnostics](https://learn.microsoft.com/en-us/azure/app-service/tutorial-troubleshoot-monitor) docs are the source set you should use while writing.
 
-Then write a ten-step slot swap runbook. Include a stop condition that triggers rollback.
+- [ ] Evaluate App Service, Container Apps, and AKS, then write the service decision and the release primitive in `decision.md`.
+- [ ] Design the App Service Plan, staging slot, sticky settings, warm-up path, swap command, and rollback criteria in `slots-runbook.md`.
+- [ ] Design separate inbound and outbound network paths in `networking.md`, including Private Endpoint, VNet Integration, DNS ownership, and access restrictions.
+- [ ] Design metric and schedule autoscale rules in `autoscale.md`, including a dependency condition that stops further web-tier scale-out.
+- [ ] Debug the imagined 503, Key Vault 403, and autoscale storm by writing the evidence query or command you would run first in `monitoring.kql`.
 
-### Task 3: Design Networking
+Success means the design can answer the seven operator questions without guessing. A reviewer should be able to see which service hosts the workload, which plan tier and worker count run it, which settings are sticky, how inbound and outbound traffic flow, which logs prove a failed release, which rollback action takes minutes, and which metric would stop web-tier scaling because the bottleneck moved to SQL, Storage, Key Vault, or another dependency. This is also the final alignment check: the Debug outcome maps to the outage evidence, the Design outcome maps to the plan/slot/network/autoscale files, and the Evaluate outcome maps to the service decision.
 
-In `networking.md`, draw the inbound and outbound paths in text. Include:
+Treat the practice as an operator handoff, not a classroom worksheet. The strongest submission is one another engineer could use during a change review or a 03:00 incident: it names the plan and slot, states whether the plan is shared, identifies exactly which settings are sticky, draws the private inbound and outbound paths, gives the first three KQL queries, and states the rollback command in full. It should also include one rejected alternative, such as Container Apps for a team that prefers revision traffic splitting or AKS for a platform team that already owns Kubernetes policy and ingress. That rejected alternative keeps the Evaluate outcome honest because it proves the App Service decision was chosen against current Azure service contracts, not by habit. If you add optional provisioning, create only a small nonproduction app and delete it after testing, because App Service plans and dependent resources can accrue cost even when the application itself is stopped. [App Service plan billing](https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans), [Container Apps revisions](https://learn.microsoft.com/en-us/azure/container-apps/revisions), [AKS](https://learn.microsoft.com/en-us/azure/aks/what-is-aks), and [diagnostic settings](https://learn.microsoft.com/en-us/azure/app-service/tutorial-troubleshoot-monitor) are the review references.
 
-- current public inbound model;
-- target private inbound model;
-- VNet integration subnet purpose;
-- private endpoints for SQL, Storage, or Key Vault;
-- DNS responsibility;
-- whether Hybrid Connections are needed.
+Before you call the exercise complete, write one "first five minutes" incident note. It should say what you check first for a 503 after swap, what evidence would make you swap back, and what evidence would make you hold traffic in production while fixing a downstream dependency. That note turns the design from a static architecture into an executable Debug runbook, and it forces the plan, slot, identity, network, autoscale, and log sections to agree with each other. [Deployment slots](https://learn.microsoft.com/en-us/azure/app-service/deploy-staging-slots) and [App Service diagnostics](https://learn.microsoft.com/en-us/azure/app-service/overview-diagnostics) are enough to ground that runbook.
 
-Explain why VNet integration alone is not enough for private inbound access.
+## Sources
 
-### Task 4: Design Autoscale
+- [Azure App Service overview](https://learn.microsoft.com/en-us/azure/app-service/overview) - product scope, supported stacks, deployment, networking, identity, and diagnostics orientation.
+- [Azure App Service plans](https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans) - plan boundary, shared versus dedicated compute, plan cost behavior, app and slot resource sharing.
+- [Azure App Service limits](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#azure-app-service-limits) - scale-out ceilings, slots, storage, networking features, access restrictions, custom domains, and diagnostic availability by tier.
+- [App Service pricing](https://azure.microsoft.com/en-us/pricing/details/app-service/windows/) and [legacy App Service pricing](https://azure.microsoft.com/en-us/pricing/details/app-service/windows-previous/) - CPU, RAM, and storage anchors for Basic, Standard, Premium v3, and Isolated v2 tiers.
+- [Set up staging environments in App Service](https://learn.microsoft.com/en-us/azure/app-service/deploy-staging-slots) - deployment slots, slot swap, warm-up, slot-specific settings, swap with preview, auto-swap caveats.
+- [Environment variables and app settings reference](https://learn.microsoft.com/en-us/azure/app-service/reference-app-settings) - swap warm-up settings and App Service configuration behavior.
+- [Managed identities for App Service](https://learn.microsoft.com/en-us/azure/app-service/overview-managed-identity) - system-assigned and user-assigned identity setup, token endpoint behavior, and identity removal.
+- [Use Key Vault references as app settings](https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references) - Key Vault reference syntax, identity use, rotation behavior, slot-setting recommendation, and troubleshooting.
+- [VNet Integration](https://learn.microsoft.com/en-us/azure/app-service/overview-vnet-integration), [Private Endpoint](https://learn.microsoft.com/en-us/azure/app-service/overview-private-endpoint), [Hybrid Connections](https://learn.microsoft.com/en-us/azure/app-service/app-service-hybrid-connections), and [access restrictions](https://learn.microsoft.com/en-us/azure/app-service/app-service-ip-restrictions) - inbound and outbound networking patterns.
+- [Automatic scaling in App Service](https://learn.microsoft.com/en-us/azure/app-service/manage-automatic-scaling) and [Azure Monitor autoscale](https://learn.microsoft.com/en-us/azure/azure-monitor/autoscale/autoscale-overview) - automatic scaling versus autoscale rules, metric rules, schedule rules, bounds, and notifications.
+- [Diagnostic logs](https://learn.microsoft.com/en-us/azure/app-service/troubleshoot-diagnostic-logs), [troubleshoot with Azure Monitor](https://learn.microsoft.com/en-us/azure/app-service/tutorial-troubleshoot-monitor), [Monitor App Service](https://learn.microsoft.com/en-us/azure/app-service/monitor-app-service), [App Service diagnostics](https://learn.microsoft.com/en-us/azure/app-service/overview-diagnostics), and [Kudu overview](https://learn.microsoft.com/en-us/azure/app-service/resources-kudu) - log paths, Log Analytics tables, diagnostics blade, KQL, and SCM tooling.
+- [Azure Container Apps overview](https://learn.microsoft.com/en-us/azure/container-apps/overview), [Container Apps revisions](https://learn.microsoft.com/en-us/azure/container-apps/revisions), and [Container Apps scaling](https://learn.microsoft.com/en-us/azure/container-apps/scale-app) - serverless container, revision, traffic splitting, KEDA, and scale-to-zero comparison anchors.
+- [What is AKS?](https://learn.microsoft.com/en-us/azure/aks/what-is-aks), [App Service Environment overview](https://learn.microsoft.com/en-us/azure/app-service/environment/overview), [App Service to Azure SQL with managed identity](https://learn.microsoft.com/en-us/azure/app-service/tutorial-connect-msi-sql-database), and [Blob access with Microsoft Entra ID](https://learn.microsoft.com/en-us/azure/storage/blobs/authorize-access-azure-active-directory) - Kubernetes comparison, ASE isolation, SQL identity, and Storage RBAC anchors.
 
-In `autoscale.md`, write a scale plan with:
+## Next Module
 
-- minimum and maximum workers;
-- CPU rule;
-- memory rule;
-- HTTP queue rule;
-- weekday schedule rule;
-- scale-in and scale-out cool-down;
-- dependency capacity warning.
-
-Explain what metric would make you stop increasing web workers and investigate SQL instead.
-
-### Task 5: Write Monitoring Queries
-
-In `monitoring.kql`, write:
-
-- one `AppServiceHTTPLogs` query for 5xx errors by path;
-- one `AppServiceHTTPLogs` query for latency percentiles;
-- one `AppServiceConsoleLogs` query for startup errors after deployment;
-- a short list of metric alerts.
-
-Use the queries in this module as a starting point, but adapt names and time windows to the scenario.
-
-### Optional Azure Provisioning
-
-If you have an approved Azure subscription, provision a small non-production Web App and staging slot. Keep cost low. Delete resources when finished. Do not run production-scale Premium or ASE resources for this lab unless your organization explicitly approved the spend.
-
-### Success Criteria
-
-You are done when:
-
-- `decision.md` explains why App Service, Container Apps, or AKS is the right first choice;
-- `slots-runbook.md` can execute a release and rollback without guessing;
-- `networking.md` separates inbound and outbound paths correctly;
-- `autoscale.md` includes scale-out, scale-in, schedule, and cool-down logic;
-- `monitoring.kql` contains at least three usable queries;
-- your design names the top two failure modes and the evidence that would prove each one.
-
-## Sources (10-12 citations from learn.microsoft.com/en-us/azure/app-service/* + adjacent paths)
-
-- [Azure App Service overview](https://learn.microsoft.com/en-us/azure/app-service/overview)
-- [Azure App Service plans](https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans)
-- [Set up staging environments in Azure App Service](https://learn.microsoft.com/en-us/azure/app-service/deploy-staging-slots)
-- [Environment variables and app settings reference for Azure App Service](https://learn.microsoft.com/en-us/azure/app-service/reference-app-settings)
-- [Integrate your app with an Azure virtual network](https://learn.microsoft.com/en-us/azure/app-service/overview-vnet-integration)
-- [Use private endpoints for Azure App Service apps](https://learn.microsoft.com/en-us/azure/app-service/overview-private-endpoint)
-- [Hybrid Connections in Azure App Service](https://learn.microsoft.com/en-us/azure/app-service/app-service-hybrid-connections)
-- [Managed identities for Azure App Service](https://learn.microsoft.com/en-us/azure/app-service/overview-managed-identity)
-- [Use Key Vault references as app settings](https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references)
-- [How to enable automatic scaling in Azure App Service](https://learn.microsoft.com/en-us/azure/app-service/manage-automatic-scaling)
-- [Troubleshoot an App Service app with Azure Monitor](https://learn.microsoft.com/en-us/azure/app-service/tutorial-troubleshoot-monitor)
-- [App Service Environment overview](https://learn.microsoft.com/en-us/azure/app-service/environment/app-service-app-service-environment-layered-security)
-
-## Next Module (close the Azure Essentials section or link to enterprise-hybrid)
-
-This closes the Azure Essentials sequence with the last major application-hosting decision point: web apps on App Service, containerized services on Container Apps, and Kubernetes platforms on AKS. From here, continue into enterprise and hybrid cloud patterns where these services become part of broader governance, network, identity, and platform operating models. Recommended next step: [Cloud Custodian -- Policy-as-Code Governance Across Multi-Cloud](../../enterprise-hybrid/module-10.11-cloud-custodian/), then revisit the Azure modules when designing policy guardrails for App Service Plans, private endpoints, managed identities, and diagnostic settings.
+This closes the Azure Essentials application-hosting decision path: App Service for slot-centered web apps, Container Apps for revision-centered container services and workers, and AKS for Kubernetes platforms. Next, carry these decisions into enterprise and hybrid cloud governance, where plan isolation, private endpoints, managed identities, diagnostics, and policy controls become reusable platform guardrails.

--- a/src/content/docs/cloud/azure-essentials/module-3.14-app-service.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.14-app-service.md
@@ -92,7 +92,7 @@ param appName string = 'app-orders-prod-eus'
 param planName string = 'asp-orders-prod-eus'
 param logAnalyticsWorkspaceId string
 
-resource plan 'Microsoft.Web/serverfarms@2023-12-01' = {
+resource plan 'Microsoft.Web/serverfarms@2025-03-01' = {
   name: planName
   location: location
   kind: 'linux'
@@ -121,11 +121,26 @@ resource app 'Microsoft.Web/sites@2023-12-01' = {
       healthCheckPath: '/healthz'
       linuxFxVersion: 'NODE|20-lts'
       appSettings: [
-        { name: 'APP_ENV'; value: 'production' }
-        { name: 'WEBSITE_HEALTHCHECK_MAXPINGFAILURES'; value: '3' }
-        { name: 'SCM_DO_BUILD_DURING_DEPLOYMENT'; value: 'true' }
-        { name: 'WEBSITE_SWAP_WARMUP_PING_PATH'; value: '/healthz/ready' }
-        { name: 'WEBSITE_SWAP_WARMUP_PING_STATUSES'; value: '200,202' }
+        {
+          name: 'APP_ENV'
+          value: 'production'
+        }
+        {
+          name: 'WEBSITE_HEALTHCHECK_MAXPINGFAILURES'
+          value: '3'
+        }
+        {
+          name: 'SCM_DO_BUILD_DURING_DEPLOYMENT'
+          value: 'true'
+        }
+        {
+          name: 'WEBSITE_SWAP_WARMUP_PING_PATH'
+          value: '/healthz/ready'
+        }
+        {
+          name: 'WEBSITE_SWAP_WARMUP_PING_STATUSES'
+          value: '200,202'
+        }
       ]
     }
   }
@@ -137,8 +152,14 @@ resource logs 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
   properties: {
     workspaceId: logAnalyticsWorkspaceId
     logs: [
-      { category: 'AppServiceHTTPLogs'; enabled: true }
-      { category: 'AppServiceConsoleLogs'; enabled: true }
+      {
+        category: 'AppServiceHTTPLogs'
+        enabled: true
+      }
+      {
+        category: 'AppServiceConsoleLogs'
+        enabled: true
+      }
     ]
   }
 }
@@ -233,11 +254,10 @@ az role assignment create \
 az webapp config appsettings set \
   --resource-group rg-appsvc-prod-eus \
   --name app-orders-prod-eus \
-  --slot-settings OrdersDbPassword \
-  --settings "OrdersDbPassword=@Microsoft.KeyVault(SecretUri=https://kv-orders-prod.vault.azure.net/secrets/orders-db-password/)"
+  --slot-settings "OrdersDbPassword=@Microsoft.KeyVault(SecretUri=https://kv-orders-prod.vault.azure.net/secrets/orders-db-password/)"
 ```
 
-Key Vault references are useful when the application still needs a secret value, because an app setting can contain an `@Microsoft.KeyVault(...)` reference and the application reads it like any other setting. The reference uses the system-assigned identity by default, can be configured to use a user-assigned identity, and automatically picks up a newer version within 24 hours when the secret URI is versionless; a configuration change restarts the app and forces an immediate refetch. Microsoft also recommends marking most Key Vault references as slot settings because environments usually have separate vaults. [Key Vault references](https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references) document these behaviors and failure modes.
+Key Vault references are useful when the application still needs a secret value, because an app setting can contain an `@Microsoft.KeyVault(...)` reference and the application reads it like any other setting. The reference uses the system-assigned identity by default, can be configured to use a user-assigned identity, and automatically picks up a newer version within 24 hours when the secret URI is versionless; any configuration change restarts the app and forces an immediate refetch. Microsoft also recommends marking most Key Vault references as slot settings because environments usually have separate vaults. [Key Vault references](https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references) document these behaviors and failure modes.
 
 Prefer direct Entra authentication when the downstream service supports it. For Azure SQL, the app identity must exist, the SQL server needs an Entra administrator, and the database must create a user for the identity and grant only the required roles. For Blob Storage, Azure RBAC data roles such as Storage Blob Data Contributor or Storage Blob Data Reader authorize data-plane access, and the role scope should be the narrowest useful container, account, resource group, or subscription scope. [App Service to Azure SQL with managed identity](https://learn.microsoft.com/en-us/azure/app-service/tutorial-connect-msi-sql-database) and [Blob access with Microsoft Entra ID](https://learn.microsoft.com/en-us/azure/storage/blobs/authorize-access-azure-active-directory) are the operator references.
 
@@ -272,7 +292,7 @@ flowchart LR
 
 VNet Integration needs subnet planning. The feature requires a dedicated subnet, consumes addresses per plan instance, temporarily doubles address use during some scale operations, and Microsoft recommends enough address space for planned maximum scale plus platform operations. It can route private-only or all outbound traffic depending on routing configuration, and NSGs or route tables on the integration subnet apply only to traffic routed through the integration. If Key Vault, Storage, SQL, or image pulls use private endpoints, DNS must resolve those names to private endpoint addresses from the app's VNet path. [Subnet requirements and routing](https://learn.microsoft.com/en-us/azure/app-service/overview-vnet-integration#subnet-requirements) and [private endpoint DNS behavior for outbound calls](https://learn.microsoft.com/en-us/azure/app-service/overview-vnet-integration#private-endpoints) are the design guardrails.
 
-Private Endpoint is configured per app slot, and a slot cannot share another slot's private endpoint. The official documentation states that each slot is configured separately, up to 100 private endpoints can be used per slot, and the private endpoint subnet cannot be the same subnet used for VNet Integration. That matters during release design: if a staging slot must be tested privately, it needs its own private endpoint and DNS story. [Private Endpoint for App Service](https://learn.microsoft.com/en-us/azure/app-service/overview-private-endpoint) and [VNet Integration subnet limitations](https://learn.microsoft.com/en-us/azure/app-service/overview-vnet-integration#limitations) make this a review item.
+Private Endpoint is configured per app slot, and a slot cannot share another slot's private endpoint. The official documentation states that each slot is configured separately, the current limits table lists 100 private endpoints per app, and the private endpoint subnet cannot be the same subnet used for VNet Integration. That matters during release design: if a staging slot must be tested privately, it needs its own private endpoint and DNS story. [Private Endpoint for App Service](https://learn.microsoft.com/en-us/azure/app-service/overview-private-endpoint) and [VNet Integration subnet limitations](https://learn.microsoft.com/en-us/azure/app-service/overview-vnet-integration#limitations) make this a review item.
 
 Access restrictions are still useful even when Private Endpoint is planned. They provide priority-ordered allow and deny rules, support IP ranges, service tags, and selected VNet subnets through service endpoints, and can be applied separately to the SCM/Kudu site. If any allow or deny entries exist, an implicit deny exists at the end unless the unmatched rule action is changed. The service returns HTTP 403 when the source is not allowed, so a sudden 403 after a network change should send the operator to the access-restriction list before blaming application auth. [Access restrictions](https://learn.microsoft.com/en-us/azure/app-service/app-service-ip-restrictions) document the rule order, 512-rule limit, service tags, and SCM-site restrictions.
 


### PR DESCRIPTION
## Summary

Rewrites Module 3.14 (Azure App Service — Operator Path) from 1100 lines / 0 citations / rubric 1.5 to a full T0 module continuing the #1369 critical-rubric ladder. Cloud track's deepest Azure compute-platform module.

- **Body**: 498 lines, ~5000 body words, T0 tier, density gates passed wide (mean_wpp=78.4, median_wpp=88.5, short_rate=4.7%)
- **Citations**: 27/27 reachable, all 200 — every citation on `learn.microsoft.com` (no deprecated `docs.microsoft.com`)
- **Preserved operator framing**: the 7 operator questions, Debug/Design/Evaluate outcomes
- **Topical depth**: App Service Plan tier matrix (Free→Isolated v2, with scale-out ceilings 1/1/3/10/30/100 verified against live limits table), deployment-slot swap mechanics (sticky vs swappable settings, auto-swap Linux caveats), managed identity via Key Vault references, VNet integration vs private endpoints (inbound vs outbound separation), autoscale (OR-for-out / AND-for-in rule), App Service vs Container Apps vs AKS decision matrix.

## Process

- Codex gpt-5.5 draft (`d5e2279e`).
- Cross-family review: claude-sonnet-4-6 — **NEEDS_CHANGES** (B1 Bicep semicolon syntax error, B2 broken `az webapp ... --slot-settings` syntax, N1–N3 staleness checks).
- Codex fixup (`47f7f9e5`) with **live doc verification** for every nit:
  - B1 fixed: Bicep object literals now use newline separators (verified against `learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/data-types#objects`).
  - B2 fixed: collapsed to single `--slot-settings "KEY=VALUE"` form (verified against `learn.microsoft.com/en-us/azure/app-service/deploy-staging-slots`).
  - N1: **kept "within 24 hours"** — sonnet's "4 hours" claim was hallucinated; live Key Vault references doc still says 24h + immediate refetch on config change.
  - N2: confirmed 100 PE per app against live App Service limits table.
  - N3: Bicep API version bumped from `2023-12-01` to `2025-03-01` (latest listed for `Microsoft.Web/serverfarms`).
- Post-fixup verifier: T0, all 27 sources reachable, all gates pass.

Refs #1369

## Learner check

> The focus is the operator path. You are not learning App Service as a portal wizard. You are learning it as a production hosting surface with shared compute, slots, warm-up behavior, identity, private access patterns, and scaling boundaries.

## Test plan

- [x] T0 verifier passes (27/27 sources @ 200 / outcomes aligned / density gates wide pass)
- [x] sonnet R1 NEEDS_CHANGES → all 2 blockers + 3 nits addressed (1 nit kept original; live-verified)
- [x] Frontmatter preserved
- [x] Operator-path framing + 7 operator questions preserved
- [x] Bicep + az CLI examples syntactically valid against live docs

