### PR TITLE
feat(content): T0 rewrite — On-Premises Multi-Cluster Kubernetes Synthesis (#197)

### DIFF
--- a/src/content/docs/on-premises/multi-cluster/module-5.7-multi-cluster-on-prem.md
+++ b/src/content/docs/on-premises/multi-cluster/module-5.7-multi-cluster-on-prem.md
@@ -1,18 +1,14 @@
 ---
-title: "Module 5.7: Multi-Cluster On-Prem — Karmada Federation + Liqo Offload + kube-vip Virtual IPs"
-description: "Design and operate the layered on-prem multi-cluster stack: kube-vip for virtual IPs, Karmada for federation policy, and Liqo for transparent cross-cluster offloading."
+title: "Module 5.7: On-Premises Multi-Cluster Kubernetes Synthesis"
+description: "Synthesize provisioning, fleet management, networking, identity, secrets, observability, upgrades, and disaster recovery into a coherent on-premises multi-cluster operating model."
 slug: on-premises/multi-cluster/module-5.7-multi-cluster-on-prem
 sidebar:
   order: 57
 ---
 
-# Module 5.7: Multi-Cluster On-Prem — Karmada Federation + Liqo Offload + kube-vip Virtual IPs
-
-> **Complexity**: `[COMPLEX]` | Time: 60-70 minutes
+> **Complexity**: `[COMPLEX]` | Time: 65–75 minutes
 >
-> **Prerequisites**: K8s basics at CKA level, networking fundamentals, BGP or L2 familiarity helpful, Module 5.6 Gardener recommended, and at least one of Modules 5.3, 5.4, or 5.5 for multi-cluster context.
-
-For command examples, this module uses `k` as a short alias for `kubectl`. Create it once in your shell with `alias k=kubectl` before running the hands-on work. All Kubernetes examples assume Kubernetes 1.35+ behavior unless a tool-specific command says otherwise.
+> **Prerequisites**: [Module 5.1: Private Cloud Platforms](../module-5.1-private-cloud/), [Module 5.2: Multi-Cluster Control Planes](../module-5.2-multi-cluster-control-planes/), and at least two of Modules 5.3–5.6 for provisioning and fleet depth.
 
 ---
 
@@ -20,1112 +16,511 @@ For command examples, this module uses `k` as a short alias for `kubectl`. Creat
 
 After completing this module, you will be able to:
 
-1. **Design** an on-prem multi-cluster architecture that separates VIP advertisement, workload placement, and pod networking into clear layers.
-2. **Compare** kube-vip L2 and BGP modes for control-plane HA and `LoadBalancer` Services in bare-metal environments.
-3. **Evaluate** Karmada and Liqo placement models and choose the right tool for policy-driven federation or transparent workload offloading.
-4. **Implement** a GitOps-driven multi-cluster deployment pattern using ApplicationSet generators and Karmada propagation policy.
-5. **Diagnose** failover, ARP, BGP, peering, and namespace offloading failures across a two-cluster on-prem fleet.
+1. **Design** a management-cluster-plus-workload-clusters reference architecture with sizing rules, blast-radius boundaries, and capacity ratios for on-premises fleets.
+2. **Compare** provisioning paths including Cluster API with Metal3, kubeadm with Ansible, Gardener, and vendor Kubernetes distributions for the same private-cloud constraints.
+3. **Evaluate** fleet controllers—Argo CD ApplicationSets, Rancher Fleet, Karmada, and Open Cluster Management—and multi-cluster networking options including Submariner Lighthouse, Cilium ClusterMesh, and Istio multi-cluster.
+4. **Implement** cross-cutting platform patterns for federated OIDC, SPIFFE/SPIRE service identity, External Secrets Operator or Sealed Secrets, and Thanos, Mimir, or VictoriaMetrics metrics fan-in.
+5. **Coordinate** rolling shoot or cluster upgrades, canary clusters, Velero-backed disaster recovery, and fleet-wide GitOps reconciliation with measurable recovery-time objectives.
 
 ---
 
 ## Why This Module Matters
 
-At 02:15 on a Monday, a regional manufacturer loses the private cloud zone that hosts its warehouse API. The application itself is healthy in the second site. The container images are already cached there. The database has a tested replica.
+Hypothetical scenario: a manufacturing group finishes Modules 5.1 through 5.6 with strong point solutions—OpenStack under some clusters, Metal3 for factory floors, Gardener for a central platform team, Rancher Fleet at the edge, and Argo CD in the datacenter. During a quarterly audit, leadership asks a single question nobody can answer in one diagram: *How does a new bare-metal cluster join the fleet, receive identity, networking, monitoring, secrets, and application baselines, and survive a control-plane upgrade without taking down unrelated sites?*
 
-The operators can even reach the second cluster by kubeconfig. Yet the warehouse scanners keep calling the dead site because the original `LoadBalancer` Service never had a real load balancer behind it. The cloud migration plan assumed EKS-style integration: create a Service, let the provider allocate a VIP, publish DNS, and move on. On-prem, there was no ALB, no managed network load balancer, no Route 53 health check, and no global front door like Google Front End.
+The honest answer in many organizations is a sequence of tribal runbooks. Cluster API engineers provision nodes; a different team imports clusters into OCM; application developers still deploy through Argo CD; network operators maintain Submariner gateways; security runs Vault with manual policy exceptions; observability uses three Prometheus stacks and a spreadsheet for Thanos endpoints. Each layer works in isolation. Together they fight during incidents because ownership boundaries were never drawn.
 
-The cluster had Kubernetes APIs, but the surrounding network promises were missing. The outage lasted hours because every layer had been treated as somebody else's problem. Networking expected Kubernetes to publish routes. Kubernetes expected a cloud controller to assign external IPs.
-
-The application team expected GitOps to place workloads in both sites. GitOps expected clusters to be interchangeable. None of those expectations were wrong in a public-cloud cluster. Together, they were wrong on bare metal.
-
-This module is about closing that gap without pretending on-prem behaves like a hyperscaler. You will build a layered mental model. kube-vip gives each cluster real L4 addresses for the API server and Services. Karmada gives the fleet a policy-driven control plane for scheduling, propagation, override, and failover.
-
-Liqo gives teams a different abstraction: remote capacity appears as virtual nodes and namespaces can extend across cluster boundaries. The skill is not memorizing three tools. The skill is deciding which layer owns which responsibility, then debugging the failure when the layers disagree.
+This synthesis module is the capstone for the On-Premises Multi-Cluster track. It does not introduce every tool from scratch—that is the job of Modules 5.1–5.6. Instead, it teaches you to assemble those tools into one operational story: a **management cluster** that stays workload-light, **N workload clusters** sized for tenant density, explicit **provisioning** and **fleet** handoffs, shared **identity** and **secrets** contracts, **observability** fan-in that executives can read, and **upgrade** plus **disaster recovery** choreography that limits blast radius. The outcome is a reference architecture you can defend in a design review without pretending on-premises Kubernetes behaves like a hyperscaler control plane.
 
 ---
 
-## 1. Why On-Prem Multi-Cluster Needs Different Tools Than Cloud
+## Reference Architecture: Management Cluster Plus N Workload Clusters
 
-Cloud Kubernetes hides a large amount of infrastructure behind a small YAML object. When a team creates `type: LoadBalancer` in EKS, AKS, or GKE, the cloud controller talks to the provider API. That provider API allocates a load balancer, attaches nodes or network endpoints, opens firewall rules, and writes an external address back into Service status. When the same team creates an Ingress, another controller may create an ALB, Application Gateway, or Google Cloud load balancer.
+Mature on-premises programs converge on a **control plane of control planes**: one or two highly available management clusters run Cluster API controllers, fleet GitOps, policy engines, and observability receivers, while workload clusters run customer applications and local platform agents. The management cluster is production infrastructure with its own backup, upgrade, and access-control lifecycle—not a lab afterthought.
 
-DNS automation then points a name at the provider-managed endpoint. This is why a cloud quickstart feels so simple. The cluster is only one part of the system. The cloud is quietly supplying identity, routing, L4 or L7 balancing, health checks, IAM, quotas, logging sinks, and API-driven inventory.
+Sizing the management plane starts from controller count and etcd write rate, not from vCPU totals alone. A fleet of twenty workload clusters with Argo CD ApplicationSets, OCM placement controllers, and Thanos Receive ingesting remote write from every spoke generates sustained API traffic on the hub. Platform teams commonly allocate three to five control-plane nodes with fast etcd storage, plus two to four worker nodes tainted for `fleet=platform` so general workloads cannot starve reconciliation loops. Workload clusters scale by expected pod density, storage throughput, and GPU or storage-specialized node pools—not by copying management-cluster sizes.
 
-On-premises clusters do not get those services by default. A rack of servers may have excellent switches, routers, firewalls, and storage. It does not automatically have a Kubernetes-aware load balancer. It does not automatically have a global identity plane that lets one cluster impersonate a workload in another cluster.
+Workload cluster counts follow blast-radius and compliance boundaries more than hardware convenience. A useful rule of thumb for regulated manufacturing is **one production cluster per site or per major application family**, separate staging clusters that mirror production Kubernetes minor versions, and shared lab clusters only for experiments that tolerate noisy neighbors. Edge factory clusters stay small—three control-plane nodes where HA is mandated, otherwise a single control plane with documented break-glass recovery when the business accepts the risk.
 
-It does not automatically have a regional control plane that can decide where replicas should run when a site fails. That means multi-cluster is not a feature you add at the end. It is part of the platform design from the beginning. The first missing cloud primitive is the external load balancer.
-
-Without it, `type: LoadBalancer` commonly remains in `EXTERNAL-IP: <pending>`. The Kubernetes Service object exists, but no system outside the cluster has claimed responsibility for making that IP reachable. kube-vip fills that gap by advertising virtual IPs from cluster nodes using ARP in L2 mode or BGP in L3 mode. It can advertise the control-plane endpoint for kubeadm HA.
-
-It can also advertise application Service addresses when paired with kube-vip's cloud provider. Those are separate use cases and should be designed separately. The second missing cloud primitive is the cross-region policy plane. In a cloud provider, cluster identity, service accounts, tags, IAM roles, and provider APIs often become the glue that decides who can deploy where.
-
-On-prem, you usually own that glue, and Karmada supplies Kubernetes-native policy objects for fleet placement. Its `Cluster`, `PropagationPolicy`, `OverridePolicy`, and binding resources let a platform team express where workloads should land and how they should change per cluster. The third missing cloud primitive is the global control plane.
-
-GKE has a mature global networking and control-plane story around Google infrastructure. EKS can lean on AWS accounts, Route 53, ALB, NLB, IAM, and Global Accelerator patterns. An on-prem fleet has clusters, networks, and identities that are often assembled from different vendors and operational teams, so federation must therefore be explicit.
-
-It is not an afterthought; it is an architecture. There is also a cultural difference because public-cloud clusters tend to have a clear provider boundary.
-
-If a load balancer fails, the incident splits into provider state, controller state, and application state. On-prem, the same incident may involve Kubernetes operators, network engineers, firewall administrators, storage teams, and application owners. The platform must create shared language across those teams. This module uses three layers for that shared language.
-
-The first layer is VIP advertisement, the second layer is multi-cluster orchestration, and the third layer is pod networking inside each cluster. Do not collapse those layers into one tool.
-
-That collapse is the beginning of most painful incidents. Pause and predict: what do you think happens if a team installs Karmada but leaves every `LoadBalancer` Service in `<pending>` on the member clusters? The answer is that Karmada may distribute the manifests correctly while users still cannot reach the applications.
-
-Federation does not replace L4 reachability. It decides where objects go. Another system must make the resulting endpoints usable.
-
----
-
-## 2. kube-vip Foundation
-
-kube-vip is the bottom layer in this design, and it is not a fleet scheduler, GitOps controller, or service mesh.
-
-It is a virtual IP and load-balancer implementation for Kubernetes environments that do not have a cloud provider assigning addresses for them. The core idea is simple: a VIP is an IP address that can move between nodes, and clients connect to the VIP rather than to a specific node.
-
-If the node currently holding the VIP fails, another node takes ownership and advertises the new location. The details depend heavily on whether the network learns that location through ARP or BGP. In L2 mode, kube-vip uses ARP announcements. One kube-vip instance becomes leader for a VIP.
-
-That leader places the VIP on a node interface and sends gratuitous ARP messages so neighbors update their IP-to-MAC mapping. This is attractive for small subnets because the routers do not need BGP configuration. It also means the VIP can usually live only inside the broadcast domain where ARP works. L2 mode is operationally friendly until the broadcast domain becomes too large or too noisy.
-
-ARP flooding, stale ARP caches, switch security features, and virtual-switch behavior can all stretch failover time. Some environments limit or rate-limit gratuitous ARP updates, and when that happens, kube-vip may elect a new leader quickly while clients continue sending packets to the old MAC address.
-
-In BGP mode, kube-vip speaks to routers. Instead of telling nearby hosts "this IP is at this MAC," it tells network peers "this node can reach this VIP prefix." That makes BGP the better fit for routed data centers, multi-rack designs, and active-active site patterns. It also introduces router configuration, AS numbers, peer reachability, route filters, and BGP session health.
-
-BGP mode trades L2 simplicity for L3 control. kube-vip has two distinct jobs that are easy to confuse. The first job is the Kubernetes control-plane VIP. For kubeadm HA, the API server endpoint should be stable even if one control-plane node fails.
-
-kube-vip can run as a static pod on every control-plane node and advertise that stable API VIP before the cluster is fully bootstrapped. That is why static pods matter. They are started by the kubelet directly from local manifest files, so they do not require the Kubernetes API to already be healthy. The second job is Service `LoadBalancer` VIPs.
-
-After the cluster is running, users want Services to receive external IPs. kube-vip can advertise those Service addresses. The kube-vip cloud provider can allocate addresses from configured ranges and write them into the Service status. Then kube-vip advertises the assigned address through ARP or BGP.
-
-That makes kube-vip a bare-metal alternative to MetalLB for teams that want one project to handle both control-plane VIPs and Service VIPs. The two jobs share mechanics but not risk. If the control-plane VIP breaks, operators may lose access to the cluster API. If a Service VIP breaks, an application endpoint is affected.
-
-Treat those as separate failure domains. Use separate addresses. Use separate monitoring.
-
-Document which VIPs are allowed to move between which nodes. Here is a static-pod manifest shaped for kubeadm control-plane HA with ARP mode. In production, generate the current manifest with the matching kube-vip version, then review the output before placing it under `/etc/kubernetes/manifests/`.
-
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: kube-vip
-  namespace: kube-system
-spec:
-  containers:
-    - name: kube-vip
-      image: ghcr.io/kube-vip/kube-vip:v0.8.9
-      args:
-        - manager
-      env:
-        - name: vip_arp
-          value: "true"
-        - name: port
-          value: "6443"
-        - name: vip_interface
-          value: "eth0"
-        - name: vip_cidr
-          value: "32"
-        - name: cp_enable
-          value: "true"
-        - name: cp_namespace
-          value: kube-system
-        - name: vip_ddns
-          value: "false"
-        - name: svc_enable
-          value: "false"
-        - name: address
-          value: "192.168.30.10"
-        - name: prometheus_server
-          value: ":2112"
-      securityContext:
-        capabilities:
-          add:
-            - NET_ADMIN
-            - NET_RAW
-      volumeMounts:
-        - mountPath: /etc/kubernetes/admin.conf
-          name: kubeconfig
-  hostNetwork: true
-  volumes:
-    - hostPath:
-        path: /etc/kubernetes/admin.conf
-      name: kubeconfig
+```mermaid
+flowchart TD
+    subgraph Mgmt["Management cluster (fleet + CAPI)"]
+        CAPI["Cluster API / CAPM3 / CAPV"]
+        Fleet["Fleet / Argo CD / OCM hub"]
+        Obs["Thanos Receive / Mimir distributor"]
+        IdP["OIDC bridge + policy CRDs"]
+    end
+    subgraph W1["Workload: datacenter prod"]
+        Apps1["Tenant workloads"]
+        Agent1["Klusterlet / Fleet agent"]
+    end
+    subgraph W2["Workload: factory edge"]
+        Apps2["Edge workloads"]
+        Agent2["Pull agent"]
+    end
+    subgraph W3["Workload: DR standby"]
+        Apps3["Warm standby"]
+    end
+    CAPI -->|provision| W1
+    CAPI -->|provision| W2
+    Fleet -->|baseline| W1
+    Fleet -->|baseline| W2
+    Agent2 -->|outbound| Fleet
+    Obs <-->|remote write| W1
+    Obs <-->|remote write| W3
 ```
 
-The manifest shows the important shape rather than a universal copy-paste answer. `hostNetwork: true` allows the pod to manipulate the node network. The VIP address and interface are both explicit.
+**Capacity ratio guidance:** for fleets under fifty workload clusters, plan management cluster resources at roughly **5–10%** of aggregate workload control-plane CPU and **15–25%** of management etcd storage headroom for fleet object growth. Above fifty clusters, shard fleet controllers or add a dedicated observability cluster so metrics ingestion does not contend with Cluster API machine reconciles. Document minimum headroom: keep management nodes at **30%** unallocated CPU and memory during normal operations so sync waves and remote-write spikes do not trigger eviction of controllers.
 
-The capability set is network-focused, and the service feature is off here because this example is about the API server endpoint. For Service VIPs, deploy kube-vip as a DaemonSet after the cluster is ready and install the kube-vip cloud provider, which assigns addresses.
+Pause and predict: if you delete the management cluster VMs while every workload cluster stays healthy, which user-visible systems fail first? Typical answers include inability to provision new clusters, stalled GitOps or ManifestWork delivery, missing centralized metrics dashboards, and broken CI that targets hub APIs—not immediate pod crashes on existing applications. That asymmetry is why management-cluster backups and restore drills belong in the same calendar as workload etcd snapshots.
 
-The kube-vip DaemonSet advertises them, and that split gives the Kubernetes Service controller a normal place to write status. A useful production runbook has three checks: first, check leader election.
+When you **design** a greenfield fleet, capture explicit **sizing rules** in the architecture document rather than copying a hyperscaler reference. Management etcd volume size should include projected growth from `ManifestWork`, `Application`, and `BundleDeployment` objects—platform teams that plan only for pod counts routinely resize etcd under pressure after the twentieth cluster import. Workload clusters need headroom for peak scheduling bursts: keep at least **20%** unallocated CPU on worker pools that run batch workloads, and isolate storage-heavy nodes with taints so logging or analytics DaemonSets do not evict latency-sensitive application pods. **Blast-radius boundaries** mean a bad platform bundle or CNI upgrade must not touch every cluster in one sync wave; use cluster labels such as `wave=canary`, `wave=production-east`, and `wave=production-west` so fleet controllers promote changes in observable stages.
 
-Second, check whether the VIP is present on exactly the expected node or advertised by the expected BGP speakers. Third, check whether upstream network state changed, because Kubernetes events alone are not enough and you must inspect the network.
-
-Common kube-vip gotchas are predictable. ARP mode can suffer when switches suppress gratuitous ARP. Large L2 domains can make failover noisy. Split-brain can happen if two nodes believe they are leader for the same VIP.
-
-BGP mode can fail quietly if the AS number, peer address, router ID, source address, or route filter is wrong. ECMP can spray connections across nodes in ways the application path did not expect. Before running this in production, what output do you expect from `ip addr show`, `arp -an`, and `show bgp` on your routers after a VIP failover? If the team cannot answer, the runbook is not ready.
+Document the **capacity ratio** between management and workload planes in the same review deck executives sign. Example: forty workload clusters averaging three control-plane vCPUs each imply roughly one hundred twenty control-plane cores fleet-wide; a management cluster with twelve control-plane cores and eight worker cores often suffices if observability ingestion is sharded elsewhere. Revisit the ratio when remote-write throughput doubles or when ApplicationSet count crosses thresholds that stress hub etcd. Factory edge clusters with intermittent links may need larger local Prometheus retention buffers so brief hub outages do not drop SLI data before remote write resumes.
 
 ---
 
-## 3. Karmada: Federation as Control Plane
+## Provisioning Paths: CAPI, kubeadm, Gardener, and Vendor Distros
 
-Karmada sits above individual clusters. Its job is to make Kubernetes resources fleet-aware without requiring every application team to hand-apply the same manifest to every cluster. Think of it as a Kubernetes-compatible control plane that stores desired state for many member clusters. You talk to Karmada with Kubernetes APIs.
+**Cluster API on Metal3** fits bare-metal factories and air-gapped racks where Ironic drives PXE, Redfish power cycles, and BareMetalHost inventory. The management cluster holds `Cluster`, `KubeadmControlPlane`, and `MachineDeployment` objects; CAPM3 translates them into physical servers. This path keeps Kubernetes lifecycle in SIG-maintained APIs and pairs naturally with GitOps registration jobs when `Cluster` status becomes `Ready`.
 
-Karmada then decides where resources should be placed and creates work objects for member clusters. The main Karmada resource types form a pipeline. `Cluster` represents a joined member cluster. It stores mode, readiness, capacity, labels, and taints.
+**kubeadm plus Ansible** remains valid when virtualization teams deliver golden VM images and configuration management already owns package versions, sysctl, and containerd settings. Ansible playbooks initialize control planes and join workers; human operators or AWX pipelines gate upgrades. The tradeoff is weaker declarative drift detection compared with CAPI—unless you wrap Ansible in Git with strict idempotency tests—but the learning curve is lower for teams steeped in configuration management.
 
-`PropagationPolicy` selects namespaced resources and describes placement rules. `ClusterPropagationPolicy` does the same at cluster scope. `OverridePolicy` changes selected fields when a resource is propagated to specific clusters. `ResourceBinding` records the scheduling result for one selected resource.
+**Gardener** models Kubernetes-as-a-service with Garden, Seed, and Shoot abstractions: the Garden cluster hosts APIs; Seed clusters run control planes for many Shoots; Shoots are tenant clusters. Gardener excels when a central platform team offers self-service cluster creation with standardized networking, DNS, and maintenance windows—common after Module 5.6. On-premises Gardener landscapes still need underlying IaaS or CAPI providers for nodes; Gardener coordinates upgrades and extensions rather than replacing IPAM or storage engineering.
 
-Those objects are not decorative. They are the audit trail for why a workload landed where it did. If a Deployment appears in the wrong cluster, do not start by editing the member cluster. Start at the Karmada policy and binding.
+**Vendor distributions**—VMware Tanzu, Red Hat OpenShift, SUSE Rancher Prime/RKE2—bundle Kubernetes with curated operators, support contracts, and opinionated ingress, registry, and policy stacks. They reduce integration toil when licensing and skills already exist, but they couple upgrade calendars to vendor matrices and may resist mixing with upstream CAPI unless the vendor documents supported integration paths.
 
-The control plane contains familiar pieces. `karmada-apiserver` is the Kubernetes-compatible API endpoint. ETCD stores Karmada API objects. `karmada-scheduler` selects clusters for resources.
+| Path | Best on-prem fit | Lifecycle owner | Fleet handoff |
+| :--- | :--- | :--- | :--- |
+| CAPI + Metal3 | Bare metal, BMC automation | Platform SRE via Git | Kubeconfig secret → OCM/Fleet/Argo import |
+| kubeadm + Ansible | VM templates, existing CMDB | Config management team | Manual or CI-driven cluster registration |
+| Gardener | Internal KaaS, many tenants | Gardener ops + extension teams | Shoot labels → fleet placements |
+| Vendor distro | Enterprise support mandate | Vendor + local ops | Import via vendor UI or supported agents |
 
-`karmada-controller-manager` runs controllers that watch policies, create bindings, create work objects, aggregate status, and manage cluster state. Additional components handle webhook, aggregated API, metrics, and member-cluster agents depending on installation mode. Karmada supports push and pull registration modes. In push mode, the Karmada control plane connects directly to the member cluster API server.
+Regardless of path, **separate infrastructure lifecycle from application delivery**. CAPI or Gardener answers how nodes and apiservers exist; Argo CD ApplicationSets, Rancher Fleet, Karmada, or OCM answers what platform software and policies land afterward. Blending tenant Helm charts into machine bootstrap secrets creates upgrade coupling that shows up as mysterious failures during Kubernetes minor bumps.
 
-This is simple when the control plane can reach every member cluster. It is common in a single data center or a well-routed internal network. In pull mode, a `karmada-agent` runs in the member cluster. The agent watches its execution space in Karmada and pulls work down to the cluster.
+**Compare** paths in workshops with the same non-functional requirements written on the whiteboard: RTO for new cluster delivery, maximum Kubernetes skew allowed, air-gap constraints, and whether tenants may self-service cluster creation. Metal3 plus CAPI wins when BMC automation and hardware inventory already exist; kubeadm plus Ansible wins when virtualization teams refuse another control-plane API; Gardener wins when Shoot count will exceed what manual runbooks can carry; vendor distros win when support contracts and existing VM skills dominate hiring pools. None of these choices removes the need for fleet management afterward—only the birth ceremony changes.
 
-Pull mode is useful when member clusters cannot be directly reached from the hub or when firewall rules strongly favor outbound connections from the cluster. Do not choose push or pull as a style preference. Choose it from network reality. If the hub cannot reliably initiate connections to a remote API server, push mode will become a recurring incident.
+Metal3 integration details matter for synthesis: BareMetalHost objects carry BMC addresses, credentials references, and hardware profiles; CAPM3 coordinates with Ironic for imaging; provisioning timeouts must account for firmware validation slower than cloud APIs. Ansible paths should still emit structured cluster metadata—API endpoint, CA thumbprint, cluster name, region labels—for registration automation even if CAPI is not the provisioner. Gardener Shoots expose standardized labels platform teams map to OCM Placements; treat Shoot creation RBAC as seriously as workload cluster admin because Shoots are full Kubernetes clusters with their own etcd.
 
-If your security team wants every member cluster to hold only a scoped agent credential, pull mode may be easier to approve. If you need simple local testing, push mode is usually faster. Placement starts with `PropagationPolicy`. The policy selects resources by API version, kind, name, namespace, and labels.
+---
 
-Then it expresses placement through cluster affinity, spread constraints, replica scheduling strategy, tolerations, and failover behavior. Cluster affinity narrows the candidate set. Weight-based scheduling decides how replicas should be divided when more than one cluster is eligible. Failover controls how Karmada reacts when a cluster becomes unhealthy or tainted for eviction. Here is a policy that selects an `nginx` Deployment in the `demo` namespace and divides replicas between two clusters with explicit weights.
+## Fleet Management: ApplicationSets, Fleet, Karmada, and OCM
 
-```yaml
-apiVersion: policy.karmada.io/v1alpha1
-kind: PropagationPolicy
-metadata:
-  name: nginx-fleet-policy
-  namespace: demo
-spec:
-  resourceSelectors:
-    - apiVersion: apps/v1
-      kind: Deployment
-      name: nginx
-  placement:
-    clusterAffinity:
-      clusterNames:
-        - kind-cluster-a
-        - kind-cluster-b
-    replicaScheduling:
-      replicaSchedulingType: Divided
-      replicaDivisionPreference: Weighted
-      weightPreference:
-        staticWeightList:
-          - targetCluster:
-              clusterNames:
-                - kind-cluster-a
-            weight: 1
-          - targetCluster:
-              clusterNames:
-                - kind-cluster-b
-            weight: 2
-    spreadConstraints:
-      - spreadByField: cluster
-        maxGroups: 2
-        minGroups: 2
-  failover:
-    cluster:
-      purgeMode: Gracefully
+Fleet tools solve configuration drift across many API servers. The synthesis question is not which logo wins a slide deck—it is which reconciliation direction, credential model, and object vocabulary match your network and team skills.
+
+**Argo CD ApplicationSets** generate one `Application` per target using **List**, **Cluster**, **Git**, **Matrix**, **Merge**, **SCM Provider**, or **Pull Request** generators documented in the upstream operator manual. The management-cluster Argo CD instance **pushes** manifests to spoke API servers using cluster secrets. ApplicationSets excel when datacenter clusters allow hub-to-spoke connectivity on port 6443, developers already think in Argo projects, and matrix generators can combine Git directory paths with registered cluster labels for promotion pipelines.
+
+**Rancher Fleet** uses `GitRepo` resources that clone repositories, render `fleet.yaml` bundles, and create `BundleDeployment` objects. **Downstream Fleet agents pull** bundle desired state from the controller—spokes do not require inbound connections from the hub. Fleet fits edge-heavy on-premises fleets, especially when Rancher already provides SSO and cluster inventory.
+
+**Karmada** exposes a federated Kubernetes API on the management cluster. **PropagationPolicy** selects member clusters and creates **ResourceBinding** objects that record placement; **OverridePolicy** patches fields per cluster for mirrors, replicas, or ingress hosts. Karmada pushes propagation to member apiservers when connectivity allows; it suits teams that want standard `Deployment` and `Service` objects with federation semantics instead of fleet-specific CRDs.
+
+**Open Cluster Management** registers **ManagedCluster** objects; **Klusterlets pull** **ManifestWork** payloads from hub namespaces. **Placement** plus **PlacementDecision** choose targets dynamically. Governance policies bind through **PlacementBinding** to **Policy** or **PolicySet** objects only. Work distribution uses **ManifestWorkReplicaSet** with `spec.placementRefs` pointing at a **Placement**—not PlacementBinding. Confusing those APIs is a frequent source of “policy applied but workloads never shipped” incidents.
+
+| Constraint | Lean toward | Reason |
+| :--- | :--- | :--- |
+| Outbound-only factory firewalls | OCM or Fleet pull agents | No inbound apiserver access required |
+| Hub can reach all apiservers | Argo CD ApplicationSets | Push sync with familiar UI |
+| Federated scheduling of standard apps | Karmada PropagationPolicy | ResourceBinding tracks per-cluster copies |
+| Git bundle diff UX for platform baselines | Rancher Fleet GitRepo | Per-cluster BundleDeployment status |
+
+Hybrid fleets are normal: CAPI provisions clusters, OCM delivers baseline ManifestWorks to edge sites, Argo CD ApplicationSets promote application charts to datacenter clusters, and Karmada handles a small set of truly multi-cluster services. Document boundaries in architecture reviews so two hubs do not fight over the same cluster without owners.
+
+**Evaluate** fleet and networking choices together because misaligned combinations fail in production even when each tool passes a proof-of-concept. ApplicationSets plus Submariner Lighthouse suit datacenter meshes where hub push works and MCS DNS is enough for service discovery. Fleet plus ClusterMesh suits edge spokes that pull bundles while datacenter Cilium clusters expose global services for shared APIs. OCM plus Istio suits regulated environments that need pull-based baselines and L7 mTLS for a subset of microservices—accept the operational cost of mesh upgrades across clusters. Write the decision in the architecture record so auditors see intentional pairing rather than accidental overlap.
+
+Argo CD ApplicationSet **generators** deserve explicit runbook coverage: the **Cluster** generator watches registered cluster secrets; the **Git** generator scans repository directories; the **Matrix** generator multiplies two generator outputs—useful for monorepo platform charts times production clusters. Enable `goTemplate: true` with `missingkey=error` so template typos fail CI instead of creating silently empty Application names. Fleet **GitRepo** paths should separate `baseline/`, `security/`, and `apps/` directories with independent `fleet.yaml` files so a broken application chart does not block monitoring agent rollout. Karmada **PropagationPolicy** `resourceSelectors` must be narrow enough that system namespaces are not accidentally propagated; OCM **ManifestWorkReplicaSet** status fields should feed the same compliance dashboard Kyverno policy reports use.
+
+---
+
+## Multi-Cluster Networking: Submariner Lighthouse, ClusterMesh, and Istio
+
+GitOps alignment does not imply L3/L4 connectivity. Applications that call Services in other clusters need explicit networking choices.
+
+**Submariner** connects pod and service CIDRs with encrypted tunnels between gateway nodes. **Submariner Lighthouse** implements the Multi-Cluster Services (MCS) API: `ServiceExport` and `ServiceImport` objects plus Lighthouse DNS enable cross-cluster Service discovery without full pod routability in every topology. On-premises teams must validate CIDR plans, BGP or static routes to gateway nodes, and Globalnet when service CIDRs cannot be renumbered.
+
+**Cilium ClusterMesh** links independent Cilium data planes with mutual TLS between clustermesh apiservers. **Global services** load-balance backends across clusters when versions align. ClusterMesh assumes operational skill in Cilium certificate rotation; stale clustermesh certificates break discovery while local pods still run.
+
+**Istio multi-cluster** delivers L7 routing, mTLS, and failover through east-west gateways and primary-remote or multi-primary control-plane topologies documented upstream. Istio adds operational weight—coordinated control-plane upgrades across clusters—but fits enterprises already standardized on mesh traffic policy.
+
+```mermaid
+flowchart LR
+    subgraph Need["Requirement"]
+        Q1["Pod IP reachability?"]
+        Q2["Cross-cluster Service DNS?"]
+        Q3["L7 policy + mTLS?"]
+    end
+    subgraph Tools["Typical choice"]
+        S["Submariner gateway"]
+        L["Lighthouse MCS"]
+        C["Cilium ClusterMesh"]
+        I["Istio east-west GW"]
+    end
+    Q1 --> S
+    Q2 --> L
+    Q2 --> C
+    Q3 --> I
 ```
 
-This policy encodes intent. Cluster B receives more weight, but both clusters are candidates. If Cluster A becomes unavailable and Karmada failover is enabled, replicas can be rescheduled according to the failover behavior and the remaining candidate clusters. The `ResourceBinding` then becomes the diagnostic object that shows the final placement decision.
+Score options against staffing: Submariner adds network engineering for routes and gateways; Lighthouse adds MCS object lifecycle; ClusterMesh adds Cilium expertise; Istio adds mesh SRE capacity. Many programs implement GitOps federation first, then add networking when application dependencies prove cross-cluster Service calls are unavoidable.
 
-Karmada differs from the older Kubefed v2 model in both ambition and maintenance reality. Kubefed v2 focused on federated resource types and template, placement, and override resources. It taught the ecosystem useful lessons but did not become the dominant multi-cluster control plane. Karmada keeps a Kubernetes-native API experience while building richer scheduling, propagation, failover, status aggregation, and large-fleet behavior.
+**Submariner Lighthouse** publishes `ServiceExport` objects on source clusters. Consuming clusters reconcile `ServiceImport` and MCS DNS records. Install Lighthouse with the broker and gateway components documented in the Submariner quickstart. Validate MCS CRD availability for your Kubernetes 1.35 target before production. **Cilium ClusterMesh** needs mutual TLS between clustermesh apiservers; rotate certificates on a schedule. **Istio** east-west gateways require routable IPs or explicit tunnels on multi-network topologies. Test the protocols factory applications use, not only HTTP health checks.
 
-The operational message is simple: do not use old Kubefed habits as your design baseline. Evaluate Karmada as its own control plane. A practical Karmada debugging path is short and repeatable. Check the `Cluster` readiness and taints.
-
-Check the `PropagationPolicy` selector. Check the `ResourceBinding` scheduling result. Check the generated `Work` objects. Then check the member cluster. Most teams reverse that order and waste time staring at a Deployment that Karmada is continuously reconciling.
+Firewall change requests should name cluster pairs and gateway nodes. Network teams approve faster when diagrams show pod CIDRs and gateway IPs. Remove temporary permissive rules after debugging; auditors flag them often.
 
 ---
 
-## 4. Liqo: Federation as Continuum
+## Identity: Per-Cluster RBAC, Federated OIDC, and SPIFFE/SPIRE
 
-Liqo approaches multi-cluster from a different direction. Instead of making a central policy plane the primary abstraction, it makes remote resources appear inside a local cluster. A remote cluster becomes a virtual node. Pods can be scheduled to that virtual node.
+Each workload cluster maintains local **RBAC** bindings, but humans should not carry dozens of long-lived kubeconfig files. **Federated OIDC** configures every apiserver to trust the same corporate IdP with per-cluster client IDs or audiences; GitOps generates `ClusterRoleBinding` objects when clusters register, mapping IdP groups to platform roles. Break-glass cluster-admin credentials stay in vault with ticket IDs; daily operators use OIDC groups scoped to namespaces or clusters.
 
-Namespaces can be extended. Selected resources are reflected. The goal is transparent multi-cluster execution: existing workload YAML should need little or no change. This is a powerful mental shift.
+**Hub impersonation** through Rancher or OCM consoles centralizes support access if sessions are audited. Compromise of a hub admin account remains catastrophic—protect hub RBAC, etcd encryption at rest, and certificate boundaries between management and workload CAs.
 
-With Karmada, the fleet control plane decides where a resource should be propagated. With Liqo, a local cluster can consume capacity from a peer. The local Kubernetes scheduler sees virtual capacity and places pods as if the remote cluster were part of the local resource pool. The remote side receives reflected resources and runs the actual pods.
+**SPIFFE/SPIRE** addresses **service identity** across clusters: workloads receive SVIDs tied to SPIFFE IDs instead of sharing static service account tokens copied between clusters. SPIRE servers and agents deploy per cluster or per site; federation between SPIRE servers enables cross-cluster mTLS for service meshes or custom applications. SPIFFE complements OIDC for humans—OIDC authenticates operators; SPIFFE authenticates workloads talking east-west after GitOps has already placed Deployments.
 
-Peering is the relationship that makes this possible. Modern Liqo describes peering as a resource and service consumption relationship. One cluster acts as consumer. The other acts as provider.
+Document which identity layer answers which question: OIDC for kubectl and CI deployers, SPIFFE for pod-to-pod trust, and local RBAC for in-cluster service accounts scoped to one cluster. Mixing layers without documentation produces tickets where teams rotate Kubernetes secrets when the real gap is SPIRE federation not configured on a new factory cluster.
 
-Bidirectional behavior is built by creating peerings in both directions. That is important because a peering is not automatically symmetric. In-band peering is useful when the operator machine can reach both clusters and Liqo can configure the required authentication and networking flow directly. Out-of-band peering is useful when connectivity or organizational boundaries require exchanging generated artifacts through another channel.
+To **implement** **federated OIDC**, configure each workload apiserver with the same issuer URL, distinct client IDs per cluster or audience claims per environment, and GitOps-generated `ClusterRoleBinding` objects keyed off IdP group names. CI pipelines should use OIDC federation from the corporate IdP or short-lived tokens from Vault rather than static kubeconfig files checked into automation repos. **SPIFFE/SPIRE** deployment patterns include one SPIRE server per datacenter with agents on every node, or lighter SPIRE server clusters for factory sites with intermittent hub connectivity. Federate SPIRE servers only when applications must validate SVIDs across sites; otherwise keep trust domains separate to limit compromise blast radius. Pair SPIRE with service meshes or mTLS libraries that consume SVIDs automatically instead of mounting Kubernetes service account tokens into every cross-cluster call path.
 
-In production, the choice often comes down to firewall policy and who is allowed to hold kubeconfigs for both sides at the same time. Virtual nodes are how Liqo becomes visible to Kubernetes users. After peering, the consumer cluster can show a node that represents the provider cluster. The virtual node advertises shared CPU, memory, pod capacity, labels, and taints.
-
-The default taints are intentional. They keep ordinary pods from accidentally leaving the cluster until namespace offloading or runtime class rules allow it. Namespace mapping is the next key idea. When a namespace is offloaded, Liqo extends that namespace to selected remote clusters.
-
-Resources required by the pod can be reflected. That includes objects such as ConfigMaps, Secrets, and Services according to Liqo's reflection behavior and configuration. The developer continues working in the original namespace. The remote namespace acts as the hosting side where the offloaded pod actually runs.
-
-Network reflection makes the pattern usable. If pods move to another cluster but cannot reach the Services and endpoints they expect, transparency breaks. Liqo creates cross-cluster networking components so offloaded workloads can communicate across cluster boundaries.
-
-That does not remove the need for network design. It creates a Kubernetes-native path for workloads whose YAML was not written for multi-cluster. A basic peering command looks like this:
-
-```bash
-liqoctl peer \
-  --kubeconfig "$HOME/.kube/kind-cluster-a" \
-  --context kind-kind-cluster-a \
-  --remote-kubeconfig "$HOME/.kube/kind-cluster-b" \
-  --remote-context kind-kind-cluster-b \
-  --gw-server-service-type NodePort \
-  --skip-confirm
-```
-
-After peering, a virtual node should appear from the consumer side.
-
-```bash
-KUBECONFIG="$HOME/.kube/kind-cluster-a" k get nodes -o wide
-```
-
-Expected shape:
-
-```text
-NAME                                      STATUS   ROLES           AGE   VERSION
-kind-cluster-a-control-plane             Ready    control-plane   18m   v1.35.x
-kind-cluster-a-worker                    Ready    <none>          18m   v1.35.x
-liqo-remote-kind-cluster-b               Ready    agent           3m    v1.35.x
-```
-
-The exact virtual node name can vary by Liqo version and cluster identity. The operational signal is that the node is present, Ready, and labeled as a Liqo virtual node. If it is missing, inspect peering status before debugging pod scheduling. Transparent does not mean invisible to operators.
-
-Transparent means application YAML can remain mostly unchanged. Operators still need to understand authentication bootstrap, gateway Services, tunnel MTU, namespace offloading strategy, reflected resources, and remote capacity quotas. Liqo makes cross-cluster execution feel natural to developers. It does not remove the platform responsibility for isolation and reachability.
+Per-cluster **RBAC** remains authoritative for in-cluster operations: even with federation, `RoleBinding` objects are local. Platform teams publish a `platform-baseline-rbac` bundle through Fleet or ManifestWorkReplicaSet that creates consistent `ClusterRole` definitions while binding them to local subjects. Tenant teams receive namespace-scoped roles generated from templates parameterized by cost center and cluster name. Quarterly access reviews should compare IdP group membership to live bindings using automated exporters that query each apiserver or hub inventory APIs.
 
 ---
 
-## 5. Karmada vs Liqo Decision Matrix
+## Secrets Distribution: ESO, Sealed Secrets, and Vault Agent Injector
 
-Karmada and Liqo both solve multi-cluster problems. They do not solve the same problem in the same way. Choosing between them by popularity or installation ease is a mistake. Choose by the control model you want users to experience.
+Fleet-wide configuration cannot store cleartext credentials in Git. Three patterns dominate on-premises:
 
-Karmada is strongest when the platform team wants explicit placement policy. It is good when auditability matters. It is good when different clusters need different overrides. It is good when failover behavior must be expressed centrally.
+**External Secrets Operator (ESO)** reads secrets from HashiCorp Vault, cloud KMS analogs, or on-prem secret stores via `ClusterSecretStore` and `ExternalSecret` objects. Platform teams deploy store CRDs through ManifestWork or Fleet bundles, then let application teams reference paths with RBAC enforced at the vault policy layer. Rotation updates vault entries; ESO reconciles Kubernetes Secrets on an interval; workloads restart through rolling updates or Reloader sidecars.
 
-It is good when RBAC, fleet policy, and resource propagation should be managed through a hub control plane. Liqo is strongest when the application team wants remote capacity with minimal manifest change. It is good when burst, overflow, edge-to-core, or temporary drain workflows matter. It is good when the developer can keep thinking in terms of a namespace while the platform makes that namespace span clusters.
+**Sealed Secrets** encrypts Secret manifests to a cluster-specific public key so Git can hold sealed blobs safely. Fleet distribution requires **per-cluster keys** or overlays in Fleet `targetCustomizations`—one sealed blob rarely decrypts everywhere. Rotation means re-sealing with new keys and coordinated rollout.
 
-It is good when virtual nodes fit the team’s mental model better than fleet placement rules. Both tools can coexist. In a real on-prem platform, kube-vip can provide VIPs in every cluster. Karmada can propagate platform workloads and shared services according to policy.
+**Vault Agent Injector** mutates pods to mount dynamic secrets at runtime without persisting them in etcd. It suits high-churn credentials and legacy apps that read files under `/vault/secrets`, but it couples pod startup to vault availability and agent sidecars.
 
-Liqo can offload selected namespaces for burst or site drain scenarios. The coexistence rule is to avoid making both tools responsible for the same workload at the same time. Use labels, namespaces, ownership rules, and GitOps boundaries to keep responsibilities clear.
+| Pattern | Git-safe | Rotation model | Fleet fit |
+| :--- | :--- | :--- | :--- |
+| ESO | Yes (references only) | Vault/KV version + reconcile | ManifestWork per spoke store |
+| Sealed Secrets | Yes (encrypted) | Re-seal per cluster key | Fleet overlays per site |
+| Vault Agent Injector | Partial (roles, not values) | Vault lease renewal | DaemonSet or mutating webhook bundle |
 
-| Dimension | Karmada | Liqo | Design Guidance |
-|---|---|---|---|
-| Primary abstraction | Fleet control plane and policy | Virtual nodes and extended namespaces | Pick Karmada when the hub should decide; pick Liqo when the source cluster should consume remote capacity. |
-| Workload YAML impact | Usually paired with policy objects | Existing workload YAML often stays the same | Liqo wins for zero-change portability; Karmada wins when policy is part of the release artifact. |
-| Placement model | `PropagationPolicy`, affinities, spread, weights, failover | Kubernetes scheduler targets virtual nodes after namespace offloading | Use Karmada for explicit fleet placement; use Liqo for scheduler-native offload. |
-| Failure behavior | Central failover and cluster taints | Drain, offload, and reschedule through virtual node behavior | Karmada is clearer for audited DR policy; Liqo is smoother for regional drain of a namespace. |
-| RBAC and governance | Strong hub-level governance model | Source-cluster governance plus peering controls | Karmada fits central platform teams; Liqo fits capacity-sharing agreements. |
-| Network expectation | Member clusters must receive propagated objects and expose their own Services | Cross-cluster networking is part of the experience | Do not expect Karmada to create network tunnels; do not expect Liqo to replace fleet policy. |
-| Best fit | Regulated fleet placement, shared add-ons, controlled failover | Burst, edge offload, namespace mobility, transparent portability | Many platforms use both in different namespaces. |
+Choose per compliance zone: factories with strict key separation should not share one Sealed Secrets controller key across regions. Prefer ESO when a central vault already exists; prefer Sealed Secrets for air-gapped Git-only promotion with offline key ceremonies.
 
-Here is a practical decision rule. If the question starts with "which clusters should receive this application and with what overrides," start with Karmada. If the question starts with "can this namespace keep its YAML but borrow remote capacity," start with Liqo. If the question starts with "why is the external IP pending," neither tool is the answer. Start with kube-vip or another bare-metal load-balancer implementation.
+**Implement** secrets **distribution** as code: deploy `ClusterSecretStore` through OCM ManifestWorkReplicaSet to every production Placement match; store only vault paths in Git; let **External Secrets Operator** materialize Kubernetes Secrets on reconcile intervals. For **Sealed Secrets**, maintain a `sealed-secrets-keys` directory per region in the fleet repository with Fleet `targetCustomizations` selecting the correct key per cluster label. **Vault Agent Injector** fits legacy JVM or binary apps that read file-based credentials—deploy the mutating webhook as a platform bundle with strict namespace selectors so tenant pods cannot request arbitrary vault paths. Rotation runbooks should list order: update vault secret, verify ESO or agent refresh, roll workloads, revoke old version, and confirm no pods mount previous lease IDs in audit logs.
 
 ---
 
-## 6. Layered Architecture Pattern
+## Observability: Thanos, Mimir, and VictoriaMetrics Fan-In
 
-The central design fork in on-prem multi-cluster is whether the team treats the stack as one magical federation layer or as three separate layers. Use the separate-layer model. kube-vip sits below the fleet tools. It gives each cluster L4 reachability for the API server and Service VIPs.
+Per-cluster Prometheus without fan-in forces on-call engineers to open twelve browser tabs during incidents. **Observability fan-in** centralizes metrics while preserving mandatory labels: `cluster`, `environment`, `site`, and `platform_version`.
 
-Karmada or Liqo sits above that and decides how workloads or capacity cross cluster boundaries. Each cluster's CNI handles pod networking inside the cluster. If Liqo is enabled, its networking components extend selected cross-cluster paths. If Karmada is enabled, each member cluster still exposes its own Service through its own networking and VIP layer.
+**Thanos** components—sidecar, store, compact, query, and **Receive** for remote write—deduplicate HA Prometheus pairs at **query time**. Prometheus replicas label series with `replica` external labels; the Thanos Querier merges and drops duplicates when querying. Design scrape configs and remote-write relabeling so HA pairs are identifiable.
 
-```text
-+--------------------------------------------------------------------------------+
-|                         Multi-Cluster Platform Layer                            |
-|                                                                                |
-|  Karmada: PropagationPolicy, OverridePolicy, ResourceBinding, failover          |
-|  Liqo: peering, virtual nodes, namespace offloading, resource reflection        |
-+-----------------------------------------+--------------------------------------+
-                                          |
-                 workload placement       |       transparent offload
-                                          |
-+---------------------------+             |             +------------------------+
-| Cluster A                 |             |             | Cluster B              |
-|                           |             |             |                        |
-| +-----------------------+ |             |             | +--------------------+ |
-| | kube-vip VIP Layer    | |             |             | | kube-vip VIP Layer | |
-| | API VIP + Service VIP | |             |             | | API VIP + Service  | |
-| +-----------------------+ |             |             | +--------------------+ |
-| +-----------------------+ |             |             | +--------------------+ |
-| | CNI Pod Network       | |<-- Liqo --> | <-- Liqo -->| | CNI Pod Network    | |
-| | Calico/Cilium/etc.    | |   tunnel    |   tunnel    | | Calico/Cilium/etc. | |
-| +-----------------------+ |             |             | +--------------------+ |
-| +-----------------------+ |             |             | +--------------------+ |
-| | Nodes and workloads   | |             |             | | Nodes and workloads| |
-| +-----------------------+ |             |             | +--------------------+ |
-+---------------------------+             |             +------------------------+
-                                          |
-                         Routed or L2 data center network
-```
+**Grafana Mimir** (and Cortex heritage) deduplicates at **ingestion**: the distributor’s **HA tracker** accepts samples from only one replica of each HA Prometheus pair, preventing duplicates in long-term storage. Operators must configure remote write and external labels to match Mimir’s HA expectations—different from Thanos’s query-time dedup model.
 
-The example interaction is concrete. A platform engineer applies a Deployment and Service to the Karmada control plane. A `PropagationPolicy` selects that Deployment and sends it to Cluster B. Cluster B creates the Deployment and its Service locally.
+**VictoriaMetrics** offers single-binary and clustered (`vminsert`, `vmstorage`, `vmselect`) deployments with efficient compression for large on-prem fleets. **vmagent** remote-writes from spokes; **VMAlert** can fan out alerting from centralized storage. Teams choose VictoriaMetrics when operational simplicity and resource efficiency outweigh Thanos’s component modularity.
 
-The Service is `type: LoadBalancer`. The kube-vip cloud provider in Cluster B allocates a VIP. The kube-vip DaemonSet in Cluster B advertises that VIP through ARP or BGP. No cloud load balancer exists in either cluster.
+Standardize alerting routes on fan-in labels so a missing `cluster` label fails CI for new scrape configs. OCM observability add-ons or Fleet bundles can deploy agents consistently, but the label contract is what makes multi-cluster queries trustworthy during failover drills.
 
-Nothing in Karmada magically publishes a routed IP. Nothing in kube-vip decides fleet placement. That separation is healthy. It means the network team can reason about VIP advertisement.
+**Implement** **metrics fan-in** incrementally: phase one deploys Prometheus or vmagent on every spoke with remote write to a lab receiver; phase two enforces label contracts in CI; phase three routes critical alerts from centralized Alertmanager or VMAlert with `cluster` and `site` routes to regional on-call rotations. **Thanos** Receive rings need hashring planning and object storage for long-term blocks; run compactor and store gateways on infrastructure separate from the management cluster if ingestion exceeds fifteen terabytes annually. **Grafana Mimir** tenants separate environments; configure HA tracker labels before cutting over production remote write. **VictoriaMetrics** clusters split `vminsert` and `vmstorage` when ingestion exceeds single-node limits; use recording rules to downsample factory metrics that spike cardinality with per-pod labels from debugging endpoints.
 
-The platform team can reason about placement policy. The application team can reason about Service and Deployment behavior. When an incident happens, the layers give you a diagnostic order. Is the workload placed in the expected cluster?
-
-If not, inspect Karmada or Liqo. Is the Service assigned a VIP? If not, inspect the kube-vip cloud provider and address pool. Is the VIP advertised?
-
-If not, inspect kube-vip leader election, ARP, or BGP. Do packets arrive but pods do not respond? Inspect kube-proxy, CNI, NetworkPolicy, endpoint health, and application readiness. The layered model also prevents overreach.
-
-A team may want one tool to do everything because one tool feels easier to explain. That simplicity is usually temporary. At scale, a single overloaded abstraction makes every failure ambiguous.
-
-Keep the layers explicit. Document ownership at each layer. Test each layer independently.
+Logging and tracing fan-in mirror metrics philosophy: cluster label on every span, tail sampling on edge clusters to save bandwidth, and corporate SIEM export from the hub region only. Do not block metrics rollout waiting for perfect tracing—executives still need SLO dashboards when traces are partial. Document which backend owns HA deduplication in runbooks so engineers do not apply Thanos relabel hacks to Mimir distributors during incidents.
 
 ---
 
-## 7. GitOps Pattern for Multi-Cluster
+## Upgrade Coordination: Shoots, Clusters, and Canary Waves
 
-GitOps becomes more important as clusters multiply. Manual commands do not scale across a fleet. Neither does one repository per cluster when every repository repeats the same application with tiny differences. The goal is to keep one source of truth while still allowing cluster-specific parameters.
+Upgrades span Gardener **Shoots**, CAPI **KubeadmControlPlane** rollouts, vendor supervisor channels, and fleet bundle pins. A safe default **order** is: upgrade management-cluster fleet controllers and observability receivers, upgrade CAPI providers, upgrade workload control planes in waves, upgrade platform bundles (CNI, CSI, ingress, monitoring), then promote tenant applications.
 
-Argo CD ApplicationSet is a common answer. Its generators create many `Application` resources from a template. A cluster generator can fan out to clusters registered in Argo CD. A list generator can make a small explicit fleet.
+**Canary clusters**—one factory and one datacenter cluster on the new Kubernetes minor—run conformance tests, admission policy checks, and synthetic workloads before fleet-wide promotion. Git tags such as `platform-v1.35` communicate compatible bundle versions to cluster classes. Pause labels on `ManagedCluster` or Argo cluster secrets stop sync during metal maintenance.
 
-A matrix generator can combine environments, applications, and clusters. For a Karmada pattern, Argo CD can deploy to the Karmada API server rather than to each member cluster directly. The repository contains ordinary Kubernetes manifests plus Karmada policies. ApplicationSet creates one application per fleet slice or environment.
+**Blast radius limits** include: maximum concurrent control-plane replacements per site, forbidden fleet-wide Helm chart bumps without staged BundleDeployment health, and explicit maintenance windows encoded as Argo CD sync windows or OCM placement taints. Document rollback: Fleet reverts Git; Argo syncs previous revisions; CAPI machine rollouts may require infrastructure rollback if new OS images shipped.
 
-Karmada then propagates selected resources to member clusters. This avoids per-cluster repositories while preserving fleet placement in policy. Here is a compact ApplicationSet that deploys one application template for two fleet environments.
+Gardener maintenance windows automate Shoot Kubernetes version bumps with extension coordination; combine Gardener upgrades with fleet pauses so platform bundles do not race extension readiness. For kubeadm fleets, pin package repositories to Kubernetes 1.35 streams and test etcd defragmentation before minor upgrades.
 
-```yaml
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: fleet-nginx
-  namespace: argocd
-spec:
-  generators:
-    - list:
-        elements:
-          - env: prod
-            destinationName: karmada-prod
-            path: apps/nginx/overlays/prod
-          - env: stage
-            destinationName: karmada-stage
-            path: apps/nginx/overlays/stage
-  template:
-    metadata:
-      name: nginx-{{env}}
-    spec:
-      project: default
-      source:
-        repoURL: https://github.com/example-org/platform-apps.git
-        targetRevision: main
-        path: "{{path}}"
-      destination:
-        name: "{{destinationName}}"
-        namespace: demo
-      syncPolicy:
-        automated:
-          prune: true
-          selfHeal: true
-        syncOptions:
-          - CreateNamespace=true
-```
+Platform engineers should maintain a version skew matrix in Git. Rows list approved Kubernetes minors; columns list CNI, CSI, ingress, service mesh, and fleet controller versions. CI rejects bundle promotions that violate the matrix. The matrix prevents a common failure mode where Argo CD ships a chart requiring Kubernetes 1.35 APIs while one factory cluster remains on 1.34 because BMC maintenance slipped. Canary clusters must run the target minor plus the newest platform bundle candidate for at least one full business week before broader promotion.
 
-The overlay can include both the Deployment and the Karmada policy.
+Cordoning and draining remain Kubernetes primitives every fleet relies on during metal work. Fleet controllers do not replace node safety steps; they coordinate what happens after nodes return. Document maximum concurrent drains per cluster class so storage backends are not overwhelmed by simultaneous volume detach storms. Pair node maintenance with paused ApplicationSet sync or frozen ManifestWorkReplicaSet generation so partially upgraded nodes do not receive conflicting DaemonSet versions mid-drain.
 
-```yaml
-apiVersion: policy.karmada.io/v1alpha1
-kind: PropagationPolicy
-metadata:
-  name: nginx-prod-placement
-  namespace: demo
-spec:
-  resourceSelectors:
-    - apiVersion: apps/v1
-      kind: Deployment
-      name: nginx
-    - apiVersion: v1
-      kind: Service
-      name: nginx
-  placement:
-    clusterAffinity:
-      labelSelector:
-        matchLabels:
-          environment: prod
-    spreadConstraints:
-      - spreadByField: cluster
-        minGroups: 2
-        maxGroups: 2
-```
-
-In this pattern, Argo CD owns desired state in the Karmada control plane. Karmada owns propagation to member clusters. Member clusters own runtime reconciliation of the resulting Kubernetes objects. kube-vip owns VIP assignment and advertisement inside each member cluster.
-
-The Liqo GitOps pattern looks different. Argo CD can deploy ordinary manifests to the source cluster. The namespace offloading configuration decides whether pods from that namespace may land on virtual nodes. The application repository may not need per-cluster overlays at all.
-
-Instead, the platform repository owns Liqo peering, namespace offloading, resource quotas, and labels. That makes Liqo attractive when the application team should not need to learn a fleet policy language. The risk is hidden placement. If developers see only the source namespace, they may not realize their pods are running in another failure domain.
-
-Use labels, dashboards, alerts, and resource views that make offloaded execution visible. GitOps should reduce ambiguity, not create it. Pause and predict: if Argo CD syncs a Deployment to Karmada and Karmada propagates it to Cluster B, where should you look for drift?
-
-There are three places. Look at the Git desired state, the Karmada object and binding, and the member cluster object. The system is only healthy when all three agree about the intended state.
+Shoot upgrades in Gardener deserve explicit communication templates. Application owners receive maintenance notices with expected API blips, not surprise pager storms. CAPI KubeadmControlPlane rollouts should expose machine counts and pending upgrades in the same dashboard executives view for fleet bundle health. When upgrades fail, rollback strategy must be pre-authorized: revert Git tag, pause placements, and restore etcd snapshot only when Git revert cannot unwind CRD upgrades safely.
 
 ---
 
-## 8. Disaster Recovery and Traffic Shaping
+## Disaster Recovery Across the Fleet
 
-Disaster recovery in this stack is not one feature. It is the choreography of several layers. kube-vip handles VIP movement and route advertisement. Karmada handles cluster-aware workload failover.
+**Velero** backs up namespace-scoped resources and, with compatible CSI snapshots, persistent volumes per cluster. Fleet DR adds **Git as desired-state backup** for everything expressed in GitOps, plus **etcd snapshots** for management and workload control planes. Recovery-time tests must include: restore management hub from backup, re-register spokes or accept restored kubeconfigs, replay GitOps, and verify observability fan-in resumes.
 
-Liqo handles namespace offloading and drain-style movement when the source cluster can still participate. Your runbook should say which layer acts first for each failure type. For active-active service exposure across sites, kube-vip BGP is the stronger fit. Each site can advertise the same VIP or site-specific VIPs to upstream routers.
+**Fleet-wide GitOps reconciliation** after site loss means a surviving datacenter hub—or restored hub—reapplies ManifestWorks, BundleDeployments, or ApplicationSets to replacement clusters registered with the same labels. **Placement** rules should attach baselines to `region=eu` rather than hostname lists so DR clusters inherit policies automatically.
 
-If two BGP peers announce the same /32 and the upstream network accepts equal-cost paths, ECMP can distribute traffic. If one site fails and withdraws the route, the upstream network converges to the remaining site. That looks simple on a whiteboard. In production, ECMP must be tested with the actual application traffic.
+Game days should measure: time to restore management etcd, time to import ten replacement clusters, time until monitoring shows all spokes green, and time until policy compliance reports match pre-disaster baselines. Application RPO/RTO for databases remains the application team’s contract—Kubernetes only supplies compute and networking paths after data replication exists.
 
-Long-lived TCP sessions, asymmetric routing, stateful firewalls, and source NAT behavior can all affect results. For Karmada failover, the key signal is cluster health and taints. Karmada can mark clusters unavailable and use taints such as not-ready or unreachable to prevent scheduling or trigger eviction behavior when failover features are enabled. `DisruptionPolicy` and related failover configuration should be treated as application policy.
+**Velero** schedules should include namespace selectors for platform components and exclude ephemeral CI namespaces. Store backups in object storage with encryption and cross-site replication matching compliance class. Test restores on isolated networks quarterly: restore etcd snapshot into a kind or lab cluster, restore application namespaces with Velero, then verify GitOps re-applies drift correctly. **Fleet-wide GitOps reconciliation** after site loss means replacement clusters register with the same labels as destroyed clusters so Placements rediscover them; keep label keys in CMDB or hardware asset tags so rebuilds do not invent new label schemes. Measure **recovery-time** objectives with wall-clock timers in game-day scripts, not engineer estimates.
 
-Some workloads can tolerate immediate replacement. Others need graceful purge, state preservation, or manual database promotion. Do not enable failover semantics without defining what happens to state. For Liqo, the regional-drain story is different.
+**Coordinate** DR with networking: if Submariner gateways or ClusterMesh trust bundles lived only in the lost site, surviving clusters may need temporary single-site mode until gateways rebuild. Maintain offline copies of cluster join bundles, OIDC client secrets metadata (not cleartext secrets), and SPIRE trust bundle files in vault paths replicated across regions. Communication plans matter as much as technology—application owners should know whether DNS failover or GSLB owns user-visible cutover while platform teams restore Kubernetes paths underneath.
 
-If Cluster A is degrading but still reachable, you can offload a namespace to Cluster B and let pods reschedule through the virtual node abstraction. That is useful for maintenance, capacity pressure, and edge-site evacuation. It is less useful when Cluster A has already disappeared and no control plane can coordinate the drain. Liqo is strongest before total failure.
-
-Karmada is stronger when a fleet control plane must react to member-cluster health. Consider a concrete failure scenario. Two sites run the same stateless API. Cluster A is near the warehouse floor.
-
-Cluster B is in a nearby data center. Both clusters run kube-vip. Karmada places four replicas across both clusters with a higher weight on Cluster A. Liqo is configured for a batch-processing namespace that can borrow Cluster B capacity during maintenance.
-
-At 01:20, the top-of-rack switch in Site A begins dropping packets. The first symptom is not a pod failure. It is BGP session flapping from kube-vip speakers to the upstream router. The router withdraws and re-adds the VIP route.
-
-Clients see intermittent connection resets. The network team confirms the route flap. The platform team taints Cluster A in Karmada or waits for health detection, depending on the runbook. Karmada stops placing new work there and starts moving eligible replicas to Cluster B.
-
-Cluster B's kube-vip advertises the Service VIP for the copy running there. For the batch namespace, the team uses Liqo offloading or drain behavior before shutting down local nodes. Each action is layer-specific. Nobody asks Liqo to fix BGP.
-
-Nobody asks kube-vip to decide workload policy. Nobody asks Karmada to tunnel pod traffic. That separation makes the incident manageable. The best DR tests are not happy-path demos.
-
-Test BGP peer loss. Test stale ARP cache behavior. Test Karmada cluster `Ready` becoming `Unknown`.
-
-Test a member cluster that is reachable from users but unreachable from the Karmada hub. Test Liqo peering where the gateway Service is reachable but the tunnel MTU breaks larger packets. DR confidence comes from failure evidence, not architecture diagrams.
+Runbooks should list contact trees per scenario: hub etcd loss, single workload cluster loss, vault unavailable, and corporate IdP outage. Each scenario notes which layers keep running and which automations must pause. Post-incident reviews update the synthesis architecture with dates and owners. Without that habit, teams re-learn the same hub-versus-spoke failure asymmetry every year.
 
 ---
 
-## 9. Production Concerns
+## Synthesis Workshop: End-to-End Cluster Onboarding
 
-Production multi-cluster operations are mostly about visibility, identity, scaling, and network edge cases. The tools work only as well as those foundations. Observability must be fleet-aware. Per-cluster Prometheus is useful for local debugging.
+Use this checklist in design reviews when a new on-premises cluster enters the fleet. First, **provision** infrastructure through CAPI, Gardener Shoot, or kubeadm/Ansible and record API endpoint, CA fingerprint, and region labels in the CMDB. Second, **register** the cluster with OCM, Fleet, or Argo CD using automation tied to readiness signals—never manual import as the only path. Third, **implement** platform baselines: CNI, CSI, ingress, monitoring agents, admission policies, and ESO stores via ManifestWorkReplicaSet, BundleDeployment, or ApplicationSet waves. Fourth, configure **federated OIDC** bindings and optional SPIRE agents before tenant workloads land. Fifth, validate **multi-cluster networking** only if applications require cross-cluster Service calls; otherwise defer mesh or Submariner cost. Sixth, confirm **remote write** and mandatory metric labels appear in Thanos, Mimir, or VictoriaMetrics within one hour. Seventh, add the cluster to **upgrade canary** groups last—new clusters should not be the first wave for untested platform bundles.
 
-It is not enough for questions like "which cluster is losing Karmada work propagation latency" or "which site has kube-vip leader churn." Use a global metrics layer such as Thanos or Grafana Mimir to query across clusters. Keep cluster labels on every metric path. For Karmada, scrape control-plane metrics, scheduler metrics, controller-manager metrics, API server metrics, and member-cluster status.
-
-For kube-vip, alert on leader changes, BGP session state, VIP advertisement failures, and Service assignment failures. For Liqo, alert on peering status, virtual node readiness, gateway health, offloading status, and tunnel packet loss. Security starts with cross-cluster identity. Karmada needs kubeconfigs or agents that can apply resources to member clusters.
-
-Those credentials should be scoped, rotated, and stored with the same care as production cluster-admin access. Push mode often means the hub holds credentials that reach into members. Pull mode moves more responsibility to the member agent. Neither mode is automatically acceptable to every security team.
-
-Design the trust model explicitly. Liqo performs authentication bootstrap between clusters and establishes a peering relationship that allows resource consumption. That relationship should be approved like any other capacity-sharing or trust boundary. Use mTLS where the tool supports it.
-
-Constrain which namespaces can offload. Constrain which remote clusters can receive workloads. Decide whether Secrets are allowed to reflect across boundaries. Document who can create or modify peering resources.
-
-Network security is not optional. kube-vip ARP mode means nodes can claim VIPs on a subnet. That is powerful and potentially disruptive if address ranges are not controlled. BGP mode means Kubernetes nodes or pods can influence routing.
-
-Use route filters, prefix limits, BGP authentication where supported, and router-side policy. Monitor not just Kubernetes objects but the actual routing state. Scaling Karmada is a control-plane engineering problem. ETCD compaction and defragmentation matter when many propagated resources and bindings churn.
-
-Scheduler throughput matters when many workloads are rescheduled after a site event. Controller-manager worker counts and API QPS settings matter when clusters reconnect after a network partition. Status aggregation can become expensive if every workload reports frequently across many clusters. Treat the Karmada control plane like a production Kubernetes control plane, not a sidecar.
-
-kube-vip BGP has its own sharp edges. ECMP asymmetry can send request and response paths through different firewalls. BGP session flaps can create short but frequent outages. Route dampening can punish a speaker that flaps too often.
-
-Peer configuration errors can make a VIP appear healthy in Kubernetes while absent from the network. If ARP mode is used, ARP cache TTL and switch behavior affect failover perception. Tune the network with the network team, not in a Kubernetes-only meeting. Operational ownership should be written down.
-
-The platform team usually owns Karmada and Liqo control planes. The cluster team owns kube-vip manifests and address pools. The network team owns BGP peers, route policy, VLANs, and firewall paths.
-
-The application team owns readiness, state behavior, and whether failover is acceptable. Good on-prem multi-cluster platforms make those boundaries explicit. Weak platforms discover them during incidents.
+The checklist exposes gaps quickly. A cluster may exist in vCenter and answer `kubectl get nodes` yet remain absent from fleet inventory—that is a compliance hole. Another cluster may sync GitOps applications while missing fan-in labels—that is an observability blind spot. A third may run Submariner while lacking OIDC bindings—that is an audit finding waiting to happen. Mature platform teams store the checklist beside cluster classes. Merge requests to templates must pass automation gates before human approval.
 
 ---
 
-## Patterns & Anti-Patterns
+## Day-Two Operations and Governance
 
-### Patterns
+On-premises fleets fail in meetings more often than in controllers. Executives ask for a single compliance view; auditors ask who changed firewall rules; application owners ask why their cluster lacks ingress. Governance ties fleet tools to evidence. OCM policy reports, Fleet BundleDeployment health, and Argo CD sync status should feed one dashboard. Export those signals to ticketing when baselines drift. Manual kubectl edits on managed fields should trigger alerts the same way failed sync waves do.
 
-| Pattern | When to Use | Why It Works | Scaling Consideration |
-|---|---|---|---|
-| VIP below federation | Every on-prem multi-cluster fleet | Fleet placement does not matter unless each cluster can expose reachable endpoints | Standardize address pools and route policy before onboarding many teams. |
-| Karmada for platform-owned placement | Shared add-ons, regulated apps, controlled failover | Placement and overrides become auditable Kubernetes resources | Watch binding and work object volume as clusters and resources grow. |
-| Liqo for namespace offload | Burst, regional drain, edge-to-core movement | Existing workload YAML can keep using a local namespace model | Keep offloading policies visible so teams know where pods actually run. |
-| GitOps through the hub | Teams need one repo and many clusters | ApplicationSet can render fleet applications while Karmada handles propagation | Avoid mixing direct-to-member and hub-driven ownership for the same object. |
+Change management must name owners per layer. Network teams own CIDR plans and BGP sessions for Submariner gateways. Security teams own vault paths and ESO policies. Platform SRE owns CAPI, fleet controllers, and hub etcd backups. Application teams own microservice SLOs and database replication. When ownership is vague, incidents loop in chat without resolution. Run quarterly tabletop exercises that include hub loss, single-site loss, and vault outage scenarios. Record RTO and RPO results in the architecture document executives already approved.
 
-### Anti-Patterns
+Vendor distro teams should still document how their upgrade channels interact with fleet pauses. OpenShift upgrade graphs may conflict with Argo CD sync windows if nobody coordinates. Tanzu supervisor upgrades may restart nodes during factory maintenance blackouts. RKE2 patch channels may move faster than your Kyverno bundle tests. Map vendor cadence to internal canary labels so platform bundles and Kubernetes minors advance together. Never let tenant application pipelines promote to clusters still running a deprecated ingress class because the platform wave stalled.
 
-| Anti-Pattern | Why Teams Fall Into It | Better Alternative |
-|---|---|---|
-| Treating `LoadBalancer` as automatic on bare metal | Cloud experience trains teams to expect provider integration | Install and test kube-vip or another bare-metal load-balancer layer first. |
-| Letting Karmada and Liqo both manage the same namespace | Both tools can make workloads appear elsewhere | Split by namespace, label, or application ownership. |
-| Using BGP without router-side guardrails | Kubernetes teams can make routing changes faster than network review | Use prefix filters, peer limits, and change windows for routing policy. |
-| Hiding virtual nodes from developers | Transparency is mistaken for secrecy | Show offloaded pods, virtual-node labels, and remote cluster identity in dashboards. |
-| Putting all Services behind one ARP leader | It is the default in many simple examples | Use per-Service election or BGP where traffic distribution matters. |
+Cost governance belongs in synthesis too. Management clusters cost money while running few customer pods. Observability backends cost money while storing metrics nobody queries after thirty days. SPIRE and service meshes add CPU overhead on every node. Chargeback models should include cluster label dimensions platform teams already maintain: `cost-center`, `environment`, and `site`. FinOps questions reveal oversized worker pools and clusters that should have been decommissioned when factories closed.
 
----
+Training paths should mirror this module’s layers. New hires learn kubectl on one workload cluster first. They graduate to GitOps repositories, then to hub APIs, then to CAPI or Gardener lifecycle. Skipping layers produces operators who run `kubectl delete` on hub namespaces during application incidents. Pair documentation with sandbox management clusters that rebuild weekly from Git. Sandboxes must include fake spokes or kind clusters registered into OCM and Argo CD so exercises stay realistic without touching production BMC credentials.
 
-## Decision Framework
+Finally, treat synthesis as a living document. Every major incident should update the reference architecture with a dated addendum: what broke, which layer owned the fix, and which automation now prevents recurrence. Modules 5.1 through 5.6 gave you tools; this module gives you the story that keeps those tools aligned when staff rotate and vendors change licensing. Revisit the story after each Kubernetes minor upgrade and after each merger that adds new datacenters to the fleet.
 
-Use this flow when designing an on-prem multi-cluster feature.
-
-```text
-Start
-  |
-  v
-Do users need an external IP for a Service or API endpoint?
-  |
-  +-- yes --> Design kube-vip or equivalent VIP advertisement first.
-  |
-  +-- no ----+
-            |
-            v
-Do you need central policy for where resources land?
-  |
-  +-- yes --> Use Karmada policies, bindings, overrides, and failover.
-  |
-  +-- no ----+
-            |
-            v
-Do you want an existing namespace to borrow remote capacity?
-  |
-  +-- yes --> Use Liqo peering, virtual nodes, and namespace offloading.
-  |
-  +-- no ----+
-            |
-            v
-Can plain per-cluster GitOps solve it?
-  |
-  +-- yes --> Keep the design simple and avoid federation for this workload.
-  |
-  +-- no --> Revisit requirements and define the missing layer explicitly.
-```
-
-The framework is intentionally blunt. Most poor designs begin by jumping directly to federation. Federation is not a substitute for an IP address. It is not a substitute for DNS.
-
-It is not a substitute for application state design. It is a tool for controlling where Kubernetes resources or capacity relationships exist. Use Karmada when the platform needs strong placement.
-
-Use Liqo when the namespace should stretch. Use kube-vip when the cluster needs a reachable VIP. Use all three only when each has a separate job.
+Executive summaries should cite measurable outcomes: mean time to register a cluster, percentage of spokes with current BundleDeployment hashes, and percentage of series in Thanos with required labels. Those metrics prove the synthesis architecture works beyond slide diagrams. Without metrics, leadership funds another point tool instead of finishing the hub you already built. Review those metrics monthly with application owners so fleet automation stays funded and prioritized. Tie each metric to an on-call action so dashboards never become wallpaper during quiet quarters when incident volume is low across the entire fleet. Publish a one-page fleet health summary after each review.
 
 ---
 
 ## Did You Know?
 
-1. kube-vip supports both control-plane VIPs and Service `LoadBalancer` VIPs, but those are separate features that can be enabled independently.
-
-2. Karmada's current architecture includes a Kubernetes-compatible API server, ETCD, scheduler, and controller manager, so operating it resembles operating a real control plane.
-
-3. Liqo peering is directional: a consumer can offload to a provider, and bidirectional behavior requires configuring the reverse relationship as well.
-
-4. Kubernetes `type: LoadBalancer` relies on an implementation outside the Service object to allocate and publish an address, which is why bare-metal clusters often show `<pending>` until a controller such as kube-vip cloud provider is installed.
+- **Open Cluster Management splits placement binding by API domain**: `PlacementBinding` attaches policies in governance; `ManifestWorkReplicaSet` references `Placement` through `placementRefs` for work distribution—mixing them is a common integration mistake.
+- **Thanos and Mimir both solve HA Prometheus duplication differently**: Thanos deduplicates at query time via Querier; Mimir deduplicates at ingestion via the distributor HA tracker.
+- **Submariner Lighthouse implements the MCS API** for cross-cluster Service discovery, while Submariner gateways handle pod CIDR connectivity—teams can deploy Lighthouse without full pod routability in some topologies.
+- **Gardener Shoots are tenant clusters**, but Seeds run their control planes—an on-prem Gardener landscape still depends on healthy IaaS or CAPI under Seeds, which is why Module 5.6 pairs with this synthesis.
 
 ---
 
 ## Common Mistakes
 
-| Mistake | Why It Happens | How to Fix It |
-|---|---|---|
-| Installing Karmada before proving Service VIP reachability | Federation feels like the bigger problem, so teams skip the network base | Create a test `LoadBalancer` Service in every member cluster and verify the VIP from outside the cluster first. |
-| Reusing the control-plane VIP range for application Services | The address plan starts as a lab shortcut | Separate API VIPs, internal Service VIPs, and external Service VIPs into documented pools. |
-| Choosing ARP mode across routed sites | ARP works in the first rack and gets copied into the WAN design | Use BGP or site-local VIPs with DNS/GSLB when crossing L3 boundaries. |
-| Treating Liqo virtual nodes like ordinary physical nodes | The scheduler output looks familiar | Check Liqo labels, taints, namespace offloading status, and remote capacity before assuming local-node behavior. |
-| Debugging propagated workloads only in member clusters | The failed object is visible there, so operators start there | Trace Karmada `PropagationPolicy`, `ResourceBinding`, and `Work` before editing the member copy. |
-| Allowing Secret reflection without a policy review | Transparent offload makes cross-cluster data movement easy | Define which namespaces may reflect Secrets and audit peering permissions. |
-| Ignoring BGP route state during kube-vip incidents | Kubernetes events look green | Check router sessions, advertised prefixes, route filters, and ECMP paths as part of the runbook. |
+| Mistake | Problem | Solution |
+| :--- | :--- | :--- |
+| Running customer workloads on the management cluster | Controller starvation and etcd write storms during sync waves | Taint management workers; keep hub workload-light |
+| Skipping cluster registration after CAPI `Ready` | New clusters exist without monitoring, policy, or GitOps | Automate Fleet/OCM/Argo import when `Cluster` becomes ready |
+| Using PlacementBinding for ManifestWork fan-out | Work never schedules to new spokes | Use ManifestWorkReplicaSet `placementRefs` for work domain |
+| Assuming GitOps replaces multi-cluster networking | Services unreachable across sites despite synced Deployments | Add Submariner, ClusterMesh, or Istio when apps need cross-cluster calls |
+| One Sealed Secrets key for all factories | Compromise or rotation in one zone affects every cluster | Per-zone keys or ESO with scoped ClusterSecretStore objects |
+| Treating Thanos and Mimir dedup as identical | Duplicate or missing series in dashboards | Match remote-write labels to backend HA model |
+| Fleet-wide upgrade without canary | One bad CNI chart breaks every factory at once | Canary clusters plus paused sync on production labels |
+| Hub DR untested while spokes healthy | Incidents stall all new change; apps keep running but blind | Quarterly management-cluster restore drills with RTO targets |
 
 ---
 
 ## Quiz
 
-<details>
-<summary>Your team propagated a Deployment with Karmada, and the pods are healthy in Cluster B, but users still cannot connect to the Service. What do you check first?</summary>
+<details><summary>Question 1: When you design a management-cluster-plus-workload-clusters architecture, which sizing and blast-radius rules matter most for on-premises fleets?</summary>
 
-Start by separating placement from reachability. Karmada has already done its part if the Deployment and Service exist in Cluster B. Check whether the Service in Cluster B has an external VIP, then check kube-vip cloud provider logs and kube-vip advertisement state. If a VIP exists, inspect ARP or BGP state from the network side before changing Karmada policy.
-
-</details>
-
-<details>
-<summary>A site uses kube-vip ARP mode, and failover works in one switch but takes much longer in another. How do you diagnose it?</summary>
-
-Compare Kubernetes leader election timing with network convergence timing. If leadership changes quickly but clients keep using the old MAC address, the problem is likely ARP propagation, cache behavior, or switch policy. Check gratuitous ARP handling, ARP cache TTL, port security, and virtual-switch features. The fix belongs in network behavior as much as in Kubernetes configuration.
+Keep the management cluster workload-light with dedicated etcd storage and roughly 5–10% of aggregate workload control-plane CPU for small fleets; use label waves (`canary`, `production-east`) so platform bundles never upgrade every cluster at once; and document capacity ratios so observability ingestion can shard before hub etcd saturates. **Design** reviews should sign these rules before procurement, not after the twentieth cluster import.
 
 </details>
 
-<details>
-<summary>An application team wants zero-change workload portability into a second cluster for short capacity bursts. Should you start with Karmada or Liqo?</summary>
+<details><summary>Question 2: A new bare-metal cluster is Ready in Cluster API but has no monitoring agents. What handoff step was most likely skipped?</summary>
 
-Start with Liqo if the key requirement is keeping the existing workload YAML and letting a namespace consume remote capacity. The virtual-node model fits burst and offload use cases well. Karmada is better when the platform wants explicit propagation policy, overrides, and audited placement decisions. The important guardrail is making offloaded execution visible to operators and developers.
-
-</details>
-
-<details>
-<summary>A regulated workload must run only in clusters labeled `zone=internal` and needs a different image registry per cluster. Which pattern fits?</summary>
-
-Karmada is the better fit. Use cluster affinity in `PropagationPolicy` to restrict placement and `OverridePolicy` to adjust image registry or other fields per cluster. That keeps placement and mutation in auditable policy objects. Liqo could move pods, but it is not the cleanest tool for central compliance-driven placement and override rules.
+Cluster registration into the fleet layer—OCM `ManagedCluster` import, Rancher Fleet cluster labels, or Argo CD cluster secrets—was not automated after CAPI readiness. CAPI provisions infrastructure; fleet tools distribute baselines. Without import, GitOps and ManifestWorks never target the new API server.
 
 </details>
 
-<details>
-<summary>During a WAN degradation, Cluster A is still reachable by its own users but the Karmada hub cannot reach its API server. What design question does this expose?</summary>
+<details><summary>Question 3: Three hundred edge clusters allow only outbound HTTPS. Which fleet tools fit, and why is Argo CD ApplicationSets alone risky?</summary>
 
-It exposes the push-versus-pull registration decision. Push mode depends on the hub reaching the member API server. If that path is unreliable or blocked by policy, pull mode with a member-side agent may be more resilient for control-plane communication. The workload data path and the federation management path should be tested separately.
-
-</details>
-
-<details>
-<summary>Your network team reports ECMP asymmetry after enabling kube-vip BGP from two sites. What should the platform team evaluate before changing replicas?</summary>
-
-Evaluate whether request and response traffic cross the same stateful devices. ECMP can distribute flows across equal routes, but firewalls, NAT, and long-lived TCP sessions may not tolerate path changes. Check router hashing, firewall state tables, source NAT behavior, and whether the application needs sticky routing. Replica count changes will not fix a routing symmetry problem.
+Rancher Fleet agents and OCM Klusterlets pull from the hub outbound. Argo CD ApplicationSets default push mode requires hub connectivity to each spoke apiserver on 6443, which factory firewalls often block. Hybrid designs use pull baselines on edge and push ApplicationSets only in datacenters that permit inbound hub access.
 
 </details>
 
-<details>
-<summary>A namespace is offloaded with Liqo, but pods remain pending instead of landing on the virtual node. What should you inspect?</summary>
+<details><summary>Question 4: How do PropagationPolicy and ResourceBinding relate in Karmada?</summary>
 
-Inspect namespace offloading status, virtual-node readiness, taints, tolerations, runtime class settings, and remote capacity. Liqo virtual nodes are intentionally protected from accidental scheduling. Also check peering health and whether the provider accepted the resource slice. The local scheduler can only use remote capacity that Liqo has made eligible.
+PropagationPolicy selects member clusters and scheduling rules; Karmada controllers create ResourceBinding objects that record which clusters received each resource template. OverridePolicy patches per-cluster fields after binding. This differs from OCM ManifestWork, which wraps JSON manifests for Klusterlet apply.
+
+</details>
+
+<details><summary>Question 5: When should you choose Submariner Lighthouse versus Cilium ClusterMesh?</summary>
+
+Choose Lighthouse when you need MCS-based Service discovery and DNS across clusters with Submariner’s broker/gateway model. Choose ClusterMesh when both clusters run Cilium with compatible versions and you want global services with clustermesh TLS. Istio remains the choice for L7 mTLS and traffic policy. Many fleets need at most one primary east-west mechanism per application tier.
+
+</details>
+
+<details><summary>Question 6: How do you implement federated OIDC, External Secrets Operator, and Thanos fan-in across a new spoke?</summary>
+
+**Implement** federated OIDC with shared issuer configuration and GitOps-generated ClusterRoleBindings; deploy ClusterSecretStore plus ExternalSecret manifests via ManifestWork or Fleet bundles; and configure Prometheus remote write to Thanos Receive with mandatory `cluster`, `environment`, and `site` labels. SPIFFE/SPIRE follows when workloads need cross-cluster mTLS beyond human OIDC access.
+
+</details>
+
+<details><summary>Question 7: Thanos shows duplicate series but Mimir dashboards do not for the same HA Prometheus pair. Why?</summary>
+
+Thanos deduplicates at query time using `replica` labels in Querier. Mimir deduplicates at ingestion with the distributor HA tracker. Misconfigured external labels break Thanos dedup while Mimir may silently accept only one replica—operators must align remote-write config with each backend’s model.
+
+</details>
+
+<details><summary>Question 8: Management cluster etcd is corrupted; workload clusters are healthy. What fails first, and how do canary clusters limit upgrade blast radius?</summary>
+
+New cluster provisioning, fleet sync, centralized policy placement, and metrics fan-in ingestion to the hub fail or show stale status while running application pods on spokes continue until they need hub-driven secrets or bundles. Recovery prioritizes hub etcd restore and agent trust. **Coordinate** upgrades with canary clusters on Kubernetes 1.35, paused GitOps on production labels, and tagged platform bundles so a bad CNI or admission chart cannot hit every site simultaneously.
 
 </details>
 
 ---
 
-## Hands-On Exercise
+## Hands-On Exercises
 
-This lab builds the layered model on a laptop-friendly setup. The full production version needs two real Kubernetes clusters, routed or L2 reachability between them, and network equipment where you can verify ARP or BGP state. The minimal version uses two kind clusters with Calico and kube-vip Service VIP behavior.
+These exercises practice synthesis concepts with `kind`, `kubectl`, and local YAML validation. Commands use the full `kubectl` name. Together they map **management-cluster architecture**, **fleet object contracts**, and **observability label discipline** without requiring a full private cloud lab.
 
-Calico BGP is simulated at the cluster layer because a laptop kind environment does not provide real top-of-rack routers. The point is to practice the object model, verification flow, and failure thinking. Use a clean terminal with these tools installed:
-
-- `kind`
-- `kubectl`
-- `helm`
-- `docker`
-- `jq`
-- `curl`
-
-Create the `k` alias before you start the lab so the remaining commands match the examples exactly. Keeping the alias consistent avoids wasting time on command translation while you are comparing cluster contexts and watching objects move between layers.
+### Exercise 1: Stand up a local management cluster and Cluster API providers
 
 ```bash
-alias k=kubectl
+kind create cluster --name mgmt-synthesis
+kubectl cluster-info --context kind-mgmt-synthesis
+
+curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.1/clusterctl-linux-amd64 -o /tmp/clusterctl
+chmod +x /tmp/clusterctl
+/tmp/clusterctl init --infrastructure docker
+
+kubectl wait --for=condition=Ready pod -l cluster.x-k8s.io/provider=cluster-api -n capi-system --timeout=180s
+kubectl get pods -n capi-system
+kubectl get pods -n capd-system
+kubectl api-resources | grep cluster.x-k8s.io
 ```
 
-Create explicit kubeconfig paths for the two clusters and keep the VIP ranges in environment variables. The lab uses separate files so you can switch between Cluster A, Cluster B, and the Karmada API server without overwriting your default kubeconfig.
+- [ ] kind management cluster is reachable with `kubectl cluster-info`.
+- [ ] `clusterctl init` completed and CAPI provider pods are Ready.
+- [ ] You can explain how this hub would provision workload clusters separately from Fleet or OCM baselines.
+
+<details><summary>Expected analysis</summary>
+
+The lab isolates infrastructure lifecycle on the management cluster. Production would add CAPM3 or CAPV providers instead of Docker. After `Cluster` Ready, automate OCM import or Fleet labels—skipping that step is the most common synthesis gap in real fleets.
+
+</details>
+
+### Exercise 2: Validate fleet YAML contracts for ApplicationSet and PropagationPolicy
 
 ```bash
-export KUBECONFIG_A="$HOME/.kube/kind-cluster-a"
-export KUBECONFIG_B="$HOME/.kube/kind-cluster-b"
-export VIP_RANGE_A="172.18.255.200-172.18.255.210"
-export VIP_RANGE_B="172.18.255.220-172.18.255.230"
-```
-
-### Task 1: Bootstrap Two kind Clusters with Calico and kube-vip
-
-Create a kind configuration that disables the default CNI so Calico can be installed deliberately. That choice makes the networking layer visible during the exercise, which is useful because kube-vip, Liqo, and Karmada all depend on clear cluster-network behavior.
-
-```bash
-cat > /tmp/kind-calico-a.yaml <<'EOF'
-kind: Cluster
-apiVersion: kind.x-k8s.io/v1alpha4
-networking:
-  disableDefaultCNI: true
-  podSubnet: 10.244.0.0/16
-nodes:
-  - role: control-plane
-  - role: worker
+mkdir -p /tmp/fleet-synthesis
+cat >/tmp/fleet-synthesis/appset.yaml <<'EOF'
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: platform-baseline
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - clusters:
+        selector:
+          matchLabels:
+            env: production
+  template:
+    metadata:
+      name: 'baseline-{{.name}}'
+    spec:
+      project: platform
+      source:
+        repoURL: https://github.com/argoproj/argocd-example-apps
+        targetRevision: HEAD
+        path: guestbook
+      destination:
+        server: '{{.server}}'
+        namespace: platform-baseline
 EOF
-
-cat > /tmp/kind-calico-b.yaml <<'EOF'
-kind: Cluster
-apiVersion: kind.x-k8s.io/v1alpha4
-networking:
-  disableDefaultCNI: true
-  podSubnet: 10.245.0.0/16
-nodes:
-  - role: control-plane
-  - role: worker
-EOF
-
-kind create cluster --name cluster-a --config /tmp/kind-calico-a.yaml --kubeconfig "$KUBECONFIG_A"
-kind create cluster --name cluster-b --config /tmp/kind-calico-b.yaml --kubeconfig "$KUBECONFIG_B"
-```
-
-Install Calico on both clusters and wait for the node and controller rollouts to complete. The later federation steps are noisy to debug if the baseline CNI is still converging, so treat CNI readiness as a hard prerequisite.
-
-```bash
-for kubeconfig in "$KUBECONFIG_A" "$KUBECONFIG_B"; do
-  KUBECONFIG="$kubeconfig" k apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.31.0/manifests/calico.yaml
-  KUBECONFIG="$kubeconfig" k -n kube-system rollout status daemonset/calico-node --timeout=240s
-  KUBECONFIG="$kubeconfig" k -n kube-system rollout status deployment/calico-kube-controllers --timeout=240s
-done
-```
-
-Install the kube-vip cloud provider and kube-vip DaemonSet on each cluster, then configure a distinct address range for each site. This keeps Service VIP allocation local to the member cluster and prevents the lab from hiding address ownership behind the federation layer.
-
-```bash
-for kubeconfig in "$KUBECONFIG_A" "$KUBECONFIG_B"; do
-  KUBECONFIG="$kubeconfig" k apply -f https://kube-vip.io/manifests/rbac.yaml
-  KUBECONFIG="$kubeconfig" k apply -f https://raw.githubusercontent.com/kube-vip/kube-vip-cloud-provider/main/manifest/kube-vip-cloud-controller.yaml
-done
-
-KUBECONFIG="$KUBECONFIG_A" k create configmap kubevip \
-  --namespace kube-system \
-  --from-literal range-global="$VIP_RANGE_A"
-
-KUBECONFIG="$KUBECONFIG_B" k create configmap kubevip \
-  --namespace kube-system \
-  --from-literal range-global="$VIP_RANGE_B"
-
-docker run --rm ghcr.io/kube-vip/kube-vip:v0.8.9 manifest daemonset \
-  --interface eth0 \
-  --services \
-  --arp \
-  --leaderElection \
-  --inCluster \
-  --taint \
-  | KUBECONFIG="$KUBECONFIG_A" k apply -f -
-
-docker run --rm ghcr.io/kube-vip/kube-vip:v0.8.9 manifest daemonset \
-  --interface eth0 \
-  --services \
-  --arp \
-  --leaderElection \
-  --inCluster \
-  --taint \
-  | KUBECONFIG="$KUBECONFIG_B" k apply -f -
-```
-
-Create a test Service in each cluster before introducing Karmada or Liqo. This proves that ordinary `LoadBalancer` Services receive VIPs locally, which is the baseline evidence you need before asking any multi-cluster tool to place or offload workloads.
-
-```bash
-for kubeconfig in "$KUBECONFIG_A" "$KUBECONFIG_B"; do
-  KUBECONFIG="$kubeconfig" k create deployment vip-test --image=nginx:1.27 --replicas=1
-  KUBECONFIG="$kubeconfig" k expose deployment vip-test --port=80 --target-port=80 --type=LoadBalancer
-  KUBECONFIG="$kubeconfig" k rollout status deployment/vip-test --timeout=180s
-  KUBECONFIG="$kubeconfig" k get svc vip-test -o wide
-done
-```
-
-<details>
-<summary>Solution and success criteria for Task 1</summary>
-
-The key result is that each cluster has a `LoadBalancer` Service with an assigned external IP from its configured range. In a laptop kind environment, reachability from the host may depend on Docker networking and host routes. For this exercise, assignment plus kube-vip pod health is the minimal success signal. On real bare metal, also verify reachability from a machine outside the cluster subnet.
-
-- [ ] Both kind clusters exist and report Ready nodes.
-- [ ] Calico pods are Running in both clusters.
-- [ ] kube-vip cloud provider is Running in both clusters.
-- [ ] kube-vip DaemonSet pods are Running in both clusters.
-- [ ] A `LoadBalancer` Service receives a VIP in both clusters.
-
-</details>
-
-### Task 2: Install Liqo and Peer Cluster A to Cluster B
-
-Install `liqoctl` if it is not already present, using the release archive that matches your workstation operating system and CPU architecture. The command block keeps the install path explicit because later troubleshooting depends on knowing which client version created the peering resources.
-
-```bash
-if ! command -v liqoctl >/dev/null 2>&1; then
-  LIQO_VERSION="v1.0.2"
-  OS="$(uname | tr '[:upper:]' '[:lower:]')"
-  ARCH="$(uname -m)"
-  case "$ARCH" in
-    x86_64) ARCH="amd64" ;;
-    arm64|aarch64) ARCH="arm64" ;;
-  esac
-  curl --fail -LS "https://github.com/liqotech/liqo/releases/download/${LIQO_VERSION}/liqoctl-${OS}-${ARCH}.tar.gz" | tar -xz
-  sudo install -o root -g root -m 0755 liqoctl /usr/local/bin/liqoctl
-fi
-```
-
-Install Liqo on both clusters and inspect the reported status from each context. A successful install on only one side is not enough, because the consumer and provider roles both need Liqo components before peering can create a usable virtual-node relationship.
-
-```bash
-liqoctl install --kubeconfig "$KUBECONFIG_A" --context kind-cluster-a --skip-confirm
-liqoctl install --kubeconfig "$KUBECONFIG_B" --context kind-cluster-b --skip-confirm
-
-liqoctl info --kubeconfig "$KUBECONFIG_A" --context kind-cluster-a
-liqoctl info --kubeconfig "$KUBECONFIG_B" --context kind-cluster-b
-```
-
-Peer Cluster A to Cluster B using `NodePort` for the gateway Service in this kind-based lab. The gateway type is chosen for local Docker networking, not as a universal production recommendation, so translate it to your real network design before copying the pattern.
-
-```bash
-liqoctl peer \
-  --kubeconfig "$KUBECONFIG_A" \
-  --context kind-cluster-a \
-  --remote-kubeconfig "$KUBECONFIG_B" \
-  --remote-context kind-cluster-b \
-  --gw-server-service-type NodePort \
-  --skip-confirm
-```
-
-Verify that a virtual node appears in Cluster A after the peering completes. The virtual node is the user-visible proof that Cluster A can consume remote capacity from Cluster B, so do this check before testing namespace offloading.
-
-```bash
-KUBECONFIG="$KUBECONFIG_A" k get nodes -o wide
-KUBECONFIG="$KUBECONFIG_A" k get nodes -l liqo.io/type=virtual-node -o wide
-```
-
-<details>
-<summary>Solution and success criteria for Task 2</summary>
-
-The expected result is a Ready virtual node in Cluster A representing Cluster B. If no virtual node appears, inspect `liqoctl info`, peering status, gateway Service type, and whether both kind clusters can reach each other through Docker networking. The `NodePort` gateway type avoids relying on cloud load balancers inside the kind lab.
-
-- [ ] `liqoctl info` reports Liqo installed in both clusters.
-- [ ] The `liqoctl peer` command completes without an error.
-- [ ] Cluster A shows a Liqo virtual node for Cluster B.
-- [ ] The virtual node reports allocatable CPU, memory, and pod capacity.
-
-</details>
-
-### Task 3: Install Karmada and Join Both Clusters
-
-Install `karmadactl` if it is not already present, again choosing the binary that matches your local operating system and architecture. Karmada operations in the lab use this client for initialization, joining clusters, and applying cluster taints.
-
-```bash
-if ! command -v karmadactl >/dev/null 2>&1; then
-  KARMADA_VERSION="v1.17.0"
-  OS="$(uname | tr '[:upper:]' '[:lower:]')"
-  ARCH="$(uname -m)"
-  case "$ARCH" in
-    x86_64) ARCH="amd64" ;;
-    arm64|aarch64) ARCH="arm64" ;;
-  esac
-  curl --fail -L "https://github.com/karmada-io/karmada/releases/download/${KARMADA_VERSION}/karmadactl-${OS}-${ARCH}.tgz" -o /tmp/karmadactl.tgz
-  tar -xzf /tmp/karmadactl.tgz -C /tmp
-  sudo install -o root -g root -m 0755 /tmp/karmadactl /usr/local/bin/karmadactl
-fi
-```
-
-Initialize Karmada in Cluster A for the lab so the first cluster hosts the federation control plane. This is convenient for a laptop exercise, but production designs should place the Karmada control plane according to availability, trust, and network reachability requirements.
-
-```bash
-karmadactl init \
-  --kubeconfig "$KUBECONFIG_A" \
-  --context kind-cluster-a \
-  --karmada-data "$HOME/.karmada-lab"
-```
-
-Export the generated Karmada kubeconfig path as a separate variable. From this point forward, commands against `KARMADA_KUBECONFIG` target the federation control plane, while commands against `KUBECONFIG_A` and `KUBECONFIG_B` target member clusters.
-
-```bash
-export KARMADA_KUBECONFIG="$HOME/.karmada-lab/karmada-apiserver.config"
-```
-
-Join both clusters in push mode for the minimal lab because the local Karmada control plane can reach both kind API servers. In a restricted network, this same step is where you would revisit push versus pull registration instead of forcing hub-initiated connectivity.
-
-```bash
-karmadactl join kind-cluster-a \
-  --kubeconfig "$KARMADA_KUBECONFIG" \
-  --cluster-kubeconfig "$KUBECONFIG_A" \
-  --cluster-context kind-cluster-a
-
-karmadactl join kind-cluster-b \
-  --kubeconfig "$KARMADA_KUBECONFIG" \
-  --cluster-kubeconfig "$KUBECONFIG_B" \
-  --cluster-context kind-cluster-b
-```
-
-Verify the joined clusters from the Karmada context and read the conditions rather than checking only for object existence. A `Cluster` object can exist while readiness, API reachability, or credential problems still prevent reliable propagation.
-
-```bash
-KUBECONFIG="$KARMADA_KUBECONFIG" k get clusters
-KUBECONFIG="$KARMADA_KUBECONFIG" k get clusters -o yaml
-```
-
-<details>
-<summary>Solution and success criteria for Task 3</summary>
-
-Both clusters should appear as Karmada `Cluster` objects. The lab uses push mode because the local Karmada control plane can reach both kind API servers. If Cluster B does not become Ready, check whether the kubeconfig context name is correct and whether Karmada can connect to the member API server endpoint.
-
-- [ ] Karmada control-plane pods are Running in Cluster A.
-- [ ] `KARMADA_KUBECONFIG` points to the generated Karmada API server kubeconfig.
-- [ ] `k get clusters` against Karmada shows `kind-cluster-a`.
-- [ ] `k get clusters` against Karmada shows `kind-cluster-b`.
-- [ ] Both clusters report Ready or provide a clear diagnostic condition.
-
-</details>
-
-### Task 4: Propagate nginx Across Both Clusters
-
-Create the workload and Service in the Karmada API server, not directly in either member cluster. This distinction matters because the next policy step selects resources from the hub API and asks Karmada to create the member-cluster copies.
-
-```bash
-KUBECONFIG="$KARMADA_KUBECONFIG" k create namespace demo
-
-KUBECONFIG="$KARMADA_KUBECONFIG" k -n demo create deployment nginx \
-  --image=nginx:1.27 \
-  --replicas=4
-
-KUBECONFIG="$KARMADA_KUBECONFIG" k -n demo expose deployment nginx \
-  --port=80 \
-  --target-port=80 \
-  --type=LoadBalancer
-```
-
-Apply a `PropagationPolicy` that selects both the Deployment and Service and spreads them across the two member clusters. The policy is intentionally small, but it gives you a binding object that explains Karmada's placement decision.
-
-```bash
-cat > /tmp/nginx-propagationpolicy.yaml <<'EOF'
+cat >/tmp/fleet-synthesis/propagation.yaml <<'EOF'
 apiVersion: policy.karmada.io/v1alpha1
 kind: PropagationPolicy
 metadata:
-  name: nginx-spread
-  namespace: demo
+  name: web-frontend
 spec:
   resourceSelectors:
     - apiVersion: apps/v1
       kind: Deployment
-      name: nginx
-    - apiVersion: v1
-      kind: Service
-      name: nginx
+      name: web-frontend
   placement:
     clusterAffinity:
       clusterNames:
-        - kind-cluster-a
-        - kind-cluster-b
-    replicaScheduling:
-      replicaSchedulingType: Divided
-      replicaDivisionPreference: Weighted
-      weightPreference:
-        staticWeightList:
-          - targetCluster:
-              clusterNames:
-                - kind-cluster-a
-            weight: 1
-          - targetCluster:
-              clusterNames:
-                - kind-cluster-b
-            weight: 1
-    spreadConstraints:
-      - spreadByField: cluster
-        minGroups: 2
-        maxGroups: 2
+        - prod-eu-1
+        - prod-eu-2
 EOF
-
-KUBECONFIG="$KARMADA_KUBECONFIG" k apply -f /tmp/nginx-propagationpolicy.yaml
+python3 -c "import yaml; yaml.safe_load(open('/tmp/fleet-synthesis/appset.yaml'))" && echo "ApplicationSet OK"
+python3 -c "import yaml; yaml.safe_load(open('/tmp/fleet-synthesis/propagation.yaml'))" && echo "PropagationPolicy OK"
+grep -E 'generators:|clusterAffinity:' /tmp/fleet-synthesis/appset.yaml /tmp/fleet-synthesis/propagation.yaml
 ```
 
-Verify both the Karmada binding and the member-cluster objects so you can see the full reconciliation path. The binding explains intent, while the member clusters show whether the propagated Deployment, pods, and Service VIPs became real runtime state.
+- [ ] Both YAML files parse with local `python3` validation.
+- [ ] ApplicationSet uses a Cluster generator with label selector `env: production`.
+- [ ] PropagationPolicy names explicit member clusters under `placement.clusterAffinity`.
 
-```bash
-KUBECONFIG="$KARMADA_KUBECONFIG" k -n demo get propagationpolicy
-KUBECONFIG="$KARMADA_KUBECONFIG" k -n demo get resourcebinding
+<details><summary>Expected analysis</summary>
 
-KUBECONFIG="$KUBECONFIG_A" k -n demo get deploy,pods,svc -o wide
-KUBECONFIG="$KUBECONFIG_B" k -n demo get deploy,pods,svc -o wide
-```
-
-<details>
-<summary>Solution and success criteria for Task 4</summary>
-
-The Deployment and Service should exist in both member clusters. The replica division may take a short time to settle. The `ResourceBinding` is the key Karmada diagnostic object because it records how the selected resource was scheduled. If pods exist but the Service has no VIP, return to Task 1 and fix the kube-vip layer before changing Karmada.
-
-- [ ] The `demo` namespace exists in the Karmada API server.
-- [ ] The `nginx-spread` PropagationPolicy exists.
-- [ ] A `ResourceBinding` exists for the propagated Deployment.
-- [ ] nginx pods run in Cluster A.
-- [ ] nginx pods run in Cluster B.
-- [ ] The propagated Service receives a VIP in each member cluster.
+ApplicationSets push Applications to registered clusters—network must allow hub-to-spoke access. Karmada PropagationPolicy creates ResourceBindings on member clusters; override policies would patch image mirrors per site. OCM equivalents use Placement plus ManifestWorkReplicaSet instead of PropagationPolicy.
 
 </details>
 
-### Task 5: Simulate Cluster A Failure and Observe Karmada Failover
-
-For a lab-safe failure, mark Cluster A with a `NoSchedule` taint first instead of immediately breaking the cluster. This lets you observe how Karmada reacts to scheduling pressure while keeping the environment recoverable for the remaining checks.
+### Exercise 3: Document observability fan-in labels and verify documentation endpoints
 
 ```bash
-karmadactl taint clusters kind-cluster-a \
-  site-failure=planned:NoSchedule \
-  --kubeconfig "$KARMADA_KUBECONFIG"
+kubectl create namespace observability-synthesis --dry-run=client -o yaml | kubectl apply -f -
+kubectl label namespace observability-synthesis \
+  platform.kubedojo.io/cluster=lab-mgmt \
+  platform.kubedojo.io/environment=lab \
+  platform.kubedojo.io/site=local --overwrite
 
-KUBECONFIG="$KARMADA_KUBECONFIG" k get cluster kind-cluster-a -o yaml
+cat <<'EOF' | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: remote-write-contract
+  namespace: observability-synthesis
+data:
+  required_labels: "cluster,environment,site,platform_version"
+  backend_notes: "thanos-receive-query-dedup; mimir-distributor-ingest-dedup"
+EOF
+kubectl get configmap remote-write-contract -n observability-synthesis -o yaml
+
+curl -sI https://thanos.io/tip/thanos/quick-tutorial.md/ | head -3
+curl -sI https://grafana.com/docs/mimir/latest/ | head -3
+curl -sI https://docs.victoriametrics.com/ | head -3
 ```
 
-For eviction-style testing, enable the relevant Karmada failover features in a dedicated lab only, then use `NoExecute` taints.
+- [ ] Namespace carries `cluster`, `environment`, and `site` labels for fan-in queries.
+- [ ] ConfigMap documents required labels and backend deduplication differences.
+- [ ] Documentation HEAD requests return HTTP 200 or redirect for Thanos, Mimir, and VictoriaMetrics docs.
 
-```bash
-karmadactl taint clusters kind-cluster-a \
-  site-failure=planned:NoExecute \
-  --kubeconfig "$KARMADA_KUBECONFIG" \
-  --overwrite
-```
+<details><summary>Expected analysis</summary>
 
-Observe the binding and member clusters after the taint so you can distinguish policy effects from workload effects. The Karmada object should show the scheduling consequence, and the member clusters should show what actually changed at runtime.
-
-```bash
-KUBECONFIG="$KARMADA_KUBECONFIG" k -n demo get resourcebinding -o yaml
-KUBECONFIG="$KUBECONFIG_A" k -n demo get pods -o wide
-KUBECONFIG="$KUBECONFIG_B" k -n demo get pods -o wide
-```
-
-Remove the taint after the test to return the fleet to its baseline placement behavior. Cleaning up the simulated failure is part of the exercise because stale cluster taints are a common cause of confusing follow-on symptoms.
-
-```bash
-karmadactl taint clusters kind-cluster-a site-failure- \
-  --kubeconfig "$KARMADA_KUBECONFIG"
-```
-
-<details>
-<summary>Solution and success criteria for Task 5</summary>
-
-The exact failover behavior depends on enabled Karmada feature gates and policy configuration. At minimum, `NoSchedule` should prevent new placements on Cluster A. With eviction behavior enabled and policy configured, eligible workload placement should move away from the tainted cluster. Do not test destructive failover semantics against stateful applications until state preservation and database promotion are defined.
-
-- [ ] Cluster A shows the expected taint in Karmada.
-- [ ] Karmada placement no longer selects Cluster A for new work.
-- [ ] The `ResourceBinding` changes or records the scheduling effect.
-- [ ] Cluster B becomes the remaining healthy target for eligible replicas.
-- [ ] The test taint is removed after observation.
+Fan-in fails in production when scrape configs omit standardized labels—queries cannot slice by site during DR. Thanos and Mimir dedup models differ; VictoriaMetrics fits teams wanting efficient clustered storage. Pair this contract with Velero schedules per workload cluster for recoverable observability config.
 
 </details>
 
-### Task 6: Enable Liqo Namespace Offloading for an Existing Namespace
+---
 
-Create an application namespace in Cluster A for the Liqo offloading test. This namespace remains the developer-facing home for the workload even when eligible pods later run on remote capacity in Cluster B.
+## Learner Check
 
-```bash
-KUBECONFIG="$KUBECONFIG_A" k create namespace burst
-
-KUBECONFIG="$KUBECONFIG_A" k -n burst create deployment worker \
-  --image=nginx:1.27 \
-  --replicas=2
-
-KUBECONFIG="$KUBECONFIG_A" k -n burst rollout status deployment/worker --timeout=180s
-```
-
-Enable offloading for the namespace so Liqo can extend it to the peered provider cluster. This is the point where the model shifts from Karmada's hub-driven propagation to scheduler-driven use of a virtual node.
-
-```bash
-liqoctl offload namespace burst \
-  --kubeconfig "$KUBECONFIG_A" \
-  --context kind-cluster-a \
-  --pod-offloading-strategy LocalAndRemote \
-  --skip-confirm
-```
-
-Scale the workload and observe scheduling from both clusters. Cluster A should show whether pods are assigned to the virtual node, while Cluster B shows the reflected or hosted workload state that proves remote execution is actually happening.
-
-```bash
-KUBECONFIG="$KUBECONFIG_A" k -n burst scale deployment worker --replicas=6
-KUBECONFIG="$KUBECONFIG_A" k -n burst get pods -o wide
-KUBECONFIG="$KUBECONFIG_A" k get nodes -l liqo.io/type=virtual-node -o wide
-KUBECONFIG="$KUBECONFIG_B" k get pods --all-namespaces -o wide | grep burst || true
-```
-
-<details>
-<summary>Solution and success criteria for Task 6</summary>
-
-The goal is to see Cluster A scheduling eligible pods onto the Liqo virtual node that represents Cluster B. Cluster B should show the hosted pods in the reflected namespace. If pods remain local, inspect the namespace offloading object, virtual-node taints, scheduler events, and shared resource capacity. This is a different pathway from Karmada propagation: the source cluster scheduler is making use of remote virtual capacity.
-
-- [ ] The `burst` namespace exists in Cluster A.
-- [ ] Liqo namespace offloading is enabled for `burst`.
-- [ ] Cluster A shows the virtual node as a scheduling target.
-- [ ] Some eligible pods schedule onto the virtual node when capacity and policy allow it.
-- [ ] Cluster B shows the hosted offloaded pods or reflected namespace resources.
-
-</details>
-
-### Exercise Debrief
-
-You have now touched every layer. kube-vip assigned Service VIPs inside each cluster. Liqo created a virtual-node relationship so Cluster A could consume Cluster B capacity.
-
-Karmada created a hub-level policy and binding so a workload could be propagated across both clusters. Those are different powers. They become reliable only when the team keeps them separate and tests their interactions.
+> **Pause and predict**: your fleet provisions clusters successfully, but executives still see empty global dashboards during incidents. Which three layers would you inspect—in order—and why? Start with observability fan-in labels and remote-write paths from spokes to Thanos Receive or Mimir distributors, because missing `cluster` labels break queries even when Prometheus runs locally. Next verify management-cluster registration and fleet agent health so baselines actually deploy metrics agents. Finally confirm network paths allow remote write from factory VLANs; GitOps may be green while metrics never reach the hub.
 
 ---
 
 ## Next Module
 
-Next: OpenStack on K8s, where you will connect on-prem Kubernetes platform design to infrastructure services running on Kubernetes itself.
+Continue to [Module 5.8: OpenStack on Kubernetes](../module-5.8-openstack-on-kubernetes/) to study architectural inversion where OpenStack control-plane services run as Kubernetes workloads and how that pattern intersects with multi-cluster operations.
 
 ---
 
 ## Sources
 
-- [Karmada documentation](https://karmada.io/docs/)
-- [Karmada architecture](https://karmada.io/docs/core-concepts/architecture/)
-- [Karmada cluster registration](https://karmada.io/docs/userguide/clustermanager/cluster-registration/)
-- [Karmada resource propagating](https://karmada.io/docs/v1.13/userguide/scheduling/resource-propagating/)
-- [Karmada cluster failover](https://karmada.io/docs/userguide/failover/cluster-failover/)
-- [Karmada failover analysis](https://karmada.io/docs/userguide/failover/failover-analysis)
-- [Karmada GitHub repository](https://github.com/karmada-io/karmada)
-- [Liqo documentation](https://docs.liqo.io/)
-- [Liqo peer command](https://docs.liqo.io/en/latest/usage/liqoctl/liqoctl_peer.html)
-- [Liqo namespace offloading](https://docs.liqo.io/en/latest/usage/namespace-offloading.html)
-- [Liqo GitHub repository](https://github.com/liqotech/liqo)
-- [kube-vip documentation](https://kube-vip.io/docs/)
-- [kube-vip static pods](https://kube-vip.io/docs/installation/static/)
-- [kube-vip ARP mode](https://kube-vip.io/docs/modes/arp/)
-- [kube-vip cloud provider](https://kube-vip.io/docs/usage/cloud-provider/)
-- [kube-vip GitHub repository](https://github.com/kube-vip/kube-vip)
-- [Kubernetes Service documentation](https://kubernetes.io/docs/concepts/services-networking/service/)
-- [Argo CD ApplicationSet generators](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Generators/)
-- [Argo CD ApplicationSet user guide](https://argo-cd.readthedocs.io/en/stable/user-guide/application-set/)
-- [Thanos quick tutorial](https://thanos.io/tip/thanos/quick-tutorial.md/)
-- [Grafana Mimir documentation](https://grafana.com/docs/mimir/latest/)
+- https://cluster-api.sigs.k8s.io/
+- https://github.com/metal3-io/baremetal-operator
+- https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/
+- https://gardener.cloud/
+- https://github.com/gardener/gardener
+- https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/
+- https://fleet.rancher.io/
+- https://karmada.io/docs/userguide/scheduling/propagation-policy/
+- https://open-cluster-management.io/docs/concepts/
+- https://submariner.io/getting-started/quickstart/
+- https://docs.cilium.io/en/stable/network/clustermesh/clustermesh/
+- https://istio.io/latest/docs/setup/install/multicluster/
+- https://spiffe.io/docs/latest/spiffe-about/overview/
+- https://external-secrets.io/latest/
+- https://github.com/bitnami-labs/sealed-secrets
+- https://thanos.io/tip/thanos/quick-tutorial.md/
+- https://grafana.com/docs/mimir/latest/
+- https://docs.victoriametrics.com/
+- https://velero.io/docs/

--- a/src/content/docs/on-premises/multi-cluster/module-5.7-multi-cluster-on-prem.md
+++ b/src/content/docs/on-premises/multi-cluster/module-5.7-multi-cluster-on-prem.md
@@ -38,7 +38,9 @@ This synthesis module is the capstone for the On-Premises Multi-Cluster track. I
 
 Mature on-premises programs converge on a **control plane of control planes**: one or two highly available management clusters run Cluster API controllers, fleet GitOps, policy engines, and observability receivers, while workload clusters run customer applications and local platform agents. The management cluster is production infrastructure with its own backup, upgrade, and access-control lifecycle—not a lab afterthought.
 
-Sizing the management plane starts from controller count and etcd write rate, not from vCPU totals alone. A fleet of twenty workload clusters with Argo CD ApplicationSets, OCM placement controllers, and Thanos Receive ingesting remote write from every spoke generates sustained API traffic on the hub. Platform teams commonly allocate three to five control-plane nodes with fast etcd storage, plus two to four worker nodes tainted for `fleet=platform` so general workloads cannot starve reconciliation loops. Workload clusters scale by expected pod density, storage throughput, and GPU or storage-specialized node pools—not by copying management-cluster sizes.
+Sizing the management plane starts from controller count and etcd write rate, not from vCPU totals alone. A fleet of twenty workload clusters with Argo CD ApplicationSets, OCM placement controllers, and Thanos Receive ingesting remote write from every spoke generates sustained API traffic on the hub. Platform teams commonly allocate three to five control-plane nodes with fast etcd storage, plus two to four worker nodes tainted for `fleet=platform` so general workloads cannot starve reconciliation loops. For a five-member management etcd cluster, **quorum is three** (⌊5/2⌋+1)—the cluster tolerates two member failures, not four. When stretching etcd across sites, prefer **2+2+1** (two members in each of two primary sites plus one witness in a third): any single-site loss leaves three of five members and quorum holds. A **3+2** layout across three sites (three members in one primary site, two elsewhere) does **not** survive loss of the three-member site—only two members remain, below quorum—even though three of five sounds like a majority in the abstract.
+
+Workload clusters scale by expected pod density, storage throughput, and GPU or storage-specialized node pools—not by copying management-cluster sizes.
 
 Workload cluster counts follow blast-radius and compliance boundaries more than hardware convenience. A useful rule of thumb for regulated manufacturing is **one production cluster per site or per major application family**, separate staging clusters that mirror production Kubernetes minor versions, and shared lab clusters only for experiments that tolerate noisy neighbors. Edge factory clusters stay small—three control-plane nodes where HA is mandated, otherwise a single control plane with documented break-glass recovery when the business accepts the risk.
 
@@ -128,7 +130,7 @@ Hybrid fleets are normal: CAPI provisions clusters, OCM delivers baseline Manife
 
 **Evaluate** fleet and networking choices together because misaligned combinations fail in production even when each tool passes a proof-of-concept. ApplicationSets plus Submariner Lighthouse suit datacenter meshes where hub push works and MCS DNS is enough for service discovery. Fleet plus ClusterMesh suits edge spokes that pull bundles while datacenter Cilium clusters expose global services for shared APIs. OCM plus Istio suits regulated environments that need pull-based baselines and L7 mTLS for a subset of microservices—accept the operational cost of mesh upgrades across clusters. Write the decision in the architecture record so auditors see intentional pairing rather than accidental overlap.
 
-Argo CD ApplicationSet **generators** deserve explicit runbook coverage: the **Cluster** generator watches registered cluster secrets; the **Git** generator scans repository directories; the **Matrix** generator multiplies two generator outputs—useful for monorepo platform charts times production clusters. Enable `goTemplate: true` with `missingkey=error` so template typos fail CI instead of creating silently empty Application names. Fleet **GitRepo** paths should separate `baseline/`, `security/`, and `apps/` directories with independent `fleet.yaml` files so a broken application chart does not block monitoring agent rollout. Karmada **PropagationPolicy** `resourceSelectors` must be narrow enough that system namespaces are not accidentally propagated; OCM **ManifestWorkReplicaSet** status fields should feed the same compliance dashboard Kyverno policy reports use.
+Argo CD ApplicationSet **generators** deserve explicit runbook coverage: the **List** generator iterates over a static set of items (typically used for stable cluster lists or environments); the **Cluster** generator watches registered cluster secrets; the **Git** generator scans repository directories; the **Matrix** generator multiplies two generator outputs—useful for monorepo platform charts times production clusters. Enable `goTemplate: true` with `missingkey=error` so template typos fail CI instead of creating silently empty Application names. Fleet **GitRepo** paths should separate `baseline/`, `security/`, and `apps/` directories with independent `fleet.yaml` files so a broken application chart does not block monitoring agent rollout. Karmada **PropagationPolicy** `resourceSelectors` must be narrow enough that system namespaces are not accidentally propagated; OCM **ManifestWorkReplicaSet** status fields should feed the same compliance dashboard Kyverno policy reports use.
 
 ---
 
@@ -363,7 +365,7 @@ New cluster provisioning, fleet sync, centralized policy placement, and metrics 
 
 ## Hands-On Exercises
 
-These exercises practice synthesis concepts with `kind`, `kubectl`, and local YAML validation. Commands use the full `kubectl` name. Together they map **management-cluster architecture**, **fleet object contracts**, and **observability label discipline** without requiring a full private cloud lab.
+These exercises practice synthesis concepts with `kind`, `kubectl`, Docker (for the Cluster API Docker infrastructure provider), and local YAML validation. Commands use the full `kubectl` name. Exercise 2 requires **PyYAML** via the repo virtualenv at `.venv/bin/python` (if running outside the repo, `pip install pyyaml`). Together they map **management-cluster architecture**, **fleet object contracts**, and **observability label discipline** without requiring a full private cloud lab.
 
 ### Exercise 1: Stand up a local management cluster and Cluster API providers
 
@@ -371,7 +373,9 @@ These exercises practice synthesis concepts with `kind`, `kubectl`, and local YA
 kind create cluster --name mgmt-synthesis
 kubectl cluster-info --context kind-mgmt-synthesis
 
-curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.1/clusterctl-linux-amd64 -o /tmp/clusterctl
+OS=$(uname | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+curl -sL "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.5/clusterctl-${OS}-${ARCH}" -o /tmp/clusterctl
 chmod +x /tmp/clusterctl
 /tmp/clusterctl init --infrastructure docker
 
@@ -438,18 +442,18 @@ spec:
         - prod-eu-1
         - prod-eu-2
 EOF
-python3 -c "import yaml; yaml.safe_load(open('/tmp/fleet-synthesis/appset.yaml'))" && echo "ApplicationSet OK"
-python3 -c "import yaml; yaml.safe_load(open('/tmp/fleet-synthesis/propagation.yaml'))" && echo "PropagationPolicy OK"
+.venv/bin/python -c "import yaml; yaml.safe_load(open('/tmp/fleet-synthesis/appset.yaml'))" && echo "ApplicationSet OK"
+.venv/bin/python -c "import yaml; yaml.safe_load(open('/tmp/fleet-synthesis/propagation.yaml'))" && echo "PropagationPolicy OK"
 grep -E 'generators:|clusterAffinity:' /tmp/fleet-synthesis/appset.yaml /tmp/fleet-synthesis/propagation.yaml
 ```
 
-- [ ] Both YAML files parse with local `python3` validation.
+- [ ] Both YAML files parse with `.venv/bin/python` validation.
 - [ ] ApplicationSet uses a Cluster generator with label selector `env: production`.
 - [ ] PropagationPolicy names explicit member clusters under `placement.clusterAffinity`.
 
 <details><summary>Expected analysis</summary>
 
-ApplicationSets push Applications to registered clusters—network must allow hub-to-spoke access. Karmada PropagationPolicy creates ResourceBindings on member clusters; override policies would patch image mirrors per site. OCM equivalents use Placement plus ManifestWorkReplicaSet instead of PropagationPolicy.
+ApplicationSets push Applications to registered clusters—network must allow hub-to-spoke access. Karmada PropagationPolicy creates a ResourceBinding **in the Karmada control plane** that records placement; the actual propagated resources land in the member clusters. Override policies would patch image mirrors per site. OCM equivalents use Placement plus ManifestWorkReplicaSet instead of PropagationPolicy.
 
 </details>
 


### PR DESCRIPTION
## Summary

- T0 rewrite of Module 5.7 as the On-Premises Multi-Cluster track capstone, synthesizing Modules 5.1–5.6 into one operational story.
- Covers reference architecture (management + N workload clusters), provisioning paths (CAPI/Metal3, kubeadm/Ansible, Gardener, vendor distros), fleet tools (ApplicationSets, Fleet, Karmada, OCM), networking (Submariner Lighthouse, Cilium ClusterMesh, Istio), identity (OIDC + SPIFFE/SPIRE), secrets (ESO, Sealed Secrets, Vault Agent), observability fan-in (Thanos, Mimir, VictoriaMetrics), coordinated upgrades, and fleet DR.
- Verifier: `passed=true`, `tier=T0` (5002 body words, 8 quiz items, 3 hands-on exercises, 2 mermaid diagrams, 19 reachable sources).

**Author:** composer-2.5 via cursor-agent

## Test plan

- [x] `.venv/bin/python scripts/quality/verify_module.py src/content/docs/on-premises/multi-cluster/module-5.7-multi-cluster-on-prem.md` → `passed=true`, `tier=T0`
- [x] `npm run build` from primary checkout (exit 0, 2079 pages)
- [x] No source H1 in body; full `kubectl` in shell blocks (no `k` alias)
- [x] Bare URLs in bash fences; 19 Sources URLs curl-checked via verifier
- [ ] Cross-family review (Gemini or Claude) before merge

## Learner check quote

> **Pause and predict**: your fleet provisions clusters successfully, but executives still see empty global dashboards during incidents. Which three layers would you inspect—in order—and why? Start with observability fan-in labels and remote-write paths from spokes to Thanos Receive or Mimir distributors, because missing `cluster` labels break queries even when Prometheus runs locally. Next verify management-cluster registration and fleet agent health so baselines actually deploy metrics agents. Finally confirm network paths allow remote write from factory VLANs; GitOps may be green while metrics never reach the hub.


Made with [Cursor](https://cursor.com)