### PR TITLE
chore(content): #1577 final — rename neural-network-fundamentals → numpy-pandas-data-tooling

### DIFF
--- a/src/content/docs/ai-ml-engineering/deep-learning/index.md
+++ b/src/content/docs/ai-ml-engineering/deep-learning/index.md
@@ -11,7 +11,7 @@ sidebar:
 
 | # | Module |
 |---|--------|
-| 1.1 | [Neural Network Fundamentals](/ai-ml-engineering/deep-learning/module-1.1-neural-network-fundamentals/) |
+| 1.1 | [NumPy, Pandas & Data Tooling for ML](/ai-ml-engineering/deep-learning/module-1.1-numpy-pandas-data-tooling/) |
 | 1.2 | [PyTorch Fundamentals](/ai-ml-engineering/deep-learning/module-1.2-pytorch-fundamentals/) |
 | 1.3 | [Training Neural Networks](/ai-ml-engineering/deep-learning/module-1.3-training-neural-networks/) |
 | 1.4 | [CNNs & Computer Vision](/ai-ml-engineering/deep-learning/module-1.4-cnns-computer-vision/) |

--- a/src/content/docs/ai-ml-engineering/deep-learning/module-1.1-numpy-pandas-data-tooling.md
+++ b/src/content/docs/ai-ml-engineering/deep-learning/module-1.1-numpy-pandas-data-tooling.md
@@ -1,6 +1,6 @@
 ---
-title: "Neural Network Fundamentals"
-slug: ai-ml-engineering/deep-learning/module-1.1-neural-network-fundamentals
+title: "NumPy, Pandas & Data Tooling for ML"
+slug: ai-ml-engineering/deep-learning/module-1.1-numpy-pandas-data-tooling
 sidebar:
   order: 1002
 ---


### PR DESCRIPTION
## Summary

Closes the last open #1577 module by resolving the title/content scope mismatch on `module-1.1-neural-network-fundamentals.md`.

The module's body has always been a NumPy/pandas/matplotlib tutorial (Travis Oliphant / NumPy 1.0 history, DataFrame manipulation, matplotlib viz). Its title and path promised "Neural Network Fundamentals" — pure scope mismatch. Per user decision 2026-05-27 (Option A from session 60 interview): rename to match content, file a separate issue for a real Neural Network Fundamentals module to be authored fresh.

## Changes

- `git mv` module-1.1-neural-network-fundamentals.md → **module-1.1-numpy-pandas-data-tooling.md**
- Frontmatter `title`: "Neural Network Fundamentals" → **"NumPy, Pandas & Data Tooling for ML"**
- Frontmatter `slug`: updated to match new filename
- `index.md` row 1.1: label + URL updated

No other cross-references found. The deep-learning track now starts with the data-tooling prereq (1.1 NumPy/Pandas → 1.2 PyTorch → 1.3 Training Neural Networks → …), which is the natural pedagogical sequence.

## Follow-up

Issue filed separately for a real "Neural Network Fundamentals" module to be authored from scratch (T0 codex dispatch — forward/backward pass, weights, gradients, manual backprop). That module will likely become a new entry in the deep-learning track at a fresh slug; the section can grow rather than displace existing modules.

## Validation

- `npm run build` → 2127 pages, 36s, 0 errors
- `grep -rln 'neural-network-fundamentals' src/` → 0 remaining references
- Renamed file preserves 99% similarity (git rename detection confirmed)

## Learner check

> Modern ML software stacks rely heavily on array operations and numerical kernels descended from the scientific Python ecosystem.

## Test plan

- [x] Build is green
- [x] No stale cross-references
- [x] Index.md updated
- [x] Frontmatter slug + title match new filename
- [ ] Optional R1 (rename-only, no content edit — light review acceptable)

Closes #1577.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
