### PR TITLE
chore(content): #1577 module 12.1-sonarqube — 2 Class A defects fixed

### DIFF
--- a/src/content/docs/platform/toolkits/security-quality/code-quality/module-12.1-sonarqube.md
+++ b/src/content/docs/platform/toolkits/security-quality/code-quality/module-12.1-sonarqube.md
@@ -298,7 +298,7 @@ sonar.exclusions=\
 
 ```bash
 # Example test command that creates the reports referenced above.
-.venv/bin/python -m pytest \
+python3 -m pytest \
   --junitxml=pytest-report.xml \
   --cov=src \
   --cov-report=xml:coverage.xml
@@ -1098,7 +1098,7 @@ This sample intentionally contains several findings: [command execution through 
 ### Part 3: Generate Test and Coverage Reports
 
 ```bash
-.venv/bin/python -m venv .venv
+python3 -m venv .venv
 .venv/bin/python -m pip install --upgrade pip
 .venv/bin/python -m pip install pytest pytest-cov
 


### PR DESCRIPTION
Refs #1577

Defects fixed:
- src/content/docs/platform/toolkits/security-quality/code-quality/module-12.1-sonarqube.md:line 301 — standalone example used `.venv/bin/python -m pytest` before `.venv` existed in that example block.
- src/content/docs/platform/toolkits/security-quality/code-quality/module-12.1-sonarqube.md:line 1101 — hands-on bootstrap used `.venv/bin/python -m venv .venv` before `.venv` existed.

## Learner check
> If you do not already have `.venv/bin/python` available in your environment, create the virtual environment exactly as shown above. The important learning point is that the scanner consumes `coverage.xml` and `pytest-report.xml`; it does not create those reports by itself.

Verification:
- `python /Users/krisztiankoos/projects/kubedojo/scripts/quality/verify_module.py src/content/docs/platform/toolkits/security-quality/code-quality/module-12.1-sonarqube.md` (fails only on pre-existing module issues: `source_h1_after_frontmatter`, `body_words_floor_met`, `sources_min_10`, unrelated to this fix)
