### PR TITLE
chore(content): #1612 — vault-eso/4.1 P2 nits from R1 review

### DIFF
--- a/src/content/docs/platform/toolkits/security-quality/security-tools/module-4.1-vault-eso.md
+++ b/src/content/docs/platform/toolkits/security-quality/security-tools/module-4.1-vault-eso.md
@@ -815,10 +815,6 @@ Continue to [Module 4.2: OPA & Gatekeeper](../module-4.2-opa-gatekeeper/) to lea
 
 *"The only secure secret is the one that doesn't exist. For everything else, there's Vault."*
 
-## Learner check
-
-> Secure secret rotation with zero-downtime patterns: `refreshInterval` on ExternalSecrets for KV sync, and `VaultDynamicSecret` generators for Vault dynamic engines (database, PKI, cloud)
-
 ## Sources
 
 - [Vault: How Vault Works](https://developer.hashicorp.com/vault/docs/about-vault/how-vault-works) — Best primary source for Vault architecture, auth, policies, audit logging, seals, and secret engines.

--- a/src/content/docs/platform/toolkits/security-quality/security-tools/module-4.1-vault-eso.md
+++ b/src/content/docs/platform/toolkits/security-quality/security-tools/module-4.1-vault-eso.md
@@ -29,7 +29,7 @@ After completing this module, you will be able to:
 
 - **Implement External Secrets Operator to sync Vault secrets into Kubernetes Secrets automatically**
 - **Configure Vault's Kubernetes authentication and dynamic secret generation for database credentials**
-- **Secure secret rotation workflows with zero-downtime deployment patterns using ESO refresh intervals**
+- **Secure secret rotation with zero-downtime patterns: `refreshInterval` on ExternalSecrets for KV sync, and `VaultDynamicSecret` generators for Vault dynamic engines (database, PKI, cloud)**
 
 
 ## Why This Module Matters
@@ -553,7 +553,7 @@ metadata:
 spec:
   path: "/database/creds/app"
   method: "GET"
-  resultType: "Auth"
+  resultType: "Data"
   provider:
     server: "https://vault.example.com"
     auth:
@@ -777,9 +777,9 @@ vault kv put secret/myapp/config \
        kind: SecretStore
      target:
        name: myapp-config
-  dataFrom:
-  - extract:
-      key: myapp/config
+     dataFrom:
+     - extract:
+         key: myapp/config
    ```
 
 4. **Verify** the Kubernetes Secret was created:
@@ -814,6 +814,10 @@ Continue to [Module 4.2: OPA & Gatekeeper](../module-4.2-opa-gatekeeper/) to lea
 ---
 
 *"The only secure secret is the one that doesn't exist. For everything else, there's Vault."*
+
+## Learner check
+
+> Secure secret rotation with zero-downtime patterns: `refreshInterval` on ExternalSecrets for KV sync, and `VaultDynamicSecret` generators for Vault dynamic engines (database, PKI, cloud)
 
 ## Sources
 


### PR DESCRIPTION
## Summary

P2 nit fix-pass for issue #1612 (vault-eso/4.1):

- YAML indent in hands-on exercise (`dataFrom`/`extract`/`key` now nest under `spec`)
- `resultType` in database generator: `"Auth"` → `"Data"` (matches ESO `VaultDynamicSecret` spec + Vault response shape)
- Learning outcome wording: rotation now distinguishes KV (`refreshInterval`) vs dynamic engines (`VaultDynamicSecret`)
- **R1 fix-pass (commit 93a1489d)**: removed misplaced `## Learner check` heading from module file (R1 by codex flagged at P3; Learner check belongs in PR body per merge-hook contract, not in published curriculum content)

## Test plan

- [x] YAML blocks parse cleanly (verified by codex R1)
- [x] `resultType: "Data"` aligned with [external-secrets.io VaultDynamicSecret docs](https://external-secrets.io/latest/api/generator/vault/)
- [x] Learning outcome accurately reflects KV/dynamic engine split
- [x] `## Learner check` heading removed from module body

## Learner check

> Secure secret rotation with zero-downtime patterns: `refreshInterval` on ExternalSecrets for KV sync, and `VaultDynamicSecret` generators for Vault dynamic engines (database, PKI, cloud)

Closes #1612
