### PR TITLE
fix(dispatch): strip user MCP schemas from headless Claude delegate calls

### DIFF
--- a/scripts/agent_runtime/configs/claude-delegate-mcp.json
+++ b/scripts/agent_runtime/configs/claude-delegate-mcp.json
@@ -1,0 +1,3 @@
+{
+  "mcpServers": {}
+}

--- a/scripts/agent_runtime/delegate_config.py
+++ b/scripts/agent_runtime/delegate_config.py
@@ -1,0 +1,42 @@
+"""Headless Claude tool_config defaults for delegate/dispatch entrypoints.
+
+Without a minimal ``--mcp-config``, the Claude CLI loads every MCP server
+from the user's global config and injects all tool schemas into the prompt,
+which can fail instantly with "Prompt is too long" before the task brief runs.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+CLAUDE_DELEGATE_MCP_CONFIG = (
+    Path(__file__).resolve().parent / "configs" / "claude-delegate-mcp.json"
+)
+
+# Built-in Claude Code tools only — no ``mcp__*`` entries.
+CLAUDE_DELEGATE_ALLOWED_TOOLS = (
+    "Read,Write,Edit,Bash,Grep,Glob,TodoWrite,WebFetch,WebSearch"
+)
+
+_DELEGATE_ENTRYPOINTS = frozenset({"delegate", "dispatch"})
+
+
+def merge_delegate_claude_tool_config(
+    agent_name: str,
+    entrypoint: str,
+    tool_config: dict | None,
+) -> dict | None:
+    """Return ``tool_config`` with minimal MCP restrictions for headless Claude.
+
+    Skips merge when the caller already set ``mcp_config_path`` or
+    ``allowed_tools`` (e.g. pipeline translation paths via ``dispatch.py``).
+    """
+    if agent_name != "claude" or entrypoint not in _DELEGATE_ENTRYPOINTS:
+        return tool_config
+    if not CLAUDE_DELEGATE_MCP_CONFIG.is_file():
+        return tool_config
+    tc = dict(tool_config or {})
+    if tc.get("mcp_config_path") or tc.get("allowed_tools"):
+        return tc
+    tc["mcp_config_path"] = str(CLAUDE_DELEGATE_MCP_CONFIG)
+    tc["allowed_tools"] = CLAUDE_DELEGATE_ALLOWED_TOOLS
+    return tc

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -36,6 +36,7 @@ from pathlib import Path
 from typing import Any
 
 from .adapters.base import AgentAdapter
+from .delegate_config import merge_delegate_claude_tool_config
 from .env_sanitize import build_agent_env
 from .errors import (
     AgentTimeoutError,
@@ -372,6 +373,11 @@ def invoke(
         raise RateLimitedError(agent_name, effective_model, reason)
 
     # ---------- 6. Build invocation plan ----------
+    effective_tool_config = merge_delegate_claude_tool_config(
+        agent_name,
+        entrypoint,
+        tool_config,
+    )
     plan = adapter.build_invocation(
         prompt=prompt,
         mode=mode,
@@ -379,7 +385,7 @@ def invoke(
         model=effective_model,
         task_id=task_id,
         session_id=session_id,
-        tool_config=tool_config,
+        tool_config=effective_tool_config,
     )
 
     # Build a sanitized child environment. We do NOT mutate os.environ itself:

--- a/scripts/tests/test_dispatch_smart_claude_mcp.py
+++ b/scripts/tests/test_dispatch_smart_claude_mcp.py
@@ -1,0 +1,127 @@
+"""Regression: headless Claude delegate/dispatch must not load user MCP schemas."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agent_runtime.adapters.claude import ClaudeAdapter
+from agent_runtime.delegate_config import (
+    CLAUDE_DELEGATE_ALLOWED_TOOLS,
+    CLAUDE_DELEGATE_MCP_CONFIG,
+    merge_delegate_claude_tool_config,
+)
+from agent_runtime import runner
+from agent_runtime.adapters.base import InvocationPlan
+from agent_runtime.result import ParseResult
+
+
+def test_delegate_mcp_fixture_is_empty_servers() -> None:
+    assert CLAUDE_DELEGATE_MCP_CONFIG.is_file()
+    payload = json.loads(CLAUDE_DELEGATE_MCP_CONFIG.read_text(encoding="utf-8"))
+    assert payload == {"mcpServers": {}}
+
+
+def test_merge_skips_non_claude_and_bridge() -> None:
+    assert merge_delegate_claude_tool_config("codex", "delegate", None) is None
+    assert merge_delegate_claude_tool_config(
+        "claude",
+        "bridge",
+        {"is_new_session": True},
+    ) == {"is_new_session": True}
+
+
+def test_merge_respects_caller_override() -> None:
+    custom = {
+        "mcp_config_path": "/tmp/custom.mcp.json",
+        "allowed_tools": "mcp__rag__verify_word,Read",
+    }
+    assert merge_delegate_claude_tool_config("claude", "delegate", custom) == custom
+
+
+@pytest.mark.parametrize("entrypoint", ["delegate", "dispatch"])
+def test_merge_applies_minimal_mcp_for_claude_delegate(entrypoint: str) -> None:
+    merged = merge_delegate_claude_tool_config("claude", entrypoint, None)
+    assert merged is not None
+    assert merged["mcp_config_path"] == str(CLAUDE_DELEGATE_MCP_CONFIG)
+    assert merged["allowed_tools"] == CLAUDE_DELEGATE_ALLOWED_TOOLS
+    assert "mcp__" not in merged["allowed_tools"]
+
+
+def test_claude_adapter_emits_mcp_flags_for_delegate_tool_config() -> None:
+    tc = merge_delegate_claude_tool_config("claude", "delegate", None)
+    plan = ClaudeAdapter().build_invocation(
+        prompt="brief",
+        mode="danger",
+        cwd=Path.cwd(),
+        model="claude-sonnet-4-6",
+        task_id="t1",
+        session_id=None,
+        tool_config=tc,
+    )
+    assert "--mcp-config" in plan.cmd
+    idx = plan.cmd.index("--mcp-config")
+    assert plan.cmd[idx + 1] == str(CLAUDE_DELEGATE_MCP_CONFIG)
+    tools_idx = plan.cmd.index("--allowedTools")
+    allowed = plan.cmd[tools_idx + 1]
+    assert allowed == CLAUDE_DELEGATE_ALLOWED_TOOLS
+    assert "mcp__" not in allowed
+
+
+def test_invoke_passes_delegate_mcp_tool_config_to_claude_adapter() -> None:
+    captured: dict[str, object] = {}
+
+    def build_invocation(**kw):
+        captured["tool_config"] = kw["tool_config"]
+        return InvocationPlan(cmd=["claude", "-p"], cwd=kw["cwd"])
+
+    adapter = type(
+        "StubClaude",
+        (),
+        {
+            "default_model": "claude-sonnet-4-6",
+            "supported_modes": frozenset({"read-only", "workspace-write", "danger"}),
+            "build_invocation": staticmethod(build_invocation),
+            "liveness_signal_paths": staticmethod(lambda _plan: ()),
+            "parse_response": staticmethod(
+                lambda **_kw: ParseResult(ok=True, response="ok"),
+            ),
+        },
+    )()
+    proc = SimpleNamespace(
+        returncode=0,
+        stdin=None,
+        poll=lambda: 0,
+        kill=lambda: None,
+        wait=lambda timeout=None: 0,
+    )
+    state = SimpleNamespace(stdout_lines=["ok"], stderr_lines=[])
+
+    with (
+        patch.object(runner, "_load_adapter", return_value=adapter),
+        patch.object(runner, "has_headroom", return_value=(True, "")),
+        patch.object(runner, "build_agent_env", return_value={}),
+        patch.object(runner.subprocess, "Popen", return_value=proc),
+        patch.object(runner, "start_watchdog", return_value=(state, [])),
+        patch.object(runner, "stop_watchdog"),
+        patch.object(runner, "write_record"),
+    ):
+        runner.invoke(
+            "claude",
+            "search task",
+            mode="read-only",
+            cwd=Path("/tmp"),
+            entrypoint="delegate",
+            skip_headroom_check=True,
+        )
+
+    tc = captured["tool_config"]
+    assert isinstance(tc, dict)
+    assert tc["mcp_config_path"] == str(CLAUDE_DELEGATE_MCP_CONFIG)
+    assert "mcp__" not in tc["allowed_tools"]

--- a/scripts/tests/test_dispatch_smart_claude_mcp.py
+++ b/scripts/tests/test_dispatch_smart_claude_mcp.py
@@ -12,6 +12,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from agent_runtime.adapters.claude import ClaudeAdapter
+from agent_runtime import delegate_config as delegate_config_mod
 from agent_runtime.delegate_config import (
     CLAUDE_DELEGATE_ALLOWED_TOOLS,
     CLAUDE_DELEGATE_MCP_CONFIG,
@@ -52,6 +53,18 @@ def test_merge_applies_minimal_mcp_for_claude_delegate(entrypoint: str) -> None:
     assert merged["mcp_config_path"] == str(CLAUDE_DELEGATE_MCP_CONFIG)
     assert merged["allowed_tools"] == CLAUDE_DELEGATE_ALLOWED_TOOLS
     assert "mcp__" not in merged["allowed_tools"]
+
+
+def test_merge_skips_when_fixture_missing() -> None:
+    """If the minimal MCP fixture is absent, the merge is a no-op (graceful)."""
+    fake_missing = SimpleNamespace(is_file=lambda: False)
+    with patch.object(delegate_config_mod, "CLAUDE_DELEGATE_MCP_CONFIG", fake_missing):
+        assert merge_delegate_claude_tool_config("claude", "delegate", None) is None
+        passthrough = {"is_new_session": True}
+        assert (
+            merge_delegate_claude_tool_config("claude", "delegate", passthrough)
+            is passthrough
+        )
 
 
 def test_claude_adapter_emits_mcp_flags_for_delegate_tool_config() -> None:


### PR DESCRIPTION
## What

Headless `dispatch_smart.py --agent claude` (and any `entrypoint="delegate"`/`"dispatch"` runner call) failed instantly with **"Prompt is too long"** — the headless Claude CLI eagerly loaded every connected MCP server's tool schemas (rag ~40, chrome ~30, IBKR, Gmail, …), overflowing the input window before the task brief.

## Root cause

`ClaudeAdapter` already supports `--mcp-config`/`--allowedTools` when `tool_config` carries both keys, but the `delegate` entrypoint never set them (only the pipeline-reviewer path did). So delegate claude calls inherited the user's full MCP catalog.

## Fix (delegate-layer, minimal)

- `scripts/agent_runtime/configs/claude-delegate-mcp.json` — committed `{"mcpServers": {}}` fixture (loads zero MCP servers).
- `scripts/agent_runtime/delegate_config.py` — `merge_delegate_claude_tool_config()` injects the minimal MCP config + a built-in-only `--allowedTools` list (`Read,Write,Edit,Bash,Grep,Glob,TodoWrite,WebFetch,WebSearch` — no `mcp__*`) for `claude` + `delegate`/`dispatch`, **skipping** when a caller already set either key (pipeline/translation overrides intact).
- `scripts/agent_runtime/runner.py` — merges that config before `build_invocation`.
- 8 unit tests (fixture, merge rules incl. bridge/override/missing-fixture, adapter argv, runner wiring).

`bridge` entrypoint and explicit caller overrides are untouched by design.

## Review & verification

- **Cross-family R1**: agy→Claude — **APPROVE_WITH_NITS**, no blockers. Confirmed bridge isolation + `mcp__*` stripping. One cosmetic reference-identity nit declined (current shallow-copy is functionally correct); the missing-fixture coverage nit was applied (commit `ec857bb4`).
- Orchestrator-verified: `pytest` 8/8 green, `ruff` clean, full logic diff read.

Author: cursor composer-2.5 → reviewer agy→Claude (Decision Card C; codex/gemini both unavailable — codex at cap, gemini quota exhausted).
