### PR TITLE
feat(calibration): --judge1 / --judge2 CLI overrides on run_wave.py

### DIFF
--- a/scripts/calibration/run_wave.py
+++ b/scripts/calibration/run_wave.py
@@ -133,6 +133,8 @@ def _dispatch_one(
     output_root: Path,
     timeout_s: int,
     score: bool,
+    judge1: str,
+    judge2: str,
 ) -> dict:
     started = time.monotonic()
     cell_id = schema.make_cell_id(
@@ -161,6 +163,8 @@ def _dispatch_one(
                     cell_id=cell_id,
                     db_path=db_path,
                     replicate_seq=spec.replicate_seq,
+                    judge1=judge1,
+                    judge2=judge2,
                 )
                 scored = True
             except Exception as exc:  # noqa: BLE001 — scoring failure ≠ dispatch failure
@@ -284,6 +288,8 @@ def run_wave(
     db_path: Path,
     output_root: Path,
     timeout_s: int,
+    judge1: str = "claude-sonnet-4-6",
+    judge2: str = "gemini-3.5-flash-high",
     max_parallel_per_family: int = 1,
     score: bool = True,
 ) -> list[dict]:
@@ -307,6 +313,8 @@ def run_wave(
                 output_root=output_root,
                 timeout_s=timeout_s,
                 score=score,
+                judge1=judge1,
+                judge2=judge2,
             )
             results.append(r)
             status = "ok" if r["ok"] else "FAIL"
@@ -358,6 +366,20 @@ def build_parser() -> argparse.ArgumentParser:
         "--models",
         nargs="*",
         help="Explicit canonical_string filter (overrides --wave).",
+    )
+    parser.add_argument(
+        "--judge1",
+        default="claude-sonnet-4-6",
+        help=(
+            "Judge 1 canonical_string passed through to score_cell. "
+            "Default is the production sonnet judge; override during a "
+            "Claude-throttle window with gemini-3.5-flash-high or codex-gpt-5.5."
+        ),
+    )
+    parser.add_argument(
+        "--judge2",
+        default="gemini-3.5-flash-high",
+        help="Judge 2 canonical_string passed through to score_cell.",
     )
     parser.add_argument(
         "--lanes",
@@ -515,6 +537,8 @@ def main(argv: list[str] | None = None) -> int:
         output_root=args.output_root,
         timeout_s=args.timeout_s,
         score=not args.no_score,
+        judge1=args.judge1,
+        judge2=args.judge2,
     )
 
     ok = sum(1 for r in results if r["ok"])

--- a/tests/calibration/test_run_wave.py
+++ b/tests/calibration/test_run_wave.py
@@ -287,3 +287,45 @@ def test_build_cells_filter_param_filters_fixtures():
     )
     assert len(cells) == 1
     assert cells[0].fixture_id == "kubedojo-review-override-rfc"
+
+
+# ---------------------------------------------------------------------------
+# --judge1 / --judge2 override (Claude-throttle window mitigation, #1441)
+# ---------------------------------------------------------------------------
+
+
+def test_main_passes_judge_args_through_to_score_cell(monkeypatch):
+    """`--judge1 X --judge2 Y` flows from main → _dispatch_one → score_cell."""
+    from scripts.calibration import run_wave, score_cell as sc_mod
+    captured: dict[str, str] = {}
+
+    def fake_score(*, cell_id, db_path, replicate_seq, judge1, judge2):
+        captured["judge1"] = judge1
+        captured["judge2"] = judge2
+        return {"gate1": True}
+
+    monkeypatch.setattr(sc_mod, "score_cell", fake_score)
+    monkeypatch.setattr(run_wave, "preflight_probe", lambda cells: [{"ok": True} for _ in cells])
+    # Stub the actual model dispatch so we don't burn API calls.
+    monkeypatch.setattr(run_wave, "run_cell", lambda **_kw: "fake-cell-id")
+
+    rc = run_wave.main([
+        "--wave", "A",
+        "--lanes", "code-writing",
+        "--judge1", "gemini-3.5-flash-high",
+        "--judge2", "codex-gpt-5.5",
+        "--no-render",
+        "--smoke",
+    ])
+    assert rc == 0, f"expected exit 0, got {rc}"
+    assert captured.get("judge1") == "gemini-3.5-flash-high"
+    assert captured.get("judge2") == "codex-gpt-5.5"
+
+
+def test_main_default_judges_are_sonnet_plus_gemini_flash():
+    """Default judges match the score_cell production defaults."""
+    from scripts.calibration import run_wave
+    parser = run_wave.build_parser()
+    ns = parser.parse_args(["--wave", "A", "--lanes", "code-writing"])
+    assert ns.judge1 == "claude-sonnet-4-6"
+    assert ns.judge2 == "gemini-3.5-flash-high"


### PR DESCRIPTION
## Summary

`run_wave.py` now threads `--judge1` and `--judge2` from CLI args through to `score_cell.score_cell`, mirroring the flags `score_cell.py` already has. Unblocks wave dispatch during Claude-throttle windows where the default sonnet judge would burn the constrained pool.

### Why

`score_cell.score_cell` accepts `judge1` / `judge2` kwargs, but `run_wave.py:_dispatch_one` called it without them. So every wave used the production defaults (`claude-sonnet-4-6` + `gemini-3.5-flash-high`). Memory: `feedback_claude_tier_discipline_opus_is_constrained` (TOP PRIORITY) → during the 2026-05-23/24 window we need to route prose-lane judges to non-Claude.

### Example invocation

```bash
python -m scripts.calibration.run_wave \
  --wave A B C D \
  --lanes harness-following \
  --fixture claude-md-context-cks-tweak \
  --models deepseek-v4-pro deepseek-v4-flash qwen3.6-plus qwen3.6 grok-4.3 \
  --judge1 gemini-3.5-flash-high \
  --judge2 codex-gpt-5.5
```

Production defaults unchanged.

Regression test: tests/calibration/test_run_wave.py (2 new tests covering main→score_cell judge-arg threading and default values)

## Test plan

- [x] `.venv/bin/python -m pytest tests/calibration/ -q` — 110 passed (108 + 2 new)
- [x] `.venv/bin/python -m ruff check scripts/calibration/run_wave.py tests/calibration/test_run_wave.py` — clean
- [x] `python -m scripts.calibration.run_wave --help` shows `--judge1` and `--judge2`
- [x] Default judge1 = `claude-sonnet-4-6`, default judge2 = `gemini-3.5-flash-high` — production wave dispatch unaffected
- [x] `--judge1 X --judge2 Y` from CLI flows through main → _dispatch_one → score_cell.score_cell
