### PR TITLE
feat(api): expand repo_guard tests + document /healthz contract (#1499)

### DIFF
--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -8521,7 +8521,11 @@ def build_api_schema() -> dict[str, Any]:
             {"path": "/benchmarks", "desc": "Calibration benchmark dashboard", "content_type": "text/html"},
             {"path": "/activity", "desc": "Activity feed with client-side track and agent filters", "content_type": "text/html"},
             {"path": "/health", "desc": "Runtime services, worktrees, and missing-module operational health", "content_type": "text/html"},
-            {"path": "/healthz", "desc": "Liveness probe"},
+            {
+                "path": "/healthz",
+                "desc": "Liveness probe with repo-root inspection. ok=false when repo_root is not the primary checkout or .pids/api.pid references a dead/unreadable process.",
+                "fields": ["ok", "repo_root", "primary_repo_root", "warnings"],
+            },
             {"path": "/api/schema", "desc": "This document"},
             {
                 "path": "/api/state/manifest",

--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -8575,7 +8575,20 @@ def build_api_schema() -> dict[str, Any]:
                 "path": "/api/tracks/readiness",
                 "desc": "Per-track, per-section production-readiness grid (cleared/in_flight/dead_letter/not_yet_enqueued)",
             },
-            {"path": "/api/runtime/services", "desc": "Runtime services (pids, uptime, ports)"},
+            {
+                "path": "/api/runtime/services",
+                "desc": "Runtime services (pids, uptime, ports) plus repo-root inspection.",
+                "fields": ["running", "stopped", "stale", "total", "services", "repo"],
+                "repo": {
+                    "fields": ["repo_root", "primary_repo_root", "process_cwd", "warnings"],
+                    "desc": (
+                        "inspect_repo_root() output: repo_root is the served checkout; "
+                        "primary_repo_root is git common-dir parent (null when git unavailable); "
+                        "process_cwd is os.getcwd(); warnings when repo_root != primary, "
+                        "cwd is under .worktrees/, or .pids/api.pid is stale/unreadable."
+                    ),
+                },
+            },
             {"path": "/api/build/run", "desc": "Spawn `npm run build` in the background", "method": "POST"},
             {"path": "/api/build/status", "desc": "Build job status + tail + warning diff", "query": ["job_id=..."]},
             {"path": "/api/pipeline/v2/status", "desc": "Pipeline v2 queue + per-track"},

--- a/tests/test_local_api_repo_guard.py
+++ b/tests/test_local_api_repo_guard.py
@@ -45,7 +45,7 @@ def test_build_healthz_payload_fails_on_stale_api_pid(tmp_path: Path) -> None:
     assert any("dead process" in warning for warning in payload["warnings"])
 
 
-def test_build_healthz_payload_warns_on_unreadable_api_pid(tmp_path: Path) -> None:
+def test_malformed_pid_file_content(tmp_path: Path) -> None:
     repo_guard = _load_repo_guard()
     pid_dir = tmp_path / ".pids"
     pid_dir.mkdir()
@@ -55,6 +55,39 @@ def test_build_healthz_payload_warns_on_unreadable_api_pid(tmp_path: Path) -> No
 
     assert payload["ok"] is False
     assert any("unreadable" in warning for warning in payload["warnings"])
+
+
+def test_unreadable_pid_file_oserror(tmp_path: Path) -> None:
+    repo_guard = _load_repo_guard()
+    pid_dir = tmp_path / ".pids"
+    pid_dir.mkdir()
+    pid_file = pid_dir / "api.pid"
+    pid_file.write_text("12345", encoding="utf-8")
+    pid_file.chmod(0o000)
+
+    try:
+        payload = repo_guard.build_healthz_payload(tmp_path)
+    finally:
+        pid_file.chmod(0o644)
+
+    assert payload["ok"] is False
+    assert any("unreadable" in warning for warning in payload["warnings"])
+
+
+def test_inspect_repo_root_warns_when_not_primary(tmp_path: Path, monkeypatch) -> None:
+    repo_guard = _load_repo_guard()
+    primary = tmp_path / "primary"
+    primary.mkdir()
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    monkeypatch.setattr(repo_guard, "resolve_primary_repo_root", lambda _start=None: primary)
+
+    inspection = repo_guard.inspect_repo_root(worktree)
+
+    assert inspection["repo_root"] == str(worktree.resolve())
+    assert inspection["primary_repo_root"] == str(primary.resolve())
+    assert any("not the primary checkout" in warning for warning in inspection["warnings"])
+    assert repo_guard.build_healthz_payload(worktree)["ok"] is False
 
 
 def test_inspect_repo_root_worktree_cwd_is_informational(tmp_path: Path, monkeypatch) -> None:
@@ -84,3 +117,17 @@ def test_schema_documents_healthz_contract() -> None:
     healthz = next(entry for entry in schema["endpoints"] if entry["path"] == "/healthz")
     assert healthz["fields"] == ["ok", "repo_root", "primary_repo_root", "warnings"]
     assert "dead/unreadable" in healthz["desc"]
+
+
+def test_schema_documents_runtime_services_repo_field() -> None:
+    local_api = _load_local_api()
+    schema = local_api.build_api_schema()
+    runtime = next(entry for entry in schema["endpoints"] if entry["path"] == "/api/runtime/services")
+    assert runtime["fields"] == ["running", "stopped", "stale", "total", "services", "repo"]
+    assert runtime["repo"]["fields"] == [
+        "repo_root",
+        "primary_repo_root",
+        "process_cwd",
+        "warnings",
+    ]
+    assert "inspect_repo_root" in runtime["repo"]["desc"]

--- a/tests/test_local_api_repo_guard.py
+++ b/tests/test_local_api_repo_guard.py
@@ -15,6 +15,16 @@ def _load_repo_guard():
     return module
 
 
+def _load_local_api():
+    module_path = Path(__file__).resolve().parent.parent / "scripts" / "local_api.py"
+    spec = importlib.util.spec_from_file_location("local_api_repo_guard", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
 def test_build_healthz_payload_ok_on_clean_tmp_path(tmp_path: Path) -> None:
     repo_guard = _load_repo_guard()
     payload = repo_guard.build_healthz_payload(tmp_path)
@@ -23,16 +33,54 @@ def test_build_healthz_payload_ok_on_clean_tmp_path(tmp_path: Path) -> None:
     assert not any("dead process" in warning for warning in payload["warnings"])
 
 
-def test_healthz_route_uses_repo_guard(tmp_path: Path) -> None:
-    local_api_path = Path(__file__).resolve().parent.parent / "scripts" / "local_api.py"
-    spec = importlib.util.spec_from_file_location("local_api_healthz", local_api_path)
-    assert spec is not None and spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
+def test_build_healthz_payload_fails_on_stale_api_pid(tmp_path: Path) -> None:
+    repo_guard = _load_repo_guard()
+    pid_dir = tmp_path / ".pids"
+    pid_dir.mkdir()
+    (pid_dir / "api.pid").write_text("999999999", encoding="utf-8")
 
-    status, body, content_type = module.route_request(tmp_path, "/healthz")
+    payload = repo_guard.build_healthz_payload(tmp_path)
+
+    assert payload["ok"] is False
+    assert any("dead process" in warning for warning in payload["warnings"])
+
+
+def test_build_healthz_payload_warns_on_unreadable_api_pid(tmp_path: Path) -> None:
+    repo_guard = _load_repo_guard()
+    pid_dir = tmp_path / ".pids"
+    pid_dir.mkdir()
+    (pid_dir / "api.pid").write_text("not-a-pid", encoding="utf-8")
+
+    payload = repo_guard.build_healthz_payload(tmp_path)
+
+    assert payload["ok"] is False
+    assert any("unreadable" in warning for warning in payload["warnings"])
+
+
+def test_inspect_repo_root_worktree_cwd_is_informational(tmp_path: Path, monkeypatch) -> None:
+    repo_guard = _load_repo_guard()
+    worktree = tmp_path / ".worktrees" / "sample"
+    worktree.mkdir(parents=True)
+    monkeypatch.chdir(worktree)
+
+    inspection = repo_guard.inspect_repo_root(tmp_path)
+
+    assert any("git worktree" in warning for warning in inspection["warnings"])
+    assert repo_guard.build_healthz_payload(tmp_path)["ok"] is True
+
+
+def test_healthz_route_uses_repo_guard(tmp_path: Path) -> None:
+    local_api = _load_local_api()
+    status, body, content_type = local_api.route_request(tmp_path, "/healthz")
     assert status == 200
     assert content_type == "application/json; charset=utf-8"
     assert body["ok"] is True
     assert "warnings" in body
+
+
+def test_schema_documents_healthz_contract() -> None:
+    local_api = _load_local_api()
+    schema = local_api.build_api_schema()
+    healthz = next(entry for entry in schema["endpoints"] if entry["path"] == "/healthz")
+    assert healthz["fields"] == ["ok", "repo_root", "primary_repo_root", "warnings"]
+    assert "dead/unreadable" in healthz["desc"]


### PR DESCRIPTION
## Summary

Expands `scripts/local_api/repo_guard.py` test coverage (PR #1493 introduced repo_guard + wired `/healthz`); documents the `/healthz` contract + `/api/runtime/services` `repo` top-level field in `/api/schema`.

Closes #1499

## Review cycle

| Round | Reviewer | Verdict | Findings |
|-------|----------|---------|----------|
| R1 | codex gpt-5.5 | NEEDS_CHANGES | (1) `/api/runtime/services` `repo` field undocumented; (2) repo-mismatch branch not tested; (3) "unreadable pid" test mislabeled (covered ValueError not OSError). |
| Fix-pass `42aa4bd8` (cursor composer-2.5) | — | — | (1) Schema entry documents `repo` + nested fields, locked by new contract test; (2) repo-mismatch test added (monkeypatched primary root exercises `resolved != primary` branch); (3) renamed `test_malformed_pid_*`; added new `test_unreadable_pid_file_oserror` with `chmod(0o000)` real OSError. |
| R2 | codex gpt-5.5 | APPROVE | No findings. 9 tests pass (was 6). chmod(0o000) verified to raise PermissionError 13. |

## Regression test

- Regression test: tests/test_local_api_repo_guard.py
- 9 tests cover: clean tmp, stale pid, malformed pid content (ValueError), worktree cwd warning, **NEW** repo-mismatch branch, **NEW** real OSError via chmod, schema contract lock for `/api/runtime/services` `repo` field.

🤖 cursor composer-2.5 + codex gpt-5.5 R1/R2 + Claude orchestrator