### PR TITLE
fix(briefing): stop critical_quality rows from dominating actions.next

### DIFF
--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -8346,20 +8346,6 @@ def build_session_briefing(repo_root: Path) -> dict[str, Any]:
                 endpoint=f"/api/pipeline/v2/events?module={mk}" if mk else None,
             )
 
-    if isinstance(quality, dict) and quality.get("exists"):
-        for m in (quality.get("critical") or [])[:5]:
-            # Rubric rows don't carry a real ``module_key`` (the
-            # audit uses human-readable labels), so we store the
-            # label itself as the key and point at /api/quality/
-            # scores for drill-down. Agents can cross-reference.
-            _add_row(
-                "next",
-                f"rubric-critical rewrite: {m.get('module','?')} "
-                f"({m.get('track','?')}) score {m.get('score','?')}",
-                module_key=m.get("module"),
-                reason="critical_quality",
-                endpoint="/api/quality/scores",
-            )
     if isinstance(reviews, dict) and reviews.get("exists"):
         for review in (reviews.get("reviews") or [])[:5]:
             mk = review.get("module_key")

--- a/tests/test_local_api.py
+++ b/tests/test_local_api.py
@@ -2593,21 +2593,24 @@ def test_briefing_top_modules_surfaces_pipeline_dead_letter(
     assert "pipeline_dead_letter" in reasons
 
 
-def test_briefing_top_modules_covers_critical_quality(tmp_path: Path) -> None:
-    """Codex round-2 gap: top_modules was missing critical_quality
-    and ready_queue categories. Rubric-critical rows must surface as
-    drillable entries, not just stringified actions.next lines."""
+def test_briefing_critical_quality_not_in_actions_next(tmp_path: Path) -> None:
+    """Critical-rubric modules stay on ``critical_quality`` + alerts;
+    they must not crowd ``actions.next`` (gaps-first orchestration)."""
     _setup_repo(tmp_path)
     _write(tmp_path / "STATUS.md", "# s\n\n## TODO\n\n- [ ] x\n")
     _seed_quality_module(tmp_path, "k8s/cka/module-2.8-bad-stub", title="Module 2.8: Bad Stub", filler_lines=30)
     with local_api._QUALITY_AUDIT_CACHE_LOCK:
         local_api._QUALITY_AUDIT_CACHE.clear()
     briefing = local_api.build_session_briefing(tmp_path)
-    reasons = {m.get("reason") for m in briefing["top_modules"]}
-    assert "critical_quality" in reasons
-    # Critical rubric entries must point at the scores endpoint.
-    cq = [m for m in briefing["top_modules"] if m.get("reason") == "critical_quality"]
-    assert cq and cq[0]["endpoint"] == "/api/quality/scores"
+    assert briefing["critical_quality"], "critical modules must surface on dedicated field"
+    next_rows = [r for r in briefing.get("action_rows") or [] if r.get("bucket") == "next"]
+    assert not any(r.get("reason") == "critical_quality" for r in next_rows)
+    assert not any(
+        "rubric-critical rewrite" in (label or "")
+        for label in briefing["actions"]["next"]
+    )
+    top_reasons = {m.get("reason") for m in briefing["top_modules"]}
+    assert "critical_quality" not in top_reasons
 
 
 def test_quality_scores_live_repo_no_citations_force_critical() -> None:


### PR DESCRIPTION
## What
Removes the injection of `critical_quality` rubric rows into the briefing's primary `actions.next` bucket (`scripts/local_api.py`, `build_session_briefing`).

## Why
Nothing else populates `next` in steady state, so 5 "rubric-critical rewrite" rows dominated the orchestrator's top-action display every cold start — repeatedly pulling sessions off the standing **"gaps first, not re-fixing existing modules"** directive (locked 3× by the user). Critical-rubric modules remain fully surfaced via the dedicated `critical_quality` field and the `alerts` line, so nothing is lost.

## Verification
- `.venv/bin/ruff check scripts/local_api.py` — clean
- New regression test `test_briefing_critical_quality_not_in_actions_next` (replaces the now-inverted `test_briefing_top_modules_covers_critical_quality`): asserts no `reason==critical_quality` row in `actions.next` while the `critical_quality` field stays populated. Passes.

Regression test: tests/test_local_api.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)