### PR TITLE
chore(content): fix #1577 module 1.10-cloudwatch — 3 Class A defects

### DIFF
--- a/src/content/docs/cloud/aws-essentials/module-1.10-cloudwatch.md
+++ b/src/content/docs/cloud/aws-essentials/module-1.10-cloudwatch.md
@@ -527,6 +527,80 @@ The agent is governed by a JSON file that explicitly declares which metrics to s
 Do not bake this config file directly into your AMI. Instead, store it centrally in Systems Manager (SSM).
 
 ```bash
+# Write the agent config (same JSON as above) before uploading to SSM
+sudo mkdir -p /opt/aws/amazon-cloudwatch-agent/etc
+sudo tee /opt/aws/amazon-cloudwatch-agent/etc/config.json <<'EOF'
+{
+  "agent": {
+    "metrics_collection_interval": 60,
+    "run_as_user": "cwagent"
+  },
+  "metrics": {
+    "namespace": "CWAgent",
+    "append_dimensions": {
+      "InstanceId": "${aws:InstanceId}",
+      "AutoScalingGroupName": "${aws:AutoScalingGroupName}"
+    },
+    "aggregation_dimensions": [
+      ["InstanceId"],
+      ["AutoScalingGroupName"]
+    ],
+    "metrics_collected": {
+      "mem": {
+        "measurement": [
+          "mem_used_percent",
+          "mem_available_percent",
+          "mem_total"
+        ],
+        "metrics_collection_interval": 60
+      },
+      "disk": {
+        "measurement": [
+          "disk_used_percent",
+          "disk_free"
+        ],
+        "resources": ["/", "/data"],
+        "metrics_collection_interval": 60
+      },
+      "swap": {
+        "measurement": ["swap_used_percent"]
+      },
+      "cpu": {
+        "measurement": [
+          "cpu_usage_idle",
+          "cpu_usage_user",
+          "cpu_usage_system",
+          "cpu_usage_iowait"
+        ],
+        "totalcpu": true,
+        "metrics_collection_interval": 60
+      }
+    }
+  },
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "/var/log/myapp/application.log",
+            "log_group_name": "/myapp/production/api",
+            "log_stream_name": "{instance_id}/application.log",
+            "retention_in_days": 30,
+            "timestamp_format": "%Y-%m-%dT%H:%M:%S"
+          },
+          {
+            "file_path": "/var/log/syslog",
+            "log_group_name": "/myapp/production/system",
+            "log_stream_name": "{instance_id}/syslog",
+            "retention_in_days": 14
+          }
+        ]
+      }
+    }
+  }
+}
+EOF
+
 # Store the config in SSM Parameter Store
 aws ssm put-parameter \
   --name "AmazonCloudWatch-linux-config" \
@@ -784,6 +858,7 @@ aws iam add-role-to-instance-profile \
 aws ec2 run-instances \
   --image-id resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64 \
   --instance-type t3.micro \
+  --monitoring Enabled=true \
   --iam-instance-profile Name=cw-lab-profile \
   --key-name YOUR_KEY_PAIR \
   --security-group-ids sg-YOUR_SG \
@@ -958,6 +1033,7 @@ Create a proactive alarm that triggers an SNS notification when CPU load exceeds
 <summary>Solution</summary>
 
 ```bash
+# Run from your local machine (AWS CLI):
 INSTANCE_ID=$(aws ec2 describe-instances --filters "Name=tag:Name,Values=cw-lab" --query "Reservations[0].Instances[0].InstanceId" --output text)
 INSTANCE_PUBLIC_IP=$(aws ec2 describe-instances --filters "Name=tag:Name,Values=cw-lab" --query "Reservations[0].Instances[0].PublicIpAddress" --output text)
 
@@ -986,15 +1062,20 @@ aws cloudwatch put-metric-alarm \
   --alarm-actions $TOPIC_ARN \
   --ok-actions $TOPIC_ARN \
   --treat-missing-data missing
+```
 
-# SSH into the instance and stress the CPU
+```bash
+# Run on the EC2 instance (via SSH):
 ssh -i your-key.pem ec2-user@$INSTANCE_PUBLIC_IP
 
-# Inside the EC2 instance, install and run stress-ng
+# Install and run stress-ng to drive CPU above the alarm threshold
 sudo yum install -y stress-ng
 stress-ng --cpu 2 --timeout 300
+```
 
-# After 2-3 minutes, check alarm state from your local machine
+```bash
+# Run from your local machine (AWS CLI):
+# After 2-3 minutes, check alarm state
 aws cloudwatch describe-alarms \
   --alarm-names "cw-lab-high-cpu" \
   --query 'MetricAlarms[0].[AlarmName,StateValue,StateReason]' \

--- a/src/content/docs/cloud/aws-essentials/module-1.10-cloudwatch.md
+++ b/src/content/docs/cloud/aws-essentials/module-1.10-cloudwatch.md
@@ -528,8 +528,7 @@ Do not bake this config file directly into your AMI. Instead, store it centrally
 
 ```bash
 # Write the agent config (same JSON as above) before uploading to SSM
-sudo mkdir -p /opt/aws/amazon-cloudwatch-agent/etc
-sudo tee /opt/aws/amazon-cloudwatch-agent/etc/config.json <<'EOF'
+cat <<'EOF' > cw-config.json
 {
   "agent": {
     "metrics_collection_interval": 60,
@@ -605,7 +604,7 @@ EOF
 aws ssm put-parameter \
   --name "AmazonCloudWatch-linux-config" \
   --type String \
-  --value file:///opt/aws/amazon-cloudwatch-agent/etc/config.json
+  --value "file://cw-config.json"
 
 # Fetch config from SSM and start the agent
 sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
@@ -1065,10 +1064,12 @@ aws cloudwatch put-metric-alarm \
 ```
 
 ```bash
-# Run on the EC2 instance (via SSH):
+# Run from your local machine to open an SSH session to the EC2 instance:
 ssh -i your-key.pem ec2-user@$INSTANCE_PUBLIC_IP
+```
 
-# Install and run stress-ng to drive CPU above the alarm threshold
+```bash
+# Run on the EC2 instance (after the ssh prompt opens):
 sudo yum install -y stress-ng
 stress-ng --cpu 2 --timeout 300
 ```

--- a/src/content/docs/cloud/aws-essentials/module-1.10-cloudwatch.md
+++ b/src/content/docs/cloud/aws-essentials/module-1.10-cloudwatch.md
@@ -872,10 +872,13 @@ Extract the instance IP automatically, SSH into the instance, and install the ag
 <summary>Solution</summary>
 
 ```bash
-# SSH into the instance
+# Run from your local machine (AWS CLI):
 INSTANCE_PUBLIC_IP=$(aws ec2 describe-instances --filters "Name=tag:Name,Values=cw-lab" --query "Reservations[0].Instances[0].PublicIpAddress" --output text)
 ssh -i your-key.pem ec2-user@$INSTANCE_PUBLIC_IP
+```
 
+```bash
+# Run on the EC2 instance (after the ssh prompt opens):
 # Install the CloudWatch Agent
 sudo yum install -y amazon-cloudwatch-agent
 


### PR DESCRIPTION
Refs #1577

## Defects fixed (initial + 2 fix-passes)

Initial commit (dad0fd48) by cursor (composer-2.5) for 3 Class A defects from #1577:
- Line 531: SSM upload step now writes config to `cw-config.json` locally (was `sudo mkdir`/`sudo tee` to `/opt/aws/...` — invasive on learner's dev box; fixed in fix-pass 1).
- Line ~870 (Defect 2 area): Added `--monitoring Enabled=true` to `aws ec2 run-instances` for 1-minute metrics, keeping the 60s alarm Period.
- Task 5 SSH block split into separate "open SSH" + "on EC2 instance" blocks (extended in fix-pass 2 to cover Task 1 sibling).

Fix-pass 1 commit (a92998a1) — gemini R1 P1.1 + P1.2:
- Replaced `sudo mkdir`/`sudo tee` with local `cw-config.json` write + `file://cw-config.json` reference.
- Split Task 5 SSH block.

Fix-pass 2 commit (e2d9809c) — gemini R2 sibling SSH catch:
- Task 1 had the same SSH/remote-command grouping anti-pattern. Applied the same split-block fix as Task 5.

## Learner check

From the "Why This Module Matters" framing of module-1.10-cloudwatch.md (line 42):

> **EC2 standard metrics have a 5-minute resolution** by default and are completely free.

This directly underpins Defect 2 — the original lab created a 60-second alarm without enabling detailed monitoring, so the 1-minute alarm could never evaluate predictably against 5-minute basic-monitoring metrics. The fix (`--monitoring Enabled=true`) keeps the teaching point of the module true at the lab level too.

## Review rounds

- R1 (gemini-3.1-pro-preview, cross-family for composer-2.5 author): NEEDS_CHANGES — sudo `/opt/aws/...` and Task 5 SSH-grouping.
- Fix-pass 1.
- R2 (gemini): NEEDS_CHANGES — Task 1 had a sibling SSH block; the fix-pass missed it (catch directly motivated [[feedback_class_a_fix_includes_sibling_grep]]).
- Fix-pass 2.
- R3 (claude-sonnet-4-6 + gemini-3.1-pro-preview, both run independently): APPROVE — Task 1 sibling fix correct, no remaining unsplit SSH blocks, scope clean (single hunk), verifier baseline preserved.
- CI: Review (gemini-3.1-pro-preview), CodeQL all SUCCESS.

Scope: Class A defects only. Density gaps (body_words=1506<5000, median_wpp=20.5<28, short-rate=41%) are out of scope and tracked separately at #1587.
