### PR TITLE
chore(content): fix #1577 module 8.5-gitpod-codespaces — 4 Class A defects

### DIFF
--- a/src/content/docs/platform/toolkits/developer-experience/devex-tools/module-8.5-gitpod-codespaces.md
+++ b/src/content/docs/platform/toolkits/developer-experience/devex-tools/module-8.5-gitpod-codespaces.md
@@ -176,7 +176,14 @@ gh codespace delete -c <codespace-name>
 
   "postCreateCommand": "npm install",
 
-  "secrets": ["DATABASE_URL", "API_KEY"],
+  "secrets": {
+    "DATABASE_URL": {
+      "description": "PostgreSQL connection string for local development and tests"
+    },
+    "API_KEY": {
+      "description": "API key injected at workspace start"
+    }
+  },
 
   "hostRequirements": {
     "cpus": 4,
@@ -386,7 +393,8 @@ RUN brew install kubectl helm k9s
 RUN sudo apt-get update && sudo apt-get install -y postgresql-client redis-tools
 
 # Custom binaries
-RUN curl -sSL https://example.com/tool | sudo tar -xzC /usr/local/bin
+# Replace URL below with the real tool release URL before building
+RUN curl -sSL https://REPLACE_WITH_TOOL_RELEASE_TARBALL_URL | sudo tar -xzC /usr/local/bin
 ```
 
 ### Gitpod Prebuilds
@@ -574,7 +582,7 @@ secrets:
 
 ### Gitpod Self-Hosted (Gitpod Flex)
 
-```yaml
+```bash
 # Gitpod Flex installation (Kubernetes)
 # https://www.gitpod.io/docs/flex/getting-started
 
@@ -592,7 +600,9 @@ helm install gitpod gitpod/gitpod \
   --namespace gitpod \
   --create-namespace \
   -f values.yaml
+```
 
+```yaml
 # values.yaml
 domain: gitpod.example.com
 database:
@@ -902,6 +912,7 @@ Before the cloud platforms can build anything, they need something to build. Cre
 ```bash
 mkdir cde-lab && cd cde-lab
 git init
+git branch -M main
 
 cat > package.json << 'EOF'
 {


### PR DESCRIPTION
Refs #1577

- Line 179: Fixed the `.devcontainer/devcontainer.json` `secrets` field to use the object shape with per-secret metadata keys (`description`), matching the specification.
- Line 389: Replaced non-runnable `RUN curl ... https://example.com/tool | tar ...` usage with a clearly labeled placeholder download instruction and explicit placeholder note (`Replace URL below with the real tool release URL before building`).
- Line 577: Split the mixed Helm install/values example into separate `bash` (helm install commands) and `yaml` (values file, with `# values.yaml` header) code blocks.
- Line 903: Added `git branch -M main` immediately after `git init` so the lab defaults to `main`.

Scope: Class A defects only. Density gaps (body_words=1102<5000, short-rate>20%, sources<10) are out of scope and will be filed as a separate follow-up.

## Learner check

From the "Why This Module Matters" framing (module-8.5-gitpod-codespaces.md:48) — the contract every Class A fix here must keep intact:

> Cloud Development Environments (CDEs) flip the model: instead of shipping code to match your environment, you ship your environment with your code.

Each defect fixed in this PR (broken devcontainer secrets shape, fake `curl | tar` pipe, mixed-fence Helm block, missing default-branch rename) would silently break that promise on first run for a learner whose first CDE is this module.

## R1 review

composer-2.5 (cursor) APPROVE — gates baseline preserved (verifier output identical between main and PR branch: 8 failing/12 passing unchanged), devcontainer secrets schema verified against `devContainer.base.schema.json`, scope clean (+14/-3).
