### PR TITLE
chore(content): #1604 — 4.1-storage Ceph anchor weakness + docs.ceph.com migration

### DIFF
--- a/src/content/docs/on-premises/storage/module-4.1-storage-architecture.md
+++ b/src/content/docs/on-premises/storage/module-4.1-storage-architecture.md
@@ -16,7 +16,7 @@ sidebar:
 
 A data analytics company deployed a 40-node Kubernetes cluster on bare metal with local SATA SSDs in each server. For the first six months, everything worked. Then they deployed Apache Kafka, which needed persistent storage that survived node rescheduling. When a worker node failed, Kafka brokers were rescheduled to new nodes — but their data was on the dead node's local SSDs. They lost 4 hours of event data and spent 3 days manually rebalancing partitions.
 
-They then deployed Ceph via Rook on the same SSDs. Performance dropped 60%. [Ceph's replication tripled the write load](https://cephdocs.readthedocs.io/en/stable/rados/configuration/pool-pg-config-ref/) on drives that were already serving application I/O. The OSD processes competed with Kubernetes workloads for CPU and memory. Their monitoring showed that Ceph rebalancing after a node failure consumed 80% of cluster I/O bandwidth for 4 hours, making all applications sluggish.
+They then deployed Ceph via Rook on the same SSDs. Performance dropped 60%. A default three-replica pool (`osd_pool_default_size = 3`) can add significant write amplification on drives already serving application I/O. This behavior is documented in the [default pool size](https://docs.ceph.com/en/stable/rados/configuration/pool-pg-config-ref/) reference. The OSD processes competed with Kubernetes workloads for CPU and memory. Their monitoring showed that Ceph rebalancing after a node failure consumed 80% of cluster I/O bandwidth for 4 hours, making all applications sluggish.
 
 The fix was dedicating 6 servers as Ceph OSD nodes with NVMe drives, separated from the Kubernetes worker nodes. Storage traffic ran on a dedicated VLAN with jumbo frames. The lesson: **storage architecture decisions must be made before you buy hardware, not after you deploy workloads.**
 
@@ -251,7 +251,7 @@ fio --name=etcd-wal \
 | SATA SSD for etcd | Leader elections under load | NVMe only for etcd (Tier 0 or 1) |
 | Hyper-converged without resource limits | Ceph OSD steals CPU/RAM from pods | Use cgroup limits: `2 cores + 4GB per OSD` |
 | No separate storage network | Ceph replication competes with pod traffic | Dedicated VLAN with jumbo frames for storage |
-| Single replication factor | Data loss on node failure | [Ceph replication factor 3](https://cephdocs.readthedocs.io/en/stable/rados/configuration/pool-pg-config-ref/) (tolerates 1 failure) |
+| Single replication factor | Data loss on node failure | [Ceph replication factor 3](https://docs.ceph.com/en/stable/rados/configuration/pool-pg-config-ref/) (tolerates 1 failure) |
 | Ceph on worker nodes at scale | Rebalancing kills application performance | Dedicated storage nodes above 100 nodes |
 | Not benchmarking before deploy | Discover performance issues in production | fio benchmark on every storage tier before use |
 | Mixing drive types in one pool | Inconsistent performance across PVs | Separate storage classes per tier |
@@ -382,7 +382,11 @@ Continue to [Module 4.2: Software-Defined Storage (Ceph/Rook)](../module-4.2-cep
 
 ## Sources
 
-- [cephdocs.readthedocs.io: pool pg config ref](https://cephdocs.readthedocs.io/en/stable/rados/configuration/pool-pg-config-ref/) — Ceph documentation explains the common three-replica pool configuration that creates three stored copies.
+- [docs.ceph.com: pool pg config ref](https://docs.ceph.com/en/stable/rados/configuration/pool-pg-config-ref/) — Ceph documentation explains the common three-replica pool configuration that creates three stored copies.
+
+## Learner check
+
+> Use docs.ceph.com (official) over cephdocs.readthedocs.io for Ceph configuration references.
 - [github.com: v1.12.0](https://github.com/container-storage-interface/spec/releases/tag/v1.12.0) — The CSI GitHub release page directly identifies v1.12.0.
 - [kubernetes.io: container storage interface ga](https://kubernetes.io/blog/2019/01/15/container-storage-interface-ga/) — The Kubernetes blog announcement states CSI was promoted to GA in v1.13.
 - [kubernetes.io: persistent volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) — The PersistentVolumes documentation lists cephfs and rbd as unavailable starting v1.31 and FlexVolume as deprecated.

--- a/src/content/docs/on-premises/storage/module-4.1-storage-architecture.md
+++ b/src/content/docs/on-premises/storage/module-4.1-storage-architecture.md
@@ -16,7 +16,7 @@ sidebar:
 
 A data analytics company deployed a 40-node Kubernetes cluster on bare metal with local SATA SSDs in each server. For the first six months, everything worked. Then they deployed Apache Kafka, which needed persistent storage that survived node rescheduling. When a worker node failed, Kafka brokers were rescheduled to new nodes — but their data was on the dead node's local SSDs. They lost 4 hours of event data and spent 3 days manually rebalancing partitions.
 
-They then deployed Ceph via Rook on the same SSDs. Performance dropped 60%. A default three-replica pool (`osd_pool_default_size = 3`) can add significant write amplification on drives already serving application I/O. This behavior is documented in the [default pool size](https://docs.ceph.com/en/stable/rados/configuration/pool-pg-config-ref/) reference. The OSD processes competed with Kubernetes workloads for CPU and memory. Their monitoring showed that Ceph rebalancing after a node failure consumed 80% of cluster I/O bandwidth for 4 hours, making all applications sluggish.
+They then deployed Ceph via Rook on the same SSDs. Performance dropped 60%. A default three-replica pool (`osd_pool_default_size = 3`) can add significant write amplification on drives already serving application I/O. This behavior is documented in the [default pool size](https://docs.ceph.com/en/latest/rados/configuration/pool-pg-config-ref/) reference. The OSD processes competed with Kubernetes workloads for CPU and memory. Their monitoring showed that Ceph rebalancing after a node failure consumed 80% of cluster I/O bandwidth for 4 hours, making all applications sluggish.
 
 The fix was dedicating 6 servers as Ceph OSD nodes with NVMe drives, separated from the Kubernetes worker nodes. Storage traffic ran on a dedicated VLAN with jumbo frames. The lesson: **storage architecture decisions must be made before you buy hardware, not after you deploy workloads.**
 
@@ -251,7 +251,7 @@ fio --name=etcd-wal \
 | SATA SSD for etcd | Leader elections under load | NVMe only for etcd (Tier 0 or 1) |
 | Hyper-converged without resource limits | Ceph OSD steals CPU/RAM from pods | Use cgroup limits: `2 cores + 4GB per OSD` |
 | No separate storage network | Ceph replication competes with pod traffic | Dedicated VLAN with jumbo frames for storage |
-| Single replication factor | Data loss on node failure | [Ceph replication factor 3](https://docs.ceph.com/en/stable/rados/configuration/pool-pg-config-ref/) (tolerates 1 failure) |
+| Single replication factor | Data loss on node failure | [Ceph replication factor 3](https://docs.ceph.com/en/latest/rados/configuration/pool-pg-config-ref/) (tolerates 1 failure) |
 | Ceph on worker nodes at scale | Rebalancing kills application performance | Dedicated storage nodes above 100 nodes |
 | Not benchmarking before deploy | Discover performance issues in production | fio benchmark on every storage tier before use |
 | Mixing drive types in one pool | Inconsistent performance across PVs | Separate storage classes per tier |
@@ -382,11 +382,7 @@ Continue to [Module 4.2: Software-Defined Storage (Ceph/Rook)](../module-4.2-cep
 
 ## Sources
 
-- [docs.ceph.com: pool pg config ref](https://docs.ceph.com/en/stable/rados/configuration/pool-pg-config-ref/) — Ceph documentation explains the common three-replica pool configuration that creates three stored copies.
-
-## Learner check
-
-> Use docs.ceph.com (official) over cephdocs.readthedocs.io for Ceph configuration references.
+- [docs.ceph.com: pool pg config ref](https://docs.ceph.com/en/latest/rados/configuration/pool-pg-config-ref/) — Ceph documentation explains the common three-replica pool configuration that creates three stored copies.
 - [github.com: v1.12.0](https://github.com/container-storage-interface/spec/releases/tag/v1.12.0) — The CSI GitHub release page directly identifies v1.12.0.
 - [kubernetes.io: container storage interface ga](https://kubernetes.io/blog/2019/01/15/container-storage-interface-ga/) — The Kubernetes blog announcement states CSI was promoted to GA in v1.13.
 - [kubernetes.io: persistent volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) — The PersistentVolumes documentation lists cephfs and rbd as unavailable starting v1.31 and FlexVolume as deprecated.

--- a/src/content/docs/platform/toolkits/infrastructure-networking/storage/module-16.2-minio.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/storage/module-16.2-minio.md
@@ -782,7 +782,7 @@ When you design alerts, pair symptoms with operator actions. An alert for offlin
 
 MinIO is a strong option, but it is not automatically the right answer. Platform engineering is mostly trade-off management: who operates the service, where the data path lives, what failure domains are acceptable, and which API the application expects. The best design may use MinIO for local hot-path artifacts and cloud S3 for off-site retention, or Ceph for block storage and MinIO for S3-compatible workloads.
 
-Cloud S3 is usually the right default when you want a managed global object store, broad ecosystem integration, and minimal operational ownership. MinIO is attractive when you need local performance, air-gapped operation, predictable internal traffic, S3 compatibility, or control over data placement. Ceph is attractive when you need a broader storage system that can provide [block, file, and object interfaces](https://cephdocs.readthedocs.io/en/latest/rbd/index.html), though that breadth comes with operational complexity.
+Cloud S3 is usually the right default when you want a managed global object store, broad ecosystem integration, and minimal operational ownership. MinIO is attractive when you need local performance, air-gapped operation, predictable internal traffic, S3 compatibility, or control over data placement. Ceph is attractive when you need a broader storage system that can provide [block, file, and object interfaces](https://docs.ceph.com/en/latest/rbd/index.html), though that breadth comes with operational complexity.
 
 | Requirement | MinIO | Cloud S3 | Ceph |
 |-------------|-------|----------|------|
@@ -1161,4 +1161,4 @@ Next: [Module 16.3: Longhorn](../module-16.3-longhorn/) - lightweight distribute
 - [github.com: backupstoragelocation.md](https://github.com/velero-io/velero-plugin-for-aws/blob/main/backupstoragelocation.md) — The Velero AWS plugin documentation directly describes backup object storage, s3ForcePathStyle, s3Url for MinIO/local storage services, and the README compatibility table documents v1.10.x to Velero v1.14.x.
 - [docs.docker.com: s3](https://docs.docker.com/build/cache/backends/s3/) — The Docker Build cache S3 backend documentation directly defines the use_path_style option this way.
 - [github.com: list.md](https://github.com/minio/minio/blob/master/docs/metrics/prometheus/list.md) — The upstream MinIO metrics list directly documents the cluster endpoint and the named metric families.
-- [cephdocs.readthedocs.io: index.html](https://cephdocs.readthedocs.io/en/latest/rbd/index.html) — The Ceph documentation mirrored on readthedocs.io directly states that the same cluster can operate RGW, CephFS, and Ceph block devices.
+- [docs.ceph.com: index.html](https://docs.ceph.com/en/latest/rbd/index.html) — The Ceph documentation on docs.ceph.com directly states that the same cluster can operate RGW, CephFS, and Ceph block devices.


### PR DESCRIPTION
## Summary

P2 fixes for issue #1604 (4.1-storage Ceph anchor weakness) + R1 fix-pass per composer-2.5 NEEDS_CHANGES:

- War-story Ceph link re-anchored to neutral wording (`docs.ceph.com/en/latest`)
- 3 occurrences of `cephdocs.readthedocs.io` migrated to `docs.ceph.com/en/latest/`
- Sibling-grep cleanup: `module-16.2-minio.md` also had a `cephdocs.readthedocs.io` link, updated to `docs.ceph.com/en/latest/`
- **R1 fix-pass (commit c80aea9d)**: corrected `en/stable` → `en/latest` (en/stable returns 404 on official ceph docs); removed misplaced `## Learner check` heading from module (it had been interleaved with the Sources list, corrupting it)

## Test plan

- [x] `check_citations.py` PASS on both touched files
- [x] All 3 `en/stable` URLs replaced with `en/latest` (verified with grep)
- [x] No `cephdocs.readthedocs.io` remaining in either touched file (sibling-grep)
- [x] `## Learner check` heading removed from module body
- [x] Sources list is contiguous (no split by the misplaced section)

## Learner check

> A default three-replica pool (`osd_pool_default_size = 3`) can add significant write amplification on drives already serving application I/O.

Closes #1604
