### PR TITLE
chore(ci): remove deepseek-v4-pro reviewer job from cross-family workflow

### DIFF
--- a/.github/workflows/cross-family-code-review.yml
+++ b/.github/workflows/cross-family-code-review.yml
@@ -39,28 +39,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash scripts/ci/cross_family_review.sh
 
-  review-deepseek-v4-pro:
-    name: Review (deepseek-v4-pro)
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    continue-on-error: true
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Run cross-family review
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          BASE_REF: ${{ github.base_ref }}
-          MODEL_TAG: deepseek-v4-pro
-          API_ENDPOINT: https://api.deepseek.com/chat/completions
-          API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
-          API_MODEL: deepseek-chat
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bash scripts/ci/cross_family_review.sh
+  # deepseek-v4-pro reviewer job removed 2026-05-26 (session 57).
+  # Hypothesis: api.deepseek.com (China-hosted) outbound from CI may have
+  # tripped a GH policy that's preventing checkout on all jobs in this repo
+  # since ~10:50 UTC today. Gemini reviewer retained as the cross-family signal.
+  # If CI resumes after this removal, the hypothesis is confirmed and we keep
+  # deepseek out of CI. Local dispatches via dispatch_smart.py can still use
+  # deepseek as an author/reviewer agent — only the CI-side automation is removed.


### PR DESCRIPTION
## Summary

Hypothesis-test PR. All Actions checkouts on kube-dojo/kube-dojo.github.io have been returning \`remote: Your account is suspended\` 403 since ~10:50 UTC 2026-05-26, blocking all PR merges. The repo is public, the actor (krisztiankoos) is unsuspended on the user side, and Actions billing is not the cause (public repos get unlimited Linux runner minutes). The CI failure happens at the \`actions/checkout\` step BEFORE any third-party API call.

Hypothesis: GitHub automated abuse / TOS / national-security detection flagged the repo for the cross-family review workflow making outbound HTTPS calls to \`api.deepseek.com\` (China-hosted) from CI runners. Removing the deepseek job from the workflow tests this hypothesis.

If CI runs on this PR (even the dedup gate or codeql analyze), the hypothesis is confirmed and deepseek stays out of CI permanently.
If CI still hits the suspension error, the hypothesis is wrong — the cause is elsewhere and we revert.

## What changed

- Removed the \`review-deepseek-v4-pro\` job from \`.github/workflows/cross-family-code-review.yml\`
- Retained \`review-gemini-3-1-pro\` (Google endpoint, no policy concern)
- Added an inline comment explaining the removal rationale and the local-dispatch fallback

## What's preserved

- Local dispatches via \`dispatch_smart.py review --agent deepseek\` still work
- The deepseek-v4-pro author lane is unchanged (T0 author rotation per \`feedback_deepseek_v4_pro_viable_for_t0_content\`)
- Memory entries on deepseek behavior remain accurate

## Verification

- [x] \`bash -n\` clean on the workflow YAML
- [x] \`uvx zizmor --offline --strict-collection .github/\` — \`No findings to report\`
- [x] Workflow still has gemini-3.1-pro reviewer job

## Test plan

- [ ] PR push triggers CI checkout (the diagnostic signal)
- [ ] If checkout succeeds: hypothesis confirmed, merge as-is and document in session 57 handoff
- [ ] If checkout still fails the same way: revert, look elsewhere for root cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)