### PR TITLE
docs(ai): reconcile frameworks-agents 1.3 LangGraph + port ReAct to foundations 1.2 (refs #1639)

### DIFF
--- a/src/content/docs/ai-ml-engineering/frameworks-agents/module-1.3-langgraph-for-agents.md
+++ b/src/content/docs/ai-ml-engineering/frameworks-agents/module-1.3-langgraph-for-agents.md
@@ -4,1487 +4,1238 @@ slug: ai-ml-engineering/frameworks-agents/module-1.3-langgraph-for-agents
 sidebar:
   order: 504
 ---
-> **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 6-8
-# Or: Making AI Think Out Loud (And Why It Actually Works)
-
-**Reading Time**: 5-6 hours
-**Prerequisites**: Module 16
-**Heureka Moment**: Six words that tripled AI's reasoning ability
+> **Complexity**: `[COMPLEX]`
+>
+> **Time to Complete**: 80-100 minutes
+>
+> **Prerequisites**: [LangChain Fundamentals](./module-1.1-langchain-fundamentals/) and [LangChain Advanced](./module-1.2-langchain-advanced/), plus ReAct basics from [Reasoning and Logic Prompts](/ai/ai-engineering-foundations/module-1.2-reasoning-and-logic-prompts/).
 
 ---
 
 ## What You'll Be Able to Do
+- **Design** stateful AI workflows using LangGraph's StateGraph and conditional routing.
+- **Implement** cyclic execution paths to enable self-correcting agent behaviors.
+- **Diagnose** infinite loops and state mutation errors in complex multi-agent architectures.
+- **Evaluate** the trade-offs between linear chains and graph-based workflow orchestration.
 
-By the end of this module, you will:
+## Why This Module Matters
+Agents rarely fail because they cannot call a tool once. They fail because the real workflow has state: a request must be classified, routed, retried, reviewed, and sometimes resumed after a human decision or service interruption. LangGraph gives that workflow an explicit graph instead of hiding control flow inside one enormous prompt.
 
-1. **Master Chain-of-Thought (CoT)** - Make LLMs "think out loud" for better reasoning
-2. **Implement Zero-shot CoT** - The magic of "Let's think step by step"
-3. **Build Few-shot CoT systems** - Guide reasoning with examples
-4. **Understand ReAct** - Combine reasoning with action for agents
-5. **Apply self-consistency** - Multiple reasoning paths for robust answers
-6. **Know the limitations** - When CoT helps and when it doesn't
+A support automation team learned this after a document-analysis assistant produced good first drafts but lost track of which checks had already passed whenever a downstream service timed out. Operators restarted whole sessions, repeated expensive model calls, and manually reconstructed decisions from logs. The cost was not just latency; it was the loss of trust when an agent could not explain where it was in the process.
 
----
-
-## The Six Words That Changed AI
-
-**Tokyo. January 2022. 3:15 AM.**
-
-Jason Wei stared at his screen, exhausted but excited. He had just run the same math problem through Google's PaLM model with one tiny change: instead of asking for the answer directly, he added six words to the prompt.
-
-"Let's think step by step."
-
-The model that had been getting 17% accuracy on grade-school math problems suddenly jumped to 79%. Not from better training data. Not from a bigger model. Just six words.
-
-Wei had stumbled onto something profound: LLMs aren't bad at reasoning—they're bad at *showing their work*. Force them to externalize their thinking, and accuracy explodes.
-
-> "We found that simply prompting the model to 'think step by step' before answering can triple performance on some reasoning tasks. It's one of the simplest and most effective techniques we've discovered."
-> — Jason Wei, Google Research (Chain-of-Thought paper, 2022)
-
-This discovery—Chain-of-Thought prompting—became one of the most cited papers in AI. It's now built into every major AI assistant.
-
----
-
-## The Heureka Moment
-
-Here's the insight that will change how you build AI systems:
-
-**Making AI "think out loud" dramatically improves its reasoning ability.**
-
-This isn't a metaphor. It's not a trick. It's a fundamental property of how language models work:
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│              THE CHAIN-OF-THOUGHT REVELATION                     │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                  │
-│  WITHOUT COT:                                                    │
-│  ────────────                                                    │
-│  Q: "A store has 23 apples. If 7 are sold and 12 more arrive,   │
-│      how many apples are there?"                                 │
-│  A: "38"   (Wrong! Model jumped to conclusion)                │
-│                                                                  │
-│  WITH COT:                                                       │
-│  ────────                                                        │
-│  Q: "A store has 23 apples. If 7 are sold and 12 more arrive,   │
-│      how many apples are there? Let's think step by step."      │
-│                                                                  │
-│  A: "Let me work through this step by step:                     │
-│      1. Starting apples: 23                                      │
-│      2. After selling 7: 23 - 7 = 16                            │
-│      3. After 12 arrive: 16 + 12 = 28                           │
-│      Therefore, there are 28 apples."                         │
-│                                                                  │
-│  Same model. Same question. Different answer.                    │
-│  The ONLY change: asking it to think out loud.                  │
-│                                                                  │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-Why does this work? Because when the model generates intermediate steps, each step becomes part of its context. The model can "see" its own reasoning and use it to guide the next step. It's like the difference between doing math in your head versus writing it down.
-
-> ** Did You Know?**
->
-> The Chain-of-Thought paper by Wei et al. (2022) at Google Brain showed that adding "Let's think step by step" improved accuracy on the GSM8K math benchmark from 17.9% to 57.1% - a 3x improvement from just 6 words!
->
-> The paper was initially met with skepticism. "You're just asking it to show its work," critics said. But that's exactly the point - the "work" IS the reasoning. Without it, the model has no intermediate representation to build upon.
-
----
-
-## Theory
-
-### Why Reasoning is Hard for LLMs
-
-Large Language Models are fundamentally next-token predictors. They're trained to answer: "Given this context, what token comes next?"
-
-Think of an LLM like a brilliant improvisational actor who has read every book ever written. Ask them to play a mathematician, and they'll deliver a convincing performance—the mannerisms, the vocabulary, the confident delivery. But ask them to actually *prove* a theorem, and the performance falls apart. The actor was trained to *look like* they're doing math, not to actually do it.
-
-This creates a fundamental tension:
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│               THE REASONING PROBLEM                              │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                  │
-│  What LLMs are trained to do:                                   │
-│  ────────────────────────────                                    │
-│  Context: "The capital of France is"                            │
-│  → Predict: "Paris" (statistically most likely continuation)    │
-│                                                                  │
-│  What reasoning requires:                                        │
-│  ───────────────────────                                         │
-│  - Breaking down problems into steps                             │
-│  - Maintaining intermediate state                                │
-│  - Backtracking when needed                                      │
-│  - Verifying consistency                                         │
-│                                                                  │
-│  The mismatch:                                                   │
-│  ─────────────                                                   │
-│  Next-token prediction SKIPS intermediate reasoning.            │
-│  The model wants to jump straight to the "answer token"         │
-│  without computing the steps that justify it.                   │
-│                                                                  │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-Chain-of-Thought prompting solves this by making the intermediate steps part of the output. The model must generate reasoning tokens BEFORE answer tokens, forcing it to "do the work."
-
-Think of it like the difference between asking someone "What's 347 × 28?" and asking them to "Show your work." When you have to write down each step—347 × 8 = 2,776, then 347 × 20 = 6,940, then 2,776 + 6,940 = 9,716—you can't skip the actual computation. The written steps ARE the computation.
-
----
-
-### Chain-of-Thought Prompting
-
-Chain-of-Thought (CoT) prompting is a technique that encourages LLMs to generate intermediate reasoning steps before producing a final answer.
-
-#### The Basic Idea
-
-Instead of:
-```
-Input: Question
-Output: Answer
-```
-
-We get:
-```
-Input: Question + "Think step by step"
-Output: Step 1 → Step 2 → Step 3 → Answer
-```
-
-#### Why It Works: Three Mechanisms
-
-**1. Decomposition**
-Complex problems are broken into simpler sub-problems. Each sub-problem can be solved more reliably.
-
-**2. Error Correction**
-When reasoning is visible, errors in early steps can influence (and sometimes be corrected in) later steps.
-
-**3. Context Extension**
-The generated reasoning becomes part of the context for generating the answer, providing "working memory."
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│             HOW COT EXTENDS "WORKING MEMORY"                     │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                  │
-│  Without CoT - All in "hidden" computation:                     │
-│  ┌─────────────────────────────────────┐                        │
-│  │  Q: Complex problem                  │                        │
-│  │  [Black box neural network magic]    │                        │
-│  │  A: 42                               │                        │
-│  └─────────────────────────────────────┘                        │
-│                                                                  │
-│  With CoT - Reasoning in context:                               │
-│  ┌─────────────────────────────────────┐                        │
-│  │  Q: Complex problem                  │                        │
-│  │  Step 1: First, I notice that...    │ ← In context!          │
-│  │  Step 2: This means...              │ ← In context!          │
-│  │  Step 3: Combining these...         │ ← In context!          │
-│  │  A: 28                              │ ← Can "see" reasoning  │
-│  └─────────────────────────────────────┘                        │
-│                                                                  │
-│  The reasoning tokens act as external working memory!           │
-│                                                                  │
-└─────────────────────────────────────────────────────────────────┘
-```
-
----
-
-### Zero-Shot Chain-of-Thought
-
-The simplest form of CoT requires just a magic phrase added to your prompt:
-
-**"Let's think step by step."**
-
-That's it. These 5 words can dramatically improve reasoning on many tasks.
-
-```python
-# Without CoT
-prompt = """
-Q: Roger has 5 tennis balls. He buys 2 more cans of tennis balls.
-Each can has 3 tennis balls. How many tennis balls does he have now?
-A:"""
-
-# With Zero-Shot CoT
-prompt = """
-Q: Roger has 5 tennis balls. He buys 2 more cans of tennis balls.
-Each can has 3 tennis balls. How many tennis balls does he have now?
-A: Let's think step by step."""
-```
-
-#### Other Effective Zero-Shot Triggers
-
-Different phrasings work for different tasks:
-
-| Trigger Phrase | Best For |
-|---------------|----------|
-| "Let's think step by step" | General reasoning, math |
-| "Let's break this down" | Complex multi-part problems |
-| "Let's analyze this carefully" | Logical analysis |
-| "First, let's understand the problem" | Word problems |
-| "Let me work through this" | Calculations |
-| "Let's consider each option" | Multiple choice |
-
-> ** Did You Know?**
->
-> Kojima et al. (2022) tested 60+ different trigger phrases. "Let's think step by step" consistently outperformed all others, but the exact wording matters less than the presence of ANY reasoning trigger. Even "Think" alone helps!
->
-> The researchers also discovered that asking the model to "Think carefully" or "Make sure you're right" actually HURT performance. These create anxiety-like patterns that lead to overthinking and second-guessing. Neutral, process-focused triggers work best.
-
----
-
-### Few-Shot Chain-of-Thought
-
-For more complex or domain-specific reasoning, provide examples of the desired reasoning pattern:
-
-```python
-few_shot_cot_prompt = """
-Solve the following math problems. Show your reasoning step by step.
-
-Example 1:
-Q: A store has 50 shirts. They sell 23 and receive a shipment of 30.
-How many shirts do they have now?
-A: Let's solve this step by step:
-1. Starting shirts: 50
-2. After selling 23: 50 - 23 = 27
-3. After receiving 30: 27 + 30 = 57
-Therefore, they have 57 shirts.
-
-Example 2:
-Q: A baker makes 12 cakes. She gives 4 to neighbors and bakes 8 more.
-How many cakes does she have?
-A: Let's solve this step by step:
-1. Starting cakes: 12
-2. After giving 4 away: 12 - 4 = 8
-3. After baking 8 more: 8 + 8 = 16
-Therefore, she has 16 cakes.
-
-Now solve this problem:
-Q: A library has 85 books. They lend out 32 and receive a donation of 45.
-How many books do they have now?
-A: Let's solve this step by step:
-"""
-```
-
-#### The Power of Examples
-
-Few-shot CoT is more powerful than zero-shot because:
-
-1. **Pattern Learning**: Model learns YOUR reasoning style
-2. **Format Consistency**: Output follows your desired structure
-3. **Domain Adaptation**: Examples can encode domain knowledge
-4. **Error Prevention**: Examples show what NOT to do
-
-Think of few-shot CoT like training a new employee by showing them how you handle similar problems. You don't just say "figure it out"—you walk them through example cases: "When a customer asks about refunds, first check their purchase date, then verify the item condition, then calculate the refund amount." After seeing a few examples, they understand not just WHAT to do, but HOW you want them to think about the problem.
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│            ZERO-SHOT vs FEW-SHOT COT                            │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                  │
-│  Zero-Shot CoT:                                                 │
-│  + Simple - just add trigger phrase                             │
-│  + Works across domains                                          │
-│  - Less control over reasoning format                           │
-│  - May not match domain conventions                              │
-│                                                                  │
-│  Few-Shot CoT:                                                   │
-│  + High control over format                                      │
-│  + Domain-specific patterns                                      │
-│  + More consistent quality                                       │
-│  - Requires good examples                                        │
-│  - Uses more context tokens                                      │
-│                                                                  │
-│  Recommendation: Start with zero-shot, add examples             │
-│  if quality is insufficient.                                     │
-│                                                                  │
-└─────────────────────────────────────────────────────────────────┘
-```
-
----
-
-### ReAct: Reasoning and Acting
-
-ReAct (Reason + Act) combines chain-of-thought reasoning with the ability to take actions (use tools). This is the foundation of modern AI agents.
-
-Think of ReAct like a detective solving a case. A bad detective just thinks about the crime from their desk—they might come up with theories, but they never verify them. A good detective alternates between thinking ("The suspect had motive, but do they have an alibi?") and investigating ("Let me check the security footage for that night"). ReAct gives AI this same investigative loop: think about what you know, act to learn more, observe the results, repeat.
-
-#### The ReAct Pattern
-
-```
-Thought: I need to find information about X
-Action: search("X")
-Observation: [search results]
-Thought: Based on this, I should now...
-Action: calculate(...)
-Observation: [calculation result]
-Thought: I now have enough information to answer
-Final Answer: ...
-```
-
-#### Why ReAct Matters
-
-Traditional CoT has a limitation: all reasoning happens in a single pass, using only the information in the prompt. ReAct solves this by:
-
-1. **Interleaving** thinking and acting
-2. **Grounding** reasoning in real observations
-3. **Adapting** based on new information
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                  COT vs REACT                                    │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                  │
-│  Chain-of-Thought:                                              │
-│  ┌─────────────────────────────────────┐                        │
-│  │  Think → Think → Think → Answer     │                        │
-│  └─────────────────────────────────────┘                        │
-│  (All reasoning from initial context)                           │
-│                                                                  │
-│  ReAct:                                                          │
-│  ┌─────────────────────────────────────────────────────────┐    │
-│  │  Think → Act → Observe → Think → Act → Observe → Answer │    │
-│  └─────────────────────────────────────────────────────────┘    │
-│  (Reasoning grounded in real observations)                      │
-│                                                                  │
-│  ReAct agents can:                                              │
-│  - Gather information they don't have                           │
-│  - Verify their assumptions                                      │
-│  - Adapt to unexpected findings                                  │
-│  - Complete multi-step tasks                                     │
-│                                                                  │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-> ** Did You Know?**
->
-> The ReAct paper (Yao et al., 2022) from Princeton and Google showed that combining reasoning traces with actions outperformed both:
-> - Pure reasoning (CoT alone): Good at planning, bad at getting facts
-> - Pure acting (actions only): Good at facts, bad at planning
->
-> ReAct achieved state-of-the-art results on knowledge-intensive tasks by letting the model "think about what to look up" and "think about what the results mean."
-
----
-
-### Implementing ReAct
-
-Here's how ReAct works in practice:
-
-```python
-REACT_PROMPT = """
-You are an assistant that uses tools to answer questions.
-
-You have access to these tools:
-- search(query): Search for information
-- calculate(expression): Do math calculations
-- lookup(entity): Get facts about an entity
-
-Use this format:
-
-Question: [the question]
-Thought: [your reasoning about what to do]
-Action: [tool_name(arguments)]
-Observation: [tool result]
-... (repeat Thought/Action/Observation as needed)
-Thought: I now have enough information to answer
-Final Answer: [your answer]
-
-Begin!
-
-Question: What is the population of France divided by 3?
-Thought: I need to find the population of France first, then divide by 3.
-Action: lookup("France population")
-Observation: France has a population of approximately 67.75 million (2023).
-Thought: Now I need to divide 67.75 million by 3.
-Action: calculate("67750000 / 3")
-Observation: 22583333.33
-Thought: I have the answer now.
-Final Answer: The population of France (67.75 million) divided by 3 is approximately 22.58 million.
-"""
-```
-
-#### The ReAct Loop in Code
-
-```python
-def react_loop(question: str, tools: dict, max_iterations: int = 10):
-    """Execute a ReAct reasoning loop."""
-
-    prompt = f"{REACT_PROMPT}\n\nQuestion: {question}\n"
-    history = []
-
-    for i in range(max_iterations):
-        # Get model response
-        response = llm(prompt)
-
-        # Check if we have a final answer
-        if "Final Answer:" in response:
-            return extract_final_answer(response)
-
-        # Parse the thought and action
-        thought = extract_thought(response)
-        action_name, action_args = extract_action(response)
-
-        # Execute the action
-        if action_name in tools:
-            observation = tools[action_name](action_args)
-        else:
-            observation = f"Unknown tool: {action_name}"
-
-        # Add to history and prompt
-        step = f"Thought: {thought}\nAction: {action_name}({action_args})\nObservation: {observation}\n"
-        history.append(step)
-        prompt += step
-
-    return "Max iterations reached without final answer"
-```
-
----
-
-### Self-Consistency
-
-Self-consistency is a powerful technique that improves CoT reliability by sampling multiple reasoning paths and selecting the most common answer.
-
-Think of it like asking five experts to independently solve the same problem. If four of them get "42" and one gets "47," you're probably safe trusting "42." The outlier likely made an arithmetic error or misread something. Self-consistency applies this same wisdom-of-crowds principle to AI reasoning.
-
-#### The Insight
-
-Different reasoning paths might lead to the same correct answer through different routes:
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│               SELF-CONSISTENCY                                   │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                  │
-│  Question: "How many legs do 3 dogs and 2 cats have?"           │
-│                                                                  │
-│  Path 1:                                                        │
-│  "Dogs have 4 legs each: 3 × 4 = 12                            │
-│   Cats have 4 legs each: 2 × 4 = 8                             │
-│   Total: 12 + 8 = 20"                                           │
-│                                                                  │
-│  Path 2:                                                        │
-│  "3 dogs + 2 cats = 5 animals                                   │
-│   Each animal has 4 legs                                        │
-│   5 × 4 = 20"                                                   │
-│                                                                  │
-│  Path 3:                                                        │
-│  "Let me count: 4 + 4 + 4 + 4 + 4 = 20"                        │
-│                                                                  │
-│  All paths → 20                                                │
-│  (High confidence in answer)                                     │
-│                                                                  │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-If one path gives 20 but another gives 18, the inconsistency signals potential error.
-
-#### Implementation
-
-```python
-def self_consistent_cot(question: str, num_samples: int = 5, temperature: float = 0.7):
-    """Generate multiple reasoning paths and vote on the answer."""
-
-    answers = []
-
-    for _ in range(num_samples):
-        # Generate reasoning with some temperature for diversity
-        response = llm(
-            prompt=f"{question}\n\nLet's think step by step.",
-            temperature=temperature
-        )
-
-        # Extract the final answer
-        answer = extract_answer(response)
-        answers.append(answer)
-
-    # Return most common answer (majority vote)
-    from collections import Counter
-    answer_counts = Counter(answers)
-    most_common = answer_counts.most_common(1)[0]
-
-    return {
-        "answer": most_common[0],
-        "confidence": most_common[1] / num_samples,
-        "all_answers": answers
-    }
-```
-
-> ** Did You Know?**
->
-> Wang et al. (2022) showed that self-consistency with just 5 samples improved CoT accuracy from 58% to 74% on math problems - a 28% relative improvement!
->
-> The technique works because errors are typically "random" - different runs make different mistakes. But correct reasoning tends to converge on the same answer. It's like having a panel of experts vote.
-
----
-
-### When CoT Helps (and When It Doesn't)
-
-Chain-of-thought isn't magic. It helps in specific situations and can actually hurt in others.
-
-#### CoT Helps Most With
-
-| Task Type | Why CoT Helps | Improvement |
-|-----------|---------------|-------------|
-| Math word problems | Forces calculation steps | 2-4x |
-| Multi-step reasoning | Makes dependencies explicit | 2-3x |
-| Logical deduction | Tracks premises and conclusions | 1.5-2x |
-| Commonsense reasoning | Surfaces implicit assumptions | 1.3-1.5x |
-| Code debugging | Forces systematic analysis | 1.5-2x |
-
-#### CoT Can Hurt With
-
-| Task Type | Why CoT Hurts | Notes |
-|-----------|--------------|-------|
-| Simple factual recall | Adds unnecessary steps | "Capital of France" |
-| Pattern matching | Overthinks simple patterns | Sentiment classification |
-| High-volume classification | Too slow | Batch processing |
-| Creative tasks | Can constrain creativity | Poetry, brainstorming |
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│            WHEN TO USE COT                                       │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                  │
-│   USE COT WHEN:                                                │
-│  - Problem requires multiple reasoning steps                    │
-│  - Answer depends on intermediate calculations                  │
-│  - Task involves combining multiple pieces of information       │
-│  - You need to verify/debug the reasoning process               │
-│  - Domain is unfamiliar to the model                            │
-│                                                                  │
-│   AVOID COT WHEN:                                              │
-│  - Simple one-step tasks                                         │
-│  - Speed is critical (real-time applications)                   │
-│  - Task is well-represented in training data                    │
-│  - Creative/open-ended generation                                │
-│  - Token budget is very limited                                  │
-│                                                                  │
-└─────────────────────────────────────────────────────────────────┘
-```
-
----
-
-### The Limits of Reasoning
-
-Even with CoT, LLMs have fundamental reasoning limitations:
-
-#### 1. Compositional Generalization
-
-LLMs struggle when problems require combining known concepts in novel ways:
-
-```python
-# Training: "John is taller than Mary. Mary is taller than Bob. Who is shortest?"
-# Test: "A is heavier than B. B is heavier than C. C is heavier than D. Who is lightest?"
-
-# The model might know how to do 2-step comparisons but fail at 4-step
-```
-
-#### 2. Arithmetic Precision
-
-Even with CoT, LLMs make arithmetic errors, especially with:
-- Large numbers
-- Many decimal places
-- Complex operations
-
-**Solution**: Use calculator tools (ReAct pattern!)
-
-#### 3. Hallucinated Reasoning
-
-The model can generate convincing but WRONG reasoning:
-
-```
-Q: "Is 17 a prime number?"
-A: "Let's check: 17 ÷ 2 = 8.5 (not whole), 17 ÷ 3 = 5.67 (not whole),
-    17 ÷ 4 = 4.25 (not whole), 17 ÷ 5 = 3.4 (not whole).
-    Since no divisors found, 17 is prime." 
-
-Q: "Is 51 a prime number?"
-A: "Let's check: 51 ÷ 2 = 25.5 (not whole), 51 ÷ 3 = 17 (whole!).
-    Wait, 51 = 3 × 17, so 51 is NOT prime." 
-
-Q: "Is 91 a prime number?"
-A: "Let's check: 91 ÷ 2 = 45.5 (not whole), 91 ÷ 3 = 30.33 (not whole),
-    91 ÷ 5 = 18.2 (not whole), 91 ÷ 7 = 13 (whole!).
-    So 91 = 7 × 13, NOT prime." 
-
-# But sometimes:
-A: "Let's check: 91 ÷ 2 = 45.5, 91 ÷ 3 = 30.33, 91 ÷ 5 = 18.2.
-    No small divisors found, so 91 is prime."  (Forgot to check 7!)
-```
-
-#### 4. Path Dependence
-
-The model's reasoning can be influenced by:
-- Order of information in prompt
-- How the question is phrased
-- Examples provided
-
-> ** Did You Know?**
->
-> Researchers at Anthropic discovered that Claude's reasoning performance varies significantly based on problem framing. Asking "What's wrong with this code?" produces different (often better) debugging than "Is this code correct?"
->
-> The insight: LLMs don't truly "reason" - they pattern-match on how problems are presented. This is why prompt engineering matters so much.
-
----
-
-### Advanced CoT Techniques
-
-#### 1. Least-to-Most Prompting
-
-Break complex problems into sub-problems, solve from simplest to hardest:
-
-```python
-prompt = """
-To solve complex problems, first break them into simpler sub-problems.
-
-Problem: "Last year, Amy was twice as old as Ben. This year, Amy is 20.
-How old is Ben this year?"
-
-Sub-problems:
-1. How old was Amy last year?
-2. How old was Ben last year (given Amy was twice his age)?
-3. How old is Ben this year?
-
-Solving each:
-1. Amy is 20 this year, so last year she was 20 - 1 = 19
-2. If Amy was twice Ben's age: 19 = 2 × Ben's age last year
-   Ben's age last year = 19 / 2 = 9.5
-3. Ben this year = 9.5 + 1 = 10.5 years old
-
-Final answer: Ben is 10.5 years old.
-"""
-```
-
-#### 2. Tree of Thoughts (ToT)
-
-Explore multiple reasoning branches, backtrack when needed:
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                  TREE OF THOUGHTS                                │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                  │
-│                     Problem                                      │
-│                        │                                         │
-│           ┌────────────┼────────────┐                           │
-│           │            │            │                           │
-│        Path A       Path B       Path C                         │
-│           │            │            │                           │
-│        Step 1       Step 1       Step 1                         │
-│           │            │            │                           │
-│        (dead end)   Step 2       Step 2                         │
-│                       │            │                            │
-│                    Step 3       (dead end)                      │
-│                       │                                         │
-│                    Answer                                      │
-│                                                                  │
-│  Unlike linear CoT, ToT can backtrack and explore alternatives │
-│                                                                  │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-#### 3. Program-Aided Language Models (PAL)
-
-Generate code instead of natural language reasoning:
-
-```python
-prompt = """
-Problem: "A store has 3 shelves. Each shelf has 4 boxes. Each box has 5 items.
-How many items total?"
-
-# Python solution
-shelves = 3
-boxes_per_shelf = 4
-items_per_box = 5
-
-total_boxes = shelves * boxes_per_shelf  # 12 boxes
-total_items = total_boxes * items_per_box  # 60 items
-
-print(f"Total items: {total_items}")
-# Output: Total items: 60
-"""
-```
-
-The model generates code, which is then executed for the actual answer. This eliminates arithmetic errors!
-
-Think of PAL like giving a student a calculator during a word problem test. They still need to understand the problem—what to multiply, what to add, in what order—but the actual number-crunching is outsourced to a tool that won't make silly mistakes. The LLM's job becomes translating human language into precise computational steps, which it's actually quite good at.
-
-#### 4. Structured Chain-of-Thought
-
-Sometimes you want even more control over the reasoning format. Structured CoT uses XML tags, JSON, or specific markers to organize reasoning:
-
-```python
-structured_cot_prompt = """
-Analyze this problem using structured reasoning.
-
-Problem: "Should we expand our product line to include organic options?"
-
-<analysis>
-<context>
-- Current market: mainstream products
-- Competitor landscape: 3 of 5 competitors have organic lines
-- Customer feedback: 23% of surveys mention organic preferences
-</context>
-
-<factors>
-<factor name="market_demand" importance="high">
-Growing organic food market (12% YoY growth)
-</factor>
-<factor name="cost" importance="medium">
-Organic ingredients cost 40% more on average
-</factor>
-<factor name="brand_alignment" importance="high">
-Company mission includes sustainability focus
-</factor>
-</factors>
-
-<reasoning>
-Step 1: Market demand is strong (12% growth) and customer surveys show interest (23%)
-Step 2: Cost increase (40%) can be offset by premium pricing (organic products command 30-50% premiums)
-Step 3: Brand alignment is strong - this fits our sustainability mission
-Step 4: Competitive pressure - 3/5 competitors already offer organic
-</reasoning>
-
-<conclusion>
-Recommendation: YES, expand to organic options
-Confidence: 78%
-Key risk: Supply chain complexity for organic certification
-</conclusion>
-</analysis>
-"""
-```
-
-This approach is particularly powerful for:
-- **Auditable decisions**: Each step is clearly labeled and can be reviewed
-- **Multi-criteria analysis**: Structure forces consideration of all factors
-- **Integration with systems**: Structured output can be parsed programmatically
-- **Consistent quality**: The template ensures nothing is forgotten
-
-#### 5. Chain-of-Verification (CoVe)
-
-A technique where the model generates an initial response, then generates verification questions, answers them, and revises if needed:
-
-```
-Initial Answer: "The capital of Australia is Sydney."
-
-Verification Questions:
-1. Is Sydney the largest city in Australia? → Yes
-2. Is the largest city always the capital? → No (e.g., New York vs DC)
-3. What is the purpose-built capital of Australia? → Canberra
-
-Revised Answer: "The capital of Australia is Canberra, not Sydney. While Sydney is the largest city, Canberra was purpose-built as the capital in 1913."
-```
-
-CoVe is especially effective for factual claims where the model might confuse similar concepts. It's like the model fact-checking its own homework.
-
----
-
-### Practical Guidelines
-
-#### Choosing Your CoT Strategy
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                 COT DECISION TREE                                │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                  │
-│  Is the task simple (< 2 reasoning steps)?                      │
-│     └─ YES → Don't use CoT (direct prompting)                   │
-│     └─ NO  → Continue...                                         │
-│                                                                  │
-│  Do you have good example reasoning traces?                     │
-│     └─ YES → Use Few-Shot CoT                                   │
-│     └─ NO  → Use Zero-Shot CoT ("Let's think step by step")    │
-│                                                                  │
-│  Does the task require external information or actions?         │
-│     └─ YES → Use ReAct pattern                                  │
-│     └─ NO  → Continue...                                         │
-│                                                                  │
-│  Is high reliability critical?                                   │
-│     └─ YES → Add Self-Consistency (multiple samples)            │
-│     └─ NO  → Single CoT pass is fine                            │
-│                                                                  │
-│  Does the task involve math/calculations?                       │
-│     └─ YES → Consider PAL (code generation) or calculator tool  │
-│     └─ NO  → Standard CoT                                        │
-│                                                                  │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-#### Crafting CoT Prompts
-
-**DO**:
-- Be specific about desired output format
-- Show examples of good reasoning
-- Ask for verification steps
-- Request intermediate calculations be shown
-
-**DON'T**:
-- Make instructions too long (model forgets)
-- Ask model to "be careful" (causes overthinking)
-- Use CoT for simple tasks (wastes tokens)
-- Trust complex arithmetic without tools
-
----
-
-## Hands-On Practice
-
-### Exercise 1: Zero-Shot CoT Comparison
-
-Compare model performance with and without Chain-of-Thought prompting on reasoning tasks.
-
-```python
-"""
-Exercise 1: Zero-Shot CoT Comparison
-
-This exercise demonstrates the dramatic difference CoT makes
-on multi-step reasoning problems.
-"""
-
-from openai import OpenAI
-
-client = OpenAI()
-
-def test_cot_vs_direct(problem: str) -> dict:
-    """Compare direct prompting vs CoT on the same problem."""
-
-    # Direct prompting (no CoT)
-    direct_prompt = f"""
-{problem}
-
-Answer with just the final number.
-"""
-
-    # CoT prompting
-    cot_prompt = f"""
-{problem}
-
-Let's think step by step.
-"""
-
-    # Get direct answer
-    direct_response = client.chat.completions.create(
-        model="gpt-5",
-        messages=[{"role": "user", "content": direct_prompt}],
-        temperature=0
-    )
-
-    # Get CoT answer
-    cot_response = client.chat.completions.create(
-        model="gpt-5",
-        messages=[{"role": "user", "content": cot_prompt}],
-        temperature=0
-    )
-
-    return {
-        "problem": problem,
-        "direct_answer": direct_response.choices[0].message.content,
-        "cot_answer": cot_response.choices[0].message.content
-    }
-
-# Test problems of increasing difficulty
-test_problems = [
-    "A farmer has 17 sheep. All but 9 die. How many sheep are left?",
-
-    "If you have 3 quarters, 4 dimes, and 2 nickels, how much money do you have in cents?",
-
-    "A bat and a ball cost $1.10 together. The bat costs $1.00 more than the ball. How much does the ball cost?",
-
-    "Three friends split a restaurant bill. The total was $45, plus 20% tip. They each paid equally. One friend paid with a $20 bill. How much change did they receive?",
-]
-
-# Run comparisons
-for problem in test_problems:
-    result = test_cot_vs_direct(problem)
-    print(f"Problem: {result['problem'][:50]}...")
-    print(f"Direct: {result['direct_answer'][:50]}")
-    print(f"CoT: {result['cot_answer'][:100]}")
-    print("-" * 50)
-```
-
-**What to observe:**
-- The "bat and ball" problem is a classic cognitive bias trap (many humans get it wrong too!)
-- CoT helps catch the "all but 9 die" trick question
-- Complex multi-step problems show the biggest improvement
-
-### Exercise 2: Building a ReAct Agent
-
-Implement a simple ReAct agent that can use tools to answer questions.
-
-```python
-"""
-Exercise 2: ReAct Agent Implementation
-
-Build a reasoning agent that interleaves thinking and action.
-"""
-
-import re
-import json
-from typing import Callable
-
-# Define some simple tools
-def search(query: str) -> str:
-    """Simulate a search tool."""
-    # In production, this would call a real search API
-    knowledge_base = {
-        "python creator": "Guido van Rossum created Python in 1991.",
-        "eiffel tower height": "The Eiffel Tower is 330 meters tall.",
-        "moon distance": "The Moon is about 384,400 km from Earth.",
-        "speed of light": "The speed of light is 299,792,458 meters per second.",
-    }
-
-    for key, value in knowledge_base.items():
-        if key in query.lower():
-            return value
-    return "No relevant information found."
-
-def calculate(expression: str) -> str:
-    """Safely evaluate a mathematical expression."""
-    try:
-        # Only allow safe math operations
-        allowed_chars = set("0123456789+-*/.(). ")
-        if all(c in allowed_chars for c in expression):
-            result = eval(expression)
-            return str(result)
-        return "Invalid expression"
-    except Exception as e:
-        return f"Calculation error: {e}"
-
-def lookup(entity: str) -> str:
-    """Look up facts about an entity."""
-    facts = {
-        "France": "Country in Western Europe. Population: 67 million. Capital: Paris.",
-        "Python": "High-level programming language. Created by Guido van Rossum in 1991.",
-        "Einstein": "Physicist who developed theory of relativity. Nobel Prize 1921.",
-    }
-    return facts.get(entity, f"No facts found for '{entity}'")
-
-
-class ReActAgent:
-    """A simple ReAct reasoning agent."""
-
-    def __init__(self, llm_client, tools: dict[str, Callable]):
-        self.llm = llm_client
-        self.tools = tools
-
-    def parse_response(self, response: str) -> tuple[str, str, str]:
-        """Parse thought, action, and action input from response."""
-        thought_match = re.search(r"Thought:\s*(.+?)(?=Action:|$)", response, re.DOTALL)
-        action_match = re.search(r"Action:\s*(\w+)\s*\((.+?)\)", response)
-
-        thought = thought_match.group(1).strip() if thought_match else ""
-
-        if action_match:
-            action_name = action_match.group(1)
-            action_input = action_match.group(2).strip('"\'')
-            return thought, action_name, action_input
-
-        # Check for final answer
-        final_match = re.search(r"Final Answer:\s*(.+)", response, re.DOTALL)
-        if final_match:
-            return thought, "FINAL", final_match.group(1).strip()
-
-        return thought, None, None
-
-    def run(self, question: str, max_iterations: int = 5) -> str:
-        """Execute the ReAct loop."""
-
-        system_prompt = """You are an assistant that uses tools to answer questions.
-
-Available tools:
-- search(query): Search for information
-- calculate(expression): Do math calculations
-- lookup(entity): Get facts about an entity
-
-Always use this format:
-
-Thought: [your reasoning]
-Action: tool_name("argument")
-
-After getting an observation, continue with another Thought/Action or give Final Answer:
-
-Thought: [your reasoning]
-Final Answer: [your answer]
-"""
-
-        messages = [
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": f"Question: {question}"}
-        ]
-
-        for i in range(max_iterations):
-            # Get model response
-            response = self.llm.chat.completions.create(
-                model="gpt-5",
-                messages=messages,
-                temperature=0
-            )
-
-            assistant_message = response.choices[0].message.content
-            messages.append({"role": "assistant", "content": assistant_message})
-
-            # Parse the response
-            thought, action_name, action_input = self.parse_response(assistant_message)
-
-            print(f"[Step {i+1}]")
-            print(f"Thought: {thought}")
-
-            if action_name == "FINAL":
-                print(f"Final Answer: {action_input}")
-                return action_input
-
-            if action_name and action_name in self.tools:
-                # Execute the tool
-                observation = self.tools[action_name](action_input)
-                print(f"Action: {action_name}({action_input})")
-                print(f"Observation: {observation}")
-
-                # Add observation to messages
-                messages.append({
-                    "role": "user",
-                    "content": f"Observation: {observation}"
-                })
-            else:
-                print(f"Unknown action: {action_name}")
-                break
-
-        return "Max iterations reached without final answer"
-
-
-# Test the agent
-if __name__ == "__main__":
-    from openai import OpenAI
-    client = OpenAI()
-
-    agent = ReActAgent(
-        llm_client=client,
-        tools={
-            "search": search,
-            "calculate": calculate,
-            "lookup": lookup
-        }
-    )
-
-    # Test questions
-    questions = [
-        "How tall is the Eiffel Tower in feet?",
-        "Who created Python and in what year?",
-        "If France's population is 67 million and each person produces 2kg of waste daily, how much total waste is produced per year in million kg?",
-    ]
-
-    for q in questions:
-        print(f"\n{'='*60}")
-        print(f"Question: {q}")
-        print('='*60)
-        answer = agent.run(q)
-        print(f"\n→ Answer: {answer}\n")
-```
-
-### Exercise 3: Self-Consistency Implementation
-
-Build a self-consistency wrapper that improves reliability through multiple samples.
-
-```python
-"""
-Exercise 3: Self-Consistency for Robust Reasoning
-
-Sample multiple reasoning paths and vote on the most common answer.
-"""
-
-from collections import Counter
-import re
-
-def extract_numeric_answer(response: str) -> str:
-    """Extract the final numeric answer from a CoT response."""
-    # Look for patterns like "the answer is X" or "= X" at the end
-    patterns = [
-        r"(?:answer|result|total).*?(\d+\.?\d*)",
-        r"=\s*(\d+\.?\d*)\s*$",
-        r"(\d+\.?\d*)\s*(?:is the answer|total|result)",
-    ]
-
-    for pattern in patterns:
-        matches = re.findall(pattern, response.lower())
-        if matches:
-            return matches[-1]  # Return last match
-
-    # Fallback: find any numbers and return the last one
-    numbers = re.findall(r'\d+\.?\d*', response)
-    return numbers[-1] if numbers else None
-
-
-def self_consistent_answer(
-    question: str,
-    llm_client,
-    num_samples: int = 5,
-    temperature: float = 0.7
-) -> dict:
-    """Get a robust answer using self-consistency."""
-
-    prompt = f"""
-{question}
-
-Let's work through this step by step.
-"""
-
-    answers = []
-    reasoning_paths = []
-
-    for i in range(num_samples):
-        response = llm_client.chat.completions.create(
-            model="gpt-5",
-            messages=[{"role": "user", "content": prompt}],
-            temperature=temperature
-        )
-
-        reasoning = response.choices[0].message.content
-        answer = extract_numeric_answer(reasoning)
-
-        answers.append(answer)
-        reasoning_paths.append(reasoning)
-
-        print(f"Sample {i+1}: Answer = {answer}")
-
-    # Vote on the most common answer
-    answer_counts = Counter(answers)
-    most_common = answer_counts.most_common(1)[0]
-
-    return {
-        "answer": most_common[0],
-        "confidence": most_common[1] / num_samples,
-        "all_answers": answers,
-        "vote_distribution": dict(answer_counts),
-        "reasoning_paths": reasoning_paths
-    }
-
-
-# Test self-consistency
-if __name__ == "__main__":
-    from openai import OpenAI
-    client = OpenAI()
-
-    # A problem where models sometimes make errors
-    problem = """
-    A store had 125 apples. They sold 47 in the morning and 38 in the afternoon.
-    A delivery of 60 apples arrived. Then they sold 29 more before closing.
-    How many apples did they have at the end of the day?
-    """
-
-    result = self_consistent_answer(problem, client, num_samples=5)
-
-    print(f"\n{'='*60}")
-    print(f"Final Answer: {result['answer']}")
-    print(f"Confidence: {result['confidence']*100:.0f}%")
-    print(f"Vote Distribution: {result['vote_distribution']}")
-```
-
-### Exercise 4: Building a Few-Shot CoT Prompt Library
-
-Create reusable CoT prompt templates for different reasoning domains.
-
-```python
-"""
-Exercise 4: Few-Shot CoT Prompt Library
-
-Build a library of domain-specific CoT prompts for consistent results.
-"""
-
-from dataclasses import dataclass
-from typing import Optional
-
-@dataclass
-class CoTPromptTemplate:
-    """A template for few-shot CoT prompting."""
-    name: str
-    domain: str
-    description: str
-    examples: list[dict[str, str]]  # List of {"question": ..., "reasoning": ..., "answer": ...}
-    instructions: str
-
-    def build_prompt(self, question: str, max_examples: int = 2) -> str:
-        """Build a complete prompt with examples and the new question."""
-
-        # Start with instructions
-        prompt_parts = [self.instructions, ""]
-
-        # Add examples
-        for i, example in enumerate(self.examples[:max_examples]):
-            prompt_parts.append(f"Example {i+1}:")
-            prompt_parts.append(f"Q: {example['question']}")
-            prompt_parts.append(f"A: {example['reasoning']}")
-            prompt_parts.append(f"Therefore, the answer is: {example['answer']}")
-            prompt_parts.append("")
-
-        # Add the new question
-        prompt_parts.append("Now solve this problem:")
-        prompt_parts.append(f"Q: {question}")
-        prompt_parts.append("A: Let's think step by step.")
-
-        return "\n".join(prompt_parts)
-
-
-# Create a library of prompts
-COT_LIBRARY = {
-    "math_word_problem": CoTPromptTemplate(
-        name="Math Word Problems",
-        domain="mathematics",
-        description="Multi-step arithmetic word problems",
-        instructions="Solve the following math problems step by step. Show your work clearly.",
-        examples=[
-            {
-                "question": "A bakery makes 45 loaves of bread. They sell 23 in the morning and make 30 more. How many do they have?",
-                "reasoning": "Let's work through this:\n1. Start with 45 loaves\n2. After selling 23: 45 - 23 = 22 loaves\n3. After making 30 more: 22 + 30 = 52 loaves",
-                "answer": "52 loaves"
-            },
-            {
-                "question": "A movie theater has 8 rows with 12 seats each. If 67 seats are taken, how many are empty?",
-                "reasoning": "Let's calculate:\n1. Total seats: 8 × 12 = 96 seats\n2. Empty seats: 96 - 67 = 29 seats",
-                "answer": "29 empty seats"
-            }
-        ]
-    ),
-
-    "logical_deduction": CoTPromptTemplate(
-        name="Logical Deduction",
-        domain="logic",
-        description="Problems requiring logical reasoning and deduction",
-        instructions="Analyze the following logical problems. State your premises and derive conclusions step by step.",
-        examples=[
-            {
-                "question": "All mammals are warm-blooded. All dogs are mammals. Is a golden retriever warm-blooded?",
-                "reasoning": "Let's analyze:\n1. Premise 1: All mammals are warm-blooded\n2. Premise 2: All dogs are mammals\n3. A golden retriever is a type of dog\n4. Therefore, a golden retriever is a mammal (from premise 2)\n5. Therefore, a golden retriever is warm-blooded (from premise 1)",
-                "answer": "Yes, a golden retriever is warm-blooded"
-            }
-        ]
-    ),
-
-    "code_debugging": CoTPromptTemplate(
-        name="Code Debugging",
-        domain="programming",
-        description="Analyzing and fixing code issues",
-        instructions="Debug the following code by analyzing it step by step. Identify the issue and explain the fix.",
-        examples=[
-            {
-                "question": "Why does this code print wrong results? `for i in range(10): total += i`",
-                "reasoning": "Let's trace through:\n1. The loop iterates i from 0 to 9\n2. Each iteration adds i to 'total'\n3. BUG: 'total' is never initialized!\n4. Python will raise NameError: 'total' is not defined\n5. Fix: Add `total = 0` before the loop",
-                "answer": "The bug is that 'total' is not initialized. Add `total = 0` before the loop."
-            }
-        ]
-    ),
-
-    "causal_reasoning": CoTPromptTemplate(
-        name="Causal Reasoning",
-        domain="causality",
-        description="Analyzing cause and effect relationships",
-        instructions="Analyze the causal relationships in the following scenarios. Consider multiple factors and their interactions.",
-        examples=[
-            {
-                "question": "Sales increased after a new advertising campaign launched. Does this prove the campaign caused higher sales?",
-                "reasoning": "Let's analyze causation vs correlation:\n1. Observed: Sales increased after campaign launch\n2. This shows correlation (events happened together)\n3. But other factors could explain it:\n   - Seasonal shopping patterns\n   - Economic conditions improving\n   - Competitor going out of business\n   - New product features released simultaneously\n4. To prove causation, we would need:\n   - Control group (no advertising)\n   - Or A/B testing\n   - Or other causal inference methods",
-                "answer": "No, correlation doesn't prove causation. Other factors could explain the increase. A controlled experiment would be needed to establish causality."
-            }
-        ]
-    )
-}
-
-
-def solve_with_template(
-    question: str,
-    template_name: str,
-    llm_client,
-    temperature: float = 0
-) -> str:
-    """Solve a problem using a specific CoT template."""
-
-    if template_name not in COT_LIBRARY:
-        raise ValueError(f"Unknown template: {template_name}. Available: {list(COT_LIBRARY.keys())}")
-
-    template = COT_LIBRARY[template_name]
-    prompt = template.build_prompt(question)
-
-    response = llm_client.chat.completions.create(
-        model="gpt-5",
-        messages=[{"role": "user", "content": prompt}],
-        temperature=temperature
-    )
-
-    return response.choices[0].message.content
-
-
-# Example usage
-if __name__ == "__main__":
-    from openai import OpenAI
-    client = OpenAI()
-
-    # Use the math template
-    math_problem = "A train leaves at 2:00 PM traveling at 60 mph. Another train leaves from the same station at 3:00 PM traveling at 80 mph. At what time will the second train catch up to the first?"
-
-    print("=== Math Problem ===")
-    print(f"Q: {math_problem}")
-    print(f"\nA: {solve_with_template(math_problem, 'math_word_problem', client)}")
-
-    # Use the logic template
-    logic_problem = "If it rains, the ground is wet. The ground is wet. Can we conclude it rained?"
-
-    print("\n=== Logic Problem ===")
-    print(f"Q: {logic_problem}")
-    print(f"\nA: {solve_with_template(logic_problem, 'logical_deduction', client)}")
-```
-
----
-
-## Key Takeaways
-
-1. **"Let's think step by step"** - These 5 words can transform model performance on reasoning tasks
-
-2. **CoT makes reasoning visible** - The model's "thinking" becomes part of its context, enabling better outputs
-
-3. **ReAct combines thinking and doing** - The foundation of modern AI agents
-
-4. **Self-consistency improves reliability** - Multiple reasoning paths catch errors
-
-5. **Know the limits** - CoT helps with complex reasoning but isn't magic for all tasks
-
-6. **Use tools for calculations** - Don't trust LLMs for math; use calculators
-
----
+This module teaches LangGraph as the orchestration layer for stateful agents: `StateGraph` for shared state, nodes for work, edges for routing, cycles for retries, checkpointers for resumability, and human interrupts for controlled decisions. Persistence appears later because production agents need it, but the core lesson is graph-shaped agent control flow.
 
 ## Did You Know?
 
-### The Accidental Discovery
+- LangGraph is part of the LangChain ecosystem, but it solves a different problem: explicit control flow for stateful, cyclic agent workflows instead of one linear chain.
+- A graph edge is not only a diagram line; in LangGraph, it is the routing rule that decides which node receives the current state next.
+- Checkpointing matters because agent work is often expensive, interruptible, and reviewable; saved state lets a workflow resume, inspect history, or wait for human approval.
 
-Chain-of-thought prompting was partially discovered by accident. Researchers at Google were testing GPT-3 on math problems and noticed that when the model happened to "show its work" in the output, it got the answer right more often.
+## Section 1: The Graph Mental Model and Linear Limitations
+Once you understand Chain-of-Thought and ReAct patterns, the next production problem is orchestration. But real production workflows require more than a single reasoning trace. They need to remember state across many steps, branch conditionally, loop back if something fails, and coordinate multiple agents.
 
-They asked: "What if we explicitly asked it to show its work?" The result was the CoT paper, which has been cited over 4,000 times.
+Think of standard linear chains like a highway with no exits. Once you start, you can only go forward. If you miss something, you have to drive to the end and start over from the beginning.
 
-### The "Let's" Breakthrough
+```mermaid
+graph TD
+    Input --> Chain1
+    Chain1 --> Chain2
+    Chain2 --> Chain3
+    Chain3 --> Output
+    Chain3 -.-> ConditionBranch
+    ConditionBranch --> PathA[Path A]
+    ConditionBranch --> PathB[Path B]
+```
 
-The specific phrase "Let's think step by step" was found through systematic testing of hundreds of variations. Interestingly:
+Real-world workflows, however, look more like a city street grid. You can loop back, take detours, or recover from wrong turns without restarting your journey. LangGraph allows you to construct these cyclic execution paths naturally.
 
-- "I will think step by step" - worse (too assertive)
-- "Think step by step" - worse (too commanding)
-- "You should think step by step" - worse (creates pressure)
-- "Let's think step by step" - best (collaborative, process-oriented)
+```mermaid
+graph TD
+    Research --> Analyze
+    Analyze --> Check
+    Check -- not good enough --> Research
+    Check --> Write
+    Write --> Review
+    Review -- revisions needed --> Write
+    Review --> Publish
+```
 
-The word "let's" creates a collaborative framing that seems to work better with how LLMs were trained.
+> **Pause and predict**: If a complex AI agent pipeline is purely linear, what architectural workarounds would you need to implement to allow an agent to correct a hallucinated answer after reviewing it?
 
-### OpenAI's Hidden Prompts
+### Why Graphs for AI Workflows?
+At its core, a graph consists of nodes and edges connecting them. In LangGraph, that simple vocabulary becomes the control surface for agent design: nodes own work, edges own decisions, and the state object carries evidence between each step.
 
-When OpenAI released gpt-5, users discovered that behind the scenes, the system prompt included CoT-style instructions. The model was being told to "think step by step" before generating responses - they had baked CoT into the product!
+```mermaid
+graph LR
+    A[Node A] --edge--> B[Node B]
+    B --edge--> C[Node C]
+    B --edge--> D[Node D]
+```
 
-This was revealed when users found ways to extract the system prompt, showing that even the model creators considered CoT essential.
+| Feature | Linear Chains | Graph Workflows |
+|---------|---------------|-----------------|
+| Conditional logic | Limited | Full branching |
+| Cycles/loops | Not possible | Native support |
+| State management | Pass through | Persistent state |
+| Error recovery | Start over | Retry specific nodes |
+| Human-in-the-loop | Awkward | Native support |
+| Multi-agent | Sequential only | True parallelism |
 
-### The Reasoning vs Pattern Matching Debate
+## Section 2: LangGraph Core Concepts
+LangGraph revolves around a few central primitives: the `StateGraph`, Nodes, Edges, Reducers, and Checkpointers. Learn these names before writing complex agents because most bugs come from confusing where data lives, who updates it, and how a route is selected.
 
-A controversial 2023 paper argued that LLMs don't actually "reason" - they pattern-match on the reasoning patterns in their training data. When CoT works, it's because the model has seen similar reasoning patterns, not because it's truly reasoning.
+| Concept | Purpose |
+|---------|---------|
+| StateGraph | Container for workflow definition |
+| Nodes | Processing functions that update state |
+| Edges | Define flow between nodes |
+| Reducers | How state updates are merged |
+| Checkpointer | Enables pause/resume and persistence |
+| Interrupts | Human-in-the-loop integration |
 
-This sparked a fierce debate: Does it matter if the model is "really" reasoning, as long as the outputs are correct? The pragmatic answer: probably not. But it does explain why novel reasoning problems remain hard.
+### 1. StateGraph
+The foundation is the `StateGraph`, which manages the state schema, nodes, and transition logic. Treat it as the workflow contract rather than a convenience wrapper, because every node and edge must agree on the same state shape.
 
-### AlphaProof and the Future
+```python
+from langgraph.graph import StateGraph, END
 
-In 2024, DeepMind's AlphaProof system used a combination of LLM-generated reasoning and formal verification to solve International Mathematical Olympiad problems at a silver-medal level.
+# Define the state type
+from typing import TypedDict, List, Annotated
+import operator
 
-The key insight: generate many reasoning attempts, verify each with a formal prover, keep the ones that work. This "generate and verify" approach may be the future of AI reasoning.
+class AgentState(TypedDict):
+    messages: Annotated[List[str], operator.add]  # Accumulates
+    current_step: str
+    result: str
 
----
+# Create the graph
+graph = StateGraph(AgentState)
+```
 
-<!-- v4:generated type=no_quiz model=codex turn=1 -->
+### 2. State Annotations
+State updates require precise instructions on how new data should merge with existing data. A list of messages should usually accumulate, while a current phase should replace its previous value, and LangGraph needs that distinction spelled out.
+
+```python
+from typing import Annotated
+import operator
+
+class MyState(TypedDict):
+    # This field gets REPLACED on each update
+    current_value: str
+
+    # This field ACCUMULATES (list concatenation)
+    history: Annotated[List[str], operator.add]
+
+    # This field uses custom reducer
+    counter: Annotated[int, lambda a, b: a + b]
+```
+
+> **Stop and think**: Why is `operator.add` crucial for tracking an LLM's conversation history? What happens to the AI's context window if a field lacks this annotation, and how would that failure appear when an agent tries to recover from a bad intermediate answer?
+
+### 3. Nodes and Edges
+Nodes receive the current state, perform logic, and return a partial state update. Edges define the conditional or unconditional routes between these nodes, so the graph can express decisions without burying them inside a long prompt or a tangled callback.
+
+```python
+def analyze_node(state: AgentState) -> dict:
+    """Analyze the input and return findings."""
+    messages = state["messages"]
+    # Do analysis...
+    return {
+        "current_step": "analyze",
+        "messages": ["Analysis complete: found 3 issues"]
+    }
+
+# Add node to graph
+graph.add_node("analyze", analyze_node)
+```
+
+```python
+# Unconditional edge: always go from A to B
+graph.add_edge("node_a", "node_b")
+
+# Conditional edge: choose based on state
+def should_continue(state: AgentState) -> str:
+    if state["result"] == "success":
+        return "finish"
+    else:
+        return "retry"
+
+graph.add_conditional_edges(
+    "check",
+    should_continue,
+    {
+        "finish": "output",
+        "retry": "process"  # Creates a cycle!
+    }
+)
+```
+
+### 4. Compilation
+Every graph requires explicit entry and exit points before it can be compiled into an executable application. Compilation is the moment LangGraph validates the topology and turns your declarative workflow into something you can invoke, stream, checkpoint, or interrupt.
+
+```python
+from langgraph.graph import START, END
+
+# Set entry point
+graph.add_edge(START, "first_node")
+
+# Set exit point (END is a special node)
+graph.add_edge("final_node", END)
+```
+
+```python
+# Compile the graph
+app = graph.compile()
+
+# Run it
+result = app.invoke({"messages": ["Hello"], "current_step": "start"})
+```
+
+## Section 3: Building Your First LangGraph Workflow
+Let's build a practical document processing pipeline. The graph structure will dynamically route documents based on classification, which makes the example small enough to read while still showing the production pattern: parse once, classify once, and then send work to the correct specialist node.
+
+```mermaid
+graph LR
+    Parse --> Classify --> Route
+    Route --> ProcessA[Process A] --> Output1[Output]
+    Route --> ProcessB[Process B] --> Output2[Output]
+```
+
+### Step 1: Define State
+```python
+from typing import TypedDict, List, Annotated, Literal
+import operator
+
+class DocumentState(TypedDict):
+    # The input document
+    document: str
+
+    # Classification result
+    doc_type: Literal["invoice", "contract", "letter", "unknown"]
+
+    # Extracted data (accumulates across nodes)
+    extracted_data: Annotated[List[dict], operator.add]
+
+    # Processing messages
+    messages: Annotated[List[str], operator.add]
+
+    # Final output
+    output: str
+```
+
+### Step 2: Define Nodes
+```python
+def parse_node(state: DocumentState) -> dict:
+    """Parse the raw document."""
+    doc = state["document"]
+    # Simulate parsing
+    return {
+        "messages": [f"Parsed document: {len(doc)} characters"]
+    }
+
+def classify_node(state: DocumentState) -> dict:
+    """Classify the document type."""
+    doc = state["document"].lower()
+
+    if "invoice" in doc or "amount due" in doc:
+        doc_type = "invoice"
+    elif "agreement" in doc or "contract" in doc:
+        doc_type = "contract"
+    elif "dear" in doc or "sincerely" in doc:
+        doc_type = "letter"
+    else:
+        doc_type = "unknown"
+
+    return {
+        "doc_type": doc_type,
+        "messages": [f"Classified as: {doc_type}"]
+    }
+
+def process_invoice(state: DocumentState) -> dict:
+    """Extract invoice-specific data."""
+    return {
+        "extracted_data": [{"type": "invoice", "amount": "$1,234.56"}],
+        "messages": ["Extracted invoice data"]
+    }
+
+def process_contract(state: DocumentState) -> dict:
+    """Extract contract-specific data."""
+    return {
+        "extracted_data": [{"type": "contract", "parties": ["A", "B"]}],
+        "messages": ["Extracted contract data"]
+    }
+
+def process_generic(state: DocumentState) -> dict:
+    """Generic processing for other documents."""
+    return {
+        "extracted_data": [{"type": "generic", "summary": "Document processed"}],
+        "messages": ["Generic processing complete"]
+    }
+
+def output_node(state: DocumentState) -> dict:
+    """Generate final output."""
+    data = state["extracted_data"]
+    return {
+        "output": f"Processed {len(data)} items: {data}",
+        "messages": ["Output generated"]
+    }
+```
+
+### Step 3: Define Routing Logic
+```python
+def route_by_type(state: DocumentState) -> str:
+    """Route to appropriate processor based on document type."""
+    doc_type = state["doc_type"]
+
+    routing = {
+        "invoice": "process_invoice",
+        "contract": "process_contract",
+        "letter": "process_generic",
+        "unknown": "process_generic"
+    }
+
+    return routing.get(doc_type, "process_generic")
+```
+
+### Step 4 & 5: Build and Run the Graph
+```python
+from langgraph.graph import StateGraph, START, END
+
+# Create graph
+workflow = StateGraph(DocumentState)
+
+# Add nodes
+workflow.add_node("parse", parse_node)
+workflow.add_node("classify", classify_node)
+workflow.add_node("process_invoice", process_invoice)
+workflow.add_node("process_contract", process_contract)
+workflow.add_node("process_generic", process_generic)
+workflow.add_node("output", output_node)
+
+# Add edges
+workflow.add_edge(START, "parse")
+workflow.add_edge("parse", "classify")
+
+# Conditional routing after classification
+workflow.add_conditional_edges(
+    "classify",
+    route_by_type,
+    {
+        "process_invoice": "process_invoice",
+        "process_contract": "process_contract",
+        "process_generic": "process_generic"
+    }
+)
+
+# All processors lead to output
+workflow.add_edge("process_invoice", "output")
+workflow.add_edge("process_contract", "output")
+workflow.add_edge("process_generic", "output")
+
+# Output leads to END
+workflow.add_edge("output", END)
+
+# Compile
+app = workflow.compile()
+```
+
+```python
+# Test with an invoice
+result = app.invoke({
+    "document": "INVOICE #123\nAmount Due: $1,234.56\nDue Date: 2024-01-15",
+    "extracted_data": [],
+    "messages": []
+})
+
+print("Document type:", result["doc_type"])
+print("Messages:", result["messages"])
+print("Output:", result["output"])
+```
+
+## Section 4: Cycles and Error Handling
+Cycles are the beating heart of robust AI workflows. A self-correcting writer agent should not restart from the beginning whenever a review fails; it should carry the draft, feedback, revision count, and approval status back through a controlled loop.
+
+```mermaid
+graph LR
+    Draft --> Review
+    Review --> Good{Good?}
+    Good -- Yes --> Publish
+    Good -- No --> Draft
+```
+
+```python
+from typing import TypedDict, List, Annotated
+import operator
+
+class WriterState(TypedDict):
+    topic: str
+    draft: str
+    feedback: str
+    revision_count: int
+    is_approved: bool
+    messages: Annotated[List[str], operator.add]
+
+def draft_node(state: WriterState) -> dict:
+    """Create or revise the draft."""
+    topic = state["topic"]
+    feedback = state.get("feedback", "")
+    count = state.get("revision_count", 0)
+
+    if count == 0:
+        # Initial draft
+        draft = f"# {topic}\n\nThis is the initial draft about {topic}."
+        msg = "Created initial draft"
+    else:
+        # Revision based on feedback
+        draft = f"# {topic}\n\nRevised draft (v{count+1}): Addressed feedback: {feedback}"
+        msg = f"Revised draft (attempt {count + 1})"
+
+    return {
+        "draft": draft,
+        "revision_count": count + 1,
+        "messages": [msg]
+    }
+
+def review_node(state: WriterState) -> dict:
+    """Review the draft and provide feedback."""
+    draft = state["draft"]
+    count = state["revision_count"]
+
+    # Simulate review (in real app, this would use an LLM)
+    if count >= 3:  # Accept after 3 attempts
+        return {
+            "is_approved": True,
+            "feedback": "Looks good!",
+            "messages": ["Review passed!"]
+        }
+    else:
+        return {
+            "is_approved": False,
+            "feedback": f"Need more detail in section {count}",
+            "messages": [f"Review failed: needs revision"]
+        }
+
+def publish_node(state: WriterState) -> dict:
+    """Publish the approved draft."""
+    return {
+        "messages": [f"Published after {state['revision_count']} revisions!"]
+    }
+
+def should_continue(state: WriterState) -> str:
+    """Decide whether to revise or publish."""
+    if state["is_approved"]:
+        return "publish"
+    else:
+        return "revise"
+
+# Build the graph
+writer = StateGraph(WriterState)
+
+writer.add_node("draft", draft_node)
+writer.add_node("review", review_node)
+writer.add_node("publish", publish_node)
+
+writer.add_edge(START, "draft")
+writer.add_edge("draft", "review")
+
+writer.add_conditional_edges(
+    "review",
+    should_continue,
+    {
+        "revise": "draft",   # CYCLE: go back to draft
+        "publish": "publish"
+    }
+)
+
+writer.add_edge("publish", END)
+
+app = writer.compile()
+
+# Run it
+result = app.invoke({
+    "topic": "LangGraph Cycles",
+    "revision_count": 0,
+    "is_approved": False,
+    "messages": []
+})
+
+print("Final messages:", result["messages"])
+# Output shows the progression through multiple revisions
+```
+
+### Safety First: Preventing Infinite Loops
+When implementing cycles, missing safety checks will stall your application entirely. Defensively wrap conditions with retry limits so the graph can fail closed, produce a partial result, or route to human review instead of consuming tokens forever.
+
+```python
+def should_continue_safe(state: WriterState) -> str:
+    """Continue with a maximum retry limit."""
+    MAX_RETRIES = 5
+
+    if state["is_approved"]:
+        return "publish"
+    elif state["revision_count"] >= MAX_RETRIES:
+        return "publish"  # Publish anyway after max retries
+    else:
+        return "revise"
+```
+
+You should also isolate error-prone operations at the node level to ensure localized recovery. If an external API fails inside one node, the graph should route from that node's error state rather than losing every previous observation.
+```python
+def safe_node(state: MyState) -> dict:
+    """Node with built-in error handling."""
+    try:
+        # Risky operation
+        result = call_external_api(state["input"])
+        return {"result": result, "error": None}
+    except Exception as e:
+        return {"result": None, "error": str(e)}
+
+def route_on_error(state: MyState) -> str:
+    """Route based on success/failure."""
+    if state.get("error"):
+        return "handle_error"
+    return "continue"
+```
+
+That localized error state works in tandem with the explicit retry pattern. The retry counter belongs in graph state because routing decisions must remain visible, replayable, and testable after a failure.
+```python
+class RetryState(TypedDict):
+    input: str
+    output: str
+    attempts: int
+    max_attempts: int
+    success: bool
+
+def process_with_retry(state: RetryState) -> dict:
+    """Process with retry tracking."""
+    attempts = state.get("attempts", 0) + 1
+
+    try:
+        # Your processing logic
+        result = risky_operation(state["input"])
+        return {
+            "output": result,
+            "attempts": attempts,
+            "success": True
+        }
+    except Exception as e:
+        return {
+            "output": str(e),
+            "attempts": attempts,
+            "success": False
+        }
+
+def should_retry(state: RetryState) -> str:
+    """Decide whether to retry."""
+    if state["success"]:
+        return "done"
+    elif state["attempts"] < state["max_attempts"]:
+        return "retry"
+    else:
+        return "failed"
+```
+
+### Integrating LLMs
+The true power emerges when node operations are powered by LLMs. Each node can use a different system prompt, tool set, model, or evaluation rule while still returning a predictable state update to the rest of the graph.
+
+```python
+from langchain_google_genai import ChatGoogleGenerativeAI
+from langchain_core.messages import HumanMessage, AIMessage, SystemMessage
+
+class LLMAgentState(TypedDict):
+    messages: Annotated[List[dict], operator.add]
+    task: str
+    result: str
+
+def create_llm_node(system_prompt: str):
+    """Factory function to create LLM nodes with different personas."""
+    llm = ChatGoogleGenerativeAI(model="gemini-2.0-flash-exp")
+
+    def node(state: LLMAgentState) -> dict:
+        # Build message history
+        messages = [SystemMessage(content=system_prompt)]
+        messages.append(HumanMessage(content=state["task"]))
+
+        # Call LLM
+        response = llm.invoke(messages)
+
+        return {
+            "result": response.content,
+            "messages": [{"role": "assistant", "content": response.content}]
+        }
+
+    return node
+
+# Create specialized nodes
+researcher = create_llm_node(
+    "You are a research assistant. Gather relevant information about the topic."
+)
+
+writer = create_llm_node(
+    "You are a skilled writer. Create engaging content based on the research."
+)
+
+editor = create_llm_node(
+    "You are a strict editor. Review and improve the writing. Be concise."
+)
+```
+
+## Section 5: Multi-Agent Orchestration & Parallelism
+When coordinating numerous specialized agents, the "Supervisor Pattern" is indispensable. A central node dictates routing while worker nodes handle isolated execution, which keeps specialization useful without letting every agent negotiate directly with every other agent.
+
+```mermaid
+graph TD
+    Supervisor[Supervisor]
+    Supervisor --> Researcher
+    Supervisor --> Analyst
+    Supervisor --> Writer
+    Researcher --> Supervisor
+    Analyst --> Supervisor
+    Writer --> Supervisor
+    Supervisor --> FinalOutput[Final Output]
+```
+
+```python
+from typing import Literal
+
+class TeamState(TypedDict):
+    task: str
+    research: str
+    analysis: str
+    draft: str
+    current_agent: str
+    next_agent: Literal["researcher", "analyst", "writer", "done"]
+    messages: Annotated[List[str], operator.add]
+
+def supervisor_node(state: TeamState) -> dict:
+    """Decide which agent should work next."""
+    if not state.get("research"):
+        return {"next_agent": "researcher", "messages": ["Assigning to researcher"]}
+    elif not state.get("analysis"):
+        return {"next_agent": "analyst", "messages": ["Assigning to analyst"]}
+    elif not state.get("draft"):
+        return {"next_agent": "writer", "messages": ["Assigning to writer"]}
+    else:
+        return {"next_agent": "done", "messages": ["All work complete!"]}
+
+def researcher_node(state: TeamState) -> dict:
+    """Research agent gathers information."""
+    task = state["task"]
+    # In real app, use LLM + tools
+    return {
+        "research": f"Research findings for: {task}",
+        "current_agent": "researcher",
+        "messages": ["Research complete"]
+    }
+
+def analyst_node(state: TeamState) -> dict:
+    """Analyst processes research."""
+    research = state["research"]
+    return {
+        "analysis": f"Analysis of: {research}",
+        "current_agent": "analyst",
+        "messages": ["Analysis complete"]
+    }
+
+def writer_node(state: TeamState) -> dict:
+    """Writer creates final content."""
+    analysis = state["analysis"]
+    return {
+        "draft": f"Final draft based on: {analysis}",
+        "current_agent": "writer",
+        "messages": ["Draft complete"]
+    }
+
+def route_to_agent(state: TeamState) -> str:
+    """Route to the next agent."""
+    return state["next_agent"]
+
+# Build the multi-agent graph
+team = StateGraph(TeamState)
+
+team.add_node("supervisor", supervisor_node)
+team.add_node("researcher", researcher_node)
+team.add_node("analyst", analyst_node)
+team.add_node("writer", writer_node)
+
+team.add_edge(START, "supervisor")
+
+team.add_conditional_edges(
+    "supervisor",
+    route_to_agent,
+    {
+        "researcher": "researcher",
+        "analyst": "analyst",
+        "writer": "writer",
+        "done": END
+    }
+)
+
+# Each agent reports back to supervisor
+team.add_edge("researcher", "supervisor")
+team.add_edge("analyst", "supervisor")
+team.add_edge("writer", "supervisor")
+
+app = team.compile()
+```
+
+### Fan-Out / Fan-In Parallelism
+Tasks devoid of interdependencies should run simultaneously. Fan-out sends the same state to independent processors, and fan-in combines their results after each branch finishes, reducing latency without sacrificing a single final decision point.
+
+```python
+from langgraph.graph import StateGraph
+
+class ParallelState(TypedDict):
+    input: str
+    result_a: str
+    result_b: str
+    result_c: str
+    final: str
+
+# Three independent processors
+def process_a(state): return {"result_a": f"A: {state['input']}"}
+def process_b(state): return {"result_b": f"B: {state['input']}"}
+def process_c(state): return {"result_c": f"C: {state['input']}"}
+
+def combine(state):
+    return {"final": f"{state['result_a']} + {state['result_b']} + {state['result_c']}"}
+
+graph = StateGraph(ParallelState)
+
+graph.add_node("a", process_a)
+graph.add_node("b", process_b)
+graph.add_node("c", process_c)
+graph.add_node("combine", combine)
+
+# Fan out from START to parallel nodes
+graph.add_edge(START, "a")
+graph.add_edge(START, "b")
+graph.add_edge(START, "c")
+
+# Fan in to combine
+graph.add_edge("a", "combine")
+graph.add_edge("b", "combine")
+graph.add_edge("c", "combine")
+
+graph.add_edge("combine", END)
+
+app = graph.compile()
+# LangGraph will execute a, b, c in parallel!
+```
+
+## Section 6: Persistence, Subgraphs, and the Human-in-the-Loop
+For high-stakes tasks, integrating human oversight is paramount. Interrupt mechanisms temporarily suspend workflows at a named boundary, preserve the current state, and allow a reviewer to approve, reject, or amend the next step before execution continues.
+
+```python
+from langgraph.checkpoint.memory import MemorySaver
+
+class ApprovalState(TypedDict):
+    proposal: str
+    approved: bool
+    feedback: str
+    messages: Annotated[List[str], operator.add]
+
+def create_proposal(state: ApprovalState) -> dict:
+    return {
+        "proposal": "I propose we invest $100K in AI infrastructure",
+        "messages": ["Proposal created"]
+    }
+
+def await_approval(state: ApprovalState) -> dict:
+    """This node will be interrupted for human input."""
+    # The interrupt happens here - human provides approved/feedback
+    return {
+        "messages": ["Awaiting approval..."]
+    }
+
+def execute_proposal(state: ApprovalState) -> dict:
+    if state["approved"]:
+        return {"messages": ["Proposal executed!"]}
+    else:
+        return {"messages": [f"Proposal rejected: {state['feedback']}"]}
+
+# Build with checkpointing
+workflow = StateGraph(ApprovalState)
+
+workflow.add_node("propose", create_proposal)
+workflow.add_node("await", await_approval)
+workflow.add_node("execute", execute_proposal)
+
+workflow.add_edge(START, "propose")
+workflow.add_edge("propose", "await")
+workflow.add_edge("await", "execute")
+workflow.add_edge("execute", END)
+
+# Compile with checkpointer for interrupts
+checkpointer = MemorySaver()
+app = workflow.compile(
+    checkpointer=checkpointer,
+    interrupt_before=["execute"]  # Interrupt before execution
+)
+```
+
+Resuming the workflow simply requires feeding the human-amended state back in. The graph does not need to rerun earlier nodes because the checkpoint already records where the workflow stopped and which state fields were available.
+```python
+# Start the workflow
+config = {"configurable": {"thread_id": "proposal-1"}}
+
+# Run until interrupt
+result = app.invoke({"approved": False, "messages": []}, config)
+print("Paused at:", result)
+
+# Human reviews and provides approval
+# Update state with human input
+app.update_state(
+    config,
+    {"approved": True, "feedback": "Looks good!"}
+)
+
+# Continue execution
+final = app.invoke(None, config)  # None continues from checkpoint
+print("Final:", final)
+```
+
+### Persistence and State Checkpoints
+Checkpointers are essential for crash-proofing applications. Memory is fine for local testing, but production systems usually need durable backends so a restart, deployment, or worker crash does not erase expensive agent progress.
+
+```python
+from langgraph.checkpoint.memory import MemorySaver
+
+checkpointer = MemorySaver()
+app = graph.compile(checkpointer=checkpointer)
+
+# Each run is identified by thread_id
+config = {"configurable": {"thread_id": "my-session-1"}}
+result = app.invoke(input_state, config)
+
+# Get history
+history = list(app.get_state_history(config))
+for state in history:
+    print(f"Step: {state.metadata}")
+```
+
+```python
+from langgraph.checkpoint.sqlite import SqliteSaver
+
+# Persistent storage
+checkpointer = SqliteSaver.from_conn_string("workflows.db")
+app = graph.compile(checkpointer=checkpointer)
+
+# Workflows survive restarts!
+```
+
+```python
+from langgraph.checkpoint.postgres import PostgresSaver
+
+checkpointer = PostgresSaver.from_conn_string(
+    "postgresql://user:pass@host:5432/db"
+)
+app = graph.compile(checkpointer=checkpointer)
+```
+
+### Streaming Operations
+LangGraph supports granular streaming. You can emit entire state updates or individual tokens generated directly by the LLM inside nodes, which gives user interfaces and operators visibility before a long workflow reaches its final state.
+
+```python
+# Stream all events
+for event in app.stream(input_state, config, stream_mode="values"):
+    print(f"State update: {event}")
+
+# Stream specific node outputs
+for event in app.stream(input_state, config, stream_mode="updates"):
+    print(f"Node output: {event}")
+```
+
+```python
+# Stream tokens from LLM calls within nodes
+async for event in app.astream_events(input_state, config, version="v2"):
+    if event["event"] == "on_llm_stream":
+        print(event["data"]["chunk"].content, end="", flush=True)
+```
+
+### Composing Workflows (Subgraphs)
+Encapsulating complexity makes architectures reusable. Any compiled graph can become a node in a broader parent graph, letting you test a workflow independently before composing it into a larger agent system.
+
+```python
+# Create a reusable subgraph
+research_graph = StateGraph(ResearchState)
+research_graph.add_node("search", search_node)
+research_graph.add_node("summarize", summarize_node)
+research_graph.add_edge(START, "search")
+research_graph.add_edge("search", "summarize")
+research_graph.add_edge("summarize", END)
+research_subgraph = research_graph.compile()
+
+# Use in parent graph
+main_graph = StateGraph(MainState)
+main_graph.add_node("research", research_subgraph)  # Subgraph as node!
+main_graph.add_node("write", write_node)
+main_graph.add_edge(START, "research")
+main_graph.add_edge("research", "write")
+main_graph.add_edge("write", END)
+```
+
+## Architecture Design Patterns
+Here are battle-tested topologies to memorize for high-performance agentic systems. The diagrams are simple, but each one encodes a design decision about feedback, validation, hierarchy, or parallelism that should be explicit before you write nodes.
+
+**Pattern 1: Research-Write-Review Cycle** fits content and analysis workflows where a draft should improve after critique. The important edge is the review loop, because it makes revision a controlled route instead of an ad-hoc second prompt.
+```mermaid
+graph LR
+    Research --> Write --> Review --> Approved{Approved?}
+    Approved -- No --> Write
+```
+
+**Pattern 2: Multi-Stage Validation** fits workflows with several independent gates. Each validation node can reject early, which keeps policy, format, and content checks separate enough to test and debug.
+```mermaid
+graph TD
+    Input --> ValFormat[Validate Format]
+    ValFormat --> ValContent[Validate Content]
+    ValContent --> ValPolicy[Validate Policy]
+    ValPolicy --> Process
+
+    ValFormat --> Reject1[Reject]
+    ValContent --> Reject2[Reject]
+    ValPolicy --> Reject3[Reject]
+```
+
+**Pattern 3: Hierarchical Agents** fits large tasks where one supervisor delegates to team leads and workers. The hierarchy reduces coordination noise because each layer summarizes state before passing it upward.
+```mermaid
+graph TD
+    Manager --> LeadA[Team Lead A]
+    Manager --> LeadB[Team Lead B]
+    Manager --> LeadC[Team Lead C]
+
+    LeadA --> Worker1[Worker 1]
+    LeadB --> Worker2[Worker 2]
+    LeadC --> Worker3[Worker 3]
+```
+
+**Pattern 4: MapReduce for Parallel Processing** fits document batches, independent retrieval shards, and multi-perspective analysis. The splitter creates independent work, while the reducer owns the final synthesis and conflict handling.
+```mermaid
+graph TD
+    Splitter --> Proc1[Process 1]
+    Splitter --> Proc2[Process 2]
+    Splitter --> Proc3[Process 3]
+
+    Proc1 --> Reducer
+    Proc2 --> Reducer
+    Proc3 --> Reducer
+```
+
+## ROI Calculation
+Why invest in the steeper learning curve of LangGraph over rudimentary Airflow scripts? The economic value comes from removing custom orchestration code, reducing restart waste, and giving operators a replayable record of how an agent reached its state.
+
+```text
+Without LangGraph (ad-hoc solution):
+- Development time: 3 months (senior engineer)
+- Crash-related rework: 15% of runs need manual intervention
+- Human review integration: Additional 2 weeks
+- Debugging production issues: 10 hours/week
+
+With LangGraph:
+- Development time: 1 month (same engineer)
+- Crash-related rework: <1% (auto-resume handles most)
+- Human review: Built-in interrupts
+- Debugging: State replay eliminates most investigation
+
+Annual savings for a team running 10K workflows/month:
+- Engineering time: ~$100K
+- Operational overhead: ~$50K
+- Reduced failures: ~$30K (API costs from restarts)
+Total: ~$180K/year
+```
+
+| Component | Without LangGraph | With LangGraph |
+|-----------|-------------------|----------------|
+| State Management | Often requires substantial custom code | Built-in |
+| Crash Recovery | Manual replay (lost time + tokens) | Automatic resume |
+| Human Review | Custom tooling | Native interrupts |
+| Debugging | Log analysis | State replay |
+
+| Company | Before LangGraph | After LangGraph | Reduction |
+|---------|------------------|-----------------|-----------|
+| Example team | thousands of lines | a few hundred lines | substantial |
+| Example team | thousands of lines | a few hundred lines | substantial |
+| Example team | thousands of lines | a few hundred lines | substantial |
+
+| Feature | Airflow/Prefect | LangGraph |
+|---------|-----------------|-----------|
+| Primary use | Data pipelines | AI workflows |
+| Node types | Python functions | LLM-aware functions |
+| State management | External | Built-in with reducers |
+| Streaming | Support varies by platform and pattern | First-class support |
+| Human-in-loop | Often requires extra orchestration | Native interrupt/resume |
+| LLM integration | DIY | Native with LangChain |
+
+## Common Mistakes
+
+| Mistake | Why it happens | Fix / Remedy |
+|---------|---------------|--------------|
+| **Forgetting State Annotations** | Defining `messages: List[str]` replaces the list on every node execution. | Use `Annotated[List[str], operator.add]` for accumulation. |
+| **Infinite Loops** | Conditional edges lack fallback limits, trapping agents in endless validation. | Track a `retry_count` in state and exit forcefully when it exceeds a threshold. |
+| **Missing Routing Edge Cases** | Conditional edge fails to account for a string variant, raising a KeyError. | Usually return a fallback/default route in routing functions for unexpected cases. |
+| **Stateful Nodes** | Relying on global Python variables (`global count`) inside nodes corrupts concurrent runs. | Enforce pure functions. Move all tracking to the `TypedDict` graph state. |
+| **Bloated State Objects** | Pushing massive 10MB payloads directly into state kills memory during checkpoints. | Persist references to external storage (`document_url: str`) instead of raw data. |
+| **Missing Graph Compilation** | You must compile the graph before invoking it. | Always instantiate via `app = graph.compile()` before invoking. |
+| **Unpersisted Threads** | Pausing for human-in-the-loop without attaching a checkpointer wipes the session. | Define `checkpointer=MemorySaver()` (or Postgres) during `.compile()`. |
+
+### Avoiding Pitfalls through Proper Design
+
+```python
+# BAD: Lists get replaced, not accumulated
+class BadState(TypedDict):
+    messages: List[str]  # Each node replaces the list!
+
+# GOOD: Use annotation for accumulation
+class GoodState(TypedDict):
+    messages: Annotated[List[str], operator.add]
+```
+
+```python
+# BAD: No exit condition
+graph.add_conditional_edges("check", should_continue, {
+    "retry": "process",
+    "done": "output"
+})
+# If should_continue always returns "retry", infinite loop!
+
+# GOOD: Add max retries
+def should_continue_safe(state):
+    if state["attempts"] >= MAX_RETRIES:
+        return "done"  # Force exit
+    return "retry" if not state["success"] else "done"
+```
+
+```python
+# BAD: Missing route
+def route(state):
+    if condition_a:
+        return "a"
+    elif condition_b:
+        return "b"
+    # What if neither? KeyError!
+
+# GOOD: Always have a default
+def route(state):
+    if condition_a:
+        return "a"
+    elif condition_b:
+        return "b"
+    else:
+        return "default"
+```
+
+```python
+# BAD: Node maintains internal state
+counter = 0
+def bad_node(state):
+    global counter
+    counter += 1  # This persists across invocations!
+    return {"count": counter}
+
+# GOOD: All state in the graph state
+def good_node(state):
+    count = state.get("count", 0) + 1
+    return {"count": count}
+```
+
+```python
+# BAD: Storing large data in state
+class BadState(TypedDict):
+    full_document: str  # 10MB document in every state snapshot!
+
+# GOOD: Store references, load when needed
+class GoodState(TypedDict):
+    document_id: str  # Reference to external storage
+```
+
+### Golden Best Practices
+
+```python
+# Think about:
+# - What needs to persist across nodes?
+# - What should accumulate vs replace?
+# - What's the minimal state needed?
+
+class WellDesignedState(TypedDict):
+    # Core data
+    input: str
+    output: str
+
+    # Progress tracking (accumulates)
+    steps_completed: Annotated[List[str], operator.add]
+
+    # Metadata (replaces)
+    current_phase: str
+    last_error: Optional[str]
+```
+
+```python
+# Node should be deterministic given same state
+def pure_node(state: MyState) -> dict:
+    # Only use state input
+    # No external side effects
+    # Return consistent output
+    return {"result": process(state["input"])}
+```
+
+```python
+# Create reusable components
+validation_subgraph = create_validation_graph()
+processing_subgraph = create_processing_graph()
+
+# Compose in main graph
+main_graph.add_node("validate", validation_subgraph)
+main_graph.add_node("process", processing_subgraph)
+```
+
+```python
+# Prevent runaway cycles
+config = {
+    "configurable": {"thread_id": "x"},
+    "recursion_limit": 50  # Max steps
+}
+result = app.invoke(state, config)
+```
+
+```python
+# Visualize your graph to catch issues
+from IPython.display import Image, display
+
+display(Image(app.get_graph().draw_mermaid_png()))
+```
+
+## Hands-On Exercise: Building a Multi-Agent Analyst
+
+**Objective**: Implement a supervisor-managed research system that handles topic searches, evaluates depth, and loops if criteria aren't met. Keep the exercise small: the goal is to understand LangGraph control flow, not to build a production research product.
+
+**Step 1: Environment Setup**
+Create a new directory and virtual environment from the repository root or another shell where the project Python is available:
+```bash
+REPO_ROOT="$(pwd)"
+mkdir langgraph-lab && cd langgraph-lab
+"$REPO_ROOT/.venv/bin/python" -m venv venv
+source venv/bin/activate
+pip install langgraph langchain-google-genai typing-extensions
+```
+
+**Step 2: Define Your TypedDict State**
+Create a python script `agent.py`. Add a state dictionary that tracks the requested `topic`, a `research_log` (using `operator.add` to accumulate discoveries), and a `loop_count` integer to cap search attempts.
+
+**Step 3: Construct Worker Nodes**
+Implement two Python functions that keep side effects obvious and return only partial state updates. This mirrors production LangGraph style, where every node should be easy to unit test with one input state and one returned patch:
+1. `researcher_node`: Appends a mocked observation to `research_log`.
+2. `reviewer_node`: Evaluates if the `research_log` has 2 or more entries. If so, updates a boolean `is_comprehensive` flag to True.
+
+**Step 4: Implement Routing**
+Write a routing function taking the current state. If `loop_count` > 3, return `"max_reached"`. If `is_comprehensive` is True, return `"done"`. Otherwise, return `"research"` so the graph cycles deliberately rather than through hidden recursion.
+
+**Step 5: Graph Compilation & Execution**
+Instantiate a `StateGraph`, link the nodes, setup the conditional edge pointing out of the reviewer node, and execute `.invoke()`. The output should show accumulated research entries and a final route that proves the loop exited for a reason.
+
+<details>
+<summary>View the Full Solution Code</summary>
+
+```python
+import operator
+from typing import TypedDict, List, Annotated
+from langgraph.graph import StateGraph, START, END
+
+# Step 2: State Definition
+class ResearchState(TypedDict):
+    topic: str
+    research_log: Annotated[List[str], operator.add]
+    loop_count: int
+    is_comprehensive: bool
+
+# Step 3: Node Implementation
+def researcher_node(state: ResearchState) -> dict:
+    current_count = state.get("loop_count", 0)
+    return {
+        "research_log": [f"Found insight part {current_count + 1}."],
+        "loop_count": current_count + 1
+    }
+
+def reviewer_node(state: ResearchState) -> dict:
+    logs = state.get("research_log", [])
+    return {
+        "is_comprehensive": len(logs) >= 2
+    }
+
+# Step 4: Routing Logic
+def routing_logic(state: ResearchState) -> str:
+    if state.get("loop_count", 0) > 3:
+        return "max_reached"
+    if state.get("is_comprehensive"):
+        return "done"
+    return "research"
+
+# Step 5: Compilation
+workflow = StateGraph(ResearchState)
+workflow.add_node("researcher", researcher_node)
+workflow.add_node("reviewer", reviewer_node)
+
+workflow.add_edge(START, "researcher")
+workflow.add_edge("researcher", "reviewer")
+workflow.add_conditional_edges(
+    "reviewer",
+    routing_logic,
+    {
+        "done": END,
+        "max_reached": END,
+        "research": "researcher"
+    }
+)
+
+app = workflow.compile()
+output = app.invoke({"topic": "Quantum Computing", "research_log": [], "loop_count": 0})
+print("Final State:", output)
+```
+</details>
+
+### Success Checklist
+- [ ] Nodes accurately append to the `research_log`.
+- [ ] Execution completes gracefully after hitting the minimum log requirement.
+- [ ] Changing the `reviewer_node` logic to require 5 items effectively triggers the max loop cutoff.
+
 ## Quiz
 
-
-**Q1.** Your team runs an internal helpdesk bot for finance staff. It keeps getting multi-step reimbursement calculations wrong when employees describe expenses in plain English, even though the questions are simple arithmetic. What is the first prompt change you should try before redesigning the system, and why?
-
 <details>
-<summary>Answer</summary>
-Add a zero-shot Chain-of-Thought trigger such as "Let's think step by step."
-
-The module explains that this often improves multi-step reasoning because it forces the model to generate intermediate steps before the final answer. Those reasoning steps become part of the context, which acts like external working memory and reduces the model's tendency to jump straight to a wrong answer.
+<summary>1. A developer notices their LangGraph workflow is replacing the message history instead of appending new messages. What is the architectural flaw?</summary>
+The developer likely assigned `messages: List[str]` in their `TypedDict` instead of applying LangGraph's accumulation annotation. Without `Annotated[List[str], operator.add]`, LangGraph falls back to its default reducer behavior. This default behavior overwrites the existing state key entirely with the newly returned dictionary value. To resolve this, the state definition must explicitly instruct the framework to merge list contents.
 </details>
 
-**Q2.** Your product team wants a claims-review assistant to explain decisions in a very specific format: identify facts, apply policy rules, and then give a conclusion. A generic "think step by step" prompt produces inconsistent structures across responses. Which approach fits best?
-
 <details>
-<summary>Answer</summary>
-Use few-shot Chain-of-Thought prompting.
-
-The module says few-shot CoT is better when you need format consistency, domain-specific reasoning patterns, and more control over how the model thinks. By showing a few examples of fact identification, policy application, and conclusion writing, you teach the model the exact reasoning structure you want it to follow.
+<summary>2. You need to implement a fallback mechanism where a failed API call is retried up to three times before halting. How does a graph accomplish this?</summary>
+You must model the error and the retry logic explicitly as state data properties rather than relying on standard try-catch blocks alone. By incorporating an `attempts: int` counter and `success: bool` flag into your State, you gain granular control over execution flow. You can then write a routing function that inspects the outcome and iterates the cycle until `attempts >= 3`. At that point, the function must forcefully return a fallback edge to break the cycle.
 </details>
 
-**Q3.** Your team is building an agent that answers questions like, "What is France's population divided by 3?" The model can reason, but it also needs to fetch current facts and then calculate with them. Should you use plain CoT or ReAct, and why?
-
 <details>
-<summary>Answer</summary>
-Use ReAct.
-
-The module explains that ReAct is for cases where the model must alternate between reasoning and actions. Here, the agent needs to look up France's population, observe the result, then perform a calculation. Plain CoT only reasons from the initial prompt, while ReAct adds a Thought → Action → Observation loop that grounds the answer in real tool results.
+<summary>3. A team is designing a system where an AI agent proposes a trade, but a human must approve it before execution. How should this be implemented natively in LangGraph?</summary>
+The framework handles this effortlessly using the specialized checkpointer interrupt feature. The team should initialize their orchestrator by calling `app.compile(checkpointer=MemorySaver(), interrupt_before=["execute"])`. This halts execution immediately before the trade execution node runs, preserving the current state safely in memory. Once human feedback is secured, it is injected back via `.update_state()`, allowing the system to proceed seamlessly.
 </details>
 
-**Q4.** A compliance team says an AI output must be highly reliable because a wrong recommendation could trigger an expensive manual review. The task is a reasoning-heavy one, not simple recall. What technique from the module would improve robustness without changing the underlying model?
-
 <details>
-<summary>Answer</summary>
-Use self-consistency.
-
-The module recommends sampling multiple reasoning paths and selecting the most common final answer. This works because correct reasoning often converges on the same answer, while mistakes tend to vary across runs. For a high-stakes reasoning task, that majority-vote approach gives a more reliable result than trusting a single chain of thought.
+<summary>4. An architect wants three distinct specialized agents to analyze a document simultaneously and then combine their insights. Which graph configuration achieves this?</summary>
+The architect should fan-out the execution by connecting the START node directly to all three worker nodes simultaneously via unconditional edges. Next, all three worker nodes must direct their downstream edges into a single downstream combination node. Because LangGraph automatically runs independent nodes in parallel, it naturally processes the three tasks concurrently. This approach eliminates latency bottlenecks before finally synchronizing the distinct outputs.
 </details>
 
-**Q5.** Your team adds CoT prompting to every request in a customer support bot, including simple questions like "What is the capital of France?" Latency and token costs increase, but quality does not. According to the module, what went wrong?
-
 <details>
-<summary>Answer</summary>
-They used CoT on a task where it is usually unnecessary and can hurt efficiency.
-
-The module says CoT helps most on multi-step reasoning, calculations, deduction, and debugging. It can hurt on simple factual recall because it adds unnecessary steps, wastes tokens, and slows responses without adding useful reasoning.
+<summary>5. A graph enters an infinite loop between a "review" node and a "draft" node. How can this architectural flaw be mitigated safely?</summary>
+A runaway cycle typically happens when a conditional edge lacks an explicit architectural cap or fallback route. To mitigate this safely, introduce a `recursion_limit` directly in the execution configuration object. Additionally, you should track the total revision count inside the node state. This allows your routing logic to force an exit or transition to a generic "publish" edge once that count hits a sensible upper limit.
 </details>
 
-**Q6.** An engineering manager notices that your LLM often produces convincing step-by-step math explanations, but sometimes the arithmetic inside those steps is still wrong. What should you change in the agent design?
-
 <details>
-<summary>Answer</summary>
-Use tools for the arithmetic, such as a calculator in a ReAct loop or a program-aided approach like PAL.
-
-The module is explicit that CoT does not solve arithmetic precision problems. LLMs still make mistakes with calculations, so the safer design is to let the model reason about what to compute, then hand the actual math to a tool that executes it correctly.
+<summary>6. During a high-traffic period, your container crashes halfway through a multi-agent debate. Without starting over, how can LangGraph resume from the exact point of failure?</summary>
+LangGraph achieves system resiliency using persistent Checkpointers backed by external databases. If the graph was compiled with a `SqliteSaver` or `PostgresSaver`, the orchestrator simply reinvokes the workflow targeting the exact `thread_id` contained within the configuration object. The application then reconstructs the last fully processed state segment automatically. From there, it picks up execution at the subsequent unexecuted node without dropping any prior context.
 </details>
-
-**Q7.** A prompt engineer changes your reasoning trigger from "Let's think step by step" to "Be very careful and make sure you're right." Accuracy drops on logic questions. Based on the module, why might that happen, and what wording is safer?
-
-<details>
-<summary>Answer</summary>
-That change likely hurt performance because the module says anxiety-like prompts such as "be careful" or "make sure you're right" can lead to overthinking and worse results.
-
-A safer wording is a neutral, process-focused trigger like "Let's think step by step." The module notes that this phrasing consistently performs well because it encourages structured reasoning without adding pressure.
-</details>
-
-<!-- /v4:generated -->
-## Further Reading
-
-### Papers
-- **Chain-of-Thought Prompting** (Wei et al., 2022) - The original CoT paper
-- **Large Language Models are Zero-Shot Reasoners** (Kojima et al., 2022) - "Let's think step by step"
-- **ReAct: Synergizing Reasoning and Acting** (Yao et al., 2022) - Combining thought and action
-- **Self-Consistency Improves Chain of Thought Reasoning** (Wang et al., 2022)
-- **Tree of Thoughts** (Yao et al., 2023) - Multi-path reasoning
-
-### Tutorials
-- [LangChain ReAct Agent Tutorial](https://python.langchain.com/docs/tutorials/agents/)
-- [OpenAI Reasoning Best Practices](https://platform.openai.com/docs/guides/reasoning)
 
 ---
+_Module complete: you now have the LangGraph mental model needed to design stateful agent workflows with routing, retries, checkpointing, human review, and multi-agent coordination._
 
-## ️ Next Steps
-
-After completing this module, you'll be ready for:
-
-**Module 18: LangGraph for Stateful Workflows** - Build sophisticated agents with persistent state, cycles, and complex control flow. LangGraph takes the ReAct pattern and scales it to production.
-
----
-
-_Last updated: 2025-11-25_
-_Status:  In Progress_
+_Next: [Module 1.5 - Building AI Agents](./module-1.5-building-ai-agents)_ — Move from framework components to full agent architectures, orchestration patterns, and production-ready design tradeoffs that combine prompts, tools, memory, routing, and runtime safeguards.
 
 ## Sources
 
-- [Chain-of-Thought Prompting Elicits Reasoning in Large Language Models](https://arxiv.org/abs/2201.11903) — Foundational paper for few-shot chain-of-thought prompting.
-- [Large Language Models are Zero-Shot Reasoners](https://arxiv.org/abs/2205.11916) — Primary source for the "Let's think step by step" zero-shot result.
-- [ReAct: Synergizing Reasoning and Acting in Language Models](https://arxiv.org/abs/2210.03629) — Primary source for interleaving thought with tool use.
-- [Self-Consistency Improves Chain of Thought Reasoning in Language Models](https://arxiv.org/abs/2203.11171) — Primary source for sampling multiple reasoning paths and majority-style aggregation.
+- [LangGraph GitHub Repository](https://github.com/langchain-ai/langgraph) — This is the allowlisted upstream home for the framework and its high-level positioning.
+- [LangGraph Releases](https://github.com/langchain-ai/langgraph/releases) — Useful for checking official release chronology and version history.

--- a/src/content/docs/ai-ml-engineering/frameworks-agents/module-1.3-langgraph-for-agents.md
+++ b/src/content/docs/ai-ml-engineering/frameworks-agents/module-1.3-langgraph-for-agents.md
@@ -549,7 +549,7 @@ class LLMAgentState(TypedDict):
 
 def create_llm_node(system_prompt: str):
     """Factory function to create LLM nodes with different personas."""
-    llm = ChatGoogleGenerativeAI(model="gemini-2.0-flash-exp")
+    llm = ChatGoogleGenerativeAI(model="gemini-2.0-flash")
 
     def node(state: LLMAgentState) -> dict:
         # Build message history
@@ -815,22 +815,24 @@ for state in history:
 ```
 
 ```python
+# pip install langgraph-checkpoint-sqlite
 from langgraph.checkpoint.sqlite import SqliteSaver
 
-# Persistent storage
-checkpointer = SqliteSaver.from_conn_string("workflows.db")
-app = graph.compile(checkpointer=checkpointer)
-
-# Workflows survive restarts!
+# from_conn_string is a context manager: the underlying connection is only
+# valid inside the `with` block, so compile and run the graph in that scope.
+with SqliteSaver.from_conn_string("workflows.db") as checkpointer:
+    app = graph.compile(checkpointer=checkpointer)
+    # ... invoke the app here; checkpoints survive process restarts.
 ```
 
 ```python
+# pip install langgraph-checkpoint-postgres
 from langgraph.checkpoint.postgres import PostgresSaver
 
-checkpointer = PostgresSaver.from_conn_string(
-    "postgresql://user:pass@host:5432/db"
-)
-app = graph.compile(checkpointer=checkpointer)
+# Also a context manager; call setup() once to create the checkpoint tables.
+with PostgresSaver.from_conn_string("postgresql://user:pass@host:5432/db") as checkpointer:
+    checkpointer.setup()  # first run only
+    app = graph.compile(checkpointer=checkpointer)
 ```
 
 ### Streaming Operations
@@ -951,12 +953,6 @@ Total: ~$180K/year
 | Crash Recovery | Manual replay (lost time + tokens) | Automatic resume |
 | Human Review | Custom tooling | Native interrupts |
 | Debugging | Log analysis | State replay |
-
-| Company | Before LangGraph | After LangGraph | Reduction |
-|---------|------------------|-----------------|-----------|
-| Example team | thousands of lines | a few hundred lines | substantial |
-| Example team | thousands of lines | a few hundred lines | substantial |
-| Example team | thousands of lines | a few hundred lines | substantial |
 
 | Feature | Airflow/Prefect | LangGraph |
 |---------|-----------------|-----------|

--- a/src/content/docs/ai/ai-engineering-foundations/module-1.2-reasoning-and-logic-prompts.md
+++ b/src/content/docs/ai/ai-engineering-foundations/module-1.2-reasoning-and-logic-prompts.md
@@ -18,7 +18,7 @@ By the end of this module, you will be able to:
 
 - **Design** reasoning-eliciting prompts for math, diagnosis, planning, classification, and decision tasks without turning every request into a long chain-of-thought ritual.
 - **Distinguish** reasoning prompts from reasoning models by deciding when prompt scaffolding helps an ordinary model and when a model with native thinking budget should be left to use its own internal trace.
-- **Compare** zero-shot CoT, few-shot CoT, self-consistency, least-to-most prompting, plan-and-execute, verifier prompts, and Tree-of-Thoughts as different cost and control points.
+- **Compare** zero-shot CoT, few-shot CoT, self-consistency, least-to-most prompting, plan-and-execute, verifier prompts, ReAct, and Tree-of-Thoughts as different cost and control points.
 - **Evaluate** reasoning effort controls across Claude, OpenAI, and Gemini APIs by naming what they budget, what they do not guarantee, and when the extra latency is justified.
 - **Build** a small experiment that prompts one task with three reasoning strategies, compares outputs against a rubric, and records which strategy should enter a reusable prompt library.
 
@@ -616,6 +616,128 @@ Reasoning quality is not the only metric.
 
 Cost, latency, user patience, and review burden are part of the prompt design.
 
+
+## ReAct: Interleaving Reasoning and Action
+
+Chain-of-thought, decomposition, and Tree-of-Thoughts all improve how a model reasons from the information already inside the prompt or candidate branch. ReAct, short for reasoning and acting, changes the loop. The model alternates between a reasoning step, a tool action, and an observation, then uses the observation to decide what to do next. That makes ReAct useful when correctness depends on facts, calculations, repository state, logs, search results, or other information the model should not invent from memory.
+
+The important shift is that the reasoning trace is no longer just explanatory text. It becomes a controller for tool use. A ReAct harness usually enforces a small grammar such as `Thought`, `Action`, `Observation`, and `Final Answer`; the model proposes the next action, the application executes only allowed tools, and the observation is appended to the next model turn. This is why ReAct belongs between reasoning prompts and agent frameworks: it is still a prompt pattern, but it only becomes dependable when a harness parses actions, records observations, limits iterations, and rejects unknown tools.
+
+```text
+Question: How tall is the Eiffel Tower in feet?
+Thought: I need the trusted height in meters before converting units.
+Action: lookup("eiffel tower height meters")
+Observation: 330
+Thought: I need the meters-to-feet conversion factor.
+Action: lookup("meters to feet")
+Observation: 3.28084
+Thought: Now I can calculate 330 * 3.28084.
+Action: calculate("330 * 3.28084")
+Observation: 1082.6772
+Thought: I have the source value, conversion factor, and calculation.
+Final Answer: The Eiffel Tower is about 1,083 feet tall.
+```
+
+Use ReAct when the model must leave the prompt to gather or transform information. Do not use it as a more dramatic form of chain-of-thought for tasks that are already fully specified. A license-date extraction prompt probably does not need ReAct. A support assistant that must inspect current deployment events, check read-only constraints, and calculate an error-budget impact may need it because each observation can change the next safe action.
+
+The following mini-harness is deliberately deterministic so you can run it without an API key. In a real application, `scripted_reasoner` would be replaced by a model call, but the parser, allow-listed tools, observation log, and max-step guard are the pieces you still need to test.
+
+```python
+from __future__ import annotations
+
+import ast
+import operator
+import re
+from collections.abc import Callable
+
+
+ACTION_RE = re.compile(r'^Action:\s*(\w+)\("([^"]*)"\)', re.MULTILINE)
+FINAL_RE = re.compile(r'^Final Answer:\s*(.+)$', re.MULTILINE)
+OPERATORS = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.USub: operator.neg,
+}
+
+
+def safe_eval(expression: str) -> float:
+    """Evaluate a tiny arithmetic expression without exposing Python eval."""
+    tree = ast.parse(expression, mode='eval')
+
+    def walk(node: ast.AST) -> float:
+        if isinstance(node, ast.Expression):
+            return walk(node.body)
+        if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+            return float(node.value)
+        if isinstance(node, ast.UnaryOp) and type(node.op) in OPERATORS:
+            return OPERATORS[type(node.op)](walk(node.operand))
+        if isinstance(node, ast.BinOp) and type(node.op) in OPERATORS:
+            return OPERATORS[type(node.op)](walk(node.left), walk(node.right))
+        raise ValueError(f'Unsupported expression: {expression}')
+
+    return walk(tree)
+
+
+def lookup(query: str) -> str:
+    facts = {
+        'eiffel tower height meters': '330',
+        'meters to feet': '3.28084',
+    }
+    return facts.get(query.lower(), 'unknown')
+
+
+def calculate(expression: str) -> str:
+    return f'{safe_eval(expression):.4f}'
+
+
+def scripted_reasoner(transcript: str) -> str:
+    """Stand in for an LLM so this example stays runnable and repeatable."""
+    if 'Observation:' not in transcript:
+        return 'Thought: I need the trusted height in meters.\nAction: lookup("eiffel tower height meters")'
+    if '330' in transcript and '3.28084' not in transcript:
+        return 'Thought: I need the unit conversion factor.\nAction: lookup("meters to feet")'
+    if '3.28084' in transcript and '1082.6772' not in transcript:
+        return 'Thought: I can now calculate meters to feet.\nAction: calculate("330 * 3.28084")'
+    return 'Thought: I have the facts and calculation.\nFinal Answer: The Eiffel Tower is about 1,083 feet tall.'
+
+
+def run_react(question: str, max_steps: int = 5) -> str:
+    tools: dict[str, Callable[[str], str]] = {
+        'lookup': lookup,
+        'calculate': calculate,
+    }
+    transcript = f'Question: {question}\n'
+
+    for _ in range(max_steps):
+        response = scripted_reasoner(transcript)
+        transcript += response + '\n'
+
+        if FINAL_RE.search(response):
+            return transcript
+
+        match = ACTION_RE.search(response)
+        if not match:
+            raise RuntimeError(f'Could not parse action from: {response}')
+
+        tool_name, argument = match.groups()
+        if tool_name not in tools:
+            raise RuntimeError(f'Tool is not allow-listed: {tool_name}')
+
+        transcript += f'Observation: {tools[tool_name](argument)}\n'
+
+    raise RuntimeError('ReAct loop stopped before a final answer')
+
+
+if __name__ == '__main__':
+    print(run_react('How tall is the Eiffel Tower in feet?'))
+```
+
+The harness shows the minimum safety shape. The model does not execute arbitrary code; it emits an action string that the application parses. The application owns the tool registry, the tool arguments, the observation log, and the stopping rule. If those boundaries are weak, ReAct can fail in ordinary ways: looping forever, calling a tool that should not be available, accepting stale observations, or treating an observation as proof when it is only another uncertain input.
+
+A practical ReAct prompt should therefore name the available tools, require one action per turn, require `Final Answer` when no further tool is needed, and tell the model to stop when observations are insufficient. The harness should then enforce those rules instead of trusting the prompt to enforce itself. Once you add durable state, branching, human interrupts, or multiple workers, the same reasoning-and-action loop becomes the conceptual bridge to LangGraph-style agent orchestration.
+
 ## Reasoning Effort APIs
 
 Vendor reasoning controls are easy to misunderstand.
@@ -953,6 +1075,7 @@ The workflow is slower, but the extra pass may be justified for support prompts 
 - [Self-Consistency Improves Chain of Thought Reasoning in Language Models](https://arxiv.org/abs/2203.11171) - Wang et al.; verified source for multiple sampled reasoning paths and answer selection.
 - [Least-to-Most Prompting Enables Complex Reasoning in Large Language Models](https://arxiv.org/abs/2205.10625) - Zhou et al.; verified source for decomposition into simpler subproblems.
 - [Tree of Thoughts: Deliberate Problem Solving with Large Language Models](https://arxiv.org/abs/2305.10601) - Yao et al.; verified source for search over intermediate thoughts.
+- [ReAct: Synergizing Reasoning and Acting in Language Models](https://arxiv.org/abs/2210.03629) - Yao et al.; verified source for interleaving reasoning traces with tool actions and observations.
 - [Chain-of-Thought Prompting Elicits Reasoning in Large Language Models](https://arxiv.org/abs/2201.11903) - Wei et al.; verified background source for few-shot CoT examples.
 - [Plan-and-Solve Prompting: Improving Zero-Shot Chain-of-Thought Reasoning by Large Language Models](https://arxiv.org/abs/2305.04091) - Wang et al.; verified background source for planning before solving.
 - [Let's Verify Step by Step](https://arxiv.org/abs/2305.20050) - Lightman et al.; verified background source for process and outcome verification concerns.

--- a/src/content/docs/ai/ai-engineering-foundations/module-1.2-reasoning-and-logic-prompts.md
+++ b/src/content/docs/ai/ai-engineering-foundations/module-1.2-reasoning-and-logic-prompts.md
@@ -855,26 +855,31 @@ Delete the scaffolds that no longer earn their keep.
 
 ### Decision Checklist
 
-Ask six questions before adding reasoning machinery.
+Ask seven questions before adding reasoning machinery.
 The answer decides the pattern.
 
 ```text
 1. Is the answer directly present in trusted context?
    Use extraction with citation.
 
-2. Does the task require several dependent steps?
+2. Does correctness depend on external facts, calculations, or system
+   state the model should not invent from memory?
+   Use ReAct: interleave reasoning with allow-listed tool actions and
+   observations, under a harness with iteration limits.
+
+3. Does the task require several dependent steps?
    Use decomposition or plan-and-execute.
 
-3. Does the task have one objective final answer but fragile paths?
+4. Does the task have one objective final answer but fragile paths?
    Use self-consistency or a verifier.
 
-4. Does the model family already support native reasoning effort?
+5. Does the model family already support native reasoning effort?
    Try effort controls before writing a rigid visible scratchpad.
 
-5. Is the wrong answer expensive enough to justify branch search?
+6. Is the wrong answer expensive enough to justify branch search?
    Use Tree-of-Thoughts with branch scoring and stop rules.
 
-6. Can the result be checked by criteria, tests, or evidence?
+7. Can the result be checked by criteria, tests, or evidence?
    Add a verifier pass before adding more generation.
 ```
 


### PR DESCRIPTION
## #1639 Option B §4(b/c) — frameworks-agents 1.3/1.4 scramble + ReAct port

Fixes a **verified title/content scramble** in the AI/ML Engineering "Frameworks & Agents" track, plus ports the one genuinely-unique reasoning topic into the canonical reasoning module.

### The scramble (verified by reference counts)
- `module-1.3-langgraph-for-agents.md` was **titled** LangGraph but its **body taught reasoning** (CoT=100, ReAct=39, only 4 incidental LangGraph mentions).
- `module-1.4-llamaindex.md` was **titled** LlamaIndex but its **body was a complete LangGraph course** (39 LangGraph / 19 StateGraph / 2 LlamaIndex).

### Changes in this PR (2 files)
- **`module-1.3-langgraph-for-agents.md`** — body replaced with the genuine LangGraph course (StateGraph, nodes/edges, cycles, multi-agent, persistence/HITL). Frontmatter/slug unchanged; LlamaIndex self-refs scrubbed (0 remaining); source H1 removed; metadata blockquote normalized.
- **`module-1.2-reasoning-and-logic-prompts.md`** (foundations) — new `## ReAct: Interleaving Reasoning and Action` section inserted after Tree-of-Thoughts, before Reasoning Effort APIs. Foundations 1.2 previously had **zero** ReAct coverage; the CoT/self-consistency that duplicated 1.2 was intentionally dropped.

> The matching LlamaIndex authoring (so 1.4 becomes a real LlamaIndex module) is the sibling PR (§4(d)). Stub retirement is PR #1649 (§4(a)).

### Authoring + a fixed regression
Authored by **codex gpt-5.5** in a worktree. The dispatch was **SIGKILLed at the 1800s edit timeout *after* completing the edits but *before* committing** — the orchestrator committed the recovered worktree. The orchestrator also **reverted codex's over-addition** of a 9th Common Mistakes row + 9th quiz question in 1.2 (those broke the 6-8 structure caps that 1.2 passed at base); the ReAct teaching section is retained.

### Gates
- `npm run build` — green, 2133 pages, 0 warnings.
- `verify_module.py`:
  - **foundations 1.2** — ✅ **PASS, tier T0** (8 mistakes, 8 quiz, 14 sources all 200, 6065 body words).
  - **frameworks 1.3** — carries the LangGraph body's **pre-existing T3 density** (1520 prose words, 2 sources). This is **not a regression** — the same content was T3 when it lived in 1.4. Pedagogically complete (6 sections + code + quiz + exercise). The density/source upgrade is logged for the curriculum audit phase (#1639 focus item 2), not silently shipped as "done."

### Learner check
> The model alternates between a reasoning step, a tool action, and an observation, then uses the observation to decide what to do next.

Refs #1639.
