### PR TITLE
feat(nav): surface AI Engineering Foundations track in AI sidebar (refs #1639)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -154,6 +154,7 @@ export default defineConfig({
           items: [
             { label: 'AI Hub', link: '/ai/' },
             { label: 'AI Foundations', autogenerate: { directory: 'ai/foundations' }, collapsed: true },
+            { label: 'AI Engineering Foundations', autogenerate: { directory: 'ai/ai-engineering-foundations' }, collapsed: true },
             { label: 'AI-Native Work', autogenerate: { directory: 'ai/ai-native-work' }, collapsed: true },
             { label: 'AI Building', autogenerate: { directory: 'ai/ai-building' }, collapsed: true },
             { label: 'Open Models & Local Inference', autogenerate: { directory: 'ai/open-models-local-inference' }, collapsed: true },


### PR DESCRIPTION
## What
Adds the `ai/ai-engineering-foundations` track (the canonical prompt → context → harness → symphony spine, 13 modules) to the **AI tab** sidebar, between "AI Foundations" (beginner literacy) and "AI-Native Work" (applied).

## Why (root cause for #1639)
Audit finding: this track was **not listed in any sidebar** — `grep ai-engineering-foundations astro.config.mjs` returned zero entries, and git history shows it was never added when the track was built (#1530). It was reachable only by direct URL. That invisibility is the core reason the prompt/context/harness subject "looks done but stays buried" per #1639.

## Verification
- `npm run build` — 0 errors, autogenerate picks up the 13 modules.

Part of #1639 (the discoverability half). Cross-links + the merge-vs-keep-distinct decisions are tracked separately. `refs #1639` (epic stays open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)