### PR TITLE
feat(content): rewrite on-prem cluster topology planning to T0

### DIFF
--- a/src/content/docs/on-premises/planning/module-1.3-cluster-topology.md
+++ b/src/content/docs/on-premises/planning/module-1.3-cluster-topology.md
@@ -83,7 +83,7 @@ From a financial perspective, the cost implications of multi-cluster topologies 
 
 If you deploy ten separate clusters, you must provision thirty physical servers. You might use substantial virtual machine equivalents instead. This hardware is purely for cluster management overhead. You pay this cost before scheduling a single revenue-generating application pod. This control plane tax forces organizations to aggressively optimize their hardware utilization. You must ensure that the clusters you deploy are densely packed enough to justify the foundational management infrastructure costs. 
 
-To combat this overhead, advanced on-premises platform teams often leverage control plane virtualization technologies. They use tools like vCluster or Kubernetes-in-Kubernetes (Kubeadm nested architectures). These tools dynamically pack multiple logical control planes onto a smaller set of high-performance physical management nodes. This saves massive capital expenditures while preserving logical isolation boundaries. The cost savings can easily reach hundreds of thousands of dollars for enterprise deployments.
+To combat this overhead, advanced on-premises platform teams often leverage control plane virtualization technologies. They use tools like vCluster (virtual Kubernetes clusters on shared hosts, using k3s, k0s, or native K8s control planes inside a pod). These tools dynamically pack multiple logical control planes onto a smaller set of high-performance physical management nodes. This saves massive capital expenditures while preserving logical isolation boundaries. The cost savings can easily reach hundreds of thousands of dollars for enterprise deployments.
 
 
 ## Core Section 2: Control-Plane Topology and etcd Placement Strategies
@@ -166,6 +166,35 @@ This verifiable, physical separation drastically simplifies complex compliance a
 The cost implications of worker pool design center entirely around hardware utilization. There is a constant tension between hardware utilization and hardware isolation. Every time you create a new, rigidly isolated worker pool, you increase stranded capacity. You inevitably increase the amount of idle compute capacity in your datacenter. Idle CPU cycles in the GPU pool cannot be dynamically reallocated. They cannot absorb a sudden traffic spike in the general-purpose web application pool. 
 
 To mitigate these severe isolation costs, platform teams must act aggressively. They must closely monitor pool utilization metrics. They should heavily rely on tools like the Kubernetes Cluster Autoscaler. If integrated with an on-premises hypervisor like VMware or OpenStack, it can dynamically power down idle nodes. It returns the resources to the overarching infrastructure fabric. For bare-metal deployments where dynamic provisioning is impossible, you must manually intervene. You must accurately right-size the static worker pools continuously. You must ensure that the expensive, specialized hardware is consistently saturated with productive workloads. This saturation is required to justify the high initial capital expenditure.
+
+### Storage Topology and Rack-Aware Replication
+
+Storage topology is an integral extension of worker pool design, often the most complex and expensive component of an on-premises Kubernetes architecture, requiring meticulous planning to prevent data loss. Unlike stateless application tiers that can rapidly scale horizontally across any available compute node, stateful workloads demand persistent, highly durable storage backends that are deeply integrated with your physical datacenter layout. When you design a storage topology, you are fundamentally defining how data is replicated across racks, rows, and datacenters to survive catastrophic hardware failures without compromising critical transaction speeds.
+
+In highly resilient environments, infrastructure teams leverage software-defined storage solutions like Ceph or OpenEBS to build distributed storage clusters that span the entire physical footprint. Ceph utilizes a highly sophisticated mechanism known as the CRUSH (Controlled Replication Under Scalable Hashing) map, which explicitly defines the physical failure domains of your hardware. By configuring the CRUSH map to understand your specific rack layouts and power distribution pathways, you can instruct the storage cluster to automatically replicate object data across completely independent power zones. This guarantees that if a localized power distribution unit (PDU) fails and instantly takes down an entire storage rack, the Ceph cluster will seamlessly serve the identical data from a surviving replica in an adjacent, unaffected rack.
+
+```yaml
+# Example: StorageClass defining rack-aware replication via Ceph RBD
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ceph-rbd-rack-aware
+provisioner: rbd.csi.ceph.com
+parameters:
+  clusterID: "ceph-production-cluster-id"
+  pool: "kubernetes-production-pool"
+  # This specific parameter tells the CSI driver to utilize a CRUSH rule
+  # that strictly mandates replication across distinct physical racks.
+  topology.kubernetes.io/zone: "rack-level-replication-enforced"
+reclaimPolicy: Retain
+allowVolumeExpansion: true
+```
+
+> **Pause and predict**: If you configure a ZFS storage pool using a standard RAID-Z2 configuration on a single physical node, how many concurrent disk failures can you tolerate? Furthermore, what happens to your stateful Kubernetes pods if the motherboard of that specific storage node suddenly catches fire?
+
+While rack-aware replication provides excellent localized durability, multi-datacenter topologies introduce the complex dilemma of choosing between synchronous and asynchronous storage replication. Synchronous replication guarantees zero data loss (RPO=0) by ensuring that every write operation is securely committed to both the primary datacenter and the secondary standby datacenter before acknowledging the transaction to the application. However, synchronous replication is severely constrained by the inescapable laws of physics; the physical distance between your datacenters dictates the latency floor. As a rule of thumb, round-trip time above approximately 5 milliseconds typically forces architects to adopt asynchronous replication; consult your storage vendor's documentation (Ceph, LINSTOR, DRBD, etc.) for the exact latency threshold of your specific backend, as synchronous replication demands vary by implementation. For datacenters separated by massive geographic distances, architects are forced to implement asynchronous replication zones, accepting a small window of potential data loss (typically measured in minutes) in exchange for maintaining high-performance application throughput in the primary site.
+
+The financial cost of an enterprise-grade storage topology is consistently staggering, often consuming more than half of the total hardware budget for an on-premises deployment. Implementing rack-aware replication typically requires provisioning three times the raw storage capacity to maintain the necessary data replicas, transforming a theoretical 100-terabyte requirement into a 300-terabyte capital expenditure. Furthermore, building high-performance Ceph clusters demands specialized, expensive hardware configurations, including dedicated 25GbE or 100GbE storage networking backbones, massive arrays of NVMe caching drives, and exceptionally high-core-count CPUs to process the hashing algorithms. To control these spiraling storage costs, platform architects must implement aggressive storage tiering strategies, ruthlessly forcing non-critical workloads onto cheaper, slower rotational drives while reserving the ultra-expensive NVMe replication pools exclusively for mission-critical, latency-sensitive database deployments.
 
 ## Core Section 4: Failure Domains and Rack-Aware Scheduling
 
@@ -301,36 +330,7 @@ The cost lens for multi-cluster federation is stark and often surprising. It is 
 For a massive enterprise deployment, this hidden sidecar tax is devastating. It can easily consume thousands of gigabytes of RAM across the fleet. This directly translates to the need for dozens of additional physical servers. To control these sprawling federation costs, platform architects must be ruthless. They must evaluate whether a specific workload truly requires encrypted cross-cluster communication. They should deliberately opt for simpler, cheaper ingress and egress gateway patterns for non-sensitive applications. They must reserve the expensive, heavy service mesh infrastructure strictly for mission-critical, zero-trust environments.
 
 ---
-
-
-## Core Section 7: Storage Topology and Rack-Aware Replication
-
-Storage topology is frequently the most complex and expensive component of an on-premises Kubernetes architecture, requiring meticulous planning to prevent data loss. Unlike stateless application tiers that can rapidly scale horizontally across any available compute node, stateful workloads demand persistent, highly durable storage backends that are deeply integrated with your physical datacenter layout. When you design a storage topology, you are fundamentally defining how data is replicated across racks, rows, and datacenters to survive catastrophic hardware failures without compromising critical transaction speeds.
-
-In highly resilient environments, infrastructure teams leverage software-defined storage solutions like Ceph or OpenEBS to build distributed storage clusters that span the entire physical footprint. Ceph utilizes a highly sophisticated mechanism known as the CRUSH (Controlled Replication Under Scalable Hashing) map, which explicitly defines the physical failure domains of your hardware. By configuring the CRUSH map to understand your specific rack layouts and power distribution pathways, you can instruct the storage cluster to automatically replicate object data across completely independent power zones. This guarantees that if a localized power distribution unit (PDU) fails and instantly takes down an entire storage rack, the Ceph cluster will seamlessly serve the identical data from a surviving replica in an adjacent, unaffected rack.
-
-```yaml
-# Example: StorageClass defining rack-aware replication via Ceph RBD
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: ceph-rbd-rack-aware
-provisioner: rbd.csi.ceph.com
-parameters:
-  clusterID: "ceph-production-cluster-id"
-  pool: "kubernetes-production-pool"
-  # This specific parameter tells the CSI driver to utilize a CRUSH rule
-  # that strictly mandates replication across distinct physical racks.
-  topology.kubernetes.io/zone: "rack-level-replication-enforced"
-reclaimPolicy: Retain
-allowVolumeExpansion: true
-```
-
-> **Pause and predict**: If you configure a ZFS storage pool using a standard RAID-Z2 configuration on a single physical node, how many concurrent disk failures can you tolerate? Furthermore, what happens to your stateful Kubernetes pods if the motherboard of that specific storage node suddenly catches fire?
-
-While rack-aware replication provides excellent localized durability, multi-datacenter topologies introduce the complex dilemma of choosing between synchronous and asynchronous storage replication. Synchronous replication guarantees zero data loss (RPO=0) by ensuring that every write operation is securely committed to both the primary datacenter and the secondary standby datacenter before acknowledging the transaction to the application. However, synchronous replication is severely constrained by the inescapable laws of physics; the physical distance between your datacenters dictates the latency floor, and stretching synchronous storage across a link with greater than 5 milliseconds of round-trip time will completely paralyze your transaction processing systems. For datacenters separated by massive geographic distances, architects are forced to implement asynchronous replication zones, accepting a small window of potential data loss (typically measured in minutes) in exchange for maintaining high-performance application throughput in the primary site.
-
-The financial cost of an enterprise-grade storage topology is consistently staggering, often consuming more than half of the total hardware budget for an on-premises deployment. Implementing rack-aware replication typically requires provisioning three times the raw storage capacity to maintain the necessary data replicas, transforming a theoretical 100-terabyte requirement into a 300-terabyte capital expenditure. Furthermore, building high-performance Ceph clusters demands specialized, expensive hardware configurations, including dedicated 25GbE or 100GbE storage networking backbones, massive arrays of NVMe caching drives, and exceptionally high-core-count CPUs to process the hashing algorithms. To control these spiraling storage costs, platform architects must implement aggressive storage tiering strategies, ruthlessly forcing non-critical workloads onto cheaper, slower rotational drives while reserving the ultra-expensive NVMe replication pools exclusively for mission-critical, latency-sensitive database deployments.
+---
 
 ## Patterns & Anti-Patterns
 

--- a/src/content/docs/on-premises/planning/module-1.3-cluster-topology.md
+++ b/src/content/docs/on-premises/planning/module-1.3-cluster-topology.md
@@ -5,7 +5,9 @@ sidebar:
   order: 4
 ---
 
-> **Complexity**: `[COMPLEX]` | Time: 60 minutes
+> **Complexity**: `[COMPLEX]`
+>
+> **Time to Complete**: 120 minutes
 >
 > **Prerequisites**: [Module 1.2: Server Sizing](../module-1.2-server-sizing/), [CKA Part 1: Cluster Architecture](/k8s/cka/part1-cluster-architecture/)
 
@@ -15,547 +17,527 @@ sidebar:
 
 After completing this module, you will be able to:
 
-1. **Design** multi-cluster topologies that balance blast radius isolation against operational complexity and compliance needs.
-2. **Evaluate** single-cluster versus multi-cluster architectures based on team structure, regulatory boundaries, and failure domain constraints.
-3. **Plan** control plane placement across racks and availability zones to implement robust, highly available clusters.
-4. **Implement** physical cluster segmentation strategies that strictly align with business domains and infrastructure resilience requirements.
-5. **Diagnose** hardware and network bottlenecks in distributed consensus systems like etcd to guarantee baseline performance.
+1. **Design** multi-cluster topologies that balance blast radius isolation against operational complexity, explicitly factoring in control plane infrastructure overhead costs.
+2. **Evaluate** single-cluster versus multi-cluster architectures based on team structure, regulatory boundaries, and physical failure domain constraints within an on-premises datacenter.
+3. **Plan** control plane placement and etcd quorum configurations across racks and availability zones to implement robust, highly available, and highly performant cluster backbones.
+4. **Implement** hardware segmentation strategies using node taints, tolerations, and node selectors to strictly align cluster workloads with business domains and infrastructure resilience requirements.
+5. **Diagnose** capacity bottlenecks and network boundaries in distributed topologies to prevent cross-AZ traffic spikes, maintain operational cost efficiency, and ensure stable Raft consensus.
 
 ---
 
 ## Why This Module Matters
 
-In a past deployment cycle, a large European insurance company ran a single 400-node Kubernetes cluster in their on-premises datacenter. Everything—the customer-facing portal, back-end claims processing, heavy actuarial calculations, and internal developer tooling—ran on this one monolithic cluster. When they performed a minor version upgrade from Kubernetes 1.34 to 1.35, an unforeseen major API deprecation caused 60% of their critical workloads to fail admission control simultaneously. Because there was no isolation, the entire company experienced a catastrophic outage that lasted for four grueling hours. 
+Hypothetical scenario: Consider a large regional banking institution. This bank decided to run their entire on-premises Kubernetes infrastructure as a single, massive 600-node cluster. Their goal was to save on control plane administration costs. They placed their core transaction processing systems on this shared platform. They also added their customer-facing web portals and internal developer testing environments. Finally, they included their heavy batch-processing data analytics workloads. 
 
-Their subsequent postmortem identified the root cause as a "catastrophic blast radius." A single cluster meant a single failure domain for over two hundred applications spread across fifteen distinct business units. They spent the next six months executing a painful migration to split their infrastructure into seven distinct clusters, designating one per business domain alongside a shared management platform. This architectural pivot cost the organization over $800,000 in engineering time and lost productivity. The Chief Technology Officer's ultimate lesson was stark: the most expensive architecture decision is the one you make on day one and have to undo on day three hundred.
+For the first year, this monolithic cluster appeared to be a triumph of efficiency. It boasted high hardware utilization and simplified monitoring. However, during a routine deployment window on a Friday evening, disaster struck. A junior developer deployed a misconfigured custom controller to an internal testing namespace. This controller contained a severe bug in its reconciliation loop. This runaway controller immediately began issuing thousands of mutating API requests per second against the Kubernetes API server. This rapidly exhausted the control plane's available CPU and memory resources.
 
-Determining how many clusters you should run, where the control planes should physically live, and whether those clusters should span multiple racks are decisions that carry immense weight. These topology choices are notoriously difficult to change later and have cascading, permanent implications for your networking layout, storage integrations, security posture, and daily operational overhead. The choices you make during the topology planning phase define the hard limits of your system's reliability.
+Because all workloads shared the same control plane, the resulting latency spike did not just affect the development namespace. It caused the entire cluster to enter a cascading failure state. The API servers became completely unresponsive. This prevented the kubelets on the worker nodes from renewing their node leases. The control plane then marked hundreds of nodes as NotReady. This triggered a massive wave of pod evictions across the entire banking platform. It took down the customer web portals and the core transaction processors simultaneously. 
 
-> **The City Planning Analogy**
->
-> Cluster topology is essentially digital city planning. One massive city (a monocluster) inevitably suffers from traffic congestion, catastrophic single points of failure, and a single mayor who controls all policies. Multiple smaller cities (a multi-cluster architecture) provide independent governance, neatly isolated failure domains, and clear boundaries. However, these smaller cities require robust highways (networking infrastructure) and complex trade agreements (service meshes) between them to function cohesively. The right answer depends heavily on your population size, geographic spread, and how much absolute autonomy each operational district requires.
+The outage lasted for six agonizing hours. Infrastructure engineers struggled to interact with the overloaded API server. They could not easily delete the offending deployment. The subsequent postmortem revealed a painful truth. Saving a few thousand dollars on additional control plane hardware cost the bank millions. They lost massive transaction revenue and suffered severe reputational damage. This single event completely changed their entire architectural philosophy regarding multi-tenant infrastructure. They realized that ignoring foundational failure domains creates unacceptable enterprise risk. They ultimately rewrote their entire platform strategy from the ground up to prioritize absolute physical isolation over minimal management overhead.
 
----
+The choices you make regarding cluster topology are permanent. How many clusters you run defines your security posture. Where you place the control plane components dictates your availability. How you segment the underlying hardware sets the absolute limits of your system's reliability. Unlike stateless applications that can be easily refactored, the topology of an on-premises cluster is notoriously difficult to alter. You cannot easily change these designs once production workloads are running. 
 
-## Single Cluster vs Multi-Cluster Architectures
-
-The first major architectural decision you will make is defining your cluster boundaries. Kubernetes releases approximately three minor versions per year. According to the official release cycle, these minor versions receive about fourteen months of support: twelve months of standard support followed by roughly two months of maintenance mode dedicated strictly to critical and CVE fixes. As of our current state, the three actively supported branches are 1.35 (the latest stable patch being 1.35.3, EOL 2027-02-28), 1.34, and 1.33. This aggressive release cadence strongly influences topology because upgrading a massive monolithic cluster is exponentially riskier than upgrading several smaller, isolated ones.
-
-### When One Cluster Is Enough
-
-A single-cluster design minimizes the sheer number of moving parts. It is highly efficient for smaller organizations that do not yet have the operational maturity to manage fleet-wide deployments.
-
-```mermaid
-flowchart TD
-    subgraph "Single Cluster"
-        CP["Control Plane"]
-        subgraph "Worker Nodes"
-            T1["Team A\nns: app-a"]
-            T2["Team B\nns: app-b"]
-            T3["Team C\nns: app-c"]
-        end
-        CP --> T1
-        CP --> T2
-        CP --> T3
-    end
-```
-
-**Pros:**
-- Simple operations (only one cluster to manage and monitor).
-- Easy service discovery (DNS resolves seamlessly within the cluster boundary).
-- Shared resources lead to better overall hardware utilization.
-- Single control plane cost minimizes infrastructure overhead.
-
-**Cons:**
-- The blast radius encompasses everything; a fatal control plane error takes down all teams.
-- Noisy neighbors are a constant threat (one team's runaway load spike degrades performance for everyone).
-- Upgrades are an all-or-nothing event.
-- RBAC complexity scales non-linearly as more teams are added to the same API server.
-
-**Best for:** Environments with fewer than 100 nodes, fewer than 5 teams, and homogeneous workloads.
-
-### When You Need Multiple Clusters
-
-When your organization scales, or when strict isolation is legally mandated, you must adopt a multi-cluster architecture. Kubernetes version skew policies dictate that the API server is the source of truth. While the `kubelet` and `kube-proxy` can be up to three minor versions older than the API server, and `kubectl` is supported within plus or minus one minor version, you cannot freeze a cluster forever. Multi-cluster environments allow you to upgrade a staging cluster to version 1.35 while keeping production safely on 1.34 until validation is complete.
-
-```mermaid
-flowchart TD
-    subgraph "Multi-Cluster"
-        PC["Platform Cluster\n(Shared Services, CI/CD, Observability)"]
-        PR["Prod Cluster\n(Customer facing workloads)"]
-        ST["Staging Cluster\n(Pre-prod testing)"]
-        DV["Dev Cluster\n(Sandbox for devs)"]
-    end
-```
-
-**Best for:**
-- Strict environment isolation (separating production from non-production workloads).
-- Multi-tenant platforms where you need a dedicated cluster per tenant or business unit.
-- Scenarios requiring different Kubernetes versions per environment.
-- Strict regulatory boundaries (such as PCI or HIPAA scope isolation).
-- Massive deployments exceeding 200 nodes, where splitting clusters preserves operational sanity.
-
-> **Pause and predict**: Your company has 120 nodes, 6 teams, and a mix of PCI-scoped payment processing and general web applications. Before reading the decision matrix, would you recommend a single cluster or multiple clusters? What is the single biggest factor driving your decision?
-
-### Topology Decision Matrix
-
-| Factor | Single Cluster | Multi-Cluster |
-|--------|---------------|---------------|
-| Teams | < 5 | 5+ or strict isolation needed |
-| Nodes | < 100-200 | 200+ or split by purpose |
-| Environments | Namespace separation OK | Need hard isolation (prod/staging/dev) |
-| Compliance | No PCI/HIPAA scope concerns | Need regulatory boundary isolation |
-| K8s versions | All teams on same version | Teams need different versions |
-| Blast radius tolerance | High (startup mentality) | Low (enterprise, regulated) |
-| Operational team size | 2-3 engineers | 4+ engineers |
+Designing a robust topology requires careful analysis. You must rigorously evaluate the trade-offs between operational simplicity and blast radius isolation. You must also meticulously map your logical Kubernetes boundaries to the physical realities of your datacenter. You need to understand how rack layouts and top-of-rack switches dictate your true failure domains. You must also account for power distribution units. By mastering these architectural principles, you ensure platform stability. Your platform will withstand both malicious configurations and catastrophic physical hardware failures. It will protect critical business operations without compromise.
 
 ---
 
-## Control Plane Placement and High Availability
+## Core Section 1: Single-Cluster vs Multi-Cluster Decision Framework
 
-In a managed cloud environment, the provider abstracts the control plane. In an on-premises datacenter, you are responsible for the physical placement and lifecycle of every control plane node. The minimum hardware requirements for a control plane node, per `kubeadm`, are 2 CPUs and 2 GB of RAM. However, production nodes require significantly more capacity. By default, `kubeadm` applies the `node-role.kubernetes.io/control-plane:NoSchedule` taint to these nodes, ensuring regular workloads do not compete for resources with critical cluster components.
+The foundational decision in any on-premises Kubernetes deployment is determining the precise boundary of a cluster. Kubernetes was originally designed to manage vast fleets of machines as a single logical entity. However, operational reality often dictates breaking that monolithic vision into smaller, manageable pieces. A single-cluster architecture minimizes the total number of moving parts. It provides a unified endpoint for service discovery. It serves as a centralized metrics aggregation point. It also offers the highest potential hardware utilization because all workloads share the same physical node pool. 
 
-The `kubeadm` utility supports two official high-availability (HA) cluster topology options: the stacked etcd topology and the external etcd topology.
+However, this unified approach inherently creates a singular, massive failure domain. Any catastrophic event will simultaneously impact every application hosted within the cluster boundary. This could be an etcd database corruption. It might be an API server panic. It could also be a fundamentally flawed cluster-wide RBAC configuration. When the control plane fails, the entire business halts. There is no isolation to contain the damage.
 
-### Pattern 1: Stacked Control Plane (Simple)
+Conversely, a multi-cluster architecture actively partitions your workloads across several entirely independent Kubernetes clusters. This deliberately sacrifices some operational simplicity to gain rigid blast radius isolation. By deploying multiple clusters, you guarantee physical separation. A fatal error in the development environment's control plane has absolutely zero technical capability to disrupt the production environment. This physical separation is frequently mandated by strict regulatory frameworks. Frameworks like the Payment Card Industry Data Security Standard (PCI DSS) demand airtight boundaries around sensitive data. The Health Insurance Portability and Accountability Act (HIPAA) requires similar isolation for medical records.
 
-The stacked topology is `kubeadm`'s default configuration. A local etcd member is created automatically on each control plane node when you run `kubeadm init` and `kubeadm join --control-plane`.
-
-```mermaid
-flowchart TD
-    subgraph "Stacked Control Plane"
-        subgraph "CP Node 1 (8 cores, 32GB, 200GB NVMe)"
-            A1[API Server] --- C1[Controller Mgr] --- S1[Scheduler] --- E1[(etcd)]
-        end
-        subgraph "CP Node 2 (8 cores, 32GB, 200GB NVMe)"
-            A2[API Server] --- C2[Controller Mgr] --- S2[Scheduler] --- E2[(etcd)]
-        end
-        subgraph "CP Node 3 (8 cores, 32GB, 200GB NVMe)"
-            A3[API Server] --- C3[Controller Mgr] --- S3[Scheduler] --- E3[(etcd)]
-        end
-        E1 <--> E2 <--> E3 <--> E1
-    end
-```
-
-**Pros:**
-- Simpler infrastructure footprint with fewer physical servers to manage.
-- It is the `kubeadm` default, making it straightforward to bootstrap.
-
-**Cons:**
-- The primary risk is "failed coupling." If a single node fails, you lose both an etcd member and a control plane instance simultaneously, significantly degrading redundancy.
-- You cannot scale the API servers independently from the etcd data store.
-
-**Best for:** Clusters with fewer than 200 nodes where extreme throughput is not the primary concern. A stacked etcd HA cluster requires a minimum of 3 control plane nodes.
-
-### Pattern 2: External etcd (Production)
-
-The external etcd topology decouples the control plane processes from the etcd state store. This means losing a control plane instance does not immediately degrade your data store quorum, but it requires twice the number of physical hosts compared to the stacked approach.
-
-```mermaid
-flowchart LR
-    subgraph "API Server Nodes"
-        A1["API Server 1\n(8 cores, 16GB)"]
-        A2["API Server 2\n(8 cores, 16GB)"]
-        A3["API Server 3\n(8 cores, 16GB)"]
-    end
-    subgraph "Dedicated etcd Nodes"
-        E1[("etcd 1\n(4 cores, 16GB, 200GB NVMe)")]
-        E2[("etcd 2\n(4 cores, 16GB, 200GB NVMe)")]
-        E3[("etcd 3\n(4 cores, 16GB, 200GB NVMe)")]
-    end
-    A1 --> E1 & E2 & E3
-    A2 --> E1 & E2 & E3
-    A3 --> E1 & E2 & E3
-    E1 <--> E2 <--> E3 <--> E1
-```
-
-**Pros:**
-- etcd runs on dedicated NVMe drives, completely eliminating resource contention.
-- You can scale API servers independently from etcd.
-- etcd hardware failures do not inherently take down the API server processes.
-
-**Cons:**
-- Requires a minimum of 3 control plane nodes AND 3 dedicated etcd nodes (6 total hosts minimum).
-- The setup is significantly more complex. `kubeadm` bootstraps the etcd cluster statically, not dynamically, requiring careful certificate distribution.
-
-**Best for:** Clusters over 200 nodes and high-throughput transactional workloads. For exceptionally large clusters, Kubernetes documentation recommends storing Event objects in a separate, completely dedicated etcd instance to prevent event spam from degrading control plane performance.
-
-### Pattern 3: Shared Management Cluster
-
-In enterprise environments operating fleets of clusters, the management cluster pattern centralizes the administrative overhead.
+Furthermore, multi-cluster architectures allow platform teams to upgrade clusters asynchronously. Upgrading Kubernetes is inherently risky. You can validate new minor versions of Kubernetes in staging environments for weeks. Only after proving stability do you apply those identical upgrades to mission-critical production clusters.
 
 ```mermaid
 flowchart TD
-    subgraph "Management Cluster (3 nodes)"
-        subgraph "Tenant Control Planes"
-            CP1["Dev CP\n(API, etcd)"]
-            CP2["Stg CP\n(API, etcd)"]
-            CP3["Prod CP\n(API, etcd)"]
+    subgraph "Single Cluster Monolith"
+        CP1["Monolithic Control Plane
+(API, etcd)"]
+        subgraph "Shared Worker Pool"
+            PCI["PCI Namespace"]
+            DEV["Dev Namespace"]
+            PROD["Prod Namespace"]
         end
+        CP1 --> PCI
+        CP1 --> DEV
+        CP1 --> PROD
     end
-    subgraph "Dev Workers (5 nodes)"
-        W1[Workloads]
+    
+    subgraph "Multi-Cluster Federation"
+        CP_PCI["PCI Control Plane"] --> W_PCI["PCI Workers"]
+        CP_PROD["Prod Control Plane"] --> W_PROD["Prod Workers"]
+        CP_DEV["Dev Control Plane"] --> W_DEV["Dev Workers"]
     end
-    subgraph "Stg Workers (10 nodes)"
-        W2[Workloads]
-    end
-    subgraph "Prod Workers (50 nodes)"
-        W3[Workloads]
-    end
-    CP1 --> W1
-    CP2 --> W2
-    CP3 --> W3
 ```
 
-This pattern leverages technologies like Cluster API and vCluster to run tenant control planes as containerized workloads inside a dedicated management cluster. This yields massive hardware savings (e.g., 3 physical servers can host the control planes for dozens of tenant clusters).
+To systematically evaluate whether a single cluster or multiple clusters are appropriate, you must analyze your organizational structure. You must assess your tolerance for risk. You must also measure the physical scale of your deployment. Suppose your engineering organization consists of fewer than twenty developers. Perhaps you operate fewer than fifty total physical nodes. In this case, the administrative burden of maintaining multiple control planes is massive. Managing distributed service meshes and federated identity management systems will likely outweigh the theoretical benefits of isolation. 
+
+However, your platform may scale beyond two hundred nodes. You might onboard entirely distinct business units with competing regulatory requirements. When this happens, the necessity for multi-cluster isolation becomes absolute. You must establish clear criteria for when a new cluster is warranted. A new cluster might be needed when a team requires cluster-admin privileges. It might be necessary when a specific workload demands an incompatible, specialized network plugin. Setting these rules prevents uncontrolled cluster sprawl.
+
+> **Pause and predict**: Imagine your security team mandates that developers must have full administrative access (cluster-admin) to their own environments. They need this to experiment with new Custom Resource Definitions (CRDs). Can you safely accommodate this requirement in a shared, single-cluster architecture using namespaces? Why or why not?
+
+From a financial perspective, the cost implications of multi-cluster topologies are significant. They are inescapable, particularly in an on-premises environment. Here, you are purchasing the underlying physical hardware upfront. Every distinct Kubernetes cluster requires its own dedicated control plane. This typically consists of three dedicated, highly available master nodes. 
+
+If you deploy ten separate clusters, you must provision thirty physical servers. You might use substantial virtual machine equivalents instead. This hardware is purely for cluster management overhead. You pay this cost before scheduling a single revenue-generating application pod. This control plane tax forces organizations to aggressively optimize their hardware utilization. You must ensure that the clusters you deploy are densely packed enough to justify the foundational management infrastructure costs. 
+
+To combat this overhead, advanced on-premises platform teams often leverage control plane virtualization technologies. They use tools like vCluster or Kubernetes-in-Kubernetes (Kubeadm nested architectures). These tools dynamically pack multiple logical control planes onto a smaller set of high-performance physical management nodes. This saves massive capital expenditures while preserving logical isolation boundaries. The cost savings can easily reach hundreds of thousands of dollars for enterprise deployments.
+
+
+## Core Section 2: Control-Plane Topology and etcd Placement Strategies
+
+Once you have defined your cluster boundaries, you must carefully design the internal topology of the control plane. This design guarantees high availability and consistent performance under extreme load. The Kubernetes control plane is the centralized brain of the cluster. It consists of the API server, the controller manager, the scheduler, and the etcd key-value datastore. In a production-grade on-premises deployment, you must deploy these components redundantly. You must spread them across multiple physical machines to survive inevitable hardware failures. 
+
+The most fundamental architectural choice in this domain is deciding your etcd topology. You must choose whether to utilize a stacked etcd topology or an external etcd topology. This decision fundamentally alters the physical footprint of your infrastructure. It also dictates the operational resilience of your management systems.
+
+In a stacked high-availability topology, every control plane node runs a full suite of management processes. Each node runs an instance of the kube-apiserver, kube-scheduler, and kube-controller-manager. Crucially, each node also runs a local member of the etcd cluster. This approach is the default configuration for tools like kubeadm. It significantly simplifies the initial bootstrapping process. It minimizes the total number of physical servers required to establish a highly available control plane. 
+
+A standard stacked topology requires exactly three control plane nodes. This allows the cluster to tolerate the catastrophic failure of any single node. It achieves this without losing the required Raft consensus quorum. However, this tightly coupled architecture has a severe drawback. It inherently binds the fate of the API server to the fate of the local etcd member. If a sudden spike in API requests exhausts the node's CPU, the local etcd process suffers. It may be starved of resources, leading to missed heartbeats. This triggers chaotic, cluster-destabilizing leader elections.
+
+```text
++-------------------------------------------------------+
+| Stacked Control Plane Topology                        |
+|                                                       |
+|  +----------------+ +----------------+ +-----------+  |
+|  |    Node 1      | |    Node 2      | |  Node 3   |  |
+|  | [API Server]   | | [API Server]   | | [API Svr] |  |
+|  | [etcd member]  | | [etcd member]  | | [etcd m]  |  |
+|  +----------------+ +----------------+ +-----------+  |
+|          |                  |                |        |
+|          +--------(Raft Consensus)-----------+        |
++-------------------------------------------------------+
+```
+
+Conversely, an external etcd topology completely decouples the control plane components from the stateful datastore. It places the etcd members on their own dedicated, isolated physical servers. This architecture requires a minimum of six distinct nodes. Three nodes host the API servers. Three separate nodes form the independent etcd cluster. This substantially increases the hardware footprint and the configuration complexity. 
+
+However, it provides unparalleled resilience for massive, high-throughput clusters. By isolating etcd on dedicated hardware, you protect the core database. These dedicated servers must be equipped with extremely fast NVMe solid-state drives. This guarantees that heavy computational loads on the API server cannot starve the datastore. Complex webhook admission controllers or massive Deployment rollouts will consume API server CPU. But they will never impact the latency-sensitive Raft consensus algorithm. This algorithm will always have the CPU cycles and disk IOPS it requires to maintain strict cluster state.
+
+> **Pause and predict**: If you deploy an external etcd topology, you might decide to provision four etcd nodes instead of three. You might do this to provide "extra redundancy." How many node failures can your four-node etcd cluster survive before it loses quorum and halts all operations?
+
+The financial cost of control plane topology choices scales linearly with hardware requirements. It depends entirely on your need for dedicated hardware and high-performance storage solutions. An external etcd topology effectively doubles the base infrastructure cost of your control plane. It demands specialized servers optimized for sequential write performance rather than general-purpose compute. 
+
+Furthermore, etcd is exceptionally sensitive to disk latency. Attempting to save money by deploying etcd onto spinning hard disk drives (HDDs) is a massive mistake. Using lower-tier, network-attached storage arrays will inevitably result in devastating API server timeouts. It will cause severe cluster instability. To optimize costs without sacrificing reliability, infrastructure teams must meticulously right-size their etcd nodes. You must invest heavily in low-latency, enterprise-grade NVMe drives. Conversely, you should scale back unnecessary CPU and RAM allocations on these specific datastore nodes. This ensures that the hardware investment is targeted exactly where the distributed consensus algorithm demands it most.
 
 ---
 
-## etcd Sizing and Version Context
+## Core Section 3: Worker Pool Design and Hardware Segregation
 
-etcd relies on the Raft consensus algorithm. It requires a strict quorum of `(n/2)+1` members to maintain consensus, where `n` is the total cluster size. This means a 3-member cluster requires 2 nodes for quorum (tolerating 1 failure), a 5-member cluster requires 3 nodes (tolerating 2 failures), and a 7-member cluster requires 4 nodes (tolerating 3 failures).
+The control plane orchestrates the cluster, but the worker nodes execute the actual business logic. Therefore, worker pool design is the most critical factor in determining application performance. It also determines your overall hardware efficiency. In a heterogeneous on-premises environment, your physical servers are rarely identical. You may have racks of dense compute nodes. You might have chassis packed with high-capacity storage drives. You may also have specialized servers equipped with expensive GPU accelerators for machine learning workloads. 
 
-> **Pause and predict**: Your CTO wants to deploy 6 etcd members "for extra safety." Based on how Raft consensus works, would 6 members be more or less resilient than 5? What is the downside of even-numbered membership?
+A robust cluster topology must intelligently expose this underlying hardware diversity to the Kubernetes scheduler. It must do this without exposing the applications to unnecessary complexity. This is primarily achieved by structuring your worker nodes into distinct logical pools. You use node labels to advertise hardware capabilities to the cluster. You employ node taints to rigorously repel incompatible workloads from specialized hardware.
 
-Deploying even-sized clusters provides absolutely zero additional fault tolerance over the next-smaller odd size. A 6-member cluster still only tolerates 2 failures (quorum is 4), but it increases the network overhead required to reach consensus. Official guidelines cap etcd clusters at no more than 7 members to prevent severe write latency degradation.
+Creating dedicated worker pools using node taints and tolerations establishes firm boundaries. These are programmatic boundaries that guarantee resource isolation at the scheduler level. Consider a scenario where you purchase a multi-million-dollar rack of NVIDIA A100 GPUs. These are intended to support a critical data science initiative. You absolutely cannot afford to have a generic, memory-leaking web application schedule onto those nodes. It would consume the underlying host's RAM, starving the ML models. 
 
-| etcd Members | Quorum | Tolerates Failures | Recommended For |
-|-------------|--------|-------------------|-----------------|
-| 1 | 1 | 0 | Dev/test only |
-| 3 | 2 | 1 | Standard production |
-| 5 | 3 | 2 | Mission-critical |
-| 7 | 4 | 3 | Rarely needed (higher write latency) |
+By applying a `NoSchedule` taint to the GPU nodes, you solve this problem. For example, you use `node.kubernetes.io/gpu=nvidia-a100:NoSchedule`. You instruct the Kubernetes scheduler to instantly reject any pod lacking a specific toleration. This guarantees that only specifically engineered ML workloads can execute there. These workloads must be configured to tolerate the taint. They must also explicitly request the GPU resource. They will be the only pods to ever execute on that expensive, specialized hardware pool.
 
-### Performance and Hardware
+```yaml
+# Example: Tainting a node to protect specialized hardware
+# Run this command during hardware provisioning
+# kubectl taint nodes gpu-worker-01 node.kubernetes.io/gpu=nvidia-a100:NoSchedule
 
-The minimum recommended etcd versions to run in Kubernetes production are 3.4.29+ and 3.5.11+. Kubernetes 1.35 relies heavily on the 3.6 release track (specifically bundling versions like 3.6.8-0 via kubeadm). The jump to etcd v3.6.0 (released in May 2025) was monumental: it completely removed the legacy v2store and reduced average memory consumption by approximately 50% by lowering the default `--snapshot-count` from 100,000 to 10,000. 
-
-Despite these software efficiency gains, etcd is brutally sensitive to disk latency. It must be backed by SSD storage delivering a minimum of 50 sequential IOPS for standard workloads, scaling up to ~500 sequential IOPS for heavy deployments (thousands of watchers). Network requirements dictate 1 GbE for common deployments, but 10 GbE is highly recommended for massive clusters to reduce the mean time to recovery during node failures. 
-
-*Authority Note on Paths:* While `/var/lib/etcd` is universally observed as the default data directory in kubeadm deployments, note that official upstream documentation does not explicitly codify this as an immutable standard, so always verify your specific environment's configurations.
-
----
-
-## Rack-Aware Topology and Failure Domains
-
-To survive a hardware outage, you must map Kubernetes to your datacenter's physical reality. 
-
-### Failure Domain Hierarchy
-
-```mermaid
-graph TD
-    DC["Datacenter\n(Entire site power/cooling failure)"] --> RM1["Room\n(Fire suppression, cooling zone)"]
-    RM1 --> RW1["Row\n(PDU circuit, top-of-row switch)"]
-    RW1 --> RK1["Rack\n(PDU, ToR switch, single UPS)"]
-    RK1 --> SV1["Server\n(PSU, disk, NIC, CPU)"]
-    RM1 --> RW2["Row"]
-    RW2 --> RK2["Rack"]
-    DC --> RM2["Room"]
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ML-model-training-job
+spec:
+  containers:
+  - name: cuda-container
+    image: nvidia/cuda:11.4.2-base-ubuntu20.04
+    resources:
+      limits:
+        nvidia.com/gpu: 1
+  # This toleration allows the pod to bypass the protective taint
+  tolerations:
+  - key: "node.kubernetes.io/gpu"
+    operator: "Equal"
+    value: "nvidia-a100"
+    effect: "NoSchedule"
+  # This node selector forces the pod onto the specific hardware pool
+  nodeSelector:
+    accelerator: "nvidia-a100"
 ```
 
-The golden rule of on-premises topology is to always spread your control plane across your failure domains. The absolute minimum standard is placing one control plane node per rack to survive a top-of-rack (ToR) switch or PDU failure. For high availability, a TCP forwarding load balancer is explicitly required in front of the `kube-apiserver`, distributing traffic to all healthy control plane nodes by performing health checks against the apiserver's default TCP port 6443. Having an odd number of control plane nodes helps with leader election in the case of machine or zone failure.
+Beyond protecting specialized hardware, node segregation is frequently employed for security. It creates dedicated infrastructure pools for highly regulated workloads. Suppose your organization processes credit card transactions. The PCI DSS compliance framework mandates strict isolation. Any server touching cardholder data must be isolated from general-purpose corporate networks. Network policies can restrict pod-to-pod communication logically. However, deploying a dedicated, tainted worker pool provides physical separation. 
 
-> **Stop and think**: You have 3 racks, each with its own PDU and ToR switch. Your cluster has 3 control plane nodes. If you put all 3 CP nodes in rack A (to simplify cabling), what happens when rack A loses power? Now consider: what happens if you spread them one per rack and rack A loses power?
+This verifiable, physical separation drastically simplifies complex compliance audits. You can confidently demonstrate to external auditors that payment pods are isolated. They are fundamentally incapable of scheduling onto the same physical hardware as developer workloads. This completely eliminates the risk of container escape vulnerabilities compromising sensitive financial data.
 
-### Rack Layout Best Practices
+The cost implications of worker pool design center entirely around hardware utilization. There is a constant tension between hardware utilization and hardware isolation. Every time you create a new, rigidly isolated worker pool, you increase stranded capacity. You inevitably increase the amount of idle compute capacity in your datacenter. Idle CPU cycles in the GPU pool cannot be dynamically reallocated. They cannot absorb a sudden traffic spike in the general-purpose web application pool. 
 
-When provisioning the hardware, ensure that every cluster node has a unique MAC address and a universally unique `product_uuid`. Duplicate UUIDs will cause catastrophic node identification failures during the `kubeadm` joining process. Furthermore, swap must be disabled on all Kubernetes nodes (`swapoff -a`), or the kubelet must be explicitly and carefully configured to tolerate it.
+To mitigate these severe isolation costs, platform teams must act aggressively. They must closely monitor pool utilization metrics. They should heavily rely on tools like the Kubernetes Cluster Autoscaler. If integrated with an on-premises hypervisor like VMware or OpenStack, it can dynamically power down idle nodes. It returns the resources to the overarching infrastructure fabric. For bare-metal deployments where dynamic provisioning is impossible, you must manually intervene. You must accurately right-size the static worker pools continuously. You must ensure that the expensive, specialized hardware is consistently saturated with productive workloads. This saturation is required to justify the high initial capital expenditure.
 
-| U-Space | Component | Notes |
-|---------|-----------|-------|
-| U42 | Patch panel | Fiber/copper ingress |
-| U41 | ToR Switch 1 | 25GbE primary |
-| U40 | ToR Switch 2 | 25GbE redundant |
-| U38 | Mgmt Switch | 1GbE out-of-band |
-| U36-U35 | Control Plane Node | 2U chassis |
-| U34-U23 | Worker Nodes 1-6 | 2U chassis blocks |
-| U22-U21 | Storage Node | Ceph OSD |
-| U00 | Primary PDU | 2x redundant, A+B feed |
+## Core Section 4: Failure Domains and Rack-Aware Scheduling
 
-**Rack Environmental Baselines:**
-- **Power budget:** ~8-12 kW per rack (check PDU rating)
-- **Cooling:** 1 ton per 3.5 kW of IT load (rule of thumb)
-- **Weight:** ~1,200 lbs fully loaded (check floor rating)
+In an on-premises datacenter, the logical abstractions of Kubernetes are inextricably bound to physical realities. You must account for power distribution, cooling zones, and network cabling. A logical node failure is usually a mild inconvenience. However, a physical top-of-rack (ToR) switch failure is a massive event. A localized power distribution unit (PDU) blowout is equally destructive. These events can instantly sever connectivity to dozens of worker nodes simultaneously. 
 
-### Enabling Zone Awareness
+To build a truly resilient cluster topology, you must explicitly map these physical failure domains. You map them into Kubernetes using node labels. Then, you forcefully instruct the scheduler to distribute application replicas across those domains. You achieve this using topology spread constraints. Failure to integrate this physical awareness into your scheduling logic guarantees future outages. Eventually, a single hardware incident will cause a catastrophic, customer-facing application outage.
 
-In multi-zone clusters, the `kubelet` automatically labels each node with `topology.kubernetes.io/zone`. Kubernetes also automatically adds corresponding zone labels to PersistentVolumes linked to a specific zone, relying on the `NoVolumeZoneConflict` scheduling predicate to ensure pods are placed in the same physical zone as their data. 
+The most critical failure domain in a standard datacenter is the server rack. A rack typically represents a single point of failure for both power and networking. If a PDU fails, the rack loses power. If the ToR switch fails, the rack loses network connectivity. During the cluster bootstrapping phase, infrastructure automation must label every node. It must meticulously label every single node with its exact physical location. 
 
-**Critical Warning:** Kubernetes does not provide any built-in cross-zone resilience for the API server endpoints themselves. You are entirely responsible for engineering external DNS or external load balancing solutions to route around catastrophic zone failures. 
-
-For large clusters, Kubernetes best practices dictate running one or two control plane instances per failure zone. You should scale these instances vertically first (adding CPU/RAM), and only scale horizontally after reaching the hard performance limits of a single instance.
-
-```bash
-# Label nodes with physical topology
-kubectl label node worker-01 \
-  topology.kubernetes.io/zone=rack-a \
-  topology.kubernetes.io/region=dc-east \
-  node.kubernetes.io/room=server-room-1 \
-  node.kubernetes.io/row=row-3
-```
+Typically, you use standard topology labels for this mapping. You use `topology.kubernetes.io/zone` to represent the specific rack or server room. You use `topology.kubernetes.io/region` to represent the broader datacenter building. Once the nodes are physically mapped, developers must configure their high-availability deployments properly. They must use `topologySpreadConstraints` to ensure their application replicas are scheduled evenly. They must be spread across the available racks. This guarantees that the loss of any single rack will only impact a fraction of the total capacity.
 
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: payment-api
+  name: mission-critical-api
 spec:
   replicas: 6
+  selector:
+    matchLabels:
+      app: mission-critical-api
   template:
     metadata:
       labels:
-        app: payment-api
+        app: mission-critical-api
     spec:
+      # This constraint forces the scheduler to distribute the 6 replicas
+      # evenly across the physical racks defined by the zone label.
       topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: topology.kubernetes.io/zone
-          whenUnsatisfiable: DoNotSchedule
-          labelSelector:
-            matchLabels:
-              app: payment-api
-      # This ensures: max 1 pod difference between racks
-      # With 6 replicas across 3 racks: 2-2-2 distribution
-      # If rack-a fails: 0-2-2 (4 replicas survive immediately)
-      #
-      # WARNING: With DoNotSchedule, the 2 replacement pods will
-      # stay Pending — placing them would create skew 0-3-3 (skew=3),
-      # violating maxSkew:1. For HA, use ScheduleAnyway instead,
-      # which treats the constraint as a preference rather than
-      # a hard requirement during scheduling.
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            app: mission-critical-api
       containers:
-        - name: payment-api
-          image: payment-api:1.0
+      - name: api-container
+        image: internal-registry.example.com/api:v2.4
 ```
+
+> **Pause and predict**: You configure a deployment with 3 replicas. You use a strict `maxSkew: 1` constraint across 3 racks. However, rack C is currently at 100% CPU capacity. What will happen to the third replica if `whenUnsatisfiable` is set to `DoNotSchedule`? Would changing it to `ScheduleAnyway` be safer for an urgent deployment?
+
+Rack-level awareness protects against localized equipment failures efficiently. However, truly resilient topologies must also plan for total datacenter outages. You achieve this using availability zones (AZs) or distinct geographic regions. An organization might operate multiple datacenters within a metropolitan area. Stretching a single Kubernetes cluster across those active-active sites provides incredible resilience. 
+
+However, this stretched design comes with a massive, non-negotiable caveat. The network latency between the sites must remain consistently below a strict threshold. It must stay below the 10-millisecond threshold demanded by the etcd Raft consensus algorithm. If the latency exceeds this threshold, the stretched cluster architecture will inevitably collapse. The etcd leader elections will constantly time out. This renders the entire control plane completely unresponsive. In high-latency geographic scenarios, you must abandon the stretched cluster pattern entirely. Instead, deploy independent, autonomous clusters in each region. Rely on global server load balancing (GSLB) to route traffic around regional failures safely.
+
+From a cost perspective, multi-zone topologies introduce significant financial overhead. They create hidden costs in the form of cross-zone network egress charges. They also demand redundant hardware provisioning. Consider an application whose replicas are spread evenly across three datacenters. The internal service-to-service communication will frequently traverse expensive fiber links. A web frontend in datacenter A might query a backend database in datacenter B. 
+
+To control these hidden networking costs, advanced topologies employ topology-aware routing features. You can configure this within Kubernetes natively or via a service mesh like Istio. This forces the kube-proxy to prioritize routing traffic to local endpoints. It prefers endpoints located within the exact same physical zone as the requesting pod. By aggressively keeping network traffic localized to the rack or the room, organizations save money. They drastically reduce their leased-line bandwidth requirements. This significantly lowers the overall total cost of ownership for highly available architectures.
 
 ---
 
-## Network Topology and Default Ports
+## Core Section 5: Network Topology Binding and BGP Alignment
 
-A correct cluster topology strictly dictates firewall configurations. Ensure the following network paths are permanently open:
+The network topology of your on-premises datacenter dictates your external connectivity. It controls how your Kubernetes clusters expose services to the internal corporate network. It also manages how services reach the external internet. Managed cloud providers seamlessly provision magical LoadBalancer objects for you. However, on-premises environments require you to do this heavy lifting manually. You must explicitly bind your Kubernetes networking stack to your physical routers. You must integrate directly with your core switches. 
 
-**Control Plane Inbound:**
-- TCP 6443: Kubernetes API server (Used by all components).
-- TCP 2379-2380: etcd server client API and peer communication.
-- TCP 10259: kube-scheduler.
-- TCP 10257: kube-controller-manager.
+This is almost universally achieved by deploying a bare-metal load balancing solution. Popular choices include MetalLB or Cilium's integrated BGP control plane. These tools advertise Kubernetes Service IP addresses to the surrounding datacenter infrastructure. Failing to properly align your logical network topology with your physical network architecture is dangerous. It will result in unroutable services. It causes massive asymmetric routing bottlenecks. It also creates a complete inability to integrate with legacy monolithic applications.
 
-**Worker Node Inbound:**
-- TCP 10250: Kubelet API (Required on all nodes, both control plane and worker).
-- TCP 10256: kube-proxy (Used by self and load balancers).
-- TCP/UDP 30000-32767: Default NodePort Services range.
+The Border Gateway Protocol (BGP) is the undisputed standard for this integration. It connects Kubernetes with enterprise on-premises routing hardware seamlessly. When you configure a service with `type: LoadBalancer`, the magic happens via BGP. Your chosen network plugin dynamically announces the allocated IP address to your top-of-rack switches. This establishes the worker nodes as the direct next-hop destinations for that specific traffic. 
 
-### Verifying System Health
+This requires careful coordination with your core network engineering team. You must allocate dedicated, non-overlapping IP address pools for your cluster. You need distinct pools for Kubernetes services (the Service CIDR). You also need massive pools for your internal pod networks (the Pod CIDR). If you accidentally allocate a Pod CIDR that overlaps with your corporate VPN subnet, disaster strikes. You will create a catastrophic routing black hole. Developers will simply not be able to reach the cluster endpoints from their local workstations.
 
-etcd members should be deployed within a single data center when possible to minimize latency and network partition risk. To validate your topology's health, use `etcdctl` to verify latency and disk performance.
-
-```bash
-# Check etcd member health and latency
-ETCDCTL_API=3 etcdctl \
-  --endpoints=https://etcd1.internal.example:2379,https://etcd2.internal.example:2379,https://etcd3.internal.example:2379 \
-  --cert=/etc/kubernetes/pki/etcd/peer.crt \
-  --key=/etc/kubernetes/pki/etcd/peer.key \
-  --cacert=/etc/kubernetes/pki/etcd/ca.crt \
-  endpoint health --write-out=table
-
-# Check etcd performance limits
-ETCDCTL_API=3 etcdctl check perf --endpoints=https://etcd1.internal.example:2379 \
-  --cert=/etc/kubernetes/pki/etcd/peer.crt \
-  --key=/etc/kubernetes/pki/etcd/peer.key \
-  --cacert=/etc/kubernetes/pki/etcd/ca.crt
+```yaml
+# Example: MetalLB BGP Peer Configuration
+# This binds the cluster's network topology to the physical ToR switches
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: tor-router-peer
+  namespace: metallb-system
+spec:
+  # The IP address of the physical top-of-rack switch
+  peerAddress: 10.0.0.1
+  # The Autonomous System Number of the physical datacenter network
+  peerASN: 65000
+  # The Autonomous System Number assigned to the Kubernetes cluster
+  myASN: 65001
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: production-services
+  namespace: metallb-system
+spec:
+  # The dedicated IP range allocated by the network engineers for K8s services
+  addresses:
+  - 192.168.100.0/24
 ```
+
+> **Pause and predict**: You might configure MetalLB to use Layer 2 mode instead of BGP. In Layer 2 mode, all traffic for a specific service is funneled through a single "leader" node. What impact will this have on network throughput for a high-traffic application? How does this compare to a BGP setup that utilizes Equal-Cost Multi-Path (ECMP) routing?
+
+Advanced network topologies frequently employ specialized Container Network Interfaces (CNIs). Tools like Calico or Cilium establish extremely granular, policy-driven network boundaries. They operate entirely within the cluster boundary. These advanced CNIs replace the basic, iptables-based `kube-proxy` implementation. They use high-performance eBPF (Extended Berkeley Packet Filter) programs instead. These eBPF programs are attached directly to the Linux kernel. 
+
+This architectural shift drastically reduces network latency for inter-pod communication. It also enables profound visibility into real-time network flows. Furthermore, these tools allow infrastructure teams to define strict egress gateways. You can force all traffic bound for a legacy mainframe database to exit through a specific node. This node has a statically assigned, predictable IP address. This satisfies strict legacy firewall constraints instantly. It achieves this without compromising the dynamic scheduling nature of the container orchestration platform.
+
+The cost of network topology design in an on-premises environment is heavily front-loaded. It is largely determined by the physical hardware required to support your chosen throughput. It also involves the administrative overhead of managing complex IP address allocations. High-performance BGP routing and ECMP load balancing require enterprise-grade equipment. Top-of-rack switches and robust core routers represent a massive capital expenditure. 
+
+Furthermore, exhausting an IPv4 address space is a costly operational nightmare. Poorly planned Pod CIDR allocations force organizations to undertake agonizing network re-architecture projects. They might have to hastily implement complex, brittle IPv6 dual-stack migrations. To optimize networking costs, platform teams must accurately forecast pod density. They must strategically size their IP pools from day one. You should avoid massive, wasteful `/16` allocations when a `/24` would easily suffice. This careful planning preserves the expensive, finite IPv4 address space across your datacenter.
+
+## Core Section 6: Multi-Cluster Federation and Cross-Cluster Communication
+
+As an organization matures, its on-premises Kubernetes footprint inevitably expands. It grows from a single monolithic cluster into a sprawling, complex fleet. When this happens, the fundamental architectural challenge shifts entirely. The focus changes from managing individual clusters to orchestrating the entire ecosystem as a cohesive platform. Multi-cluster federation is the advanced practice of securely connecting these independent clusters. It enables seamless workload mobility across different datacenters. It allows centralized policy enforcement from a single management plane. It also provides resilient cross-cluster service discovery. 
+
+Without a clearly defined federation strategy, managing ten independent clusters quickly degenerates. It becomes an operational nightmare of fragmented deployment pipelines. It creates wildly inconsistent security postures across environments. It also forces engineers into manual, error-prone configuration synchronization.
+
+The simplest approach to multi-cluster orchestration relies heavily on GitOps methodologies. Teams utilize powerful declarative tools like ArgoCD or Flux. These tools ensure that declarative configurations are identically applied across all clusters. They pull these configurations directly from a centralized Git repository. However, this approach only synchronizes configuration state. 
+
+When applications actually need to communicate with services hosted in different clusters, configuration sync is insufficient. You must implement a robust cross-cluster networking mesh. Technologies like Cilium ClusterMesh or Istio Multi-Cluster establish secure, encrypted tunnels. They bridge the isolated network environments seamlessly. This allows a web frontend in the `Prod-East` cluster to transparently query a database backend. That database can reside in the completely separate `Prod-West` cluster. The frontend simply uses standard Kubernetes DNS resolution to find it. This architecture provides unparalleled disaster recovery capabilities. It allows platform teams to seamlessly shift user traffic away from a failing datacenter. They can do this without requiring complex, external DNS failover scripts.
+
+```text
++-------------------------------------------------------------+
+| Multi-Cluster Federation with Cilium ClusterMesh            |
+|                                                             |
+|   +-------------------+             +-------------------+   |
+|   | Cluster: DC-East  |             | Cluster: DC-West  |   |
+|   |                   |             |                   |   |
+|   |  [Web Frontend]   | <---------> |  [User Database]  |   |
+|   |      (Pod A)      |  Encrypted  |      (Pod B)      |   |
+|   |                   |  eBPF Link  |                   |   |
+|   +-------------------+             +-------------------+   |
+|                                                             |
+|   * Both clusters share a synchronized global service       |
+|     directory, enabling transparent cross-DC routing.       |
++-------------------------------------------------------------+
+```
+
+Some environments require centralized, active workload orchestration. An architect might want to submit a single Deployment manifest to a central endpoint. They want that workload intelligently distributed across multiple clusters based on real-time capacity. For these scenarios, advanced federation APIs like Karmada are employed. Karmada essentially provides a unified, "meta" Kubernetes API server. It aggregates the compute capacity of the entire underlying fleet. 
+
+It allows operators to define powerful propagation policies. These policies automatically duplicate critical workloads across multiple geographic regions for high availability. They can also dynamically shift heavy batch processing jobs. The jobs are routed to whichever on-premises cluster currently has the most available CPU resources. This level of orchestration transforms a disjointed collection of clusters into a true private cloud. It maximizes overall hardware utilization and completely minimizes manual workload placement decisions.
+
+The cost lens for multi-cluster federation is stark and often surprising. It is dominated by massive operational overhead and severe computational taxes. These taxes are primarily imposed by service mesh sidecars and global control planes. Consider running an expansive Istio mesh across ten massive clusters. This requires injecting an Envoy proxy sidecar into every single application pod. This sidecar continually consumes CPU and memory simply to route and encrypt traffic. 
+
+For a massive enterprise deployment, this hidden sidecar tax is devastating. It can easily consume thousands of gigabytes of RAM across the fleet. This directly translates to the need for dozens of additional physical servers. To control these sprawling federation costs, platform architects must be ruthless. They must evaluate whether a specific workload truly requires encrypted cross-cluster communication. They should deliberately opt for simpler, cheaper ingress and egress gateway patterns for non-sensitive applications. They must reserve the expensive, heavy service mesh infrastructure strictly for mission-critical, zero-trust environments.
+
+---
+
+
+## Core Section 7: Storage Topology and Rack-Aware Replication
+
+Storage topology is frequently the most complex and expensive component of an on-premises Kubernetes architecture, requiring meticulous planning to prevent data loss. Unlike stateless application tiers that can rapidly scale horizontally across any available compute node, stateful workloads demand persistent, highly durable storage backends that are deeply integrated with your physical datacenter layout. When you design a storage topology, you are fundamentally defining how data is replicated across racks, rows, and datacenters to survive catastrophic hardware failures without compromising critical transaction speeds.
+
+In highly resilient environments, infrastructure teams leverage software-defined storage solutions like Ceph or OpenEBS to build distributed storage clusters that span the entire physical footprint. Ceph utilizes a highly sophisticated mechanism known as the CRUSH (Controlled Replication Under Scalable Hashing) map, which explicitly defines the physical failure domains of your hardware. By configuring the CRUSH map to understand your specific rack layouts and power distribution pathways, you can instruct the storage cluster to automatically replicate object data across completely independent power zones. This guarantees that if a localized power distribution unit (PDU) fails and instantly takes down an entire storage rack, the Ceph cluster will seamlessly serve the identical data from a surviving replica in an adjacent, unaffected rack.
+
+```yaml
+# Example: StorageClass defining rack-aware replication via Ceph RBD
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ceph-rbd-rack-aware
+provisioner: rbd.csi.ceph.com
+parameters:
+  clusterID: "ceph-production-cluster-id"
+  pool: "kubernetes-production-pool"
+  # This specific parameter tells the CSI driver to utilize a CRUSH rule
+  # that strictly mandates replication across distinct physical racks.
+  topology.kubernetes.io/zone: "rack-level-replication-enforced"
+reclaimPolicy: Retain
+allowVolumeExpansion: true
+```
+
+> **Pause and predict**: If you configure a ZFS storage pool using a standard RAID-Z2 configuration on a single physical node, how many concurrent disk failures can you tolerate? Furthermore, what happens to your stateful Kubernetes pods if the motherboard of that specific storage node suddenly catches fire?
+
+While rack-aware replication provides excellent localized durability, multi-datacenter topologies introduce the complex dilemma of choosing between synchronous and asynchronous storage replication. Synchronous replication guarantees zero data loss (RPO=0) by ensuring that every write operation is securely committed to both the primary datacenter and the secondary standby datacenter before acknowledging the transaction to the application. However, synchronous replication is severely constrained by the inescapable laws of physics; the physical distance between your datacenters dictates the latency floor, and stretching synchronous storage across a link with greater than 5 milliseconds of round-trip time will completely paralyze your transaction processing systems. For datacenters separated by massive geographic distances, architects are forced to implement asynchronous replication zones, accepting a small window of potential data loss (typically measured in minutes) in exchange for maintaining high-performance application throughput in the primary site.
+
+The financial cost of an enterprise-grade storage topology is consistently staggering, often consuming more than half of the total hardware budget for an on-premises deployment. Implementing rack-aware replication typically requires provisioning three times the raw storage capacity to maintain the necessary data replicas, transforming a theoretical 100-terabyte requirement into a 300-terabyte capital expenditure. Furthermore, building high-performance Ceph clusters demands specialized, expensive hardware configurations, including dedicated 25GbE or 100GbE storage networking backbones, massive arrays of NVMe caching drives, and exceptionally high-core-count CPUs to process the hashing algorithms. To control these spiraling storage costs, platform architects must implement aggressive storage tiering strategies, ruthlessly forcing non-critical workloads onto cheaper, slower rotational drives while reserving the ultra-expensive NVMe replication pools exclusively for mission-critical, latency-sensitive database deployments.
+
+## Patterns & Anti-Patterns
+
+| Pattern/Anti-Pattern | Description | Why It Happens / When to Use | The Impact / Better Alternative |
+|----------------------|-------------|------------------------------|---------------------------------|
+| **Pattern: Environment Segregation** | Deploying entirely distinct clusters for Production, Staging, and Development. | **When to use:** Mandated by compliance or when upgrading clusters requires high confidence. | Provides absolute blast radius isolation. Guarantees a staging configuration error cannot break production APIs. |
+| **Pattern: Rack-Aware Scheduling** | Meticulously labeling nodes with physical datacenter topologies and using `topologySpreadConstraints`. | **When to use:** In any on-premises environment where ToR switch or PDU failures are inevitable. | Ensures applications survive localized hardware failures gracefully. Replicas are distributed across independent power zones. |
+| **Pattern: External etcd for Scale** | Decoupling the etcd datastore onto dedicated NVMe-backed hardware, separating it from the API servers. | **When to use:** For clusters exceeding 200 nodes. Crucial for environments with extreme, constant CRD and webhook mutation rates. | Protects Raft consensus from API server CPU starvation. Ensures robust cluster stability during massive scaling events. |
+| **Anti-Pattern: The Mega-Monocluster** | Cramming every single company workload into one massive, shared Kubernetes cluster to save hardware costs. | **Why it happens:** Teams severely underestimate the operational complexity. They ignore the blast radius of a shared control plane. | A single runaway controller takes down the entire company. The alternative is strategic multi-cluster isolation. |
+| **Anti-Pattern: Stretched High-Latency Clusters** | Attempting to stretch a single etcd quorum across datacenters with >10ms network latency. | **Why it happens:** Architects desire "seamless" disaster recovery. They do not understand Raft protocol timing limitations. | Results in constant etcd leader election timeouts and total cluster collapse. Alternative is independent clusters with global load balancing. |
+| **Anti-Pattern: Ignoring Network Topology** | Allocating overlapping Pod CIDRs. Failing to integrate LoadBalancer services with physical BGP routing. | **Why it happens:** Network engineering and Kubernetes platform teams operate in silos. They fail to communicate during the design phase. | Creates unroutable traffic black holes and isolates the cluster. Alternative is meticulous BGP and IP pool planning before bootstrapping. |
+
+---
+
+## Decision Framework: Single vs. Multi-Cluster Architecture
+
+When determining your foundational cluster boundaries, you must balance competing priorities. You must weigh operational simplicity against the rigid isolation required by enterprise scale. Use this matrix to drive your architectural consensus logically.
+
+| Decision Factor | Favor Single Cluster | Favor Multi-Cluster | Trade-Off / Cost Implication |
+|-----------------|----------------------|---------------------|------------------------------|
+| **Total Node Count** | Under 100 physical nodes. | Exceeding 200-300 physical nodes. | Single clusters maximize hardware density but drastically increase the impact of a control plane outage. |
+| **Engineering Teams**| 1 to 3 teams with a unified culture. | 5+ independent business units. | Multi-cluster requires complex federation tooling (ArgoCD, meshes) but prevents noisy neighbor conflicts. |
+| **Compliance Scope** | No strict regulatory data processing. | PCI DSS, HIPAA, or strict data sovereignty. | Multi-cluster physically isolates sensitive data, drastically reducing audit scope, but doubles control plane hardware costs. |
+| **Upgrade Risk Tolerance** | High; organization tolerates occasional weekend downtime. | Low; mission-critical APIs must maintain five nines (99.999%) uptime. | Multi-cluster allows asynchronous upgrades (Staging first, then Prod), eliminating all-or-nothing upgrade anxiety. |
+| **Hardware Diversity** | Homogeneous servers; uniform workloads. | Mix of specialized GPUs, heavy storage nodes, and edge locations. | Managing massively disparate hardware in one cluster requires exhaustive taint/toleration hygiene to prevent scheduling errors. |
 
 ---
 
 ## Did You Know?
 
-- **Kubernetes v1.35 supports massive scale:** The maximum supported limits for a single cluster are 5,000 nodes, 110 pods per node, 150,000 total pods, and 300,000 total containers. Beyond 5,000 nodes, the API server's watch cache, etcd's storage, and the scheduler's throughput become bottlenecks. Most production clusters stay under 500 nodes and split beyond that.
-- **Google runs approximately 15,000 Kubernetes clusters internally** (Borg/GKE hybrid). They do not run one giant cluster — they use the multi-cluster pattern with automated lifecycle management. Even at Google's scale, the operational overhead of one massive cluster is worse than many smaller ones.
-- **etcd 3.6 was a major architectural shift:** Released in May 2025, it achieved an incredible 50% average memory reduction primarily by dropping the default `--snapshot-count` limit.
-- **The Kubernetes release cadence is relentless:** With approximately three minor versions per year, each offering only about 14 months of total support, update automation is not optional—it is a survival requirement.
-- **Spotify operates over 150 independent Kubernetes clusters:** Rather than wrestling with the blast radius of a monocluster, they built a massive multi-cluster fleet mapped tightly to specific engineering domains.
+- **etcd is brutally sensitive to latency:** The etcd Raft consensus algorithm fundamentally relies on a default heartbeat interval of just 100 milliseconds. If disk IOPS or network latency causes a leader to miss heartbeats, the cluster continuously triggers chaotic, destructive elections.
+- **Kubernetes limits are staggering but finite:** A single officially supported Kubernetes v1.35 cluster can theoretically scale to 5,000 nodes, 150,000 total pods, and 300,000 containers. However, long before you hit these limits, your API server's watch cache and your etcd storage will become massive operational bottlenecks.
+- **The sidecar tax is incredibly expensive:** Deploying a comprehensive service mesh like Istio across a multi-cluster fleet requires injecting an Envoy proxy into every pod. At scale, this can easily consume gigabytes of overhead RAM per node, drastically altering the financial viability of your hardware sizing.
+- **Even numbers break quorum logic:** Deploying an even number of etcd members (like 4 or 6) provides absolutely zero additional fault tolerance over the next-smaller odd number (3 or 5). Instead, it actively increases the network overhead required to reach consensus, degrading overall cluster write performance.
 
 ---
 
 ## Common Mistakes
 
-| Mistake | Why It Causes Outages | Fix |
-|---------|---------|----------|
-| One giant monolithic cluster | Blast radius equals the entire company; a single API server panic creates a total outage. | Split by environment, then by business domain. |
-| Too many micro-clusters | Operational overhead rapidly exceeds your platform engineering team's capacity. | Ensure 1 engineer can manage ~5-10 clusters via heavy declarative automation. |
-| CP nodes in the same rack | A single PDU or ToR switch failure takes down the cluster quorum immediately. | Spread CP nodes across physical racks or rows. |
-| Stretching etcd across DCs | Latency absolutely kills Raft consensus performance, causing API server timeouts. | Keep etcd in one DC; use application federation for multi-DC needs. |
-| No lifecycle automation | Manual cluster creation takes days and guarantees configuration drift over time. | Use Cluster API and GitOps for declarative lifecycle management. |
-| Namespace isolation only | Namespaces do not provide hard security boundaries for sensitive workloads. | Use separate clusters for hard trust boundaries, namespaces for organization. |
-| Not labeling nodes | The scheduler cannot utilize topology spread constraints without physical mapping data. | Label every node meticulously with rack, row, room, and DC metadata. |
-| Even number of etcd members | Even numbers provide no extra fault tolerance but create severe split-brain risks without a tiebreaker. | Always use odd numbers: 3, 5, or 7. |
+| Mistake | Why It Happens | How to Fix It |
+|---------|----------------|---------------|
+| **Deploying etcd on spinning hard drives (HDDs)** | Teams attempt to save money by utilizing cheap, high-capacity legacy storage arrays for the control plane. | Move the etcd `data-dir` exclusively to enterprise-grade NVMe SSDs capable of sustaining >500 sequential IOPS consistently. |
+| **Failing to label physical rack topology** | Infrastructure automation deploys the operating system but forgets to inject physical location metadata into the kubelet configurations. | Mandate that all bootstrapping scripts inject `topology.kubernetes.io/zone` labels corresponding to the exact physical PDU and rack layout. |
+| **Stretching clusters across high-latency WANs** | Architects attempt to build active-active datacenters without respecting the rigid timing constraints of distributed consensus. | Never stretch a cluster across a link exceeding 10ms RTT. Deploy independent clusters and federate traffic via external DNS or GSLB. |
+| **Overlapping corporate IP subnets** | Platform engineers arbitrarily choose a `10.0.0.0/16` Pod CIDR without consulting the core network routing teams. | Execute exhaustive IP Address Management (IPAM) planning. Carve out dedicated, non-overlapping blocks for Pod and Service CIDRs. |
+| **Relying solely on namespaces for compliance** | Security teams mistakenly believe that logical namespaces provide sufficient isolation for PCI-DSS payment environments. | Deploy physically separate, dedicated clusters for highly regulated workloads. Establish an impenetrable, verifiable hardware boundary. |
+| **Ignoring control plane CPU starvation** | Teams utilize a stacked etcd topology but fail to apply heavy resource requests/limits to the API server components. | Migrate to an external etcd topology for massive clusters. Strictly isolate the datastore from the compute-heavy API processes. |
+| **Over-provisioning isolated worker pools** | Infrastructure engineers aggressively taint multiple pools for every team. This results in massive amounts of idle, unusable hardware. | Consolidate workloads wherever possible. Use taints exclusively for strict compliance boundaries or specialized hardware (GPUs). |
+| **Neglecting egress network architecture** | Clusters are deployed into corporate networks but cannot reach legacy mainframe databases. This is due to asymmetric routing or missing NAT rules. | Implement highly specific egress gateways using Cilium or Calico. Force legacy-bound traffic out through a predictable, static IP address. |
 
 ---
 
 ## Quiz
 
-### Question 1
-Your company has 300 nodes, 8 teams, and a regulatory requirement to isolate PCI-scoped workloads. How many clusters would you recommend?
-
 <details>
-<summary>Answer</summary>
-
-**Minimum 3 clusters, recommended 4-5:**
-First, the PCI cluster is non-negotiable because regulatory scope isolation requires a hard boundary at both the control plane and network levels to pass compliance audits. Second, a dedicated production cluster handles the bulk of your workloads, ensuring that general applications do not impose PCI audit constraints on themselves. Third, a non-production cluster is required to prevent staging incidents and developer experiments from affecting production stability. Finally, a management or platform cluster is highly recommended to isolate CI/CD tooling, observability stacks, and GitOps controllers, thereby reducing the blast radius of any single control plane failure. This brings the total to four independent environments to properly isolate failure domains.
+<summary>Question 1: Your organization consists of five distinct engineering teams. Your security department just mandated that the new payment processing system must be strictly isolated. It must be separated from the experimental developer sandbox environments to pass a PCI compliance audit. Based on the decision framework, how should you architect your cluster topology to satisfy this requirement?</summary>
+You must immediately design a multi-cluster architecture. Logical namespaces provide excellent organization for standard workloads. However, they do not provide the impenetrable, physical hardware boundaries required for strict regulatory compliance. You must deploy an entirely independent, dedicated cluster specifically for the payment processing workloads. This physical separation guarantees that a compromised developer pod cannot affect financial systems. It ensures a fatal API server configuration in the sandbox environment has zero blast radius on production. This is the only verifiable way to limit compliance scope efficiently.
 </details>
 
-### Question 2
-You are designing the physical layout for a new datacenter with 3 racks, each powered by a separate PDU. You have exactly 3 control plane nodes. How should you distribute them to maximize high availability?
-
 <details>
-<summary>Answer</summary>
-
-**One control plane node per rack:**
-```text
-Rack A: CP-1 + Workers
-Rack B: CP-2 + Workers
-Rack C: CP-3 + Workers
-```
-You must distribute the control plane nodes perfectly evenly, placing exactly one node in each of the three racks. This physical distribution ensures that a severe rack-level failure—such as a blown PDU, a dead ToR switch, or localized cooling loss—takes down at most one control plane node. Because etcd requires a strict majority `(n/2)+1` to maintain consensus, the remaining two nodes will successfully preserve the Raft quorum and keep the cluster operational. If you were forced to place two nodes in a single rack due to space constraints, a failure of that specific rack would immediately break quorum and cause a total cluster outage.
+<summary>Question 2: You are designing a massive, 400-node cluster. This cluster will process thousands of webhook mutations per second. You are concerned that heavy API server CPU usage will destabilize the cluster state. How should you design your control plane topology to prevent this?</summary>
+You must architect an external etcd topology. Do not use the default stacked configuration. You must physically decouple the etcd key-value datastore from the API servers. Place its members on their own dedicated, isolated servers equipped with fast NVMe drives. This completely eliminates resource contention. The `kube-apiserver` might consume massive CPU while processing webhooks or Deployment rollouts. Regardless, the latency-sensitive Raft consensus algorithm will always remain stable. It will always have the dedicated compute cycles and disk IOPS it requires.
 </details>
 
-### Question 3
-A financial institution is designing a 400-node cluster for high-frequency trading APIs. The architecture review board mandates that any spikes in API server CPU usage—due to heavy webhook processing—must never impact data store latency. Which high-availability topology should they choose and why?
-
 <details>
-<summary>Answer</summary>
-
-**They must deploy the external etcd topology.**
-This architecture is required to satisfy the review board's strict performance mandate. When a cluster scales rapidly and experiences heavy webhook or CRD loads, the API server consumes massive amounts of CPU and memory, which can easily starve co-located processes. By placing etcd on dedicated servers with isolated NVMe drives, this topology guarantees zero resource contention with the heavy API server processes. Structurally decoupling the API server processes from the etcd data store allows the API servers to horizontally scale independently, fully protecting the latency-sensitive Raft consensus mechanism from application-layer traffic spikes.
+<summary>Question 3: Your on-premises datacenter consists of three distinct physical racks. Each rack is powered by a completely independent Power Distribution Unit (PDU). You have exactly three control plane nodes to deploy. How must you physically distribute these nodes to guarantee maximum cluster resilience?</summary>
+You must meticulously deploy exactly one control plane node into each of the three physical racks. This strategic physical distribution ensures maximum resilience. A catastrophic failure might occur, such as a blown PDU or a dead top-of-rack switch. This will only take down a single control plane node. The etcd cluster requires a strict majority to maintain operations. The remaining two nodes in the unaffected racks will successfully preserve the Raft consensus. This keeps the Kubernetes API completely responsive and the cluster fully operational.
 </details>
 
-### Question 4
-A platform engineering team proposes stretching a single etcd cluster across two datacenters located 100 miles apart. The datacenters have a reliable 25ms round-trip time. They argue this will provide seamless site-level fault tolerance. Why will this design fail during peak operational loads?
-
 <details>
-<summary>Answer</summary>
-
-**The latency exceeds the ~10ms maximum threshold for stable Raft consensus.**
-This design will fail catastrophically because the 25ms network latency far exceeds the practical limits for etcd stability. etcd relies on the Raft protocol, which strictly requires the leader to replicate log entries to a majority of members before acknowledging every single write operation. Because the default heartbeat interval is just 100ms, a 25ms round-trip time consumes a significant portion of the election timeout window, triggering severe leader election instability under heavy load. To achieve multi-datacenter resilience without breaking etcd, you must instead deploy completely separate Kubernetes clusters in each site and use application-layer federation or traffic routing to manage failover.
+<summary>Question 4: Your platform team recently purchased a highly expensive rack of NVIDIA GPUs. They are meant for machine learning workloads. During the first week of operation, you notice standard Java web applications randomly scheduling onto these nodes. These applications are starving the ML models. How do you implement a hardware segmentation strategy to fix this?</summary>
+You must immediately apply a `NoSchedule` taint to all the physical GPU nodes. For example, use `node.kubernetes.io/gpu=true:NoSchedule`. This programmatic taint actively repels any standard workload from the hardware. To allow the machine learning models to access the hardware, you must update their specific pod manifests. Include a corresponding toleration for that exact taint in their configuration. You must also include a `nodeSelector` explicitly directing them to the GPU hardware pool. This guarantees that only authorized workloads can consume the specialized compute resources.
 </details>
 
-### Question 5
-An engineer notices that during a massive deployment involving thousands of pods, the control plane becomes entirely unresponsive. The cluster is running a stacked HA topology backed by traditional rotational hard drives (HDDs). What is the likely root cause of this outage?
-
 <details>
-<summary>Answer</summary>
-
-**Insufficient disk IOPS disrupting etcd consensus.**
-The root cause is almost certainly insufficient disk performance disrupting the etcd consensus mechanism. etcd requires incredibly fast, low-latency disk writes to append Raft logs reliably and maintain cluster state. Rotational hard drives cannot reliably meet the strict minimum requirement of 50 sequential IOPS required for basic stability, let alone the approximately 500 IOPS demanded during a heavy deployment load. When the underlying disk writes stall, the etcd leader fails to commit log entries in time, prompting chaotic, continuous leader elections that completely block all cluster API operations.
+<summary>Question 5: You are managing a cluster utilizing a stacked control plane topology. Following a massive deployment of 10,000 new pods, the API server becomes completely unresponsive. The logs indicate that etcd is constantly dropping leader elections. The underlying physical servers are utilizing traditional spinning hard disk drives (HDDs). What is the critical bottleneck you must diagnose and fix?</summary>
+The critical bottleneck is catastrophic disk latency. This is caused by the inadequate performance of the spinning HDDs. The etcd Raft consensus algorithm strictly requires fast, low-latency sequential writes. It needs these to append log entries and maintain cluster state securely. When the massive deployment triggered thousands of state changes, the HDDs failed. They could not provide the minimum required sequential IOPS. This caused the etcd leader to miss its strict heartbeat deadlines continuously. You must immediately migrate the etcd `data-dir` to enterprise-grade NVMe solid-state drives.
 </details>
 
-### Question 6
-Your organization is planning a major upgrade window to move your production control plane from Kubernetes v1.34 to v1.35. However, due to application freeze periods, the worker nodes must remain on kubelet v1.33 for another month. Is this upgrade path officially supported, and what are the implications?
-
 <details>
-<summary>Answer</summary>
-
-**Yes, this upgrade strategy is officially supported by the Kubernetes version skew policy.**
-The policy explicitly permits the `kubelet` and `kube-proxy` components to be up to three minor versions older than the `kube-apiserver` in versions 1.25 and newer. Because your control plane will be at v1.35, a `kubelet` running v1.33 is exactly two minor versions behind, ensuring complete compatibility. This deliberate skew allowance empowers platform teams to upgrade the control plane first, thoroughly verifying stability before incrementally rolling out updates to the massive fleet of worker nodes. Always ensure you consult the version skew documentation before finalizing your cluster upgrade plans.
+<summary>Question 6: An enterprise architect proposes stretching a single Kubernetes cluster across two datacenters. The datacenters are located 200 miles apart. He wants to achieve "active-active" disaster recovery. The leased fiber link between the sites has a consistent round-trip time (RTT) of 35 milliseconds. Why must you reject this multi-cluster topology design?</summary>
+You must reject this design entirely. The 35ms network latency far exceeds the practical limits for stable etcd Raft consensus. The etcd system relies on an incredibly tight default heartbeat interval of just 100 milliseconds. A 35ms RTT consumes a massive portion of that critical window immediately. This guarantees that the cluster will suffer from severe, continuous leader election instability under load. To achieve multi-datacenter resilience across that distance safely, you must deploy fully independent clusters in each site. You must then utilize global server load balancing (GSLB) to route traffic securely.
 </details>
 
-### Question 7
-A site reliability engineer spreads three control plane nodes across three distinct availability zones to survive a catastrophic zone failure. During a subsequent incident where Zone A loses power, developers report that `kubectl` commands are randomly timing out instead of seamlessly failing over. Why didn't Kubernetes automatically reroute the API requests?
+<details>
+<summary>Question 7: Your developers complain that they cannot access a newly deployed LoadBalancer service from their corporate workstations. Upon investigation, you discover a massive routing conflict. The Pod CIDR network block assigned to the cluster perfectly overlaps with the IP subnet utilized by the corporate VPN. What architectural error occurred, and what is the impact?</summary>
+The architectural error was a failure to properly align the Kubernetes network topology with the physical corporate network. The teams bypassed rigorous IP Address Management (IPAM) planning. By allocating an overlapping IP subnet for the internal pods, you have created a severe asymmetric routing conflict. The corporate routers do not know whether to send traffic to the VPN clients or to the Kubernetes worker nodes. The immediate impact is a complete routing black hole. It requires a massive, highly disruptive reconfiguration of the cluster's foundational networking layer.
+</details>
 
 <details>
-<summary>Answer</summary>
-
-**Kubernetes explicitly does not provide built-in cross-zone resilience for the API server endpoints.**
-While the internal cluster scheduler intelligently handles pod resilience using node labels like `topology.kubernetes.io/zone`, the inbound traffic to the control plane is managed externally. You are entirely responsible for engineering an external TCP forwarding load balancer to manage this failover. The load balancer must be configured to constantly execute health checks against TCP port 6443 and actively reroute inbound traffic away from the dead zone to the surviving control plane nodes. Without this external load balancer, client requests will continue to hit the dead control plane node and time out.
+<summary>Question 8: You are configuring a highly critical web application Deployment. It must survive a localized datacenter power failure gracefully. You configure `topologySpreadConstraints` with `maxSkew: 1` keyed to the `topology.kubernetes.io/zone` label. You also set `whenUnsatisfiable: DoNotSchedule`. If one rack is completely full and cannot accept new pods, what is the operational risk to your deployment rollout?</summary>
+The severe operational risk is that the deployment will permanently stall. It will remain stuck in a `Pending` state. You utilized the strict `DoNotSchedule` enforcement directive. Because of this, the Kubernetes scheduler is mathematically forbidden from placing the remaining application replicas onto the available racks. Doing so would violate the strict `maxSkew` balance rule you defined. To maintain high availability during urgent deployments or capacity crunches, you must adjust this. It is significantly safer to utilize the `ScheduleAnyway` directive. This treats the spread constraint as a strong preference rather than a hard, deployment-breaking requirement.
 </details>
 
 ---
 
-## Hands-On Exercise: Design a Cluster Topology
+## Hands-On Exercise: Architecting an On-Premises Topology
 
-**Task**: Given an organization's requirements, design a complete cluster topology with physical placement that satisfies strict regulatory and high-availability demands.
+**Task**: You are the lead infrastructure architect for a massive healthcare provider. You must design and systematically define the cluster topology. You must also plan the control plane placement and network boundaries. You are building a highly secure, resilient on-premises Kubernetes environment. It must survive a complete rack failure while completely isolating highly regulated patient data.
 
 ### Scenario
 
-A manufacturing company is deploying Kubernetes on-premises:
-- 2 datacenters (DC-East and DC-West, located 50km apart, maintaining 5ms RTT).
-- 150 total nodes needed to support global operations.
-- 4 distinct teams: Platform, Product, Data Science, and QA.
-- A strict PCI compliance requirement for payment processing (20 nodes).
-- Specialized GPU workloads for quality inspection ML models (10 nodes).
-- The entire architecture must survive a full datacenter failure.
+The healthcare provider operates a single, large datacenter. It consists of three highly dense server racks (Rack-Alpha, Rack-Beta, Rack-Gamma).
+- You have 150 total bare-metal servers available for provisioning.
+- You must support two distinct business units simultaneously. One is the highly regulated Patient Records team (HIPAA compliance mandatory). The other is the experimental Data Analytics team.
+- The control plane must survive the complete loss of any single rack automatically.
+- You must ensure that the heavy Data Analytics workloads cannot consume resources dedicated to the Patient Records team.
 
 ### Steps
 
-**Step 1: Determine the cluster count.**
-You must establish strict isolation boundaries.
-- **PCI cluster** (dedicated, DC-East): 15 worker nodes + 3 CP = 18 nodes.
-- **Production cluster** (DC-East primary): 50 worker nodes + 10 GPU nodes + 3 CP = 63 nodes.
-- **DR/Standby cluster** (DC-West): 35 worker nodes + 3 CP = 38 nodes.
-- **Non-prod cluster** (DC-West): 28 worker nodes + 3 CP = 31 nodes.
-- **Total:** 18 + 63 + 38 + 31 = 150 nodes.
+**Step 1: Define the Cluster Boundaries (Blast Radius)**
+First, explicitly determine how many clusters are required to satisfy the strict regulatory constraints.
 
-**Step 2: Place the control planes across failure domains.**
-Ensure no single rack failure breaks quorum for any cluster.
+<details>
+<summary>Solution: Cluster Boundaries</summary>
 
+You must deploy a multi-cluster architecture consisting of exactly **two distinct clusters**.
+1. **Regulated-Cluster**: Dedicated entirely to the Patient Records team to satisfy strict HIPAA compliance and isolate sensitive healthcare data.
+2. **Analytics-Cluster**: Dedicated to the experimental Data Analytics team. This ensures their heavy, resource-intensive batch jobs cannot destabilize the control plane of the highly regulated cluster.
+</details>
+
+**Step 2: Design the Control Plane Topology**
+Determine the etcd architecture and the precise physical placement of the control plane nodes across the datacenter for the **Regulated-Cluster**.
+
+<details>
+<summary>Solution: Control Plane Topology</summary>
+
+Given the critical nature of the patient data, you should select an **External etcd Topology**.
+You must distribute the nodes perfectly across the three physical failure domains:
+- **Rack-Alpha**: API-Server-1, etcd-member-1
+- **Rack-Beta**: API-Server-2, etcd-member-2
+- **Rack-Gamma**: API-Server-3, etcd-member-3
+
+This precise distribution guarantees maximum resilience. If Rack-Beta loses power entirely, the cluster retains two API servers and a two-node etcd quorum. It survives the localized disaster without any downtime.
+</details>
+
+**Step 3: Implement Hardware Segregation via Taints**
+Assume the Data Analytics team requires access to a specialized pool of 10 nodes. These are equipped with custom FPGA accelerators located in Rack-Gamma. Write the exact `kubectl` command to taint one of these nodes.
+
+<details>
+<summary>Solution: Tainting the Node</summary>
+
+You must apply a strict `NoSchedule` taint referencing the custom hardware explicitly:
 ```bash
-# DC-East (3 racks) — 81 nodes total (PCI: 18, Prod: 63)
-# Rack A: PCI CP-1, Prod CP-1, 5 PCI workers, 20 Prod workers  (27 nodes)
-# Rack B: PCI CP-2, Prod CP-2, 5 PCI workers, 20 Prod workers  (27 nodes)
-# Rack C: PCI CP-3, Prod CP-3, 5 PCI workers, 10 Prod workers + 10 GPU  (27 nodes)
-
-# DC-West (3 racks) — 69 nodes total (DR: 38, NonProd: 31)
-# Rack D: DR CP-1, NonProd CP-1, 12 DR workers, 9 NonProd workers  (23 nodes)
-# Rack E: DR CP-2, NonProd CP-2, 12 DR workers, 9 NonProd workers  (23 nodes)
-# Rack F: DR CP-3, NonProd CP-3, 11 DR workers, 10 NonProd workers (23 nodes)
+kubectl taint nodes rack-gamma-fpga-01 hardware-type=fpga-accelerator:NoSchedule
 ```
+This physically repels all standard web applications automatically. It ensures the specialized hardware remains idle and available exclusively for the Analytics team's configured batch jobs.
+</details>
 
-**Step 3: Label and taint the physical nodes.**
-Apply the proper topology labels so the scheduler understands the physical datacenter layout. Isolate the expensive GPU hardware.
+**Step 4: Design the Network Binding (BGP)**
+The datacenter engineers have assigned ASN `64512` to the top-of-rack switches. You are configuring MetalLB for the Regulated-Cluster. Write the core BGPPeer YAML configuration required to bind the cluster to the physical network.
 
-```bash
-# DC-East nodes
-kubectl label node east-rack-a-01 \
-  topology.kubernetes.io/region=dc-east \
-  topology.kubernetes.io/zone=rack-a \
-  node.kubernetes.io/purpose=worker
-
-# GPU nodes — label and taint to isolate
-kubectl label node east-rack-c-gpu-01 \
-  topology.kubernetes.io/region=dc-east \
-  topology.kubernetes.io/zone=rack-c \
-  node.kubernetes.io/gpu=nvidia-a100 \
-  node.kubernetes.io/purpose=gpu
-
-kubectl taint nodes east-rack-c-gpu-01 \
-  node.kubernetes.io/gpu=nvidia-a100:NoSchedule
-```
-
-**Checkpoint Verification:**
-```bash
-kubectl get nodes -l topology.kubernetes.io/zone=rack-c,node.kubernetes.io/purpose=gpu --show-labels
-kubectl describe node east-rack-c-gpu-01 | grep Taints
-```
-
-**Step 4: Define the topology spread constraints.**
-Configure the application workloads to gracefully distribute themselves across the racks.
+<details>
+<summary>Solution: MetalLB BGP Binding</summary>
 
 ```yaml
-# Production deployment spread across racks
-# Using ScheduleAnyway so replacements can schedule after a rack failure
-topologySpreadConstraints:
-  - maxSkew: 1
-    topologyKey: topology.kubernetes.io/zone
-    whenUnsatisfiable: ScheduleAnyway
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: tor-rack-alpha
+  namespace: metallb-system
+spec:
+  peerAddress: 10.100.0.1  # IP of the ToR switch
+  peerASN: 64512           # Datacenter ASN
+  myASN: 64513             # Dedicated ASN for the Kubernetes cluster
 ```
+</details>
+
+**Step 5: Enforce Rack-Aware Application Scheduling**
+Write the specific `topologySpreadConstraints` YAML snippet for a critical Patient Records Deployment. Ensure its replicas are distributed evenly across the three racks, utilizing the standard zone label.
+
+<details>
+<summary>Solution: Topology Spread Constraint</summary>
+
+```yaml
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: patient-records-api
+```
+Using `ScheduleAnyway` ensures stability. If a massive capacity crunch occurs on one rack, the deployment will not stall indefinitely.
+</details>
 
 ### Success Criteria
-- [ ] The cluster count is justified with sound architectural reasoning.
-- [ ] High-risk PCI workloads are fully isolated in a dedicated cluster.
-- [ ] Control planes are perfectly spread across physical failure domains (racks).
-- [ ] etcd consensus is protected because clusters do not stretch across DCs.
-- [ ] The DR strategy can seamlessly handle a full DC-East failure.
-- [ ] Node labels are comprehensively defined for topology-aware scheduling.
-- [ ] Expensive GPU nodes are structurally isolated with both labels and taints.
+- [ ] You have successfully justified the requirement for a multi-cluster architecture to enforce regulatory isolation.
+- [ ] You have mapped the control plane nodes precisely across the three physical rack failure domains to maintain Raft consensus.
+- [ ] You have utilized `kubectl taint` commands to successfully segregate specialized hardware from general-purpose workloads.
+- [ ] You have correctly configured the BGP ASN settings to bind the cluster's logical networking to the physical datacenter switches.
+- [ ] You have implemented robust `topologySpreadConstraints` to ensure high availability for application replicas.
+
+---
+
+## Sources
+
+- https://kubernetes.io/docs/setup/production-environment/
+- https://etcd.io/docs/v3.5/faq/
+- https://cluster-api.sigs.k8s.io/
+- https://karmada.io/docs/
+- https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+- https://metallb.universe.tf/configuration/
+- https://docs.cilium.io/en/stable/network/clustermesh/
+- https://docs.ceph.com/en/latest/rados/operations/crush-map/
+- https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+- https://kubernetes.io/docs/concepts/architecture/nodes/
 
 ---
 


### PR DESCRIPTION
## Module 1.3: Cluster Topology Planning — Critical-Rubric Rewrite

Rubric: **1.5 → T0 (all 20 gates green)**. First gemini-3.1-pro-preview T0-author trial in session 56 → APPROVE_WITH_NITS after one fix-pass cycle.

### What's covered
- Single-cluster vs multi-cluster decision matrix (regulatory, blast radius, team boundaries, scale)
- Control-plane topology: 3 vs 5 etcd nodes, stacked vs external, geographic placement
- Worker pool design: pool-per-role vs heterogeneous, taint/toleration boundaries, hardware-class node selectors
- Failure domains: rack/row/zone awareness, topology spread constraints, hardware redundancy patterns
- Network topology binding: pod/service CIDR sizing, MetalLB/Calico/Cilium placement, BGP boundary alignment
- Multi-cluster federation: when Karmada/Cluster API beats ad-hoc, network mesh implications
- 5-task hands-on: multi-cluster + external etcd + taint + MetalLB BGPPeer + topology spread constraints

### Verifier (post-fix-pass)
- body_words: 5074 (≥5000 floor)
- median_wpp: 70 · mean_wpp: 68.6 · short_para_rate: 0.014 · max_consecutive_short: 1
- 10 sources, ALL 10 HTTP 200 (no redirects, no 404s — cleanest source state of session)
- **6 core sections** (HARD CAP respected after fix-pass)
- All 20 gates: true, tier T0
- `npm run build`: green

### Review chain
- **Author: gemini-3.1-pro-preview T0 trial #1** — succeeded on first pass, full-depth module not outline (confirmed verifier T0)
- R1 (deepseek-v4-pro, cross-family): NEEDS_CHANGES — 3 findings (vCluster Kubeadm hallucination L86, 7→6 core sections overshoot, L331 unsourced 5ms RTT claim)
- Fix-pass (deepseek): all 3 addressed
- R2 (cursor composer-2.5, Decision Card C canonical): **APPROVE_WITH_NITS** — all R1 items fixed, 3 cosmetic nits non-blocking (StorageClass param naming, cosmetic duplicate `---`, vCluster cross-link to module-1.2)

### Routing significance
This PR validates **gemini-3.1-pro-preview as a 4th T0-author option** alongside codex/cursor/deepseek. See `memory/feedback_gemini_3_1_pro_viable_t0_author.md` for the calibration record.

### Files changed (1)
- `src/content/docs/on-premises/planning/module-1.3-cluster-topology.md` (rewritten: 2050 → 5074 body words; structure to spec)

Critical-rubric drain: 5 of 122 closed via session-56 batch (modules 7.4, 1.3, 1.5 done; 2.2 in flight).

## Learner check

> When determining your foundational cluster boundaries, you must balance competing priorities. You must weigh operational simplicity against the rigid isolation required by enterprise scale. Use this matrix to drive your architectural consensus logically.
