### PR TITLE
feat(calibration): llm judges for content-review + fact-check — phase 2 of benchmark trust arc (#1441)

### DIFF
--- a/scripts/calibration/constants.py
+++ b/scripts/calibration/constants.py
@@ -10,6 +10,8 @@ PROSE_LANES = frozenset(
         "summarization",
         "content-writing-long",
         "architecting",
+        "content-review",
+        "fact-check",
         "mcp-use",
         "harness-following",
     )
@@ -18,8 +20,6 @@ MECHANICAL_LANES = frozenset(
     (
         "code-writing",
         "code-review",
-        "content-review",
-        "fact-check",
         "debugging",
     )
 )

--- a/scripts/calibration/ground-truth/v1/content-review/flawed-module-rubric-review.yaml
+++ b/scripts/calibration/ground-truth/v1/content-review/flawed-module-rubric-review.yaml
@@ -23,3 +23,17 @@ hallucination_terms:
   - "PSA labels"
   - "container runtime"
 
+llm_rubric: |-
+  Return JSON: {"score": 0-10, "rationale": "..."}.
+
+  10 = caught all 8 planted flaws with correct severity and concrete
+       file:line evidence; no hallucinated flaws.
+  8  = caught most flaws (6-7/8); minor verdict/severity miscalibration;
+       no hallucinated flaws.
+  6  = caught half (4-5/8); some verdict reasoning weak; ≤1 hallucinated
+       flaw.
+  4  = caught a few (2-3/8); generic verdicts; multiple hallucinated
+       flaws.
+  2  = missed most planted flaws; review is mostly stylistic noise.
+  0  = approved with no findings, or generated entirely-hallucinated
+       review.

--- a/scripts/calibration/ground-truth/v1/fact-check/k8s-1-35-claims.yaml
+++ b/scripts/calibration/ground-truth/v1/fact-check/k8s-1-35-claims.yaml
@@ -13,3 +13,19 @@ claims:
     verdict: "FALSE"
   - claim_id: C5
     verdict: "FALSE"
+
+llm_rubric: |-
+  Return JSON: {"score": 0-10, "rationale": "..."}.
+
+  10 = all verdicts correct; every rationale cites primary-source URLs
+       (kubernetes.io docs, KEP, release notes); dates and versions are
+       specific.
+  8  = most verdicts correct; most rationales have URLs but some are
+       weak (blog posts, secondary sources); versions mostly specific.
+  6  = mixed verdicts; mixed citations; some "common knowledge" appeals
+       without sources.
+  4  = mostly wrong verdicts OR mostly unsourced rationales; vague
+       version claims.
+  2  = wrong verdicts and unsourced; citations don't actually support
+       the claim.
+  0  = no rationale, or rationale contradicts the verdict.

--- a/scripts/calibration/score_cell.py
+++ b/scripts/calibration/score_cell.py
@@ -35,6 +35,8 @@ PROSE_LANES: frozenset[str] = frozenset(
         # mcp-use / harness-following: ratio-gates can be keyword-gamed; judge unconditionally.
         "mcp-use",
         "harness-following",
+        "content-review",
+        "fact-check",
     },
 )
 
@@ -292,7 +294,19 @@ class ContentReviewScorer:
         response: str,
         ground_truth: dict[str, Any],
     ) -> str | None:
-        return None
+        return _judge_prompt(
+            "content-review",
+            response,
+            (
+                "Score the review's quality at distinguishing real flaws from "
+                "stylistic noise. Reward concrete file:line evidence, correct "
+                "flaw class attribution, and verdict severity that matches the "
+                "actual planted defect. Penalize generic 'looks good' verdicts, "
+                "hallucinated flaws not in the planted set, and missed flaws "
+                "of high severity."
+            ),
+            ground_truth,
+        )
 
 
 class FactCheckScorer:
@@ -341,7 +355,19 @@ class FactCheckScorer:
         response: str,
         ground_truth: dict[str, Any],
     ) -> str | None:
-        return None
+        return _judge_prompt(
+            "fact-check",
+            response,
+            (
+                "Score the rationale-grounding quality of partial-verdict cells. "
+                "Reward primary-source citations (project docs, RFCs, release "
+                "notes), specific dates/versions, and verdict reasoning that "
+                "tracks the actual claim. Penalize unsourced confidence, vague "
+                "'common knowledge' appeals, and citations that don't actually "
+                "support the verdict."
+            ),
+            ground_truth,
+        )
 
 
 class ArchitectingScorer:
@@ -949,6 +975,8 @@ JUDGE_TIMEOUTS_S: dict[str, int] = {
     "architecting": 180,
     "content-writing-long": 180,
     "refactoring": 180,
+    "content-review": 180,
+    "fact-check": 120,
 }
 DEFAULT_JUDGE_TIMEOUT_S = 180
 

--- a/tests/calibration/test_score_cell.py
+++ b/tests/calibration/test_score_cell.py
@@ -4,7 +4,7 @@ import json
 import subprocess
 from pathlib import Path
 
-from scripts.calibration import schema, score_cell
+from scripts.calibration import constants, schema, score_cell
 from scripts.calibration.models import model_by_canonical
 from scripts.calibration.run_cell import DispatchResult
 
@@ -1017,3 +1017,123 @@ def test_debugging_scorer_alias_dict_term_shape():
     gates = score_cell.SCORERS["debugging"].deterministic_gates(response, gt)
     assert gates["patch_targets_bug"] is True  # both fix terms hit via aliases + flat
     assert gates["root_cause_identified"] is True
+
+
+def test_content_review_scorer_llm_judge_prompt_is_set():
+    ground_truth = score_cell.load_ground_truth(
+        "content-review",
+        "flawed-module-rubric-review",
+    )
+    prompt = score_cell.SCORERS["content-review"].llm_judge_prompt("...", ground_truth)
+    assert isinstance(prompt, str)
+    assert prompt != ""
+
+
+def test_fact_check_scorer_llm_judge_prompt_is_set():
+    ground_truth = score_cell.load_ground_truth("fact-check", "k8s-1-35-claims")
+    prompt = score_cell.SCORERS["fact-check"].llm_judge_prompt("...", ground_truth)
+    assert isinstance(prompt, str)
+    assert prompt != ""
+
+
+def test_content_review_in_prose_lanes():
+    assert "content-review" in score_cell.PROSE_LANES
+    assert "content-review" in constants.PROSE_LANES
+    assert "content-review" not in constants.MECHANICAL_LANES
+
+
+def test_fact_check_in_prose_lanes():
+    assert "fact-check" in score_cell.PROSE_LANES
+    assert "fact-check" in constants.PROSE_LANES
+    assert "fact-check" not in constants.MECHANICAL_LANES
+
+
+def test_judge_timeouts_cover_new_lanes():
+    assert "content-review" in score_cell.JUDGE_TIMEOUTS_S
+    assert "fact-check" in score_cell.JUDGE_TIMEOUTS_S
+
+
+def test_score_cell_runs_judge_on_content_review_despite_gate_fail(tmp_path):
+    db_path, cell_id = _seed_cell(
+        tmp_path,
+        lane="content-review",
+        fixture_id="flawed-module-rubric-review",
+        response="No issues listed and no concrete evidence references.",
+    )
+    calls = []
+
+    def fake_judge_fn(model_name: str, prompt: str) -> str:
+        calls.append((model_name, prompt))
+        return json.dumps({"score": 8.0, "rationale": "pass"})
+
+    gates = score_cell.score_cell(
+        cell_id=cell_id,
+        db_path=db_path,
+        judge_fn=fake_judge_fn,
+        judge1="dummy-model-1",
+        judge2="dummy-model-2",
+    )
+    assert gates["finding_recall"] is False
+    assert len(calls) == 2
+
+    with schema.connect(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT gate_name, scorer, score_value, gate_failure_reason
+            FROM scores
+            WHERE cell_id = ?
+            ORDER BY gate_name, scorer
+            """,
+            (cell_id,),
+        ).fetchall()
+    deterministic_rows = [row for row in rows if row["scorer"] == "deterministic"]
+    judge_rows = [row for row in rows if str(row["scorer"]).startswith("llm-judge:")]
+    assert len(deterministic_rows) == 2
+    assert len(judge_rows) == 2
+    assert {row["gate_failure_reason"] for row in judge_rows} == {"gate_passed"}
+
+
+def test_score_cell_runs_judge_on_fact_check_despite_gate_fail(tmp_path):
+    db_path, cell_id = _seed_cell(
+        tmp_path,
+        lane="fact-check",
+        fixture_id="k8s-1-35-claims",
+        response=(
+            "[{\"claim_id\":\"C1\",\"verdict\":\"FALSE\"},"
+            "{\"claim_id\":\"C2\",\"verdict\":\"FALSE\"},"
+            "{\"claim_id\":\"C3\",\"verdict\":\"FALSE\"},"
+            "{\"claim_id\":\"C4\",\"verdict\":\"VERIFIED\"},"
+            "{\"claim_id\":\"C5\",\"verdict\":\"VERIFIED\"}]"
+        ),
+    )
+    calls = []
+
+    def fake_judge_fn(model_name: str, prompt: str) -> str:
+        calls.append((model_name, prompt))
+        return json.dumps({"score": 8.0, "rationale": "pass"})
+
+    gates = score_cell.score_cell(
+        cell_id=cell_id,
+        db_path=db_path,
+        judge_fn=fake_judge_fn,
+        judge1="dummy-model-1",
+        judge2="dummy-model-2",
+    )
+    assert gates["verdict_recall"] is False
+    assert len(calls) == 2
+
+    with schema.connect(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT gate_name, scorer, score_value, gate_failure_reason
+            FROM scores
+            WHERE cell_id = ?
+            ORDER BY gate_name, scorer
+            """,
+            (cell_id,),
+        ).fetchall()
+    deterministic_rows = [row for row in rows if row["scorer"] == "deterministic"]
+    judge_rows = [row for row in rows if str(row["scorer"]).startswith("llm-judge:")]
+    assert len(deterministic_rows) == 2
+    assert len(judge_rows) == 2
+    assert {row["gate_failure_reason"] for row in judge_rows} == {"gate_passed"}


### PR DESCRIPTION
## Summary

Phase 2.1 + 2.2 bundled (mirrors #1443 phase 1.1+1.2 bundling).

`ContentReviewScorer` and `FactCheckScorer` get `llm_judge_prompt` implementations focused on what the deterministic gates cannot judge:
- **content-review** — flaw-class semantics, verdict severity calibration, file:line evidence quality, hallucinated-finding rate
- **fact-check** — rationale grounding, primary-source citation quality, version/date specificity

Both lanes move from `MECHANICAL_LANES` → `PROSE_LANES` in both `score_cell.py` and `constants.py`. After this PR:
- **PROSE_LANES** (9): orchestrating, refactoring, summarization, content-writing-long, architecting, mcp-use, harness-following, content-review, fact-check
- **MECHANICAL_LANES** (3): code-writing, code-review, debugging

Per #1441 design: prose-lane judges fire unconditionally (gates are advisory); mechanical-lane judges only fire on gate-pass.

`JUDGE_TIMEOUTS_S` extended with content-review (180s) and fact-check (120s). Two ground-truth fixtures get `llm_rubric` blocks calibrated to the 0-10 composite-score letter-grade bands.

Regression test: tests/calibration/test_score_cell.py (7 new tests covering #1441 phases 2.1 + 2.2)

## Test plan

- [x] `.venv/bin/pytest tests/calibration/test_score_cell.py -q` — green (~54 tests)
- [x] `.venv/bin/ruff check scripts/calibration/score_cell.py scripts/calibration/constants.py tests/calibration/test_score_cell.py` — clean
- [x] Prose-lane set in `score_cell.py` and `constants.py` stay in sync (test guards both)
- [x] Mechanical-lane set is now exactly 3 (code-writing / code-review / debugging)
- [x] Existing `test_score_cell_mechanical_lane_skips_judge_when_gate_fails` updated if it parameterized over the moved lanes

## Notes

- No re-fire of historical content-review or fact-check dispatches needed in this PR — re-scoring against the new judge-fires-too design is a follow-up cell-by-cell run once the cascade is wired downstream.
- Phase 3 (fixture expansion across 6 solid lanes per #1413) and Phase 4 (gpt-5.5-xhigh judge3 on prose lanes, budget-permitting) remain open.
