### PR TITLE
chore(ci): drop gemini-3.5-flash@high reviewer

### DIFF
--- a/.github/workflows/cross-family-code-review.yml
+++ b/.github/workflows/cross-family-code-review.yml
@@ -39,33 +39,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash scripts/ci/cross_family_review.sh
 
-  review-gemini-3-5-flash-high:
-    name: Review (gemini-3.5-flash@high)
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    continue-on-error: true
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Run cross-family review
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          BASE_REF: ${{ github.base_ref }}
-          MODEL_TAG: gemini-3.5-flash@high
-          API_ENDPOINT: https://generativelanguage.googleapis.com/v1beta/openai/chat/completions
-          API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          API_MODEL: gemini-3.5-flash
-          REASONING_EFFORT: high
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bash scripts/ci/cross_family_review.sh
-
   review-deepseek-v4-pro:
     name: Review (deepseek-v4-pro)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
User directive 2026-05-26: no need for two Gemini models in cross-family CI when `gemini-3.1-pro-preview` is the primary reviewer.
Removed the `review-gemini-3-5-flash-high` job from `.github/workflows/cross-family-code-review.yml`; kept `review-gemini-3-1-pro` and `review-deepseek-v4-pro` unchanged.
`uvx zizmor --offline --strict-collection .github/` passes with no new findings.

## Test plan
- [ ] Confirm PR triggers only two review jobs (gemini-3.1-pro-preview, deepseek-v4-pro)

Made with [Cursor](https://cursor.com)