### PR TITLE
feat(quality): scoped stdout snapshots for verify_module (Phase 1, #1382)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,4 @@ logs/
 .clawpatch/runs/
 .clawpatch/locks/
 .clawpatch/patches/
+calibration/v1/verifier-snapshots/

--- a/docs/decisions/2026-05-21-verifier-snapshots-allowlist-scope.md
+++ b/docs/decisions/2026-05-21-verifier-snapshots-allowlist-scope.md
@@ -37,9 +37,17 @@ well-defined error output when a cluster is absent.**
 
 ### Denylist (always blocked, regardless of allowlist match)
 
+- **Shell metacharacters** — any line containing `|`, `;`, `&&`, `||`, `&`,
+  `>`, `>>`, `<`, `` ` ``, or `$(` is rejected before the allowlist is
+  consulted.  This closes the pipe-bypass class: `kubectl get pods | xargs
+  kubectl delete pod` would otherwise pass the allowlist check because
+  `shlex.split` presents `cmd='kubectl'`, `sub='get'` to `is_allowed`, hiding
+  the destructive second command entirely.  Redirection (`> file`) and command
+  substitution (`` `...` `` / `$(...)`) are denied for the same reason.
 - Any token that is `--force`
 - Bare commands `rm`, `kill`, `drop`, `truncate`
-- `kubectl delete` without `--dry-run=client` (handled in allowlist logic)
+- `kubectl delete` without `--dry-run=client` (handled in allowlist logic;
+  `kubectl delete` *with* `--dry-run=client` and no metacharacters is allowed)
 - Any command not in {kubectl, helm, kind, k3d} is implicitly denied
 
 ### Snapshot format

--- a/docs/decisions/2026-05-21-verifier-snapshots-allowlist-scope.md
+++ b/docs/decisions/2026-05-21-verifier-snapshots-allowlist-scope.md
@@ -1,0 +1,109 @@
+# ADR: Verifier Snapshots — Allowlist Scope and Phase Boundary
+
+**Date:** 2026-05-21
+**Issue:** [#1382](https://github.com/kube-dojo/kube-dojo.github.io/issues/1382)
+**Status:** Accepted (Phase 1 implemented)
+
+---
+
+## Context
+
+Issue #1382 proposes capturing stdout from commands in module bash code blocks so that future runs
+can detect silent output drift (e.g., `kubectl explain pod` output changing between k8s 1.34 and
+1.35). The issue notes the approach is "risk-bounded" and explicitly calls out Phase 2 (diff
+alerting) as a follow-up.
+
+The design question was: which commands should the snapshot capture actually execute?
+
+---
+
+## Decision
+
+**Phase 1 implements an opt-in allowlist-driven approach (`--snapshot` flag on `verify_module.py`)
+that executes only commands that are safe to run without a live cluster or at worst produce
+well-defined error output when a cluster is absent.**
+
+### Allowlist (what runs)
+
+| Command | Subcommand / condition | Rationale |
+|---------|----------------------|-----------|
+| `kubectl` | `version`, `explain`, `help`, `api-resources`, `api-versions` | Client-side; no cluster needed |
+| `kubectl` | `get`, `describe` | Informational; produces "connection refused" when offline, which is itself capturable |
+| `kubectl` | `apply`, `create`, `patch`, `run` + `--dry-run=client` | Validates YAML syntax client-side |
+| `kubectl` | `delete` + `--dry-run=client` | Dry-run only; write path blocked otherwise |
+| `helm` | `template`, `version`, `help` | Template rendering is cluster-free |
+| `kind` | `get`, `version`, `help` | Cluster lifecycle info only |
+| `k3d` | `version`, `help`, or `--help` flag | Version/help info only |
+
+### Denylist (always blocked, regardless of allowlist match)
+
+- Any token that is `--force`
+- Bare commands `rm`, `kill`, `drop`, `truncate`
+- `kubectl delete` without `--dry-run=client` (handled in allowlist logic)
+- Any command not in {kubectl, helm, kind, k3d} is implicitly denied
+
+### Snapshot format
+
+```
+calibration/v1/verifier-snapshots/<module-key>/<YYYY-MM-DD>.txt
+```
+
+Each file contains per-block, per-command: the command string, exit code, combined stdout+stderr,
+and a SHA256 hash of all outputs for quick change detection.
+
+---
+
+## Alternatives considered
+
+### A. Run ALL commands in the code block
+
+**Rejected.** Modules contain `kubectl apply -f https://raw.githubusercontent.com/...` and
+similar live-cluster bootstrap commands. Running those without gating causes:
+- Network calls from CI
+- Real Kubernetes resource creation/deletion if a kubeconfig is present
+- Non-deterministic output dependent on cluster state
+
+### B. Run only `kubectl version --client` and `kubectl explain`
+
+**Rejected as too narrow.** The value of snapshots is capturing the full range of commands
+learners see — including `kubectl get`, `kubectl describe`, and `helm template` — so that changes
+in output format (column names, field ordering, deprecation warnings) are surfaced. Pure-client
+commands are a subset of what matters.
+
+### C. Shell-parse + rewrite every command with `--dry-run=client` appended
+
+**Rejected.** Rewriting shell commands is fragile: pipes, variable substitution, here-docs,
+and multi-command chains all break naively. The allowlist pattern is simpler and safer.
+
+### D. Store expected output and fail on mismatch (Phase 2 in Phase 1)
+
+**Rejected for this phase.** Diffing and alerting require baseline management, version tagging,
+and a decision about what constitutes "acceptable drift" — all out of scope for #1382 Phase 1.
+Phase 1's job is to build the snapshot corpus; Phase 2 reads it.
+
+---
+
+## Consequences
+
+**Positive:**
+- `--snapshot` is opt-in; default `verify_module.py` behavior is unchanged — existing CI unaffected.
+- The snapshot corpus grows organically as engineers run `--snapshot` on modules.
+- SHA256 hashes enable Phase 2 to detect drift cheaply (compare hash files before loading content).
+- Offline environments produce useful snapshots too (connection-refused output is versioned output).
+
+**Negative / accepted risk:**
+- `kubectl get` and `kubectl describe` without `--dry-run=client` execute against whatever
+  cluster the current kubeconfig points to. Engineers must be aware when running `--snapshot`
+  on a production kubeconfig. (Mitigation: these commands are read-only.)
+- Commands that need files (e.g., `kubectl apply --dry-run=client -f pod.yaml`) fail with "no
+  such file" in isolation; the snapshot captures the error, which is still useful for tracking
+  whether the error message format changes.
+
+---
+
+## Phase 2 (out of scope, tracked as follow-up)
+
+- Diff-aware alerting: compare `<YYYY-MM-DD>.txt` SHA256 against a previous date's file.
+- Schema-change detection: structured diff of `kubectl explain` JSON fields.
+- CI integration: run `--snapshot` in the verify job and fail if SHA256 changes unexpectedly.
+- Version tagging: record the k8s client version in the snapshot header.

--- a/scripts/quality/verifier_snapshots.py
+++ b/scripts/quality/verifier_snapshots.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Stdout snapshots for verify_module.py — Phase 1 capture only.
+
+For each bash code block in a module, extracts commands that match the
+allowlist (kubectl dry-run/get variants, helm template, kind/k3d version/help),
+runs them with a 30-second timeout, captures stdout+stderr, and writes a
+dated snapshot file under calibration/v1/verifier-snapshots/<module-key>/.
+
+Phase 2 (diff-aware alerting when output schemas change across runs) is
+tracked in a follow-up issue.
+"""
+from __future__ import annotations
+
+import hashlib
+import re
+import shlex
+import subprocess
+from datetime import date
+from pathlib import Path
+from typing import NamedTuple
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SNAPSHOT_DIR = REPO_ROOT / "calibration" / "v1" / "verifier-snapshots"
+
+_RUNNABLE_LANGS = {"bash", "sh", "shell", "zsh"}
+
+# Tokens that are always denied regardless of surrounding context.
+_DENY_WORDS = {"rm", "kill", "drop", "truncate"}
+
+CMD_TIMEOUT = 30
+
+
+class CommandResult(NamedTuple):
+    cmd: str
+    exit_code: int
+    output: str  # stdout + stderr combined
+
+
+# ---------------------------------------------------------------------------
+# Markdown parsing (thin reimplementation; avoids circular import from verify_module)
+# ---------------------------------------------------------------------------
+
+def _fenced_code_blocks(text: str) -> list[tuple[str, str]]:
+    """Return (info_string, code) pairs for all fenced code blocks."""
+    return [
+        (m.group(1).strip(), m.group(2))
+        for m in re.finditer(r"```([^\n]*)\n(.*?)```", text, re.DOTALL)
+    ]
+
+
+def _fence_language(info: str) -> str:
+    return info.strip().split(maxsplit=1)[0].lower() if info.strip() else ""
+
+
+def _strip_frontmatter(text: str) -> str:
+    match = re.match(r"^---\s*\n.*?\n---\s*(?:\n|$)", text, re.DOTALL)
+    return text[match.end():] if match else text
+
+
+def _logical_lines(code: str) -> list[str]:
+    """Join continuation lines and return logical shell commands."""
+    lines: list[str] = []
+    current = ""
+    for physical in code.splitlines():
+        stripped = physical.strip()
+        if not stripped or stripped.startswith("#"):
+            if current:
+                lines.append(current)
+                current = ""
+            continue
+        # Strip leading shell-prompt marker
+        if stripped.startswith("$ "):
+            stripped = stripped[2:]
+        current = f"{current} {stripped}" if current else stripped
+        if current.rstrip().endswith("\\"):
+            current = current.rstrip()[:-1].rstrip()
+        else:
+            lines.append(current)
+            current = ""
+    if current:
+        lines.append(current)
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# Allowlist / denylist
+# ---------------------------------------------------------------------------
+
+def _tokens(line: str) -> list[str]:
+    try:
+        return shlex.split(line, comments=True, posix=True)
+    except ValueError:
+        return line.split()
+
+
+def _has_flag(tokens: list[str], *flags: str) -> bool:
+    for tok in tokens:
+        for flag in flags:
+            if tok == flag or tok.startswith(f"{flag}="):
+                return True
+    return False
+
+
+def _has_deny_token(tokens: list[str]) -> bool:
+    """True when any token is an unconditionally-denied word or flag."""
+    for tok in tokens:
+        if tok == "--force":
+            return True
+        # Match bare command tokens only (not substrings of flags/resource names)
+        bare = tok.lstrip("-").split("=")[0]
+        if bare in _DENY_WORDS:
+            return True
+    return False
+
+
+def _kubectl_allowed(tokens: list[str]) -> bool:
+    if len(tokens) < 2:
+        return False
+    sub = tokens[1]
+
+    if sub in ("version", "explain", "help", "--help", "-h", "api-resources", "api-versions"):
+        return True
+
+    # get and describe are informational (may need cluster; output captured regardless)
+    if sub in ("get", "describe"):
+        return True
+
+    # apply/create/patch/run/delete require --dry-run=client
+    if sub in ("apply", "create", "patch", "run"):
+        return _has_flag(tokens, "--dry-run=client", "--dry-run")
+
+    # delete is allowlist-denied UNLESS --dry-run=client is present
+    if sub == "delete":
+        return _has_flag(tokens, "--dry-run=client", "--dry-run")
+
+    return False
+
+
+def _helm_allowed(tokens: list[str]) -> bool:
+    if len(tokens) < 2:
+        return False
+    return tokens[1] in ("template", "version", "help", "--help", "-h")
+
+
+def _kind_allowed(tokens: list[str]) -> bool:
+    if len(tokens) < 2:
+        return False
+    return tokens[1] in ("get", "version", "help", "--help", "-h")
+
+
+def _k3d_allowed(tokens: list[str]) -> bool:
+    if len(tokens) < 2:
+        return False
+    return tokens[1] in ("version", "help", "--help", "-h") or _has_flag(tokens, "--help", "-h")
+
+
+def is_allowed(line: str) -> bool:
+    """Return True when this shell line is safe to snapshot."""
+    toks = _tokens(line)
+    if not toks:
+        return False
+    if _has_deny_token(toks):
+        return False
+    cmd = toks[0].rsplit("/", 1)[-1]  # basename
+    if cmd == "kubectl":
+        return _kubectl_allowed(toks)
+    if cmd == "helm":
+        return _helm_allowed(toks)
+    if cmd == "kind":
+        return _kind_allowed(toks)
+    if cmd == "k3d":
+        return _k3d_allowed(toks)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Execution
+# ---------------------------------------------------------------------------
+
+def run_command(line: str) -> CommandResult:
+    """Run a shell command and capture combined stdout+stderr."""
+    try:
+        result = subprocess.run(
+            line,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=CMD_TIMEOUT,
+        )
+        output = (result.stdout + result.stderr).strip()
+        return CommandResult(cmd=line, exit_code=result.returncode, output=output)
+    except subprocess.TimeoutExpired:
+        return CommandResult(cmd=line, exit_code=-1, output=f"[TIMEOUT after {CMD_TIMEOUT}s]")
+    except Exception as exc:  # noqa: BLE001
+        return CommandResult(cmd=line, exit_code=-2, output=f"[ERROR: {exc}]")
+
+
+# ---------------------------------------------------------------------------
+# Module key
+# ---------------------------------------------------------------------------
+
+def _module_key(path: Path) -> str:
+    """Produce a filesystem-safe identifier from the module path."""
+    try:
+        rel = path.resolve().relative_to(REPO_ROOT / "src" / "content" / "docs").as_posix()
+    except ValueError:
+        rel = path.as_posix()
+        prefix = str(REPO_ROOT) + "/"
+        if rel.startswith(prefix):
+            rel = rel[len(prefix):]
+        if rel.startswith("src/content/docs/"):
+            rel = rel[len("src/content/docs/"):]
+    if rel.endswith(".md"):
+        rel = rel[:-3]
+    return rel.replace("/", "__")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def snapshot_module(path: Path, out_dir: Path | None = None) -> Path | None:
+    """Extract, filter, execute, and snapshot commands from a module's bash blocks.
+
+    Returns the path of the written snapshot file, or None when no runnable
+    commands were found (no snapshot file is created).
+    """
+    text = path.read_text(encoding="utf-8")
+    body = _strip_frontmatter(text)
+    blocks = _fenced_code_blocks(body)
+
+    # (block_number, list[CommandResult])
+    block_results: list[tuple[int, list[CommandResult]]] = []
+    block_num = 0
+    for info, code in blocks:
+        if _fence_language(info) not in _RUNNABLE_LANGS:
+            continue
+        block_num += 1
+        results: list[CommandResult] = []
+        for line in _logical_lines(code):
+            if is_allowed(line):
+                results.append(run_command(line))
+        if results:
+            block_results.append((block_num, results))
+
+    if not block_results:
+        return None
+
+    module_key = _module_key(path)
+    today = date.today().isoformat()
+    target_dir = (out_dir or SNAPSHOT_DIR) / module_key
+    target_dir.mkdir(parents=True, exist_ok=True)
+    snapshot_path = target_dir / f"{today}.txt"
+
+    all_outputs: list[str] = []
+    section_lines: list[str] = []
+    for block_idx, results in block_results:
+        section_lines.append(f"## Block {block_idx}")
+        for r in results:
+            section_lines += [
+                f"### Command: {r.cmd}",
+                f"### Exit: {r.exit_code}",
+                "### Output:",
+                r.output,
+                "",
+            ]
+            all_outputs.append(r.output)
+
+    content_hash = hashlib.sha256("\n".join(all_outputs).encode()).hexdigest()
+    header = [
+        f"# Snapshot: {path}",
+        f"# Module: {module_key}",
+        f"# Date: {today}",
+        f"# SHA256: {content_hash}",
+        "",
+    ]
+    snapshot_path.write_text("\n".join(header + section_lines) + "\n", encoding="utf-8")
+    return snapshot_path

--- a/scripts/quality/verifier_snapshots.py
+++ b/scripts/quality/verifier_snapshots.py
@@ -27,6 +27,12 @@ _RUNNABLE_LANGS = {"bash", "sh", "shell", "zsh"}
 # Tokens that are always denied regardless of surrounding context.
 _DENY_WORDS = {"rm", "kill", "drop", "truncate"}
 
+# Matches any shell metacharacter that enables command chaining, redirection,
+# or command substitution.  A line containing any of these is rejected before
+# the allowlist is consulted so that piped/chained invocations (e.g.
+# "kubectl get pods | xargs kubectl delete") cannot bypass per-command checks.
+_SHELL_METACHAR_RE = re.compile(r'[|;&<>`]|\$\(')
+
 CMD_TIMEOUT = 30
 
 
@@ -101,6 +107,17 @@ def _has_flag(tokens: list[str], *flags: str) -> bool:
     return False
 
 
+def _has_shell_metachar(line: str) -> bool:
+    """True when the line contains a shell metacharacter making it unsafe to execute.
+
+    Catches pipes (|), semicolons (;), &&/||, background (&), redirections
+    (> >> <), backtick command substitution, and $() command substitution.
+    A piped command like "kubectl get pods | xargs kubectl delete pod" would
+    otherwise pass is_allowed() because shlex sees cmd='kubectl', sub='get'.
+    """
+    return bool(_SHELL_METACHAR_RE.search(line))
+
+
 def _has_deny_token(tokens: list[str]) -> bool:
     """True when any token is an unconditionally-denied word or flag."""
     for tok in tokens:
@@ -156,6 +173,8 @@ def _k3d_allowed(tokens: list[str]) -> bool:
 
 def is_allowed(line: str) -> bool:
     """Return True when this shell line is safe to snapshot."""
+    if _has_shell_metachar(line):
+        return False
     toks = _tokens(line)
     if not toks:
         return False

--- a/scripts/quality/verify_module.py
+++ b/scripts/quality/verify_module.py
@@ -1841,6 +1841,15 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--skip-source-check", action="store_true", help="Skip live source reachability checks")
     parser.add_argument("--max-workers", type=int, default=8, help="Max source-check worker threads")
     parser.add_argument("--tier-only", action="store_true", help='Print "path: tier" for fast triage')
+    parser.add_argument(
+        "--snapshot",
+        action="store_true",
+        help=(
+            "Capture stdout from allowlisted kubectl/helm/kind/k3d commands in each module's "
+            "bash code blocks and write dated snapshot files under "
+            "calibration/v1/verifier-snapshots/<module-key>/. Default off; existing CI unaffected."
+        ),
+    )
     args = parser.parse_args(argv)
 
     paths = _collect_paths(args)
@@ -1851,10 +1860,24 @@ def main(argv: list[str] | None = None) -> int:
         if not args.quiet and args.out:
             print(f"verifying {path}", file=sys.stderr)
         records.append(verify(path, skip_source_check=args.skip_source_check, max_workers=args.max_workers))
+        if args.snapshot:
+            _run_snapshot(path, quiet=args.quiet)
     _write_records(records, args.out, args.tier_only)
     if args.summary:
         _print_summary(records)
     return 0
+
+
+def _run_snapshot(path: Path, *, quiet: bool) -> None:
+    # Ensure repo root is on sys.path (verify_module strips "" and its own dir at import time).
+    _root = str(REPO_ROOT)
+    if _root not in sys.path:
+        sys.path.insert(0, _root)
+    from scripts.quality import verifier_snapshots  # local import to keep default path fast
+
+    snap = verifier_snapshots.snapshot_module(path)
+    if snap and not quiet:
+        print(f"snapshot → {snap}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/quality/test_verifier_snapshots.py
+++ b/tests/quality/test_verifier_snapshots.py
@@ -102,6 +102,32 @@ class TestDenylist:
 
 
 # ---------------------------------------------------------------------------
+# Shell-metachar regression tests (blocker from sonnet R1 review)
+# ---------------------------------------------------------------------------
+
+class TestShellMetacharDenial:
+    def test_pipe_with_delete_is_denied(self):
+        # Piped command: shlex sees cmd='kubectl', sub='get' → allowlist passes
+        # without the metachar check.  The metachar check must fire first.
+        assert not is_allowed("kubectl get pods | xargs kubectl delete pod")
+
+    def test_redirect_to_file_is_denied(self):
+        assert not is_allowed("kubectl get pods > /tmp/dump.yaml")
+
+    def test_semicolon_chain_with_rm_is_denied(self):
+        assert not is_allowed("kubectl version ; rm -rf /tmp")
+
+    def test_kubectl_delete_with_dry_run_client_is_allowed(self):
+        assert is_allowed("kubectl delete -f manifest.yaml --dry-run=client")
+
+    def test_kubectl_delete_without_dry_run_is_denied(self):
+        assert not is_allowed("kubectl delete -f manifest.yaml")
+
+    def test_command_substitution_is_denied(self):
+        assert not is_allowed("echo $(kubectl get pods -o name)")
+
+
+# ---------------------------------------------------------------------------
 # Timeout handling
 # ---------------------------------------------------------------------------
 

--- a/tests/quality/test_verifier_snapshots.py
+++ b/tests/quality/test_verifier_snapshots.py
@@ -1,0 +1,227 @@
+"""Hermetic tests for scripts/quality/verifier_snapshots.py.
+
+All subprocess.run calls are mocked; no real commands are executed.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scripts.quality.verifier_snapshots import (
+    CommandResult,
+    _module_key,
+    is_allowed,
+    run_command,
+    snapshot_module,
+)
+
+
+# ---------------------------------------------------------------------------
+# Allowlist tests
+# ---------------------------------------------------------------------------
+
+class TestAllowlist:
+    def test_kubectl_get_allowed(self):
+        assert is_allowed("kubectl get pods")
+
+    def test_kubectl_get_yaml_allowed(self):
+        assert is_allowed("kubectl get pods -o yaml")
+
+    def test_kubectl_get_json_allowed(self):
+        assert is_allowed("kubectl get deployment my-app -o json")
+
+    def test_kubectl_describe_allowed(self):
+        assert is_allowed("kubectl describe pod my-pod")
+
+    def test_kubectl_version_allowed(self):
+        assert is_allowed("kubectl version --client")
+
+    def test_kubectl_explain_allowed(self):
+        assert is_allowed("kubectl explain pod.spec.containers")
+
+    def test_kubectl_apply_dry_run_allowed(self):
+        assert is_allowed("kubectl apply --dry-run=client -f pod.yaml")
+
+    def test_kubectl_create_dry_run_allowed(self):
+        assert is_allowed("kubectl create deployment nginx --image=nginx --dry-run=client")
+
+    def test_helm_template_allowed(self):
+        assert is_allowed("helm template my-release ./mychart")
+
+    def test_helm_version_allowed(self):
+        assert is_allowed("helm version")
+
+    def test_kind_get_clusters_allowed(self):
+        assert is_allowed("kind get clusters")
+
+    def test_k3d_version_allowed(self):
+        assert is_allowed("k3d version")
+
+    def test_k3d_help_flag_allowed(self):
+        assert is_allowed("k3d cluster --help")
+
+
+# ---------------------------------------------------------------------------
+# Denylist tests
+# ---------------------------------------------------------------------------
+
+class TestDenylist:
+    def test_kubectl_delete_no_dry_run_denied(self):
+        assert not is_allowed("kubectl delete pod my-pod")
+
+    def test_kubectl_delete_with_dry_run_allowed(self):
+        assert is_allowed("kubectl delete pod my-pod --dry-run=client")
+
+    def test_kubectl_apply_force_denied(self):
+        assert not is_allowed("kubectl apply --force -f pod.yaml")
+
+    def test_rm_command_denied(self):
+        assert not is_allowed("rm -rf /tmp/foo")
+
+    def test_kill_command_denied(self):
+        assert not is_allowed("kill -9 1234")
+
+    def test_unknown_command_denied(self):
+        assert not is_allowed("curl https://example.com")
+
+    def test_docker_denied(self):
+        assert not is_allowed("docker run --rm nginx")
+
+    def test_empty_line_denied(self):
+        assert not is_allowed("")
+
+    def test_comment_only_denied(self):
+        assert not is_allowed("# kubectl get pods")
+
+
+# ---------------------------------------------------------------------------
+# Timeout handling
+# ---------------------------------------------------------------------------
+
+class TestRunCommand:
+    def test_timeout_returns_sentinel(self):
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("kubectl", 30)):
+            result = run_command("kubectl version --client")
+        assert result.exit_code == -1
+        assert "TIMEOUT" in result.output
+
+    def test_success_captures_stdout_and_stderr(self):
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.stdout = "Client Version: v1.29.0\n"
+        mock_proc.stderr = ""
+        with patch("subprocess.run", return_value=mock_proc):
+            result = run_command("kubectl version --client")
+        assert result.exit_code == 0
+        assert "Client Version" in result.output
+
+    def test_exception_captured(self):
+        with patch("subprocess.run", side_effect=OSError("no such file")):
+            result = run_command("kubectl version --client")
+        assert result.exit_code == -2
+        assert "ERROR" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Snapshot path layout
+# ---------------------------------------------------------------------------
+
+class TestSnapshotPathLayout:
+    def _make_module(self, tmp_path: Path, content: str) -> Path:
+        module = tmp_path / "test-module.md"
+        module.write_text(content, encoding="utf-8")
+        return module
+
+    def _fixed_run(self, output: str = "Client Version: v1.29.0") -> MagicMock:
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.stdout = output
+        mock_proc.stderr = ""
+        return mock_proc
+
+    def test_snapshot_directory_is_module_key(self, tmp_path: Path):
+        module = self._make_module(tmp_path, "---\ntitle: Test\n---\n\n```bash\nkubectl version --client\n```")
+        snap_dir = tmp_path / "snapshots"
+        with patch("subprocess.run", return_value=self._fixed_run()):
+            result = snapshot_module(module, out_dir=snap_dir)
+        assert result is not None
+        assert result.parent.name == _module_key(module)
+
+    def test_snapshot_filename_is_today(self, tmp_path: Path):
+        module = self._make_module(tmp_path, "---\ntitle: Test\n---\n\n```bash\nkubectl version --client\n```")
+        snap_dir = tmp_path / "snapshots"
+        with patch("subprocess.run", return_value=self._fixed_run()):
+            result = snapshot_module(module, out_dir=snap_dir)
+        assert result is not None
+        assert result.name == f"{date.today().isoformat()}.txt"
+
+    def test_no_allowed_commands_returns_none(self, tmp_path: Path):
+        module = self._make_module(
+            tmp_path,
+            "---\ntitle: Test\n---\n\n```bash\ncurl https://example.com\nrm -rf /tmp\n```",
+        )
+        result = snapshot_module(module, out_dir=tmp_path / "snapshots")
+        assert result is None
+
+    def test_non_bash_blocks_skipped(self, tmp_path: Path):
+        module = self._make_module(
+            tmp_path,
+            "---\ntitle: Test\n---\n\n```yaml\nkubectl get pods\n```\n\n```python\nkubectl get pods\n```\n\n```bash\nkubectl version --client\n```",
+        )
+        snap_dir = tmp_path / "snapshots"
+        with patch("subprocess.run", return_value=self._fixed_run()) as mock_run:
+            result = snapshot_module(module, out_dir=snap_dir)
+        assert result is not None
+        # subprocess.run called exactly once — yaml and python blocks were skipped
+        assert mock_run.call_count == 1
+
+    def test_snapshot_contains_sha256_header(self, tmp_path: Path):
+        module = self._make_module(tmp_path, "---\ntitle: Test\n---\n\n```bash\nkubectl version --client\n```")
+        snap_dir = tmp_path / "snapshots"
+        with patch("subprocess.run", return_value=self._fixed_run()):
+            result = snapshot_module(module, out_dir=snap_dir)
+        assert result is not None
+        text = result.read_text()
+        assert any(line.startswith("# SHA256:") for line in text.splitlines())
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+class TestIdempotency:
+    def test_same_output_same_hash(self, tmp_path: Path):
+        """Same command output → identical SHA256 across two independent runs."""
+        module = tmp_path / "mod.md"
+        module.write_text(
+            "---\ntitle: Test\n---\n\n```bash\nkubectl version --client\n```",
+            encoding="utf-8",
+        )
+        fixed_output = "Client Version: v1.29.0"
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.stdout = fixed_output
+        mock_proc.stderr = ""
+
+        with patch("subprocess.run", return_value=mock_proc):
+            r1 = snapshot_module(module, out_dir=tmp_path / "snap1")
+        with patch("subprocess.run", return_value=mock_proc):
+            r2 = snapshot_module(module, out_dir=tmp_path / "snap2")
+
+        assert r1 is not None and r2 is not None
+
+        def sha_line(path: Path) -> str:
+            for line in path.read_text().splitlines():
+                if line.startswith("# SHA256:"):
+                    return line
+            return ""
+
+        assert sha_line(r1) == sha_line(r2)
+        assert sha_line(r1) != ""


### PR DESCRIPTION
## Summary

Closes #1382 (Phase 1). Adds opt-in `--snapshot` to verify_module.py + helper that captures stdout from allowlisted non-destructive commands embedded in module bash blocks.

## What

- `scripts/quality/verifier_snapshots.py` — token-based allowlist (kubectl get/describe/explain/version/dry-run, helm template, kind get, k3d help/version) + denylist (rm, kill, drop, truncate, --force, kubectl delete without --dry-run=client)
- `scripts/quality/verify_module.py` — `--snapshot` opt-in flag; default behavior unchanged
- `calibration/v1/verifier-snapshots/<module-key>/<YYYY-MM-DD>.txt` — SHA256-headed per-module snapshot file (gitignored)
- 31 hermetic tests in `tests/quality/test_verifier_snapshots.py`, all passing
- ADR at `docs/decisions/2026-05-21-verifier-snapshots-allowlist-scope.md` documenting scope choices + Phase 2 deferral

## Why

Per zodchii post #6 — verification skills include programmatic-output recording for drift detection. Phase 1 captures snapshots; Phase 2 (cross-version diffing) deferred to a follow-up issue per the issue body.

## Test plan

- [x] 31 unit tests pass (`tests/quality/test_verifier_snapshots.py`)
- [x] Spot-check via `python scripts/quality/verify_module.py --snapshot src/content/docs/k8s/cka/part3-services-networking/module-3.4-ingress.md` — file created at expected path with SHA256 header

🤖 Generated with [Claude Code](https://claude.com/claude-code)