### PR TITLE
fix(scripts): #1586 — dispatch_smart no longer forces danger mode on review/search

### DIFF
--- a/scripts/dispatch_smart.py
+++ b/scripts/dispatch_smart.py
@@ -611,12 +611,14 @@ def main() -> int:
     timeout_s = args.timeout or cfg.default_timeout_s
     task_id = args.task_id or make_task_id(args.task_class, args.agent)
 
-    # Codex always runs in danger mode — read-only starves it of network/
-    # filesystem and produces garbage (rc=-9 stale-rollout salvage). Three
-    # failures in a single session 2026-05-07. This override fires before
-    # the worktree validation below so that the worktree requirement still
-    # applies to all non-dry-run codex dispatches.
-    if args.agent == "codex" and mode != "danger":
+    # Codex always runs in danger mode for write classes — read-only starves it
+    # of network/filesystem and produces garbage (rc=-9 stale-rollout salvage).
+    # Review/search are read-only by design and must keep default mode.
+    if (
+        args.agent == "codex"
+        and args.task_class not in ("review", "search")
+        and mode != "danger"
+    ):
         if args.mode is not None and args.mode != "danger":
             p.error(
                 f"--agent codex always runs in danger mode (you passed "
@@ -626,12 +628,16 @@ def main() -> int:
             )
         mode = "danger"
 
-    # Agy always runs in danger mode for the same reason — read-only would
-    # cause its tool-permission prompts to hang waiting for human input in
-    # a headless dispatch, since the runtime cannot answer the prompt.
+    # Agy always runs in danger mode for write classes — read-only would cause
+    # tool-permission prompts to hang waiting for human input in a headless
+    # dispatch, since the runtime cannot answer the prompt.
     # `--dangerously-skip-permissions` is the equivalent of codex's danger
     # sandbox: auto-approve all tool calls. User direction 2026-05-19.
-    if args.agent == "agy" and mode != "danger":
+    if (
+        args.agent == "agy"
+        and args.task_class not in ("review", "search")
+        and mode != "danger"
+    ):
         if args.mode is not None and args.mode != "danger":
             p.error(
                 f"--agent agy always runs in danger mode (you passed "

--- a/scripts/dispatch_smart.py
+++ b/scripts/dispatch_smart.py
@@ -611,14 +611,9 @@ def main() -> int:
     timeout_s = args.timeout or cfg.default_timeout_s
     task_id = args.task_id or make_task_id(args.task_class, args.agent)
 
-    # Codex always runs in danger mode for write classes — read-only starves it
-    # of network/filesystem and produces garbage (rc=-9 stale-rollout salvage).
-    # Review/search are read-only by design and must keep default mode.
-    if (
-        args.agent == "codex"
-        and args.task_class not in ("review", "search")
-        and mode != "danger"
-    ):
+    # Codex always runs in danger mode — read-only starves it of
+    # network/filesystem and produces garbage (rc=-9 stale-rollout salvage).
+    if args.agent == "codex" and mode != "danger":
         if args.mode is not None and args.mode != "danger":
             p.error(
                 f"--agent codex always runs in danger mode (you passed "
@@ -646,6 +641,13 @@ def main() -> int:
                 f"interactive permission prompts. Drop --mode to use the default."
             )
         mode = "danger"
+
+    # Read-only task classes for codex run in danger mode, but they do not
+    # require a worktree.
+    codex_readonly_class = (
+        args.agent == "codex"
+        and args.task_class in {"review", "search"}
+    )
 
     if args.prompt is None:
         sys.stderr.write("[smart] no prompt — pass as arg or `-` for stdin\n")
@@ -691,10 +693,6 @@ def main() -> int:
         # permission prompts (--dangerously-skip-permissions); it does not
         # write files. Review-class agy dispatches don't need a worktree.
         # codex review/search carve-out: read-only task classes; no worktree.
-        codex_readonly_class = (
-            args.agent == "codex"
-            and args.task_class in {"review", "search"}
-        )
         if args.agent != "agy" and not codex_readonly_class:
             p.error("--mode danger requires --worktree (no override)")
 
@@ -703,7 +701,12 @@ def main() -> int:
         worktree = Path(args.worktree)
         if not worktree.is_absolute():
             worktree = PRIMARY_REPO / worktree
-    elif mode != "read-only" and not args.dry_run and args.agent != "agy":
+    elif (
+        mode != "read-only"
+        and not args.dry_run
+        and args.agent != "agy"
+        and not codex_readonly_class
+    ):
         sys.stderr.write(
             f"[smart] mode={mode} requires --worktree to avoid trampling "
             "the main checkout\n"

--- a/tests/test_dispatch_smart.py
+++ b/tests/test_dispatch_smart.py
@@ -101,7 +101,13 @@ def test_dispatch_smart_codex_forces_danger_mode() -> None:
 
 
 def test_dispatch_smart_codex_review_no_worktree_required() -> None:
-    """Codex review/search remain runtime-necessary in danger mode but do not need a worktree."""
+    """Codex review/search remain runtime-necessary in danger mode but do not need a worktree.
+
+    Regression test for #1586: dispatch_smart.py previously forced --worktree for any
+    codex dispatch because mode=danger required it; that broke Decision Card C codex-as-reviewer
+    pairings. The fix carves out the worktree REQUIREMENT for codex review/search while keeping
+    codex in danger mode (codex adapter needs network+FS for tool-calls).
+    """
     result = _run_dispatch_smart(["review", "--agent", "codex", "--dry-run", "x"])
     assert result.returncode == 0
     assert "mode=danger" in result.stdout

--- a/tests/test_dispatch_smart.py
+++ b/tests/test_dispatch_smart.py
@@ -89,13 +89,22 @@ def test_codex_edit_default_unchanged() -> None:
     assert TASK_CLASSES["edit"].models["codex"] == "gpt-5.3-codex-spark"
 
 
-def test_dispatch_smart_codex_danger_still_requires_worktree() -> None:
-    """The agy carve-out must NOT loosen the requirement for codex,
-    which actually writes under danger mode."""
-    # Codex auto-forces mode=danger, so any codex dispatch without --worktree
-    # should hard-fail.
+def test_dispatch_smart_codex_forces_danger_mode() -> None:
+    """Codex always resolves to danger mode."""
+    # Codex auto-forces mode=danger, so non-read-only-like dispatches still
+    # require a worktree.
     result = _run_dispatch_smart(["edit", "--agent", "codex", "x"])
     merged_output = (result.stdout or "") + (result.stderr or "")
     assert result.returncode != 0
     assert "danger" in merged_output
     assert "worktree" in merged_output
+
+
+def test_dispatch_smart_codex_review_no_worktree_required() -> None:
+    """Codex review/search remain runtime-necessary in danger mode but do not need a worktree."""
+    result = _run_dispatch_smart(["review", "--agent", "codex", "--dry-run", "x"])
+    assert result.returncode == 0
+    assert "mode=danger" in result.stdout
+    assert "worktree=(none — danger)" in result.stdout
+    merged_output = (result.stdout or "") + (result.stderr or "")
+    assert "requires --worktree" not in merged_output


### PR DESCRIPTION
## Summary
Fixes `scripts/dispatch_smart.py` so `dispatch_smart.py review --agent codex` no longer requires `--worktree`. Critical for Decision Card C codex-as-reviewer pairings (cursor author → codex R1, agy author → codex R1) which have been forced to gemini-3.1-pro-preview workaround since session 58.

## What changed (after R1 fix-pass — commit 6190f8e4)
- **Codex always runs in danger mode** (reverted earlier attempt to set mode=read-only — that broke CodexAdapter runtime per R1).
- **Hoisted `codex_readonly_class` definition** to top-level after mode resolution.
- **Worktree REQUIREMENT** (line 700) is what's actually carved out for codex review/search — not the danger mode itself.
- **Agy carve-out kept** as originally proposed: agy adapter supports read-only properly.
- **Tests updated**: `test_dispatch_smart_codex_forces_danger_mode` reflects that codex always runs in danger; new `test_dispatch_smart_codex_review_no_worktree_required` covers the previously-broken case. 9 tests passing.

## Review history
- **R1** (composer-2.5): NEEDS_CHANGES — first attempt set codex `mode=read-only` for review/search, which fixed the dispatcher symptom but broke the CodexAdapter runtime (codex needs network+FS via danger). The correct split: codex always danger, only the worktree REQUIREMENT lifts for read-only classes.
- **R2** (composer-2.5): APPROVE_WITH_NITS — architecture is correct. P2 nit: `dispatch_smart.py review --agent codex` still needs a `cwd` default for the codex runtime to actually launch end-to-end (the dispatcher passes through cleanly, but codex itself wants a working directory). Filing as follow-up.

## Verification (PR branch, after fix-pass)
- `review --agent codex --dry-run "x"` → `mode=danger`, `worktree=(none — danger)` — no error.
- `edit --agent codex --worktree .worktrees/bug-1586 --dry-run "x"` → `mode=danger`, worktree honored.
- `review --agent agy --dry-run "x"` → `mode=read-only` (default), no worktree required.
- `.venv/bin/python -m pytest tests/test_dispatch_smart.py -v` → 9 passed.

Regression test: tests/test_dispatch_smart.py

Closes #1586
