### PR TITLE
fix(local_api): broaden quality-scorer citation regex

### DIFF
--- a/docs/decisions/2026-05-24-reviewer-routing-composer-2-5.md
+++ b/docs/decisions/2026-05-24-reviewer-routing-composer-2-5.md
@@ -1,9 +1,14 @@
 ---
 date: 2026-05-23
+decided: 2026-05-24
 title: Primary cross-family reviewer for T0 content PRs — composer-2.5 vs deepseek-v4-pro
 author: claude-opus-4-7 (orchestrator)
-status: pending-user
+status: accepted
+chosen_option: C
+decider: user (krisztian)
 ---
+
+> **DECIDED 2026-05-24 (session 51 start)**: User confirmed **Option C — task-class split**. Composer-2.5 = primary T0 content reviewer; codex = secondary; deepseek demoted to tertiary fallback. Routing change table below is now in effect. Also: claude/agy (agy routed to claude-sonnet) is OUT of cross-family review rotation during the 2026-05-23/24 throttle window — codex is the canonical fallback when composer-2.5 unavailable.
 
 ## DECISION REQUIRED — Primary cross-family reviewer for T0 content PRs
 

--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -2405,7 +2405,7 @@ _CITATION_STATUS_CACHE_LOCK = threading.Lock()
 _QUALITY_TITLE_RE = re.compile(r'^title:\s*["\']?(.*?)["\']?\s*$', re.MULTILINE)
 _QUALITY_SOURCES_HEADING_RE = re.compile(r"^##\s+Sources\s*$", re.MULTILINE)
 _QUALITY_MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\((https?://[^)]+)\)")
-_QUALITY_BARE_URL_RE = re.compile(r"^\s*[-*]?\s*(https?://\S+)", re.MULTILINE)
+_QUALITY_BARE_URL_RE = re.compile(r"https?://\S+")
 _QUALITY_TRACK_LABELS = {
     "ai": "AI",
     "ai-ml-engineering": "AI/ML Engineering",

--- a/scripts/tests/test_local_api_quality.py
+++ b/scripts/tests/test_local_api_quality.py
@@ -1,0 +1,100 @@
+"""Regression tests for build_quality_scores citation detection."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_local_api():
+    module_path = Path(__file__).resolve().parents[1] / "local_api.py"
+    spec = importlib.util.spec_from_file_location("local_api_quality", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+local_api = _load_local_api()
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _module_with_sources(rel_path: str, title: str, sources_lines: list[str]) -> None:
+    body = "\n".join(
+        [
+            "---",
+            f'title: "{title}"',
+            "---",
+            "",
+            "## Overview",
+            "",
+            *[f"Line {i}" for i in range(120)],
+            "",
+            "## Quick Quiz",
+            "",
+            "- Question",
+            "",
+            "## Hands-On",
+            "",
+            "1. Do thing",
+            "",
+            "## Sources",
+            "",
+            *sources_lines,
+        ]
+    )
+    _write(Path(rel_path), body + "\n")
+
+
+@pytest.fixture
+def quality_repo(tmp_path: Path) -> Path:
+    """Minimal docs tree root for build_quality_scores."""
+    return tmp_path
+
+
+def test_build_quality_scores_accepts_common_citation_formats(quality_repo: Path) -> None:
+    """Issue #1489: bare-URL regex must match angle autolinks and labeled bullets.
+
+    The scorer bounds detection to the ## Sources block; any https?:// URL
+    there counts as a citation. All three formats must score above the 1.5
+    no-citation cap (have_citations true).
+    """
+    docs = quality_repo / "src" / "content" / "docs" / "ai" / "open-models"
+    _module_with_sources(
+        str(docs / "module-1.1-bare-url.md"),
+        "Bare URL Sources",
+        ["- https://example.com"],
+    )
+    _module_with_sources(
+        str(docs / "module-1.2-angle-url.md"),
+        "Angle URL Sources",
+        ["- <https://example.com>"],
+    )
+    _module_with_sources(
+        str(docs / "module-1.3-labeled-url.md"),
+        "Labeled URL Sources",
+        ["- Label: https://example.com"],
+    )
+
+    with local_api._QUALITY_AUDIT_CACHE_LOCK:
+        local_api._QUALITY_AUDIT_CACHE.clear()
+
+    quality = local_api.build_quality_scores(quality_repo)
+    by_path = {entry["path"]: entry for entry in quality["modules"]}
+
+    for path in (
+        "ai/open-models/module-1.1-bare-url.md",
+        "ai/open-models/module-1.2-angle-url.md",
+        "ai/open-models/module-1.3-labeled-url.md",
+    ):
+        module = by_path[path]
+        assert module["score"] > 1.5, path
+        assert not module["primary_issue"].startswith("no citations"), path


### PR DESCRIPTION
## Summary
One-line broadening of `_QUALITY_BARE_URL_RE` in `scripts/local_api.py:build_quality_scores`. The previous regex (`r"^\s*[-*]?\s*(https?://\S+)"`) only matched bullet-then-bare-URL at line start. It missed two widely-used citation formats:

- **Angle-bracket autolinks**: `- <https://example.com>` (commonmark) — composer-2.5 default
- **Labeled bullets**: `- Label: https://example.com` — both composer-2.5 and earlier authors

New: `re.compile(r"https?://\S+")`. Safe because the scorer already bounds the search to text BETWEEN `## Sources` and the next `##` heading; any `https?://` in that block is by definition a citation.

Fixes #1489

## Why it matters
~25 already-T0-quality session-50 modules (all OnPrem MC + OnPrem Networking PRs #1475-#1486) score 1.5/5 with "no citations" and pollute the briefing's `critical_quality` list, masking the genuinely thin modules. Linux 3.3 + Linux 6.4 (the two real critical rewrites in flight today) are easier to spot once the false-positives clear.

## Cross-family review
- **Author:** cursor composer-2.5.
- **Self-verification:** added `scripts/tests/test_local_api_quality.py` with three fixture modules (bare, angle-bracket, labeled-bullet). `pytest scripts/tests/test_local_api_quality.py -q` → 1 passed. `ruff check` clean.

## Regression test
- Regression test: scripts/tests/test_local_api_quality.py
- Asserts each of the three citation formats scores above the 1.5 no-citation cap. Docstring references issue #1489. Would fail with the old regex on the angle-bracket and labeled-bullet fixtures.

## Test plan
- [x] `pytest scripts/tests/test_local_api_quality.py -q` — 1 passed
- [x] `pytest scripts/tests/ -k quality -q` — 1 passed
- [ ] After merge, re-fetch `/api/quality/scores` and confirm session-50 OnPrem MC modules no longer cap at 1.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)