### PR TITLE
chore(reliability): move incident-xref closer to Chaos Monkey trigger

### DIFF
--- a/src/content/docs/platform/foundations/reliability-engineering/module-2.1-what-is-reliability.md
+++ b/src/content/docs/platform/foundations/reliability-engineering/module-2.1-what-is-reliability.md
@@ -902,7 +902,7 @@ These are the patterns that look reasonable but lead to unreliable systems:
 
 - **The first software reliability model** was created by [John Musa at Bell Labs in 1975](https://en.wikipedia.org/wiki/John_D._Musa). He applied hardware reliability mathematics to software, founding the field of software reliability engineering. His insight: software bugs follow statistical patterns just like hardware failures.
 
-- **Netflix popularized the "Chaos Monkey" approach** — see the [chaos engineering canonical module](../../disciplines/reliability-security/chaos-engineering/module-1.1-chaos-principles/) for the full story. The principle that matters here: if you haven't tested a failure, you don't know if you can survive it. <!-- incident-xref: netflix-chaos-monkey -->
+- **Netflix popularized the "Chaos Monkey" approach** <!-- incident-xref: netflix-chaos-monkey --> — see the [chaos engineering canonical module](../../disciplines/reliability-security/chaos-engineering/module-1.1-chaos-principles/) for the full story. The principle that matters here: if you haven't tested a failure, you don't know if you can survive it.
 
 - [**The Space Shuttle had five redundant computers**](https://en.wikipedia.org/wiki/Space_Shuttle) running different software written by different teams. Why? A single bug could kill astronauts. The fifth computer ran entirely different software to protect against systematic bugs. This is the ultimate "defense in depth."
 


### PR DESCRIPTION
The `incident_dedup_gate.py --mode absolute` check requires every `<!-- incident-xref: ... -->` comment within 200 chars of its trigger phrase; the `netflix-chaos-monkey` xref in `module-2.1-what-is-reliability.md` was ~310 chars away (at end-of-line), causing the gate to fail on every PR targeting main. This change moves the comment immediately after **"Chaos Monkey"** so it falls within the 200-char window.

Regression test: scripts/quality/incident_dedup_gate.py --mode absolute (already wired as the "Incident dedup gate" CI workflow; was red on PRs #1442 / #1443, will be green after this lands).

## Learner check

> if you haven't tested a failure, you don't know if you can survive it.
