### PR TITLE
feat(dispatch): add cursor-agent (composer-2.5) as supported agent (#1463 follow-up)

### DIFF
--- a/scripts/ai_agent_bridge/__init__.py
+++ b/scripts/ai_agent_bridge/__init__.py
@@ -110,6 +110,7 @@ __all__ = [
     # Claude
     "ask_claude",
     "ask_codex",
+    "ask_cursor",
     # Gemini
     "ask_gemini",
     "bridge_status",

--- a/scripts/ai_agent_bridge/__init__.py
+++ b/scripts/ai_agent_bridge/__init__.py
@@ -34,6 +34,7 @@ from ._broker import (
 from ._claude import ask_claude, process_for_claude
 from ._cli import interactive_mode, main, process_all_claude, process_all_gemini
 from ._codex import ask_codex, process_all_codex, process_for_codex
+from ._cursor import ask_cursor
 from ._config import (
     _MODEL_CACHE,
     _MODEL_CACHE_TTL,

--- a/scripts/ai_agent_bridge/_channels.py
+++ b/scripts/ai_agent_bridge/_channels.py
@@ -69,6 +69,7 @@ VALID_AGENTS = (
     "agy",
     "claude",
     "codex",
+    "cursor",
     "deepseek",
     "gemini",
     "hermes",

--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -64,6 +64,7 @@ _DISCUSSION_CLARIFICATION_MODES = {
     "qwen": "yolo",
     "hermes": "yolo",
     "opencode": "yolo",
+    "cursor": "yolo",
 }
 
 _DISCUSSION_RUNTIME_MODES = {
@@ -75,6 +76,7 @@ _DISCUSSION_RUNTIME_MODES = {
     "qwen": "workspace-write",
     "hermes": "workspace-write",
     "opencode": "workspace-write",
+    "cursor": "workspace-write",
 }
 
 _DISCUSSION_MCP_EXCLUDE_TOKENS: tuple[str, ...] = (
@@ -185,7 +187,7 @@ def _agent_runtime_mode(agent_name: str, sandbox_mode: str | None) -> str:
         if sandbox_mode == "read-only":
             return "read-only"
         return "workspace-write"
-    if agent_name in {"hermes", "opencode"}:
+    if agent_name in {"hermes", "opencode", "cursor"}:
         # These router CLIs do not expose project sandbox modes. Preserve the
         # label for audit/session logic; the CLI invocation itself treats it
         # as advisory.
@@ -1241,7 +1243,7 @@ def _handle_discuss(args) -> int:
         print(f"   root message: {root_id[:12]} / thread {correlation_id[:12]}")
         print()
 
-    # Session-less agents (agy / qwen / deepseek / hermes / opencode) map
+    # Session-less agents (agy / qwen / deepseek / hermes / opencode / cursor) map
     # to all-None tuples;
     # the per-agent branch at "if agent_name in {claude, gemini}" later
     # in this function correctly skips session persistence for them, and
@@ -1257,6 +1259,7 @@ def _handle_discuss(args) -> int:
         "deepseek": (None, None, None),
         "hermes": (None, None, None),
         "opencode": (None, None, None),
+        "cursor": (None, None, None),
     }
     resume_thread_session: dict[str, str | None] = {}
     if args.resume_thread:
@@ -1393,6 +1396,30 @@ def _handle_discuss(args) -> int:
                 started = time.monotonic()
                 model = _opencode._DEFAULT_MODEL
                 ok, response, stderr_excerpt = _opencode._invoke_opencode(
+                    prompt_text,
+                    model,
+                    timeout_s=900,
+                    cwd=cwd,
+                )
+                return Result(
+                    ok=ok,
+                    agent=agent_name,
+                    model=model,
+                    mode=mode,
+                    response=response,
+                    stderr_excerpt=stderr_excerpt or None,
+                    duration_s=time.monotonic() - started,
+                    session_id=None,
+                    rate_limited=False,
+                    stalled=False,
+                    returncode=0 if ok else 1,
+                ), None
+            if agent_name == "cursor":
+                from . import _cursor
+
+                started = time.monotonic()
+                model = _cursor._DEFAULT_MODEL
+                ok, response, stderr_excerpt = _cursor._invoke_cursor(
                     prompt_text,
                     model,
                     timeout_s=900,

--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -32,6 +32,7 @@ from ._messaging import (
 )
 from ._model import check_model
 from ._opencode import ask_opencode
+from ._cursor import ask_cursor
 from ._prompts import build_review_message
 from ._qwen import ask_qwen
 
@@ -44,6 +45,7 @@ AGENT_CHOICES = (
     "agy",
     "claude",
     "codex",
+    "cursor",
     "deepseek",
     "gemini",
     "hermes",
@@ -576,6 +578,25 @@ def _build_parser() -> argparse.ArgumentParser:
     ask_opencode_parser.add_argument("--review", action="store_true",
                                      help="Prepend docs/review-protocol.md")
 
+    # ask-cursor
+    ask_cursor_parser = subparsers.add_parser("ask-cursor", help="Send message AND invoke Cursor (one-step)")
+    ask_cursor_parser.add_argument("content", help="Message content (use '-' to read from stdin)")
+    ask_cursor_parser.add_argument("--task-id", help="Task ID for session tracking")
+    ask_cursor_parser.add_argument("--type", default="query", help="Message type (default: query)")
+    ask_cursor_parser.add_argument("--data", help="Path to data file to attach")
+    ask_cursor_parser.add_argument("--new-session", dest="new_session", action="store_true",
+                                  help="Force new session even if one exists")
+    ask_cursor_parser.add_argument("--from", dest="from_llm", default="gemini",
+                                  help="Sender agent family. Default: gemini")
+    ask_cursor_parser.add_argument("--from-model", dest="from_model",
+                                  help="Exact sender model ID")
+    ask_cursor_parser.add_argument("--to-model", dest="to_model",
+                                  help="Target model ID")
+    ask_cursor_parser.add_argument("--no-timeout", dest="no_timeout", action="store_true",
+                                  help="Run sync without timeout")
+    ask_cursor_parser.add_argument("--review", action="store_true",
+                                  help="Prepend docs/review-protocol.md")
+
     # converse — multi-turn conversation with Gemini
     converse_parser = subparsers.add_parser("converse", help="Multi-turn conversation with Gemini (includes history)")
     converse_parser.add_argument("content", help="Message content (use '-' to read from stdin)")
@@ -690,6 +711,8 @@ def _dispatch_command(args):
         _handle_ask_hermes(args)
     elif args.command == "ask-opencode":
         _handle_ask_opencode(args)
+    elif args.command == "ask-cursor":
+        _handle_ask_cursor(args)
     elif args.command == "converse":
         content = sys.stdin.read() if args.content == "-" else args.content
         converse_gemini(content, args.task_id, args.model,
@@ -818,6 +841,17 @@ def _handle_ask_opencode(args):
     ask_opencode(content, args.task_id, args.type, data,
                  args.new_session, args.from_llm, args.from_model,
                  args.to_model, args.no_timeout, args.review)
+
+
+def _handle_ask_cursor(args):
+    """Handle ask-cursor subcommand."""
+    data = None
+    if args.data:
+        data = Path(args.data).read_text()
+    content = sys.stdin.read() if args.content == "-" else args.content
+    ask_cursor(content, args.task_id, args.type, data,
+               args.new_session, args.from_llm, args.from_model,
+               args.to_model, args.no_timeout, args.review)
 
 
 def main():

--- a/scripts/ai_agent_bridge/_cursor.py
+++ b/scripts/ai_agent_bridge/_cursor.py
@@ -1,0 +1,293 @@
+"""Cursor interaction: ask_cursor and process_for_cursor."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from ._config import REPO_ROOT
+from ._db import get_db
+from ._messaging import acknowledge, send_message
+
+_AGENT_NAME = "cursor"
+_AGENT_TITLE = "Cursor"
+_DEFAULT_BRIDGE_TIMEOUT_SECONDS = 900
+_NO_TIMEOUT_BRIDGE_TIMEOUT_SECONDS = 24 * 60 * 60
+_DEFAULT_MODEL = os.environ.get("AB_CURSOR_MODEL", "composer-2.5")
+_TIMEOUT_ENV = "CURSOR_BRIDGE_TIMEOUT"
+
+
+def _cursor_binary() -> str:
+    """Resolve the cursor-agent executable."""
+    return (
+        os.environ.get("KUBEDOJO_CURSOR_CMD")
+        or shutil.which("cursor-agent")
+        or str(Path.home() / ".local" / "bin" / "cursor-agent")
+    )
+
+
+def _build_command(prompt: str, model: str) -> list[str]:
+    """Build the cursor one-shot command."""
+    return [
+        _cursor_binary(),
+        "--print",
+        "--force",
+        "--trust",
+        "--model",
+        model,
+        "--output-format",
+        "text",
+        prompt,
+    ]
+
+
+def _resolve_bridge_timeout(no_timeout: bool = False) -> int:
+    """Resolve the hard timeout from CLI flag/env with a safe fallback."""
+    if no_timeout:
+        return _NO_TIMEOUT_BRIDGE_TIMEOUT_SECONDS
+
+    raw = os.environ.get(_TIMEOUT_ENV)
+    if raw is None:
+        return _DEFAULT_BRIDGE_TIMEOUT_SECONDS
+
+    value = raw.strip().lower()
+    if value in {"0", "none", "off", "false", "no"}:
+        return _NO_TIMEOUT_BRIDGE_TIMEOUT_SECONDS
+
+    try:
+        timeout = int(value)
+    except ValueError:
+        print(
+            f"Invalid {_TIMEOUT_ENV}={raw!r}; "
+            f"falling back to {_DEFAULT_BRIDGE_TIMEOUT_SECONDS}s"
+        )
+        return _DEFAULT_BRIDGE_TIMEOUT_SECONDS
+
+    if timeout <= 0:
+        return _NO_TIMEOUT_BRIDGE_TIMEOUT_SECONDS
+    return timeout
+
+
+def ask_cursor(
+    content: str,
+    task_id: str | None = None,
+    msg_type: str = "query",
+    data: str | None = None,
+    new_session: bool = False,
+    from_llm: str = "gemini",
+    from_model: str | None = None,
+    to_model: str | None = None,
+    no_timeout: bool = False,
+    review: bool = False,
+) -> int:
+    """Send a message to Cursor and invoke it to process the message."""
+    msg_id = send_message(
+        content,
+        task_id,
+        msg_type,
+        data,
+        from_llm=from_llm,
+        to_llm=_AGENT_NAME,
+        from_model=from_model,
+        to_model=to_model,
+    )
+    print(f"\nInvoking {_AGENT_TITLE} to process message #{msg_id}...")
+    process_for_cursor(msg_id, new_session, no_timeout, review=review)
+    return msg_id
+
+
+def process_for_cursor(
+    message_id: int,
+    new_session: bool = False,
+    no_timeout: bool = False,
+    review: bool = False,
+) -> None:
+    """Read a message addressed to Cursor, invoke the CLI, and reply."""
+    msg = _fetch_message(message_id)
+    if not msg:
+        return
+
+    _ = new_session  # Cursor is session-less for bridge calls.
+    timeout_val = _resolve_bridge_timeout(no_timeout)
+    model = _extract_target_model(msg) or _DEFAULT_MODEL
+    prompt = _build_prompt(msg, review)
+
+    print(f"Message #{msg['id']}")
+    print(f"   From: {msg['from']} -> To: {msg['to']}")
+    print(f"   Type: {msg['type']}")
+    print(f"   Task: {msg['task_id'] or 'N/A'}")
+    print(f"   Model: {model}")
+    if timeout_val == _NO_TIMEOUT_BRIDGE_TIMEOUT_SECONDS:
+        print("   Hard timeout: no-timeout requested (24h ceiling)")
+    else:
+        print(f"   Hard timeout: {timeout_val}s")
+
+    ok, response, stderr_excerpt = _invoke_cursor(
+        prompt,
+        model,
+        timeout_s=timeout_val,
+        cwd=REPO_ROOT,
+    )
+    if not ok:
+        _handle_error(
+            msg,
+            message_id,
+            stderr_excerpt or f"{_AGENT_TITLE} returned no final message",
+        )
+        return
+
+    print(f"\n{_AGENT_TITLE} finished ({len(response)} chars)")
+    reply_id = send_message(
+        content=response,
+        task_id=msg["task_id"],
+        msg_type="response",
+        from_llm=_AGENT_NAME,
+        to_llm=msg["from"],
+    )
+    acknowledge(message_id)
+    acknowledge(reply_id)
+
+
+def _invoke_cursor(
+    prompt: str,
+    model: str,
+    *,
+    timeout_s: int,
+    cwd: Path | None = None,
+) -> tuple[bool, str, str]:
+    """Run cursor and return (ok, stdout response, stderr excerpt)."""
+    command = _build_command(prompt, model)
+    try:
+        completed = subprocess.run(
+            command,
+            input="",
+            cwd=cwd or REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout_s,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout if isinstance(exc.stdout, str) else ""
+        stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+        return False, stdout.strip(), (
+            f"{_AGENT_TITLE} timed out after {timeout_s}s\n{stderr}"
+        ).strip()
+    except OSError as exc:
+        return False, "", f"{type(exc).__name__}: {exc}"
+
+    response = completed.stdout.strip()
+    stderr_excerpt = completed.stderr.strip()
+    ok = completed.returncode == 0 and bool(response)
+    if not ok and not stderr_excerpt:
+        stderr_excerpt = (
+            f"{_AGENT_TITLE} exited {completed.returncode} with no stdout"
+        )
+    return ok, response, stderr_excerpt[:500]
+
+
+def _fetch_message(message_id: int) -> dict[str, object] | None:
+    """Fetch a message addressed to this agent from the database."""
+    conn = get_db()
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        SELECT id, task_id, from_llm, to_llm, message_type, content, data, timestamp
+        FROM messages
+        WHERE id = ? AND to_llm = ?
+        """,
+        (message_id, _AGENT_NAME),
+    )
+    row = cursor.fetchone()
+    conn.close()
+
+    if not row:
+        print(f"Message {message_id} not found or not addressed to {_AGENT_TITLE}")
+        return None
+
+    return {
+        "id": row[0],
+        "task_id": row[1],
+        "from": row[2],
+        "to": row[3],
+        "type": row[4],
+        "content": row[5],
+        "data": row[6],
+        "timestamp": row[7],
+    }
+
+
+def _extract_target_model(msg: dict[str, object]) -> str | None:
+    """Read optional to_model from message metadata JSON."""
+    data = msg.get("data")
+    if not data:
+        return None
+    try:
+        payload = json.loads(data)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    model = payload.get("to_model")
+    return str(model) if model else None
+
+
+def _build_prompt(msg: dict[str, object], review: bool = False) -> str:
+    """Build a direct one-shot bridge prompt."""
+    prompt = f"""You are {_AGENT_TITLE}, receiving a message from {msg['from'].title()} via the message broker.
+
+---
+Task ID: {msg['task_id'] or 'none'}
+Type: {msg['type']}
+From: {msg['from']}
+
+{msg['content']}
+"""
+    if msg["data"]:
+        prompt += f"""
+---
+Attached data:
+{msg['data']}
+"""
+    prompt += """
+
+---
+
+Standing rules for bridge Q&A:
+- Respond directly. Be concise. This bridge is for quick questioning
+  and short coordination, not long-running task execution.
+- Do NOT use broker or MCP messaging tools to send your response.
+  Output your response directly.
+"""
+    return _prepend_review_protocol(prompt, review)
+
+
+def _prepend_review_protocol(prompt: str, review: bool) -> str:
+    """Prepend docs/review-protocol.md when --review is requested."""
+    if not review:
+        return prompt
+    prefix = (REPO_ROOT / "docs" / "review-protocol.md").read_text(
+        encoding="utf-8"
+    ).rstrip()
+    return f"{prefix}\n\n{prompt}"
+
+
+def _handle_error(
+    msg: dict[str, object],
+    message_id: int,
+    reason: str,
+) -> None:
+    """Record an agent failure as an error response and acknowledge it."""
+    print(f"\n{_AGENT_TITLE} error for message #{message_id}: {reason}")
+    reply_id = send_message(
+        content=f"[{_AGENT_TITLE} error] {reason}",
+        task_id=msg["task_id"],
+        msg_type="error",
+        from_llm=_AGENT_NAME,
+        to_llm=msg["from"],
+    )
+    acknowledge(message_id)
+    acknowledge(reply_id)

--- a/scripts/ai_agent_bridge/tests/test_cursor.py
+++ b/scripts/ai_agent_bridge/tests/test_cursor.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import sys
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def test_cursor_command_construction(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from ai_agent_bridge import _cursor
+
+    captured: dict[str, Any] = {}
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return subprocess.CompletedProcess(cmd, 0, stdout="CURSOR OK\n", stderr="")
+
+    monkeypatch.setenv("KUBEDOJO_CURSOR_CMD", "cursor-agent")
+    monkeypatch.setattr(_cursor.subprocess, "run", fake_run)
+
+    ok, response, stderr = _cursor._invoke_cursor(
+        "hello world",
+        "composer-2.5",
+        timeout_s=3,
+        cwd=tmp_path,
+    )
+
+    assert ok is True
+    assert response == "CURSOR OK"
+    assert stderr == ""
+    assert captured["cmd"] == [
+        "cursor-agent",
+        "--print",
+        "--force",
+        "--trust",
+        "--model",
+        "composer-2.5",
+        "--output-format",
+        "text",
+        "hello world",
+    ]
+    assert captured["kwargs"]["input"] == ""
+    assert captured["kwargs"]["cwd"] == tmp_path
+    assert captured["kwargs"]["timeout"] == 3
+    assert captured["kwargs"]["capture_output"] is True
+
+
+def test_cursor_default_model_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    import importlib
+
+    monkeypatch.setenv("AB_CURSOR_MODEL", "composer-2.5-fast")
+    import ai_agent_bridge._cursor as _cursor
+
+    importlib.reload(_cursor)
+
+    assert _cursor._DEFAULT_MODEL == "composer-2.5-fast"
+
+
+def test_cursor_binary_resolution(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KUBEDOJO_CURSOR_CMD", "/opt/alt/bin/cursor-agent")
+
+    from ai_agent_bridge import _cursor
+
+    assert _cursor._cursor_binary() == "/opt/alt/bin/cursor-agent"

--- a/scripts/dispatch_smart.py
+++ b/scripts/dispatch_smart.py
@@ -89,6 +89,7 @@ SUPPORTED_AGENTS = (
     "agy",
     "claude",
     "codex",
+    "cursor",
     "deepseek",
     "gemini",
     "hermes",
@@ -122,6 +123,7 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
             "codex": "gpt-5.4-mini",
             "deepseek": "deepseek-v4-flash",
             "gemini": "gemini-3.1-flash-lite-preview",
+            "cursor": "composer-2.5-fast",
             "hermes": "qwen-3.6-flash",
             "opencode": "openrouter/qwen/qwen3.6-flash",
             "qwen": "qwen/qwen3.6-flash",
@@ -138,6 +140,7 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
             "codex": "gpt-5.3-codex-spark",
             "deepseek": "deepseek-v4-pro",
             "gemini": "gemini-3.1-pro-preview",
+            "cursor": "composer-2.5",
             "hermes": "grok-4.3",
             "opencode": "openrouter/qwen/qwen3.7-max",
             "qwen": "qwen/qwen3.6-plus",
@@ -154,6 +157,7 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
             "codex": "gpt-5.3-codex-spark",
             "deepseek": "deepseek-v4-pro",
             "gemini": "gemini-3.1-pro-preview",
+            "cursor": "composer-2.5",
             "hermes": "grok-4.3",
             "opencode": "openrouter/qwen/qwen3.7-max",
             "qwen": "qwen/qwen3.6-plus",
@@ -170,6 +174,7 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
             "codex": "gpt-5.5",
             "deepseek": "deepseek-v4-pro",
             "gemini": "gemini-3.1-pro-preview",
+            "cursor": "gpt-5.5",
             "hermes": "claude-sonnet-4-6",
             "opencode": "openrouter/qwen/qwen3.7-max",
             "qwen": "qwen/qwen3.6-plus",
@@ -186,6 +191,7 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
             "codex": "gpt-5.5",
             "deepseek": "deepseek-v4-pro",
             "gemini": "gemini-3.1-pro-preview",
+            "cursor": "composer-2.5",
             "hermes": "claude-opus-4-6",
             "opencode": "openrouter/anthropic/claude-sonnet-4.5",
             "qwen": "qwen/qwen3.6-plus",
@@ -273,6 +279,15 @@ def _hermes_binary() -> str:
     )
 
 
+def _cursor_binary() -> str:
+    """Resolve the cursor-agent CLI path with an env override for local installs."""
+    return (
+        os.environ.get("KUBEDOJO_CURSOR_CMD")
+        or shutil.which("cursor-agent")
+        or str(Path.home() / ".local" / "bin" / "cursor-agent")
+    )
+
+
 def _hermes_provider_for_model(model: str) -> str:
     """Pick a Hermes provider from the model name, unless env overrides it."""
     override = os.environ.get("KUBEDOJO_HERMES_PROVIDER")
@@ -298,6 +313,18 @@ def _router_command(agent: str, model: str, prompt: str) -> list[str]:
     """Build the subprocess command for direct router CLIs."""
     if agent == "opencode":
         return [_opencode_binary(), "run", "-m", model, "-"]
+    if agent == "cursor":
+        return [
+            _cursor_binary(),
+            "--print",
+            "--force",
+            "--trust",
+            "--model",
+            model,
+            "--output-format",
+            "text",
+            prompt,
+        ]
     if agent == "hermes":
         cli_model = _hermes_cli_model(model)
         return [
@@ -323,6 +350,8 @@ def _run_router_agent(
     """Invoke a session-less router CLI and return (ok, stdout, stderr)."""
     cmd = _router_command(agent, model, prompt)
     stdin_payload = prompt if agent == "opencode" else ""
+    if agent == "cursor":
+        stdin_payload = ""
     try:
         proc = subprocess.run(
             cmd,
@@ -355,7 +384,7 @@ def fire(*, agent: str, task_class: str, prompt: str, mode: str, model: str,
     if worktree:
         print(f"[smart] cwd={worktree}")
     print(f"[smart] task_id={task_id}")
-    if agent in {"hermes", "opencode"}:
+    if agent in {"cursor", "hermes", "opencode"}:
         print("[smart] mode is advisory for this router CLI")
 
     started = time.time()
@@ -370,7 +399,7 @@ def fire(*, agent: str, task_class: str, prompt: str, mode: str, model: str,
         env = os.environ.copy()
         env["KUBEDOJO_DISPATCHED"] = "1"
         os.environ.update(env)
-        if agent in {"hermes", "opencode"}:
+        if agent in {"cursor", "hermes", "opencode"}:
             ok, response, stderr_excerpt = _run_router_agent(
                 agent=agent,
                 prompt=prompt,
@@ -467,9 +496,9 @@ def main() -> int:
                         "branch off main.")
     p.add_argument("--mode",
                    choices=["read-only", "workspace-write", "danger"],
-                   help="Override task-class default mode. For opencode "
-                        "and hermes this is advisory; their CLIs enforce "
-                        "their own sandbox behavior.")
+                   help="Override task-class default mode. For opencode, "
+                        "hermes, and cursor this is advisory; their CLIs "
+                        "enforce their own sandbox behavior.")
     p.add_argument("--model",
                    help="Override task-class default model "
                         "(rarely needed — let the class+agent pick).")


### PR DESCRIPTION
## Summary
- Added first-class Cursor support to dispatch, legacy CLI, and channel discussion paths.
- Added `scripts/ai_agent_bridge/_cursor.py` with Opencode-style broker and positional prompt CLI invocation for `cursor-agent`.
- Wired Cursor into `dispatch_smart`, `ask-cursor` CLI handler, discussion agent capabilities, and routing maps.
- Added `scripts/ai_agent_bridge/tests/test_cursor.py` to cover command construction, default-model env override, and binary resolution.

## Test plan
- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python -c "import sys; sys.path.insert(0, 'scripts'); from ai_agent_bridge import _cursor; print(_cursor._AGENT_NAME); print(_cursor._DEFAULT_MODEL); print(_cursor._cursor_binary()); print(_cursor._build_command('hello world', 'composer-2.5'))"`
- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python -m pytest scripts/ai_agent_bridge/tests/test_cursor.py -v`
- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python -m pytest scripts/ai_agent_bridge/tests/test_opencode_hermes.py -v`
- `/Users/krisztiankoos/projects/kubedojo/.venv/bin/python scripts/dispatch_smart.py edit --agent cursor --dry-run "test prompt"`

## Learner check
> [
  _cursor_binary(),
  "--print",
  "--force",
  "--trust",
  "--model",
  model,
  "--output-format",
  "text",
  prompt,
]
