### PR TITLE
fix(reliability): xref Netflix Chaos Monkey to canonical (unblock incident-dedup gate)

### DIFF
--- a/src/content/docs/platform/foundations/reliability-engineering/module-2.1-what-is-reliability.md
+++ b/src/content/docs/platform/foundations/reliability-engineering/module-2.1-what-is-reliability.md
@@ -902,7 +902,7 @@ These are the patterns that look reasonable but lead to unreliable systems:
 
 - **The first software reliability model** was created by [John Musa at Bell Labs in 1975](https://en.wikipedia.org/wiki/John_D._Musa). He applied hardware reliability mathematics to software, founding the field of software reliability engineering. His insight: software bugs follow statistical patterns just like hardware failures.
 
-- **Netflix popularized the "Chaos Monkey" approach**, randomly killing production instances to ensure their systems could handle failures. Why the name? Because it's like having a monkey loose in your data center, randomly unplugging things. This evolved into chaos engineering—deliberately injecting failures to build confidence. If you haven't tested a failure, you don't know if you can survive it.
+- **Netflix popularized the "Chaos Monkey" approach** — see the [chaos engineering canonical module](../../disciplines/reliability-security/chaos-engineering/module-1.1-chaos-principles/) for the full story. The principle that matters here: if you haven't tested a failure, you don't know if you can survive it. <!-- incident-xref: netflix-chaos-monkey -->
 
 - [**The Space Shuttle had five redundant computers**](https://en.wikipedia.org/wiki/Space_Shuttle) running different software written by different teams. Why? A single bug could kill astronauts. The fifth computer ran entirely different software to protect against systematic bugs. This is the ultimate "defense in depth."
 


### PR DESCRIPTION
## Summary

Pre-existing absolute-mode dedup violation in main: module-2.1-what-is-reliability.md line 905 fully retold the Netflix Chaos Monkey story while the canonical for that incident is module-1.1-chaos-principles.md. The gate had been failing in absolute mode on every PR — blocked #1433 from merging.

## Fix

Replace the dramatic retelling with a one-sentence pointer + the `<!-- incident-xref: netflix-chaos-monkey -->` marker the gate looks for.

## Verification

Local `scripts/check_incident_reuse.py` returns 0 violations after the fix.

## Learner check

> Explain the difference between availability, durability, and reliability and why each requires distinct engineering strategies

## Regression test: tests/test_incident_dedup_gate.py

Covered by existing tests in #1430.

🤖 Generated with [Claude Code](https://claude.com/claude-code)