### PR TITLE
chore(content): clean linux module-6.4 broken link

### DIFF
--- a/src/content/docs/linux/operations/troubleshooting/module-6.4-network-debugging.md
+++ b/src/content/docs/linux/operations/troubleshooting/module-6.4-network-debugging.md
@@ -717,7 +717,7 @@ Write three sentences answering: which layer falsified your first guess in each 
 
 ## Next Module
 
-Continue to [Module 7.1: Bash Fundamentals](/linux/shell-scripting/module-7.1-bash-fundamentals/) to automate these diagnostics into reusable checks and incident scripts.
+Continue to [Module 7.1: Bash Fundamentals](/linux/operations/shell-scripting/module-7.1-bash-fundamentals/) to automate these diagnostics into reusable checks and incident scripts.
 
 Bridge from [Module 6.3: Process Debugging](../module-6.3-process-debugging/): when `ss` shows a listening socket but the process `wchan` in `/proc` suggests endless `do_epoll_wait`, combine this module’s capture path with process-level `strace` on the same PID in the same network namespace.
 


### PR DESCRIPTION
## Summary

Fixes the one remaining broken link called out in PR #1550 (`linux/operations/troubleshooting/module-6.4-network-debugging.md`).

- **Warning:** `check_site_health.py` reported a possibly broken absolute link: `/linux/shell-scripting/module-7.1-bash-fundamentals/` (line 720, "Next Module").
- **Classification:** Class A (slug/path typo) — module 7.1 exists at `linux/operations/shell-scripting/module-7.1-bash-fundamentals`; the link omitted the `operations/` segment.
- **Resolution:** Updated the href to `/linux/operations/shell-scripting/module-7.1-bash-fundamentals/`.

## Verification

- [x] `.venv/bin/python scripts/check_site_health.py` — broken-link count 7 → 6; linux 6.4 warning gone
- [x] `npm run build` from primary checkout (detached at branch tip) — exit 0

## Review

Tagging for **codex** cross-family review per Decision Card C (composer-2.5 author → codex reviewer).


Made with [Cursor](https://cursor.com)

## Learner check

> **Warning:** `conntrack -F` and `iptables -F` destroy **host-wide** state. They can terminate your SSH session, reset unrelated production flows, and erase the evidence you still need. Never use them as a first remediation. Snapshot read-only state (`iptables-save`, `conntrack -S`, pcaps) and agree on blast radius with another operator first.
