### PR TITLE
fix(dispatch): hermes argv flag order

### DIFF
--- a/scripts/dispatch_smart.py
+++ b/scripts/dispatch_smart.py
@@ -327,14 +327,18 @@ def _router_command(agent: str, model: str, prompt: str) -> list[str]:
         ]
     if agent == "hermes":
         cli_model = _hermes_cli_model(model)
+        # -z/--oneshot: one-shot mode; PROMPT is a single argv token (not stdin).
+        # Flags must precede -z: argparse binds the next token after -z as the
+        # prompt, so ``-z … --provider`` mis-parses when the prompt is empty or
+        # starts with ``-`` (e.g. ``--provider`` becomes -z's value).
         return [
             _hermes_binary(),
-            "-z",
-            prompt,
             "--provider",
             _hermes_provider_for_model(model),
             "-m",
             cli_model,
+            "-z",
+            prompt,
         ]
     raise ValueError(f"unsupported direct router agent: {agent}")
 
@@ -582,6 +586,8 @@ def main() -> int:
         print(f"[dry-run] worktree={_wt_label}")
         print(f"[dry-run] task_id={task_id}")
         print(f"[dry-run] prompt_chars={len(prompt)}")
+        if args.agent in {"cursor", "hermes", "opencode"}:
+            print(f"[dry-run] argv={_router_command(args.agent, model, prompt)!r}")
         return 0
 
     if worktree and mode != "read-only":

--- a/scripts/dispatch_smart.py
+++ b/scripts/dispatch_smart.py
@@ -327,18 +327,16 @@ def _router_command(agent: str, model: str, prompt: str) -> list[str]:
         ]
     if agent == "hermes":
         cli_model = _hermes_cli_model(model)
-        # -z/--oneshot: one-shot mode; PROMPT is a single argv token (not stdin).
-        # Flags must precede -z: argparse binds the next token after -z as the
-        # prompt, so ``-z … --provider`` mis-parses when the prompt is empty or
-        # starts with ``-`` (e.g. ``--provider`` becomes -z's value).
+        # --oneshot (-z): one-shot mode; PROMPT must be a single argv token.
+        # Use ``--oneshot=<prompt>`` so flag-like prompts (e.g. ``--provider``)
+        # are bound as the flag value, not parsed as a separate CLI flag.
         return [
             _hermes_binary(),
             "--provider",
             _hermes_provider_for_model(model),
             "-m",
             cli_model,
-            "-z",
-            prompt,
+            f"--oneshot={prompt}",
         ]
     raise ValueError(f"unsupported direct router agent: {agent}")
 

--- a/tests/test_dispatch_smart.py
+++ b/tests/test_dispatch_smart.py
@@ -54,13 +54,24 @@ def test_dispatch_smart_agy_danger_no_worktree_passes_guards() -> None:
 
 
 def test_hermes_router_argv_puts_oneshot_last() -> None:
-    """Hermes -z/--oneshot must follow --provider and -m so flags are not misparsed."""
+    """Hermes --oneshot=<prompt> must follow --provider and -m (equals-form)."""
     sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
     from dispatch_smart import _router_command
 
     cmd = _router_command("hermes", "qwen-3.6-flash", "hello")
-    assert cmd[-2:] == ["-z", "hello"]
+    assert cmd[-1] == "--oneshot=hello"
+    assert "-z" not in cmd
     assert cmd[1:5] == ["--provider", "openrouter", "-m", "qwen/qwen3.6-flash"]
+
+
+def test_hermes_router_argv_handles_flag_like_prompt() -> None:
+    """Flag-like prompts bind via --oneshot= so argparse never treats them as flags."""
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+    from dispatch_smart import _router_command
+
+    argv = _router_command("hermes", "qwen-3.6-flash", "--provider")
+    assert "--oneshot=--provider" in argv
+    assert "-z" not in argv
 
 
 def test_dispatch_smart_codex_danger_still_requires_worktree() -> None:

--- a/tests/test_dispatch_smart.py
+++ b/tests/test_dispatch_smart.py
@@ -53,6 +53,16 @@ def test_dispatch_smart_agy_danger_no_worktree_passes_guards() -> None:
     )
 
 
+def test_hermes_router_argv_puts_oneshot_last() -> None:
+    """Hermes -z/--oneshot must follow --provider and -m so flags are not misparsed."""
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+    from dispatch_smart import _router_command
+
+    cmd = _router_command("hermes", "qwen-3.6-flash", "hello")
+    assert cmd[-2:] == ["-z", "hello"]
+    assert cmd[1:5] == ["--provider", "openrouter", "-m", "qwen/qwen3.6-flash"]
+
+
 def test_dispatch_smart_codex_danger_still_requires_worktree() -> None:
     """The agy carve-out must NOT loosen the requirement for codex,
     which actually writes under danger mode."""


### PR DESCRIPTION
## Root cause

Hermes `-z` / `--oneshot` is **one-shot mode**: it takes a single argv token as the prompt and prints only the final response to stdout (no banner/spinner). Anything immediately after `-z` is bound as that prompt.

`dispatch_smart.py` built argv as `hermes -z PROMPT --provider … -m …`. When the prompt is empty, starts with `-`, or is omitted, argparse treats the next token (e.g. `--provider`) as `-z`'s value. Repro locally:

```bash
hermes -z --provider openrouter -m qwen/qwen3.6-flash   # usage error (mis-parse)
```

Session 54 hit this on `dispatch_smart --agent hermes` dispatches; direct `hermes --provider … -m … -z PROMPT` worked.

## Fix

Reorder the hermes branch of `_router_command()` to `hermes --provider PROVIDER -m MODEL -z PROMPT` so flags are parsed before the oneshot prompt. Added an in-code comment documenting `-z` semantics. `--dry-run` now prints `argv=` for router CLIs (hermes/cursor/opencode).

## Round 2 fix-pass

Codex R1 confirmed flag ordering fixes normal prompts but caught a **second bug**: flag-like prompts still fail when passed as a separate argv token after `-z`. Example dry-run argv was `['hermes', '--provider', 'openrouter', '-m', 'qwen/qwen3.6-flash', '-z', '--provider']` — Hermes argparse then treats `--provider` as a new flag, not as `-z`'s value (`hermes: error: argument -z/--oneshot: expected one argument`).

**Fix:** bind the prompt with equals-form `f"--oneshot={prompt}"` (single argv token). Confirmed via `hermes --help` that `-z` is `--oneshot PROMPT`. Flag-like prompts such as `--provider` are now `--oneshot=--provider` and cannot be misparsed.

**Test:** `test_hermes_router_argv_handles_flag_like_prompt` asserts `--oneshot=--provider` in argv and that `-z` is gone; existing test updated for equals-form.

## Test plan

- [x] `hermes --help` — confirmed `-z` is `--oneshot PROMPT`
- [x] Repro: `hermes -z --provider openrouter -m qwen/qwen3.6-flash` → argparse usage error
- [x] `.venv/bin/python scripts/dispatch_smart.py --agent hermes --dry-run search "hello"` → argv contains `--oneshot=hello`
- [x] `.venv/bin/python scripts/dispatch_smart.py --agent hermes --dry-run search -- --provider` → argv contains `--oneshot=--provider`
- [x] `.venv/bin/python scripts/dispatch_smart.py --agent hermes search "what is 2+2"` → `OK: True`, `2+2 = 4`
- [x] `.venv/bin/ruff check scripts/dispatch_smart.py tests/test_dispatch_smart.py`
- [x] `.venv/bin/python -m pytest tests/test_dispatch_smart.py::test_hermes_router_argv_puts_oneshot_last tests/test_dispatch_smart.py::test_hermes_router_argv_handles_flag_like_prompt -q`
- [x] `npm run build` — skipped (Python-only)

**Cross-family review:** please route to **codex** per Decision Card C.

Regression test: tests/test_dispatch_smart.py (test_hermes_router_argv_handles_flag_like_prompt added in R2 fix-pass; asserts --oneshot=--provider binds correctly for the #1543 edge case)
