### PR TITLE
chore(hooks): inject FIRST ACTION reminder in session-setup

### DIFF
--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -79,12 +79,13 @@ if [ -f "$MEMORY_FILE" ]; then
   fi
 fi
 
-# Build output
-if [ ${#ISSUES[@]} -eq 0 ] && [ ${#INFO[@]} -eq 0 ]; then
-  exit 0
-fi
+# Build output. The FIRST ACTION reminder is always emitted (interactive sessions
+# only — headless already exited at line 6). Belt-and-suspenders for CLAUDE.md
+# "FIRST ACTION, every session — no exceptions" — the rule still drives, this
+# just keeps it in working memory on follow-on turns.
+CONTEXT="FIRST ACTION (per CLAUDE.md): if you have not yet invoked the curriculum-orchestrator skill this session, do it now via the Skill tool BEFORE responding to the user.
 
-CONTEXT="SESSION SETUP CHECK:"
+SESSION SETUP CHECK:"
 
 if [ ${#ISSUES[@]} -gt 0 ]; then
   CONTEXT="$CONTEXT

--- a/agents_extensions/claude/hooks/session-setup.sh
+++ b/agents_extensions/claude/hooks/session-setup.sh
@@ -79,12 +79,13 @@ if [ -f "$MEMORY_FILE" ]; then
   fi
 fi
 
-# Build output
-if [ ${#ISSUES[@]} -eq 0 ] && [ ${#INFO[@]} -eq 0 ]; then
-  exit 0
-fi
+# Build output. The FIRST ACTION reminder is always emitted (interactive sessions
+# only — headless already exited at line 6). Belt-and-suspenders for CLAUDE.md
+# "FIRST ACTION, every session — no exceptions" — the rule still drives, this
+# just keeps it in working memory on follow-on turns.
+CONTEXT="FIRST ACTION (per CLAUDE.md): if you have not yet invoked the curriculum-orchestrator skill this session, do it now via the Skill tool BEFORE responding to the user.
 
-CONTEXT="SESSION SETUP CHECK:"
+SESSION SETUP CHECK:"
 
 if [ ${#ISSUES[@]} -gt 0 ]; then
   CONTEXT="$CONTEXT


### PR DESCRIPTION
## Summary
- SessionStart hook (`agents_extensions/claude/hooks/session-setup.sh` → deployed at `.claude/hooks/session-setup.sh`) now prepends a one-line `FIRST ACTION` reminder to `additionalContext` on every interactive session start.
- Tells the agent to invoke the `curriculum-orchestrator` skill via the Skill tool before responding to the user — belt-and-suspenders for the CLAUDE.md "FIRST ACTION, every session — no exceptions" rule.
- Headless sessions skip unchanged (existing `CLAUDE_NON_INTERACTIVE` / `KUBEDOJO_PIPELINE` / `GEMINI_SESSION` early-exit at line 6).

## Motivation
User flagged that the learn-ukrainian project appears to auto-orient at session start, asked if kubedojo could match. Investigation showed learn-ukrainian uses an AGENT pattern (`.claude/agents/curriculum-orchestrator.md` with `initialPrompt:` frontmatter + `"agent"` field in settings.json) — different architecture from kubedojo's SKILL pattern with sub-skills. Full conversion would tax every session with ~200 lines of orchestrator context.

This is the lighter fix: keep the SKILL architecture, just reinforce the existing CLAUDE.md rule from the hook.

## Test plan
- [x] `CLAUDE_NON_INTERACTIVE=1 bash .claude/hooks/session-setup.sh` → exit 0, no output (headless skip)
- [x] Interactive run → `FIRST ACTION` line appears at top of `additionalContext`, existing ISSUES/INFO follow
- [ ] Cross-family reviewer (per Decision Card C: claude-authored → composer-2.5)
- [ ] Verify on next interactive session that the reminder fires

## Not in scope
- Pre-existing drift in `.claude/hooks/inject-codex-danger-mode.sh` (deployed copy is missing `|| true` safety + comment vs source — separate cleanup needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)