### PR TITLE
fix(local_api): detect ASCII box-drawing diagrams in quality scorer

### DIFF
--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -2452,6 +2452,11 @@ _QUALITY_TITLE_RE = re.compile(r'^title:\s*["\']?(.*?)["\']?\s*$', re.MULTILINE)
 _QUALITY_SOURCES_HEADING_RE = re.compile(r"^##\s+Sources\s*$", re.MULTILINE)
 _QUALITY_MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\((https?://[^)]+)\)")
 _QUALITY_BARE_URL_RE = re.compile(r"https?://\S+")
+_QUALITY_BOX_DRAWING_LINE_RE = re.compile(
+    r"^[^\n]*[─-╿][^\n]*$",
+    re.MULTILINE,
+)
+_QUALITY_BOX_DRAWING_MIN_LINES = 5
 _QUALITY_TRACK_LABELS = {
     "ai": "AI",
     "ai-ml-engineering": "AI/ML Engineering",
@@ -2547,7 +2552,11 @@ def build_quality_scores(repo_root: Path) -> dict[str, Any]:
             )
         )
         has_exercise = bool(re.search(r"^##+\s+(exercise|hands-on|practice|lab)\b", text, re.IGNORECASE | re.MULTILINE))
-        has_diagram = "```mermaid" in text or "<details>" in text
+        has_diagram = (
+            "```mermaid" in text
+            or "<details>" in text
+            or len(_QUALITY_BOX_DRAWING_LINE_RE.findall(text)) >= _QUALITY_BOX_DRAWING_MIN_LINES
+        )
         sources_match = _QUALITY_SOURCES_HEADING_RE.search(text)
         if sources_match:
             after_sources = text[sources_match.end():]

--- a/scripts/tests/test_local_api_quality.py
+++ b/scripts/tests/test_local_api_quality.py
@@ -1,4 +1,4 @@
-"""Regression tests for build_quality_scores citation detection."""
+"""Regression tests for build_quality_scores heuristics (citations, diagrams)."""
 
 from __future__ import annotations
 
@@ -25,6 +25,40 @@ local_api = _load_local_api()
 def _write(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content, encoding="utf-8")
+
+
+def _clear_quality_cache() -> None:
+    with local_api._QUALITY_AUDIT_CACHE_LOCK:
+        local_api._QUALITY_AUDIT_CACHE.clear()
+
+
+def _module_with_diagram(rel_path: str, title: str, diagram_block: str) -> None:
+    body = "\n".join(
+        [
+            "---",
+            f'title: "{title}"',
+            "---",
+            "",
+            "## Overview",
+            "",
+            diagram_block,
+            "",
+            *[f"Line {i}" for i in range(120)],
+            "",
+            "## Quick Quiz",
+            "",
+            "- Question",
+            "",
+            "## Hands-On",
+            "",
+            "1. Do thing",
+            "",
+            "## Sources",
+            "",
+            "- https://example.com",
+        ]
+    )
+    _write(Path(rel_path), body + "\n")
 
 
 def _module_with_sources(rel_path: str, title: str, sources_lines: list[str]) -> None:
@@ -84,8 +118,7 @@ def test_build_quality_scores_accepts_common_citation_formats(quality_repo: Path
         ["- Label: https://example.com"],
     )
 
-    with local_api._QUALITY_AUDIT_CACHE_LOCK:
-        local_api._QUALITY_AUDIT_CACHE.clear()
+    _clear_quality_cache()
 
     quality = local_api.build_quality_scores(quality_repo)
     by_path = {entry["path"]: entry for entry in quality["modules"]}
@@ -98,3 +131,76 @@ def test_build_quality_scores_accepts_common_citation_formats(quality_repo: Path
         module = by_path[path]
         assert module["score"] > 1.5, path
         assert not module["primary_issue"].startswith("no citations"), path
+
+
+def test_build_quality_scores_detects_diagram_formats(quality_repo: Path) -> None:
+    """Issue #1503: has_diagram must recognize Mermaid, details, and ASCII box art.
+
+    ASCII diagrams need at least five lines with Unicode box-drawing characters
+    (U+2500-U+257F). Fewer lines are incidental decoration and must not count.
+    """
+    docs = quality_repo / "src" / "content" / "docs" / "ai" / "diagrams"
+    _module_with_diagram(
+        str(docs / "module-1.1-mermaid.md"),
+        "Mermaid Diagram",
+        "```mermaid\nflowchart LR\n  A --> B\n```",
+    )
+    _module_with_diagram(
+        str(docs / "module-1.2-details.md"),
+        "Details Diagram",
+        "<details>\n<summary>Architecture</summary>\n<pre>svc</pre>\n</details>",
+    )
+    ascii_five = "\n".join(
+        [
+            "┌─────────┐     ┌─────────┐",
+            "│ Source  │────▶│  Sink   │",
+            "└─────────┘     └─────────┘",
+            "       │               │",
+            "       └───────┬───────┘",
+        ]
+    )
+    _module_with_diagram(
+        str(docs / "module-1.3-ascii-five.md"),
+        "ASCII Diagram",
+        ascii_five,
+    )
+    ascii_three = "\n".join(
+        [
+            "┌─────┐",
+            "│ one │",
+            "└─────┘",
+            "plain text line",
+            "another plain line",
+        ]
+    )
+    _module_with_diagram(
+        str(docs / "module-1.4-ascii-few.md"),
+        "ASCII Decoration",
+        ascii_three,
+    )
+    _module_with_diagram(
+        str(docs / "module-1.5-none.md"),
+        "No Diagram",
+        "Just prose about pipelines with no visual.",
+    )
+
+    _clear_quality_cache()
+    quality = local_api.build_quality_scores(quality_repo)
+    by_path = {entry["path"]: entry for entry in quality["modules"]}
+
+    for path in (
+        "ai/diagrams/module-1.1-mermaid.md",
+        "ai/diagrams/module-1.2-details.md",
+        "ai/diagrams/module-1.3-ascii-five.md",
+    ):
+        module = by_path[path]
+        assert "no diagram" not in module["primary_issue"], path
+        assert module["score"] == pytest.approx(4.3), path
+
+    for path in (
+        "ai/diagrams/module-1.4-ascii-few.md",
+        "ai/diagrams/module-1.5-none.md",
+    ):
+        module = by_path[path]
+        assert "no diagram" in module["primary_issue"], path
+        assert module["score"] == pytest.approx(3.6), path


### PR DESCRIPTION
## Summary

`has_diagram` in `scripts/local_api.py:build_quality_scores` only matched ` ```mermaid` fences and `<details>` elements. ASCII box-drawing diagrams (Unicode U+2500-U+257F) — explicitly endorsed by `docs/quality-rubric.md` and `.claude/rules/module-quality.md` — were invisible to the scorer.

Module `ai-ml-engineering/mlops/module-1.7-data-pipelines.md` has **107 lines of box-drawing diagrams** and was the only module in the 304-module starter set (prerequisites + linux + ai + ai-ml-engineering + cloud) scoring below 5.0 (4.30, "no diagram").

Fix adds a third clause: module counts as having a diagram if it has **≥5 lines containing at least one Unicode box-drawing character** (U+2500-U+257F). Threshold avoids false positives from incidental decoration.

Same false-positive class as PR #1491 citation regex fix — too-narrow heuristic blind to a widely-used real form.

Fixes #1503

## Cross-family review

- **Author:** cursor composer-2.5 (commit `62c401cd`)
- **R1 reviewer:** codex gpt-5.5 → **APPROVE, no findings**

> Regex matches U+2500-U+257F and excludes adjacent U+24FF/U+2580 boundaries (verified against Unicode UCD Blocks.txt). `has_diagram` is additive. Test covers all 5 cases. Target module scores 5.0 with `primary_issue: balanced`. Ruff clean, pytest pass, `git diff --check` clean.

## Regression test

- Regression test: scripts/tests/test_local_api_quality.py
- Docstring references issue #1503. Covers: mermaid + `<details>` still detected (no regression); ASCII ≥5 box-char lines detected; <5 lines NOT counted; no-diagram NOT counted.

## Expected impact

After API restart (`./services.sh restart api`), AI/ML Engineering track goes 103/103 at 5.0 — all 304 starter-track modules at the heuristic 5.0 ceiling.

🤖 cursor composer-2.5 author + codex gpt-5.5 R1 cross-family review + Claude orchestrator