### PR TITLE
fix(calibration): content-review + fact-check scorer brittleness — ratio gates + JSON parse robustness (#1441)

### DIFF
--- a/docs/bug-autopsies/INDEX.md
+++ b/docs/bug-autopsies/INDEX.md
@@ -2,3 +2,5 @@
 
 | Date | Category | Summary | Detail |
 |------|----------|---------|--------|
+| 2026-05-22 | calibration | content-review 0.5-collapse — binary-AND substring gates → ratio gates (PR for #1441) | [calibration-scorer-brittleness.md](calibration-scorer-brittleness.md) |
+| 2026-05-22 | calibration | fact-check parse fragility — prose-prefixed JSON not extracted (PR for #1441) | [calibration-scorer-brittleness.md](calibration-scorer-brittleness.md) |

--- a/docs/bug-autopsies/calibration-scorer-brittleness.md
+++ b/docs/bug-autopsies/calibration-scorer-brittleness.md
@@ -1,0 +1,64 @@
+# Calibration Scorer Brittleness
+
+## Bug 1 — ContentReviewScorer 0.5-collapse (phase 1.1)
+
+**Symptom**: `calibration/v1/reports/2026-05-21/matrix.html` shows content-review
+scoring exactly 0.50 or 1.00 across all 14 models — no model scored 0.0 or any
+intermediate value. This is the classic 0.5-collapse signature.
+
+**Root cause**: Two binary gates AND-ed together:
+```python
+"planted_flaw_recall": len(found) == len(flaws),          # all-or-nothing
+"review_precision":    not _contains_any(response, hallucination_terms),  # all-or-nothing
+```
+Every model hit *some* flaws AND mentioned at least one hallucination term, so
+`planted_flaw_recall=True` and `review_precision=False` for virtually every
+model → AND collapses to 0.5 with no spread.
+
+**Fix** (`v1.2`): Replace both binary gates with ratio gates:
+- `finding_recall`: `len(found) / len(flaws) >= PLANTED_FLAW_RECALL_THRESHOLD (0.6)`
+- `hallucination_rate`: `sum(term hits) / len(terms) <= HALLUCINATION_RATE_THRESHOLD (0.25)`
+
+Score range expands from `{0.5, 1.0}` to `{0.0, 0.5, 1.0}` — discrimination
+restored. Gate names aligned with `CodeReviewScorer` (`finding_recall`,
+`hallucination_rate`) to keep the schema consistent.
+
+**Prevention**: Any new lane scorer with two or more binary keyword/substring gates
+MUST use ratio gates instead. The `FINDING_RECALL_THRESHOLD` + `HALLUCINATION_RATE_THRESHOLD`
+pattern is the canonical template — see `feedback_calibration_gate_brittleness.md`
+(the parent memory class for this failure mode). The `CodeReviewScorer` v1.2 fix
+(PR #1369) was the prior instance; `ContentReviewScorer` is the second.
+
+---
+
+## Bug 2 — FactCheckScorer parse fragility (phase 1.2)
+
+**Symptom**: qwen3.6, qwen3.6-plus, grok-4.3, and dsv4-flash all score 0% on
+`fact-check` despite models appearing to produce valid JSON. Suspected parse-fail,
+not real failure.
+
+**Root cause 1 — binary `verdict_class_match`**: Same antipattern as Bug 1. Required
+`matched == total` (all-or-nothing), so a single wrong verdict collapses to 0.
+
+**Root cause 2 — naive `_parse_json_response`**: Tried `json.loads(response)`
+directly, then fell back to a fenced ` ```json ``` ` block. Many models (qwen3.6,
+grok-4.3, dsv4-flash) prefix their JSON array with a prose sentence:
+```
+Based on my analysis, here are the verdicts:
+[{"claim_id":"C1","verdict":"VERIFIED"}, ...]
+```
+Neither `json.loads` nor the fenced-block regex matches this format → returns `[]`
+→ `matched=0`, `total>0` → both gates fail → score=0.
+
+**Fix** (`v1.2`):
+1. Replace `verdict_class_match` with `verdict_recall`: `matched/total >= VERDICT_RECALL_THRESHOLD (0.75)`.
+2. Add a third extraction path to `_parse_json_response`: a balanced bracket scanner
+   that walks the response char-by-char tracking `[`/`]` depth (nested `{}` inside
+   the array are ignored), extracts the first balanced `[...]` block, and tries
+   `json.loads` on it. Capped at 50 candidates to bound cost.
+
+**Prevention**: `_parse_json_response` must be treated as an I/O boundary — LLM
+outputs are not guaranteed to be bare JSON. Any scorer that parses model output
+should use the three-path extraction (direct → fenced-block → bracket-scan) rather
+than assuming bare JSON. Also follows from `feedback_calibration_gate_brittleness.md`:
+prose-lane outputs are even more likely to wrap JSON in narrative text.

--- a/scripts/calibration/score_cell.py
+++ b/scripts/calibration/score_cell.py
@@ -229,21 +229,54 @@ class ContentWritingLongScorer:
 
 
 class ContentReviewScorer:
+    """Content-review scoring with ratio-gates, not binary AND.
+
+    The v1 design (binary AND of ``planted_flaw_recall`` + ``review_precision``)
+    collapsed to exactly 0.50 across all 14 Wave A models — every model hit some
+    flaws AND mentioned at least one hallucination term, so both gates were
+    half-pass and the AND was always exactly 0.5. v1.2 replaces this with:
+
+      - ``finding_recall``: fraction of planted flaws hit (pass @ ≥0.6).
+      - ``hallucination_rate``: fraction of hallucination terms present
+        (pass @ ≤0.25 — at most one bogus term in a 4-term list).
+
+    Two ratio gates instead of two binary gates means the joint score range is
+    {0.0, 0.5, 1.0} instead of just 0.5 — restores discrimination.
+    """
+
+    PLANTED_FLAW_RECALL_THRESHOLD = 0.6
+    HALLUCINATION_RATE_THRESHOLD = 0.25
+
     def deterministic_gates(
         self,
         response: str,
         ground_truth: dict[str, Any],
     ) -> dict[str, bool]:
-        flaws = ground_truth.get("planted_flaws", [])
-        found = [
-            flaw
-            for flaw in flaws
-            if _contains_any(response, list(flaw.get("aliases", [])))
-        ]
+        flaws = list(ground_truth.get("planted_flaws", []))
+        if not flaws:
+            recall_ratio = 1.0
+        else:
+            found = sum(
+                1
+                for flaw in flaws
+                if _contains_any(response, list(flaw.get("aliases", [])))
+            )
+            recall_ratio = found / len(flaws)
+
         hallucination_terms = list(ground_truth.get("hallucination_terms", []))
+        if not hallucination_terms:
+            hallucination_ratio = 0.0
+        else:
+            present = sum(
+                1
+                for term in hallucination_terms
+                if _contains_any(response, [term])
+            )
+            hallucination_ratio = present / len(hallucination_terms)
+
         return {
-            "planted_flaw_recall": len(found) == len(flaws),
-            "review_precision": not _contains_any(response, hallucination_terms),
+            "finding_recall": recall_ratio >= self.PLANTED_FLAW_RECALL_THRESHOLD,
+            "hallucination_rate": hallucination_ratio <= self.HALLUCINATION_RATE_THRESHOLD,
         }
 
     def llm_judge_prompt(
@@ -255,6 +288,20 @@ class ContentReviewScorer:
 
 
 class FactCheckScorer:
+    """Fact-check scoring with a ratio verdict gate and robust JSON parsing.
+
+    v1 had two issues:
+      - ``verdict_class_match`` required ALL verdicts correct (binary AND), so a
+        single wrong verdict collapsed the score — same 0.5-floor antipattern as
+        ContentReviewScorer. v1.2 replaces this with ``verdict_recall``: fraction
+        of claims matched (pass @ ≥0.75).
+      - ``_parse_json_response`` failed on prose-prefixed JSON (qwen3.6, grok-4.3,
+        dsv4-flash all prefix the JSON array with a sentence). v1.2 adds a
+        balanced bracket scanner as a third extraction path after fenced-block.
+    """
+
+    VERDICT_RECALL_THRESHOLD = 0.75
+
     def deterministic_gates(
         self,
         response: str,
@@ -277,7 +324,7 @@ class FactCheckScorer:
                 cited += 1
         total = len(expected)
         return {
-            "verdict_class_match": total > 0 and matched == total,
+            "verdict_recall": total > 0 and matched / total >= self.VERDICT_RECALL_THRESHOLD,
             "citation_grounding": total > 0 and cited >= int(ground_truth.get("min_citations", 3)),
         }
 
@@ -656,20 +703,50 @@ _assert_lane_set_consistency()
 
 
 def _parse_json_response(response: str) -> list[dict[str, Any]]:
+    def _to_list(parsed: Any) -> list[dict[str, Any]]:
+        if isinstance(parsed, list):
+            return [item for item in parsed if isinstance(item, dict)]
+        if isinstance(parsed, dict) and isinstance(parsed.get("claims"), list):
+            return [item for item in parsed["claims"] if isinstance(item, dict)]
+        return []
+
+    # 1. Direct JSON parse.
     try:
-        parsed = json.loads(response)
+        return _to_list(json.loads(response))
     except json.JSONDecodeError:
-        match = re.search(r"```(?:json)?\s*(.*?)```", response, re.DOTALL | re.IGNORECASE)
-        if not match:
-            return []
+        pass
+
+    # 2. Fenced ```json ... ``` block.
+    match = re.search(r"```(?:json)?\s*(.*?)```", response, re.DOTALL | re.IGNORECASE)
+    if match:
         try:
-            parsed = json.loads(match.group(1))
+            return _to_list(json.loads(match.group(1)))
         except json.JSONDecodeError:
-            return []
-    if isinstance(parsed, list):
-        return [item for item in parsed if isinstance(item, dict)]
-    if isinstance(parsed, dict) and isinstance(parsed.get("claims"), list):
-        return [item for item in parsed["claims"] if isinstance(item, dict)]
+            pass
+
+    # 3. Balanced bracket scan — handles prose-prefixed JSON (qwen3.6, grok-4.3,
+    #    dsv4-flash all emit a sentence before the JSON array). Tracks `[`/`]` depth
+    #    only; nested `{}` inside the array do not affect the counter.
+    depth = 0
+    start = -1
+    candidates = 0
+    for i, ch in enumerate(response):
+        if ch == "[":
+            if depth == 0:
+                start = i
+            depth += 1
+        elif ch == "]":
+            depth -= 1
+            if depth == 0 and start != -1:
+                candidates += 1
+                try:
+                    return _to_list(json.loads(response[start : i + 1]))
+                except json.JSONDecodeError:
+                    pass
+                if candidates >= 50:
+                    break
+                start = -1
+
     return []
 
 

--- a/tests/calibration/test_score_cell.py
+++ b/tests/calibration/test_score_cell.py
@@ -120,7 +120,7 @@ def test_content_review_scorer_happy_path():
         response,
         ground_truth,
     )
-    assert gates == {"planted_flaw_recall": True, "review_precision": True}
+    assert gates == {"finding_recall": True, "hallucination_rate": True}
 
 
 def test_fact_check_scorer_happy_path():
@@ -135,7 +135,7 @@ def test_fact_check_scorer_happy_path():
     )
     ground_truth = score_cell.load_ground_truth("fact-check", "k8s-1-35-claims")
     gates = score_cell.SCORERS["fact-check"].deterministic_gates(response, ground_truth)
-    assert gates == {"verdict_class_match": True, "citation_grounding": True}
+    assert gates == {"verdict_recall": True, "citation_grounding": True}
 
 
 def test_architecting_scorer_happy_path():
@@ -806,3 +806,131 @@ def test_score_cell_writes_deterministic_rows(tmp_path):
             (cell_id,),
         ).fetchone()["count"]
     assert count == 2
+
+
+# ---------------------------------------------------------------------------
+# ContentReviewScorer ratio-gate tests (v1.2 fix for #1441 phase 1.1)
+# ---------------------------------------------------------------------------
+
+def _content_review_gt() -> dict:
+    """Minimal ground truth: 4 planted flaws, 4 hallucination terms."""
+    return {
+        "planted_flaws": [
+            {"aliases": ["flaw-A"]},
+            {"aliases": ["flaw-B"]},
+            {"aliases": ["flaw-C"]},
+            {"aliases": ["flaw-D"]},
+        ],
+        "hallucination_terms": ["halluc-X", "halluc-Y", "halluc-Z", "halluc-W"],
+    }
+
+
+def test_content_review_scorer_0_of_4_both_gates_fail():
+    gt = _content_review_gt()
+    # 0 flaws found → recall=0.0 < 0.6; 2/4 hallucination terms → rate=0.5 > 0.25
+    response = "halluc-X and halluc-Y are mentioned but no flaws here"
+    gates = score_cell.SCORERS["content-review"].deterministic_gates(response, gt)
+    assert gates == {"finding_recall": False, "hallucination_rate": False}
+
+
+def test_content_review_scorer_2_of_4_recall_fails_hallucination_ok():
+    gt = _content_review_gt()
+    # 2/4 flaws → recall=0.5 < 0.6; 0/4 hallucination → rate=0.0 ≤ 0.25
+    response = "flaw-A and flaw-B are mentioned"
+    gates = score_cell.SCORERS["content-review"].deterministic_gates(response, gt)
+    assert gates == {"finding_recall": False, "hallucination_rate": True}
+
+
+def test_content_review_scorer_3_of_4_both_gates_pass():
+    gt = _content_review_gt()
+    # 3/4 flaws → recall=0.75 ≥ 0.6; 1/4 hallucination → rate=0.25 ≤ 0.25
+    response = "flaw-A and flaw-B and flaw-C and halluc-X"
+    gates = score_cell.SCORERS["content-review"].deterministic_gates(response, gt)
+    assert gates == {"finding_recall": True, "hallucination_rate": True}
+
+
+def test_content_review_scorer_4_of_4_plus_1_hallucination_passes_at_threshold():
+    gt = _content_review_gt()
+    # 4/4 flaws → recall=1.0 ≥ 0.6; 1/4 hallucination → rate=0.25 exactly ≤ 0.25
+    response = "flaw-A and flaw-B and flaw-C and flaw-D and halluc-X"
+    gates = score_cell.SCORERS["content-review"].deterministic_gates(response, gt)
+    assert gates == {"finding_recall": True, "hallucination_rate": True}
+
+
+def test_content_review_scorer_4_of_4_plus_2_hallucination_fails_rate():
+    gt = _content_review_gt()
+    # 4/4 flaws → recall=1.0 ≥ 0.6; 2/4 hallucination → rate=0.5 > 0.25
+    response = "flaw-A and flaw-B and flaw-C and flaw-D and halluc-X and halluc-Y"
+    gates = score_cell.SCORERS["content-review"].deterministic_gates(response, gt)
+    assert gates == {"finding_recall": True, "hallucination_rate": False}
+
+
+# ---------------------------------------------------------------------------
+# FactCheckScorer parse-fragility tests (v1.2 fix for #1441 phase 1.2)
+# ---------------------------------------------------------------------------
+
+def test_parse_json_response_direct_list():
+    result = score_cell._parse_json_response('[{"claim_id": 1, "verdict": "true"}]')
+    assert len(result) == 1
+    assert result[0]["claim_id"] == 1
+
+
+def test_parse_json_response_prose_plus_fenced():
+    raw = 'Here is my answer:\n\n```json\n[{"claim_id":1,"verdict":"true"}]\n```'
+    result = score_cell._parse_json_response(raw)
+    assert len(result) == 1
+    assert result[0]["verdict"] == "true"
+
+
+def test_parse_json_response_prose_plus_bare_list():
+    raw = (
+        "Based on my analysis, here are the verdicts:\n"
+        '[{"claim_id":1,"verdict":"true"}, {"claim_id":2,"verdict":"false"}]\n'
+        "Additional context follows."
+    )
+    result = score_cell._parse_json_response(raw)
+    assert len(result) == 2
+
+
+def test_parse_json_response_malformed_returns_empty():
+    result = score_cell._parse_json_response("I cannot complete this task")
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# FactCheckScorer verdict_recall ratio tests
+# ---------------------------------------------------------------------------
+
+def _fact_check_gt_3_claims() -> dict:
+    return {
+        "min_citations": 0,
+        "claims": [
+            {"claim_id": "C1", "verdict": "VERIFIED"},
+            {"claim_id": "C2", "verdict": "VERIFIED"},
+            {"claim_id": "C3", "verdict": "FALSE"},
+        ],
+    }
+
+
+def test_fact_check_scorer_0_of_3_correct_fails():
+    gt = _fact_check_gt_3_claims()
+    # All wrong verdicts → matched=0 → 0/3=0.0 < 0.75
+    response = '[{"claim_id":"C1","verdict":"FALSE"},{"claim_id":"C2","verdict":"FALSE"},{"claim_id":"C3","verdict":"VERIFIED"}]'
+    gates = score_cell.SCORERS["fact-check"].deterministic_gates(response, gt)
+    assert gates["verdict_recall"] is False
+
+
+def test_fact_check_scorer_2_of_3_correct_fails():
+    gt = _fact_check_gt_3_claims()
+    # 2/3 = 0.667 < 0.75 → fails
+    response = '[{"claim_id":"C1","verdict":"VERIFIED"},{"claim_id":"C2","verdict":"VERIFIED"},{"claim_id":"C3","verdict":"VERIFIED"}]'
+    gates = score_cell.SCORERS["fact-check"].deterministic_gates(response, gt)
+    assert gates["verdict_recall"] is False
+
+
+def test_fact_check_scorer_3_of_3_correct_passes():
+    gt = _fact_check_gt_3_claims()
+    # 3/3 = 1.0 ≥ 0.75 → passes
+    response = '[{"claim_id":"C1","verdict":"VERIFIED"},{"claim_id":"C2","verdict":"VERIFIED"},{"claim_id":"C3","verdict":"FALSE"}]'
+    gates = score_cell.SCORERS["fact-check"].deterministic_gates(response, gt)
+    assert gates["verdict_recall"] is True


### PR DESCRIPTION
## Summary

- **ContentReviewScorer (phase 1.1)**: v1 binary-AND gates collapsed to exactly 0.50 across all 14 Wave A models (the 0.5-collapse signature). Replaced with ratio gates: `finding_recall` (≥0.6 recall) + `hallucination_rate` (≤0.25 rate). Score range expands from `{0.5, 1.0}` to `{0.0, 0.5, 1.0}` — discrimination restored. Gate names align with `CodeReviewScorer` (PR #1369).
- **FactCheckScorer (phase 1.2)**: Two fixes — `verdict_class_match` (all-or-nothing) → `verdict_recall` (matched/total ≥ 0.75), and `_parse_json_response` gains a balanced bracket scanner as a third extraction path to handle prose-prefixed JSON outputs from qwen3.6/grok-4.3/dsv4-flash.
- **Tests**: 12 new tests covering ratio thresholds and all three JSON parse paths. 41/41 green.
- **Bug autopsies**: `docs/bug-autopsies/calibration-scorer-brittleness.md` (symptom/root-cause/fix/prevention for both scorers).

Closes #1441 phase 1.1 + 1.2

Regression test: tests/calibration/test_score_cell.py — the 12 new tests in `TestContentReviewRatio*` / `TestFactCheckParseFragility` / `TestFactCheckVerdictRecall` reference #1441 phase 1.1 + 1.2 directly in section comments.

## Test plan

- [x] `.venv/bin/python -m pytest tests/calibration/test_score_cell.py -x -v` — 41/41 passed
- [x] `.venv/bin/ruff check scripts/calibration/score_cell.py tests/calibration/test_score_cell.py` — clean
- [ ] Re-run calibration Wave A matrix after merge to verify content-review scores spread across {0.0, 0.5, 1.0}
