### PR TITLE
feat(calibration): orchestrating fixture 2/3 — schedule-plan-dependency-chain

### DIFF
--- a/scripts/calibration/ground-truth/v1/orchestrating/schedule-plan-dependency-chain.yaml
+++ b/scripts/calibration/ground-truth/v1/orchestrating/schedule-plan-dependency-chain.yaml
@@ -11,7 +11,6 @@ required_categories:
   - "CI runner cap"
   - "kill-switch"
   - "cost budget"
-  - "decision card"
 novel_risk_terms:
   - "rebase storm"
   - "reviewer starvation"

--- a/scripts/calibration/ground-truth/v1/orchestrating/schedule-plan-dependency-chain.yaml
+++ b/scripts/calibration/ground-truth/v1/orchestrating/schedule-plan-dependency-chain.yaml
@@ -25,7 +25,6 @@ llm_rubric: |-
   Reward clear separation of parallelizable review/CI waiting time from serialized authoring, review, and merge gates.
   Reward an explicit kill-switch or checkpoint with a fallback action for review queueing, CI runner exhaustion, or weekly-cap exhaustion.
   Reward honest rough time and cost budgets tied to the concrete 18-minute PR gates, 25-minute smoke, 30-minute reviewer SLA, and available agent capacity.
-  Reward using Decision Card vocabulary only when there is a real tradeoff or disagreement to surface.
   Penalize parallel plans that violate the same-family cap, cross-family review rule, reviewer queue limit, or CI runner cap.
   Penalize vague "monitor and adjust" language without a named checkpoint, threshold, or fallback action.
   Penalize ignoring reviewer-stage queueing, hand-waving the weekly cap, or treating a full wave dispatch as part of the fixture-authoring PR.

--- a/scripts/calibration/ground-truth/v1/orchestrating/schedule-plan-dependency-chain.yaml
+++ b/scripts/calibration/ground-truth/v1/orchestrating/schedule-plan-dependency-chain.yaml
@@ -1,0 +1,32 @@
+# Fixture source: v1.1 spec lane 7, schedule plan w/ dependency chain. Phase 3 fixture #2/3 per #1413.
+fixture_id: schedule-plan-dependency-chain
+lane: orchestrating
+required_categories:
+  - "binding constraint"
+  - "weekly cap"
+  - "reviewer SLA"
+  - "review-stage queueing"
+  - "same-family"
+  - "cross-family review"
+  - "CI runner cap"
+  - "kill-switch"
+  - "cost budget"
+  - "decision card"
+novel_risk_terms:
+  - "rebase storm"
+  - "reviewer starvation"
+  - "weekly burnout"
+  - "sandbox queue pileup"
+llm_rubric: |-
+  Return JSON: {"score": 0-10, "rationale": "..."}.
+
+  Reward plans that name the binding constraint before optimizing the schedule.
+  Reward explicit dependency boundaries among PR-A through PR-E, including that PR-C waits for both fixture PRs and PR-E waits for a green combined registry smoke.
+  Reward cost-aware sequencing that protects the 6-run codex weekly cap and keeps OpenAI-family work serialized when required.
+  Reward clear separation of parallelizable review/CI waiting time from serialized authoring, review, and merge gates.
+  Reward an explicit kill-switch or checkpoint with a fallback action for review queueing, CI runner exhaustion, or weekly-cap exhaustion.
+  Reward honest rough time and cost budgets tied to the concrete 18-minute PR gates, 25-minute smoke, 30-minute reviewer SLA, and available agent capacity.
+  Reward using Decision Card vocabulary only when there is a real tradeoff or disagreement to surface.
+  Penalize parallel plans that violate the same-family cap, cross-family review rule, reviewer queue limit, or CI runner cap.
+  Penalize vague "monitor and adjust" language without a named checkpoint, threshold, or fallback action.
+  Penalize ignoring reviewer-stage queueing, hand-waving the weekly cap, or treating a full wave dispatch as part of the fixture-authoring PR.

--- a/scripts/calibration/prompts/v1/orchestrating/schedule-plan-dependency-chain.md
+++ b/scripts/calibration/prompts/v1/orchestrating/schedule-plan-dependency-chain.md
@@ -19,4 +19,4 @@ Deliver:
 1. An ordered timeline with dependencies for all five work items.
 2. Which steps are serialized vs parallel and why, naming the binding constraint.
 3. A kill-switch or fallback if review, CI, or the codex weekly cap blocks progress.
-4. A rough cost/time budget. If there is a real tradeoff, use the KubeDojo Decision Card vocabulary: Option A, Option B, disagreement, awaiting.
+4. A rough cost/time budget.

--- a/scripts/calibration/prompts/v1/orchestrating/schedule-plan-dependency-chain.md
+++ b/scripts/calibration/prompts/v1/orchestrating/schedule-plan-dependency-chain.md
@@ -1,0 +1,22 @@
+You are scheduling the next KubeDojo calibration prep block. Produce a plan; do not dispatch a calibration wave yet.
+
+Work items waiting:
+- PR-A: author orchestrating fixture #2 and register it in `run_wave.py`.
+- PR-B: author orchestrating fixture #3; it should not reuse PR-A's exact rubric pattern.
+- PR-C: update the calibration README/index after PR-A and PR-B both merge.
+- PR-D: run schema/ruff smoke checks on the combined registry after PR-C.
+- PR-E: open the one-fixture-per-model wave issue only after PR-D is green.
+
+Binding constraints:
+- Only one Gemini reviewer is available; reviewer SLA is 30 minutes per PR, and no more than two PRs may sit in review at once.
+- The CI pool has 2 runners. Each PR gate takes 18 minutes; the combined registry
+  smoke takes 25 minutes and must have a free runner.
+- Codex has 6 high-tier runs left this weekly cap, and OpenAI-family agent work must be serialized: max 1 codex/sonnet task inflight.
+- Cross-family review is mandatory: a Codex-authored PR needs Gemini review before
+  merge. Claude is throttled today, so do not count on Claude review capacity.
+
+Deliver:
+1. An ordered timeline with dependencies for all five work items.
+2. Which steps are serialized vs parallel and why, naming the binding constraint.
+3. A kill-switch or fallback if review, CI, or the codex weekly cap blocks progress.
+4. A rough cost/time budget. If there is a real tradeoff, use the KubeDojo Decision Card vocabulary: Option A, Option B, disagreement, awaiting.

--- a/scripts/calibration/run_wave.py
+++ b/scripts/calibration/run_wave.py
@@ -45,6 +45,7 @@ LANE_FIXTURES: dict[str, list[str]] = {
     ],
     "orchestrating": [
         "multi-task-routing-brief",
+        "schedule-plan-dependency-chain",
         "runbook-followup-status-to-actions",
     ],
     "debugging": ["pod-pending-topology-mismatch"],


### PR DESCRIPTION
## Summary
- Adds the orchestrating schedule-plan-dependency-chain fixture for the schedule-plan variety dimension in #1413.
- Prompt asks for a dependent five-work-item timeline under reviewer SLA, CI runner cap, same-family serialization, weekly cap, and cross-family review constraints.
- Registers the fixture after multi-task-routing-brief in run_wave.py.

## Gate strategy
- No expected_routes by design: routing_accuracy vacuous-pass is correct for this sequencing fixture.
- LLM judge plus required_categories/novel_risk_terms carry the prose-lane signal.
- Rubric rewards explicit dependency boundaries, binding-constraint naming, same-family serialization, kill-switches, and honest budget estimates.

## Validation
- .venv/bin/python -c "import yaml; yaml.safe_load(open('scripts/calibration/ground-truth/v1/orchestrating/schedule-plan-dependency-chain.yaml'))"
- .venv/bin/ruff check scripts/calibration/run_wave.py
- git diff --check

No wave run in this PR per feedback_one_fixture_per_model_per_wave.