### PR TITLE
docs(ai): cross-link neighbor AI tracks to canonical engineering-foundations spine (refs #1639)

### DIFF
--- a/src/content/docs/ai-ml-engineering/ai-native-development/module-1.1-ai-coding-tools-landscape.md
+++ b/src/content/docs/ai-ml-engineering/ai-native-development/module-1.1-ai-coding-tools-landscape.md
@@ -28,7 +28,7 @@ That distinction matters because AI coding tools do not differ only by brand. Th
 
 This module gives you a practical landscape map. You will not memorize every plan name or model version, because those change too quickly. Instead, you will learn a durable evaluation model: decide what work needs to be done, identify the authority a tool needs to do that work, and put verification around the authority you grant. By the end, you should be able to choose a sane starter stack, explain why it fits your constraints, and reject tools that look impressive but solve the wrong problem.
 
-> **Where this fits:** This phase maps tooling authority; the canonical prompt → context → harness → symphony spine lives in [AI Engineering Foundations](/ai/ai-engineering-foundations/).
+> **Go deeper:** This phase maps tooling authority; the canonical prompt → context → harness → symphony spine lives in [AI Engineering Foundations](/ai/ai-engineering-foundations/).
 
 ## The Landscape Is About Authority, Not Hype
 

--- a/src/content/docs/ai-ml-engineering/ai-native-development/module-1.1-ai-coding-tools-landscape.md
+++ b/src/content/docs/ai-ml-engineering/ai-native-development/module-1.1-ai-coding-tools-landscape.md
@@ -28,6 +28,8 @@ That distinction matters because AI coding tools do not differ only by brand. Th
 
 This module gives you a practical landscape map. You will not memorize every plan name or model version, because those change too quickly. Instead, you will learn a durable evaluation model: decide what work needs to be done, identify the authority a tool needs to do that work, and put verification around the authority you grant. By the end, you should be able to choose a sane starter stack, explain why it fits your constraints, and reject tools that look impressive but solve the wrong problem.
 
+> **Where this fits:** This phase maps tooling authority; the canonical prompt → context → harness → symphony spine lives in [AI Engineering Foundations](/ai/ai-engineering-foundations/).
+
 ## The Landscape Is About Authority, Not Hype
 
 The easiest mistake in this space is comparing tools by model name alone. Model quality matters, but a coding workflow is shaped just as much by the tool wrapper around the model. A browser chat may use a strong model and still be awkward for a repository-wide refactor because it cannot inspect your tree, apply patches, or run tests. A smaller model inside a well-integrated agent may outperform it on a routine migration because the agent has the right files, can make edits, and can observe the test output.

--- a/src/content/docs/ai-ml-engineering/frameworks-agents/module-1.6-agent-memory-planning.md
+++ b/src/content/docs/ai-ml-engineering/frameworks-agents/module-1.6-agent-memory-planning.md
@@ -38,6 +38,8 @@ A senior engineer should treat an agent as a distributed system, not as a clever
 
 This module teaches agent memory and planning from first principles, then connects those ideas to production-grade constraints. You will start with the simplest memory problem, add retrieval and summarization, compare planning algorithms, examine multi-agent topologies, and finish with a fully traced worked example. The goal is not to memorize pattern names. The goal is to make defensible design decisions when an agent must complete a complex task safely, cheaply, and observably.
 
+> **Go deeper:** For retrieval, tool, and memory boundary design as one engineering layer, see [Retrieval, Tools, and Memory Boundaries](/ai/ai-engineering-foundations/module-2.3-retrieval-tools-and-memory-boundaries/).
+
 ---
 
 ## Part 1: What Changes When a Model Becomes an Agent

--- a/src/content/docs/ai-ml-engineering/frameworks-agents/module-1.8-model-context-protocol.md
+++ b/src/content/docs/ai-ml-engineering/frameworks-agents/module-1.8-model-context-protocol.md
@@ -17,6 +17,8 @@ This incident highlighted the extreme fragility of treating tool integration as 
 
 The Model Context Protocol (MCP) fundamentally solves this problem by introducing a standardized, open-source architecture for connecting AI models to data sources and tools. By decoupling the client (the model or agent) from the server (the data or tool provider), MCP allows developers to build robust, reusable integrations that work seamlessly across different models and platforms. Understanding and implementing MCP is no longer an optional optimization; it is the foundational requirement for building secure, scalable, and maintainable AI agent architectures in the modern enterprise landscape. It represents the shift from artisanal prompt engineering to rigorous systems engineering in the AI domain.
 
+> **Go deeper:** MCP is one harness integration surface; for layers, system-of-record, and operating the loop around tools, see [Harness Fundamentals](/ai/ai-engineering-foundations/module-3.1-harness-fundamentals-layers-and-system-of-record/).
+
 ## Learning Outcomes
 
 Upon completing this module, you will be able to:

--- a/src/content/docs/ai/ai-building/module-1.2-models-apis-context-structured-output.md
+++ b/src/content/docs/ai/ai-building/module-1.2-models-apis-context-structured-output.md
@@ -28,6 +28,8 @@ A strong AI product is designed around that mismatch, and the builder chooses a 
 
 It then introduces structured output because software needs contracts, and it finishes with the validation layer because structured output without validation is just a better-looking failure.
 
+> **Go deeper:** For end-to-end context engineering (budgets, retrieval boundaries, and orchestration), see [Context Engineering Fundamentals](/ai/ai-engineering-foundations/module-2.1-context-fundamentals/).
+
 ## Model Choice Is Product Design
 
 Model choice is not only an infrastructure decision, and it changes the user experience, and it changes cost. It changes latency, and it changes how often the application needs fallback behavior, and it changes which tasks should be automated and which tasks should pause for review. A model that is excellent for a slow, high-stakes analysis may be a poor choice for inline autocomplete. A model that is excellent for cheap classification may be a poor choice for debugging a multi-step incident report.

--- a/src/content/docs/ai/ai-building/module-1.3-tools-retrieval-and-boundaries.md
+++ b/src/content/docs/ai/ai-building/module-1.3-tools-retrieval-and-boundaries.md
@@ -37,6 +37,8 @@ Real practitioners separate two questions that beginners often merge: what does 
 
 This module teaches you to keep those questions separate. You will classify product briefs, climb a capability ladder gradually, evaluate tool boundaries before exposure, and debug failures by locating the layer that introduced them. The goal is not to avoid powerful systems; the goal is to earn power one boundary at a time, with enough evidence that each promotion is justified.
 
+> **Go deeper:** For the canonical treatment of retrieval, tools, and memory boundaries in production agents, see [Retrieval, Tools, and Memory Boundaries](/ai/ai-engineering-foundations/module-2.3-retrieval-tools-and-memory-boundaries/).
+
 ## The Real Distinction: Knowledge Versus Capability
 
 The first thing to internalize is that "give the model more power" is not a single design decision. It is at least two decisions stacked on top of each other, and they have very different risk profiles. Knowledge expands what the model has in its working context when it answers: documents, snippets, search results, embeddings of internal data, or explicit facts returned by a trusted retriever. Capability expands what happens outside the chat as a side effect of the model's response: a function called, a row written, a ticket closed, an email sent, or a Kubernetes object changed. Treating those as the same lever is the architectural mistake that turns a promising assistant into an incident waiting for a prompt.

--- a/src/content/docs/ai/ai-for-kubernetes-platform-work/module-1.1-ai-for-yaml-manifests-config-review.md
+++ b/src/content/docs/ai/ai-for-kubernetes-platform-work/module-1.1-ai-for-yaml-manifests-config-review.md
@@ -33,6 +33,8 @@ That scenario is not a warning against using AI for platform work. It is a warni
 
 This module teaches a review-first workflow for AI-assisted Kubernetes YAML review. You will still use AI, but you will constrain the task, ask for uncertainty, classify every claim, verify operational assertions, and keep a written trail of why a change was accepted or deferred. The goal is not to make AI write Kubernetes YAML faster. The goal is to make your team inspect, question, and explain Kubernetes YAML with more discipline than a quick human skim or an unconstrained prompt would provide.
 
+> **Go deeper:** For prompt contracts, delimiters, and review-oriented prompting patterns beyond platform YAML, see [Prompt Fundamentals](/ai/ai-engineering-foundations/module-1.1-prompt-fundamentals/).
+
 ## The Review Mindset: AI Is a Reviewer, Not the Owner
 
 The safest starting point is a simple mental model: the human owns the manifest, and the AI helps inspect it. That means the assistant is not allowed to invent missing context, silently assume policy defaults, or turn a vague request into a production recommendation. A reviewer can raise concerns, ask questions, and explain tradeoffs, but the owner must verify and decide. This model sounds strict, yet it is the same expectation you already have for human code review on infrastructure changes.

--- a/src/content/docs/ai/ai-native-work/module-1.1-practical-ai-tool-use.md
+++ b/src/content/docs/ai/ai-native-work/module-1.1-practical-ai-tool-use.md
@@ -29,6 +29,8 @@ The operational problem is not that AI tools are weak; it is that teams often ch
 
 In this module, you will build a practical decision model for choosing the smallest safe tool that gives useful leverage without giving up control. The word "smallest" matters because every escalation adds cost, latency, permissions, and new ways to be wrong. The word "safe" matters because the right tool is not the one with the most impressive demo; it is the one whose output can be checked with the time, evidence, and access you actually have.
 
+> **Go deeper:** This module stays at operator-level tool choice; for systematic prompt design see [Prompt Fundamentals](/ai/ai-engineering-foundations/module-1.1-prompt-fundamentals/) and for how applications package evidence and constraints see [Context Engineering Fundamentals](/ai/ai-engineering-foundations/module-2.1-context-fundamentals/).
+
 ## Start With The Task, Not The Tool
 
 Many people begin with the question, "Which AI tool should I use?" That question feels practical, but it is already one step too late because it makes the tool the center of the decision. A better starting point is to name the kind of work you are doing: explanation, summarization, source discovery, drafting, rewriting, code inspection, code generation, or multi-step execution. Once the task type is visible, the tool choice becomes a consequence of the work instead of a guess based on whatever interface is open.

--- a/src/content/docs/ai/ai-native-work/module-1.2-ai-agents-and-assistants.md
+++ b/src/content/docs/ai/ai-native-work/module-1.2-ai-agents-and-assistants.md
@@ -31,6 +31,8 @@ This module gives you a practical vocabulary for that decision. You will separat
 
 The important habit is to define the workflow before choosing the tool. A mature team does not ask whether it can use an agent everywhere. It asks where delegated action reduces toil, where bounded tool use improves feedback, and where human review remains the cheapest control. That discipline keeps AI-native work from turning into either fear of automation or blind trust in automation.
 
+> **Go deeper:** For harness layers, system-of-record, and how agent loops sit inside controlled runtimes, see [Harness Fundamentals](/ai/ai-engineering-foundations/module-3.1-harness-fundamentals-layers-and-system-of-record/).
+
 ## The Autonomy Spectrum
 
 People often use the words chatbot, assistant, copilot, and agent as if they were interchangeable. They are related, but they are not the same operational pattern. The difference is not whether a model is impressive or whether the interface looks conversational. The difference is who drives the loop, which context enters the system, which tools can be called, and what happens after the model produces an answer.

--- a/src/content/docs/ai/ai-native-work/module-1.3-designing-ai-workflows.md
+++ b/src/content/docs/ai/ai-native-work/module-1.3-designing-ai-workflows.md
@@ -30,6 +30,8 @@ That difference matters because the real value of AI usually comes from workflow
 
 In this module, you will design workflows the way an engineer designs a production path: define the input, shape the context, constrain the output, verify the result, revise when the result fails, and assign responsibility before anything important changes state. You will not learn a magic prompt that fixes every task. You will learn a repeatable design method for deciding where AI belongs, where it should stop, and what evidence must exist before a person or system trusts its output.
 
+> **Go deeper:** When workflows graduate to multi-agent orchestration and fleet-scale coordination, see [Symphony](/ai/ai-engineering-foundations/module-4.1-symphony-work-orchestration-as-applied-harness/) in the engineering-foundations spine.
+
 ## From Prompting to Workflow Design
 
 A workflow is not "a lot of prompts." A workflow is a repeatable structure for moving from an input, through a sequence of steps, toward an output, with clear ownership and verification. That definition sounds simple, but it is the line between casual AI usage and operational AI usage. A casual prompt can be helpful when you are exploring ideas alone. A workflow is what you need when another person must repeat the process, review the result, or depend on the output later.

--- a/src/content/docs/ai/foundations/module-1.3-prompting-basics.md
+++ b/src/content/docs/ai/foundations/module-1.3-prompting-basics.md
@@ -22,6 +22,8 @@ Prompting is disciplined task framing. A prompt works like a ticket written for 
 
 This module teaches the first practical layer: writing prompts that produce reviewable work instead of lucky prose. You will practice turning vague requests into prompt contracts, choosing when to use examples, asking for structured output, and deciding when a second prompt is better than one enormous prompt. The next module focuses on verification, so this one stops at the handoff point: the answer should be clear enough that a human or tool can check it.
 
+> **Go deeper:** For the full prompt-engineering spine (contracts, reasoning prompts, libraries, and safety), see [Prompt Fundamentals](/ai/ai-engineering-foundations/module-1.1-prompt-fundamentals/) in [AI Engineering Foundations](/ai/ai-engineering-foundations/).
+
 ## A Prompt Is a Small Contract
 
 A prompt is not a spell, and treating it like one creates bad habits quickly. The useful mental model is a small contract: it names the work, provides the evidence, states the boundaries, and describes the deliverable. The model still generates probable text rather than guaranteed truth, but a contract narrows the problem enough that the answer can be judged. Without that narrowing, the model fills empty space with default assumptions from common examples it has seen before.


### PR DESCRIPTION
## What
Adds additive "Go deeper" cross-links from 10 neighbor AI modules (across the `ai/` and `ai-ml-engineering/` trees) to the canonical `ai-engineering-foundations` spine (Prompt Fundamentals, Context Engineering Fundamentals, Retrieval/Tools/Memory Boundaries, Harness Fundamentals, Symphony). 20 insertions, 0 deletions — no content rewrites.

## Why (part of #1639)
The prompt/context/harness subject had multiple disconnected front doors. Paired with the sidebar fix (#1642, merged), this gives the subject one discoverable canonical home and routes readers of the neighbor tracks there for depth.

Index audit: `ai/ai-native-work/index.md` and `ai-ml-engineering/ai-native-development/index.md` already link to the spine — left unchanged.

## Verification
- `npm run build` — exit 0
- `python scripts/check_site_health.py` — 0 errors

## Learner check
> In this module, you will design workflows the way an engineer designs a production path: define the input, shape the context, constrain the output, verify the result, revise when the result fails, and assign responsibility before anything important changes state.

(verbatim from the touched module `src/content/docs/ai/ai-native-work/module-1.3-designing-ai-workflows.md`, which now links to Symphony in the engineering-foundations spine)

`refs #1639` (epic stays open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
