### PR TITLE
chore(ai): retire 3 moved-stubs with redirects (refs #1639)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -29,6 +29,14 @@ export default defineConfig({
       '/ai-ml-engineering/machine-learning/module-1.6-xgboost-gradient-boosting/',
     '/ai-ml-engineering/classical-ml/module-1.3-time-series-forecasting/':
       '/ai-ml-engineering/machine-learning/module-1.12-time-series-forecasting/',
+    // #1639 Option B §4: retired moved-stubs — prompt/harness/symphony teaching
+    // consolidated into the canonical ai-engineering-foundations spine.
+    '/ai/ai-native-work/module-2.1-harness-engineering/':
+      '/ai/ai-engineering-foundations/module-3.1-harness-fundamentals-layers-and-system-of-record/',
+    '/ai/ai-native-work/module-2.2-orchestrating-fleets-symphony/':
+      '/ai/ai-engineering-foundations/module-4.1-symphony-work-orchestration-as-applied-harness/',
+    '/ai-ml-engineering/ai-native-development/module-1.6-prompt-engineering-fundamentals/':
+      '/ai/ai-engineering-foundations/module-1.1-prompt-fundamentals/',
   },
   markdown: {
     remarkPlugins: [remarkMath],

--- a/src/content/docs/ai-ml-engineering/ai-native-development/index.md
+++ b/src/content/docs/ai-ml-engineering/ai-native-development/index.md
@@ -20,7 +20,6 @@ This phase is about practical leverage: tool choice, local models, CLI agents, I
 | 1.3 | [Claude Code & CLI Deep Dive](/ai-ml-engineering/ai-native-development/module-1.3-claude-code-cli-deep-dive/) |
 | 1.4 | [Agent-First IDEs](/ai-ml-engineering/ai-native-development/module-1.4-agent-first-ides/) |
 | 1.5 | [CLI AI Coding Agents](/ai-ml-engineering/ai-native-development/module-1.5-cli-ai-coding-agents/) |
-| 1.6 | Prompt Engineering Fundamentals — [moved to AI Engineering Foundations](/ai/ai-engineering-foundations/module-1.1-prompt-fundamentals/) |
 | 1.7 | [AI-Powered Code Generation](/ai-ml-engineering/ai-native-development/module-1.7-ai-powered-code-generation/) |
 | 1.8 | [AI-Assisted Debugging & Optimization](/ai-ml-engineering/ai-native-development/module-1.8-ai-assisted-debugging-optimization/) |
 | 1.9 | [Building with AI Coding Assistants](/ai-ml-engineering/ai-native-development/module-1.9-building-with-ai-coding-assistants/) |

--- a/src/content/docs/ai-ml-engineering/ai-native-development/module-1.6-prompt-engineering-fundamentals.md
+++ b/src/content/docs/ai-ml-engineering/ai-native-development/module-1.6-prompt-engineering-fundamentals.md
@@ -1,8 +1,0 @@
----
-title: "Prompt Engineering Fundamentals"
-slug: ai-ml-engineering/ai-native-development/module-1.6-prompt-engineering-fundamentals
-sidebar:
-  order: 207
----
-
-This module has moved. See [Prompt Fundamentals](/ai/ai-engineering-foundations/module-1.1-prompt-fundamentals/).

--- a/src/content/docs/ai/ai-native-work/module-2.1-harness-engineering.md
+++ b/src/content/docs/ai/ai-native-work/module-2.1-harness-engineering.md
@@ -1,8 +1,0 @@
----
-title: "Harness Engineering"
-slug: ai/ai-native-work/module-2.1-harness-engineering
-sidebar:
-  order: 5
----
-
-This module has moved. See [Harness Fundamentals — Layers and System of Record](../../ai-engineering-foundations/module-3.1-harness-fundamentals-layers-and-system-of-record/).

--- a/src/content/docs/ai/ai-native-work/module-2.2-orchestrating-fleets-symphony.md
+++ b/src/content/docs/ai/ai-native-work/module-2.2-orchestrating-fleets-symphony.md
@@ -1,8 +1,0 @@
----
-title: "Orchestrating Fleets: Symphony and Project-Management-as-Control-Plane"
-slug: ai/ai-native-work/module-2.2-orchestrating-fleets-symphony
-sidebar:
-  order: 6
----
-
-This module has moved. See [Symphony — Work Orchestration as Applied Harness](../../ai-engineering-foundations/module-4.1-symphony-work-orchestration-as-applied-harness/).


### PR DESCRIPTION
## #1639 Option B §4(a) — retire moved-stubs with redirects

The prompt / harness / symphony teaching content was already consolidated into the canonical `ai/ai-engineering-foundations/` spine in a prior session. Three files were left behind as inert "this module has moved" stubs (18–25 words each). This PR retires them from visible nav while keeping their URLs alive via Starlight `redirects`.

### Changes
- **`astro.config.mjs`** — 3 redirects (old slug → canonical foundations module):
  - `ai/ai-native-work/module-2.1-harness-engineering` → `ai-engineering-foundations/module-3.1-harness-fundamentals-…`
  - `ai/ai-native-work/module-2.2-orchestrating-fleets-symphony` → `ai-engineering-foundations/module-4.1-symphony-…`
  - `ai-ml-engineering/ai-native-development/module-1.6-prompt-engineering-fundamentals` → `ai-engineering-foundations/module-1.1-prompt-fundamentals`
- Delete the 3 stub files (the AI sidebar is `autogenerate` → they drop out of nav automatically).
- `ai-ml-engineering/ai-native-development/index.md` — drop the now-redundant 1.6 "moved" pointer row (the redirect covers inbound links).

### Gates
- `npm run build` — green, 2127 pages, 0 warnings.
- `check_site_health.py` — **0 errors** (5 pre-existing warnings, all unrelated).
- `grep` for inbound internal links to the 3 retired slugs across `src/content/docs/` — **zero** (the only stale links were already fixed in #1646).
- Teaching-content-only; no labs.

### Learner check
> This phase is about practical leverage: tool choice, local models, CLI agents, IDE agents, MCP, and runtime control patterns.

Refs #1639.
