### PR TITLE
feat(hooks): post-write Python autoformat + pre-read large-log warning (#1380)

### DIFF
--- a/.claude/hooks/post-write-py-autoformat.sh
+++ b/.claude/hooks/post-write-py-autoformat.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Hook: PostToolUse (Edit/Write) — auto-format .py files with ruff after writes.
+# Scope: .py files in the primary tree only; skip dispatched sessions,
+# worktrees, logs, dist, node_modules, .venv, and src/content/docs.
+# shellcheck source=.claude/hooks/_lib.sh
+source "${BASH_SOURCE[0]%/*}/_lib.sh"
+
+RAW_PAYLOAD=$(cat)
+
+# Only fire for Edit or Write tool calls
+TOOL_NAME=$(jq -r '.tool_name // ""' <<<"$RAW_PAYLOAD" 2>/dev/null || true)
+if [ "$TOOL_NAME" != "Edit" ] && [ "$TOOL_NAME" != "Write" ]; then
+  exit 0
+fi
+
+# Skip inside dispatch pipelines (set by scripts/dispatch*.py)
+if [ "${KUBEDOJO_DISPATCHED:-0}" = "1" ]; then
+  exit 0
+fi
+
+FILE_PATH=$(jq -r '.tool_input.file_path // ""' <<<"$RAW_PAYLOAD" 2>/dev/null || true)
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# Must be a Python file
+case "$FILE_PATH" in
+  *.py) ;;
+  *) exit 0 ;;
+esac
+
+# Resolve primary tree root
+PRIMARY_DIR=$(normalize_path "$(detect_primary_dir)")
+if [ -z "$PRIMARY_DIR" ]; then
+  exit 0
+fi
+
+# Resolve to absolute path if relative
+if [ "${FILE_PATH:0:1}" != "/" ]; then
+  FILE_PATH="$PRIMARY_DIR/$FILE_PATH"
+fi
+
+# File must exist (tool_input path should always be valid, but fail-open)
+[ -f "$FILE_PATH" ] || exit 0
+
+# Skip files outside the primary tree (e.g. those inside .worktrees/)
+if ! is_inside_primary "$FILE_PATH"; then
+  exit 0
+fi
+
+# Skip excluded directories
+case "$FILE_PATH" in
+  */logs/*|*/dist/*|*/node_modules/*|*/.venv/*|*/.worktrees/*|*/src/content/docs/*)
+    exit 0
+    ;;
+esac
+
+# Use ruff from the project venv only; skip silently if not installed
+RUFF="$PRIMARY_DIR/.venv/bin/ruff"
+if [ ! -x "$RUFF" ]; then
+  exit 0
+fi
+
+# Check if ruff would reformat (exit 1) vs already formatted (exit 0) vs error (2+)
+CHECK_RESULT=0
+"$RUFF" format --check --quiet "$FILE_PATH" 2>/dev/null || CHECK_RESULT=$?
+
+if [ "$CHECK_RESULT" = "1" ]; then
+  "$RUFF" format --quiet "$FILE_PATH" 2>/dev/null || true
+  jq -n --arg f "$FILE_PATH" \
+    '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":("ruff auto-formatted " + $f + " — whitespace/style only; re-read if you need the exact final state")}}'
+fi
+
+exit 0

--- a/.claude/hooks/pre-read-warn-large-log.sh
+++ b/.claude/hooks/pre-read-warn-large-log.sh
@@ -42,12 +42,21 @@ fi
 
 FILE_KB=$((FILE_SIZE / 1024))
 
-MSG="Log file ${FILE_PATH} is ${FILE_KB} KB — reading it whole will flood context.
+if [[ "${FILE_PATH}" == *.jsonl ]]; then
+  MSG="Log file ${FILE_PATH} is ${FILE_KB} KB — reading it whole will flood context.
 Consider targeted queries instead:
   jq 'select(.status==\"error\")' \"${FILE_PATH}\" | head -20    # filter errors
   jq -r '.module_key' \"${FILE_PATH}\" | sort | uniq -c           # module counts
   tail -n 20 \"${FILE_PATH}\" | jq '.'                            # recent entries
 Proceeding with Read — this is advisory only."
+else
+  MSG="Log file ${FILE_PATH} is ${FILE_KB} KB — reading it whole will flood context.
+Consider targeted queries instead (plain-text response file):
+  tail -n 100 \"${FILE_PATH}\"                                    # recent output
+  grep -nE 'VERDICT|BLOCKERS|ERROR' \"${FILE_PATH}\"              # extract verdict/errors
+  head -n 50 \"${FILE_PATH}\"                                     # opening summary
+Proceeding with Read — this is advisory only."
+fi
 
 jq -n --arg msg "$MSG" \
   '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":$msg}}'

--- a/.claude/hooks/pre-read-warn-large-log.sh
+++ b/.claude/hooks/pre-read-warn-large-log.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Hook: PreToolUse (Read) — warn when reading large dispatch log files cold.
+# Informational only — never blocks. Suggests jq query alternatives to avoid
+# flooding Claude's context with multi-MB JSONL or response text files.
+
+RAW_PAYLOAD=$(cat)
+
+# Only fire for Read tool calls
+TOOL_NAME=$(jq -r '.tool_name // ""' <<<"$RAW_PAYLOAD" 2>/dev/null || true)
+if [ "$TOOL_NAME" != "Read" ]; then
+  exit 0
+fi
+
+FILE_PATH=$(jq -r '.tool_input.file_path // ""' <<<"$RAW_PAYLOAD" 2>/dev/null || true)
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# Match only known dispatch log files (handles both absolute and relative paths)
+IS_LOG=0
+case "$FILE_PATH" in
+  *logs/smart_dispatch.jsonl|*logs/dispatch_responses/*.txt)
+    IS_LOG=1
+    ;;
+esac
+
+if [ "$IS_LOG" = "0" ]; then
+  exit 0
+fi
+
+# File must exist to stat it
+if [ ! -f "$FILE_PATH" ]; then
+  exit 0
+fi
+
+FILE_SIZE=$(wc -c < "$FILE_PATH" 2>/dev/null || echo 0)
+LIMIT_BYTES=102400  # 100 KB
+
+if [ "$FILE_SIZE" -le "$LIMIT_BYTES" ]; then
+  exit 0
+fi
+
+FILE_KB=$((FILE_SIZE / 1024))
+
+MSG="Log file ${FILE_PATH} is ${FILE_KB} KB — reading it whole will flood context.
+Consider targeted queries instead:
+  jq 'select(.status==\"error\")' \"${FILE_PATH}\" | head -20    # filter errors
+  jq -r '.module_key' \"${FILE_PATH}\" | sort | uniq -c           # module counts
+  tail -n 20 \"${FILE_PATH}\" | jq '.'                            # recent entries
+Proceeding with Read — this is advisory only."
+
+jq -n --arg msg "$MSG" \
+  '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":$msg}}'
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -32,11 +32,23 @@
         "hooks": [
           {"type": "command", "command": ".claude/hooks/block-agent-worktree-isolation.sh"}
         ]
+      },
+      {
+        "matcher": "Read",
+        "hooks": [
+          {"type": "command", "command": ".claude/hooks/pre-read-warn-large-log.sh"}
+        ]
       }
     ],
     "PostToolUse": [
       {
         "hooks": [{"type": "command", "command": ".claude/hooks/context-monitor.sh"}]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {"type": "command", "command": ".claude/hooks/post-write-py-autoformat.sh"}
+        ]
       }
     ],
     "SessionStart": [

--- a/docs/decisions/2026-05-21-quality-hooks-conservative-scope.md
+++ b/docs/decisions/2026-05-21-quality-hooks-conservative-scope.md
@@ -1,0 +1,62 @@
+# 2026-05-21 — Quality Hooks: Conservative Scope for Auto-Format and Log-Filter
+
+**Status**: ACCEPTED
+**Decided by**: Claude (sonnet-4-6), worktree infra-1380
+**Scope**: `.claude/hooks/` quality hooks for issue #1380
+
+## Context
+
+Issue #1380 asked for two quality hooks inspired by the zodchii post:
+
+1. **Post-write auto-format** — automatically run `ruff format` after Python file edits so Claude never leaves formatting debt in scripts.
+2. **Pre-read log-filter** — warn Claude before it reads a large dispatch log file cold, to avoid context bloat.
+
+Both hooks interact with an active dispatch pipeline where agents write files, read logs, and run automated batches. Any over-broad scope risks: (a) mangling content modules that contain frontmatter and code blocks, (b) corrupting JSONL log entries that pipeline readers rely on, or (c) causing noisy reruns in dispatch chains.
+
+## Decision
+
+### Hook 1 — Post-write auto-format
+
+**Scope: `.py` files only, in the primary tree, outside excluded directories.**
+
+**Why `.py` only:**
+- Python files have no frontmatter, no fenced-code-block nesting, and ruff has no destructive edge cases on valid Python.
+- Markdown auto-format is excluded: markdownlint and prettier both modify frontmatter patterns that Astro/Starlight parses for sidebar config. One bad reformat can break 1,999 pages.
+- YAML auto-format is excluded: Astro frontmatter is embedded YAML. yamlfix and prettier both strip or reorder keys in ways that break `title:`, `sidebar.order:`, and `slug:` fields.
+- TypeScript auto-format is excluded: it requires a separate node toolchain; `npx prettier` has different installation guarantees than `.venv/bin/ruff`.
+
+**Why excluded directories:**
+- `logs/`, `dist/`, `node_modules/`, `.venv/` — not human-authored Python; formatting changes corrupt binary data or pollute venv contents.
+- `.worktrees/` — dispatch agents write into worktrees; formatting their in-progress files adds unrequested diff noise to PRs.
+- `src/content/docs/` — content modules are Markdown, not Python; this guard is belt-and-suspenders.
+
+**Skip conditions:**
+- `KUBEDOJO_DISPATCHED=1` — dispatch pipelines set this env var; the hook skips to avoid double-formatting and noisy pipeline logs.
+- Ruff not installed at `.venv/bin/ruff` — fail-open; never error in a missing-venv environment.
+
+### Hook 2 — Pre-read log-filter
+
+**Scope: `logs/smart_dispatch.jsonl` and `logs/dispatch_responses/*.txt` only, when file > 100 KB.**
+
+**Why log-warn-only (never block):**
+- Blocking a Read on a log file could prevent Claude from debugging a stuck pipeline.
+- The value is in flagging the pattern (read whole log = context flood) and offering targeted `jq` alternatives, not in enforcement.
+- Exit code is always 0; `hookSpecificOutput.additionalContext` injects the advisory into Claude's next turn.
+
+**Why 100 KB threshold:**
+- Smart dispatch JSONL files grow at ~2 KB/entry. 100 KB ≈ 50 entries — large enough to be a real log, small enough that a cold-read is still reasonable.
+- Response text files in `dispatch_responses/` are typically 5-50 KB; only multi-agent batches exceed 100 KB.
+
+## Deferred (follow-up issue)
+
+The following were explicitly deferred to avoid blast radius:
+- **Markdown auto-format** — requires a frontmatter-aware formatter and isolated testing against Astro builds.
+- **YAML auto-format** — needs agreement on which YAML files are safe (pure config vs embedded frontmatter).
+- **TypeScript auto-format** — requires node toolchain coordination and ESLint/Prettier version pinning.
+
+## References
+
+- Issue: #1380
+- Hook files: `.claude/hooks/post-write-py-autoformat.sh`, `.claude/hooks/pre-read-warn-large-log.sh`
+- Tests: `tests/test_quality_hooks.py`
+- Similar pattern: `.claude/hooks/block-orchestrator-content-edits.sh` (KUBEDOJO_DISPATCHED guard)

--- a/tests/test_quality_hooks.py
+++ b/tests/test_quality_hooks.py
@@ -226,7 +226,11 @@ def test_log_filter_silent_on_small_dispatch_log(tmp_path: Path) -> None:
 
 
 def test_log_filter_warns_on_large_dispatch_response_txt(tmp_path: Path) -> None:
-    """Large dispatch_responses/*.txt → hook emits advisory warning."""
+    """Large dispatch_responses/*.txt → hook emits advisory warning.
+
+    Note the .txt branch suggests grep/tail (NOT jq, since the file is plain
+    text and jq would parse-fail). The jq advisory only fires for .jsonl.
+    """
     primary = tmp_path / "kubedojo"
     primary.mkdir()
     response_file = primary / "logs" / "dispatch_responses" / "run-001.txt"
@@ -237,7 +241,9 @@ def test_log_filter_warns_on_large_dispatch_response_txt(tmp_path: Path) -> None
 
     assert result.returncode == 0
     assert "hookSpecificOutput" in result.stdout
-    assert "jq" in result.stdout
+    # .txt files get tail/grep alternatives (plain-text), not jq
+    assert "tail " in result.stdout or "grep" in result.stdout
+    assert "jq " not in result.stdout
 
 
 def test_log_filter_skips_non_log_file(tmp_path: Path) -> None:

--- a/tests/test_quality_hooks.py
+++ b/tests/test_quality_hooks.py
@@ -1,0 +1,282 @@
+"""Tests for quality hooks: post-write-py-autoformat and pre-read-warn-large-log."""
+
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BASH = "/bin/bash"
+AUTO_FORMAT_HOOK = REPO_ROOT / ".claude" / "hooks" / "post-write-py-autoformat.sh"
+LOG_WARN_HOOK = REPO_ROOT / ".claude" / "hooks" / "pre-read-warn-large-log.sh"
+
+
+def run_hook(
+    hook: Path,
+    payload: dict,
+    primary: Path,
+    *,
+    env_overrides: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.pop("KUBEDOJO_DISPATCHED", None)
+    env["CLAUDE_PROJECT_DIR"] = str(primary)
+    if env_overrides:
+        env.update(env_overrides)
+    return subprocess.run(
+        [BASH, str(hook)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+        cwd=str(primary),
+    )
+
+
+def make_ruff_mock(venv_bin: Path, *, check_exits: int = 0) -> None:
+    """Install a fake ruff that controls --check exit code."""
+    venv_bin.mkdir(parents=True, exist_ok=True)
+    ruff = venv_bin / "ruff"
+    ruff.write_text(
+        f'#!/bin/bash\n'
+        f'for arg in "$@"; do [ "$arg" = "--check" ] && exit {check_exits}; done\n'
+        f'exit 0\n'
+    )
+    ruff.chmod(ruff.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def make_py_payload(file_path: str, tool_name: str = "Edit") -> dict:
+    return {
+        "tool_name": tool_name,
+        "tool_input": {"file_path": file_path},
+        "tool_response": {"type": "result", "result": "ok"},
+    }
+
+
+def make_read_payload(file_path: str) -> dict:
+    return {
+        "tool_name": "Read",
+        "tool_input": {"file_path": file_path},
+    }
+
+
+# ── post-write-py-autoformat tests ────────────────────────────────────────
+
+
+def test_autoformat_triggers_and_emits_context(tmp_path: Path) -> None:
+    """Ruff reports file needs formatting → hook formats and emits hookSpecificOutput."""
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+    make_ruff_mock(primary / ".venv" / "bin", check_exits=1)
+    py_file = primary / "scripts" / "foo.py"
+    py_file.parent.mkdir()
+    py_file.write_text("x=1\n")
+
+    result = run_hook(AUTO_FORMAT_HOOK, make_py_payload(str(py_file)), primary)
+
+    assert result.returncode == 0
+    assert "hookSpecificOutput" in result.stdout
+    assert "ruff auto-formatted" in result.stdout
+
+
+def test_autoformat_silent_when_already_formatted(tmp_path: Path) -> None:
+    """Ruff reports no changes needed → hook exits silently, no stdout."""
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+    make_ruff_mock(primary / ".venv" / "bin", check_exits=0)
+    py_file = primary / "scripts" / "foo.py"
+    py_file.parent.mkdir()
+    py_file.write_text("x = 1\n")
+
+    result = run_hook(AUTO_FORMAT_HOOK, make_py_payload(str(py_file)), primary)
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_autoformat_skips_non_py_file(tmp_path: Path) -> None:
+    """Non-.py extension → hook exits 0 immediately without invoking ruff."""
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+    make_ruff_mock(primary / ".venv" / "bin", check_exits=1)
+
+    result = run_hook(
+        AUTO_FORMAT_HOOK,
+        make_py_payload(str(primary / "docs" / "guide.md")),
+        primary,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_autoformat_skips_when_dispatched(tmp_path: Path) -> None:
+    """KUBEDOJO_DISPATCHED=1 → hook skips entirely, no ruff invoked."""
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+    make_ruff_mock(primary / ".venv" / "bin", check_exits=1)
+    py_file = primary / "scripts" / "foo.py"
+    py_file.parent.mkdir()
+    py_file.write_text("x=1\n")
+
+    result = run_hook(
+        AUTO_FORMAT_HOOK,
+        make_py_payload(str(py_file)),
+        primary,
+        env_overrides={"KUBEDOJO_DISPATCHED": "1"},
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_autoformat_skips_file_in_worktrees(tmp_path: Path) -> None:
+    """File inside .worktrees/ → hook skips (not in primary tree)."""
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+    make_ruff_mock(primary / ".venv" / "bin", check_exits=1)
+    wt_file = primary / ".worktrees" / "feature-1" / "scripts" / "foo.py"
+    wt_file.parent.mkdir(parents=True)
+    wt_file.write_text("x=1\n")
+
+    result = run_hook(AUTO_FORMAT_HOOK, make_py_payload(str(wt_file)), primary)
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_autoformat_skips_when_ruff_not_installed(tmp_path: Path) -> None:
+    """No .venv/bin/ruff → hook exits 0 silently (fail-open)."""
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+    # Deliberately no .venv/bin/ruff
+    py_file = primary / "scripts" / "foo.py"
+    py_file.parent.mkdir()
+    py_file.write_text("x=1\n")
+
+    result = run_hook(AUTO_FORMAT_HOOK, make_py_payload(str(py_file)), primary)
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_autoformat_skips_venv_path(tmp_path: Path) -> None:
+    """File inside .venv/ → hook skips (excluded directory)."""
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+    make_ruff_mock(primary / ".venv" / "bin", check_exits=1)
+    venv_file = primary / ".venv" / "lib" / "python3.11" / "site-packages" / "foo.py"
+    venv_file.parent.mkdir(parents=True)
+    venv_file.write_text("x=1\n")
+
+    result = run_hook(AUTO_FORMAT_HOOK, make_py_payload(str(venv_file)), primary)
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_autoformat_write_tool_also_triggers(tmp_path: Path) -> None:
+    """Write tool (not just Edit) also triggers autoformat."""
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+    make_ruff_mock(primary / ".venv" / "bin", check_exits=1)
+    py_file = primary / "scripts" / "new_file.py"
+    py_file.parent.mkdir()
+    py_file.write_text("x=1\n")
+
+    result = run_hook(AUTO_FORMAT_HOOK, make_py_payload(str(py_file), "Write"), primary)
+
+    assert result.returncode == 0
+    assert "ruff auto-formatted" in result.stdout
+
+
+# ── pre-read-warn-large-log tests ─────────────────────────────────────────
+
+
+def test_log_filter_warns_on_large_smart_dispatch_jsonl(tmp_path: Path) -> None:
+    """Large smart_dispatch.jsonl → hook emits advisory hookSpecificOutput."""
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+    log_file = primary / "logs" / "smart_dispatch.jsonl"
+    log_file.parent.mkdir()
+    log_file.write_bytes(b"x" * 110_000)  # > 100 KB
+
+    result = run_hook(LOG_WARN_HOOK, make_read_payload(str(log_file)), primary)
+
+    assert result.returncode == 0
+    assert "hookSpecificOutput" in result.stdout
+    assert "jq" in result.stdout
+
+
+def test_log_filter_silent_on_small_dispatch_log(tmp_path: Path) -> None:
+    """Small smart_dispatch.jsonl → hook exits 0 with no stdout."""
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+    log_file = primary / "logs" / "smart_dispatch.jsonl"
+    log_file.parent.mkdir()
+    log_file.write_bytes(b"x" * 1_000)  # < 100 KB
+
+    result = run_hook(LOG_WARN_HOOK, make_read_payload(str(log_file)), primary)
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_log_filter_warns_on_large_dispatch_response_txt(tmp_path: Path) -> None:
+    """Large dispatch_responses/*.txt → hook emits advisory warning."""
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+    response_file = primary / "logs" / "dispatch_responses" / "run-001.txt"
+    response_file.parent.mkdir(parents=True)
+    response_file.write_bytes(b"x" * 200_000)  # > 100 KB
+
+    result = run_hook(LOG_WARN_HOOK, make_read_payload(str(response_file)), primary)
+
+    assert result.returncode == 0
+    assert "hookSpecificOutput" in result.stdout
+    assert "jq" in result.stdout
+
+
+def test_log_filter_skips_non_log_file(tmp_path: Path) -> None:
+    """Non-log file, even if large → hook exits 0 with no output."""
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+    doc_file = primary / "docs" / "some_report.html"
+    doc_file.parent.mkdir()
+    doc_file.write_bytes(b"x" * 200_000)
+
+    result = run_hook(LOG_WARN_HOOK, make_read_payload(str(doc_file)), primary)
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_log_filter_never_blocks(tmp_path: Path) -> None:
+    """Hook never returns exit code 2 (blocking) — always advisory."""
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+    log_file = primary / "logs" / "smart_dispatch.jsonl"
+    log_file.parent.mkdir()
+    log_file.write_bytes(b"x" * 10_000_000)  # 10 MB
+
+    result = run_hook(LOG_WARN_HOOK, make_read_payload(str(log_file)), primary)
+
+    assert result.returncode == 0  # never 2
+
+
+def test_log_filter_skips_non_read_tool(tmp_path: Path) -> None:
+    """Non-Read tool_name → hook exits 0 immediately."""
+    primary = tmp_path / "kubedojo"
+    primary.mkdir()
+    log_file = primary / "logs" / "smart_dispatch.jsonl"
+    log_file.parent.mkdir()
+    log_file.write_bytes(b"x" * 200_000)
+
+    payload = {"tool_name": "Bash", "tool_input": {"command": f"cat {log_file}"}}
+    result = run_hook(LOG_WARN_HOOK, payload, primary)
+
+    assert result.returncode == 0
+    assert result.stdout == ""


### PR DESCRIPTION
## Summary

Closes #1380 (Phase 1). Two quality hooks per zodchii post #6 — scoped conservatively for safety in dispatch chains.

## What

- `.claude/hooks/post-write-py-autoformat.sh` — runs `ruff format` on .py files in primary tree after Edit/Write. Skip if non-.py, KUBEDOJO_DISPATCHED=1, .worktrees/, .venv/, logs/, dist/, src/content/docs/, or ruff not installed.
- `.claude/hooks/pre-read-warn-large-log.sh` — never blocks; injects jq advisory when reading large dispatch logs (>100 KB).
- `.claude/settings.json` — registered both, existing hooks preserved.
- `tests/test_quality_hooks.py` — 14 hermetic tests pass.
- ADR `docs/decisions/2026-05-21-quality-hooks-conservative-scope.md` — why scope is .py-only + log-warn-only; md/yaml/ts deferred to follow-up.

## Why

Quality hooks shift formatting off-author. Conservative scope chosen so dispatch chains and content modules can't be mangled mid-flight.

## Test plan

- [x] 14 unit tests pass (`tests/test_quality_hooks.py`)
- [x] Manual trigger of each hook produces expected JSON output

🤖 Generated with [Claude Code](https://claude.com/claude-code)