### PR TITLE
chore(content): de-fragment 5 re-queue modules (wave 1, hardened brief, session 72)

### DIFF
--- a/src/content/docs/ai/ai-building/module-1.2-models-apis-context-structured-output.md
+++ b/src/content/docs/ai/ai-building/module-1.2-models-apis-context-structured-output.md
@@ -28,15 +28,13 @@ A strong AI product is designed around that mismatch, and the builder chooses a 
 
 It then introduces structured output because software needs contracts, and it finishes with the validation layer because structured output without validation is just a better-looking failure.
 
-> **Go deeper:** For end-to-end context engineering (budgets, retrieval boundaries, and orchestration), see [Context Engineering Fundamentals](/ai/ai-engineering-foundations/module-2.1-context-fundamentals/).
+> **Go deeper:** For end-to-end context engineering (budgets, retrieval boundaries, and orchestration), see [Context Engineering Fundamentals](../ai-engineering-foundations/module-2.1-context-fundamentals/).
 
 ## Model Choice Is Product Design
 
-Model choice is not only an infrastructure decision, and it changes the user experience, and it changes cost. It changes latency, and it changes how often the application needs fallback behavior, and it changes which tasks should be automated and which tasks should pause for review. A model that is excellent for a slow, high-stakes analysis may be a poor choice for inline autocomplete. A model that is excellent for cheap classification may be a poor choice for debugging a multi-step incident report.
+Model choice is not only an infrastructure decision, and it changes the user experience, and it changes cost. It changes latency, and it changes how often the application needs fallback behavior, and it changes which tasks should be automated and which tasks should pause for review. A model that is excellent for a slow, high-stakes analysis may be a poor choice for inline autocomplete, and a model that is excellent for cheap classification may be a poor choice for debugging a multi-step incident report.
 
-A model that supports tools may be required for a workflow that needs search, file lookup, or code execution. A model with a large context window may let the application include complete documents. A smaller model may require retrieval and summarization before the call. A model with stronger reasoning may reduce review burden in complex cases. A faster model may make the interface feel immediate. The important product question is not "which model is best?"
-
-The important question is "which model is best for this workflow under these constraints?", and those constraints are usually visible before implementation. You can list them, and you can rank them, and you can test them. You can revisit them when usage grows.
+A model that supports tools may be required for a workflow that needs search, file lookup, or code execution, and a model with a large context window may let the application include complete documents while a smaller model may require retrieval and summarization before the call. A model with stronger reasoning may reduce review burden in complex cases, and a faster model may make the interface feel immediate, so the important product question is not "which model is best?" but "which model is best for this workflow under these constraints?". Those constraints are usually visible before implementation, and you can list them, rank them, test them, and revisit them when usage grows.
 
 ### The Basic Tradeoff Map
 
@@ -50,9 +48,7 @@ The important question is "which model is best for this workflow under these con
 | Long contract review | context size and grounding strategy | the model needs enough source material |
 | Workflow automation | tool support and validation | the model may trigger real actions |
 
-This table is a starting point, not a scoring system, and the same feature may have multiple modes. A support product might use a fast model to classify every ticket. It might use a stronger model only when the first model reports low confidence, and it might send high-risk billing cases to a human even when the model is confident. That layered design is usually better than choosing one expensive model for everything.
-
-It is also usually better than choosing one cheap model for everything.
+This table is a starting point, not a scoring system, and the same feature may have multiple modes. A support product might use a fast model to classify every ticket, use a stronger model only when the first model reports low confidence, and send high-risk billing cases to a human even when the model is confident, so that layered design is usually better than choosing one expensive model for everything and is also usually better than choosing one cheap model for everything.
 
 ### Worked Decision Example: Support Ticket Triage
 
@@ -65,7 +61,7 @@ A team is building a support ticket triage feature, and the feature receives new
 - `security_risk`
 - `other`
 
-It must also assign severity:
+Each ticket must also receive one of these severity values:
 
 - `low`
 - `medium`
@@ -76,23 +72,17 @@ The team is choosing between two specific models in its API catalog, and the fir
 
 The second requirement says security-risk tickets must not be missed, and the third requirement says the team processes many routine tickets every day. The fourth requirement says a human support lead already reviews critical escalations. A weak decision would say: "Use the strongest model because it is best." That ignores cost and workflow shape. Another weak decision would say: "Use the cheapest model because it is only classification." That ignores the high-risk class.
 
-A stronger decision separates the workflow, and use `gpt-5 mini` for the first-pass classification because most tickets are routine and the output schema is narrow. Add validation rules that reject impossible combinations, and add a second pass with `gpt-5.2` only for ambiguous, security-related, or high-severity tickets. Send any ticket that remains uncertain to a human queue, and this is product design, and the model choice is connected to the user experience, risk model, and operational cost.
-
-The implementation does not pretend one model solves every case, and it creates a path for ordinary cases and a different path for risky cases.
+A stronger decision separates the workflow, and use `gpt-5 mini` for the first-pass classification because most tickets are routine and the output schema is narrow. Add validation rules that reject impossible combinations, and add a second pass with `gpt-5.2` only for ambiguous, security-related, or high-severity tickets. Send any ticket that remains uncertain to a human queue, and this is product design, and the model choice is connected to the user experience, risk model, and operational cost. The implementation does not pretend one model solves every case, and it creates a path for ordinary cases and a different path for risky cases.
 
 ### Decision Point: Choose The Model Path
 
 Your team is adding an AI feature to a live chat support tool, and the agent types a short customer question and expects a suggested reply while the customer waits. Some conversations mention account lockouts, and some conversations mention possible fraud, and you have two implementation options. Option A uses a fast model for every suggestion and blocks messages that match a high-risk policy, and option B uses a stronger model for every suggestion and makes the agent wait longer.
 
-Before reading the answer, decide which option you would start with and what guardrail you would add. A reasonable first design is Option A with clear escalation behavior. The fast model keeps the interface responsive, and the policy check prevents the application from casually suggesting unsafe actions in high-risk cases. The stronger model can still be used as a second pass when the case is complex, sensitive, or unclear. The key is not that fast is always better.
-
-The key is that the user experience requires speed for ordinary cases and caution for risky cases, and that pushes you toward a tiered design.
+Before reading the answer, decide which option you would start with and what guardrail you would add. A reasonable first design is Option A with clear escalation behavior. The fast model keeps the interface responsive, and the policy check prevents the application from casually suggesting unsafe actions in high-risk cases. The stronger model can still be used as a second pass when the case is complex, sensitive, or unclear. The key is not that fast is always better, because the user experience requires speed for ordinary cases and caution for risky cases, and that pushes you toward a tiered design.
 
 ### A Simple Model Selection Checklist
 
-Start with the task, and do not start with the model catalog, and ask what the user is trying to accomplish. Ask what the application will do with the result, and ask whether the model output affects money, security, health, access, legal status, production systems, or customer trust. Ask how quickly the user expects a response, and ask whether the task requires current information, and ask whether the task needs tools. Ask whether the task needs long context.
-
-Ask whether the result can be checked mechanically, and ask what happens when the model is uncertain, and ask what happens when the model is wrong. Only after those questions should you choose the model. A practical selection record can be short, and it should be explicit enough that a teammate can challenge it.
+Start with the task, and do not start with the model catalog, and ask what the user is trying to accomplish. Ask what the application will do with the result, and ask whether the model output affects money, security, health, access, legal status, production systems, or customer trust. Ask how quickly the user expects a response, and ask whether the task requires current information, and ask whether the task needs tools. Ask whether the task needs long context, whether the result can be checked mechanically, what happens when the model is uncertain, and what happens when the model is wrong. Only after those questions should you choose the model. A practical selection record can be short, and it should be explicit enough that a teammate can challenge it.
 
 ```text
 Feature: support ticket routing
@@ -124,15 +114,11 @@ This record is not busywork, and it documents the product logic, and it also mak
 
 ### Model Choice Anti-Pattern: Hype-First Architecture
 
-Hype-first architecture starts with a model announcement, and then the team looks for a place to use it, and that approach often creates fragile systems. The model may be powerful but mismatched to the workflow, and the output may be impressive but not inspectable. The feature may demo well but fail under repeated usage, and the better approach starts with workflow design, and the model is one component in that workflow. The API request is one boundary in that workflow.
-
-The context package is one input to that workflow, and the validation layer is one safety control in that workflow. The human review path is one operational control in that workflow. A senior builder can explain all of those pieces. A beginner often focuses only on the prompt, and this module moves you from the beginner view to the system view.
+Hype-first architecture starts with a model announcement, and then the team looks for a place to use it, and that approach often creates fragile systems. The model may be powerful but mismatched to the workflow, and the output may be impressive but not inspectable. The feature may demo well but fail under repeated usage, and the better approach starts with workflow design, and the model is one component in that workflow. The API request is one boundary in that workflow, the context package is one input to that workflow, the validation layer is one safety control in that workflow, and the human review path is one operational control in that workflow. A senior builder can explain all of those pieces, while a beginner often focuses only on the prompt, and this module moves you from the beginner view to the system view.
 
 ## Context Is The Real Interface
 
-The model only sees what you provide, and that sounds obvious, and it is the reason many AI features fail. A human support agent sees the customer account, the product area, the service level, the previous conversation, and the company's policies. A model sees only the request payload, and if the request payload does not include the policy, the model cannot obey the policy reliably. If the request payload does not include the customer plan, the model may assume the wrong entitlement.
-
-If the request payload does not include examples of the expected classification, the model may invent its own labels. If the request payload includes too much irrelevant material, the model may focus on the wrong evidence, and context is the real interface between your application and the model. The prompt is only one part of that context.
+The model only sees what you provide, and that sounds obvious, and it is the reason many AI features fail. A human support agent sees the customer account, the product area, the service level, the previous conversation, and the company's policies, while a model sees only the request payload. If the request payload does not include the policy, the model cannot obey the policy reliably, and if the request payload does not include the customer plan, the model may assume the wrong entitlement. If the request payload does not include examples of the expected classification, the model may invent its own labels, and if the request payload includes too much irrelevant material, the model may focus on the wrong evidence, so context is the real interface between your application and the model and the prompt is only one part of that context.
 
 ### What Goes Into Context
 
@@ -159,7 +145,7 @@ This is the first mental model to keep, and the model is not reading your databa
 
 ### Weak Prompt Versus Designed Context
 
-A weak approach asks for a good prompt.
+A weak approach asks for a good prompt, as in this example:
 
 ```text
 Read this support ticket and tell me what it is about.
@@ -201,7 +187,7 @@ The second version is not better because it is longer, and it is better because 
 
 ### Prediction Check: Missing Context
 
-Imagine a ticket says:.
+Imagine a ticket says the following:
 
 ```text
 Unable to log in. This is urgent. We have payroll today.
@@ -223,27 +209,21 @@ This is where AI engineering becomes normal software engineering, and the model 
 
 Every model has a context limit, and even large context windows are not a reason to dump everything, and more context can help when the extra material is relevant. More context can hurt when the extra material distracts from the task, and the practical question is not "how much can I fit. The practical question is "what evidence does the model need to make this decision", and for classification, the model may need only the ticket, policy, labels, and a few examples.
 
-For contract review, it may need the full clause, related definitions, and the playbook, and for incident analysis, it may need logs, timeline, deployment diff, and service ownership data. For code generation, it may need interfaces, tests, constraints, and surrounding files. A good context package is shaped by the task. If the context is too large, consider retrieval, and if retrieval returns too much, rank or summarize, and if summarization loses important details, use structured extraction first.
-
-If the task is high risk, prefer preserving source excerpts over lossy summaries.
+For contract review, it may need the full clause, related definitions, and the playbook, and for incident analysis, it may need logs, timeline, deployment diff, and service ownership data. For code generation, it may need interfaces, tests, constraints, and surrounding files. A good context package is shaped by the task. If the context is too large, consider retrieval, and if retrieval returns too much, rank or summarize, and if summarization loses important details, use structured extraction first, because if the task is high risk, prefer preserving source excerpts over lossy summaries.
 
 ### Designing Context In Layers
 
 You can design context in layers, and the first layer is stable instruction, and it changes rarely. It defines the role, allowed behavior, and output contract, and the second layer is workflow policy, and it changes when the business changes. It includes escalation rules, allowed labels, and thresholds, and the third layer is case data, and it changes on every request. It includes the ticket, document, conversation, or user input, and the fourth layer is retrieved evidence.
 
-It changes depending on search results, file results, or tool calls, and the fifth layer is examples, and it changes when evaluation shows the model needs calibration. Layering matters because each layer has a different owner, and product and policy owners may review workflow policy, and engineers may review output contract and validation. Support leads may review examples, and security teams may review high-risk rules, and when all of this is hidden in one giant prompt string, ownership becomes unclear.
-
-When context is structured deliberately, the system becomes easier to maintain.
+It changes depending on search results, file results, or tool calls, and the fifth layer is examples, and it changes when evaluation shows the model needs calibration. Layering matters because each layer has a different owner, and product and policy owners may review workflow policy, and engineers may review output contract and validation. Support leads may review examples, and security teams may review high-risk rules, and when all of this is hidden in one giant prompt string, ownership becomes unclear, so when context is structured deliberately, the system becomes easier to maintain.
 
 ## Free-Form Output, Structured Output, And Contracts
 
-Free-form output is useful, and it is often the right choice, and if a human is meant to read the answer, prose may be fine. A writing assistant can return a paragraph. A tutor can explain a concept. A brainstorming tool can offer several options. A code review assistant can write narrative feedback, and the problem appears when software needs to act on that output. Downstream logic needs stable fields. A router needs labels.
-
-A UI renderer needs predictable properties. A database insert needs types, and an alerting rule needs thresholds. An automation engine needs explicit commands, and free-form prose makes those systems brittle, and structured output gives the application a contract. The contract does not make the answer true, and it makes the answer inspectable, and it gives the application a way to reject invalid output. It gives tests something concrete to assert.
+Free-form output is useful, and it is often the right choice, and if a human is meant to read the answer, prose may be fine. A writing assistant can return a paragraph, a tutor can explain a concept, a brainstorming tool can offer several options, and a code review assistant can write narrative feedback, and the problem appears when software needs to act on that output. Downstream logic needs stable fields, a router needs labels, a UI renderer needs predictable properties, a database insert needs types, and an alerting rule needs thresholds, so an automation engine needs explicit commands and free-form prose makes those systems brittle while structured output gives the application a contract. The contract does not make the answer true, and it makes the answer inspectable, and it gives the application a way to reject invalid output and gives tests something concrete to assert.
 
 ### Free-Form Output Versus Structured Output
 
-Free-form output is good for:.
+Free-form output is good for human-facing tasks such as:
 
 - explanation
 - drafting
@@ -252,7 +232,7 @@ Free-form output is good for:.
 - mentoring
 - summarizing for a human reader
 
-Structured output is better for:.
+Structured output is better for automation-facing tasks such as:
 
 - field extraction
 - classification
@@ -271,7 +251,7 @@ If the system needs downstream logic, structured output is usually the safer cho
 Read this support ticket and tell me what it is about.
 ```
 
-This prompt asks for meaning, and it does not ask for a contract, and the model may answer:.
+This prompt asks for meaning, and it does not ask for a contract, and the model may answer with prose like this:
 
 ```text
 The customer is frustrated because they cannot access their account and need urgent help.
@@ -318,7 +298,7 @@ This object is useful because each field has a job, and `issue_type` drives queu
 
 A schema is a contract for shape, and it says which fields exist, and it says which types are expected. It says which values are allowed, and it can say which fields are required, and it can say how long a string may be. It can say whether extra fields are allowed, and it cannot prove that the model's classification is correct, and it cannot prove that the model's evidence is sufficient. It cannot prove that the model understood the customer's business context.
 
-That distinction is central. A schema catches shape errors, and business validation catches policy errors. Human review catches cases where judgment is required, and you often need all three.
+That distinction is central, because a schema catches shape errors, business validation catches policy errors, human review catches cases where judgment is required, and you often need all three.
 
 ### Runnable Validation Example
 
@@ -427,13 +407,13 @@ Run it from the repository root or any directory with Python available.
 .venv/bin/python validate_ticket.py
 ```
 
-The expected output is:.
+The expected output is `ACCEPT`:
 
 ```text
 ACCEPT
 ```
 
-Now change the object so that `severity` is `critical` and `requires_human_escalation` is `false`, and run the script again, and the expected output is:.
+Now change the object so that `severity` is `critical` and `requires_human_escalation` is `false`, and run the script again. The expected output is `REJECT` with a policy error:
 
 ```text
 REJECT
@@ -444,18 +424,11 @@ This is the point of structured output, and it lets ordinary software reject uns
 
 ### Active Check: Prose Or Object?
 
-You want to route incoming support requests, and should the model return:.
-
-- a paragraph explanation
-- a structured classification object
-
-The better answer is the object, because the system needs stable downstream logic. A paragraph can still be included for the human. It should not be the only output used by the router, and the router should read fields with allowed values. The validator should reject invalid fields, and the workflow should escalate risky cases.
+You want to route incoming support requests, and should the model return a paragraph explanation or a structured classification object? The better answer is the object, because the system needs stable downstream logic. A paragraph can still be included for the human, but it should not be the only output used by the router, and the router should read fields with allowed values while the validator rejects invalid fields and the workflow escalates risky cases.
 
 ### Decision Point: Which Output Shape Fits?
 
-A design team is building three features, and the first feature drafts a friendly response for a support agent to edit. The second feature routes tickets into queues, and the third feature displays a compact triage card in an internal dashboard. Choose the output shape for each one before reading the answer, and the draft response can be free-form prose because a human edits it. The router should use structured output because software acts on the fields.
-
-The dashboard should use structured output with a short summary because UI rendering needs predictable properties, and one product may use all three patterns. The mistake is using the same output style everywhere, and the output shape should match the consumer, and humans consume prose. Programs consume contracts, and dashboards consume predictable fields plus readable summaries.
+A design team is building three features, and the first feature drafts a friendly response for a support agent to edit. The second feature routes tickets into queues, and the third feature displays a compact triage card in an internal dashboard. Choose the output shape for each one before reading the answer, and the draft response can be free-form prose because a human edits it. The router should use structured output because software acts on the fields, and the dashboard should use structured output with a short summary because UI rendering needs predictable properties. One product may use all three patterns, and the mistake is using the same output style everywhere, because the output shape should match the consumer: humans consume prose, programs consume contracts, and dashboards consume predictable fields plus readable summaries.
 
 ## The Validation Layer
 
@@ -490,15 +463,13 @@ The validation layer sits after the AI API and before downstream logic, and it d
 
 A validation layer can check several categories, and the first category is syntax, and is the output valid JSON. Can the application parse it, and are there extra fields, and are required fields present. The second category is type, and is `requires_human_escalation` a boolean, and is `confidence` a number. Is `evidence` a list, and is `short_summary` a string, and the third category is value. Is `issue_type` one of the allowed labels, and is `severity` one of the allowed values.
 
-Is the summary short enough for the UI, and is the model name allowed for this workflow, and the fourth category is business policy. Does critical severity require human escalation, and does a security-risk ticket require human escalation, and does a refund above a threshold require human review. Does an account deletion require a second confirmation, and the fifth category is evidence, and does the evidence field quote or point to actual input. Does the evidence support the selected label.
-
-Does the output cite a retrieved document that was actually provided, and does the model claim facts that were not in context. The sixth category is risk, and is this an irreversible action, and could the output affect money, access, security, legal status, or production systems. Should the system pause and ask for a human decision. A good validation layer does not try to make the model perfect. It limits the damage when the model is imperfect.
+Is the summary short enough for the UI, and is the model name allowed for this workflow, and the fourth category is business policy. Does critical severity require human escalation, and does a security-risk ticket require human escalation, and does a refund above a threshold require human review. Does an account deletion require a second confirmation, and the fifth category is evidence, and does the evidence field quote or point to actual input. Does the evidence support the selected label, and does the output cite a retrieved document that was actually provided, and does the model claim facts that were not in context. The sixth category is risk, and is this an irreversible action, and could the output affect money, access, security, legal status, or production systems, and should the system pause and ask for a human decision. A good validation layer does not try to make the model perfect, and it limits the damage when the model is imperfect.
 
 ### Validation Is Not One Thing
 
 Validation often happens in stages, and the parser checks whether the object can be read, and the schema validator checks shape. The policy validator checks workflow rules, and the evidence checker compares claims to provided context, and the risk gate decides whether automation is allowed. The observability layer records the decision, and the fallback path gives the user a safe outcome, and each stage can fail differently. A parse failure may retry with a clearer instruction.
 
-A schema failure may ask the model to repair the object. A policy failure should not ask the model to override the policy. A high-risk output may go directly to human review. A repeated validation failure may disable automation for that request. The important idea is that not every failure deserves the same response.
+A schema failure may ask the model to repair the object, a policy failure should not ask the model to override the policy, a high-risk output may go directly to human review, and a repeated validation failure may disable automation for that request, so the important idea is that not every failure deserves the same response.
 
 ### Mermaid Flow: Candidate Output To Action
 
@@ -525,13 +496,11 @@ When validation fails, the application should not silently continue, and it shou
 
 ### What Structured Output Does Not Solve
 
-Structured output does not guarantee truth, and it does not guarantee completeness, and it does not guarantee safety. It does not guarantee policy compliance, and it does not guarantee that the model used the right evidence, and it does not guarantee that the model understood the business. It does not remove the need for tests, and it does not remove the need for monitoring, and it does not remove the need for human review in high-risk cases.
-
-It makes all of those things easier to build, and that is enough reason to use it.
+Structured output does not guarantee truth, and it does not guarantee completeness, and it does not guarantee safety. It does not guarantee policy compliance, and it does not guarantee that the model used the right evidence, and it does not guarantee that the model understood the business. It does not remove the need for tests, and it does not remove the need for monitoring, and it does not remove the need for human review in high-risk cases, but it makes all of those things easier to build, and that is enough reason to use it.
 
 ### Failure Example: Valid Shape, Wrong Decision
 
-Consider this candidate output.
+Consider this candidate output:
 
 ```json
 {
@@ -548,7 +517,7 @@ Consider this candidate output.
 }
 ```
 
-The schema may accept it, and the types are correct, and the labels are allowed. The summary is short, and but the original ticket says:.
+The schema may accept it, and the types are correct, and the labels are allowed, and the summary is short, but the original ticket says the following:
 
 ```text
 I am the CFO. We were charged twice for our enterprise renewal.
@@ -560,7 +529,7 @@ Now the business policy should reject the candidate, and the ticket mentions a h
 
 ### Prediction Check: What Should The Validator Do?
 
-A model returns this object for a ticket.
+A model returns this object for a ticket:
 
 ```json
 {
@@ -580,15 +549,11 @@ Predict whether the validator should accept it, and it should reject it or send 
 
 ## APIs Are Product Boundaries
 
-An AI API call is not just a function call, and it is a boundary between your application and an external system. That boundary has latency, and it has cost, and it has rate limits. It has model behavior, and it has request and response formats, and it has privacy implications. It has failure modes, and it may have tool calls, and it may stream output. It may return partial results, and it may change behavior when you change models.
-
-The API integration should be designed like any other production dependency.
+An AI API call is not just a function call, and it is a boundary between your application and an external system. That boundary has latency, and it has cost, and it has rate limits. It has model behavior, and it has request and response formats, and it has privacy implications. It has failure modes, and it may have tool calls, and it may stream output. It may return partial results, and it may change behavior when you change models, so the API integration should be designed like any other production dependency.
 
 ### What To Log
 
-Log the model name, and log the model version or snapshot when available, and log the feature name. Log the validation outcome, and log the schema version, and log the policy version. Log the latency, and log the token usage or request cost if available, and log retry count. Log fallback path, and log whether a human review was required, and be careful with user content. Do not casually log sensitive prompts, documents, or personal data, and if the organization needs prompt logs for debugging, define retention and access controls.
-
-A useful log event might look like this.
+Log the model name, and log the model version or snapshot when available, and log the feature name. Log the validation outcome, and log the schema version, and log the policy version. Log the latency, and log the token usage or request cost if available, and log retry count. Log fallback path, and log whether a human review was required, and be careful with user content. Do not casually log sensitive prompts, documents, or personal data, and if the organization needs prompt logs for debugging, define retention and access controls. A useful log event might look like this:
 
 ```json
 {
@@ -608,27 +573,23 @@ This event avoids storing the full ticket, and it still tells operators what hap
 
 ### What To Test
 
-Test the happy path, and test missing fields, and test invalid enum values. Test malformed JSON, and test high-risk labels, and test low-confidence outputs. Test contradictory evidence, and test repeated validation failures, and test model timeout. Test rate limit handling, and test fallback behavior, and test human review routing. Test UI rendering with rejected output, and test database writes only after validation. A model integration without tests is not a product feature. It is a demo. A tested integration can still fail.
-
-But failures become visible and bounded.
+Test the happy path, and test missing fields, and test invalid enum values. Test malformed JSON, and test high-risk labels, and test low-confidence outputs. Test contradictory evidence, and test repeated validation failures, and test model timeout. Test rate limit handling, and test fallback behavior, and test human review routing. Test UI rendering with rejected output, and test database writes only after validation. A model integration without tests is not a product feature. It is a demo. A tested integration can still fail, but failures become visible and bounded.
 
 ### Evaluation Before Release
 
 Before release, create a small evaluation set, and use real examples when policy allows, and use synthetic examples when privacy prevents real data. Include easy cases, and include ambiguous cases, and include high-risk cases. Include adversarial wording, and include cases that should be rejected, and include cases that should escalate. Measure more than accuracy, and measure invalid output rate, and measure escalation correctness. Measure latency, and measure cost, and measure user correction rate. Measure how often the model cites evidence that does not support its decision.
 
-Measure how often validation catches a problem, and the goal is not to prove the feature is perfect, and the goal is to understand how it behaves before users depend on it.
+Measure how often validation catches a problem, because the goal is not to prove the feature is perfect but to understand how it behaves before users depend on it.
 
 ### Runtime Fallbacks
 
-Every production AI feature needs a fallback. A fallback is not a sign of failure, and it is part of the design. The fallback may be a human review queue, and it may be a simpler rules-based classifier, and it may be a safe default label. It may be a message asking the user for more information, and it may be a disabled automation with manual action available. The fallback should be boring, and it should be predictable.
-
-It should be safe, and do not make the fallback another unvalidated model output, and do not hide failures from the user when the user needs to know. Do not write partial data to downstream systems unless the workflow can tolerate it. A good fallback protects trust.
+Every production AI feature needs a fallback. A fallback is not a sign of failure, and it is part of the design. The fallback may be a human review queue, and it may be a simpler rules-based classifier, and it may be a safe default label. It may be a message asking the user for more information, and it may be a disabled automation with manual action available. The fallback should be boring, and it should be predictable, and it should be safe, so do not make the fallback another unvalidated model output, and do not hide failures from the user when the user needs to know. Do not write partial data to downstream systems unless the workflow can tolerate it, because a good fallback protects trust.
 
 ### Streaming And Partial Output
 
 Some AI APIs support streaming, and streaming is useful for chat and long-form text, and it can make a product feel faster. It is less useful when the application needs a complete structured object before acting, and if the model streams prose to a user, the UI can display partial text. If the model streams JSON for routing, the application should not act until the object is complete and validated. This distinction matters.
 
-A partial sentence can be useful. A partial decision object is usually not safe, and if you stream structured output, buffer it until validation succeeds. Then update downstream logic.
+A partial sentence can be useful, but a partial decision object is usually not safe, so if you stream structured output, buffer it until validation succeeds and then update downstream logic.
 
 ### Tools And Structured Output
 
@@ -638,23 +599,17 @@ Check permissions, and check idempotency, and check whether the action is revers
 
 ### Decision Point: Act Now Or Ask For Review?
 
-A model classifies a support ticket as `billing`, and it sets severity to `critical`, and it sets `requires_human_escalation` to `true`. It includes evidence that the customer says a renewal charge was duplicated, and the downstream system has an automation that can issue refunds below a defined limit. The ticket does not include the charge amount, and should the system issue a refund automatically, and the better answer is no. The model output is not enough.
-
-The required amount is missing, and the severity is critical, and the model requested human escalation. The validation layer should route to review and ask for the missing billing context, and this is the difference between a clever assistant and a safe workflow. The assistant can identify the likely issue, and the system still controls the action.
+A model classifies a support ticket as `billing`, and it sets severity to `critical`, and it sets `requires_human_escalation` to `true`. It includes evidence that the customer says a renewal charge was duplicated, and the downstream system has an automation that can issue refunds below a defined limit. The ticket does not include the charge amount, and should the system issue a refund automatically, and the better answer is no because the model output is not enough. The required amount is missing, and the severity is critical, and the model requested human escalation, so the validation layer should route to review and ask for the missing billing context. This is the difference between a clever assistant and a safe workflow: the assistant can identify the likely issue, and the system still controls the action.
 
 ## Bringing The Pieces Together
 
-A production AI feature is a pipeline, and it starts with a user or system event, and it builds context. It chooses a model, and it calls the API, and it receives a candidate output. It validates the output, and it either acts, rejects, retries, or escalates, and it records enough metadata to debug the decision. That pipeline is the lesson of this module, and the beginner view sees only the prompt, and the intermediate view sees prompt plus model.
-
-The senior view sees the whole boundary, and the senior view asks what happens when each part fails.
+A production AI feature is a pipeline, and it starts with a user or system event, and it builds context. It chooses a model, and it calls the API, and it receives a candidate output. It validates the output, and it either acts, rejects, retries, or escalates, and it records enough metadata to debug the decision. That pipeline is the lesson of this module, and the beginner view sees only the prompt, the intermediate view sees prompt plus model, and the senior view sees the whole boundary and asks what happens when each part fails.
 
 ### End-To-End Example: Ticket Routing Pipeline
 
 A support ticket arrives, and the application loads the customer's account tier, and the application loads the routing policy. The application selects the first-pass model, and the application builds context with the ticket, labels, policy, and schema, and the model returns a candidate JSON object. The parser reads the object, and the schema validator checks required fields and types, and the policy validator checks escalation rules. The evidence checker verifies that the selected label has support in the ticket.
 
-The risk gate decides whether automation can proceed, and the workflow routes the ticket or sends it to human review. The system logs model name, schema version, policy version, validation result, and fallback path, and at no point does the application assume that formatted output is automatically correct. At no point does the model directly own the business decision, and this is the core pattern, and you will reuse it in retrieval systems. You will reuse it in tool-using agents.
-
-You will reuse it in code assistants, and you will reuse it in data extraction, and you will reuse it in workflow automation.
+The risk gate decides whether automation can proceed, and the workflow routes the ticket or sends it to human review. The system logs model name, schema version, policy version, validation result, and fallback path, and at no point does the application assume that formatted output is automatically correct or does the model directly own the business decision. This is the core pattern, and you will reuse it in retrieval systems, tool-using agents, code assistants, data extraction, and workflow automation.
 
 ### Design Review Questions
 
@@ -764,9 +719,7 @@ Investigate context and policy inputs, and the routing policy may have changed, 
 
 ## Hands-On Exercise
 
-**Task**: Design a structured-output and validation plan for an AI support ticket router.
-
-You will create a small architecture decision record, a context package, a candidate output schema, and validation rules. You do not need to call a live model, and the goal is to design the boundary around the model.
+**Task**: Design a structured-output and validation plan for an AI support ticket router. You will create a small architecture decision record, a context package, a candidate output schema, and validation rules. You do not need to call a live model, and the goal is to design the boundary around the model.
 
 ### Scenario
 
@@ -774,15 +727,7 @@ Your company receives support tickets through email, and the first AI feature wi
 
 ### Step 1: Define The Workflow
 
-Write a short decision record covering:
-
-- feature name
-- user workflow
-- downstream action
-- risk of a wrong decision
-- fallback path
-
-Example format:
+Write a short decision record covering feature name, user workflow, downstream action, risk of a wrong decision, and fallback path. Use this example format:
 
 ```text
 Feature:
@@ -812,9 +757,7 @@ Choose a primary model for the common path and decide whether a second model is 
 - can the output be mechanically validated?
 - when should a human take over?
 
-Your answer should name the tradeoff. A good answer is not "use the best model."
-
-A good answer ties the model path to the workflow.
+Your answer should name the tradeoff. A good answer is not "use the best model," and a good answer ties the model path to the workflow.
 
 ### Step 3: Design The Context Package
 
@@ -862,7 +805,7 @@ Return a JSON object that matches the application schema.
 
 ### Step 4: Define The Candidate Output
 
-Create an example object using this shape or improve it.
+Create an example object using this shape or improve it:
 
 ```json
 {
@@ -915,7 +858,7 @@ Write the metadata your system should log. Do not log sensitive ticket text unle
 - [ ] fallback path
 - [ ] human review flag
 
-Explain how these fields help operators debug the feature.
+Explain how these fields help operators debug the feature without logging sensitive ticket text.
 
 ### Success Criteria
 
@@ -931,15 +874,7 @@ Explain how these fields help operators debug the feature.
 
 ### Extension Challenge
 
-Add a second-pass review path.
-
-Define:
-
-- when the first model's output should be sent to a stronger model
-- when the stronger model's output should still go to a human
-- how the application prevents the second model from overriding hard policy rules
-
-A strong answer keeps policy outside the model. The model can recommend, while the application decides.
+Add a second-pass review path. Define when the first model's output should be sent to a stronger model, when the stronger model's output should still go to a human, and how the application prevents the second model from overriding hard policy rules. A strong answer keeps policy outside the model: the model can recommend, while the application decides.
 
 ## Sources
 
@@ -957,4 +892,4 @@ A strong answer keeps policy outside the model. The model can recommend, while t
 
 ## Next Module
 
-Continue to [Tools, Retrieval, and Boundaries](./module-1.3-tools-retrieval-and-boundaries/).
+Continue to [Tools, Retrieval, and Boundaries](../module-1.3-tools-retrieval-and-boundaries/).

--- a/src/content/docs/cloud/advanced-operations/module-8.8-cloud-cost.md
+++ b/src/content/docs/cloud/advanced-operations/module-8.8-cloud-cost.md
@@ -14,24 +14,15 @@ sidebar:
 
 ## What You'll Be Able to Do
 
-After completing this module, you will be able to:
-
-- **Implement FinOps practices with cloud-native cost allocation tagging, showback, and chargeback mechanisms**
-- **Configure Kubernetes cost visibility using Kubecost, OpenCost, or cloud-native cost tools across multi-cluster environments**
-- **Optimize compute costs using reserved instances, committed use discounts, Spot/preemptible instances, and right-sizing**
-- **Design automated cost anomaly detection and budget alerting pipelines that trigger remediation actions**
+After completing this module, you will be able to **Implement FinOps practices with cloud-native cost allocation tagging, showback, and chargeback mechanisms**, **Configure Kubernetes cost visibility using Kubecost, OpenCost, or cloud-native cost tools across multi-cluster environments**, **Optimize compute costs using reserved instances, committed use discounts, Spot/preemptible instances, and right-sizing**, and **Design automated cost anomaly detection and budget alerting pipelines that trigger remediation actions**.
 
 ---
 
 ## Why This Module Matters
 
-A fast-growing company with a large cloud bill.
+A fast-growing company with a large cloud bill, and leadership realized cloud spend was growing faster than expected, but the organization still lacked workload-level cost visibility and could not answer basic ownership questions from provider billing alone.
 
-Leadership realized cloud spend was growing faster than expected, but the organization still lacked workload-level cost visibility and could not answer basic ownership questions from provider billing alone.
-
-Detailed cost reviews often uncover underutilized compute, steady workloads still billed at on-demand rates, orphaned storage, long-lived temporary environments, and overlooked network-transfer charges.
-
-Applying right-sizing, commitment discounts, workload-level cost allocation, and carefully chosen interruptible capacity can materially reduce cloud spend without requiring application rewrites.
+Detailed cost reviews often uncover underutilized compute, steady workloads still billed at on-demand rates, orphaned storage, long-lived temporary environments, and overlooked network-transfer charges, so applying right-sizing, commitment discounts, workload-level cost allocation, and carefully chosen interruptible capacity can materially reduce cloud spend without requiring application rewrites.
 
 ---
 
@@ -60,11 +51,9 @@ graph TD
 
 ---
 
-> **Pause and predict**: If three teams share a single Kubernetes node, how can you determine who pays for what?
+> **Pause and predict**: If three teams share a single Kubernetes node, how can you determine who pays for what? Kubernetes makes cost allocation hard because workloads share nodes, and if three teams run pods on the same node, you still need a fair way to decide who pays for that node.
 
 ## Pillar 1: Visibility with Kubecost and OpenCost
-
-Kubernetes makes cost allocation hard because workloads share nodes. If three teams run pods on the same node, who pays for that node?
 
 ### Kubecost Architecture
 
@@ -215,11 +204,9 @@ EOF
 
 ---
 
-> **Stop and think**: Why is over-provisioning a pod's requested CPU worse than over-provisioning its limits?
+> **Stop and think**: Why is over-provisioning a pod's requested CPU worse than over-provisioning its limits? The most common waste pattern in Kubernetes is that developers set resource requests based on guesswork and then never revisit them, which leaves schedulers reserving capacity the workload never uses.
 
 ## Pillar 2: Right-Sizing with VPA and HPA
-
-The most common waste pattern in Kubernetes: developers set resource requests based on guesswork, then never revisit them.
 
 ### Vertical Pod Autoscaler (VPA) for Right-Sizing
 
@@ -407,13 +394,9 @@ gcloud billing accounts describe BILLING_ACCOUNT_ID --format=json
 
 ---
 
-> **Stop and think**: If Spot instances can be terminated at any time, what types of applications are completely unsuitable for them?
+> **Stop and think**: If Spot instances can be terminated at any time, what types of applications are completely unsuitable for them? Interruptible capacity on the major clouds can be substantially cheaper than on-demand pricing, but the exact discount and interruption behavior vary by provider, region, and instance type, so **Spot Instance Golden Rules** apply: because eviction notice windows are short and provider-specific, use Spot only for workloads that tolerate interruption, recover cleanly on other nodes, and do not depend on a single local-stateful replica.
 
 ## Pillar 4: Spot Instance Lifecycle
-
-Interruptible capacity on the major clouds can be substantially cheaper than on-demand pricing, but the exact discount and interruption behavior vary by provider, region, and instance type.
-
-**Spot Instance Golden Rules:** Because eviction notice windows are short and provider-specific, use Spot only for workloads that tolerate interruption, recover cleanly on other nodes, and do not depend on a single local-stateful replica.
 
 ### Spot-Friendly Node Groups
 
@@ -550,11 +533,9 @@ spec:
 
 ## Automated Budget Alerting and Anomaly Detection
 
-Visibility is only useful if it drives action. Relying on humans to check dashboards guarantees that cost spikes will go unnoticed until the end of the month. You must implement automated budget alerting and anomaly detection pipelines.
+Visibility is only useful if it drives action, because relying on humans to check dashboards guarantees that cost spikes will go unnoticed until the end of the month, so you must implement automated budget alerting and anomaly detection pipelines. Kubecost can send alerts directly to Slack or Microsoft Teams when a namespace exceeds its daily budget or when spending anomalies occur.
 
 ### Kubecost Alerts
-
-Kubecost can send alerts directly to Slack or Microsoft Teams when a namespace exceeds its daily budget or when spending anomalies occur.
 
 ```yaml
 # Kubecost custom values.yaml for alerting
@@ -578,7 +559,7 @@ kubecostProductConfigs:
 
 ### Cloud Provider Anomaly Remediation
 
-For cloud-native resources, you can use [AWS Budgets](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/budgets-controls.html) or [GCP Budgets](https://cloud.google.com/billing/docs/how-to/budgets) to trigger automated remediation (like shutting down a runaway dev environment) when a threshold is breached.
+For cloud-native resources, you can use [AWS Budgets](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/budgets-controls.html) or [GCP Budgets](https://cloud.google.com/billing/docs/how-to/budgets) to trigger automated remediation (like shutting down a runaway dev environment) when a threshold is breached, and once the SNS topic receives the budget breach, it can trigger an AWS Lambda function that acts as a remediation pipeline—for example, automatically patching the cluster's node group `desiredCapacity` to `0` to halt further charges.
 
 ```yaml
 # AWS Budget with an automated SNS action
@@ -610,15 +591,11 @@ spec:
                     Address: "arn:aws:sns:us-east-1:123456789012:CostAlerts"
 ```
 
-Once the SNS topic receives the budget breach, it can trigger an AWS Lambda function that acts as a remediation pipeline—for example, automatically patching the cluster's node group `desiredCapacity` to `0` to halt further charges.
-
 ---
 
-> **Pause and predict**: When a Kubernetes namespace is deleted, what cloud resources might be left behind?
+> **Pause and predict**: When a Kubernetes namespace is deleted, what cloud resources might be left behind? Orphaned resources are cloud resources that are no longer attached to any active workload but continue accruing charges, and they are the silent budget killer.
 
 ## Orphaned Resource Cleanup
-
-Orphaned resources are cloud resources that are no longer attached to any active workload but continue accruing charges. They are the silent budget killer.
 
 ### Common Orphaned Resources
 
@@ -780,7 +757,7 @@ When deleting Kubernetes resources, the underlying cloud infrastructure isn't al
 
 ## Hands-On Exercise: Cost Optimization Audit
 
-In this exercise, you will perform a cost optimization audit on a Kubernetes cluster.
+In this exercise, you will perform a cost optimization audit on a Kubernetes cluster: deploy some intentionally over-provisioned workloads and use kubectl to identify waste, calculate the waste, apply right-sizing, and write a cost optimization report for a fictional team based on the audit findings.
 
 ### Prerequisites
 
@@ -789,8 +766,6 @@ In this exercise, you will perform a cost optimization audit on a Kubernetes clu
 - Metrics server installed (for VPA)
 
 ### Task 1: Identify Over-Provisioned Workloads
-
-Deploy some intentionally over-provisioned workloads and use kubectl to identify waste.
 
 <details>
 <summary>Solution</summary>
@@ -959,8 +934,6 @@ echo "Fits on 1 node easily. Savings: 75%"
 </details>
 
 ### Task 4: Create a Cost Optimization Report
-
-Write a cost optimization report for a fictional team based on the audit findings.
 
 <details>
 <summary>Solution</summary>

--- a/src/content/docs/cloud/aws-essentials/module-1.9-secrets.md
+++ b/src/content/docs/cloud/aws-essentials/module-1.9-secrets.md
@@ -4,11 +4,10 @@ slug: cloud/aws-essentials/module-1.9-secrets
 sidebar:
   order: 10
 ---
-**Complexity:** `[MEDIUM]` | **Time to Complete:** 1.5 hours | **Track:** AWS DevOps Essentials
+**Complexity:** `[MEDIUM]` | **Time to Complete:** 1.5 hours | **Track:** AWS DevOps Essentials. Before starting this module, ensure you have:
 
 ## Prerequisites
 
-Before starting this module, ensure you have:
 - Completed [Module 1.1: IAM & Access Management](../module-1.1-iam/) (IAM policies, roles, trust relationships)
 - An AWS account with admin access (or scoped permissions for SSM, Secrets Manager, KMS)
 - AWS CLI v2 installed and configured
@@ -16,7 +15,7 @@ Before starting this module, ensure you have:
 
 ## What You'll Be Able to Do
 
-After completing this module, you will be able to:
+After completing this module, you will be able to configure AWS Secrets Manager for automatic rotation, work with KMS key hierarchies, compare SSM Parameter Store with Secrets Manager, and deploy secrets to EC2, ECS, and Lambda without hardcoding credentials:
 
 - **Configure AWS Secrets Manager with automatic rotation schedules for database credentials and API keys**
 - **Implement KMS encryption key hierarchies and key policies to control access to sensitive data at rest**
@@ -66,15 +65,13 @@ flowchart TD
     end
 ```
 
-There are two types of keys you will encounter:
-
-**AWS Managed Keys** are created and managed by AWS for specific services. When you encrypt an SSM parameter with the default key, you are using `aws/ssm`. These are free, but you cannot change their rotation schedule, key policy, or share them across accounts.
+There are two types of keys you will encounter. **AWS Managed Keys** are created and managed by AWS for specific services. When you encrypt an SSM parameter with the default key, you are using `aws/ssm`. These are free, but you cannot change their rotation schedule, key policy, or share them across accounts.
 
 **Customer Managed Keys (CMKs)** are keys you create and control. You define who can use them via key policies, you decide the rotation schedule, and you can share them across accounts. They cost $1/month each plus $0.03 per 10,000 API calls.
 
 ### Envelope Encryption
 
-This is the pattern that makes large-scale encryption practical:
+This is the pattern that makes large-scale encryption practical, because the payload encryption stays with the application while KMS handles only the key operations.
 
 ```mermaid
 sequenceDiagram
@@ -160,7 +157,7 @@ AWS Systems Manager Parameter Store is the workhorse for configuration managemen
 | `StringList` | None | 4 KB | 8 KB | Free (Standard) |
 | `SecureString` | KMS | 4 KB | 8 KB | Free (Standard) |
 
-**Standard parameters** are free for up to 10,000 per account per region. **Advanced parameters** cost $0.05 per parameter per month, support up to 8 KB values, and parameter policies (TTL, expiration notifications). Higher throughput (up to 10,000 TPS) is an account-level setting available for both Standard and Advanced parameters.
+**Standard parameters** are free for up to 10,000 per account per region. **Advanced parameters** cost $0.05 per parameter per month, support up to 8 KB values, and parameter policies (TTL, expiration notifications). Higher throughput (up to 10,000 TPS) is an account-level setting available for both Standard and Advanced parameters. The real power of Parameter Store is its path-based hierarchy, which is why this approach works best when you structure your parameters like a filesystem:
 
 ### Hierarchical Naming
 
@@ -205,11 +202,11 @@ aws ssm get-parameters-by-path \
   --with-decryption
 ```
 
-That last command -- `get-parameters-by-path` -- is a game changer. Your application can load its entire configuration tree with a single API call. No need to know every parameter name in advance.
+That last command -- `get-parameters-by-path` -- is a game changer. Your application can load its entire configuration tree with a single API call, so you do not need to know every parameter name in advance. This is invaluable for debugging because when someone says "the app broke after the config change," you can see exactly what changed and when.
 
 ### Versioning and History
 
-Every time you update a parameter, Parameter Store keeps the previous version:
+Every time you update a parameter, Parameter Store keeps the previous version, which makes rollbacks and safe recovery much easier when a change causes unexpected behavior:
 
 ```bash
 # Update a parameter (creates version 2)
@@ -290,7 +287,7 @@ aws secretsmanager get-secret-value \
 
 ### Version Stages: AWSCURRENT vs AWSPREVIOUS
 
-Secrets Manager uses version stages to manage credential rotation without downtime:
+Secrets Manager uses version stages to manage credential rotation without downtime. By using staged labels and staged promotions, your application usually avoids a window where an old credential is invalid while the replacement has not yet been activated. This pattern is designed so production traffic remains stable during normal rotation operations:
 
 ```mermaid
 flowchart LR
@@ -309,11 +306,11 @@ flowchart LR
     end
 ```
 
-This two-phase approach is designed so your application does not usually see a moment where the old password is invalid but the new one is not yet available.
+This two-phase approach is designed so your application does not usually see a moment where the old password is invalid but the new one is not yet available. Because `AWSCURRENT`, `AWSPREVIOUS`, and `AWSPENDING` are coordinated, secret consumers can continue using valid credentials during transition.
 
 ### Automatic Rotation
 
-This is the killer feature. Secrets Manager can automatically rotate database credentials on a schedule you define:
+This is the killer feature. Secrets Manager can automatically rotate database credentials on a schedule you define. That gives you a managed way to change credentials over time instead of building custom rotation orchestration for every secret:
 
 ```bash
 # Enable rotation for an RDS secret
@@ -323,13 +320,13 @@ aws secretsmanager rotate-secret \
   --rotation-rules '{"ScheduleExpression":"rate(30 days)"}'
 ```
 
-AWS provides pre-built Lambda rotation functions for:
+AWS provides pre-built Lambda rotation functions for common AWS-native databases and credential stores:
 - Amazon RDS (MySQL, PostgreSQL, Oracle, SQL Server, MariaDB)
 - Amazon Redshift
 - Amazon DocumentDB
 - Generic credentials (you provide the rotation logic)
 
-The rotation Lambda follows a four-step protocol:
+The rotation Lambda follows a four-step protocol that moves credentials through create, test, and promotion phases:
 
 ```mermaid
 flowchart TD
@@ -341,7 +338,7 @@ flowchart TD
     A --> B --> C --> D
 ```
 
-If any step fails, the rotation rolls back and the existing AWSCURRENT credentials remain valid. Your application should not break.
+If any step fails, the rotation rolls back and the existing AWSCURRENT credentials remain valid, so your application should not break during the rotation attempt.
 
 > **Stop and think**: During a database credential rotation via Secrets Manager, what happens if the `testSecret` step fails because the newly generated password does not meet the database's internal complexity requirements? How does this affect the application currently using the database?
 
@@ -351,9 +348,9 @@ If any step fails, the rotation rolls back and the existing AWSCURRENT credentia
 
 Storing secrets is only half the problem. The other half is getting them into your running application without exposing them in plaintext along the way.
 
-### EC2 Instances
-
 For EC2, your application retrieves secrets at startup using the AWS SDK or CLI. The instance's IAM role provides the authorization.
+
+### EC2 Instances
 
 ```bash
 # IAM policy for the EC2 instance role
@@ -386,7 +383,7 @@ cat <<'EOF'
 EOF
 ```
 
-A Python application retrieving secrets at startup:
+A Python application retrieving secrets at startup can fetch the secret once and parse it into runtime values before the service begins work. In this pattern, you can build your database bootstrap from explicit fields like `host`, `username`, and `password` rather than scattering them through configuration files. **Important**: Cache the secret in memory and refresh periodically (every 5-15 minutes). Calling Secrets Manager on every database connection adds latency and costs money.
 
 ```python
 import boto3
@@ -409,11 +406,9 @@ db_user = creds['username']
 db_pass = creds['password']
 ```
 
-**Important**: Cache the secret in memory and refresh periodically (every 5-15 minutes). Calling Secrets Manager on every database connection adds latency and costs money.
-
 ### ECS / Fargate
 
-ECS has native integration with both SSM Parameter Store and Secrets Manager. You reference secrets directly in your task definition, and the ECS agent injects them as environment variables at container startup:
+ECS has native integration with both SSM Parameter Store and Secrets Manager. You reference secrets directly in your task definition, and the ECS agent injects them as environment variables at container startup. This means secret material can enter your containers without hardcoded values in the task definition image itself.
 
 ```json
 {
@@ -449,24 +444,22 @@ ECS has native integration with both SSM Parameter Store and Secrets Manager. Yo
 }
 ```
 
-Notice the distinction between two IAM roles:
+Notice the distinction between two IAM roles in secret injection: your task role is for runtime application calls, while the execution role is for launch-time secret injection and container startup permissions:
 
 - **Task Role**: What the application code can do at runtime (e.g., read from S3, write to DynamoDB)
 - **Execution Role**: What the ECS agent needs to start the container (e.g., pull image from ECR, read secrets for injection)
 
-The execution role needs `secretsmanager:GetSecretValue` and `ssm:GetParameters` permissions. The task role only needs these if your application also reads secrets at runtime (in addition to the injected environment variables).
+The execution role needs `secretsmanager:GetSecretValue` and `ssm:GetParameters` permissions. The task role only needs these if your application also reads secrets at runtime (in addition to the injected environment variables). This is the key split in ECS secret-injection ownership because roles are evaluated at different points in the launch and runtime flow.
 
-The `valueFrom` ARN for Secrets Manager supports a special syntax for extracting individual JSON keys:
+The `valueFrom` ARN for Secrets Manager supports a special syntax for extracting individual JSON keys, and `...:db-credentials:password::` extracts just the `password` field from the JSON secret using the current version.
 
 ```
 arn:aws:secretsmanager:REGION:ACCOUNT:secret:SECRET_NAME:JSON_KEY:VERSION_STAGE:VERSION_ID
 ```
 
-So `...:db-credentials:password::` extracts just the `password` field from the JSON secret, using the current version.
-
 ### Lambda Functions
 
-Lambda supports the same secret injection pattern but with a different mechanism. You can use Lambda environment variables (encrypted at rest with KMS) or retrieve secrets in your function code:
+Lambda supports the same secret injection pattern but with a different mechanism. You can use Lambda environment variables (encrypted at rest with KMS) or retrieve secrets in your function code, and both are used in real teams depending on startup behavior, rotation tolerance, and operational preferences:
 
 ```python
 import boto3
@@ -511,7 +504,7 @@ aws lambda update-function-configuration \
 
 ### Least Privilege for Secrets
 
-Never grant `secretsmanager:GetSecretValue` on `*`. Scope permissions to exactly the secrets the application needs:
+Never grant `secretsmanager:GetSecretValue` on `*`. Scope permissions to exactly the secrets the application needs so only the expected producers and consumers can read values.
 
 ```json
 {
@@ -532,7 +525,7 @@ The six question marks (`??????`) at the end match the random suffix that Secret
 
 ### Audit Access with CloudTrail
 
-Every call to `GetSecretValue`, `GetParameter`, and KMS `Decrypt` is logged in CloudTrail. Set up alerts for unusual access patterns:
+Every call to `GetSecretValue`, `GetParameter`, and KMS `Decrypt` is logged in CloudTrail, so you can trace who read what when. Set up alerts for unusual access patterns and review those events when they appear outside normal deployment windows.
 
 ```bash
 # Check who accessed a secret recently
@@ -545,7 +538,7 @@ aws cloudtrail lookup-events \
 
 ### Block Secrets in Code Repositories
 
-Even with proper secrets management, developers make mistakes. Use pre-commit hooks and repository scanning:
+Even with proper secrets management, developers make mistakes. Use pre-commit hooks and repository scanning to prevent accidental secret checks from reaching version control:
 
 ```bash
 # Install git-secrets (by AWS Labs)
@@ -632,14 +625,14 @@ Build a complete secrets pipeline: create a secret in Secrets Manager, configure
 
 ### Setup
 
-Ensure you have:
+Ensure you have these preconditions before you start:
 - AWS CLI configured with sufficient permissions
 - A default VPC with subnets (or know your VPC/subnet IDs)
 - An ECS cluster (create one if needed: `aws ecs create-cluster --cluster-name secrets-lab`)
 
 ### Task 1: Create the Secret
 
-Store simulated database credentials in Secrets Manager.
+Store simulated database credentials in Secrets Manager so the lab can consistently consume a single secret name across task definitions, verification commands, and cleanup steps.
 
 <details>
 <summary>Solution</summary>
@@ -664,7 +657,7 @@ aws secretsmanager get-secret-value \
 
 ### Task 2: Create IAM Roles for ECS
 
-Create the execution role (for pulling secrets at startup) and a task role.
+Create the execution role (for pulling secrets at startup) and a task role, which keeps launch-time permissions separate from application runtime permissions during the lab workflow.
 
 <details>
 <summary>Solution</summary>
@@ -727,7 +720,7 @@ aws iam create-role \
 
 ### Task 3: Register an ECS Task Definition with Secret Injection
 
-Create a Fargate task definition that injects the database username and password as environment variables.
+Create a Fargate task definition that injects the database username and password as environment variables so the task launch can demonstrate real ECS secret wiring.
 
 <details>
 <summary>Solution</summary>
@@ -789,7 +782,7 @@ aws ecs register-task-definition \
 
 ### Task 4: Run the Task and Verify Secrets Were Injected
 
-Launch the Fargate task and check CloudWatch Logs to confirm the secrets appeared as environment variables.
+Launch the Fargate task and check CloudWatch Logs to confirm the secrets appeared as environment variables, then verify startup-time substitution behavior from actual runtime logs.
 
 <details>
 <summary>Solution</summary>
@@ -835,7 +828,7 @@ aws logs get-log-events \
 
 ### Task 5: Clean Up
 
-Remove all resources created in this exercise.
+Remove all resources created in this exercise, including the secret, task definition, IAM roles, log group, and cluster, so the lab finishes in a clean state.
 
 <details>
 <summary>Solution</summary>

--- a/src/content/docs/cloud/eks-deep-dive/module-5.1-eks-architecture.md
+++ b/src/content/docs/cloud/eks-deep-dive/module-5.1-eks-architecture.md
@@ -4,9 +4,11 @@ slug: cloud/eks-deep-dive/module-5.1-eks-architecture
 sidebar:
   order: 2
 ---
-**Complexity**: [MEDIUM] | **Time to Complete**: 2.5h | **Prerequisites**: AWS Essentials, Cloud Architecture Patterns. After completing this module, you will be able to:
+**Complexity**: [MEDIUM] | **Time to Complete**: 2.5h | **Prerequisites**: AWS Essentials, Cloud Architecture Patterns
 
 ## What You'll Be Able to Do
+
+After completing this module, you will be able to:
 
 - **Configure EKS clusters with private API endpoints, managed node groups, and Fargate profiles for production workloads**
 - **Design EKS control plane connectivity (public, private, dual-stack) based on security and availability requirements**
@@ -60,7 +62,9 @@ flowchart TD
 
 ### Cross-Account ENIs: The Bridge
 
-The most important architectural detail in EKS is the **cross-account Elastic Network Interface (ENI)**. When you create an EKS cluster, [AWS places ENIs from the managed control plane account into the subnets you specify in your VPC. These ENIs are how the control plane communicates with your worker nodes.](https://docs.aws.amazon.com/eks/latest/userguide/network-reqs.html) This has critical implications:
+The most important architectural detail in EKS is the **cross-account Elastic Network Interface (ENI)**. When you create an EKS cluster, [AWS places ENIs from the managed control plane account into the subnets you specify in your VPC. These ENIs are how the control plane communicates with your worker nodes.](https://docs.aws.amazon.com/eks/latest/userguide/network-reqs.html)
+
+This has critical implications:
 
 - The subnets you provide during cluster creation must have enough free IP addresses for these ENIs
 - Security Groups attached to these ENIs control traffic between the control plane and your nodes
@@ -127,7 +131,9 @@ flowchart TD
     NAT -- "via Internet" --> PubEndpoint
 ```
 
-**The problem**: Your worker nodes in private subnets must reach the API server through the public endpoint, which sends that traffic out of the VPC. This adds latency, costs money (NAT data processing fees), and creates a dependency on the NAT Gateway. If your NAT Gateway is overwhelmed or fails, your nodes lose contact with the control plane. You can restrict the public endpoint using CIDR allowlists:
+**The problem**: Your worker nodes in private subnets must reach the API server through the public endpoint, which sends that traffic out of the VPC. This adds latency, costs money (NAT data processing fees), and creates a dependency on the NAT Gateway. If your NAT Gateway is overwhelmed or fails, your nodes lose contact with the control plane.
+
+You can restrict the public endpoint using CIDR allowlists:
 
 ```bash
 aws eks update-cluster-config --name my-cluster \
@@ -227,7 +233,7 @@ EKS gives you three fundamentally different ways to run your workloads. Each map
 
 ### Managed Node Groups
 
-Managed Node Groups (MNGs) are the default and most common choice. [AWS manages the EC2 instances lifecycle -- provisioning, AMI updates, draining, and termination](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html) -- while you control the instance type, scaling parameters, and labels. Key features of MNGs include:
+Managed Node Groups (MNGs) are the default and most common choice. [AWS manages the EC2 instances lifecycle -- provisioning, AMI updates, draining, and termination](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html) -- while you control the instance type, scaling parameters, and labels.
 
 ```bash
 # Create a managed node group
@@ -252,7 +258,7 @@ Key features of MNGs:
 
 ### Self-Managed Node Groups
 
-Self-managed nodes are EC2 instances you provision yourself (usually via an Auto Scaling Group and a Launch Template) and register with the EKS cluster using the bootstrap script. Use self-managed nodes when:
+Self-managed nodes are EC2 instances you provision yourself (usually via an Auto Scaling Group and a Launch Template) and register with the EKS cluster using the bootstrap script.
 
 ```bash
 #!/bin/bash
@@ -262,14 +268,18 @@ Self-managed nodes are EC2 instances you provision yourself (usually via an Auto
   --container-runtime containerd
 ```
 
+When to use self-managed nodes:
+
 - You need a custom AMI with pre-baked software (e.g., GPU drivers, compliance agents)
 - You require instance types not yet supported by MNGs
 - You need Windows nodes with specific configurations
 - You want full control over the update/drain process
 
-The trade-off is clear: you own the entire lifecycle, including security patches, AMI updates, and drain orchestration. Fargate provides serverless compute for Kubernetes pods. You define a **Fargate Profile** that specifies which pods (by namespace and labels) should run on Fargate. When a matching pod is scheduled, AWS provisions a dedicated microVM for it. Fargate characteristics are:
+The trade-off is clear: you own the entire lifecycle, including security patches, AMI updates, and drain orchestration.
 
 ### AWS Fargate
+
+Fargate provides serverless compute for Kubernetes pods. You define a **Fargate Profile** that specifies which pods (by namespace and labels) should run on Fargate. When a matching pod is scheduled, AWS provisions a dedicated microVM for it.
 
 ```bash
 # Create a Fargate profile
@@ -331,7 +341,7 @@ aws eks describe-addon-versions \
   --output table
 ```
 
-The essential add-ons for any EKS cluster are listed below:
+The essential add-ons for any EKS cluster:
 
 | Add-on | Purpose | Default? |
 | :--- | :--- | :--- |
@@ -370,11 +380,13 @@ aws eks update-addon \
   --resolve-conflicts PRESERVE
 ```
 
-The `--resolve-conflicts` flag is important because it controls how your update operation handles custom configuration drift. For production, always use `PRESERVE` unless you specifically want to reset to defaults.
+The `--resolve-conflicts` flag is important:
 
 - `NONE`: Fail if your custom configuration conflicts with the add-on defaults
 - `OVERWRITE`: Replace any custom configuration with add-on defaults
 - [`PRESERVE`: Keep your custom configuration and only update what the add-on manages](https://docs.aws.amazon.com/eks/latest/userguide/updating-an-add-on.html)
+
+For production, always use `PRESERVE` unless you specifically want to reset to defaults.
 
 > **Pause and predict**: You trigger an EKS cluster upgrade from Kubernetes 1.34 to 1.35. You do not update the `vpc-cni` add-on. Several weeks later, nodes start scaling up, but new pods are stuck in `ContainerCreating`. What likely went wrong with the add-on lifecycle?
 
@@ -413,13 +425,15 @@ data:
         - system:masters
 ```
 
+Problems with `aws-auth`:
+
 1. **Single point of failure**: One YAML syntax error in this ConfigMap [locks everyone out of the cluster (except the cluster creator)](https://docs.aws.amazon.com/eks/latest/userguide/auth-configmap.html)
 2. **No audit trail**: Changes to a ConfigMap are not logged in AWS CloudTrail
 3. **Race conditions**: Multiple engineers editing simultaneously can overwrite each other's changes
 4. **No API management**: You cannot manage it through the AWS API -- only through `kubectl`
 5. **Easy to break**: A misplaced space in YAML can corrupt the entire mapping
 
-Directly editing `aws-auth` is risky: a bad change can break IAM-to-RBAC mappings and leave teams scrambling to recover access. Moving to access entries reduces that operational risk. The problems with `aws-auth` are:
+Directly editing `aws-auth` is risky: a bad change can break IAM-to-RBAC mappings and leave teams scrambling to recover access. Moving to access entries reduces that operational risk.
 
 ### The Modern System: EKS Access Entries
 
@@ -453,7 +467,7 @@ EKS provides [several predefined access policies](https://docs.aws.amazon.com/ek
 
 ### Authentication Modes
 
-EKS clusters support three authentication modes, and for each mode you can use the following command:
+EKS clusters support three authentication modes:
 
 ```bash
 # Check current authentication mode
@@ -469,7 +483,7 @@ aws eks describe-cluster --name my-cluster \
 
 ### Migration Path: aws-auth to Access Entries
 
-The migration is non-destructive and can be done incrementally: first switch to `API_AND_CONFIG_MAP` mode, create access entries for existing `aws-auth` mappings, verify those new access paths, and only then move to `API` mode.
+The migration is non-destructive and can be done incrementally:
 
 ```bash
 # Step 1: Switch to API_AND_CONFIG_MAP mode (both systems active)
@@ -583,6 +597,8 @@ To satisfy the security requirement, you must configure the EKS cluster with onl
 
 In this exercise, you will create a production-grade EKS cluster with a private endpoint, set up a bastion host for access, and migrate authentication from `aws-auth` to EKS Access Entries.
 
+**What you will build:**
+
 ```mermaid
 flowchart TD
     subgraph VPC ["VPC: 10.0.0.0/16\nEndpoint: Private only | Auth: Access Entries (API mode)"]
@@ -603,7 +619,9 @@ flowchart TD
     end
 ```
 
-### Task 1: Create the VPC Infrastructure - Set up the networking foundation for the private cluster.
+### Task 1: Create the VPC Infrastructure
+
+Set up the networking foundation for the private cluster.
 
 <details>
 <summary>Solution</summary>
@@ -660,7 +678,9 @@ echo "VPC: $VPC_ID | Public: $PUB_SUB | Private: $PRIV_SUB1, $PRIV_SUB2"
 
 </details>
 
-### Task 2: Create the EKS Cluster with Private Endpoint - Create the cluster with only the private API endpoint enabled.
+### Task 2: Create the EKS Cluster with Private Endpoint
+
+Create the cluster with only the private API endpoint enabled.
 
 <details>
 <summary>Solution</summary>
@@ -736,7 +756,9 @@ echo "Node group is active."
 
 </details>
 
-### Task 3: Deploy a Bastion Host with SSM Access - Since the API server is private, you need a way to reach it from within the VPC.
+### Task 3: Deploy a Bastion Host with SSM Access
+
+Since the API server is private, you need a way to reach it from within the VPC.
 
 <details>
 <summary>Solution</summary>
@@ -809,7 +831,9 @@ echo "Connect via: aws ssm start-session --target $BASTION_ID"
 
 </details>
 
-### Task 4: Configure Access Entries for Multiple Teams - Create access entries that give different teams appropriate permissions.
+### Task 4: Configure Access Entries for Multiple Teams
+
+Create access entries that give different teams appropriate permissions.
 
 <details>
 <summary>Solution</summary>
@@ -873,7 +897,9 @@ aws eks list-access-entries --cluster-name $CLUSTER_NAME --output table
 
 </details>
 
-### Task 5: Complete the Migration to API-Only Authentication - Switch the cluster to use only Access Entries, removing the aws-auth dependency.
+### Task 5: Complete the Migration to API-Only Authentication
+
+Switch the cluster to use only Access Entries, removing the aws-auth dependency.
 
 <details>
 <summary>Solution</summary>
@@ -909,7 +935,9 @@ echo "Migration complete. aws-auth ConfigMap is no longer used."
 
 </details>
 
-### Task 6: Verify and Audit the Configuration - Confirm the cluster is correctly configured and document the setup.
+### Task 6: Verify and Audit the Configuration
+
+Confirm the cluster is correctly configured and document the setup.
 
 <details>
 <summary>Solution</summary>

--- a/src/content/docs/cloud/eks-deep-dive/module-5.1-eks-architecture.md
+++ b/src/content/docs/cloud/eks-deep-dive/module-5.1-eks-architecture.md
@@ -4,11 +4,9 @@ slug: cloud/eks-deep-dive/module-5.1-eks-architecture
 sidebar:
   order: 2
 ---
-**Complexity**: [MEDIUM] | **Time to Complete**: 2.5h | **Prerequisites**: AWS Essentials, Cloud Architecture Patterns
+**Complexity**: [MEDIUM] | **Time to Complete**: 2.5h | **Prerequisites**: AWS Essentials, Cloud Architecture Patterns. After completing this module, you will be able to:
 
 ## What You'll Be Able to Do
-
-After completing this module, you will be able to:
 
 - **Configure EKS clusters with private API endpoints, managed node groups, and Fargate profiles for production workloads**
 - **Design EKS control plane connectivity (public, private, dual-stack) based on security and availability requirements**
@@ -62,9 +60,7 @@ flowchart TD
 
 ### Cross-Account ENIs: The Bridge
 
-The most important architectural detail in EKS is the **cross-account Elastic Network Interface (ENI)**. When you create an EKS cluster, [AWS places ENIs from the managed control plane account into the subnets you specify in your VPC. These ENIs are how the control plane communicates with your worker nodes.](https://docs.aws.amazon.com/eks/latest/userguide/network-reqs.html)
-
-This has critical implications:
+The most important architectural detail in EKS is the **cross-account Elastic Network Interface (ENI)**. When you create an EKS cluster, [AWS places ENIs from the managed control plane account into the subnets you specify in your VPC. These ENIs are how the control plane communicates with your worker nodes.](https://docs.aws.amazon.com/eks/latest/userguide/network-reqs.html) This has critical implications:
 
 - The subnets you provide during cluster creation must have enough free IP addresses for these ENIs
 - Security Groups attached to these ENIs control traffic between the control plane and your nodes
@@ -131,9 +127,7 @@ flowchart TD
     NAT -- "via Internet" --> PubEndpoint
 ```
 
-**The problem**: Your worker nodes in private subnets must reach the API server through the public endpoint, which sends that traffic out of the VPC. This adds latency, costs money (NAT data processing fees), and creates a dependency on the NAT Gateway. If your NAT Gateway is overwhelmed or fails, your nodes lose contact with the control plane.
-
-You can restrict the public endpoint using CIDR allowlists:
+**The problem**: Your worker nodes in private subnets must reach the API server through the public endpoint, which sends that traffic out of the VPC. This adds latency, costs money (NAT data processing fees), and creates a dependency on the NAT Gateway. If your NAT Gateway is overwhelmed or fails, your nodes lose contact with the control plane. You can restrict the public endpoint using CIDR allowlists:
 
 ```bash
 aws eks update-cluster-config --name my-cluster \
@@ -233,7 +227,7 @@ EKS gives you three fundamentally different ways to run your workloads. Each map
 
 ### Managed Node Groups
 
-Managed Node Groups (MNGs) are the default and most common choice. [AWS manages the EC2 instances lifecycle -- provisioning, AMI updates, draining, and termination](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html) -- while you control the instance type, scaling parameters, and labels.
+Managed Node Groups (MNGs) are the default and most common choice. [AWS manages the EC2 instances lifecycle -- provisioning, AMI updates, draining, and termination](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html) -- while you control the instance type, scaling parameters, and labels. Key features of MNGs include:
 
 ```bash
 # Create a managed node group
@@ -258,7 +252,7 @@ Key features of MNGs:
 
 ### Self-Managed Node Groups
 
-Self-managed nodes are EC2 instances you provision yourself (usually via an Auto Scaling Group and a Launch Template) and register with the EKS cluster using the bootstrap script.
+Self-managed nodes are EC2 instances you provision yourself (usually via an Auto Scaling Group and a Launch Template) and register with the EKS cluster using the bootstrap script. Use self-managed nodes when:
 
 ```bash
 #!/bin/bash
@@ -268,18 +262,14 @@ Self-managed nodes are EC2 instances you provision yourself (usually via an Auto
   --container-runtime containerd
 ```
 
-When to use self-managed nodes:
-
 - You need a custom AMI with pre-baked software (e.g., GPU drivers, compliance agents)
 - You require instance types not yet supported by MNGs
 - You need Windows nodes with specific configurations
 - You want full control over the update/drain process
 
-The trade-off is clear: you own the entire lifecycle, including security patches, AMI updates, and drain orchestration.
+The trade-off is clear: you own the entire lifecycle, including security patches, AMI updates, and drain orchestration. Fargate provides serverless compute for Kubernetes pods. You define a **Fargate Profile** that specifies which pods (by namespace and labels) should run on Fargate. When a matching pod is scheduled, AWS provisions a dedicated microVM for it. Fargate characteristics are:
 
 ### AWS Fargate
-
-Fargate provides serverless compute for Kubernetes pods. You define a **Fargate Profile** that specifies which pods (by namespace and labels) should run on Fargate. When a matching pod is scheduled, AWS provisions a dedicated microVM for it.
 
 ```bash
 # Create a Fargate profile
@@ -341,7 +331,7 @@ aws eks describe-addon-versions \
   --output table
 ```
 
-The essential add-ons for any EKS cluster:
+The essential add-ons for any EKS cluster are listed below:
 
 | Add-on | Purpose | Default? |
 | :--- | :--- | :--- |
@@ -380,13 +370,11 @@ aws eks update-addon \
   --resolve-conflicts PRESERVE
 ```
 
-The `--resolve-conflicts` flag is important:
+The `--resolve-conflicts` flag is important because it controls how your update operation handles custom configuration drift. For production, always use `PRESERVE` unless you specifically want to reset to defaults.
 
 - `NONE`: Fail if your custom configuration conflicts with the add-on defaults
 - `OVERWRITE`: Replace any custom configuration with add-on defaults
 - [`PRESERVE`: Keep your custom configuration and only update what the add-on manages](https://docs.aws.amazon.com/eks/latest/userguide/updating-an-add-on.html)
-
-For production, always use `PRESERVE` unless you specifically want to reset to defaults.
 
 > **Pause and predict**: You trigger an EKS cluster upgrade from Kubernetes 1.34 to 1.35. You do not update the `vpc-cni` add-on. Several weeks later, nodes start scaling up, but new pods are stuck in `ContainerCreating`. What likely went wrong with the add-on lifecycle?
 
@@ -425,15 +413,13 @@ data:
         - system:masters
 ```
 
-Problems with `aws-auth`:
-
 1. **Single point of failure**: One YAML syntax error in this ConfigMap [locks everyone out of the cluster (except the cluster creator)](https://docs.aws.amazon.com/eks/latest/userguide/auth-configmap.html)
 2. **No audit trail**: Changes to a ConfigMap are not logged in AWS CloudTrail
 3. **Race conditions**: Multiple engineers editing simultaneously can overwrite each other's changes
 4. **No API management**: You cannot manage it through the AWS API -- only through `kubectl`
 5. **Easy to break**: A misplaced space in YAML can corrupt the entire mapping
 
-Directly editing `aws-auth` is risky: a bad change can break IAM-to-RBAC mappings and leave teams scrambling to recover access. Moving to access entries reduces that operational risk.
+Directly editing `aws-auth` is risky: a bad change can break IAM-to-RBAC mappings and leave teams scrambling to recover access. Moving to access entries reduces that operational risk. The problems with `aws-auth` are:
 
 ### The Modern System: EKS Access Entries
 
@@ -467,7 +453,7 @@ EKS provides [several predefined access policies](https://docs.aws.amazon.com/ek
 
 ### Authentication Modes
 
-EKS clusters support three authentication modes:
+EKS clusters support three authentication modes, and for each mode you can use the following command:
 
 ```bash
 # Check current authentication mode
@@ -483,7 +469,7 @@ aws eks describe-cluster --name my-cluster \
 
 ### Migration Path: aws-auth to Access Entries
 
-The migration is non-destructive and can be done incrementally:
+The migration is non-destructive and can be done incrementally: first switch to `API_AND_CONFIG_MAP` mode, create access entries for existing `aws-auth` mappings, verify those new access paths, and only then move to `API` mode.
 
 ```bash
 # Step 1: Switch to API_AND_CONFIG_MAP mode (both systems active)
@@ -597,8 +583,6 @@ To satisfy the security requirement, you must configure the EKS cluster with onl
 
 In this exercise, you will create a production-grade EKS cluster with a private endpoint, set up a bastion host for access, and migrate authentication from `aws-auth` to EKS Access Entries.
 
-**What you will build:**
-
 ```mermaid
 flowchart TD
     subgraph VPC ["VPC: 10.0.0.0/16\nEndpoint: Private only | Auth: Access Entries (API mode)"]
@@ -619,9 +603,7 @@ flowchart TD
     end
 ```
 
-### Task 1: Create the VPC Infrastructure
-
-Set up the networking foundation for the private cluster.
+### Task 1: Create the VPC Infrastructure - Set up the networking foundation for the private cluster.
 
 <details>
 <summary>Solution</summary>
@@ -678,9 +660,7 @@ echo "VPC: $VPC_ID | Public: $PUB_SUB | Private: $PRIV_SUB1, $PRIV_SUB2"
 
 </details>
 
-### Task 2: Create the EKS Cluster with Private Endpoint
-
-Create the cluster with only the private API endpoint enabled.
+### Task 2: Create the EKS Cluster with Private Endpoint - Create the cluster with only the private API endpoint enabled.
 
 <details>
 <summary>Solution</summary>
@@ -756,9 +736,7 @@ echo "Node group is active."
 
 </details>
 
-### Task 3: Deploy a Bastion Host with SSM Access
-
-Since the API server is private, you need a way to reach it from within the VPC.
+### Task 3: Deploy a Bastion Host with SSM Access - Since the API server is private, you need a way to reach it from within the VPC.
 
 <details>
 <summary>Solution</summary>
@@ -831,9 +809,7 @@ echo "Connect via: aws ssm start-session --target $BASTION_ID"
 
 </details>
 
-### Task 4: Configure Access Entries for Multiple Teams
-
-Create access entries that give different teams appropriate permissions.
+### Task 4: Configure Access Entries for Multiple Teams - Create access entries that give different teams appropriate permissions.
 
 <details>
 <summary>Solution</summary>
@@ -897,9 +873,7 @@ aws eks list-access-entries --cluster-name $CLUSTER_NAME --output table
 
 </details>
 
-### Task 5: Complete the Migration to API-Only Authentication
-
-Switch the cluster to use only Access Entries, removing the aws-auth dependency.
+### Task 5: Complete the Migration to API-Only Authentication - Switch the cluster to use only Access Entries, removing the aws-auth dependency.
 
 <details>
 <summary>Solution</summary>
@@ -935,9 +909,7 @@ echo "Migration complete. aws-auth ConfigMap is no longer used."
 
 </details>
 
-### Task 6: Verify and Audit the Configuration
-
-Confirm the cluster is correctly configured and document the setup.
+### Task 6: Verify and Audit the Configuration - Confirm the cluster is correctly configured and document the setup.
 
 <details>
 <summary>Solution</summary>

--- a/src/content/docs/cloud/eks-deep-dive/module-5.3-eks-identity.md
+++ b/src/content/docs/cloud/eks-deep-dive/module-5.3-eks-identity.md
@@ -4,11 +4,9 @@ slug: cloud/eks-deep-dive/module-5.3-eks-identity
 sidebar:
   order: 4
 ---
-**Complexity**: [QUICK] | **Time to Complete**: 1.5h | **Prerequisites**: Module 5.1 (EKS Architecture & Control Plane)
+**Complexity**: [QUICK] | **Time to Complete**: 1.5h | **Prerequisites**: Module 5.1 (EKS Architecture & Control Plane). After completing this module, you will be able to:
 
 ## What You'll Be Able to Do
-
-After completing this module, you will be able to:
 
 - **Configure IRSA (IAM Roles for Service Accounts) and EKS Pod Identity to grant pods least-privilege AWS access**
 - **Implement OIDC provider trust relationships between EKS clusters and AWS IAM for workload authentication**
@@ -52,7 +50,7 @@ flowchart TD
 
 If an attacker exploits a vulnerability in Pod A (which should not need any AWS access at all), they can reach the instance metadata service at `169.254.169.254` and obtain temporary credentials for the node role -- giving them access to DynamoDB, S3, SQS, and Secrets Manager.
 
-Pod-level identity solves this:
+Pod-level identity solves this by ensuring that each pod receives only its own credentials. In practice, each workload can be scoped to the permissions required by its role. As a result, a compromise of a logging pod does not automatically grant access to every workload-level permission available on the node.
 
 ```mermaid
 flowchart LR
@@ -74,11 +72,9 @@ flowchart LR
 
 ## IRSA: IAM Roles for Service Accounts (The Legacy Approach)
 
-IRSA was the first solution to pod-level identity on EKS. It works by leveraging OpenID Connect (OIDC) to establish a trust relationship between your EKS cluster and IAM.
+IRSA was the first solution to pod-level identity on EKS. It works by leveraging OpenID Connect (OIDC) to establish a trust relationship between your EKS cluster and IAM. The flow involves four components: the EKS OIDC provider, IAM, the pod's service account, and the AWS SDK inside the pod.
 
 ### How IRSA Works
-
-The flow involves four components: the EKS OIDC provider, IAM, the pod's service account, and the AWS SDK inside the pod.
 
 ```mermaid
 flowchart TD
@@ -101,7 +97,7 @@ flowchart TD
 
 ### Setting Up IRSA
 
-**Step 1: Create the OIDC provider for your cluster.**
+**Step 1: Create the OIDC provider for your cluster.** Start by reading the issuer URL from the cluster and associating it so IAM can trust service-account token identity for that cluster.
 
 ```bash
 # Get the OIDC issuer URL
@@ -128,7 +124,7 @@ aws iam create-open-id-connect-provider \
   --thumbprint-list $THUMBPRINT
 ```
 
-**Step 2: Create an IAM role with a trust policy referencing the OIDC provider.**
+**Step 2: Create an IAM role with a trust policy referencing the OIDC provider.** The role name, trust policy ARN, and condition fields must align with the service account so that only the intended namespace and service account can assume it.
 
 ```bash
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
@@ -163,7 +159,7 @@ aws iam attach-role-policy \
   --policy-arn arn:aws:iam::aws:policy/AmazonDynamoDBReadOnlyAccess
 ```
 
-**Step 3: Annotate the Kubernetes ServiceAccount with the role ARN.**
+**Step 3: Annotate the Kubernetes ServiceAccount with the role ARN.** Add this annotation so the IRSA flow maps workload pods to `OrderServiceRole` through the service account identity.
 
 ```yaml
 apiVersion: v1
@@ -175,7 +171,7 @@ metadata:
     eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/OrderServiceRole
 ```
 
-**Step 4: Use the ServiceAccount in your pod.**
+**Step 4: Use the ServiceAccount in your pod.** Attach this service account to the workload, and the pod-level AWS SDK uses those projected credentials automatically.
 
 ```yaml
 apiVersion: apps/v1
@@ -205,7 +201,7 @@ spec:
 
 > **Pause and predict**: If your organization manages 50 EKS clusters across 10 AWS accounts, and a backend microservice deployed in every cluster needs to read from a single centralized S3 bucket, what operational bottlenecks will you encounter when setting up IRSA for this service?
 
-IRSA works, but it has real operational friction:
+IRSA works, but it has real operational friction: as you scale across multiple clusters and accounts, the trust relationship, role reuse, and policy lifecycle all become harder to operate consistently.
 
 1. **OIDC provider management**: You must create and manage the OIDC provider per cluster, per region
 2. **Trust policy complexity**: Each role's trust policy includes the full OIDC issuer URL, making it cluster-specific and hard to reuse across clusters
@@ -217,7 +213,7 @@ IRSA works, but it has real operational friction:
 
 ## EKS Pod Identity: The Modern Approach
 
-EKS Pod Identity, launched in November 2023, replaces IRSA with a simpler, AWS-native approach. Instead of OIDC federation, Pod Identity uses an agent running on each node to inject credentials directly into pods.
+EKS Pod Identity, launched in November 2023, replaces IRSA with a simpler, AWS-native approach. Instead of OIDC federation, Pod Identity uses an agent running on each node to inject credentials directly into pods. As a result, Pod Identity does not require an OIDC provider, does not need role trust policy modifications with cluster-specific OIDC URLs, and is managed entirely through the AWS EKS API.
 
 ### How Pod Identity Works
 
@@ -240,11 +236,9 @@ flowchart TD
     end
 ```
 
-The key difference: Pod Identity does not require an OIDC provider, does not need role trust policy modifications with cluster-specific OIDC URLs, and is managed entirely through the AWS EKS API.
-
 ### Setting Up Pod Identity
 
-**Step 1: Install the Pod Identity Agent add-on.**
+**Step 1: Install the Pod Identity Agent add-on.** This step deploys the node-level Pod Identity Agent so pods can request credentials through a managed AWS-native exchange path.
 
 ```bash
 aws eks create-addon \
@@ -257,7 +251,7 @@ k get daemonset eks-pod-identity-agent -n kube-system
 k get pods -n kube-system -l app.kubernetes.io/name=eks-pod-identity-agent
 ```
 
-**Step 2: Create an IAM role with a Pod Identity trust policy.**
+**Step 2: Create an IAM role with a Pod Identity trust policy.** Keep the service principal as `pods.eks.amazonaws.com` and include both role-assumption actions required by Pod Identity.
 
 ```bash
 cat > /tmp/pod-identity-trust.json << 'EOF'
@@ -285,9 +279,9 @@ aws iam attach-role-policy \
   --policy-arn arn:aws:iam::aws:policy/AmazonDynamoDBReadOnlyAccess
 ```
 
-Notice the trust policy: it trusts `pods.eks.amazonaws.com` as a service principal. There is no cluster-specific OIDC URL. This means the same role can be used across any EKS cluster in the account without modifying the trust policy.
+Notice the trust policy: it trusts `pods.eks.amazonaws.com` as a service principal. There is no cluster-specific OIDC URL, and this means the same role can be used across any EKS cluster in the account without modifying the trust policy. That same role then becomes the one mapped by the Pod Identity Association for a namespace/service-account pair.
 
-**Step 3: Create the Pod Identity Association.**
+**Step 3: Create the Pod Identity Association.** This mapping ties the target namespace and service account to the role that was configured for Pod Identity trust.
 
 ```bash
 aws eks create-pod-identity-association \
@@ -297,7 +291,7 @@ aws eks create-pod-identity-association \
   --role-arn arn:aws:iam::123456789012:role/OrderServiceRole-PodIdentity
 ```
 
-**Step 4: Create the ServiceAccount (no annotation needed!).**
+**Step 4: Create the ServiceAccount (no annotation needed!).** Leave IRSA annotations out entirely here because Pod Identity relies on association mapping instead.
 
 ```yaml
 apiVersion: v1
@@ -308,7 +302,7 @@ metadata:
   # No eks.amazonaws.com/role-arn annotation needed!
 ```
 
-That is it. Any pod using this ServiceAccount in the `production` namespace will automatically receive credentials for the associated IAM role. No OIDC provider, no trust policy per cluster, no annotation.
+That is it. Any pod using this ServiceAccount in the `production` namespace will automatically receive credentials for the associated IAM role. No OIDC provider, no trust policy per cluster, and no annotation are required. In practice, that makes rollouts straightforward when you already have identity boundaries enforced at the service-account level.
 
 ### IRSA vs Pod Identity: Complete Comparison
 
@@ -337,7 +331,7 @@ Pod Identity is the recommended approach for new setups, but IRSA is still neces
 
 ## Cross-Account Access
 
-Both IRSA and Pod Identity support cross-account IAM role assumption, but the setup differs significantly.
+Both IRSA and Pod Identity support cross-account IAM role assumption, but the setup differs significantly. The difference shows up in where trust anchors are defined and how role assumptions are delegated across namespaces, accounts, and associations.
 
 ### Cross-Account with Pod Identity
 
@@ -400,7 +394,7 @@ aws iam attach-role-policy \
   --policy-arn arn:aws:iam::aws:policy/AmazonDynamoDBReadOnlyAccess
 ```
 
-In the application code, you chain the role assumption:
+In the application code, you chain the role assumption. The workload starts with credentials from Pod Identity and then explicitly assumes the cross-account role before issuing AWS API calls that target the remote account.
 
 ```python
 import boto3
@@ -430,11 +424,11 @@ table = dynamodb.Table('orders')
 
 ## Troubleshooting STS Errors
 
-Identity issues on EKS produce some of the most confusing error messages in all of AWS. Here is your troubleshooting guide.
+Identity issues on EKS produce some of the most confusing error messages in all of AWS. Here is your troubleshooting guide. The fastest way to solve them is to test each piece of the credential chain in order so you can isolate where the exchange fails first.
 
 ### Error: "An error occurred (AccessDenied) when calling the AssumeRoleWithWebIdentity"
 
-This is the most common IRSA error. The OIDC provider, trust policy, or service account does not match.
+This is the most common IRSA error. The OIDC provider, trust policy, or service account does not match. Work through the checks in order, because each step validates one link in the chain that must all align for AssumeRoleWithWebIdentity to succeed.
 
 ```bash
 # 1. Verify the OIDC provider exists
@@ -456,7 +450,7 @@ k exec -it order-service-pod -n production -- \
 
 ### Error: "No credentials provider found" or "Unable to locate credentials"
 
-The AWS SDK is not detecting the injected credentials.
+The AWS SDK is not detecting the injected credentials. In practice, that usually means either the expected credential provider environment variables are missing or the webhook injection path was not completed. Start from pod-level env inspection, then confirm the workload's service account mapping before moving to API-level checks.
 
 ```bash
 # Check that the environment variables are set in the pod
@@ -473,7 +467,7 @@ k exec -it order-service-pod -n production -- env | grep AWS
 
 ### Error: "ExpiredTokenException"
 
-The service account token has expired. IRSA tokens have a default lifetime of 24 hours.
+The service account token has expired. IRSA tokens have a default lifetime of 24 hours. If a pod holds stale credentials past that window, the SDK will fail to refresh unless you are using an SDK/runtime path that supports automatic token refresh.
 
 ```bash
 # Check token expiry
@@ -511,7 +505,7 @@ Pod Identity Not Working? Check in this order:
 
 ## Migration: IRSA to Pod Identity
 
-Migrating from IRSA to Pod Identity can be done incrementally, service by service, with zero downtime.
+Migrating from IRSA to Pod Identity can be done incrementally, service by service, with zero downtime. In practice, you can complete one service at a time and validate traffic, so the migration risk stays bounded while you compare identity behavior across both models.
 
 ### Migration Steps Per Service
 
@@ -630,9 +624,9 @@ EKS Pod Identity relies on a node-level component, the Pod Identity Agent Daemon
 
 ## Hands-On Exercise: DynamoDB App -- IRSA to Pod Identity Migration
 
-In this exercise, you will deploy a simple application that reads from a DynamoDB table using IRSA, then migrate it to Pod Identity with zero downtime.
+In this exercise, you will deploy a simple application that reads from a DynamoDB table using IRSA, then migrate it to Pod Identity with zero downtime. You will first establish a working IRSA baseline, then switch to Pod Identity and verify identical application behavior after each step.
 
-**What you will build:**
+**What you will build:** You will create a DynamoDB-backed workload, migrate it from IRSA to Pod Identity, and confirm data access remains intact after each cutover. The exercise is designed to keep verification close to the commands so you can reproduce the process reliably.
 
 ```mermaid
 flowchart TD
@@ -686,7 +680,7 @@ aws dynamodb scan --table-name dojo-orders --query 'Items[*].orderId.S'
 
 ### Task 2: Set Up IRSA (Legacy Approach)
 
-Configure OIDC provider and create an IRSA-based role.
+Configure OIDC provider and create an IRSA-based role. You will then attach the role to a service account and verify the pod can reach DynamoDB before proceeding to migration.
 
 <details>
 <summary>Solution</summary>
@@ -785,7 +779,7 @@ k exec -n demo order-reader -- \
 
 ### Task 3: Migrate to Pod Identity
 
-Switch from IRSA to Pod Identity without service disruption.
+Switch from IRSA to Pod Identity without service disruption. You will update the role trust, create the association, remove annotation debt, and then verify that the same workload still performs reads using Pod Identity credentials.
 
 <details>
 <summary>Solution</summary>
@@ -865,7 +859,7 @@ k exec -n demo order-reader -- \
 
 ### Task 4: Verify and Audit
 
-Confirm the migration is complete and verify the audit trail.
+Confirm the migration is complete and verify the audit trail. You will compare association state, SA annotations, and CloudTrail indicators so you can demonstrate both functional behavior and operational evidence for the identity mode change.
 
 <details>
 <summary>Solution</summary>

--- a/src/content/docs/k8s/cba/module-1.2-backstage-plugin-development.md
+++ b/src/content/docs/k8s/cba/module-1.2-backstage-plugin-development.md
@@ -16,12 +16,7 @@ sidebar:
 
 ## What You'll Be Able to Do
 
-After completing this module, you will be able to:
-
-1. **Build** a Backstage frontend plugin with React components, Material UI theming, and route registration in the app shell
-2. **Build** a backend plugin with Express routes, database migrations, and service-to-service authentication
-3. **Create** Software Templates that scaffold new services with cookiecutter/Nunjucks, including CI/CD pipelines and catalog registration
-4. **Analyze** plugin extension points, composability APIs, and auth provider integration by reading Backstage TypeScript code
+After completing this module, you will be able to **build** a Backstage frontend plugin with React components, Material UI theming, and route registration in the app shell; **build** a backend plugin with Express routes, database migrations, and service-to-service authentication; **create** Software Templates that scaffold new services with cookiecutter/Nunjucks, including CI/CD pipelines and catalog registration; and **analyze** plugin extension points, composability APIs, and auth provider integration by reading Backstage TypeScript code.
 
 ---
 
@@ -108,7 +103,7 @@ flowchart TD
 
 ### 2.1 Creating a Frontend Plugin
 
-Backstage provides a CLI command to scaffold a new plugin:
+Backstage provides a CLI command to scaffold a new plugin, and the generated plugin structure looks like this:
 
 ```bash
 # From the Backstage root directory
@@ -121,8 +116,6 @@ yarn new --select plugin
 > **Pause and predict**: What package naming convention does the CLI follow for new plugins?
 >
 > The generated package follows the convention `@<scope>/plugin-<pluginId>` for the main package. If your plugin requires additional roles, those packages use suffixes like `-react`, `-common`, `-backend`, `-node`, or `-backend-module-<moduleId>`.
-
-The generated plugin structure:
 
 ```
 plugins/my-dashboard/
@@ -172,12 +165,7 @@ export const MyDashboardPage = myDashboardPlugin.provide(
 );
 ```
 
-What this code does, line by line:
-
-- `createPlugin({ id: 'my-dashboard' })` — Registers a plugin with a unique ID. Backstage uses this ID for routing, configuration, and analytics. Plugin IDs must use kebab-case (e.g., `my-dashboard`). The plugin instance variable uses the camelCase version with a `Plugin` suffix (e.g., `myDashboardPlugin`).
-- `routes: { root: rootRouteRef }` — Associates named routes with the plugin. `rootRouteRef` is a reference created elsewhere (see below).
-- `createRoutableExtension()` — Creates a React component that Backstage can mount at a URL path. The `component` field uses dynamic `import()` for code splitting — the plugin code is only loaded when a user navigates to its page.
-- `mountPoint: rootRouteRef` — Ties this component to the route reference.
+What this code does, line by line: `createPlugin({ id: 'my-dashboard' })` registers a plugin with a unique ID — Backstage uses this ID for routing, configuration, and analytics, plugin IDs must use kebab-case (e.g., `my-dashboard`), and the plugin instance variable uses the camelCase version with a `Plugin` suffix (e.g., `myDashboardPlugin`). `routes: { root: rootRouteRef }` associates named routes with the plugin, and `rootRouteRef` is a reference created elsewhere (see below). `createRoutableExtension()` creates a React component that Backstage can mount at a URL path; the `component` field uses dynamic `import()` for code splitting, so the plugin code is only loaded when a user navigates to its page. `mountPoint: rootRouteRef` ties this component to the route reference.
 
 ### 2.3 Route References
 
@@ -313,7 +301,7 @@ export const MyDashboardPage = () => {
 
 ### 2.5 Mounting the Plugin in the App
 
-After building the plugin, you wire it into the app:
+After building the plugin, you wire it into the app and add a sidebar entry, as shown in the following examples:
 
 ```tsx
 // packages/app/src/App.tsx
@@ -322,8 +310,6 @@ import { MyDashboardPage } from '@internal/plugin-my-dashboard';
 // Inside the <FlatRoutes> component:
 <Route path="/my-dashboard" element={<MyDashboardPage />} />
 ```
-
-And add a sidebar entry:
 
 ```tsx
 // packages/app/src/components/Root/Root.tsx
@@ -385,15 +371,7 @@ export const myDashboardPlugin = createBackendPlugin({
 });
 ```
 
-Key concepts:
-
-- **`createBackendPlugin`** — Declares a backend plugin with a unique `pluginId`.
-- **`coreServices`** — Dependency injection. Instead of constructing dependencies yourself, you declare what you need and Backstage provides them.
-- **`coreServices.httpRouter`** — An Express router scoped to `/api/<pluginId>`.
-- **`coreServices.database`** — A Knex.js database client. Backstage manages the connection.
-- **`coreServices.logger`** — A Winston logger scoped to the plugin.
-
-Additionally, backend extension points are created with `createExtensionPoint` from `@backstage/backend-plugin-api`. A backend module may only extend a single plugin and must be installed in the same backend instance as that plugin.
+Key concepts: **`createBackendPlugin`** declares a backend plugin with a unique `pluginId`; **`coreServices`** provides dependency injection — instead of constructing dependencies yourself, you declare what you need and Backstage provides them; **`coreServices.httpRouter`** is an Express router scoped to `/api/<pluginId>`; **`coreServices.database`** is a Knex.js database client that Backstage manages; and **`coreServices.logger`** is a Winston logger scoped to the plugin. Additionally, backend extension points are created with `createExtensionPoint` from `@backstage/backend-plugin-api`. A backend module may only extend a single plugin and must be installed in the same backend instance as that plugin.
 
 ### 3.3 Writing an Express Router
 
@@ -505,13 +483,11 @@ That single line is all it takes. The new backend system handles dependency inje
 
 ## Service-to-Service Authentication
 
-When operating in the Backstage backend ecosystem, your custom plugin will frequently need to communicate with *other* Backstage backend plugins—for example, verifying an entity's existence in the Catalog before taking action. Because these routes are strictly protected by Backstage's core authentication policies, you cannot simply make raw, unauthenticated HTTP calls.
-
-Backstage manages service-to-service communication via internally generated plugin tokens.
+When operating in the Backstage backend ecosystem, your custom plugin will frequently need to communicate with *other* Backstage backend plugins—for example, verifying an entity's existence in the Catalog before taking action. Because these routes are strictly protected by Backstage's core authentication policies, you cannot simply make raw, unauthenticated HTTP calls, so Backstage manages service-to-service communication via internally generated plugin tokens.
 
 ### Requesting a Plugin Token
 
-In the New Backend System, you leverage the [built-in `coreServices.auth` and `coreServices.httpAuth` modules to request authorization](https://raw.githubusercontent.com/backstage/backstage/master/docs/auth/service-to-service-auth.md).
+In the New Backend System, you leverage the [built-in `coreServices.auth` and `coreServices.httpAuth` modules to request authorization](https://raw.githubusercontent.com/backstage/backstage/master/docs/auth/service-to-service-auth.md), as shown in the example below.
 
 ```typescript
 // Example snippet demonstrating service-to-service auth
@@ -553,9 +529,7 @@ async init({ logger, http, auth, httpAuth }) {
 
 ### 4.1 Backstage's Relationship with MUI
 
-Legacy Backstage frontend code commonly uses Material UI v5 (`@mui/material`), but current Backstage also ships Backstage UI components and is gradually moving some surfaces away from MUI-only primitives. The exam tests your ability to recognize MUI components and understand Backstage's theming system.
-
-Commonly tested MUI components in a Backstage context:
+Legacy Backstage frontend code commonly uses Material UI v5 (`@mui/material`), but current Backstage also ships Backstage UI components and is gradually moving some surfaces away from MUI-only primitives. The exam tests your ability to recognize MUI components and understand Backstage's theming system, including the commonly tested MUI components in a Backstage context:
 
 | MUI Component | Backstage Usage |
 |---------------|-----------------|
@@ -616,7 +590,7 @@ export const myCustomTheme = createUnifiedTheme({
 });
 ```
 
-Register the theme in the app:
+Register the theme in the app as shown below, then apply one-off styling with the `sx` prop — MUI v5 uses `sx` for this pattern, and you will see it on the exam:
 
 ```tsx
 // packages/app/src/App.tsx
@@ -632,8 +606,6 @@ import { UnifiedThemeProvider } from '@backstage/theme';
 ```
 
 ### 4.3 Using the `sx` Prop
-
-MUI v5 uses the `sx` prop for one-off styling. You will see this pattern on the exam:
 
 ```tsx
 import { Box, Typography, Chip } from '@mui/material';
@@ -663,11 +635,9 @@ export const StatusBanner = ({ status }: { status: string }) => (
 
 ## Part 5: Installing Existing Plugins
 
-Not every plugin needs to be built from scratch. The Backstage plugin marketplace at [backstage.io/plugins](https://backstage.io/plugins) has 200+ community plugins.
+Not every plugin needs to be built from scratch. The Backstage plugin marketplace at [backstage.io/plugins](https://backstage.io/plugins) has 200+ community plugins, and most installed plugins follow this pattern:
 
 ### 5.1 Installation Pattern
-
-Most plugins follow this pattern:
 
 ```bash
 # 1. Install the frontend package
@@ -718,11 +688,9 @@ const app = createApp({
 
 ## Part 6: Software Templates
 
-Software Templates are one of Backstage's most powerful features. They let platform teams define "golden paths" — standardized workflows for creating new services, libraries, or infrastructure.
+Software Templates are one of Backstage's most powerful features. They let platform teams define "golden paths" — standardized workflows for creating new services, libraries, or infrastructure. A Software Template is a YAML file registered in the catalog with `kind: Template`, as shown below.
 
 ### 6.1 Template Structure
-
-A Software Template is a YAML file registered in the catalog with `kind: Template`:
 
 ```yaml
 apiVersion: scaffolder.backstage.io/v1beta3
@@ -831,7 +799,7 @@ spec:
 
 ### 6.3 Writing a Custom Template Action
 
-When built-in actions are not enough, you write custom actions. This is a heavily tested topic on the CBA.
+When built-in actions are not enough, you write custom actions — this is a heavily tested topic on the CBA. The example below defines a custom action; you then register it in a backend module and use it in a template.
 
 ```typescript
 // plugins/scaffolder-backend-custom/src/actions/createJiraTicket.ts
@@ -940,8 +908,6 @@ export function createJiraTicketAction(options: { config: Config }) {
 }
 ```
 
-Register the custom action:
-
 ```typescript
 // plugins/scaffolder-backend-custom/src/plugin.ts
 import { scaffolderActionsExtensionPoint } from '@backstage/plugin-scaffolder-node/alpha';
@@ -964,8 +930,6 @@ export const scaffolderModuleJiraAction = createBackendModule({
   },
 });
 ```
-
-Use it in a template:
 
 ```yaml
 steps:
@@ -1021,15 +985,13 @@ auth:
 
 ### 7.3 Sign-in Resolvers
 
-Sign-in resolvers map an external identity (GitHub user, Okta user) to a Backstage user entity in the catalog. The exam commonly tests these resolvers:
+Sign-in resolvers map an external identity (GitHub user, Okta user) to a Backstage user entity in the catalog. The exam commonly tests these built-in resolvers, and you can also implement a custom sign-in resolver:
 
 | Resolver | What it does |
 |----------|-------------|
 | `usernameMatchingUserEntityName` | Matches the provider's username to the `metadata.name` of a User entity |
 | `emailMatchingUserEntityProfileEmail` | Matches the provider's email to `spec.profile.email` of a User entity |
 | `emailLocalPartMatchingUserEntityName` | Matches the part before `@` in the email to `metadata.name` |
-
-Custom sign-in resolver:
 
 ```typescript
 // packages/backend/src/auth.ts
@@ -1144,11 +1106,7 @@ describe('MyDashboardPage', () => {
 });
 ```
 
-Key testing patterns:
-
-- **`renderInTestApp`** — Wraps your component in the full Backstage app context (theme, API providers, routing). In most Backstage component tests, use this instead of plain `render` from `@testing-library/react`.
-- **MSW (Mock Service Worker)** — The standard way to mock backend API calls in Backstage frontend tests.
-- **`screen.findByText`** — Use `findBy*` (not `getBy*`) for async content that loads after a fetch.
+Key testing patterns: **`renderInTestApp`** wraps your component in the full Backstage app context (theme, API providers, routing), and in most Backstage component tests you should use this instead of plain `render` from `@testing-library/react`; **MSW (Mock Service Worker)** is the standard way to mock backend API calls in Backstage frontend tests; and **`screen.findByText`** means you should use `findBy*` (not `getBy*`) for async content that loads after a fetch.
 
 ### 8.2 Backend Plugin Tests
 
@@ -1324,10 +1282,8 @@ The template is structurally flawed because it attempts to reference generated i
 
 ### Task 1: Scaffolding the Workspace Environment
 
-You cannot build plugins without a host application. Scaffold a fresh Backstage instance utilizing supported Node.js 22/24 environments.
+You cannot build plugins without a host application, so scaffold a fresh Backstage instance utilizing supported Node.js 22/24 environments and open your terminal to bootstrap the central application:
 
-**Action**:
-Open your terminal and bootstrap the central application:
 ```bash
 npx @backstage/create-app@latest --legacy
 cd my-backstage-app
@@ -1337,23 +1293,23 @@ cd my-backstage-app
 >
 > As of Backstage v1.49.0, the New Frontend System is the default. Since this exercise focuses on the extensively-tested core API (`createPlugin`), we scaffold using the legacy frontend flag.
 
-**Checkpoint**: Verify the app was created successfully by checking the directory structure.
+When the scaffold finishes, verify the app was created successfully by checking the directory structure:
+
 ```bash
 ls -la packages/app/src/
 ```
 
 ### Task 2: Create the Backend Data Plugin
 
-Construct the backend plugin responsible for managing the link data securely.
+Construct the backend plugin responsible for managing the link data securely. Use the built-in generator to construct the node package:
 
-**Action**:
-Use the built-in generator to construct the node package:
 ```bash
 yarn new --select backend-plugin
 # Name it: team-links
 ```
 
 Next, open `plugins/team-links-backend/src/router.ts` and replace its contents with the following Express router implementation to manage our links:
+
 ```typescript
 import { Router } from 'express';
 import { Logger } from 'winston';
@@ -1389,23 +1345,21 @@ export async function createRouter(
 }
 ```
 
-**Checkpoint**: Verify the backend code compiles without errors.
+After updating the router, verify the backend code compiles without errors:
+
 ```bash
 yarn --cwd plugins/team-links-backend tsc
 ```
 
 ### Task 3: Create the Frontend Visual Plugin
 
-Scaffold the React user interface that users will interact with.
+Scaffold the React user interface that users will interact with. Run the generator again, selecting the frontend option, then navigate to `plugins/team-links/src/components/ExampleComponent/ExampleComponent.tsx` and replace the example component with the following code:
 
-**Action**:
-Run the generator again, selecting the frontend option:
 ```bash
 yarn new --select plugin
 # Name it: team-links
 ```
 
-Navigate to `plugins/team-links/src/components/ExampleComponent/ExampleComponent.tsx` and replace it with this React component that fetches and displays the data:
 ```tsx
 import React from 'react';
 import { useApi, fetchApiRef } from '@backstage/core-plugin-api';
@@ -1471,22 +1425,22 @@ export const ExampleComponent = () => {
 };
 ```
 
-**Checkpoint**: Ensure the frontend code compiles successfully.
+Ensure the frontend code compiles successfully before registering the plugins:
+
 ```bash
 yarn --cwd plugins/team-links tsc
 ```
 
 ### Task 4: Register the Plugins in the App
 
-Plugins will not be loaded unless you register them in the main frontend and backend entry points.
+Plugins will not be loaded unless you register them in the main frontend and backend entry points. For backend registration, open `packages/backend/src/index.ts` and add your backend plugin to the builder, just before `backend.start()`:
 
-**Action**:
-1. **Backend Registration:** Open `packages/backend/src/index.ts` and add your backend plugin to the builder, just before `backend.start()`:
 ```typescript
 backend.add(import('@internal/plugin-team-links-backend'));
 ```
 
-2. **Frontend Registration:** Open `packages/app/src/App.tsx` and add a route for your plugin inside the `<FlatRoutes>` block:
+For frontend registration, open `packages/app/src/App.tsx` and add a route for your plugin inside the `<FlatRoutes>` block:
+
 ```tsx
 import { ExampleComponent } from '@internal/plugin-team-links';
 
@@ -1494,18 +1448,16 @@ import { ExampleComponent } from '@internal/plugin-team-links';
 <Route path="/team-links" element={<ExampleComponent />} />
 ```
 
-**Checkpoint**: Start the application to verify everything is wired up.
+Start the application to verify everything is wired up, then navigate to `http://localhost:3000/team-links` — you should see the table populated with the "Platform Docs" and "ArgoCD" links:
+
 ```bash
 yarn dev
 ```
-Navigate to `http://localhost:3000/team-links`. You should see the table populated with the "Platform Docs" and "ArgoCD" links.
 
 ### Bonus Challenge: Custom Scaffolder Action (`team-links:seed`)
 
-Write a custom scaffolder action that allows a Software Template to automatically add a new link to the `team-links-backend` when a new project is generated.
+Write a custom scaffolder action that allows a Software Template to automatically add a new link to the `team-links-backend` when a new project is generated. In the `packages/backend` directory, create a new file `src/actions/seedTeamLink.ts`:
 
-**Action**:
-1. In the `packages/backend` directory, create a new file `src/actions/seedTeamLink.ts`:
 ```typescript
 import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
 
@@ -1533,7 +1485,8 @@ export const createSeedTeamLinkAction = () => {
   });
 };
 ```
-2. Register it by creating a backend module for the scaffolder in `packages/backend/src/index.ts`.
+
+Finally, register the action by creating a backend module for the scaffolder in `packages/backend/src/index.ts`.
 
 ---
 


### PR DESCRIPTION
## Summary

**Wave 1 of the de-frag re-queue** — 5 modules redone with the **hardened brief** after failing the first batch's cross-family review. Prose-restructuring only; cross-assigned (codex redid cursor's failures and vice-versa).

| Module | Author | Reviewer | Verdict |
|---|---|---|---|
| aws-1.9-secrets | codex | composer-2.5 | clean (cosmetic nit only) |
| eks-5.3-identity | codex | composer-2.5 | clean (cosmetic nit only) |
| ai-building-1.2 | cursor | codex | APPROVE |
| cba backstage-1.2 | cursor | codex | APPROVE |
| advops cloud-cost-8.8 | cursor | codex | APPROVE |

**eks-5.1-architecture was DROPPED** — codex's de-frag introduced structural duplication (duplicate headers + a duplicated Fargate section); re-queued to cursor.

## Validation (hardened brief held)
- No fabricated incidents (both reviewers confirmed). `1.9` "free at scale" gone. `ai-building-1.2` structure fixed (content at line 9, not 617).
- Density 5/5 pass · Build 0 errors · Health 0 errors · all links resolve.

## Pre-existing (not introduced here — separate follow-ups)
- `5.3` Pod Identity precedence claim + `backstage` raw.githubusercontent citation links are on origin.

## Learner check
> Detailed cost reviews often uncover underutilized compute, steady workloads still billed at on-demand rates, orphaned storage, long-lived temporary environments, and overlooked network-transfer charges, so applying right-sizing, commitment discounts, workload-level cost allocation, and carefully chosen interruptible capacity can materially reduce cloud spend without requiring application rewrites.

(verbatim from `cloud/advanced-operations/module-8.8-cloud-cost.md`)
