### PR TITLE
feat(api): wire poll-stale indicators on dashboard refresh pages (#1495)

### DIFF
--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -116,6 +116,14 @@ def _render_page_chrome(*, include_afk: bool = False) -> str:
     return _ui_fragments_module().render_global_chrome(include_search=True, include_afk=include_afk)
 
 
+def _poll_stale_css() -> str:
+    return _ui_fragments_module().POLL_STALE_CSS
+
+
+def _render_poll_stale_script() -> str:
+    return _ui_fragments_module().render_poll_stale_script()
+
+
 _CHANNEL_ROUTES = _load_channel_routes_module()
 _DECISION_ROUTES = _load_decision_routes_module()
 _SEARCH_ROUTES = _load_search_routes_module()
@@ -6098,6 +6106,7 @@ _ACTIVITY_PAGE_JS = r"""
       const parts = [['commit', 'commits'], ['pipeline_event', 'events'], ['bridge_message', 'msgs']]
         .filter(([k]) => counts[k]).map(([k, label]) => `${counts[k]} ${label}`);
       $('#activity-badge').textContent = `${shown.length === items.length ? '' : `${shown.length}/${items.length} shown / `}${parts.join(' / ') || 'Quiet'}`;
+      setPollTs($('#activity-badge'), activityData);
       if (!shown.length) { el.innerHTML = '<div class="empty-state">No activity matches these filters</div>'; return; }
       const now = activityData.generated_at || Math.floor(Date.now() / 1000);
       el.innerHTML = `<ul class="activity-feed">${shown.map(item => {
@@ -6310,6 +6319,7 @@ _HEALTH_PAGE_JS = r"""
       renderServices(services);
       renderWorktrees(worktrees);
       renderMissing(missing);
+      setPollTs($('#svc-badge'), services);
     }
     loadHealthPage().catch(err => {
       $('#services').innerHTML = '<div class="empty-state">Health data unavailable</div>';
@@ -6697,6 +6707,7 @@ _QUALITY_BOARD_PAGE_JS = r"""
       try {
         const board = await fetchJson('/api/quality/board');
         renderQualityBoard(board);
+        setPollTs($('#last-updated'), board);
         $('#last-updated').textContent = `Updated ${new Date().toLocaleTimeString()}`;
       } catch (err) {
         console.error('Quality board refresh failed:', err);
@@ -6805,6 +6816,7 @@ _OPERATOR_PAGE_JS = """
         const briefing = await fetchJson('/api/briefing/session?compact=1');
         if (briefing.error) throw new Error(briefing.error);
         renderOperator(briefing);
+        setPollTs($('#last-updated'), briefing);
         $('#last-updated').textContent = `Updated ${new Date().toLocaleTimeString()}`;
         const pill = $('#conn-status');
         pill.innerHTML = '<span class="dot"></span> Connected';
@@ -7023,6 +7035,7 @@ def render_quality_board_page_html() -> str:
   <style>
 {_TOP_NAV_CSS}
 {_QUALITY_BOARD_PAGE_CSS}
+{_poll_stale_css()}
   </style>
 </head>
 <body>
@@ -7053,6 +7066,7 @@ def render_quality_board_page_html() -> str:
 <script>
 {_QUALITY_BOARD_PAGE_JS}
 </script>
+{_render_poll_stale_script()}
 </body>
 </html>"""
 
@@ -7216,6 +7230,7 @@ def render_operator_page_html() -> str:
   <style>
 {_TOP_NAV_CSS}
 {_OPERATOR_PAGE_CSS}
+{_poll_stale_css()}
   </style>
 </head>
 <body>
@@ -7271,6 +7286,7 @@ def render_operator_page_html() -> str:
   <script>
 {_OPERATOR_PAGE_JS}
   </script>
+{_render_poll_stale_script()}
 </body>
 </html>"""
 
@@ -7287,6 +7303,7 @@ def render_pipeline_page_html(repo_root: Path, *, tail: int = 30) -> str:
   <style>
 {_TOP_NAV_CSS}
 {_PIPELINE_PAGE_CSS}
+{_poll_stale_css()}
   </style>
 </head>
 <body>
@@ -7381,6 +7398,7 @@ def render_pipeline_page_html(repo_root: Path, *, tail: int = 30) -> str:
       ]);
       renderPipelinePanel('#v2-body', '#v2-badge', v2Status, 'V2 Pipeline');
       renderPipelineEvents(events);
+      setPollTs($('#v2-badge'), v2Status);
     }}
 
     loadPipelinePage().catch(err => {{
@@ -7389,6 +7407,7 @@ def render_pipeline_page_html(repo_root: Path, *, tail: int = 30) -> str:
       console.error('Pipeline page load failed:', err);
     }});
   </script>
+{_render_poll_stale_script()}
 </body>
 </html>"""
 
@@ -7405,6 +7424,7 @@ def render_activity_page_html() -> str:
 {_TOP_NAV_CSS}
 {_ACTIVITY_PAGE_CSS}
 {_ACTIVITY_FEED_CSS}
+{_poll_stale_css()}
   </style>
 </head>
 <body>
@@ -7456,6 +7476,7 @@ def render_activity_page_html() -> str:
   <script>
 {_ACTIVITY_PAGE_JS}
   </script>
+{_render_poll_stale_script()}
 </body>
 </html>"""
 
@@ -7471,6 +7492,7 @@ def render_health_page_html() -> str:
   <style>
 {_TOP_NAV_CSS}
 {_HEALTH_PAGE_CSS}
+{_poll_stale_css()}
   </style>
 </head>
 <body>
@@ -7524,6 +7546,7 @@ def render_health_page_html() -> str:
   <script>
 {_HEALTH_PAGE_JS}
   </script>
+{_render_poll_stale_script()}
 </body>
 </html>"""
 
@@ -7585,6 +7608,7 @@ def render_dashboard_html(repo_root: Path = REPO_ROOT, *, issue_number: int = DE
     .op-summary-link,.quality-summary-link,.pipeline-summary-link,.activity-summary-link,.summary-link {{ color:var(--accent); font-size:13px; font-weight:800; white-space:nowrap; }}
     @media (max-width:860px) {{ .summary-grid {{ grid-template-columns:1fr; }} .op-summary-card,.pipeline-summary-card,.benchmarks-summary-card {{ grid-template-columns:repeat(2,minmax(0,1fr)); }} .op-summary-link,.pipeline-summary-link {{ justify-self:start; }} }}
     @media (max-width:640px) {{ .main {{ padding:16px; }} .header-inner {{ padding:16px; align-items:flex-start; flex-direction:column; }} .op-summary-card,.quality-summary-card,.pipeline-summary-card,.activity-summary-card,.channels-summary-card,.benchmarks-summary-card,.artifacts-summary-card,.decisions-summary-card {{ grid-template-columns:1fr; }} .quality-summary-counts,.summary-copy,.health-summary-copy {{ white-space:normal; }} }}
+    {_poll_stale_css()}
   </style>
 </head>
 <body>
@@ -7713,6 +7737,7 @@ def render_dashboard_html(repo_root: Path = REPO_ROOT, *, issue_number: int = DE
           fetchJson('/api/missing-modules/status'), fetchJson('/api/pipeline/v2/status'), fetchJson('/api/briefing/session?compact=1'), fetchJson('/api/quality/board'), fetchJson('/api/activity?limit=3')
         ]);
         renderOperator(briefing); renderQuality(qualityBoard); renderPipeline(pipelineStatus); renderActivity(activitySummary); renderHealth(briefing, missing);
+        setPollTs($('#last-updated'), briefing);
         $('#last-updated').textContent = `Updated ${{new Date().toLocaleTimeString()}}`;
         const pill = $('#conn-status'); pill.innerHTML = '<span class="dot"></span> Connected'; tone(pill, 'green');
       }} catch (err) {{ const pill = $('#conn-status'); pill.innerHTML = '<span class="dot"></span> Error'; tone(pill, 'red'); console.error('Dashboard refresh failed:', err); }}
@@ -7720,6 +7745,7 @@ def render_dashboard_html(repo_root: Path = REPO_ROOT, *, issue_number: int = DE
     }}
     $('#refresh').addEventListener('click', refresh); refresh(); setInterval(refresh, 60000);
   </script>
+{_render_poll_stale_script()}
 </body>
 </html>"""
 

--- a/scripts/local_api/routes/ui_fragments.py
+++ b/scripts/local_api/routes/ui_fragments.py
@@ -18,8 +18,11 @@ def render_poll_stale_script() -> str:
     if (!el) return;
     let ts = payload?.generated_at ?? payload?.snapshot?.generated_at ?? payload?.freshness?.refresh_completed_at;
     if (ts == null || !Number.isFinite(Number(ts))) ts = Math.floor(Date.now() / 1000);
-    el.dataset.pollTs = String(Math.floor(Number(ts)));
-    el.classList.remove("poll-stale");
+    const tsSec = Math.floor(Number(ts));
+    el.dataset.pollTs = String(tsSec);
+    const tsMs = tsSec * 1000;
+    const stale = Number.isFinite(tsMs) && tsMs > 0 && Date.now() - tsMs > STALE_MS;
+    el.classList.toggle("poll-stale", stale);
   };
   function markStalePolls() {
     document.querySelectorAll("[data-poll-ts]").forEach((el) => {

--- a/scripts/local_api/routes/ui_fragments.py
+++ b/scripts/local_api/routes/ui_fragments.py
@@ -14,6 +14,13 @@ def render_poll_stale_script() -> str:
 <script>
 (() => {
   const STALE_MS = 24 * 60 * 60 * 1000;
+  window.setPollTs = function setPollTs(el, payload) {
+    if (!el) return;
+    let ts = payload?.generated_at ?? payload?.snapshot?.generated_at ?? payload?.freshness?.refresh_completed_at;
+    if (ts == null || !Number.isFinite(Number(ts))) ts = Math.floor(Date.now() / 1000);
+    el.dataset.pollTs = String(Math.floor(Number(ts)));
+    el.classList.remove("poll-stale");
+  };
   function markStalePolls() {
     document.querySelectorAll("[data-poll-ts]").forEach((el) => {
       const ts = Number(el.dataset.pollTs) * 1000;

--- a/tests/test_local_api_poll_stale.py
+++ b/tests/test_local_api_poll_stale.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    module_path = Path(__file__).resolve().parent.parent / "scripts" / "local_api.py"
+    spec = importlib.util.spec_from_file_location("local_api_poll_stale", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_ui_fragments():
+    module_path = (
+        Path(__file__).resolve().parent.parent / "scripts" / "local_api" / "routes" / "ui_fragments.py"
+    )
+    spec = importlib.util.spec_from_file_location("ui_fragments_poll_stale", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+local_api = _load_module()
+ui_fragments = _load_ui_fragments()
+
+
+POLL_PAGES = ("/", "/operator", "/pipeline", "/activity", "/health", "/quality")
+
+
+def test_poll_stale_script_marks_elements_older_than_24h() -> None:
+    script = ui_fragments.render_poll_stale_script()
+    assert "setPollTs" in script
+    assert "poll-stale" in script
+    assert "24 * 60 * 60 * 1000" in script
+
+
+def test_auto_refresh_pages_include_poll_stale_assets(tmp_path: Path) -> None:
+    for route in POLL_PAGES:
+        status, body, content_type = local_api.route_request(tmp_path, route)
+        assert status == 200, route
+        assert "text/html" in content_type, route
+        assert ".poll-stale" in body, route
+        assert "setPollTs" in body, route
+        assert "markStalePolls" in body, route
+
+
+def test_auto_refresh_pages_wire_set_poll_ts_in_refresh_handlers(tmp_path: Path) -> None:
+    status, body, _ = local_api.route_request(tmp_path, "/operator")
+    assert status == 200
+    assert "setPollTs($('#last-updated'), briefing)" in body
+
+    status, body, _ = local_api.route_request(tmp_path, "/quality")
+    assert status == 200
+    assert "setPollTs($('#last-updated'), board)" in body

--- a/tests/test_local_api_poll_stale.py
+++ b/tests/test_local_api_poll_stale.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import importlib.util
+import re
 import sys
 from pathlib import Path
+
+import pytest
 
 
 def _load_module():
@@ -27,11 +30,30 @@ def _load_ui_fragments():
     return module
 
 
+def _set_poll_ts_body(script: str) -> str:
+    match = re.search(
+        r"window\.setPollTs = function setPollTs\(el, payload\) \{.*?\n  \};",
+        script,
+        re.DOTALL,
+    )
+    assert match is not None
+    return match.group(0)
+
+
 local_api = _load_module()
 ui_fragments = _load_ui_fragments()
 
 
 POLL_PAGES = ("/", "/operator", "/pipeline", "/activity", "/health", "/quality")
+
+SET_POLL_TS_CALL_SITES = (
+    ("/", "setPollTs($('#last-updated'), briefing)"),
+    ("/operator", "setPollTs($('#last-updated'), briefing)"),
+    ("/pipeline", "setPollTs($('#v2-badge'), v2Status)"),
+    ("/activity", "setPollTs($('#activity-badge'), activityData)"),
+    ("/health", "setPollTs($('#svc-badge'), services)"),
+    ("/quality", "setPollTs($('#last-updated'), board)"),
+)
 
 
 def test_poll_stale_script_marks_elements_older_than_24h() -> None:
@@ -39,6 +61,23 @@ def test_poll_stale_script_marks_elements_older_than_24h() -> None:
     assert "setPollTs" in script
     assert "poll-stale" in script
     assert "24 * 60 * 60 * 1000" in script
+
+
+def test_set_poll_ts_toggles_stale_immediately() -> None:
+    script = ui_fragments.render_poll_stale_script()
+    body = _set_poll_ts_body(script)
+    assert "STALE_MS" in body
+    assert 'classList.toggle("poll-stale", stale)' in body
+    assert "classList.remove" not in body
+
+
+def test_set_poll_ts_reapplies_stale_for_old_cached_timestamp() -> None:
+    """Stale cached refresh must not clear poll-stale until data is fresh."""
+    script = ui_fragments.render_poll_stale_script()
+    body = _set_poll_ts_body(script)
+    assert "Date.now() - tsMs > STALE_MS" in body
+    assert "el.dataset.pollTs" in body
+    assert 'classList.toggle("poll-stale", stale)' in body
 
 
 def test_auto_refresh_pages_include_poll_stale_assets(tmp_path: Path) -> None:
@@ -51,11 +90,10 @@ def test_auto_refresh_pages_include_poll_stale_assets(tmp_path: Path) -> None:
         assert "markStalePolls" in body, route
 
 
-def test_auto_refresh_pages_wire_set_poll_ts_in_refresh_handlers(tmp_path: Path) -> None:
-    status, body, _ = local_api.route_request(tmp_path, "/operator")
-    assert status == 200
-    assert "setPollTs($('#last-updated'), briefing)" in body
-
-    status, body, _ = local_api.route_request(tmp_path, "/quality")
-    assert status == 200
-    assert "setPollTs($('#last-updated'), board)" in body
+@pytest.mark.parametrize("route,needle", SET_POLL_TS_CALL_SITES)
+def test_auto_refresh_page_wires_set_poll_ts_in_refresh_handler(
+    tmp_path: Path, route: str, needle: str
+) -> None:
+    status, body, _ = local_api.route_request(tmp_path, route)
+    assert status == 200, route
+    assert needle in body, route


### PR DESCRIPTION
## Summary

Wires `POLL_STALE_CSS` + `setPollTs()` on all six auto-refresh local-monitor pages. PR #1493 added these helpers to `scripts/local_api/routes/ui_fragments.py` but nothing was rendering them. Stale styling kicks in after 24h of no refresh.

Closes #1495

## Review cycle

| Round | Reviewer | Verdict | Findings |
|-------|----------|---------|----------|
| R1 | codex gpt-5.5 | NEEDS_CHANGES | (1) P1: `setPollTs()` set new ts but unconditionally removed `poll-stale` class without re-evaluating threshold — race/flicker on already-stale cached refreshes. (2) Test coverage gap — only operator + quality had setPollTs() call-site assertions; other 4 pages were asset-presence only. |
| Fix-pass `8ac98343` (cursor composer-2.5) | — | — | (1) `setPollTs()` now computes `stale = Date.now() - tsMs > STALE_MS` immediately and uses `classList.toggle("poll-stale", stale)`. (2) Parametrized call-site assertions added for all 6 pages: `/`, `/operator`, `/pipeline`, `/activity`, `/health`, `/quality`. Tests grew 3 → 10 passing. |
| R2 | codex gpt-5.5 | PASS | No R2 blockers. Race-fix tests verified to fail against old implementation. All 6 page call-sites covered. |

## Regression test

- Regression test: tests/test_local_api_poll_stale.py
- 10 tests cover: helper presence, asset linking on all 6 pages, immediate STALE_MS toggle in setPollTs (would fail against old unconditional-remove), parametrized call-site assertions for all 6 pages.

🤖 cursor composer-2.5 + codex gpt-5.5 R1/R2 + Claude orchestrator