### PR TITLE
feat(content): T0 rewrite — On-Premises Cross-Cluster Networking (#197)

### DIFF
--- a/src/content/docs/on-premises/networking/module-3.5-cross-cluster-networking.md
+++ b/src/content/docs/on-premises/networking/module-3.5-cross-cluster-networking.md
@@ -32,7 +32,7 @@ This module teaches the full stack: MCS as the Kubernetes-native discovery contr
 ## Did You Know
 
 - The MCS API defines `ServiceExport` and `ServiceImport` objects but does not implement packet forwarding; you still need Submariner, Cilium ClusterMesh, or another datapath.
-- Submariner Lighthouse publishes exported services under `svc.clusterset.local`, while pod-level headless exports use `pod.namespace.svc.clusterset.local` naming rules from the MCS specification.
+- MCS DNS (KEP-1645) uses `<service>.<namespace>.svc.clusterset.local` for endpoint sets; named headless endpoints use `<hostname>.<clusterid>.<service>.<namespace>.svc.clusterset.local`.
 - Cilium Cluster Mesh defaults to KVStoreMesh in recent releases to scale endpoint synchronization, but every cluster in the mesh must agree on `maxConnectedClusters` at install time.
 - Istio primary-primary installs require reciprocal remote secrets so each control plane can discover endpoints in peer clusters on the same `network`.
 
@@ -68,7 +68,7 @@ flowchart LR
 
 Encryption is handled by Submariner’s cable drivers. **IPsec** (Libreswan) and **WireGuard** are the common choices on bare metal. IPsec introduces IKE negotiation phases; misaligned lifetimes can cause brief outages during rekey that look like application instability. WireGuard is stateless at the session layer relative to IKE and is often preferred when operators want predictable failover behavior, at the cost of distributing keys through Submariner’s own control plane.
 
-**Lighthouse** implements MCS-oriented [service discovery](https://submariner.io/getting-started/architecture/service-discovery/). When you create a `ServiceExport`, Lighthouse advertises the service to the cluster set. Imported services are reachable at `service.namespace.svc.clusterset.local`. For headless services, individual pods can be addressed with `pod.service.namespace.svc.clusterset.local` when names satisfy DNS label rules. Lighthouse integrates with CoreDNS through a multicluster plugin so queries for `clusterset.local` forward to Lighthouse rather than looping inside a single cluster’s stub domains.
+**Lighthouse** implements MCS-oriented [service discovery](https://submariner.io/getting-started/architecture/service-discovery/). When you create a `ServiceExport`, Lighthouse advertises the service to the cluster set. Imported services are reachable at `service.namespace.svc.clusterset.local` (KEP-1645 endpoint-set form). For headless services, individual pods use the named endpoint form `hostname.clusterid.service.namespace.svc.clusterset.local` when names satisfy DNS label rules. Lighthouse integrates with CoreDNS through a multicluster plugin so queries for `clusterset.local` forward to Lighthouse rather than looping inside a single cluster’s stub domains.
 
 Submariner’s optional **Globalnet** controller matters on bare metal because many clusters were built with identical default pod CIDRs. Cilium Cluster Mesh refuses overlapping pod ranges; Submariner can NAT overlapping spaces when Globalnet is enabled. The tradeoff is gateway concentration: all cross-cluster traffic hairpins through gateway nodes, which can become throughput bottlenecks and SNAT port exhaustion points under heavy microservice chatter. Plan sysctl tuning for `net.ipv4.ip_local_port_range` and conntrack limits on gateways when you expect high connection churn.
 
@@ -456,7 +456,7 @@ kind create cluster --name cm-cluster2 --image kindest/node:v1.35.1 --config /tm
 ```
 
 ```bash
-cilium install --version 1.16.5 --context kind-cm-cluster1 \
+cilium install --version 1.19.4 --context kind-cm-cluster1 \
   --set cluster.name=cm-cluster1 \
   --set cluster.id=1 \
   --set ipam.operator.clusterPoolIPv4PodCIDRList=10.10.0.0/16 \
@@ -464,7 +464,7 @@ cilium install --version 1.16.5 --context kind-cm-cluster1 \
   --set encryption.type=wireguard \
   --set clustermesh.useAPIServer=true
 
-cilium install --version 1.16.5 --context kind-cm-cluster2 \
+cilium install --version 1.19.4 --context kind-cm-cluster2 \
   --set cluster.name=cm-cluster2 \
   --set cluster.id=2 \
   --set ipam.operator.clusterPoolIPv4PodCIDRList=10.20.0.0/16 \
@@ -488,7 +488,13 @@ cilium clustermesh status --context kind-cm-cluster1 --wait
 ```bash
 kubectl --context kind-cm-cluster2 create deployment nginx --image=nginx:1.27-alpine
 kubectl --context kind-cm-cluster2 expose deployment nginx --port=80
-kubectl --context kind-cm-cluster2 annotate service nginx io.cilium/global-service=true
+kubectl --context kind-cm-cluster2 annotate service nginx service.cilium.io/global="true"
+
+# Cluster Mesh global services require the same Service name/namespace in every
+# cluster. A stub Service in cluster 1 (no matching pods) still enables DNS and
+# cross-cluster load-balancing to backends in cluster 2.
+kubectl --context kind-cm-cluster1 create service clusterip nginx --tcp-port=80:80
+kubectl --context kind-cm-cluster1 annotate service nginx service.cilium.io/global="true"
 
 kubectl --context kind-cm-cluster1 run netshoot --image=nicolaka/netshoot --restart=Never -- sleep infinity
 kubectl --context kind-cm-cluster1 wait --for=condition=Ready pod/netshoot --timeout=120s
@@ -497,7 +503,7 @@ kubectl --context kind-cm-cluster2 wait --for=condition=Ready pod -l app=nginx -
 kubectl --context kind-cm-cluster1 exec netshoot -- curl -sS --max-time 10 http://nginx.default.svc.cluster.local
 ```
 
-Expected output: the curl command returns nginx HTML from cluster two while the client pod runs in cluster one. If it times out, run `cilium clustermesh status --context kind-cm-cluster1` and confirm remote nodes show connected before debugging DNS.
+Expected output: the curl command returns nginx HTML from cluster two while the client pod runs in cluster one. Cilium ClusterMesh global services need an identically named `Service` in each connected cluster (selector mismatches on a stub cluster are fine). Without the cluster-1 stub, CoreDNS returns NXDOMAIN for `nginx.default.svc.cluster.local` before Cilium can load-balance. If curl times out, run `cilium clustermesh status --context kind-cm-cluster1` and confirm remote nodes show connected before debugging DNS.
 
 ### Exercise 2: CoreDNS ndots and search paths
 
@@ -519,7 +525,7 @@ Expected output: `resolv.conf` lists `ndots:5` and search domains ending in `svc
 ### Exercise 3: MTU sizing across Cluster Mesh
 
 ```bash
-NGINX_POD=$(kubectl --context kind-cm-cluster2 get pod -l app=nginx -o jsonpath='{.items[0].metadata.status.podIP}')
+NGINX_POD=$(kubectl --context kind-cm-cluster2 get pod -l app=nginx -o jsonpath='{.items[0].status.podIP}')
 kubectl --context kind-cm-cluster1 exec netshoot -- ping -c 2 -M do -s 1472 "${NGINX_POD}"
 kubectl --context kind-cm-cluster1 exec netshoot -- ping -c 2 -M do -s 1400 "${NGINX_POD}"
 kubectl --context kind-cm-cluster1 exec netshoot -- ping -c 2 -M do -s 1200 "${NGINX_POD}"

--- a/src/content/docs/on-premises/networking/module-3.5-cross-cluster-networking.md
+++ b/src/content/docs/on-premises/networking/module-3.5-cross-cluster-networking.md
@@ -99,7 +99,7 @@ Prerequisites are strict on bare metal. All clusters must use the same datapath 
 
 Each cluster needs a unique `cluster.name` and numeric `cluster.id` (1–255 by default, up to 511 with `maxConnectedClusters`). Security identities embed cluster bits; changing IDs on live clusters requires workload restarts. **KVStoreMesh** is enabled by default in modern Cilium releases to reduce etcd load when synchronizing remote endpoints. All clusters must agree on `maxConnectedClusters`; changing it after installation is unsupported and can break policy enforcement.
 
-Cilium implements MCS and also supports **global services** via annotations such as `io.cilium/global-service: "true"` for deployments that predate full MCS controllers. For service IP planning, Cluster Mesh distinguishes configurations where **cluster-local service IPs may overlap** versus designs that require globally unique service CIDR planning. Overlapping service IPs are workable inside Cilium’s logical service mapping because resolution combines cluster ID with service identity in the eBPF datapath, but overlapping **pod** CIDRs remain invalid. This asymmetry trips teams migrating from Submariner Globalnet: pod overlap still requires redesign or NAT.
+Cilium implements MCS and also supports **global services** for cross-cluster load balancing when exports must work outside strict MCS import paths. For service IP planning, Cluster Mesh distinguishes configurations where **cluster-local service IPs may overlap** versus designs that require globally unique service CIDR planning. Overlapping service IPs are workable inside Cilium’s logical service mapping because resolution combines cluster ID with service identity in the eBPF datapath, but overlapping **pod** CIDRs remain invalid. This asymmetry trips teams migrating from Submariner Globalnet: pod overlap still requires redesign or NAT.
 
 Identity propagation is the hidden advantage. Network policies reference numeric identities that Cilium maps to labels. When Cluster Mesh is enabled, remote endpoints receive cluster-scoped identities so policies written in cluster A can reference labels on pods in cluster B without flattening Kubernetes RBAC boundaries. The cost is operational: you must protect clustermesh API servers, rotate Cluster Mesh certificates, and monitor clustermesh connectivity with `cilium clustermesh status` during upgrades.
 
@@ -125,7 +125,7 @@ Linkerd extends automatic mTLS across clusters. Gateways reject connections that
 
 Kubernetes pod DNS configuration is documented in [DNS for Services and Pods](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/). Each pod receives a resolver configuration with `ndots:5` and search domains such as `default.svc.cluster.local`, `svc.cluster.local`, and `cluster.local`. When an application requests `api`, the resolver tries `api.default.svc.cluster.local` before treating the name as fully qualified. That behavior prevents accidental leakage of short names but increases query volume.
 
-Cross-cluster names such as `payment.svc.clusterset.local` are fully qualified and bypass excessive search expansion when written with a trailing dot or enough dots to exceed the `ndots` threshold. Operational mistakes happen when developers use partial names like `payment.clusterset.local` without understanding search order, or when operators add a `forward . /etc/resolv.conf` stub that captures `clusterset.local` and forwards it upstream to corporate DNS that knows nothing about Kubernetes exports.
+Cross-cluster names such as `payment.default.svc.clusterset.local` are fully qualified and bypass excessive search expansion when written with a trailing dot or enough dots to exceed the `ndots` threshold. Operational mistakes happen when developers use partial names like `payment.clusterset.local` without understanding search order, or when operators add a `forward . /etc/resolv.conf` stub that captures `clusterset.local` and forwards it upstream to corporate DNS that knows nothing about Kubernetes exports.
 
 Lighthouse and MCS controllers typically install CoreDNS **stub domains** or plugins that route only `clusterset.local` to the multicluster resolver. The anti-pattern is reciprocal forwarding between two clusters’ CoreDNS deployments, which creates resolution loops and CPU spikes. Scope forwarding narrowly, log `SERVFAIL` and `NXDOMAIN` rates per zone, and teach application teams to log the exact name they requested when opening incidents.
 
@@ -493,7 +493,7 @@ kubectl --context kind-cm-cluster2 annotate service nginx service.cilium.io/glob
 # Cluster Mesh global services require the same Service name/namespace in every
 # cluster. A stub Service in cluster 1 (no matching pods) still enables DNS and
 # cross-cluster load-balancing to backends in cluster 2.
-kubectl --context kind-cm-cluster1 create service clusterip nginx --tcp-port=80:80
+kubectl --context kind-cm-cluster1 create service clusterip nginx --tcp=80:80
 kubectl --context kind-cm-cluster1 annotate service nginx service.cilium.io/global="true"
 
 kubectl --context kind-cm-cluster1 run netshoot --image=nicolaka/netshoot --restart=Never -- sleep infinity

--- a/src/content/docs/on-premises/networking/module-3.5-cross-cluster-networking.md
+++ b/src/content/docs/on-premises/networking/module-3.5-cross-cluster-networking.md
@@ -1,335 +1,565 @@
 ---
-revision_pending: true
-title: "Cross-Cluster Networking"
-description: "East-west traffic routing, service discovery, and encrypted tunnels across bare metal Kubernetes clusters."
+title: "Module 3.5: Cross-Cluster Networking"
+description: "East-west routing, MCS service discovery, encrypted tunnels, and mesh-based multicluster patterns for bare-metal Kubernetes."
 slug: on-premises/networking/module-3.5-cross-cluster-networking
+revision_pending: false
 sidebar:
   order: 35
 ---
 
-# Cross-Cluster Networking
+> **Complexity**: `[COMPLEX]` | Time: 120 minutes
+>
+> **Prerequisites**: [Module 3.2: BGP & Routing](../module-3.2-bgp-routing/), [Module 3.3: Load Balancing](../module-3.3-load-balancing/), [Module 3.4: DNS & Certificates](../module-3.4-dns-certs/)
 
 ## Learning Outcomes
-- Compare Submariner, Cilium Cluster Mesh, and Liqo for bare-metal cross-cluster connectivity.
-- Calculate and configure optimal MTU/MSS settings for encrypted cross-cluster tunnels.
-- Implement Cilium Cluster Mesh across isolated bare-metal environments.
-- Diagnose cross-cluster service discovery failures using the Multi-Cluster Services (MCS) API.
 
-## The Multi-Cluster Services (MCS) API
+After completing this module, you will be able to:
 
-By design, Kubernetes' networking model is cluster-scoped, giving each pod a unique cluster-wide IP and enabling pod-to-pod communication across nodes within a cluster without mandatory proxy/NAT in the basic model. Only a few Kubernetes networking functions are implemented by core Kubernetes itself; endpoint networking and proxy behavior are mostly provided by optional external components such as CNI/pod network implementations.
+1. **Compare** Submariner Lighthouse, Cilium ClusterMesh, Istio multi-cluster, and Linkerd multicluster datapaths and discovery models on bare metal.
+2. **Configure** Multi-Cluster Services (MCS) `ServiceExport` and `ServiceImport` workflows plus CoreDNS `ndots` behavior for `clusterset.local` resolution.
+3. **Implement** encrypted cross-cluster tunnels with WireGuard or IPsec and validate MTU and MSS settings for overlay overhead.
+4. **Design** BGP-based service exposure across clusters and diagnose split-brain, latency excursion, and asymmetric MTU failure modes.
+5. **Operate** identity federation and mTLS certificate rotation across connected clusters without silent trust breaks.
 
-A Kubernetes Service exposes a stable address for one or more pod backends, while Kubernetes automatically manages EndpointSlice information for those backends. Service types include `ClusterIP`, `NodePort`, and `LoadBalancer` (though Kubernetes itself does not provide a built-in load-balancing component for external load-balanced services). Service DNS records are created for services and pods, allowing services to be discovered by DNS names inside the cluster. However, a pod’s default DNS search list includes its own namespace plus the cluster domain; DNS queries without a namespace are limited to the pod’s namespace.
+## Why This Module Matters
 
-When you need to span multiple clusters, they must first agree on how to discover services across boundaries. You could manually create a Kubernetes Service without selectors to route to external services, including those in other namespaces or clusters. For more advanced ingress, the Gateway API handles cross-namespace references using a `ReferenceGrant` (a CORE conformance-level requirement in the Standard channel since v0.6.0). However, for native east-west service discovery, the Multi-Cluster Services (MCS) API is the standard.
+On public cloud platforms, cross-cluster connectivity is often a managed product: cloud routers, private interconnects, and provider DNS integrations hide the datapath. On bare metal, you own every hop between racks, every tunnel endpoint, every DNS search path, and every certificate trust anchor that allows east-west traffic to flow. A platform team can deploy excellent single-cluster networking and still fail production multicluster rollouts because service discovery, encryption, and routing were designed as separate projects that never met in an integration test.
 
-The MCS API is an extension of the Kubernetes Service across clusters using the concept of Namespace Sameness. It is API-focused and introduces two primary Custom Resource Definitions (CRDs):
+The failure pattern is predictable. Teams export a service with the MCS API, see a `ServiceImport` appear remotely, and assume packets will follow. DNS resolves `payment.default.svc.clusterset.local`, but TCP hangs on large payloads while small health checks succeed. Another team enables Istio primary-primary across two datacenters without aligning `network` IDs, and endpoints leak across clusters in ways that violate data residency. A third team mirrors Linkerd services without rotating issuer credentials together, and gateways accept connections until midnight when mTLS suddenly fails cluster-wide.
 
-1. `ServiceExport`: Created in the exporting cluster to declare a service available globally. It maps a service by name, and can be combined across clusters by namespaced name. This exposes the service in the cluster-set under `svc.clusterset.local`, utilizing per-cluster EndpointSlices.
-2. `ServiceImport`: Created automatically in importing clusters by the MCS controller to represent the remote service.
+This module teaches the full stack: MCS as the Kubernetes-native discovery contract, CNIs and overlays as the datapath, service meshes as optional L7 policy planes, CoreDNS `ndots` as the resolver behavior that makes or breaks cross-cluster names, and operational discipline for MTU, BGP, identity, and certificate rotation. The goal is not to pick a single winner for every environment. The goal is to know which layer owns which failure mode before your incident bridge does.
 
-When a `ServiceExport` is created, the cross-cluster control plane synchronizes the endpoint slices to all participating clusters. A global DNS record (typically `svc.clusterset.local`) is provisioned.
+## Did You Know
 
-> **Stop and think**: If the MCS API defines the standard for service discovery, who is responsible for actually routing the packets between clusters? The MCS API documentation explicitly states it focuses on API and behavior, providing no reference implementation for the datapath. You still need an overlay or CNI to handle the traffic.
+- The MCS API defines `ServiceExport` and `ServiceImport` objects but does not implement packet forwarding; you still need Submariner, Cilium ClusterMesh, or another datapath.
+- Submariner Lighthouse publishes exported services under `svc.clusterset.local`, while pod-level headless exports use `pod.namespace.svc.clusterset.local` naming rules from the MCS specification.
+- Cilium Cluster Mesh defaults to KVStoreMesh in recent releases to scale endpoint synchronization, but every cluster in the mesh must agree on `maxConnectedClusters` at install time.
+- Istio primary-primary installs require reciprocal remote secrets so each control plane can discover endpoints in peer clusters on the same `network`.
 
-:::note
-MCS does not handle the actual datapath routing. It only handles service discovery and endpoint synchronization. You still need an overlay, routing daemon, or CNI to push packets between the nodes of different clusters.
-:::
+## Section 1: Kubernetes networking stops at the cluster boundary
 
-## Datapath Architectures: Cilium vs Submariner vs Liqo
+Kubernetes assigns each pod a cluster-routable IP and expects the CNI to deliver pod-to-pod connectivity inside one cluster. `Service` objects provide stable virtual IPs and DNS names inside that cluster. CoreDNS expands short names using a search list that typically includes `namespace.svc.cluster.local` and `svc.cluster.local`, with `ndots:5` meaning names with fewer than six dots are tried as relative queries first. That behavior is correct for single-cluster operations and confusing the moment you expect `backend` in another cluster to resolve the same way as `backend` locally.
 
-On bare metal, you lack cloud-provider transit gateways. You must build your own encrypted east-west tunnels between cluster nodes.
+Cross-cluster networking therefore has two distinct problems. First, **reachability**: can a packet sourced from a pod IP in cluster A arrive at a pod IP in cluster B without NAT surprises or overlapping CIDR collisions? Second, **discovery**: can a client learn which IP addresses and ports represent a logical service that spans clusters? Confusing these layers produces tickets where “DNS works” but “the database connection stalls,” because DNS returned an address that is not reachable with the configured MTU or policy.
 
-### Cilium Cluster Mesh
+The Multi-Cluster Services (MCS) API, standardized in [KEP-1645](https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api), addresses discovery. A `ServiceExport` in the source cluster signals intent to expose a `Service`. Controllers create `ServiceImport` objects in peer clusters and synchronize `EndpointSlice` data. Clients that understand MCS can consume `clusterset.local` names. Nothing in the MCS API installs tunnels, BGP sessions, or gateway pods. Treat MCS as the contract; treat your CNI, VPN, or mesh as the implementation.
 
-Cilium Cluster Mesh extends networking across connected clusters with pod-to-pod connectivity and full policy enforcement, and offers load-balancing for cross-cluster services. It is the de facto standard if you are already using Cilium as your CNI.
+```mermaid
+flowchart LR
+  subgraph ClusterA["Cluster A"]
+    PodA[Client Pod] --> DNSA[CoreDNS]
+    PodA --> CNIA[CNI datapath]
+    SE[ServiceExport]
+  end
+  subgraph ClusterB["Cluster B"]
+    SI[ServiceImport]
+    PodB[Backend Pod]
+    CNIB[CNI datapath]
+  end
+  DNSA -->|clusterset.local| SI
+  SE -->|endpoint sync| SI
+  CNIA <-->|encrypted tunnel or routed underlay| CNIB
+  CNIB --> PodB
+```
 
-- **Datapath**: eBPF-based VXLAN, Geneve, or direct routing (BGP).
-- **Encryption**: IPsec or WireGuard.
-- **Service Discovery**: Implements the MCS API natively.
-- **Constraint**: Requires consistent datapath mode and non-conflicting PodCIDRs across all participating clusters. Unique human-readable cluster IDs/names must be configured per cluster at install time. By default, it supports 255 connected clusters (or 511 with `maxConnectedClusters`), and this limit must match across clusters and cannot be changed safely on running clusters.
-- **Control Plane**: Uses an internal etcd cluster (kvstore) to synchronize endpoints, or a dedicated Cluster Mesh API server. As of Cilium v1.16, `KVStoreMesh` is enabled by default to optimize scalability when enabling Cluster Mesh.
+## Section 2: Submariner, Lighthouse, and gateway-centric datapaths
+
+[Submariner](https://submariner.io/getting-started/architecture/) connects Kubernetes clusters by flattening networks so pod and service CIDRs become reachable across a cluster set. The [Gateway Engine](https://submariner.io/getting-started/architecture/gateway-engine/) runs on designated gateway nodes and terminates encrypted tunnels to peer clusters. **Route agents** on every node steer cross-cluster traffic toward the active gateway. A **broker** cluster (or dedicated broker deployment) exchanges metadata so gateways discover one another. This architecture is deliberately CNI-agnostic: Flannel, Calico, or other CNIs can remain in place while Submariner adds an overlay for inter-cluster traffic.
+
+Encryption is handled by Submariner’s cable drivers. **IPsec** (Libreswan) and **WireGuard** are the common choices on bare metal. IPsec introduces IKE negotiation phases; misaligned lifetimes can cause brief outages during rekey that look like application instability. WireGuard is stateless at the session layer relative to IKE and is often preferred when operators want predictable failover behavior, at the cost of distributing keys through Submariner’s own control plane.
+
+**Lighthouse** implements MCS-oriented [service discovery](https://submariner.io/getting-started/architecture/service-discovery/). When you create a `ServiceExport`, Lighthouse advertises the service to the cluster set. Imported services are reachable at `service.namespace.svc.clusterset.local`. For headless services, individual pods can be addressed with `pod.service.namespace.svc.clusterset.local` when names satisfy DNS label rules. Lighthouse integrates with CoreDNS through a multicluster plugin so queries for `clusterset.local` forward to Lighthouse rather than looping inside a single cluster’s stub domains.
+
+Submariner’s optional **Globalnet** controller matters on bare metal because many clusters were built with identical default pod CIDRs. Cilium Cluster Mesh refuses overlapping pod ranges; Submariner can NAT overlapping spaces when Globalnet is enabled. The tradeoff is gateway concentration: all cross-cluster traffic hairpins through gateway nodes, which can become throughput bottlenecks and SNAT port exhaustion points under heavy microservice chatter. Plan sysctl tuning for `net.ipv4.ip_local_port_range` and conntrack limits on gateways when you expect high connection churn.
 
 ```mermaid
 graph TD
-    subgraph Cluster A
-        A_Pod1[Pod A] --> A_Cilium[Cilium Agent]
-        A_Cilium --> A_API[Cluster Mesh API]
-    end
-    subgraph Cluster B
-        B_Pod1[Pod B] --> B_Cilium[Cilium Agent]
-        B_Cilium --> B_API[Cluster Mesh API]
-    end
-    A_API <-->|Endpoint Sync| B_API
-    A_Cilium <-->|WireGuard/IPsec Tunnel| B_Cilium
+  subgraph Cluster1
+    P1[Pod] --> RA1[Route Agent]
+    RA1 --> GW1[Active Gateway]
+    GW1 -->|WireGuard or IPsec cable| TUN1[Tunnel]
+  end
+  subgraph Cluster2
+    TUN2[Tunnel] --> GW2[Active Gateway]
+    GW2 --> RA2[Route Agent]
+    RA2 --> P2[Remote Pod]
+  end
+  TUN1 --- TUN2
+  LH[Lighthouse + MCS DNS] -.-> GW1
+  LH -.-> GW2
+  BR[Broker metadata] -.-> GW1
+  BR -.-> GW2
 ```
 
-### Submariner
+## Section 3: Cilium ClusterMesh, eBPF identities, and service IP modes
 
-Submariner is a dedicated cross-cluster networking tool designed to work *alongside* your existing CNI (Flannel, Calico, Weave). It explicitly claims compatibility with all currently-supported Kubernetes versions (where the release policy tracks the three most recent minor branches and 1.19+ receives about 1 year of patch support) and is completely cloud-provider agnostic, with support tested across multiple CNI plugins.
+If Cilium is already your CNI, [Cluster Mesh](https://docs.cilium.io/en/stable/network/clustermesh/clustermesh/) is the native multicluster datapath. Cilium connects clusters with pod-to-pod connectivity, propagates security identities across clusters, and can load-balance global services. Unlike Submariner’s gateway hairpin, Cilium establishes **node-to-node** tunnels (VXLAN, Geneve, or direct routing with BGP) so cross-cluster traffic does not require a central gateway choke point for every flow.
 
-- **Datapath**: Deploys a Gateway Engine pod on a designated gateway node in each cluster. All cross-cluster traffic is routed through these gateways.
-- **Encryption**: IPsec (via Libreswan) or WireGuard.
-- **Service Discovery**: Deploys Lighthouse, its own CoreDNS plugin for cross-cluster resolution.
-- **Constraint**: Gateway nodes can become bottlenecks. Active/Passive high availability is standard, meaning failover takes time.
-- **Advantage**: Quickstart guidance assumes non-overlapping Pod/Service CIDRs by default, but recommends Globalnet when CIDRs overlap. Globalnet dynamically translates overlapping IPs using SNAT/DNAT, allowing connection of clusters with identical IP spaces.
+Prerequisites are strict on bare metal. All clusters must use the same datapath mode. **Pod CIDRs must be unique and non-overlapping** across the entire mesh. Nodes must have IP connectivity on their Kubernetes `InternalIP` addresses, which usually means datacenter routing, EVPN, or site-to-site VPN between facilities. Firewall rules must allow the documented Cluster Mesh ports documented in Cilium [system requirements](https://docs.cilium.io/en/stable/operations/system_requirements/#firewall-requirements).
 
-> **Pause and predict**: If Submariner relies on Gateway Nodes to route traffic across clusters, what happens to cross-cluster traffic if the active Gateway Node fails? Expect a temporary connectivity drop until the passive gateway takes over and re-establishes the tunnels.
+Each cluster needs a unique `cluster.name` and numeric `cluster.id` (1–255 by default, up to 511 with `maxConnectedClusters`). Security identities embed cluster bits; changing IDs on live clusters requires workload restarts. **KVStoreMesh** is enabled by default in modern Cilium releases to reduce etcd load when synchronizing remote endpoints. All clusters must agree on `maxConnectedClusters`; changing it after installation is unsupported and can break policy enforcement.
 
-### Liqo
+Cilium implements MCS and also supports **global services** via annotations such as `io.cilium/global-service: "true"` for deployments that predate full MCS controllers. For service IP planning, Cluster Mesh distinguishes configurations where **cluster-local service IPs may overlap** versus designs that require globally unique service CIDR planning. Overlapping service IPs are workable inside Cilium’s logical service mapping because resolution combines cluster ID with service identity in the eBPF datapath, but overlapping **pod** CIDRs remain invalid. This asymmetry trips teams migrating from Submariner Globalnet: pod overlap still requires redesign or NAT.
 
-Liqo takes a peer-to-peer approach using the "Virtual Node" abstraction.
+Identity propagation is the hidden advantage. Network policies reference numeric identities that Cilium maps to labels. When Cluster Mesh is enabled, remote endpoints receive cluster-scoped identities so policies written in cluster A can reference labels on pods in cluster B without flattening Kubernetes RBAC boundaries. The cost is operational: you must protect clustermesh API servers, rotate Cluster Mesh certificates, and monitor clustermesh connectivity with `cilium clustermesh status` during upgrades.
 
-- **Datapath**: Uses a dynamically established VPN tunnel (WireGuard).
-- **Architecture**: Cluster A registers Cluster B as a `VirtualNode`. Pods scheduled to this `VirtualNode` are actually executed on Cluster B, but appear to be running locally in Cluster A.
-- **Use Case**: Best for multi-cluster compute offloading (bursting) rather than pure service-to-service communication.
+## Section 4: Istio multi-cluster, networks, and ServiceEntry patterns
 
-### Comparison Matrix
+[Istio](https://istio.io/latest/docs/setup/install/multicluster/multi-primary/) multicluster patterns split along two axes: **network** membership and **control plane** topology. A *network* is a routable L3 domain. Clusters on the same network can use pod-to-pod addresses directly if the underlay allows it. Clusters on different networks require east-west gateways that terminate Istio mTLS and re-originate traffic into the remote network. The `network` field in `IstioOperator` values must be consistent for clusters that share L3 connectivity and distinct when they do not.
 
-| Feature | Cilium Cluster Mesh | Submariner | Liqo |
-| :--- | :--- | :--- | :--- |
-| **Primary Use Case** | Native eBPF multi-cluster routing | CNI-agnostic cross-cluster overlay | Compute bursting / offloading |
-| **Datapath bottleneck** | None (Node-to-Node) | Gateway Node | Gateway Node |
-| **Handles Overlapping CIDRs?** | No | Yes (via Globalnet) | Yes (via NAT) |
-| **Encryption** | WireGuard, IPsec | WireGuard, IPsec | WireGuard |
-| **Service Discovery** | Native MCS API | Lighthouse (Custom DNS) | Native Kubernetes Services |
+**Primary-primary** topologies install a full Istio control plane in each cluster. Each primary watches remote Kubernetes APIs via `istioctl create-remote-secret` so endpoint discovery is bidirectional. This model suits active-active application footprints where both clusters schedule workloads and need mutual discovery. **Primary-remote** (not detailed in the install guide above but common in operations) centralizes configuration in one primary while remotes receive only dataplane components; it reduces control-plane overhead but creates a resilience dependency on the primary cluster’s availability.
 
-:::caution
-For bare-metal production environments operating at high throughput, **Cilium Cluster Mesh** is the recommended architecture. Gateway-based approaches (Submariner, Liqo) introduce a single point of failure and a throughput choke point at the gateway node.
-:::
+Cross-cluster service consumption often uses **`ServiceEntry`** and **`WorkloadEntry`**. A `ServiceEntry` declares external or remote hosts and ports that should appear in the mesh routing table. A `WorkloadEntry` registers individual endpoints (VMs or pods outside the local cluster) with addresses and labels so Istio can apply the same mTLS and telemetry as in-cluster workloads. Together they let you model a remote payment API as `payment.global.svc` with explicit endpoint IPs learned from MCS imports or manual operations. Misconfigured `ServiceEntry` resolution—especially mixing DNS resolution modes—produces 503 errors where kube-proxy health looks fine.
 
-## MTU and MSS Considerations
+Istio’s deployment models documentation stresses aligning `meshID`, `clusterName`, and network IDs before enabling cross-cluster secrets. Skipping [before-you-begin](https://istio.io/latest/docs/setup/install/multicluster/before-you-begin/) checks (distinct cluster names, non-overlapping service entries where required, and reachable gateway IPs) is a frequent source of primary-primary installs that appear healthy while cross-network routing blackholes.
 
-Maximum Transmission Unit (MTU) misconfiguration is the leading cause of cross-cluster networking failures. When packets are routed between clusters, they are encapsulated in tunnels. This encapsulation adds overhead. If the resulting packet exceeds the physical network's MTU, it is fragmented or dropped.
+## Section 5: Linkerd multicluster gateways and mirrored services
 
-When standard physical networks use an MTU of 1500 bytes, you must subtract the overhead of your encapsulation and encryption protocols.
+[Linkerd multicluster](https://linkerd.io/2.18/tasks/multicluster/) takes a service-mirroring approach. A **gateway** deployment in the `linkerd-multicluster` namespace exposes a `LoadBalancer` (or NodePort on bare metal) that accepts mTLS connections verified against a **shared trust anchor** across clusters. A **service mirror** controller in the source cluster watches exported services in the target cluster and creates mirrored `Service` objects locally. Endpoints on mirrored services point at the remote gateway IP so application code continues to use familiar `service.namespace` names.
 
-- **VXLAN overhead**: 50 bytes
-- **WireGuard overhead**: 60 bytes (IPv4) / 80 bytes (IPv6)
-- **IPsec overhead**: ~50-73 bytes (depending on crypto suite)
+Export is explicit: services must carry the `mirror.linkerd.io/exported=true` label (or a custom selector configured on the `Link` CR). This prevents accidental exposure of cluster-internal admin services. Linking clusters uses `linkerd multicluster link-gen` to produce credentials secrets and `Link` custom resources that include gateway address and identity. On bare metal, allocate routable gateway IPs with MetalLB or kube-vip before mirroring, because the mirror controller copies remote gateway addresses into local endpoint slices.
 
-### The Blackhole Effect
-If Cluster A sends a 1500-byte packet to Cluster B over a WireGuard tunnel, the tunnel interface must add 60 bytes. The new 1560-byte packet hits the physical NIC (MTU 1500). If the "Don't Fragment" (DF) bit is set (common in modern TCP stacks), the NIC drops the packet and sends an ICMP "Fragmentation Needed" message back. If firewalls drop this ICMP message (Path MTU Discovery failure), the connection hangs indefinitely. This is the MTU Blackhole.
+Linkerd extends automatic mTLS across clusters. Gateways reject connections that do not present certificates signed by the shared trust anchor. **mTLS rotation** therefore becomes a fleet operation: rotate trust anchor and issuer credentials on a documented schedule, distribute secrets to every cluster, and restart gateways before workload certificates expire. Running independent `linkerd install` commands without shared anchors yields meshes that appear linked while gateways silently reject traffic.
 
-### Calculating the Safe MTU
+## Section 6: CoreDNS, ndots, and clusterset.local resolution
 
-To prevent MTU blackholes, configure the CNI MTU explicitly:
+Kubernetes pod DNS configuration is documented in [DNS for Services and Pods](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/). Each pod receives a resolver configuration with `ndots:5` and search domains such as `default.svc.cluster.local`, `svc.cluster.local`, and `cluster.local`. When an application requests `api`, the resolver tries `api.default.svc.cluster.local` before treating the name as fully qualified. That behavior prevents accidental leakage of short names but increases query volume.
 
-```yaml
-# Example: Physical MTU 1500, using Cilium with VXLAN and WireGuard
-# 1500 - 50 (VXLAN) - 60 (WireGuard) = 1390
-cni:
-  mtu: 1390
-```
+Cross-cluster names such as `payment.svc.clusterset.local` are fully qualified and bypass excessive search expansion when written with a trailing dot or enough dots to exceed the `ndots` threshold. Operational mistakes happen when developers use partial names like `payment.clusterset.local` without understanding search order, or when operators add a `forward . /etc/resolv.conf` stub that captures `clusterset.local` and forwards it upstream to corporate DNS that knows nothing about Kubernetes exports.
 
-:::tip
-Always configure TCP Maximum Segment Size (MSS) clamping on your ingress controllers or CNI if you suspect Path MTU Discovery (PMTUD) issues on intermediate bare-metal routers. MSS clamping forces TCP handshakes to negotiate a smaller segment size, bypassing ICMP blackholes entirely.
-:::
+Lighthouse and MCS controllers typically install CoreDNS **stub domains** or plugins that route only `clusterset.local` to the multicluster resolver. The anti-pattern is reciprocal forwarding between two clusters’ CoreDNS deployments, which creates resolution loops and CPU spikes. Scope forwarding narrowly, log `SERVFAIL` and `NXDOMAIN` rates per zone, and teach application teams to log the exact name they requested when opening incidents.
 
-## Dual-Stack Cross-Cluster Routing
+For troubleshooting, deploy a debug pod with `nslookup` or `dig` and compare results for:
 
-Bare metal environments frequently leverage IPv6 for node addressing to avoid RFC1918 IPv4 exhaustion. When implementing cross-cluster networking in a dual-stack environment:
+- `service.namespace.svc.cluster.local` (local cluster only)
+- `service.namespace.svc.clusterset.local` (MCS global name)
+- `service.namespace.svc.clusterset.local.` (FQDN with trailing dot)
 
-1. **Tunnel Endpoints**: The underlay tunnels (WireGuard/IPsec) should ideally be established over IPv6 to avoid NAT traversal complexities between data centers.
-2. **Overlay Addressing**: Ensure Pod and Service CIDRs for both IPv4 and IPv6 do not overlap across clusters.
-3. **MCS Resolution**: `ServiceExport` endpoints will synchronize both A and AAAA records. Ensure your applications are configured with `Happy Eyeballs` (RFC 8305) to gracefully handle cases where cross-cluster IPv4 routing fails but IPv6 succeeds.
+If local resolution works and clusterset fails, the datapath may still be fine while discovery is broken. Fix exports and Lighthouse before touching tunnels.
 
-## Hands-on Lab
+## Section 7: VPN overlays with WireGuard between ingress endpoints
 
-In this lab, we will configure a two-cluster Cilium Cluster Mesh using `kind`. We will simulate a bare-metal environment by explicitly defining non-overlapping CIDRs and establishing a WireGuard tunnel between the clusters.
+Not every organization adopts a full multicluster CNI. A pragmatic bare-metal pattern connects **site ingress nodes** or **border gateways** with **WireGuard** tunnels, then advertises remote pod or service CIDRs with static routes or BGP. The [WireGuard quick start](https://www.wireguard.com/quickstart/) model applies: each site has a UDP port, public keys distributed through configuration management, and `AllowedIPs` listing remote CIDRs. Kubernetes nodes do not need to terminate WireGuard individually if the underlay already routes remote pod CIDRs to a gateway pair.
 
-### Prerequisites
-- `kind` installed.
-- `cilium` CLI installed.
-- Docker or Podman.
+This design trades automation for control. You must keep `AllowedIPs` updated when pod CIDRs expand, rotate keys without dropping all tunnels simultaneously, and ensure MSS clamping on tunnel interfaces. WireGuard adds encapsulation overhead (commonly 60 bytes for IPv4), which feeds directly into the MTU math in Section 8. When WireGuard terminates on ingress nodes rather than on every node, SNAT may still occur at the boundary; document whether return traffic is symmetric.
 
-### Step 1: Create the Clusters
+Combine WireGuard with **[MetalLB BGP mode](https://metallb.universe.tf/concepts/bgp/)** when you need remote clusters to attract service IPs. MetalLB speakers on cluster A can advertise a `LoadBalancer` VIP into datacenter BGP; cluster B learns the route across the WireGuard tunnel if the VIP lives in an allowed prefix. Policy must filter which communities may cross site boundaries so you do not leak internal service IPs into the public Internet routing table.
 
-Create two `kind` clusters with explicitly non-overlapping Pod and Service CIDRs.
+## Section 8: BGP-based service exposure across clusters
+
+Module 3.2 established BGP fundamentals for pod and service advertisement on a single cluster. Multicluster BGP extends the idea: treat remote cluster service CIDRs or `/32` host routes as learned prefixes with explicit community tags marking origin cluster. On bare metal, this is how teams expose `LoadBalancer` VIPs from multiple clusters to a shared spine without merging Kubernetes control planes.
+
+Design rules that survive audits:
+
+- Tag advertisements with **BGP communities** identifying `cluster-id` and `service-type`.
+- Never redistribute overlapping pod CIDRs without a NAT boundary; BGP will happily install ambiguous paths.
+- Use **BFD** on inter-site links when failover must beat Kubernetes endpoint propagation delay.
+- Separate **internal service VIP pools** per cluster when policy requires deterministic return paths.
+
+When MCS exports synchronize endpoints but BGP does not advertise the correct next hop, symptoms look like asymmetric routing: SYN reaches the backend, return path exits through a different site with a firewall rule that drops established flows.
+
+## Section 9: MTU, MSS, and asymmetric path failures
+
+Encapsulation stacks subtract from the physical MTU. A 1500-byte Ethernet MTU with VXLAN (50 bytes) and WireGuard (60 bytes) leaves roughly 1390 bytes safe payload before fragmentation. IPsec overhead varies with cipher suites but is often similar. TCP may set DF; if ICMP “Fragmentation Needed” is filtered, you get an **MTU blackhole**: small pings succeed, large TLS or database frames hang.
+
+Mitigations include lowering CNI interface MTU, enabling **TCP MSS clamping** on tunnel ingress, and validating end-to-end with `ping -M do -s <size>` between pod networks on both sides of the tunnel. **Asymmetric MTU** environments—jumbo frames inside one datacenter, 1500-byte Internet VPN outside—produce failures that appear only for cross-site flows. Document MTU per segment on the network diagram and test from application pods, not only from jump hosts.
+
+Latency excursions are separate from blackholes. Gateway-based designs add extra hops; cross-country RTT dominates service SLOs once connectivity is “up.” Measure TCP connect time and TLS handshake time separately from ICMP RTT when triaging multicluster incidents.
+
+## Section 10: Failure modes — split brain, latency, and control-plane partition
+
+**Split brain** in multicluster networking usually means two active gateways or two brokers believe they own routing authority. Submariner gateway failover is active/passive; if both gateways forward, duplicate or asymmetric paths may appear. Istio multicluster split brain manifests as divergent endpoint sets when remote secrets stop updating but old endpoints remain cached. Linkerd mirror controllers may continue pointing to a stale gateway IP after MetalLB reallocates a VIP.
+
+**Latency excursion** often tracks gateway CPU, tunnel reordering, or sudden cross-site traffic shifts after a failover event. Compare direct Cilium node paths versus Submariner gateway paths when deciding architecture for latency-sensitive workloads.
+
+**Control-plane partition** separates clusters while tunnels remain partially up. MCS may stop updating `EndpointSlice` objects while connections to old IPs still work until timeouts clear. Monitor export conditions on `ServiceExport` resources and clustermesh connection health independently.
+
+## Section 11: Identity federation and mTLS rotation across clusters
+
+Service meshes and zero-trust designs require a **shared root of trust** or federated SPIFFE trust bundles. Linkerd explicitly requires the same trust anchor across linked clusters. Istio uses mesh-wide CA configuration; rotating Citadel or external CA credentials without rolling data plane proxies causes hard TLS failures. Cilium Cluster Mesh ships its own CA secrets for clustermesh-apiserver; copy `cilium-ca` only through controlled procedures documented upstream.
+
+Operational checklist for rotation without outage:
+
+1. Generate new issuer credentials before expiry.
+2. Distribute secrets to all clusters in the mesh.
+3. Roll data plane components (gateways first, then workloads).
+4. Validate cross-cluster probes with explicit SNI and certificate inspection.
+5. Remove old CA only after dual-trust windows end.
+
+Treat **identity federation** as a fleet process, not a per-cluster ticket. The same team that owns DNS search paths should own trust bundle distribution, or exports will resolve while TLS fails with inscrutable `CERTIFICATE_VERIFY_FAILED` messages in application logs.
+
+## Section 12: Architecture selection for bare-metal multicluster
+
+Choosing a cross-cluster stack is an exercise in constraints, not brand preference. Start from non-negotiable inputs: Are pod CIDRs unique? Is full pod-to-pod routing required, or is gateway-based NAT acceptable? Must applications keep using plain Kubernetes `Service` DNS without sidecars? Does security mandate L7 policy and mTLS at the application layer, or is encrypted CNI transport sufficient? Answers map cleanly to component classes.
+
+When pod CIDRs overlap because clusters were cloned from the same `kubeadm` template, **Submariner Globalnet** or full re-IP is mandatory before Cilium Cluster Mesh can work. When Cilium is already standard and CIDRs are planned, **Cluster Mesh** offers the best throughput story because it avoids gateway hairpins. When teams already run **Istio** for L7 policy, adding primary-primary multicluster may be cheaper than introducing a second overlay, provided network IDs and east-west gateways match real routing. When minimalism matters and only a few services cross clusters, **Linkerd mirroring** with explicit export labels reduces accidental exposure.
+
+| Requirement | Strong fit | Caveat |
+|-------------|------------|--------|
+| Overlapping pod CIDRs | Submariner + Globalnet | Gateway throughput and SNAT limits |
+| eBPF policy across clusters | Cilium Cluster Mesh | Non-overlapping CIDRs; clustermesh API HA |
+| L7 policy + multicluster | Istio multi-primary or remote | Control-plane coupling; gateway IPs on bare metal |
+| Minimal app changes + mTLS | Linkerd multicluster | Shared trust anchor operations |
+| Standards-based discovery only | MCS + your datapath | MCS does not forward packets |
+| Site-to-site without CNI swap | WireGuard + BGP (MetalLB) | Manual CIDR and key lifecycle |
+
+Hybrid designs are common and valid. A platform team might run Cilium Cluster Mesh for pod connectivity, Istio for L7 policy on edge services, and MCS `ServiceExport` objects as the discovery contract visible to application developers. The failure mode to avoid is two unrelated overlays fighting for the same routes—document which component owns default routes to remote pod CIDRs and which owns service VIP advertisement.
+
+## Section 13: MCS export and import lifecycle in operations
+
+Day-two operations for MCS begin with namespace sameness decisions inside a **cluster set**. Namespaces with the same name in different clusters are treated as the same logical namespace for export semantics. If cluster B lacks `payments`, an export from cluster A may never materialize a healthy `ServiceImport` in B. Platform teams should codify namespace creation in GitOps templates so multicluster consumers do not chase missing namespaces during incidents.
+
+Creating a `ServiceExport` is a deliberate user action—controllers do not auto-export every `Service`. After export, inspect conditions:
 
 ```bash
-# Cluster 1 Configuration
-cat <<EOF > cluster1.yaml
-kind: Cluster
-apiVersion: kind.x-k8s.io/v1alpha4
-name: cluster1
-networking:
-  disableDefaultCNI: true
-  podSubnet: "10.10.0.0/16"
-  serviceSubnet: "10.11.0.0/16"
-EOF
-
-# Cluster 2 Configuration
-cat <<EOF > cluster2.yaml
-kind: Cluster
-apiVersion: kind.x-k8s.io/v1alpha4
-name: cluster2
-networking:
-  disableDefaultCNI: true
-  podSubnet: "10.20.0.0/16"
-  serviceSubnet: "10.21.0.0/16"
-EOF
-
-kind create cluster --config cluster1.yaml
-kind create cluster --config cluster2.yaml
+kubectl get serviceexport payment -n payments -o yaml
+kubectl get serviceimport -A | grep payment
+kubectl get endpointslice -n payments -l kubernetes.io/service-name=payment
 ```
 
-### Step 2: Install Cilium with Cluster Mesh Enabled
+A `Conflict` condition often indicates two clusters exported differently named backends that collided in the clusterset aggregate. A missing `Valid` condition with empty endpoints usually means selectors mismatch pods, not that tunnels failed. Train application on-call engineers to capture these three commands before escalating to networking.
 
-Install Cilium on both clusters, configuring the cluster name and ID. We enable WireGuard for encryption.
+For headless services, document per-pod DNS expectations under MCS. StatefulSets exported headlessly expose pod DNS names that include the pod name label. Clients must use those names when they need direct pod affinity; clusterIP-style virtual IPs are not in play. This matters for stateful middleware that pins to pod identity during rolling upgrades across clusters.
 
-```bash
-# Install on Cluster 1
-cilium install \
-  --context kind-cluster1 \
-  --set cluster.name=cluster1 \
-  --set cluster.id=1 \
-  --set ipam.operator.clusterPoolIPv4PodCIDRList="10.10.0.0/16" \
-  --set l7Proxy=false \
-  --set encryption.enabled=true \
-  --set encryption.type=wireguard \
-  --set clustermesh.useAPIServer=true
+## Section 14: Submariner broker placement and gateway operations
 
-# Install on Cluster 2
-cilium install \
-  --context kind-cluster2 \
-  --set cluster.name=cluster2 \
-  --set cluster.id=2 \
-  --set ipam.operator.clusterPoolIPv4PodCIDRList="10.20.0.0/16" \
-  --set l7Proxy=false \
-  --set encryption.enabled=true \
-  --set encryption.type=wireguard \
-  --set clustermesh.useAPIServer=true
-```
+The Submariner [broker](https://submariner.io/getting-started/architecture/) holds cluster metadata and credentials used by gateways. It can run on a dedicated management cluster or inside one member cluster with restricted RBAC. Broker loss does not immediately drop established tunnels, but new gateways cannot discover peers, which blocks recovery after gateway node drains. Run the broker on a stable cluster with etcd backups and monitor its API like any other control plane.
 
-Verify Cilium is running:
-```bash
-cilium status --context kind-cluster1 --wait
-```
+Gateway node selection should follow bare-metal constraints: nodes with stable north-south connectivity, sufficient CPU for encryption, and labels that exclude them from arbitrary batch workloads. When the active gateway fails, passive takeover introduces a brief window where conntrack entries and ARP caches on switches must converge. Schedule gateway maintenance with cordon and drain on the gateway node itself—never scale a Deployment to zero replicas on gateway nodes as a substitute for `kubectl cordon` and controlled failover.
 
-### Step 3: Enable Cluster Mesh and Connect
+Use `subctl` diagnostics in addition to Kubernetes events. Verify cable driver status, NAT rules when Globalnet is enabled, and Lighthouse DNS plugin health. The [kind quickstart](https://submariner.io/getting-started/quickstart/kind/) is valuable for learning broker and join semantics even when production runs on bare metal with routed underlays.
 
-Enable the Cluster Mesh API on both clusters and connect them.
+## Section 15: Istio multi-network east-west gateways
 
-```bash
-cilium clustermesh enable --context kind-cluster1 --service-type NodePort
-cilium clustermesh enable --context kind-cluster2 --service-type NodePort
+When clusters live on different L3 networks, Istio expects **east-west gateways** that terminate mesh mTLS and forward to remote networks. The gateway deployment is not the same as an ingress gateway facing users; it is a dedicated path for pod-to-pod mesh traffic crossing network boundaries. On bare metal, expose gateway Services with MetalLB or kube-vip and ensure corporate firewalls allow the Istio discovery ports and tunnel protocols you enable.
 
-cilium clustermesh status --context kind-cluster1 --wait
-cilium clustermesh status --context kind-cluster2 --wait
+`ServiceEntry` objects represent external hosts. For multicluster, hosts may be public DNS names, private VIPs, or clusterset names depending on integration. Choose `resolution: DNS` when addresses change dynamically; choose `STATIC` endpoints when importing MCS slices into Istio manually. **`WorkloadEntry`** registers out-of-cluster endpoints with labels so policies attach consistently. A frequent mistake is creating `ServiceEntry` without matching sidecar injection labels on clients, leaving traffic on plain kube-proxy paths that bypass intended policy.
 
-# Connect the clusters
-cilium clustermesh connect \
-  --context kind-cluster1 \
-  --destination-context kind-cluster2
-```
+Primary-remote topologies reduce duplicated control planes but concentrate risk. If the primary cluster suffers regional loss, remotes may continue running workloads yet lose configuration updates. Document whether remotes can operate with last-known config and for how long. Primary-primary trades operational cost for resilience; both patterns are supported, but bare-metal teams often underestimate certificate and secret distribution work across all primaries.
 
-Wait for the connection to establish:
-```bash
-cilium clustermesh status --context kind-cluster1
-# Expected output includes:
-# 🔌 Cluster Connections:
-# - cluster2: 1/1 configured, 1/1 connected
-```
+## Section 16: Linkerd mirroring, TrafficSplit, and failover drills
 
-### Step 4: Verify Cross-Cluster Routing
+After mirroring, services appear locally with suffixed names (for example `podinfo-east`). Applications must target mirrored names or use `TrafficSplit` to weight between local and remote backends. Failover drills should measure how quickly weights shift without code changes. Combine mirroring with PodDisruptionBudgets on gateway nodes so maintenance does not remove the only path to a remote cluster.
 
-Deploy a test service in Cluster 2 and access it from Cluster 1. We use the global service annotation `io.cilium/global-service: "true"` (Cilium's legacy implementation of MCS concepts, still widely used for simple deployments).
+Gateway identity is embedded in `Link` resources. If MetalLB reassigns a gateway IP, regenerate links or update endpoint slices before applications time out. Run multicluster checks after every platform upgrade: `linkerd multicluster check` and gateway stat commands validate trust, not just pod readiness.
 
-```bash
-# Deploy Nginx in Cluster 2
-kubectl --context kind-cluster2 create deployment nginx --image=nginx
-kubectl --context kind-cluster2 expose deployment nginx --port=80
+## Section 17: WireGuard operations between ingress pairs
 
-# Annotate the service to make it global
-kubectl --context kind-cluster2 annotate service nginx \
-  io.cilium/global-service="true"
+For WireGuard between ingress pairs, maintain infrastructure-as-code for `AllowedIPs` that lists every remote pod and service CIDR. When a cluster expands, update both ends before scheduling pods in the new range. Key rotation should use overlapping validity windows: bring up tunnels with new keys, migrate traffic, retire old keys. Monitor UDP encapsulation drops on firewalls that treat long-lived UDP as idle.
 
-# Deploy a client pod in Cluster 1
-kubectl --context kind-cluster1 run curl --image=curlimages/curl -- sleep infinity
+Pair WireGuard with MSS clamping on the tunnel interface. Many Linux distributions do not clamp automatically. nftables or iptables rules can clamp SYN packets to `MTU - overhead - headers`. Document the exact rule set per distribution because automation that works on Ubuntu may differ on RHEL.
 
-# Wait for pods to be ready
-kubectl --context kind-cluster1 wait --for=condition=Ready pod/curl
-kubectl --context kind-cluster2 wait --for=condition=Ready pod -l app=nginx
+## Section 18: BGP propagation with MCS and MetalLB together
 
-# Access the service from Cluster 1
-kubectl --context kind-cluster1 exec curl -- curl -s http://nginx.default.svc.cluster.local
-```
+MetalLB speakers advertise VIPs to ToR switches. When VIPs must be reachable from remote clusters, ensure BGP sessions propagate only intended prefixes. Use separate communities for `local-preference` manipulation on backup sites. Test withdrawal timing: when a speaker stops advertising, remote clusters should not continue sending traffic to stale VIPs longer than application timeouts allow.
 
-*Troubleshooting note*: If the curl command times out, verify the WireGuard tunnel status using `kubectl --context kind-cluster1 -n kube-system exec -ti ds/cilium -- cilium-dbg node list`. You should see the nodes of `cluster2` listed with their encryption status.
+Combine MCS endpoint sync with BGP health checks. MCS may list backends that are unreachable if BGP on one site withdrew routes. Application health checks should span clusters for active-active designs. Keep kube-proxy or eBPF service maps in mind: BGP advertises VIPs, not necessarily every pod IP, unless you also export pod CIDRs via Calico or Cilium BGP features from Module 3.2.
 
-## Practitioner Gotchas
+## Section 19: Incident triage checklist
 
-### 1. The Overlapping CIDR Trap
-**Context**: You inherited two bare-metal clusters built with the standard `kubeadm` defaults (`10.244.0.0/16` for pods). You attempt to link them with Cilium Cluster Mesh.
-**Fix**: Cilium will silently fail to route traffic because it cannot distinguish local pods from remote pods. You must rebuild one of the clusters with a new CIDR, or pivot to Submariner and configure Globalnet to perform NAT between the clusters.
+Use a ordered checklist during multicluster incidents to avoid thrashing:
 
-### 2. NodePort Port Exhaustion on Gateway Nodes
-**Context**: When using Submariner, all cross-cluster traffic funnels through a single Gateway Node. The gateway uses SNAT to route traffic to the destination cluster.
-**Fix**: The Gateway Node can quickly run out of ephemeral ports (SNAT port exhaustion) during high-throughput microservice communication. Increase the `net.ipv4.ip_local_port_range` sysctl on the gateway nodes and monitor `conntrack` limits carefully.
+1. **Export/import conditions** — Is the `ServiceExport` valid and do `ServiceImport` objects show endpoints?
+2. **DNS** — Does a debug pod resolve the clusterset FQDN with and without search paths?
+3. **Datapath** — Can pods ping remote pod IPs by IP address, bypassing DNS?
+4. **MTU** — Do sized pings fail only near 1500 bytes?
+5. **Mesh TLS** — Do gateways or sidecars log certificate errors after a rotation?
+6. **BGP** — Do speakers advertise expected communities; are stale routes present?
 
-### 3. IPsec Key Rotation Outages
-**Context**: Clusters connected via IPsec tunnels suddenly lose connectivity for 30-60 seconds during standard operations.
-**Fix**: IPsec relies on ISAKMP/IKE for key exchange. If the IKE lifetimes are misaligned across clusters, or if the control plane drops packets during a phase 2 rekey, the tunnel drops. Hardcode Phase 1 and Phase 2 lifetimes in your CNI config, and prefer WireGuard for bare-metal multi-cluster; its stateless cryptokey routing avoids IKE negotiation latency.
+Record which layer failed in the incident ticket so postmortems improve architecture docs instead of repeating the same kubectl commands.
 
-### 4. CoreDNS Forwarding Loops
-**Context**: You configure CoreDNS to forward `clusterset.local` queries to the cross-cluster DNS provider, but resolution times out, and CoreDNS CPU spikes to 100%.
-**Fix**: You accidentally configured CoreDNS in Cluster A to forward to Cluster B, and Cluster B to forward to Cluster A, creating a routing loop for unknown domains. Always scope cross-cluster DNS forwarding strictly to the `.clusterset.local` domain, never to `.`.
+## Section 20: Capacity, latency budgets, and SLO math
 
-### 5. Diagnosing MCS API Sync Failures
-**Context**: You created a `ServiceExport` but the `ServiceImport` never appears in the remote clusters, causing DNS resolution for `svc.clusterset.local` to fail.
-**Fix**: The MCS control plane relies on status conditions. Run `kubectl get serviceexport <name> -o yaml` and check for the `Valid` and `Conflict` conditions. A common cause of sync failure is attempting to export a service without valid endpoints, or a namespace mismatch where the remote cluster lacks the destination namespace.
+Cross-cluster calls add RTT and encryption cost. If single-cluster p99 latency is 5 ms inside a rack, the same call across a 40 ms RTT link becomes dominated by network regardless of CPU. Set SLOs per call pattern: synchronous chains that hop clusters twice per request may violate user-facing budgets even when each cluster is healthy.
+
+Gateway designs add CPU per gigabit for encryption. Size gateway nodes with measured iperf or mesh benchmark tools after enabling WireGuard or IPsec. Cilium node-to-node designs spread load but still encrypt on every node; total CPU may be higher aggregate yet avoid a single choke point.
+
+Plan connection table sizes on gateways when SNAT is involved. A microservice storm that opens short-lived connections can exhaust conntrack entries before bandwidth saturates. Monitor `nf_conntrack_count` and increase limits only alongside sysctl tuning reviewed by security.
+
+## Section 21: Dual-stack and Happy Eyeballs across clusters
+
+Dual-stack clusters export both A and AAAA records when MCS synchronizes endpoints. Clients using Happy Eyeballs ([RFC 8305](https://datatracker.ietf.org/doc/html/rfc8305)) may prefer IPv6 paths that traverse different firewalls than IPv4. Validate both address families through tunnels, not only the family your laptop uses on VPN. If IPv6 is experimental in your datacenter, consider disabling AAAA exports until path MTU and ACLs are identical for both protocols.
+
+Tunnel endpoints on IPv6 underlays avoid NAT traversal pain between sites that only have public IPv6. WireGuard and IPsec both support UDP over IPv6; ensure DNS and MCS records your applications consume match the family you actually route. Mixed-family SNAT at gateways can break return path symmetry when one direction uses IPv4 and the other IPv6.
+
+## Section 22: Security policy spanning clusters
+
+NetworkPolicy and CiliumNetworkPolicy resources are cluster-local unless your CNI propagates identities across Cluster Mesh. When policies reference labels on remote pods, verify the identity import semantics for your version. A policy that allows `role=backend` in cluster A may not include remote endpoints until clustermesh identity synchronization completes after upgrades.
+
+For service meshes, authorization policies may reference service accounts that do not exist in peer clusters. Use explicit host matchers in `ServiceEntry` and namespace-scoped trust boundaries when regulatory requirements forbid implicit trust. Document which cluster owns certificate issuance for each DNS name exposed through MCS.
+
+Audit east-west gateways and Submariner gateways like border firewalls. They terminate encrypted traffic and re-forward plaintext inside the cluster network. Compromise of a gateway node is high impact; apply hardened images, minimal RBAC, and rapid patching SLAs comparable to control plane nodes.
+
+## Section 23: Upgrade and rollback discipline
+
+Upgrade order should be documented before production multicluster goes live. A conservative pattern upgrades broker and Lighthouse components first, then gateway software, then route agents, then CNI datapaths, and finally service mesh control planes. After each step, run cross-cluster synthetic probes that include DNS, TCP connect, and TLS handshake where applicable.
+
+Rollback plans must state whether tunnels can coexist across versions. Some cable drivers cannot interop across minor versions; keep at least one maintenance window where both versions run with separate gateway pairs if required. For Cilium, snapshot clustermesh API server certificates before upgrades; restore procedures should include reconnecting clusters if secrets rotate unexpectedly.
+
+Never patch gateway nodes with destructive merge patches that replace entire `containers` arrays on DaemonSets. Use rolling update parameters and cordon-first maintenance as taught in node operations modules. Scaling gateway Deployments to zero is not a maintenance strategy—it forces unplanned failover.
+
+## Section 24: Observability signals that actually help
+
+Metrics should distinguish local versus remote traffic. Cilium Hubble can mark cluster IDs on flows when Cluster Mesh is enabled. Istio telemetry should include `destination_cluster` labels when multicluster is configured. Linkerd stat commands can show mirrored service traffic separately from local services.
+
+Logs to collect during incidents include CoreDNS query logs (with QNAME), gateway tunnel establishment logs, BGP session state from ToR switches, and MCS controller logs if you run a community implementation. Correlate timestamps across clusters using synchronized NTP; skewed clocks make split-brain investigations misleading.
+
+Tracing across clusters requires consistent propagation headers. Without tracing, latency excursions look like application regressions. Inject OpenTelemetry context at ingress and verify spans continue on mirrored service paths through gateways.
+
+## Section 25: Hands-on preparation for production bare metal
+
+The kind labs in this module validate concepts on Docker networks. Production bare metal introduces LACP, ECMP, and firewall tiers kind does not simulate. Before promoting Cluster Mesh, run the same three exercises against real nodes: confirm `InternalIP` reachability between racks, verify ToR routes include remote pod CIDRs, and repeat MTU probes from application pods scheduled on worker nodes—not only from jump hosts.
+
+Document your chosen stack in a one-page decision record: datapath owner, discovery owner, DNS owner, certificate owner, and BGP owner. When an incident arrives, the bridge assigns each owner a parallel track instead of debating fundamentals under pressure.
+
+Run quarterly game days that combine controlled failures: broker read-only mode, gateway cordon, Istio remote secret deletion, and MetalLB speaker withdrawal. Measure time-to-detect and time-to-mitigate for each scenario. Teams that only test happy-path connectivity discover MTU, DNS, and trust-anchor failures during customer peaks instead of during practice.
+
+Finally, align change management with application release trains. A multicluster platform change during a retail freeze window transfers risk to revenue-bearing services even when the change is “only networking.” Schedule overlay upgrades outside application blackouts, and require automated rollback artifacts (known-good Helm values, prior clustermesh secrets, prior BGP community maps) before any production edit.
+
+Keep a living “known-good” packet capture library: successful DNS answers for `clusterset.local`, a three-way TCP handshake across clusters, and a TLS handshake through mesh gateways. During incidents, compare live captures to the library to spot extra SYN retransmits, ICMP administratively prohibited messages, or certificate issuer mismatches within minutes instead of hours. Store those captures with cluster version metadata so upgrades that change tunnel headers or DNS plugin behavior are obvious when regressions appear later in production.
+
+## Common Mistakes
+
+| Mistake | Problem | Fix |
+|---------|---------|-----|
+| Exporting MCS services without a datapath | DNS resolves `clusterset.local` but TCP never connects | Install Submariner, Cilium ClusterMesh, or routed VPN before exporting services |
+| Connecting Cilium clusters with overlapping pod CIDRs | Policies and routing select wrong endpoints | Re-IP pods or adopt Submariner Globalnet for overlap at pod layer |
+| Forwarding all DNS zones reciprocally between clusters | CoreDNS loops and resolver CPU spikes | Stub only `clusterset.local` to Lighthouse or MCS resolver |
+| Ignoring tunnel MTU on a 1500-byte underlay | Large payloads hang while ICMP succeeds | Lower CNI MTU, clamp MSS, verify PMTUD ICMP is permitted |
+| Mixing Istio `network` labels on clusters without L3 reachability | Endpoints point at unroutable pod IPs | Align `network` with actual topology; add east-west gateways |
+| Linking Linkerd clusters without shared trust anchors | Gateways reject cross-cluster mTLS | Generate one anchor, distribute issuer secrets to every cluster |
+| Treating MetalLB BGP advertisements as MCS | VIP routes exist but exports absent | Create `ServiceExport` or mesh mirror labels plus BGP where needed |
+| Rotating mesh CA in one cluster only | Intermittent TLS failures after TTL | Coordinate rotation windows and dual-trust across the fleet |
 
 ## Quiz
 
-**1. You are tasked with connecting two bare-metal Kubernetes clusters that were both provisioned using identical default kubeadm subnets (`10.244.0.0/16`). Your goal is to establish cross-cluster connectivity without completely rebuilding the existing clusters. Which technology is most appropriate?**
-- A) Cilium Cluster Mesh
-- B) Submariner with Globalnet enabled
-- C) Multi-Cluster Services (MCS) API standalone
-- D) BGP Peering via Calico
+### Question 1
 
-**Answer: B**
-*Explanation: Submariner supports Globalnet, which performs SNAT/DNAT to explicitly handle overlapping CIDRs between clusters. In contrast, Cilium Cluster Mesh strictly requires non-conflicting PodCIDRs across all connected clusters to route traffic natively via eBPF. BGP cannot resolve identical IP spaces without highly complex VRF configurations that are difficult to maintain and configure correctly in standard Kubernetes. Furthermore, standard MCS provides an API for service discovery but does not handle datapath routing at all, meaning it cannot solve the IP overlap problem.*
+You inherit two bare-metal clusters that both use pod CIDR `10.244.0.0/16`. Leadership wants native pod-to-pod routing with eBPF policies. Which approach fits?
 
-**2. A cross-cluster WireGuard tunnel is successfully established, but developers report a strange issue: while a basic `ping` works between pods in different clusters, large database queries frequently return timeouts. What is the most likely cause?**
-- A) The `ServiceExport` resource is misconfigured.
-- B) WireGuard keys are mismatched.
-- C) Path MTU Discovery (PMTUD) is failing, causing an MTU blackhole for large packets.
-- D) The CoreDNS forwarder is caching stale IP addresses.
+<details>
+<summary>Answer</summary>
 
-**Answer: C**
-*Explanation: Small packets like an ICMP ping easily fit within the standard MTU and pass through the tunnel without issue. However, large TCP packets such as database payloads exceed the physical network's MTU when the 60-byte WireGuard overhead is added. Without Path MTU Discovery (PMTUD) functioning correctly on the underlay network, these large packets are silently dropped by intermediate switches. Configuring TCP MSS clamping on the CNI can mitigate this by forcing smaller segment sizes during the initial connection handshake, thus bypassing the blackhole effect.*
+Cilium Cluster Mesh requires non-overlapping pod CIDRs, so you cannot simply connect these clusters without renumbering one fleet or changing IPAM. Submariner with Globalnet exists specifically to NAT overlapping pod networks. Istio and Linkerd can carry application traffic but do not by themselves solve overlapping pod routing at the CNI layer. The correct operational choice is either re-IP a cluster or adopt Submariner Globalnet (accepting gateway hairpin tradeoffs) before expecting direct pod routing.
+</details>
 
-**3. You are troubleshooting a latency issue between a frontend pod in Cluster A and a backend pod in Cluster B within a Cilium Cluster Mesh environment. To trace the packets efficiently, you need to understand the exact datapath. How does Cilium route this traffic?**
-- A) Traffic is routed through a centralized Gateway Node in Cluster A, then to a Gateway Node in Cluster B.
-- B) Traffic goes through the Cluster Mesh API server, which proxies the connection.
-- C) Traffic is routed directly from the source Pod's host node in Cluster A to the destination Pod's host node in Cluster B.
-- D) Traffic is encapsulated in an HTTP/2 tunnel via the Ingress Controller.
+### Question 2
 
-**Answer: C**
-*Explanation: Cilium establishes direct node-to-node tunnels (using VXLAN, Geneve, or WireGuard) across the connected clusters. It does not funnel traffic through a centralized gateway node like Submariner does, which avoids single points of failure and prevents bottlenecks. The traffic leaves the source pod's host node and goes directly to the destination pod's host node over the encapsulated tunnel. This direct routing is possible because Cilium requires non-overlapping PodCIDRs to ensure global routing visibility across the entire mesh.*
+A developer reports that `curl payment.default.svc.clusterset.local` times out, but `kubectl get serviceimport` shows endpoints. ICMP between node IPs works. What should you investigate first?
 
-**4. Your team has deployed a new payment microservice in Cluster A and wants to make it discoverable to billing services running in Cluster B using the MCS API standard. What specific action must the team take to trigger the creation of a global DNS record for this service?**
-- A) Creating a `ServiceExport` resource in the cluster where the service resides.
-- B) Annotating the namespace with `mcs.k8s.io/enabled: true`.
-- C) Changing the `Service` type to `LoadBalancer`.
-- D) Creating a `ServiceImport` resource in the destination cluster.
+<details>
+<summary>Answer</summary>
 
-**Answer: A**
-*Explanation: The Multi-Cluster Services (MCS) API relies on the `ServiceExport` custom resource to signal intent for cross-cluster exposure. By creating a `ServiceExport` in the cluster where the service resides (Cluster A), the multi-cluster controller is notified that the service should be available globally. The controller then synchronizes the endpoint data across the mesh. Finally, it triggers the automatic creation of corresponding `ServiceImport` resources and DNS records (typically under `svc.clusterset.local`) in the participating clusters to enable discovery.*
+Separate discovery from datapath. Endpoints on `ServiceImport` prove MCS synchronization; timeouts with working node ICMP suggest tunnel MTU blackholes, firewall rules blocking pod CIDRs, or asymmetric routing rather than DNS failure. Capture path MTU with sized pings from a client pod, verify security groups and datacenter ACLs allow pod-to-pod CIDRs (not only node `/32` routes), and confirm the active Submariner gateway or Cilium tunnel is healthy.
+</details>
 
-**5. Your infrastructure team has deployed a new bare-metal Kubernetes cluster. The physical switch MTU is configured strictly to 1500 bytes. Your security policy mandates IPsec encryption, and you are using VXLAN for the overlay network. To prevent packet fragmentation and blackholes, what is the maximum safe MTU you should configure for the CNI?**
-- A) 1500
-- B) 1450
-- C) 1370
-- D) 1200
+### Question 3
 
-**Answer: C**
-*Explanation: When calculating the safe CNI MTU, you must strictly subtract all encapsulation and encryption overhead from the physical MTU base value. From the physical MTU of 1500 bytes, you must subtract the VXLAN overhead (50 bytes) and the IPsec overhead (approximately 73 bytes, depending on the specific cryptographic suite). Subtracting both overheads (1500 - 50 - 73) yields exactly 1377 bytes. Therefore, configuring 1370 as the maximum safe MTU ensures you completely avoid dropping packets due to fragmentation.*
+Which Submariner component publishes MCS DNS records for exported services?
 
-## Further Reading
-- [Kubernetes Multi-Cluster Services API (KEP-1645)](https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api)
-- [Cilium Cluster Mesh Architecture](https://docs.cilium.io/en/stable/network/clustermesh/clustermesh/)
-- [Submariner Architecture](https://submariner.io/architecture/)
-- [Liqo Documentation](https://doc.liqo.io/)
-- [Understanding MTU in Kubernetes](https://docs.cilium.io/en/stable/network/mtu/)
+<details>
+<summary>Answer</summary>
+
+Lighthouse provides MCS-oriented service discovery and integrates with CoreDNS for `clusterset.local` names. The Gateway Engine terminates encrypted cables; route agents steer traffic to gateways; the broker exchanges metadata between gateways. Confusing Lighthouse with the gateway leads teams to fix tunnels while DNS remains misconfigured.
+</details>
+
+### Question 4
+
+In Istio primary-primary on a shared L3 network, what must exist after installing both control planes?
+
+<details>
+<summary>Answer</summary>
+
+Each cluster needs a remote secret created with `istioctl create-remote-secret` applied on the peer so both control planes discover endpoints. Without reciprocal secrets, endpoint information stays local and multicluster routing fails even when `meshID` matches. Network IDs must reflect actual reachability: same network only when pod IPs are routable without an east-west gateway.
+</details>
+
+### Question 5
+
+Linkerd multicluster gateways reject connections from a newly linked cluster. Local services mirror correctly. What is the most likely cause?
+
+<details>
+<summary>Answer</summary>
+
+The remote cluster does not present a client certificate signed by the shared trust anchor configured during `linkerd install`. Mirroring can succeed while mTLS fails if issuer credentials or trust anchor files differ between clusters. Regenerate and distribute matching anchor and issuer secrets, roll gateways, then retry verified connections with `linkerd multicluster check`.
+</details>
+
+### Question 6
+
+Applications report only large HTTP payloads failing between clusters on WireGuard overlays with 1500-byte physical MTU. Small health checks succeed. What explains the pattern?
+
+<details>
+<summary>Answer</summary>
+
+This is classic PMTUD failure or insufficient MTU headroom after encapsulation. WireGuard adds overhead; if ICMP fragmentation messages are filtered, TCP with DF set hangs on large segments while small probes pass. Lower tunnel interface MTU, enable MSS clamping on ingress, and test with `ping -M do` using incrementing sizes from pod network namespaces.
+</details>
+
+### Question 7
+
+When designing BGP advertisement for multicluster `LoadBalancer` VIPs, what policy reduces ambiguous routing?
+
+<details>
+<summary>Answer</summary>
+
+Use distinct VIP pools per cluster, tag routes with BGP communities identifying origin, and avoid redistributing overlapping pod CIDRs without NAT. Combine MCS exports (logical service identity) with BGP (reachable VIP) instead of assuming one replaces the other. Filter communities at site borders so internal VIPs never leak externally.
+</details>
+
+### Question 8
+
+CoreDNS CPU spikes after enabling cross-cluster forwarding. Logs show cyclic queries between two clusters. What misconfiguration is likely?
+
+<details>
+<summary>Answer</summary>
+
+Reciprocal `forward` stanzas that send all unknown zones—including peer cluster DNS—to one another create resolution loops. Restrict forwarding to `clusterset.local` (or the exact MCS zone) via Lighthouse or a dedicated stub, never to `.` upstream of another cluster’s CoreDNS. Validate with `ndots`-aware FQDNs and trailing-dot queries before reopening wide forwards.
+</details>
+
+## Hands-On Exercise: Cross-Cluster Networking Labs
+
+Complete all three exercises in order on a workstation with `kind`, `kubectl`, and the Cilium CLI installed. These labs use Kubernetes **1.35** node images to match the curriculum target version.
+
+- [ ] Exercise 1: Build two kind clusters, enable Cilium Cluster Mesh with WireGuard, and verify pod-to-pod connectivity across clusters.
+- [ ] Exercise 2: Inspect CoreDNS `ndots` and search-list behavior, then resolve local versus `clusterset.local`-style names from a debug pod.
+- [ ] Exercise 3: Measure MTU limits with sized pings across the Cluster Mesh tunnel and record safe MSS/MTU values for your underlay.
+- [ ] Compare Submariner gateway hairpin routing versus Cilium node-to-node tunnels in your notes for future architecture reviews.
+
+### Exercise 1: Cilium Cluster Mesh on kind 1.35
+
+```bash
+cat <<'EOF' > /tmp/cm-cluster1.yaml
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: cm-cluster1
+nodes:
+  - role: control-plane
+  - role: worker
+networking:
+  disableDefaultCNI: true
+  podSubnet: 10.10.0.0/16
+  serviceSubnet: 10.11.0.0/16
+EOF
+
+cat <<'EOF' > /tmp/cm-cluster2.yaml
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: cm-cluster2
+nodes:
+  - role: control-plane
+  - role: worker
+networking:
+  disableDefaultCNI: true
+  podSubnet: 10.20.0.0/16
+  serviceSubnet: 10.21.0.0/16
+EOF
+
+kind create cluster --name cm-cluster1 --image kindest/node:v1.35.1 --config /tmp/cm-cluster1.yaml
+kind create cluster --name cm-cluster2 --image kindest/node:v1.35.1 --config /tmp/cm-cluster2.yaml
+```
+
+```bash
+cilium install --version 1.16.5 --context kind-cm-cluster1 \
+  --set cluster.name=cm-cluster1 \
+  --set cluster.id=1 \
+  --set ipam.operator.clusterPoolIPv4PodCIDRList=10.10.0.0/16 \
+  --set encryption.enabled=true \
+  --set encryption.type=wireguard \
+  --set clustermesh.useAPIServer=true
+
+cilium install --version 1.16.5 --context kind-cm-cluster2 \
+  --set cluster.name=cm-cluster2 \
+  --set cluster.id=2 \
+  --set ipam.operator.clusterPoolIPv4PodCIDRList=10.20.0.0/16 \
+  --set encryption.enabled=true \
+  --set encryption.type=wireguard \
+  --set clustermesh.useAPIServer=true
+
+cilium status --context kind-cm-cluster1 --wait
+cilium status --context kind-cm-cluster2 --wait
+```
+
+```bash
+cilium clustermesh enable --context kind-cm-cluster1 --service-type NodePort
+cilium clustermesh enable --context kind-cm-cluster2 --service-type NodePort
+cilium clustermesh status --context kind-cm-cluster1 --wait
+cilium clustermesh status --context kind-cm-cluster2 --wait
+cilium clustermesh connect --context kind-cm-cluster1 --destination-context kind-cm-cluster2
+cilium clustermesh status --context kind-cm-cluster1 --wait
+```
+
+```bash
+kubectl --context kind-cm-cluster2 create deployment nginx --image=nginx:1.27-alpine
+kubectl --context kind-cm-cluster2 expose deployment nginx --port=80
+kubectl --context kind-cm-cluster2 annotate service nginx io.cilium/global-service=true
+
+kubectl --context kind-cm-cluster1 run netshoot --image=nicolaka/netshoot --restart=Never -- sleep infinity
+kubectl --context kind-cm-cluster1 wait --for=condition=Ready pod/netshoot --timeout=120s
+kubectl --context kind-cm-cluster2 wait --for=condition=Ready pod -l app=nginx --timeout=120s
+
+kubectl --context kind-cm-cluster1 exec netshoot -- curl -sS --max-time 10 http://nginx.default.svc.cluster.local
+```
+
+Expected output: the curl command returns nginx HTML from cluster two while the client pod runs in cluster one. If it times out, run `cilium clustermesh status --context kind-cm-cluster1` and confirm remote nodes show connected before debugging DNS.
+
+### Exercise 2: CoreDNS ndots and search paths
+
+```bash
+kubectl --context kind-cm-cluster1 run dns-debug --image=busybox:1.36 --restart=Never -- sleep infinity
+kubectl --context kind-cm-cluster1 wait --for=condition=Ready pod/dns-debug --timeout=120s
+kubectl --context kind-cm-cluster1 exec dns-debug -- cat /etc/resolv.conf
+kubectl --context kind-cm-cluster1 exec dns-debug -- nslookup kubernetes.default
+kubectl --context kind-cm-cluster1 exec dns-debug -- nslookup kubernetes.default.svc.cluster.local
+```
+
+```bash
+kubectl --context kind-cm-cluster1 exec dns-debug -- nslookup nginx.default.svc.cluster.local
+kubectl --context kind-cm-cluster1 exec dns-debug -- nslookup nginx.default.svc.clusterset.local || true
+```
+
+Expected output: `resolv.conf` lists `ndots:5` and search domains ending in `svc.cluster.local`. Short names like `kubernetes.default` resolve via search list expansion. The `clusterset.local` query may fail in this Cilium-only lab without Lighthouse; record that discovery requires MCS DNS components even when Cluster Mesh datapath works.
+
+### Exercise 3: MTU sizing across Cluster Mesh
+
+```bash
+NGINX_POD=$(kubectl --context kind-cm-cluster2 get pod -l app=nginx -o jsonpath='{.items[0].metadata.status.podIP}')
+kubectl --context kind-cm-cluster1 exec netshoot -- ping -c 2 -M do -s 1472 "${NGINX_POD}"
+kubectl --context kind-cm-cluster1 exec netshoot -- ping -c 2 -M do -s 1400 "${NGINX_POD}"
+kubectl --context kind-cm-cluster1 exec netshoot -- ping -c 2 -M do -s 1200 "${NGINX_POD}"
+```
+
+Expected output: the largest probe near 1500 bytes may fail when WireGuard and overlay overhead exceed path MTU, while 1200-byte probes succeed. Document the largest reliable size and subtract encapsulation overhead before setting production CNI MTU.
+
+<details>
+<summary>Expected analysis</summary>
+
+Exercise 1 validates datapath connectivity independent of MCS controllers. Exercise 2 shows how `ndots` and search domains affect resolver behavior for cross-cluster names. Exercise 3 connects MTU theory to measurable blackhole thresholds on your lab underlay. In production, repeat measurements from application pods on both sides of site-to-site VPNs, not only from kind nodes.
+</details>
+
+## Next Module
+
+Continue to [Module 3.6: Service Mesh on Bare Metal](../module-3.6-service-mesh-bare-metal/) to layer L7 policy, ingress gateways, and sidecar dataplanes on top of the cross-cluster foundations you built here.
+
+## Learner Check
+
+> **Pause and predict**: You exported a payment service with `ServiceExport`, CoreDNS returns a `clusterset.local` address, and small HTTP probes succeed while settlement batches stall. Name the two layers you would split in your incident bridge (discovery versus datapath), and which MTU test you would run first from an application pod.
+
+## Sources
+
+- <https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/>
+- <https://kubernetes.io/docs/concepts/services-networking/service/>
+- <https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api>
+- <https://docs.cilium.io/en/stable/network/clustermesh/clustermesh/>
+- <https://docs.cilium.io/en/stable/operations/troubleshooting/#troubleshooting-clustermesh>
+- <https://docs.cilium.io/en/stable/operations/system_requirements/#firewall-requirements>
+- <https://submariner.io/getting-started/architecture/>
+- <https://submariner.io/getting-started/architecture/gateway-engine/>
+- <https://submariner.io/getting-started/architecture/service-discovery/>
+- <https://submariner.io/getting-started/quickstart/kind/>
+- <https://istio.io/latest/docs/setup/install/multicluster/multi-primary/>
+- <https://istio.io/latest/docs/setup/install/multicluster/before-you-begin/>
+- <https://istio.io/latest/docs/ops/deployment/deployment-models/>
+- <https://istio.io/latest/docs/reference/config/networking/service-entry/>
+- <https://istio.io/latest/docs/reference/config/networking/workload-entry/>
+- <https://linkerd.io/2.18/tasks/multicluster/>
+- <https://linkerd.io/2.18/features/multicluster/>
+- <https://metallb.universe.tf/concepts/bgp/>
+- <https://www.wireguard.com/quickstart/>
+- <https://datatracker.ietf.org/doc/html/rfc8305>


### PR DESCRIPTION
## Summary

- Rewrote `module-3.5-cross-cluster-networking.md` to T0 quality (~5,000 words): MCS API, Submariner/Lighthouse, Cilium ClusterMesh, Istio multi-cluster, Linkerd mirroring, CoreDNS `ndots`, WireGuard overlays, BGP exposure, failure modes, and mTLS rotation.
- Added 8 quiz items with `<details>`, 8-row Common Mistakes table, 4 Did You Know bullets, 2 mermaid diagrams, and three kind 1.35 + Cilium Cluster Mesh hands-on exercises.
- Verified with `verify_module.py` (`passed=true`, `tier=T0`) and `npm run build` on primary checkout (exit 0).

## Test plan

- [x] `.venv/bin/python scripts/quality/verify_module.py src/content/docs/on-premises/networking/module-3.5-cross-cluster-networking.md` → `tier=T0`, `passed=true`
- [x] All 20 Sources URLs curl-verified (0×404)
- [x] `npm run build` from primary repo at commit `b5c6e6a4` (2079 pages, 0 errors)
- [ ] Cross-family review (Gemini/Codex) before merge

## Learner check

> **Pause and predict**: You exported a payment service with `ServiceExport`, CoreDNS returns a `clusterset.local` address, and small HTTP probes succeed while settlement batches stall. Name the two layers you would split in your incident bridge (discovery versus datapath), and which MTU test you would run first from an application pod.

---

composer-2.5 via cursor-agent

Made with [Cursor](https://cursor.com)