### PR TITLE
chore(content): #1577 module 5.4-fleet-management — PyYAML lab prerequisites

### DIFF
--- a/src/content/docs/on-premises/multi-cluster/module-5.4-fleet-management.md
+++ b/src/content/docs/on-premises/multi-cluster/module-5.4-fleet-management.md
@@ -558,6 +558,7 @@ spec:
   paths:
     - multi-cluster/helm
 EOF
+python3 -m pip install pyyaml
 python3 -c "import yaml; yaml.safe_load(open('/tmp/fleet-lab/gitrepo.yaml'))" && echo "GitRepo YAML OK"
 python3 -c "import yaml; yaml.safe_load(open('/tmp/fleet-lab/baseline/fleet.yaml'))" && echo "fleet.yaml OK"
 grep -E 'kind:|repo:|paths:' /tmp/fleet-lab/gitrepo.yaml
@@ -648,6 +649,7 @@ spec:
         server: '{{.server}}'
         namespace: '{{.app}}'
 EOF
+python3 -m pip install pyyaml
 python3 -c "import yaml; yaml.safe_load(open('/tmp/appset-lab/appset.yaml'))" && echo "ApplicationSet YAML OK"
 grep -c 'generators:' /tmp/appset-lab/appset.yaml
 grep 'matchLabels' /tmp/appset-lab/appset.yaml


### PR DESCRIPTION
## Summary

- Add `python3 -m pip install pyyaml` before local YAML validation in Exercise 2 (Fleet GitRepo) and Exercise 3 (ApplicationSet) so learners without PyYAML do not hit `ModuleNotFoundError`.
- Scoped to dependency-install only; no content rewrite (density gaps remain #1587).

Refs #1577

## Class A defects fixed

| Line(s) | Defect |
|---------|--------|
| 561–562 | Exercise 2: `python3 -c "import yaml; ..."` without PyYAML install step |
| 651 | Exercise 3: same undocumented `import yaml` dependency |

## Sibling import scan

```
grep -n 'import yaml\|import requests\|import boto3\|import kubernetes\|import jinja2\|import click' module-5.4-fleet-management.md
```

Only `import yaml` occurrences (lines 561–562, 651); no other third-party Python imports in this module.

## Test plan

- [x] `.venv/bin/python scripts/quality/verify_module.py src/content/docs/on-premises/multi-cluster/module-5.4-fleet-management.md` — passed

## Learner check

> You are ready to continue when you can compare push and pull fleet loops without notes and justify which fits a factory edge network with outbound-only firewalls.


Made with [Cursor](https://cursor.com)