### PR TITLE
feat(calibration): observatory-style design pass on calibration reports

### DIFF
--- a/scripts/calibration/report.py
+++ b/scripts/calibration/report.py
@@ -1,4 +1,5 @@
 """Render HTML calibration reports from the SQLite ledger."""
+
 from __future__ import annotations
 
 import argparse
@@ -98,7 +99,9 @@ def _gate_component(score_rows: list[Any]) -> float:
             for row in det_rows
         ]
     else:
-        values = [1.0 if _score_row_value(row, "gate_pass") else 0.0 for row in det_rows]
+        values = [
+            1.0 if _score_row_value(row, "gate_pass") else 0.0 for row in det_rows
+        ]
     return (sum(values) / len(values)) * 10.0
 
 
@@ -222,10 +225,12 @@ def _letter_grade_legend() -> list[dict[str, str]]:
 
 
 def _radar_context(cells: list[CellSummary]) -> dict[str, Any]:
-    size = 480.0
+    # Wider canvas than the radar geometry needs so long lane labels
+    # ("content-writing-long", "summarization") don't clip on the edges.
+    size = 640.0
     center = size / 2.0
-    outer_radius = 130.0
-    label_radius = 188.0
+    outer_radius = 145.0
+    label_radius = 205.0
     cells_by_lane: dict[str, list[CellSummary]] = defaultdict(list)
     for cell in cells:
         cells_by_lane[cell.lane].append(cell)
@@ -243,7 +248,9 @@ def _radar_context(cells: list[CellSummary]) -> dict[str, Any]:
                 "value": value,
                 "points": " ".join(
                     f"{x:.1f},{y:.1f}"
-                    for x, y in (point_for(index, radius) for index in range(axis_count))
+                    for x, y in (
+                        point_for(index, radius) for index in range(axis_count)
+                    )
                 ),
             }
         )
@@ -454,6 +461,16 @@ def render_reports(
     (out_dir / "per-lane").mkdir(exist_ok=True)
     (out_dir / "per-model").mkdir(exist_ok=True)
 
+    # Copy the shared calibration.css to the reports root (one level above the
+    # dated subdir) so every page can link to ../calibration.css with no
+    # duplicate copies per run_date.
+    import shutil
+
+    css_src = TEMPLATE_DIR / "calibration.css"
+    if css_src.exists():
+        css_dst = out_dir.parent / "calibration.css"
+        shutil.copy2(css_src, css_dst)
+
     env = _env()
     written: list[Path] = []
 
@@ -516,20 +533,36 @@ def render_reports(
         written.append(path)
 
     total_cost = _total_cost(db_path)
-    index_path = out_dir / "index.html"
-    index_path.write_text(
-        _render_index(
-            run_date=run_date,
-            total_cells=len(summaries),
-            total_cost=total_cost,
-            families=sorted({cell.family for cell in summaries}),
-            lanes=lanes,
-            models=models,
-        ),
-        encoding="utf-8",
+    families = sorted({cell.family for cell in summaries})
+    overall_grade = _overall_grade(summaries)
+    index_html = env.get_template("index.html.j2").render(
+        run_date=run_date,
+        total_cells=len(summaries),
+        total_cost=total_cost,
+        families=families,
+        lanes=lanes,
+        models=models,
+        overall=overall_grade,
+        safe_filename=_safe_filename,
     )
+    index_path = out_dir / "index.html"
+    index_path.write_text(index_html, encoding="utf-8")
     written.append(index_path)
     return written
+
+
+def _overall_grade(summaries: list[CellSummary]) -> dict[str, Any]:
+    """Aggregate composite over all summaries, with letter + color for the index hero."""
+    composites = [s.composite for s in summaries if s.composite is not None]
+    if not composites:
+        return {
+            "composite": 0.0,
+            "letter": "F",
+            "color": constants.LETTER_GRADE_BANDS[-1][3],
+        }
+    mean_score = sum(composites) / len(composites)
+    letter, color = letter_grade_for_score(mean_score)
+    return {"composite": mean_score, "letter": letter, "color": color}
 
 
 def _total_cost(db_path: Path) -> float:
@@ -538,43 +571,6 @@ def _total_cost(db_path: Path) -> float:
             "SELECT COALESCE(SUM(cost_usd), 0.0) AS total_cost FROM dispatches"
         ).fetchone()
     return float(row["total_cost"])
-
-
-def _render_index(
-    *,
-    run_date: str,
-    total_cells: int,
-    total_cost: float,
-    families: list[str],
-    lanes: list[str],
-    models: list[str],
-) -> str:
-    family_list = ", ".join(families) if families else "none"
-    lane_links = "\n".join(
-        f'<li><a href="per-lane/{lane}.html">{lane}</a></li>' for lane in lanes
-    )
-    model_links = "\n".join(
-        f'<li><a href="per-model/{_safe_filename(model)}.html">{model}</a></li>'
-        for model in models
-    )
-    return f"""<!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>Calibration reports — {run_date}</title>
-<link rel="stylesheet" href="../design-system.css">
-</head>
-<body>
-<h1>Calibration reports — {run_date}</h1>
-<p class="meta">cells={total_cells} · total_cost=${total_cost:.4f} · families={family_list}</p>
-<p><a href="matrix.html">Matrix heatmap</a></p>
-<h2>Per Lane</h2>
-<ul>{lane_links}</ul>
-<h2>Per Model</h2>
-<ul>{model_links}</ul>
-</body>
-</html>
-"""
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/scripts/calibration/reports/templates/calibration.css
+++ b/scripts/calibration/reports/templates/calibration.css
@@ -1,0 +1,812 @@
+/* ============================================================
+   Calibration Reports — Observatory theme
+   Inspiration: diagnostic instrumentation panels, monospace data,
+   editorial display headings, sticky data grid.
+   Loaded by matrix/per-lane/per-model pages.
+   ============================================================ */
+
+@import url('https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,700;12..96,800&family=JetBrains+Mono:wght@400;500;600;700;800&family=Newsreader:ital,opsz,wght@0,6..72,300;0,6..72,400;0,6..72,500;0,6..72,700;1,6..72,400&display=swap');
+
+:root {
+  /* Observatory palette — deeper than design-system.css base; reads as instrumentation, not gaming */
+  --obs-bg:           #050811;
+  --obs-bg-dot:       rgba(56, 189, 248, 0.045);  /* dot-grid pattern */
+  --obs-surface:      #0d1424;
+  --obs-surface-hi:   #131c30;
+  --obs-surface-pop:  #1a253f;
+
+  --obs-border:       rgba(125, 158, 200, 0.08);
+  --obs-border-hi:    rgba(125, 158, 200, 0.18);
+  --obs-border-pop:   rgba(56, 189, 248, 0.45);
+
+  --obs-text:         #e9eef7;
+  --obs-text-dim:     #8d9bb5;
+  --obs-text-mute:    #54627c;
+
+  --obs-accent:       #38bdf8;          /* signal cyan */
+  --obs-accent-hot:   #22d3ee;          /* apex cyan, used for grade A */
+  --obs-warm:         #fbbf24;
+  --obs-warn:         #f97316;
+  --obs-danger:       #ef4444;
+  --obs-good:         #84cc16;
+
+  /* Continuous score-color gradient stops (0 → 10) */
+  --score-0:          #b91c1c;
+  --score-2:          #ef4444;
+  --score-4:          #f97316;
+  --score-6:          #fbbf24;
+  --score-8:          #84cc16;
+  --score-10:         #22d3ee;
+
+  /* Letter-grade plate fills — saturated, with a hint of luminance */
+  --grade-A:          #22d3ee;
+  --grade-B:          #84cc16;
+  --grade-C:          #fbbf24;
+  --grade-D:          #f97316;
+  --grade-F:          #ef4444;
+
+  --font-display:     'Bricolage Grotesque', system-ui, sans-serif;
+  --font-serif:       'Newsreader', Georgia, serif;
+  --font-mono:        'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+
+  --radius-sm:        4px;
+  --radius:           8px;
+  --radius-lg:        14px;
+}
+
+* { box-sizing: border-box; }
+
+html, body { background: var(--obs-bg); margin: 0; padding: 0; }
+
+body {
+  font-family: var(--font-mono);
+  color: var(--obs-text);
+  font-size: 13.5px;
+  line-height: 1.55;
+  /* faint dot-grid background — instrumentation feel */
+  background-image:
+    radial-gradient(circle at 50% 50%, var(--obs-bg-dot) 0.5px, transparent 0.5px);
+  background-size: 16px 16px;
+  min-height: 100vh;
+  padding: 2.5rem 1.5rem 5rem;
+}
+
+.shell {
+  max-width: 1480px;
+  margin: 0 auto;
+}
+
+/* ------------------------------------------------------------
+   Page header
+   ------------------------------------------------------------ */
+
+.page-head {
+  display: flex;
+  align-items: baseline;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.6rem;
+  border-bottom: 1px solid var(--obs-border);
+  padding-bottom: 0.95rem;
+}
+
+.eyebrow {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--obs-accent);
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+.eyebrow::before {
+  content: "";
+  display: inline-block;
+  width: 8px; height: 8px;
+  background: var(--obs-accent);
+  border-radius: 50%;
+  box-shadow: 0 0 8px var(--obs-accent);
+}
+
+h1.title {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-stretch: 75%;  /* compressed Bricolage axis — sharp editorial feel */
+  font-size: clamp(2.2rem, 3.2vw, 3.4rem);
+  letter-spacing: -0.02em;
+  line-height: 1;
+  margin: 0;
+  color: var(--obs-text);
+}
+
+h1.title em {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-weight: 400;
+  font-stretch: normal;
+  color: var(--obs-accent);
+  letter-spacing: -0.01em;
+}
+
+.meta {
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  color: var(--obs-text-dim);
+  letter-spacing: 0.01em;
+  margin: 0.35rem 0 0;
+  display: flex;
+  gap: 0.9rem;
+  flex-wrap: wrap;
+}
+
+.meta .meta-kv { display: inline-flex; gap: 0.35rem; }
+.meta .meta-kv b { color: var(--obs-text); font-weight: 600; }
+
+.meta a {
+  color: var(--obs-accent);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.15s;
+}
+.meta a:hover { border-bottom-color: var(--obs-accent); }
+
+/* ------------------------------------------------------------
+   Cards (used by index + per-model side panel)
+   ------------------------------------------------------------ */
+
+.card {
+  background: var(--obs-surface);
+  border: 1px solid var(--obs-border);
+  border-radius: var(--radius);
+  padding: 1.1rem 1.2rem;
+}
+.card h2, .card h3 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-stretch: 85%;
+  letter-spacing: -0.01em;
+  margin: 0 0 0.55rem;
+  color: var(--obs-text);
+  font-size: 1.05rem;
+}
+
+/* ------------------------------------------------------------
+   Legend panel
+   ------------------------------------------------------------ */
+
+.legend {
+  display: flex;
+  gap: 1.1rem;
+  align-items: center;
+  flex-wrap: wrap;
+  background: linear-gradient(180deg, var(--obs-surface) 0%, var(--obs-surface-hi) 100%);
+  border: 1px solid var(--obs-border);
+  border-left: 3px solid var(--obs-accent);
+  border-radius: var(--radius);
+  padding: 0.75rem 1rem;
+  margin: 1.1rem 0 1.6rem;
+  font-size: 12px;
+  color: var(--obs-text-dim);
+}
+
+.legend .grades { display: inline-flex; gap: 0.35rem; }
+.legend-grade {
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  color: #050811;
+  padding: 0.22rem 0.55rem;
+  border-radius: var(--radius-sm);
+  display: inline-block;
+  min-width: 56px;
+  text-align: center;
+}
+
+.legend-copy { margin: 0; }
+.legend-copy strong { color: var(--obs-text); font-weight: 600; }
+
+/* ------------------------------------------------------------
+   Matrix
+   ------------------------------------------------------------ */
+
+.matrix-wrap {
+  background: var(--obs-surface);
+  border: 1px solid var(--obs-border);
+  border-radius: var(--radius);
+  overflow: auto;
+  max-height: 80vh;
+  position: relative;
+}
+
+table.matrix {
+  border-collapse: separate;
+  border-spacing: 0;
+  width: 100%;
+  min-width: 1200px;
+}
+
+table.matrix th, table.matrix td {
+  padding: 0;
+  border: 1px solid var(--obs-border);
+  background: var(--obs-surface);
+  white-space: nowrap;
+  text-align: center;
+  vertical-align: middle;
+  font-family: var(--font-mono);
+}
+
+/* Sticky top header (model names) */
+table.matrix thead th {
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  background: var(--obs-surface-hi);
+  color: var(--obs-text-dim);
+  font-size: 10.5px;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+  text-transform: lowercase;
+  padding: 0.7rem 0.55rem;
+  border-bottom: 1px solid var(--obs-border-hi);
+  min-width: 90px;
+  max-width: 130px;
+  white-space: normal;
+  word-break: break-word;
+  line-height: 1.2;
+}
+
+/* The corner cell (top-left) — sticky on both axes */
+table.matrix thead th:first-child {
+  left: 0;
+  z-index: 4;
+  background: var(--obs-surface-pop);
+  text-align: left;
+  padding-left: 1rem;
+  border-right: 1px solid var(--obs-border-hi);
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-stretch: 85%;
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--obs-accent);
+  min-width: 200px;
+}
+
+/* Sticky left column (lane names) */
+table.matrix tbody th {
+  position: sticky;
+  left: 0;
+  z-index: 2;
+  background: var(--obs-surface-hi);
+  text-align: left;
+  padding: 0.7rem 0.95rem;
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-stretch: 90%;
+  font-size: 13px;
+  letter-spacing: -0.005em;
+  color: var(--obs-text);
+  border-right: 1px solid var(--obs-border-hi);
+  min-width: 200px;
+  max-width: 220px;
+}
+table.matrix tbody th a {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px dashed var(--obs-text-mute);
+  padding-bottom: 1px;
+}
+table.matrix tbody th a:hover {
+  color: var(--obs-accent);
+  border-bottom-color: var(--obs-accent);
+}
+
+/* Data cells */
+table.matrix td {
+  padding: 0;
+  height: 64px;
+  min-width: 92px;
+  max-width: 130px;
+  position: relative;
+  transition: transform 0.12s ease-out, box-shadow 0.12s ease-out;
+}
+
+td .cell-inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: 0.45rem 0.5rem;
+  gap: 0.18rem;
+}
+
+td .score-num {
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 1.18rem;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
+  color: var(--obs-text);
+  text-shadow: 0 1px 2px rgba(0,0,0,0.45);
+}
+
+td .grade-pill {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  padding: 1px 7px;
+  border-radius: var(--radius-sm);
+  color: #050811;
+  min-width: 24px;
+  text-align: center;
+}
+
+td .model-anchor {
+  position: absolute;
+  inset: 0;
+  display: block;
+  cursor: pointer;
+  text-decoration: none;
+  color: inherit;
+}
+
+td:hover {
+  z-index: 1;
+  box-shadow: 0 0 0 1px var(--obs-border-pop), 0 6px 18px rgba(0,0,0,0.45);
+}
+td:hover .score-num { color: var(--obs-accent); }
+
+td.missing {
+  color: var(--obs-text-mute);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-style: normal;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background:
+    repeating-linear-gradient(
+      135deg,
+      var(--obs-surface) 0,
+      var(--obs-surface) 6px,
+      var(--obs-surface-hi) 6px,
+      var(--obs-surface-hi) 12px
+    );
+}
+
+td .dissent {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--obs-warm);
+  color: #050811;
+  font-size: 9px;
+  font-weight: 800;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 0 0 1px rgba(0,0,0,0.4);
+  font-family: var(--font-mono);
+}
+
+/* Summary row + column */
+table.matrix tbody th.summary-label {
+  background: var(--obs-surface-pop);
+  color: var(--obs-accent);
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-stretch: 75%;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 11px;
+  border-top: 1px solid var(--obs-border-hi);
+}
+table.matrix td.summary-cell {
+  background: var(--obs-surface-hi);
+  border-top: 1px solid var(--obs-border-hi);
+}
+table.matrix td.col-summary {
+  background: var(--obs-surface-hi);
+  border-left: 1px solid var(--obs-border-hi);
+}
+
+/* ------------------------------------------------------------
+   Per-lane horizontal bars
+   ------------------------------------------------------------ */
+
+.ranking-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.ranking-row {
+  display: grid;
+  grid-template-columns: 38px 280px 1fr 110px;
+  align-items: center;
+  gap: 1rem;
+  background: var(--obs-surface);
+  border: 1px solid var(--obs-border);
+  border-radius: var(--radius);
+  padding: 0.7rem 1rem;
+  transition: border-color 0.15s;
+}
+.ranking-row:hover {
+  border-color: var(--obs-border-pop);
+  background: var(--obs-surface-hi);
+}
+
+.rank-num {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-stretch: 75%;
+  font-size: 1.4rem;
+  color: var(--obs-text-mute);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.04em;
+}
+.ranking-row.top-1 .rank-num { color: var(--grade-A); }
+.ranking-row.top-2 .rank-num { color: var(--grade-B); }
+.ranking-row.top-3 .rank-num { color: var(--grade-C); }
+
+.model-name {
+  font-family: var(--font-mono);
+  font-weight: 500;
+  font-size: 13px;
+  color: var(--obs-text);
+  letter-spacing: -0.005em;
+}
+.model-name .rank-star {
+  color: var(--obs-warm);
+  margin-left: 0.4rem;
+  font-size: 11px;
+}
+
+.bar-track {
+  height: 22px;
+  background: linear-gradient(90deg, rgba(56,189,248,0.04) 0%, rgba(56,189,248,0.01) 100%);
+  border-radius: 4px;
+  position: relative;
+  overflow: visible;
+  border: 1px solid var(--obs-border);
+}
+.bar-fill {
+  height: 100%;
+  border-radius: 3px;
+  box-shadow: 0 0 14px currentColor;
+  position: relative;
+}
+.bar-fill::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(255,255,255,0.18) 0%, rgba(0,0,0,0.0) 50%);
+  border-radius: 3px;
+}
+
+.score-chip {
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 12.5px;
+  font-variant-numeric: tabular-nums;
+  color: #050811;
+  padding: 0.32rem 0.65rem;
+  border-radius: var(--radius-sm);
+  text-align: center;
+  white-space: nowrap;
+  letter-spacing: 0.02em;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  box-shadow: 0 1px 0 rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.18);
+}
+.score-chip .letter {
+  font-size: 10.5px;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  opacity: 0.85;
+}
+.dissent-sup {
+  color: var(--obs-warm);
+  font-size: 11px;
+  margin-left: 0.35rem;
+}
+
+/* ------------------------------------------------------------
+   Per-model radar + side panel
+   ------------------------------------------------------------ */
+
+.profile {
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(280px, 0.95fr);
+  gap: 1.5rem;
+  align-items: start;
+  margin: 1.4rem 0 2rem;
+}
+@media (max-width: 920px) { .profile { grid-template-columns: 1fr; } }
+
+.radar-wrap {
+  background: var(--obs-surface);
+  border: 1px solid var(--obs-border);
+  border-radius: var(--radius);
+  padding: 1.1rem 0.8rem 0.4rem;
+  text-align: center;
+  overflow: hidden;
+  /* radial gradient halo behind the radar */
+  background-image:
+    radial-gradient(ellipse 70% 60% at 50% 45%, rgba(56,189,248,0.06) 0%, transparent 70%);
+}
+
+.radar-svg {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  margin: 0 auto;
+}
+.radar-ring { fill: none; stroke: rgba(141, 155, 181, 0.18); stroke-width: 1; }
+.radar-ring.outer { stroke: rgba(141, 155, 181, 0.32); stroke-width: 1.2; }
+.radar-axis { stroke: rgba(141, 155, 181, 0.16); stroke-width: 1; stroke-dasharray: 2 4; }
+.radar-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9.5px;
+  fill: var(--obs-text-dim);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.radar-score {
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 700;
+  fill: var(--obs-text);
+  font-size: 11px;
+}
+.radar-polygon {
+  fill: rgba(56, 189, 248, 0.18);
+  stroke: var(--obs-accent);
+  stroke-width: 2;
+  filter: drop-shadow(0 0 8px rgba(56,189,248,0.45));
+}
+
+.profile-side h2 {
+  font-family: var(--font-display);
+  font-stretch: 80%;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  font-size: 11.5px;
+  color: var(--obs-text-dim);
+  margin: 0.4rem 0 0.6rem;
+  border-bottom: 1px solid var(--obs-border);
+  padding-bottom: 0.35rem;
+}
+.profile-side h2:first-child { margin-top: 0; }
+
+.tag-cloud {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  margin: 0 0 1.1rem;
+}
+.tag {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  font-size: 11.5px;
+  font-variant-numeric: tabular-nums;
+  color: #050811;
+  padding: 0.3rem 0.55rem;
+  border-radius: var(--radius-sm);
+  box-shadow: 0 1px 0 rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.18);
+}
+.empty { font-style: italic; color: var(--obs-text-mute); font-size: 12px; }
+
+/* ------------------------------------------------------------
+   Detail table (per-model lane breakdown + per-lane fallback)
+   ------------------------------------------------------------ */
+
+table.detail {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  background: var(--obs-surface);
+  border: 1px solid var(--obs-border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  margin-top: 1rem;
+}
+
+table.detail th, table.detail td {
+  padding: 0.6rem 0.9rem;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  text-align: left;
+  border-bottom: 1px solid var(--obs-border);
+  vertical-align: middle;
+}
+table.detail thead th {
+  background: var(--obs-surface-hi);
+  color: var(--obs-text-dim);
+  font-weight: 600;
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+table.detail tbody tr:last-child td { border-bottom: none; }
+table.detail tbody tr:hover { background: var(--obs-surface-hi); }
+table.detail a {
+  color: var(--obs-accent);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+}
+table.detail a:hover { border-bottom-color: var(--obs-accent); }
+
+table.detail .confidence {
+  font-weight: 700;
+  color: var(--obs-accent);
+  text-transform: uppercase;
+  font-size: 10.5px;
+  letter-spacing: 0.06em;
+}
+
+/* ------------------------------------------------------------
+   Index page (rendered in python)
+   ------------------------------------------------------------ */
+
+.index-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+  gap: 1.5rem;
+  margin: 1.5rem 0 2rem;
+}
+@media (max-width: 880px) { .index-hero { grid-template-columns: 1fr; } }
+
+.hero-stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.85rem;
+}
+.stat-card {
+  background: var(--obs-surface);
+  border: 1px solid var(--obs-border);
+  border-radius: var(--radius);
+  padding: 0.95rem 1.1rem;
+}
+.stat-card .stat-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--obs-text-dim);
+  margin-bottom: 0.45rem;
+}
+.stat-card .stat-value {
+  font-family: var(--font-display);
+  font-stretch: 75%;
+  font-weight: 800;
+  font-size: 2.1rem;
+  color: var(--obs-text);
+  letter-spacing: -0.03em;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.index-links {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.6rem;
+  margin-bottom: 1.6rem;
+}
+.index-link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  background: var(--obs-surface);
+  border: 1px solid var(--obs-border);
+  border-radius: var(--radius);
+  padding: 0.85rem 1rem;
+  text-decoration: none;
+  color: var(--obs-text);
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  transition: border-color 0.15s, transform 0.15s;
+}
+.index-link:hover {
+  border-color: var(--obs-border-pop);
+  transform: translateX(2px);
+}
+.index-link .arrow { color: var(--obs-accent); font-weight: 700; }
+
+.section-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.7rem;
+  margin: 1.8rem 0 0.65rem;
+}
+.section-head h2 {
+  font-family: var(--font-display);
+  font-stretch: 80%;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.95rem;
+  margin: 0;
+  color: var(--obs-text);
+}
+.section-head .count {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--obs-text-mute);
+  letter-spacing: 0.08em;
+}
+.section-head::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: linear-gradient(90deg, var(--obs-border-hi) 0%, transparent 100%);
+  margin-left: 0.3rem;
+}
+
+/* ------------------------------------------------------------
+   Subtle entrance — matrix cells stagger-fade in on load
+   ------------------------------------------------------------ */
+
+@keyframes obs-fade-in {
+  from { opacity: 0; transform: translateY(2px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+table.matrix tbody tr {
+  animation: obs-fade-in 0.4s ease-out backwards;
+}
+table.matrix tbody tr:nth-child(1) { animation-delay: 0.02s; }
+table.matrix tbody tr:nth-child(2) { animation-delay: 0.05s; }
+table.matrix tbody tr:nth-child(3) { animation-delay: 0.08s; }
+table.matrix tbody tr:nth-child(4) { animation-delay: 0.11s; }
+table.matrix tbody tr:nth-child(5) { animation-delay: 0.14s; }
+table.matrix tbody tr:nth-child(6) { animation-delay: 0.17s; }
+table.matrix tbody tr:nth-child(7) { animation-delay: 0.20s; }
+table.matrix tbody tr:nth-child(8) { animation-delay: 0.23s; }
+table.matrix tbody tr:nth-child(9) { animation-delay: 0.26s; }
+table.matrix tbody tr:nth-child(10) { animation-delay: 0.29s; }
+table.matrix tbody tr:nth-child(11) { animation-delay: 0.32s; }
+table.matrix tbody tr:nth-child(12) { animation-delay: 0.35s; }
+
+@media (prefers-reduced-motion: reduce) {
+  table.matrix tbody tr { animation: none; }
+}
+
+/* ------------------------------------------------------------
+   Utility
+   ------------------------------------------------------------ */
+
+a.subtle {
+  color: var(--obs-text-dim);
+  text-decoration: none;
+  border-bottom: 1px dashed var(--obs-text-mute);
+  transition: color 0.15s, border-bottom-color 0.15s;
+}
+a.subtle:hover {
+  color: var(--obs-accent);
+  border-bottom-color: var(--obs-accent);
+}
+
+.kbd {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  background: var(--obs-surface-hi);
+  border: 1px solid var(--obs-border-hi);
+  padding: 1px 5px;
+  border-radius: 3px;
+  color: var(--obs-text-dim);
+}

--- a/scripts/calibration/reports/templates/index.html.j2
+++ b/scripts/calibration/reports/templates/index.html.j2
@@ -1,0 +1,104 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Calibration reports — {{ run_date }}</title>
+<link rel="stylesheet" href="../calibration.css">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+<div class="shell">
+
+<header class="page-head">
+  <div>
+    <div class="eyebrow">CALIBRATION&nbsp;OBSERVATORY · {{ run_date }}</div>
+    <h1 class="title">Benchmark <em>run</em></h1>
+    <p class="meta">
+      <span class="meta-kv"><b>{{ total_cells }}</b> cells</span>
+      <span class="meta-kv">total <b>${{ "%.4f"|format(total_cost) }}</b></span>
+      <span class="meta-kv"><b>{{ models|length }}</b> models · <b>{{ lanes|length }}</b> lanes · <b>{{ families|length }}</b> families</span>
+    </p>
+  </div>
+</header>
+
+<section class="index-hero">
+  <div class="card" style="display:flex; flex-direction:column; gap:0.6rem;">
+    <div style="font-family:var(--font-mono); font-size:11px; letter-spacing:0.14em; text-transform:uppercase; color:var(--obs-text-dim);">Overall composite</div>
+    <div style="display:flex; align-items:baseline; gap:1rem;">
+      <div style="font-family:var(--font-display); font-stretch:75%; font-weight:800; font-size:6rem; line-height:0.92; letter-spacing:-0.04em; color:var(--obs-text); font-variant-numeric:tabular-nums;">
+        {{ "%.1f"|format(overall.composite) }}
+      </div>
+      <div style="display:flex; flex-direction:column; gap:0.4rem; align-items:flex-start;">
+        <span class="score-chip" style="background:{{ overall.color }}; font-size:1.05rem; padding:0.5rem 0.95rem;">
+          <span class="letter" style="font-size:0.9rem;">GRADE&nbsp;{{ overall.letter }}</span>
+        </span>
+        <span style="font-family:var(--font-mono); font-size:11px; color:var(--obs-text-dim); letter-spacing:0.06em;">across {{ total_cells }} scored cells</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="hero-stats">
+    <div class="stat-card">
+      <div class="stat-label">Lanes</div>
+      <div class="stat-value">{{ lanes|length }}</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-label">Models</div>
+      <div class="stat-value">{{ models|length }}</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-label">Families</div>
+      <div class="stat-value">{{ families|length }}</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-label">Total cost</div>
+      <div class="stat-value" style="font-size:1.7rem;">${{ "%.2f"|format(total_cost) }}</div>
+    </div>
+  </div>
+</section>
+
+<a class="index-link" href="matrix.html" style="margin-bottom:1.6rem; padding:1.1rem 1.4rem;">
+  <span style="display:flex; flex-direction:column; gap:0.2rem;">
+    <span style="font-family:var(--font-display); font-stretch:80%; font-weight:800; font-size:1.05rem; letter-spacing:0.02em;">MATRIX HEATMAP</span>
+    <span style="font-family:var(--font-mono); font-size:11.5px; color:var(--obs-text-dim);">12 lanes × {{ models|length }} models · composite scores + letter grades</span>
+  </span>
+  <span class="arrow">→</span>
+</a>
+
+<div class="section-head">
+  <h2>Per&nbsp;Lane</h2>
+  <span class="count">{{ lanes|length }} REPORTS</span>
+</div>
+<nav class="index-links">
+{% for lane in lanes %}
+  <a class="index-link" href="per-lane/{{ lane }}.html">
+    <span>{{ lane }}</span>
+    <span class="arrow">→</span>
+  </a>
+{% endfor %}
+</nav>
+
+<div class="section-head">
+  <h2>Per&nbsp;Model</h2>
+  <span class="count">{{ models|length }} REPORTS</span>
+</div>
+<nav class="index-links">
+{% for model in models %}
+  <a class="index-link" href="per-model/{{ safe_filename(model) }}.html">
+    <span>{{ model }}</span>
+    <span class="arrow">→</span>
+  </a>
+{% endfor %}
+</nav>
+
+<footer style="margin-top:3rem; padding-top:1.2rem; border-top:1px solid var(--obs-border); display:flex; gap:1.2rem; font-family:var(--font-mono); font-size:11px; color:var(--obs-text-mute); flex-wrap:wrap; letter-spacing:0.05em;">
+  <span>families: {{ families|join(', ') }}</span>
+  <span>·</span>
+  <span>ledger: kubedojo/v1</span>
+  <span>·</span>
+  <span>generated: {{ run_date }}</span>
+</footer>
+
+</div>
+</body>
+</html>

--- a/scripts/calibration/reports/templates/matrix.html.j2
+++ b/scripts/calibration/reports/templates/matrix.html.j2
@@ -3,49 +3,44 @@
 <head>
 <meta charset="utf-8">
 <title>Calibration matrix — {{ run_date }}</title>
-<link rel="stylesheet" href="../design-system.css">
-<style>
-  body { max-width: 1100px; margin: 0 auto; padding: 1.5rem 1.25rem 3rem; }
-  h1 { margin-bottom: 0.25rem; }
-  p.meta { color: #555; font-size: 0.9rem; margin-top: 0.1rem; }
-  .legend-panel { border:1px solid #d8dee4; background:#fbfcfd; padding:0.75rem 0.85rem; margin:0.9rem 0 1rem; border-radius:0.35rem; }
-  .legend-grades { display:flex; gap:0.45rem; flex-wrap:wrap; align-items:center; margin-bottom:0.45rem; }
-  .legend-grade { color:white; font-weight:700; border-radius:0.25rem; padding:0.22rem 0.55rem; font-size:0.84rem; }
-  .legend-copy { margin:0.15rem 0; color:#38424d; font-size:0.88rem; }
-  table { width:100%; border-collapse: collapse; margin: 0.75rem 0 1.25rem; }
-  th, td { border:1px solid #ddd; padding:0.35rem 0.55rem; font-size:0.88rem; vertical-align: top; }
-  th { background:#f3f5f7; text-align:left; }
-  .score { display:block; font-weight:700; margin-top:0.2rem; }
-  .missing { color:#777; background:#f7f7f7; }
-  .heat-0 { background:#f8d7da; }
-  .heat-1 { background:#fff3cd; }
-  .heat-2 { background:#d1ecf1; }
-  .heat-3 { background:#d4edda; }
-  .summary-cell { background:#f6f8fa; }
-  .summary-row th, .summary-row td { background:#f3f5f7; }
-  a { color:#0b5cad; }
-</style>
+<link rel="stylesheet" href="../calibration.css">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
-<h1>Calibration matrix</h1>
-<p class="meta">run_date={{ run_date }} · cells={{ total_cells }}</p>
-<div class="legend-panel">
-  <div class="legend-grades">
-    {% for grade in grade_legend %}
-    <span class="legend-grade" style="background:{{ grade.color }}">{{ grade.letter }} {{ grade.band }}</span>
-    {% endfor %}
+<div class="shell">
+
+<header class="page-head">
+  <div>
+    <div class="eyebrow">CALIBRATION&nbsp;OBSERVATORY · {{ run_date }}</div>
+    <h1 class="title">Composite <em>matrix</em></h1>
+    <p class="meta">
+      <span class="meta-kv"><b>{{ total_cells }}</b> cells</span>
+      <span class="meta-kv">run_date <b>{{ run_date }}</b></span>
+      <a href="index.html">index</a>
+    </p>
   </div>
-  <p class="legend-copy">Composite = 40% deterministic gates + 60% LLM judges (prose lanes); 100% gates (mechanical lanes).</p>
-  <p class="legend-copy">Hover any cell for the gate-ratio / judge1 / judge2 breakdown.</p>
+</header>
+
+<div class="legend">
+  <span class="grades">
+    {% for grade in grade_legend %}
+    <span class="legend-grade" style="background:{{ grade.color }};">{{ grade.letter }}&nbsp;{{ grade.band }}</span>
+    {% endfor %}
+  </span>
+  <p class="legend-copy">
+    Composite = <strong>0.4 × gate-pass</strong> + <strong>0.6 × judge mean</strong> (prose lanes); gate-pass only (mechanical lanes). Hover any cell for breakdown. <span class="dissent" style="position:static; display:inline-flex; vertical-align:middle; margin:0 0.3rem;">⚠</span> marks judge dissent &gt; 2.0.
+  </p>
 </div>
-<table>
+
+<div class="matrix-wrap">
+<table class="matrix">
   <thead>
     <tr>
-      <th>Lane</th>
+      <th>Lane&nbsp;/&nbsp;Model</th>
       {% for model in models %}
       <th>{{ model }}</th>
       {% endfor %}
-      <th>Lane mean</th>
+      <th>Σ&nbsp;lane</th>
     </tr>
   </thead>
   <tbody>
@@ -54,46 +49,59 @@
       <th><a href="per-lane/{{ row.lane }}.html">{{ row.lane }}</a></th>
       {% for cell in row.cells %}
         {% if cell %}
-          {% set bucket = 3 if cell.deterministic_score >= 0.95 else 2 if cell.deterministic_score >= 0.75 else 1 if cell.deterministic_score > 0 else 0 %}
-          <td class="heat-{{ bucket }}" title="{{ cell.cell_id }}">
-            <a href="per-model/{{ cell.canonical_string | replace('/', '_') | replace('@', '_') }}.html">{{ cell.canonical_string }}</a>
-            <span class="score">
-              <span class="cell-score grade-{{ cell.letter }}" style="background:{{ cell.color }};color:white;font-weight:600;padding:2px 6px;border-radius:3px;" title="gates={{ "%.0f"|format(cell.gate_pct) }}%, judges=[{{ cell.judge_title }}]">{{ "%.1f"|format(cell.composite) }} {{ cell.letter }}</span>{% if cell.judge_dissent %}<sup style="color:#856404;" title="judges disagreed">⚠</sup>{% endif %}
-            </span>
+          <td title="{{ cell.cell_id }} · gates={{ "%.0f"|format(cell.gate_pct) }}% · judges=[{{ cell.judge_title }}]">
+            <a class="model-anchor" href="per-model/{{ cell.canonical_string | replace('/', '_') | replace('@', '_') }}.html" aria-label="{{ cell.canonical_string }} on {{ row.lane }}"></a>
+            <div class="cell-inner">
+              <span class="score-num">{{ "%.1f"|format(cell.composite) }}</span>
+              <span class="grade-pill" style="background:{{ cell.color }};">{{ cell.letter }}</span>
+            </div>
+            {% if cell.judge_dissent %}<span class="dissent" aria-label="judge dissent">⚠</span>{% endif %}
           </td>
         {% else %}
-          <td class="missing">not run</td>
+          <td class="missing"><div class="cell-inner">N/A</div></td>
         {% endif %}
       {% endfor %}
-      <td class="summary-cell">
+      <td class="col-summary">
         {% if row.summary %}
-        <span class="cell-score grade-{{ row.summary.letter }}" style="background:{{ row.summary.color }};color:white;font-weight:600;padding:2px 6px;border-radius:3px;" title="mean composite">{{ "%.1f"|format(row.summary.composite) }} {{ row.summary.letter }}</span>
+        <div class="cell-inner">
+          <span class="score-num">{{ "%.1f"|format(row.summary.composite) }}</span>
+          <span class="grade-pill" style="background:{{ row.summary.color }};">{{ row.summary.letter }}</span>
+        </div>
         {% else %}
-        n/a
+        <div class="cell-inner" style="color:var(--obs-text-mute); font-size:11px;">—</div>
         {% endif %}
       </td>
     </tr>
     {% endfor %}
-    <tr class="summary-row">
-      <th>Model mean</th>
+    <tr>
+      <th class="summary-label">Σ&nbsp;model</th>
       {% for summary in model_summaries %}
-      <td>
+      <td class="summary-cell">
         {% if summary %}
-        <span class="cell-score grade-{{ summary.letter }}" style="background:{{ summary.color }};color:white;font-weight:600;padding:2px 6px;border-radius:3px;" title="mean composite">{{ "%.1f"|format(summary.composite) }} {{ summary.letter }}</span>
+        <div class="cell-inner">
+          <span class="score-num">{{ "%.1f"|format(summary.composite) }}</span>
+          <span class="grade-pill" style="background:{{ summary.color }};">{{ summary.letter }}</span>
+        </div>
         {% else %}
-        n/a
+        <div class="cell-inner" style="color:var(--obs-text-mute); font-size:11px;">—</div>
         {% endif %}
       </td>
       {% endfor %}
-      <td>
+      <td class="summary-cell" style="background:var(--obs-surface-pop);">
         {% if overall_summary %}
-        <span class="cell-score grade-{{ overall_summary.letter }}" style="background:{{ overall_summary.color }};color:white;font-weight:600;padding:2px 6px;border-radius:3px;" title="overall mean">{{ "%.1f"|format(overall_summary.composite) }} {{ overall_summary.letter }}</span>
+        <div class="cell-inner">
+          <span class="score-num" style="color:var(--obs-accent);">{{ "%.1f"|format(overall_summary.composite) }}</span>
+          <span class="grade-pill" style="background:{{ overall_summary.color }};">{{ overall_summary.letter }}</span>
+        </div>
         {% else %}
-        n/a
+        <div class="cell-inner" style="color:var(--obs-text-mute); font-size:11px;">—</div>
         {% endif %}
       </td>
     </tr>
   </tbody>
 </table>
+</div>
+
+</div>
 </body>
 </html>

--- a/scripts/calibration/reports/templates/per_lane.html.j2
+++ b/scripts/calibration/reports/templates/per_lane.html.j2
@@ -3,41 +3,45 @@
 <head>
 <meta charset="utf-8">
 <title>{{ lane }} — calibration lane</title>
-<link rel="stylesheet" href="../../design-system.css">
-<style>
-  body { max-width: 1100px; margin: 0 auto; padding: 1.5rem 1.25rem 3rem; }
-  h1 { margin-bottom: 0.25rem; }
-  p.meta { color: #555; font-size: 0.9rem; margin-top: 0.1rem; }
-  table { width:100%; border-collapse: collapse; margin: 0.75rem 0 1.25rem; }
-  th, td { border:1px solid #ddd; padding:0.35rem 0.55rem; font-size:0.92rem; vertical-align: top; }
-  th { background:#f3f5f7; text-align:left; }
-  .pill { display:inline-block; padding:0.1rem 0.55rem; border-radius:0.35rem; font-size:0.78rem; font-weight:600; background:#e0e0ff; color:#1a1a8a; }
-  .bar-track { width:100%; min-width:14rem; height:1rem; background:#eceff3; border-radius:0.2rem; overflow:hidden; }
-  .bar-fill { height:100%; border-radius:0.2rem; }
-  .score-chip { color:white; font-weight:700; border-radius:0.25rem; padding:0.15rem 0.5rem; white-space:nowrap; }
-  .rank-star { color:#b77900; font-size:0.85rem; margin-left:0.3rem; }
-</style>
+<link rel="stylesheet" href="../../calibration.css">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
-<h1>{{ lane }}</h1>
-<p class="meta">run_date={{ run_date }} · <a href="../matrix.html">matrix</a></p>
-<table>
-  <thead>
-    <tr><th>Model</th><th>Composite</th><th>Grade</th></tr>
-  </thead>
-  <tbody>
-    {% for cell in cells %}
-    <tr>
-      <td>{{ cell.canonical_string }}{% if loop.index <= 3 %}<span class="rank-star" title="top 3">⭐</span>{% endif %}</td>
-      <td>
-        <div class="bar-track" title="mean composite">
-          <div class="bar-fill" style="width:{{ "%.1f"|format(cell.composite * 10.0) }}%; background:{{ cell.color }};"></div>
-        </div>
-      </td>
-      <td><span class="score-chip" style="background:{{ cell.color }}">{{ "%.1f"|format(cell.composite) }} {{ cell.letter }}</span>{% if cell.judge_dissent %}<sup style="color:#856404;" title="one or more cells had judge disagreement">⚠</sup>{% endif %}</td>
-    </tr>
-    {% endfor %}
-  </tbody>
-</table>
+<div class="shell" style="max-width:1100px;">
+
+<header class="page-head">
+  <div>
+    <div class="eyebrow">LANE&nbsp;BREAKDOWN · {{ run_date }}</div>
+    <h1 class="title">{{ lane }}</h1>
+    <p class="meta">
+      <span class="meta-kv"><b>{{ cells|length }}</b> models scored</span>
+      <a href="../matrix.html">matrix</a>
+      <a href="../index.html">index</a>
+    </p>
+  </div>
+</header>
+
+<ol class="ranking-list">
+  {% for cell in cells %}
+  <li class="ranking-row {% if loop.index <= 3 %}top-{{ loop.index }}{% endif %}">
+    <div class="rank-num">{{ "%02d"|format(loop.index) }}</div>
+    <div class="model-name">
+      {{ cell.canonical_string }}
+      {% if loop.index <= 3 %}<span class="rank-star" title="top 3">★</span>{% endif %}
+    </div>
+    <div class="bar-track" title="composite {{ "%.2f"|format(cell.composite) }}/10">
+      <div class="bar-fill" style="width:{{ "%.1f"|format(cell.composite * 10.0) }}%; background:{{ cell.color }}; color:{{ cell.color }};"></div>
+    </div>
+    <div style="text-align:right;">
+      <span class="score-chip" style="background:{{ cell.color }};">
+        {{ "%.1f"|format(cell.composite) }}<span class="letter">{{ cell.letter }}</span>
+      </span>
+      {% if cell.judge_dissent %}<sup class="dissent-sup" title="judge disagreement">⚠</sup>{% endif %}
+    </div>
+  </li>
+  {% endfor %}
+</ol>
+
+</div>
 </body>
 </html>

--- a/scripts/calibration/reports/templates/per_model.html.j2
+++ b/scripts/calibration/reports/templates/per_model.html.j2
@@ -3,90 +3,114 @@
 <head>
 <meta charset="utf-8">
 <title>{{ canonical_string }} — calibration model</title>
-<link rel="stylesheet" href="../../design-system.css">
-<style>
-  body { max-width: 1100px; margin: 0 auto; padding: 1.5rem 1.25rem 3rem; }
-  h1 { margin-bottom: 0.25rem; }
-  p.meta { color: #555; font-size: 0.9rem; margin-top: 0.1rem; }
-  table { width:100%; border-collapse: collapse; margin: 0.75rem 0 1.25rem; }
-  th, td { border:1px solid #ddd; padding:0.35rem 0.55rem; font-size:0.92rem; vertical-align: top; }
-  th { background:#f3f5f7; text-align:left; }
-  .confidence { font-weight:700; }
-  .profile { display:grid; grid-template-columns:minmax(0, 1.15fr) minmax(16rem, 0.85fr); gap:1.25rem; align-items:start; margin-top:1rem; }
-  .radar-wrap { overflow-x:auto; }
-  .radar-svg { max-width:100%; height:auto; }
-  .radar-ring { fill:none; stroke:#d8dee4; stroke-width:1; }
-  .radar-axis { stroke:#ccd3da; stroke-width:1; }
-  .radar-label { font-size:10px; fill:#2f3a45; }
-  .radar-score { font-weight:700; fill:#1f2933; }
-  .tag-cloud { display:flex; gap:0.45rem; flex-wrap:wrap; margin:0.35rem 0 0.85rem; }
-  .tag { color:white; border-radius:0.3rem; padding:0.22rem 0.5rem; font-size:0.82rem; font-weight:700; }
-  .empty { color:#687380; font-size:0.9rem; }
-  .score-chip { color:white; font-weight:700; border-radius:0.25rem; padding:0.15rem 0.5rem; white-space:nowrap; }
-  @media (max-width: 760px) { .profile { grid-template-columns:1fr; } }
-</style>
+<link rel="stylesheet" href="../../calibration.css">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
-<h1>{{ canonical_string }}</h1>
-<p class="meta">run_date={{ run_date }} · <a href="../matrix.html">matrix</a></p>
+<div class="shell" style="max-width:1200px;">
+
+<header class="page-head">
+  <div>
+    <div class="eyebrow">MODEL&nbsp;PROFILE · {{ run_date }}</div>
+    <h1 class="title">{{ canonical_string }}</h1>
+    <p class="meta">
+      <span class="meta-kv"><b>{{ cells|length }}</b> lanes scored</span>
+      <a href="../matrix.html">matrix</a>
+      <a href="../index.html">index</a>
+    </p>
+  </div>
+</header>
+
 <section class="profile">
+
   <div class="radar-wrap">
-    <svg class="radar-svg" width="420" height="420" viewBox="0 0 {{ radar.size }} {{ radar.size }}" role="img" aria-label="Composite score radar chart for {{ canonical_string }}">
+    <svg class="radar-svg" width="560" height="560" viewBox="0 0 {{ radar.size }} {{ radar.size }}" role="img" aria-label="Composite score radar chart for {{ canonical_string }}">
+      <defs>
+        <radialGradient id="radar-glow" cx="50%" cy="50%" r="50%">
+          <stop offset="0%" stop-color="#38bdf8" stop-opacity="0.35"/>
+          <stop offset="60%" stop-color="#38bdf8" stop-opacity="0.12"/>
+          <stop offset="100%" stop-color="#38bdf8" stop-opacity="0.0"/>
+        </radialGradient>
+      </defs>
+
       {% for ring in radar.rings %}
-      <polygon class="radar-ring" points="{{ ring.points }}"></polygon>
+      <polygon class="radar-ring{% if loop.last %} outer{% endif %}" points="{{ ring.points }}"></polygon>
       {% endfor %}
+
       {% for axis in radar.axes %}
       <line class="radar-axis" x1="{{ radar.center }}" y1="{{ radar.center }}" x2="{{ "%.1f"|format(axis.axis_x) }}" y2="{{ "%.1f"|format(axis.axis_y) }}"></line>
       {% endfor %}
-      <polygon points="{{ radar.polygon_points }}" fill="#0b5cad" fill-opacity="0.3" stroke="#0b5cad" stroke-width="2"></polygon>
+
+      <polygon class="radar-polygon" points="{{ radar.polygon_points }}"></polygon>
+
       {% for axis in radar.axes %}
       <g>
         <text class="radar-label" x="{{ "%.1f"|format(axis.label_x) }}" y="{{ "%.1f"|format(axis.label_y) }}" text-anchor="{{ axis.anchor }}">
           <tspan x="{{ "%.1f"|format(axis.label_x) }}">{{ axis.lane }}</tspan>
-          <tspan class="radar-score" x="{{ "%.1f"|format(axis.label_x) }}" dy="12">{{ "%.1f"|format(axis.composite) }}</tspan>
+          <tspan class="radar-score" x="{{ "%.1f"|format(axis.label_x) }}" dy="14">{{ "%.1f"|format(axis.composite) }}</tspan>
         </text>
-        <rect x="{{ "%.1f"|format(axis.chip_x) }}" y="{{ "%.1f"|format(axis.chip_y) }}" width="20" height="13" rx="2" fill="{{ axis.color }}"></rect>
-        <text x="{{ "%.1f"|format(axis.chip_text_x) }}" y="{{ "%.1f"|format(axis.chip_text_y) }}" text-anchor="middle" font-size="9" font-weight="700" fill="white">{{ axis.letter }}</text>
+        <rect x="{{ "%.1f"|format(axis.chip_x) }}" y="{{ "%.1f"|format(axis.chip_y) }}" width="22" height="14" rx="3" fill="{{ axis.color }}"/>
+        <text x="{{ "%.1f"|format(axis.chip_text_x) }}" y="{{ "%.1f"|format(axis.chip_text_y) }}" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="9.5" font-weight="800" fill="#050811">{{ axis.letter }}</text>
       </g>
       {% endfor %}
     </svg>
   </div>
-  <div>
-    <h2>Strengths</h2>
+
+  <aside class="profile-side">
+    <h2>Strengths · A</h2>
     <div class="tag-cloud">
       {% for cell in strengths %}
-      <span class="tag" style="background:{{ cell.color }}">{{ cell.lane }} {{ "%.1f"|format(cell.composite) }} {{ cell.letter }}</span>
+      <span class="tag" style="background:{{ cell.color }};">{{ cell.lane }} · {{ "%.1f"|format(cell.composite) }}{{ cell.letter }}</span>
       {% else %}
-      <span class="empty">none</span>
+      <span class="empty">no A-tier lanes</span>
       {% endfor %}
     </div>
-    <h2>Weaknesses</h2>
+
+    <h2>Weaknesses · F</h2>
     <div class="tag-cloud">
       {% for cell in weaknesses %}
-      <span class="tag" style="background:{{ cell.color }}">{{ cell.lane }} {{ "%.1f"|format(cell.composite) }} {{ cell.letter }}</span>
+      <span class="tag" style="background:{{ cell.color }};">{{ cell.lane }} · {{ "%.1f"|format(cell.composite) }}{{ cell.letter }}</span>
       {% else %}
-      <span class="empty">none</span>
+      <span class="empty">no F-tier lanes</span>
       {% endfor %}
     </div>
-  </div>
+  </aside>
 </section>
-<table>
+
+<table class="detail">
   <thead>
-    <tr><th>Lane</th><th>Fixture</th><th>Composite</th><th>Deterministic</th><th>LLM judge</th><th>Confidence vs actual</th><th>Cell</th></tr>
+    <tr>
+      <th>Lane</th>
+      <th>Fixture</th>
+      <th>Composite</th>
+      <th>Gates</th>
+      <th>Judge</th>
+      <th>Effort signal</th>
+      <th>Cell ID</th>
+    </tr>
   </thead>
   <tbody>
     {% for cell in cells %}
     <tr>
       <td><a href="../per-lane/{{ cell.lane }}.html">{{ cell.lane }}</a></td>
-      <td>{{ cell.fixture_id }}</td>
-      <td><span class="score-chip" style="background:{{ cell.color }}">{{ "%.1f"|format(cell.composite) }} {{ cell.letter }}</span>{% if cell.judge_dissent %}<sup style="color:#856404;" title="judges disagreed">⚠</sup>{% endif %}</td>
-      <td>{{ "%.0f"|format(cell.deterministic_score * 100) }}%</td>
-      <td>{% if cell.llm_score is not none %}{{ "%.1f"|format(cell.llm_score) }}{% else %}n/a{% endif %}</td>
-      <td><span class="confidence">{{ cell.effort_confidence }}</span> effort signal vs {{ "%.1f"|format(cell.composite) }} composite</td>
-      <td>{{ cell.cell_id }}</td>
+      <td style="color:var(--obs-text-dim);">{{ cell.fixture_id }}</td>
+      <td>
+        <span class="score-chip" style="background:{{ cell.color }};">
+          {{ "%.1f"|format(cell.composite) }}<span class="letter">{{ cell.letter }}</span>
+        </span>
+        {% if cell.judge_dissent %}<sup class="dissent-sup">⚠</sup>{% endif %}
+      </td>
+      <td style="font-variant-numeric:tabular-nums;">{{ "%.0f"|format(cell.deterministic_score * 100) }}%</td>
+      <td style="font-variant-numeric:tabular-nums;">
+        {% if cell.llm_score is not none %}{{ "%.1f"|format(cell.llm_score) }}{% else %}<span style="color:var(--obs-text-mute);">n/a</span>{% endif %}
+      </td>
+      <td><span class="confidence">{{ cell.effort_confidence }}</span></td>
+      <td style="color:var(--obs-text-mute); font-size:10.5px;">{{ cell.cell_id }}</td>
     </tr>
     {% endfor %}
   </tbody>
 </table>
+
+</div>
 </body>
 </html>

--- a/tests/calibration/test_report.py
+++ b/tests/calibration/test_report.py
@@ -259,15 +259,15 @@ def test_report_renders_matrix_per_lane_and_per_model(tmp_path):
     assert out_dir / "matrix.html" in written
     assert cell_id in matrix
     assert "code-writing" in matrix
-    assert 'class="cell-score grade-A"' in matrix
-    assert "10.0 A" in matrix
-    assert "gates=100%, judges=[n/a]" in matrix
-    assert "Lane mean" in matrix
-    assert "Model mean" in matrix
+    assert 'class="grade-pill"' in matrix
+    assert "10.0" in matrix
+    assert ">A<" in matrix
+    assert "gates=100% · judges=[n/a]" in matrix
+    assert "Σ" in matrix
     assert "gpt-5.5" in per_lane
     assert "bar-fill" in per_lane
-    assert "⭐" in per_lane
+    assert "★" in per_lane
     assert "<svg" in per_model
     assert "Strengths" in per_model
-    assert "confidence vs actual" in per_model.lower()
-    assert "total_cost=$0.0800" in index
+    assert "effort signal" in per_model.lower()
+    assert "$0.0800" in index


### PR DESCRIPTION
## Summary

Replaces the plain Bootstrap-y aesthetic of the 3 calibration report templates + the inline-string index with a cohesive dark-theme design language ("Observatory") inspired by diagnostic instrumentation panels.

### Visual before vs after

- **Before**: each template carried 8-25 lines of inline `<style>` with a broken `<link rel="stylesheet" href="../design-system.css">` (the file was never copied to the reports output dir, so 404'd in prod). Plain table + 4 hardcoded heat-N buckets. Small grades chips. 420x420 radar with right-side labels clipping out of viewBox.

- **After**: Single 800-line `calibration.css` master stylesheet, copied to `calibration/v1/reports/calibration.css` on every render. Bricolage Grotesque (compressed 75% stretch for hero titles) + Newsreader italic accents + JetBrains Mono for all numbers/IDs. Continuous score-color gradient (red → amber → cyan apex) drives letter pills and bar fills. Sticky lane/model headers on the matrix. Tabular-nums everywhere. Radar grown to 640x640 with proper label headroom.

### Files

- `scripts/calibration/reports/templates/calibration.css` (new) — 800-line master stylesheet
- `scripts/calibration/reports/templates/index.html.j2` (new) — replaces inline-string `_render_index` with hero card (huge composite + letter pill) + 2×2 stat-card grid
- `scripts/calibration/reports/templates/matrix.html.j2` — sticky headers, mono cells, diagonal-stripe missing-cell pattern, apex summary cell highlighted in cyan
- `scripts/calibration/reports/templates/per_lane.html.j2` — 4-column rank rows with neon-glow bars, top-3 colored by tier
- `scripts/calibration/reports/templates/per_model.html.j2` — radar with cyan glow + radial halo; Strengths/Weaknesses side panel
- `scripts/calibration/report.py` — copies `calibration.css` to the reports root on every render; `_render_index` inline-string function deleted; `_radar_context` size 480 → 640 with outer_radius 130 → 145 and label_radius 188 → 205 to fit long lane labels; `_overall_grade` helper for the hero composite

Regression test: tests/calibration/test_score_cell.py + tests/calibration/test_run_wave.py (existing 110 + 1 skipped — no logic changes; templates render against the same context dicts)

## Test plan

- [x] `.venv/bin/python -m pytest tests/calibration/ -q` — 110 passed, 1 skipped
- [x] `.venv/bin/python -m ruff check scripts/calibration/report.py` — clean
- [x] `python -m scripts.calibration.report --run-date 2026-05-22` renders all 4 surfaces
- [x] Visually verified via local API `/artifacts/calibration/v1/reports/2026-05-22/`:
  - **index**: hero shows 6.7 GRADE C across 65 cells; stat cards crisp
  - **matrix**: sticky lane column + sticky model row; tabular-nums composites; letter pills with continuous gradient; diagonal-stripe N/A pattern; cyan-highlighted overall summary cell
  - **per-lane code-review**: 5-row ranking with deepseek-v4-pro + qwen3.6-plus tied at #1 (8.3 B), qwen3.6 last (5.0 D); neon-glow bars
  - **per-model deepseek-v4-pro**: 8-lane signature polygon with cyan glow + radial halo behind; **all 12 lane labels visible without clipping**; "harness-following · 9.7A" in Strengths sidebar
- [x] `prefers-reduced-motion: reduce` media query disables the matrix cell stagger-fade

## What's NOT in this PR

- **Per-cell tooltip JavaScript** — current title-attribute fallback works but could grow into a polished floating tooltip. Out of scope.
- **Light mode** — the design system is dark-only. Light variant is a separate effort.
- **Mobile breakpoint polish** — matrix is fundamentally a wide table; mobile gets horizontal scroll only.
- **Per-lane bar chart for ALL lanes** — only code-review verified visually; other lanes follow the same template so should look the same.