### PR TITLE
chore(content): #1602 fix — vault-eso/4.1 Class A security defects

### DIFF
--- a/src/content/docs/platform/toolkits/security-quality/security-tools/module-4.1-vault-eso.md
+++ b/src/content/docs/platform/toolkits/security-quality/security-tools/module-4.1-vault-eso.md
@@ -27,7 +27,6 @@ Hardcoded secrets in Git are a security incident waiting to happen. This module 
 
 After completing this module, you will be able to:
 
-- **Deploy HashiCorp Vault with auto-unseal and configure secret engines for Kubernetes workloads**
 - **Implement External Secrets Operator to sync Vault secrets into Kubernetes Secrets automatically**
 - **Configure Vault's Kubernetes authentication and dynamic secret generation for database credentials**
 - **Secure secret rotation workflows with zero-downtime deployment patterns using ESO refresh intervals**
@@ -37,7 +36,7 @@ After completing this module, you will be able to:
 
 Every production breach post-mortem includes "we found credentials in..." somewhere. Secrets sprawl is inevitable without proper tooling. Vault and ESO provide the infrastructure to manage secrets at scale—centralized storage, automatic rotation, audit trails, and least-privilege access.
 
-> 💡 **Did You Know?** HashiCorp Vault was open-sourced in 2015 and now manages secrets for most Fortune 500 companies. Its design philosophy of "secrets as a service" fundamentally changed how organizations think about credential management.
+> 💡 **Did You Know?** Vault has long been a core secrets platform in many enterprise environments. Its design philosophy of "secrets as a service" fundamentally changed how organizations think about credential lifecycle and access.
 
 ---
 
@@ -228,9 +227,12 @@ vault write auth/kubernetes/config \
 vault write auth/kubernetes/role/myapp \
   bound_service_account_names=myapp \
   bound_service_account_namespaces=production \
+  audiences=vault \
   policies=app-readonly \
   ttl=1h
 ```
+
+> **Note:** Vault 1.21+ validates token `aud` claims for Kubernetes auth roles. Ensure `audiences` matches the service account token audience claim (commonly `vault` in managed clusters).
 
 ---
 
@@ -347,11 +349,11 @@ spec:
   data:
   - secretKey: username         # Key in K8s Secret
     remoteRef:
-      key: secret/data/production/database
+      key: production/database
       property: username        # Key in Vault
   - secretKey: password
     remoteRef:
-      key: secret/data/production/database
+      key: production/database
       property: password
 ---
 # Sync entire secret (all keys)
@@ -368,7 +370,7 @@ spec:
     name: app-config
   dataFrom:
   - extract:
-      key: secret/data/production/app-config
+      key: production/app-config
 ---
 # Template the secret
 apiVersion: external-secrets.io/v1beta1
@@ -389,11 +391,11 @@ spec:
   data:
   - secretKey: username
     remoteRef:
-      key: secret/data/production/database
+      key: production/database
       property: username
   - secretKey: password
     remoteRef:
-      key: secret/data/production/database
+      key: production/database
       property: password
 ```
 
@@ -507,11 +509,11 @@ spec:
   data:
   - secretKey: tls.crt
     remoteRef:
-      key: secret/data/shared/certificates/wildcard
+      key: shared/certificates/wildcard
       property: certificate
   - secretKey: tls.key
     remoteRef:
-      key: secret/data/shared/certificates/wildcard
+      key: shared/certificates/wildcard
       property: private_key
 ```
 
@@ -541,9 +543,26 @@ vault write database/roles/app \
   max_ttl="24h"
 ```
 
-### ESO Refresh and Push
+### Dynamic rotation with VaultDynamicSecret
 
 ```yaml
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: VaultDynamicSecret
+metadata:
+  name: dynamic-db-credentials
+spec:
+  path: "/database/creds/app"
+  method: "GET"
+  resultType: "Auth"
+  provider:
+    server: "https://vault.example.com"
+    auth:
+      kubernetes:
+        mountPath: "kubernetes"
+        role: "external-secrets-operator"
+        serviceAccountRef:
+          name: "external-secrets"
+---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -557,16 +576,15 @@ spec:
     name: db-credentials
     creationPolicy: Owner
     deletionPolicy: Retain  # Keep secret if ExternalSecret deleted
-  data:
-  - secretKey: username
-    remoteRef:
-      key: database/creds/app  # Dynamic secret path
-      property: username
-  - secretKey: password
-    remoteRef:
-      key: database/creds/app
-      property: password
+  dataFrom:
+  - sourceRef:
+      generatorRef:
+        apiVersion: generators.external-secrets.io/v1alpha1
+        kind: VaultDynamicSecret
+        name: dynamic-db-credentials
 ```
+
+Use a static `ExternalSecret` with `refreshInterval` for KV secrets (example: `myapp/config` from Vault KV). For Vault dynamic engines such as database credentials, AWS STS, or PKI, use `VaultDynamicSecret` generators so new values are minted per secret engine semantics rather than merely polling a static key.
 
 ### Handling Rotation in Applications
 
@@ -614,7 +632,7 @@ helm install reloader stakater/reloader -n kube-system
 
 ## War Story: The Great Secret Migration
 
-*A team migrated 200+ Kubernetes Secrets to Vault+ESO over a weekend. Monday morning, half the apps were down.*
+*A platform team moved a large batch of Kubernetes Secrets to Vault+ESO during a staged migration. The transition initially caused partial outages because validation was rushed.*
 
 **What went wrong**: They deleted the old Kubernetes Secrets before verifying ESO had synced successfully. Several ExternalSecrets had typos in the `remoteRef.key` paths.
 
@@ -685,7 +703,7 @@ kubectl logs -n external-secrets -l app.kubernetes.io/name=external-secrets
 kubectl describe secretstore <store-name>
 
 # 4. Common causes:
-# - Wrong Vault path (secret/myapp vs secret/data/myapp for KV v2)
+# - Wrong remoteRef key path (use `myapp/config`, not `secret/myapp` or `secret/data/myapp`)
 # - Auth issues (service account, role binding)
 # - Network (can ESO reach Vault?)
 # - Policy (does Vault policy allow read?)
@@ -759,9 +777,9 @@ vault kv put secret/myapp/config \
        kind: SecretStore
      target:
        name: myapp-config
-     dataFrom:
-     - extract:
-         key: secret/data/myapp/config
+  dataFrom:
+  - extract:
+      key: myapp/config
    ```
 
 4. **Verify** the Kubernetes Secret was created:


### PR DESCRIPTION
## Summary

Fix-pass on issue #1602 — vault-eso/4.1 Class A security-critical defects from composer-2.5 R1 backfill review.

This module had **4 P1 security-critical defects** that would teach learners broken Vault + ESO patterns. All addressed.

## P1 fixes (4)

1. **ESO `secret/data` path anti-pattern removed** (KV v2 quirk taught wrong). Per [ESO docs](https://external-secrets.io/latest/provider/hashicorp-vault/), `remoteRef.key` must be the bare path (`myapp/config`), not the Vault HTTP-API form (`secret/data/myapp/config`). Wrong pattern means secrets don't sync.
   - Replaced 8 occurrences across the module:
     - `secret/data/production/database` → `production/database` (lines ~352, 356, 394, 398)
     - `secret/data/production/app-config` → `production/app-config` (line ~373)
     - `secret/data/shared/certificates/wildcard` → `shared/certificates/wildcard` (lines ~512, 516)
     - `secret/data/myapp/config` → `myapp/config` (Hands-On, line ~782)
   - Sister module `module-6.6-secrets-management-vault.md` uses the correct pattern (reference).

2. **Rotation example replaced with VaultDynamicSecret generator**. Static `ExternalSecret` + `refreshInterval` doesn't rotate dynamic engine credentials (DB, AWS STS, PKI). Per [ESO generator docs](https://external-secrets.io/latest/api/generator/vault/), dynamic engines need the `VaultDynamicSecret` CR + `sourceRef.generatorRef`. Added explicit distinction text: KV/static vs dynamic engines.

3. **K8s auth `audiences` field added** (Vault 1.21+ requirement). Per [Vault K8s auth docs](https://developer.hashicorp.com/vault/docs/auth/kubernetes), Vault 1.21+ validates the SA token's `aud` claim against the role's `audiences`. Added `audiences=vault` to the `vault write auth/kubernetes/role/myapp` example + explanatory note.

4. **Q3 path debugging answer corrected** — updated to reflect the correct ESO bare-path form.

## P2 (opportunistic, same commit)

- Removed undeployed `auto-unseal` from "What you'll be able to do" outcomes
- Softened "Fortune 500" oversell + tightened war story tone

## Sibling-grep

Per `feedback_class_a_fix_includes_sibling_grep`. Searched `security-quality/security-tools/*.md` for `remoteRef`/`extract` keys containing `secret/data` → **0 matches in other files**. Anti-pattern is isolated to this module.

## Validation

- `npm run build` → exit 0, 2127 pages, no build errors
- 8 incorrect `remoteRef.key` paths replaced with correct bare paths
- Rotation example now uses ESO's documented dynamic-secret pattern

## Learner check

> Every production breach post-mortem includes "we found credentials in..." somewhere. Secrets sprawl is inevitable without proper tooling. Vault and ESO provide the infrastructure to manage secrets at scale—centralized storage, automatic rotation, audit trails, and least-privilege access.

## Test plan

- [x] 4 P1 Class A security defects addressed
- [x] Sibling-grep clean across security-tools/
- [x] Build green
- [ ] R1 cross-family review (composer-2.5 per Decision Card C)

Closes #1602.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.7 orchestrating, codex authoring)
