### PR TITLE
fix(dispatch): scripts/dispatch.py hermes argv equals-form

### DIFF
--- a/scripts/agent_runtime/adapters/deepseek.py
+++ b/scripts/agent_runtime/adapters/deepseek.py
@@ -5,8 +5,8 @@ peer to codex / claude / gemini for code review, deliberation, and fix lanes.
 
 Key design points:
 
-- **Transport:** ``hermes`` CLI in oneshot mode (``-z -`` reads prompt
-  from stdin). Hermes proxies to DeepSeek via the ``deepseek`` provider.
+- **Transport:** ``hermes`` CLI in oneshot mode (``--oneshot=<prompt>``
+  argv binding). Hermes proxies to DeepSeek via the ``deepseek`` provider.
 - **Modes:** All three (read-only / workspace-write / danger) supported.
   Mode → hermes toolset mapping is conservative for read-only (no
   terminal/file tools), permissive for workspace-write and danger.
@@ -132,20 +132,11 @@ class DeepSeekAdapter:
         cmd: list[str] = [binary]
 
         # Reasoning effort hint applied first so the final prompt string is
-        # the argv positional we pass to -z.
+        # bound via --oneshot= below.
         effort = tc.get("effort")
         final_prompt = prompt
         if effort and effort != "default":
             final_prompt = f"[Reasoning effort hint: {effort}]\n\n{prompt}"
-
-        # Oneshot mode. Pass the prompt as argv positional, NOT stdin.
-        # ``hermes -z -`` (stdin marker) is interpreted as "no prompt
-        # provided, run in project-introspection mode" — the prompt
-        # piped on stdin is ignored. ARG_MAX is ~1 MB on macOS so the
-        # ~10 KB review prompts fit comfortably; if a caller needs to
-        # pass a multi-megabyte prompt, write it to a temp file and use
-        # a different transport (not the runtime's concern today).
-        cmd.extend(["-z", final_prompt])
 
         # Model
         cmd.extend(["-m", model or self.default_model])
@@ -181,6 +172,13 @@ class DeepSeekAdapter:
         # more important than context awareness.
         if bool(tc.get("isolated", False)):
             cmd.extend(["--ignore-user-config", "--ignore-rules"])
+
+        # --oneshot (-z): one-shot mode; PROMPT must be a single argv token.
+        # Use ``--oneshot=<prompt>`` so flag-like prompts (e.g. ``--provider``)
+        # are bound as the flag value, not parsed as a separate CLI flag.
+        # Do NOT use stdin (``hermes -z -``) — that is interpreted as
+        # "no prompt, project-introspection mode".
+        cmd.append(f"--oneshot={final_prompt}")
 
         # Defensively drop session_id — resume_policy=never.
         _ = session_id

--- a/scripts/agent_runtime/adapters/qwen.py
+++ b/scripts/agent_runtime/adapters/qwen.py
@@ -6,8 +6,8 @@ and write lanes.
 
 Key design points:
 
-- **Transport:** ``hermes`` CLI in oneshot mode (``-z -`` reads prompt
-  from stdin). Hermes proxies to Qwen via the ``openrouter`` provider.
+- **Transport:** ``hermes`` CLI in oneshot mode (``--oneshot=<prompt>``
+  argv binding). Hermes proxies to Qwen via the ``openrouter`` provider.
 - **Modes:** All three (read-only / workspace-write / danger) supported.
   Mode → hermes toolset mapping is conservative for read-only (no
   terminal/file tools), permissive for workspace-write and danger.
@@ -129,20 +129,11 @@ class QwenAdapter:
         cmd: list[str] = [binary]
 
         # Reasoning effort hint applied first so the final prompt string is
-        # the argv positional we pass to -z.
+        # bound via --oneshot= below.
         effort = tc.get("effort")
         final_prompt = prompt
         if effort and effort != "default":
             final_prompt = f"[Reasoning effort hint: {effort}]\n\n{prompt}"
-
-        # Oneshot mode. Pass the prompt as argv positional, NOT stdin.
-        # ``hermes -z -`` (stdin marker) is interpreted as "no prompt
-        # provided, run in project-introspection mode" — the prompt
-        # piped on stdin is ignored. ARG_MAX is ~1 MB on macOS so the
-        # ~10 KB review prompts fit comfortably; if a caller needs to
-        # pass a multi-megabyte prompt, write it to a temp file and use
-        # a different transport (not the runtime's concern today).
-        cmd.extend(["-z", final_prompt])
 
         # Model
         cmd.extend(["-m", model or self.default_model])
@@ -178,6 +169,13 @@ class QwenAdapter:
         # more important than context awareness.
         if bool(tc.get("isolated", False)):
             cmd.extend(["--ignore-user-config", "--ignore-rules"])
+
+        # --oneshot (-z): one-shot mode; PROMPT must be a single argv token.
+        # Use ``--oneshot=<prompt>`` so flag-like prompts (e.g. ``--provider``)
+        # are bound as the flag value, not parsed as a separate CLI flag.
+        # Do NOT use stdin (``hermes -z -``) — that is interpreted as
+        # "no prompt, project-introspection mode".
+        cmd.append(f"--oneshot={final_prompt}")
 
         # Defensively drop session_id — resume_policy=never.
         _ = session_id

--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -762,11 +762,13 @@ def dispatch_qwen(prompt: str, model: str = QWEN_DEFAULT_MODEL,
     if effort and effort != "default":
         final_prompt = f"[Reasoning effort hint: {effort}]\n\n{prompt}"
 
-    # IMPORTANT: pass prompt via argv, NOT stdin. `hermes -z -` is interpreted
-    # as "no prompt, project-introspection mode" — see comment in
-    # scripts/agent_runtime/adapters/qwen.py for the empirical evidence.
+    # --oneshot (-z): one-shot mode; PROMPT must be a single argv token.
+    # Use ``--oneshot=<prompt>`` so flag-like prompts (e.g. ``--provider``)
+    # are bound as the flag value, not parsed as a separate CLI flag.
+    # Do NOT use stdin (``hermes -z -``) — that is interpreted as
+    # "no prompt, project-introspection mode" (see agent_runtime/adapters/qwen.py).
     cmd = [
-        "hermes", "-z", final_prompt,
+        "hermes",
         "-m", model,
         "--provider", QWEN_PROVIDER,
         "-t", toolsets,
@@ -775,6 +777,7 @@ def dispatch_qwen(prompt: str, model: str = QWEN_DEFAULT_MODEL,
         cmd.append("--yolo")
     if isolated:
         cmd.extend(["--ignore-user-config", "--ignore-rules"])
+    cmd.append(f"--oneshot={final_prompt}")
 
     t0 = time.time()
     try:

--- a/tests/test_deepseek_adapter.py
+++ b/tests/test_deepseek_adapter.py
@@ -22,16 +22,16 @@ def test_build_invocation_read_only(monkeypatch) -> None:
     cmd = plan.cmd
     assert cmd == [
         "hermes",
-        "-z",
-        "p",
         "-m",
         "deepseek-v4-pro",
         "--provider",
         "deepseek",
         "-t",
         "web",
+        "--oneshot=p",
     ]
     assert "--yolo" not in cmd
+    assert "-z" not in cmd
 
 
 def test_build_invocation_workspace_write(monkeypatch) -> None:
@@ -154,3 +154,42 @@ def test_parse_response_long_response_with_bash_codeblock_still_passes() -> None
 
     assert result.ok is True
     assert result.response.startswith("VERDICT: APPROVE")
+
+
+def test_deepseek_hermes_argv_puts_oneshot_last(monkeypatch) -> None:
+    """Hermes --oneshot=<prompt> must follow --provider and -m (equals-form)."""
+    monkeypatch.setattr("agent_runtime.adapters.deepseek.shutil.which", lambda _: "hermes")
+    adapter = DeepSeekAdapter()
+    plan = adapter.build_invocation(
+        prompt="hello",
+        mode="read-only",
+        cwd=Path("/tmp"),
+        model=None,
+        task_id=None,
+        session_id=None,
+        tool_config=None,
+    )
+    cmd = plan.cmd
+    assert cmd[-1] == "--oneshot=hello"
+    assert "-z" not in cmd
+    assert cmd[0] == "hermes"
+    assert cmd[cmd.index("-m") + 1] == "deepseek-v4-pro"
+    assert cmd[cmd.index("--provider") + 1] == "deepseek"
+
+
+def test_deepseek_hermes_argv_handles_flag_like_prompt(monkeypatch) -> None:
+    """Flag-like prompts bind via --oneshot= so argparse never treats them as flags."""
+    monkeypatch.setattr("agent_runtime.adapters.deepseek.shutil.which", lambda _: "hermes")
+    adapter = DeepSeekAdapter()
+    plan = adapter.build_invocation(
+        prompt="--provider",
+        mode="read-only",
+        cwd=Path("/tmp"),
+        model=None,
+        task_id=None,
+        session_id=None,
+        tool_config=None,
+    )
+    cmd = plan.cmd
+    assert "--oneshot=--provider" in cmd
+    assert "-z" not in cmd

--- a/tests/test_dispatch_qwen_hermes.py
+++ b/tests/test_dispatch_qwen_hermes.py
@@ -1,0 +1,60 @@
+"""Regression tests for dispatch_qwen hermes argv (--oneshot= equals-form)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+
+
+def _load_dispatch():
+    if str(SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS_DIR))
+    spec = importlib.util.spec_from_file_location("dispatch", SCRIPTS_DIR / "dispatch.py")
+    dispatch = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(dispatch)  # type: ignore[union-attr]
+    return dispatch
+
+
+def _capture_qwen_cmd(**kwargs) -> list[str]:
+    dispatch = _load_dispatch()
+    captured_cmd: list[str] = []
+
+    class FakeResult:
+        returncode = 0
+        stdout = "ok"
+        stderr = ""
+
+    def fake_run(cmd, *_args, **_kwargs):
+        captured_cmd.extend(cmd)
+        return FakeResult()
+
+    dispatch._run_with_process_group = fake_run  # type: ignore[attr-defined]
+    defaults = {
+        "prompt": "hello",
+        "model": "qwen/qwen3.6-plus",
+        "timeout": 10,
+    }
+    defaults.update(kwargs)
+    dispatch.dispatch_qwen(**defaults)
+    return captured_cmd
+
+
+def test_dispatch_qwen_hermes_argv_puts_oneshot_last() -> None:
+    """Hermes --oneshot=<prompt> must follow --provider and -m (equals-form)."""
+    cmd = _capture_qwen_cmd(prompt="hello")
+    assert cmd[-1] == "--oneshot=hello"
+    assert "-z" not in cmd
+    assert cmd[0] == "hermes"
+    assert cmd[cmd.index("-m") + 1] == "qwen/qwen3.6-plus"
+    assert cmd[cmd.index("--provider") + 1] == "openrouter"
+
+
+def test_dispatch_qwen_hermes_argv_handles_flag_like_prompt() -> None:
+    """Flag-like prompts bind via --oneshot= so argparse never treats them as flags."""
+    cmd = _capture_qwen_cmd(prompt="--provider")
+    assert "--oneshot=--provider" in cmd
+    assert "-z" not in cmd

--- a/tests/test_qwen_adapter.py
+++ b/tests/test_qwen_adapter.py
@@ -22,16 +22,16 @@ def test_build_invocation_read_only(monkeypatch) -> None:
     cmd = plan.cmd
     assert cmd == [
         "hermes",
-        "-z",
-        "p",
         "-m",
         "qwen/qwen3.6-plus",
         "--provider",
         "openrouter",
         "-t",
         "web",
+        "--oneshot=p",
     ]
     assert "--yolo" not in cmd
+    assert "-z" not in cmd
 
 
 def test_build_invocation_workspace_write(monkeypatch) -> None:
@@ -115,3 +115,42 @@ def test_parse_response_detects_rate_limit() -> None:
 
     assert result.rate_limited is True
     assert result.ok is False
+
+
+def test_qwen_hermes_argv_puts_oneshot_last(monkeypatch) -> None:
+    """Hermes --oneshot=<prompt> must follow --provider and -m (equals-form)."""
+    monkeypatch.setattr("agent_runtime.adapters.qwen.shutil.which", lambda _: "hermes")
+    adapter = QwenAdapter()
+    plan = adapter.build_invocation(
+        prompt="hello",
+        mode="read-only",
+        cwd=Path("/tmp"),
+        model=None,
+        task_id=None,
+        session_id=None,
+        tool_config=None,
+    )
+    cmd = plan.cmd
+    assert cmd[-1] == "--oneshot=hello"
+    assert "-z" not in cmd
+    assert cmd[0] == "hermes"
+    assert cmd[cmd.index("-m") + 1] == "qwen/qwen3.6-plus"
+    assert cmd[cmd.index("--provider") + 1] == "openrouter"
+
+
+def test_qwen_hermes_argv_handles_flag_like_prompt(monkeypatch) -> None:
+    """Flag-like prompts bind via --oneshot= so argparse never treats them as flags."""
+    monkeypatch.setattr("agent_runtime.adapters.qwen.shutil.which", lambda _: "hermes")
+    adapter = QwenAdapter()
+    plan = adapter.build_invocation(
+        prompt="--provider",
+        mode="read-only",
+        cwd=Path("/tmp"),
+        model=None,
+        task_id=None,
+        session_id=None,
+        tool_config=None,
+    )
+    cmd = plan.cmd
+    assert "--oneshot=--provider" in cmd
+    assert "-z" not in cmd


### PR DESCRIPTION
## Summary

- Apply the same hermes `--oneshot=<prompt>` equals-form argv pattern from PR #1543 (`scripts/dispatch_smart.py`) and PR #1547 (`scripts/ai_agent_bridge/_hermes.py`) to the third remaining call-site in `dispatch_qwen()` (`scripts/dispatch.py`).
- Provider/model/toolset flags are built first; prompt binding is appended last so flag-like prompt text (e.g. `--provider`) cannot be parsed as separate CLI flags.

## Why a separate PR

Codex R1 on PR #1547 flagged `scripts/dispatch.py:769` as out-of-scope follow-up. This PR closes that gap without re-touching the already-merged smart-router or bridge fixes.

## Test plan

- [x] `.venv/bin/python -m pytest tests/test_dispatch_qwen_hermes.py -v`
- [x] `.venv/bin/ruff check scripts/dispatch.py tests/test_dispatch_qwen_hermes.py`

Regression test: tests/test_dispatch_qwen_hermes.py

## Cross-family review

@codex — please R1 review per Decision Card C (author family: cursor/composer).

Made with [Cursor](https://cursor.com)

## R2 fix-pass

Codex R1 (https://github.com/kube-dojo/kube-dojo.github.io/pull/1549#issuecomment-4536965363) flagged two more Hermes call-sites still using the broken `["-z", final_prompt]` argv pattern:

- `scripts/agent_runtime/adapters/qwen.py`
- `scripts/agent_runtime/adapters/deepseek.py`

This commit applies the same `--oneshot=<prompt>` equals-form binding (provider/model/toolset flags first, prompt last) and adds regression tests in `tests/test_qwen_adapter.py` and `tests/test_deepseek_adapter.py`.

**Series-completeness grep** (`grep -rn '\["-z"' scripts/ --include="*.py"`):

```
(no matches — unsafe cmd.extend(["-z", prompt]) pattern gone)
```

Remaining `-z` usages in `scripts/` are stdin markers (`"-z", "-"`) or other PRs (`dispatch_smart.py`, `_hermes.py`).

**R2 verification**

- [x] `PYTHONPATH=scripts .venv/bin/python -m pytest tests/test_qwen_adapter.py tests/test_deepseek_adapter.py tests/test_dispatch_qwen_hermes.py -q` (20 passed)
- [x] `.venv/bin/ruff check scripts/agent_runtime/adapters/qwen.py scripts/agent_runtime/adapters/deepseek.py`

@codex — please re-review (R2); do not merge until approved.