### PR TITLE
feat(calibration): 0-10 composite score + letter-grade rendering for benchmark reports (#1441)

### DIFF
--- a/docs/calibration/v1-spec.html
+++ b/docs/calibration/v1-spec.html
@@ -181,6 +181,27 @@
 
 <p>All LLM-as-judge dispatches are <strong>headless</strong> (<code>claude -p</code>, <code>codex exec</code>, <code>agy-cli</code> subprocess, hermes subprocess). While <code>agy-cli</code> is TUI-controlled for interactive use, the kubedojo adapter (<code>scripts/agent_runtime/adapters/agy.py</code>) invokes it headlessly via subprocess with the model identifier in the brief; the TUI label in the Locked anchor table refers to interactive model-selection, not dispatch invocation. The interactive orchestrator does not grade itself or any other dispatch. This keeps judge runs reproducible across sessions and avoids billing-pool conflation.</p>
 
+<h2>Composite score <span class="pill pill-revised">REVISED</span></h2>
+
+<p>Parent roadmap issue <strong>#1441</strong> adds a render-only <code>0&ndash;10</code> composite score and letter-grade layer on top of the existing score ledger. No SQLite column stores the composite; reports compute it at render time from <code>scores</code> rows.</p>
+
+<p>For each cell, deterministic rows are <code>scorer = "deterministic"</code> excluding <code>human_spot_check</code>. If any deterministic row exposes a ratio-like <code>score_value</code> in <code>[0, 1]</code>, the gate component averages <code>score_value</code> where present and falls back to <code>gate_pass</code> booleans where absent. Otherwise it averages the gate booleans. The result is scaled to <code>0&ndash;10</code>.</p>
+
+<p>Mechanical lanes use the gate component directly. Prose lanes blend the gate component with parsed LLM judge scores: <code>composite = 0.4 * gates + 0.6 * judges</code>. If all prose judges crash or are unparseable, the report keeps only the gate signal and applies the gate weight: <code>composite = 0.4 * gates</code>. Unknown lanes fall back to gates only. The final value is clamped to <code>0&ndash;10</code>.</p>
+
+<table>
+<thead><tr><th>Grade</th><th>Band</th><th>Report color</th></tr></thead>
+<tbody>
+<tr><td><strong>A</strong></td><td><code>8.5+</code></td><td>deep green</td></tr>
+<tr><td><strong>B</strong></td><td><code>7.0&ndash;8.5</code></td><td>green</td></tr>
+<tr><td><strong>C</strong></td><td><code>5.5&ndash;7.0</code></td><td>amber</td></tr>
+<tr><td><strong>D</strong></td><td><code>4.0&ndash;5.5</code></td><td>orange</td></tr>
+<tr><td><strong>F</strong></td><td><code>&lt;4.0</code></td><td>red</td></tr>
+</tbody>
+</table>
+
+<p>The weights, grade bands, and judge-dissent threshold live in <code>scripts/calibration/constants.py</code>. The matrix report renders the same five grade bands as a legend, explains that prose lanes are <code>40%</code> deterministic gates plus <code>60%</code> LLM judges while mechanical lanes are <code>100%</code> gates, and notes that hovering a cell shows the gate ratio and judge breakdown. Prose cells where parsed judges differ by more than <code>2.0</code> show a dissent marker.</p>
+
 <h2>Effort verification methodology</h2>
 
 <ol>

--- a/scripts/calibration/constants.py
+++ b/scripts/calibration/constants.py
@@ -2,3 +2,39 @@
 from __future__ import annotations
 
 DETERMINISTIC_SCORERS = ("deterministic", "respected_inline_return")
+
+PROSE_LANES = frozenset(
+    (
+        "orchestrating",
+        "refactoring",
+        "summarization",
+        "content-writing-long",
+        "architecting",
+        "mcp-use",
+        "harness-following",
+    )
+)
+MECHANICAL_LANES = frozenset(
+    (
+        "code-writing",
+        "code-review",
+        "content-review",
+        "fact-check",
+        "debugging",
+    )
+)
+
+COMPOSITE_GATE_WEIGHT = 0.4
+COMPOSITE_JUDGE_WEIGHT = 0.6
+
+# Letter grade bands are lower-inclusive and upper-exclusive except A, whose
+# 10.01 upper bound admits a clamped 10.0 score.
+LETTER_GRADE_BANDS = [
+    ("A", 8.5, 10.01, "#1f8a3f"),
+    ("B", 7.0, 8.5, "#4caf50"),
+    ("C", 5.5, 7.0, "#ffb300"),
+    ("D", 4.0, 5.5, "#fb8c00"),
+    ("F", 0.0, 4.0, "#e53935"),
+]
+
+JUDGE_DISSENT_THRESHOLD = 2.0

--- a/scripts/calibration/report.py
+++ b/scripts/calibration/report.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import math
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
@@ -9,8 +10,8 @@ from typing import Any
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
+from . import constants
 from . import schema
-from .constants import DETERMINISTIC_SCORERS
 from .models import ANCHORS, LANES
 from .run_cell import DEFAULT_DB_PATH, DEFAULT_OUTPUT_ROOT
 
@@ -29,7 +30,274 @@ class CellSummary:
     effort_confidence: str
     deterministic_score: float
     llm_score: float | None
+    composite: float
+    letter: str
+    color: str
+    gate_pct: float
+    judge_title: str
+    judge_dissent: bool
     response_path: str | None
+
+
+@dataclass(frozen=True)
+class LaneGrade:
+    lane: str
+    composite: float
+    letter: str
+    color: str
+
+
+@dataclass(frozen=True)
+class LaneModelSummary:
+    canonical_string: str
+    composite: float
+    letter: str
+    color: str
+    judge_dissent: bool
+
+
+def _score_row_value(row: Any, key: str) -> Any:
+    try:
+        return row[key]
+    except (KeyError, IndexError, TypeError):
+        return getattr(row, key)
+
+
+def _deterministic_rows(score_rows: list[Any]) -> list[Any]:
+    return [
+        row
+        for row in score_rows
+        if _score_row_value(row, "scorer") == "deterministic"
+        and _score_row_value(row, "gate_name") != "human_spot_check"
+    ]
+
+
+def _judge_rows(score_rows: list[Any]) -> list[Any]:
+    return [
+        row
+        for row in score_rows
+        if str(_score_row_value(row, "scorer")).startswith("llm-judge:")
+    ]
+
+
+def _gate_component(score_rows: list[Any]) -> float:
+    det_rows = _deterministic_rows(score_rows)
+    if not det_rows:
+        return 0.0
+
+    has_ratios = any(
+        _score_row_value(row, "score_value") is not None
+        and 0.0 <= float(_score_row_value(row, "score_value")) <= 1.0
+        for row in det_rows
+    )
+    if has_ratios:
+        values = [
+            float(_score_row_value(row, "score_value"))
+            if _score_row_value(row, "score_value") is not None
+            else (1.0 if _score_row_value(row, "gate_pass") else 0.0)
+            for row in det_rows
+        ]
+    else:
+        values = [1.0 if _score_row_value(row, "gate_pass") else 0.0 for row in det_rows]
+    return (sum(values) / len(values)) * 10.0
+
+
+def _parsed_judge_scores(score_rows: list[Any]) -> list[float]:
+    return [
+        float(_score_row_value(row, "score_value"))
+        for row in _judge_rows(score_rows)
+        if _score_row_value(row, "score_value") is not None
+    ]
+
+
+def _judge_title(score_rows: list[Any]) -> str:
+    values: list[str] = []
+    for row in _judge_rows(score_rows):
+        score_value = _score_row_value(row, "score_value")
+        values.append("n/a" if score_value is None else f"{float(score_value):.1f}")
+    return ", ".join(values) if values else "n/a"
+
+
+def letter_grade_for_score(score: float) -> tuple[str, str]:
+    for letter, lower, upper, color in constants.LETTER_GRADE_BANDS:
+        if lower <= score < upper:
+            return letter, color
+    return constants.LETTER_GRADE_BANDS[-1][0], constants.LETTER_GRADE_BANDS[-1][3]
+
+
+def judge_dissent(score_rows: list[Any], lane: str) -> bool:
+    if lane not in constants.PROSE_LANES:
+        return False
+    judge_scores = _parsed_judge_scores(score_rows)
+    if len(judge_scores) < 2:
+        return False
+    return max(judge_scores) - min(judge_scores) > constants.JUDGE_DISSENT_THRESHOLD
+
+
+def composite_score(score_rows: list[Any], lane: str) -> tuple[float, str, str]:
+    gate_component = _gate_component(score_rows)
+    parsed_judge_scores = _parsed_judge_scores(score_rows)
+
+    if lane in constants.MECHANICAL_LANES:
+        composite = gate_component
+    elif lane in constants.PROSE_LANES:
+        if parsed_judge_scores:
+            judge_component = sum(parsed_judge_scores) / len(parsed_judge_scores)
+            composite = (
+                constants.COMPOSITE_GATE_WEIGHT * gate_component
+                + constants.COMPOSITE_JUDGE_WEIGHT * judge_component
+            )
+        else:
+            composite = constants.COMPOSITE_GATE_WEIGHT * gate_component
+    else:
+        composite = gate_component
+
+    composite = max(0.0, min(10.0, composite))
+    letter, color = letter_grade_for_score(composite)
+    return composite, letter, color
+
+
+def _grade_summary(cells: list[CellSummary]) -> dict[str, Any] | None:
+    if not cells:
+        return None
+    score = sum(cell.composite for cell in cells) / len(cells)
+    letter, color = letter_grade_for_score(score)
+    return {"composite": score, "letter": letter, "color": color}
+
+
+def _lane_grades(cells: list[CellSummary]) -> list[LaneGrade]:
+    grouped: dict[str, list[CellSummary]] = defaultdict(list)
+    for cell in cells:
+        grouped[cell.lane].append(cell)
+
+    grades: list[LaneGrade] = []
+    for lane in LANES:
+        summary = _grade_summary(grouped.get(lane, []))
+        if summary is None:
+            continue
+        grades.append(
+            LaneGrade(
+                lane=lane,
+                composite=float(summary["composite"]),
+                letter=str(summary["letter"]),
+                color=str(summary["color"]),
+            )
+        )
+    return grades
+
+
+def _lane_model_summaries(cells: list[CellSummary]) -> list[LaneModelSummary]:
+    grouped: dict[str, list[CellSummary]] = defaultdict(list)
+    for cell in cells:
+        grouped[cell.canonical_string].append(cell)
+
+    summaries: list[LaneModelSummary] = []
+    for model in sorted(grouped):
+        summary = _grade_summary(grouped[model])
+        if summary is None:
+            continue
+        summaries.append(
+            LaneModelSummary(
+                canonical_string=model,
+                composite=float(summary["composite"]),
+                letter=str(summary["letter"]),
+                color=str(summary["color"]),
+                judge_dissent=any(cell.judge_dissent for cell in grouped[model]),
+            )
+        )
+    return summaries
+
+
+def _letter_grade_legend() -> list[dict[str, str]]:
+    legend = []
+    for letter, lower, upper, color in constants.LETTER_GRADE_BANDS:
+        if letter == "A":
+            band = f"{lower:.1f}+"
+        elif letter == "F":
+            band = f"<{upper:.1f}"
+        else:
+            band = f"{lower:.1f}-{upper:.1f}"
+        legend.append({"letter": letter, "band": band, "color": color})
+    return legend
+
+
+def _radar_context(cells: list[CellSummary]) -> dict[str, Any]:
+    size = 480.0
+    center = size / 2.0
+    outer_radius = 130.0
+    label_radius = 188.0
+    cells_by_lane: dict[str, list[CellSummary]] = defaultdict(list)
+    for cell in cells:
+        cells_by_lane[cell.lane].append(cell)
+    axis_count = len(LANES)
+
+    def point_for(index: int, radius: float) -> tuple[float, float]:
+        angle = -math.pi / 2 + (2 * math.pi * index / axis_count)
+        return center + radius * math.cos(angle), center + radius * math.sin(angle)
+
+    rings = []
+    for value in (2, 4, 6, 8, 10):
+        radius = outer_radius * value / 10.0
+        rings.append(
+            {
+                "value": value,
+                "points": " ".join(
+                    f"{x:.1f},{y:.1f}"
+                    for x, y in (point_for(index, radius) for index in range(axis_count))
+                ),
+            }
+        )
+
+    axes = []
+    polygon_points = []
+    for index, lane in enumerate(LANES):
+        summary = _grade_summary(cells_by_lane.get(lane, []))
+        composite = float(summary["composite"]) if summary else 0.0
+        letter = str(summary["letter"]) if summary else letter_grade_for_score(0.0)[0]
+        color = str(summary["color"]) if summary else letter_grade_for_score(0.0)[1]
+        axis_x, axis_y = point_for(index, outer_radius)
+        score_x, score_y = point_for(index, outer_radius * composite / 10.0)
+        label_x, label_y = point_for(index, label_radius)
+        cos_value = math.cos(-math.pi / 2 + (2 * math.pi * index / axis_count))
+        if cos_value < -0.35:
+            anchor = "end"
+            chip_x = label_x - 22.0
+        elif cos_value > 0.35:
+            anchor = "start"
+            chip_x = label_x + 4.0
+        else:
+            anchor = "middle"
+            chip_x = label_x + 16.0
+        chip_x = max(8.0, min(size - 28.0, chip_x))
+        chip_y = label_y + 3.0
+        axes.append(
+            {
+                "lane": lane,
+                "axis_x": axis_x,
+                "axis_y": axis_y,
+                "label_x": max(18.0, min(size - 18.0, label_x)),
+                "label_y": max(18.0, min(size - 18.0, label_y)),
+                "anchor": anchor,
+                "chip_x": chip_x,
+                "chip_y": chip_y,
+                "chip_text_x": chip_x + 10.0,
+                "chip_text_y": chip_y + 10.0,
+                "composite": composite,
+                "letter": letter,
+                "color": color,
+                "missing": summary is None,
+            }
+        )
+        polygon_points.append(f"{score_x:.1f},{score_y:.1f}")
+
+    return {
+        "axes": axes,
+        "rings": rings,
+        "polygon_points": " ".join(polygon_points),
+        "center": center,
+        "outer_radius": outer_radius,
+        "size": size,
+    }
 
 
 def _env() -> Environment:
@@ -90,22 +358,16 @@ def load_summaries_for_run(
     summaries: list[CellSummary] = []
     for cell in cells:
         cell_scores = score_rows[str(cell["cell_id"])]
-        deterministic = [
-            int(row["gate_pass"])
-            for row in cell_scores
-            if str(row["scorer"]) in DETERMINISTIC_SCORERS
-            and str(row["gate_name"]) != "human_spot_check"
-        ]
         llm = [
             float(row["score_value"])
             for row in cell_scores
             if str(row["scorer"]).startswith("llm-judge:")
             and row["score_value"] is not None
         ]
-        deterministic_score = (
-            sum(deterministic) / len(deterministic) if deterministic else 0.0
-        )
+        gate_component = _gate_component(cell_scores)
+        deterministic_score = gate_component / 10.0
         llm_score = sum(llm) / len(llm) if llm else None
+        composite, letter, color = composite_score(cell_scores, str(cell["lane"]))
         summaries.append(
             CellSummary(
                 cell_id=str(cell["cell_id"]),
@@ -118,6 +380,12 @@ def load_summaries_for_run(
                 effort_confidence=str(cell["effort_confidence"]),
                 deterministic_score=deterministic_score,
                 llm_score=llm_score,
+                composite=composite,
+                letter=letter,
+                color=color,
+                gate_pct=gate_component * 10.0,
+                judge_title=_judge_title(cell_scores),
+                judge_dissent=judge_dissent(cell_scores, str(cell["lane"])),
                 response_path=response_paths.get(str(cell["cell_id"])),
             )
         )
@@ -145,17 +413,29 @@ def _matrix_context(summaries: list[CellSummary]) -> dict[str, Any]:
     models = [model.canonical_string for model in ANCHORS]
     lanes = [lane for lane in LANES if any(cell.lane == lane for cell in summaries)]
     by_key = {(cell.lane, cell.canonical_string): cell for cell in summaries}
-    rows = [
-        {
-            "lane": lane,
-            "cells": [by_key.get((lane, model)) for model in models],
-        }
-        for lane in lanes
+    rows = []
+    for lane in lanes:
+        cells = [by_key.get((lane, model)) for model in models]
+        rows.append(
+            {
+                "lane": lane,
+                "cells": cells,
+                "summary": _grade_summary(
+                    [cell for cell in summaries if cell.lane == lane]
+                ),
+            }
+        )
+    model_summaries = [
+        _grade_summary([cell for cell in summaries if cell.canonical_string == model])
+        for model in models
     ]
     return {
         "lanes": lanes,
         "models": models,
         "rows": rows,
+        "model_summaries": model_summaries,
+        "overall_summary": _grade_summary(summaries),
+        "grade_legend": _letter_grade_legend(),
         "total_cells": len(summaries),
     }
 
@@ -188,16 +468,16 @@ def render_reports(
     per_lane_template = env.get_template("per_lane.html.j2")
     lanes = sorted({cell.lane for cell in summaries})
     for lane in lanes:
-        lane_cells = sorted(
-            [cell for cell in summaries if cell.lane == lane],
-            key=lambda cell: (cell.deterministic_score, cell.llm_score or 0.0),
+        lane_models = sorted(
+            _lane_model_summaries([cell for cell in summaries if cell.lane == lane]),
+            key=lambda cell: cell.composite,
             reverse=True,
         )
         path = out_dir / "per-lane" / f"{lane}.html"
         path.write_text(
             per_lane_template.render(
                 lane=lane,
-                cells=lane_cells,
+                cells=lane_models,
                 run_date=run_date,
             ),
             encoding="utf-8",
@@ -211,11 +491,24 @@ def render_reports(
             [cell for cell in summaries if cell.canonical_string == canonical_string],
             key=lambda cell: LANES.index(cell.lane),
         )
+        lane_grades = _lane_grades(model_cells)
+        strengths = sorted(
+            [grade for grade in lane_grades if grade.letter == "A"],
+            key=lambda grade: grade.composite,
+            reverse=True,
+        )
+        weaknesses = sorted(
+            [grade for grade in lane_grades if grade.letter == "F"],
+            key=lambda grade: grade.composite,
+        )
         path = out_dir / "per-model" / f"{_safe_filename(canonical_string)}.html"
         path.write_text(
             per_model_template.render(
                 canonical_string=canonical_string,
                 cells=model_cells,
+                radar=_radar_context(model_cells),
+                strengths=strengths,
+                weaknesses=weaknesses,
                 run_date=run_date,
             ),
             encoding="utf-8",

--- a/scripts/calibration/reports/templates/matrix.html.j2
+++ b/scripts/calibration/reports/templates/matrix.html.j2
@@ -8,21 +8,36 @@
   body { max-width: 1100px; margin: 0 auto; padding: 1.5rem 1.25rem 3rem; }
   h1 { margin-bottom: 0.25rem; }
   p.meta { color: #555; font-size: 0.9rem; margin-top: 0.1rem; }
+  .legend-panel { border:1px solid #d8dee4; background:#fbfcfd; padding:0.75rem 0.85rem; margin:0.9rem 0 1rem; border-radius:0.35rem; }
+  .legend-grades { display:flex; gap:0.45rem; flex-wrap:wrap; align-items:center; margin-bottom:0.45rem; }
+  .legend-grade { color:white; font-weight:700; border-radius:0.25rem; padding:0.22rem 0.55rem; font-size:0.84rem; }
+  .legend-copy { margin:0.15rem 0; color:#38424d; font-size:0.88rem; }
   table { width:100%; border-collapse: collapse; margin: 0.75rem 0 1.25rem; }
   th, td { border:1px solid #ddd; padding:0.35rem 0.55rem; font-size:0.88rem; vertical-align: top; }
   th { background:#f3f5f7; text-align:left; }
-  .score { display:block; font-weight:700; }
+  .score { display:block; font-weight:700; margin-top:0.2rem; }
   .missing { color:#777; background:#f7f7f7; }
   .heat-0 { background:#f8d7da; }
   .heat-1 { background:#fff3cd; }
   .heat-2 { background:#d1ecf1; }
   .heat-3 { background:#d4edda; }
+  .summary-cell { background:#f6f8fa; }
+  .summary-row th, .summary-row td { background:#f3f5f7; }
   a { color:#0b5cad; }
 </style>
 </head>
 <body>
 <h1>Calibration matrix</h1>
 <p class="meta">run_date={{ run_date }} · cells={{ total_cells }}</p>
+<div class="legend-panel">
+  <div class="legend-grades">
+    {% for grade in grade_legend %}
+    <span class="legend-grade" style="background:{{ grade.color }}">{{ grade.letter }} {{ grade.band }}</span>
+    {% endfor %}
+  </div>
+  <p class="legend-copy">Composite = 40% deterministic gates + 60% LLM judges (prose lanes); 100% gates (mechanical lanes).</p>
+  <p class="legend-copy">Hover any cell for the gate-ratio / judge1 / judge2 breakdown.</p>
+</div>
 <table>
   <thead>
     <tr>
@@ -30,6 +45,7 @@
       {% for model in models %}
       <th>{{ model }}</th>
       {% endfor %}
+      <th>Lane mean</th>
     </tr>
   </thead>
   <tbody>
@@ -41,15 +57,42 @@
           {% set bucket = 3 if cell.deterministic_score >= 0.95 else 2 if cell.deterministic_score >= 0.75 else 1 if cell.deterministic_score > 0 else 0 %}
           <td class="heat-{{ bucket }}" title="{{ cell.cell_id }}">
             <a href="per-model/{{ cell.canonical_string | replace('/', '_') | replace('@', '_') }}.html">{{ cell.canonical_string }}</a>
-            <span class="score">{{ "%.0f"|format(cell.deterministic_score * 100) }}%</span>
-            <span>judge {% if cell.llm_score is not none %}{{ "%.1f"|format(cell.llm_score) }}{% else %}n/a{% endif %}</span>
+            <span class="score">
+              <span class="cell-score grade-{{ cell.letter }}" style="background:{{ cell.color }};color:white;font-weight:600;padding:2px 6px;border-radius:3px;" title="gates={{ "%.0f"|format(cell.gate_pct) }}%, judges=[{{ cell.judge_title }}]">{{ "%.1f"|format(cell.composite) }} {{ cell.letter }}</span>{% if cell.judge_dissent %}<sup style="color:#856404;" title="judges disagreed">⚠</sup>{% endif %}
+            </span>
           </td>
         {% else %}
           <td class="missing">not run</td>
         {% endif %}
       {% endfor %}
+      <td class="summary-cell">
+        {% if row.summary %}
+        <span class="cell-score grade-{{ row.summary.letter }}" style="background:{{ row.summary.color }};color:white;font-weight:600;padding:2px 6px;border-radius:3px;" title="mean composite">{{ "%.1f"|format(row.summary.composite) }} {{ row.summary.letter }}</span>
+        {% else %}
+        n/a
+        {% endif %}
+      </td>
     </tr>
     {% endfor %}
+    <tr class="summary-row">
+      <th>Model mean</th>
+      {% for summary in model_summaries %}
+      <td>
+        {% if summary %}
+        <span class="cell-score grade-{{ summary.letter }}" style="background:{{ summary.color }};color:white;font-weight:600;padding:2px 6px;border-radius:3px;" title="mean composite">{{ "%.1f"|format(summary.composite) }} {{ summary.letter }}</span>
+        {% else %}
+        n/a
+        {% endif %}
+      </td>
+      {% endfor %}
+      <td>
+        {% if overall_summary %}
+        <span class="cell-score grade-{{ overall_summary.letter }}" style="background:{{ overall_summary.color }};color:white;font-weight:600;padding:2px 6px;border-radius:3px;" title="overall mean">{{ "%.1f"|format(overall_summary.composite) }} {{ overall_summary.letter }}</span>
+        {% else %}
+        n/a
+        {% endif %}
+      </td>
+    </tr>
   </tbody>
 </table>
 </body>

--- a/scripts/calibration/reports/templates/per_lane.html.j2
+++ b/scripts/calibration/reports/templates/per_lane.html.j2
@@ -12,6 +12,10 @@
   th, td { border:1px solid #ddd; padding:0.35rem 0.55rem; font-size:0.92rem; vertical-align: top; }
   th { background:#f3f5f7; text-align:left; }
   .pill { display:inline-block; padding:0.1rem 0.55rem; border-radius:0.35rem; font-size:0.78rem; font-weight:600; background:#e0e0ff; color:#1a1a8a; }
+  .bar-track { width:100%; min-width:14rem; height:1rem; background:#eceff3; border-radius:0.2rem; overflow:hidden; }
+  .bar-fill { height:100%; border-radius:0.2rem; }
+  .score-chip { color:white; font-weight:700; border-radius:0.25rem; padding:0.15rem 0.5rem; white-space:nowrap; }
+  .rank-star { color:#b77900; font-size:0.85rem; margin-left:0.3rem; }
 </style>
 </head>
 <body>
@@ -19,18 +23,18 @@
 <p class="meta">run_date={{ run_date }} · <a href="../matrix.html">matrix</a></p>
 <table>
   <thead>
-    <tr><th>Model</th><th>Fixture</th><th>Family</th><th>Effort</th><th>Deterministic</th><th>LLM judge</th><th>Response</th></tr>
+    <tr><th>Model</th><th>Composite</th><th>Grade</th></tr>
   </thead>
   <tbody>
     {% for cell in cells %}
     <tr>
-      <td>{{ cell.canonical_string }}</td>
-      <td>{{ cell.fixture_id }}</td>
-      <td>{{ cell.family }}</td>
-      <td><span class="pill">{{ cell.effort_requested }} / {{ cell.effort_confidence }}</span></td>
-      <td>{{ "%.0f"|format(cell.deterministic_score * 100) }}%</td>
-      <td>{% if cell.llm_score is not none %}{{ "%.1f"|format(cell.llm_score) }}{% else %}n/a{% endif %}</td>
-      <td>{% if cell.response_path %}{{ cell.response_path }}{% else %}n/a{% endif %}</td>
+      <td>{{ cell.canonical_string }}{% if loop.index <= 3 %}<span class="rank-star" title="top 3">⭐</span>{% endif %}</td>
+      <td>
+        <div class="bar-track" title="mean composite">
+          <div class="bar-fill" style="width:{{ "%.1f"|format(cell.composite * 10.0) }}%; background:{{ cell.color }};"></div>
+        </div>
+      </td>
+      <td><span class="score-chip" style="background:{{ cell.color }}">{{ "%.1f"|format(cell.composite) }} {{ cell.letter }}</span>{% if cell.judge_dissent %}<sup style="color:#856404;" title="one or more cells had judge disagreement">⚠</sup>{% endif %}</td>
     </tr>
     {% endfor %}
   </tbody>

--- a/scripts/calibration/reports/templates/per_model.html.j2
+++ b/scripts/calibration/reports/templates/per_model.html.j2
@@ -12,23 +12,77 @@
   th, td { border:1px solid #ddd; padding:0.35rem 0.55rem; font-size:0.92rem; vertical-align: top; }
   th { background:#f3f5f7; text-align:left; }
   .confidence { font-weight:700; }
+  .profile { display:grid; grid-template-columns:minmax(0, 1.15fr) minmax(16rem, 0.85fr); gap:1.25rem; align-items:start; margin-top:1rem; }
+  .radar-wrap { overflow-x:auto; }
+  .radar-svg { max-width:100%; height:auto; }
+  .radar-ring { fill:none; stroke:#d8dee4; stroke-width:1; }
+  .radar-axis { stroke:#ccd3da; stroke-width:1; }
+  .radar-label { font-size:10px; fill:#2f3a45; }
+  .radar-score { font-weight:700; fill:#1f2933; }
+  .tag-cloud { display:flex; gap:0.45rem; flex-wrap:wrap; margin:0.35rem 0 0.85rem; }
+  .tag { color:white; border-radius:0.3rem; padding:0.22rem 0.5rem; font-size:0.82rem; font-weight:700; }
+  .empty { color:#687380; font-size:0.9rem; }
+  .score-chip { color:white; font-weight:700; border-radius:0.25rem; padding:0.15rem 0.5rem; white-space:nowrap; }
+  @media (max-width: 760px) { .profile { grid-template-columns:1fr; } }
 </style>
 </head>
 <body>
 <h1>{{ canonical_string }}</h1>
 <p class="meta">run_date={{ run_date }} · <a href="../matrix.html">matrix</a></p>
+<section class="profile">
+  <div class="radar-wrap">
+    <svg class="radar-svg" width="420" height="420" viewBox="0 0 {{ radar.size }} {{ radar.size }}" role="img" aria-label="Composite score radar chart for {{ canonical_string }}">
+      {% for ring in radar.rings %}
+      <polygon class="radar-ring" points="{{ ring.points }}"></polygon>
+      {% endfor %}
+      {% for axis in radar.axes %}
+      <line class="radar-axis" x1="{{ radar.center }}" y1="{{ radar.center }}" x2="{{ "%.1f"|format(axis.axis_x) }}" y2="{{ "%.1f"|format(axis.axis_y) }}"></line>
+      {% endfor %}
+      <polygon points="{{ radar.polygon_points }}" fill="#0b5cad" fill-opacity="0.3" stroke="#0b5cad" stroke-width="2"></polygon>
+      {% for axis in radar.axes %}
+      <g>
+        <text class="radar-label" x="{{ "%.1f"|format(axis.label_x) }}" y="{{ "%.1f"|format(axis.label_y) }}" text-anchor="{{ axis.anchor }}">
+          <tspan x="{{ "%.1f"|format(axis.label_x) }}">{{ axis.lane }}</tspan>
+          <tspan class="radar-score" x="{{ "%.1f"|format(axis.label_x) }}" dy="12">{{ "%.1f"|format(axis.composite) }}</tspan>
+        </text>
+        <rect x="{{ "%.1f"|format(axis.chip_x) }}" y="{{ "%.1f"|format(axis.chip_y) }}" width="20" height="13" rx="2" fill="{{ axis.color }}"></rect>
+        <text x="{{ "%.1f"|format(axis.chip_text_x) }}" y="{{ "%.1f"|format(axis.chip_text_y) }}" text-anchor="middle" font-size="9" font-weight="700" fill="white">{{ axis.letter }}</text>
+      </g>
+      {% endfor %}
+    </svg>
+  </div>
+  <div>
+    <h2>Strengths</h2>
+    <div class="tag-cloud">
+      {% for cell in strengths %}
+      <span class="tag" style="background:{{ cell.color }}">{{ cell.lane }} {{ "%.1f"|format(cell.composite) }} {{ cell.letter }}</span>
+      {% else %}
+      <span class="empty">none</span>
+      {% endfor %}
+    </div>
+    <h2>Weaknesses</h2>
+    <div class="tag-cloud">
+      {% for cell in weaknesses %}
+      <span class="tag" style="background:{{ cell.color }}">{{ cell.lane }} {{ "%.1f"|format(cell.composite) }} {{ cell.letter }}</span>
+      {% else %}
+      <span class="empty">none</span>
+      {% endfor %}
+    </div>
+  </div>
+</section>
 <table>
   <thead>
-    <tr><th>Lane</th><th>Fixture</th><th>Deterministic</th><th>LLM judge</th><th>Confidence vs actual</th><th>Cell</th></tr>
+    <tr><th>Lane</th><th>Fixture</th><th>Composite</th><th>Deterministic</th><th>LLM judge</th><th>Confidence vs actual</th><th>Cell</th></tr>
   </thead>
   <tbody>
     {% for cell in cells %}
     <tr>
       <td><a href="../per-lane/{{ cell.lane }}.html">{{ cell.lane }}</a></td>
       <td>{{ cell.fixture_id }}</td>
+      <td><span class="score-chip" style="background:{{ cell.color }}">{{ "%.1f"|format(cell.composite) }} {{ cell.letter }}</span>{% if cell.judge_dissent %}<sup style="color:#856404;" title="judges disagreed">⚠</sup>{% endif %}</td>
       <td>{{ "%.0f"|format(cell.deterministic_score * 100) }}%</td>
       <td>{% if cell.llm_score is not none %}{{ "%.1f"|format(cell.llm_score) }}{% else %}n/a{% endif %}</td>
-      <td><span class="confidence">{{ cell.effort_confidence }}</span> effort signal vs {{ "%.0f"|format(cell.deterministic_score * 100) }}% deterministic</td>
+      <td><span class="confidence">{{ cell.effort_confidence }}</span> effort signal vs {{ "%.1f"|format(cell.composite) }} composite</td>
       <td>{{ cell.cell_id }}</td>
     </tr>
     {% endfor %}

--- a/tests/calibration/test_report.py
+++ b/tests/calibration/test_report.py
@@ -1,7 +1,27 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+import pytest
+
+from scripts.calibration import constants
 from scripts.calibration import report, schema
 from scripts.calibration.models import model_by_canonical
+
+
+def _score_row(
+    *,
+    scorer="deterministic",
+    gate_name="gate",
+    gate_pass=True,
+    score_value=1.0,
+):
+    return SimpleNamespace(
+        scorer=scorer,
+        gate_name=gate_name,
+        gate_pass=gate_pass,
+        score_value=score_value,
+    )
 
 
 def _insert_cell(db_path, lane, fixture_id, canonical, score):
@@ -29,6 +49,175 @@ def _insert_cell(db_path, lane, fixture_id, canonical, score):
             score_value=score,
         )
     return cell_id
+
+
+class TestComposite:
+    def test_mechanical_lane_all_pass_is_a(self):
+        composite, letter, _color = report.composite_score(
+            [_score_row(gate_pass=True, score_value=None)],
+            "code-writing",
+        )
+
+        assert composite == 10.0
+        assert letter == "A"
+
+    def test_mechanical_lane_half_pass_is_d(self):
+        composite, letter, _color = report.composite_score(
+            [
+                _score_row(gate_pass=True, score_value=None),
+                _score_row(gate_name="lint", gate_pass=False, score_value=None),
+            ],
+            "code-writing",
+        )
+
+        assert composite == 5.0
+        assert letter == "D"
+
+    def test_mechanical_lane_no_pass_is_f(self):
+        composite, letter, _color = report.composite_score(
+            [_score_row(gate_pass=False, score_value=None)],
+            "code-review",
+        )
+
+        assert composite == 0.0
+        assert letter == "F"
+
+    def test_prose_lane_blends_gates_and_judges(self):
+        composite, letter, _color = report.composite_score(
+            [
+                _score_row(gate_pass=True, score_value=1.0),
+                _score_row(
+                    scorer="llm-judge:one",
+                    gate_name="llm_judge_score",
+                    gate_pass=True,
+                    score_value=9.5,
+                ),
+                _score_row(
+                    scorer="llm-judge:two",
+                    gate_name="llm_judge_score",
+                    gate_pass=True,
+                    score_value=9.0,
+                ),
+            ],
+            "architecting",
+        )
+
+        assert composite == pytest.approx(9.55)
+        assert letter == "A"
+
+    def test_prose_lane_half_gates_and_mid_judges_is_d(self):
+        composite, letter, _color = report.composite_score(
+            [
+                _score_row(gate_pass=True, score_value=None),
+                _score_row(gate_name="lint", gate_pass=False, score_value=None),
+                _score_row(
+                    scorer="llm-judge:one",
+                    gate_name="judge_one",
+                    gate_pass=True,
+                    score_value=5.0,
+                ),
+                _score_row(
+                    scorer="llm-judge:two",
+                    gate_name="judge_two",
+                    gate_pass=True,
+                    score_value=5.0,
+                ),
+            ],
+            "content-writing-long",
+        )
+
+        assert composite == 5.0
+        assert letter == "D"
+
+    def test_prose_lane_unparseable_judges_is_gate_weight_penalized(self):
+        composite, letter, _color = report.composite_score(
+            [
+                _score_row(gate_pass=True, score_value=0.8),
+                _score_row(
+                    scorer="llm-judge:one",
+                    gate_name="judge_one",
+                    gate_pass=False,
+                    score_value=None,
+                ),
+                _score_row(
+                    scorer="llm-judge:two",
+                    gate_name="judge_two",
+                    gate_pass=False,
+                    score_value=None,
+                ),
+            ],
+            "summarization",
+        )
+
+        assert composite == pytest.approx(3.2)
+        assert letter == "F"
+
+    def test_judge_dissent_uses_mean_and_flags(self):
+        rows = [
+            _score_row(gate_pass=True, score_value=1.0),
+            _score_row(
+                scorer="llm-judge:one",
+                gate_name="judge_one",
+                gate_pass=True,
+                score_value=9.0,
+            ),
+            _score_row(
+                scorer="llm-judge:two",
+                gate_name="judge_two",
+                gate_pass=True,
+                score_value=6.5,
+            ),
+        ]
+
+        composite, letter, _color = report.composite_score(rows, "architecting")
+
+        assert composite == pytest.approx(8.65)
+        assert letter == "A"
+        assert report.judge_dissent(rows, "architecting") is True
+
+    def test_composite_clamps_to_ten(self):
+        composite, letter, _color = report.composite_score(
+            [
+                _score_row(gate_pass=True, score_value=1.0),
+                _score_row(
+                    scorer="llm-judge:one",
+                    gate_name="judge_one",
+                    gate_pass=True,
+                    score_value=20.0,
+                ),
+            ],
+            "architecting",
+        )
+
+        assert composite == 10.0
+        assert letter == "A"
+
+    def test_report_reads_constants_for_weights_and_grades(self, monkeypatch):
+        monkeypatch.setattr(constants, "COMPOSITE_GATE_WEIGHT", 1.0)
+        monkeypatch.setattr(constants, "COMPOSITE_JUDGE_WEIGHT", 0.0)
+        monkeypatch.setattr(
+            constants,
+            "LETTER_GRADE_BANDS",
+            [("Z", 0.0, 10.01, "#000000")],
+        )
+
+        composite, letter, color = report.composite_score(
+            [
+                _score_row(gate_pass=True, score_value=None),
+                _score_row(gate_name="lint", gate_pass=False, score_value=None),
+                _score_row(
+                    scorer="llm-judge:one",
+                    gate_name="judge_one",
+                    gate_pass=True,
+                    score_value=10.0,
+                ),
+            ],
+            "content-writing-long",
+        )
+
+        assert composite == 5.0
+        assert letter == "Z"
+        assert color == "#000000"
 
 
 def test_report_renders_matrix_per_lane_and_per_model(tmp_path):
@@ -70,8 +259,15 @@ def test_report_renders_matrix_per_lane_and_per_model(tmp_path):
     assert out_dir / "matrix.html" in written
     assert cell_id in matrix
     assert "code-writing" in matrix
-    assert "judge n/a" in matrix
+    assert 'class="cell-score grade-A"' in matrix
+    assert "10.0 A" in matrix
+    assert "gates=100%, judges=[n/a]" in matrix
+    assert "Lane mean" in matrix
+    assert "Model mean" in matrix
     assert "gpt-5.5" in per_lane
-    assert ">n/a</td>" in per_lane
+    assert "bar-fill" in per_lane
+    assert "⭐" in per_lane
+    assert "<svg" in per_model
+    assert "Strengths" in per_model
     assert "confidence vs actual" in per_model.lower()
     assert "total_cost=$0.0800" in index


### PR DESCRIPTION
Refs #1441 — render-layer change for human-readable benchmark reports.

Summary:
- Adds render-time composite scoring from existing score rows only; no SQLite schema or scorer changes.
- Mechanical lanes render 0-10 from deterministic gates; prose lanes render 40% deterministic gates + 60% parsed LLM judges, with gate-weight penalty when judges are unparseable.
- Adds configurable weights, grade bands, prose/mechanical lane sets, and judge dissent threshold in scripts/calibration/constants.py.
- Updates matrix cells to show colored composite/letter chips, hover gate/judge breakdowns, dissent markers, lane means, model means, and a grade legend.
- Updates per-lane pages to sorted model-level horizontal bars and per-model pages to inline 12-axis SVG radar charts with strengths/weaknesses tags.
- Documents the composite-score contract in docs/calibration/v1-spec.html.

Validation:
- .venv/bin/python -m pytest tests/calibration/ -x — 71 passed, 1 skipped
- .venv/bin/ruff check scripts/calibration/report.py scripts/calibration/constants.py tests/calibration/test_report.py — clean
- git diff --check — clean
- Rendered with .venv/bin/python -m scripts.calibration.report --db-path /Users/krisztiankoos/projects/kubedojo/calibration/v1/ledger.db --out-dir calibration/v1/reports/2026-05-21 --run-date 2026-05-21
- Inspected generated HTML for cell-score grade chips, 5.0 D/10.0 A examples, dissent markers, legend, per-lane bars, and per-model SVG radar. In-app browser backend was unavailable, so verification used direct HTML inspection.
- npm run build skipped: no src/content/docs or Astro config changes.

Diff budget:
- 7 files changed; 682 insertions, 35 deletions.
