### PR TITLE
fix(calibration): enforce 1-fixture-per-model-per-wave rule (#1450)

### DIFF
--- a/scripts/calibration/run_wave.py
+++ b/scripts/calibration/run_wave.py
@@ -105,6 +105,7 @@ def build_cells(
     *,
     models: Iterable[CalibrationModel],
     lanes: Iterable[str],
+    fixture_filter: str | None = None,
 ) -> list[CellSpec]:
     cells = []
     for model in models:
@@ -113,6 +114,8 @@ def build_cells(
             if not fixtures:
                 raise KeyError(f"no fixture mapping for lane {lane!r}")
             for fixture_id in fixtures:
+                if fixture_filter is not None and fixture_id != fixture_filter:
+                    continue
                 cells.append(CellSpec(lane=lane, fixture_id=fixture_id, model=model))
     return cells
 
@@ -357,6 +360,16 @@ def build_parser() -> argparse.ArgumentParser:
         default=list(LANES),
         help=f"Lanes to dispatch (default: all {len(LANES)} lanes).",
     )
+    parser.add_argument(
+        "--fixture",
+        help=(
+            "When given, restrict the wave to this single fixture id within "
+            "the selected lane(s). REQUIRED when any selected lane has more "
+            "than 1 fixture in LANE_FIXTURES, per the 1-fixture-per-model-"
+            "per-wave rule (memory: feedback_one_fixture_per_model_per_wave)."
+        ),
+        default=None,
+    )
     parser.add_argument("--run-date", help="ISO date for the cell rows.")
     parser.add_argument("--db-path", type=Path, default=DEFAULT_DB_PATH)
     parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
@@ -394,6 +407,48 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _validate_fixture_arg(
+    args: argparse.Namespace,
+    lanes: Iterable[str],
+) -> tuple[bool, str]:
+    """Enforce 1-fixture-per-model-per-wave rule.
+
+    Returns (ok, error_message). When ok=False, main() exits 2 with the
+    message. Rule: if any selected lane has more than 1 fixture mapped,
+    --fixture MUST be passed to pin the wave to a single fixture.
+    """
+    if args.fixture is None:
+        offending: list[tuple[str, list[str]]] = []
+        for lane in lanes:
+            fixtures = LANE_FIXTURES.get(lane, [])
+            if len(fixtures) > 1:
+                offending.append((lane, fixtures))
+        if offending:
+            lines = [
+                (
+                    "error: 1-fixture-per-model-per-wave rule: the following "
+                    "lane(s) have multiple fixtures and require --fixture <id>:"
+                )
+            ]
+            for lane, fixtures in offending:
+                lines.append(f"  - {lane}: {', '.join(fixtures)}")
+            lines.append(
+                "  Pick one fixture per wave run; run the wave N times for "
+                "N fixtures. Memory: feedback_one_fixture_per_model_per_wave."
+            )
+            return False, "\n".join(lines)
+        return True, ""
+
+    for lane in lanes:
+        fixtures = LANE_FIXTURES.get(lane, [])
+        if args.fixture not in fixtures:
+            return False, (
+                f"error: --fixture {args.fixture!r} is not registered for "
+                f"lane {lane!r}. Valid: {', '.join(fixtures)}"
+            )
+    return True, ""
+
+
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     run_date = args.run_date or schema.today_iso()
@@ -409,8 +464,16 @@ def main(argv: list[str] | None = None) -> int:
     if not models:
         print("error: no models matched the filter", file=sys.stderr)
         return 2
+    ok, err = _validate_fixture_arg(args, args.lanes)
+    if not ok:
+        print(err, file=sys.stderr)
+        return 2
 
-    cells = build_cells(models=models, lanes=args.lanes)
+    cells = build_cells(
+        models=models,
+        lanes=args.lanes,
+        fixture_filter=args.fixture,
+    )
     if args.smoke:
         cells = cells[:1]
     if not cells:

--- a/tests/calibration/test_run_wave.py
+++ b/tests/calibration/test_run_wave.py
@@ -155,3 +155,135 @@ def test_build_cells_multi_lane_total_count():
     expected = sum(len(run_wave.LANE_FIXTURES[lane]) for lane in lanes)
     cells = run_wave.build_cells(models=[test_model], lanes=lanes)
     assert len(cells) == expected
+
+
+# ---------------------------------------------------------------------------
+# --fixture CLI enforcement (#1450) — 1-fixture-per-model-per-wave rule
+# ---------------------------------------------------------------------------
+
+
+def test_main_rejects_multi_fixture_lane_without_fixture_arg(capsys):
+    """Running --lanes architecting (3 fixtures) without --fixture must exit 2."""
+    from scripts.calibration import run_wave
+
+    rc = run_wave.main(
+        [
+            "--wave", "A",
+            "--lanes", "architecting",
+            "--skip-preflight",
+            "--no-render",
+            "--no-score",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 2, f"expected exit 2, got {rc}"
+    assert "1-fixture-per-model-per-wave" in captured.err
+    assert "architecting" in captured.err
+
+
+def test_main_accepts_single_fixture_lane_without_fixture_arg(monkeypatch):
+    """--lanes code-writing (1 fixture) without --fixture remains backward-compatible.
+
+    Stub _dispatch_one to avoid an actual model dispatch — we're only proving
+    the validation gate doesn't reject this shape.
+    """
+    from scripts.calibration import run_wave
+
+    calls: list[run_wave.CellSpec] = []
+
+    def fake_dispatch(spec, **_kwargs):
+        calls.append(spec)
+        return {
+            "ok": True,
+            "cell_id": "fake",
+            "lane": spec.lane,
+            "model": spec.model.canonical_string,
+            "family": spec.model.family,
+            "replicate_seq": 0,
+            "elapsed_s": 0.0,
+            "scored": False,
+        }
+
+    monkeypatch.setattr(run_wave, "_dispatch_one", fake_dispatch)
+    monkeypatch.setattr(run_wave, "preflight_probe", lambda cells: [{"ok": True} for _ in cells])
+    rc = run_wave.main(
+        [
+            "--wave", "A",
+            "--lanes", "code-writing",
+            "--no-render",
+            "--no-score",
+            "--smoke",
+        ]
+    )
+    assert rc == 0, f"expected exit 0, got {rc}"
+    assert len(calls) >= 1
+    assert all(c.fixture_id == "parse-dependabot-cooldown" for c in calls)
+
+
+def test_main_accepts_multi_fixture_lane_with_fixture_arg(monkeypatch):
+    """--lanes architecting --fixture <id> dispatches only that fixture."""
+    from scripts.calibration import run_wave
+
+    calls: list[run_wave.CellSpec] = []
+
+    def fake_dispatch(spec, **_kwargs):
+        calls.append(spec)
+        return {
+            "ok": True,
+            "cell_id": "fake",
+            "lane": spec.lane,
+            "model": spec.model.canonical_string,
+            "family": spec.model.family,
+            "replicate_seq": 0,
+            "elapsed_s": 0.0,
+            "scored": False,
+        }
+
+    monkeypatch.setattr(run_wave, "_dispatch_one", fake_dispatch)
+    monkeypatch.setattr(run_wave, "preflight_probe", lambda cells: [{"ok": True} for _ in cells])
+    rc = run_wave.main(
+        [
+            "--wave", "A",
+            "--lanes", "architecting",
+            "--fixture", "cascade-reviewer-tiebreak-policy",
+            "--no-render",
+            "--no-score",
+            "--smoke",
+        ]
+    )
+    assert rc == 0, f"expected exit 0, got {rc}"
+    assert all(c.fixture_id == "cascade-reviewer-tiebreak-policy" for c in calls)
+
+
+def test_main_rejects_unknown_fixture_id(capsys):
+    """--fixture id that isn't in LANE_FIXTURES[lane] must exit 2 with a clear error."""
+    from scripts.calibration import run_wave
+
+    rc = run_wave.main(
+        [
+            "--wave", "A",
+            "--lanes", "architecting",
+            "--fixture", "does-not-exist",
+            "--no-render",
+            "--no-score",
+            "--smoke",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "does-not-exist" in captured.err
+    assert "Valid:" in captured.err
+
+
+def test_build_cells_filter_param_filters_fixtures():
+    """build_cells with fixture_filter restricts to a single fixture per lane."""
+    from scripts.calibration import models, run_wave
+
+    test_model = next(iter(models.ANCHORS))
+    cells = run_wave.build_cells(
+        models=[test_model],
+        lanes=["architecting"],
+        fixture_filter="kubedojo-review-override-rfc",
+    )
+    assert len(cells) == 1
+    assert cells[0].fixture_id == "kubedojo-review-override-rfc"


### PR DESCRIPTION
## Summary

Closes #1450. Enforces the 1-fixture-per-model-per-wave calibration rule deterministically in `run_wave.py`.

PR #1449 added the multi-fixture wave runner (`LANE_FIXTURES: dict[str, list[str]]`) but the runner then silently expanded a lane to ALL its fixtures in one invocation. Per user rule (memory: `feedback_one_fixture_per_model_per_wave`, TOP PRIORITY), each wave run dispatches at most 1 fixture per model.

### Behavior change

| Invocation | Before | After |
|---|---|---|
| `--lanes architecting` (3 fixtures) | 42 cells dispatched | Exit 2 with named error |
| `--lanes architecting --fixture <id>` | (flag didn't exist) | 14 cells (1 fixture × 14 models) |
| `--lanes code-writing` (1 fixture) | 14 cells | 14 cells (unchanged) |
| `--lanes architecting --fixture <bogus>` | (flag didn't exist) | Exit 2 with "Valid: ..." error |

### Error message shape

```
error: 1-fixture-per-model-per-wave rule: the following lane(s) have multiple fixtures and require --fixture <id>:
  - architecting: kubedojo-review-override-rfc, cascade-reviewer-tiebreak-policy, dispatch-pipeline-scaling
  Pick one fixture per wave run; run the wave N times for N fixtures. Memory: feedback_one_fixture_per_model_per_wave.
```

Regression test: tests/calibration/test_run_wave.py (5 new tests covering the enforcement gate)

## Test plan

- [x] `.venv/bin/python -m pytest tests/calibration/ -q` — 108 passed (103 + 5)
- [x] `.venv/bin/python -m ruff check scripts/calibration/run_wave.py tests/calibration/test_run_wave.py` — clean
- [x] CLI smoke: `python -m scripts.calibration.run_wave --wave A --lanes architecting --no-render --no-score --smoke` exits 2 with rule error (no model dispatch fires)
- [x] CLI smoke with --fixture: same command + `--fixture cascade-reviewer-tiebreak-policy` proceeds to preflight

## Notes

- The 42 cells from the rule-violating sweep that prompted this PR are still in the ledger and remain valid data points (model dispatches are stateless — order doesn't change responses). Only the scheduling was wrong, not the data.
- Single-fixture lanes (11 of 12 currently) are backward-compatible.
- Phase 3 fixture-expansion workflow now: land prompts + ground-truth YAML in one PR, fire each fixture as its OWN `--fixture <id>` wave run (14 cells each).
