### PR TITLE
docs(tooling): cross-family PR review runbook (#1501)

### DIFF
--- a/scripts/agent_onboarding.md
+++ b/scripts/agent_onboarding.md
@@ -138,18 +138,30 @@ The briefing API exists so deep file crawls are normally unnecessary.
 
 Cross-family review is mandatory (`docs/review-protocol.md`, AGENTS.md rule 10). Implementation agents open PRs; the **orchestrator merges** after review.
 
-**Pick a reviewer from a different model family than the author** (Codex writes → Claude or Gemini reviews; Claude writes → Gemini or Codex; etc.).
+**Reviewer routing (Decision Card C)** — full rationale and updates live in [`docs/decisions/2026-05-24-reviewer-routing-composer-2-5.md`](docs/decisions/2026-05-24-reviewer-routing-composer-2-5.md):
+
+| Task class | Primary | Secondary | Notes |
+|---|---|---|---|
+| T0 content review (R1 + R2) | composer-2.5 (`cursor`) | codex | deepseek tertiary; bash-runnability brief required |
+| Content authoring | codex / composer-2.5 / deepseek (rotation) | — | — |
+| Code / dispatcher / CI review | codex | composer-2.5 (`cursor`) | unchanged |
+| Lab-runnability + ground-truth | composer-2.5 (`cursor`) | codex | bash-runnability specialty |
+| Translation review (UK) | gemini-cli (when quota back) | codex | unchanged |
+
+**Symmetric rule:** pick a reviewer from a **different model family** than the author (composer-2.5 / Cursor-authored content → **codex** reviews; codex-authored code → **composer-2.5** or Gemini reviews).
 
 | When | Tool | Command |
 |------|------|---------|
 | Headless Gemini (Ultra OAuth) | `dispatch.py` | `KUBEDOJO_GEMINI_SUBSCRIPTION=1 .venv/bin/python scripts/dispatch.py gemini - --review` |
-| Bridge review with `gh pr diff` | `ab ask-gemini` | `scripts/ab ask-gemini --review --allow-write` |
-| Quote verification (always) | `verify_review.py` | `.venv/bin/python scripts/verify_review.py --pr N --branch origin/<branch>` |
+| T0 content / lab-runnability review | `dispatch_smart.py` | `.venv/bin/python scripts/dispatch_smart.py review --agent cursor --model composer-2.5 --task-id review-pr-N -` (stdin brief; see workflow) |
+| Code / dispatcher / CI review | `dispatch_smart.py` | `.venv/bin/python scripts/dispatch_smart.py review --agent codex --worktree .worktrees/<branch> --task-id review-pr-N -` (stdin brief) |
+| Quote verification (always) | `verify_review.py` | `.venv/bin/python scripts/verify_review.py --pr N --from-pr --branch origin/<branch>` |
 
 Workflow:
 
-1. Post the review as `gh pr comment` — not `gh pr review --approve` when the same GitHub identity owns author and reviewer.
-2. Run `verify_review.py` before treating `NEEDS CHANGES` as blocking; ignore `quote_missing` findings unless the verifier confirms them.
-3. Orchestrator merges after an independent-family review is posted; coding agents do not merge their own PRs.
+1. Dispatch the reviewer with a brief that includes `gh pr diff N` and `docs/review-protocol.md` (heredoc on `-` is fine).
+2. Post the review as `gh pr comment` — not `gh pr review --approve` when the same GitHub identity owns author and reviewer.
+3. Run `verify_review.py --from-pr` (or pipe the saved review on stdin) before treating `NEEDS CHANGES` as blocking; ignore `quote_missing` findings unless the verifier confirms them. **Do not** run `--pr` without `--from-pr` and without stdin — that reads empty stdin and falsely reports `0 verified`.
+4. Orchestrator merges after an independent-family review is posted; coding agents do not merge their own PRs.
 
-Smoketest: `bash scripts/ops/smoketest_review_verifier.sh` (fixture with one verified + one quote_missing finding).
+Smoketest: `bash scripts/ops/smoketest_review_verifier.sh` (CLI fixture with one verified + one quote_missing finding).

--- a/scripts/agent_onboarding.md
+++ b/scripts/agent_onboarding.md
@@ -138,7 +138,7 @@ The briefing API exists so deep file crawls are normally unnecessary.
 
 Cross-family review is mandatory (`docs/review-protocol.md`, AGENTS.md rule 10). Implementation agents open PRs; the **orchestrator merges** after review.
 
-**Reviewer routing (Decision Card C)** — full rationale and updates live in [`docs/decisions/2026-05-24-reviewer-routing-composer-2-5.md`](docs/decisions/2026-05-24-reviewer-routing-composer-2-5.md):
+**Reviewer routing (Decision Card C)** — full rationale and updates live in [`docs/decisions/2026-05-24-reviewer-routing-composer-2-5.md`](../docs/decisions/2026-05-24-reviewer-routing-composer-2-5.md):
 
 | Task class | Primary | Secondary | Notes |
 |---|---|---|---|

--- a/scripts/agent_onboarding.md
+++ b/scripts/agent_onboarding.md
@@ -133,3 +133,23 @@ The briefing API exists so deep file crawls are normally unnecessary.
 - **Errors are JSON envelopes**: `{"error": "<code>", ...optional context}` with an HTTP status that matches the code.
 - **Cache**: cacheable endpoints return a weak ETag; `If-None-Match` yields `304`.
 - **Compact**: `/api/briefing/session?compact=1` drops navigation aids (`next_reads`, `links`, worktree list) while keeping the actionable surface.
+
+## 9. Cross-family PR review (before merge)
+
+Cross-family review is mandatory (`docs/review-protocol.md`, AGENTS.md rule 10). Implementation agents open PRs; the **orchestrator merges** after review.
+
+**Pick a reviewer from a different model family than the author** (Codex writes → Claude or Gemini reviews; Claude writes → Gemini or Codex; etc.).
+
+| When | Tool | Command |
+|------|------|---------|
+| Headless Gemini (Ultra OAuth) | `dispatch.py` | `KUBEDOJO_GEMINI_SUBSCRIPTION=1 .venv/bin/python scripts/dispatch.py gemini - --review` |
+| Bridge review with `gh pr diff` | `ab ask-gemini` | `scripts/ab ask-gemini --review --allow-write` |
+| Quote verification (always) | `verify_review.py` | `.venv/bin/python scripts/verify_review.py --pr N --branch origin/<branch>` |
+
+Workflow:
+
+1. Post the review as `gh pr comment` — not `gh pr review --approve` when the same GitHub identity owns author and reviewer.
+2. Run `verify_review.py` before treating `NEEDS CHANGES` as blocking; ignore `quote_missing` findings unless the verifier confirms them.
+3. Orchestrator merges after an independent-family review is posted; coding agents do not merge their own PRs.
+
+Smoketest: `bash scripts/ops/smoketest_review_verifier.sh` (fixture with one verified + one quote_missing finding).

--- a/scripts/ops/smoketest_review_verifier.sh
+++ b/scripts/ops/smoketest_review_verifier.sh
@@ -13,16 +13,27 @@ if [[ ! -x "$PYTHON" ]]; then
   exit 1
 fi
 
-REVIEW="$(cat <<'EOF'
+FIXTURE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/review-verifier-smoke.XXXXXX")"
+trap 'rm -rf "$FIXTURE_DIR"' EXIT
+
+cat >"$FIXTURE_DIR/fixture.py" <<'EOF'
+alpha = 1
+beta = 2
+gamma = 3
+EOF
+
+FIXTURE_PATH="$FIXTURE_DIR/fixture.py"
+
+REVIEW="$(cat <<EOF
 FINDING: verified quote
-FILE:LINE: fixture.py:2
+FILE:LINE: ${FIXTURE_PATH}:2
 CURRENT CODE:
   beta = 2
 WHY: example
 FIX: n/a
 
 FINDING: hallucinated quote
-FILE:LINE: fixture.py:4
+FILE:LINE: ${FIXTURE_PATH}:4
 CURRENT CODE:
   delta = 99
 WHY: example
@@ -30,27 +41,46 @@ FIX: n/a
 EOF
 )"
 
-OUTPUT="$(
-  printf '%s\n' "$REVIEW" | "$PYTHON" -c "
-import sys
-from pathlib import Path
+# Documented runbook path: stdin review + --pr (no --from-pr).
+REVIEW_FILE="$FIXTURE_DIR/review.txt"
+printf '%s\n' "$REVIEW" >"$REVIEW_FILE"
+set +e
+CLI_OUT="$("$PYTHON" scripts/verify_review.py --pr 0 <"$REVIEW_FILE" 2>&1)"
+CLI_RC=$?
+set -e
 
-sys.path.insert(0, str(Path('scripts').resolve()))
-from verify_review import verify_review
-
-review = sys.stdin.read()
-source = 'alpha = 1\nbeta = 2\ngamma = 3\n'
-results = verify_review(review, lambda _path: source)
-statuses = [row['status'] for row in results]
-print(','.join(statuses))
-if statuses != ['verified', 'quote_missing']:
-    raise SystemExit(f'unexpected statuses: {statuses}')
-"
-)"
-
-if [[ "$OUTPUT" != "verified,quote_missing" ]]; then
-  echo "smoketest_review_verifier: expected verified,quote_missing got ${OUTPUT}" >&2
+if [[ "$CLI_RC" -ne 1 ]]; then
+  echo "smoketest_review_verifier: expected exit 1 (quote_missing), got ${CLI_RC}" >&2
   exit 1
 fi
 
-echo "smoketest_review_verifier: ok (${OUTPUT})"
+if ! grep -q '1 verified, 0 line_mismatch, 1 quote_missing' <<<"$CLI_OUT"; then
+  echo "smoketest_review_verifier: unexpected verifier summary:" >&2
+  echo "$CLI_OUT" >&2
+  exit 1
+fi
+
+if ! grep -q '`verified` '"$FIXTURE_PATH"':2' <<<"$CLI_OUT"; then
+  echo "smoketest_review_verifier: missing verified row in output" >&2
+  exit 1
+fi
+
+if ! grep -q '`quote_missing` '"$FIXTURE_PATH"':4' <<<"$CLI_OUT"; then
+  echo "smoketest_review_verifier: missing quote_missing row in output" >&2
+  exit 1
+fi
+
+# Anti-regression: empty stdin must not be mistaken for a clean verification pass.
+EMPTY_OUT="$("$PYTHON" scripts/verify_review.py --pr 0 </dev/null 2>&1 || true)"
+if ! grep -q '0 verified, 0 line_mismatch, 0 quote_missing' <<<"$EMPTY_OUT"; then
+  echo "smoketest_review_verifier: empty stdin did not emit expected zero-count summary" >&2
+  exit 1
+fi
+
+# Parser surface must exist (runbook documents --from-pr).
+if ! "$PYTHON" scripts/verify_review.py --help | grep -q -- '--from-pr'; then
+  echo "smoketest_review_verifier: verify_review.py missing --from-pr flag" >&2
+  exit 1
+fi
+
+echo "smoketest_review_verifier: ok (verified,quote_missing via CLI)"

--- a/scripts/ops/smoketest_review_verifier.sh
+++ b/scripts/ops/smoketest_review_verifier.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+PYTHON="${ROOT}/.venv/bin/python"
+if [[ ! -x "$PYTHON" ]]; then
+  PYTHON="$(cd "$ROOT/../.." && pwd)/.venv/bin/python"
+fi
+if [[ ! -x "$PYTHON" ]]; then
+  echo "smoketest_review_verifier: missing .venv/bin/python" >&2
+  exit 1
+fi
+
+REVIEW="$(cat <<'EOF'
+FINDING: verified quote
+FILE:LINE: fixture.py:2
+CURRENT CODE:
+  beta = 2
+WHY: example
+FIX: n/a
+
+FINDING: hallucinated quote
+FILE:LINE: fixture.py:4
+CURRENT CODE:
+  delta = 99
+WHY: example
+FIX: n/a
+EOF
+)"
+
+OUTPUT="$(
+  printf '%s\n' "$REVIEW" | "$PYTHON" -c "
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path('scripts').resolve()))
+from verify_review import verify_review
+
+review = sys.stdin.read()
+source = 'alpha = 1\nbeta = 2\ngamma = 3\n'
+results = verify_review(review, lambda _path: source)
+statuses = [row['status'] for row in results]
+print(','.join(statuses))
+if statuses != ['verified', 'quote_missing']:
+    raise SystemExit(f'unexpected statuses: {statuses}')
+"
+)"
+
+if [[ "$OUTPUT" != "verified,quote_missing" ]]; then
+  echo "smoketest_review_verifier: expected verified,quote_missing got ${OUTPUT}" >&2
+  exit 1
+fi
+
+echo "smoketest_review_verifier: ok (${OUTPUT})"


### PR DESCRIPTION
## Summary

Cross-family PR review runbook in `scripts/agent_onboarding.md` + new `scripts/ops/smoketest_review_verifier.sh`. Codifies AGENTS.md rule 10 + Decision Card C routing so agents stop merging on hallucinated reviews / fabricated commands.

Closes #1501

## Review cycle

| Round | Reviewer | Verdict | Findings |
|-------|----------|---------|----------|
| R1 | codex gpt-5.5 | NEEDS_CHANGES | (1) fabricated `ab ask-gemini --review --allow-write` (argparse error); (2) verifier doc allowed silent "0 verified" false-bless; (3) missing Decision Card C routing specifics; (4) smoketest too shallow (in-process import, not CLI). |
| Fix-pass `cd33041a` (cursor composer-2.5) | — | — | All 4 fixed: real `dispatch.py`/`dispatch_smart.py` invocations + verified parser surfaces; verifier doc uses `--from-pr` + stdin form; routing table added; smoketest now exercises CLI surface (stdin + fixture, exit-code 1 on quote_missing, asserts `--from-pr` in `--help`). |
| R2 | codex gpt-5.5 | APPROVE_WITH_NITS | 1 nit: link path `docs/decisions/...` resolves as `scripts/docs/...` on GitHub from inside `scripts/agent_onboarding.md`. |
| R2 nit (orchestrator inline) | — | — | One-char fix: `docs/...` → `../docs/...`. |

## Verification

- `bash scripts/ops/smoketest_review_verifier.sh` → exit 0, `smoketest_review_verifier: ok (verified,quote_missing via CLI)`
- All documented commands now parse against real CLIs (codex R2 verified).
- Decision Card C routing table matches `docs/decisions/2026-05-24-reviewer-routing-composer-2-5.md`.

🤖 cursor composer-2.5 + codex gpt-5.5 R1/R2 + Claude orchestrator