### PR TITLE
docs(api): document deferred Research artifact index in /api/schema (#1500)

### DIFF
--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -8510,7 +8510,7 @@ def build_api_schema() -> dict[str, Any]:
         },
         "endpoints": [
             {"path": "/", "desc": "HTML dashboard", "content_type": "text/html"},
-            {"path": "/artifacts", "desc": "Browseable HTML and Markdown artifact index", "content_type": "text/html"},
+            {"path": "/artifacts", "desc": "Browseable HTML and Markdown artifact index", "content_type": "text/html", "query": ["include=research", "include_research=1"]},
             {
                 "path": "/artifacts/{rel-path}",
                 "desc": "Static HTML/assets and server-rendered Markdown from approved artifact directories",
@@ -8533,7 +8533,7 @@ def build_api_schema() -> dict[str, Any]:
                 "desc": "Single primary action + up to 3 alternatives + blockers/alerts. Punch-line orientation derived from the session briefing.",
                 "content_type": "application/json",
             },
-            {"path": "/api/artifacts", "desc": "JSON index of HTML and Markdown artifacts served by /artifacts"},
+            {"path": "/api/artifacts", "desc": "JSON index of HTML and Markdown artifacts served by /artifacts. Research category omitted by default for performance; opt in with ?include=research or ?include_research=1.", "query": ["include=research", "include_research=1"]},
             {
                 "path": "/api/briefing/session",
                 "desc": "Agent cold-start orientation snapshot. First call for fresh agents.",

--- a/tests/test_local_api_artifacts.py
+++ b/tests/test_local_api_artifacts.py
@@ -175,3 +175,14 @@ def test_home_has_artifacts_and_decisions_cards(tmp_path: Path) -> None:
     assert "View artifacts" in body
     assert 'class="decisions-summary-card" href="/decisions"' in body
     assert "View decisions" in body
+
+
+def test_schema_documents_research_artifact_deferral() -> None:
+    schema = local_api.build_api_schema()
+    endpoints = {entry["path"]: entry for entry in schema["endpoints"]}
+    api_artifacts = endpoints["/api/artifacts"]
+    html_artifacts = endpoints["/artifacts"]
+    assert "Research" in api_artifacts["desc"]
+    assert "include=research" in api_artifacts["query"]
+    assert "include_research=1" in api_artifacts["query"]
+    assert "include=research" in html_artifacts["query"]


### PR DESCRIPTION
## Summary

Documents the `?include=research` / `?include_research=1` query-param deferral semantics for Research artifacts in `/api/schema`. Tracks the PR #1493 deferral (30s TTL cache; `docs/research/**` excluded from default `/api/artifacts` and `/artifacts` index for performance, opt-in via query params).

Closes #1500

## Cross-family review

- **Author:** cursor composer-2.5
- **R1 reviewer:** codex gpt-5.5 → **PASS, no findings**

> PR-branch `/api/schema` documents both params for `/artifacts` and `/api/artifacts`. `/api/artifacts` default omits Research; both `?include=research` and `?include_research=1` include it. `/artifacts?include=research` renders the Research section. 30s cache present in both artifact index cache and route cache. Ruff clean, pytest 2 passed.

🤖 cursor composer-2.5 + codex gpt-5.5 R1 + Claude orchestrator