### PR TITLE
fix(bridge): hermes argv equals-form follow-up

### DIFF
--- a/scripts/ai_agent_bridge/_hermes.py
+++ b/scripts/ai_agent_bridge/_hermes.py
@@ -56,14 +56,16 @@ def _build_command(
     provider: str | None = None,
 ) -> list[str]:
     """Build the hermes one-shot command."""
+    # --oneshot (-z): one-shot mode; PROMPT must be a single argv token.
+    # Use ``--oneshot=<prompt>`` so flag-like prompts (e.g. ``--provider``)
+    # are bound as the flag value, not parsed as a separate CLI flag.
     return [
         _hermes_binary(),
-        "-z",
-        prompt,
         "--provider",
         provider or _detect_provider(model),
         "-m",
         _cli_model(model),
+        f"--oneshot={prompt}",
     ]
 
 

--- a/scripts/ai_agent_bridge/tests/test_opencode_hermes.py
+++ b/scripts/ai_agent_bridge/tests/test_opencode_hermes.py
@@ -109,12 +109,11 @@ def test_hermes_command_construction(
     assert stderr == ""
     assert captured["cmd"] == [
         "hermes",
-        "-z",
-        "prompt",
         "--provider",
         "anthropic",
         "-m",
         "claude-sonnet-4-6",
+        "--oneshot=prompt",
     ]
     assert captured["kwargs"]["input"] == ""
     assert captured["kwargs"]["cwd"] == tmp_path
@@ -151,14 +150,32 @@ def test_hermes_qwen_route_label_maps_to_cli_model(
     assert stderr == ""
     assert captured["cmd"] == [
         "hermes",
-        "-z",
-        "prompt",
         "--provider",
         "openrouter",
         "-m",
         "qwen/qwen3.6-flash",
+        "--oneshot=prompt",
     ]
     assert captured["kwargs"]["input"] == ""
+
+
+def test_hermes_build_command_puts_oneshot_last() -> None:
+    """Hermes --oneshot=<prompt> must follow --provider and -m (equals-form)."""
+    from ai_agent_bridge import _hermes
+
+    cmd = _hermes._build_command("hello", "qwen-3.6-flash")
+    assert cmd[-1] == "--oneshot=hello"
+    assert "-z" not in cmd
+    assert cmd[1:5] == ["--provider", "openrouter", "-m", "qwen/qwen3.6-flash"]
+
+
+def test_hermes_build_command_handles_flag_like_prompt() -> None:
+    """Flag-like prompts bind via --oneshot= so argparse never treats them as flags."""
+    from ai_agent_bridge import _hermes
+
+    cmd = _hermes._build_command("--provider", "qwen-3.6-flash")
+    assert "--oneshot=--provider" in cmd
+    assert "-z" not in cmd
 
 
 def test_task_classes_include_opencode_and_hermes() -> None:


### PR DESCRIPTION
## Summary
- Mirrors the fix from PR #1543 in scripts/ai_agent_bridge/_hermes.py.
- Same root cause (flag-like prompts break with `-z` + separate token); same fix (`--oneshot=<prompt>` equals-form).

## Why a separate PR
- PR #1543 was scoped to dispatch_smart.py only per its brief. PR #1543 R1 (codex) confirmed the bridge file has the same bug.

## Cross-family review (Decision Card C)
- **Reviewer:** Codex (different family from bridge author)
- **Scope:** argv shape, test coverage for flag-like prompts, no dispatch_smart.py drift

## Test plan
- [x] `pytest scripts/ai_agent_bridge/tests/test_opencode_hermes.py` — 8 passed
- [x] `.venv/bin/ruff check scripts/ai_agent_bridge/_hermes.py` — clean
- [ ] Bridge dry-run (if applicable) shows `--oneshot=<prompt>` in argv.
- [ ] Existing/new test asserts `-z` removed and equals-form present.
- [ ] Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)

Regression test: scripts/ai_agent_bridge/tests/test_opencode_hermes.py (test_hermes_build_command_puts_oneshot_last + test_hermes_build_command_handles_flag_like_prompt mirror the dispatch_smart fix and assert --oneshot=<prompt> equals-form for the #1543 flag-like-prompt class)
