### PR TITLE
fix(security): close 4 CodeQL alerts in scripts/local_api.py

### DIFF
--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -4910,8 +4910,8 @@ def _html_fragment_to_text(fragment: str) -> str:
 
 def _strip_html_noncontent(text: str) -> str:
     text = re.sub(r"<!--.*?-->", " ", text, flags=re.DOTALL)
-    text = re.sub(r"<script\b[^>]*>.*?</script>", " ", text, flags=re.IGNORECASE | re.DOTALL)
-    return re.sub(r"<style\b[^>]*>.*?</style>", " ", text, flags=re.IGNORECASE | re.DOTALL)
+    text = re.sub(r"<script\b[^>]*>.*?</script\s*>", " ", text, flags=re.IGNORECASE | re.DOTALL)
+    return re.sub(r"<style\b[^>]*>.*?</style\s*>", " ", text, flags=re.IGNORECASE | re.DOTALL)
 
 
 def _extract_html_h1(text: str) -> str | None:
@@ -6835,9 +6835,12 @@ def render_quality_module_page_html(repo_root: Path, module_key: str) -> str | N
         if not raw_path:
             return ""
         try:
-            return Path(raw_path).resolve().relative_to(repo_root).as_posix()
+            resolved = Path(raw_path).resolve()
+            return resolved.relative_to(repo_root).as_posix()
         except (OSError, ValueError):
-            return str(raw_path)
+            # Path doesn't exist or escapes repo_root; avoid reflecting arbitrary
+            # user-provided paths into generated HTML.
+            return ""
 
     gate_items = []
     for item in diagnostics:
@@ -9012,6 +9015,7 @@ def make_handler(repo_root: Path) -> type[BaseHTTPRequestHandler]:
             self.send_header("Content-Type", content_type)
             self.send_header("Content-Length", str(len(body)))
             if location is not None:
+                location = _safe_header_value(location)
                 self.send_header("Location", location)
             if 200 <= status_code < 300:
                 self.send_header("ETag", etag)
@@ -9075,6 +9079,7 @@ def make_handler(repo_root: Path) -> type[BaseHTTPRequestHandler]:
                 self.send_header("Content-Type", content_type)
                 self.send_header("Content-Length", str(len(body)))
                 if location is not None:
+                    location = _safe_header_value(location)
                     self.send_header("Location", location)
                 if 200 <= status_code < 300:
                     self.send_header("ETag", etag)

--- a/tests/test_local_api_security.py
+++ b/tests/test_local_api_security.py
@@ -114,3 +114,99 @@ def test_post_response_headers_do_not_split_on_crlf(monkeypatch, tmp_path: Path)
         assert "\n" not in response.getheader("Content-Type", "")
 
     _with_server(tmp_path, request)
+
+
+def test_strip_html_noncontent_handles_script_with_trailing_space() -> None:
+    assert "<x>" not in local_api._strip_html_noncontent("<script>x</script >")
+
+
+def test_strip_html_noncontent_handles_style_with_trailing_space() -> None:
+    assert "<x>" not in local_api._strip_html_noncontent("<style >x</style >")
+
+
+def test_relative_path_returns_empty_for_path_outside_repo_root(
+    monkeypatch: Callable[..., None],
+    tmp_path: Path,
+) -> None:
+    module_key = "module-key"
+
+    def fake_find_quality_board_module(_repo_root: Path, _module_key: str) -> dict[str, str]:
+        return {"title": "Module", "track": "prerequisites", "status": "unknown", "score": "100"}
+
+    def fake_build_module_state(_repo_root: Path, _module_key: str) -> dict[str, object]:
+        return {"english_path": "/etc/passwd", "ukrainian_path": None}
+
+    monkeypatch.setattr(local_api, "_find_quality_board_module", fake_find_quality_board_module)
+    monkeypatch.setattr(local_api, "build_module_state", fake_build_module_state)
+
+    html = local_api.render_quality_module_page_html(tmp_path, module_key)
+    assert html is not None
+    assert "/etc/passwd" not in html
+    assert '<a href="//etc/passwd">english</a>' not in html
+
+
+def test_relative_path_returns_empty_for_nonexistent_path(
+    monkeypatch: Callable[..., None],
+    tmp_path: Path,
+) -> None:
+    module_key = "module-key"
+
+    def fake_find_quality_board_module(_repo_root: Path, _module_key: str) -> dict[str, str]:
+        return {"title": "Module", "track": "prerequisites", "status": "unknown", "score": "100"}
+
+    def fake_build_module_state(_repo_root: Path, _module_key: str) -> dict[str, object]:
+        return {"english_path": "/totally/made/up/file", "ukrainian_path": None}
+
+    monkeypatch.setattr(local_api, "_find_quality_board_module", fake_find_quality_board_module)
+    monkeypatch.setattr(local_api, "build_module_state", fake_build_module_state)
+
+    html = local_api.render_quality_module_page_html(tmp_path, module_key)
+    assert html is not None
+    assert "/totally/made/up/file" not in html
+    assert "<a href=\"//totally/made/up/file\">english</a>" not in html
+
+
+def test_head_response_sanitizes_crlf_in_location(monkeypatch, tmp_path: Path) -> None:
+    malicious_location = "/ok\r\nX-Injected-Location: 1"
+
+    def fake_serve_request(_repo_root: Path, _path: str):
+        return 302, malicious_location.encode("utf-8"), "text/plain", ""
+
+    monkeypatch.setattr(local_api, "serve_request", fake_serve_request)
+
+    def request(port: int) -> None:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("HEAD", "/api/schema")
+        response = conn.getresponse()
+        response.read()
+
+        assert response.status == 302
+        assert response.getheader("Location") == local_api._safe_header_value(malicious_location)
+        assert response.getheader("X-Injected-Location") is None
+        assert "\r" not in response.getheader("Location", "")
+        assert "\n" not in response.getheader("Location", "")
+
+    _with_server(tmp_path, request)
+
+
+def test_get_response_sanitizes_crlf_in_location(monkeypatch, tmp_path: Path) -> None:
+    malicious_location = "/ok\r\nX-Injected-Location: 1"
+
+    def fake_serve_request(_repo_root: Path, _path: str):
+        return 302, malicious_location.encode("utf-8"), "text/plain", ""
+
+    monkeypatch.setattr(local_api, "serve_request", fake_serve_request)
+
+    def request(port: int) -> None:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("GET", "/api/schema")
+        response = conn.getresponse()
+        response.read()
+
+        assert response.status == 302
+        assert response.getheader("Location") == local_api._safe_header_value(malicious_location)
+        assert response.getheader("X-Injected-Location") is None
+        assert "\r" not in response.getheader("Location", "")
+        assert "\n" not in response.getheader("Location", "")
+
+    _with_server(tmp_path, request)


### PR DESCRIPTION
## Summary

Closes 4 open CodeQL alerts on `scripts/local_api.py`:

| Alert | Severity | Rule | Fix |
|---|---|---|---|
| #30 | warning | py/bad-tag-filter (line 4913-4914) | `</script>` → `</script\\s*>` (and same for `</style>`) — handles whitespace before close-bracket |
| #26 | error | py/path-injection (line 6838) | `_relative_path` returns `""` instead of reflecting paths outside `repo_root` |
| #28 | error | py/http-response-splitting (line 9015) | `location = _safe_header_value(location)` before `send_header("Location", ...)` |
| #29 | error | py/http-response-splitting (line 9078) | Same fix at the second call site |

Regression test: tests/test_local_api_security.py (6 new tests covering CodeQL alerts #26 / #28 / #29 / #30):
- `test_strip_html_noncontent_handles_script_with_trailing_space`
- `test_strip_html_noncontent_handles_style_with_trailing_space`
- `test_relative_path_returns_empty_for_path_outside_repo_root`
- `test_relative_path_returns_empty_for_nonexistent_path`
- `test_head_response_sanitizes_crlf_in_location`
- `test_get_response_sanitizes_crlf_in_location`

## Test plan

- [x] `.venv/bin/python -m pytest tests/test_local_api_security.py -q -x` — green
- [x] `.venv/bin/python -m ruff check scripts/local_api.py` — clean
- [x] `.venv/bin/python -m pytest tests/ -q -x` — fails due pre-existing collection error in `tests/test_quality_queue.py` (`ImportError: cannot import name '_read_frontmatter' from conftest`), unrelated to this PR
- [ ] CodeQL re-scan on PR to confirm open alerts reduced from 4 to 0
- [x] `_relative_path` caller audit: confirmed no caller depends on raw-path fallback for paths outside `repo_root`

## Notes — defense-in-depth follow-ups

Not in this PR (minimal fix only):

- **Location header** could also validate `not location.startswith("//")` (protocol-relative routing off-origin) and `not re.search(r"[^\\x20-\\x7e]", location)` (non-ASCII / control chars).
- **`_safe_header_value`** silently strips CRLF; an alternative is to reject + log when input contains CRLF to preserve injection telemetry.
- **`_strip_html_noncontent`** still relies on regex and remains brittle for complex HTML/script nesting; parser-based stripping is stronger long-term.
