### PR TITLE
chore(content): #1577 module 1.2-ebpf-deepdive — 2 Class A defects fixed

### DIFF
--- a/src/content/docs/platform/foundations/ebpf/module-1.2-ebpf-security-networking-deepdive.md
+++ b/src/content/docs/platform/foundations/ebpf/module-1.2-ebpf-security-networking-deepdive.md
@@ -269,7 +269,7 @@ Tetragon can export to stdout, files, or gRPC consumers. Kernel `Sigkill` events
 
 | Requirement | Prefer | Avoid |
 |-------------|--------|-------|
-| Block execution of `/tmp/evil` at exec time | LSM `bprm_check_security` or stable exec tracepoint | Bare `sys_execve` kprobe with path pointer only |
+| Block execution of `/tmp/evil` before exec completes | LSM `bprm_check_security` via `bpf_lsm` (Linux 5.7+) | `sched_process_exec` tracepoint (post-event: observe or kill-after only, not pre-block); bare `sys_execve` kprobe with path pointer only |
 | Kill cryptominer by binary name | kprobe/tracepoint on `sched_process_exec` with vetted args | Over-broad `Sigkill` on `sys_openat` |
 | Audit only | tracepoint + `Post` | `Sigkill` on noisy hooks |
 | Block connect to IP | kprobe `security_socket_connect` with BTF types | Userspace-only IP sets without kernel enforcement |
@@ -534,6 +534,23 @@ spec:
 ```
 
 ```bash
+cat <<'EOF' > lab-exec-observe.yaml
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: lab-exec-observe
+spec:
+  tracepoints:
+    - subsystem: sched
+      event: sched_process_exec
+      raw: true
+      args:
+        - index: 2
+          type: linux_binprm
+      selectors:
+        - matchActions:
+            - action: Post
+EOF
 kubectl apply -f lab-exec-observe.yaml
 kubectl run exec-probe --rm -it --restart=Never --image=busybox:1.36 -- /bin/true
 kubectl exec -n kube-system ds/tetragon -c tetragon -- tetra getevents -o compact | grep sched_process_exec | head


### PR DESCRIPTION
## Summary

Fixes two Class A learner-blocker defects in `module-1.2-ebpf-security-networking-deepdive.md` (Refs #1577).

## Defects fixed

| # | Line(s) | Issue | Fix |
|---|---------|-------|-----|
| 1 | ~272 | Hook table recommended a "stable exec tracepoint" to block execution at exec time; `sched_process_exec` fires after exec completes | Prefer `bpf_lsm` / `bprm_check_security` for pre-completion block; move `sched_process_exec` to Avoid column as observe/kill-after only |
| 2 | ~537 | `kubectl apply -f lab-exec-observe.yaml` with no prior step creating the manifest | Added `cat <<'EOF' > lab-exec-observe.yaml` heredoc immediately before `kubectl apply` |

## Sibling scan

- **`kubectl apply -f *.yaml`**: Only `lab-exec-observe.yaml` at line 537; no other `kubectl apply -f` occurrences in this module. No sibling lab manifest gaps.
- **Tracepoint vs pre-block conflation**: Grep for `sched_process_exec`, `tracepoint`, `bpf_lsm` — only line 272 conflated observation tracepoints with pre-event blocking; line 273 correctly describes kill-after on `sched_process_exec`. No additional edits.

## Test plan

- [x] `.venv/bin/python scripts/quality/verify_module.py` on touched module — passed
- [ ] Cross-family review (per project protocol)

## Learner check

> To ensure the operation is not completed, combine `Sigkill` with `Override`, or prefer **LSM hooks** (`file_open`, `bprm_check_security`) where the kernel evaluates policy on copied-in kernel objects **before** the syscall returns — stronger for true prevention than syscall kprobes alone.


Made with [Cursor](https://cursor.com)