### PR TITLE
feat(api): quality board design-system + global search chrome (#1496)

### DIFF
--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -7020,6 +7020,7 @@ def render_quality_board_page_html() -> str:
   <meta charset=\"utf-8\">
   <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
   <title>Quality Board - KubeDojo Local Monitor</title>
+  {_design_system_link()}
   <style>
 {_TOP_NAV_CSS}
 {_QUALITY_BOARD_PAGE_CSS}
@@ -7027,6 +7028,7 @@ def render_quality_board_page_html() -> str:
 </head>
 <body>
  {_render_top_nav("quality")}
+{_render_page_chrome()}
 <main class=\"main\">
   <div class=\"page-head\">
     <div>

--- a/tests/test_local_api_quality.py
+++ b/tests/test_local_api_quality.py
@@ -25,4 +25,6 @@ def test_quality_route_remains_real_page(tmp_path: Path) -> None:
     assert "text/html" in content_type
     assert 'id="quality-board"' in body
     assert '<a class="navlink active" href="/quality"' in body
+    assert 'href="/static/design-system.css"' in body
+    assert 'data-search-widget' in body
 


### PR DESCRIPTION
## Summary

Quality board dashboard inherits design-system link + global search chrome from PR #1493 helpers (`_design_system_link()` + `_render_page_chrome()`). Brings parity across operator / pipeline / activity / health / quality monitor pages.

Closes #1496

## Cross-family review

- **Author:** cursor composer-2.5
- **R1 reviewer:** codex gpt-5.5 → **APPROVE, no blocking findings**

> Chrome/helper usage correct: `/quality` uses `_design_system_link()` and `_render_page_chrome()` in the same head/body positions as other monitor pages. No duplicated chrome HTML or fabricated helper names. No quality-board regression: existing markers (`quality-board`, `qb-search`, `qb-track`, `qb-status`, `qb-legend`, `qb-tracks`) remain. Smoke from worktree-rooted local API: `/quality`, `/static/design-system.css`, `/api/quality/board`, `/api/search` all fetched successfully (board returned 784 modules / 69 tracks, search 3 results). Ruff + pytest pass.

🤖 cursor composer-2.5 + codex gpt-5.5 R1 + Claude orchestrator