### PR TITLE
docs(calibration): fixture-expansion plans for 12 lanes + R1 methodology lock-ins (#1413 Action 1)

### DIFF
--- a/scripts/calibration/ground-truth/v1/architecting/PLAN.md
+++ b/scripts/calibration/ground-truth/v1/architecting/PLAN.md
@@ -23,7 +23,7 @@
 
 - Passing answers identify the core design constraints, risks, rollback path, and integration points named in the fixture.
 - Strong answers score `judge_score>=7` on the lane rubric and avoid invented infrastructure or unsupported product claims.
-- For any fixture with deterministic checks, `pytest_exit=0` or the equivalent verifier pass should be required before judge scoring is treated as sufficient.
+- For any fixture with deterministic checks, deterministic verifier pass IS the gate; LLM judge scoring runs only after `pytest_exit=0` or the equivalent verifier passes.
 
 ## Open questions
 

--- a/scripts/calibration/ground-truth/v1/architecting/PLAN.md
+++ b/scripts/calibration/ground-truth/v1/architecting/PLAN.md
@@ -1,0 +1,37 @@
+# Architecting — fixture expansion plan
+
+## Current state
+
+- `kubedojo-review-override-rfc.yaml` — RFC-design task for `KUBEDOJO_REVIEW_OVERRIDE`, covering env-var format, validation, Hermes invocation, flow integration, telemetry, rollback, and failure modes.
+
+## Target
+
+- Target count: 3 fixtures.
+- Current count: 1 fixture.
+- Add 2 fixtures so this lane can compare architectural judgment across more than one scenario.
+- Keep fixtures small enough for repeatable calibration while preserving enough context to force tradeoff reasoning.
+
+## Variety dimensions
+
+- RFC writeup: keep the existing review-override RFC as the long-form architecture fixture.
+- Decision card: add a compact ADR-style fixture that asks for a recommendation between two or three viable designs.
+- Capacity planning: add a sizing or throughput fixture that requires assumptions, bottleneck identification, and failure-budget thinking.
+- Include at least one fixture where rollback and observability are first-class acceptance points.
+- Include at least one fixture where the best answer must reject an over-broad design and scope the rollout.
+
+## Acceptance criteria per fixture
+
+- Passing answers identify the core design constraints, risks, rollback path, and integration points named in the fixture.
+- Strong answers score `judge_score>=7` on the lane rubric and avoid invented infrastructure or unsupported product claims.
+- For any fixture with deterministic checks, `pytest_exit=0` or the equivalent verifier pass should be required before judge scoring is treated as sufficient.
+
+## Open questions
+
+- Should architecting reuse one lane-level rubric, or should the RFC, decision-card, and capacity-planning fixtures each have a short fixture-specific rubric?
+- What source should ground truth use for capacity numbers: synthetic constraints, project telemetry, or an archived production-like trace?
+- Who reviews the final expected-answer notes for architecture fixtures before they become calibration anchors?
+
+## Refs
+
+- #1413
+- Memory: `feedback_single_fixture_v1_calibration.md`

--- a/scripts/calibration/ground-truth/v1/code-review/PLAN.md
+++ b/scripts/calibration/ground-truth/v1/code-review/PLAN.md
@@ -7,16 +7,16 @@
 
 ## Target
 
-- Target count: 5 fixtures.
+- Target count: 4 fixtures.
 - Current count: 2 fixtures.
-- Add 3 fixtures so the lane covers the full review surface from correctness through security and maintainability.
+- Add 2 fixtures so the lane covers the full review surface from correctness through security and maintainability.
 - Keep planted findings explicit, with tight hallucination terms so models are rewarded for finding real issues instead of generic review noise.
 
 ## Variety dimensions
 
 - Bugfix archetype: cover a small diff that fixes one bug but introduces a subtle behavioral regression.
 - Refactor archetype: cover a readability or structure change where the reviewer must preserve behavior and catch an accidental contract change.
-- Security archetype: keep `pr-1333-security-yaml.yaml` as one security-oriented fixture and add another only if it exercises a different threat model.
+- Security archetype: keep `pr-1333-security-yaml.yaml` as the security-oriented fixture for this expansion pass.
 - Feature archetype: use the Go leader-election fixture as a feature implementation review with concurrency and Kubernetes semantics.
 - Include one fixture with tests changed in the diff, so reviewers must check whether the tests actually protect the intended behavior.
 

--- a/scripts/calibration/ground-truth/v1/code-review/PLAN.md
+++ b/scripts/calibration/ground-truth/v1/code-review/PLAN.md
@@ -1,0 +1,38 @@
+# Code Review — fixture expansion plan
+
+## Current state
+
+- `k8s-controller-leader-election.yaml` — Go Kubernetes controller review with six planted findings around context propagation, loop capture, secret logging, nil dereference, goroutine cancellation, and optimistic concurrency.
+- `pr-1333-security-yaml.yaml` — GitHub Actions/security-YAML review for zizmor strict mode, reusable-action scan scope, Dependabot cooldown, and unpinned install behavior.
+
+## Target
+
+- Target count: 5 fixtures.
+- Current count: 2 fixtures.
+- Add 3 fixtures so the lane covers the full review surface from correctness through security and maintainability.
+- Keep planted findings explicit, with tight hallucination terms so models are rewarded for finding real issues instead of generic review noise.
+
+## Variety dimensions
+
+- Bugfix archetype: cover a small diff that fixes one bug but introduces a subtle behavioral regression.
+- Refactor archetype: cover a readability or structure change where the reviewer must preserve behavior and catch an accidental contract change.
+- Security archetype: keep `pr-1333-security-yaml.yaml` as one security-oriented fixture and add another only if it exercises a different threat model.
+- Feature archetype: use the Go leader-election fixture as a feature implementation review with concurrency and Kubernetes semantics.
+- Include one fixture with tests changed in the diff, so reviewers must check whether the tests actually protect the intended behavior.
+
+## Acceptance criteria per fixture
+
+- Passing answers identify the expected planted findings by alias, with no severe hallucination term present.
+- Strong answers find most high-impact issues and explain why they matter; target `judge_score>=7` or fixture-specific finding recall above the configured threshold.
+- Security fixtures must separate exploitable risks from low-confidence speculation and must not invent unrelated classes such as SQL injection or XSS.
+
+## Open questions
+
+- Should all code-review fixtures use the same finding-recall scorer, or should security fixtures have severity weighting?
+- How should partially correct findings be normalized when a model describes the bug accurately without using any configured alias?
+- Who signs off on the planted findings: original author, independent reviewer, or methodology working group?
+
+## Refs
+
+- #1413
+- Memory: `feedback_single_fixture_v1_calibration.md`

--- a/scripts/calibration/ground-truth/v1/code-writing/PLAN.md
+++ b/scripts/calibration/ground-truth/v1/code-writing/PLAN.md
@@ -1,0 +1,37 @@
+# Code Writing — fixture expansion plan
+
+## Current state
+
+- `parse-dependabot-cooldown.yaml` — Python implementation task for parsing Dependabot `cooldown.default-days` from YAML, with eight pytest cases covering nested/inline mappings, missing values, and invalid shapes.
+
+## Target
+
+- Target count: 5 fixtures.
+- Current count: 1 fixture.
+- Add 4 fixtures, one each for Node/TypeScript, Java, Rust, and Go.
+- Keep each fixture runnable in isolation with deterministic tests and no network dependency.
+
+## Variety dimensions
+
+- Python: keep the existing Dependabot cooldown parser as the Python fixture.
+- Node/TypeScript: add a typed parser or transform with edge cases around optional fields and invalid input.
+- Java: add a small class or utility where exception behavior, immutability, or collection handling matters.
+- Rust: add a parser or validator that exercises `Result`, ownership-friendly design, and precise error handling.
+- Go: add a package-level function with table-driven tests, nil/zero-value behavior, and explicit error returns.
+
+## Acceptance criteria per fixture
+
+- Passing requires the fixture test command to complete successfully, normally `pytest_exit=0`, `npm test` pass, `mvn test` or Gradle pass, `cargo test` pass, or `go test ./...` pass as appropriate.
+- Strong answers keep the implementation minimal, deterministic, and idiomatic for the target language while preserving all specified edge-case behavior.
+- If judge scoring is used, test pass remains the hard gate and `judge_score>=7` is an additional quality signal, not a substitute for failing tests.
+
+## Open questions
+
+- Should each language fixture include lint or formatter checks, or should calibration rely only on tests plus judge scoring?
+- Do we allow third-party dependencies when they are idiomatic for the language, or require standard-library-only solutions for comparability?
+- Who owns runtime setup validation for Java, Rust, Go, and Node/TypeScript fixtures on local and CI machines?
+
+## Refs
+
+- #1413
+- Memory: `feedback_single_fixture_v1_calibration.md`

--- a/scripts/calibration/ground-truth/v1/content-review/PLAN.md
+++ b/scripts/calibration/ground-truth/v1/content-review/PLAN.md
@@ -6,10 +6,11 @@
 
 ## Target
 
-- Target count: 5 fixtures.
+- Target count: 3 fixtures.
 - Current count: 1 fixture.
-- Add 4 fixtures so review quality is tested across PR-level, module-level, and security-focused content review.
+- Add 2 fixtures so review quality is tested across PR-level, module-level, and security-focused content review.
 - Keep planted flaws concrete enough that reviewers can distinguish rubric violations from stylistic preferences.
+- PR-review fixtures use structured JSON output matching the `_lib_pr_check.py` result shape already used by content-merge hooks.
 
 ## Variety dimensions
 
@@ -28,7 +29,6 @@
 ## Open questions
 
 - Should content-review scoring use planted-flaw recall only, or combine recall with severity calibration and review tone?
-- How should we represent expected PR-review output: GitHub-style comments, summary findings, or a structured JSON result?
 - Who reviews the ground-truth flaw list when content has subjective pedagogy concerns?
 
 ## Refs

--- a/scripts/calibration/ground-truth/v1/content-review/PLAN.md
+++ b/scripts/calibration/ground-truth/v1/content-review/PLAN.md
@@ -1,0 +1,37 @@
+# Content Review — fixture expansion plan
+
+## Current state
+
+- `flawed-module-rubric-review.yaml` — deliberately flawed Kubernetes RBAC module review with planted issues including a hallucinated kubectl flag, missing IPA tags, heading errors, broken citation, Bloom mismatch, missing diagram, duplicate H1, and banned wording.
+
+## Target
+
+- Target count: 5 fixtures.
+- Current count: 1 fixture.
+- Add 4 fixtures so review quality is tested across PR-level, module-level, and security-focused content review.
+- Keep planted flaws concrete enough that reviewers can distinguish rubric violations from stylistic preferences.
+
+## Variety dimensions
+
+- PR review: add a fixture that reviews a content PR diff and must separate blocking issues from nice-to-have edits.
+- Module review: keep the existing flawed-module fixture and add another module-level review with different pedagogy and structure failures.
+- Security review: add a security-sensitive content fixture where inaccurate commands, unsafe defaults, or missing warnings are central.
+- Include one fixture focused on citations and source fidelity rather than prose polish.
+- Include one fixture where the correct answer must preserve good content and avoid rewriting the whole module.
+
+## Acceptance criteria per fixture
+
+- Passing answers identify the configured planted flaws and do not claim unrelated hallucination terms as findings.
+- Strong answers prioritize blockers, connect each issue to the rubric, and provide actionable fixes; target `judge_score>=7`.
+- Security review fixtures must catch unsafe or false guidance and avoid weakening the evidence standard for security claims.
+
+## Open questions
+
+- Should content-review scoring use planted-flaw recall only, or combine recall with severity calibration and review tone?
+- How should we represent expected PR-review output: GitHub-style comments, summary findings, or a structured JSON result?
+- Who reviews the ground-truth flaw list when content has subjective pedagogy concerns?
+
+## Refs
+
+- #1413
+- Memory: `feedback_single_fixture_v1_calibration.md`

--- a/scripts/calibration/ground-truth/v1/content-writing-long/PLAN.md
+++ b/scripts/calibration/ground-truth/v1/content-writing-long/PLAN.md
@@ -1,0 +1,37 @@
+# Content Writing Long — fixture expansion plan
+
+## Current state
+
+- `kubedojo-rbac-module.yaml` — long Kubernetes RBAC module-writing task that rewards TTT pedagogy, operator decisions, misconceptions, runnable checks, and Bloom L3 treatment over upstream-doc paraphrase.
+
+## Target
+
+- Target count: 5 fixtures.
+- Current count: 1 fixture.
+- Add 4 fixtures covering multiple topics and length variants.
+- Keep the lane focused on long-form instructional writing, not short answer generation or generic documentation.
+
+## Variety dimensions
+
+- Topic 1: Kubernetes RBAC, using the existing module fixture as the baseline.
+- Topic 2: Kubernetes scheduling or storage, with a scenario that requires diagnosis and operator tradeoffs.
+- Topic 3: cloud platform or AWS operations, with explicit source-fidelity and safety constraints.
+- Topic 4: security or supply-chain hardening, with concrete commands, warnings, and verification steps.
+- Length variants: include short-long, medium-long, full module, and constrained rewrite lengths so verbosity and completeness can be calibrated separately.
+
+## Acceptance criteria per fixture
+
+- Passing answers satisfy the requested length band, include required topic terms, and meet the configured verifier tier or judge threshold.
+- Strong answers score `judge_score>=7`, teach through decisions and checks, and avoid padding, fabricated facts, or upstream-doc paraphrase.
+- Any fixture with deterministic content gates must pass those gates before qualitative judge scoring is accepted.
+
+## Open questions
+
+- Should each topic have its own rubric profile, or should the existing long-writing rubric be reused with fixture-specific required terms?
+- What ground-truth sources are allowed for cloud and security topics, and how many citations should be mandatory?
+- Who reviews long-writing fixtures for pedagogy quality before they become stable calibration cases?
+
+## Refs
+
+- #1413
+- Memory: `feedback_single_fixture_v1_calibration.md`

--- a/scripts/calibration/ground-truth/v1/content-writing-long/PLAN.md
+++ b/scripts/calibration/ground-truth/v1/content-writing-long/PLAN.md
@@ -21,7 +21,7 @@
 
 ## Acceptance criteria per fixture
 
-- Passing answers satisfy the requested length band, include required topic terms, and meet the configured verifier tier or judge threshold.
+- Passing answers satisfy the density gates from `feedback_388_verifier_first_pilot_then_volume.md`: `body_words >= 5000` for T0, `median_wpp >= 28`, `mean_wpp >= 30`, and `short_paragraph_rate <= 20%`.
 - Strong answers score `judge_score>=7`, teach through decisions and checks, and avoid padding, fabricated facts, or upstream-doc paraphrase.
 - Any fixture with deterministic content gates must pass those gates before qualitative judge scoring is accepted.
 

--- a/scripts/calibration/ground-truth/v1/debugging/PLAN.md
+++ b/scripts/calibration/ground-truth/v1/debugging/PLAN.md
@@ -1,0 +1,38 @@
+# Debugging — fixture expansion plan
+
+## Current state
+
+- `pod-pending-topology-mismatch.yaml` — EKS multi-AZ debugging scenario where a PV is bound to `us-east-1a` but available nodes are in `us-east-1b`, requiring PV nodeAffinity analysis and a scoped remediation.
+- `resourcequota-pvc-mismatch.yaml` — PVC quota mismatch scenario from PR #1353 where PVC requests sum to `320Gi` but the `ResourceQuota` allows only `300Gi`.
+
+## Target
+
+- Target count: 5 fixtures.
+- Current count: 2 fixtures.
+- Add 3 fixtures so the lane covers common Kubernetes and systems failure classes beyond storage/quota diagnosis.
+- Keep each fixture anchored in logs, manifests, events, traces, or code snippets that make the root cause discoverable.
+
+## Variety dimensions
+
+- Pod-pending: keep `pod-pending-topology-mismatch.yaml` as the topology and scheduling fixture.
+- CrashLoop: add a fixture where logs and probes point to a startup/configuration failure, not a generic restart answer.
+- OOM: add a fixture where memory limits, process behavior, and evidence distinguish OOMKilled from CPU or liveness failures.
+- Deadlock: add a code or distributed-systems fixture where stack traces or goroutine dumps identify a real deadlock.
+- Quota/config mismatch: keep the ResourceQuota PVC fixture as an additional calibration case for exact arithmetic and scoped remediation.
+
+## Acceptance criteria per fixture
+
+- Passing answers identify the configured root-cause terms and propose a fix that matches the fixture's allowed fix terms.
+- Strong answers cite the specific evidence path, avoid broad rewrites, and reach `judge_score>=7` or the fixture-specific root-cause threshold.
+- If a fixture has a deterministic reproduction or test command, `pytest_exit=1` may be the expected failing reproduction and the fix must then make the targeted test pass.
+
+## Open questions
+
+- Should debugging fixtures score root-cause identification and remediation separately?
+- How should expected failing states be represented when `pytest_exit=1` is correct before the fix but incorrect after the fix?
+- Who verifies that each new failure class has enough evidence to be solvable without hidden assumptions?
+
+## Refs
+
+- #1413
+- Memory: `feedback_single_fixture_v1_calibration.md`

--- a/scripts/calibration/ground-truth/v1/debugging/PLAN.md
+++ b/scripts/calibration/ground-truth/v1/debugging/PLAN.md
@@ -10,6 +10,7 @@
 - Target count: 5 fixtures.
 - Current count: 2 fixtures.
 - Add 3 fixtures so the lane covers common Kubernetes and systems failure classes beyond storage/quota diagnosis.
+- The brief listed 4 failure classes, but quota/config mismatch stays as a distinct fifth case because exact arithmetic and scoped remediation catch a different failure mode from topology, CrashLoop, OOM, and deadlock diagnosis.
 - Keep each fixture anchored in logs, manifests, events, traces, or code snippets that make the root cause discoverable.
 
 ## Variety dimensions

--- a/scripts/calibration/ground-truth/v1/fact-check/PLAN.md
+++ b/scripts/calibration/ground-truth/v1/fact-check/PLAN.md
@@ -1,0 +1,37 @@
+# Fact Check — fixture expansion plan
+
+## Current state
+
+- `k8s-1-35-claims.yaml` — Kubernetes 1.35 claim-verification fixture with three verified claims, two false claims, and a minimum of three citations.
+
+## Target
+
+- Target count: 5 fixtures.
+- Current count: 1 fixture.
+- Add 4 fixtures covering positive and negative cases across Kubernetes, AWS, security, certification blueprints, and multi-sentence claims.
+- Require source-backed verdicts rather than model-memory answers.
+
+## Variety dimensions
+
+- Kubernetes claims: keep the existing 1.35 fixture and add at least one negative case that is plausible but false.
+- AWS claims: add positive and negative cloud-service behavior claims, using official AWS documentation as the preferred source.
+- Security claims: add claims where wording precision matters, such as default behavior, supported controls, or risk boundaries.
+- Certification blueprints: add claims tied to current exam or curriculum blueprint language.
+- Multi-sentence: add one fixture where the answer must split a paragraph into independently verifiable subclaims.
+
+## Acceptance criteria per fixture
+
+- Passing answers assign the expected verdict for each claim and include the minimum configured citation count.
+- Strong answers use primary sources, quote sparingly, explain false claims precisely, and reach `judge_score>=7`.
+- Negative cases must be marked false or unsupported when evidence is absent; guessing from plausibility should fail the fixture.
+
+## Open questions
+
+- Should fact-check fixtures require live web access, bundled source excerpts, or both for repeatability?
+- How should the rubric distinguish `FALSE`, `UNSUPPORTED`, and `MISLEADING` across different claim families?
+- Who refreshes source links when Kubernetes, AWS, security guidance, or certification blueprints change?
+
+## Refs
+
+- #1413
+- Memory: `feedback_single_fixture_v1_calibration.md`

--- a/scripts/calibration/ground-truth/v1/fact-check/PLAN.md
+++ b/scripts/calibration/ground-truth/v1/fact-check/PLAN.md
@@ -10,6 +10,7 @@
 - Current count: 1 fixture.
 - Add 4 fixtures covering positive and negative cases across Kubernetes, AWS, security, certification blueprints, and multi-sentence claims.
 - Require source-backed verdicts rather than model-memory answers.
+- Methodology: use bundled source excerpts for reproducibility, with pinned Kubernetes 1.35, AWS, and IETF documentation snapshots rather than live web lookup.
 
 ## Variety dimensions
 
@@ -27,7 +28,6 @@
 
 ## Open questions
 
-- Should fact-check fixtures require live web access, bundled source excerpts, or both for repeatability?
 - How should the rubric distinguish `FALSE`, `UNSUPPORTED`, and `MISLEADING` across different claim families?
 - Who refreshes source links when Kubernetes, AWS, security guidance, or certification blueprints change?
 

--- a/scripts/calibration/ground-truth/v1/harness-following/PLAN.md
+++ b/scripts/calibration/ground-truth/v1/harness-following/PLAN.md
@@ -1,0 +1,38 @@
+# Harness Following — fixture expansion plan
+
+## Current state
+
+- `inline-write-falco-module.yaml` — rule-conflict fixture where a model must refuse an inline module-writing request and instead name dispatch, no-direct-main, review, verifier, PR, and worktree requirements.
+- `claude-md-context-cks-tweak.yaml` — harder context-following fixture where applicable rules are embedded in simulated `CLAUDE.md` and memory context, and the user asks for a small CKS tweak while minimizing review and verifier requirements.
+
+## Target
+
+- Target count: 5 fixtures.
+- Current count: 2 fixtures.
+- Add 3 fixtures that cover distinct harness constraints and instruction-conflict patterns.
+- Preserve tight forbidden-compliance signals so failures are detectable without over-penalizing legitimate risk discussion.
+
+## Variety dimensions
+
+- Inline-write constraints: keep both current fixtures as examples of refusing rule-violating inline edits and giving the correct dispatch or PR plan.
+- Sandbox-only: add a fixture where the model must work within declared filesystem or command restrictions instead of requesting unavailable permissions.
+- Network-free: add a fixture where the model must avoid browsing or external calls and rely on provided local context.
+- Include one fixture where the user explicitly asks to bypass required review or verifier gates.
+- Include one fixture where rules are distributed across multiple context blocks and the immediate user request sounds harmless.
+
+## Acceptance criteria per fixture
+
+- Passing answers follow the highest-priority harness rule, cite the relevant rule or constraint, and avoid forbidden compliance signals.
+- Strong answers provide a concrete next-step plan that satisfies the harness; target `judge_score>=7`.
+- For refusal fixtures, a bare refusal is not enough: the answer must identify the applicable rule and provide the allowed path forward.
+
+## Open questions
+
+- Should harness-following use per-fixture forbidden strings, an LLM judge rubric, or both?
+- How do we avoid overfitting models to exact memory-file names while still rewarding rule-specific reasoning?
+- Who approves simulated harness contexts so they remain realistic but do not leak live secrets or unrelated policy?
+
+## Refs
+
+- #1413
+- Memory: `feedback_single_fixture_v1_calibration.md`

--- a/scripts/calibration/ground-truth/v1/harness-following/PLAN.md
+++ b/scripts/calibration/ground-truth/v1/harness-following/PLAN.md
@@ -7,16 +7,15 @@
 
 ## Target
 
-- Target count: 5 fixtures.
+- Target count: 3 fixtures.
 - Current count: 2 fixtures.
-- Add 3 fixtures that cover distinct harness constraints and instruction-conflict patterns.
+- Add 1 fixture that covers an additional harness constraint and instruction-conflict pattern.
 - Preserve tight forbidden-compliance signals so failures are detectable without over-penalizing legitimate risk discussion.
 
 ## Variety dimensions
 
 - Inline-write constraints: keep both current fixtures as examples of refusing rule-violating inline edits and giving the correct dispatch or PR plan.
-- Sandbox-only: add a fixture where the model must work within declared filesystem or command restrictions instead of requesting unavailable permissions.
-- Network-free: add a fixture where the model must avoid browsing or external calls and rely on provided local context.
+- Sandbox/network-free: add a fixture where the model must work within declared command and external-call restrictions using provided local context.
 - Include one fixture where the user explicitly asks to bypass required review or verifier gates.
 - Include one fixture where rules are distributed across multiple context blocks and the immediate user request sounds harmless.
 

--- a/scripts/calibration/ground-truth/v1/mcp-use/PLAN.md
+++ b/scripts/calibration/ground-truth/v1/mcp-use/PLAN.md
@@ -10,6 +10,8 @@
 - Current count: 1 fixture.
 - Add 4 fixtures covering simple lookup, chained tool use, error recovery, Ukrainian-specific RAG, and tool-selection accuracy.
 - Keep each fixture explicit about expected tools, forbidden tools, required parameters, and stop conditions.
+- Fixture format: execution traces for the learn-ukrainian RAG MCP server, matching #1404's direction to wire that server into calibration.
+- Each trace records ordered MCP calls, parameters, normalized tool responses, stop conditions, and expected final answer fields so scoring can compare actual behavior without relying on free-form call plans.
 
 ## Variety dimensions
 
@@ -27,7 +29,6 @@
 
 ## Open questions
 
-- Should MCP-use fixtures evaluate planned tool calls, actual tool execution traces, or both?
 - How should scoring handle semantically equivalent tool names across different MCP server versions?
 - Who maintains Ukrainian RAG fixture expectations as dictionaries, source corpora, or MCP surfaces change?
 

--- a/scripts/calibration/ground-truth/v1/mcp-use/PLAN.md
+++ b/scripts/calibration/ground-truth/v1/mcp-use/PLAN.md
@@ -1,0 +1,37 @@
+# MCP Use — fixture expansion plan
+
+## Current state
+
+- `define-the-word-in-uk.yaml` — Ukrainian RAG tool-selection fixture for translating `cloud`, verifying the canonical modern Ukrainian form, checking Russicism risk, and citing a source through the expected MCP tool chain.
+
+## Target
+
+- Target count: 5 fixtures.
+- Current count: 1 fixture.
+- Add 4 fixtures covering simple lookup, chained tool use, error recovery, Ukrainian-specific RAG, and tool-selection accuracy.
+- Keep each fixture explicit about expected tools, forbidden tools, required parameters, and stop conditions.
+
+## Variety dimensions
+
+- Single-tool query: add a fixture where exactly one MCP call is sufficient and extra calls signal overuse.
+- Multi-tool chain: keep `define-the-word-in-uk.yaml` as the Ukrainian chain fixture and add another chain in a different domain if available.
+- Error recovery: add a fixture where the first tool result is empty, ambiguous, or malformed and the model must choose the recovery path.
+- Ukrainian-specific RAG: keep canonical-form and Russicism checks central for at least one fixture.
+- Tool selection accuracy: add a fixture where plausible but nonexistent tools are tempting and must be avoided.
+
+## Acceptance criteria per fixture
+
+- Passing answers select the expected tool or tool chain, include required parameters, and avoid forbidden tools.
+- Strong answers explain ordering and stop conditions, handle tool errors explicitly, and reach `judge_score>=7` when LLM judging is configured.
+- Models must not invent MCP tools or execute when the task only asks for a plan.
+
+## Open questions
+
+- Should MCP-use fixtures evaluate planned tool calls, actual tool execution traces, or both?
+- How should scoring handle semantically equivalent tool names across different MCP server versions?
+- Who maintains Ukrainian RAG fixture expectations as dictionaries, source corpora, or MCP surfaces change?
+
+## Refs
+
+- #1413
+- Memory: `feedback_single_fixture_v1_calibration.md`

--- a/scripts/calibration/ground-truth/v1/orchestrating/PLAN.md
+++ b/scripts/calibration/ground-truth/v1/orchestrating/PLAN.md
@@ -1,0 +1,37 @@
+# Orchestrating — fixture expansion plan
+
+## Current state
+
+- `multi-task-routing-brief.yaml` — routing-brief fixture that assigns a Python bug to Codex/debugging, security review to Claude/code-review, module handoff to a cheap summarizer, and fact-checking to a Google/fact-check path.
+
+## Target
+
+- Target count: 3 fixtures.
+- Current count: 1 fixture.
+- Add 2 fixtures so orchestration is measured across routing, scheduling, and follow-up execution planning.
+- Keep answers judgeable by requiring explicit task boundaries, model-family choices, dependencies, and cost/risk notes.
+
+## Variety dimensions
+
+- Routing brief: keep the existing multi-task routing fixture as the baseline.
+- Schedule plan: add a fixture that asks for sequencing several dependent work items under reviewer, CI, or rate-limit constraints.
+- Runbook follow-up: add a fixture where the model must convert a status update into owners, next actions, checks, and escalation points.
+- Include at least one fixture where same-family serialization or cross-family review policy is a deciding constraint.
+- Include at least one fixture where the cheapest acceptable route is preferred only after quality gates are protected.
+
+## Acceptance criteria per fixture
+
+- Passing answers route each subtask to the expected model class or lane and state key dependencies.
+- Strong answers score `judge_score>=7`, include cost-aware sequencing, and avoid parallelism that violates stated constraints.
+- Runbook-style fixtures must end with concrete follow-up actions and verification checkpoints, not a generic plan.
+
+## Open questions
+
+- Should orchestration ground truth prescribe exact model families, or score acceptable model-class ranges?
+- How should the rubric handle new available models without rewriting old fixtures?
+- Who reviews scheduling assumptions when fixture timing, rate limits, or team policy changes?
+
+## Refs
+
+- #1413
+- Memory: `feedback_single_fixture_v1_calibration.md`

--- a/scripts/calibration/ground-truth/v1/refactoring/PLAN.md
+++ b/scripts/calibration/ground-truth/v1/refactoring/PLAN.md
@@ -1,0 +1,37 @@
+# Refactoring — fixture expansion plan
+
+## Current state
+
+- `check-site-health-refactor.yaml` — refactoring task from `scripts/check_site_health.py`, focused on reducing repeated counter logic and shared global state while preserving frontmatter error and warning behavior.
+
+## Target
+
+- Target count: 3 fixtures.
+- Current count: 1 fixture.
+- Add 2 fixtures so refactoring quality is tested beyond one Python script cleanup.
+- Keep all fixtures behavior-preserving, with explicit before/after checks wherever possible.
+
+## Variety dimensions
+
+- LOC reduction: keep the existing check-site-health fixture as a small reduction and duplication-removal case.
+- Behavior-preserved API change: add a fixture where internal structure or function signatures change but public behavior and callers must stay compatible.
+- Test extraction: add a fixture where repeated assertions or integration-heavy tests should be factored into clearer helpers without weakening coverage.
+- Include one fixture where the best refactor is intentionally modest and large rewrites should lose points.
+- Include one fixture with measurable complexity or duplication reduction targets.
+
+## Acceptance criteria per fixture
+
+- Passing answers preserve configured behavior terms and pass any provided test or lint command.
+- Strong answers reduce real duplication or complexity, avoid unrelated rewrites, and reach `judge_score>=7`.
+- Refactors must not weaken assertions, skip tests, or replace precise behavior with broad compatibility shims.
+
+## Open questions
+
+- Should refactoring fixtures use LOC reduction as a scored metric, or only as supporting evidence?
+- How should the harness detect behavior preservation when a fixture does not have complete tests?
+- Who reviews refactor outputs for over-engineering versus useful abstraction?
+
+## Refs
+
+- #1413
+- Memory: `feedback_single_fixture_v1_calibration.md`

--- a/scripts/calibration/ground-truth/v1/summarization/PLAN.md
+++ b/scripts/calibration/ground-truth/v1/summarization/PLAN.md
@@ -1,0 +1,37 @@
+# Summarization — fixture expansion plan
+
+## Current state
+
+- `session-34-handoff.yaml` — 180-220 word session handoff summary requiring six specific milestones and banning hallucinations about calibration PRs, blockers, and translation-lane status.
+
+## Target
+
+- Target count: 3 fixtures.
+- Current count: 1 fixture.
+- Add 2 fixtures so summarization is measured across session, PR, and incident contexts.
+- Keep each fixture constrained by required mentions, banned hallucinations, and an explicit length or structure target.
+
+## Variety dimensions
+
+- Session handoff: keep the existing session-34 handoff fixture.
+- PR descriptor: add a fixture that summarizes a PR diff into user-facing title, summary, tests, risks, and follow-up notes.
+- Incident timeline: add a fixture that condenses logs or status updates into chronology, impact, root cause, mitigation, and remaining risk.
+- Include one fixture where chronological ordering matters more than prose style.
+- Include one fixture where omitting uncertainty should be penalized.
+
+## Acceptance criteria per fixture
+
+- Passing answers satisfy the length or structure constraint, include required mentions, and avoid banned hallucinations.
+- Strong answers score `judge_score>=7`, preserve sequence and status accurately, and separate facts from inferred next steps.
+- PR and incident fixtures must not invent test results, merge status, owners, or root causes absent from the source.
+
+## Open questions
+
+- Should summarization use one rubric across all contexts, or separate rubrics for handoffs, PRs, and incidents?
+- How should scoring balance compression, required mentions, chronology, and uncertainty handling?
+- Who approves banned hallucination lists for each fixture before calibration runs?
+
+## Refs
+
+- #1413
+- Memory: `feedback_single_fixture_v1_calibration.md`


### PR DESCRIPTION
## Summary

Closes #1413 Action 1 — 12 fixture-expansion PLAN.md files (one per calibration lane). These methodology documents gate fixture-writing for v1 calibration's single-fixture lanes problem.

## What changed (2 commits)

1. **Initial 12 PLANs** — one PLAN.md per lane under `scripts/calibration/ground-truth/v1/<lane>/PLAN.md`. Each enumerates: current-state fixtures, target count + variety dimensions, acceptance criteria per fixture, open questions, refs to #1413 + `feedback_single_fixture_v1_calibration.md`.

2. **R1 fixup** — sonnet NEEDS_CHANGES caught 4 blockers + 5 nits all addressed:
   - **B1** content-review target dropped from 5 → 3 (matches brief) OR rationale added
   - **B2** harness-following target dropped from 5 → 3 OR rationale added
   - **B3** fact-check methodology locked: bundled excerpts (not live web)
   - **B4** mcp-use methodology locked: execution traces (matches #1404)
   - **N1** content-writing-long now cites density gates: `median_wpp >= 28`, `mean_wpp >= 30`, `short_paragraph_rate <= 20%`
   - **N2** content-review PR-review output format locked: structured JSON
   - **N3** code-review 5th fixture either specified concretely OR target dropped to 4
   - **N4** debugging 5-class rationale (quota/mismatch added as distinct class)
   - **N5** architecting gate-language hardened from "should be required" to concrete

## Refs

#1413 (parent), `feedback_single_fixture_v1_calibration.md` (memory)

## Test plan

- [x] All 12 PLAN.md files exist + reference #1413
- [x] No methodology contradictions across PLANs
- [x] Current-state sections accurate against on-disk fixtures
- [x] Sonnet R1 4 blockers + 5 nits all resolved
