### PR TITLE
chore(content): #1577 module 5.3-memory-management — 2 Class A defects fixed

### DIFF
--- a/src/content/docs/linux/operations/performance/module-5.3-memory-management.md
+++ b/src/content/docs/linux/operations/performance/module-5.3-memory-management.md
@@ -397,24 +397,24 @@ The phrase "BestEffort pods die first" is a simplification, but it is a useful o
 
 Container memory accounting can also surprise application teams because the limit is not just the language heap. Cgroup v2 tracks anonymous memory, file cache, kernel stack, slab usage, and events under the cgroup hierarchy. A process can appear below its heap target while the cgroup crosses the limit because file-backed cache or other charged memory grew inside the same boundary.
 
-```bash
+```text
 # cgroup v2 is the standard for modern Kubernetes 1.35+
 
 # cgroup memory stats
-cat /sys/fs/cgroup/kubepods.slice/kubepods-pod...slice/memory.stat
+Pattern: /sys/fs/cgroup/kubepods.slice/kubepods-pod<UID>.slice/memory.stat
 # anon 209715200       # Anonymous memory (heap, stack)
 # file 104857600       # Page cache
 # kernel_stack 36864
 # slab 165432
 
 # Current usage
-cat /sys/fs/cgroup/kubepods.slice/kubepods-pod...slice/memory.current
+Pattern: /sys/fs/cgroup/kubepods.slice/kubepods-pod<UID>.slice/memory.current
 
 # Limit
-cat /sys/fs/cgroup/kubepods.slice/kubepods-pod...slice/memory.max
+Pattern: /sys/fs/cgroup/kubepods.slice/kubepods-pod<UID>.slice/memory.max
 
 # OOM events
-cat /sys/fs/cgroup/kubepods.slice/kubepods-pod...slice/memory.events
+Pattern: /sys/fs/cgroup/kubepods.slice/kubepods-pod<UID>.slice/memory.events
 # oom 1
 # oom_kill 1
 ```
@@ -440,7 +440,7 @@ cat /proc/pressure/memory
 # Higher values = more pressure
 
 # Node conditions in Kubernetes
-k describe node | grep -A 5 Conditions
+kubectl describe node | grep -A 5 Conditions
 # MemoryPressure   False   # Becomes True under pressure
 ```
 
@@ -515,10 +515,10 @@ Container diagnosis adds one more layer because the pod status, kubelet events, 
 docker stats --no-stream
 
 # Kubernetes equivalent
-k top pod
+kubectl top pod
 
 # Check if container was OOM killed
-k describe pod <pod> | grep -A 10 "Last State"
+kubectl describe pod <pod> | grep -A 10 "Last State"
 # Reason:   OOMKilled
 
 # Increase memory limit or fix the application


### PR DESCRIPTION
Refs #1577.

## Defect 1: Runable `k` alias in ````bash` blocks without `alias k=kubectl`

Three `k <verb>` calls in fenced ````bash` blocks lacked the alias definition, so copy-paste fails for learners without a manual `alias k=kubectl`. Replaced with explicit `kubectl`.

| Line | Before | After |
|------|--------|-------|
| 443 | `k describe node \| grep -A 5 Conditions` | `kubectl describe node \| grep -A 5 Conditions` |
| 518 | `k top pod` | `kubectl top pod` |
| 521 | `k describe pod <pod> \| grep -A 10 "Last State"` | `kubectl describe pod <pod> \| grep -A 10 "Last State"` |

Lines 518 and 521 were sibling violations found during the required grep sweep.

## Defect 2: Ellipsis placeholder in ````bash` block

The ````bash` block at lines 404-420 used literal `kubepods-pod...slice` in `cat` commands — no real cgroup directory exists at that path. Demoted the fence to ````text` and rewrote all four paths as explicit `Pattern:` templates with `<UID>` placeholders.

| Line | Before | After |
|------|--------|-------|
| 404 | `cat /sys/fs/cgroup/kubepods.slice/kubepods-pod...slice/memory.stat` | `Pattern: /sys/fs/cgroup/kubepods.slice/kubepods-pod<UID>.slice/memory.stat` |
| 411 | `cat /sys/fs/cgroup/kubepods.slice/kubepods-pod...slice/memory.current` | `Pattern: /sys/fs/cgroup/kubepods.slice/kubepods-pod<UID>.slice/memory.current` |
| 414 | `cat /sys/fs/cgroup/kubepods.slice/kubepods-pod...slice/memory.max` | `Pattern: /sys/fs/cgroup/kubepods.slice/kubepods-pod<UID>.slice/memory.max` |
| 417 | `cat /sys/fs/cgroup/kubepods.slice/kubepods-pod...slice/memory.events` | `Pattern: /sys/fs/cgroup/kubepods.slice/kubepods-pod<UID>.slice/memory.events` |

Lines 411, 414, and 417 were sibling violations in the same fenced block.

## Verifier

```
median_wpp: 59.0 (≥ 28 ✓)
mean_wpp: 56.8 (≥ 30 ✓)
short_paragraph_rate: 0.011 (≤ 20% ✓)
runnable_no_kubectl_alias: true
kubectl_alias_violations: []
```

Density gates unchanged. Pre-existing `gate_no_source_h1` is out of scope (tracked at #1587).

## Learner check

> Cgroup v2 tracks anonymous memory, file cache, kernel stack, slab usage, and events under the cgroup hierarchy. A process can appear below its heap target while the cgroup crosses the limit because file-backed cache or other charged memory grew inside the same boundary.

This passage — immediately before the cgroup block fixed in Defect 2 — explains why reading `memory.stat`, `memory.current`, `memory.max`, and `memory.events` directly is essential: dashboards can hide the counters that the kernel actually enforces. The pattern notation keeps the pedagogical signal intact while removing the broken copy-paste path.