### PR TITLE
feat(ab): send-codex-ui / send-cursor-ui / send-agy-ui — bridge into running Desktop sessions

### DIFF
--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -660,6 +660,114 @@ def _build_parser() -> argparse.ArgumentParser:
     # interactive
     subparsers.add_parser("interactive", help="Interactive mode")
 
+    # send-codex-ui — drives a running Codex Desktop UI session via
+    # `codex exec resume <UUID> --json -`. Port from learn-ukrainian #2285.
+    send_codex_ui_parser = subparsers.add_parser(
+        "send-codex-ui",
+        help="Send a prompt to a running Codex Desktop UI session via `codex exec resume`",
+    )
+    send_codex_ui_parser.add_argument(
+        "--thread", required=True,
+        help="Codex thread UUID (find via `codex sessions list --last` or ~/.codex/sessions/)",
+    )
+    send_codex_ui_parser.add_argument(
+        "--bridge-id", default=None,
+        help="Correlation id (auto-generated if not given)",
+    )
+    send_codex_ui_parser.add_argument(
+        "--cwd", default=None,
+        help="Working directory for the codex subprocess (default: caller's cwd)",
+    )
+    send_codex_ui_parser.add_argument(
+        "--timeout", type=int, default=1800,
+        help="Max wall-clock seconds (default 1800 = 30min)",
+    )
+    send_codex_ui_parser.add_argument(
+        "--from-file", default=None,
+        help="Read message body from a file (use '-' for stdin)",
+    )
+    send_codex_ui_parser.add_argument(
+        "--json", action="store_true",
+        help="Print result as compact JSON (excludes verbose events list)",
+    )
+    send_codex_ui_parser.add_argument(
+        "message", nargs="?",
+        help="Inline message text. Mutually exclusive with --from-file.",
+    )
+
+    # send-cursor-ui — Cursor Desktop bridge via `cursor-agent --resume`.
+    # New for kubedojo; learn-ukrainian deferred the cursor adapter in #2285.
+    send_cursor_ui_parser = subparsers.add_parser(
+        "send-cursor-ui",
+        help="Send a prompt to a running Cursor Desktop chat via `cursor-agent --resume`",
+    )
+    send_cursor_ui_parser.add_argument(
+        "--thread", default=None,
+        help="Cursor chat id. Omit or pass 'new' to create a fresh chat via `cursor-agent create-chat`",
+    )
+    send_cursor_ui_parser.add_argument(
+        "--bridge-id", default=None,
+        help="Correlation id (auto-generated if not given)",
+    )
+    send_cursor_ui_parser.add_argument(
+        "--cwd", default=None,
+        help="Working directory for the cursor-agent subprocess (default: caller's cwd)",
+    )
+    send_cursor_ui_parser.add_argument(
+        "--timeout", type=int, default=1800,
+        help="Max wall-clock seconds (default 1800 = 30min)",
+    )
+    send_cursor_ui_parser.add_argument(
+        "--model", default=None,
+        help="Model override (default composer-2.5 or $AB_CURSOR_UI_MODEL)",
+    )
+    send_cursor_ui_parser.add_argument(
+        "--from-file", default=None,
+        help="Read message body from a file (use '-' for stdin)",
+    )
+    send_cursor_ui_parser.add_argument(
+        "--json", action="store_true",
+        help="Print result as compact JSON (excludes verbose events list)",
+    )
+    send_cursor_ui_parser.add_argument(
+        "message", nargs="?",
+        help="Inline message text. Mutually exclusive with --from-file.",
+    )
+
+    # send-agy-ui — Antigravity UI bridge via `agy --conversation ... --print`.
+    send_agy_ui_parser = subparsers.add_parser(
+        "send-agy-ui",
+        help="Send a prompt to an Antigravity UI conversation via `agy --print`",
+    )
+    send_agy_ui_parser.add_argument(
+        "--thread", default=None,
+        help="Antigravity conversation id (omit or pass 'new' for a fresh conversation)",
+    )
+    send_agy_ui_parser.add_argument(
+        "--bridge-id", default=None,
+        help="Correlation id (auto-generated if not given)",
+    )
+    send_agy_ui_parser.add_argument(
+        "--cwd", default=None,
+        help="Working directory for the agy subprocess (default: caller's cwd)",
+    )
+    send_agy_ui_parser.add_argument(
+        "--timeout", type=int, default=1800,
+        help="Max wall-clock seconds (default 1800 = 30min)",
+    )
+    send_agy_ui_parser.add_argument(
+        "--from-file", default=None,
+        help="Read message body from a file (use '-' for stdin)",
+    )
+    send_agy_ui_parser.add_argument(
+        "--json", action="store_true",
+        help="Print result as compact JSON (excludes verbose events list)",
+    )
+    send_agy_ui_parser.add_argument(
+        "message", nargs="?",
+        help="Inline message text. Mutually exclusive with --from-file.",
+    )
+
     # Channel bridge commands (#1190) — registered in _channels_cli
     from ._channels_cli import register_channel_commands
     register_channel_commands(subparsers)
@@ -734,6 +842,60 @@ def _dispatch_command(args):
         bridge_status()
     elif args.command == "interactive":
         interactive_mode()
+    elif args.command == "send-codex-ui":
+        from ._ui_codex import cli_main as _ui_codex_cli_main
+        argv: list[str] = ["--thread", args.thread]
+        if args.bridge_id:
+            argv += ["--bridge-id", args.bridge_id]
+        if args.cwd:
+            argv += ["--cwd", args.cwd]
+        if args.timeout != 1800:
+            argv += ["--timeout", str(args.timeout)]
+        if getattr(args, "json", False):
+            argv += ["--json"]
+        if args.from_file:
+            argv += ["--from-file", args.from_file]
+        if args.message:
+            argv += [args.message]
+        sys.exit(_ui_codex_cli_main(argv))
+    elif args.command == "send-cursor-ui":
+        from ._ui_cursor import cli_main as _ui_cursor_cli_main
+        argv = []
+        if args.thread:
+            argv += ["--thread", args.thread]
+        if args.bridge_id:
+            argv += ["--bridge-id", args.bridge_id]
+        if args.cwd:
+            argv += ["--cwd", args.cwd]
+        if args.timeout != 1800:
+            argv += ["--timeout", str(args.timeout)]
+        if args.model:
+            argv += ["--model", args.model]
+        if getattr(args, "json", False):
+            argv += ["--json"]
+        if args.from_file:
+            argv += ["--from-file", args.from_file]
+        if args.message is not None:
+            argv += [args.message]
+        sys.exit(_ui_cursor_cli_main(argv))
+    elif args.command == "send-agy-ui":
+        from ._ui_agy import cli_main as _ui_agy_cli_main
+        argv = []
+        if args.thread:
+            argv += ["--thread", args.thread]
+        if args.bridge_id:
+            argv += ["--bridge-id", args.bridge_id]
+        if args.cwd:
+            argv += ["--cwd", args.cwd]
+        if args.timeout != 1800:
+            argv += ["--timeout", str(args.timeout)]
+        if getattr(args, "json", False):
+            argv += ["--json"]
+        if args.from_file:
+            argv += ["--from-file", args.from_file]
+        if args.message is not None:
+            argv += [args.message]
+        sys.exit(_ui_agy_cli_main(argv))
     elif args.command in ("channel", "post", "p", "sync", "discuss"):
         # Channel bridge commands (#1190)
         from ._channels_cli import dispatch_channel_command

--- a/scripts/ai_agent_bridge/_ui_agy.py
+++ b/scripts/ai_agent_bridge/_ui_agy.py
@@ -1,0 +1,405 @@
+"""Send a prompt to an Antigravity UI conversation via `agy --print`.
+
+Lane 2 implementation for the agent bridge: drive a persisted Antigravity
+(`agy`) conversation in the same orchestration shape as `send-codex-ui`.
+
+## How it works
+
+`agy --conversation <CONVERSATION_ID> --print "<message>"` resumes a
+persisted Antigravity conversation non-interactively. Unlike Codex, agy does
+not emit a JSON event stream on stdout in print mode. It prints plain text,
+then writes richer turn events to its local transcript files.
+
+The bridge runs agy in print mode, prefixes the prompt with a `Bridge-ID:`
+line for correlation, and returns a structured result. When the transcript is
+available, the final message is extracted from the latest
+`MODEL_RESPONSE`/`PLANNER_RESPONSE` event. Otherwise stdout is treated as the
+final message.
+
+## Empirical findings (2026-05-27 bridge probe)
+
+Commands run from this worktree:
+
+1. `agy --print-timeout 60s --print 'Reply with exactly: hello-from-agy-probe'`
+   returned plain stdout: `hello-from-agy-probe`.
+2. The invocation created conversation
+   `48fd721e-a259-438c-9eb9-53b0fd271c11` under
+   `~/.gemini/antigravity-cli/conversations/48fd721e-a259-438c-9eb9-53b0fd271c11.pb`.
+3. `~/.gemini/antigravity-cli/cache/last_conversations.json` maps the
+   worktree path to that conversation id.
+4. `agy --print-timeout 60s --conversation 48fd721e-a259-438c-9eb9-53b0fd271c11
+   --print 'Reply with exactly: resumed-agy-probe'` succeeded. The log line
+   said `Print mode: resuming conversation 48fd...`; stdout contained the
+   prior and current short replies, while the transcript JSONL contained the
+   latest `PLANNER_RESPONSE` content `resumed-agy-probe`.
+5. Turn transcripts are written at
+   `~/.gemini/antigravity-cli/brain/<conversation-id>/.system_generated/logs/transcript.jsonl`.
+
+## Usage from CLI
+
+    ab send-agy-ui --thread <CONVERSATION-ID> "your message"
+    ab send-agy-ui --thread <CONVERSATION-ID> --from-file relay.md
+    ab send-agy-ui --cwd ~/some/worktree --from-file relay.md --json
+
+Omit `--thread`, or pass `--thread new`, to start a fresh conversation. The
+result's `thread_id` is then parsed from the agy log file.
+
+## Usage from Python
+
+    from ai_agent_bridge._ui_agy import send
+    result = send(thread_id="48fd721e-...", message="ping", cwd=Path("/tmp"))
+    print(result["final_message"])
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+AGY_APP_DATA_ROOT = Path.home() / ".gemini" / "antigravity-cli"
+AGY_CONVERSATIONS_ROOT = AGY_APP_DATA_ROOT / "conversations"
+DEFAULT_TIMEOUT_S = 1800  # 30 min - covers most multi-turn dispatches
+
+_AGY_CONVERSATION_RE = re.compile(
+    r"\b(?:conversation=|Created conversation\s+|resuming conversation\s+)"
+    r"(?P<id>[0-9a-fA-F-]{36})\b",
+    re.IGNORECASE,
+)
+_NEW_THREAD_SENTINELS = {"", "-", "new", "fresh", "none", "null"}
+
+
+def find_session_file(thread_id: str) -> Path | None:
+    """Locate Antigravity's persisted conversation protobuf for *thread_id*."""
+    if not thread_id:
+        return None
+    exact = AGY_CONVERSATIONS_ROOT / f"{thread_id}.pb"
+    if exact.exists():
+        return exact
+    matches = sorted(
+        AGY_CONVERSATIONS_ROOT.glob(f"*{thread_id}*.pb"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    return matches[0] if matches else None
+
+
+def _transcript_file(thread_id: str | None) -> Path | None:
+    if not thread_id:
+        return None
+    path = (
+        AGY_APP_DATA_ROOT
+        / "brain"
+        / thread_id
+        / ".system_generated"
+        / "logs"
+        / "transcript.jsonl"
+    )
+    return path if path.exists() else None
+
+
+def _read_transcript_events(thread_id: str | None) -> list[dict]:
+    transcript = _transcript_file(thread_id)
+    if transcript is None:
+        return []
+
+    events: list[dict] = []
+    try:
+        lines = transcript.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(event, dict):
+            events.append(event)
+    return events
+
+
+def _parse_stdout_events(stdout: str) -> list[dict]:
+    """Parse stdout JSON lines, or wrap plain print-mode stdout as one event."""
+    events: list[dict] = []
+    saw_json = False
+    for line in stdout.splitlines():
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(event, dict):
+            events.append(event)
+            saw_json = True
+
+    if saw_json:
+        return events
+
+    text = stdout.strip()
+    if not text:
+        return []
+    return [{"type": "stdout_text", "content": text}]
+
+
+def _extract_final_message(events: list[dict]) -> str | None:
+    """Pick the last informative model message from agy or fallback events."""
+    final_content: str | None = None
+
+    for evt in events:
+        event_type = evt.get("type")
+        content = evt.get("content")
+        if event_type in {"MODEL_RESPONSE", "PLANNER_RESPONSE", "stdout_text"}:
+            if isinstance(content, str) and content.strip():
+                final_content = content.strip()
+            continue
+
+        # Keep this fallback compatible with Codex-style synthetic tests and
+        # future agy JSON stream shapes.
+        if event_type == "item.completed":
+            item = evt.get("item", {})
+            item_type = item.get("type")
+            if item_type == "agent_message":
+                text = item.get("text") or item.get("content")
+                if isinstance(text, str) and text.strip():
+                    final_content = text.strip()
+            elif item_type == "command_execution":
+                output = item.get("aggregated_output")
+                if isinstance(output, str) and output.strip():
+                    final_content = output.strip()
+
+    return final_content
+
+
+def _thread_arg_is_new(thread_id: str | None) -> bool:
+    return thread_id is None or thread_id.strip().lower() in _NEW_THREAD_SENTINELS
+
+
+def _conversation_id_from_log(log_file: Path) -> str | None:
+    latest: str | None = None
+    try:
+        with log_file.open(encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                match = _AGY_CONVERSATION_RE.search(line)
+                if match:
+                    latest = match.group("id")
+    except OSError:
+        return None
+    return latest
+
+
+def _decode_timeout_text(value: str | bytes | None) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value or ""
+
+
+def send(
+    thread_id: str | None,
+    message: str,
+    *,
+    bridge_id: str | None = None,
+    cwd: Path | None = None,
+    timeout_s: int = DEFAULT_TIMEOUT_S,
+) -> dict:
+    """Send a prompt to an Antigravity UI conversation via `agy --print`.
+
+    Args:
+        thread_id: Antigravity conversation id. Pass None, "", "-", or
+            "new" to start a fresh conversation.
+        message: prompt body. A `Bridge-ID: <id>` line is prepended for
+            correlation; the receiving agent should echo the Bridge-ID in
+            its reply if asked.
+        bridge_id: correlation id (auto-generated if None).
+        cwd: working directory for the agy subprocess. If None, inherits
+            the caller's cwd. Agy chooses workspace context from this cwd.
+        timeout_s: max wall-clock for the agy subprocess (default 30 min).
+
+    Returns:
+        dict with:
+            bridge_id (str), thread_id (str | None), exit_code (int),
+            events (list[dict] parsed from agy transcript/stdout),
+            final_message (str | None), duration_s (float),
+            session_file (str | None) for the conversation protobuf,
+            stderr (str).
+    """
+    bridge_id = bridge_id or f"bridge-{uuid.uuid4().hex[:8]}"
+    framed_message = f"Bridge-ID: {bridge_id}\n\n{message}"
+    requested_thread_id = None if _thread_arg_is_new(thread_id) else thread_id
+    session_file = find_session_file(requested_thread_id or "")
+    preexisting_transcript_count = (
+        len(_read_transcript_events(requested_thread_id)) if requested_thread_id else 0
+    )
+
+    log_path = Path(tempfile.gettempdir()) / f"agy-ui-bridge-{bridge_id}.log"
+    cmd = [
+        "agy",
+        "--print-timeout",
+        f"{timeout_s}s",
+        "--dangerously-skip-permissions",
+        "--log-file",
+        str(log_path),
+    ]
+    if requested_thread_id:
+        cmd += ["--conversation", requested_thread_id]
+    cmd += ["--print", framed_message]
+
+    start = datetime.now(UTC)
+    try:
+        try:
+            proc = subprocess.run(
+                cmd,
+                cwd=str(cwd) if cwd else None,
+                capture_output=True,
+                text=True,
+                timeout=timeout_s,
+                check=False,
+            )
+            stdout = proc.stdout
+            stderr = proc.stderr
+            exit_code = proc.returncode
+        except subprocess.TimeoutExpired as e:
+            stdout = _decode_timeout_text(e.stdout)
+            stderr = f"[timeout after {timeout_s}s]\n{_decode_timeout_text(e.stderr)}"
+            exit_code = -1
+        duration_s = (datetime.now(UTC) - start).total_seconds()
+
+        resolved_thread_id = requested_thread_id or _conversation_id_from_log(log_path)
+        if resolved_thread_id and session_file is None:
+            session_file = find_session_file(resolved_thread_id)
+
+        stdout_events = _parse_stdout_events(stdout)
+        all_transcript_events = _read_transcript_events(resolved_thread_id)
+        if requested_thread_id and resolved_thread_id == requested_thread_id:
+            transcript_events = all_transcript_events[preexisting_transcript_count:]
+        else:
+            transcript_events = all_transcript_events
+        events = transcript_events or stdout_events
+        final_message = _extract_final_message(events) or _extract_final_message(stdout_events)
+
+        return {
+            "bridge_id": bridge_id,
+            "thread_id": resolved_thread_id,
+            "exit_code": exit_code,
+            "events": events,
+            "final_message": final_message,
+            "duration_s": duration_s,
+            "session_file": str(session_file) if session_file else None,
+            "stderr": stderr,
+        }
+    finally:
+        with contextlib.suppress(OSError):
+            log_path.unlink()
+
+
+def cli_main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="ab send-agy-ui",
+        description=(
+            "Send a prompt to an Antigravity UI conversation via "
+            "`agy --conversation ... --print`. Returns the agy subprocess "
+            "exit code."
+        ),
+    )
+    parser.add_argument(
+        "--thread",
+        default=None,
+        help=(
+            "Antigravity conversation id. Omit or pass 'new' to start a "
+            "fresh conversation."
+        ),
+    )
+    parser.add_argument(
+        "--bridge-id",
+        default=None,
+        help="Correlation id (auto-generated if not given).",
+    )
+    parser.add_argument(
+        "--cwd",
+        type=Path,
+        default=None,
+        help=(
+            "Working directory for the agy subprocess. Agy will choose "
+            "workspace context from this cwd."
+        ),
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=DEFAULT_TIMEOUT_S,
+        help=f"Max wall-clock seconds (default {DEFAULT_TIMEOUT_S}).",
+    )
+    parser.add_argument(
+        "--from-file",
+        type=Path,
+        default=None,
+        help="Read message body from a file (use '-' for stdin).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print result as compact JSON (excludes the verbose events list).",
+    )
+    parser.add_argument(
+        "message",
+        nargs="?",
+        help="Inline message text. Mutually exclusive with --from-file.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.from_file and args.message:
+        parser.error("provide either --from-file or a positional message, not both")
+    if args.from_file:
+        message = (
+            sys.stdin.read()
+            if str(args.from_file) == "-"
+            else args.from_file.read_text(encoding="utf-8")
+        )
+    elif args.message is not None:
+        message = args.message
+    else:
+        parser.error("must provide a message via positional arg or --from-file")
+
+    result = send(
+        thread_id=args.thread,
+        message=message,
+        bridge_id=args.bridge_id,
+        cwd=args.cwd,
+        timeout_s=args.timeout,
+    )
+
+    if args.json:
+        compact = {k: v for k, v in result.items() if k != "events"}
+        compact["event_count"] = len(result["events"])
+        print(json.dumps(compact, indent=2, default=str))
+    else:
+        print(f"thread:       {result['thread_id']}")
+        print(f"bridge_id:    {result['bridge_id']}")
+        print(f"exit_code:    {result['exit_code']}")
+        print(f"duration_s:   {result['duration_s']:.2f}")
+        print(f"events:       {len(result['events'])}")
+        print(f"session_file: {result['session_file']}")
+        if result["final_message"]:
+            print()
+            print("=== final message ===")
+            print(result["final_message"])
+        if result["stderr"]:
+            print()
+            print("=== stderr (truncated) ===")
+            print(result["stderr"][:2000])
+
+    return 0 if result["exit_code"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(cli_main())

--- a/scripts/ai_agent_bridge/_ui_codex.py
+++ b/scripts/ai_agent_bridge/_ui_codex.py
@@ -1,0 +1,279 @@
+"""Send a prompt to a running Codex Desktop UI session via `codex exec resume`.
+
+Lane 1 implementation from issue #2285 (agent bridge — send + receive to
+running Codex UI / Cursor / Claude Code Desktop sessions).
+
+## How it works
+
+`codex exec resume <THREAD_UUID> --json -` (Codex CLI 0.133.0+) resumes a
+persisted thread non-interactively. The subprocess emits a JSON event stream
+on stdout containing turn events, item executions, and the agent's final
+message. We feed the prompt via stdin (prefixed with a `Bridge-ID:` line for
+correlation), then parse the stream.
+
+## Empirical findings (2026-05-25 bridge probe)
+
+The probe ran `codex exec resume 019e6063-... --json -` with a small prompt,
+targeting a thread that the Codex Desktop process held open for write.
+Observed behavior:
+
+1. The original session JSONL grew (codex APPENDED events). The live UI
+   process (PID 83697) and the resume subprocess BOTH wrote to the same
+   rollout file. The thread state is consistent on disk regardless of
+   which subprocess produced an event.
+2. A NEW parallel rollout JSONL was ALSO created (new UUID, sharing thread
+   history). This is harmless overhead — both files reflect the same turn.
+3. The resume subprocess inherits the caller's CWD. Codex executed
+   `git rev-parse --short HEAD` and saw the caller's commit SHA, NOT the
+   UI session's worktree HEAD. Callers wanting the work to happen in a
+   specific worktree must `cd` there before invoking (or use `cwd=` here).
+4. Whether the visible Codex Desktop window displays the new turn live is
+   not verified here. The thread state is consistent on disk — re-opening
+   the same thread in the UI shows the appended events regardless.
+
+## Usage from CLI
+
+    ab send-codex-ui --thread <UUID> "your message"
+    ab send-codex-ui --thread <UUID> --from-file relay.md
+    ab send-codex-ui --thread <UUID> --cwd ~/some/worktree "message"
+
+## Usage from Python
+
+    from ai_agent_bridge._ui_codex import send
+    result = send(thread_id="019e6063-...", message="ping", cwd=Path("/tmp"))
+    print(result["final_message"])
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+CODEX_SESSIONS_ROOT = Path.home() / ".codex" / "sessions"
+DEFAULT_TIMEOUT_S = 1800  # 30 min — covers most multi-turn dispatches
+
+
+def find_session_file(thread_id: str) -> Path | None:
+    """Locate the most recent rollout JSONL for a given thread UUID.
+
+    Codex stores session JSONLs as
+    `~/.codex/sessions/YYYY/MM/DD/rollout-<timestamp>-<UUID>.jsonl`. The
+    `<UUID>` segment matches the thread id. There may be multiple files
+    per thread when `codex exec resume` has been invoked previously; we
+    return the most recently modified.
+    """
+    matches = sorted(
+        CODEX_SESSIONS_ROOT.glob(f"**/rollout-*{thread_id}.jsonl"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    return matches[0] if matches else None
+
+
+def _extract_final_message(events: list[dict]) -> str | None:
+    """Pick the last informative message from a stream of resume events.
+
+    Prefer the last `agent_message` content. Fall back to the last
+    completed `command_execution`'s aggregated_output if no agent_message
+    fired (e.g. when the prompt asked codex to print a shell line directly).
+    """
+    final_agent_msg: str | None = None
+    final_cmd_output: str | None = None
+    for evt in events:
+        if evt.get("type") != "item.completed":
+            continue
+        item = evt.get("item", {})
+        item_type = item.get("type")
+        if item_type == "agent_message":
+            final_agent_msg = item.get("text") or item.get("content")
+        elif item_type == "command_execution":
+            final_cmd_output = item.get("aggregated_output")
+    return final_agent_msg or final_cmd_output
+
+
+def send(
+    thread_id: str,
+    message: str,
+    *,
+    bridge_id: str | None = None,
+    cwd: Path | None = None,
+    timeout_s: int = DEFAULT_TIMEOUT_S,
+) -> dict:
+    """Send a prompt to a running Codex Desktop UI session via `codex exec resume`.
+
+    Args:
+        thread_id: UUID of the persisted codex thread (find via
+            `codex sessions list` or by inspecting `~/.codex/sessions/`
+            for a rollout JSONL whose codex process holds it open for write).
+        message: prompt body. A `Bridge-ID: <id>` line is prepended for
+            correlation; the receiving agent should echo the Bridge-ID
+            in its reply if asked.
+        bridge_id: correlation id (auto-generated if None).
+        cwd: working directory for the codex subprocess. If None, inherits
+            the caller's cwd. Codex will run shell commands against this
+            directory's git state — important when targeting a worktree.
+        timeout_s: max wall-clock for the codex subprocess (default 30 min).
+
+    Returns:
+        dict with:
+            bridge_id (str), thread_id (str), exit_code (int),
+            events (list[dict] of parsed JSON event lines from stdout),
+            final_message (str | None) — best-effort extraction,
+            duration_s (float), session_file (str | None) — path to the
+            original UI session JSONL if locatable, stderr (str).
+    """
+    bridge_id = bridge_id or f"bridge-{uuid.uuid4().hex[:8]}"
+    framed_message = f"Bridge-ID: {bridge_id}\n\n{message}"
+    session_file = find_session_file(thread_id)
+
+    start = datetime.now(UTC)
+    try:
+        proc = subprocess.run(
+            ["codex", "exec", "resume", "--json", thread_id, "-"],
+            input=framed_message,
+            cwd=str(cwd) if cwd else None,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+        stdout = proc.stdout
+        stderr = proc.stderr
+        exit_code = proc.returncode
+    except subprocess.TimeoutExpired as e:
+        stdout = e.stdout.decode("utf-8", errors="replace") if isinstance(e.stdout, bytes) else (e.stdout or "")
+        stderr = e.stderr.decode("utf-8", errors="replace") if isinstance(e.stderr, bytes) else (e.stderr or "")
+        stderr = f"[timeout after {timeout_s}s]\n{stderr}"
+        exit_code = -1
+    duration_s = (datetime.now(UTC) - start).total_seconds()
+
+    events: list[dict] = []
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            events.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+    return {
+        "bridge_id": bridge_id,
+        "thread_id": thread_id,
+        "exit_code": exit_code,
+        "events": events,
+        "final_message": _extract_final_message(events),
+        "duration_s": duration_s,
+        "session_file": str(session_file) if session_file else None,
+        "stderr": stderr,
+    }
+
+
+def cli_main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="ab send-codex-ui",
+        description=(
+            "Send a prompt to a running Codex Desktop UI session via "
+            "`codex exec resume`. Lane 1 from issue #2285. "
+            "Returns the codex subprocess exit code."
+        ),
+    )
+    parser.add_argument(
+        "--thread",
+        required=True,
+        help=(
+            "Codex thread UUID. Find via `codex sessions list --last` or "
+            "by inspecting `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`"
+            " (the file whose codex process holds it open for write)."
+        ),
+    )
+    parser.add_argument(
+        "--bridge-id",
+        default=None,
+        help="Correlation id (auto-generated if not given).",
+    )
+    parser.add_argument(
+        "--cwd",
+        type=Path,
+        default=None,
+        help=(
+            "Working directory for the codex subprocess. Codex will run "
+            "shell commands against this directory's git state — point it "
+            "at the target worktree when relevant."
+        ),
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=DEFAULT_TIMEOUT_S,
+        help=f"Max wall-clock seconds (default {DEFAULT_TIMEOUT_S}).",
+    )
+    parser.add_argument(
+        "--from-file",
+        type=Path,
+        default=None,
+        help="Read message body from a file (use '-' for stdin).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print result as compact JSON (excludes the verbose events list).",
+    )
+    parser.add_argument(
+        "message",
+        nargs="?",
+        help="Inline message text. Mutually exclusive with --from-file.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.from_file and args.message:
+        parser.error("provide either --from-file or a positional message, not both")
+    if args.from_file:
+        message = (
+            sys.stdin.read()
+            if str(args.from_file) == "-"
+            else args.from_file.read_text(encoding="utf-8")
+        )
+    elif args.message:
+        message = args.message
+    else:
+        parser.error("must provide a message via positional arg or --from-file")
+
+    result = send(
+        thread_id=args.thread,
+        message=message,
+        bridge_id=args.bridge_id,
+        cwd=args.cwd,
+        timeout_s=args.timeout,
+    )
+
+    if args.json:
+        compact = {k: v for k, v in result.items() if k != "events"}
+        compact["event_count"] = len(result["events"])
+        print(json.dumps(compact, indent=2, default=str))
+    else:
+        print(f"thread:       {result['thread_id']}")
+        print(f"bridge_id:    {result['bridge_id']}")
+        print(f"exit_code:    {result['exit_code']}")
+        print(f"duration_s:   {result['duration_s']:.2f}")
+        print(f"events:       {len(result['events'])}")
+        print(f"session_file: {result['session_file']}")
+        if result["final_message"]:
+            print()
+            print("=== final message ===")
+            print(result["final_message"])
+        if result["stderr"]:
+            print()
+            print("=== stderr (truncated) ===")
+            print(result["stderr"][:2000])
+
+    return 0 if result["exit_code"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(cli_main())

--- a/scripts/ai_agent_bridge/_ui_cursor.py
+++ b/scripts/ai_agent_bridge/_ui_cursor.py
@@ -32,6 +32,29 @@ cursor-agent saw at create-chat time. Pass `--cwd <repo-root>` to keep all
 bridge chats in the same workspace; otherwise a chat may end up bifurcated
 across multiple workspace_hash directories.
 
+## Scope: agent-routing only, NOT visible-Composer driving
+
+Verified 2026-05-27 (inverse-direction probe against IDE Composer chat
+`88876106-8229-4fc3-86cf-7a67c80756f7`): cursor-agent --resume against
+an IDE Composer chat id forks a parallel headless agent run that writes
+to the transcript surface. The IDE Composer pane is NOT driven.
+
+Use this bridge for:
+- Agent-to-agent orchestration (Claude / codex / gemini → composer-2.5)
+- Durable work products that another agent (or grep / bridge polling)
+  picks up from the agent-transcripts JSONL.
+
+Do NOT use it for:
+- "Drive the user's open Composer chat from the orchestrator." The CLI
+  cannot reach the IDE Composer's cloud-backed state even when given
+  the IDE-visible chat id.
+
+Cursor's own `cursor-app-control` MCP exposes workspace/environment
+steering (move_agent_to_root, open_resource, rename_chat) but no
+"send to active Composer" tool. AppleScript paste (Lane 2 from
+learn-ukrainian #2285) is the only known path to drive visible
+Composer, and it is out of scope here.
+
 ## Event shape (empirical, cursor-agent 2026.05.x)
 
     {"type":"system","subtype":"init","session_id":"...","model":"Composer 2.5", ...}

--- a/scripts/ai_agent_bridge/_ui_cursor.py
+++ b/scripts/ai_agent_bridge/_ui_cursor.py
@@ -1,0 +1,376 @@
+"""Send a prompt to a running Cursor Desktop chat session via `cursor-agent --resume`.
+
+Sibling of `_ui_codex.py` / `_ui_agy.py`: mirrors the design from issue #2285
+(agent bridge — send + receive to running Desktop sessions) but targets the
+Cursor Desktop family of "agentic" sessions (Composer, Auto mode, etc.).
+
+## How it works
+
+`cursor-agent --resume <CHAT_ID> --print --output-format stream-json --trust
+--force "<message>"` resumes a persisted Cursor chat non-interactively. The
+subprocess emits a JSON event stream on stdout containing init, user/assistant
+turn events, optional `thinking/delta` chunks, and a terminal `result` event.
+
+When `--thread new` (or omitted) is passed, we first call `cursor-agent
+create-chat`, capture the new chat id from stdout, and resume into it. This
+keeps the orchestration shape identical to Codex/Agy.
+
+The same chat id is the directory name under `~/.cursor/chats/<workspace>/
+<CHAT_ID>/store.db`, which we surface as `session_file` so callers can verify
+the session landed on disk regardless of whether the Cursor Desktop window
+displays the new turn live (an open question — see issue #2285).
+
+## Event shape (empirical, cursor-agent 2026.05.x)
+
+    {"type":"system","subtype":"init","session_id":"...","model":"Composer 2.5", ...}
+    {"type":"user","message":{"role":"user","content":[{"type":"text","text":"..."}]}, ...}
+    {"type":"thinking","subtype":"delta","text":"...","session_id":"...","timestamp_ms":...}
+    {"type":"thinking","subtype":"completed", ...}
+    {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"..."}]}, ...}
+    {"type":"result","subtype":"success","duration_ms":...,"result":"<final text>",
+     "session_id":"...","usage":{...}}
+
+The terminal event is `result` with `subtype` in {success, error}. The
+`result` field carries the final assistant text directly — preferred over
+concatenating `assistant` message chunks.
+
+## Usage from CLI
+
+    ab send-cursor-ui --thread <CHAT_ID> "your message"
+    ab send-cursor-ui --thread new --from-file relay.md       # creates a fresh chat
+    ab send-cursor-ui --thread <CHAT_ID> --cwd ~/some/worktree "message"
+    ab send-cursor-ui --thread <CHAT_ID> --model gpt-5 "..."  # override model
+
+## Usage from Python
+
+    from ai_agent_bridge._ui_cursor import send
+    result = send(thread_id="705e5125-...", message="ping", cwd=Path("/tmp"))
+    print(result["final_message"])
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+CURSOR_CHATS_ROOT = Path.home() / ".cursor" / "chats"
+DEFAULT_TIMEOUT_S = 1800  # 30 min — covers most multi-turn dispatches
+DEFAULT_MODEL = os.environ.get("AB_CURSOR_UI_MODEL", "composer-2.5")
+_NEW_THREAD_SENTINELS = {"", "-", "new", "fresh", "none", "null"}
+
+
+def _cursor_binary() -> str:
+    """Resolve the cursor-agent executable (or the legacy `agent` alias)."""
+    return (
+        os.environ.get("KUBEDOJO_CURSOR_CMD")
+        or shutil.which("cursor-agent")
+        or shutil.which("agent")
+        or "cursor-agent"
+    )
+
+
+def find_session_file(thread_id: str) -> Path | None:
+    """Locate the cursor chat store.db for a given chat id.
+
+    Cursor stores per-chat state at
+    `~/.cursor/chats/<workspace_hash>/<CHAT_ID>/store.db`. There is exactly
+    one such directory per chat across all workspaces.
+    """
+    if not thread_id:
+        return None
+    matches = sorted(
+        CURSOR_CHATS_ROOT.glob(f"*/{thread_id}/store.db"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    return matches[0] if matches else None
+
+
+def _thread_arg_is_new(thread_id: str | None) -> bool:
+    return thread_id is None or thread_id.strip().lower() in _NEW_THREAD_SENTINELS
+
+
+def _create_chat(cwd: Path | None) -> str:
+    """Spawn `cursor-agent create-chat` and return the new chat UUID."""
+    proc = subprocess.run(
+        [_cursor_binary(), "create-chat"],
+        cwd=str(cwd) if cwd else None,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"cursor-agent create-chat exited {proc.returncode}: "
+            f"{proc.stderr.strip()[-500:]}"
+        )
+    chat_id = proc.stdout.strip().splitlines()[-1].strip() if proc.stdout else ""
+    if not chat_id:
+        raise RuntimeError("cursor-agent create-chat returned empty chat id")
+    return chat_id
+
+
+def _extract_final_message(events: list[dict]) -> str | None:
+    """Pick the final assistant message from a stream-json event list.
+
+    Prefer the terminal `result/success` event's `result` field. Fall back to
+    concatenating the last `assistant` message's text content blocks.
+    """
+    final_result: str | None = None
+    final_assistant: str | None = None
+    for evt in events:
+        if not isinstance(evt, dict):
+            continue
+        etype = evt.get("type")
+        if etype == "result":
+            val = evt.get("result")
+            if isinstance(val, str) and val.strip():
+                final_result = val
+        elif etype == "assistant":
+            msg = evt.get("message") or {}
+            content = msg.get("content") if isinstance(msg, dict) else None
+            if isinstance(content, list):
+                parts = [
+                    blk.get("text", "")
+                    for blk in content
+                    if isinstance(blk, dict) and blk.get("type") == "text"
+                ]
+                text = "".join(parts).strip()
+                if text:
+                    final_assistant = text
+    return final_result or final_assistant
+
+
+def send(
+    thread_id: str | None,
+    message: str,
+    *,
+    bridge_id: str | None = None,
+    cwd: Path | None = None,
+    timeout_s: int = DEFAULT_TIMEOUT_S,
+    model: str | None = None,
+) -> dict:
+    """Send a prompt to a running Cursor Desktop chat via `cursor-agent --resume`.
+
+    Args:
+        thread_id: Cursor chat id (UUID). Pass None, "", "-", or "new" to
+            spawn a fresh chat first via `cursor-agent create-chat`.
+        message: prompt body. A `Bridge-ID: <id>` line is prepended for
+            correlation; the receiving agent should echo the Bridge-ID in
+            its reply if asked.
+        bridge_id: correlation id (auto-generated if None).
+        cwd: working directory for the cursor-agent subprocess. cursor-agent
+            chooses workspace context from this cwd — point it at the target
+            worktree when relevant.
+        timeout_s: max wall-clock for the cursor-agent subprocess.
+        model: override the model (default `composer-2.5`, or
+            `$AB_CURSOR_UI_MODEL`).
+
+    Returns:
+        dict with:
+            bridge_id (str), thread_id (str | None), exit_code (int),
+            events (list[dict] parsed from stream-json stdout),
+            final_message (str | None), duration_s (float),
+            session_file (str | None) for `store.db`, stderr (str).
+    """
+    bridge_id = bridge_id or f"bridge-{uuid.uuid4().hex[:8]}"
+    framed_message = f"Bridge-ID: {bridge_id}\n\n{message}"
+    effective_model = model or DEFAULT_MODEL
+
+    resolved_thread_id: str | None = thread_id
+    if _thread_arg_is_new(thread_id):
+        try:
+            resolved_thread_id = _create_chat(cwd)
+        except (RuntimeError, subprocess.TimeoutExpired, OSError) as exc:
+            return {
+                "bridge_id": bridge_id,
+                "thread_id": None,
+                "exit_code": -1,
+                "events": [],
+                "final_message": None,
+                "duration_s": 0.0,
+                "session_file": None,
+                "stderr": f"create-chat failed: {exc}",
+            }
+
+    session_file = find_session_file(resolved_thread_id or "")
+
+    cmd = [
+        _cursor_binary(),
+        "--resume",
+        resolved_thread_id or "",
+        "--print",
+        "--output-format",
+        "stream-json",
+        "--trust",
+        "--force",
+        "--model",
+        effective_model,
+        framed_message,
+    ]
+
+    start = datetime.now(UTC)
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=str(cwd) if cwd else None,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+        stdout = proc.stdout
+        stderr = proc.stderr
+        exit_code = proc.returncode
+    except subprocess.TimeoutExpired as e:
+        stdout = e.stdout.decode("utf-8", errors="replace") if isinstance(e.stdout, bytes) else (e.stdout or "")
+        stderr = e.stderr.decode("utf-8", errors="replace") if isinstance(e.stderr, bytes) else (e.stderr or "")
+        stderr = f"[timeout after {timeout_s}s]\n{stderr}"
+        exit_code = -1
+    duration_s = (datetime.now(UTC) - start).total_seconds()
+
+    events: list[dict] = []
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            events.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+    # If we created the chat ourselves, re-resolve session_file now that the
+    # store.db should exist.
+    if session_file is None and resolved_thread_id:
+        session_file = find_session_file(resolved_thread_id)
+
+    return {
+        "bridge_id": bridge_id,
+        "thread_id": resolved_thread_id,
+        "exit_code": exit_code,
+        "events": events,
+        "final_message": _extract_final_message(events),
+        "duration_s": duration_s,
+        "session_file": str(session_file) if session_file else None,
+        "stderr": stderr,
+    }
+
+
+def cli_main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="ab send-cursor-ui",
+        description=(
+            "Send a prompt to a running Cursor Desktop chat via "
+            "`cursor-agent --resume`. Sibling of send-codex-ui / send-agy-ui. "
+            "Returns the cursor-agent subprocess exit code."
+        ),
+    )
+    parser.add_argument(
+        "--thread",
+        default=None,
+        help=(
+            "Cursor chat id (UUID). Omit or pass 'new' to spawn a fresh "
+            "chat via `cursor-agent create-chat`."
+        ),
+    )
+    parser.add_argument(
+        "--bridge-id",
+        default=None,
+        help="Correlation id (auto-generated if not given).",
+    )
+    parser.add_argument(
+        "--cwd",
+        type=Path,
+        default=None,
+        help=(
+            "Working directory for the cursor-agent subprocess. cursor-agent "
+            "chooses workspace context from this cwd."
+        ),
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=DEFAULT_TIMEOUT_S,
+        help=f"Max wall-clock seconds (default {DEFAULT_TIMEOUT_S}).",
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help=(
+            f"Model override (default {DEFAULT_MODEL!r}; honors "
+            "$AB_CURSOR_UI_MODEL)."
+        ),
+    )
+    parser.add_argument(
+        "--from-file",
+        type=Path,
+        default=None,
+        help="Read message body from a file (use '-' for stdin).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print result as compact JSON (excludes the verbose events list).",
+    )
+    parser.add_argument(
+        "message",
+        nargs="?",
+        help="Inline message text. Mutually exclusive with --from-file.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.from_file and args.message:
+        parser.error("provide either --from-file or a positional message, not both")
+    if args.from_file:
+        message = (
+            sys.stdin.read()
+            if str(args.from_file) == "-"
+            else args.from_file.read_text(encoding="utf-8")
+        )
+    elif args.message is not None:
+        message = args.message
+    else:
+        parser.error("must provide a message via positional arg or --from-file")
+
+    result = send(
+        thread_id=args.thread,
+        message=message,
+        bridge_id=args.bridge_id,
+        cwd=args.cwd,
+        timeout_s=args.timeout,
+        model=args.model,
+    )
+
+    if args.json:
+        compact = {k: v for k, v in result.items() if k != "events"}
+        compact["event_count"] = len(result["events"])
+        print(json.dumps(compact, indent=2, default=str))
+    else:
+        print(f"thread:       {result['thread_id']}")
+        print(f"bridge_id:    {result['bridge_id']}")
+        print(f"exit_code:    {result['exit_code']}")
+        print(f"duration_s:   {result['duration_s']:.2f}")
+        print(f"events:       {len(result['events'])}")
+        print(f"session_file: {result['session_file']}")
+        if result["final_message"]:
+            print()
+            print("=== final message ===")
+            print(result["final_message"])
+        if result["stderr"]:
+            print()
+            print("=== stderr (truncated) ===")
+            print(result["stderr"][:2000])
+
+    return 0 if result["exit_code"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(cli_main())

--- a/scripts/ai_agent_bridge/_ui_cursor.py
+++ b/scripts/ai_agent_bridge/_ui_cursor.py
@@ -15,10 +15,22 @@ When `--thread new` (or omitted) is passed, we first call `cursor-agent
 create-chat`, capture the new chat id from stdout, and resume into it. This
 keeps the orchestration shape identical to Codex/Agy.
 
-The same chat id is the directory name under `~/.cursor/chats/<workspace>/
-<CHAT_ID>/store.db`, which we surface as `session_file` so callers can verify
-the session landed on disk regardless of whether the Cursor Desktop window
-displays the new turn live (an open question — see issue #2285).
+## Storage — two locations, both real (verified 2026-05-27)
+
+Every chat is persisted in two places, and the bridge surfaces both:
+
+- `~/.cursor/chats/<workspace_hash>/<CHAT_ID>/store.db` — cursor-agent's
+  CLI session state (binary SQLite). Surfaced as `session_file`.
+- `~/.cursor/projects/<workspace_slug>/agent-transcripts/<CHAT_ID>/<CHAT_ID>.jsonl`
+  — the human-readable JSONL transcript that Cursor Desktop indexes for
+  its agent-transcripts surface. Surfaced as `transcript_file`. This is
+  what other in-Cursor agents (Composer chat, the in-IDE assistant) can
+  grep to find bridge-delivered work.
+
+The `workspace_hash` / `workspace_slug` is derived from the cwd that
+cursor-agent saw at create-chat time. Pass `--cwd <repo-root>` to keep all
+bridge chats in the same workspace; otherwise a chat may end up bifurcated
+across multiple workspace_hash directories.
 
 ## Event shape (empirical, cursor-agent 2026.05.x)
 
@@ -61,6 +73,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 CURSOR_CHATS_ROOT = Path.home() / ".cursor" / "chats"
+CURSOR_PROJECTS_ROOT = Path.home() / ".cursor" / "projects"
 DEFAULT_TIMEOUT_S = 1800  # 30 min — covers most multi-turn dispatches
 DEFAULT_MODEL = os.environ.get("AB_CURSOR_UI_MODEL", "composer-2.5")
 _NEW_THREAD_SENTINELS = {"", "-", "new", "fresh", "none", "null"}
@@ -79,14 +92,37 @@ def _cursor_binary() -> str:
 def find_session_file(thread_id: str) -> Path | None:
     """Locate the cursor chat store.db for a given chat id.
 
-    Cursor stores per-chat state at
-    `~/.cursor/chats/<workspace_hash>/<CHAT_ID>/store.db`. There is exactly
-    one such directory per chat across all workspaces.
+    Cursor stores per-chat CLI state at
+    `~/.cursor/chats/<workspace_hash>/<CHAT_ID>/store.db`. The same chat
+    may have store.db copies under multiple workspace_hash directories
+    (one per cwd cursor-agent has seen the chat from); we return the
+    most recently modified.
     """
     if not thread_id:
         return None
     matches = sorted(
         CURSOR_CHATS_ROOT.glob(f"*/{thread_id}/store.db"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    return matches[0] if matches else None
+
+
+def find_transcript_file(thread_id: str) -> Path | None:
+    """Locate the Cursor Desktop agent-transcripts jsonl for a given chat id.
+
+    cursor-agent mirrors each chat to
+    `~/.cursor/projects/<workspace_slug>/agent-transcripts/<CHAT_ID>/<CHAT_ID>.jsonl`.
+    This is the surface Cursor Desktop indexes for its agent-transcripts /
+    "Background Agents" view — the user-facing artifact, distinct from the
+    raw CLI store.db. Empirically verified 2026-05-27 (kubedojo PR #1613).
+    """
+    if not thread_id:
+        return None
+    matches = sorted(
+        CURSOR_PROJECTS_ROOT.glob(
+            f"*/agent-transcripts/{thread_id}/{thread_id}.jsonl"
+        ),
         key=lambda p: p.stat().st_mtime,
         reverse=True,
     )
@@ -251,6 +287,7 @@ def send(
     # store.db should exist.
     if session_file is None and resolved_thread_id:
         session_file = find_session_file(resolved_thread_id)
+    transcript_file = find_transcript_file(resolved_thread_id or "")
 
     return {
         "bridge_id": bridge_id,
@@ -260,6 +297,7 @@ def send(
         "final_message": _extract_final_message(events),
         "duration_s": duration_s,
         "session_file": str(session_file) if session_file else None,
+        "transcript_file": str(transcript_file) if transcript_file else None,
         "stderr": stderr,
     }
 
@@ -360,6 +398,7 @@ def cli_main(argv: list[str] | None = None) -> int:
         print(f"duration_s:   {result['duration_s']:.2f}")
         print(f"events:       {len(result['events'])}")
         print(f"session_file: {result['session_file']}")
+        print(f"transcript:   {result['transcript_file']}")
         if result["final_message"]:
             print()
             print("=== final message ===")


### PR DESCRIPTION
## Summary

Three new subcommands on the agent bridge drive a prompt into an **already-running** Desktop UI session non-interactively. Mirror of learn-ukrainian's UI bridge (issue #2285), extended with a **Cursor adapter** that learn-ukrainian deferred.

- \`ab send-codex-ui  --thread <UUID>\`  → \`codex exec resume <UUID> --json -\`
- \`ab send-cursor-ui --thread <CHAT_ID>\` → \`cursor-agent --resume <ID> --print --output-format stream-json --trust --force\`
- \`ab send-agy-ui    --thread <ID>\`    → \`agy --conversation <ID> --print\`

Each returns: \`{bridge_id, thread_id, exit_code, events, final_message, duration_s, session_file, stderr}\`. Pass \`--thread new\` (cursor / agy) to spawn a fresh session via \`cursor-agent create-chat\` / a first \`agy --print\`.

## Why

The existing \`ab\` bridge spawns NEW headless CLI processes — it cannot talk to already-running Desktop sessions. Multi-phase deliveries via Codex Desktop or Cursor Desktop's Auto mode required physical human paste-relays between UIs. This closes that loop.

Cursor Desktop is the trailblazer of agentic IDEs; running its \`create-chat\` + \`--resume\` flow against a long-running chat is exactly the same primitive shape as Codex's \`exec resume\` and unlocks the same orchestration.

## Test plan

- [x] \`./scripts/ab send-codex-ui --help\` — schema renders, parser accepts args
- [x] \`./scripts/ab send-cursor-ui --help\` — schema renders, parser accepts args
- [x] \`./scripts/ab send-agy-ui --help\` — schema renders, parser accepts args
- [x] **Live roundtrip (Cursor)**: \`send-cursor-ui --thread <existing UUID> --json\` → exit 0, \`final_message\` matches sent prompt, \`session_file\` points at \`~/.cursor/chats/<workspace>/<UUID>/store.db\`, 12s wall clock
- [x] **Live roundtrip (Cursor, --thread new)**: spawns fresh chat via \`cursor-agent create-chat\`, resumes into it, replies, store.db on disk in 21s
- [x] \`ruff check\` clean on all three new files + \`_cli.py\`
- [ ] **Open question** (same as learn-ukrainian #2285): does \`cursor-agent --resume <id>\` update the visible Cursor Desktop window live, or run in parallel? Thread state is consistent on disk either way; live UI visibility is an open question to verify against an open Cursor Desktop window.

## Files

- \`scripts/ai_agent_bridge/_ui_codex.py\` (new) — Codex Desktop send via \`codex exec resume\`. Port from learn-ukrainian.
- \`scripts/ai_agent_bridge/_ui_cursor.py\` (new) — Cursor Desktop send via \`cursor-agent --resume\`. Auto-creates chat when \`--thread new\`.
- \`scripts/ai_agent_bridge/_ui_agy.py\` (new) — Antigravity Desktop send via \`agy --print\`. Port from learn-ukrainian.
- \`scripts/ai_agent_bridge/_cli.py\` — register the three subparsers and dispatcher forwarders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)