### PR TITLE
fix(citation_backfill): preserve raw response on agent_response_invalid

### DIFF
--- a/scripts/citation_backfill.py
+++ b/scripts/citation_backfill.py
@@ -1182,6 +1182,8 @@ def run_research(
             "ok": False,
             "error": "agent_response_invalid",
             "detail": "agent response missing claims/schema_version or bridge error payload",
+            "raw_head": raw[:400],
+            "raw_tail": raw[-400:],
         }
 
     seed.setdefault("module_key", normalized_key)

--- a/tests/test_citation_backfill.py
+++ b/tests/test_citation_backfill.py
@@ -449,3 +449,41 @@ def test_run_inject_soft_skips_codex_dropped_cited_claims(
     assert c003[0]["kind"] == "inline"
     assert c003[0]["status"] == "skipped"
     assert c003[0]["reason"] == "not_addressed_by_agent"
+
+
+def test_run_research_agent_response_invalid_preserves_raw_snippets(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Regression for #1621: invalid agent JSON must retain raw_head/raw_tail."""
+    module_path = tmp_path / "on-premises" / "storage" / "module-4.4-object-storage.md"
+    module_path.parent.mkdir(parents=True)
+    module_path.write_text("# Object storage\n\nBare-metal object storage notes.\n", encoding="utf-8")
+
+    monkeypatch.setattr(citation_backfill, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(citation_backfill, "DOCS_ROOT", tmp_path)
+    monkeypatch.setattr(citation_backfill, "resolve_module_path", lambda _key: module_path)
+    monkeypatch.setattr(citation_backfill, "load_section_pool", lambda *a, **kw: None)
+
+    pad_head = "HEAD-" * 80
+    pad_tail = "TAIL-" * 80
+    inner = json.dumps({"foo": "bar"})
+    raw = f"{pad_head}{inner}{pad_tail}"
+
+    def fake_dispatch(_prompt: str, *, task_id: str) -> tuple[bool, str]:
+        del task_id
+        return True, raw
+
+    monkeypatch.setattr(citation_backfill, "dispatch_codex", fake_dispatch)
+
+    result = citation_backfill.run_research(
+        "on-premises/storage/module-4.4-object-storage-bare-metal",
+        agent="codex",
+    )
+
+    assert result["ok"] is False
+    assert result["error"] == "agent_response_invalid"
+    assert result["detail"] == (
+        "agent response missing claims/schema_version or bridge error payload"
+    )
+    assert result["raw_head"] == raw[:400]
+    assert result["raw_tail"] == raw[-400:]


### PR DESCRIPTION
## Summary

When `run_research` hits `agent_response_invalid` (parsed JSON lacks `claims`/`schema_version` or is a bridge error shape), the error dict now includes `raw_head` and `raw_tail` — the same diagnostic fields already returned on `parse_failed`. This unblocks root-cause analysis for citation backfill research failures on specific modules (#1621 `agent_response_invalid`, #1605 codex hang/timeout).

## Why

The `agent_response_invalid` path dropped the raw agent response entirely, so logs only showed the generic detail string. Operators could not see what codex actually returned after ~10 minutes.

## Test plan

- [x] `.venv/bin/ruff check scripts/citation_backfill.py tests/test_citation_backfill.py`
- [x] `.venv/bin/pytest tests/test_citation_backfill.py -k agent_response_invalid`

Regression test: tests/test_citation_backfill.py

Test function: `test_run_research_agent_response_invalid_preserves_raw_snippets`

Refs #1621 #1605

Made with [Cursor](https://cursor.com)
