### PR TITLE
feat(content): distributed-systems 5.5 clock skew and ordering (refs #1624)

### DIFF
--- a/src/content/docs/platform/foundations/distributed-systems/index.md
+++ b/src/content/docs/platform/foundations/distributed-systems/index.md
@@ -33,6 +33,7 @@ Understanding these challenges helps you design systems that work despite them.
 | 5.2 | [Module 5.2: Consensus and Coordination](module-5.2-consensus-and-coordination/) | 35-40 min | Paxos, Raft, leader election, distributed locks, etcd |
 | 5.3 | [Module 5.3: Eventual Consistency](module-5.3-eventual-consistency/) | 30-35 min | Consistency models, replication, conflict resolution, CRDTs |
 | 5.4 | [Module 5.4: Partial Failure and Timeouts](module-5.4-partial-failure-and-timeouts/) | 60-75 min | Timeouts, idempotent retries, retry storms, jitter, circuit breakers |
+| 5.5 | [Module 5.5: Clock Skew and Ordering](module-5.5-clock-skew-and-ordering/) | 45-55 min | Wall clocks, monotonic clocks, logical time, LWW hazards |
 
 ---
 
@@ -82,6 +83,16 @@ START HERE
 └──────────────────┬──────────────────┘
                    │
                    ▼
+┌─────────────────────────────────────┐
+│  Module 5.5                         │
+│  Clock Skew and Ordering            │
+│  └── Wall vs monotonic clocks        │
+│  └── Lamport and vector clocks       │
+│  └── Last-writer-wins hazards        │
+│  └── Ordering fixes                  │
+└──────────────────┬──────────────────┘
+                   │
+                   ▼
            FOUNDATIONS COMPLETE
                    │
     ┌──────────────┼──────────────┐
@@ -111,6 +122,12 @@ Discipline    Engineering   Discipline
 | Idempotency | 5.4 | Making repeated attempts produce one logical effect |
 | Retry Storm | 5.4 | Retries amplifying load during partial failure |
 | Circuit Breaker | 5.4 | Failing locally to protect an unhealthy dependency |
+| Wall Clock | 5.5 | Calendar time for human-facing labels |
+| Monotonic Clock | 5.5 | Local elapsed time that does not step backward |
+| Clock Skew | 5.5 | Different machines disagreeing about the current time |
+| Happens-Before | 5.5 | Causal ordering based on process order and messages |
+| Lamport Timestamp | 5.5 | Logical counter that preserves causal direction |
+| Last Writer Wins | 5.5 | Conflict rule that can lose writes under skew |
 
 ---
 
@@ -173,7 +190,7 @@ This is the final track in the Foundations series. You've now covered:
 2. **Reliability Engineering**: Design for failure, measure with SLOs
 3. **Observability Theory**: Understand through metrics, logs, traces
 4. **Security Principles**: Defense in depth, least privilege
-5. **Distributed Systems**: Consensus, consistency, coordination
+5. **Distributed Systems**: Consensus, consistency, coordination, ordering
 
 These foundations prepare you for the practical Disciplines and Toolkits tracks.
 

--- a/src/content/docs/platform/foundations/distributed-systems/module-5.5-clock-skew-and-ordering.md
+++ b/src/content/docs/platform/foundations/distributed-systems/module-5.5-clock-skew-and-ordering.md
@@ -1,0 +1,664 @@
+---
+title: "Module 5.5: Clock Skew and Ordering"
+slug: platform/foundations/distributed-systems/module-5.5-clock-skew-and-ordering
+sidebar:
+  order: 6
+---
+> **Complexity**: `[COMPLEX]`
+>
+> **Time to Complete**: 45-55 minutes
+>
+> **Prerequisites**: [Module 5.3: Eventual Consistency](../module-5.3-eventual-consistency/)
+>
+> **Track**: Foundations
+
+## What You'll Be Able to Do
+
+After completing this module, you will be able to explain and operate the timing choices that decide whether distributed systems preserve work or quietly reorder it:
+
+1. **Explain wall clocks and monotonic clocks** so timeouts, leases, retries, latency measurement, and audit timestamps use the correct source.
+2. **Diagnose clock skew and NTP limits** as production failure modes rather than assuming synchronization makes clocks perfectly trustworthy.
+3. **Explain happens-before, Lamport timestamps, and vector clocks** as practical alternatives to wall-clock ordering.
+4. **Evaluate last-writer-wins lost writes** and identify when skew can silently discard a later, acknowledged update.
+5. **Design quorum, consensus, or logical ordering fixes** for data paths where the application cannot safely merge conflicts later.
+
+---
+
+## Why This Module Matters
+
+A distributed system does not have one "now." It has many machines, each with its own oscillator, kernel, clock discipline, pauses, virtual machine scheduling delays, leap adjustments, and network path to the rest of the system. The wall clock on each machine is useful for human-facing timestamps, compliance logs, billing periods, and calendar deadlines. It is not a trustworthy witness for deciding which of two distributed events happened first. Justin Sheehy's ACM Queue essay ["There is No Now"](https://queue.acm.org/detail.cfm?id=2745385) frames the operator lesson directly: systems exist in the physical world, signals take time to travel, and components fail in ways that make a single shared present a dangerous simplification.
+
+This matters because many systems quietly smuggle wall-clock assumptions into places where they do not belong. A retry loop computes elapsed time by subtracting two wall-clock readings. A cache lease expires because the node's clock jumped forward. A database resolves concurrent updates by choosing the write with the largest timestamp. A monitoring rule says the primary is "behind" because two hosts disagree about time more than they disagree about work. Each individual shortcut looks reasonable when the system is small. At scale, those shortcuts turn time into a hidden dependency, and hidden dependencies become incident causes.
+
+Leslie Lamport's 1978 paper ["Time, Clocks, and the Ordering of Events in a Distributed System"](https://lamport.azurewebsites.net/pubs/time-clocks.pdf) gave us the core mental model: in a distributed system, "happened before" is not the same as "has a smaller timestamp." Some events are causally related because one process observed or communicated with another. Other events are concurrent because neither could have influenced the other. If you force every event into a total order using physical timestamps, you may produce an order that is convenient for software but false for the system you are operating.
+
+---
+
+## Part 1: Two Kinds of Time
+
+### 1.1 Wall Clocks Answer Calendar Questions
+
+A **wall clock** answers the question a human would ask: what date and time is it? On Linux, the wall clock is typically exposed through clock sources behind APIs such as `CLOCK_REALTIME`, standard library calls such as `time.time()`, and log formats such as RFC 3339 timestamps. It is the right tool when the value must align with civil time: "the certificate expires at midnight UTC," "this invoice closed on April 30," or "this audit entry was recorded at 2026-05-28T14:03:12Z."
+
+The operational hazard is that a wall clock is allowed to move in surprising ways. NTP can slew it gradually or step it abruptly. An operator can correct it manually. A virtual machine can pause and resume with a stale view of time. A leap adjustment can make a second unusual. A laptop can sleep, wake, and discover that the world advanced while the process did not run. None of these behaviors are bugs in the wall clock. They are exactly what a wall clock must do to remain aligned with calendar time.
+
+That makes wall-clock time a poor source for measuring elapsed durations. Suppose a service starts a request at `10:00:00.000`, records the wall clock, does work for two seconds, and then the host's clock is corrected backward by five seconds before the service records the end time. Subtracting end from start now says the request took negative time. The request did not move backward through physics. The measurement used a clock whose job was calendar alignment, not monotonic progress.
+
+### 1.2 Monotonic Clocks Answer Elapsed-Time Questions
+
+A **monotonic clock** answers a different question: how much local time has elapsed according to this process or host? It is designed to move forward monotonically, so it is the right tool for measuring durations, timeouts, retry budgets, lock hold time within one process, and latency histograms. In most languages, the standard library gives you a monotonic source: Go's `time.Since`, Java's `System.nanoTime`, Python's `time.monotonic`, Rust's `Instant`, and POSIX `CLOCK_MONOTONIC` exist precisely because elapsed time should not depend on calendar correction.
+
+The rule is simple enough to memorize and important enough to enforce in reviews: use the wall clock to label events for people, and use a monotonic clock to measure elapsed time for machines. If a timeout starts now and should fire after 250 milliseconds, record a monotonic deadline. If a metric reports request latency, subtract monotonic readings. If a lease must be compared across machines, pause and ask whether a local monotonic measurement is enough or whether the design actually needs coordination.
+
+This distinction is especially important in operators and controllers. Kubernetes controllers often reconcile by comparing observed state against desired state and then scheduling future work. If the controller uses wall-clock deltas for local backoff, a clock step can make retries storm or stall. If it records wall-clock timestamps for status fields, that is fine because humans and other controllers use those fields as labels, not proof that every node agrees about elapsed time.
+
+### 1.3 Skew and Drift Are Different Problems
+
+**Clock skew** is the difference between two clock readings at the same real instant. If node A says `12:00:05` while node B says `12:00:00`, their wall clocks have five seconds of skew. **Clock drift** is the rate at which a clock moves away from a reference over time. A host with a slightly fast oscillator may gain milliseconds every minute until a synchronization system corrects it. Skew is what you see now; drift is how the error grows between corrections.
+
+NTP and related clock synchronization systems are valuable, and you should run them well. They estimate network delay, compare a host to one or more references, and discipline the local clock so that it stays close to civil time. Sheehy describes NTP as accounting for message travel time when adjusting clocks, while also warning against turning synchronization into an assumption of perfect simultaneity. Synchronization reduces uncertainty; it does not eliminate uncertainty, network delay, host pauses, bad hardware, misconfiguration, or asymmetric paths.
+
+An operator habit follows from that fact: treat clock health as an input to safety, not as a proof of safety. Alert on large skew. Monitor NTP or chrony state. Investigate hosts that step time. Prefer monotonic timers for local elapsed duration. Avoid data models where one bad clock can write a timestamp from the future and suppress correct updates until real time catches up. If a system's correctness depends on "all clocks are close enough," write down how close is enough and what happens when that assumption is violated.
+
+---
+
+## Part 2: Ordering Without a Global Clock
+
+### 2.1 Happens-Before Is a Causal Relation
+
+Lamport's core move was to define ordering without physical clocks. Event A **happens before** event B when the system has a causal reason to order them. If both events occur in the same process and A comes first in that process, then A happens before B. If A is the sending of a message and B is receiving that message, then A happens before B. If A happens before B and B happens before C, then A happens before C. Those rules define a partial order, not a total order.
+
+The word "partial" is the key. A partial order means some pairs of events can be compared, while other pairs cannot. If two events happen on separate machines, no message connects them, and neither process observed the other, then the system has no causal evidence that one happened before the other. You can still sort them by some arbitrary rule, but that sort is a policy decision, not a discovered truth. Many production bugs come from forgetting the difference.
+
+```text
+Process A                         Process B
+---------                         ---------
+a1: accept write
+      |
+      | message replicates
+      v
+                                   b1: receive write
+                                   b2: update index
+
+Here: a1 happens-before b1, and b1 happens-before b2.
+
+Process C                         Process D
+---------                         ---------
+c1: accept profile edit            d1: accept billing edit
+
+Here: c1 and d1 are concurrent unless a message, read, or shared
+coordination path creates a causal relationship between them.
+```
+
+When you operate a distributed system, this relation is more useful than "which timestamp is larger?" It tells you whether a replica is missing a dependency, whether a comment can appear before the post it replies to, whether a write can safely overwrite another write, and whether an incident timeline is showing causality or merely correlation. It also gives you a language for explaining why two datacenters may both be correct locally while disagreeing globally.
+
+### 2.2 Lamport Timestamps Preserve Causal Direction
+
+A **Lamport timestamp** is a logical counter. Each process increments its counter for local events. When it sends a message, it includes the counter. When another process receives the message, it advances its own counter to be greater than both its current value and the received value. The result is not a physical time. It is a compact causal label that satisfies a useful property: if event A happens before event B, then A's Lamport timestamp is smaller than B's.
+
+The reverse is not guaranteed. If A's Lamport timestamp is smaller than B's, that does not prove A happened before B. Two concurrent events can receive different counter values because of local increments or tie-breakers. This is why Lamport timestamps are excellent for preserving causal direction, but insufficient for detecting all concurrency by themselves. They can help construct a deterministic total order, yet that total order may still impose an arbitrary order on events that were actually concurrent.
+
+```text
+Node A counter = 0                 Node B counter = 0
+
+A local event: counter = 1
+A sends message with timestamp 1  ------------>
+                                   B receives message
+                                   B counter = max(0, 1) + 1 = 2
+                                   B local event: counter = 3
+```
+
+The operator mental model is that Lamport time is a "causal breadcrumb," not a stopwatch. It is useful when a workflow carries state from step to step: a client reads version 12, writes version 13, and the next service must not treat that write as older than something it causally depended on. It is less useful when two disconnected users concurrently edit the same field and you need to know whether one edit should dominate. For that, you need richer causality tracking or a business merge rule.
+
+### 2.3 Vector Clocks and Version Vectors Detect Concurrency
+
+A **vector clock** expands the logical timestamp into one counter per actor. Instead of recording "this event has logical time 7," a vector might record `{us-east: 4, eu-west: 2, ap-south: 1}`. Each actor increments its own slot when it creates an event. When actors exchange state, they merge by taking the maximum value for each slot. Comparing vectors lets the system distinguish "newer because it includes everything the other version saw" from "concurrent because each version contains work the other has not seen."
+
+Version vectors apply the same idea to versions of data. If version X has vector `{A: 3, B: 1}` and version Y has `{A: 3, B: 2}`, Y dominates X because it has seen at least as much history in every slot and more in B's slot. If version X has `{A: 4, B: 1}` and version Y has `{A: 3, B: 2}`, neither dominates. X contains A's extra update; Y contains B's extra update. The correct conclusion is not "pick the largest timestamp." The correct conclusion is "these versions are concurrent and require a merge policy."
+
+```text
+Baseline:      {A: 1, B: 1}
+
+A edits name:  {A: 2, B: 1}
+B edits email: {A: 1, B: 2}
+
+Neither vector dominates. The edits are concurrent.
+If the fields are independent, merge them. If they touch the same field,
+ask the domain model how conflicts should be resolved.
+```
+
+Martin Kleppmann's *Designing Data-Intensive Applications* emphasizes this practical split between ordering, causality, and consistency guarantees: timestamps can make systems appear simple, but the real design question is what guarantees the application needs and what anomalies it can tolerate ([book site](https://dataintensive.net/)). Version vectors are not free; they add metadata and require actor identity management. They earn their cost when losing an acknowledged write would be worse than surfacing a conflict.
+
+### 2.4 Two Datacenters Cannot Always Be Totally Ordered
+
+Imagine two users edit the same profile from different continents. User A writes through a service in Virginia. User B writes through a service in Frankfurt. The requests arrive at nearly the same physical moment, neither datacenter communicates with the other before accepting its write, and replication between regions is delayed. You can ask each datacenter what it saw locally, but no participant observed both writes before accepting its own. There is no causal evidence that one write happened before the other.
+
+The temptation is to say, "Just compare timestamps." That produces an answer, but it does not produce truth. If Virginia's clock is 80 milliseconds fast and Frankfurt's clock is 20 milliseconds slow, a timestamp comparison can reverse the real arrival order. Even if the clocks are close, network delay and scheduling noise can be larger than the gap between events. The closer the events are, the less confidence you should place in physical timestamp ordering.
+
+This is why global databases, queues, and controllers either relax the guarantee or pay for ordering. They may accept concurrent writes and merge them later. They may route all writes for a key through one leader. They may require quorum reads and writes. They may use consensus to append operations to a replicated log. They may expose conflicts to the application. They may use bounded clock uncertainty, as Spanner does with TrueTime, and wait out uncertainty before exposing a commit. Each approach is a trade-off; pretending physical timestamps are a free total order is not.
+
+---
+
+## Part 3: The Last-Writer-Wins Hazard
+
+### 3.1 Why LWW Is So Attractive
+
+**Last writer wins** sounds like common sense. If two replicas have different values for the same key, keep the value with the latest timestamp and discard the older one. The rule is deterministic, compact, easy to implement, and easy to explain. Every replica can independently choose the same winner once it sees the candidate values. Storage stays small because the system keeps one value, not a conflict set.
+
+Those strengths explain why LWW appears in real systems, especially systems optimized for availability and simple replication. The weakness is that LWW hides a policy decision inside the word "last." If "last" means "largest wall-clock timestamp," then one bad clock can choose the wrong winner. If "last" means "arrived last at this replica," then replicas can disagree unless another mechanism orders arrivals. If "last" means "highest logical version from a leader," then LWW is no longer a clock shortcut; it is using a real ordering mechanism.
+
+The silent part is what makes LWW dangerous. A client can receive an acknowledgement for a write, the write can replicate, and then a different value can erase it without an error. The losing write is not rejected. It is not marked as a conflict. It is simply absent from the winning state. For data such as shopping carts, user preferences, access-control changes, or payment metadata, that behavior is rarely what the business intended.
+
+### 3.2 How Clock Skew Loses a Later Write
+
+Consider a replicated key called `customer_status`. Node A's wall clock is two minutes fast. Node B's wall clock is correct. A client writes `status=trial_extended` through node A at real time `10:00:00`, and node A tags the write as `10:02:00`. Thirty seconds later, an operator writes `status=fraud_hold` through node B at real time `10:00:30`, and node B tags the write as `10:00:30`. The operator's write happened later in real time and may be more important, but LWW chooses node A's earlier write because `10:02:00` is larger.
+
+| Real Order | Node | Wall-Clock Timestamp | Value | LWW Result |
+|------------|------|----------------------|-------|------------|
+| First | A, clock fast by 120 seconds | 10:02:00 | `trial_extended` | Wins because timestamp is largest |
+| Second | B, clock correct | 10:00:30 | `fraud_hold` | Lost despite happening later |
+
+The most painful version of this incident is a future timestamp. If a host writes a value with a timestamp hours or years ahead, legitimate updates from healthy hosts may lose until wall time passes the bad timestamp or an operator repairs the data. This is not theoretical. Jepsen's Scylla 4.2-rc3 analysis found that timestamp behavior around non-lightweight transactions could lose acknowledged inserts, and that "even skews as small as one second resulted in lost updates" during the tested workloads ([Jepsen Scylla 4.2-rc3](https://jepsen.io/analyses/scylla-4.2-rc3)).
+
+### 3.3 Production Case Study: When "Commutative" Inserts Disappeared
+
+The instructive part of the Scylla analysis is not merely that a database had bugs. It is that experienced users could reasonably expect set inserts to commute. Adding `a` and adding `b` to a set should produce a set containing both values, regardless of order. In the Jepsen workload, however, imperfect timestamps interacted with the database's internal representation of collection updates. Higher clock skew increased write loss, and even one second of skew was enough to make acknowledged inserts disappear in the observed test.
+
+That should change how you read product claims. "Eventual consistency" does not automatically mean "safe merge." "Set" does not automatically mean "mathematical set under every internal write path." "Timestamps" do not automatically mean "the most recent real event." The only reliable question is what the system actually orders by, what conflict rule it actually applies, and how that rule behaves under skew, partitions, retries, and process pauses.
+
+The practical lesson for operators is to treat timestamp-based conflict resolution as an explicit risk. When you inherit a datastore that uses LWW, ask whether timestamps are client-supplied or server-assigned, whether clock health is monitored, whether future timestamps can quarantine a key, whether the application writes whole objects or commutative operations, and whether a safer mode exists for critical updates. If the answer is "we have NTP," the design review is not finished.
+
+---
+
+## Part 4: Practical Fixes
+
+### 4.1 Use Logical Timestamps When You Need Causal Order
+
+Logical timestamps are a good fit when the application can carry causality through the workflow. A client that reads version 41 and writes version 42 can include that dependency. A service that receives a command can advance its local counter before emitting follow-up events. A reconciler can store an observed generation and refuse to act on state older than the generation it already processed. These patterns do not require every host to agree on a wall-clock instant.
+
+The discipline is to name the guarantee precisely. A Lamport counter can preserve "this operation happened after that operation in the workflow." It cannot prove that an unrelated operation in another region was physically earlier or later. A vector clock can detect that two versions are concurrent. It cannot decide whether "rename project" should beat "archive project" without a domain rule. Logical clocks are tools for representing causality; they are not substitutes for product semantics.
+
+### 4.2 Use Version Vectors When Conflicts Must Be Seen
+
+Version vectors are useful when concurrent writes are expected and data loss is unacceptable. Instead of collapsing every conflict to one winner, the datastore can return siblings or conflict candidates to the application. The application then applies a semantic merge. Shopping carts often merge by item identity. Counters may use CRDT counters. Access policies might refuse automatic merge and require a human or a strongly ordered workflow. The right answer depends on the data, not on the clock.
+
+This approach changes the operational symptom. With LWW, a bad conflict rule produces missing data later. With version vectors, the system may produce explicit conflicts now. That can feel worse at first because it moves complexity into application code and user experience. In safety-critical domains, explicit conflict is often the better failure mode. A visible conflict can be reviewed, retried, or merged. A lost write may only be discovered after a customer, auditor, or incident commander asks why acknowledged work vanished.
+
+### 4.3 Use Quorum or Consensus When Total Order Is the Requirement
+
+Sometimes the correct fix is not a better timestamp. Sometimes the system truly needs one ordered history. Payment ledgers, Kubernetes object updates, leader election, schema migrations, and inventory reservations often need a linearizable or serializable path. In those cases, use a mechanism that actually creates an order: a single leader for a shard, a quorum protocol, a compare-and-swap version check, or a consensus log such as Raft.
+
+The cost is latency and availability under failure. A quorum write must wait for enough replicas. A consensus group cannot commit safely without a majority. A single leader may be far from some clients. Those costs are real, which is why this track spent a full module on consensus before returning to clocks. The habit is to pay for ordering only where the business invariant requires it, and to avoid pretending that timestamp sorting gives the same guarantee at a lower price.
+
+### 4.4 TrueTime Makes Uncertainty Explicit
+
+Google Spanner is often cited as a system that "solved clocks," but that summary misses the point. Spanner's TrueTime exposes bounded uncertainty rather than pretending a single exact now exists. Google Cloud's Spanner documentation explains that TrueTime provides a distributed clock API used to generate monotonically increasing timestamps across servers, and that Spanner uses those timestamps to provide external consistency for transactions ([Spanner TrueTime overview](https://cloud.google.com/spanner/docs/true-time-external-consistency)).
+
+The operator lesson is not "copy Spanner." Most teams do not have Google's clock infrastructure, GPS and atomic clock integration, uncertainty monitoring, and commit-wait design. The lesson is to make uncertainty explicit. If your system depends on physical time, identify the uncertainty bound, monitor it, and design behavior for when the bound is too large. If you cannot bound uncertainty tightly enough, use logical time or coordination instead.
+
+### 4.5 Choosing an Ordering Strategy
+
+| Requirement | Safer Strategy | Why It Fits |
+|-------------|----------------|-------------|
+| Measure request latency or retry delay | Monotonic local clock | The measurement is local elapsed time and should not move backward when civil time changes. |
+| Display audit timestamps to humans | Wall clock plus timezone discipline | The timestamp is a label for people, not proof of global ordering across machines. |
+| Preserve order inside one causal workflow | Lamport timestamp or version counter | The workflow can carry causality forward without trusting synchronized wall clocks. |
+| Detect concurrent edits from multiple writers | Vector clock or version vector | The metadata can show that neither version includes the other's history. |
+| Merge independent user changes | Domain merge or CRDT-style operation | The data model decides how concurrent operations combine without dropping work. |
+| Enforce a single ordered history | Quorum, CAS, or consensus | The invariant requires real coordination, not a timestamp heuristic. |
+| Use physical time for globally ordered commits | Bounded uncertainty with commit wait | The design must expose and wait out uncertainty rather than pretending it is zero. |
+
+---
+
+## Current Landscape
+
+Clock and ordering choices appear in ordinary production systems more often than they appear in architecture diagrams. The point of this table is not to memorize products, but to notice which guarantee a design is asking for before the implementation hides that guarantee behind a timestamp field, a retry loop, or a conflict resolver.
+
+| Approach | Where You See It | Operator Habit |
+|----------|------------------|----------------|
+| Wall-clock timestamps | Logs, audit fields, object metadata, certificate checks | Use them for human interpretation, then correlate with trace IDs and causal context before assigning blame. |
+| Monotonic timers | Timeouts, latency histograms, retry budgets, local leases | Review code paths that subtract wall-clock readings when they should measure elapsed duration. |
+| Optimistic version checks | Kubernetes `resourceVersion`, SQL `WHERE version = ?`, object generation checks | Treat conflicts as useful feedback that another actor changed state before your write committed. |
+| Logical timestamps | Event streams, workflow engines, replicated state machines, causal metadata | Propagate the metadata with the operation, and document what causal guarantee it actually provides. |
+| Version vectors | Eventually consistent stores, sync engines, multi-device state | Decide whether conflicts are merged automatically, exposed to users, or routed to a stronger write path. |
+| Consensus logs | etcd, Raft-backed stores, control planes, lock services | Use them sparingly for invariants that need one agreed order, and budget for quorum latency. |
+| Bounded clock uncertainty | Spanner-style externally consistent databases | Monitor uncertainty as a production signal and fail safely when the bound is outside design assumptions. |
+
+---
+
+## Best Practices
+
+1. **Measure elapsed time with monotonic APIs** - Timeouts, request duration, backoff windows, and local scheduling delays should use a monotonic source so that wall-clock correction cannot create negative durations or accidental stalls.
+2. **Keep wall-clock timestamps as labels, not judges** - Logs and audit fields are valuable, but they should be combined with request IDs, trace spans, versions, and message edges before you infer causality.
+3. **Make conflict policy part of the data model** - Decide whether concurrent writes should merge, conflict, retry, or route through consensus before production traffic discovers the answer for you.
+4. **Monitor clock health without depending on perfection** - NTP or chrony alerts are necessary hygiene, but the application should still tolerate realistic skew, host pauses, and temporary synchronization failure.
+5. **Use coordination for invariants that cannot be repaired later** - If a wrong order can move money incorrectly, grant access incorrectly, or corrupt a control plane, pay for quorum or consensus at that boundary.
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Why It's Bad | Better Approach |
+|--------------|--------------|-----------------|
+| Subtracting wall-clock timestamps for latency | Clock steps can produce negative or inflated durations and mislead autoscaling, SLOs, and incident analysis. | Use monotonic elapsed-time APIs and export the result as a metric. |
+| Treating NTP as a correctness proof | Synchronization reduces skew but cannot eliminate pauses, misconfiguration, asymmetric delay, or bad hardware. | Monitor clock health and design ordering around causality or coordination. |
+| Using LWW for user data by default | A skewed or future timestamp can silently discard acknowledged writes without surfacing a conflict. | Use version vectors, semantic merges, or a strongly ordered write path for important fields. |
+| Sorting incident timelines by timestamp alone | Logs from different hosts can be misordered, especially during pauses, drift, or delayed shipping. | Reconstruct causality with traces, message IDs, queue offsets, resource versions, and operator actions. |
+| Adding consensus everywhere | Strong ordering is expensive and can reduce availability during partitions or quorum loss. | Reserve consensus for invariants, and use weaker but explicit semantics elsewhere. |
+
+---
+
+## Part 5: Operator Playbook
+
+### 5.1 Read Timelines as Evidence, Not Truth
+
+During an incident, the first shared artifact is often a timeline assembled from logs. That timeline is useful, but it is not automatically causal. Logs from host A may be stamped by a clock that was fast, shipped through a buffer that was slow, and displayed beside logs from host B whose clock was corrected during the same window. If the team treats the sorted log view as ground truth, it can spend the response chasing the event that merely appears first. A better habit is to label early timelines as hypotheses and keep asking which entries are connected by request IDs, trace spans, queue offsets, database versions, or explicit messages.
+
+This changes how you speak in a review. Instead of saying "the cache expired before the write committed" because one timestamp appears earlier, say "the log view shows the cache expiry line before the commit line, but we need the trace edge or storage version to establish order." That distinction sounds careful because it is careful. It prevents a common failure mode where a team fixes the component with the earliest timestamp while the real cause sits behind a delayed replication edge, an unobserved retry, or a paused process.
+
+The same discipline applies to dashboards. A graph that overlays metrics from multiple machines is an excellent way to see correlation, but it may not prove sequence. Scrape intervals differ. Exporters buffer. Agents batch. The monitoring backend may ingest samples late. If one region's error rate rises on the graph before another region's saturation, that is a lead, not a verdict. Tie it back to causal artifacts: which client requests crossed the boundary, which deployment reached which pods, which leader term accepted which write, and which queue offset became visible to which consumer.
+
+### 5.2 Review Timestamp Fields Like You Review Locks
+
+Timestamp fields deserve design-review scrutiny because they often smuggle synchronization assumptions into data models. A field named `updated_at` might be harmless when it supports display ordering in a UI. The same field becomes risky when the storage layer uses it to decide which write survives. A field named `expires_at` may be correct for a business deadline, but wrong for a local lease if two actors on different machines can compare it and assume mutual exclusion. The question is not whether timestamps are bad. The question is what authority the system gives them.
+
+When a design proposes timestamp-based ordering, ask where the timestamp is generated, how much skew is tolerated, whether clients can supply values, and what happens when a timestamp appears from the future. Ask whether a losing write is observable as a conflict or disappears as a normal overwrite. Ask whether retries reuse the same timestamp or generate a later one that changes conflict behavior. Ask whether backup restoration, regional failover, or VM suspend/resume can introduce old or future values. These are ordinary operational events, not exotic failures.
+
+This is also where schema shape matters. Whole-object replacement is more vulnerable to LWW data loss than operation-shaped writes. Replacing an entire cart with `items=[book]` can erase a concurrent `items=[keyboard]` write. Recording "add item book with unique operation ID" and "add item keyboard with unique operation ID" gives the system a chance to merge. The more the write encodes intent, the less the resolver has to guess from timestamps. This is why many robust eventually consistent designs store operations, facts, or immutable events rather than repeatedly overwriting one mutable blob.
+
+### 5.3 Separate Local Safety From Distributed Safety
+
+A monotonic clock gives strong local safety for elapsed time, but it does not create distributed safety by itself. If one process starts a 500-millisecond timeout, a monotonic deadline is exactly the right tool. If two processes on different machines each hold a local monotonic deadline and compare notes later, those readings do not share an epoch and cannot be used as a global order. The safe conclusion is narrow: this process waited this much local elapsed time. Anything beyond that needs causality or coordination.
+
+This boundary appears in leases. A local lease timeout can prevent one process from using a resource forever, but a distributed lease that grants exclusive ownership needs a design for clock uncertainty, renewals, fencing tokens, or consensus. Without fencing, an old lease holder that paused for a long garbage collection cycle may wake up and continue writing after a new holder has taken over. Without a monotonically increasing fencing token checked by the storage system, the old holder's writes may still be accepted. The problem is not that the timeout was measured incorrectly; the problem is that local elapsed time was mistaken for distributed authority.
+
+Kubernetes gives a useful everyday example through optimistic concurrency. Clients update objects through the API server, and conflicts are detected with resource versions rather than by asking which client has the later wall-clock timestamp. A controller that reads an object, computes a patch, and submits it against stale state gets a conflict it must handle. That conflict is not noise. It is the control plane telling the controller that another actor changed the object in the observed history. Retrying against fresh state is safer than overwriting based on local time.
+
+### 5.4 Choose the Failure Mode You Want
+
+Every ordering strategy chooses a failure mode. Wall-clock LWW chooses simplicity and risks invisible loss. Version vectors choose explicit conflict and require merge code. CRDT-style operations choose restricted data types and gain deterministic convergence. Quorum and consensus choose latency and reduced availability during some failures to protect one agreed order. Bounded uncertainty chooses infrastructure and waiting behavior to make physical time usable within a known envelope. The mature design question is not "which one is best?" It is "which failure mode can this workflow survive?"
+
+For collaborative text, visible conflict or CRDT merge may be acceptable because users can see and repair intent. For a payment ledger, visible conflict after the fact may be too late, so a strongly ordered commit path is justified. For analytics counters, approximate convergence may be fine. For access control, a lost revoke can be severe, so a stronger write path or explicit version check may be required. The data's meaning decides the ordering mechanism. The infrastructure merely enforces the decision.
+
+This is why "we use NTP" should never be the final answer in a design review. Good clock discipline is part of responsible operations, just like backups and alerts. It is not a replacement for deciding what the system does under uncertainty. When the application can merge safely, represent operations so they merge. When the application must expose conflicts, preserve enough version history to detect them. When the application needs one order, use a component whose job is ordering. When the application relies on physical time, expose the uncertainty and test the path where uncertainty grows too large.
+
+One useful review exercise is to remove every wall-clock timestamp from the design for ten minutes and ask what information remains. If the system can still explain causality with versions, operation IDs, trace edges, queue offsets, or consensus indexes, the timestamps are probably labels. If the design suddenly cannot decide which write wins, which lease holder is valid, or which action is safe to retry, the timestamp was carrying correctness. That is the moment to replace assumption with an explicit ordering mechanism.
+
+### 5.5 A Worked Ordering Review
+
+Suppose a team proposes a multi-region account settings service. Each region accepts writes locally for low latency. The table has `account_id`, `email`, `marketing_opt_in`, `admin_locked`, `value_blob`, and `updated_at`. Replication is asynchronous. Conflicts are resolved by choosing the row with the largest `updated_at`. At first glance, the design looks available and easy to operate. Under the clock model from this module, it has at least three separate policies hidden behind one timestamp.
+
+The `email` field may need conflict detection because two devices changing it at the same time should not silently pick one address without user confirmation. The `marketing_opt_in` field might be safe with a domain-specific rule, perhaps preserving the most privacy-protective value when there is uncertainty. The `admin_locked` field likely needs a strongly ordered or version-checked path because a lost lock or lost unlock has security implications. Treating all fields as one `value_blob` makes every conflict a whole-object conflict, and treating `updated_at` as the resolver makes the fastest clock the policy owner.
+
+A stronger design separates those meanings. Store independent fields with independent conflict rules where possible. Carry version vectors or per-field versions when concurrent user edits must be detected. Route security-sensitive administrative changes through a compare-and-swap or quorum-backed path. Keep `updated_at` for display and audit correlation, not as the final authority over state. If the team still wants LWW for a low-value field, document that losing one of two concurrent writes is acceptable. That documentation is not bureaucracy; it is the place where the system admits its chosen failure mode before production traffic discovers it.
+
+---
+
+## Did You Know?
+
+- Lamport's 1978 paper defines happens-before without physical clocks, then introduces logical clocks as counters that preserve causal ordering; the paper's lasting value is the separation between causality and calendar time.
+- TrueTime does not return a magic single global now; Spanner's design uses bounded uncertainty and timestamp ordering to provide external consistency, which is a much stronger guarantee than eventual consistency.
+- Jepsen's Scylla 4.2-rc3 analysis found clock-skew-sensitive lost updates in workloads where users might reasonably expect independent set or map inserts to commute safely.
+- NTP is specified as a protocol for synchronizing system clocks over packet-switched networks, but its existence does not remove the need to design for network delay, host pauses, and failed synchronization.
+
+---
+
+## Common Mistakes
+
+| Mistake | Problem | Solution |
+|---------|---------|----------|
+| Assuming a later timestamp means a later event | Skew, drift, and clock steps can reverse the apparent order of distributed writes. | Ask whether there is a causal path, and use logical metadata when ordering matters. |
+| Measuring timeouts with wall-clock time | A backward step can extend a timeout, while a forward step can fire it too early. | Compute local deadlines using monotonic elapsed-time APIs. |
+| Believing LWW is harmless because it is deterministic | Every replica may choose the same wrong winner and discard useful acknowledged data. | Detect conflicts explicitly or merge operations according to domain semantics. |
+| Ignoring future timestamps | One bad host can write a value that suppresses legitimate updates until the future arrives. | Validate timestamp sources, alert on large skew, and repair poisoned records deliberately. |
+| Confusing Lamport order with physical recency | Lamport timestamps preserve causality but can arbitrarily order concurrent events. | Use vector clocks for concurrency detection or consensus for a real total order. |
+| Reconstructing incidents from logs alone | Independent host clocks and delayed log shipping can make timelines look cleaner than reality. | Combine logs with traces, queue offsets, database versions, and deployment events. |
+
+---
+
+## Quiz
+
+1. **A service measures request duration by recording `time.time()` at the start and end of each request. During an NTP correction, some requests report negative latency. What is wrong with the measurement, and what should the service use instead?**
+   <details>
+   <summary>Answer</summary>
+   The service is using wall-clock time to measure elapsed duration. A wall clock can move backward or forward when it is corrected, so subtracting two readings can produce negative or inflated durations. The service should measure request duration with a monotonic clock such as `CLOCK_MONOTONIC`, Go's monotonic `time.Since`, Java's `System.nanoTime`, Python's `time.monotonic`, or the equivalent API in its runtime.
+   </details>
+
+2. **Two writes to the same key arrive in different regions during a replication delay. Neither region observed the other write before accepting its own. What does the happens-before relation say about these events, and why is sorting by timestamp not enough?**
+   <details>
+   <summary>Answer</summary>
+   The events are concurrent because there is no causal path between them. Neither write happened before the other in the system's observable history. Sorting by timestamp imposes a total order, but that order may reflect clock skew rather than causality. The system needs a conflict policy, version-vector detection, semantic merge, or a coordinated write path if the application requires one winner.
+   </details>
+
+3. **A database uses last-writer-wins with client-supplied wall-clock timestamps. One application server's clock jumps five minutes into the future and writes a profile value. What failure mode should operators expect?**
+   <details>
+   <summary>Answer</summary>
+   Operators should expect future legitimate writes from healthy servers to lose against the future timestamp until real time catches up or the poisoned value is repaired. The database may acknowledge those later writes and still discard them during conflict resolution. This is silent data loss from the user's perspective, not a clean rejected write, so operators need clock alerts, timestamp validation, and a safer conflict strategy for important data.
+   </details>
+
+4. **When should you choose consensus or quorum ordering instead of logical clocks or version vectors? Give one example where the extra latency is justified.**
+   <details>
+   <summary>Answer</summary>
+   Choose consensus or quorum ordering when the business invariant requires one agreed history and conflicts cannot be safely merged later. A payment ledger, Kubernetes control-plane update, leader election, or inventory reservation can justify the added latency because the cost of a wrong order is higher than the cost of coordination. Logical clocks and version vectors help represent causality and detect conflicts, but they do not by themselves enforce a single committed order.
+   </details>
+
+5. **A controller reads a Kubernetes object, computes a patch, and receives a conflict because the object changed before the patch committed. Why is that conflict useful, and why would a wall-clock comparison be weaker?**
+   <details>
+   <summary>Answer</summary>
+   The conflict is useful because it tells the controller that it acted on stale observed state. The safe behavior is to re-read the object, recompute the desired change, and submit a new update against the latest resource version. A wall-clock comparison would be weaker because it could only compare timestamps from different actors; it would not prove which object version the controller actually observed before making its decision.
+   </details>
+
+6. **A product team says LWW is acceptable for a multi-region settings service because conflicts are rare and all machines run NTP. What design questions should you ask before accepting that answer?**
+   <details>
+   <summary>Answer</summary>
+   Ask which fields can safely lose an acknowledged write, whether timestamps are client-supplied or server-generated, how much skew is tolerated, what happens when a future timestamp is written, and whether conflicts are visible or silently discarded. Also ask whether some fields need separate policies: user preferences might tolerate a merge rule, while security-sensitive settings may need compare-and-swap, quorum, or consensus ordering.
+   </details>
+
+---
+
+## Hands-On Exercise
+
+**Task**: Run a deterministic kind lab that simulates two pods with different timestamp sources, observes last-writer-wins selecting the wrong write, and fixes the outcome with a Lamport-style logical timestamp carried by the client workflow.
+
+The lab creates two writer pods. `writer-a` has a wall-clock offset of +120 seconds. `writer-b` has no offset. A client Job writes to `writer-a` first, then writes to `writer-b` second. Because `writer-a` is fast by two minutes, wall-clock LWW chooses the first write even though the second write happened later. The same client also carries Lamport counters `1` and `2`, so logical ordering correctly chooses the second write.
+
+**Prerequisites**: Docker, `kind`, and `kubectl` installed locally. The commands create or reuse a kind cluster named `clock-skew-lab` and clean only the namespace named `clock-skew-lab`.
+
+### Step 1: Create the kind cluster
+
+```bash
+kind get clusters | grep -qx clock-skew-lab || kind create cluster --name clock-skew-lab --image kindest/node:v1.35.0
+kubectl config use-context kind-clock-skew-lab
+```
+
+### Step 2: Deploy the skewed writer pods and the verifier Job
+
+```bash
+kubectl delete namespace clock-skew-lab --ignore-not-found --wait=true
+kubectl create namespace clock-skew-lab
+
+cat <<'YAML' | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clock-demo-code
+  namespace: clock-skew-lab
+data:
+  writer.py: |
+    import json
+    import os
+    import time
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+    from urllib.parse import parse_qs, urlparse
+
+    NODE_ID = os.environ["NODE_ID"]
+    OFFSET_SECONDS = float(os.environ["CLOCK_OFFSET_SECONDS"])
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            parsed = urlparse(self.path)
+            if parsed.path != "/write":
+                self.send_response(404)
+                self.end_headers()
+                return
+            query = parse_qs(parsed.query)
+            value = query.get("value", ["missing"])[0]
+            lamport = int(query.get("lamport", ["0"])[0])
+            payload = {
+                "node": NODE_ID,
+                "value": value,
+                "wall_ms": int((time.time() + OFFSET_SECONDS) * 1000),
+                "monotonic_ms": int(time.monotonic() * 1000),
+                "offset_seconds": OFFSET_SECONDS,
+                "lamport": lamport,
+            }
+            body = json.dumps(payload, sort_keys=True).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format, *args):
+            return
+
+    HTTPServer(("0.0.0.0", 8080), Handler).serve_forever()
+  client.py: |
+    import json
+    import sys
+    import time
+    import urllib.parse
+    import urllib.request
+
+    def fetch(url, value, lamport):
+        encoded_value = urllib.parse.quote(value)
+        target = f"{url}/write?value={encoded_value}&lamport={lamport}"
+        deadline = time.monotonic() + 45
+        last_error = None
+        while time.monotonic() < deadline:
+            try:
+                with urllib.request.urlopen(target, timeout=3) as response:
+                    return json.loads(response.read().decode())
+            except Exception as exc:
+                last_error = exc
+                time.sleep(1)
+        raise RuntimeError(f"could not reach {target}: {last_error}")
+
+    first = fetch("http://writer-a:8080", "A-first-write-from-fast-clock", 1)
+    time.sleep(0.25)
+    second = fetch("http://writer-b:8080", "B-second-write-from-correct-clock", 2)
+    events = [first, second]
+
+    lww_winner = max(events, key=lambda event: event["wall_ms"])
+    lamport_winner = max(events, key=lambda event: (event["lamport"], event["node"]))
+
+    print("Observed writes in real execution order:")
+    for event in events:
+        print(json.dumps(event, sort_keys=True))
+    print(f"LWW winner: {lww_winner['node']} -> {lww_winner['value']}")
+    print(f"Lamport winner: {lamport_winner['node']} -> {lamport_winner['value']}")
+
+    if lww_winner["node"] != "writer-a":
+        print("ERROR: expected wall-clock LWW to choose writer-a because its clock is fast")
+        sys.exit(1)
+    if lamport_winner["node"] != "writer-b":
+        print("ERROR: expected Lamport ordering to choose writer-b because it is the second causal write")
+        sys.exit(1)
+
+    print("RESULT: wall-clock LWW lost the later write; logical ordering preserved it.")
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: writer-a
+  namespace: clock-skew-lab
+  labels:
+    app: writer-a
+spec:
+  containers:
+    - name: writer
+      image: python:3.12-alpine
+      imagePullPolicy: IfNotPresent
+      command: ["/usr/local/bin/python", "/demo/writer.py"]
+      env:
+        - name: NODE_ID
+          value: writer-a
+        - name: CLOCK_OFFSET_SECONDS
+          value: "120"
+      ports:
+        - containerPort: 8080
+      volumeMounts:
+        - name: code
+          mountPath: /demo
+  volumes:
+    - name: code
+      configMap:
+        name: clock-demo-code
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: writer-a
+  namespace: clock-skew-lab
+spec:
+  selector:
+    app: writer-a
+  ports:
+    - port: 8080
+      targetPort: 8080
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: writer-b
+  namespace: clock-skew-lab
+  labels:
+    app: writer-b
+spec:
+  containers:
+    - name: writer
+      image: python:3.12-alpine
+      imagePullPolicy: IfNotPresent
+      command: ["/usr/local/bin/python", "/demo/writer.py"]
+      env:
+        - name: NODE_ID
+          value: writer-b
+        - name: CLOCK_OFFSET_SECONDS
+          value: "0"
+      ports:
+        - containerPort: 8080
+      volumeMounts:
+        - name: code
+          mountPath: /demo
+  volumes:
+    - name: code
+      configMap:
+        name: clock-demo-code
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: writer-b
+  namespace: clock-skew-lab
+spec:
+  selector:
+    app: writer-b
+  ports:
+    - port: 8080
+      targetPort: 8080
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: clock-client
+  namespace: clock-skew-lab
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: client
+          image: python:3.12-alpine
+          imagePullPolicy: IfNotPresent
+          command: ["/usr/local/bin/python", "/demo/client.py"]
+          volumeMounts:
+            - name: code
+              mountPath: /demo
+      volumes:
+        - name: code
+          configMap:
+            name: clock-demo-code
+YAML
+```
+
+### Step 3: Wait for the deterministic result and read the output
+
+```bash
+kubectl -n clock-skew-lab wait --for=condition=Ready pod/writer-a pod/writer-b --timeout=120s
+kubectl -n clock-skew-lab wait --for=condition=complete job/clock-client --timeout=120s
+kubectl -n clock-skew-lab logs job/clock-client
+```
+
+The output includes dynamic timestamp values because the pods generate fresh event payloads during the run, but the winner lines below are deterministic because `writer-a` is always offset by two minutes and `writer-b` always carries the larger Lamport counter.
+
+```text
+LWW winner: writer-a -> A-first-write-from-fast-clock
+Lamport winner: writer-b -> B-second-write-from-correct-clock
+RESULT: wall-clock LWW lost the later write; logical ordering preserved it.
+```
+
+### Step 4: Clean up the lab namespace when finished
+
+```bash
+kubectl delete namespace clock-skew-lab --wait=true
+```
+
+### Success Criteria
+
+- [ ] You created or reused a local kind cluster and deployed two writer pods with different timestamp offsets.
+- [ ] You observed LWW choose `writer-a`, the first real write, because its wall-clock timestamp was artificially ahead.
+- [ ] You observed Lamport ordering choose `writer-b`, the second causal write, because the client carried a larger logical counter.
+- [ ] You can explain why the monotonic timestamp in the payload is useful for local elapsed time but not for cross-pod conflict resolution.
+
+---
+
+## Next Module
+
+This is the final distributed-systems foundation lesson currently available in this section. Continue into the discipline and toolkit tracks when you are ready to apply these ordering habits to production reliability work, platform control planes, GitOps reconciliation loops, and observability systems that must reconstruct causality from imperfect signals.
+
+---
+
+## Key Takeaways
+
+- [ ] **Wall clocks label events for humans**: Use them for audit entries, log timestamps, calendar deadlines, and external reporting, but do not treat them as proof of distributed order.
+- [ ] **Monotonic clocks measure elapsed local time**: Use them for timeouts, retries, latency, backoff, and local scheduling decisions that must not break when civil time changes.
+- [ ] **Clock synchronization is hygiene, not magic**: NTP and chrony reduce skew, but production systems must still tolerate drift, pauses, misconfiguration, and temporary loss of synchronization.
+- [ ] **Happens-before is causal, not chronological**: Some distributed events are ordered by process order and messages, while other events are genuinely concurrent from the system's perspective.
+- [ ] **Lamport timestamps preserve causal direction**: They ensure causally later events receive larger counters, but they do not prove that every smaller counter was physically earlier.
+- [ ] **Version vectors expose concurrency**: They help the system distinguish dominated versions from concurrent versions that need a merge or conflict workflow.
+- [ ] **LWW is lossy under skew**: A fast clock, slow clock, or future timestamp can silently discard a later acknowledged write without producing an error.
+- [ ] **Strong ordering has a price**: Use quorum, compare-and-swap, or consensus where invariants demand one history, and use explicit weaker semantics where they are acceptable.
+- [ ] **Bounded uncertainty is an advanced physical-clock strategy**: Spanner's TrueTime model works because uncertainty is measured, exposed, and incorporated into commit behavior.
+
+---
+
+## Further Reading
+
+- **[Leslie Lamport, "Time, Clocks, and the Ordering of Events in a Distributed System"](https://lamport.azurewebsites.net/pubs/time-clocks.pdf)** - The foundational paper for happens-before, logical clocks, and why distributed ordering cannot start with physical clock assumptions.
+- **[Martin Kleppmann, "Designing Data-Intensive Applications"](https://dataintensive.net/)** - The clearest practitioner treatment of replication, clocks, consistency guarantees, and the hazards of timestamp-based conflict resolution.
+- **[Justin Sheehy, "There is No Now"](https://queue.acm.org/detail.cfm?id=2745385)** - A practical essay on simultaneity, failure, and why Spanner should be read as an uncertainty-aware design rather than proof that clocks are solved.
+- **[Google Cloud Spanner TrueTime documentation](https://cloud.google.com/spanner/docs/true-time-external-consistency)** - A production example of bounded uncertainty used to support externally consistent distributed transactions.
+- **[Jepsen: Scylla 4.2-rc3](https://jepsen.io/analyses/scylla-4.2-rc3)** - A concrete analysis showing how timestamp behavior and clock skew can contribute to lost updates in systems with Cassandra-style conflict semantics.
+- **[RFC 5905: Network Time Protocol Version 4](https://www.rfc-editor.org/rfc/rfc5905)** - The protocol specification behind modern NTP behavior and terminology.
+- **[Python `time.monotonic` documentation](https://docs.python.org/3/library/time.html#time.monotonic)** - Runtime documentation that distinguishes monotonic elapsed-time measurement from wall-clock APIs.
+- **[Go `time.Since` documentation](https://pkg.go.dev/time#Since)** - Runtime documentation for elapsed-time measurement built around Go's monotonic clock support.
+- **[Linux `clock_gettime` manual](https://man7.org/linux/man-pages/man2/clock_gettime.2.html)** - System-level reference for wall-clock and monotonic clock IDs on Linux.
+- **[Kubernetes API resource version documentation](https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions)** - Practical control-plane example of version-based optimistic concurrency instead of wall-clock overwrite.
+- **[Jepsen lost write phenomenon](https://jepsen.io/consistency/phenomena/lost-write)** - A concise definition of write loss that helps frame why silent LWW overwrites are dangerous.
+- **[Spanner research publication](https://research.google/pubs/spanner-googles-globally-distributed-database/)** - The original system paper behind Spanner's externally consistent transaction design.
+
+---
+
+## Track Complete: Distributed Systems
+
+You have now connected the main mental models in this foundation: distribution creates partial failure, consensus creates one agreed order when the invariant requires it, eventual consistency accepts temporary disagreement, and clock-aware design prevents wall-clock shortcuts from corrupting that disagreement. The next time you see a timestamp in a distributed design, ask whether it is a label, a measurement, a causal marker, or an ordering decision.
+
+### Where This Leads
+
+| Your Interest | Next Track |
+|---------------|------------|
+| Platform building | [Platform Engineering Discipline](/platform/disciplines/core-platform/platform-engineering/) |
+| Reliability | [SRE Discipline](/platform/disciplines/core-platform/sre/) |
+| Kubernetes deep dive | [CKA Certification](/k8s/cka/) |
+| Observability tools | [Observability Toolkit](/platform/toolkits/observability-intelligence/observability/) |
+
+---
+
+### Key Links
+
+- [Module 5.2: Consensus and Coordination](../module-5.2-consensus-and-coordination/)
+- [Module 5.3: Eventual Consistency](../module-5.3-eventual-consistency/)
+- [Platform Engineering Discipline](/platform/disciplines/core-platform/platform-engineering/)
+- [SRE Discipline](/platform/disciplines/core-platform/sre/)
+- [Observability Toolkit](/platform/toolkits/observability-intelligence/observability/)

--- a/src/content/docs/platform/foundations/distributed-systems/module-5.5-clock-skew-and-ordering.md
+++ b/src/content/docs/platform/foundations/distributed-systems/module-5.5-clock-skew-and-ordering.md
@@ -358,27 +358,23 @@ A stronger design separates those meanings. Store independent fields with indepe
 
 ## Hands-On Exercise
 
-**Task**: Reinforce clock skew, last-writer-wins hazards, and ordering choices through observation and design — without deploying custom services or verifier Jobs.
+**Task**: Reinforce clock skew, last-writer-wins hazards, and ordering choices through observation and design.
 
-**Prerequisites**: Any existing Kubernetes cluster (kind, minikube, or a test cluster) with `kubectl` configured. Commands below use the `default` namespace; adjust if your environment restricts it.
+**Prerequisites**: Any existing Kubernetes cluster (kind, minikube, or a test cluster) with `kubectl` configured.
 
 **Task 1: Wall-clock timestamps as evidence, not truth**
 
-Create a short burst of API activity, then list cluster Events sorted by wall-clock time. Notice that `lastTimestamp` is a label each apiserver or component recorded locally — not proof of global order.
+Using only read-only `kubectl`, list cluster Events sorted by wall-clock time. Notice that `lastTimestamp` is a label each apiserver or component recorded locally — not proof of global order.
 
 ```bash
-kubectl create configmap clock-skew-observe --from-literal=phase=1
-kubectl patch configmap clock-skew-observe -p '{"data":{"phase":"2"}}'
-kubectl delete configmap clock-skew-observe
-
 kubectl get events -A --sort-by=.lastTimestamp | tail -20
 ```
 
-In your notes, answer: (a) Do the Events appear in strict causal order of your three commands? (b) Could two Events from different nodes share the same second but reflect different real-time instants?
+Pick two Events that appear close together in the sorted list (same second or adjacent lines). In your notes, answer: (a) Does sorted order prove which underlying cluster change happened first in causal history? (b) Could two Events from different nodes share the same `lastTimestamp` second while reflecting different real-time instants under clock skew?
 
 <details>
 <summary>Solution & Explanation</summary>
-Sorted Events show **when each component chose to record** an observation, not a single shared "now." Your ConfigMap create, patch, and delete may interleave with unrelated Events (scheduling, image pulls, other namespaces). Two Events can share an identical `lastTimestamp` second while originating from hosts whose wall clocks differ by hundreds of milliseconds — or more under skew. Treat wall-clock fields as **audit evidence**: useful for humans correlating logs, unsafe as the sole arbiter of which distributed write happened first.
+Sorted Events show **when each component chose to record** an observation, not a single shared "now." The list mixes unrelated activity (scheduling, image pulls, other namespaces) with no guarantee that wall-clock order matches causal order. Two Events can share an identical `lastTimestamp` second while originating from hosts whose wall clocks differ by hundreds of milliseconds — or more under skew. Treat wall-clock fields as **audit evidence**: useful for humans correlating logs, unsafe as the sole arbiter of which distributed write happened first.
 </details>
 
 **Task 2: Last-writer-wins under clock skew (pen-and-paper)**
@@ -399,7 +395,7 @@ LWW keeps **Region A's** `theme=light` because `12:05:00Z` > `12:03:30Z` even th
 
 **Task 3: Pick an ordering strategy (pen-and-paper)**
 
-For each requirement, choose **one primary** mechanism: wall-clock LWW, Lamport timestamps, version vectors, or quorum/consensus (e.g. etcd/Raft). Briefly justify the trade-off.
+For each requirement, choose **one primary** mechanism: wall-clock LWW, Lamport timestamps, version vectors, resourceVersion / compare-and-swap (optimistic concurrency), or quorum/consensus (e.g. etcd/Raft). Briefly justify the trade-off.
 
 1. **Collaborative document title** — concurrent offline edits must surface as conflicts, not silent merges.
 2. **Global payment ledger** — no two clients may observe different committed balances for the same account.
@@ -410,7 +406,7 @@ For each requirement, choose **one primary** mechanism: wall-clock LWW, Lamport 
 <summary>Solution & Explanation</summary>
 1. **Version vectors** (or explicit conflict branches) — detect concurrent edits so the product can merge or ask the user; LWW would hide concurrency.
 2. **Quorum/consensus** — financial invariants need one agreed history; latency cost is acceptable.
-3. **Lamport timestamps** (or idempotent keys + monotonic sequence per series) — preserve causal direction without requiring physical clock agreement across regions.
+3. **Stable idempotency key per batch (or per sample) plus a per-series monotonic or logical sequence number** — retries must carry the same idempotency key so the receiver drops duplicates; the sequence orders related samples without requiring physical clock agreement. Lamport or hybrid logical clocks can annotate causal order but do **not** deduplicate by themselves.
 4. **Resource-version / compare-and-swap** — the API already exposes version-based optimistic concurrency instead of wall-clock overwrite; this matches the control-plane pattern in Part 4 of this module.
 </details>
 

--- a/src/content/docs/platform/foundations/distributed-systems/module-5.5-clock-skew-and-ordering.md
+++ b/src/content/docs/platform/foundations/distributed-systems/module-5.5-clock-skew-and-ordering.md
@@ -358,9 +358,7 @@ A stronger design separates those meanings. Store independent fields with indepe
 
 ## Hands-On Exercise
 
-**Task**: Reinforce clock skew, last-writer-wins hazards, and ordering choices through observation and design.
-
-**Prerequisites**: Any existing Kubernetes cluster (kind, minikube, or a test cluster) with `kubectl` configured.
+**Task**: Reinforce clock skew, last-writer-wins hazards, and ordering choices through observation and design. **Prerequisites**: any existing Kubernetes cluster (kind, minikube, or a test cluster) with `kubectl` configured for Task 1; Tasks 2 through 4 are pen-and-paper and need no cluster at all.
 
 **Task 1: Wall-clock timestamps as evidence, not truth**
 

--- a/src/content/docs/platform/foundations/distributed-systems/module-5.5-clock-skew-and-ordering.md
+++ b/src/content/docs/platform/foundations/distributed-systems/module-5.5-clock-skew-and-ordering.md
@@ -358,248 +358,77 @@ A stronger design separates those meanings. Store independent fields with indepe
 
 ## Hands-On Exercise
 
-**Task**: Run a deterministic kind lab that simulates two pods with different timestamp sources, observes last-writer-wins selecting the wrong write, and fixes the outcome with a Lamport-style logical timestamp carried by the client workflow.
+**Task**: Reinforce clock skew, last-writer-wins hazards, and ordering choices through observation and design — without deploying custom services or verifier Jobs.
 
-The lab creates two writer pods. `writer-a` has a wall-clock offset of +120 seconds. `writer-b` has no offset. A client Job writes to `writer-a` first, then writes to `writer-b` second. Because `writer-a` is fast by two minutes, wall-clock LWW chooses the first write even though the second write happened later. The same client also carries Lamport counters `1` and `2`, so logical ordering correctly chooses the second write.
+**Prerequisites**: Any existing Kubernetes cluster (kind, minikube, or a test cluster) with `kubectl` configured. Commands below use the `default` namespace; adjust if your environment restricts it.
 
-**Prerequisites**: Docker, `kind`, and `kubectl` installed locally. The commands create or reuse a kind cluster named `clock-skew-lab` and clean only the namespace named `clock-skew-lab`.
+**Task 1: Wall-clock timestamps as evidence, not truth**
 
-### Step 1: Create the kind cluster
-
-```bash
-kind get clusters | grep -qx clock-skew-lab || kind create cluster --name clock-skew-lab --image kindest/node:v1.35.0
-kubectl config use-context kind-clock-skew-lab
-```
-
-### Step 2: Deploy the skewed writer pods and the verifier Job
+Create a short burst of API activity, then list cluster Events sorted by wall-clock time. Notice that `lastTimestamp` is a label each apiserver or component recorded locally — not proof of global order.
 
 ```bash
-kubectl delete namespace clock-skew-lab --ignore-not-found --wait=true
-kubectl create namespace clock-skew-lab
+kubectl create configmap clock-skew-observe --from-literal=phase=1
+kubectl patch configmap clock-skew-observe -p '{"data":{"phase":"2"}}'
+kubectl delete configmap clock-skew-observe
 
-cat <<'YAML' | kubectl apply -f -
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: clock-demo-code
-  namespace: clock-skew-lab
-data:
-  writer.py: |
-    import json
-    import os
-    import time
-    from http.server import BaseHTTPRequestHandler, HTTPServer
-    from urllib.parse import parse_qs, urlparse
-
-    NODE_ID = os.environ["NODE_ID"]
-    OFFSET_SECONDS = float(os.environ["CLOCK_OFFSET_SECONDS"])
-
-    class Handler(BaseHTTPRequestHandler):
-        def do_GET(self):
-            parsed = urlparse(self.path)
-            if parsed.path != "/write":
-                self.send_response(404)
-                self.end_headers()
-                return
-            query = parse_qs(parsed.query)
-            value = query.get("value", ["missing"])[0]
-            lamport = int(query.get("lamport", ["0"])[0])
-            payload = {
-                "node": NODE_ID,
-                "value": value,
-                "wall_ms": int((time.time() + OFFSET_SECONDS) * 1000),
-                "monotonic_ms": int(time.monotonic() * 1000),
-                "offset_seconds": OFFSET_SECONDS,
-                "lamport": lamport,
-            }
-            body = json.dumps(payload, sort_keys=True).encode()
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json")
-            self.send_header("Content-Length", str(len(body)))
-            self.end_headers()
-            self.wfile.write(body)
-
-        def log_message(self, format, *args):
-            return
-
-    HTTPServer(("0.0.0.0", 8080), Handler).serve_forever()
-  client.py: |
-    import json
-    import sys
-    import time
-    import urllib.parse
-    import urllib.request
-
-    def fetch(url, value, lamport):
-        encoded_value = urllib.parse.quote(value)
-        target = f"{url}/write?value={encoded_value}&lamport={lamport}"
-        deadline = time.monotonic() + 45
-        last_error = None
-        while time.monotonic() < deadline:
-            try:
-                with urllib.request.urlopen(target, timeout=3) as response:
-                    return json.loads(response.read().decode())
-            except Exception as exc:
-                last_error = exc
-                time.sleep(1)
-        raise RuntimeError(f"could not reach {target}: {last_error}")
-
-    first = fetch("http://writer-a:8080", "A-first-write-from-fast-clock", 1)
-    time.sleep(0.25)
-    second = fetch("http://writer-b:8080", "B-second-write-from-correct-clock", 2)
-    events = [first, second]
-
-    lww_winner = max(events, key=lambda event: event["wall_ms"])
-    lamport_winner = max(events, key=lambda event: (event["lamport"], event["node"]))
-
-    print("Observed writes in real execution order:")
-    for event in events:
-        print(json.dumps(event, sort_keys=True))
-    print(f"LWW winner: {lww_winner['node']} -> {lww_winner['value']}")
-    print(f"Lamport winner: {lamport_winner['node']} -> {lamport_winner['value']}")
-
-    if lww_winner["node"] != "writer-a":
-        print("ERROR: expected wall-clock LWW to choose writer-a because its clock is fast")
-        sys.exit(1)
-    if lamport_winner["node"] != "writer-b":
-        print("ERROR: expected Lamport ordering to choose writer-b because it is the second causal write")
-        sys.exit(1)
-
-    print("RESULT: wall-clock LWW lost the later write; logical ordering preserved it.")
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: writer-a
-  namespace: clock-skew-lab
-  labels:
-    app: writer-a
-spec:
-  containers:
-    - name: writer
-      image: python:3.12-alpine
-      imagePullPolicy: IfNotPresent
-      command: ["/usr/local/bin/python", "/demo/writer.py"]
-      env:
-        - name: NODE_ID
-          value: writer-a
-        - name: CLOCK_OFFSET_SECONDS
-          value: "120"
-      ports:
-        - containerPort: 8080
-      volumeMounts:
-        - name: code
-          mountPath: /demo
-  volumes:
-    - name: code
-      configMap:
-        name: clock-demo-code
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: writer-a
-  namespace: clock-skew-lab
-spec:
-  selector:
-    app: writer-a
-  ports:
-    - port: 8080
-      targetPort: 8080
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: writer-b
-  namespace: clock-skew-lab
-  labels:
-    app: writer-b
-spec:
-  containers:
-    - name: writer
-      image: python:3.12-alpine
-      imagePullPolicy: IfNotPresent
-      command: ["/usr/local/bin/python", "/demo/writer.py"]
-      env:
-        - name: NODE_ID
-          value: writer-b
-        - name: CLOCK_OFFSET_SECONDS
-          value: "0"
-      ports:
-        - containerPort: 8080
-      volumeMounts:
-        - name: code
-          mountPath: /demo
-  volumes:
-    - name: code
-      configMap:
-        name: clock-demo-code
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: writer-b
-  namespace: clock-skew-lab
-spec:
-  selector:
-    app: writer-b
-  ports:
-    - port: 8080
-      targetPort: 8080
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: clock-client
-  namespace: clock-skew-lab
-spec:
-  backoffLimit: 0
-  template:
-    spec:
-      restartPolicy: Never
-      containers:
-        - name: client
-          image: python:3.12-alpine
-          imagePullPolicy: IfNotPresent
-          command: ["/usr/local/bin/python", "/demo/client.py"]
-          volumeMounts:
-            - name: code
-              mountPath: /demo
-      volumes:
-        - name: code
-          configMap:
-            name: clock-demo-code
-YAML
+kubectl get events -A --sort-by=.lastTimestamp | tail -20
 ```
 
-### Step 3: Wait for the deterministic result and read the output
+In your notes, answer: (a) Do the Events appear in strict causal order of your three commands? (b) Could two Events from different nodes share the same second but reflect different real-time instants?
 
-```bash
-kubectl -n clock-skew-lab wait --for=condition=Ready pod/writer-a pod/writer-b --timeout=120s
-kubectl -n clock-skew-lab wait --for=condition=complete job/clock-client --timeout=120s
-kubectl -n clock-skew-lab logs job/clock-client
-```
+<details>
+<summary>Solution & Explanation</summary>
+Sorted Events show **when each component chose to record** an observation, not a single shared "now." Your ConfigMap create, patch, and delete may interleave with unrelated Events (scheduling, image pulls, other namespaces). Two Events can share an identical `lastTimestamp` second while originating from hosts whose wall clocks differ by hundreds of milliseconds — or more under skew. Treat wall-clock fields as **audit evidence**: useful for humans correlating logs, unsafe as the sole arbiter of which distributed write happened first.
+</details>
 
-The output includes dynamic timestamp values because the pods generate fresh event payloads during the run, but the winner lines below are deterministic because `writer-a` is always offset by two minutes and `writer-b` always carries the larger Lamport counter.
+**Task 2: Last-writer-wins under clock skew (pen-and-paper)**
 
-```text
-LWW winner: writer-a -> A-first-write-from-fast-clock
-Lamport winner: writer-b -> B-second-write-from-correct-clock
-RESULT: wall-clock LWW lost the later write; logical ordering preserved it.
-```
+A multi-region settings row stores `{theme: "dark"}`. Two writers update the same key:
 
-### Step 4: Clean up the lab namespace when finished
+| Step | Writer | Real execution order | Wall-clock timestamp on write | Value |
+|------|--------|----------------------|-------------------------------|-------|
+| 1 | Region A (clock +90s fast) | First | `2026-05-29T12:05:00Z` | `theme=light` |
+| 2 | Region B (NTP-correct) | Second | `2026-05-29T12:03:30Z` | `theme=dark` |
 
-```bash
-kubectl delete namespace clock-skew-lab --wait=true
-```
+The store resolves conflicts with **last-writer-wins by wall-clock timestamp**. Which value survives after both writes succeed? What did the user who received `200 OK` from Region B actually lose?
 
-### Success Criteria
+<details>
+<summary>Solution & Explanation</summary>
+LWW keeps **Region A's** `theme=light` because `12:05:00Z` > `12:03:30Z` even though Region B's write happened second in real time. The user who got `200 OK` from Region B believed their preference was stored; after convergence, reads return `light` — a **silent lost update**. No error surfaced because the database did exactly what the policy said: pick the largest timestamp. This is why skew turns LWW from a convenience into an incident class, and why operators ask whether timestamps are server-assigned, client-supplied, or replaced by logical versions.
+</details>
 
-- [ ] You created or reused a local kind cluster and deployed two writer pods with different timestamp offsets.
-- [ ] You observed LWW choose `writer-a`, the first real write, because its wall-clock timestamp was artificially ahead.
-- [ ] You observed Lamport ordering choose `writer-b`, the second causal write, because the client carried a larger logical counter.
-- [ ] You can explain why the monotonic timestamp in the payload is useful for local elapsed time but not for cross-pod conflict resolution.
+**Task 3: Pick an ordering strategy (pen-and-paper)**
+
+For each requirement, choose **one primary** mechanism: wall-clock LWW, Lamport timestamps, version vectors, or quorum/consensus (e.g. etcd/Raft). Briefly justify the trade-off.
+
+1. **Collaborative document title** — concurrent offline edits must surface as conflicts, not silent merges.
+2. **Global payment ledger** — no two clients may observe different committed balances for the same account.
+3. **Metrics batch idempotency** — duplicate delivery of the same sample must not double-count; causal order among related samples is enough.
+4. **Kubernetes object updates** — controllers must not clobber each other's optimistic patches.
+
+<details>
+<summary>Solution & Explanation</summary>
+1. **Version vectors** (or explicit conflict branches) — detect concurrent edits so the product can merge or ask the user; LWW would hide concurrency.
+2. **Quorum/consensus** — financial invariants need one agreed history; latency cost is acceptable.
+3. **Lamport timestamps** (or idempotent keys + monotonic sequence per series) — preserve causal direction without requiring physical clock agreement across regions.
+4. **Resource-version / compare-and-swap** — the API already exposes version-based optimistic concurrency instead of wall-clock overwrite; this matches the control-plane pattern in Part 4 of this module.
+</details>
+
+**Task 4: Design a skew-tolerant user-preference service**
+
+Sketch (bullet list is fine) a design for `user_id → {locale, theme}` replicated to three regions. Constraints: reads should be low-latency; **no acknowledged write may be silently discarded**; operators run NTP but do not assume perfect sync. Specify: (1) what you store per write besides the payload, (2) how replicas merge on sync, (3) what the client sees when two regions edit offline concurrently.
+
+<details>
+<summary>Solution & Explanation</summary>
+Store each write with a **version vector** or hybrid logical clock plus the payload — not wall-clock LWW alone. On sync, if one version dominates another (all counters ≥ and at least one >), keep the dominator; if vectors are concurrent, **flag a conflict** and return both variants (or a CRDT merge for commutative fields like `theme` if the product defines merge rules). Clients read from the nearest replica but must send their last-seen vector on write; concurrent offline edits yield `409 Conflict` or a merge UI, never a silent revert. For `locale` (non-commutative), force explicit resolution; for `theme` you might allow a defined merge policy. Optional: use **monotonic deadlines** locally for timeouts while keeping wall clocks only in audit logs.
+</details>
+
+**Success Criteria**:
+
+- [ ] You listed Events with `kubectl get events` and explained why sort-by timestamp is not global causal order.
+- [ ] You identified the LWW survivor and the lost write in Task 2 without relying on a custom lab.
+- [ ] You matched each Task 3 scenario to a defensible ordering mechanism and stated the trade-off.
+- [ ] Your Task 4 design names a non-wall-clock ordering or conflict signal and avoids silent discard of acknowledged writes.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds Module 5.5: Clock Skew and Ordering to the Distributed Systems foundation track.
- Teaches wall vs monotonic clocks, skew/drift, NTP limits, Lamport/vector clocks, happens-before, LWW hazards, and practical ordering fixes.
- Updates the Distributed Systems index module count, module table, learning path, and key concepts for 5.5.

## Learner check

> A distributed system does not have one "now." It has many machines, each with its own oscillator, kernel, clock discipline, pauses, virtual machine scheduling delays, leap adjustments, and network path to the rest of the system.

## Validation

- `.venv/bin/python scripts/quality/verify_module.py src/content/docs/platform/foundations/distributed-systems/module-5.5-clock-skew-and-ordering.md` -> passed T0; 5,036 counted body words.
- Kind lab sanity check -> ran successfully; LWW picked `writer-a` and Lamport ordering picked `writer-b` as expected.
- `git diff --check` -> clean.
- `.venv/bin/python scripts/check_site_health.py` -> 0 errors, 8 warnings.
- `.venv/bin/python scripts/test_pipeline.py` -> 170 tests OK.
- `npm run build` from the primary checkout -> passed; existing site-wide warnings observed (Vite chunk size, UK route conflicts, LaTeX Unicode warning).