### PR TITLE
chore(content): #1577 module 10-gitops-bridge — 2 Class A defects fixed

### DIFF
--- a/src/content/docs/prerequisites/git-deep-dive/module-10-gitops-bridge.md
+++ b/src/content/docs/prerequisites/git-deep-dive/module-10-gitops-bridge.md
@@ -379,9 +379,9 @@ The missing action is a reviewed change to the infrastructure repository that re
 </details>
 
 <details>
-<summary>2. A junior engineer accidentally creates a public NodePort Service during an incident. The Service is not declared in Git, pruning is enabled, and the GitOps operator is healthy. What should happen, and what should you verify afterward?</summary>
+<summary>2. A junior engineer accidentally creates a public NodePort Service during an incident. The Service is not declared in Git, was never managed by the GitOps operator, pruning is enabled, and the operator is healthy. What happens, and what should you do?</summary>
 
-The operator should delete the unmanaged Service during reconciliation because it does not exist in the desired state. Afterward, you should verify the operator event history, confirm no other public Service remains, and review why the engineer had permission to create it. The technical self-heal is useful, but the durable fix is tightening routine write access and documenting a safer incident path. GitOps corrects drift, while process changes reduce how often drift is introduced.
+The operator will not delete the Service. Pruning only removes resources that were previously managed by GitOps (tracked via owner labels or annotations) and whose declaration was subsequently deleted from Git — it does not touch objects GitOps never owned. You should manually delete the unmanaged Service, verify no other unowned public Service remains, and review why the engineer had permission to create it. The durable fix is tightening routine write access and documenting a safer incident path.
 
 </details>
 


### PR DESCRIPTION
Refs #1577

## Defects fixed

1. **Line 382 (quiz question setup):** The question stated "The Service is not declared in Git, pruning is enabled, and the GitOps operator is healthy. What should happen, and what should you verify afterward?" — implying pruning would act on an unmanaged Service. Fixed to clarify the Service was never managed by GitOps, and the question now asks what actually happens.

2. **Line 384 (quiz answer):** Claimed "The operator should delete the unmanaged Service during reconciliation because it does not exist in the desired state." This is factually wrong. Both Argo CD and Flux prune only resources that were previously managed (tracked by owner labels/annotations) and whose Git declaration was subsequently removed. Arbitrary unmanaged objects are never touched. Fixed to explain what pruning actually does and what it does not do.

## Sibling grep audit

- Line 315: "pruning removes live resources that were previously managed" — **correct**, no change needed.
- Line 368: "removed manifests should delete previously managed resources" — **correct**, no change needed.
- Line 231: `prune: true` — config snippet, no prose claim — ok.

## Verification

```
.venv/bin/python scripts/quality/verify_module.py src/content/docs/prerequisites/git-deep-dive/module-10-gitops-bridge.md
→ "passed": true, all density gates green
```

## Learner check

> The operator will not delete the Service. Pruning only removes resources that were previously managed by GitOps (tracked via owner labels or annotations) and whose declaration was subsequently deleted from Git — it does not touch objects GitOps never owned.