### PR TITLE
feat(calibration): orchestrating fixture 3/3 — runbook-followup-status-to-actions

### DIFF
--- a/scripts/calibration/ground-truth/v1/orchestrating/runbook-followup-status-to-actions.yaml
+++ b/scripts/calibration/ground-truth/v1/orchestrating/runbook-followup-status-to-actions.yaml
@@ -1,0 +1,34 @@
+# Fixture source: v1.1 spec lane 7, runbook follow-up. Phase 3 fixture #3/3 per #1413.
+fixture_id: runbook-followup-status-to-actions
+lane: orchestrating
+required_categories:
+  - "owner"
+  - "lane"
+  - "next action"
+  - "verification"
+  - "escalation"
+  - "decision card"
+  - "serialize"
+  - "cost"
+  - "gh pr"
+  - "ledger"
+  - "wave"
+  - "git ls-remote"
+novel_risk_terms:
+  - "silent push failure"
+  - "reviewer starvation"
+  - "stale lease"
+  - "missing verification"
+  - "orphaned worktree"
+llm_rubric: |-
+  Return JSON: {"score": 0-10, "rationale": "..."}.
+
+  Reward explicit owner and lane assignments for every open thread in the status update.
+  Reward concrete next actions with named commands, PR steps, ledger queries, or log paths rather than vague verbs.
+  Reward verification checks that state exactly how completion will be confirmed, such as `gh pr view`, `git ls-remote`, the calibration ledger, or the cited log file.
+  Reward an escalation rule that names a Decision Card and ties it to real criteria from the hand-off, such as live disagreement, multiple viable retry policies, or a high-leverage decision affecting many cells.
+  Reward same-family serialization when two threads share a model family and lane, especially for codex-owned debugging or code-review work.
+  Reward honest per-thread cost and time budgets that preserve the no-wave-run constraint and protect reviewer capacity.
+  Penalize vague actions such as "look at it" or "check the logs" without commands or confirmation criteria.
+  Penalize missing verification steps, parallelism that violates same-family serialization, or dispatching a wave before the stated dependencies are cleared.
+  Penalize fabricating escalation points without a real decision criterion or treating routine one-line fixes as Decision Cards.

--- a/scripts/calibration/ground-truth/v1/orchestrating/runbook-followup-status-to-actions.yaml
+++ b/scripts/calibration/ground-truth/v1/orchestrating/runbook-followup-status-to-actions.yaml
@@ -7,28 +7,27 @@ required_categories:
   - "next action"
   - "verification"
   - "escalation"
-  - "decision card"
-  - "serialize"
-  - "cost"
-  - "gh pr"
+  - "policy"
+  - "concurrency"
+  - "budget"
   - "ledger"
   - "wave"
-  - "git ls-remote"
+  - "reviewer"
 novel_risk_terms:
-  - "silent push failure"
   - "reviewer starvation"
-  - "stale lease"
   - "missing verification"
   - "orphaned worktree"
+  - "duplicate ledger rows"
+  - "retry replay loop"
 llm_rubric: |-
   Return JSON: {"score": 0-10, "rationale": "..."}.
 
-  Reward explicit owner and lane assignments for every open thread in the status update.
-  Reward concrete next actions with named commands, PR steps, ledger queries, or log paths rather than vague verbs.
-  Reward verification checks that state exactly how completion will be confirmed, such as `gh pr view`, `git ls-remote`, the calibration ledger, or the cited log file.
-  Reward an escalation rule that names a Decision Card and ties it to real criteria from the hand-off, such as live disagreement, multiple viable retry policies, or a high-leverage decision affecting many cells.
-  Reward same-family serialization when two threads share a model family and lane, especially for codex-owned debugging or code-review work.
-  Reward honest per-thread cost and time budgets that preserve the no-wave-run constraint and protect reviewer capacity.
-  Penalize vague actions such as "look at it" or "check the logs" without commands or confirmation criteria.
-  Penalize missing verification steps, parallelism that violates same-family serialization, or dispatching a wave before the stated dependencies are cleared.
-  Penalize fabricating escalation points without a real decision criterion or treating routine one-line fixes as Decision Cards.
+  Reward explicit owner-and-lane assignment for every open thread in the hand-off.
+  Reward concrete next actions naming the specific command, PR step, ledger query, or log path used to advance the thread (not vague verbs).
+  Reward verification checks that name the artifact to inspect (ledger row, remote branch SHA, PR state, named log file).
+  Reward the policy-escalation criterion when the hand-off raises a real tradeoff (e.g., thread D retry policy).
+  Reward concurrency limits when two threads share a model-family + lane bucket, with the reason stated.
+  Reward honest per-thread cost and time budgets that preserve the no-wave-run constraint and reviewer capacity.
+  Penalize vague verbs ("look at it", "check the logs") without a confirmation criterion.
+  Penalize parallelism that violates a stated same-family or reviewer-capacity constraint.
+  Penalize fabricating escalation points without a real decision criterion or treating routine one-line fixes as policy escalations.

--- a/scripts/calibration/prompts/v1/orchestrating/runbook-followup-status-to-actions.md
+++ b/scripts/calibration/prompts/v1/orchestrating/runbook-followup-status-to-actions.md
@@ -1,0 +1,24 @@
+Turn this KubeDojo shift hand-off into structured follow-up.
+
+Status update, 07:40:
+Overnight calibration wave `2026-05-23-orch-smoke` was not a real wave, but 12 cells were queued anyway after a dry-run flag got dropped in one dispatch wrapper.
+Ledger shows 7 completed, 3 stuck `in_flight` for 96 minutes, and 2 never got a result row; I think the missing rows are a silent push failure, but I have not confirmed.
+`scripts/dispatch_smart.py --agent codex review` timed out twice on the same code-review cell; the log is `.pipeline/logs/calibration/2026-05-23/orch-smoke-codex-review.log`.
+Gemini fact-check workers hit a 429 storm between 02:10 and 02:48, then recovered; no one has checked whether retries duplicated ledger rows.
+PR #1459 is waiting on a security-review author response, and the reviewer says they will not re-review until the branch tip changes.
+The branch `feat/calibration-orchestrating-fixture-2-schedule-plan` may have pushed, but Slack only has "pushed maybe"; we need remote confirmation before rebasing this fixture.
+There is an old worktree `.worktrees/calibration-fixture-2` whose lease says `active`, but its process is gone; not sure if that is the same branch or a stale lease.
+I penciled codex/debugging for both the stuck-cell cleanup and the stale worktree/remote-branch triage, but no one confirmed whether cheap haiku can take one; same-family queue pressure matters.
+Open thread A: clear the 3 `in_flight` rows without losing evidence.
+Open thread B: confirm whether fixture #2 exists remotely before this fixture edits `LANE_FIXTURES`.
+Open thread C: unblock PR #1459 security review after the author answers or branch tip changes.
+Open thread D: decide whether retry policy for 429 storms should auto-replay or require human approval when more than 5 cells are affected.
+Dependency: do not dispatch any wave until A and B are verified; do not request security re-review on C until the author response is visible.
+
+Deliver:
+1. Owners: assign each open thread to a model class (codex / sonnet / opus / gemini / claude-haiku / qwen / agy) and lane (debugging / code-review / orchestration / fact-check / summarization / etc.).
+2. Next actions: give concrete commands or PR steps, not vague verbs.
+3. Verification checks: say exactly how each next action is confirmed, using tools such as `gh pr view`, `git ls-remote`, a ledger query, or a named log path.
+4. Escalation points: name the conditions that demote a thread to a Decision Card under `.claude/rules/decision-card.md`.
+5. Same-family serialization: if two threads share a model family and lane, say so and serialize them.
+6. Cost / time budget: give a short estimate for each thread.

--- a/scripts/calibration/prompts/v1/orchestrating/runbook-followup-status-to-actions.md
+++ b/scripts/calibration/prompts/v1/orchestrating/runbook-followup-status-to-actions.md
@@ -18,7 +18,7 @@ Dependency: do not dispatch any wave until A and B are verified; do not request 
 Deliver:
 1. Owners: assign each open thread to a model class (codex / sonnet / opus / gemini / claude-haiku / qwen / agy) and lane (debugging / code-review / orchestration / fact-check / summarization / etc.).
 2. Next actions: give concrete commands or PR steps, not vague verbs.
-3. Verification checks: say exactly how each next action is confirmed, using tools such as `gh pr view`, `git ls-remote`, a ledger query, or a named log path.
-4. Escalation points: name the conditions that demote a thread to a Decision Card under `.claude/rules/decision-card.md`.
-5. Same-family serialization: if two threads share a model family and lane, say so and serialize them.
+3. Verification checks: say exactly how each next action is confirmed, naming the specific artifact or query to inspect.
+4. Escalation: which threads warrant policy escalation, and under what specific criteria?
+5. Concurrency policy: identify threads that must not run in parallel, and explain why.
 6. Cost / time budget: give a short estimate for each thread.

--- a/scripts/calibration/run_wave.py
+++ b/scripts/calibration/run_wave.py
@@ -43,7 +43,10 @@ LANE_FIXTURES: dict[str, list[str]] = {
         "cascade-reviewer-tiebreak-policy",
         "dispatch-pipeline-scaling",
     ],
-    "orchestrating": ["multi-task-routing-brief"],
+    "orchestrating": [
+        "multi-task-routing-brief",
+        "runbook-followup-status-to-actions",
+    ],
     "debugging": ["pod-pending-topology-mismatch"],
     "refactoring": ["check-site-health-refactor"],
     "summarization": ["session-34-handoff"],


### PR DESCRIPTION
## Summary
- Adds orchestrating fixture 3/3 for #1413: runbook follow-up status-to-actions.
- Prompt is a messy KubeDojo incident handoff with owners, concrete next actions, verification checks, escalation points, same-family serialization, and cost/time budgets.
- Registers the fixture in `scripts/calibration/run_wave.py` without running any wave.

## Gate strategy
- No `expected_routes`: this follow-up format does not fit the alias-route matrix, so routing accuracy intentionally vacuous-passes.
- Signal comes from the LLM judge, required categories, novel risk terms, and the existing orchestrating substring gates for cost awareness, decision-card discipline, and same-family serialization.

## Coordination note
- Parallel fixture #2 (schedule-plan-dependency-chain) also edits `LANE_FIXTURES`.
- If fixture #2 lands first, rebase and keep all three in order: `multi-task-routing-brief`, `schedule-plan-dependency-chain`, `runbook-followup-status-to-actions`.

## Validation
- `../../.venv/bin/python -c "import yaml; yaml.safe_load(open('scripts/calibration/ground-truth/v1/orchestrating/runbook-followup-status-to-actions.yaml'))"`
- `../../.venv/bin/ruff check scripts/calibration/run_wave.py`
- `git diff --check`
- `../../.venv/bin/python scripts/test_pipeline.py` (170 tests OK)

No calibration wave run was performed per feedback_one_fixture_per_model_per_wave.