### PR TITLE
fix(calibration): debugging-scorer ratio gates — phase 1.3 of benchmark trust arc (#1441)

### DIFF
--- a/scripts/calibration/score_cell.py
+++ b/scripts/calibration/score_cell.py
@@ -65,6 +65,14 @@ def _contains_any(text: str, terms: list[str]) -> bool:
     return any(term.lower() in lowered for term in terms)
 
 
+def _term_present(text: str, term: "str | dict[str, Any]") -> bool:
+    """Check if a term (flat string or alias-dict) appears in text."""
+    if isinstance(term, dict):
+        aliases = list(term.get("aliases", []))
+        return _contains_any(text, aliases) if aliases else False
+    return _contains_any(text, [term])
+
+
 def _word_count(text: str) -> int:
     return len(re.findall(r"\b[\w'-]+\b", text))
 
@@ -445,20 +453,68 @@ class OrchestratingScorer:
 
 
 class DebuggingScorer:
+    """Debugging-lane scoring with ratio gates instead of binary OR.
+
+    The v1 design used ``_contains_any`` on ``fix_terms`` and
+    ``root_cause_terms`` — a binary OR that fires on ANY single keyword hit.
+    A model that paraphrases ("zone mismatch" vs "topology mismatch") all-fails
+    even when the diagnosis is correct; one incidental keyword all-passes.
+    The ``broad_rewrite_terms`` gate had the same problem inverted: one
+    incidental mention of "delete the PVC" flipped ``minimal_patch`` to False.
+
+    v1.3 replaces all three binary gates with ratio gates (#1441 phase 1.3),
+    mirroring the ContentReviewScorer pattern from PR #1443:
+
+      - ``patch_targets_bug``: fraction of ``fix_terms`` hit (pass @
+        ≥ PATCH_TERM_RECALL_THRESHOLD = 0.5).
+      - ``root_cause_identified``: fraction of ``root_cause_terms`` hit (pass
+        @ ≥ ROOT_CAUSE_RECALL_THRESHOLD = 0.5).
+      - ``minimal_patch``: fraction of ``broad_rewrite_terms`` must be LOW
+        (pass @ ≤ BROAD_REWRITE_THRESHOLD = 0.25 — at most 1-in-4 broad-patch
+        signals present).
+
+    Each term entry can be a flat string or a dict with an ``aliases`` list;
+    ``_term_present`` handles both shapes.  ``tests_pass`` stays deterministic
+    from ``_run_optional_command``.  ``llm_judge_prompt`` returns ``None`` —
+    debugging is a mechanical lane; ratio recall IS truth per #1441.
+    """
+
+    PATCH_TERM_RECALL_THRESHOLD = 0.5
+    ROOT_CAUSE_RECALL_THRESHOLD = 0.5
+    BROAD_REWRITE_THRESHOLD = 0.25
+
     def deterministic_gates(
         self,
         response: str,
         ground_truth: dict[str, Any],
     ) -> dict[str, bool]:
-        patch_ok = _contains_any(response, list(ground_truth.get("fix_terms", [])))
-        root_cause_ok = _contains_any(response, list(ground_truth.get("root_cause_terms", [])))
-        broad_rewrite = _contains_any(response, list(ground_truth.get("broad_rewrite_terms", [])))
+        fix_terms = list(ground_truth.get("fix_terms", []))
+        if not fix_terms:
+            patch_ratio = 1.0
+        else:
+            found = sum(1 for t in fix_terms if _term_present(response, t))
+            patch_ratio = found / len(fix_terms)
+
+        root_terms = list(ground_truth.get("root_cause_terms", []))
+        if not root_terms:
+            root_ratio = 1.0
+        else:
+            found = sum(1 for t in root_terms if _term_present(response, t))
+            root_ratio = found / len(root_terms)
+
+        broad_terms = list(ground_truth.get("broad_rewrite_terms", []))
+        if not broad_terms:
+            broad_ratio = 0.0
+        else:
+            found = sum(1 for t in broad_terms if _term_present(response, t))
+            broad_ratio = found / len(broad_terms)
+
         test_result = _run_optional_command(ground_truth.get("pytest_command"))
         return {
-            "root_cause_identified": root_cause_ok,
-            "patch_targets_bug": patch_ok,
+            "root_cause_identified": root_ratio >= self.ROOT_CAUSE_RECALL_THRESHOLD,
+            "patch_targets_bug": patch_ratio >= self.PATCH_TERM_RECALL_THRESHOLD,
             "tests_pass": test_result,
-            "minimal_patch": not broad_rewrite,
+            "minimal_patch": broad_ratio <= self.BROAD_REWRITE_THRESHOLD,
         }
 
     def llm_judge_prompt(

--- a/tests/calibration/test_score_cell.py
+++ b/tests/calibration/test_score_cell.py
@@ -934,3 +934,86 @@ def test_fact_check_scorer_3_of_3_correct_passes():
     response = '[{"claim_id":"C1","verdict":"VERIFIED"},{"claim_id":"C2","verdict":"VERIFIED"},{"claim_id":"C3","verdict":"FALSE"}]'
     gates = score_cell.SCORERS["fact-check"].deterministic_gates(response, gt)
     assert gates["verdict_recall"] is True
+
+
+# ---------------------------------------------------------------------------
+# DebuggingScorer ratio-gate tests (v1.3 fix for #1441 phase 1.3)
+# ---------------------------------------------------------------------------
+
+
+def _debugging_gt() -> dict:
+    """Minimal ground truth: 4 fix terms, 4 root_cause terms, 4 broad_rewrite terms."""
+    return {
+        "fix_terms": ["fix-A", "fix-B", "fix-C", "fix-D"],
+        "root_cause_terms": ["root-A", "root-B", "root-C", "root-D"],
+        "broad_rewrite_terms": ["broad-A", "broad-B", "broad-C", "broad-D"],
+    }
+
+
+def test_debugging_scorer_all_terms_match_minimal_patch():
+    gt = _debugging_gt()
+    # 4/4 fix -> 1.0 >= 0.5; 4/4 root -> 1.0 >= 0.5; 0/4 broad -> 0.0 <= 0.25
+    response = "fix-A fix-B fix-C fix-D root-A root-B root-C root-D"
+    gates = score_cell.SCORERS["debugging"].deterministic_gates(response, gt)
+    assert gates["root_cause_identified"] is True
+    assert gates["patch_targets_bug"] is True
+    assert gates["minimal_patch"] is True
+
+
+def test_debugging_scorer_half_terms_match_at_threshold():
+    gt = _debugging_gt()
+    # 2/4 fix -> 0.5 >= 0.5 (passes exactly at threshold); 2/4 root -> 0.5 >= 0.5
+    response = "fix-A fix-B root-A root-B"
+    gates = score_cell.SCORERS["debugging"].deterministic_gates(response, gt)
+    assert gates["root_cause_identified"] is True
+    assert gates["patch_targets_bug"] is True
+
+
+def test_debugging_scorer_one_of_three_fails_recall():
+    gt = {
+        "fix_terms": ["fix-A", "fix-B", "fix-C"],
+        "root_cause_terms": ["root-A", "root-B", "root-C"],
+        "broad_rewrite_terms": [],
+    }
+    # 1/3 fix -> 0.333 < 0.5; 1/3 root -> 0.333 < 0.5
+    response = "fix-A and root-A only"
+    gates = score_cell.SCORERS["debugging"].deterministic_gates(response, gt)
+    assert gates["patch_targets_bug"] is False
+    assert gates["root_cause_identified"] is False
+
+
+def test_debugging_scorer_broad_rewrite_at_threshold():
+    gt = _debugging_gt()
+    # 1/4 broad -> 0.25 <= 0.25 (passes); plus full fix + root coverage
+    response = "fix-A fix-B fix-C fix-D root-A root-B root-C root-D broad-A"
+    gates = score_cell.SCORERS["debugging"].deterministic_gates(response, gt)
+    assert gates["minimal_patch"] is True
+
+
+def test_debugging_scorer_broad_rewrite_above_threshold_fails():
+    gt = _debugging_gt()
+    # 2/4 broad -> 0.5 > 0.25 -> minimal_patch=False
+    response = "fix-A fix-B fix-C fix-D root-A root-B root-C root-D broad-A broad-B"
+    gates = score_cell.SCORERS["debugging"].deterministic_gates(response, gt)
+    assert gates["minimal_patch"] is False
+
+
+def test_debugging_scorer_empty_term_lists_are_vacuous_pass():
+    gt = {"fix_terms": [], "root_cause_terms": [], "broad_rewrite_terms": []}
+    gates = score_cell.SCORERS["debugging"].deterministic_gates("any response", gt)
+    assert gates["patch_targets_bug"] is True
+    assert gates["root_cause_identified"] is True
+    assert gates["minimal_patch"] is True
+
+
+def test_debugging_scorer_alias_dict_term_shape():
+    """_term_present handles dict-with-aliases shape (forward-compat for richer fixtures)."""
+    gt = {
+        "fix_terms": [{"aliases": ["scaled up", "added replicas"]}, "patched"],
+        "root_cause_terms": ["misconfig"],
+        "broad_rewrite_terms": [],
+    }
+    response = "I scaled up the deployment and patched the misconfig"
+    gates = score_cell.SCORERS["debugging"].deterministic_gates(response, gt)
+    assert gates["patch_targets_bug"] is True  # both fix terms hit via aliases + flat
+    assert gates["root_cause_identified"] is True


### PR DESCRIPTION
## Summary

Closes the last gate-brittle lane (#1441 phase 1.3). Mirrors #1369 (code-review) and #1443 (content-review + fact-check).

**Three binary gates → three ratio gates** in `DebuggingScorer`:

| Gate | Old | New |
|------|-----|-----|
| `patch_targets_bug` | `_contains_any(fix_terms)` — passes on any single keyword | `fix_terms` recall ratio ≥ 0.5 |
| `root_cause_identified` | `_contains_any(root_cause_terms)` — passes on any single keyword | `root_cause_terms` recall ratio ≥ 0.5 |
| `minimal_patch` | `not _contains_any(broad_rewrite_terms)` — flips on any single mention | `broad_rewrite_terms` ratio ≤ 0.25 |

Thresholds live on the class as constants for cheap retuning. New `_term_present` helper handles both flat-string and dict-with-aliases ground-truth shapes (forward-compat for #1413 richer fixtures).

`tests_pass` stays deterministic via `_run_optional_command(pytest_command)`. `llm_judge_prompt` stays `None` — debugging is mechanical per #1441 ("ratio recall IS truth").

Regression test: tests/calibration/test_score_cell.py (7 new tests covering #1441 phase 1.3)

## Test plan

- [x] `.venv/bin/pytest tests/calibration/test_score_cell.py -q` — 48 passed (41 + 7 new)
- [x] `.venv/bin/ruff check scripts/calibration/score_cell.py tests/calibration/test_score_cell.py` — clean
- [x] 7 new tests covering all-pass / threshold-edge / recall-fail / broad-rewrite-fail / empty-term vacuous pass / alias-dict shape
- [x] Existing test_debugging_scorer_happy_path + test_debugging_topology_mismatch_recall still pass against the new gates (live fixtures have enough term coverage)
- [x] Sonnet cross-family review: APPROVE — math verified, no off-by-one, no scope creep, no neighbor regressions

## Notes

Re-scoring existing debugging-lane dispatches against the new gates is free since the lane is mechanical (no LLM judge re-fire). Closes Phase 1 of #1441 — all 12 lanes now have correct gates. Phase 2.1/2.2 (add LLM judges to ContentReview + FactCheck) is the next stage.