### PR TITLE
chore(content): fix #1577 module 8.2-network-administration — 3 Class A defects

### DIFF
--- a/src/content/docs/linux/operations/module-8.2-network-administration.md
+++ b/src/content/docs/linux/operations/module-8.2-network-administration.md
@@ -558,7 +558,7 @@ ssh -i ~/.ssh/id_ed25519 user@server
 
 Edit `/etc/ssh/sshd_config` deliberately, because every directive below changes either who may authenticate or what a successful SSH session may do:
 
-```bash
+```text
 # Disable password authentication (key-only)
 PasswordAuthentication no
 
@@ -598,7 +598,10 @@ sudo sshd -t
 # No output = no errors
 
 # Restart SSH
-sudo systemctl restart sshd
+# Ubuntu/Debian:
+sudo systemctl restart ssh
+# RHEL/CentOS:
+# sudo systemctl restart sshd
 
 # CRITICAL: Test from another terminal BEFORE closing your current session
 # If config is wrong, you can still fix it from the existing session
@@ -682,7 +685,7 @@ The ordered approach is not academic OSI-model theater; it prevents destructive 
 5. **Firewall (Layer 4)**: Is a firewall blocking the traffic locally or remotely?
    ```bash
    sudo firewall-cmd --list-all
-   telnet destination_ip port  # Test if the port is open
+   telnet portquiz.net 80
    ```
 
 Here is a worked example. A developer says a new host cannot clone from a Git server by hostname. You check `ip link show eth0` and see the interface is up with carrier. `ip addr show eth0` shows the expected address and prefix. `ip route show` includes a default route, and `ping -c 4 8.8.8.8` succeeds, proving general outbound routing. `resolvectl status` then shows the profile still points at a retired DNS server, which explains why the hostname fails while the network path itself is healthy.

--- a/src/content/docs/linux/operations/module-8.2-network-administration.md
+++ b/src/content/docs/linux/operations/module-8.2-network-administration.md
@@ -876,7 +876,10 @@ sudo sed -i 's/X11Forwarding yes/X11Forwarding no/' /etc/ssh/sshd_config
 sudo sshd -t
 
 # Restart
-sudo systemctl restart sshd
+# Ubuntu/Debian:
+sudo systemctl restart ssh
+# RHEL/CentOS:
+# sudo systemctl restart sshd
 ```
 
 <details>
@@ -951,7 +954,10 @@ The profile should show the address, gateway, DNS servers, and manual IPv4 metho
 ```bash
 # Restore SSH config
 sudo cp /etc/ssh/sshd_config.bak /etc/ssh/sshd_config
-sudo systemctl restart sshd
+# Ubuntu/Debian:
+sudo systemctl restart ssh
+# RHEL/CentOS:
+# sudo systemctl restart sshd
 
 # Remove firewalld test rules
 sudo firewall-cmd --remove-service=https --permanent


### PR DESCRIPTION
Refs #1577

## Defects fixed (one fix-pass + one nit-fix-pass)

Initial commit by deepseek-v4-pro:
- Line 561: ```bash → ```text on sshd_config directives block (config syntax no longer mistaken for shell commands).
- Line 601: `sudo systemctl restart sshd` → `sudo systemctl restart ssh` (Ubuntu/Debian) with commented RHEL/CentOS alternative.
- Line 685: `telnet destination_ip port` (placeholder) → `telnet portquiz.net 80` (real runnable target).

Nit-fix commit d2ffca99 by deepseek-v4-pro (after composer-2.5 R1):
- Sibling occurrences of the same `restart sshd` defect on lines 879 and 954 (Ubuntu lab path) — fixed with the same Ubuntu/RHEL pattern as line 601.

## Learner check

From the failure narrative in the "Why This Module Matters" section of module-8.2-network-administration.md:

> A password-login hardening change is made before key login is tested, and the only reachable shell disappears.

Defect 1 (sshd_config in a bash fence) and Defect 2 (Ubuntu/RHEL sshd service mismatch) both directly fall into this failure class — copy-pasted as shown, the lab steps would either run config directives as shell or fail to restart the SSH service.

## R1 + R2 review

- R1: composer-2.5 (cursor) APPROVE_WITH_NITS — surfaced sibling sshd occurrences at lines 879/954 (not in original #1577 listing).
- Fix-pass: d2ffca99 (deepseek) — applied same Ubuntu/RHEL pattern to both sibling lines.
- R2: composer-2.5 (cursor) APPROVE — sibling fixes applied correctly, scope clean (+6/-3 lines, 2 hunks), original 3 Class A fixes intact, verifier baseline preserved (only pre-existing `gate_no_source_h1` at line 15 still fails — out of scope).
- CI: Review (gemini-3.1-pro-preview), CodeQL all SUCCESS.
