### PR TITLE
chore(linux): raise TCP/IP Essentials to T0/T1 + R1 nits

### DIFF
--- a/src/content/docs/linux/foundations/networking/module-3.1-tcp-ip-essentials.md
+++ b/src/content/docs/linux/foundations/networking/module-3.1-tcp-ip-essentials.md
@@ -12,8 +12,6 @@ lab:
   environment: "ubuntu"
 ---
 
-# Module 3.1: TCP/IP Essentials
-
 > **Linux Foundations** | Complexity: `[MEDIUM]` | Time: 35-40 min. This is the operator-grade packet model that later modules use for DNS, namespaces, veth pairs, iptables, and Kubernetes Service debugging.
 
 ## Prerequisites
@@ -24,7 +22,7 @@ Before starting this module:
 - **Helpful**: [Module 1.1: Kernel & Architecture](/linux/foundations/system-essentials/module-1.1-kernel-architecture/)
 - **Next bridge**: [Module 3.3: Network Namespaces & veth](../module-3.3-network-namespaces/) uses the same addressing, routing, neighbor, and MTU model inside isolated network stacks.
 
-For Kubernetes examples, define `alias k=kubectl` once. The lesson is Linux-first, but the goal is Kubernetes 1.35+ operations: pod IPs, Service virtual IPs, CNI routes, ingress sockets, egress NAT, and DNS all collapse to kernel packet decisions during troubleshooting.
+Kubernetes examples use full `kubectl` commands rather than shell aliases so transcripts remain portable. The lesson is Linux-first, but the goal is Kubernetes 1.35+ operations: pod IPs, Service virtual IPs, CNI routes, ingress sockets, egress NAT, and DNS all collapse to kernel packet decisions during troubleshooting.
 
 ## What You'll Be Able to Do
 
@@ -44,9 +42,13 @@ A platform engineer who cannot reason about TCP state machines, MTU, ARP/NDP, ro
 
 Treat every network failure as a claim about one layer of evidence. `ping` may prove ICMP reachability but not a TCP listener. `dig` may prove DNS resolution but not routing to the answer. `ss` may prove a local socket exists but not that a remote firewall lets SYN packets through. `tcpdump` may prove a packet arrived at one interface while the real drop happens later in netfilter or in an overlay MTU mismatch. The discipline is to ask: which kernel decision did I just prove?
 
+The useful habit is to turn a vague outage report into a sequence of falsifiable claims. "The Service is down" is not yet a network diagnosis. "A pod can resolve the Service name, the ClusterIP DNATs to endpoint `10.244.2.37`, the node route sends that endpoint through `vxlan.calico`, and TCP reaches `SYN-SENT` but never receives `SYN-ACK`" is a diagnosis shape. It names a destination, an address family, a dataplane decision, and a missing packet. That level of specificity lets another operator reproduce the failure without trusting your interpretation.
+
+Cloud networking makes this discipline more important because control-plane health and packet forwarding can disagree. A managed load balancer can be healthy while its backend security group blocks return traffic. A CNI can report Ready while the host route table points a remote pod CIDR at a stale tunnel device. A DNS record can be correct while the resolver expands search domains into extra queries and hits a conntrack or CoreDNS limit. The Linux model is the common language across those systems.
+
 ## Layers as Kernel Decisions
 
-OSI is useful vocabulary, but Linux operators usually debug the TCP/IP model because it maps to kernel surfaces. RFC 1122 organizes host requirements across link, internet, and transport layers; RFC 9293 is the current consolidated TCP specification and obsoletes the original RFC 793 as the core TCP reference. In Linux, each layer corresponds to objects you can inspect: links, neighbors, routes, sockets, conntrack entries, and resolver configuration. ([RFC 1122](https://www.rfc-editor.org/rfc/rfc1122), [RFC 793](https://www.rfc-editor.org/rfc/rfc793), [RFC 9293](https://www.rfc-editor.org/rfc/rfc9293))
+OSI is useful vocabulary, but Linux operators usually debug the TCP/IP model because it maps to kernel surfaces. RFC 1122 organizes host requirements across link, internet, and transport layers; RFC 9293 is the current consolidated TCP specification and obsoletes the original RFC 793 as the core TCP reference. In Linux, each layer corresponds to objects you can inspect: links, neighbors, routes, sockets, conntrack entries, and resolver configuration. ([RFC 1122](https://www.rfc-editor.org/info/rfc1122), [RFC 793](https://www.rfc-editor.org/info/rfc793), [RFC 9293](https://www.rfc-editor.org/info/rfc9293))
 
 | OSI view | TCP/IP view | Kernel-level operator question |
 |---|---|---|
@@ -78,9 +80,13 @@ flowchart LR
 
 The diagram is not just teaching art. It is a triage map. If `ip route get` selects the wrong egress interface, the TCP state is a consequence, not the root cause. If a listener is bound to `127.0.0.1:8080`, a Service cannot make remote clients reach it without a process listening on the pod or node address. If VXLAN reduces the usable inner MTU, HTTP may connect and then hang only on larger responses. Each symptom points to a decision surface.
 
+At the kernel layer, layering is less about a clean textbook stack and more about when metadata becomes available. The neighbor table cannot choose a MAC address until routing has selected an egress device and next hop. Netfilter cannot correctly reverse a DNATed reply unless conntrack has stored the original and translated tuples. TCP cannot move a socket to `ESTAB` unless both directions of the route, neighbor, firewall, and sequence-number exchange work. When you debug in that order, you stop treating every failed request as an application mystery.
+
+The reverse direction is just as important. Operators often prove that the client-to-server SYN arrived and then stop, but many real incidents live in the reply path. A node may receive a SYN on one interface and route the SYN-ACK out another. A pod may send a reply with a source address that a cloud router does not know. A NAT gateway may rewrite the source for egress but expire the idle reverse mapping before the next write. A complete packet model always asks who sends the next packet and which kernel decision it must pass.
+
 ## Addressing: IPv4, IPv6, and Kubernetes CIDRs
 
-IPv4 addresses are 32-bit values; IPv6 addresses are 128-bit values. CIDR notation says how many leading bits form the network prefix. RFC 1918 defines the familiar private IPv4 ranges, RFC 4193 defines IPv6 Unique Local Addresses, and RFC 8200 specifies IPv6 itself. The operator move is to calculate the boundary instead of comparing dotted strings by sight. ([RFC 1918](https://www.rfc-editor.org/rfc/rfc1918), [RFC 4193](https://www.rfc-editor.org/rfc/rfc4193), [RFC 8200](https://www.rfc-editor.org/rfc/rfc8200), [RFC 4632](https://www.rfc-editor.org/rfc/rfc4632))
+IPv4 addresses are 32-bit values; IPv6 addresses are 128-bit values. CIDR notation says how many leading bits form the network prefix. RFC 1918 defines the familiar private IPv4 ranges, RFC 4193 defines IPv6 Unique Local Addresses, and RFC 8200 specifies IPv6 itself. The operator move is to calculate the boundary instead of comparing dotted strings by sight. ([RFC 1918](https://www.rfc-editor.org/info/rfc1918), [RFC 4193](https://www.rfc-editor.org/info/rfc4193), [RFC 8200](https://www.rfc-editor.org/info/rfc8200), [RFC 4632](https://www.rfc-editor.org/info/rfc4632))
 
 ```text
 10.244.2.37/24
@@ -96,25 +102,29 @@ A Kubernetes cluster normally has at least three address domains. Node IPs belon
 | Address domain | Example | What it means | First Linux check |
 |---|---:|---|---|
 | Node CIDR / node IPs | `192.168.10.0/24` | Real host network reachability between nodes and gateways | `ip addr`, `ip route get <node-ip>` |
-| Pod CIDR | `10.244.0.0/16` | Workload addresses routed, bridged, overlaid, or eBPF-forwarded by CNI | `k get pods -o wide`, `ip route get <pod-ip>` |
-| Service CIDR | `10.96.0.0/12` | Virtual Service destinations selected and rewritten to endpoints | `k get svc`, `nft list ruleset` or `iptables-save` |
+| Pod CIDR | `10.244.0.0/16` | Workload addresses routed, bridged, overlaid, or eBPF-forwarded by CNI | `kubectl get pods -o wide`, `ip route get <pod-ip>` |
+| Service CIDR | `10.96.0.0/12` | Virtual Service destinations selected and rewritten to endpoints | `kubectl get svc`, `nft list ruleset` or `iptables-save` |
 | IPv6 ULA | `fd00:10:244::/56` | Private IPv6-style cluster or site addressing | `ip -6 addr`, `ip -6 route get <addr>` |
 
 The common overlap problem is simple to miss. If the corporate WAN uses `10.244.0.0/16` and a new cluster also uses `10.244.0.0/16` for pods, some destinations become ambiguous. Linux will choose the most specific matching route; humans may see only that both are "10 dot" networks. Calculate the prefixes, then ask the kernel for the actual lookup.
+
+CIDR math is also a blast-radius tool. If one worker owns `10.244.2.0/24`, the address `10.244.2.37` should be local to that node in a per-node pod-CIDR design, while `10.244.9.37` should route toward another node or tunnel. If `ip route get 10.244.2.37` leaves through the physical NIC instead of a CNI bridge or local veth path, the failure is not "pod networking" in general; it is a contradiction between the expected prefix owner and the installed route. For dual-stack clusters, repeat the same reasoning for IPv6 rather than assuming the IPv4 path explains both families.
+
+Service CIDRs deserve a separate mental bucket because they are not workload locations. A ClusterIP is an address selected by clients, not normally an address bound by the backend pod. If you search every interface with `ip addr` and do not find the Service IP, that may be normal. The question is whether the local dataplane captures traffic to that virtual destination and rewrites it to an endpoint. That is why a Service failure often requires both `kubectl get svc,endpointslices` and Linux NAT or eBPF evidence.
 
 ```bash
 ip -br addr
 ip route get 10.244.2.37
 ip -6 route get fd00:10:244::37
-k get pods -A -o wide
-k get svc -A -o wide
+kubectl get pods -A -o wide
+kubectl get svc -A -o wide
 ```
 
 Do not treat a Service IP as if it must appear on an interface. In kube-proxy iptables mode, Kubernetes documents that kube-proxy installs rules redirecting virtual IP traffic to endpoint rules, and those endpoint rules use destination NAT to backend pods. In nftables mode, kube-proxy uses the kernel netfilter subsystem through nftables instead. The Linux debugging surface is therefore routes plus packet-filter state, not only `ip addr`. ([Kubernetes Virtual IPs and Service Proxies](https://v1-35.docs.kubernetes.io/docs/reference/networking/virtual-ips/))
 
 ## Neighbor Discovery: ARP, NDP, and VIPs
 
-Routing chooses the next-hop IP and egress device; neighbor discovery finds the link-layer destination for that next hop. IPv4 commonly uses ARP, standardized in RFC 826. IPv6 uses Neighbor Discovery Protocol, specified in RFC 4861. Linux exposes both through the neighbor table, so `ip neigh` is the modern inspection tool. ([RFC 826](https://www.rfc-editor.org/rfc/rfc826), [RFC 4861](https://www.rfc-editor.org/rfc/rfc4861), [ip-neighbour(8)](https://man7.org/linux/man-pages/man8/ip-neighbour.8.html))
+Routing chooses the next-hop IP and egress device; neighbor discovery finds the link-layer destination for that next hop. IPv4 commonly uses ARP, standardized in RFC 826. IPv6 uses Neighbor Discovery Protocol, specified in RFC 4861. Linux exposes both through the neighbor table, so `ip neigh` is the modern inspection tool. ([RFC 826](https://www.rfc-editor.org/info/rfc826), [RFC 4861](https://www.rfc-editor.org/info/rfc4861), [ip-neighbour(8)](https://man7.org/linux/man-pages/man8/ip-neighbour.8.html))
 
 ```bash
 ip neigh show
@@ -126,6 +136,10 @@ sudo ip neigh flush dev eth0 nud failed
 Neighbor state matters when the failure looks like "same subnet but no traffic." If a node believes `192.168.10.44` is on-link, it will ARP for that address instead of sending the packet to a gateway. If no host answers, packets queue and then fail below TCP. If the wrong host answers, traffic goes to the wrong MAC. Active-active VIP systems amplify this risk: two nodes advertising the same virtual IP can create neighbor cache flapping, especially when gratuitous ARP or unsolicited NDP announcements are misconfigured.
 
 Use neighbor evidence before changing routes. A route such as `192.168.10.0/24 dev eth0` can be correct while a stale neighbor entry points to an old MAC after failover. Conversely, a failed neighbor lookup may be the symptom of a bad prefix: the host is ARPing because it incorrectly thinks the destination is local. This is why CIDR and ARP/NDP must be read together.
+
+VIP failover is the place where this becomes operationally sharp. A load balancer pair may move `192.168.10.50` from node A to node B and send gratuitous ARP so peers update their caches. If one switch, host, or security appliance ignores the update, some clients continue sending frames to the old MAC. Kubernetes does not remove that failure mode when you run bare-metal ingress or external load balancers. You still need to inspect the neighbor entry on the client, the gateway, and the node that should own the VIP.
+
+For IPv6, the same idea appears through Neighbor Discovery, router advertisements, and solicited-node multicast rather than broadcast ARP. Dual-stack incidents often look asymmetric because IPv4 neighbor state is healthy while IPv6 NDP is blocked or stale. Use `ip -6 neigh`, capture ICMPv6 neighbor solicitations and advertisements, and remember that blocking all ICMPv6 is not equivalent to blocking harmless ping traffic. It can break essential address resolution and PMTUD behavior.
 
 ## Routing: FIB, RIB, Longest Prefix, and Policy Rules
 
@@ -145,9 +159,13 @@ Kubernetes makes this visible on every node. A directly routed CNI may install o
 
 Policy routing explains asymmetric outages on multi-homed nodes. A request can arrive on `eth0`, but the reply lookup may select `eth1` because the destination client network is more specific through another table. Stateful firewalls and cloud security systems often drop that reply as unexpected. During triage, inspect both directions: route from client to server, and route from server back to client.
 
+The route cache answer from `ip route get` is usually more valuable than the raw table because it includes selected source address, device, next hop, and policy rule effects. When an ingress node has a public interface, a private interface, and pod-facing devices, the selected source address can decide whether replies survive upstream filtering. If the kernel chooses a node-private source for a public client path, the packet may leave correctly but be discarded by the first router that enforces source validation.
+
+Do not confuse the cluster routing contract with one particular CNI implementation. Some CNIs install Linux routes for remote pod CIDRs. Some encapsulate traffic into tunnel devices. Some rely on eBPF maps and show fewer iptables rules than older kube-proxy paths. Some cloud CNIs give pods VPC-routable addresses and move part of the decision into cloud route tables or elastic network interfaces. The Linux checks still anchor the investigation: what address is selected, which interface carries it, and what packet appears on that interface?
+
 ## TCP: Handshake, State, Close, and Keepalive
 
-TCP is a reliable byte stream with connection state, sequence numbers, acknowledgments, retransmission, flow control, and congestion control. RFC 9293 is the current TCP specification, and Linux exposes many TCP behaviors through `ss`, `/proc/sys/net/ipv4/tcp_*`, and socket state. A TCP incident is often just a state-machine question hidden under application language. ([RFC 9293](https://www.rfc-editor.org/rfc/rfc9293), [tcp(7)](https://man7.org/linux/man-pages/man7/tcp.7.html), [ss(8)](https://man7.org/linux/man-pages/man8/ss.8.html))
+TCP is a reliable byte stream with connection state, sequence numbers, acknowledgments, retransmission, flow control, and congestion control. RFC 9293 is the current TCP specification, and Linux exposes many TCP behaviors through `ss`, `/proc/sys/net/ipv4/tcp_*`, and socket state. A TCP incident is often just a state-machine question hidden under application language. ([RFC 9293](https://www.rfc-editor.org/info/rfc9293), [tcp(7)](https://man7.org/linux/man-pages/man7/tcp.7.html), [ss(8)](https://man7.org/linux/man-pages/man8/ss.8.html))
 
 Ports are part of the transport evidence, not application folklore. IANA maintains the service name and transport protocol port registry, which is why operators recognize TCP 22 for SSH, TCP 443 for HTTPS, UDP/TCP 53 for DNS, and Kubernetes control-plane ports such as TCP 6443 as conventions to verify rather than assumptions to trust blindly. A Service `port`, `targetPort`, `nodePort`, and container listener may all differ, so the reliable question is still: which tuple did the kernel see, and which process or NAT rule owned it? ([IANA Service Name and Transport Protocol Port Number Registry](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml), [Kubernetes Ports and Protocols](https://v1-35.docs.kubernetes.io/docs/reference/networking/ports-and-protocols/))
 
@@ -168,7 +186,7 @@ stateDiagram-v2
     TIME_WAIT --> CLOSED: 2MSL timeout
 ```
 
-Read `ss -tan` as evidence. `SYN-SENT` on a client means SYN packets left or are queued but no SYN-ACK has completed the handshake. `SYN-RECV` on a server means SYNs arrived and replies were attempted, but the final ACK did not complete or accept queue pressure exists. `ESTAB` proves the handshake completed. `CLOSE-WAIT` means the peer closed and the local application has not closed its side. `TIME-WAIT` is normal on the side that actively closed; it prevents old duplicate segments from corrupting a later connection using the same tuple.
+Read `ss -tan` as evidence. `SYN-SENT` on a client means SYN packets left or are queued but no SYN-ACK has completed the handshake. `SYN-RECV` on a server means SYNs arrived and replies were attempted, but the final ACK did not complete or accept queue pressure exists; it is the `SYN_RECEIVED` state in the diagram above. `ESTAB` proves the handshake completed. `CLOSE-WAIT` means the peer closed and the local application has not closed its side. `TIME-WAIT` is normal on the side that actively closed; it prevents old duplicate segments from corrupting a later connection using the same tuple.
 
 ```bash
 ss -tan
@@ -182,9 +200,15 @@ Keepalive is not a health check. Linux TCP keepalive probes can eventually detec
 
 A useful interpretation rule is refusal versus timeout. A refused connection usually means a RST came back: the host stack was reachable, but no listener accepted that destination port or policy actively rejected it. A timeout means SYNs, SYN-ACKs, or later packets disappeared. That points toward firewall, routing, neighbor, MTU, conntrack, or security group behavior before it points toward application code.
 
+Backlog pressure has its own signature. A server can listen on the correct port and still fail under SYN queue pressure, accept queue pressure, or application stalls after accept. On the client you may see retries and `SYN-SENT`; on the server you may see `SYN-RECV`, retransmitted SYN-ACKs, or a listener with high queue counts in `ss -ltn`. That evidence changes the action. You do not fix a full accept queue by editing a Service selector; you inspect the process, kernel backlog settings, load balancer health behavior, and whether the application can accept and handle connections quickly enough.
+
+Close states also prevent false alarms. `TIME-WAIT` is not automatically a leak; it is expected on the active closer and protects connection identity while old segments age out. `CLOSE-WAIT` is more suspicious because it means the peer already sent FIN and the local application has not closed its socket. A node with many `CLOSE-WAIT` sockets for an ingress backend may be revealing application close handling, while a node with many `TIME-WAIT` sockets may simply be doing high connection churn. Read the state before changing sysctls.
+
+Keepalive settings belong in an end-to-end timeout budget. Suppose an application holds idle database connections for an hour, a cloud NAT expires idle TCP mappings after a shorter period, and Linux keepalive probes start later than both. The first request after the idle period may fail even though the original handshake succeeded. The fix may be application pool validation, shorter idle lifetime, load balancer timeout alignment, or TCP keepalive tuning. The packet model tells you why the symptom appears only after quiet periods.
+
 ## UDP and QUIC: Connectionless Kernel, Stateful Userspace
 
-UDP gives applications datagrams, ports, and checksums without a kernel-managed connection state machine. The kernel can show UDP sockets, queue pressure, drops, and ICMP errors, but it does not turn a UDP exchange into `ESTABLISHED` the way TCP does. RFC 1122 covers UDP host requirements, and the Linux `udp(7)` page documents Linux UDP socket behavior. ([RFC 1122](https://www.rfc-editor.org/rfc/rfc1122), [udp(7)](https://man7.org/linux/man-pages/man7/udp.7.html))
+UDP gives applications datagrams, ports, and checksums without a kernel-managed connection state machine. The kernel can show UDP sockets, queue pressure, drops, and ICMP errors, but it does not turn a UDP exchange into `ESTABLISHED` the way TCP does. RFC 1122 covers UDP host requirements, and the Linux `udp(7)` page documents Linux UDP socket behavior. ([RFC 1122](https://www.rfc-editor.org/info/rfc1122), [udp(7)](https://man7.org/linux/man-pages/man7/udp.7.html))
 
 ```bash
 ss -uanp
@@ -193,13 +217,15 @@ tcpdump -ni any udp port 53
 tcpdump -ni any udp port 443
 ```
 
-QUIC deliberately uses UDP while implementing streams, connection IDs, loss recovery, encryption, and path migration in the protocol above UDP. RFC 9000 defines QUIC as a UDP-based multiplexed and secure transport. For operators, this means a QUIC or HTTP/3 ingress on UDP/443 will not appear as TCP `ESTAB` sockets. You inspect UDP sockets, packet captures, ingress HTTP/3 or QUIC metrics, and load balancer UDP handling. ([RFC 9000](https://www.rfc-editor.org/rfc/rfc9000))
+QUIC deliberately uses UDP while implementing streams, connection IDs, loss recovery, encryption, and path migration in the protocol above UDP. RFC 9000 defines QUIC as a UDP-based multiplexed and secure transport. For operators, this means a QUIC or HTTP/3 ingress on UDP/443 will not appear as TCP `ESTAB` sockets. You inspect UDP sockets, packet captures, ingress HTTP/3 or QUIC metrics, and load balancer UDP handling. ([RFC 9000](https://www.rfc-editor.org/info/rfc9000))
 
 The Kubernetes implication is direct. A TCP Service gives you handshake evidence; a UDP Service often gives you request/response silence unless the application logs or metrics expose protocol-level state. If DNS works intermittently in-cluster, packet loss, conntrack expiry, CoreDNS saturation, and resolver search behavior can all look like "UDP timeout." Use packet captures and application counters instead of expecting TCP-style states.
 
+QUIC adds another operational split because connection identity can survive address changes at the protocol layer while the kernel still sees UDP datagrams. A client roaming between networks may continue a QUIC session using connection IDs, but a stateless UDP load balancer or firewall may see a new source tuple. For ingress operations, verify that every component in the path handles UDP/443 intentionally: cloud load balancer, node firewall, Service protocol field, ingress controller listener, metrics pipeline, and packet capture filters.
+
 ## Conntrack, NAT, and Service Rewrites
 
-Connection tracking records flows so stateful filtering and NAT can handle replies consistently. Netfilter documentation describes conntrack as fundamental to NAT, and the kernel documents conntrack sysctls such as maximum entries and protocol timeout controls. Kubernetes Services rely on this machinery in Linux kube-proxy modes: iptables mode redirects Service virtual IP traffic to endpoints using destination NAT, and nftables mode uses the nftables API of the same netfilter subsystem. ([Netfilter Hacking HOWTO](https://www.netfilter.org/documentation/HOWTO/netfilter-hacking-HOWTO-3.html), [Netfilter NAT HOWTO](https://www.netfilter.org/documentation/HOWTO/NAT-HOWTO-5.html), [Linux nf_conntrack sysctl](https://docs.kernel.org/networking/nf_conntrack-sysctl.html), [Kubernetes Virtual IPs and Service Proxies](https://v1-35.docs.kubernetes.io/docs/reference/networking/virtual-ips/))
+Connection tracking records flows so stateful filtering and NAT can handle replies consistently. Linux netfilter documentation describes the hook-based packet path, and the kernel documents conntrack sysctls such as maximum entries and protocol timeout controls. Kubernetes Services rely on this machinery in Linux kube-proxy modes: iptables mode redirects Service virtual IP traffic to endpoints using destination NAT, and nftables mode uses the nftables API of the same netfilter subsystem. ([Linux netfilter documentation](https://docs.kernel.org/networking/netfilter.html), [Linux nf_conntrack sysctl](https://docs.kernel.org/networking/nf_conntrack-sysctl.html), [Kubernetes Virtual IPs and Service Proxies](https://v1-35.docs.kubernetes.io/docs/reference/networking/virtual-ips/))
 
 ```mermaid
 flowchart TD
@@ -233,9 +259,15 @@ sysctl net.netfilter.nf_conntrack_max net.netfilter.nf_conntrack_count 2>/dev/nu
 
 Do not flush conntrack as a reflex. It can repair stale NAT state in a lab, but in production it can also drop legitimate long-lived connections across the node. First prove the mismatch: packet capture before and after NAT, ruleset selection, route decision, and conntrack entry. Then decide whether the correct fix is endpoint draining, kube-proxy sync, firewall rule repair, timeout tuning, or a targeted conntrack deletion.
 
+For Service debugging, draw both tuples. The original tuple is what the client believes: source IP and port to ClusterIP and Service port. The reply tuple is what the backend and NAT path use after DNAT: client IP and port to pod IP and targetPort, possibly with SNAT if the dataplane masquerades traffic. If those tuples do not line up, symptoms can look arbitrary. One backend receives packets but replies from an address the client never contacted; another backend never sees traffic because the rule or eBPF map selects a different endpoint.
+
+Conntrack exhaustion is a capacity incident, not just a kernel counter. UDP-heavy DNS, short-lived HTTP clients, node-local proxies, and egress NAT can all consume entries. When `nf_conntrack_count` approaches `nf_conntrack_max`, new flows may be dropped or fail to create NAT state. The operator question is which workload creates the pressure, which timeout class keeps entries alive, and whether the node role should carry that much state. Increasing the maximum without understanding memory and traffic shape can move the failure rather than solve it.
+
+Packet-filter hook order matters when evidence seems contradictory. A packet can be accepted by one chain and still be DNATed later, routed differently after DNAT, or SNATed on egress. A local process curling a ClusterIP starts in `OUTPUT`, not `PREROUTING`, so rules that handle only forwarded packets may never see it. A pod packet entering the host from a veth can look like forwarded traffic even though the application that initiated it feels local to the developer. Match the hook path to the packet origin before reading counters.
+
 ## MTU, Fragmentation, and Overlay Penalties
 
-MTU is the maximum frame payload a link can carry without fragmentation at that layer. IPv4 supports fragmentation, but Path MTU Discovery tries to avoid it by learning the smallest usable path size. IPv6 relies on source fragmentation and Packet Too Big signaling rather than router fragmentation. RFC 1191 covers IPv4 PMTUD, RFC 8201 covers IPv6 PMTUD, and Linux exposes MTU on links and routes. ([RFC 1191](https://www.rfc-editor.org/rfc/rfc1191), [RFC 8201](https://www.rfc-editor.org/rfc/rfc8201), [ip-link(8)](https://man7.org/linux/man-pages/man8/ip-link.8.html), [Linux IP sysctl](https://docs.kernel.org/networking/ip-sysctl.html))
+MTU is the maximum frame payload a link can carry without fragmentation at that layer. IPv4 supports fragmentation, but Path MTU Discovery tries to avoid it by learning the smallest usable path size. IPv6 relies on source fragmentation and Packet Too Big signaling rather than router fragmentation. RFC 1191 covers IPv4 PMTUD, RFC 8201 covers IPv6 PMTUD, and Linux exposes MTU on links and routes. ([RFC 1191](https://www.rfc-editor.org/info/rfc1191), [RFC 8201](https://www.rfc-editor.org/info/rfc8201), [ip-link(8)](https://man7.org/linux/man-pages/man8/ip-link.8.html), [Linux IP sysctl](https://docs.kernel.org/networking/ip-sysctl.html))
 
 ```bash
 ip link show
@@ -248,6 +280,10 @@ ping -M do -s 1472 192.168.10.20
 Overlay networking makes MTU visible because encapsulation adds outer headers. VXLAN runs over UDP and Linux documents VXLAN devices as tunnel devices; IPIP, GRE, Geneve, WireGuard, and cloud fabrics have their own overhead. If the physical NIC MTU is 1500 and the overlay adds headers, the pod-facing MTU must usually be smaller. Otherwise small health checks pass while larger TLS records, image pulls, or gRPC responses stall. ([Linux VXLAN documentation](https://docs.kernel.org/networking/vxlan.html))
 
 The operational clue is size sensitivity. A TCP handshake succeeds, small requests work, and larger payloads hang or retransmit. Packet captures may show ICMP Fragmentation Needed or IPv6 Packet Too Big messages, or they may show silence if a firewall drops those control messages. Fixing the app will not help if the path cannot carry the packet size the app emits.
+
+MTU incidents are often introduced by an otherwise correct migration. Moving from direct routing to VXLAN, adding WireGuard encryption, enabling a cloud transit gateway, or chaining a service mesh sidecar can all reduce usable payload size. The service owner sees TLS, HTTP, or gRPC errors because those are the protocols that notice the stall, but the first broken assumption is lower: the path cannot carry the encapsulated packet without fragmentation or PMTUD. Compare the pod device MTU, tunnel MTU, node NIC MTU, and any route-specific MTU before changing application chunk sizes.
+
+Fragmentation also affects observability. A packet capture on the sender may show a large packet leaving the pod interface, while a capture on the underlay shows smaller outer packets or no packet if the kernel refuses to fragment with DF set. A capture at the receiver may show the first fragment but not the later one, causing the reassembled transport segment never to exist. This is why the best MTU test controls packet size, observes ICMP feedback, and captures at both the inner and outer interfaces when overlays are involved.
 
 ## DNS Resolution: From Pod Name to Packet
 
@@ -266,6 +302,10 @@ Kubernetes configures pod DNS so containers can resolve Services by name. The v1
 
 DNS is therefore not one thing. A failure may be NSS order, `/etc/hosts`, systemd-resolved forwarding, CoreDNS, upstream DNS, UDP loss, TCP fallback, search path expansion, or Service record generation. The packet tools enter only after you know what nameserver and query name the resolver actually used.
 
+In Kubernetes, DNS triage begins inside the pod because that is where the resolver configuration is mounted. A node may use one `/etc/resolv.conf`, kubelet may pass another file to pods, and the pod may add `dnsConfig` overrides. If the pod queries `my-api` and the resolver expands it through namespace and cluster search domains, CoreDNS sees multiple candidate names before the one humans expected. The right packet capture filter is therefore not only `port 53`; it is the specific query name, nameserver IP, protocol, and retry pattern.
+
+Application runtime behavior can diverge from glibc examples. Some languages use c-ares, Go's resolver, JVM caching, or custom DNS libraries; some honor `/etc/resolv.conf` differently; some cache negative answers longer than expected. The Linux baseline still matters because it tells you what the environment offered, but an operator should compare command-line resolver behavior with application traces before declaring DNS fixed. A successful `dig` proves the DNS service can answer that query; it does not prove the application used the same query, timeout, cache, or search order.
+
 ## Operator Triage Toolkit
 
 Use modern tools that match the kernel model. Legacy net-tools such as `ifconfig`, `route`, and `netstat` still appear in old runbooks, but this course uses `ip`, `ss`, and protocol-specific tools because they expose namespaces, policy routing, modern socket state, and link attributes more directly.
@@ -281,13 +321,18 @@ Use modern tools that match the kernel model. Legacy net-tools such as `ifconfig
 | Whether a TCP port handshakes | `nc -vz <host> <port>` | Transport reachability | TLS or HTTP success |
 | Where path loss or latency appears | `mtr`, `tracepath` | Hop pattern, PMTU clues | Stateful firewall verdicts |
 
-A strong triage sequence is short. Identify the name and IP, ask Linux for the route, check neighbor state if the next hop is local, test the transport, inspect local sockets, then capture at the boundary where your evidence splits. In Kubernetes, add `k get pod -o wide`, `k get svc -o wide`, and endpoint inspection to map object names to real addresses before you run Linux tools.
+A strong triage sequence is short. Identify the name and IP, ask Linux for the route, check neighbor state if the next hop is local, test the transport, inspect local sockets, then capture at the boundary where your evidence splits. In Kubernetes, add `kubectl get pod -o wide`, `kubectl get svc -o wide`, and endpoint inspection to map object names to real addresses before you run Linux tools.
+
+Choose capture points by the question you are asking. A capture inside a pod namespace proves what the workload sent or received. A capture on the host veth peer proves what crossed the namespace boundary. A capture on the bridge, tunnel, or physical NIC proves what the node dataplane emitted. A capture on only `any` can be useful for quick discovery, but it can hide which interface saw the packet and whether encapsulation changed the headers. When an outage is expensive, spend the extra minute to capture at the boundary that separates two hypotheses.
+
+Write down negative evidence with the same care as positive evidence. "No SYN-ACK observed on `eth0` after SYN leaves" is useful. "No packets" is not, unless it names the interface, filter, time window, and expected tuple. This precision matters when handing off to a network, cloud, or application team. You are not asking them to believe Linux is broken; you are giving them a reproducible packet decision that contradicts the intended design.
 
 ```bash
 TARGET=10.244.2.37
 PORT=8443
 ip route get "$TARGET"
-ip neigh show nud failed,stale,reachable
+ip neigh show
+mtr --report "$TARGET"
 nc -vz "$TARGET" "$PORT"
 ss -tan "( dport = :$PORT or sport = :$PORT )"
 sudo tcpdump -ni any "host $TARGET and tcp port $PORT"
@@ -301,9 +346,34 @@ Avoid command roulette. Running `tcpdump`, `dig`, `nc`, `curl`, `mtr`, and `ss` 
 
 Also avoid "Kubernetes object equals packet path." A Ready pod can have a broken route. A Service can have endpoints and still fail because DNAT, conntrack, or firewall state is wrong. A NetworkPolicy can be correct while the underlay drops encapsulated packets. Kubernetes gives intent; Linux still executes the path.
 
-## Scenario Checks
+The strongest operators keep two models in parallel. The declarative model says what Kubernetes, cloud load balancers, DNS records, and CNI configuration intend. The packet model says what the node kernel, neighbor table, route lookup, socket table, resolver, and conntrack state actually did. An outage is the gap between those models. Your job is not to memorize every implementation detail; it is to narrow the gap until the next repair action is obvious and testable.
 
-<details><summary>Question 1: A client gets `connection refused` to a ClusterIP Service, but `k get endpoints` shows ready pods. What is your first split?</summary>
+## Did You Know
+
+- ARP and IPv6 NDP are not optional trivia on "modern" clusters; bare-metal ingress, node failover, and same-subnet gateways still depend on neighbor cache behavior.
+- A Kubernetes ClusterIP can be unreachable even when no interface owns that IP, because normal Service forwarding happens through a virtual IP dataplane rather than address assignment.
+- `TIME-WAIT` is usually a correctness feature, not a defect; `CLOSE-WAIT` more often points to an application that has not closed after the peer's FIN.
+- QUIC gives applications connection-like behavior over UDP, so the kernel will not expose QUIC sessions as TCP `ESTAB` sockets.
+
+These facts are useful because they stop common misreads. A missing ClusterIP in `ip addr` is not proof that the Service is absent. A full screen of `TIME-WAIT` is not proof that TCP is broken. A healthy TCP ingress tells you little about UDP/443. The kernel exposes the evidence you ask for; the operator has to ask the question that matches the protocol.
+
+## Common Mistakes: TCP/IP Triage
+
+| Mistake | Why it misleads | Better operator move |
+|---|---|---|
+| Treating DNS success as application reachability | A name can resolve while routing, firewall, MTU, or listener state still fails | Resolve the name, then test route, socket, and packet path to the returned address |
+| Looking for a ClusterIP in `ip addr` | Service IPs are often virtual destinations handled by kube-proxy or another dataplane | Inspect Service objects, endpoint selection, and NAT/eBPF forwarding evidence |
+| Debugging TCP with only `ping` | ICMP reachability does not prove a TCP listener, stateful firewall, or path for replies | Use `ss`, `nc`, and packet captures for the exact TCP tuple |
+| Flushing conntrack before proving the tuple | A broad flush can drop legitimate flows and destroy evidence | Compare original and translated tuples, then delete only targeted stale entries if needed |
+| Ignoring return routes | SYN arrival does not prove the SYN-ACK can return through policy routing or firewalls | Run route checks and captures in both directions |
+| Treating small successful probes as proof MTU is fine | Overlay overhead can break only larger payloads | Test size-sensitive traffic and PMTUD evidence |
+| Using legacy net-tools output as the source of truth | Older tools hide policy routing, namespaces, and modern socket detail | Prefer `ip`, `ss`, `tcpdump`, `dig`, `mtr`, `tracepath`, and `conntrack` |
+
+The pattern behind these mistakes is premature conclusion. Each command proves one boundary, not the whole network. A good incident note says what the command proved and what it left unproven. That makes the next command smaller and prevents the team from changing random knobs under pressure.
+
+## Knowledge Check
+
+<details><summary>Question 1: A client gets `connection refused` to a ClusterIP Service, but `kubectl get endpoints` shows ready pods. What is your first split?</summary>
 
 Separate Service translation from backend socket state. `connection refused` usually means a RST returned, so inspect whether the selected backend pod actually has a listener on the targetPort with `ss -tlnp` in the correct namespace or debug container. Then inspect Service port to targetPort mapping and kube-proxy rules. Do not start with MTU or DNS; the refusal is transport evidence.
 
@@ -367,8 +437,8 @@ Record whether you saw refusal, timeout, or immediate local error. Tie each resu
 ### Task 3: Inspect Kubernetes Addresses
 
 ```bash
-k get pods -A -o wide
-k get svc -A -o wide
+kubectl get pods -A -o wide
+kubectl get svc -A -o wide
 POD_IP=<choose-a-pod-ip>
 ip route get "$POD_IP"
 ```
@@ -398,11 +468,11 @@ Find the egress interface MTU and any PMTU clue from `tracepath`. If you are on 
 
 ### Success Criteria
 
-- [ ] Calculated at least one IPv4 or IPv6 prefix boundary instead of guessing from address strings.
-- [ ] Used `ip route get` and `ip neigh` to separate routing from link-layer resolution.
-- [ ] Interpreted at least three TCP states from `ss -tan` output.
-- [ ] Explained how a Kubernetes ClusterIP flow can be DNATed to a pod endpoint and tracked by conntrack.
-- [ ] Connected DNS resolver configuration to actual DNS packets.
+- [ ] Analyze a failing Kubernetes or host connection by separating link, neighbor, route, transport, conntrack, DNS, and application evidence.
+- [ ] Calculate IPv4 and IPv6 prefix boundaries, then decide whether a pod, node, Service, gateway, or VIP is local, routed, or virtual.
+- [ ] Trace TCP connection state from `SYN-SENT` through `TIME-WAIT` and use `ss -tan` output to distinguish refusal, timeout, backlog, close, and keepalive symptoms.
+- [ ] Diagnose Service and ingress failures by connecting Linux conntrack, DNAT, netfilter hooks, sockets, and kube-proxy proxy modes.
+- [ ] Design a triage sequence for MTU, DNS, ARP/NDP, routing, and transport incidents without falling back to legacy net-tools.
 - [ ] Chose modern `ip`, `ss`, `tcpdump`, `dig`, `mtr`, `nc`, and `conntrack` tools instead of legacy net-tools.
 
 ## Next Module
@@ -411,20 +481,23 @@ Next, continue to [Module 3.2: DNS in Linux](../module-3.2-dns-linux/) to go dee
 
 ## Sources
 
-- [RFC 1122: Requirements for Internet Hosts - Communication Layers](https://www.rfc-editor.org/rfc/rfc1122)
-- [RFC 9293: Transmission Control Protocol](https://www.rfc-editor.org/rfc/rfc9293)
-- [RFC 1918: Address Allocation for Private Internets](https://www.rfc-editor.org/rfc/rfc1918)
-- [RFC 4193: Unique Local IPv6 Unicast Addresses](https://www.rfc-editor.org/rfc/rfc4193)
-- [RFC 826: Address Resolution Protocol](https://www.rfc-editor.org/rfc/rfc826)
-- [RFC 4861: Neighbor Discovery for IPv6](https://www.rfc-editor.org/rfc/rfc4861)
-- [RFC 1191: Path MTU Discovery](https://www.rfc-editor.org/rfc/rfc1191)
-- [RFC 8201: Path MTU Discovery for IPv6](https://www.rfc-editor.org/rfc/rfc8201)
-- [RFC 9000: QUIC](https://www.rfc-editor.org/rfc/rfc9000)
+- [RFC 1122: Requirements for Internet Hosts - Communication Layers](https://www.rfc-editor.org/info/rfc1122)
+- [RFC 9293: Transmission Control Protocol](https://www.rfc-editor.org/info/rfc9293)
+- [RFC 1918: Address Allocation for Private Internets](https://www.rfc-editor.org/info/rfc1918)
+- [RFC 4632: Classless Inter-domain Routing (CIDR)](https://www.rfc-editor.org/info/rfc4632)
+- [RFC 4193: Unique Local IPv6 Unicast Addresses](https://www.rfc-editor.org/info/rfc4193)
+- [RFC 8200: Internet Protocol, Version 6 (IPv6) Specification](https://www.rfc-editor.org/info/rfc8200)
+- [RFC 826: Address Resolution Protocol](https://www.rfc-editor.org/info/rfc826)
+- [RFC 4861: Neighbor Discovery for IPv6](https://www.rfc-editor.org/info/rfc4861)
+- [RFC 1191: Path MTU Discovery](https://www.rfc-editor.org/info/rfc1191)
+- [RFC 8201: Path MTU Discovery for IPv6](https://www.rfc-editor.org/info/rfc8201)
+- [RFC 9000: QUIC](https://www.rfc-editor.org/info/rfc9000)
 - [IANA Service Name and Transport Protocol Port Number Registry](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml)
 - [Linux ip-route manual](https://man7.org/linux/man-pages/man8/ip-route.8.html)
 - [Linux ip-rule manual](https://man7.org/linux/man-pages/man8/ip-rule.8.html)
 - [Linux ip-neighbour manual](https://man7.org/linux/man-pages/man8/ip-neighbour.8.html)
 - [Linux ss manual](https://man7.org/linux/man-pages/man8/ss.8.html)
+- [Linux kernel netfilter documentation](https://docs.kernel.org/networking/netfilter.html)
 - [Linux kernel conntrack sysctl documentation](https://docs.kernel.org/networking/nf_conntrack-sysctl.html)
 - [Linux kernel IP sysctl documentation](https://docs.kernel.org/networking/ip-sysctl.html)
 - [Linux kernel VXLAN documentation](https://docs.kernel.org/networking/vxlan.html)

--- a/src/content/docs/linux/foundations/networking/module-3.1-tcp-ip-essentials.md
+++ b/src/content/docs/linux/foundations/networking/module-3.1-tcp-ip-essentials.md
@@ -14,633 +14,419 @@ lab:
 
 # Module 3.1: TCP/IP Essentials
 
-> **Linux Foundations** | Complexity: `[MEDIUM]` | Time: 30-35 min
+> **Linux Foundations** | Complexity: `[MEDIUM]` | Time: 35-40 min. This is the operator-grade packet model that later modules use for DNS, namespaces, veth pairs, iptables, and Kubernetes Service debugging.
 
 ## Prerequisites
 
 Before starting this module:
-- **Required**: Basic understanding of what networks are
+
+- **Required**: Basic comfort with Linux shells and process troubleshooting.
 - **Helpful**: [Module 1.1: Kernel & Architecture](/linux/foundations/system-essentials/module-1.1-kernel-architecture/)
+- **Next bridge**: [Module 3.3: Network Namespaces & veth](../module-3.3-network-namespaces/) uses the same addressing, routing, neighbor, and MTU model inside isolated network stacks.
 
-For Kubernetes examples in this networking track, define the short alias once with `alias k=kubectl` and then use commands such as `k get pods -o wide` when you need cluster context. This module is mostly about Linux itself, but the same routing, socket, and transport behavior explains why Kubernetes 1.35+ pods, Services, NodePorts, and ingress controllers behave the way they do during an incident.
+For Kubernetes examples, define `alias k=kubectl` once. The lesson is Linux-first, but the goal is Kubernetes 1.35+ operations: pod IPs, Service virtual IPs, CNI routes, ingress sockets, egress NAT, and DNS all collapse to kernel packet decisions during troubleshooting.
 
-## Learning Outcomes
+## What You'll Be Able to Do
 
-After this module, you will be able to:
-- **Trace** TCP connection behavior from SYN through FIN and diagnose reset, timeout, and listener failures.
-- **Calculate** CIDR subnet boundaries and compare whether two hosts share the same local network.
-- **Diagnose** Linux connectivity by interpreting `ping`, `traceroute`, `ss`, `ip route`, and interface statistics together.
-- **Evaluate** TCP versus UDP tradeoffs and choose the right transport behavior for Linux and Kubernetes services.
-- **Design** routing checks for Kubernetes 1.35+ pod, Service, and node networks using longest-prefix match reasoning.
+After completing this module, you will be able to reason about TCP/IP as an operated Linux system rather than as a vocabulary list.
+
+1. **Analyze** a failing Kubernetes or host connection by separating link, neighbor, route, transport, conntrack, DNS, and application evidence.
+2. **Calculate** IPv4 and IPv6 prefix boundaries, then decide whether a pod, node, Service, gateway, or VIP is local, routed, or virtual.
+3. **Trace** TCP connection state from `SYN-SENT` through `TIME-WAIT` and use `ss -tan` output to distinguish refusal, timeout, backlog, close, and keepalive symptoms.
+4. **Diagnose** Service and ingress failures by connecting Linux conntrack, DNAT, netfilter hooks, sockets, and kube-proxy proxy modes.
+5. **Design** a triage sequence for MTU, DNS, ARP/NDP, routing, and transport incidents without falling back to legacy net-tools.
 
 ## Why This Module Matters
 
-At 02:18 on a trading platform's busiest morning of the quarter, the dashboard said the application was healthy while customers saw spinning browsers and failed checkout requests. The pods were running, the Service existed, and the ingress controller had not restarted, so the first team on call kept looking upward at the application logs. Forty minutes later, a network engineer found the real fault: one node had learned a more specific route for the pod CIDR through the wrong gateway, so replies were taking a path the firewall silently dropped. The incident cost the company a six-figure revenue window, but the technical cause was not exotic; it was ordinary TCP/IP behavior misunderstood under pressure.
+At 02:11, a platform team sees checkout requests timing out through an ingress controller. Pods are Ready, the Service exists, CoreDNS is healthy, and the application logs show no errors. The first useful clue comes from a node: `ip route get <pod-ip>` chooses the wrong interface, `ss -tan` shows many client sockets in `SYN-SENT`, and `conntrack -L` shows stale translated Service flows. Nothing in that evidence is Kubernetes-specific. Kubernetes supplied the objects, but Linux made the packet decisions.
 
-Linux networking rewards engineers who can move from symptom to layer without guessing. A successful `ping` proves that one kind of packet can make a round trip, but it does not prove that a TCP handshake to port 443 can complete, that the server process is listening, that the reply route is symmetric, or that the MTU lets application payloads pass. Kubernetes adds useful abstractions, yet every packet still leaves a namespace through an interface, matches a route, crosses a transport protocol, and lands on a socket. When those basics are clear, the difference between "DNS is broken," "the port is closed," "the firewall is dropping SYN packets," and "the wrong subnet mask created an ARP problem" becomes visible.
+A platform engineer who cannot reason about TCP state machines, MTU, ARP/NDP, routes, and conntrack is blind during real outages. Service IPs are virtual addresses, CNI plugins may use overlays or direct routing, ingress may terminate TCP or QUIC, egress often rewrites source addresses, and active-active VIPs rely on neighbor behavior. The abstraction is useful only when you can descend through it to a packet-on-the-wire decision. Kubernetes documents that Services get cluster IPs through a virtual IP mechanism, and kube-proxy programs Linux packet forwarding rules in iptables, nftables, or IPVS modes depending on configuration. ([Kubernetes Services](https://v1-35.docs.kubernetes.io/docs/concepts/services-networking/service/), [Kubernetes Virtual IPs and Service Proxies](https://v1-35.docs.kubernetes.io/docs/reference/networking/virtual-ips/))
 
-This module builds the mental model you need before the later DNS, namespace, and firewall modules. You will trace what Linux adds to application data, calculate what a CIDR mask really means, compare TCP and UDP as engineering choices, read routing tables using longest-prefix match, and connect ports to processes with `ss`. The goal is not to memorize commands in isolation; it is to learn how to test one hypothesis at a time until the packet path makes sense.
+Treat every network failure as a claim about one layer of evidence. `ping` may prove ICMP reachability but not a TCP listener. `dig` may prove DNS resolution but not routing to the answer. `ss` may prove a local socket exists but not that a remote firewall lets SYN packets through. `tcpdump` may prove a packet arrived at one interface while the real drop happens later in netfilter or in an overlay MTU mismatch. The discipline is to ask: which kernel decision did I just prove?
 
-## The Network Stack: What Linux Adds Before Bytes Leave
+## Layers as Kernel Decisions
 
-The easiest mistake in network debugging is to treat "the network" as a single opaque thing. Linux does not send a web request as one magical object; it wraps application bytes in several layers of headers, and each layer answers a different operational question. The application layer asks what the program wants to say, the transport layer asks which process conversation this belongs to, the internet layer asks which machine should receive it, and the network access layer asks how to put the next frame on the local link. When you debug with that structure, you stop asking broad questions like "is the network down?" and start asking testable questions like "did the SYN reach a listener?" or "did the reply choose the expected interface?"
+OSI is useful vocabulary, but Linux operators usually debug the TCP/IP model because it maps to kernel surfaces. RFC 1122 organizes host requirements across link, internet, and transport layers; RFC 9293 is the current consolidated TCP specification and obsoletes the original RFC 793 as the core TCP reference. In Linux, each layer corresponds to objects you can inspect: links, neighbors, routes, sockets, conntrack entries, and resolver configuration. ([RFC 1122](https://www.rfc-editor.org/rfc/rfc1122), [RFC 793](https://www.rfc-editor.org/rfc/rfc793), [RFC 9293](https://www.rfc-editor.org/rfc/rfc9293))
 
-The OSI model and the TCP/IP model describe the same practical reality at different levels of detail. OSI separates presentation and session concerns because it is a teaching and architecture model, while the TCP/IP model groups those responsibilities around the protocols Linux actually uses every day. For KubeDojo work, the TCP/IP model is usually the sharper tool because it maps directly to the commands you run: `ss` shows transport-layer sockets, `ip route` shows internet-layer decisions, and `ip link` shows network-access interfaces.
+| OSI view | TCP/IP view | Kernel-level operator question |
+|---|---|---|
+| Physical / Data link | Link | Is the interface up, what MTU applies, and which neighbor MAC receives the next frame? |
+| Network | Internet | Which source address, route, policy table, and next hop does the kernel select? |
+| Transport | Transport | Which local socket owns the port, and what TCP/UDP state is visible? |
+| Session / Presentation / Application | Application | Which resolver, TLS, HTTP, DNS, or QUIC behavior produced the bytes above transport? |
 
-```mermaid
-graph LR
-    subgraph OSI Model
-        direction TB
-        O7["7. Application"]
-        O6["6. Presentation"]
-        O5["5. Session"]
-        O4["4. Transport (TCP, UDP)"]
-        O3["3. Network (IP)"]
-        O2["2. Data Link"]
-        O1["1. Physical (Ethernet, WiFi)"]
-    end
-    
-    subgraph TCP/IP Model
-        direction TB
-        T4["Application (HTTP, DNS, SSH)"]
-        T3["Transport (TCP, UDP)"]
-        T2["Internet (IP)"]
-        T1["Network Access (Ethernet)"]
-    end
+| TCP/IP layer | Kernel decision | Linux evidence | Kubernetes anchor |
+|---|---|---|---|
+| Link | Which local interface and next-hop MAC can carry the frame? | `ip link`, `ip -s link`, `ip neigh`, `tcpdump -i <if>` | veth, bridge, CNI device, node NIC |
+| Internet | Which source address, prefix, route, and policy table apply? | `ip addr`, `ip route get`, `ip rule show` | pod CIDR, node CIDR, Service CIDR, dual-stack family |
+| Transport | Which socket, port, sequence state, and protocol contract apply? | `ss -tanp`, `ss -uanp`, `/proc/sys/net/ipv4/tcp_*` | containerPort, Service port, NodePort, ingress listener |
+| Application | Which name, TLS, HTTP, gRPC, DNS, or QUIC behavior is active? | `dig`, `curl -v`, app logs, ingress logs | CoreDNS, Service DNS, Gateway/Ingress routing |
 
-    O7 ~~~ T4
-    O6 ~~~ T4
-    O5 ~~~ T4
-    O4 ~~~ T3
-    O3 ~~~ T2
-    O2 ~~~ T1
-    O1 ~~~ T1
-```
-
-Picture a request to `http://10.0.0.50/index.html`. The application produces HTTP bytes, TCP wraps those bytes with source and destination ports plus sequencing state, IP wraps the segment with source and destination addresses, and Ethernet wraps the packet with source and destination MAC addresses for the next hop. The destination MAC might be the final server on the same LAN, or it might be the router's MAC when the final IP is elsewhere. That distinction is why an IP address can stay the same across a trip while the MAC address changes at every routed hop.
+Packet headers are nested, but operational responsibility is not purely nested. A Kubernetes ClusterIP packet may be routed toward a virtual destination, hit netfilter in `PREROUTING` or `OUTPUT`, be DNATed to an endpoint pod IP, then be routed again. A pod-to-pod packet may leave a namespace through a veth, cross a bridge or eBPF datapath, enter VXLAN, and finally leave the node NIC. The layer model helps because each step leaves different evidence.
 
 ```mermaid
-graph TD
-    App["Application: GET /index.html HTTP/1.1"]
-    
-    subgraph Transport["Transport Layer (TCP)"]
-        T_Details["Source Port: 54321<br/>Dest Port: 80<br/>Sequence Number, ACK, Flags"]
-    end
-    
-    subgraph Network["Network Layer (IP)"]
-        N_Details["Source IP: 192.168.1.100<br/>Dest IP: 10.0.0.50<br/>TTL, Protocol"]
-    end
-    
-    subgraph DataLink["Data Link Layer (Ethernet)"]
-        D_Details["Source MAC: aa:bb:cc:dd:ee:ff<br/>Dest MAC: 11:22:33:44:55:66"]
-    end
-    
-    Wire["Wire / Radio / Fiber"]
-    
-    App --> Transport
-    Transport --> Network
-    Network --> DataLink
-    DataLink --> Wire
+flowchart LR
+    App[App bytes<br/>HTTP, DNS, TLS, QUIC] --> L4[Transport<br/>TCP or UDP ports]
+    L4 --> L3[Internet<br/>IPv4 or IPv6 source/destination]
+    L3 --> L2[Link<br/>interface, MTU, neighbor MAC]
+    L2 --> Wire[Wire, tunnel, or virtual peer]
+    Wire --> L2b[Next hop link]
+    L2b --> L3b[Route or local delivery]
+    L3b --> L4b[Socket or conntrack/NAT]
+    L4b --> Appb[Receiving process]
 ```
 
-The practical consequence is that every diagnostic tool reveals only a slice of the trip. `ping` tests ICMP reachability at the IP layer, but it does not prove that a TCP service accepts connections. `curl` proves more because it exercises DNS if a name is used, routing, TCP, TLS when HTTPS is involved, and the application response. `ss` looks inward at local sockets, which makes it ideal when you need to prove whether the kernel has a listener for a given port. A good investigation combines these views rather than trusting any one command as a verdict.
+The diagram is not just teaching art. It is a triage map. If `ip route get` selects the wrong egress interface, the TCP state is a consequence, not the root cause. If a listener is bound to `127.0.0.1:8080`, a Service cannot make remote clients reach it without a process listening on the pod or node address. If VXLAN reduces the usable inner MTU, HTTP may connect and then hang only on larger responses. Each symptom points to a decision surface.
 
-In Kubernetes, the stack is still there even when the packet begins inside a pod network namespace. A pod sends from its own IP address, the node routes that traffic through a CNI-created interface, kube-proxy or an eBPF dataplane may translate a Service IP, and the physical node network carries the frame toward another node or an external gateway. If you run `k get pods -o wide`, the pod IPs you see are not decoration; they are addresses Linux must route. The cluster abstraction changes who creates the interfaces and routes, not the fact that packets obey the kernel's networking rules.
+## Addressing: IPv4, IPv6, and Kubernetes CIDRs
 
-Pause and predict: if `ping 10.0.0.50` works from a client but `curl http://10.0.0.50` hangs, which layer has been proven healthy and which layer still needs a direct test? Write down your answer before continuing, because this exact distinction separates many quick fixes from long incident calls.
-
-A useful worked example starts with a web server that fails from a client but appears healthy locally. First, `ip addr` confirms the host owns the expected source address; then `ip route get 10.0.0.50` predicts which interface and gateway Linux will use; then `nc -zv 10.0.0.50 80` tests the TCP port directly; finally `ss -tlnp` on the server checks whether a process is listening. Each command narrows the search by one layer. If the route is wrong, restarting the app is irrelevant; if no socket is listening, changing the gateway will not help.
-
-## IP Addressing and CIDR: Deciding What Is Local
-
-An IPv4 address is a 32-bit number usually written as four decimal octets because humans prefer `192.168.1.100` to a long string of bits. The subnet mask says how many leading bits describe the network portion and how many trailing bits describe host addresses inside that network. Linux uses that split to decide whether a destination is local enough to reach directly on the link or remote enough to send to a router. When the split is wrong, two machines can make opposite decisions about the same conversation, which creates asymmetric failures that look confusing until you calculate the masks.
+IPv4 addresses are 32-bit values; IPv6 addresses are 128-bit values. CIDR notation says how many leading bits form the network prefix. RFC 1918 defines the familiar private IPv4 ranges, RFC 4193 defines IPv6 Unique Local Addresses, and RFC 8200 specifies IPv6 itself. The operator move is to calculate the boundary instead of comparing dotted strings by sight. ([RFC 1918](https://www.rfc-editor.org/rfc/rfc1918), [RFC 4193](https://www.rfc-editor.org/rfc/rfc4193), [RFC 8200](https://www.rfc-editor.org/rfc/rfc8200), [RFC 4632](https://www.rfc-editor.org/rfc/rfc4632))
 
 ```text
-IP Address: 192.168.1.100
-Binary:     11000000.10101000.00000001.01100100
-
-Subnet Mask: 255.255.255.0 (or /24)
-Binary:      11111111.11111111.11111111.00000000
-
-Network:     192.168.1.0   (first 24 bits)
-Host:        .100          (last 8 bits)
-Broadcast:   192.168.1.255 (all host bits = 1)
+10.244.2.37/24
+network bits: 24
+host bits:     8
+network:       10.244.2.0
+usable range:  10.244.2.1 - 10.244.2.254
+broadcast:     10.244.2.255
 ```
 
-With `192.168.1.100/24`, the first twenty-four bits are the network, so addresses from `192.168.1.1` through `192.168.1.254` are usable host addresses in the same subnet. The network address, `192.168.1.0`, identifies the subnet itself, and the broadcast address, `192.168.1.255`, targets every host on that subnet. This is why a host at `192.168.2.10/24` is not local to `192.168.1.100/24`, even though the first two octets match. The mask, not the visual similarity of the address, defines the boundary.
+A Kubernetes cluster normally has at least three address domains. Node IPs belong to the underlay: cloud VPC, bare-metal VLAN, or host network. Pod IPs come from CNI-managed ranges and must be reachable according to the cluster networking design. Service ClusterIPs come from a Service CIDR and are virtual destinations that kube-proxy or another dataplane captures and redirects. Kubernetes states that normal Services resolve to cluster IPs, while headless Services return endpoint IPs instead of relying on virtual IP forwarding. ([Kubernetes DNS for Services and Pods](https://v1-35.docs.kubernetes.io/docs/concepts/services-networking/dns-pod-service/), [Kubernetes Services](https://v1-35.docs.kubernetes.io/docs/concepts/services-networking/service/))
 
-CIDR notation exists because classful network labels stopped being flexible enough for real deployments. A `/32` identifies a single host route, a `/24` is common for a small LAN, and a `/16` can cover many smaller subnets under one route summary. The number after the slash is not a count of hosts; it is a count of fixed network bits. To find the number of host addresses, you count the remaining bits, raise two to that power, and subtract the reserved network and broadcast addresses for traditional IPv4 subnets.
+| Address domain | Example | What it means | First Linux check |
+|---|---:|---|---|
+| Node CIDR / node IPs | `192.168.10.0/24` | Real host network reachability between nodes and gateways | `ip addr`, `ip route get <node-ip>` |
+| Pod CIDR | `10.244.0.0/16` | Workload addresses routed, bridged, overlaid, or eBPF-forwarded by CNI | `k get pods -o wide`, `ip route get <pod-ip>` |
+| Service CIDR | `10.96.0.0/12` | Virtual Service destinations selected and rewritten to endpoints | `k get svc`, `nft list ruleset` or `iptables-save` |
+| IPv6 ULA | `fd00:10:244::/56` | Private IPv6-style cluster or site addressing | `ip -6 addr`, `ip -6 route get <addr>` |
 
-| CIDR | Subnet Mask | Hosts | Common Use |
-|------|-------------|-------|------------|
-| /32 | 255.255.255.255 | 1 | Single host |
-| /24 | 255.255.255.0 | 254 | Small network |
-| /16 | 255.255.0.0 | 65,534 | Medium network |
-| /8 | 255.0.0.0 | 16M | Large network |
-
-Private address ranges matter because most lab networks, home networks, cloud VPCs, and Kubernetes clusters use them internally. These ranges are not routed on the public internet, so organizations can reuse them behind NAT, VPNs, and private WAN links. The flexibility is useful, but overlap becomes painful when two networks need to talk. A cluster pod CIDR of `10.244.0.0/16` can collide with an existing corporate route if the organization already uses that block, and the resulting failures usually look like partial connectivity rather than a clean outage.
-
-| Range | CIDR | Class | Use |
-|-------|------|-------|-----|
-| 10.0.0.0 - 10.255.255.255 | 10.0.0.0/8 | A | Large orgs |
-| 172.16.0.0 - 172.31.255.255 | 172.16.0.0/12 | B | Medium orgs |
-| 192.168.0.0 - 192.168.255.255 | 192.168.0.0/16 | C | Home/small |
-
-Kubernetes usually separates node, pod, and Service address ranges because they mean different things. Node IPs belong to the underlying machine network, pod IPs belong to the CNI-managed overlay or routed pod network, and ClusterIP Service addresses are virtual destinations handled by the cluster dataplane. A Service IP is not normally assigned to a physical interface the way a node IP is. That difference matters when you use Linux tools: `ip route` explains how a node reaches pod networks, while Service translation may happen through iptables, IPVS, or eBPF rules depending on the cluster implementation.
-
-```mermaid
-graph TD
-    subgraph K8s["Kubernetes Networking"]
-        direction TB
-        Nets["Pod Network: 10.244.0.0/16<br/>Service Network: 10.96.0.0/12<br/>Node Network: 192.168.1.0/24"]
-        Exs["Pod on Node 1: 10.244.1.15/24<br/>Pod on Node 2: 10.244.2.23/24<br/>ClusterIP Service: 10.96.0.1"]
-        Nets ~~~ Exs
-    end
-```
-
-When you inspect a Linux host, start by identifying addresses, interfaces, and the prefix length attached to each address. The `ip` command replaced older tools because it exposes the kernel's current networking model more accurately, though you will still see `ifconfig` in older runbooks. The brief view is often enough during an incident, while the full view shows flags, scope, MAC addresses, and secondary addresses. If the expected source IP is missing here, later tests against routing or sockets are likely to mislead you.
+The common overlap problem is simple to miss. If the corporate WAN uses `10.244.0.0/16` and a new cluster also uses `10.244.0.0/16` for pods, some destinations become ambiguous. Linux will choose the most specific matching route; humans may see only that both are "10 dot" networks. Calculate the prefixes, then ask the kernel for the actual lookup.
 
 ```bash
-# Show all interfaces
-ip addr
-
-# Show specific interface
-ip addr show eth0
-
-# Legacy command
-ifconfig
-
-# Show IPv4 only
-ip -4 addr
-
-# Brief format
 ip -br addr
+ip route get 10.244.2.37
+ip -6 route get fd00:10:244::37
+k get pods -A -o wide
+k get svc -A -o wide
 ```
 
-Consider a bare-metal Kubernetes node with `192.168.1.50/24` and a second node configured as `192.168.2.10/16`. The first node sees `192.168.2.10` as remote because its `/24` only includes `192.168.1.0` through `192.168.1.255`, so it sends traffic through a gateway. The second node sees `192.168.1.50` as local because its `/16` includes all of `192.168.0.0` through `192.168.255.255`, so it may try direct ARP on a link where the first node is not actually present. This mismatch creates one-way assumptions, and one-way assumptions create outages that feel random until you compare both masks.
+Do not treat a Service IP as if it must appear on an interface. In kube-proxy iptables mode, Kubernetes documents that kube-proxy installs rules redirecting virtual IP traffic to endpoint rules, and those endpoint rules use destination NAT to backend pods. In nftables mode, kube-proxy uses the kernel netfilter subsystem through nftables instead. The Linux debugging surface is therefore routes plus packet-filter state, not only `ip addr`. ([Kubernetes Virtual IPs and Service Proxies](https://v1-35.docs.kubernetes.io/docs/reference/networking/virtual-ips/))
 
-Stop and think: if your pod gets the IP address `10.244.1.15/24`, what is the highest IP address that can exist in that exact same subnet before traffic needs a route beyond the local pod network segment? The answer is not the largest address inside `10.244.0.0/16`; it is the largest usable address inside the pod's own `/24`, because the prefix length defines the local boundary.
+## Neighbor Discovery: ARP, NDP, and VIPs
 
-## TCP and UDP: Choosing Reliability, Latency, and Failure Behavior
+Routing chooses the next-hop IP and egress device; neighbor discovery finds the link-layer destination for that next hop. IPv4 commonly uses ARP, standardized in RFC 826. IPv6 uses Neighbor Discovery Protocol, specified in RFC 4861. Linux exposes both through the neighbor table, so `ip neigh` is the modern inspection tool. ([RFC 826](https://www.rfc-editor.org/rfc/rfc826), [RFC 4861](https://www.rfc-editor.org/rfc/rfc4861), [ip-neighbour(8)](https://man7.org/linux/man-pages/man8/ip-neighbour.8.html))
 
-TCP and UDP are not simply "safe" and "fast" versions of each other. They represent different contracts between an application and the network. TCP creates a connection, numbers bytes, acknowledges delivery, retransmits loss, manages receiver capacity, and slows down when congestion appears. UDP sends independent datagrams with a smaller contract: the kernel will try to place the datagram on the network, but it will not establish a session, resend missing packets, or reorder arrivals for the application. The better protocol depends on what kind of failure the application can tolerate.
+```bash
+ip neigh show
+ip neigh show dev eth0
+ip -6 neigh show
+sudo ip neigh flush dev eth0 nud failed
+```
 
-TCP begins with a handshake because both sides need initial sequence numbers and connection state before reliable byte delivery can work. The client sends SYN, the server replies with SYN-ACK if a listener accepts the port, and the client returns ACK. Only then does normal data transfer begin. If the server host exists but nothing listens on the destination port, the kernel commonly sends a reset, which tells the client the host was reachable but the port was closed. If a firewall drops the SYN without answering, the client waits and retries until it times out.
+Neighbor state matters when the failure looks like "same subnet but no traffic." If a node believes `192.168.10.44` is on-link, it will ARP for that address instead of sending the packet to a gateway. If no host answers, packets queue and then fail below TCP. If the wrong host answers, traffic goes to the wrong MAC. Active-active VIP systems amplify this risk: two nodes advertising the same virtual IP can create neighbor cache flapping, especially when gratuitous ARP or unsolicited NDP announcements are misconfigured.
+
+Use neighbor evidence before changing routes. A route such as `192.168.10.0/24 dev eth0` can be correct while a stale neighbor entry points to an old MAC after failover. Conversely, a failed neighbor lookup may be the symptom of a bad prefix: the host is ARPing because it incorrectly thinks the destination is local. This is why CIDR and ARP/NDP must be read together.
+
+## Routing: FIB, RIB, Longest Prefix, and Policy Rules
+
+Linux uses route tables to populate forwarding decisions. Network teams often say RIB for routing information base and FIB for forwarding information base; in day-to-day Linux triage, `ip route` shows the installed route entries the kernel can use, while `ip route get` asks for a concrete forwarding decision. The `ip-route` manual describes route table management, route types, next hops, route metrics, MTU attributes, and the special `default` prefix. ([ip-route(8)](https://man7.org/linux/man-pages/man8/ip-route.8.html))
+
+Longest prefix match is the core rule. A `/32` host route beats a `/24`, a `/24` beats a `/16`, and all of them beat `default` (`0.0.0.0/0` or `::/0`). Metrics matter after comparable matches; they do not make a broad default route beat a specific pod route. Policy routing adds another layer: `ip rule` can select a different table based on source address, fwmark, incoming interface, or other selectors. ([ip-rule(8)](https://man7.org/linux/man-pages/man8/ip-rule.8.html))
+
+```bash
+ip route show
+ip route get 10.244.2.37
+ip route get 203.0.113.10 from 192.168.10.25
+ip rule show
+ip route show table all
+```
+
+Kubernetes makes this visible on every node. A directly routed CNI may install one route per remote pod CIDR. An overlay CNI may route pod traffic into a VXLAN, IPIP, or WireGuard device. A cloud CNI may rely on VPC route tables rather than visible host routes for every pod. The check remains the same: ask the node how it would reach the pod IP, then compare that answer with the CNI design.
+
+Policy routing explains asymmetric outages on multi-homed nodes. A request can arrive on `eth0`, but the reply lookup may select `eth1` because the destination client network is more specific through another table. Stateful firewalls and cloud security systems often drop that reply as unexpected. During triage, inspect both directions: route from client to server, and route from server back to client.
+
+## TCP: Handshake, State, Close, and Keepalive
+
+TCP is a reliable byte stream with connection state, sequence numbers, acknowledgments, retransmission, flow control, and congestion control. RFC 9293 is the current TCP specification, and Linux exposes many TCP behaviors through `ss`, `/proc/sys/net/ipv4/tcp_*`, and socket state. A TCP incident is often just a state-machine question hidden under application language. ([RFC 9293](https://www.rfc-editor.org/rfc/rfc9293), [tcp(7)](https://man7.org/linux/man-pages/man7/tcp.7.html), [ss(8)](https://man7.org/linux/man-pages/man8/ss.8.html))
+
+Ports are part of the transport evidence, not application folklore. IANA maintains the service name and transport protocol port registry, which is why operators recognize TCP 22 for SSH, TCP 443 for HTTPS, UDP/TCP 53 for DNS, and Kubernetes control-plane ports such as TCP 6443 as conventions to verify rather than assumptions to trust blindly. A Service `port`, `targetPort`, `nodePort`, and container listener may all differ, so the reliable question is still: which tuple did the kernel see, and which process or NAT rule owned it? ([IANA Service Name and Transport Protocol Port Number Registry](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml), [Kubernetes Ports and Protocols](https://v1-35.docs.kubernetes.io/docs/reference/networking/ports-and-protocols/))
 
 ```mermaid
-sequenceDiagram
-    participant Client
-    participant Server
-
-    Client->>Server: SYN (seq=100)
-    Server->>Client: SYN-ACK (seq=300, ack=101)
-    Client->>Server: ACK (seq=101, ack=301)
-    Note over Client,Server: Connection Established
-    Client->>Server: Data Transfer
-    Server->>Client: Data Transfer
-    Client->>Server: FIN
-    Server->>Client: FIN-ACK
-    Client->>Server: ACK
+stateDiagram-v2
+    [*] --> CLOSED
+    CLOSED --> SYN_SENT: active open / SYN
+    CLOSED --> LISTEN: passive open
+    LISTEN --> SYN_RECEIVED: receive SYN / send SYN-ACK
+    SYN_SENT --> ESTABLISHED: receive SYN-ACK / send ACK
+    SYN_RECEIVED --> ESTABLISHED: receive ACK
+    ESTABLISHED --> FIN_WAIT_1: local close / FIN
+    ESTABLISHED --> CLOSE_WAIT: remote FIN / ACK
+    FIN_WAIT_1 --> FIN_WAIT_2: receive ACK
+    FIN_WAIT_2 --> TIME_WAIT: receive FIN / ACK
+    CLOSE_WAIT --> LAST_ACK: app closes / FIN
+    LAST_ACK --> CLOSED: receive ACK
+    TIME_WAIT --> CLOSED: 2MSL timeout
 ```
 
-This handshake gives you useful diagnostic signals. "Connection refused" usually means a reset came back, so routing to the host worked and the destination stack rejected the port. "Connection timed out" often means packets or replies disappeared, so you investigate firewalls, routes, security groups, or host reachability. "No route to host" points even earlier, toward the local route lookup or neighbor discovery. Treat these messages as evidence, not decoration; they are the kernel telling you where the conversation broke.
-
-TCP Features:
-- **Reliable** — Retransmits lost packets
-- **Ordered** — Packets delivered in sequence
-- **Connection-oriented** — Handshake required
-- **Flow control** — Sender adjusts to receiver capacity
-- **Congestion control** — Adapts to network conditions
-
-UDP has less machinery, which can be exactly the right design. DNS commonly uses UDP for small queries because a short request and response should not pay the cost of a connection setup. Streaming, telemetry, voice, and some game traffic may prefer fresh data over guaranteed old data. If a monitoring agent emits thousands of samples per second and a congested link drops some, UDP lets the application continue with newer samples instead of building an ever-larger reliable backlog. The tradeoff is that loss becomes an application concern rather than a transport guarantee.
-
-```mermaid
-sequenceDiagram
-    participant Client
-    participant Server
-
-    Client->>Server: Data
-    Client->>Server: Data
-    Client->>Server: Data
-    Note over Client,Server: No handshake, no acknowledgments, no guarantees
-```
-
-UDP Features:
-- **Fast** — No connection overhead
-- **Simple** — Just send data
-- **Unreliable** — Packets can be lost
-- **Unordered** — Packets can arrive out of order
-- **No flow control** — Sender can overwhelm receiver
-
-The transport choice also affects load balancers and Kubernetes Services. A TCP Service can observe connection state and often has clearer health semantics because a backend either accepts a connection or it does not. A UDP Service must rely on datagrams and timeout behavior, which makes some failures harder to distinguish from quiet applications. Kubernetes supports both, but the operational evidence changes. If you expose a UDP game server or DNS service, you need probes, metrics, and packet captures that reflect datagram behavior instead of expecting TCP-style connection logs.
-
-| TCP | UDP |
-|-----|-----|
-| HTTP/HTTPS | DNS (queries) |
-| SSH | DHCP |
-| Database connections | Video streaming |
-| API calls | Gaming |
-| File transfer | VoIP |
-
-Pause and predict: if a client sends a SYN packet to a server, but the server's application has crashed and is not listening on that port, what should the server's operating system send back when no firewall interferes? Now compare that with the case where a firewall silently drops the same SYN. The difference between a reset and a timeout is one of the fastest ways to separate "host reachable, service absent" from "path or policy is blocking the packet."
-
-A practical war story from platform teams involves metrics pipelines during congestion. A TCP-based collector can protect data integrity by retrying every sample, but that same guarantee can create memory pressure when downstream storage slows down. The sender keeps buffers full of unacknowledged bytes, retries increase, and a process that looked efficient during normal traffic can crash under backpressure. UDP would avoid that buffer growth, but it would also lose samples. The engineering decision is not "which protocol is better"; it is whether accurate historical completeness or graceful lossy behavior matters more for that workload.
-
-## Routing: Longest Prefix Match and the Next Hop
-
-Once Linux knows the destination IP, it must decide where to send the packet next. The routing table is the kernel's decision list, and the most important rule is longest prefix match. If `10.244.2.23` matches both a broad default route and a more specific pod-network route, the route with the longer prefix wins because it describes a smaller, more exact destination set. Metrics decide between otherwise comparable routes, but specificity comes first. This is why a single accidental `/32` host route can override a default gateway and break one destination while everything else works.
-
-```mermaid
-graph TD
-    Packet["Packet destined for: 10.0.0.50"]
-    
-    subgraph RoutingTable["Routing Table"]
-        direction TB
-        R1["192.168.1.0/24 via 0.0.0.0 (eth0, metric 0)"]
-        R2["10.0.0.0/8 via 192.168.1.1 (eth0, metric 100)"]
-        R3["0.0.0.0/0 via 192.168.1.1 (eth0, metric 0)"]
-    end
-    
-    Match["Match: 10.0.0.0/8<br/>Send to gateway 192.168.1.1 via eth0"]
-    
-    Packet --> RoutingTable
-    R2 ==> Match
-```
-
-Routes can point directly to a device for locally connected networks or to a next-hop gateway for remote networks. A route such as `192.168.1.0/24 dev eth0` says hosts in that subnet are on the local link, so Linux can use neighbor discovery or ARP to find the next frame destination. A route such as `10.0.0.0/8 via 192.168.1.1 dev eth0` says the final destination is remote, but the next hop is the gateway at `192.168.1.1`. In both cases, the packet keeps the final destination IP while the link-layer frame targets the next hop.
+Read `ss -tan` as evidence. `SYN-SENT` on a client means SYN packets left or are queued but no SYN-ACK has completed the handshake. `SYN-RECV` on a server means SYNs arrived and replies were attempted, but the final ACK did not complete or accept queue pressure exists. `ESTAB` proves the handshake completed. `CLOSE-WAIT` means the peer closed and the local application has not closed its side. `TIME-WAIT` is normal on the side that actively closed; it prevents old duplicate segments from corrupting a later connection using the same tuple.
 
 ```bash
-# Show routing table
-ip route
-
-# Legacy command
-route -n
-netstat -rn
-
-# Example output:
-# default via 192.168.1.1 dev eth0 proto dhcp metric 100
-# 10.244.0.0/16 via 10.244.0.0 dev cni0
-# 192.168.1.0/24 dev eth0 proto kernel scope link src 192.168.1.100
-```
-
-In Kubernetes, node routes and CNI routes decide how pod CIDRs are reached. A simple Flannel-style setup might route local pods through `cni0` and remote node pod CIDRs through the node network. Other CNIs may use overlays, BGP, eBPF, or cloud route tables, but Linux still needs a next-hop decision somewhere in the datapath. When pod-to-pod traffic fails across nodes but works on the same node, the likely fault is not the application protocol. It is often the route to the remote pod CIDR, encapsulation, forwarding, firewall policy, or return path.
-
-```bash
-# Pod-to-pod routing on same node
-10.244.1.0/24 dev cni0  # Local pods
-
-# Pod-to-pod routing across nodes (example with Flannel)
-10.244.2.0/24 via 192.168.1.102 dev eth0  # Pods on node2
-
-# Default route for external traffic
-default via 192.168.1.1 dev eth0
-```
-
-Adding routes by hand is useful in a lab because it shows cause and effect, but it is dangerous as a production fix unless you know how persistence is managed. Commands entered with `ip route add` modify the running kernel table, and those changes usually disappear after reboot or network service restart. On Ubuntu, persistence may live in netplan or NetworkManager; in cloud environments, route tables may live outside the host; in Kubernetes, the CNI agent may reconcile routes continuously. A manual route that fights the owner of the network will not stay fixed.
-
-```bash
-# Add route
-sudo ip route add 10.0.0.0/8 via 192.168.1.1
-
-# Add default gateway
-sudo ip route add default via 192.168.1.1
-
-# Delete route
-sudo ip route del 10.0.0.0/8
-
-# Routes are not persistent! Use netplan/NetworkManager for persistence
-```
-
-The best route diagnostic is often `ip route get`, because it asks the kernel to predict the actual decision for one destination. Instead of reading a table and mentally sorting prefixes, you give Linux an address and inspect the selected interface, source address, and gateway. If an application binds to a specific source IP, or if policy routing is involved, that prediction may differ from a simple glance at `ip route`. During incidents, the exact question "how would this host route to that IP right now?" is more useful than a general route dump.
-
-Stop and think: if a Linux server has two network interfaces, `eth0` and `eth1`, and it receives a request on `eth0`, does the reply always leave through `eth0`? The answer is no. Linux routes replies according to the destination of the reply and its routing policy, so asymmetric routing can happen unless routes, source addresses, and policy rules are designed to keep the path consistent.
-
-A routing failure becomes clearer when you follow both directions. Suppose a client reaches a node IP through the default gateway, but the node has a more specific route back to the client network through a VPN tunnel. The inbound packet arrives successfully, the service processes it, and the reply leaves another interface where a firewall drops it as invalid or unexpected. From the client side, the connection times out. From the server side, the application may look healthy. The fix is not in the app; it is in route symmetry, firewall state, or policy routing.
-
-## Ports, Sockets, and Local Listeners
-
-An IP address identifies a host or interface, but a port identifies a conversation endpoint on that host. When an application listens on TCP port 443, it asks the kernel to accept connection attempts for that port and hand established connections to the process. When a client opens a connection, the client side usually uses an ephemeral source port chosen from a high-numbered range. The complete TCP conversation is identified by source IP, source port, destination IP, destination port, and protocol, which is why one web server can handle many clients on the same destination port at once.
-
-| Range | Name | Use |
-|-------|------|-----|
-| 0-1023 | Well-known | System services (requires root) |
-| 1024-49151 | Registered | Applications |
-| 49152-65535 | Dynamic/Ephemeral | Client connections |
-
-Well-known ports are convention rather than magic, but the convention matters because clients expect services in predictable places. SSH normally listens on TCP 22, HTTP on TCP 80, HTTPS on TCP 443, the Kubernetes API on TCP 6443, kubelet on TCP 10250, and etcd on TCP 2379. DNS is a special everyday example because small queries often use UDP 53 while larger transfers and zone operations may use TCP 53. The port table is not a substitute for discovery, but it gives you a useful first hypothesis when a service is unreachable.
-
-| Port | Service | Protocol |
-|------|---------|----------|
-| 22 | SSH | TCP |
-| 53 | DNS | UDP/TCP |
-| 80 | HTTP | TCP |
-| 443 | HTTPS | TCP |
-| 6443 | Kubernetes API | TCP |
-| 10250 | Kubelet | TCP |
-| 2379 | etcd | TCP |
-
-The `ss` command shows sockets from the kernel's point of view, which makes it one of the fastest ways to distinguish network reachability from local service state. A process can be running and still not listening on the expected address, especially if it bound only to `127.0.0.1` instead of `0.0.0.0` or the node IP. A firewall can allow a port, but the kernel will still reject a connection if no listener exists. Conversely, a listener can be perfect while an upstream route or policy drops packets before they arrive.
-
-```bash
-# Show all listening ports
+ss -tan
 ss -tlnp
-# t=TCP, l=listening, n=numeric, p=process
-
-# Show all connections
-ss -tanp
-
-# Legacy netstat
-netstat -tlnp
-
-# Find what's using a port
-ss -tlnp | grep :80
-lsof -i :80
+ss -tan state syn-sent
+ss -tan state time-wait '( sport = :443 or dport = :443 )'
+sysctl net.ipv4.tcp_keepalive_time net.ipv4.tcp_keepalive_intvl net.ipv4.tcp_keepalive_probes
 ```
 
-The flags are worth reading once so the output becomes less mysterious. `-t` filters TCP sockets, `-l` shows listeners, `-n` keeps addresses numeric so troubleshooting does not depend on DNS, and `-p` adds process information when permissions allow. For established connections, the state column tells you whether a socket is listening, established, waiting to close, or stuck in another transition. If you see many connections in SYN-SENT from a client, outbound SYN packets may not be receiving replies. If you see SYN-RECV on a server, SYNs are arriving but handshakes may not be completing.
+Keepalive is not a health check. Linux TCP keepalive probes can eventually detect a dead idle peer, but defaults are often far longer than application SLOs. If a load balancer, NAT gateway, or conntrack table expires idle flows earlier than application traffic resumes, the next write can fail after a long quiet period. Tune application timeouts, ingress timeouts, TCP keepalive, and conntrack timeouts as one design, not as independent knobs. The Linux kernel documents TCP sysctls such as keepalive and path MTU behavior in `ip-sysctl`. ([Linux IP sysctl](https://docs.kernel.org/networking/ip-sysctl.html))
 
-Pause and predict: if you run a Node.js app as a standard non-root user and tell it to listen on port 80, what will happen on a typical Linux system? The likely failure is a permission error because ports below 1024 are privileged unless the process has the needed capability or a supervisor binds the port on its behalf. Containers and systemd units can change the packaging, but the kernel rule is still the starting point.
+A useful interpretation rule is refusal versus timeout. A refused connection usually means a RST came back: the host stack was reachable, but no listener accepted that destination port or policy actively rejected it. A timeout means SYNs, SYN-ACKs, or later packets disappeared. That points toward firewall, routing, neighbor, MTU, conntrack, or security group behavior before it points toward application code.
 
-In Kubernetes, ports appear in several places that beginners often mix together. A container port documents where the process listens inside the pod, a Service port exposes a stable port on the Service IP, a targetPort points to the backend pod port, and a NodePort opens a port on each node. Those are cluster abstractions, yet each ultimately maps back to sockets, packet translation, and routing. When an ingress controller fails with `bind: address already in use`, the fastest local test is still `ss -tlnp | grep :443` on the node or inside the relevant namespace.
+## UDP and QUIC: Connectionless Kernel, Stateful Userspace
 
-## Practical Diagnostics: Build Evidence One Layer at a Time
-
-Network troubleshooting should feel like controlled narrowing, not command roulette. Start with the symptom, name the layer you are testing, and decide what result would confirm or reject your hypothesis. If an application cannot reach a remote API by name, first decide whether you are testing name resolution, IP routing, TCP connectivity, TLS, or HTTP behavior. Jumping straight to packet captures can be useful for deep cases, but most incidents are solved faster by combining `ip addr`, `ip route get`, `ping`, `nc`, `curl`, `traceroute`, `ss`, and interface counters in a deliberate sequence.
+UDP gives applications datagrams, ports, and checksums without a kernel-managed connection state machine. The kernel can show UDP sockets, queue pressure, drops, and ICMP errors, but it does not turn a UDP exchange into `ESTABLISHED` the way TCP does. RFC 1122 covers UDP host requirements, and the Linux `udp(7)` page documents Linux UDP socket behavior. ([RFC 1122](https://www.rfc-editor.org/rfc/rfc1122), [udp(7)](https://man7.org/linux/man-pages/man7/udp.7.html))
 
 ```bash
-# Basic ping
-ping -c 4 8.8.8.8
-
-# TCP connectivity test
-nc -zv 10.0.0.50 80
-# or
-curl -v telnet://10.0.0.50:80
-
-# Test with timeout
-timeout 5 bash -c "</dev/tcp/10.0.0.50/80" && echo "Open" || echo "Closed"
+ss -uanp
+ss -uap state established 2>/dev/null || true
+tcpdump -ni any udp port 53
+tcpdump -ni any udp port 443
 ```
 
-`ping` is useful because it is simple, but it is also frequently overinterpreted. A successful ping means ICMP echo requests and replies made the round trip; it does not mean TCP port 80 is open, DNS is correct, or an HTTP service is healthy. A failed ping also does not always mean the host is down, because many firewalls block ICMP while allowing application traffic. Use ping to test basic reachability and latency, then switch to a protocol-specific test before drawing conclusions about the application.
+QUIC deliberately uses UDP while implementing streams, connection IDs, loss recovery, encryption, and path migration in the protocol above UDP. RFC 9000 defines QUIC as a UDP-based multiplexed and secure transport. For operators, this means a QUIC or HTTP/3 ingress on UDP/443 will not appear as TCP `ESTAB` sockets. You inspect UDP sockets, packet captures, ingress HTTP/3 or QUIC metrics, and load balancer UDP handling. ([RFC 9000](https://www.rfc-editor.org/rfc/rfc9000))
 
-TCP connectivity tests answer a different question. `nc -zv 10.0.0.50 80` attempts a connection without sending an application request, so it can show whether the port accepts a handshake. `curl -v telnet://10.0.0.50:80` can provide similar evidence when netcat is unavailable. For HTTPS or HTTP services, ordinary `curl -v` goes further by showing DNS resolution, connect timing, TLS negotiation, headers, and response status. The extra detail is valuable, but it also means more layers are involved, so read the output in order.
+The Kubernetes implication is direct. A TCP Service gives you handshake evidence; a UDP Service often gives you request/response silence unless the application logs or metrics expose protocol-level state. If DNS works intermittently in-cluster, packet loss, conntrack expiry, CoreDNS saturation, and resolver search behavior can all look like "UDP timeout." Use packet captures and application counters instead of expecting TCP-style states.
+
+## Conntrack, NAT, and Service Rewrites
+
+Connection tracking records flows so stateful filtering and NAT can handle replies consistently. Netfilter documentation describes conntrack as fundamental to NAT, and the kernel documents conntrack sysctls such as maximum entries and protocol timeout controls. Kubernetes Services rely on this machinery in Linux kube-proxy modes: iptables mode redirects Service virtual IP traffic to endpoints using destination NAT, and nftables mode uses the nftables API of the same netfilter subsystem. ([Netfilter Hacking HOWTO](https://www.netfilter.org/documentation/HOWTO/netfilter-hacking-HOWTO-3.html), [Netfilter NAT HOWTO](https://www.netfilter.org/documentation/HOWTO/NAT-HOWTO-5.html), [Linux nf_conntrack sysctl](https://docs.kernel.org/networking/nf_conntrack-sysctl.html), [Kubernetes Virtual IPs and Service Proxies](https://v1-35.docs.kubernetes.io/docs/reference/networking/virtual-ips/))
+
+```mermaid
+flowchart TD
+    NIC[Packet enters node NIC] --> PRE[PREROUTING<br/>raw, conntrack, mangle, DNAT]
+    PRE --> R{Route decision}
+    R -->|local socket| IN[INPUT<br/>filter to local process]
+    R -->|forwarded packet| FWD[FORWARD<br/>filter routed traffic]
+    FWD --> POST[POSTROUTING<br/>SNAT/MASQUERADE]
+    IN --> PROC[Local process or proxy]
+    PROC --> OUT[OUTPUT<br/>local packet, possible DNAT]
+    OUT --> R2{Route decision}
+    R2 --> POST
+    POST --> DEV[Transmit on egress device]
+```
+
+| Path | Hook order you should expect | Typical Kubernetes example | First inspection |
+|---|---|---|---|
+| Remote client to local listener | `PREROUTING` -> route -> `INPUT` | NodePort or hostNetwork ingress socket | `ss -tlnp`, firewall rules |
+| Forwarded pod or Service traffic | `PREROUTING` -> route -> `FORWARD` -> `POSTROUTING` | pod-to-pod, Service to endpoint, egress NAT | `conntrack -L`, ruleset, route |
+| Local process to Service IP | `OUTPUT` -> route -> `POSTROUTING` | node process curls ClusterIP | output DNAT rules, conntrack |
+| Pod egress with masquerade | `PREROUTING` -> route -> `FORWARD` -> `POSTROUTING` SNAT | pod to internet through node | MASQUERADE rule, reply tuple |
+
+A conntrack entry is a memory of a tuple and its translated tuple. For a ClusterIP flow, the client may believe it is talking to `10.96.12.34:443`, while conntrack remembers the DNAT to `10.244.2.37:8443` so replies can be mapped back. If the table is full, timeouts are wrong, or a rule changes while long-lived flows remain, symptoms can appear as resets, black holes, or one backend receiving traffic after it should have drained.
 
 ```bash
-# Trace route
-traceroute 8.8.8.8
-# or
-mtr 8.8.8.8
-
-# TCP traceroute (for firewalled networks)
-traceroute -T -p 443 8.8.8.8
+sudo conntrack -L -p tcp 2>/dev/null | sed -n '1,40p'
+sudo conntrack -L -p udp 2>/dev/null | sed -n '1,40p'
+sudo cat /proc/net/nf_conntrack 2>/dev/null | sed -n '1,40p'
+sysctl net.netfilter.nf_conntrack_max net.netfilter.nf_conntrack_count 2>/dev/null
 ```
 
-Path discovery tools use TTL behavior to learn about hops between source and destination. Standard traceroute may use UDP or ICMP depending on implementation, which means firewalls can treat it differently from your actual application traffic. TCP traceroute with `-T -p 443` is often more relevant for web services because it probes the path using TCP toward the port you care about. Missing hops are not always failures, since some routers decline to answer TTL-expired probes, but changes in the path can reveal where traffic leaves the expected network.
+Do not flush conntrack as a reflex. It can repair stale NAT state in a lab, but in production it can also drop legitimate long-lived connections across the node. First prove the mismatch: packet capture before and after NAT, ruleset selection, route decision, and conntrack entry. Then decide whether the correct fix is endpoint draining, kube-proxy sync, firewall rule repair, timeout tuning, or a targeted conntrack deletion.
 
-Interface statistics help when symptoms suggest packet loss, duplex problems, driver issues, or MTU trouble. Counters for errors, drops, overruns, and carrier changes can explain why a service works at low volume but fails during transfers. MTU mismatches are especially frustrating because small packets pass while larger payloads stall or fragment poorly. If `curl` connects but hangs during a larger response, and interface counters show errors or drops, the problem may be below the application even though the initial handshake looked fine.
+## MTU, Fragmentation, and Overlay Penalties
+
+MTU is the maximum frame payload a link can carry without fragmentation at that layer. IPv4 supports fragmentation, but Path MTU Discovery tries to avoid it by learning the smallest usable path size. IPv6 relies on source fragmentation and Packet Too Big signaling rather than router fragmentation. RFC 1191 covers IPv4 PMTUD, RFC 8201 covers IPv6 PMTUD, and Linux exposes MTU on links and routes. ([RFC 1191](https://www.rfc-editor.org/rfc/rfc1191), [RFC 8201](https://www.rfc-editor.org/rfc/rfc8201), [ip-link(8)](https://man7.org/linux/man-pages/man8/ip-link.8.html), [Linux IP sysctl](https://docs.kernel.org/networking/ip-sysctl.html))
 
 ```bash
-# Interface stats
-ip -s link
-
-# Detailed stats
-cat /proc/net/dev
-
-# Watch in real-time
-watch -n1 'cat /proc/net/dev'
+ip link show
+ip -d link show vxlan.calico 2>/dev/null || true
+ip route get 10.244.2.37
+tracepath 10.244.2.37
+ping -M do -s 1472 192.168.10.20
 ```
 
-A disciplined diagnostic sequence for a Kubernetes 1.35+ node starts outside the cluster abstraction and then moves inward. Confirm the node interface and route, test the remote node or pod IP, check whether the service port accepts TCP, inspect listeners with `ss`, and only then inspect Service rules or CNI state. `k get pods -o wide` can tell you where a pod lives and which IP it has, but Linux decides how to reach that IP. If you treat the pod IP as a real routing destination, the cluster becomes much easier to reason about.
+Overlay networking makes MTU visible because encapsulation adds outer headers. VXLAN runs over UDP and Linux documents VXLAN devices as tunnel devices; IPIP, GRE, Geneve, WireGuard, and cloud fabrics have their own overhead. If the physical NIC MTU is 1500 and the overlay adds headers, the pod-facing MTU must usually be smaller. Otherwise small health checks pass while larger TLS records, image pulls, or gRPC responses stall. ([Linux VXLAN documentation](https://docs.kernel.org/networking/vxlan.html))
 
-Before running the next command in a real incident, ask what output you expect. If you expect `ip route get 10.244.2.23` to choose `eth0` via another node and it chooses the default internet gateway instead, you have found a routing issue before touching the application. If you expect `ss -tlnp` to show Nginx on `0.0.0.0:443` and it shows only `127.0.0.1:443`, remote clients cannot connect even though local curl tests may pass. Prediction turns commands into experiments.
+The operational clue is size sensitivity. A TCP handshake succeeds, small requests work, and larger payloads hang or retransmit. Packet captures may show ICMP Fragmentation Needed or IPv6 Packet Too Big messages, or they may show silence if a firewall drops those control messages. Fixing the app will not help if the path cannot carry the packet size the app emits.
 
-## Patterns & Anti-Patterns
+## DNS Resolution: From Pod Name to Packet
 
-Good network operations use patterns that reduce ambiguity. The first pattern is layered testing: prove local configuration, then route selection, then transport reachability, then application behavior. This works because each layer depends on the one below it, and the tests produce evidence you can share. It also scales well across teams because an application engineer, platform engineer, and network engineer can agree on which layer failed instead of arguing from different tool outputs.
+Name resolution begins before packets leave the process. glibc uses NSS (`/etc/nsswitch.conf`) to decide whether `hosts` lookups consult files, DNS, systemd modules, or other providers. The resolver reads `/etc/resolv.conf` for nameservers, search domains, timeout behavior, attempts, and `ndots`. systemd-resolved may replace `/etc/resolv.conf` with a local stub file, which Kubernetes explicitly calls out as a node DNS consideration. ([nsswitch.conf(5)](https://man7.org/linux/man-pages/man5/nsswitch.conf.5.html), [resolv.conf(5)](https://man7.org/linux/man-pages/man5/resolv.conf.5.html), [Kubernetes Debugging DNS Resolution](https://v1-35.docs.kubernetes.io/docs/tasks/administer-cluster/dns-debugging-resolution/))
 
-The second pattern is source-and-destination pairing. Always inspect both sides of a conversation when you can, because one-way evidence is incomplete. A client timeout may be caused by an outbound firewall, an inbound firewall, a missing server listener, a broken reply route, or an MTU problem after the handshake. Checking the server's `ss` output, route back to the client, and interface counters often turns a vague timeout into a specific mismatch.
+```bash
+cat /etc/nsswitch.conf
+cat /etc/resolv.conf
+resolvectl status 2>/dev/null || true
+dig kubernetes.default.svc.cluster.local A
+dig +search my-service
+nslookup my-service.default.svc.cluster.local
+```
 
-The third pattern is route prediction before route editing. Use `ip route get` to ask the kernel what it will do, then compare that prediction with the intended design. If you must add a route in a lab, record why it is needed and where it should be made persistent. In production, identify the owner of the route, such as netplan, NetworkManager, the cloud VPC, or the CNI agent, before making changes. Temporary route commands are useful scalpels, not configuration management.
+Kubernetes configures pod DNS so containers can resolve Services by name. The v1.35 DNS docs show the pod search list and `options ndots:5`; they also explain that a short name like `data` can expand through namespace and cluster search domains. This is useful, but it can multiply queries. A pod that resolves `api.github.com` with `ndots:5` may first try cluster search variants before the absolute public name, depending on resolver behavior and trailing dots. ([Kubernetes DNS for Services and Pods](https://v1-35.docs.kubernetes.io/docs/concepts/services-networking/dns-pod-service/), [resolv.conf(5)](https://man7.org/linux/man-pages/man5/resolv.conf.5.html))
 
-Common anti-patterns usually come from overtrusting one piece of evidence. Treating ping as proof of application health is the classic example because ICMP and TCP can be allowed, blocked, routed, or prioritized differently. Another anti-pattern is fixing a Kubernetes Service before checking whether the backend process is listening, which wastes time when the real fault is a bind address or port conflict. A third is changing firewall rules before calculating subnets and routes, because policy can look guilty when the packet is simply going to the wrong next hop.
+DNS is therefore not one thing. A failure may be NSS order, `/etc/hosts`, systemd-resolved forwarding, CoreDNS, upstream DNS, UDP loss, TCP fallback, search path expansion, or Service record generation. The packet tools enter only after you know what nameserver and query name the resolver actually used.
 
-## Decision Framework
+## Operator Triage Toolkit
 
-Use the symptom to choose the first layer, then move only when the result justifies it. If the host has no expected IP address, stay with interface configuration. If the IP exists but the route prediction is wrong, stay with routing. If the route is correct but a TCP connection is refused, check the listener. If the connection times out, compare path, firewall, and return route. If the TCP connection succeeds but the application fails, move upward to TLS, HTTP, authentication, or application logs. This framework keeps you from changing three variables at once.
+Use modern tools that match the kernel model. Legacy net-tools such as `ifconfig`, `route`, and `netstat` still appear in old runbooks, but this course uses `ip`, `ss`, and protocol-specific tools because they expose namespaces, policy routing, modern socket state, and link attributes more directly.
 
-When the symptom includes Kubernetes, separate the cluster object from the packet path. A Service can exist while no pod is ready, a pod can be ready while the process listens on the wrong port, and both can be correct while the node cannot route to a remote pod CIDR. Start with the object that names the intended destination, then verify the Linux evidence underneath it. For example, use `k get pods -o wide` to find the pod IP and node, but use `ip route get` and `ss` to prove how the node handles that destination and port.
+| Use when you need to know... | Command | What it proves | What it does not prove |
+|---|---|---|---|
+| Which addresses and links exist | `ip -br addr`, `ip -s link` | Interface state, MTU, counters | Remote reachability |
+| Which next hop Linux will use | `ip route get <ip>` | Route, source, device, gateway | Firewall or listener state |
+| Whether ARP/NDP resolved | `ip neigh show` | Next-hop MAC state | Correct higher-layer protocol |
+| Which TCP/UDP sockets exist | `ss -tlnp`, `ss -tan`, `ss -uanp` | Local listeners and socket state | Remote path correctness |
+| Whether packets hit an interface | `tcpdump -ni <if> <filter>` | Observed packets at that point | What happened elsewhere |
+| Whether DNS answers exist | `dig`, `nslookup` | Query path and records | Application can connect |
+| Whether a TCP port handshakes | `nc -vz <host> <port>` | Transport reachability | TLS or HTTP success |
+| Where path loss or latency appears | `mtr`, `tracepath` | Hop pattern, PMTU clues | Stateful firewall verdicts |
 
-Choose TCP when the application needs ordered, reliable byte delivery and can tolerate connection setup and retransmission behavior. Choose UDP when the application can tolerate loss, values freshness over completeness, or implements its own reliability semantics. Choose a route change only when route prediction proves the packet path is wrong, and choose a socket fix only when `ss` proves the process is not listening where clients connect. The decision is strongest when it names both the evidence and the layer.
+A strong triage sequence is short. Identify the name and IP, ask Linux for the route, check neighbor state if the next hop is local, test the transport, inspect local sockets, then capture at the boundary where your evidence splits. In Kubernetes, add `k get pod -o wide`, `k get svc -o wide`, and endpoint inspection to map object names to real addresses before you run Linux tools.
 
-## Did You Know?
+```bash
+TARGET=10.244.2.37
+PORT=8443
+ip route get "$TARGET"
+ip neigh show nud failed,stale,reachable
+nc -vz "$TARGET" "$PORT"
+ss -tan "( dport = :$PORT or sport = :$PORT )"
+sudo tcpdump -ni any "host $TARGET and tcp port $PORT"
+```
 
-- **TCP was standardized before Kubernetes existed by decades** — modern TCP is maintained through IETF RFCs, and RFC 9293 consolidated core TCP behavior in 2022 after many years of updates.
-- **The 3-way handshake costs at least one round trip before request bytes flow** — on a 100 ms round-trip path, connection setup alone can noticeably affect short-lived requests.
-- **IPv4 has about 4.3 billion possible addresses** — private ranges, NAT, and IPv6 adoption exist because that 32-bit space was not enough for global growth.
-- **Linux can track very large numbers of sockets when tuned carefully** — limits such as file descriptors, ephemeral ports, memory, and conntrack often become the practical ceiling before the protocol design does.
+## Decision Patterns and Anti-Patterns
 
-## Common Mistakes
+Use routes before rules. If `ip route get` chooses the wrong interface, firewall changes may only hide the real problem. Use sockets before Services. If no process listens on the target port inside the pod or node namespace, Service edits cannot create an application listener. Use packet size before retries. If only large responses fail, MTU and PMTUD deserve attention before client retry tuning.
 
-| Mistake | Why It Happens | How to Fix It |
-|---------|----------------|---------------|
-| Trusting ping as proof that an app works | ICMP reachability does not test TCP ports, TLS, HTTP, or application listeners | Follow ping with `nc -zv`, `curl -v`, and `ss -tlnp` on the destination |
-| Using the wrong subnet mask | Teams compare dotted addresses visually and forget that the prefix length defines locality | Calculate the CIDR range on both hosts and make the masks consistent |
-| Missing or incorrect default route | A host can reach local addresses but has no next hop for remote destinations | Check `ip route`, then add the gateway through the persistent network manager |
-| Ignoring longest-prefix match | A specific route overrides the default route even when the default looks correct | Use `ip route get <destination>` to inspect the actual selected route |
-| Assuming a listener binds every address | Apps often bind only `127.0.0.1`, a pod IP, or one node address | Use `ss -tlnp` and bind to the intended address or `0.0.0.0` when appropriate |
-| Treating TCP and UDP failures the same | UDP has no handshake, so timeout evidence is less explicit than TCP connection states | Test with protocol-specific tools and add application-level health signals for UDP |
-| Making temporary route fixes permanent by accident | Manual `ip route add` commands change running state but not necessarily owned config | Document the owner, then update netplan, NetworkManager, cloud routes, or CNI config |
-| Overlooking MTU and interface errors | Small probes pass while larger packets fail, making the application look guilty | Inspect `ip -s link`, path MTU behavior, and encapsulation overhead |
+Avoid command roulette. Running `tcpdump`, `dig`, `nc`, `curl`, `mtr`, and `ss` without a hypothesis creates transcripts, not evidence. Before each command, write down what result would move you up or down the stack. If the observed result contradicts your model, keep that contradiction; it is often the fastest path to the fault.
 
-## Knowledge Check
+Also avoid "Kubernetes object equals packet path." A Ready pod can have a broken route. A Service can have endpoints and still fail because DNAT, conntrack, or firewall state is wrong. A NetworkPolicy can be correct while the underlay drops encapsulated packets. Kubernetes gives intent; Linux still executes the path.
 
-<details><summary>Your team deploys a Kubernetes 1.35+ API service, and clients report `connection refused` to the Service backend port while `ping` to the node works. What do you check first, and why?</summary>
+## Scenario Checks
 
-Start by checking whether the backend process has a TCP listener on the expected address and port with `ss -tlnp`, then verify the pod or node port mapping. `connection refused` usually means the SYN reached a host stack and the stack returned a reset because no listener accepted that port. Ping only proves ICMP reachability and does not test the TCP socket. If the listener exists, the next checks are Service targetPort mapping and firewall policy, but the refusal message makes socket state the strongest first hypothesis.
+<details><summary>Question 1: A client gets `connection refused` to a ClusterIP Service, but `k get endpoints` shows ready pods. What is your first split?</summary>
 
-</details>
-
-<details><summary>A node has `192.168.1.50/24`, another has `192.168.2.10/16`, and pod traffic fails only in one direction. How do you calculate the likely subnet problem?</summary>
-
-Calculate each node's local range from its prefix length. The `/24` node treats only `192.168.1.0` through `192.168.1.255` as local, while the `/16` node treats `192.168.0.0` through `192.168.255.255` as local. That means the two nodes may make different routing and ARP decisions for replies. The fix is to make the subnet design consistent with the real broadcast domains and then verify both directions with `ip route get`.
-
-</details>
-
-<details><summary>A packet for `10.244.2.23` matches both `10.244.0.0/16 via 192.168.1.102` and `default via 192.168.1.1`. Which route wins, and what diagnostic proves it?</summary>
-
-The `10.244.0.0/16` route wins because Linux uses longest-prefix match before it falls back to broader routes. The default route is `0.0.0.0/0`, so it matches everything but is less specific than the pod CIDR route. Run `ip route get 10.244.2.23` to ask the kernel which route, source address, gateway, and interface it will actually use. This is more reliable than visually scanning the route table during an incident.
-
-</details>
-
-<details><summary>A telemetry daemon sends tiny samples over TCP and crashes when the network slows because memory grows quickly. Would UDP help, and what tradeoff are you accepting?</summary>
-
-UDP could help if the crash is caused by TCP buffering unacknowledged data while congestion prevents timely delivery. With UDP, the sender does not maintain a reliable byte stream or retransmission queue in the same way, so old samples can be dropped instead of accumulating. The tradeoff is permanent data loss during congestion, plus the need for application-level monitoring that understands loss. This is acceptable for some freshness-oriented telemetry but not for audit logs or transactions.
+Separate Service translation from backend socket state. `connection refused` usually means a RST returned, so inspect whether the selected backend pod actually has a listener on the targetPort with `ss -tlnp` in the correct namespace or debug container. Then inspect Service port to targetPort mapping and kube-proxy rules. Do not start with MTU or DNS; the refusal is transport evidence.
 
 </details>
 
-<details><summary>An ingress controller fails with `bind: address already in use` on port 443. Which command identifies the culprit, and what part of the output matters?</summary>
+<details><summary>Question 2: Pod-to-pod traffic works on the same node but fails across nodes after enabling VXLAN. Small probes pass, large responses hang. Which layer do you test next?</summary>
 
-Run `ss -tlnp | grep :443` with sufficient privileges on the relevant host or namespace. The listening socket line shows the local address and port, while the process column identifies the program and PID when permissions allow it. That evidence tells you whether another ingress, web server, proxy, or leftover process already owns the port. Killing or reconfiguring the correct process is safer than changing firewall rules, because the failure is local socket binding.
-
-</details>
-
-<details><summary>A client can `curl` a small health endpoint but large downloads hang, and interface counters show drops. Which layer should you investigate next?</summary>
-
-Investigate the link and path behavior below the application, especially MTU, encapsulation overhead, driver errors, and packet drops. A successful small request proves routing, TCP setup, and basic application handling, but it does not prove larger payloads can traverse the path cleanly. `ip -s link`, path MTU tests, and packet captures around the failing transfer can reveal whether frames are being dropped or fragmented incorrectly. Restarting the application would not address evidence of interface-level loss.
+Test MTU and PMTUD. VXLAN adds outer headers, so the inner pod MTU must leave room for encapsulation. Use `ip link show`, `tracepath`, packet captures for ICMP Fragmentation Needed or IPv6 Packet Too Big, and a size-controlled ping where appropriate. The same-node path may avoid the overlay overhead, which explains the split.
 
 </details>
 
-<details><summary>You run `k get pods -o wide` and see a backend pod at `10.244.2.23` on another node, but the current node routes that IP to the default gateway. What design check follows?</summary>
+<details><summary>Question 3: A node has `192.168.10.20/24`, and a teammate adds `192.168.11.30/16` to another node on a different VLAN. Why can return traffic fail?</summary>
 
-Check the pod CIDR routing design for the CNI and confirm that the current node has a route for the remote pod range through the correct node, overlay device, or CNI dataplane. A pod IP is still a real destination from Linux's perspective, so sending it to the ordinary default gateway is usually wrong unless the environment deliberately routes pod CIDRs there. Use `ip route get 10.244.2.23` and compare the result with the CNI's intended route model. Then inspect the CNI agent or cloud route table that owns those routes.
+The two nodes disagree about what is local. The `/16` node treats `192.168.10.20` as on-link and may ARP instead of using a gateway, while the `/24` node treats `192.168.11.30` as remote. That creates asymmetric route and neighbor behavior. Calculate both prefixes, then prove each direction with `ip route get` and `ip neigh`.
+
+</details>
+
+<details><summary>Question 4: An ingress enables HTTP/3 on UDP/443. `ss -tan` shows no established connections for those clients, but traffic is flowing. Is that wrong?</summary>
+
+No. QUIC runs over UDP, so TCP state output is the wrong evidence surface. Inspect `ss -uanp`, UDP packet captures on port 443, ingress HTTP/3 or QUIC metrics, and load balancer UDP health. TCP `ESTAB` sockets are relevant for HTTPS over TCP, not for QUIC connections carried in UDP datagrams.
+
+</details>
+
+<details><summary>Question 5: A pod resolves `api.example.com` slowly, and CoreDNS logs show multiple failed cluster-suffix queries first. What configuration explains this?</summary>
+
+Kubernetes pod DNS commonly includes search domains and `options ndots:5`. A name with fewer dots than the threshold can be tried through search domains before an absolute query, depending on resolver behavior. Inspect the pod's `/etc/resolv.conf`, repeat with a trailing dot (`api.example.com.`), and decide whether the application, pod `dnsConfig`, or resolver strategy should change.
+
+</details>
+
+<details><summary>Question 6: A Service worked before a rolling update, but some long-lived clients now reset against the ClusterIP. What Linux state should you inspect before deleting pods?</summary>
+
+Inspect conntrack and kube-proxy rules. Long-lived Service flows may keep translated tuples while endpoints change, and Service translation still depends on Linux packet-filter and NAT state. Use `conntrack -L` with the Service and endpoint tuples, check kube-proxy sync health, and compare packet captures before and after DNAT. A blind pod delete may erase useful evidence.
 
 </details>
 
 ## Hands-On Exercise
 
-This lab turns the module's concepts into a repeatable investigation. Use any Linux system where you can run standard networking tools; a disposable VM or lab node is ideal because route and interface output varies by environment. Do not worry if your interface is not named `eth0`; modern Linux systems often use names such as `ens33`, `enp0s3`, or cloud-specific names. The point is to identify what your host really uses, then connect each command to one layer of evidence.
+Use a disposable Linux VM, lab node, or Kubernetes worker where you have permission to inspect networking state. Capture outputs in a scratch note and label each one with the layer it proves.
 
-### Task 1: Inspect IP Configuration
-
-Run the interface commands and record your primary IPv4 address, prefix length, and interface name. Then calculate the local subnet range from that prefix before looking at any route output. This makes the routing table easier to read because you already know which destinations should be directly connected.
+### Task 1: Map Your Current Packet Path
 
 ```bash
-# 1. View your IP addresses
-ip addr
-
-# 2. Note your main interface name and IP
-ip -4 -br addr
-
-# 3. View interface details
-ip addr show eth0 || ip addr show ens33 || ip addr show enp0s3
-
-# 4. Check MAC address
-ip link show | grep ether
-```
-
-<details><summary>Solution notes</summary>
-
-Your primary interface is usually the one with an IPv4 address that is not `127.0.0.1` and that has the default route in the next task. The prefix length appears after the slash, such as `/24`, and defines the local network boundary. If the explicit interface names fail, use the interface shown by `ip -4 -br addr` and rerun `ip addr show <name>`. The MAC address belongs to the link layer and is used for the next hop on the local network.
-
-</details>
-
-### Task 2: Predict and Verify Routing
-
-Before running the route commands, predict which gateway your host should use for an internet destination and which route should cover your local subnet. Then compare that prediction with the kernel's route table and a specific route lookup. If the output surprises you, explain whether the surprise comes from a more specific route, a metric, or a different interface.
-
-```bash
-# 1. View routing table
-ip route
-
-# 2. Find default gateway
-ip route | grep default
-
-# 3. Trace route to internet
-traceroute -m 10 8.8.8.8 || tracepath 8.8.8.8
-
-# 4. Check which interface reaches a destination
-ip route get 8.8.8.8
-```
-
-<details><summary>Solution notes</summary>
-
-The default route normally appears as `default via <gateway> dev <interface>`, and `ip route get 8.8.8.8` should select that gateway unless a more specific route exists. The connected subnet usually appears as a route directly attached to your primary interface. Traceroute output may hide some hops because routers are not required to answer probes. The selected route is still valuable even when the path display is incomplete.
-
-</details>
-
-### Task 3: Compare ICMP and TCP Connectivity
-
-Test the gateway with ICMP, then test an external IP and a TCP port. Treat each result as evidence for a different layer rather than a general pass or fail. If ICMP fails but TCP works, note that policy may treat protocols differently. If TCP fails while ICMP works, focus on port policy, listener state, or application reachability rather than basic routing alone.
-
-```bash
-# 1. Ping local gateway
-GATEWAY=$(ip route | grep default | awk '{print $3}')
-ping -c 4 $GATEWAY
-
-# 2. Ping external
-ping -c 4 8.8.8.8
-
-# 3. Test TCP connectivity
-nc -zv google.com 443 || timeout 5 bash -c "</dev/tcp/google.com/443" && echo "Open"
-
-# 4. Time a connection
-time curl -s -o /dev/null https://google.com
-```
-
-<details><summary>Solution notes</summary>
-
-A gateway ping checks local reachability to the next hop, while the external ping checks a wider route and ICMP policy. The TCP test to port 443 proves more about web-style connectivity than ping does because it attempts a transport handshake. The `time curl` result adds application-layer and TLS behavior, so failures there need to be read carefully. If DNS resolution affects the command, repeat with a known IP or save DNS analysis for the next module.
-
-</details>
-
-### Task 4: Map Ports to Processes
-
-List listening TCP sockets, identify one service that is listening, and explain whether it is bound to loopback, all addresses, or a specific interface address. Then count current TCP states to see what the host is doing right now. This task connects the abstract idea of ports to concrete kernel socket state.
-
-```bash
-# 1. List listening ports
+ip -br addr
+ip route get 1.1.1.1
+ip neigh show
 ss -tlnp
-
-# 2. List all TCP connections
-ss -tanp | head -20
-
-# 3. Check a specific port
-ss -tlnp | grep :22
-
-# 4. Count connections by state
-ss -tan | awk 'NR>1 {print $1}' | sort | uniq -c
 ```
 
-<details><summary>Solution notes</summary>
+Explain which interface, source address, gateway, and local listeners are involved. If the route uses a gateway, identify the neighbor entry for that gateway.
 
-Look at the local address column first. `127.0.0.1:22` would mean only local clients can connect, while `0.0.0.0:22` means the listener accepts connections on all IPv4 addresses unless firewall policy blocks them. The process information may require root privileges, so missing process names do not necessarily mean no process exists. Connection states such as LISTEN, ESTAB, SYN-SENT, and TIME-WAIT describe where sockets are in their lifecycle.
-
-</details>
-
-### Task 5: Inspect Interface Health
-
-Read packet and error counters for your primary interface, then decide whether the interface evidence supports or weakens a network-layer hypothesis. The goal is not to memorize every counter; it is to notice when drops, errors, or carrier changes point below TCP and the application. Repeat the command while generating traffic if you want to see counters move.
+### Task 2: Compare Refusal and Timeout
 
 ```bash
-# 1. View packet counts
-ip -s link show eth0 || ip -s link show $(ip route | grep default | awk '{print $5}')
-
-# 2. Check for errors
-ip -s link | grep -A2 errors
-
-# 3. View detailed stats
-cat /proc/net/dev
+nc -vz 127.0.0.1 1
+nc -vz 203.0.113.1 443
+ss -tan state syn-sent
 ```
 
-<details><summary>Solution notes</summary>
+Record whether you saw refusal, timeout, or immediate local error. Tie each result to TCP state or route evidence rather than to a generic "network broken" label.
 
-Most quiet lab systems show low or zero error counters, which is fine. In production, rising errors, drops, or overruns can explain slow transfers, retransmissions, and intermittent application symptoms. If your interface is not `eth0`, the fallback command uses the interface from the default route. Interface evidence should be combined with route, socket, and protocol tests rather than used alone.
+### Task 3: Inspect Kubernetes Addresses
 
-</details>
+```bash
+k get pods -A -o wide
+k get svc -A -o wide
+POD_IP=<choose-a-pod-ip>
+ip route get "$POD_IP"
+```
+
+Classify the selected pod IP as local-node, remote-node, overlay, or unknown based on route output and your CNI design. If you choose a ClusterIP, explain why `ip route get` alone may not show the eventual backend pod.
+
+### Task 4: Trace DNS to a Packet
+
+```bash
+cat /etc/resolv.conf
+dig kubernetes.default.svc.cluster.local A
+dig +search kubernetes.default
+sudo tcpdump -ni any port 53 -c 10
+```
+
+Identify the nameserver, search behavior, query name, and transport protocol. If your node uses systemd-resolved, compare `/etc/resolv.conf` with `resolvectl status`.
+
+### Task 5: Check MTU Evidence
+
+```bash
+ip link show
+tracepath 1.1.1.1
+ip route get 1.1.1.1
+```
+
+Find the egress interface MTU and any PMTU clue from `tracepath`. If you are on an overlay node, compare the pod-facing device MTU with the physical NIC MTU and account for encapsulation overhead.
 
 ### Success Criteria
 
-- [ ] Calculated your IP address and subnet boundary from CIDR notation.
-- [ ] Found your default gateway and verified route selection with `ip route get`.
-- [ ] Compared ICMP and TCP connectivity instead of treating ping as a full application test.
-- [ ] Used `ss` to map a listening port to a local socket and, where permitted, a process.
-- [ ] Interpreted interface statistics as evidence for or against link-layer packet loss.
-- [ ] Explained how the same checks apply to a Kubernetes 1.35+ pod IP found with `k get pods -o wide`.
+- [ ] Calculated at least one IPv4 or IPv6 prefix boundary instead of guessing from address strings.
+- [ ] Used `ip route get` and `ip neigh` to separate routing from link-layer resolution.
+- [ ] Interpreted at least three TCP states from `ss -tan` output.
+- [ ] Explained how a Kubernetes ClusterIP flow can be DNATed to a pod endpoint and tracked by conntrack.
+- [ ] Connected DNS resolver configuration to actual DNS packets.
+- [ ] Chose modern `ip`, `ss`, `tcpdump`, `dig`, `mtr`, `nc`, and `conntrack` tools instead of legacy net-tools.
 
 ## Next Module
 
-Next, continue to [Module 3.2: DNS in Linux](/linux/foundations/networking/module-3.2-dns-linux/) to learn how names become IP addresses and why resolver behavior is essential for Kubernetes service discovery.
+Next, continue to [Module 3.2: DNS in Linux](../module-3.2-dns-linux/) to go deeper on resolver behavior, CoreDNS interactions, and the failure modes behind Service discovery.
 
-## Further Reading
+## Sources
 
-- [TCP/IP Illustrated](https://www.amazon.com/TCP-Illustrated-Vol-Addison-Wesley-Professional/dp/0201633469) by W. Richard Stevens
-- [Linux Network Administrator's Guide](https://tldp.org/LDP/nag2/index.html)
-- [iproute2 Documentation](https://wiki.linuxfoundation.org/networking/iproute2)
-- [Kubernetes Networking Guide](https://kubernetes.io/docs/concepts/cluster-administration/networking/)
+- [RFC 1122: Requirements for Internet Hosts - Communication Layers](https://www.rfc-editor.org/rfc/rfc1122)
 - [RFC 9293: Transmission Control Protocol](https://www.rfc-editor.org/rfc/rfc9293)
-- [RFC 791: Internet Protocol](https://www.rfc-editor.org/rfc/rfc791)
-- [RFC 4632: Classless Inter-domain Routing](https://www.rfc-editor.org/rfc/rfc4632)
+- [RFC 1918: Address Allocation for Private Internets](https://www.rfc-editor.org/rfc/rfc1918)
+- [RFC 4193: Unique Local IPv6 Unicast Addresses](https://www.rfc-editor.org/rfc/rfc4193)
+- [RFC 826: Address Resolution Protocol](https://www.rfc-editor.org/rfc/rfc826)
+- [RFC 4861: Neighbor Discovery for IPv6](https://www.rfc-editor.org/rfc/rfc4861)
+- [RFC 1191: Path MTU Discovery](https://www.rfc-editor.org/rfc/rfc1191)
+- [RFC 8201: Path MTU Discovery for IPv6](https://www.rfc-editor.org/rfc/rfc8201)
+- [RFC 9000: QUIC](https://www.rfc-editor.org/rfc/rfc9000)
+- [IANA Service Name and Transport Protocol Port Number Registry](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml)
 - [Linux ip-route manual](https://man7.org/linux/man-pages/man8/ip-route.8.html)
-- [Linux ip-address manual](https://man7.org/linux/man-pages/man8/ip-address.8.html)
+- [Linux ip-rule manual](https://man7.org/linux/man-pages/man8/ip-rule.8.html)
+- [Linux ip-neighbour manual](https://man7.org/linux/man-pages/man8/ip-neighbour.8.html)
 - [Linux ss manual](https://man7.org/linux/man-pages/man8/ss.8.html)
+- [Linux kernel conntrack sysctl documentation](https://docs.kernel.org/networking/nf_conntrack-sysctl.html)
 - [Linux kernel IP sysctl documentation](https://docs.kernel.org/networking/ip-sysctl.html)
-- [Kubernetes Services, Load Balancing, and Networking](https://kubernetes.io/docs/concepts/services-networking/service/)
+- [Linux kernel VXLAN documentation](https://docs.kernel.org/networking/vxlan.html)
+- [Kubernetes v1.35 Virtual IPs and Service Proxies](https://v1-35.docs.kubernetes.io/docs/reference/networking/virtual-ips/)
+- [Kubernetes v1.35 DNS for Services and Pods](https://v1-35.docs.kubernetes.io/docs/concepts/services-networking/dns-pod-service/)


### PR DESCRIPTION
## Summary

Raises `src/content/docs/linux/foundations/networking/module-3.1-tcp-ip-essentials.md` from T3 to T0.

## What changed (2 commits)

1. **T0 rewrite** — Operator-grade TCP/IP for K8s + cloud-native engineers. Kernel layering, RFC 1122/793/9293 citations, CIDR math + RFC 1918/4193, ARP/NDP, ip route + ip rule policy routing, TCP state machine + TIME_WAIT + tcp_keepalive, conntrack for k8s ClusterIP DNAT, MTU/fragmentation with VXLAN/GRE pitfalls, DNS path with k8s ndots, operator tool surface (ip/ss/tcpdump/mtr/dig/nc).

2. **R1 fixup** — sonnet APPROVE (0 blockers, 5 nits applied surgically).

## Learner check

> After completing this module, you will be able to reason about TCP/IP as an operated Linux system rather than as a vocabulary list.

## Test plan

- [x] Verifier T0
- [x] Sonnet R1 APPROVE → 5 nits applied
