### PR TITLE
feat(tooling): align cold-start with API-first organizer ritual (#1505)

### DIFF
--- a/.claude/skills/cold-start/SKILL.md
+++ b/.claude/skills/cold-start/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: cold-start
+description: KubeDojo agent session orientation. Use at the start of every fresh session or when picking up a GitHub issue. Triggers on "cold start", "orient", "session start", "issue-driven".
+---
+
+# Cold-start Skill
+
+Deterministic orientation for KubeDojo coding agents: **issue in → API orient → minimal file reads → work**.
+
+Full ritual: [`scripts/prompts/cold-start.md`](../../../scripts/prompts/cold-start.md)
+
+## When to Use
+
+- First call on a fresh agent session
+- Picking up a GitHub issue (#N)
+- After a long break when briefing may be stale
+
+## Steps
+
+1. **Read parent task verbatim** — `gh issue view N --repo kube-dojo/kube-dojo.github.io`
+2. **Run cold-start** — `KUBEDOJO_ISSUE=N bash scripts/cold-start.sh`
+3. **Claim if assigned** — `gh issue comment N --body "Claiming — worktree .worktrees/<name>"`
+4. **Worktree only** — never commit on primary `main`
+5. **Handoff on demand** — read `docs/session-state/*` only when orient/briefing leave a narrative gap
+
+## Script output sections
+
+Parse the labeled blocks from stdout:
+
+- `kubedojo:orient` — **start here** for "what to do now" (primary + up to 3 alternatives)
+- `kubedojo:briefing` — full compact snapshot (`actions`, `top_modules`, blockers)
+- `kubedojo:session` — latest handoff path (do not read the HTML file unless needed)
+- `kubedojo:pending-decisions` — blocking Decision Cards in `docs/decisions/pending/`
+
+Optional: `bash scripts/cold-start.sh --manifest` for route discovery via `/api/state/manifest`.
+
+## API-down
+
+Script exits **0** with `kubedojo:fallback` (STATUS excerpt) + `kubedojo:handoff-path`. Continue with local files; do not treat API failure as a hard stop.
+
+## Do NOT cold-start when
+
+The dispatch brief explicitly forbids shell scripts (e.g. headless content rewrites in worktrees where `services-up` is unnecessary).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,17 +7,23 @@
 
 ## Cold start (first call on a fresh session)
 
-**Do not start with `git log` or a grep sweep.** Run:
+**Do not start with `git log` or a grep sweep.** Issue-driven sessions: read the GitHub issue verbatim first, then run:
 
 ```bash
-bash scripts/cold-start.sh          # services-up + compact briefing in one call
+KUBEDOJO_ISSUE=N bash scripts/cold-start.sh   # issue reminder + orient in one call
+# or without an issue:
+bash scripts/cold-start.sh
 ```
 
-The briefing returns `actions.{active, blocked, next}` + `top_modules[]` — answers "what should I touch" in the same call as "what is the global state". Responses carry a weak ETag; send `If-None-Match` for 304 on repeat polls.
+The script brings up services, prints `git status`, pending Decision Cards, then API blocks:
+`briefing` (compact snapshot), `orient` (primary action + alternatives), `session` (handoff pointer).
+Optional route discovery: `bash scripts/cold-start.sh --manifest`.
+
+Full copy-paste ritual: [`scripts/prompts/cold-start.md`](scripts/prompts/cold-start.md).
 
 Before claiming work: `GET /api/pipeline/leases`. Before fixing a module: `GET /api/module/{key}/state` (structured `diagnostics[]`). Before re-reviewing: `GET /api/reviews?module={key}`. Situational awareness: `GET /api/tracks/readiness` + `GET /api/activity`.
 
-If the API is down, fall back to `STATUS.md` + `CLAUDE.md`.
+If the API is down, the script **exits 0** with a `STATUS.md` excerpt and handoff path — then read `CLAUDE.md` only if that block is insufficient. More recipes: [`scripts/agent_onboarding.md`](scripts/agent_onboarding.md).
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,47 +4,28 @@ KubeDojo — free, open-source cloud native curriculum.
 
 ## Agent Orientation (first call on a cold start)
 
-The orientation sequence is API-first to reduce token use and get a complete cold-start picture (`actions`, blockers, leases, and top modules) before reading local handoff files.
+**Issue-driven sessions:** read the GitHub issue verbatim, then run one script:
 
-1. Pull compact briefing:
 ```bash
-curl -s --max-time 2 "http://127.0.0.1:8768/api/briefing/session?compact=1"
-```
-If 200, parse the payload and proceed. If timeout or non-200, record `API down` — still run steps 2 and 3 (local filesystem state is independent of the API), then fall back to step 6 instead of step 4.
-
-2. Run local working-tree awareness:
-```bash
-git status --short
+KUBEDOJO_ISSUE=N bash scripts/cold-start.sh
 ```
 
-3. Scan for blocking decisions:
-```bash
-ls docs/decisions/pending/
-```
-Respect `.claude/rules/decision-card.md` and only process what is declared blocking.
+Standalone session: `bash scripts/cold-start.sh` (add `--manifest` for route discovery).
 
-4. Pull the latest handoff via API (preferred) or fall back to the file:
-```bash
-curl -s --max-time 2 "http://127.0.0.1:8768/api/session/current"
-```
-Returns the most recent handoff path plus predecessor chain. Only read the underlying `docs/session-state/<date>-*.{md,html}` file when the briefing leaves a real narrative-why gap; use the path from the API response or from STATUS.md's `Latest handoff` row.
+The script is API-first: services-up, `git status`, pending Decision Cards, then compact
+briefing + orient punch-line + session handoff pointer. It exits 0 with a `STATUS.md`
+fallback when the API is down. Full ritual: [`scripts/prompts/cold-start.md`](scripts/prompts/cold-start.md).
+Individual curl recipes: [`scripts/agent_onboarding.md`](scripts/agent_onboarding.md).
 
-5. Optional situational check for recent orchestration context:
-```bash
-curl -s --max-time 2 "http://127.0.0.1:8768/api/activity?limit=30"
-```
-
-6. Fallback path if API is down:
-`STATUS.md` → latest handoff → `MEMORY.md` → `CLAUDE.md`.
+Only read the underlying `docs/session-state/<date>-*.{md,html}` file when briefing/orient
+leave a real narrative-why gap. Respect `.claude/rules/decision-card.md` for pending decisions.
 
 **Before you claim/fix/re-review work**:
 - `GET /api/pipeline/leases`
 - `GET /api/module/{key}/state`
 - `GET /api/reviews?module={key}`
 
-**Self-discovery**: `curl -s http://127.0.0.1:8768/api/state/manifest` returns the categorized route inventory (cold_start / dashboards / pipeline / etc.) — use this when uncertain which endpoint serves a given concern.
-
-**Orientation punch-line**: `curl -s --max-time 2 http://127.0.0.1:8768/api/orient` returns the single primary action + up to 3 alternatives + blockers/alerts in ~1.3 KB. Use this when the briefing is overkill.
+Optional situational check: `GET /api/activity?limit=30`.
 
 Standalone session = main orchestrator. Drive the queue; ask only on irreversible or ambiguous actions.
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -15,9 +15,12 @@
 
 ## Cold-start protocol
 
-1. Hit `curl -s http://127.0.0.1:8768/api/briefing/session?compact=1` (the API parses the `## TODO` and `## Blockers` sections of this file).
-2. Scan [`docs/decisions/pending/`](./docs/decisions/pending/) for outstanding Decision Cards and surface any pending user decision before unrelated work.
-3. Read the row in **Latest handoff** below — that's the only file you need for current state.
+1. **Issue-driven:** read GitHub issue #N verbatim, then `KUBEDOJO_ISSUE=N bash scripts/cold-start.sh`.
+   **Standalone:** `bash scripts/cold-start.sh` (add `--manifest` for route discovery).
+   The script runs services-up, `git status`, pending decisions, compact briefing, orient, and session handoff pointer.
+   On API failure it prints a STATUS excerpt + handoff path (exit 0). Ritual: [`scripts/prompts/cold-start.md`](./scripts/prompts/cold-start.md).
+2. Scan [`docs/decisions/pending/`](./docs/decisions/pending/) for outstanding Decision Cards and surface any pending user decision before unrelated work (also listed by the script).
+3. Read the row in **Latest handoff** below only when briefing/orient leave a narrative gap — that's the file for current state.
 4. Skim **Cross-thread notes (still active)** for stuff that spans sessions.
 5. If picking up a long-running thread, click into the relevant **Predecessor chain** row.
 6. Pre-2026-04-28 sessions (29 of them, going back to session 1) live in [`docs/session-state/archive-pre-2026-04-28.md`](./docs/session-state/archive-pre-2026-04-28.md) — kept for spelunking only, not actively maintained.

--- a/scripts/agent_onboarding.md
+++ b/scripts/agent_onboarding.md
@@ -4,10 +4,34 @@ Single source of concrete `curl` recipes for any agent (Claude, Codex, Gemini) s
 
 ## 1. Cold-start orientation
 
+**Single entry point** (preferred — replaces manual curl crawl):
+
 ```bash
-# One call replaces "cat CLAUDE.md + STATUS.md + git log -20 + git status + ls".
-# Compact form is the agent path — ~0.7K tokens, 76% reduction vs. the crawl.
-curl -s http://127.0.0.1:8768/api/briefing/session?compact=1
+# Issue-driven session:
+KUBEDOJO_ISSUE=1234 bash scripts/cold-start.sh
+
+# Standalone session:
+bash scripts/cold-start.sh
+
+# Optional route discovery:
+bash scripts/cold-start.sh --manifest
+```
+
+Emits labeled sections: `workspace`, `pending-decisions`, `briefing`, `orient`, `session`.
+On API failure: `STATUS.md` excerpt + handoff path, exit 0. Copy-paste ritual:
+[`scripts/prompts/cold-start.md`](prompts/cold-start.md).
+
+Individual endpoints (when you need one call without the full ritual):
+
+```bash
+# Compact briefing — ~0.7K tokens, 76% reduction vs. the crawl.
+curl -s --max-time 2 http://127.0.0.1:8768/api/briefing/session?compact=1
+
+# Punch-line orientation — primary action + up to 3 alternatives (~1.3 KB).
+curl -s --max-time 2 http://127.0.0.1:8768/api/orient
+
+# Latest handoff pointer (path + title/tldr, not full HTML body).
+curl -s --max-time 2 http://127.0.0.1:8768/api/session/current
 
 # Full briefing (~1.5K) when you also want next_reads + the worktree list.
 curl -s http://127.0.0.1:8768/api/briefing/session
@@ -91,14 +115,16 @@ The same endpoints feed an HTML dashboard at `http://127.0.0.1:8768/`. The Opera
 
 ## 7. Fallback
 
-If the API is down, agents should:
+`bash scripts/cold-start.sh` handles API-down automatically: prints the first 40 lines of
+`STATUS.md` plus the Latest handoff path, then exits 0.
 
-1. `cat STATUS.md` for focus + blockers.
+If that block is insufficient:
+
+1. Read the handoff file from the `kubedojo:handoff-path` section.
 2. `cat CLAUDE.md` for project overview.
-3. `git log -20 --oneline` for recent commits.
-4. `git status` for worktree state.
+3. `git status` for worktree state (also emitted by the script when API is up).
 
-The briefing endpoint exists so none of the above is normally necessary.
+The briefing API exists so deep file crawls are normally unnecessary.
 
 ## 8. Conventions
 

--- a/scripts/cold-start.sh
+++ b/scripts/cold-start.sh
@@ -18,12 +18,24 @@ while [[ $# -gt 0 ]]; do
       INCLUDE_MANIFEST=1
       shift
       ;;
+    --issue)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing argument for --issue" >&2
+        exit 2
+      fi
+      KUBEDOJO_ISSUE="$2"
+      shift 2
+      ;;
     -h|--help)
       cat <<'EOF'
-Usage: scripts/cold-start.sh [--manifest]
+Usage: scripts/cold-start.sh [--manifest] [--issue N]
 
 Deterministic cold-start for coding agents: services-up, workspace state,
 pending decisions, then API orientation (briefing + orient + session pointer).
+
+Options:
+  --issue N            Print issue-first reminder for GitHub issue #N
+                       (same as KUBEDOJO_ISSUE=N; flag takes precedence)
 
 Environment:
   KUBEDOJO_ISSUE=N     Print issue-first reminder for GitHub issue #N
@@ -125,10 +137,15 @@ head -n 40 STATUS.md
 echo ""
 
 echo "--- kubedojo:handoff-path ---"
-handoff_path=""
-if handoff_path=$(grep -m1 -oE 'docs/session-state/[^)\]]+\.(html|md)' STATUS.md 2>/dev/null); then
-  :
-else
+handoff_path=$(awk '
+  /^## Latest handoff/ { in_section=1; next }
+  in_section && /^## / { exit }
+  in_section && match($0, /docs\/session-state\/[A-Za-z0-9._\/-]+\.(html|md)/) {
+    print substr($0, RSTART, RLENGTH)
+    exit
+  }
+' STATUS.md)
+if [ -z "$handoff_path" ]; then
   handoff_path="(could not parse Latest handoff path from STATUS.md)"
 fi
 echo "$handoff_path"

--- a/scripts/cold-start.sh
+++ b/scripts/cold-start.sh
@@ -1,27 +1,136 @@
 #!/usr/bin/env bash
 # Cold-start ritual for a fresh KubeDojo agent session.
-# Brings up services (idempotent) and prints the compact briefing.
-# Handoffs reference this script instead of duplicating the curl ritual.
+# Brings up services, emits local working-tree state, API orientation,
+# and a STATUS.md fallback when the API is unreachable.
+#
+# Single source of truth for agent orientation — see also:
+#   scripts/prompts/cold-start.md
+#   .claude/skills/cold-start/SKILL.md
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
-scripts/services-up >&2
+INCLUDE_MANIFEST=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --manifest)
+      INCLUDE_MANIFEST=1
+      shift
+      ;;
+    -h|--help)
+      cat <<'EOF'
+Usage: scripts/cold-start.sh [--manifest]
+
+Deterministic cold-start for coding agents: services-up, workspace state,
+pending decisions, then API orientation (briefing + orient + session pointer).
+
+Environment:
+  KUBEDOJO_ISSUE=N     Print issue-first reminder for GitHub issue #N
+  KUBEDOJO_API=URL       API base (default http://127.0.0.1:8768)
+  KUBEDOJO_API_TIMEOUT=  curl --max-time seconds (default 2)
+
+On API failure: prints STATUS.md excerpt + handoff path, exits 0.
+EOF
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1 (try --help)" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -n "${KUBEDOJO_ISSUE:-}" ]]; then
+  echo "--- kubedojo:issue ---"
+  echo "Parent task: gh issue view ${KUBEDOJO_ISSUE} --repo kube-dojo/kube-dojo.github.io"
+  echo "Claim via: gh issue comment ${KUBEDOJO_ISSUE} --body \"Claiming — worktree .worktrees/<name>\""
+  echo ""
+fi
+
+scripts/services-up >&2 || true
+
+echo "--- kubedojo:workspace ---"
+git status --short || true
+echo ""
+
+echo "--- kubedojo:pending-decisions ---"
+if pending=$(ls docs/decisions/pending/ 2>/dev/null | head -5); then
+  printf '%s\n' "$pending"
+else
+  echo "(empty)"
+fi
+echo ""
 
 API="${KUBEDOJO_API:-http://127.0.0.1:8768}"
-BRIEFING_URL="${API}/api/briefing/session?compact=1"
+MAX_TIME="${KUBEDOJO_API_TIMEOUT:-2}"
+TMPDIR_COLD="/tmp/kubedojo_coldstart_$$"
+mkdir -p "$TMPDIR_COLD"
+trap 'rm -rf "$TMPDIR_COLD"' EXIT
 
-TMP="/tmp/kubedojo_briefing.$$"
-trap 'rm -f "$TMP"' EXIT
+api_get() {
+  curl -sf --max-time "$MAX_TIME" "${API}${1}" 2>/dev/null
+}
 
+API_OK=0
 for _ in 1 2 3 4 5; do
-  if curl -sf "$BRIEFING_URL" >"$TMP"; then
-    cat "$TMP"
-    exit 0
+  if api_get "/api/briefing/session?compact=1" >"$TMPDIR_COLD/briefing.json"; then
+    API_OK=1
+    break
   fi
   sleep 1
 done
 
-echo "ERROR: briefing API did not respond at $BRIEFING_URL — falling back to STATUS.md" >&2
-exit 1
+if [[ "$API_OK" -eq 1 ]]; then
+  echo "--- kubedojo:briefing ---"
+  cat "$TMPDIR_COLD/briefing.json"
+  echo ""
+
+  echo "--- kubedojo:orient ---"
+  if api_get "/api/orient" >"$TMPDIR_COLD/orient.json"; then
+    cat "$TMPDIR_COLD/orient.json"
+  else
+    echo '{"error":"orient_unavailable"}'
+  fi
+  echo ""
+
+  echo "--- kubedojo:session ---"
+  if api_get "/api/session/current" >"$TMPDIR_COLD/session.json"; then
+    cat "$TMPDIR_COLD/session.json"
+  else
+    echo '{"error":"session_unavailable"}'
+  fi
+  echo ""
+
+  if [[ "$INCLUDE_MANIFEST" -eq 1 ]]; then
+    echo "--- kubedojo:manifest ---"
+    if api_get "/api/state/manifest" >"$TMPDIR_COLD/manifest.json"; then
+      cat "$TMPDIR_COLD/manifest.json"
+    else
+      echo '{"error":"manifest_unavailable"}'
+    fi
+    echo ""
+  fi
+
+  exit 0
+fi
+
+echo "--- kubedojo:api-down ---" >&2
+echo "API down — falling back to STATUS.md" >&2
+echo ""
+
+echo "--- kubedojo:fallback ---"
+echo "# STATUS.md (first 40 lines)"
+head -n 40 STATUS.md
+echo ""
+
+echo "--- kubedojo:handoff-path ---"
+handoff_path=""
+if handoff_path=$(grep -m1 -oE 'docs/session-state/[^)\]]+\.(html|md)' STATUS.md 2>/dev/null); then
+  :
+else
+  handoff_path="(could not parse Latest handoff path from STATUS.md)"
+fi
+echo "$handoff_path"
+
+exit 0

--- a/scripts/cold-start.sh
+++ b/scripts/cold-start.sh
@@ -34,6 +34,7 @@ Deterministic cold-start for coding agents: services-up, workspace state,
 pending decisions, then API orientation (briefing + orient + session pointer).
 
 Options:
+  --manifest           Append the /api/state/manifest section (route discovery)
   --issue N            Print issue-first reminder for GitHub issue #N
                        (same as KUBEDOJO_ISSUE=N; flag takes precedence)
 

--- a/scripts/prompts/cold-start.md
+++ b/scripts/prompts/cold-start.md
@@ -1,0 +1,65 @@
+# Cold-start ritual — issue-driven agent sessions
+
+Copy-paste sequence for a fresh KubeDojo coding session. Single shell entry point:
+`scripts/cold-start.sh` (also documented in `AGENTS.md`, `CLAUDE.md`, and
+`.claude/skills/cold-start/SKILL.md`).
+
+## Ritual
+
+```
+1. Read GitHub issue #N verbatim (parent task).
+   gh issue view N --repo kube-dojo/kube-dojo.github.io
+
+2. Orient (services-up + workspace + API):
+   KUBEDOJO_ISSUE=N bash scripts/cold-start.sh
+   # Optional route discovery:
+   bash scripts/cold-start.sh --manifest
+
+3. If claiming the issue:
+   gh issue comment N --body "Claiming — worktree .worktrees/<short-name>"
+
+4. Create worktree on main (never work on primary main):
+   git worktree add .worktrees/<short-name> -b <branch> main
+
+5. Work in the worktree only. Do not merge — cross-family review via
+   scripts/dispatch.py or scripts/ab; organizer merges.
+
+6. Read the full handoff file ONLY if briefing/orient leaves a narrative gap.
+   Path comes from --- kubedojo:session --- (API) or --- kubedojo:handoff-path --- (fallback).
+```
+
+## What the script emits
+
+| Section | Source |
+|---------|--------|
+| `kubedojo:issue` | `KUBEDOJO_ISSUE=N` reminder (optional) |
+| `kubedojo:workspace` | `git status --short` |
+| `kubedojo:pending-decisions` | `docs/decisions/pending/` (first 5) |
+| `kubedojo:briefing` | `GET /api/briefing/session?compact=1` |
+| `kubedojo:orient` | `GET /api/orient` — primary action + alternatives |
+| `kubedojo:session` | `GET /api/session/current` — handoff pointer only |
+| `kubedojo:manifest` | `GET /api/state/manifest` (with `--manifest`) |
+
+API base: `http://127.0.0.1:8768` (`KUBEDOJO_API` override). Timeout: 2s per request.
+
+## API-down fallback
+
+When the briefing API does not respond after retries, the script **exits 0** and prints:
+
+- First 40 lines of `STATUS.md`
+- Latest handoff path parsed from the `## Latest handoff` table
+
+Then read `CLAUDE.md` / `MEMORY.md` only if the fallback block is insufficient.
+
+## Before claiming / fixing / re-reviewing
+
+After cold-start, use the local API (see `scripts/agent_onboarding.md`):
+
+- Claim work: `GET /api/pipeline/leases`
+- Fix module: `GET /api/module/{key}/state`
+- Re-review: `GET /api/reviews?module={key}`
+
+## Skip cold-start
+
+Content dispatches that must not invoke skills or shell scripts should say so
+explicitly in the brief (see session-50 dispatch preamble pattern).


### PR DESCRIPTION
## Summary

- Extends `scripts/cold-start.sh` to emit labeled sections in one invocation: workspace, pending decisions, compact briefing, orient punch-line, and session handoff pointer (`--manifest` optional).
- API-down path prints STATUS excerpt + handoff path and **exits 0** (not 1); tolerates benign `services-up` SIGPIPE from its tail pipeline.
- Adds `scripts/prompts/cold-start.md` + `.claude/skills/cold-start/SKILL.md`; dedupes `AGENTS.md`, `CLAUDE.md`, `agent_onboarding.md`, and `STATUS.md` cold-start protocol to the single script entry point.
- `--issue N` flag or `KUBEDOJO_ISSUE=N` env-var prints issue-first reminder for issue-driven sessions.

Closes #1505

## Review cycle

| Round | Reviewer | Verdict | Findings |
|-------|----------|---------|----------|
| R1 | codex gpt-5.5 | NEEDS_CHANGES | HIGH: API-down fallback emitted "(could not parse...)" not real handoff path (`grep -m1` picked archive pointer from cold-start prose above the table; BSD-grep char class also malformed). LOW: `--issue` flag mentioned in brief but not implemented. |
| Fix-pass `6feeab0c` (cursor composer-2.5) | — | — | HIGH: bounded handoff extraction via `awk '/^## Latest handoff/,/^## /'` then `grep` with portable char class; LOW: added `--issue N` flag (flag precedes env-var). |
| R2 | codex gpt-5.5 | APPROVE_WITH_NITS | Nit: `--help` Options section documented `--issue N` only, should also document `--manifest`. |
| Nit fix `7aa8aa3a` (orchestrator inline) | — | — | Added `--manifest` line to `--help` Options block. |

## Codex R2 verification

> Verified: HEAD is `6feeab0c`. Bounded handoff extraction starts at `^## Latest handoff`, exits on next `^## `, and API-down smoke prints the real latest handoff path. Missing `## Latest handoff` heading degrades to empty awk output, then the fallback string path is taken. `--issue N` sets `KUBEDOJO_ISSUE`; flag precedence over env-var verified. All 5 requested smoke tests passed, including API-down exit 0 and `--issue 1505`.

## Test plan

- [x] `bash -n scripts/cold-start.sh`
- [x] `bash scripts/cold-start.sh` — emits briefing + orient + session (exit 0)
- [x] `bash scripts/cold-start.sh --manifest` — adds manifest section
- [x] `KUBEDOJO_API=http://127.0.0.1:1 bash scripts/cold-start.sh` — fallback block with real latest handoff path, exit 0
- [x] `KUBEDOJO_ISSUE=1505 bash scripts/cold-start.sh` — issue reminder block
- [x] `bash scripts/cold-start.sh --issue 1505` — issue reminder block (flag form)
- [x] `git diff --check` clean

🤖 Made with [Cursor](https://cursor.com) (composer-2.5 author) + codex gpt-5.5 R1/R2 cross-family review + Claude orchestrator