### PR TITLE
feat(content): T0 author — Edge K8s Distros Landscape (closes #1519)

### DIFF
--- a/src/content/docs/platform/toolkits/infrastructure-networking/k8s-distributions/index.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/k8s-distributions/index.md
@@ -4,11 +4,11 @@ sidebar:
   order: 0
   label: "K8s Distributions"
 ---
-> **Toolkit Track** | 7 Modules | ~6.5 hours total
+> **Toolkit Track** | 8 Modules | ~7.5 hours total
 
 ## Overview
 
-The Kubernetes Distributions Toolkit covers lightweight Kubernetes alternatives for edge, IoT, development, and resource-constrained environments. When vanilla Kubernetes is too heavy—requiring too much RAM, too many nodes, or too complex to manage—these distributions deliver Kubernetes-compatible APIs with dramatically lower overhead.
+The Kubernetes Distributions Toolkit covers lightweight Kubernetes alternatives for edge, IoT, development, and resource-constrained environments. When vanilla Kubernetes is too heavy—requiring too much RAM, too many nodes, or too complex to manage—these distributions deliver Kubernetes-compatible APIs with dramatically lower overhead. The toolkit also teaches the edge landscape, where footprint, autonomy, immutable operating systems, and cloud-edge synchronization have to be evaluated together.
 
 This toolkit applies concepts from [Systems Thinking](../../../foundations/systems-thinking/) and [Platform Engineering](../../../disciplines/core-platform/platform-engineering/).
 
@@ -31,6 +31,7 @@ Before starting this toolkit:
 | 14.5 | [OpenShift](module-14.5-openshift/) | `[COMPLEX]` | 50-55 min |
 | 14.6 | [Managed Kubernetes](module-14.6-managed-kubernetes/) | `[COMPLEX]` | 55-60 min |
 | 14.7 | [RKE2](module-14.7-rke2/) | `[COMPLEX]` | 50-55 min |
+| 14.8 | [Edge Kubernetes Distros Landscape](module-14.8-edge-distros-landscape/) | `[COMPLEX]` | 60-75 min |
 
 ## Learning Outcomes
 
@@ -43,7 +44,8 @@ After completing this toolkit, you will be able to:
 5. **Navigate OpenShift** — Enterprise Kubernetes with batteries included
 6. **Compare managed services** — EKS vs GKE vs AKS decision making
 7. **Deploy RKE2** — Enterprise-hardened, FIPS-compliant Kubernetes for high-security environments
-8. **Choose the right distribution** — Match specific infrastructure and compliance requirements to distribution strengths
+8. **Evaluate edge architectures** — Compare lightweight distributions, immutable node operating systems, and cloud-edge frameworks
+9. **Choose the right distribution** — Match specific infrastructure, edge, and compliance requirements to distribution strengths
 
 ## Distribution Selection Guide
 
@@ -241,6 +243,12 @@ Module 14.7: RKE2
      │  CIS Benchmark compliance
      │  FIPS 140-2 validated
      ▼
+Module 14.8: Edge Kubernetes Distros Landscape
+     │
+     │  k3s, k0s, MicroK8s, Talos, Kairos
+     │  KubeEdge and OpenYurt autonomy patterns
+     │  Fleet-scale edge decision tree
+     ▼
 [Toolkit Complete] → Next: CI/CD Pipelines Toolkit
 ```
 
@@ -278,6 +286,7 @@ CPU                2 cores     2 cores     2 cores     4 cores     2 cores
 | OpenShift | S2I builds, Routes, BuildConfigs |
 | Managed K8s | Multi-provider comparison, cost analysis |
 | RKE2 | Deploy CIS hardened cluster, verify air-gap registry |
+| Edge Distros Landscape | Use bpftrace to expose mutable-host assumptions and compare edge operating models |
 
 ## Related Tracks
 

--- a/src/content/docs/platform/toolkits/infrastructure-networking/k8s-distributions/module-14.8-edge-distros-landscape.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/k8s-distributions/module-14.8-edge-distros-landscape.md
@@ -1,0 +1,480 @@
+---
+citations_verified: true
+title: "Module 14.8: Edge Kubernetes Distros Landscape"
+slug: platform/toolkits/infrastructure-networking/k8s-distributions/module-14.8-edge-distros-landscape
+sidebar:
+  order: 9
+---
+> **Toolkit Track** | Complexity: `[COMPLEX]` | Time: 60-75 minutes
+
+## Overview
+
+Edge Kubernetes is not simply Kubernetes with fewer CPUs. It is Kubernetes placed where networks fail more often, hardware varies more widely, local people may not be operators, and application behavior may matter even when the central control plane is unreachable. That changes the distribution decision from "Which installer is easiest?" to "Which operating model can survive the site, fleet, and outage patterns we actually have?"
+
+This module teaches the landscape rather than crowning a single winner. You will compare [k3s](../module-14.1-k3s/), [k0s](../module-14.2-k0s/), [MicroK8s](../module-14.3-microk8s/), [Talos](../module-14.4-talos/), Kairos, KubeEdge, and OpenYurt as different answers to different constraints. Some are lightweight Kubernetes distributions. Some are immutable operating-system patterns. Some extend Kubernetes toward cloud-edge coordination. The senior skill is recognizing which problem you are solving before the tool choice hardens into fleet reality.
+
+## Prerequisites
+
+- Kubernetes basics, including Pods, Deployments, Services, ConfigMaps, Secrets, node conditions, and `kubectl get events`.
+- Linux operations basics, especially systemd services, package managers, SSH, filesystems, kernel versioning, and host networking.
+- Familiarity with the earlier distribution modules for [k3s](../module-14.1-k3s/), [k0s](../module-14.2-k0s/), [MicroK8s](../module-14.3-microk8s/), and [Talos](../module-14.4-talos/) helps but is not required.
+- Basic awareness of edge networking from [Cilium](../../networking/module-5.1-cilium/), [MetalLB](../../networking/module-5.4-metallb/), [Flannel](../../networking/module-5.5-flannel/), and edge-friendly storage from [Longhorn](../../storage/module-16.3-longhorn/).
+
+## Learning Outcomes
+
+After completing this module, you will be able to:
+
+- **Evaluate** edge Kubernetes distributions by matching resource footprint, OS coupling, autonomy, upgrade mechanics, and fleet-management needs to a concrete site profile.
+- **Design** a single-node, multi-node, or cloud-edge topology that makes honest trade-offs between local survivability, operational cost, and consistency with central platform standards.
+- **Debug** a failed edge platform choice by separating distribution limitations from networking, storage, observability, hardware, and human-operating-model failures.
+- **Compare** lightweight distributions, immutable Kubernetes operating systems, and edge-native extensions without collapsing them into one "small Kubernetes" category.
+- **Defend** a recommendation in front of application, security, networking, and operations stakeholders using evidence instead of tool preference.
+
+## Why This Module Matters
+
+JYSK, the international retail chain, provides a useful real incident because the story is not a dramatic outage caused by a broken binary. It is the quieter kind of platform failure that happens when an early proof of concept scales into fleet operations. In a public Sidero Labs case study, JYSK is described as operating more than 3,400 stores across 48 countries, with a Kubernetes edge initiative supporting in-store commerce systems and other store software. The initial approach combined a lightweight Kubernetes distribution, k3s, with GitOps and Cilium, and it worked during early testing. Then the fleet realities arrived: frequent patching, varied store networks, centralized traffic bottlenecks, shared image-cache complexity, limited bandwidth, local power issues, and hardware diversity. The proof of concept was paused before full day-2 operations because the team saw the long-term operational risk becoming too large for the chosen model. JYSK then moved toward Talos, custom images, NoCloud-style provisioning, registry mirroring, and a more automated immutable-node workflow for the store fleet ([JYSK case study](https://www.siderolabs.com/case-studies/supporting-jysks-digital-transformation-with-3400-strong-edge-deployment/)).
+
+The important lesson is not "k3s was wrong" or "Talos is always right." k3s can be an excellent edge distribution when the site count, update path, storage assumptions, and support model fit it. The lesson is that a distribution can be technically sound and still be the wrong fleet substrate. A retail estate with thousands of stores is not a lab with one Raspberry Pi, and it is not a cloud region with uniform instance types, reliable underlay networking, and a staffed operations console. The edge turns small operational gaps into repeated work, and repeated work becomes the real cost center.
+
+Think about the multiplication effect. A single manual host fix that takes 15 minutes is annoying in one cluster. Across 3,400 sites, that same fix becomes 850 staff-hours before verification, retries, night windows, and failed stores are counted. That arithmetic is why edge platform design cares so much about immutable images, automatic registration, local survivability, registry strategy, and the ability to rebuild a node instead of lovingly repairing it. At edge scale, the platform is only as good as its worst repeatable procedure.
+
+## 1. Edge Is A Continuum, Not A Size Class
+
+The CNCF Cloud Native Glossary defines edge computing as moving storage and compute from a central data center closer to the data source, such as a store, factory floor, city system, or device fleet, so local processing can happen nearer to users and events ([CNCF glossary](https://glossary.cncf.io/edge-computing/)). That definition is useful because it avoids a common trap: "edge" is about placement, dependency, and constraints, not only physical distance. A warehouse server, telco access site, vehicle gateway, retail back-office box, and CDN point of presence can all be edge contexts while having very different hardware and operations profiles.
+
+For Kubernetes decisions, it helps to split the continuum into three working categories. Far-edge sites are closest to devices and usually have the least forgiving environment: limited CPU and memory, constrained power, intermittent network, and few or no local operators. Near-edge sites are larger local environments such as retail stores, factories, hospitals, campuses, or telco access locations. Regional-edge sites are server-class facilities closer to users than a central region, often connected to peering, CDN, or service-provider networks; the LF Edge glossary describes regional edge as server-class infrastructure in regional data centers that reduce latency and network hops compared with centralized data centers ([Open Glossary of Edge Computing](https://stateoftheedge.com/project/glossary/)).
+
+| Edge tier | Typical location | Kubernetes pressure | Distro implication |
+|---|---|---|---|
+| Far edge | IoT gateway, vehicle, kiosk, robot cell, remote sensor box | Small footprint, local restart, minimal moving parts, sometimes one node | k3s, k0s, Kairos, or KubeEdge edge nodes may fit depending on cloud-edge sync needs |
+| Near edge | Store, branch, factory line, clinic, telco access site | Local services must survive WAN loss; lifecycle must scale across many sites | k3s, Talos, Kairos, MicroK8s, KubeEdge, or OpenYurt become plausible depending on fleet tooling |
+| Regional edge | CDN POP, metro facility, regional colocation, service-provider edge | More hardware but stronger latency, routing, multi-tenant, and compliance needs | Standard Kubernetes, Talos, RKE2, OpenShift, or managed regional services may beat tiny distros |
+
+The edge-native design whitepaper from the CNCF IoT Edge Working Group highlights constraints that appear repeatedly in these environments: connectivity limits, data locality, resource limits, security boundaries, and autonomy during degraded links ([CNCF edge-native principles](https://www.cncf.io/reports/edge-native-applications-principles-whitepaper/)). Those constraints are why a distribution choice must be tested against actual failure modes. If an application must continue scanning groceries while the WAN is down, a design that depends on continuous cloud API access is fragile even if it uses a lightweight binary. If a telco edge site has redundant fiber and a staffed operations path, the same design pressure may be much lower.
+
+**Pause and predict:** A team says, "We need edge Kubernetes, so we need the smallest distribution." Before reading further, list three cases where the smallest distribution would not be the best choice. A strong answer mentions at least one lifecycle issue, one security issue, and one network-partition issue, because edge success depends on more than booting Kubernetes in little memory.
+
+```text
+EDGE DISTANCE IS NOT THE SAME AS EDGE CONSTRAINT
+
+central cloud
+    |
+    | reliable backbone, managed control planes, standard instance types
+    v
+regional edge
+    |
+    | lower latency, more routing ownership, often server-class hardware
+    v
+near edge
+    |
+    | stores, factories, clinics, branches, telco access, mixed hardware
+    v
+far edge
+    |
+    | gateways, devices, local sensors, intermittent links, tiny staff footprint
+    v
+physical process
+```
+
+## 2. The Landscape: Seven Different Answers
+
+The seven technologies in this module do not occupy one tidy product category. k3s, k0s, and MicroK8s are lightweight Kubernetes distributions. Talos and Kairos are operating-system strategies for running Kubernetes with stronger image or immutability assumptions. KubeEdge and OpenYurt extend Kubernetes toward edge autonomy and cloud-edge coordination. Comparing them only by memory footprint hides the most important differences: what owns the host, how the control plane behaves when links fail, how upgrades roll through thousands of nodes, and how much local mutation the team accepts.
+
+| Option | What it is | Edge strength | Trade-off to test |
+|---|---|---|---|
+| [k3s](https://docs.k3s.io/) | Fully compliant Kubernetes packaged as a single binary or minimal image, with SQLite as the default datastore and packaged components such as containerd, Flannel, CoreDNS, Traefik, ServiceLB, and local-path storage | Very strong fit for small clusters, constrained hosts, quick bootstrap, and teams that want standard Kubernetes APIs with a small operational surface | Bundled defaults are convenient but must be standardized deliberately across many sites; SQLite is single-server only, and HA means embedded etcd or an external datastore |
+| [k0s](https://docs.k0sproject.io/stable/) | All-inclusive Kubernetes distribution packaged as a single binary with zero host OS dependencies besides the kernel | Good fit when host OS diversity is unavoidable and the team wants fewer bundled opinions than k3s | The base may be cleaner, but the team still owns CNI, ingress, storage, lifecycle automation, and fleet policy choices |
+| [MicroK8s](https://canonical.com/microk8s/docs) | Canonical's low-ops Kubernetes delivered through snap packages with an add-on ecosystem and single-node-to-HA growth path | Good fit for Ubuntu-heavy environments, developer-to-appliance workflows, and teams that want add-ons enabled through a familiar command path | Snap delivery and add-on behavior must fit the organization's OS policy, air-gap pattern, and production change-control process |
+| [Talos](https://docs.siderolabs.com/talos/v1.13/overview/what-is-talos) | Kubernetes-optimized Linux distribution with API management, immutable filesystem, minimal packages, and secure defaults | Strong fit when the team wants Kubernetes nodes to behave like reproducible appliances rather than mutable Linux servers | Operators must give up SSH-first debugging and package-manager fixes; hardware drivers and node customizations need planned image or extension workflows |
+| [Kairos](https://kairos.io/docs/architecture/meta/) | Immutable Linux meta-distribution that can convert supported Linux bases into an immutable layout with Kubernetes-native components; standard provider support includes k3s and k0s | Strong fit when the team wants immutable edge nodes but needs more base-distribution flexibility than Talos | More flexibility also means more design ownership; teams must define which base OS, provider, network fabric, and lifecycle controls are standard |
+| [KubeEdge](https://www.cncf.io/projects/kubeedge/) | CNCF Graduated Kubernetes-native edge framework with cloud-side and edge-side components for cloud-edge coordination, device management, and autonomy | Strong fit when cloud-edge sync, device integration, and edge-node autonomy are central requirements rather than optional extras | It adds architecture, components, version compatibility, and operational concepts beyond a normal distribution install |
+| [OpenYurt](https://www.cncf.io/projects/openyurt/) | CNCF Incubating platform that extends native Kubernetes to edge with non-intrusive enhancements, local caching, heartbeat proxying, and region-aware concepts | Strong fit when the team wants to preserve standard Kubernetes management while improving autonomy and locality for edge workloads | It is an extension pattern, not a magic WAN fix; teams still need tested behavior for partitions, upgrades, and recovery |
+
+The first useful distinction is "distribution" versus "architecture." k3s, k0s, and MicroK8s answer, "How do I run Kubernetes with less installation and host overhead?" Talos and Kairos answer, "How should the node operating system behave when the cluster is treated as a replaceable fleet?" KubeEdge and OpenYurt answer, "How should Kubernetes change when the cloud-edge network is not reliable enough to pretend every node is in one data center?" Those questions overlap, but they are not the same question.
+
+The second distinction is "batteries included" versus "batteries removed." k3s includes many practical defaults, which is exactly why it is attractive for small edge clusters. k0s deliberately keeps a cleaner base and expects you to choose extensions. MicroK8s offers add-ons through Canonical's ecosystem. Talos removes host conveniences such as shell-driven mutation and expects declarative API-based operations. KubeEdge and OpenYurt add edge-specific controllers and data paths. The right choice depends on whether your team needs a fast opinionated start, a minimal base, a locked-down host, or an edge coordination model.
+
+```yaml
+# edge-site-profile.yaml
+site:
+  tier: near-edge
+  sites: 3400
+  local_staff_can_admin_linux: false
+  wan_outage_budget_minutes: 240
+  nodes_per_site: 3
+  cpu_architectures: [x86_64, arm64]
+  local_stateful_workloads: true
+  image_pull_policy: local_mirror_required
+  host_customization: planned_image_only
+
+decision_flags:
+  if_single_node_and_recoverable: "k3s or k0s may be enough"
+  if_ssh_fix_runbooks_are_banned: "Talos or Kairos should be evaluated"
+  if_device_sync_and_cloud_edge_messaging_are_core: "KubeEdge should be evaluated"
+  if_native_kubernetes_with_edge_autonomy_is_core: "OpenYurt should be evaluated"
+```
+
+## 3. Decision Criteria That Actually Bite
+
+Resource footprint matters, but it is only the first gate. Official k3s requirements list a server minimum of 2 cores and 2 GB RAM, with an agent minimum of 1 core and 512 MB RAM; the same page shows a sizing guide where a 2 CPU and 4 GB server is positioned for 0 to 350 agents under standard conditions ([k3s requirements](https://docs.k3s.io/installation/requirements)). k0s documents a 1 vCPU and 1 GB controller minimum, a 0.5 GB worker minimum, and controller recommendations that scale from 10 workers and 1,000 pods to much larger clusters ([k0s requirements](https://docs.k0sproject.io/stable/system-requirements/)). Those numbers help with initial feasibility, but they do not decide whether the fleet can be patched, secured, and recovered.
+
+OS coupling is the second gate. A conventional Linux host running k3s, k0s, or MicroK8s is familiar and flexible: SSH, systemd, package managers, kernel modules, local files, and standard troubleshooting tools are all available unless you remove them yourself. That can be valuable in a messy hardware estate. It can also create drift, unrepeatable repairs, and a bigger host attack surface. Talos flips the default by making the node API-managed, immutable, minimal, and secure by default; its philosophy documentation states that Talos has no shell, SSH, GNU utilities, packages, or systemd in the traditional sense ([Talos philosophy](https://docs.siderolabs.com/talos/v1.11/learn-more/philosophy)). Kairos sits in a different part of the design space: it aims to turn supported Linux bases into an immutable layout while keeping a modular provider model for Kubernetes components ([Kairos meta-distribution](https://kairos.io/docs/architecture/meta/)).
+
+Upgrade story is the third gate, and it is where many edge designs become expensive. A good one-site upgrade is not enough. You need a policy for staging, canaries, local rollback, image availability, certificate rotation, CNI changes, host kernel changes, workload drain behavior, and store-by-store remediation. MicroK8s high availability is automatically enabled for clusters with three or more nodes, with dqlite voters, standbys, and transparent leader election, but that still means the team must understand snap channels, node roles, and cluster removal behavior ([MicroK8s HA](https://canonical.com/microk8s/docs/high-availability)). Talos and Kairos push upgrades toward image and node lifecycle automation. KubeEdge and OpenYurt add the question of how cloud-side and edge-side components are versioned together.
+
+Fleet management is the fourth gate. The edge punishes manual variance. A team can tolerate one unusual cloud cluster if it has a skilled team watching it. It cannot tolerate thousands of slightly different store clusters with undocumented hotfixes. The design should answer where identity comes from, how bootstrap secrets are rotated, how image mirrors are populated, how failed nodes are rebuilt, how local data is protected, how telemetry returns during a partition, and how the platform proves a site is healthy after a power cycle. If those answers are not written down, the distribution choice is not finished.
+
+**Try this:** Score a proposed edge distribution from 1 to 5 on each criterion below before debating brand names. Then multiply the scores by site count. A weak "upgrade story" score is a nuisance at 3 nodes; it is an organizational liability at 3,000 stores.
+
+| Criterion | What to ask | Strong signal | Warning signal |
+|---|---|---|---|
+| Footprint | Can the control plane and workload fit with headroom? | Measured CPU, memory, disk, and IO under real workload | "It boots" is treated as enough |
+| Autonomy | What works when the WAN is down for hours? | Local services, metadata, and observability degrade intentionally | Central API calls are hidden in critical paths |
+| OS model | Are host changes declared or improvised? | Immutable image or controlled config pipeline | SSH fixes become accepted operations |
+| Upgrade path | Can we patch 1%, 10%, and 100% safely? | Canary rings, rollback, and site health gates exist | Every site upgrade is a snowflake |
+| Fleet identity | How does a node prove what site and role it owns? | Bootstrap identity, certificate rotation, and inventory are automated | Hostnames, tokens, or labels are hand-managed |
+| Storage | What local data must survive rebuilds? | Data class is explicit; rebuildable and durable data are separated | Stateful workloads are discovered after failure |
+| Observability | What can responders see during a partition? | Local and central telemetry plans both exist | The platform goes dark when the WAN fails |
+
+## 4. Single-Node, Multi-Node, And Cloud-Edge Patterns
+
+Single-node edge Kubernetes is not automatically irresponsible. It can be the right answer when the workload is locally recoverable, the site has one physical box, the business can tolerate a short local outage, and the rebuild path is simpler than maintaining quorum. A k3s or k0s single-node cluster can be easier to understand than a miniature HA system whose etcd quorum is more fragile than the workload. The honest design phrase is "recoverable architecture," not "high availability." That means backups, golden images, GitOps, registry mirrors, local data classification, and a tested wipe-and-rejoin path matter more than pretending one node is redundant.
+
+Multi-node edge Kubernetes is justified when local service continuity matters during a single-node failure and the site can support the operational cost. Three nodes give you placement choices, local failover, and room for controlled drains, but they also introduce quorum, network, storage, and power-domain questions. MicroK8s documents that HA needs at least three nodes and uses dqlite roles such as voters and standbys, while k3s uses SQLite for simple single-server cases and embedded etcd or external databases for multi-server HA ([MicroK8s HA](https://canonical.com/microk8s/docs/high-availability/), [k3s datastore](https://docs.k3s.io/datastore)). The design must decide whether the site is running one cluster with local quorum, several independent single-node clusters, or a larger regional cluster with edge nodes.
+
+Cloud-edge architectures are justified when the edge problem is not just "small cluster" but "coordination across unreliable links." KubeEdge's edge architecture includes MetaManager, which stores and retrieves metadata from a lightweight SQLite database and tracks cloud connection state; its pod status sync interval defaults to 60 seconds in the documented configuration ([KubeEdge MetaManager](https://kubeedge.io/docs/architecture/edge/metamanager/)). OpenYurt emphasizes extending upstream Kubernetes to edge, including local caching and heartbeat proxy mechanisms so edge services can continue operating more reliably when cloud-edge connectivity is abnormal ([OpenYurt overview](https://openyurt.io/)). Those projects should be evaluated when disconnected behavior and cloud-edge synchronization are primary requirements, not as drop-in replacements for choosing a smaller node binary.
+
+```text
+PATTERN A: SINGLE-NODE RECOVERABLE SITE
+
+central Git + registry mirror intent
+        |
+        v
+  one edge node
+  k3s or k0s
+  local workload
+  rebuild beats repair
+
+Good when: outage blast radius is one site, local state is minimal, and rebuild is automated.
+Risk: no local node failover, so hardware failure equals local service interruption.
+
+
+PATTERN B: THREE-NODE LOCAL SITE
+
+central intent
+        |
+        v
+  site cluster
+  node A + node B + node C
+  local quorum and local service placement
+
+Good when: local continuity matters and the site can support quorum, storage, and upgrade discipline.
+Risk: tiny HA clusters can fail in surprising ways when power, disks, or network are not independent.
+
+
+PATTERN C: CLOUD-EDGE COORDINATION
+
+cloud control side
+        |
+        | intermittent, high-latency, or private network
+        v
+edge side components
+local metadata, device access, autonomy behavior
+
+Good when: edge nodes must keep doing useful work despite cloud-edge partitions.
+Risk: more components and compatibility rules than a normal distribution install.
+```
+
+The key debugging move is to identify which pattern the organization actually bought, not which pattern the slide deck implied. If a team selected k3s but expects cloud-edge metadata sync, the missing piece may be KubeEdge or OpenYurt rather than a different lightweight distribution. If a team selected Talos but still expects SSH-based emergency edits, the problem is not Talos instability; the problem is an operating model mismatch. If a team selected MicroK8s for add-on speed but production requires strict air-gap and channel pinning, the problem is lifecycle design.
+
+## 5. A Five-Question Decision Tree
+
+This decision tree deliberately returns only a primary direction. It is not a procurement answer, and it is not a substitute for a proof of concept. Its job is to prevent the most common category mistake: choosing a lightweight distribution when you needed autonomy architecture, or choosing an immutable OS when you needed host flexibility. After the tree gives a direction, you still validate CNI, storage, ingress, registry, observability, security, and upgrade behavior with real site constraints.
+
+```text
+START
+  |
+  | Q1: Must workloads continue meaningful local operation during WAN loss?
+  |        |
+  |        +-- yes --> Q2: Do you need device/cloud-edge metadata sync as a core feature?
+  |        |              |
+  |        |              +-- yes --> Evaluate KubeEdge first.
+  |        |              |
+  |        |              +-- no  --> Evaluate OpenYurt or a local-site cluster pattern.
+  |        |
+  |        +-- no  --> Q3
+  |
+  | Q3: Is the site mostly one or two constrained nodes with rebuildable state?
+  |        |
+  |        +-- yes --> Evaluate k3s first; compare k0s if you want fewer bundled opinions.
+  |        |
+  |        +-- no  --> Q4
+  |
+  | Q4: Is eliminating SSH drift and host mutation more important than Linux familiarity?
+  |        |
+  |        +-- yes --> Evaluate Talos first; compare Kairos if base-OS flexibility matters.
+  |        |
+  |        +-- no  --> Q5
+  |
+  | Q5: Is the organization standardized on Ubuntu and snap-based operations?
+  |        |
+  |        +-- yes --> Evaluate MicroK8s.
+  |        |
+  |        +-- no  --> Compare k0s, k3s, RKE2, or standard Kubernetes by fleet requirements.
+```
+
+The tree intentionally makes k3s, Talos, and KubeEdge appear as common first stops because they represent three different centers of gravity. k3s is the quick lightweight distribution answer. Talos is the immutable Kubernetes-node operating model answer. KubeEdge is the cloud-edge coordination answer. A mature edge platform may combine ideas from more than one branch: for example, a team may run k3s at the site, use an immutable image process for the host, and add separate fleet tooling for registration and upgrades.
+
+Here is a more concrete scoring example. Suppose a factory line needs two local services to keep running for four hours without WAN, has three x86 nodes per site, uses local PLC gateways, and forbids interactive SSH in production. That profile should not default to "smallest binary." It should test Talos or Kairos for immutable host operations, evaluate whether KubeEdge or OpenYurt is needed for cloud-edge behavior, and only then compare the raw distribution footprint. The smallest successful cluster is not useful if the wrong dependency fails during the first network partition.
+
+## 6. What The Distribution Does Not Decide
+
+The distribution does not decide your CNI risk. A k3s site using Flannel has a very different operational profile from a k3s site using Cilium with eBPF datapath features, and a Talos cluster still needs a network plugin that matches the site's routing and security requirements. If you expect service maps, policy visibility, or kernel-level enforcement at the edge, connect this decision to [Cilium](../../networking/module-5.1-cilium/), [Tetragon](../../../security-quality/security-tools/module-4.5-tetragon/), [KubeArmor](../../../security-quality/security-tools/module-4.6-kubearmor/), and [Pixie](../../../observability-intelligence/observability/module-1.6-pixie/) rather than assuming the distribution solves runtime observability.
+
+The distribution does not decide your data durability. Edge storage often looks deceptively simple until the first node replacement, SD-card failure, or WAN outage collides with local state. Longhorn can be a practical fit for small and edge clusters because it narrows the storage problem to Kubernetes-native replicated block volumes, but it still requires disk planning, backup targets, and rebuild bandwidth awareness. If every edge site keeps irreplaceable local data, the distribution decision must be paired with a data classification and backup strategy before rollout.
+
+The distribution does not decide your human operating model. If the runbook says "SSH into the host, install a package, edit a file, restart a daemon," then Talos will feel hostile by design and a mutable Linux distribution may be a better short-term fit. If the security model says "no undocumented host mutation, all node changes come from signed images, and failed nodes are wiped," then a conventional Linux host with ad hoc fixes will feel fragile. Neither posture is morally superior. The wrong posture is the one your team cannot execute consistently under incident pressure.
+
+The distribution also does not decide whether one cluster per site is the right abstraction. One cluster per store gives strong local blast-radius boundaries but creates many API servers, many certificate sets, many upgrade events, and many health objects. A regional cluster with edge nodes reduces some control-plane sprawl but may increase dependency on network reachability and regional failure domains. KubeEdge and OpenYurt exist partly because pretending a normal centralized cluster can stretch cleanly across unreliable edge links is often false.
+
+### What A Serious Edge Proof Of Concept Tests
+
+A serious proof of concept should start with a site profile, not an install command. Write down the number of sites, nodes per site, CPU architecture mix, expected WAN outage duration, image-registry reachability, local data classes, acceptable local downtime, and who is allowed to touch the hardware. Then select two or three candidates and run the same tests against each. This prevents a polished quickstart from beating a tool that handles day-2 operations better but takes more initial design work. The output should be a decision record that names the rejected options and the exact evidence that rejected them.
+
+The first test is a cold bootstrap test from empty hardware or a clean VM snapshot. Measure how identity arrives, how the node learns its site and role, how secrets are distributed, how the CNI appears, how the image mirror is configured, and how long the first useful workload takes to become ready. This is where k3s often looks excellent because the path from Linux host to working API server is short. It is also where Talos or Kairos can look excellent if the team has invested in boot assets and machine configuration. The winner is not the fastest demo; the winner is the path that can be repeated by automation without a senior engineer reading a console.
+
+The second test is a partition test. Disconnect the site from central Git, the registry, the identity provider, and the central observability backend in separate test runs, because those failures have different shapes. During each partition, restart one edge node, restart one workload, rotate a local service, and record which operations still work. If the application remains healthy only because nothing restarted, you have not proven autonomy. You have proven that already-running processes can keep running for a while. KubeEdge and OpenYurt should be tested here with edge-side restarts, metadata reads, and reconciliation after the link returns, because their value lives in degraded-mode behavior rather than install speed.
+
+The third test is an upgrade test with rings. Upgrade one lab site, then one hardware class, then a small percentage of sites, and finally a larger batch. In each ring, record node drain behavior, CNI disruption, API-server availability, image pulls, disk pressure, workload readiness, and rollback steps. For immutable-node approaches, decide whether rollback means booting the previous image, resetting a node, or restoring a previous machine configuration. For mutable Linux approaches, decide which host packages and services are part of the supported state. A platform that cannot explain rollback before the first production rollout is not ready for an edge fleet.
+
+The fourth test is a local-data and rebuild test. Pick a workload that writes local state, then force the most likely failure: power loss, disk replacement, node reimage, or accidental local-path deletion. The test should prove which data is disposable, which data is replicated within the site, which data is backed up centrally, and which data is simply not allowed at the edge. Many edge incidents become painful because teams discover data durability requirements only after choosing a distribution. The distribution can give you primitives, but it will not decide whether checkout events, sensor buffers, model-cache files, or customer-visible transaction state may be lost.
+
+The fifth test is a security and drift test. Attempt the exact operations your responders currently use under pressure: SSH login, package installation, service restart, manual file edit, privileged debug pod, hostPath mount, kernel-module dependency, and direct log scraping. On a mutable host, decide which of those operations are approved and how they are audited. On Talos, decide how each action maps to `talosctl`, Kubernetes audit evidence, a machine configuration patch, a debug container, or a node rebuild. On Kairos, decide which mutations belong in the image and which belong in Kubernetes-managed lifecycle components. This test prevents a team from discovering during an incident that its favorite repair technique is outside the supported model.
+
+The sixth test is observability under damage. A good edge design has a central view, but it should not depend entirely on the central view. During WAN loss, the local site should still expose enough evidence for a remote or local responder to distinguish application failure, disk pressure, CNI failure, DNS failure, registry failure, and node health. Pixie, Cilium Hubble, Tetragon, KubeArmor, logs, node events, and local probes can all contribute, but each has a cost in CPU, memory, storage, and operational complexity. Observability agents are not free at the edge, so the proof of concept should measure their overhead as part of the distribution decision.
+
+The seventh test is fleet arithmetic. For each candidate, estimate the recurring work per site per month: planned upgrades, emergency patching, certificate rotation, hardware replacement, image-cache maintenance, audit evidence, and support escalations. Use pessimistic numbers and multiply by site count. A distribution that saves 10 minutes during installation may lose if it adds 5 minutes of manual validation every month forever. Conversely, a distribution that takes a week to automate well may win if it removes manual host repair across thousands of nodes. The edge platform choice is a finance and staffing decision as much as a technical decision.
+
+The proof of concept should end with a recommendation that states assumptions plainly. For example: "Choose k3s for the first 200 single-node sites because workloads are stateless, WAN outages are tolerable for four hours, and node rebuild is automated from Git and image mirror." Or: "Choose Talos for store clusters because the security model forbids SSH, patching must be image-based, and the team accepts API-driven debugging." Or: "Evaluate KubeEdge before choosing the node distribution because device sync and local metadata autonomy are the primary risk." A good recommendation is falsifiable; it tells reviewers what evidence would cause the team to change direction.
+
+This is also where cross-functional defense matters. Application teams care about local service behavior and release speed. Security teams care about host mutation, certificates, privileged workloads, and auditability. Networking teams care about NAT, routing, DNS, IP exhaustion, and partition behavior. Operations teams care about rollout rings, failed hardware, paging, and evidence during outages. If your recommendation cannot explain the same choice to all four groups in their own risk language, it is not ready for production even if the cluster passes `kubectl get nodes`.
+
+### Writing The Decision Record
+
+The decision record should begin with the site class, because every later claim depends on it. "Near-edge retail store with three nodes and intermittent WAN" is a different decision than "regional edge facility with staffed network operations and redundant transit." Include the number of expected sites, the growth target, the node count per site, the expected hardware classes, the local operator skill level, and the outage assumptions. This context prevents future reviewers from reusing the decision in an environment where it no longer applies. A strong decision record says, in effect, "This is the edge we mean."
+
+Next, name the workload behavior that shaped the choice. A cluster running local inference, point-of-sale adapters, or industrial control helpers has different failure expectations from a cluster running cacheable static content. Write down whether workloads are stateless, locally stateful but rebuildable, locally stateful and business-critical, or tightly coupled to devices. Then describe what happens during WAN loss, node restart, and registry unavailability. If a workload cannot start without the central identity provider, that fact matters more than whether the distribution binary is small. If a workload can operate for hours from local state and queue events for later sync, the architecture can tolerate a very different control-plane posture.
+
+Then describe the operating model in verbs, not slogans. Do operators patch, replace, rebuild, enroll, drain, mirror, rotate, audit, and roll back through documented automation, or do they rely on manual host access? If the chosen path is k3s on a mutable Linux host, the record should say exactly which host mutations are allowed and how they are enforced. If the chosen path is Talos, the record should say how responders collect logs, patch machine configuration, recover API access, and replace a node when Kubernetes is unhealthy. If the chosen path is KubeEdge or OpenYurt, the record should say which edge-side components own degraded-mode behavior and what compatibility constraints come with them.
+
+After that, record the rejected options with respect. A useful rejection says, "MicroK8s was not selected because snap refresh governance and air-gap mirroring were not acceptable for this fleet," or "Talos was not selected because two required device drivers were not ready for the image pipeline and local technicians still need a supported host-debug path." That style is more valuable than "MicroK8s is bad" or "Talos is too weird." Future teams can revisit a rejected option when constraints change, and they can see that the original decision was based on evidence rather than taste.
+
+The record also needs a rollback strategy for the decision itself. Many teams define workload rollback but forget platform rollback. If the first 50 sites reveal that the chosen distribution creates support pain, what happens next? Can you rebuild sites onto another distribution with the same manifests? Are storage formats portable? Are node labels, admission policies, and GitOps paths distribution-neutral? Did you depend on a bundled ingress, local-path provisioner, or service load balancer that will not exist in the alternative? Designing for reversibility does not mean you expect failure. It means you understand that edge fleets are expensive places to discover irreversible coupling.
+
+Finally, give the recommendation an expiration condition. Edge platforms live in a moving ecosystem: Kubernetes versions advance, CNCF project maturity changes, hardware supply shifts, security policy tightens, and the organization's operating skills improve. A decision that is excellent for the first 200 sites may be insufficient for 2,000 sites. A recommendation that fits one-node recoverable stores may fail when application teams add local databases. Write the date, the Kubernetes version target, the fleet size assumption, and the trigger for re-evaluation. Senior engineers make decisions that can be audited later, not decisions that pretend time stopped on rollout day.
+
+### A Practical Rollout Contract
+
+Before the first production site, define a rollout contract between platform and application teams. The platform team promises what the site substrate provides: Kubernetes version range, CNI behavior, ingress behavior, storage classes, image mirror availability, DNS behavior, node labels, observability signals, maintenance windows, and degraded-mode guarantees. Application teams promise what workloads provide: resource requests, readiness probes, graceful shutdown, local data classification, retry behavior, offline behavior, and acceptable recovery time. Without that contract, distribution debates become a substitute for product requirements, and no distribution can save the platform from ambiguous ownership.
+
+For example, a store cluster may promise that already-pulled images remain available during WAN loss but not that new images can be fetched from the central registry. That means application releases cannot assume emergency deploys during a partition. A factory cluster may promise local DNS and device gateway access during WAN loss but not central authentication for new operator sessions. That means workloads need cached credentials, local break-glass policy, or a documented degraded-mode path. A regional edge cluster may promise redundant transit but not store-level isolation. That means the blast radius and compliance story differ from near-edge clusters even if both run the same Kubernetes version.
+
+The rollout contract should include a "no hidden central dependency" review. Many edge workloads accidentally call central services for license checks, feature flags, telemetry upload, model fetches, certificate validation, or user lookup in paths that operators think are local. During normal conditions, those calls are invisible. During a WAN outage, they become the reason the site fails. Distribution choice cannot detect those dependencies. A good proof of concept uses packet capture, service mesh telemetry, Cilium flow visibility, application logs, or synthetic outage tests to find them before the platform team declares the edge substrate ready.
+
+The contract should also define what "site healthy" means. A central cluster health dashboard may show all nodes Ready while the local checkout application is unable to reach a scanner gateway, a local disk is rebuilding, or image pulls are stalled behind a failed mirror. Site health should combine Kubernetes health, workload health, local dependency health, and edge-specific degraded-mode indicators. The exact implementation can vary, but the definition should be shared before rollout. If no one can say whether a site is healthy without asking three teams to interpret separate dashboards, the distribution decision has not produced an operable platform.
+
+Treat the first production sites as an engineering instrument, not a victory lap. Capture every manual step, every unclear alert, every exception, every missing driver, every surprising firewall rule, every image-cache miss, and every human handoff. Then update the automation and the decision record before expanding the ring. This is how a team turns an edge Kubernetes proof of concept into a platform. The goal is not to avoid discovering problems; the goal is to discover them while the blast radius is small enough that learning is cheap.
+
+## Did You Know?
+
+- **k3s separates server and agent minimums.** The official requirements list 2 cores and 2 GB RAM for a server node, but only 1 core and 512 MB RAM for an agent node; that distinction matters when sizing constrained sites ([k3s requirements](https://docs.k3s.io/installation/requirements)).
+- **k0s documents both tiny minimums and large-cluster sizing.** Its requirements page lists a 1 GB controller minimum and a 0.5 GB worker minimum, then gives recommendations up to 5,000 workers and 150,000 pods ([k0s requirements](https://docs.k0sproject.io/stable/system-requirements/)).
+- **MicroK8s HA has concrete timing behavior.** Its HA documentation says leader election after an ungracefully removed leader can take up to 5 seconds, while promoting a non-voter to voter can take up to 30 seconds ([MicroK8s HA](https://canonical.com/microk8s/docs/high-availability)).
+- **KubeEdge and OpenYurt are now mature CNCF edge projects with different status.** CNCF lists KubeEdge as accepted on March 18, 2019 and Graduated on September 11, 2024, while OpenYurt was accepted on September 8, 2020 and moved to Incubating on January 10, 2025 ([KubeEdge CNCF](https://www.cncf.io/projects/kubeedge/), [OpenYurt CNCF](https://www.cncf.io/projects/openyurt/)).
+
+## Common Mistakes
+
+| Mistake | Why It Hurts | Fix |
+|---|---|---|
+| Treating "lightweight" as a synonym for "edge-ready" | A small control plane can still depend on a fragile WAN, manual upgrades, or mutable host fixes | Start with site failure modes, then choose footprint, autonomy, and lifecycle model |
+| Running SQLite where multi-server HA is expected | k3s documents SQLite as the default datastore but not for multiple-server clusters | Use single-node recoverable architecture honestly, or move to embedded etcd/external datastore for HA |
+| Choosing Talos while keeping SSH-first runbooks | Talos intentionally removes shell and SSH, so incident muscle memory will fail | Rewrite runbooks around `talosctl`, Kubernetes evidence, config patches, and node replacement |
+| Standardizing on MicroK8s without snap policy review | Snap channels, confinement, refresh behavior, and air-gap packaging may conflict with enterprise OS policy | Test snap lifecycle, channel pinning, offline installs, and maintenance windows before fleet rollout |
+| Ignoring image distribution | Edge outages often turn registry access into the hidden platform dependency | Design local mirrors, pre-pull policy, registry credentials, and image garbage-collection limits |
+| Stretching one normal cluster across unreliable edge links | Native Kubernetes assumes reasonably reliable API-server connectivity for many operations | Evaluate KubeEdge, OpenYurt, local-site clusters, or regional control-plane designs explicitly |
+| Forgetting hardware diversity | Edge fleets mix NICs, disks, firmware, CPU architectures, and power behavior | Maintain a hardware compatibility matrix and test upgrades by hardware class, not only by software version |
+| Skipping observability during partitions | Central dashboards may go dark exactly when local responders need evidence | Keep local health checks, log buffers, and delayed-forwarding telemetry paths in the design |
+
+## Quiz
+
+1. **A retail team has one small server per store, no local operator, and workloads that can be recreated from Git plus a local image cache. The business can tolerate a short outage during hardware replacement. Which pattern should you evaluate first?**
+
+   <details>
+   <summary>Answer</summary>
+
+   Evaluate a single-node recoverable pattern first, commonly with k3s or k0s. The key phrase is "recoverable," not "highly available." You should prove rebuild, bootstrap identity, image cache, workload sync, and local data classification before adding multi-node quorum complexity that the site may not actually support.
+
+   </details>
+
+2. **A factory platform uses local devices and must continue controlling a line for several hours when the WAN link to the central data center fails. The team also needs cloud-side intent to synchronize back when connectivity returns. Which part of the landscape deserves early attention?**
+
+   <details>
+   <summary>Answer</summary>
+
+   Evaluate cloud-edge coordination systems such as KubeEdge or OpenYurt early. A lightweight distribution may still be part of the node design, but the core requirement is local autonomy and cloud-edge synchronization behavior. Testing should include a real partition, an edge-node restart during the partition, and reconciliation after the link returns.
+
+   </details>
+
+3. **A security team bans SSH access and undocumented host mutation for production Kubernetes nodes. Operators are comfortable replacing failed nodes but not comfortable logging in to repair them. Which options fit that operating model best?**
+
+   <details>
+   <summary>Answer</summary>
+
+   Talos is the clearest fit because its design is API-managed, immutable, minimal, and intentionally lacks SSH and a shell. Kairos may also fit when the organization wants an immutable edge OS approach while retaining more base-distribution flexibility. The proof of concept should focus on hardware support, image customization, `talosctl` or equivalent operations, and node replacement workflows.
+
+   </details>
+
+4. **A team says it wants MicroK8s because developers like `microk8s enable`, but production clusters are air-gapped and change control requires explicit version pinning. What should you challenge before approving the choice?**
+
+   <details>
+   <summary>Answer</summary>
+
+   Challenge the snap lifecycle and add-on supply chain. The team must show how snap channels are pinned, how packages and add-ons are mirrored into the air-gapped environment, how refresh windows are controlled, and how rollback is verified. Developer convenience is valuable, but production delivery mechanics decide whether MicroK8s fits the edge fleet.
+
+   </details>
+
+5. **A platform owner wants one distribution for cloud regions, regional edge, stores, and IoT gateways. How would you defend a recommendation to application, security, networking, and operations stakeholders without forcing one tool everywhere?**
+
+   <details>
+   <summary>Answer</summary>
+
+   Defend the recommendation by separating shared principles from implementation choices. A cloud region may need managed control planes and provider integrations, a regional edge site may need hardened multi-node clusters, a store may need recoverable local services, and an IoT gateway may need tiny footprint plus device integration. Application stakeholders get evidence about local service behavior, security stakeholders get evidence about host mutation and auditability, networking stakeholders get partition and routing tests, and operations stakeholders get rollout and recovery data. Standardizing APIs, lifecycle controls, and evidence may be wiser than forcing one binary everywhere.
+
+   </details>
+
+6. **During a proof of concept, a three-node edge cluster survives one node reboot but fails when the store loses WAN during an image pull. Was the distribution choice proven?**
+
+   <details>
+   <summary>Answer</summary>
+
+   No. The test only proved some local node resilience. It did not prove registry independence, image preloading, local mirror behavior, or degraded-mode application behavior. Edge validation must include WAN loss, cold restart, registry unavailability, local DNS failure, disk pressure, and recovery after connectivity returns.
+
+   </details>
+
+7. **A team chooses k3s because it includes Traefik, ServiceLB, Flannel, CoreDNS, local-path storage, and other convenient packaged components. What should they document before rollout?**
+
+   <details>
+   <summary>Answer</summary>
+
+   They should document which packaged components are accepted as fleet standards, which are disabled and replaced, how configuration is pinned, and how component upgrades are tested. Bundled defaults are useful because they reduce initial assembly, but production edge fleets need deliberate standards rather than accidental defaults.
+
+   </details>
+
+8. **A cluster at a store is "healthy" in the central dashboard, but local users report checkout latency after a power event. What evidence should you collect before blaming the distribution?**
+
+   <details>
+   <summary>Answer</summary>
+
+   Collect local node events, pod restart history, disk and filesystem errors, CNI status, DNS behavior, image pull delays, local storage rebuild activity, and network latency to any central dependencies. The distribution may be innocent; the incident may live in storage, image cache, local DNS, workload readiness, or a central service dependency that the edge architecture failed to isolate.
+
+   </details>
+
+## Hands-On Exercise: Trace Your Host Assumptions With bpftrace
+
+This exercise is intentionally safe: it does not require installing a Kubernetes distribution, and it does not mutate the host beyond running a short tracing command. The goal is to make the operating-model difference visible. A mutable Linux host makes shell, package, service-manager, and filesystem assumptions easy. An immutable Kubernetes OS such as Talos removes many of those assumptions, so runbooks must move from "log in and fix" to "observe through APIs, patch desired state, or replace the node."
+
+The exercise requires a Linux box with `bpftrace` installed and permission to run it with `sudo`. bpftrace supports tracepoints, kprobes, interval probes, and other probe types for attaching short BPF programs to kernel and user-space events ([bpftrace language reference](https://bpftrace.org/docs/release_023/language)). You will use `execve` tracing to watch a controlled shell command reveal which host administration tools exist on your current machine.
+
+### Step 1: Confirm bpftrace Works
+
+```bash
+sudo bpftrace --info | sed -n '1,40p'
+sudo bpftrace -l 'tracepoint:syscalls:sys_enter_execve' | head -1
+```
+
+You should see bpftrace feature output and the `tracepoint:syscalls:sys_enter_execve` probe. If the probe is missing, your kernel or tracing permissions are not ready for this exercise.
+
+### Step 2: Trace A Controlled Administration Probe
+
+```bash
+sudo bpftrace -e '
+tracepoint:syscalls:sys_enter_execve
+{
+  printf("%-16s -> %s\n", comm, str(args->filename));
+  @[str(args->filename)] = count();
+}
+END
+{
+  print(@);
+}
+' -c 'sh -lc "
+  uname -r >/dev/null
+  command -v systemctl >/dev/null || true
+  command -v sshd >/dev/null || true
+  command -v apt >/dev/null || command -v dnf >/dev/null || command -v yum >/dev/null || command -v snap >/dev/null || true
+"'
+```
+
+The output should show the shell and the commands it executes, plus a final map of executed paths. On a conventional Linux host you will usually see `/bin/sh`, `/usr/bin/uname`, and one or more administrative tools such as `systemctl`, `apt`, `dnf`, `yum`, `snap`, or `sshd` if they are installed. The exact paths vary by distribution, which is part of the point: mutable Linux gives operators many local tools, and those tools become implicit dependencies in troubleshooting habits.
+
+### Step 3: Turn The Trace Into A Distribution Decision
+
+Create a short note with three columns: "Observed host assumption," "Works on mutable k3s/k0s/MicroK8s host," and "Works on Talos-style immutable host." For each command path from the trace, decide whether your current production runbooks rely on that capability. If the answer is yes for SSH, package installation, or local file edits, then an immutable OS migration is also a runbook migration. If the answer is no because your team already uses declarative config, node replacement, and API-based evidence, then Talos or Kairos may be operationally realistic.
+
+### Optional Disposable-VM Extension
+
+On a disposable Linux VM, you can install k3s and repeat the trace around service startup. Do not run this on your workstation or a shared server unless you intend to install Kubernetes there.
+
+```bash
+curl -sfL https://get.k3s.io -o /tmp/get-k3s.sh
+sudo sh /tmp/get-k3s.sh
+sudo k3s kubectl get nodes
+sudo systemctl status k3s --no-pager
+```
+
+Now compare what you did with the Talos model. The k3s path used a shell script, systemd, host packages and files, and a normal Linux service manager. Talos would move that work into machine configuration, boot assets, `talosctl`, and Kubernetes APIs. Neither workflow is automatically better. The correct question is which workflow your edge fleet can execute repeatedly without undocumented drift.
+
+### Success Criteria
+
+- You captured `execve` events with bpftrace and can explain at least three host assumptions visible in the trace.
+- You can state whether your current runbooks depend on SSH, package managers, systemd service edits, or local shell debugging.
+- You can explain why those assumptions make k3s, k0s, or MicroK8s easier in some environments and why they make Talos or Kairos attractive in others.
+- You can name at least one case where KubeEdge or OpenYurt would be evaluated even if the node distribution itself is already chosen.
+
+### Verification Checklist
+
+- [ ] The bpftrace command produced at least one `execve` line and printed a final map of executed paths.
+- [ ] Your note separates mutable-host assumptions from immutable-host assumptions instead of treating them as tool preferences.
+- [ ] Your recommendation names one distribution or framework choice and the specific evidence that would make you reject it.
+
+## Key Takeaways
+
+Edge Kubernetes design starts with site reality. Far-edge, near-edge, and regional-edge environments have different resource, network, autonomy, and human-support constraints, so a single tool label cannot carry the architecture. k3s, k0s, MicroK8s, Talos, Kairos, KubeEdge, and OpenYurt are best understood as answers to different questions about footprint, host model, lifecycle, and cloud-edge behavior.
+
+The most expensive edge mistakes usually come from mismatched operating models rather than broken installers. If you choose a mutable Linux distribution, standardize how hosts are patched and repaired. If you choose an immutable OS, rewrite SSH-first runbooks before production. If you choose a cloud-edge framework, test partitions and reconciliation instead of only testing happy-path deployment. At fleet scale, repeatability is reliability.
+
+## Next Module
+
+Continue to [Module 3.1: Dagger](../../../cicd-delivery/ci-cd-pipelines/module-3.1-dagger/) to connect cluster decisions with CI/CD execution, or return to [Module 14.1: k3s](../module-14.1-k3s/) if this landscape showed that lightweight single-node Kubernetes is the next decision to test.
+
+## References
+
+- [JYSK edge deployment case study](https://www.siderolabs.com/case-studies/supporting-jysks-digital-transformation-with-3400-strong-edge-deployment/)
+- [CNCF Cloud Native Glossary: Edge Computing](https://glossary.cncf.io/edge-computing/)
+- [Open Glossary of Edge Computing](https://stateoftheedge.com/project/glossary/)
+- [CNCF Edge Native Applications Principles Whitepaper](https://www.cncf.io/reports/edge-native-applications-principles-whitepaper/)
+- [k3s documentation](https://docs.k3s.io/)
+- [k3s requirements](https://docs.k3s.io/installation/requirements)
+- [k3s datastore documentation](https://docs.k3s.io/datastore)
+- [k0s documentation](https://docs.k0sproject.io/stable/)
+- [k0s system requirements](https://docs.k0sproject.io/stable/system-requirements/)
+- [MicroK8s documentation](https://canonical.com/microk8s/docs)
+- [MicroK8s high availability](https://canonical.com/microk8s/docs/high-availability)
+- [Talos overview](https://docs.siderolabs.com/talos/v1.13/overview/what-is-talos)
+- [Talos philosophy](https://docs.siderolabs.com/talos/v1.11/learn-more/philosophy)
+- [Kairos meta-distribution](https://kairos.io/docs/architecture/meta/)
+- [KubeEdge CNCF project page](https://www.cncf.io/projects/kubeedge/)
+- [KubeEdge MetaManager](https://kubeedge.io/docs/architecture/edge/metamanager/)
+- [OpenYurt CNCF project page](https://www.cncf.io/projects/openyurt/)
+- [OpenYurt project overview](https://openyurt.io/)
+- [bpftrace language reference](https://bpftrace.org/docs/release_023/language)


### PR DESCRIPTION
Closes #1519. Self-tests green: verifier + build + health check. Cross-family reviewer per Decision Card C: cursor composer-2.5.

Additional validation:
- .venv/bin/python scripts/test_pipeline.py: OK (170 tests)
- git diff --check: clean

Placement note: repo section is src/content/docs/platform/toolkits/infrastructure-networking/k8s-distributions/, so this lands as module 14.8 rather than creating a duplicate k8s-distros directory.

Cross-link follow-up candidates from eBPF-adjacent modules:
- src/content/docs/platform/toolkits/infrastructure-networking/networking/module-5.1-cilium.md
- src/content/docs/platform/toolkits/security-quality/security-tools/module-4.5-tetragon.md
- src/content/docs/platform/toolkits/security-quality/security-tools/module-4.6-kubearmor.md
- src/content/docs/platform/toolkits/observability-intelligence/observability/module-1.6-pixie.md

## Learner check

Quoted from `module-14.8-edge-distros-landscape.md` line 37:

> The important lesson is not "k3s was wrong" or "Talos is always right." k3s can be an excellent edge distribution when the site count, update path, storage assumptions, and support model fit it. The lesson is that a distribution can be technically sound and still be the wrong fleet substrate.

Confirms the module teaches the why behind distro choice, not a feature listicle. Cursor R1 rubric scored Engagement 4/5 and Real-World Connection 5/5 on the JYSK narrative.