### PR TITLE
feat(dispatch): add opencode + hermes as supported agents

### DIFF
--- a/scripts/ai_agent_bridge/_channels.py
+++ b/scripts/ai_agent_bridge/_channels.py
@@ -65,7 +65,17 @@ from ._db import get_db
 
 # ── Constants ──────────────────────────────────────────────────────────
 
-VALID_AGENTS = ("claude", "gemini", "codex", "user")
+VALID_AGENTS = (
+    "agy",
+    "claude",
+    "codex",
+    "deepseek",
+    "gemini",
+    "hermes",
+    "opencode",
+    "qwen",
+    "user",
+)
 VALID_KINDS = ("post", "reply", "system", "fanout_start", "fanout_end")
 VALID_DELIVERY_STATUSES = (
     "pending",

--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -62,6 +62,8 @@ _DISCUSSION_CLARIFICATION_MODES = {
     "codex": "danger",
     "deepseek": "yolo",
     "qwen": "yolo",
+    "hermes": "yolo",
+    "opencode": "yolo",
 }
 
 _DISCUSSION_RUNTIME_MODES = {
@@ -71,6 +73,8 @@ _DISCUSSION_RUNTIME_MODES = {
     "codex": "danger",
     "deepseek": "workspace-write",
     "qwen": "workspace-write",
+    "hermes": "workspace-write",
+    "opencode": "workspace-write",
 }
 
 _DISCUSSION_MCP_EXCLUDE_TOKENS: tuple[str, ...] = (
@@ -178,6 +182,13 @@ def _agent_runtime_mode(agent_name: str, sandbox_mode: str | None) -> str:
     if agent_name == "deepseek":
         # DeepSeek via hermes accepts workspace-write; sandbox is enforced by
         # toolset selection (see _agent_tool_config), not a mode flag.
+        if sandbox_mode == "read-only":
+            return "read-only"
+        return "workspace-write"
+    if agent_name in {"hermes", "opencode"}:
+        # These router CLIs do not expose project sandbox modes. Preserve the
+        # label for audit/session logic; the CLI invocation itself treats it
+        # as advisory.
         if sandbox_mode == "read-only":
             return "read-only"
         return "workspace-write"
@@ -1230,7 +1241,8 @@ def _handle_discuss(args) -> int:
         print(f"   root message: {root_id[:12]} / thread {correlation_id[:12]}")
         print()
 
-    # Session-less agents (agy / qwen / deepseek) map to all-None tuples;
+    # Session-less agents (agy / qwen / deepseek / hermes / opencode) map
+    # to all-None tuples;
     # the per-agent branch at "if agent_name in {claude, gemini}" later
     # in this function correctly skips session persistence for them, and
     # `stored_session.get(None)` returns None which feeds the resume-skip
@@ -1243,6 +1255,8 @@ def _handle_discuss(args) -> int:
         "agy": (None, None, None),
         "qwen": (None, None, None),
         "deepseek": (None, None, None),
+        "hermes": (None, None, None),
+        "opencode": (None, None, None),
     }
     resume_thread_session: dict[str, str | None] = {}
     if args.resume_thread:
@@ -1367,12 +1381,62 @@ def _handle_discuss(args) -> int:
             """
             nonlocal gemini_use_subscription_auth
             skip_headroom_check = False
-            runtime_tool_config = dict(tool_config)
+            runtime_tool_config = dict(tool_config or {})
             if is_new_session and agent_name in {"claude", "gemini"}:
                 runtime_tool_config["is_new_session"] = True
             if agent_name == "gemini" and use_subscription_auth:
                 runtime_tool_config["use_subscription_auth"] = True
                 skip_headroom_check = True
+            if agent_name == "opencode":
+                from . import _opencode
+
+                started = time.monotonic()
+                model = _opencode._DEFAULT_MODEL
+                ok, response, stderr_excerpt = _opencode._invoke_opencode(
+                    prompt_text,
+                    model,
+                    timeout_s=900,
+                    cwd=cwd,
+                )
+                return Result(
+                    ok=ok,
+                    agent=agent_name,
+                    model=model,
+                    mode=mode,
+                    response=response,
+                    stderr_excerpt=stderr_excerpt or None,
+                    duration_s=time.monotonic() - started,
+                    session_id=None,
+                    rate_limited=False,
+                    stalled=False,
+                    returncode=0 if ok else 1,
+                ), None
+            if agent_name == "hermes":
+                from . import _hermes
+
+                started = time.monotonic()
+                model = _hermes._DEFAULT_MODEL
+                provider = _hermes._detect_provider(model)
+                ok, response, stderr_excerpt = _hermes._invoke_hermes(
+                    prompt_text,
+                    model,
+                    provider=provider,
+                    timeout_s=900,
+                    cwd=cwd,
+                )
+                return Result(
+                    ok=ok,
+                    agent=agent_name,
+                    model=model,
+                    mode=mode,
+                    response=response,
+                    stderr_excerpt=stderr_excerpt or None,
+                    duration_s=time.monotonic() - started,
+                    session_id=None,
+                    rate_limited=False,
+                    stalled=False,
+                    returncode=0 if ok else 1,
+                ), None
             try:
                 result = runtime_invoke(
                     agent_name,
@@ -1526,7 +1590,7 @@ def _handle_discuss(args) -> int:
                 False,
             )
 
-        if result is not None:
+        if result is not None and session_field is not None:
             persist_session_id = result.session_id
             if agent_name == "codex" and not persist_session_id:
                 header_payload = getattr(result, "stdout", None) or getattr(

--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -21,6 +21,7 @@ from ._config import GEMINI_DEFAULT_MODEL, GEMINI_REVIEW_MODEL
 from ._db import get_db
 from ._deepseek import ask_deepseek
 from ._gemini import ask_gemini, converse_gemini, process_and_respond
+from ._hermes import ask_hermes
 from ._messaging import (
     acknowledge,
     acknowledge_all,
@@ -30,6 +31,7 @@ from ._messaging import (
     send_message,
 )
 from ._model import check_model
+from ._opencode import ask_opencode
 from ._prompts import build_review_message
 from ._qwen import ask_qwen
 
@@ -37,6 +39,17 @@ try:
     from dispatch import GEMINI_WRITER_MODEL
 except ImportError:  # pragma: no cover - package import path variant
     GEMINI_WRITER_MODEL = "gemini-3.1-pro-preview"
+
+AGENT_CHOICES = (
+    "agy",
+    "claude",
+    "codex",
+    "deepseek",
+    "gemini",
+    "hermes",
+    "opencode",
+    "qwen",
+)
 
 
 def interactive_mode():
@@ -340,7 +353,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     # inbox
     inbox_parser = subparsers.add_parser("inbox", help="Check inbox for messages")
-    inbox_parser.add_argument("--for", dest="for_llm", default="gemini", choices=['gemini', 'claude', 'codex', 'qwen', 'agy', 'deepseek'],
+    inbox_parser.add_argument("--for", dest="for_llm", default="gemini", choices=AGENT_CHOICES,
                              help="Check inbox for which agent (default: gemini)")
 
     # read
@@ -350,7 +363,7 @@ def _build_parser() -> argparse.ArgumentParser:
     # send
     send_parser = subparsers.add_parser("send", help="Send message to another agent")
     send_parser.add_argument("content", help="Message content")
-    send_parser.add_argument("--to", dest="to_llm", default="claude", choices=['claude', 'gemini', 'codex', 'qwen', 'agy', 'deepseek'],
+    send_parser.add_argument("--to", dest="to_llm", default="claude", choices=AGENT_CHOICES,
                             help="Target agent (default: claude)")
     send_parser.add_argument("--from", dest="from_llm", default="gemini",
                             help="Sender agent name (default: gemini)")
@@ -366,7 +379,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     # ack-all
     ack_all_parser = subparsers.add_parser("ack-all", help="Acknowledge ALL unread messages for an agent")
-    ack_all_parser.add_argument("agent", choices=['claude', 'gemini', 'codex', 'qwen', 'agy', 'deepseek'], help="Agent whose inbox to clear")
+    ack_all_parser.add_argument("agent", choices=AGENT_CHOICES, help="Agent whose inbox to clear")
 
     # conversation
     conv_parser = subparsers.add_parser("conversation", help="Get conversation history")
@@ -525,6 +538,44 @@ def _build_parser() -> argparse.ArgumentParser:
     ask_deepseek_parser.add_argument("--review", action="store_true",
                                      help="Prepend docs/review-protocol.md")
 
+    # ask-hermes
+    ask_hermes_parser = subparsers.add_parser("ask-hermes", help="Send message AND invoke Hermes (one-step)")
+    ask_hermes_parser.add_argument("content", help="Message content (use '-' to read from stdin)")
+    ask_hermes_parser.add_argument("--task-id", help="Task ID for session tracking")
+    ask_hermes_parser.add_argument("--type", default="query", help="Message type (default: query)")
+    ask_hermes_parser.add_argument("--data", help="Path to data file to attach")
+    ask_hermes_parser.add_argument("--new-session", dest="new_session", action="store_true",
+                                   help="Force new session even if one exists")
+    ask_hermes_parser.add_argument("--from", dest="from_llm", default="gemini",
+                                   help="Sender agent family. Default: gemini")
+    ask_hermes_parser.add_argument("--from-model", dest="from_model",
+                                   help="Exact sender model ID")
+    ask_hermes_parser.add_argument("--to-model", dest="to_model",
+                                   help="Target model ID")
+    ask_hermes_parser.add_argument("--no-timeout", dest="no_timeout", action="store_true",
+                                   help="Run sync without timeout")
+    ask_hermes_parser.add_argument("--review", action="store_true",
+                                   help="Prepend docs/review-protocol.md")
+
+    # ask-opencode
+    ask_opencode_parser = subparsers.add_parser("ask-opencode", help="Send message AND invoke OpenCode (one-step)")
+    ask_opencode_parser.add_argument("content", help="Message content (use '-' to read from stdin)")
+    ask_opencode_parser.add_argument("--task-id", help="Task ID for session tracking")
+    ask_opencode_parser.add_argument("--type", default="query", help="Message type (default: query)")
+    ask_opencode_parser.add_argument("--data", help="Path to data file to attach")
+    ask_opencode_parser.add_argument("--new-session", dest="new_session", action="store_true",
+                                     help="Force new session even if one exists")
+    ask_opencode_parser.add_argument("--from", dest="from_llm", default="gemini",
+                                     help="Sender agent family. Default: gemini")
+    ask_opencode_parser.add_argument("--from-model", dest="from_model",
+                                     help="Exact sender model ID")
+    ask_opencode_parser.add_argument("--to-model", dest="to_model",
+                                     help="Target model ID")
+    ask_opencode_parser.add_argument("--no-timeout", dest="no_timeout", action="store_true",
+                                     help="Run sync without timeout")
+    ask_opencode_parser.add_argument("--review", action="store_true",
+                                     help="Prepend docs/review-protocol.md")
+
     # converse — multi-turn conversation with Gemini
     converse_parser = subparsers.add_parser("converse", help="Multi-turn conversation with Gemini (includes history)")
     converse_parser.add_argument("content", help="Message content (use '-' to read from stdin)")
@@ -635,6 +686,10 @@ def _dispatch_command(args):
         _handle_ask_qwen(args)
     elif args.command == "ask-deepseek":
         _handle_ask_deepseek(args)
+    elif args.command == "ask-hermes":
+        _handle_ask_hermes(args)
+    elif args.command == "ask-opencode":
+        _handle_ask_opencode(args)
     elif args.command == "converse":
         content = sys.stdin.read() if args.content == "-" else args.content
         converse_gemini(content, args.task_id, args.model,
@@ -739,6 +794,28 @@ def _handle_ask_deepseek(args):
         data = Path(args.data).read_text()
     content = sys.stdin.read() if args.content == "-" else args.content
     ask_deepseek(content, args.task_id, args.type, data,
+                 args.new_session, args.from_llm, args.from_model,
+                 args.to_model, args.no_timeout, args.review)
+
+
+def _handle_ask_hermes(args):
+    """Handle ask-hermes subcommand."""
+    data = None
+    if args.data:
+        data = Path(args.data).read_text()
+    content = sys.stdin.read() if args.content == "-" else args.content
+    ask_hermes(content, args.task_id, args.type, data,
+               args.new_session, args.from_llm, args.from_model,
+               args.to_model, args.no_timeout, args.review)
+
+
+def _handle_ask_opencode(args):
+    """Handle ask-opencode subcommand."""
+    data = None
+    if args.data:
+        data = Path(args.data).read_text()
+    content = sys.stdin.read() if args.content == "-" else args.content
+    ask_opencode(content, args.task_id, args.type, data,
                  args.new_session, args.from_llm, args.from_model,
                  args.to_model, args.no_timeout, args.review)
 

--- a/scripts/ai_agent_bridge/_hermes.py
+++ b/scripts/ai_agent_bridge/_hermes.py
@@ -25,7 +25,7 @@ def _hermes_binary() -> str:
     return (
         os.environ.get("KUBEDOJO_HERMES_CMD")
         or shutil.which("hermes")
-        or "/Users/krisztiankoos/.local/bin/hermes"
+        or str(Path.home() / ".local" / "bin" / "hermes")
     )
 
 
@@ -34,6 +34,8 @@ def _detect_provider(model: str) -> str:
     override = os.environ.get("KUBEDOJO_HERMES_PROVIDER")
     if override:
         return override
+    if model.startswith("openrouter/"):
+        return "openrouter"
     if model.startswith("claude-"):
         return "anthropic"
     if model.startswith("grok-"):

--- a/scripts/ai_agent_bridge/_hermes.py
+++ b/scripts/ai_agent_bridge/_hermes.py
@@ -1,0 +1,318 @@
+"""Hermes interaction: ask_hermes and process_for_hermes."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from ._config import REPO_ROOT
+from ._db import get_db
+from ._messaging import acknowledge, send_message
+
+_AGENT_NAME = "hermes"
+_AGENT_TITLE = "Hermes"
+_DEFAULT_BRIDGE_TIMEOUT_SECONDS = 900
+_NO_TIMEOUT_BRIDGE_TIMEOUT_SECONDS = 24 * 60 * 60
+_DEFAULT_MODEL = os.environ.get("AB_HERMES_MODEL", "grok-4.3")
+_TIMEOUT_ENV = "HERMES_BRIDGE_TIMEOUT"
+
+
+def _hermes_binary() -> str:
+    """Resolve the hermes executable."""
+    return (
+        os.environ.get("KUBEDOJO_HERMES_CMD")
+        or shutil.which("hermes")
+        or "/Users/krisztiankoos/.local/bin/hermes"
+    )
+
+
+def _detect_provider(model: str) -> str:
+    """Infer the Hermes provider from the model name."""
+    override = os.environ.get("KUBEDOJO_HERMES_PROVIDER")
+    if override:
+        return override
+    if model.startswith("claude-"):
+        return "anthropic"
+    if model.startswith("grok-"):
+        return "xai"
+    return "openrouter"
+
+
+def _cli_model(model: str) -> str:
+    """Map KubeDojo's route labels to Hermes v0.14 CLI model IDs."""
+    if model.startswith("qwen-"):
+        return f"qwen/qwen{model.removeprefix('qwen-')}"
+    return model
+
+
+def _build_command(
+    prompt: str,
+    model: str,
+    provider: str | None = None,
+) -> list[str]:
+    """Build the hermes one-shot command."""
+    return [
+        _hermes_binary(),
+        "-z",
+        prompt,
+        "--provider",
+        provider or _detect_provider(model),
+        "-m",
+        _cli_model(model),
+    ]
+
+
+def _resolve_bridge_timeout(no_timeout: bool = False) -> int:
+    """Resolve the hard timeout from CLI flag/env with a safe fallback."""
+    if no_timeout:
+        return _NO_TIMEOUT_BRIDGE_TIMEOUT_SECONDS
+
+    raw = os.environ.get(_TIMEOUT_ENV)
+    if raw is None:
+        return _DEFAULT_BRIDGE_TIMEOUT_SECONDS
+
+    value = raw.strip().lower()
+    if value in {"0", "none", "off", "false", "no"}:
+        return _NO_TIMEOUT_BRIDGE_TIMEOUT_SECONDS
+
+    try:
+        timeout = int(value)
+    except ValueError:
+        print(
+            f"Invalid {_TIMEOUT_ENV}={raw!r}; "
+            f"falling back to {_DEFAULT_BRIDGE_TIMEOUT_SECONDS}s"
+        )
+        return _DEFAULT_BRIDGE_TIMEOUT_SECONDS
+
+    if timeout <= 0:
+        return _NO_TIMEOUT_BRIDGE_TIMEOUT_SECONDS
+    return timeout
+
+
+def ask_hermes(
+    content: str,
+    task_id: str | None = None,
+    msg_type: str = "query",
+    data: str | None = None,
+    new_session: bool = False,
+    from_llm: str = "gemini",
+    from_model: str | None = None,
+    to_model: str | None = None,
+    no_timeout: bool = False,
+    review: bool = False,
+) -> int:
+    """Send a message to Hermes and invoke it to process the message."""
+    msg_id = send_message(
+        content,
+        task_id,
+        msg_type,
+        data,
+        from_llm=from_llm,
+        to_llm=_AGENT_NAME,
+        from_model=from_model,
+        to_model=to_model,
+    )
+    print(f"\nInvoking {_AGENT_TITLE} to process message #{msg_id}...")
+    process_for_hermes(msg_id, new_session, no_timeout, review=review)
+    return msg_id
+
+
+def process_for_hermes(
+    message_id: int,
+    new_session: bool = False,
+    no_timeout: bool = False,
+    review: bool = False,
+) -> None:
+    """Read a message addressed to Hermes, invoke the CLI, and reply."""
+    msg = _fetch_message(message_id)
+    if not msg:
+        return
+
+    _ = new_session  # Hermes is session-less for bridge calls.
+    timeout_val = _resolve_bridge_timeout(no_timeout)
+    model = _extract_target_model(msg) or _DEFAULT_MODEL
+    provider = _detect_provider(model)
+    prompt = _build_prompt(msg, review)
+
+    print(f"Message #{msg['id']}")
+    print(f"   From: {msg['from']} -> To: {msg['to']}")
+    print(f"   Type: {msg['type']}")
+    print(f"   Task: {msg['task_id'] or 'N/A'}")
+    print(f"   Model: {model}")
+    print(f"   Provider: {provider}")
+    if timeout_val == _NO_TIMEOUT_BRIDGE_TIMEOUT_SECONDS:
+        print("   Hard timeout: no-timeout requested (24h ceiling)")
+    else:
+        print(f"   Hard timeout: {timeout_val}s")
+
+    ok, response, stderr_excerpt = _invoke_hermes(
+        prompt,
+        model,
+        provider=provider,
+        timeout_s=timeout_val,
+        cwd=REPO_ROOT,
+    )
+    if not ok:
+        _handle_error(
+            msg,
+            message_id,
+            stderr_excerpt or f"{_AGENT_TITLE} returned no final message",
+        )
+        return
+
+    print(f"\n{_AGENT_TITLE} finished ({len(response)} chars)")
+    reply_id = send_message(
+        content=response,
+        task_id=msg["task_id"],
+        msg_type="response",
+        from_llm=_AGENT_NAME,
+        to_llm=msg["from"],
+    )
+    acknowledge(message_id)
+    acknowledge(reply_id)
+
+
+def _invoke_hermes(
+    prompt: str,
+    model: str,
+    *,
+    provider: str | None = None,
+    timeout_s: int,
+    cwd: Path | None = None,
+) -> tuple[bool, str, str]:
+    """Run hermes and return (ok, stdout response, stderr excerpt)."""
+    command = _build_command(prompt, model, provider)
+    try:
+        completed = subprocess.run(
+            command,
+            input="",
+            cwd=cwd or REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout_s,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout if isinstance(exc.stdout, str) else ""
+        stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+        return False, stdout.strip(), (
+            f"{_AGENT_TITLE} timed out after {timeout_s}s\n{stderr}"
+        ).strip()
+    except OSError as exc:
+        return False, "", f"{type(exc).__name__}: {exc}"
+
+    response = completed.stdout.strip()
+    stderr_excerpt = completed.stderr.strip()
+    ok = completed.returncode == 0 and bool(response)
+    if not ok and not stderr_excerpt:
+        stderr_excerpt = (
+            f"{_AGENT_TITLE} exited {completed.returncode} with no stdout"
+        )
+    return ok, response, stderr_excerpt[:500]
+
+
+def _fetch_message(message_id: int) -> dict[str, object] | None:
+    """Fetch a message addressed to this agent from the database."""
+    conn = get_db()
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        SELECT id, task_id, from_llm, to_llm, message_type, content, data, timestamp
+        FROM messages
+        WHERE id = ? AND to_llm = ?
+        """,
+        (message_id, _AGENT_NAME),
+    )
+    row = cursor.fetchone()
+    conn.close()
+
+    if not row:
+        print(f"Message {message_id} not found or not addressed to {_AGENT_TITLE}")
+        return None
+
+    return {
+        "id": row[0],
+        "task_id": row[1],
+        "from": row[2],
+        "to": row[3],
+        "type": row[4],
+        "content": row[5],
+        "data": row[6],
+        "timestamp": row[7],
+    }
+
+
+def _extract_target_model(msg: dict[str, object]) -> str | None:
+    """Read optional to_model from message metadata JSON."""
+    data = msg.get("data")
+    if not data:
+        return None
+    try:
+        payload = json.loads(data)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    model = payload.get("to_model")
+    return str(model) if model else None
+
+
+def _build_prompt(msg: dict[str, object], review: bool = False) -> str:
+    """Build a direct one-shot bridge prompt."""
+    prompt = f"""You are {_AGENT_TITLE}, receiving a message from {msg['from'].title()} via the message broker.
+
+---
+Task ID: {msg['task_id'] or 'none'}
+Type: {msg['type']}
+From: {msg['from']}
+
+{msg['content']}
+"""
+    if msg["data"]:
+        prompt += f"""
+---
+Attached data:
+{msg['data']}
+"""
+    prompt += """
+
+---
+
+Standing rules for bridge Q&A:
+- Respond directly. Be concise. This bridge is for quick questioning
+  and short coordination, not long-running task execution.
+- Do NOT use broker or MCP messaging tools to send your response.
+  Output your response directly.
+"""
+    return _prepend_review_protocol(prompt, review)
+
+
+def _prepend_review_protocol(prompt: str, review: bool) -> str:
+    """Prepend docs/review-protocol.md when --review is requested."""
+    if not review:
+        return prompt
+    prefix = (REPO_ROOT / "docs" / "review-protocol.md").read_text(
+        encoding="utf-8"
+    ).rstrip()
+    return f"{prefix}\n\n{prompt}"
+
+
+def _handle_error(
+    msg: dict[str, object],
+    message_id: int,
+    reason: str,
+) -> None:
+    """Record an agent failure as an error response and acknowledge it."""
+    print(f"\n{_AGENT_TITLE} error for message #{message_id}: {reason}")
+    reply_id = send_message(
+        content=f"[{_AGENT_TITLE} error] {reason}",
+        task_id=msg["task_id"],
+        msg_type="error",
+        from_llm=_AGENT_NAME,
+        to_llm=msg["from"],
+    )
+    acknowledge(message_id)
+    acknowledge(reply_id)

--- a/scripts/ai_agent_bridge/_opencode.py
+++ b/scripts/ai_agent_bridge/_opencode.py
@@ -1,0 +1,286 @@
+"""OpenCode interaction: ask_opencode and process_for_opencode."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from ._config import REPO_ROOT
+from ._db import get_db
+from ._messaging import acknowledge, send_message
+
+_AGENT_NAME = "opencode"
+_AGENT_TITLE = "OpenCode"
+_DEFAULT_BRIDGE_TIMEOUT_SECONDS = 900
+_NO_TIMEOUT_BRIDGE_TIMEOUT_SECONDS = 24 * 60 * 60
+_DEFAULT_MODEL = os.environ.get(
+    "AB_OPENCODE_MODEL",
+    "openrouter/qwen/qwen3.7-max",
+)
+_TIMEOUT_ENV = "OPENCODE_BRIDGE_TIMEOUT"
+
+
+def _opencode_binary() -> str:
+    """Resolve the opencode executable."""
+    return (
+        os.environ.get("KUBEDOJO_OPENCODE_CMD")
+        or shutil.which("opencode")
+        or "/opt/homebrew/bin/opencode"
+    )
+
+
+def _build_command(model: str) -> list[str]:
+    """Build the opencode one-shot command."""
+    return [_opencode_binary(), "run", "-m", model, "-"]
+
+
+def _resolve_bridge_timeout(no_timeout: bool = False) -> int:
+    """Resolve the hard timeout from CLI flag/env with a safe fallback."""
+    if no_timeout:
+        return _NO_TIMEOUT_BRIDGE_TIMEOUT_SECONDS
+
+    raw = os.environ.get(_TIMEOUT_ENV)
+    if raw is None:
+        return _DEFAULT_BRIDGE_TIMEOUT_SECONDS
+
+    value = raw.strip().lower()
+    if value in {"0", "none", "off", "false", "no"}:
+        return _NO_TIMEOUT_BRIDGE_TIMEOUT_SECONDS
+
+    try:
+        timeout = int(value)
+    except ValueError:
+        print(
+            f"Invalid {_TIMEOUT_ENV}={raw!r}; "
+            f"falling back to {_DEFAULT_BRIDGE_TIMEOUT_SECONDS}s"
+        )
+        return _DEFAULT_BRIDGE_TIMEOUT_SECONDS
+
+    if timeout <= 0:
+        return _NO_TIMEOUT_BRIDGE_TIMEOUT_SECONDS
+    return timeout
+
+
+def ask_opencode(
+    content: str,
+    task_id: str | None = None,
+    msg_type: str = "query",
+    data: str | None = None,
+    new_session: bool = False,
+    from_llm: str = "gemini",
+    from_model: str | None = None,
+    to_model: str | None = None,
+    no_timeout: bool = False,
+    review: bool = False,
+) -> int:
+    """Send a message to OpenCode and invoke it to process the message."""
+    msg_id = send_message(
+        content,
+        task_id,
+        msg_type,
+        data,
+        from_llm=from_llm,
+        to_llm=_AGENT_NAME,
+        from_model=from_model,
+        to_model=to_model,
+    )
+    print(f"\nInvoking {_AGENT_TITLE} to process message #{msg_id}...")
+    process_for_opencode(msg_id, new_session, no_timeout, review=review)
+    return msg_id
+
+
+def process_for_opencode(
+    message_id: int,
+    new_session: bool = False,
+    no_timeout: bool = False,
+    review: bool = False,
+) -> None:
+    """Read a message addressed to OpenCode, invoke the CLI, and reply."""
+    msg = _fetch_message(message_id)
+    if not msg:
+        return
+
+    _ = new_session  # OpenCode is session-less for bridge calls.
+    timeout_val = _resolve_bridge_timeout(no_timeout)
+    model = _extract_target_model(msg) or _DEFAULT_MODEL
+    prompt = _build_prompt(msg, review)
+
+    print(f"Message #{msg['id']}")
+    print(f"   From: {msg['from']} -> To: {msg['to']}")
+    print(f"   Type: {msg['type']}")
+    print(f"   Task: {msg['task_id'] or 'N/A'}")
+    print(f"   Model: {model}")
+    if timeout_val == _NO_TIMEOUT_BRIDGE_TIMEOUT_SECONDS:
+        print("   Hard timeout: no-timeout requested (24h ceiling)")
+    else:
+        print(f"   Hard timeout: {timeout_val}s")
+
+    ok, response, stderr_excerpt = _invoke_opencode(
+        prompt,
+        model,
+        timeout_s=timeout_val,
+        cwd=REPO_ROOT,
+    )
+    if not ok:
+        _handle_error(
+            msg,
+            message_id,
+            stderr_excerpt or f"{_AGENT_TITLE} returned no final message",
+        )
+        return
+
+    print(f"\n{_AGENT_TITLE} finished ({len(response)} chars)")
+    reply_id = send_message(
+        content=response,
+        task_id=msg["task_id"],
+        msg_type="response",
+        from_llm=_AGENT_NAME,
+        to_llm=msg["from"],
+    )
+    acknowledge(message_id)
+    acknowledge(reply_id)
+
+
+def _invoke_opencode(
+    prompt: str,
+    model: str,
+    *,
+    timeout_s: int,
+    cwd: Path | None = None,
+) -> tuple[bool, str, str]:
+    """Run opencode and return (ok, stdout response, stderr excerpt)."""
+    command = _build_command(model)
+    try:
+        completed = subprocess.run(
+            command,
+            input=prompt,
+            cwd=cwd or REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout_s,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout if isinstance(exc.stdout, str) else ""
+        stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+        return False, stdout.strip(), (
+            f"{_AGENT_TITLE} timed out after {timeout_s}s\n{stderr}"
+        ).strip()
+    except OSError as exc:
+        return False, "", f"{type(exc).__name__}: {exc}"
+
+    response = completed.stdout.strip()
+    stderr_excerpt = completed.stderr.strip()
+    ok = completed.returncode == 0 and bool(response)
+    if not ok and not stderr_excerpt:
+        stderr_excerpt = (
+            f"{_AGENT_TITLE} exited {completed.returncode} with no stdout"
+        )
+    return ok, response, stderr_excerpt[:500]
+
+
+def _fetch_message(message_id: int) -> dict[str, object] | None:
+    """Fetch a message addressed to this agent from the database."""
+    conn = get_db()
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        SELECT id, task_id, from_llm, to_llm, message_type, content, data, timestamp
+        FROM messages
+        WHERE id = ? AND to_llm = ?
+        """,
+        (message_id, _AGENT_NAME),
+    )
+    row = cursor.fetchone()
+    conn.close()
+
+    if not row:
+        print(f"Message {message_id} not found or not addressed to {_AGENT_TITLE}")
+        return None
+
+    return {
+        "id": row[0],
+        "task_id": row[1],
+        "from": row[2],
+        "to": row[3],
+        "type": row[4],
+        "content": row[5],
+        "data": row[6],
+        "timestamp": row[7],
+    }
+
+
+def _extract_target_model(msg: dict[str, object]) -> str | None:
+    """Read optional to_model from message metadata JSON."""
+    data = msg.get("data")
+    if not data:
+        return None
+    try:
+        payload = json.loads(data)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    model = payload.get("to_model")
+    return str(model) if model else None
+
+
+def _build_prompt(msg: dict[str, object], review: bool = False) -> str:
+    """Build a direct one-shot bridge prompt."""
+    prompt = f"""You are {_AGENT_TITLE}, receiving a message from {msg['from'].title()} via the message broker.
+
+---
+Task ID: {msg['task_id'] or 'none'}
+Type: {msg['type']}
+From: {msg['from']}
+
+{msg['content']}
+"""
+    if msg["data"]:
+        prompt += f"""
+---
+Attached data:
+{msg['data']}
+"""
+    prompt += """
+
+---
+
+Standing rules for bridge Q&A:
+- Respond directly. Be concise. This bridge is for quick questioning
+  and short coordination, not long-running task execution.
+- Do NOT use broker or MCP messaging tools to send your response.
+  Output your response directly.
+"""
+    return _prepend_review_protocol(prompt, review)
+
+
+def _prepend_review_protocol(prompt: str, review: bool) -> str:
+    """Prepend docs/review-protocol.md when --review is requested."""
+    if not review:
+        return prompt
+    prefix = (REPO_ROOT / "docs" / "review-protocol.md").read_text(
+        encoding="utf-8"
+    ).rstrip()
+    return f"{prefix}\n\n{prompt}"
+
+
+def _handle_error(
+    msg: dict[str, object],
+    message_id: int,
+    reason: str,
+) -> None:
+    """Record an agent failure as an error response and acknowledge it."""
+    print(f"\n{_AGENT_TITLE} error for message #{message_id}: {reason}")
+    reply_id = send_message(
+        content=f"[{_AGENT_TITLE} error] {reason}",
+        task_id=msg["task_id"],
+        msg_type="error",
+        from_llm=_AGENT_NAME,
+        to_llm=msg["from"],
+    )
+    acknowledge(message_id)
+    acknowledge(reply_id)

--- a/scripts/ai_agent_bridge/tests/test_opencode_hermes.py
+++ b/scripts/ai_agent_bridge/tests/test_opencode_hermes.py
@@ -31,6 +31,16 @@ def test_hermes_provider_auto_detection(
     assert _hermes._detect_provider("claude-sonnet-4-6") == "local-test"
 
 
+def test_openrouter_prefix_routes_to_openrouter() -> None:
+    from scripts.ai_agent_bridge._hermes import _detect_provider
+
+    assert (
+        _detect_provider("openrouter/anthropic/claude-opus-4-6")
+        == "openrouter"
+    )
+    assert _detect_provider("openrouter/qwen/qwen3.7-max") == "openrouter"
+
+
 def test_opencode_command_construction(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/scripts/ai_agent_bridge/tests/test_opencode_hermes.py
+++ b/scripts/ai_agent_bridge/tests/test_opencode_hermes.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def test_hermes_provider_auto_detection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from ai_agent_bridge import _hermes
+
+    monkeypatch.delenv("KUBEDOJO_HERMES_PROVIDER", raising=False)
+
+    assert _hermes._detect_provider("claude-sonnet-4-6") == "anthropic"
+    assert _hermes._detect_provider("claude-opus-4-6") == "anthropic"
+    assert _hermes._detect_provider("grok-4.3") == "xai"
+    assert _hermes._detect_provider("openrouter/qwen/qwen3.7-max") == "openrouter"
+    assert _hermes._detect_provider("qwen-3.6-flash") == "openrouter"
+
+    monkeypatch.setenv("KUBEDOJO_HERMES_PROVIDER", "local-test")
+
+    assert _hermes._detect_provider("claude-sonnet-4-6") == "local-test"
+
+
+def test_opencode_command_construction(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from ai_agent_bridge import _opencode
+
+    captured: dict[str, Any] = {}
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return subprocess.CompletedProcess(cmd, 0, stdout="OPENCODE OK\n", stderr="")
+
+    monkeypatch.setenv("KUBEDOJO_OPENCODE_CMD", "opencode")
+    monkeypatch.setattr(_opencode.subprocess, "run", fake_run)
+
+    ok, response, stderr = _opencode._invoke_opencode(
+        "prompt",
+        "openrouter/qwen/qwen3.7-max",
+        timeout_s=3,
+        cwd=tmp_path,
+    )
+
+    assert ok is True
+    assert response == "OPENCODE OK"
+    assert stderr == ""
+    assert captured["cmd"] == [
+        "opencode",
+        "run",
+        "-m",
+        "openrouter/qwen/qwen3.7-max",
+        "-",
+    ]
+    assert captured["kwargs"]["input"] == "prompt"
+    assert captured["kwargs"]["cwd"] == tmp_path
+    assert captured["kwargs"]["timeout"] == 3
+    assert captured["kwargs"]["capture_output"] is True
+
+
+def test_hermes_command_construction(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from ai_agent_bridge import _hermes
+
+    captured: dict[str, Any] = {}
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return subprocess.CompletedProcess(cmd, 0, stdout="HERMES OK\n", stderr="")
+
+    monkeypatch.setenv("KUBEDOJO_HERMES_CMD", "hermes")
+    monkeypatch.delenv("KUBEDOJO_HERMES_PROVIDER", raising=False)
+    monkeypatch.setattr(_hermes.subprocess, "run", fake_run)
+
+    ok, response, stderr = _hermes._invoke_hermes(
+        "prompt",
+        "claude-sonnet-4-6",
+        timeout_s=3,
+        cwd=tmp_path,
+    )
+
+    assert ok is True
+    assert response == "HERMES OK"
+    assert stderr == ""
+    assert captured["cmd"] == [
+        "hermes",
+        "-z",
+        "prompt",
+        "--provider",
+        "anthropic",
+        "-m",
+        "claude-sonnet-4-6",
+    ]
+    assert captured["kwargs"]["input"] == ""
+    assert captured["kwargs"]["cwd"] == tmp_path
+    assert captured["kwargs"]["timeout"] == 3
+    assert captured["kwargs"]["capture_output"] is True
+
+
+def test_hermes_qwen_route_label_maps_to_cli_model(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from ai_agent_bridge import _hermes
+
+    captured: dict[str, Any] = {}
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return subprocess.CompletedProcess(cmd, 0, stdout="HERMES OK\n", stderr="")
+
+    monkeypatch.setenv("KUBEDOJO_HERMES_CMD", "hermes")
+    monkeypatch.delenv("KUBEDOJO_HERMES_PROVIDER", raising=False)
+    monkeypatch.setattr(_hermes.subprocess, "run", fake_run)
+
+    ok, response, stderr = _hermes._invoke_hermes(
+        "prompt",
+        "qwen-3.6-flash",
+        timeout_s=3,
+        cwd=tmp_path,
+    )
+
+    assert ok is True
+    assert response == "HERMES OK"
+    assert stderr == ""
+    assert captured["cmd"] == [
+        "hermes",
+        "-z",
+        "prompt",
+        "--provider",
+        "openrouter",
+        "-m",
+        "qwen/qwen3.6-flash",
+    ]
+    assert captured["kwargs"]["input"] == ""
+
+
+def test_task_classes_include_opencode_and_hermes() -> None:
+    from dispatch_smart import SUPPORTED_AGENTS, TASK_CLASSES
+
+    expected = {
+        "search": {
+            "opencode": "openrouter/qwen/qwen3.6-flash",
+            "hermes": "qwen-3.6-flash",
+        },
+        "edit": {
+            "opencode": "openrouter/qwen/qwen3.7-max",
+            "hermes": "grok-4.3",
+        },
+        "draft": {
+            "opencode": "openrouter/qwen/qwen3.7-max",
+            "hermes": "grok-4.3",
+        },
+        "review": {
+            "opencode": "openrouter/qwen/qwen3.7-max",
+            "hermes": "claude-sonnet-4-6",
+        },
+        "architect": {
+            "opencode": "openrouter/anthropic/claude-sonnet-4.5",
+            "hermes": "claude-opus-4-6",
+        },
+    }
+
+    assert "opencode" in SUPPORTED_AGENTS
+    assert "hermes" in SUPPORTED_AGENTS
+    for task_class, models in expected.items():
+        for agent, model in models.items():
+            assert TASK_CLASSES[task_class].models[agent] == model

--- a/scripts/dispatch_smart.py
+++ b/scripts/dispatch_smart.py
@@ -1,4 +1,4 @@
-"""Smart-routing headless dispatcher (Claude or Codex).
+"""Smart-routing headless dispatcher.
 
 Single CLI for dispatching work to a headless agent that picks an
 appropriate model based on the task class — instead of always burning
@@ -59,8 +59,9 @@ Reuse with --dry-run to print the chosen plan without firing.
 from __future__ import annotations
 
 import argparse
-import os
 import json
+import os
+import shutil
 import subprocess
 import sys
 import time
@@ -84,7 +85,16 @@ LOG_PATH = PRIMARY_REPO / "logs" / "smart_dispatch.jsonl"
 RESPONSE_DIR = PRIMARY_REPO / "logs" / "dispatch_responses"
 
 
-SUPPORTED_AGENTS = ("agy", "claude", "codex", "deepseek", "gemini", "qwen")
+SUPPORTED_AGENTS = (
+    "agy",
+    "claude",
+    "codex",
+    "deepseek",
+    "gemini",
+    "hermes",
+    "opencode",
+    "qwen",
+)
 
 
 @dataclass(frozen=True)
@@ -112,6 +122,8 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
             "codex": "gpt-5.4-mini",
             "deepseek": "deepseek-v4-flash",
             "gemini": "gemini-3.1-flash-lite-preview",
+            "hermes": "qwen-3.6-flash",
+            "opencode": "openrouter/qwen/qwen3.6-flash",
             "qwen": "qwen/qwen3.6-flash",
         },
         default_mode="read-only",
@@ -126,6 +138,8 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
             "codex": "gpt-5.3-codex-spark",
             "deepseek": "deepseek-v4-pro",
             "gemini": "gemini-3.1-pro-preview",
+            "hermes": "grok-4.3",
+            "opencode": "openrouter/qwen/qwen3.7-max",
             "qwen": "qwen/qwen3.6-plus",
         },
         default_mode="workspace-write",
@@ -140,6 +154,8 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
             "codex": "gpt-5.3-codex-spark",
             "deepseek": "deepseek-v4-pro",
             "gemini": "gemini-3.1-pro-preview",
+            "hermes": "grok-4.3",
+            "opencode": "openrouter/qwen/qwen3.7-max",
             "qwen": "qwen/qwen3.6-plus",
         },
         default_mode="workspace-write",
@@ -154,6 +170,8 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
             "codex": "gpt-5.5",
             "deepseek": "deepseek-v4-pro",
             "gemini": "gemini-3.1-pro-preview",
+            "hermes": "claude-sonnet-4-6",
+            "opencode": "openrouter/qwen/qwen3.7-max",
             "qwen": "qwen/qwen3.6-plus",
         },
         default_mode="read-only",
@@ -168,6 +186,8 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
             "codex": "gpt-5.5",
             "deepseek": "deepseek-v4-pro",
             "gemini": "gemini-3.1-pro-preview",
+            "hermes": "claude-opus-4-6",
+            "opencode": "openrouter/anthropic/claude-sonnet-4.5",
             "qwen": "qwen/qwen3.6-plus",
         },
         default_mode="workspace-write",
@@ -235,16 +255,106 @@ def persist_response(task_id: str, response: str, stderr_excerpt: str) -> Path:
     return response_path
 
 
+def _opencode_binary() -> str:
+    """Resolve the opencode CLI path with an env override for local installs."""
+    return (
+        os.environ.get("KUBEDOJO_OPENCODE_CMD")
+        or shutil.which("opencode")
+        or "/opt/homebrew/bin/opencode"
+    )
+
+
+def _hermes_binary() -> str:
+    """Resolve the hermes CLI path with an env override for local installs."""
+    return (
+        os.environ.get("KUBEDOJO_HERMES_CMD")
+        or shutil.which("hermes")
+        or "/Users/krisztiankoos/.local/bin/hermes"
+    )
+
+
+def _hermes_provider_for_model(model: str) -> str:
+    """Pick a Hermes provider from the model name, unless env overrides it."""
+    override = os.environ.get("KUBEDOJO_HERMES_PROVIDER")
+    if override:
+        return override
+    if model.startswith("claude-"):
+        return "anthropic"
+    if model.startswith("grok-"):
+        return "xai"
+    return "openrouter"
+
+
+def _hermes_cli_model(model: str) -> str:
+    """Map KubeDojo's route labels to Hermes v0.14 CLI model IDs."""
+    if model.startswith("qwen-"):
+        return f"qwen/qwen{model.removeprefix('qwen-')}"
+    return model
+
+
+def _router_command(agent: str, model: str, prompt: str) -> list[str]:
+    """Build the subprocess command for direct router CLIs."""
+    if agent == "opencode":
+        return [_opencode_binary(), "run", "-m", model, "-"]
+    if agent == "hermes":
+        cli_model = _hermes_cli_model(model)
+        return [
+            _hermes_binary(),
+            "-z",
+            prompt,
+            "--provider",
+            _hermes_provider_for_model(model),
+            "-m",
+            cli_model,
+        ]
+    raise ValueError(f"unsupported direct router agent: {agent}")
+
+
+def _run_router_agent(
+    *,
+    agent: str,
+    prompt: str,
+    model: str,
+    cwd: Path,
+    timeout_s: int,
+) -> tuple[bool, str, str]:
+    """Invoke a session-less router CLI and return (ok, stdout, stderr)."""
+    cmd = _router_command(agent, model, prompt)
+    stdin_payload = prompt if agent == "opencode" else ""
+    try:
+        proc = subprocess.run(
+            cmd,
+            input=stdin_payload,
+            cwd=cwd,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout_s,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout if isinstance(exc.stdout, str) else ""
+        stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+        return False, stdout, f"{agent} timed out after {timeout_s}s\n{stderr}".strip()
+    except OSError as exc:
+        return False, "", f"{type(exc).__name__}: {exc}"
+
+    response = proc.stdout or ""
+    stderr = proc.stderr or ""
+    ok = proc.returncode == 0 and bool(response.strip())
+    if not ok and not stderr.strip():
+        stderr = f"{agent} exited {proc.returncode} with no stdout"
+    return ok, response.strip(), stderr.strip()
+
+
 def fire(*, agent: str, task_class: str, prompt: str, mode: str, model: str,
          worktree: Path | None, task_id: str, timeout_s: int) -> int:
-    sys.path.insert(0, str(REPO / "scripts"))
-    from agent_runtime.runner import invoke
-
     print(f"[smart] agent={agent} task_class={task_class} model={model} "
           f"mode={mode} timeout={timeout_s}s")
     if worktree:
         print(f"[smart] cwd={worktree}")
     print(f"[smart] task_id={task_id}")
+    if agent in {"hermes", "opencode"}:
+        print("[smart] mode is advisory for this router CLI")
 
     started = time.time()
     previous_search: str | None = None
@@ -258,20 +368,33 @@ def fire(*, agent: str, task_class: str, prompt: str, mode: str, model: str,
         env = os.environ.copy()
         env["KUBEDOJO_DISPATCHED"] = "1"
         os.environ.update(env)
-        result = invoke(
-            agent,
-            prompt,
-            mode=mode,
-            cwd=worktree,
-            model=model,
-            task_id=task_id,
-            entrypoint="delegate",
-            hard_timeout=timeout_s,
-        )
-        ok = bool(result.ok)
-        response = result.response or ""
-        session_id = result.session_id
-        stderr_excerpt = result.stderr_excerpt or ""
+        if agent in {"hermes", "opencode"}:
+            ok, response, stderr_excerpt = _run_router_agent(
+                agent=agent,
+                prompt=prompt,
+                model=model,
+                cwd=worktree or Path.cwd(),
+                timeout_s=timeout_s,
+            )
+            session_id = None
+        else:
+            sys.path.insert(0, str(REPO / "scripts"))
+            from agent_runtime.runner import invoke
+
+            result = invoke(
+                agent,
+                prompt,
+                mode=mode,
+                cwd=worktree,
+                model=model,
+                task_id=task_id,
+                entrypoint="delegate",
+                hard_timeout=timeout_s,
+            )
+            ok = bool(result.ok)
+            response = result.response or ""
+            session_id = result.session_id
+            stderr_excerpt = result.stderr_excerpt or ""
     except Exception as exc:  # surface the failure but still log it
         ok = False
         response = ""
@@ -324,7 +447,7 @@ def fire(*, agent: str, task_class: str, prompt: str, mode: str, model: str,
 
 def main() -> int:
     p = argparse.ArgumentParser(
-        description="Dispatch a headless agent (Claude or Codex) with a "
+        description="Dispatch a headless agent with a "
                     "task-class-based model choice. Mirrors the AGENTS.md "
                     "economical multi-agent policy across agents.",
     )
@@ -342,7 +465,9 @@ def main() -> int:
                         "branch off main.")
     p.add_argument("--mode",
                    choices=["read-only", "workspace-write", "danger"],
-                   help="Override task-class default mode.")
+                   help="Override task-class default mode. For opencode "
+                        "and hermes this is advisory; their CLIs enforce "
+                        "their own sandbox behavior.")
     p.add_argument("--model",
                    help="Override task-class default model "
                         "(rarely needed — let the class+agent pick).")

--- a/scripts/dispatch_smart.py
+++ b/scripts/dispatch_smart.py
@@ -269,7 +269,7 @@ def _hermes_binary() -> str:
     return (
         os.environ.get("KUBEDOJO_HERMES_CMD")
         or shutil.which("hermes")
-        or "/Users/krisztiankoos/.local/bin/hermes"
+        or str(Path.home() / ".local" / "bin" / "hermes")
     )
 
 
@@ -278,6 +278,8 @@ def _hermes_provider_for_model(model: str) -> str:
     override = os.environ.get("KUBEDOJO_HERMES_PROVIDER")
     if override:
         return override
+    if model.startswith("openrouter/"):
+        return "openrouter"
     if model.startswith("claude-"):
         return "anthropic"
     if model.startswith("grok-"):


### PR DESCRIPTION
## Summary
- Add opencode and hermes to `dispatch_smart.py` for all five task classes with `--model` override support.
- Add bridge adapters and `ask-opencode` / `ask-hermes` CLI commands.
- Register both agents as session-less channel/discuss participants and extend valid bridge agent choices.

Implementation note: Hermes v0.14.0 exposes `-z PROMPT` rather than stdin for oneshot mode. The public search route remains `qwen-3.6-flash`; the invocation maps that route label to Hermes' working OpenRouter CLI ID `qwen/qwen3.6-flash`.

## Validation
- `git diff --check`
- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/ruff check scripts/dispatch_smart.py scripts/ai_agent_bridge/_opencode.py scripts/ai_agent_bridge/_hermes.py scripts/ai_agent_bridge/tests/test_opencode_hermes.py scripts/ai_agent_bridge/_cli.py scripts/ai_agent_bridge/_channels_cli.py scripts/ai_agent_bridge/_channels.py` -> `All checks passed!`
- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/pytest scripts/ai_agent_bridge/tests/test_opencode_hermes.py scripts/ai_agent_bridge/tests/test_new_agent_ask_commands.py scripts/ai_agent_bridge/tests/test_discuss_bridge_bugs.py -q` -> `13 passed in 3.53s`
- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/test_pipeline.py` -> `Ran 170 tests in 71.085s OK`
- `npm run build` skipped: no Astro/content/frontend changes.

## Smoke output
```text
[dry-run] agent=opencode task_class=search model=openrouter/qwen/qwen3.6-flash mode=read-only timeout=600s
[dry-run] worktree=(none — read-only)
[dry-run] task_id=smoke-search-opencode
[dry-run] prompt_chars=6
[dry-run] agent=opencode task_class=edit model=openrouter/qwen/qwen3.7-max mode=workspace-write timeout=1800s
[dry-run] worktree=(none — workspace-write)
[dry-run] task_id=smoke-edit-opencode
[dry-run] prompt_chars=6
[dry-run] agent=opencode task_class=draft model=openrouter/qwen/qwen3.7-max mode=workspace-write timeout=3600s
[dry-run] worktree=(none — workspace-write)
[dry-run] task_id=smoke-draft-opencode
[dry-run] prompt_chars=6
[dry-run] agent=opencode task_class=review model=openrouter/qwen/qwen3.7-max mode=read-only timeout=1800s
[dry-run] worktree=(none — read-only)
[dry-run] task_id=smoke-review-opencode
[dry-run] prompt_chars=6
[dry-run] agent=opencode task_class=architect model=openrouter/anthropic/claude-sonnet-4.5 mode=workspace-write timeout=3600s
[dry-run] worktree=(none — workspace-write)
[dry-run] task_id=smoke-architect-opencode
[dry-run] prompt_chars=6
[dry-run] agent=hermes task_class=search model=qwen-3.6-flash mode=read-only timeout=600s
[dry-run] worktree=(none — read-only)
[dry-run] task_id=smoke-search-hermes
[dry-run] prompt_chars=6
[dry-run] agent=hermes task_class=edit model=grok-4.3 mode=workspace-write timeout=1800s
[dry-run] worktree=(none — workspace-write)
[dry-run] task_id=smoke-edit-hermes
[dry-run] prompt_chars=6
[dry-run] agent=hermes task_class=draft model=grok-4.3 mode=workspace-write timeout=3600s
[dry-run] worktree=(none — workspace-write)
[dry-run] task_id=smoke-draft-hermes
[dry-run] prompt_chars=6
[dry-run] agent=hermes task_class=review model=claude-sonnet-4-6 mode=read-only timeout=1800s
[dry-run] worktree=(none — read-only)
[dry-run] task_id=smoke-review-hermes
[dry-run] prompt_chars=6
[dry-run] agent=hermes task_class=architect model=claude-opus-4-6 mode=workspace-write timeout=3600s
[dry-run] worktree=(none — workspace-write)
[dry-run] task_id=smoke-architect-hermes
[dry-run] prompt_chars=6
[smart] agent=opencode task_class=search model=openrouter/qwen/qwen3.6-flash mode=read-only timeout=60s
[smart] task_id=smoke-opencode-real
[smart] mode is advisory for this router CLI
======================================================================
OK: True  |  elapsed: 5s  |  resp_chars: 11
response_path: logs/dispatch_responses/smoke-opencode-real.txt
======================================================================
OPENCODE OK
---- stderr ----
[0m
> build · qwen/qwen3.6-flash
[0m
[smart] agent=hermes task_class=search model=qwen-3.6-flash mode=read-only timeout=60s
[smart] task_id=smoke-hermes-real
[smart] mode is advisory for this router CLI
======================================================================
OK: True  |  elapsed: 2s  |  resp_chars: 9
response_path: logs/dispatch_responses/smoke-hermes-real.txt
======================================================================
HERMES OK
```
