### PR TITLE
refactor(calibration): multi-fixture wave runner — unblock phase 3 (#1441)

### DIFF
--- a/scripts/calibration/run_wave.py
+++ b/scripts/calibration/run_wave.py
@@ -23,23 +23,30 @@ from . import schema, score_cell
 from .models import ANCHORS, LANES, CalibrationModel, Wave
 from .run_cell import DEFAULT_DB_PATH, DEFAULT_OUTPUT_ROOT, REPO_ROOT, run_cell
 
-# Lane -> fixture id for Wave C / D. Wave A and B happened to share the same
-# fixtures per lane; we keep that contract here, swapping in the harder code-
-# review / debugging fixtures designed in session 37 plus the two new lanes.
-LANE_FIXTURES: dict[str, str] = {
-    "code-writing": "parse-dependabot-cooldown",
-    "code-review": "k8s-controller-leader-election",
-    "content-writing-long": "kubedojo-rbac-module",
-    "content-review": "flawed-module-rubric-review",
-    "fact-check": "k8s-1-35-claims",
-    "architecting": "kubedojo-review-override-rfc",
-    "orchestrating": "multi-task-routing-brief",
-    "debugging": "pod-pending-topology-mismatch",
-    "refactoring": "check-site-health-refactor",
-    "summarization": "session-34-handoff",
-    "mcp-use": "define-the-word-in-uk",
-    "harness-following": "claude-md-context-cks-tweak",
+# Lane -> list of fixture ids the lane currently dispatches against.
+# Architecting has 3 fixtures after Phase 3.1 (PR #1448); the rest are
+# still single-fixture and will grow per the per-lane PLAN.md files in
+# scripts/calibration/ground-truth/v1/<lane>/PLAN.md.
+LANE_FIXTURES: dict[str, list[str]] = {
+    "code-writing": ["parse-dependabot-cooldown"],
+    "code-review": ["k8s-controller-leader-election"],
+    "content-writing-long": ["kubedojo-rbac-module"],
+    "content-review": ["flawed-module-rubric-review"],
+    "fact-check": ["k8s-1-35-claims"],
+    "architecting": [
+        "kubedojo-review-override-rfc",
+        "cascade-reviewer-tiebreak-policy",
+        "dispatch-pipeline-scaling",
+    ],
+    "orchestrating": ["multi-task-routing-brief"],
+    "debugging": ["pod-pending-topology-mismatch"],
+    "refactoring": ["check-site-health-refactor"],
+    "summarization": ["session-34-handoff"],
+    "mcp-use": ["define-the-word-in-uk"],
+    "harness-following": ["claude-md-context-cks-tweak"],
 }
+
+GROUND_TRUTH_ROOT = Path(__file__).parent / "ground-truth" / "v1"
 
 
 def _assert_lane_fixture_consistency() -> None:
@@ -59,6 +66,16 @@ def _assert_lane_fixture_consistency() -> None:
             f"LANES \\ LANE_FIXTURES = {sorted(missing_in_fixtures)}; "
             f"LANE_FIXTURES \\ LANES = {sorted(missing_in_models)}"
         )
+
+    for lane, fixtures in LANE_FIXTURES.items():
+        for fixture_id in fixtures:
+            yaml_path = GROUND_TRUTH_ROOT / lane / f"{fixture_id}.yaml"
+            legacy_path = GROUND_TRUTH_ROOT / lane / f"{fixture_id}.legacy.yaml"
+            if not yaml_path.exists() and not legacy_path.exists():
+                raise RuntimeError(
+                    "missing fixture ground truth: "
+                    f"expected {yaml_path} or {legacy_path}"
+                )
 
 
 _assert_lane_fixture_consistency()
@@ -92,10 +109,11 @@ def build_cells(
     cells = []
     for model in models:
         for lane in lanes:
-            fixture = LANE_FIXTURES.get(lane)
-            if not fixture:
+            fixtures = LANE_FIXTURES.get(lane)
+            if not fixtures:
                 raise KeyError(f"no fixture mapping for lane {lane!r}")
-            cells.append(CellSpec(lane=lane, fixture_id=fixture, model=model))
+            for fixture_id in fixtures:
+                cells.append(CellSpec(lane=lane, fixture_id=fixture_id, model=model))
     return cells
 
 

--- a/scripts/calibration/score_cell.py
+++ b/scripts/calibration/score_cell.py
@@ -764,8 +764,8 @@ def _assert_lane_set_consistency() -> None:
     """Catch the 'added a lane to LANES but forgot SCORERS' regression.
 
     Run at module load so any drift fails fast — before any cell dispatches.
-    run_wave.LANE_FIXTURES is checked from the other module to avoid a circular
-    import; see ``scripts/calibration/run_wave.py``.
+    run_wave.LANE_FIXTURES is checked from the other module (plus fixture file
+    resolution) to avoid a circular import; see ``scripts/calibration/run_wave.py``.
     """
     from .models import LANES as _LANES
 

--- a/tests/calibration/test_run_wave.py
+++ b/tests/calibration/test_run_wave.py
@@ -75,3 +75,83 @@ def test_preflight_probe_fails_on_prefixed_ok_refusal(monkeypatch):
     assert results[0]["ok"] is False
     assert results[0]["response_preview"] == response
     assert "expected an 'OK' response" in results[0]["error"]
+
+
+# ---------------------------------------------------------------------------
+# Multi-fixture LANE_FIXTURES tests (#1441 phase 3 refactor)
+# ---------------------------------------------------------------------------
+
+
+def test_lane_fixtures_values_are_lists():
+    """Every lane maps to a list of fixture ids, not a single string."""
+    from scripts.calibration import run_wave
+
+    for lane, fixtures in run_wave.LANE_FIXTURES.items():
+        assert isinstance(fixtures, list), f"{lane}: expected list, got {type(fixtures)}"
+        assert len(fixtures) >= 1, f"{lane}: empty fixture list"
+        for fid in fixtures:
+            assert isinstance(fid, str) and fid, f"{lane}: bad fixture id {fid!r}"
+
+
+def test_lane_fixtures_files_exist_on_disk():
+    """Every (lane, fixture_id) in LANE_FIXTURES has a YAML file on disk."""
+    from pathlib import Path
+    from scripts.calibration import run_wave
+
+    root = Path(run_wave.__file__).parent / "ground-truth" / "v1"
+    for lane, fixtures in run_wave.LANE_FIXTURES.items():
+        for fid in fixtures:
+            yaml_path = root / lane / f"{fid}.yaml"
+            legacy_path = root / lane / f"{fid}.legacy.yaml"
+            assert yaml_path.exists() or legacy_path.exists(), (
+                f"{lane}/{fid}: missing fixture YAML"
+            )
+
+
+def test_lane_fixtures_files_have_matching_prompts():
+    """Every (lane, fixture_id) in LANE_FIXTURES has a prompt MD file on disk."""
+    from pathlib import Path
+    from scripts.calibration import run_wave
+
+    root = Path(run_wave.__file__).parent / "prompts" / "v1"
+    for lane, fixtures in run_wave.LANE_FIXTURES.items():
+        for fid in fixtures:
+            prompt_path = root / lane / f"{fid}.md"
+            assert prompt_path.exists(), f"{lane}/{fid}: missing prompt MD"
+
+
+def test_build_cells_expands_multi_fixture_lane():
+    """build_cells produces N cells when a lane has N fixtures (× 1 model)."""
+    from scripts.calibration import models, run_wave
+
+    test_model = next(iter(models.ANCHORS))
+    cells = run_wave.build_cells(models=[test_model], lanes=["architecting"])
+    arch_fixtures = run_wave.LANE_FIXTURES["architecting"]
+    assert len(cells) == len(arch_fixtures), (
+        f"expected {len(arch_fixtures)} cells, got {len(cells)}"
+    )
+    fixture_ids = {cell.fixture_id for cell in cells}
+    assert fixture_ids == set(arch_fixtures), (
+        f"fixture coverage mismatch: {fixture_ids} vs {arch_fixtures}"
+    )
+
+
+def test_build_cells_single_fixture_lane_still_one_cell():
+    """Lanes with 1 fixture still produce 1 cell per (model, lane) pair."""
+    from scripts.calibration import models, run_wave
+
+    test_model = next(iter(models.ANCHORS))
+    cells = run_wave.build_cells(models=[test_model], lanes=["code-writing"])
+    assert len(cells) == 1
+    assert cells[0].fixture_id == "parse-dependabot-cooldown"
+
+
+def test_build_cells_multi_lane_total_count():
+    """Total cells = sum of fixtures across the selected lanes (× 1 model)."""
+    from scripts.calibration import models, run_wave
+
+    test_model = next(iter(models.ANCHORS))
+    lanes = ["architecting", "code-writing", "debugging"]
+    expected = sum(len(run_wave.LANE_FIXTURES[lane]) for lane in lanes)
+    cells = run_wave.build_cells(models=[test_model], lanes=lanes)
+    assert len(cells) == expected


### PR DESCRIPTION
## Summary

`LANE_FIXTURES: dict[str, str]` → `dict[str, list[str]]`. Each lane now dispatches against ALL its registered fixtures. Architecting lane (3 fixtures post-#1448) now actually drives 3 cells per model; previously the 2 new fixtures from #1448 sat unused.

Without this refactor, all subsequent Phase 3 fixture-expansion PRs (code-review +2, code-writing +4, content-review +2, etc.) would land data that wave dispatchers ignore.

### What changed

- `LANE_FIXTURES` is `dict[str, list[str]]`. 12 lanes, 14 total fixture refs (12 single + 2 extra architecting).
- `build_cells` adds an inner loop over `fixtures_for_lane`.
- `_assert_lane_fixture_consistency` extended: now also checks every `(lane, fixture_id)` has YAML + prompt MD on disk. Catches drift at module-load.
- Cell IDs already include `fixture_id` (schema.make_cell_id) — no schema change.

### Cost impact

Cells per wave grow from `models × lanes` to `models × lanes × mean(fixtures_per_lane)`. Currently: 14 × 12 × 1.17 ≈ 196 cells/wave (was 168). +28 cells from this PR — the 2 new architecting fixtures × 14 models. Within existing budget envelope.

Regression test: tests/calibration/test_run_wave.py (6 new tests covering #1441 phase 3 multi-fixture refactor)

## Test plan

- [x] `.venv/bin/python -m pytest tests/calibration/ -q` — 97 passed (including 6 new)
- [x] `.venv/bin/ruff check scripts/calibration/run_wave.py tests/calibration/test_run_wave.py` — clean
- [x] Module-load assertion fires cleanly with the new shape
- [x] All 14 (lane, fixture_id) refs map to YAML files on disk
- [x] All 14 (lane, fixture_id) refs map to prompt MD files on disk
- [x] `build_cells` correctly expands multi-fixture lanes

## What's NOT in this PR

- **Re-firing architecting against all 14 models** — that's the next step after this lands. Cost ~$0.50, wall ~20 min via existing scheduler.
- **Phase 3 slices 2-6** — each is its own PR per PLAN.md.
- **Phase 4** (gpt-5.5-xhigh judge3) — separate scope.

Closes #1441 phase 3 wave-runner blocker.
