### PR TITLE
feat(calibration): architecting lane +2 fixtures — phase 3.1 of benchmark trust arc (#1441)

### DIFF
--- a/scripts/calibration/ground-truth/v1/architecting/cascade-reviewer-tiebreak-policy.yaml
+++ b/scripts/calibration/ground-truth/v1/architecting/cascade-reviewer-tiebreak-policy.yaml
@@ -1,0 +1,27 @@
+# Fixture source: v1.1 spec lane 6, cascade reviewer tiebreak ADR. Phase 3 fixture #2 per #1441.
+fixture_id: cascade-reviewer-tiebreak-policy
+lane: architecting
+required_categories:
+  - "tiebreak policy"
+  - "third reviewer"
+  - "auto-block"
+  - "cross-family"
+  - "observability"
+  - "rollback"
+  - "metrics"
+  - "decision authority"
+  - "human override"
+novel_risk_terms:
+  - "correlated priors"
+  - "echo chamber"
+  - "single point of failure"
+llm_rubric: |-
+  Return JSON: {"score": 0-10, "rationale": "..."}.
+
+  Reward a clear choice between the 3 options with justified tradeoffs.
+  Reward concrete observability hooks (named metric, log line, or dashboard).
+  Reward a specific rollback path (env-var, config flag, or PR revert pattern).
+  Reward identifying that LLM agents have correlated priors (an auto-tiebreaker may not be independent).
+  Penalize indecisive "depends on" answers without a recommended default.
+  Penalize ignoring the rollback or observability acceptance points.
+

--- a/scripts/calibration/ground-truth/v1/architecting/dispatch-pipeline-scaling.yaml
+++ b/scripts/calibration/ground-truth/v1/architecting/dispatch-pipeline-scaling.yaml
@@ -1,0 +1,29 @@
+# Fixture source: v1.1 spec lane 6, dispatch pipeline scaling. Phase 3 fixture #3 per #1441.
+fixture_id: dispatch-pipeline-scaling
+lane: architecting
+required_categories:
+  - "codex weekly cap"
+  - "bottleneck"
+  - "throughput"
+  - "concurrency limit"
+  - "pilot rollout"
+  - "kill-switch"
+  - "failure budget"
+  - "scale-up gate"
+  - "cost ceiling"
+  - "review-stage queueing"
+novel_risk_terms:
+  - "noisy-neighbor"
+  - "weekly burnout"
+  - "rebase storms"
+llm_rubric: |-
+  Return JSON: {"score": 0-10, "rationale": "..."}.
+
+  Reward identifying the WEEKLY CAP (not per-minute rate) as the hard bottleneck.
+  Reward a SCOPED pilot (2-3 concurrent workers) before a full 5x rollout — explicit kill-switch and a single named scale-up gate (e.g., "ratio of clean-merge PRs ≥0.8 over 5 days").
+  Reward identifying review-stage queueing as a second bottleneck if parallel writers outrun the reviewer.
+  Reward naming failure-budget thinking (X% PR-revert rate triggers rollback).
+  Penalize "spin up 5 workers" answers that ignore the cap.
+  Penalize ignoring the review bottleneck.
+  Penalize hand-wavy "monitor and adjust" without concrete gates.
+

--- a/scripts/calibration/prompts/v1/architecting/cascade-reviewer-tiebreak-policy.md
+++ b/scripts/calibration/prompts/v1/architecting/cascade-reviewer-tiebreak-policy.md
@@ -1,0 +1,30 @@
+Create a decision-card / ADR for KubeDojo’s PR-review cascade when the primary review pair disagrees.
+
+Scenario:
+
+- Primary code reviewer (claude-sonnet-4-6) says APPROVE.
+- Cross-family reviewer (codex gpt-5.5) says NEEDS_CHANGES.
+- The current runtime tiebreak is informal and undocumented.
+
+Task:
+
+Choose one of the three designs and justify it:
+
+Option A — Auto-route to a third reviewer (cheapest quality-tier model such as agy/gemini-flash), then merge by majority vote.
+
+Option B — Block the PR automatically and require explicit human decision.
+
+Option C — Trust codex over in-family (use codex verdict as final decision).
+
+Write a crisp decision-card that names the selected option as the default policy and explains the tradeoffs in this specific workflow. Include a brief decision matrix, explicit failure modes, and the minimum viable implementation steps.
+
+Acceptance points for this fixture:
+
+1. Rollback path must be first-class: how do we disable or revert this policy if it causes incorrect approvals/blocks?
+2. Observability first-class: define a concrete metric (or named event) for how often tiebreak policy is triggered, and how to alert on it.
+3. Independence check: consider whether auto-tiebreakers share correlated priors with existing reviewers and what that implies for false-positive risk.
+4. Decision authority boundaries: what is allowed to auto-decline, what requires human approval, and when.
+5. Guardrails for "false-positive rate" and adverse behavior (e.g., repetitive auto-block loops).
+
+Output a **600–1200 word** decision-card in ADR style, with explicit recommended default and a one-paragraph rollback playbook.
+

--- a/scripts/calibration/prompts/v1/architecting/dispatch-pipeline-scaling.md
+++ b/scripts/calibration/prompts/v1/architecting/dispatch-pipeline-scaling.md
@@ -1,0 +1,29 @@
+Design a rollout plan for KubeDojo’s rewrite lane to target **100 modules/week** safely.
+
+Current constraints:
+
+- `dispatch_smart.py` currently runs one codex/sonnet dispatch at a time per task class.
+- Codex weekly subscription cost cap is roughly **$200/week effective** across pooled ChatGPT Plus + Pro.
+- Expected cost is about **$0.10–$0.30 per dispatch** and **~$0.05 per review**, or about **$0.20/module** total.
+- Wall-clock per module is **30–45 minutes** when running sequentially.
+
+Task:
+
+Create a concrete 500–1000 word capacity plan that answers:
+
+1. Whether spinning up five workers immediately is correct or dangerous in this system.
+2. Which system bottleneck is binding first at these constraints (include both writer and reviewer lanes).
+3. A scoped rollout plan for concurrency increase that protects reliability and quality while aiming toward the 100 modules/week target.
+4. Concrete gates and a kill-switch policy for stopping expansion if the rollout degrades.
+5. A failure budget and rollback trigger if review quality starts regressing.
+
+Required constraints:
+
+- This is a weekly-cap planning problem, not a raw RPS/per-minute tuning problem.
+- Include at least one **pilot with 2–3 concurrent workers** only.
+- Include a **named scale-up gate** (e.g., “clean merge ratio ≥ 0.8 over 5 rolling days”) and explicit thresholds.
+- Include a rollback action and an explicit kill-switch for concurrency changes.
+- Address **review-stage queueing** if writers outrun reviewers.
+
+Output a prioritized implementation plan, sequencing, and metrics stack (what to instrument, what to graph, and what fails the gate). End with a clear decision: why not full 5x rollout initially.
+


### PR DESCRIPTION
## Summary

Slice 1 of Phase 3 fixture expansion (#1441 phase 3 / #1413). Adds 2 architecting fixtures so per-model rankings in this lane no longer reduce to \"on the one fixture.\"

| Fixture | Variety dim | Acceptance bite |
|---|---|---|
| `cascade-reviewer-tiebreak-policy` | Decision card / ADR | Rollback path + observability metric must be first-class |
| `dispatch-pipeline-scaling` | Capacity planning | Must reject the over-broad rollout and scope the pilot |

4 new files (2 prompt md + 2 ground-truth yaml). Wave runner (`run_wave.py:LANE_FIXTURES`) still points to the existing fixture for backward compat — multi-fixture wave dispatch is a follow-up PR.

Regression test: yaml.safe_load validation in commit body (no new pytest needed — these are data files, not code).

## Test plan

- [x] All 3 architecting fixtures parse via `yaml.safe_load` with required fields (fixture_id, lane, required_categories, llm_rubric)
- [x] 3 prompt files exist in `scripts/calibration/prompts/v1/architecting/`
- [x] PLAN.md variety dimensions covered: RFC (existing) + decision card (cascade-reviewer-tiebreak-policy) + capacity planning (dispatch-pipeline-scaling)
- [x] PLAN.md acceptance criteria covered: rollback + observability (cascade fixture); over-broad-rejection + pilot-scoping (capacity fixture)

## What's NOT in this PR

- **Multi-fixture wave dispatch** — `run_wave.py:LANE_FIXTURES` still maps lane \u2192 ONE fixture. Re-firing the lane across all 14 models on the new fixtures requires that refactor + ~$0.50 in API spend. Separate PR.
- **Other 5 lane fixture expansions** — code-review, code-writing, content-review, content-writing-long, refactoring, summarization, orchestrating, etc. Each is its own PR per PLAN.md.

Closes #1441 phase 3 fixture slice 1/6.