### PR TITLE
feat(calibration): enforce prose-lane rule + LLM-judge failure reasons (#1412)

### DIFF
--- a/scripts/calibration/reports/templates/matrix.html.j2
+++ b/scripts/calibration/reports/templates/matrix.html.j2
@@ -42,7 +42,7 @@
           <td class="heat-{{ bucket }}" title="{{ cell.cell_id }}">
             <a href="per-model/{{ cell.canonical_string | replace('/', '_') | replace('@', '_') }}.html">{{ cell.canonical_string }}</a>
             <span class="score">{{ "%.0f"|format(cell.deterministic_score * 100) }}%</span>
-            {% if cell.llm_score is not none %}<span>judge {{ "%.1f"|format(cell.llm_score) }}</span>{% endif %}
+            <span>judge {% if cell.llm_score is not none %}{{ "%.1f"|format(cell.llm_score) }}{% else %}n/a{% endif %}</span>
           </td>
         {% else %}
           <td class="missing">not run</td>

--- a/scripts/calibration/schema.py
+++ b/scripts/calibration/schema.py
@@ -74,6 +74,7 @@ CREATE TABLE IF NOT EXISTS scores (
   scorer TEXT NOT NULL,
   replicate_seq INTEGER NOT NULL DEFAULT 0,
   stderr_excerpt TEXT,
+  gate_failure_reason TEXT,
   scored_at TEXT NOT NULL,
   PRIMARY KEY (cell_id, gate_name, scorer)
 );
@@ -149,6 +150,7 @@ def init_db(db_path: Path | str) -> None:
             {
                 "replicate_seq": "INTEGER NOT NULL DEFAULT 0",
                 "stderr_excerpt": "TEXT",
+                "gate_failure_reason": "TEXT",
             },
         )
 
@@ -313,6 +315,7 @@ def insert_score(
     scorer: str = "deterministic",
     replicate_seq: int = 0,
     stderr_excerpt: str | None = None,
+    gate_failure_reason: str | None = None,
     scored_at: str | None = None,
 ) -> None:
     scorer = _scorer_for_replicate(scorer, replicate_seq)
@@ -320,13 +323,14 @@ def insert_score(
         """
         INSERT INTO scores (
           cell_id, gate_name, gate_pass, score_value, scorer, stderr_excerpt,
-          replicate_seq, scored_at
+          gate_failure_reason, replicate_seq, scored_at
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(cell_id, gate_name, scorer) DO UPDATE SET
           gate_pass=excluded.gate_pass,
           score_value=excluded.score_value,
           stderr_excerpt=excluded.stderr_excerpt,
+          gate_failure_reason=excluded.gate_failure_reason,
           replicate_seq=excluded.replicate_seq,
           scored_at=excluded.scored_at
         """,
@@ -337,6 +341,7 @@ def insert_score(
             score_value,
             scorer,
             stderr_excerpt,
+            gate_failure_reason,
             replicate_seq,
             scored_at or utc_now_iso(),
         ),

--- a/scripts/calibration/score_cell.py
+++ b/scripts/calibration/score_cell.py
@@ -14,14 +14,10 @@ import yaml
 
 from . import schema
 from .models import model_by_canonical
-from .run_cell import DEFAULT_DB_PATH, REPO_ROOT, dispatch_prompt
+from .run_cell import DEFAULT_DB_PATH, REPO_ROOT, DispatchResult, dispatch_prompt
 from .scorers import respected_inline_return
 
 GROUND_TRUTH_ROOT = REPO_ROOT / "scripts" / "calibration" / "ground-truth" / "v1"
-# refactoring is listed here so it routes through the prose-lane judge path
-# the day RefactoringScorer gains an llm_judge_prompt. Today its judge prompt
-# returns None and the function returns early before the PROSE_LANES guard
-# fires — so this membership is forward-declaration, not active behavior.
 PROSE_LANES: frozenset[str] = frozenset(
     {
         "orchestrating",
@@ -446,7 +442,15 @@ class RefactoringScorer:
         response: str,
         ground_truth: dict[str, Any],
     ) -> str | None:
-        return None
+        return _judge_prompt(
+            "refactoring",
+            response,
+            (
+                "Score whether the refactor preserves the requested behavior, "
+                "reduces complexity, and remains testable."
+            ),
+            ground_truth,
+        )
 
 
 class SummarizationScorer:
@@ -753,23 +757,40 @@ def _latest_response_path(conn: Any, cell_id: str) -> Path:
     return _response_path_from_dispatch(_latest_dispatch(conn, cell_id))
 
 
+class JudgeParseError(ValueError):
+    """Raised when a judge response is not valid score JSON."""
+
+
 def _parse_judge_score(response: str) -> float:
-    rows = _parse_json_response(response)
-    if rows and "score" in rows[0]:
-        return float(rows[0]["score"])
     try:
         parsed = json.loads(response)
-        if isinstance(parsed, dict) and "score" in parsed:
-            return float(parsed["score"])
-    except (json.JSONDecodeError, TypeError, ValueError):
-        pass
-    match = re.search(r"\b(?:score\s*[:=]\s*)?([0-9](?:\.[0-9])?|10)\b", response)
-    if not match:
-        raise ValueError(f"judge response does not contain a score: {response[:120]}")
-    return float(match.group(1))
+    except json.JSONDecodeError as exc:
+        match = re.search(r"```(?:json)?\s*(.*?)```", response, re.DOTALL | re.IGNORECASE)
+        if not match:
+            raise JudgeParseError(
+                f"judge response does not contain JSON: {response[:120]}"
+            ) from exc
+        try:
+            parsed = json.loads(match.group(1))
+        except json.JSONDecodeError as fenced_exc:
+            raise JudgeParseError(
+                f"judge fenced JSON is malformed: {response[:120]}"
+            ) from fenced_exc
+    if isinstance(parsed, list) and parsed and isinstance(parsed[0], dict):
+        parsed = parsed[0]
+    if not isinstance(parsed, dict) or "score" not in parsed:
+        raise JudgeParseError(f"judge JSON missing score field: {response[:120]}")
+    try:
+        score = float(parsed["score"])
+    except (TypeError, ValueError) as exc:
+        raise JudgeParseError(f"judge score is not numeric: {response[:120]}") from exc
+    if not 0.0 <= score <= 10.0:
+        raise JudgeParseError(f"judge score outside 0..10: {score}")
+    return score
 
 
-JudgeFn = Callable[[str, str], str]
+JudgeRawResult = str | DispatchResult
+JudgeFn = Callable[[str, str], JudgeRawResult]
 
 # Per-lane judge dispatch ceilings. A hanging judge stalls the family thread
 # in run_wave for this long, so keep the ceilings tight. Numbers are derived
@@ -788,10 +809,13 @@ JUDGE_TIMEOUTS_S: dict[str, int] = {
 DEFAULT_JUDGE_TIMEOUT_S = 180
 
 
-def dispatch_judge(judge_model: str, prompt: str, timeout_s: int = DEFAULT_JUDGE_TIMEOUT_S) -> str:
+def dispatch_judge(
+    judge_model: str,
+    prompt: str,
+    timeout_s: int = DEFAULT_JUDGE_TIMEOUT_S,
+) -> DispatchResult:
     model = model_by_canonical(judge_model)
-    result = dispatch_prompt(model, prompt, REPO_ROOT, timeout_s)
-    return result.response
+    return dispatch_prompt(model, prompt, REPO_ROOT, timeout_s)
 
 
 def _judge_accepts_timeout(judge_fn: JudgeFn) -> bool:
@@ -820,6 +844,7 @@ def score_cell(
 ) -> dict[str, bool]:
     if replicate_seq < 0:
         raise ValueError("replicate_seq must be >= 0")
+    judge_models = (judge1, judge2)
     schema.init_db(db_path)
     with schema.connect(db_path) as conn:
         cell = schema.fetch_cell(conn, cell_id)
@@ -858,53 +883,80 @@ def score_cell(
 
         if lane not in PROSE_LANES and not all(gates.values()):
             # Mechanical lanes keep deterministic-gate-as-gate behavior.
+            for model_name in judge_models:
+                schema.insert_score(
+                    conn,
+                    cell_id=cell_id,
+                    gate_name="llm_judge_score",
+                    gate_pass=False,
+                    score_value=None,
+                    scorer=f"llm-judge:{model_name}",
+                    gate_failure_reason="scorer_skipped_by_two_stage_rule",
+                    replicate_seq=replicate_seq,
+                )
             return gates
 
     # Judges run outside the DB transaction so they can fan out in parallel
     # without blocking on a single sqlite connection. Each call is an
     # independent CLI dispatch to a different family (claude + gemini), so
     # there is no contention between them.
-    judge_models = (judge1, judge2)
     judge_timeout_s = JUDGE_TIMEOUTS_S.get(lane, DEFAULT_JUDGE_TIMEOUT_S)
 
-    def _run_one_judge(model_name: str) -> tuple[str, float | None, str | None]:
+    def _run_one_judge(
+        model_name: str,
+    ) -> tuple[str, float | None, str, str | None]:
         try:
             # Real judges accept timeout_s; mocked judges in tests don't.
             # Pass it via inspect so tests don't have to grow a signature.
-            judge_response = (
+            raw_result = (
                 judge_fn(model_name, prompt, timeout_s=judge_timeout_s)  # type: ignore[call-arg]
                 if _judge_accepts_timeout(judge_fn)
                 else judge_fn(model_name, prompt)
             )
-            return model_name, _parse_judge_score(judge_response), None
         except Exception as exc:  # noqa: BLE001 — judge crash ≠ cell crash
-            return model_name, None, repr(exc)
+            return model_name, None, "scorer_crashed", repr(exc)
+        if isinstance(raw_result, DispatchResult):
+            if raw_result.returncode not in (None, 0):
+                return (
+                    model_name,
+                    None,
+                    "scorer_crashed",
+                    raw_result.stderr_excerpt or f"returncode={raw_result.returncode}",
+                )
+            judge_response = raw_result.response
+            stderr_excerpt = raw_result.stderr_excerpt
+        else:
+            judge_response = raw_result
+            stderr_excerpt = None
+        try:
+            judge_score = _parse_judge_score(judge_response)
+        except JudgeParseError as exc:
+            return model_name, None, "scorer_unparseable_output", str(exc)
+        normalized_score = judge_score / 10.0
+        reason = (
+            "gate_passed"
+            if normalized_score >= 0.5
+            else "gate_failed_legitimately"
+        )
+        return model_name, judge_score, reason, stderr_excerpt
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=len(judge_models)) as pool:
         judge_outcomes = list(pool.map(_run_one_judge, judge_models))
 
     judge_scores: list[float] = []
     with schema.connect(db_path) as conn:
-        for model_name, judge_score, error in judge_outcomes:
-            if judge_score is None:
-                schema.insert_score(
-                    conn,
-                    cell_id=cell_id,
-                    gate_name="llm_judge_error",
-                    gate_pass=False,
-                    score_value=None,
-                    scorer=f"llm-judge:{model_name}:error={error}",
-                    replicate_seq=replicate_seq,
-                )
-                continue
-            judge_scores.append(judge_score)
+        for model_name, judge_score, reason, stderr_excerpt in judge_outcomes:
+            if judge_score is not None:
+                judge_scores.append(judge_score)
             schema.insert_score(
                 conn,
                 cell_id=cell_id,
                 gate_name="llm_judge_score",
-                gate_pass=judge_score >= 7.0,
+                gate_pass=judge_score is not None and judge_score >= 7.0,
                 score_value=judge_score,
                 scorer=f"llm-judge:{model_name}",
+                stderr_excerpt=stderr_excerpt,
+                gate_failure_reason=reason,
                 replicate_seq=replicate_seq,
             )
         if len(judge_scores) == 2 and abs(judge_scores[0] - judge_scores[1]) > 1.0:

--- a/scripts/calibration/v1/render_stability_report.py
+++ b/scripts/calibration/v1/render_stability_report.py
@@ -110,10 +110,19 @@ def _per_model_link(model: str, label: str | None = None) -> str:
     return f'<a href="per-model/{_href(model)}.html"><code>{_h(text)}</code></a>'
 
 
-def load_cell_stats(db_path: Path) -> list[CellStats]:
+def load_cell_stats(
+    db_path: Path,
+    *,
+    include_deterministic_gates: bool = False,
+) -> list[CellStats]:
+    scorer_filter = (
+        ""
+        if include_deterministic_gates
+        else "AND s.scorer LIKE 'llm-judge:%'"
+    )
     with _connect(db_path) as conn:
         rows = conn.execute(
-            """
+            f"""
             SELECT
               s.cell_id,
               c.lane,
@@ -126,6 +135,7 @@ def load_cell_stats(db_path: Path) -> list[CellStats]:
             FROM scores AS s
             JOIN cells AS c ON c.cell_id = s.cell_id
             WHERE s.score_value IS NOT NULL
+              {scorer_filter}
             ORDER BY c.lane, c.canonical_string, c.fixture_id, s.gate_name, s.scorer
             """
         ).fetchall()
@@ -257,6 +267,7 @@ def render_report(
     candidates: list[dict[str, Any]],
     out_path: Path,
     report_date: str,
+    include_deterministic_gates: bool = False,
 ) -> str:
     stats_by_cell = {row.cell_id: row for row in cell_stats}
     coverage_rows = build_coverage(candidates, stats_by_cell)
@@ -283,6 +294,11 @@ def render_report(
         str(out_path.relative_to(REPO_ROOT))
         if out_path.is_relative_to(REPO_ROOT)
         else str(out_path)
+    )
+    scorer_scope = (
+        "all scorer rows"
+        if include_deterministic_gates
+        else "LLM-judge scorer rows only"
     )
 
     return f"""<!doctype html>
@@ -313,11 +329,11 @@ def render_report(
 <body>
 
 <h1>Stability variance report</h1>
-<p class="meta">{report_date} &middot; {len(cell_stats)} scored cells &middot; {len(candidates)} stability candidates &middot; replicate_seq={", ".join(str(seq) for seq in replicate_seqs) or "none"} &middot; output=<code>{_h(report_rel)}</code></p>
+<p class="meta">{report_date} &middot; {len(cell_stats)} scored cells &middot; {len(candidates)} stability candidates &middot; {scorer_scope} &middot; replicate_seq={", ".join(str(seq) for seq in replicate_seqs) or "none"} &middot; output=<code>{_h(report_rel)}</code></p>
 
 <h2>1. Headline variance floor</h2>
 <div class="tldr">
-  <strong>Variance floor.</strong> Across all scored cells in <code>calibration/v1/ledger.db</code>, per-cell unit-normalized <code>score_value</code> standard deviation averages <strong>{_fmt(headline_mean)}</strong>, with median <strong>{_fmt(headline_median)}</strong> and p95 <strong>{_fmt(headline_p95)}</strong>.
+  <strong>Variance floor.</strong> Across {scorer_scope} in <code>calibration/v1/ledger.db</code>, per-cell unit-normalized <code>score_value</code> standard deviation averages <strong>{_fmt(headline_mean)}</strong>, with median <strong>{_fmt(headline_median)}</strong> and p95 <strong>{_fmt(headline_p95)}</strong>.
 </div>
 <table>
   <thead><tr><th>Metric</th><th>Value</th></tr></thead>
@@ -350,7 +366,7 @@ def render_report(
 </table>
 
 <h2>4. Methodology</h2>
-<p>Scorer-disagreement is the <code>max(unit_score) - min(unit_score)</code> span across all score rows for a cell, with <code>llm_judge_score</code> divided by 10 and deterministic gates clamped to the same 0..1 scale. Replicate-variance is the standard deviation after repeated dispatches of the lane-boundary candidates selected near the pass/fail midpoint, and the coverage table shows which of those 42 cells have enough scored samples to trust that estimate. The headline variance floor aggregates every scored cell, not just candidates, and serves as the current noise estimate for the model fleet.</p>
+<p>Scorer-disagreement is the <code>max(unit_score) - min(unit_score)</code> span across {scorer_scope} for a cell, with <code>llm_judge_score</code> divided by 10 and deterministic gates clamped to the same 0..1 scale when <code>--include-deterministic-gates</code> is enabled. Replicate-variance is the standard deviation after repeated dispatches of the lane-boundary candidates selected near the pass/fail midpoint, and the coverage table shows which of those 42 cells have enough scored samples to trust that estimate. The headline variance floor aggregates every scored cell in scope, not just candidates, and serves as the current noise estimate for the model fleet.</p>
 
 <h2>5. Links</h2>
 <ul>
@@ -382,6 +398,11 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Output HTML path. Default: calibration/v1/reports/<date>/stability.html.",
     )
+    parser.add_argument(
+        "--include-deterministic-gates",
+        action="store_true",
+        help="Include deterministic gate rows in variance calculations and top disagreement.",
+    )
     return parser
 
 
@@ -395,13 +416,17 @@ def main(argv: list[str] | None = None) -> int:
         return 2
     out_path = args.out or default_out_path(str(args.date))
 
-    cell_stats = load_cell_stats(args.db_path)
+    cell_stats = load_cell_stats(
+        args.db_path,
+        include_deterministic_gates=bool(args.include_deterministic_gates),
+    )
     candidates = load_candidates(args.candidates)
     rendered = render_report(
         cell_stats=cell_stats,
         candidates=candidates,
         out_path=out_path,
         report_date=str(args.date),
+        include_deterministic_gates=bool(args.include_deterministic_gates),
     )
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(rendered, encoding="utf-8")

--- a/tests/calibration/test_render_stability_report.py
+++ b/tests/calibration/test_render_stability_report.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from scripts.calibration import schema
+from scripts.calibration.models import model_by_canonical
+from scripts.calibration.v1 import render_stability_report
+
+
+def test_stability_report_filters_to_llm_judge_scores_by_default(tmp_path):
+    db_path = tmp_path / "ledger.db"
+    schema.init_db(db_path)
+    model = model_by_canonical("claude-opus-4-7")
+    row = schema.build_cell_row(
+        lane="orchestrating",
+        fixture_id="multi-task-routing-brief",
+        model=model,
+        run_date="2026-05-21",
+    )
+    with schema.connect(db_path) as conn:
+        cell_id = schema.insert_cell(conn, row)
+        schema.insert_score(
+            conn,
+            cell_id=cell_id,
+            gate_name="deterministic_gate",
+            gate_pass=False,
+            score_value=0.0,
+        )
+        schema.insert_score(
+            conn,
+            cell_id=cell_id,
+            gate_name="llm_judge_score",
+            gate_pass=True,
+            score_value=8.0,
+            scorer="llm-judge:a",
+            gate_failure_reason="gate_passed",
+        )
+        schema.insert_score(
+            conn,
+            cell_id=cell_id,
+            gate_name="llm_judge_score",
+            gate_pass=False,
+            score_value=4.0,
+            scorer="llm-judge:b",
+            gate_failure_reason="gate_failed_legitimately",
+        )
+
+    llm_only = render_stability_report.load_cell_stats(db_path)
+    with_deterministic = render_stability_report.load_cell_stats(
+        db_path,
+        include_deterministic_gates=True,
+    )
+
+    assert len(llm_only) == 1
+    assert llm_only[0].n_scores == 2
+    assert llm_only[0].score_min == 0.4
+    assert len(with_deterministic) == 1
+    assert with_deterministic[0].n_scores == 3
+    assert with_deterministic[0].score_min == 0.0

--- a/tests/calibration/test_report.py
+++ b/tests/calibration/test_report.py
@@ -44,6 +44,16 @@ def test_report_renders_matrix_per_lane_and_per_model(tmp_path):
     _insert_cell(db_path, "code-writing", "parse-dependabot-cooldown", "claude-opus-4-7", 0.0)
     _insert_cell(db_path, "fact-check", "k8s-1-35-claims", "gpt-5.5", 1.0)
     _insert_cell(db_path, "fact-check", "k8s-1-35-claims", "claude-opus-4-7", 1.0)
+    with schema.connect(db_path) as conn:
+        schema.insert_score(
+            conn,
+            cell_id=cell_id,
+            gate_name="llm_judge_score",
+            gate_pass=False,
+            score_value=None,
+            scorer="llm-judge:dummy",
+            gate_failure_reason="scorer_unparseable_output",
+        )
 
     out_dir = tmp_path / "reports"
     written = report.render_reports(db_path=db_path, out_dir=out_dir)
@@ -60,7 +70,8 @@ def test_report_renders_matrix_per_lane_and_per_model(tmp_path):
     assert out_dir / "matrix.html" in written
     assert cell_id in matrix
     assert "code-writing" in matrix
+    assert "judge n/a" in matrix
     assert "gpt-5.5" in per_lane
+    assert ">n/a</td>" in per_lane
     assert "confidence vs actual" in per_model.lower()
     assert "total_cost=$0.0800" in index
-

--- a/tests/calibration/test_schema.py
+++ b/tests/calibration/test_schema.py
@@ -33,6 +33,10 @@ def test_schema_initializes_cells_dispatches_scores(tmp_path):
         )
         stored = schema.fetch_cell(conn, cell_id)
         indexes = schema.list_indexes(conn)
+        score_columns = {
+            str(row["name"])
+            for row in conn.execute("PRAGMA table_info(scores)").fetchall()
+        }
 
     assert cell_id == (
         "code-writing-parse-dependabot-cooldown-"
@@ -47,4 +51,34 @@ def test_schema_initializes_cells_dispatches_scores(tmp_path):
         "idx_cells_run_date",
         "idx_scores_cell",
     }.issubset(indexes)
+    assert "gate_failure_reason" in score_columns
 
+
+def test_schema_gate_failure_reason_migration_is_idempotent(tmp_path):
+    db_path = tmp_path / "ledger.db"
+    with schema.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE scores (
+              cell_id TEXT NOT NULL,
+              gate_name TEXT NOT NULL,
+              gate_pass INTEGER NOT NULL CHECK (gate_pass IN (0, 1)),
+              score_value REAL,
+              scorer TEXT NOT NULL,
+              replicate_seq INTEGER NOT NULL DEFAULT 0,
+              stderr_excerpt TEXT,
+              scored_at TEXT NOT NULL,
+              PRIMARY KEY (cell_id, gate_name, scorer)
+            )
+            """
+        )
+
+    schema.init_db(db_path)
+    schema.init_db(db_path)
+
+    with schema.connect(db_path) as conn:
+        score_columns = [
+            str(row["name"])
+            for row in conn.execute("PRAGMA table_info(scores)").fetchall()
+        ]
+    assert score_columns.count("gate_failure_reason") == 1

--- a/tests/calibration/test_score_cell.py
+++ b/tests/calibration/test_score_cell.py
@@ -2,13 +2,44 @@ from __future__ import annotations
 
 import json
 import subprocess
+from pathlib import Path
 
 from scripts.calibration import schema, score_cell
 from scripts.calibration.models import model_by_canonical
+from scripts.calibration.run_cell import DispatchResult
 
 
 def _completed(returncode: int = 0) -> subprocess.CompletedProcess[str]:
     return subprocess.CompletedProcess(args=[], returncode=returncode, stdout="", stderr="")
+
+
+def _seed_cell(
+    tmp_path: Path,
+    *,
+    lane: str,
+    fixture_id: str,
+    response: str,
+) -> tuple[Path, str]:
+    db_path = tmp_path / "ledger.db"
+    response_path = tmp_path / f"{lane}-{fixture_id}.md"
+    response_path.write_text(response, encoding="utf-8")
+    model = model_by_canonical("claude-opus-4-7")
+    row = schema.build_cell_row(
+        lane=lane,
+        fixture_id=fixture_id,
+        model=model,
+        run_date="2026-05-21",
+    )
+    schema.init_db(db_path)
+    with schema.connect(db_path) as conn:
+        cell_id = schema.insert_cell(conn, row)
+        schema.insert_dispatch(
+            conn,
+            cell_id=cell_id,
+            task_id="task",
+            response_path=str(response_path),
+        )
+    return db_path, cell_id
 
 
 def test_code_writing_scorer_happy_path(monkeypatch):
@@ -265,31 +296,17 @@ def test_summarization_scorer_happy_path():
 
 
 def test_score_cell_prose_lane_runs_judge_despite_gate_fail(tmp_path):
-    db_path = tmp_path / "ledger.db"
-    response_path = tmp_path / "response.md"
-    response_path.write_text(
-        "Bug fix in scripts/check_links.py mapped to codex debugging. "
-        "security regressions via claude in code-review. module handoff by "
-        "cheap summarization. Fact-check with google. Draft a decision card."
-        " Include a cost estimate.",
-        encoding="utf-8",
-    )
-    model = model_by_canonical("claude-opus-4-7")
-    row = schema.build_cell_row(
+    db_path, cell_id = _seed_cell(
+        tmp_path,
         lane="orchestrating",
         fixture_id="multi-task-routing-brief",
-        model=model,
-        run_date="2026-05-21",
+        response=(
+            "Bug fix in scripts/check_links.py mapped to codex debugging. "
+            "security regressions via claude in code-review. module handoff by "
+            "cheap summarization. Fact-check with google. Draft a decision card."
+            " Include a cost estimate."
+        ),
     )
-    schema.init_db(db_path)
-    with schema.connect(db_path) as conn:
-        cell_id = schema.insert_cell(conn, row)
-        schema.insert_dispatch(
-            conn,
-            cell_id=cell_id,
-            task_id="task",
-            response_path=str(response_path),
-        )
     calls = []
 
     def fake_judge_fn(model_name: str, prompt: str) -> str:
@@ -305,6 +322,211 @@ def test_score_cell_prose_lane_runs_judge_despite_gate_fail(tmp_path):
     )
     assert gates["same_family_serialized"] is False
     assert len(calls) == 2
+    with schema.connect(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT gate_name, scorer, score_value, gate_failure_reason
+            FROM scores
+            WHERE cell_id = ?
+            ORDER BY gate_name, scorer
+            """,
+            (cell_id,),
+        ).fetchall()
+    deterministic_rows = [row for row in rows if row["scorer"] == "deterministic"]
+    judge_rows = [
+        row
+        for row in rows
+        if str(row["scorer"]).startswith("llm-judge:")
+    ]
+    assert len(deterministic_rows) == 4
+    assert len(judge_rows) == 2
+    assert {row["gate_failure_reason"] for row in judge_rows} == {"gate_passed"}
+
+
+def test_score_cell_mechanical_lane_skips_judge_when_gate_fails(
+    tmp_path,
+    monkeypatch,
+):
+    class FakeMechanicalScorer:
+        def deterministic_gates(self, response, ground_truth):
+            return {"mock_gate": False}
+
+        def llm_judge_prompt(self, response, ground_truth):
+            return "judge this mechanical response"
+
+    db_path, cell_id = _seed_cell(
+        tmp_path,
+        lane="code-review",
+        fixture_id="pr-1333-security-yaml",
+        response="No findings listed and no real observations.",
+    )
+    monkeypatch.setitem(score_cell.SCORERS, "code-review", FakeMechanicalScorer())
+    calls = []
+
+    def fake_judge_fn(model_name: str, prompt: str) -> str:
+        calls.append((model_name, prompt))
+        return json.dumps({"score": 8.0, "rationale": "pass"})
+
+    gates = score_cell.score_cell(
+        cell_id=cell_id,
+        db_path=db_path,
+        judge_fn=fake_judge_fn,
+        judge1="dummy-model-1",
+        judge2="dummy-model-2",
+    )
+
+    assert gates == {"mock_gate": False}
+    assert calls == []
+    with schema.connect(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT gate_name, scorer, score_value, gate_failure_reason
+            FROM scores
+            WHERE cell_id = ?
+            ORDER BY gate_name, scorer
+            """,
+            (cell_id,),
+        ).fetchall()
+    deterministic_rows = [row for row in rows if row["scorer"] == "deterministic"]
+    judge_rows = [
+        row
+        for row in rows
+        if str(row["scorer"]).startswith("llm-judge:")
+    ]
+    assert [(row["gate_name"], row["score_value"]) for row in deterministic_rows] == [
+        ("mock_gate", 0.0)
+    ]
+    assert len(judge_rows) == 2
+    assert {row["score_value"] for row in judge_rows} == {None}
+    assert {row["gate_failure_reason"] for row in judge_rows} == {
+        "scorer_skipped_by_two_stage_rule"
+    }
+
+
+def test_score_cell_parseable_judge_sets_failure_reason(tmp_path):
+    db_path, cell_id = _seed_cell(
+        tmp_path,
+        lane="orchestrating",
+        fixture_id="multi-task-routing-brief",
+        response=(
+            "Python bug -> codex -> debugging. security regressions -> claude -> "
+            "code-review. module handoff -> cheap -> summarization. fact-check -> "
+            "google -> fact-check. Serialize same-family Codex work, include a "
+            "cost estimate, and draft a decision card."
+        ),
+    )
+
+    def fake_judge_fn(model_name: str, prompt: str) -> str:
+        score = 8.0 if model_name == "dummy-model-1" else 4.0
+        return json.dumps({"score": score, "rationale": "ok"})
+
+    score_cell.score_cell(
+        cell_id=cell_id,
+        db_path=db_path,
+        judge_fn=fake_judge_fn,
+        judge1="dummy-model-1",
+        judge2="dummy-model-2",
+    )
+
+    with schema.connect(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT scorer, score_value, gate_failure_reason
+            FROM scores
+            WHERE cell_id = ? AND gate_name = 'llm_judge_score'
+            ORDER BY scorer
+            """,
+            (cell_id,),
+        ).fetchall()
+    assert [(row["score_value"], row["gate_failure_reason"]) for row in rows] == [
+        (8.0, "gate_passed"),
+        (4.0, "gate_failed_legitimately"),
+    ]
+
+
+def test_score_cell_unparseable_judge_sets_null_score_and_reason(tmp_path):
+    db_path, cell_id = _seed_cell(
+        tmp_path,
+        lane="orchestrating",
+        fixture_id="multi-task-routing-brief",
+        response=(
+            "Python bug -> codex -> debugging. security regressions -> claude -> "
+            "code-review. module handoff -> cheap -> summarization. fact-check -> "
+            "google -> fact-check. Serialize same-family Codex work, include a "
+            "cost estimate, and draft a decision card."
+        ),
+    )
+
+    def fake_judge_fn(model_name: str, prompt: str) -> str:
+        return "score: eight"
+
+    score_cell.score_cell(
+        cell_id=cell_id,
+        db_path=db_path,
+        judge_fn=fake_judge_fn,
+        judge1="dummy-model-1",
+        judge2="dummy-model-2",
+    )
+
+    with schema.connect(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT score_value, gate_failure_reason
+            FROM scores
+            WHERE cell_id = ? AND gate_name = 'llm_judge_score'
+            """,
+            (cell_id,),
+        ).fetchall()
+    assert len(rows) == 2
+    assert {row["score_value"] for row in rows} == {None}
+    assert {row["gate_failure_reason"] for row in rows} == {
+        "scorer_unparseable_output"
+    }
+
+
+def test_score_cell_nonzero_judge_returncode_sets_crashed_reason(tmp_path):
+    db_path, cell_id = _seed_cell(
+        tmp_path,
+        lane="orchestrating",
+        fixture_id="multi-task-routing-brief",
+        response=(
+            "Python bug -> codex -> debugging. security regressions -> claude -> "
+            "code-review. module handoff -> cheap -> summarization. fact-check -> "
+            "google -> fact-check. Serialize same-family Codex work, include a "
+            "cost estimate, and draft a decision card."
+        ),
+    )
+
+    def fake_judge_fn(model_name: str, prompt: str) -> DispatchResult:
+        return DispatchResult(
+            response=json.dumps({"score": 8.0, "rationale": "ignored"}),
+            task_id=f"judge-{model_name}",
+            latency_s=0.1,
+            returncode=2,
+            stderr_excerpt="judge crashed",
+        )
+
+    score_cell.score_cell(
+        cell_id=cell_id,
+        db_path=db_path,
+        judge_fn=fake_judge_fn,
+        judge1="dummy-model-1",
+        judge2="dummy-model-2",
+    )
+
+    with schema.connect(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT score_value, gate_failure_reason, stderr_excerpt
+            FROM scores
+            WHERE cell_id = ? AND gate_name = 'llm_judge_score'
+            """,
+            (cell_id,),
+        ).fetchall()
+    assert len(rows) == 2
+    assert {row["score_value"] for row in rows} == {None}
+    assert {row["gate_failure_reason"] for row in rows} == {"scorer_crashed"}
+    assert {row["stderr_excerpt"] for row in rows} == {"judge crashed"}
 
 
 def test_score_cell_mechanical_lane_with_no_judge_returns_early(tmp_path):
@@ -350,32 +572,18 @@ def test_score_cell_mechanical_lane_with_no_judge_returns_early(tmp_path):
     assert calls == []
 
 
-def test_score_cell_writes_infra_error_gate_when_judge_fails(tmp_path):
-    db_path = tmp_path / "ledger.db"
-    response_path = tmp_path / "response.md"
-    response_path.write_text(
-        "Bug fix in scripts/check_links.py mapped to codex debugging. "
-        "security regressions via claude in code-review. module handoff by "
-        "cheap summarization. Fact-check with google. Draft a decision card."
-        " Include a cost estimate.",
-        encoding="utf-8",
-    )
-    model = model_by_canonical("claude-opus-4-7")
-    row = schema.build_cell_row(
+def test_score_cell_writes_crashed_reason_when_judge_raises(tmp_path):
+    db_path, cell_id = _seed_cell(
+        tmp_path,
         lane="orchestrating",
         fixture_id="multi-task-routing-brief",
-        model=model,
-        run_date="2026-05-21",
+        response=(
+            "Bug fix in scripts/check_links.py mapped to codex debugging. "
+            "security regressions via claude in code-review. module handoff by "
+            "cheap summarization. Fact-check with google. Draft a decision card."
+            " Include a cost estimate."
+        ),
     )
-    schema.init_db(db_path)
-    with schema.connect(db_path) as conn:
-        cell_id = schema.insert_cell(conn, row)
-        schema.insert_dispatch(
-            conn,
-            cell_id=cell_id,
-            task_id="task",
-            response_path=str(response_path),
-        )
 
     def fake_judge_fn(model_name: str, prompt: str) -> str:
         if model_name == "dummy-model-1":
@@ -392,19 +600,25 @@ def test_score_cell_writes_infra_error_gate_when_judge_fails(tmp_path):
 
     with schema.connect(db_path) as conn:
         rows = conn.execute(
-            "SELECT gate_name, score_value, scorer FROM scores WHERE "
-            "cell_id = ? AND gate_name IN ('llm_judge_score', 'llm_judge_error')",
+            """
+            SELECT gate_name, score_value, scorer, gate_failure_reason, stderr_excerpt
+            FROM scores
+            WHERE cell_id = ? AND gate_name = 'llm_judge_score'
+            """,
             (cell_id,),
         ).fetchall()
 
-    llm_judge_scores = [row for row in rows if row["gate_name"] == "llm_judge_score"]
-    llm_judge_errors = [row for row in rows if row["gate_name"] == "llm_judge_error"]
+    llm_judge_scores = [row for row in rows if row["score_value"] is not None]
+    llm_judge_errors = [row for row in rows if row["score_value"] is None]
 
     assert len(llm_judge_scores) == 1
     assert llm_judge_scores[0]["score_value"] == 8.0
+    assert llm_judge_scores[0]["gate_failure_reason"] == "gate_passed"
     assert len(llm_judge_errors) == 1
-    assert llm_judge_errors[0]["score_value"] is None
-    assert "RuntimeError('judge transport offline')" in llm_judge_errors[0]["scorer"]
+    assert llm_judge_errors[0]["gate_failure_reason"] == "scorer_crashed"
+    assert "RuntimeError('judge transport offline')" in llm_judge_errors[0][
+        "stderr_excerpt"
+    ]
 
 
 def test_mcp_use_scorer_happy_path():


### PR DESCRIPTION
## Summary

Enforces the prose-lane rule documented in memory `feedback_calibration_gate_brittleness.md` (was never enforced in code) + adds LLM-judge failure-reason disambiguation. Closes #1412.

## What changed (1 commit: `b735f322`)

1. **Idempotent `gate_failure_reason` column** in `scores` table (PRAGMA-guarded `_ensure_columns` in `schema.py`).
2. **Prose-lane judge runs unconditionally** for `{orchestrating, refactoring, summarization, content-writing-long, architecting}`. Mechanical lanes keep the 2-stage gate-gates-judge rule. `RefactoringScorer.llm_judge_prompt` activated (was no-op forward-declaration).
3. **Five explicit failure reasons** mapped from code paths: `gate_passed`, `gate_failed_legitimately`, `scorer_unparseable_output`, `scorer_crashed`, `scorer_skipped_by_two_stage_rule`.
4. **NULL semantics**: unparseable/crashed/skipped rows get `score_value = NULL`. Renderer + stability report exclude NULL via `WHERE s.score_value IS NOT NULL` so no ZeroDivisionError risk.
5. **Stability variance report defaults to LLM-judge only**; `--include-deterministic-gates` flag for the broader view.
6. **Report HTML** shows `judge n/a` for NULL.

## Review

Sonnet R1 **APPROVE_WITH_NITS** — 3 non-blocking nits flagged as follow-ups not blockers:

- N1: `scorer_crashed` absorbs both Python exceptions and non-zero returncode; a `judge_timed_out` tag would distinguish flaky-latency from hard-failure in post-hoc analysis. (Diagnostic.)
- N2: No dedicated `refactoring` lane end-to-end test (the code path is identical to orchestrating which IS tested). (Coverage.)
- N3: F-string SQL pattern in `render_stability_report.py:133` is safe today (hardcoded literal) but worth a defensive `# never interpolate user input` comment.

Filing each as a small follow-up rather than re-rolling.

## Test plan

- [x] 33 calibration tests passing
- [x] `scripts/test_pipeline.py` — 170 tests OK
- [x] `ruff check` clean
- [x] Migration idempotent (verified by `test_schema_gate_failure_reason_migration_is_idempotent`)
- [x] Backward-compat: pre-migration NULL rows handled by renderer

Refs #1412

