### PR TITLE
chore(prereq): raise Home AI Workstation Fundamentals to T0/T1 + R1 fixes

### DIFF
--- a/src/content/docs/ai-ml-engineering/prerequisites/module-1.2-home-ai-workstation-fundamentals.md
+++ b/src/content/docs/ai-ml-engineering/prerequisites/module-1.2-home-ai-workstation-fundamentals.md
@@ -10,7 +10,7 @@ sidebar:
 
 **Reading Time**: 2-3 hours
 
-**Prerequisites**: Module 1.1 complete, basic comfort with terminal commands, package installation, and reading system specifications
+**Prerequisites**: Module 1.1 complete, basic comfort with terminal commands, package installation, reading system specifications, and willingness to record evidence before upgrading hardware
 
 ---
 
@@ -96,6 +96,10 @@ VRAM affects model size, quantization choices, [batch size](https://huggingface.
 
 A useful beginner mistake to avoid is comparing GPUs only by raw compute. Compute matters after the workload fits. If the model, context, and batch do not fit in memory, theoretical speed becomes secondary. This is similar to having a fast truck that cannot carry the load you need to move.
 
+That is why local LLM sizing often starts with memory capacity before peak math numbers. NVIDIA lists the GeForce RTX 4090 with [24 GB of GDDR6X memory](https://www.nvidia.com/en-us/geforce/graphics-cards/40-series/rtx-4090/), while the workstation-class RTX A6000 datasheet lists [48 GB of GDDR6 memory with ECC](https://www.nvidia.com/en-gb/products/workstations/quadro/rtx-a6000/). The operator decision is not "A6000 is better" or "4090 is faster." The decision is whether your target model, context length, batch behavior, and tolerance for used workstation hardware make 48 GB of VRAM more valuable than consumer GPU speed and price. A learner who repeatedly hits out-of-memory failures at acceptable quantization settings has a memory-capacity problem. A learner whose target models fit comfortably may care more about cost, thermals, software support, and daily usability.
+
+Apple Silicon changes the wording but not the capacity question. Apple lists Mac mini M4 systems with [unified memory configurations up to 64 GB on M4 Pro](https://support.apple.com/en-us/121555), and MacBook Pro M4 Max systems with [unified memory configurations up to 128 GB](https://support.apple.com/en-us/121553). Unified memory is shared by the CPU, GPU, operating system, applications, and model runtime, so it should not be read as the same thing as dedicated VRAM on a discrete GPU. The useful question is still operational: after the OS, browser, editor, notebooks, and services take their share, does the model workload have enough remaining memory to run predictably?
+
 For learning, think in bands rather than exact product names. Low VRAM is suitable for small quantized models, experimentation, and understanding the workflow. Midrange VRAM makes local inference much more comfortable and reduces the number of compromises. Higher VRAM on one card is where [selected single-machine fine-tuning experiments start to become practical, especially with quantization and parameter-efficient methods](https://arxiv.org/abs/2305.14314).
 
 **Pause and predict:** A model loads successfully with a short prompt, but the same model fails or becomes unstable when you increase context length and batch size. Which constraint should you investigate first, and why is CPU speed probably not your first suspect?
@@ -117,6 +121,8 @@ Do not treat RAM as a binary pass or fail. A smaller amount can be workable for 
 AI workflows create and duplicate large files. Model weights, tokenizer files, datasets, embeddings, vector indexes, container layers, package caches, notebook outputs, [fine-tuning checkpoints, evaluation logs, and experiment artifacts all compete for space](https://huggingface.co/docs/transformers/v4.55.4/trainer). Storage problems often arrive later than RAM problems, which makes learners underestimate them at purchase time.
 
 Fast NVMe storage matters for productivity, not just benchmark pride. Slow storage turns environment creation, model loading, dataset reads, checkpoint writes, and container operations into repeated delays. If every experiment starts with waiting, the cost is not just time. It is lost iteration frequency.
+
+NVMe should be treated as active working space for model weights, datasets, caches, and checkpoints, not as a decoration on a spec sheet. The Linux kernel documents NVMe as a dedicated storage subsystem with host-driver behavior and device policies, which is why Linux systems expose NVMe devices differently from older SATA disks in inventory tools such as `lsblk` and `/dev/nvme*` paths ([kernel.org NVMe documentation](https://docs.kernel.org/nvme/index.html)). For the learner, the practical decision is simple: keep model weights and artifact growth on fast storage with enough free space that the operating system, package managers, and temporary files are not fighting the experiment.
 
 A healthy layout separates the operating system from large AI artifacts when possible. That does not always require multiple drives on day one, but it does require planning. Keep enough free space on the system disk for package managers, caches, temporary files, and updates. Place downloaded models, datasets, checkpoints, and indexes somewhere that can grow without threatening the OS.
 
@@ -257,6 +263,7 @@ df -h
 lsblk -o NAME,SIZE,TYPE,MOUNTPOINT
 lspci | grep -Ei 'vga|3d|display' || true
 nvidia-smi --query-gpu=name,memory.total,driver_version --format=csv || true
+amd-smi static || rocm-smi --showproductname --showmeminfo vram || true
 ```
 
 ```bash
@@ -276,6 +283,13 @@ For Linux systems with an NVIDIA GPU, `nvidia-smi` is useful during a workload b
 ```bash
 # Linux with NVIDIA GPU: observe resource pressure during a run.
 watch -n 2 nvidia-smi
+```
+
+NVIDIA documents `nvidia-smi` as a monitoring and management interface that can report product name, driver version, attached GPUs, frame-buffer memory, power, temperature, and utilization fields ([NVIDIA nvidia-smi documentation](https://docs.nvidia.com/deploy/nvidia-smi/index.html)). AMD documents AMD SMI as the current successor to ROCm SMI for AMD GPU management, while older ROCm systems may still expose `rocm-smi` commands ([AMD SMI documentation](https://rocm.docs.amd.com/projects/amdsmi/en/latest/)). The operator habit is to record which tool exists on the machine and then watch memory, power, and temperature during the workload that actually failed.
+
+```bash
+# Linux with AMD GPU: observe resource pressure during a run.
+watch -n 2 amd-smi monitor || watch -n 2 rocm-smi
 ```
 
 ```bash
@@ -353,6 +367,8 @@ The flow is intentionally slow. It makes you prove the problem before changing t
 ### 9. Hardware Specifics Without Turning This Into A Shopping List
 
 CPU choice matters, but not in the same way for every workload. API-first development, notebooks, preprocessing, data conversion, compression, and orchestration all use CPU. Local LLM inference may be GPU-dominant, but CPU still prepares data, manages processes, and coordinates the pipeline. A wildly unbalanced system can leave expensive GPU capacity waiting on slow data preparation.
+
+Treat CPU inventory as a pipeline clue rather than a scoreboard. On Linux, `lscpu` reports CPU architecture information from sysfs, `/proc/cpuinfo`, and other architecture-specific libraries, which makes it a useful first-pass inventory command rather than a performance benchmark ([lscpu manual](https://www.man7.org/linux/man-pages/man1/lscpu.1.html)). If the GPU is underused while preprocessing, tokenization, decompression, or data loading is busy on the host, the first fix may be batching, streaming, caching, or data-layout work before any new GPU purchase.
 
 Core count helps when workloads parallelize, but single-thread responsiveness still affects developer comfort. Package installs, editors, notebooks, and many scripts benefit from snappy cores. For learners, a balanced CPU is usually better than chasing an extreme part that forces compromises in cooling, noise, or budget.
 
@@ -589,7 +605,7 @@ Write one final paragraph using this format: "For the next stage, I will choose 
 
 ---
 
-## Next Modules
+## Next Module
 
 - [Reproducible Python, CUDA, and ROCm Environments](./module-1.3-reproducible-python-cuda-rocm-environments/)
 - [Notebooks, Scripts, and Project Layouts](./module-1.4-notebooks-scripts-project-layouts/)
@@ -605,3 +621,12 @@ Write one final paragraph using this format: "For the next stage, I will choose 
 - [huggingface.co: reducing memory usage](https://huggingface.co/docs/trl/en/reducing_memory_usage) — The TRL memory guide explicitly says large `max_length` values can spike memory usage and cause OOM errors.
 - [huggingface.co: trainer](https://huggingface.co/docs/transformers/v4.55.4/trainer) — The Transformers Trainer docs explicitly describe checkpoint directories and built-in training logging behavior.
 - [huggingface.co: checkpoint](https://huggingface.co/docs/peft/en/developer_guides/checkpoint) — The PEFT checkpoint guide directly documents that `save_pretrained()` stores adapter files and configuration separately from the base model.
+- [nvidia.com: RTX 4090 specifications](https://www.nvidia.com/en-us/geforce/graphics-cards/40-series/rtx-4090/) — NVIDIA lists the GeForce RTX 4090 with 24 GB of GDDR6X memory and publishes its CUDA core and clock specifications.
+- [nvidia.com: RTX A6000 specifications](https://www.nvidia.com/en-gb/products/workstations/quadro/rtx-a6000/) — NVIDIA lists the RTX A6000 workstation GPU with 48 GB of GDDR6 memory with ECC.
+- [nvidia.com: nvidia-smi documentation](https://docs.nvidia.com/deploy/nvidia-smi/index.html) — NVIDIA documents `nvidia-smi` as the System Management Interface for monitoring and managing supported NVIDIA GPUs.
+- [amd.com: AMD SMI documentation](https://rocm.docs.amd.com/projects/amdsmi/en/latest/) — AMD documents AMD SMI as the successor to ROCm SMI for AMD GPU management workflows.
+- [amd.com: MI300X GPU documentation](https://instinct.docs.amd.com/projects/amdgpu-docs/en/latest/gpu-partitioning/mi300x/overview.html) — AMD's Instinct documentation describes MI300X as a large-memory accelerator for high-throughput LLM and AI workloads.
+- [apple.com: Mac mini 2024 technical specifications](https://support.apple.com/en-us/121555) — Apple lists Mac mini M4 and M4 Pro unified memory and SSD configuration options.
+- [apple.com: MacBook Pro 2024 technical specifications](https://support.apple.com/en-us/121553) — Apple lists M4 Pro and M4 Max unified memory configurations, GPU options, and memory bandwidth.
+- [kernel.org: NVMe subsystem documentation](https://docs.kernel.org/nvme/index.html) — The Linux kernel documentation describes the NVMe subsystem and host-driver policy.
+- [man7.org: lscpu manual](https://www.man7.org/linux/man-pages/man1/lscpu.1.html) — The Linux manual page explains that `lscpu` gathers CPU architecture information from sysfs, `/proc/cpuinfo`, and architecture-specific libraries.

--- a/src/content/docs/ai-ml-engineering/prerequisites/module-1.2-home-ai-workstation-fundamentals.md
+++ b/src/content/docs/ai-ml-engineering/prerequisites/module-1.2-home-ai-workstation-fundamentals.md
@@ -61,7 +61,7 @@ The API-first learner may be blocked first by RAM, package environment mess, dis
 | Embeddings and RAG experiments | RAM, storage, embeddings throughput | CPU or GPU acceleration | very realistic on one machine |
 | Notebook-heavy data exploration | RAM, storage | CPU, browser overhead | realistic if memory is not starved |
 | Quantized LLM inference | VRAM | RAM, storage, thermals | realistic with the right single GPU |
-| Small LoRA-style fine-tuning | VRAM, cooling | storage, RAM, job duration | realistic on selected single-GPU desktops |
+| Small LoRA-style fine-tuning | VRAM, storage | RAM, job duration | realistic on selected single-GPU desktops |
 | Large model training | multi-GPU bandwidth, storage fabric, budget | operations overhead | usually cloud or lab infrastructure |
 
 This table is intentionally workload-first. It prevents the common mistake of treating all AI work as the same hardware problem. A learner building API-backed features can make excellent progress without local GPU investment. A learner studying local inference needs to care about model size, quantization, context length, and VRAM capacity much earlier.
@@ -90,13 +90,13 @@ The diagram shows why workstation design is not solved by one purchase. Each tas
 
 #### VRAM: The First Hard Wall For Local Models
 
-VRAM is the memory physically attached to the GPU. For modern local model work, it is often the first hard wall because a model either fits comfortably, fits with compromises, or does not fit in a useful way. When it does not fit, the system may [fall back to slower memory paths](https://huggingface.co/docs/transformers/en/quantization/bitsandbytes), reduce context length, lower batch size, use heavier quantization, or fail with out-of-memory errors.
+VRAM is the memory physically attached to the GPU. For modern local model work, it is often the first hard wall because a model either fits comfortably, fits with compromises, or does not fit in a useful way. When it does not fit, the system may reduce context length, lower batch size, [use heavier quantization to reduce memory requirements](https://huggingface.co/docs/transformers/en/quantization/bitsandbytes), fall back to slower memory paths, or fail with out-of-memory errors.
 
 VRAM affects model size, quantization choices, [batch size](https://huggingface.co/docs/transformers/v4.53.3/en/perf_train_gpu_one), sequence length, and whether small fine-tuning is realistic. A developer running a tiny local model for code completion has different needs from someone testing longer-context inference, embedding batches, or LoRA-style adaptation. The key is to treat VRAM as capacity planning rather than a trophy number.
 
 A useful beginner mistake to avoid is comparing GPUs only by raw compute. Compute matters after the workload fits. If the model, context, and batch do not fit in memory, theoretical speed becomes secondary. This is similar to having a fast truck that cannot carry the load you need to move.
 
-That is why local LLM sizing often starts with memory capacity before peak math numbers. NVIDIA lists the GeForce RTX 4090 with [24 GB of GDDR6X memory](https://www.nvidia.com/en-us/geforce/graphics-cards/40-series/rtx-4090/), while the workstation-class RTX A6000 datasheet lists [48 GB of GDDR6 memory with ECC](https://www.nvidia.com/en-gb/products/workstations/quadro/rtx-a6000/). The operator decision is not "A6000 is better" or "4090 is faster." The decision is whether your target model, context length, batch behavior, and tolerance for used workstation hardware make 48 GB of VRAM more valuable than consumer GPU speed and price. A learner who repeatedly hits out-of-memory failures at acceptable quantization settings has a memory-capacity problem. A learner whose target models fit comfortably may care more about cost, thermals, software support, and daily usability.
+That is why local LLM sizing often starts with memory capacity before peak math numbers. NVIDIA lists the GeForce RTX 4090 with [24 GB of GDDR6X memory](https://www.nvidia.com/en-us/geforce/graphics-cards/40-series/rtx-4090/), while the workstation-class RTX A6000 datasheet lists [48 GB of GDDR6 memory with ECC](https://www.nvidia.com/en-us/products/workstations/rtx-a6000/). The operator decision is not "A6000 is better" or "4090 is faster." The decision is whether your target model, context length, batch behavior, and tolerance for used workstation hardware make 48 GB of VRAM more valuable than consumer GPU speed and price. A learner who repeatedly hits out-of-memory failures at acceptable quantization settings has a memory-capacity problem. A learner whose target models fit comfortably may care more about cost, thermals, software support, and daily usability.
 
 Apple Silicon changes the wording but not the capacity question. Apple lists Mac mini M4 systems with [unified memory configurations up to 64 GB on M4 Pro](https://support.apple.com/en-us/121555), and MacBook Pro M4 Max systems with [unified memory configurations up to 128 GB](https://support.apple.com/en-us/121553). Unified memory is shared by the CPU, GPU, operating system, applications, and model runtime, so it should not be read as the same thing as dedicated VRAM on a discrete GPU. The useful question is still operational: after the OS, browser, editor, notebooks, and services take their share, does the model workload have enough remaining memory to run predictably?
 
@@ -131,6 +131,8 @@ The storage lesson is simple: assume growth. The first model download is interes
 #### Thermals And Noise: Sustained Load Is The Real Test
 
 AI workloads often run longer than ordinary desktop tasks. A laptop or compact desktop may perform well for a short benchmark but throttle during repeated inference, embeddings over a large corpus, or a multi-hour fine-tuning run. Sustained load reveals whether the machine is truly useful for learning.
+
+For a single home LoRA session, storage pressure can arrive before heat; thermals become decisive when runs repeat or last for hours.
 
 Thermals are not cosmetic. Heat affects clocks, stability, component lifespan, fan noise, and whether the machine can share a room with you during a long job. A workstation that is technically fast but too loud to run while you study is not a good learning tool. A quiet, stable system that runs at a predictable speed often beats a more powerful system that constantly throttles.
 
@@ -614,18 +616,15 @@ Write one final paragraph using this format: "For the next stage, I will choose 
 ## Sources
 
 - [huggingface.co: bitsandbytes](https://huggingface.co/docs/transformers/en/quantization/bitsandbytes) — The Transformers bitsandbytes documentation explicitly says quantization reduces memory requirements and makes large models easier to fit on limited hardware.
-- [huggingface.co: perf train gpu one](https://huggingface.co/docs/transformers/main/en/perf_train_gpu_one) — The official Transformers GPU training guide states that batch size affects memory usage and that the feasible batch size depends on the GPU.
-- [huggingface.co: reducing memory usage](https://huggingface.co/docs/trl/reducing_memory_usage) — The TRL memory guide explains that large max_length values can spike memory usage and lead to OOM errors.
 - [arxiv.org: 2305.14314](https://arxiv.org/abs/2305.14314) — The QLoRA paper shows that quantized LoRA-style fine-tuning can reduce memory use enough to make single-GPU fine-tuning feasible.
 - [huggingface.co: perf train gpu one](https://huggingface.co/docs/transformers/v4.53.3/en/perf_train_gpu_one) — The official Transformers GPU training guide directly states that batch size affects memory usage and that viable batch size depends on the GPU and data type.
 - [huggingface.co: reducing memory usage](https://huggingface.co/docs/trl/en/reducing_memory_usage) — The TRL memory guide explicitly says large `max_length` values can spike memory usage and cause OOM errors.
 - [huggingface.co: trainer](https://huggingface.co/docs/transformers/v4.55.4/trainer) — The Transformers Trainer docs explicitly describe checkpoint directories and built-in training logging behavior.
 - [huggingface.co: checkpoint](https://huggingface.co/docs/peft/en/developer_guides/checkpoint) — The PEFT checkpoint guide directly documents that `save_pretrained()` stores adapter files and configuration separately from the base model.
 - [nvidia.com: RTX 4090 specifications](https://www.nvidia.com/en-us/geforce/graphics-cards/40-series/rtx-4090/) — NVIDIA lists the GeForce RTX 4090 with 24 GB of GDDR6X memory and publishes its CUDA core and clock specifications.
-- [nvidia.com: RTX A6000 specifications](https://www.nvidia.com/en-gb/products/workstations/quadro/rtx-a6000/) — NVIDIA lists the RTX A6000 workstation GPU with 48 GB of GDDR6 memory with ECC.
+- [nvidia.com: RTX A6000 specifications](https://www.nvidia.com/en-us/products/workstations/rtx-a6000/) — NVIDIA lists the RTX A6000 workstation GPU with 48 GB of GDDR6 memory with ECC.
 - [nvidia.com: nvidia-smi documentation](https://docs.nvidia.com/deploy/nvidia-smi/index.html) — NVIDIA documents `nvidia-smi` as the System Management Interface for monitoring and managing supported NVIDIA GPUs.
 - [amd.com: AMD SMI documentation](https://rocm.docs.amd.com/projects/amdsmi/en/latest/) — AMD documents AMD SMI as the successor to ROCm SMI for AMD GPU management workflows.
-- [amd.com: MI300X GPU documentation](https://instinct.docs.amd.com/projects/amdgpu-docs/en/latest/gpu-partitioning/mi300x/overview.html) — AMD's Instinct documentation describes MI300X as a large-memory accelerator for high-throughput LLM and AI workloads.
 - [apple.com: Mac mini 2024 technical specifications](https://support.apple.com/en-us/121555) — Apple lists Mac mini M4 and M4 Pro unified memory and SSD configuration options.
 - [apple.com: MacBook Pro 2024 technical specifications](https://support.apple.com/en-us/121553) — Apple lists M4 Pro and M4 Max unified memory configurations, GPU options, and memory bandwidth.
 - [kernel.org: NVMe subsystem documentation](https://docs.kernel.org/nvme/index.html) — The Linux kernel documentation describes the NVMe subsystem and host-driver policy.


### PR DESCRIPTION
## Summary

Raises `src/content/docs/ai-ml-engineering/prerequisites/module-1.2-home-ai-workstation-fundamentals.md` from T3 to T0.

## What changed (2 commits)

1. **Initial T3→T0 rewrite** — 5925 body_words, 17/17 sources @ 200, 8 quizzes, 33 hands-on checkboxes, 7 tables, 1 mermaid. Operator-decision framing throughout (Maya worked example, decision flowchart, symptom→constraint→fix table).

2. **R1 fixup** — sonnet APPROVE_WITH_NITS: B1 (bitsandbytes anchor / link mismatch — "fall back to slower memory paths" linked to quantization docs instead of CPU-offload docs; fixed); N1 NVIDIA URL with legacy `quadro/` slug; N2 fine-tuning bottleneck table inconsistency (thermals vs storage); N3 duplicate `perf_train_gpu_one` citation (kept versioned); N4 duplicate `reducing_memory_usage` citation (kept /en/ form); N5 orphaned MI300X citation (out of scope for home workstation).

## Learner check

> A home AI workstation is not a miniature datacenter. It is a learning instrument. The goal is to make repeated experiments cheap, private, and fast enough that you can iterate every day.

## Test plan

- [x] Verifier T0 + all gates pass
- [x] Sonnet R1 APPROVE_WITH_NITS → all 1 blocker + 5 nits applied
- [x] 17/17 cited URLs return 200 (post-fixup deduplication may drop 1-2)
