### PR TITLE
chore(content): #1577 module 7.4-observability — 2 Class A defects fixed

### DIFF
--- a/src/content/docs/on-premises/operations/module-7.4-observability.md
+++ b/src/content/docs/on-premises/operations/module-7.4-observability.md
@@ -145,10 +145,10 @@ processors:
     auth_type: serviceAccount
     extract:
       metadata:
-        - k8s.cluster.uid
         - k8s.namespace.name
         - k8s.pod.name
-        - k8s.container.name
+        - k8s.pod.uid
+        - k8s.node.name
   resource/no_egress_labels:
     attributes:
       - key: deployment.environment.name


### PR DESCRIPTION
Refs #1577

## Defects fixed
- **Lines 148, 151**: OTel Collector `k8sattributesprocessor` metadata block contained invalid attribute names `k8s.cluster.uid` and `k8s.container.name` — these are not extracted from pod metadata by the `k8sattributesprocessor`. Replaced with `k8s.pod.uid` and `k8s.node.name`, which are valid extracted attributes per the [k8sattributesprocessor README](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/k8sattributesprocessor/README.md).

## Learner check
> Silent telemetry loss is worse than a noisy failure because it creates false confidence during an incident.