### PR TITLE
feat(calibration): code-review lane +2 fixtures — phase 3.2 (#1441)

### DIFF
--- a/scripts/calibration/ground-truth/v1/code-review/python-cache-ttl-fix-with-regression.yaml
+++ b/scripts/calibration/ground-truth/v1/code-review/python-cache-ttl-fix-with-regression.yaml
@@ -1,0 +1,52 @@
+# Fixture source: v1.1 spec lane 2, Python cache TTL "fix" introducing falsy-collision regression.
+# Fixture 3 of phase 3.2, targeting bugfix archetype coverage.
+fixture_id: python-cache-ttl-fix-with-regression
+lane: code-review
+findings:
+  - id: F1
+    aliases:
+      - "falsy"
+      - "not value"
+      - "empty string"
+      - "zero is cached"
+      - "treats 0 as missing"
+      - "[] as missing"
+  - id: F2
+    aliases:
+      - "test doesn't cover"
+      - "missing test for empty values"
+      - "no falsy test"
+      - "test only covers None"
+      - "regression not exercised"
+  - id: F3
+    aliases:
+      - "off-by-one"
+      - "<= vs <"
+      - "inclusive comparison"
+      - "boundary expiration"
+      - "ttl boundary"
+  - id: F4
+    aliases:
+      - "deepcopy"
+      - "shared reference"
+      - "mutable cache object"
+      - "caller can mutate cache"
+      - "removed copy"
+      - "data corruption"
+  - id: F5
+    aliases:
+      - "lock"
+      - "held too long"
+      - "long critical section"
+      - "critical section during compute"
+      - "lock during compute"
+      - "latency regression"
+hallucination_terms:
+  - "SQL injection"
+  - "XSS"
+  - "CSRF"
+  - "buffer overflow"
+  - "memory corruption"
+  - "race condition on the GIL"
+  - "deadlock on the asyncio loop"
+  - "missing TLS verification"

--- a/scripts/calibration/ground-truth/v1/code-review/typescript-event-emitter-refactor-with-contract-break.yaml
+++ b/scripts/calibration/ground-truth/v1/code-review/typescript-event-emitter-refactor-with-contract-break.yaml
@@ -1,0 +1,51 @@
+# Fixture source: v1.1 spec lane 2, EventEmitter refactor with contract break.
+# Fixture 4 of phase 3.2, targeting refactor archetype coverage.
+fixture_id: typescript-event-emitter-refactor-with-contract-break
+lane: code-review
+findings:
+  - id: F1
+    aliases:
+      - "pre-handler removal"
+      - "remove before callback"
+      - "resubscribe timing"
+      - "once cleanup before call"
+      - "listener removed too early"
+  - id: F2
+    aliases:
+      - "error bubbles"
+      - "throws out of emit"
+      - "missing try catch"
+      - "no error isolation"
+      - "silent failure removed"
+  - id: F3
+    aliases:
+      - "EventHandler"
+      - "exported type renamed"
+      - "no alias"
+      - "breaking API rename"
+      - "no compatibility type"
+      - "handler type changed"
+  - id: F4
+    aliases:
+      - "resubscribe test removed"
+      - "deleted once resubscribe test"
+      - "test deleted"
+      - "test was removed"
+      - "coverage gap"
+  - id: F5
+    aliases:
+      - "listeners mutated during emit"
+      - "subscribeOnce helper"
+      - "mutated list"
+      - "index-based emit loop"
+      - "reentrant emit"
+      - "iteration over live array"
+hallucination_terms:
+  - "memory leak"
+  - "prototype pollution"
+  - "race condition"
+  - "promise rejection swallowed"
+  - "this-binding leak"
+  - "circular reference"
+  - "stack overflow"
+  - "regex catastrophic backtracking"

--- a/scripts/calibration/prompts/v1/code-review/python-cache-ttl-fix-with-regression.md
+++ b/scripts/calibration/prompts/v1/code-review/python-cache-ttl-fix-with-regression.md
@@ -1,0 +1,123 @@
+Review this Python diff from a cache-layer change. Output one finding per line with:
+
+- file:line citation
+- classification: `correctness`, `concurrency`, `resource-leak`, or `style`
+- concise rationale grounded only in the diff
+
+Unsupported claims count as hallucinations. Do not claim a finding unless the diff
+directly supports it.
+
+```diff
+diff --git a/src/cache.py b/src/cache.py
+@@
+ import threading
+ import time
+ from typing import Callable, TypeVar
+-import copy
+ 
+ K = TypeVar("K")
+ V = TypeVar("V")
+ 
+ 
+ class TTLCache:
+     def __init__(self, default_ttl: float = 30.0):
+         self._values: dict[K, V] = {}
+         self._expires: dict[K, float] = {}
+         self._lock = threading.Lock()
+         self._ttl = default_ttl
+ 
+     def _now(self) -> float:
+         return time.monotonic()
+ 
+     def get(self, key: K) -> V | None:
+         with self._lock:
+             value = self._values.get(key)
+-            if value is None:
++            if not value:
+                 return None
+ 
+             expiry = self._expires.get(key)
+-            if expiry is None or expiry < self._now():
++            if expiry is None or expiry <= self._now():
+                 self._values.pop(key, None)
+                 self._expires.pop(key, None)
+                 return None
+-            return copy.deepcopy(value)
++            return value
+ 
+     def set(self, key: K, value: V) -> None:
+         with self._lock:
+-            self._values[key] = copy.deepcopy(value)
++            self._values[key] = value
+             self._expires[key] = self._now() + self._ttl
+ 
+     def get_or_compute(self, key: K, loader: Callable[[K], V]) -> V:
+-        value = self.get(key)
+-        if value is None:
+-            value = loader(key)
+-            self.set(key, value)
+-        return value
++        with self._lock:
++            value = self._values.get(key)
++            if value is not None:
++                return value
++
++            # bugfix: memoize directly inside the lock so loads are not duplicated
++            value = loader(key)
++            self._values[key] = value
++            self._expires[key] = self._now() + self._ttl
++            return value
+diff --git a/tests/test_cache.py b/tests/test_cache.py
+@@
+ from __future__ import annotations
+ 
+ import time
+ import pytest
+ from src.cache import TTLCache
+ 
+ 
+ def test_get_returns_none_for_missing_key() -> None:
+     cache = TTLCache()
+     assert cache.get("missing") is None
+ 
+ 
+-@pytest.mark.parametrize("value", ["", 0, [], "cached"])
+-def test_get_or_compute_round_trips(value: str | int | list[str]) -> None:
+-    cache = TTLCache(default_ttl=30.0)
+-    calls = 0
+-
+-    def load(k: str) -> str | int | list[str]:
+-        nonlocal calls
+-        calls += 1
+-        return value
+-
+-    first = cache.get_or_compute("entry", load)
+-    second = cache.get_or_compute("entry", load)
+-
+-    assert first == value
+-    assert second == value
+-    assert calls == 1
++def test_get_or_compute_only_hits_none() -> None:
++    cache = TTLCache(default_ttl=30.0)
++    calls = 0
++
++    def load(k: str) -> None | object:
++        nonlocal calls
++        calls += 1
++        return None
++
++    first = cache.get_or_compute("entry", load)
++    second = cache.get_or_compute("entry", load)
++
++    assert first is None
++    assert second is None
++    assert calls == 1
+ 
+ 
+ def test_ttl_is_enforced() -> None:
+     cache = TTLCache(default_ttl=0.05)
+     cache.set("foo", "bar")
+     time.sleep(0.06)
+     assert cache.get("foo") is None
+*** End Patch
+    

--- a/scripts/calibration/prompts/v1/code-review/typescript-event-emitter-refactor-with-contract-break.md
+++ b/scripts/calibration/prompts/v1/code-review/typescript-event-emitter-refactor-with-contract-break.md
@@ -1,0 +1,147 @@
+Review this TypeScript refactor diff from an EventEmitter utility. Output one finding per line with:
+
+- file:line citation
+- classification: `correctness`, `api`, `concurrency`, or `style`
+- concise rationale grounded only in the diff
+
+Unsupported claims count as hallucinations. Do not claim a finding unless the diff
+directly supports it.
+
+```diff
+diff --git a/src/event_emitter.ts b/src/event_emitter.ts
+@@
+-export type EventHandler<T = unknown> = (payload: T) => void;
++export type Handler<T = unknown> = (payload: T) => void;
+ 
+ type Listener<T = unknown> = {
+-  handler: EventHandler<T>;
++  handler: Handler<T>;
+   once: boolean;
+ };
+ 
+ export class EventEmitter<T = unknown> {
+-  private readonly listeners = new Map<string, Listener<T>[]>();
++  private readonly listeners = new Map<string, Listener<T>[]>();
+ 
+-  on(event: string, handler: EventHandler<T>): () => void {
+-    const listeners = this.listeners.get(event) ?? [];
+-    listeners.push({ handler, once: false });
+-    this.listeners.set(event, listeners);
+-    return () => this.off(event, handler);
+-  }
++  on(event: string, handler: Handler<T>): () => void {
++    const listeners = this.listeners.get(event) ?? [];
++    listeners.push({ handler, once: false });
++    this.listeners.set(event, listeners);
++    return () => this.off(event, handler);
++  }
+ 
+-  once(event: string, handler: EventHandler<T>): () => void {
+-    const listeners = this.listeners.get(event) ?? [];
+-    listeners.push({ handler, once: true });
+-    this.listeners.set(event, listeners);
+-    return () => this.off(event, handler);
+-  }
++  once(event: string, handler: Handler<T>): () => void {
++    const listeners = this.listeners.get(event) ?? [];
++    const entry: Listener<T> = { handler, once: true };
++    entry.handler = this.subscribeOnce(event, entry);
++    listeners.push(entry);
++    this.listeners.set(event, listeners);
++    return () => this.off(event, entry.handler);
++  }
++
++  private subscribeOnce(event: string, entry: Listener<T>): Handler<T> {
++    return (payload: T) => {
++      const listeners = this.listeners.get(event) ?? [];
++      const index = listeners.indexOf(entry);
++      if (index >= 0) {
++        listeners.splice(index, 1);
++      }
++      entry.handler(payload);
++    };
++  }
+ 
+   emit(event: string, payload: T): void {
+     const listeners = this.listeners.get(event);
+     if (!listeners) {
+       return;
+     }
+-    for (const listener of [...listeners]) {
+-      try {
+-        listener.handler(payload);
+-      } catch (error) {
+-        console.error(`EventEmitter handler for ${event} failed`, error);
+-      } finally {
+-        if (listener.once) {
+-          this.off(event, listener.handler);
+-        }
+-      }
+-    }
++    for (let i = 0; i < listeners.length; i++) {
++      listeners[i].handler(payload);
++    }
++  }
++
++  private off(event: string, handler: Handler<T>): void {
++    const listeners = this.listeners.get(event);
++    if (!listeners) {
++      return;
++    }
++    const next = listeners.filter((listener) => listener.handler !== handler);
++    if (next.length === 0) {
++      this.listeners.delete(event);
++    } else {
++      this.listeners.set(event, next);
++    }
+   }
+ }
+diff --git a/tests/event_emitter.test.ts b/tests/event_emitter.test.ts
+@@
+-import { EventEmitter, EventHandler } from "../src/event_emitter";
++import { EventEmitter, Handler } from "../src/event_emitter";
+ import { describe, expect, it } from "vitest";
+ 
+ describe("EventEmitter", () => {
+   it("calls once handler only once", () => {
+-    const emitter = new EventEmitter<string>();
+-    const values: string[] = [];
+-    const handler: EventHandler<string> = (value) => values.push(value);
++    const emitter = new EventEmitter<string>();
++    const values: string[] = [];
++    const handler: Handler<string> = (value) => values.push(value);
+ 
+     emitter.once("ready", handler);
+     emitter.emit("ready", "a");
+     emitter.emit("ready", "b");
+ 
+     expect(values).toEqual(["a"]);
+   });
+ 
+-  it("supports re-subscribing from inside a once handler", () => {
+-    const emitter = new EventEmitter<number>();
+-    const values: number[] = [];
+-
+-    emitter.once("tick", (value) => {
+-      values.push(value);
+-      emitter.once("tick", () => values.push(value + 1));
+-    });
+-
+-    emitter.emit("tick", 1);
+-    emitter.emit("tick", 2);
+-    expect(values).toEqual([1, 2]);
+-  });
++  it("can surface handler failures from emit()", () => {
++    const emitter = new EventEmitter<number>();
++    const handler: Handler<number> = () => {
++      throw new Error("handler failure");
++    };
++    const values: number[] = [1];
++
++    emitter.on("tick", (value) => values.push(value));
++    emitter.on("tick", handler);
++    expect(() => emitter.emit("tick", 2)).toThrow("handler failure");
++    expect(values).toEqual([1, 2]);
++  });
+ });
+```

--- a/scripts/calibration/run_wave.py
+++ b/scripts/calibration/run_wave.py
@@ -29,7 +29,12 @@ from .run_cell import DEFAULT_DB_PATH, DEFAULT_OUTPUT_ROOT, REPO_ROOT, run_cell
 # scripts/calibration/ground-truth/v1/<lane>/PLAN.md.
 LANE_FIXTURES: dict[str, list[str]] = {
     "code-writing": ["parse-dependabot-cooldown"],
-    "code-review": ["k8s-controller-leader-election"],
+    "code-review": [
+        "k8s-controller-leader-election",
+        "pr-1333-security-yaml",
+        "python-cache-ttl-fix-with-regression",
+        "typescript-event-emitter-refactor-with-contract-break",
+    ],
     "content-writing-long": ["kubedojo-rbac-module"],
     "content-review": ["flawed-module-rubric-review"],
     "fact-check": ["k8s-1-35-claims"],


### PR DESCRIPTION
## Summary

Slice 2 of Phase 3 fixture expansion. Code-review lane goes from 2 → 4 fixtures, covering the remaining bugfix + refactor archetypes per PLAN.md.

| Fixture | Archetype | Planted findings | Notes |
|---|---|---|---|
| `python-cache-ttl-fix-with-regression` | Bugfix → regression | 5 | \"Fix\" introduces falsy-collision; deletes deepcopy; over-long lock |
| `typescript-event-emitter-refactor-with-contract-break` | Refactor → contract break | 5 | Moves listener-removal timing; drops error isolation; mutates test |

5 files changed: 4 fixture artifacts (2 prompt MD + 2 ground-truth YAML) + `LANE_FIXTURES[\"code-review\"]` expansion in `run_wave.py`.

Regression test: tests/calibration/test_run_wave.py (existing on-disk existence checks now cover the 2 new fixtures)

## Test plan

- [x] All 4 code-review fixtures parse via `yaml.safe_load` with `findings` + `hallucination_terms`
- [x] 4 prompt MD files exist in `scripts/calibration/prompts/v1/code-review/`
- [x] `LANE_FIXTURES[\"code-review\"]` has 4 entries; total ref count = 16
- [x] `.venv/bin/python -m pytest tests/calibration/ -q` — 108 passed
- [x] `.venv/bin/python -m ruff check scripts/calibration/run_wave.py` — clean
- [x] Per the 1-fixture-per-wave rule, sweeps now require `--fixture <id>` for code-review

## What's NOT in this PR

- **Re-firing code-review across all 14 models on the 2 new fixtures** — separate per-fixture wave runs per #1450 enforcement. Land the data first, dispatch second.
- **Phase 3 slices 3-6** — content-review (+2), code-writing (+4), code-writing-long (+4), refactoring/summarization. Each their own PR.

Closes #1441 phase 3 fixture slice 2/6.