### PR TITLE
feat(api): benchmarks dashboard global search chrome parity (#1497)

### DIFF
--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -5499,6 +5499,7 @@ def _render_benchmarks_page(repo_root: Path) -> str:
 </head>
 <body>
 {_render_top_nav("benchmarks")}
+{_render_page_chrome()}
 <main class="wrap">
   <header class="hero">
     <div><h1>Benchmarks</h1><div class="sub">Calibration report dashboard.</div></div>
@@ -5576,6 +5577,7 @@ def _render_benchmarks_page(repo_root: Path) -> str:
 </head>
 <body>
 {_render_top_nav("benchmarks")}
+{_render_page_chrome()}
 <main class="wrap">
   <section class="bench-head">
     <div>

--- a/tests/test_local_api_benchmarks_ui.py
+++ b/tests/test_local_api_benchmarks_ui.py
@@ -104,6 +104,7 @@ def test_benchmarks_page_renders_latest_report_dashboard(tmp_path: Path) -> None
     assert "12 lanes" in body
     assert 'href="/artifacts/calibration/v1/reports/2026-05-21/per-lane/code-review.html"' in body
     assert 'href="/artifacts/calibration/v1/reports/2026-05-21/stability.html"' in body
+    assert 'data-search-widget' in body
 
 
 def test_benchmarks_page_disables_missing_stability_report(tmp_path: Path) -> None:
@@ -116,6 +117,7 @@ def test_benchmarks_page_disables_missing_stability_report(tmp_path: Path) -> No
     assert '<span class="bench-tile disabled">' in body
     assert 'href="/artifacts/calibration/v1/reports/2026-05-21/stability.html"' not in body
     assert "stability-candidates.json" not in body
+    assert 'data-search-widget' in body
 
 
 def test_benchmarks_top_nav_link_appears_on_existing_ui_routes(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Benchmarks dashboard now matches operator/pipeline chrome — design-system link + global search widget on both empty AND populated states.

Closes #1497

## Cross-family review

- **Author:** cursor composer-2.5
- **R1 reviewer:** codex gpt-5.5 → **PASS, no blocking findings**

> `_render_page_chrome()` present in both `/benchmarks` branches. Populated view includes `/static/design-system.css`. Empty state: design-system link + `data-search-widget`. Populated: design-system link + `data-search-widget`. Matrix sticky header/lane column preserved. Per-model radar SVG renders with nonzero dimensions and labels/polygon. Ruff + pytest (test_local_api_benchmarks_ui.py) + git diff --check all clean.

🤖 cursor composer-2.5 + codex gpt-5.5 R1 + Claude orchestrator