### PR TITLE
chore(content): remove leaked source-H1 from 27 linux modules

### DIFF
--- a/scripts/quality/fix_leaked_source_h1.py
+++ b/scripts/quality/fix_leaked_source_h1.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Remove a leaked source-H1 from KubeDojo modules.
+
+A module fails the verifier's `gate_no_source_h1` when the first real content
+line after the frontmatter is an `# ` H1 heading. Starlight already renders an
+H1 from the `title:` frontmatter, so this duplicate H1 must be removed.
+
+Detection mirrors `verify_module.source_h1_metrics` EXACTLY: walk the post-
+frontmatter body, skipping blank / blockquote (`>`) / `---` / `<!--` lines; the
+first remaining line is the violation iff it starts with `# `.
+
+Deterministic, single-line removal. Use `--check` to list without editing.
+
+  python scripts/quality/fix_leaked_source_h1.py <path>... [--check]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+FRONTMATTER = re.compile(r"^---\s*\n(.*?)\n---\s*(?:\n|$)", re.DOTALL)
+
+
+def find_leaked_h1_index(text: str) -> int | None:
+    """Return the 0-based line index of the leaked source-H1, or None."""
+    match = FRONTMATTER.match(text)
+    body = text[match.end() :] if match else text
+    body_offset = text[: match.end()].count("\n") if match else 0
+
+    for i, line in enumerate(body.splitlines()):
+        stripped = line.strip()
+        if (
+            not stripped
+            or stripped.startswith(">")
+            or stripped == "---"
+            or stripped.startswith("<!--")
+        ):
+            continue
+        if stripped.startswith("# "):
+            return body_offset + i
+        return None
+    return None
+
+
+def fix_text(text: str) -> tuple[str, str | None]:
+    """Return (new_text, removed_line) — removed_line is None if no violation."""
+    idx = find_leaked_h1_index(text)
+    if idx is None:
+        return text, None
+    # Preserve trailing newline semantics by splitting with keepends.
+    lines = text.splitlines(keepends=True)
+    removed = lines[idx].rstrip("\n")
+    del lines[idx]
+    # Collapse a resulting double blank line at the removal point.
+    if (
+        idx < len(lines)
+        and idx > 0
+        and lines[idx].strip() == ""
+        and lines[idx - 1].strip() == ""
+    ):
+        del lines[idx]
+    return "".join(lines), removed
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("paths", nargs="+", type=Path)
+    ap.add_argument(
+        "--check", action="store_true", help="List violations without editing."
+    )
+    args = ap.parse_args(argv)
+
+    fixed = 0
+    clean = 0
+    for p in args.paths:
+        text = p.read_text(encoding="utf-8")
+        new_text, removed = fix_text(text)
+        if removed is None:
+            clean += 1
+            continue
+        fixed += 1
+        if args.check:
+            print(f"[would fix] {p}: remove leaked H1 -> {removed!r}")
+        else:
+            p.write_text(new_text, encoding="utf-8")
+            print(f"[fixed]    {p}: removed leaked H1 -> {removed!r}")
+    verb = "would fix" if args.check else "fixed"
+    print(f"\n{verb} {fixed} module(s); {clean} had no leaked H1.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/content/docs/linux/foundations/container-primitives/module-2.1-namespaces.md
+++ b/src/content/docs/linux/foundations/container-primitives/module-2.1-namespaces.md
@@ -7,8 +7,6 @@ sidebar:
 revision_pending: false
 ---
 
-# Module 2.1: Linux Namespaces
-
 This Linux Foundations module is a `[MEDIUM]` lesson designed for a 35-45 minute study session, with lab time focused on inspecting real namespace boundaries instead of memorizing container vocabulary.
 
 ## Prerequisites

--- a/src/content/docs/linux/foundations/container-primitives/module-2.2-cgroups.md
+++ b/src/content/docs/linux/foundations/container-primitives/module-2.2-cgroups.md
@@ -5,7 +5,6 @@ slug: linux/foundations/container-primitives/module-2.2-cgroups
 sidebar:
   order: 3
 ---
-# Module 2.2: Control Groups (cgroups)
 
 > **Linux Foundations** | Complexity: `[MEDIUM]` | Time: 30-35 min. This medium-depth lesson assumes you can already read basic Linux commands and Kubernetes pod output, and it focuses on turning cgroup files into practical operational decisions.
 

--- a/src/content/docs/linux/foundations/container-primitives/module-2.3-capabilities-lsms.md
+++ b/src/content/docs/linux/foundations/container-primitives/module-2.3-capabilities-lsms.md
@@ -6,8 +6,6 @@ sidebar:
   order: 4
 ---
 
-# Module 2.3: Capabilities & Linux Security Modules
-
 > **Linux Foundations** | Complexity: `[MEDIUM]` | Time: 35-45 min | Focus: least-privilege process control for container workloads on shared Linux kernels.
 
 ## Prerequisites

--- a/src/content/docs/linux/foundations/container-primitives/module-2.4-union-filesystems.md
+++ b/src/content/docs/linux/foundations/container-primitives/module-2.4-union-filesystems.md
@@ -5,7 +5,6 @@ slug: linux/foundations/container-primitives/module-2.4-union-filesystems
 sidebar:
   order: 5
 ---
-# Module 2.4: Union Filesystems
 
 > **Linux Foundations** | Complexity: `[MEDIUM]` | Time: 45-60 min
 

--- a/src/content/docs/linux/foundations/everyday-use/module-0.1-cli-power-user.md
+++ b/src/content/docs/linux/foundations/everyday-use/module-0.1-cli-power-user.md
@@ -12,8 +12,6 @@ lab:
   environment: "ubuntu"
 ---
 
-# Module 0.1: The CLI Power User (Search & Streams)
-
 **Complexity:** [QUICK]. **Time to Complete:** 45 minutes. **Prerequisites:** Zero to Terminal (Module 0.8). This module assumes you can open a shell, move through directories, and run basic commands, then shows how those small skills become repeatable investigation workflows.
 
 ## Learning Outcomes

--- a/src/content/docs/linux/foundations/everyday-use/module-0.2-environment-permissions.md
+++ b/src/content/docs/linux/foundations/everyday-use/module-0.2-environment-permissions.md
@@ -12,8 +12,6 @@ lab:
   environment: "ubuntu"
 ---
 
-# Module 0.2: Environment & Permissions (Who You Are & Where You Are)
-
 > **Everyday Use** | Complexity: `[QUICK]` | Time: 45 min | This practical lesson focuses on diagnosing the identity, lookup, inheritance, and permission failures that make everyday Linux work feel unpredictable.
 
 ## Prerequisites

--- a/src/content/docs/linux/foundations/everyday-use/module-0.3-processes-resources.md
+++ b/src/content/docs/linux/foundations/everyday-use/module-0.3-processes-resources.md
@@ -11,7 +11,6 @@ lab:
   difficulty: "intermediate"
   environment: "ubuntu"
 ---
-# Module 0.3: Process & Resource Survival Guide
 
 > **Everyday Use** | Complexity: `[QUICK]` | Time: 40 min. This quick module is still written as a full operational lesson because process and resource triage becomes useful only when the commands fit into a repeatable diagnostic sequence.
 

--- a/src/content/docs/linux/foundations/networking/module-3.2-dns-linux.md
+++ b/src/content/docs/linux/foundations/networking/module-3.2-dns-linux.md
@@ -12,8 +12,6 @@ lab:
   environment: "ubuntu"
 ---
 
-# Module 3.2: DNS in Linux
-
 > **Linux Foundations** | Complexity: `[HIGH]` | Time: 45-60 min
 
 ## Prerequisites

--- a/src/content/docs/linux/foundations/networking/module-3.4-iptables-netfilter.md
+++ b/src/content/docs/linux/foundations/networking/module-3.4-iptables-netfilter.md
@@ -11,7 +11,6 @@ lab:
   difficulty: "advanced"
   environment: "ubuntu"
 ---
-# Module 3.4: iptables & netfilter
 
 Complexity: `[COMPLEX]` | Time: 65-75 min | Track: Linux Foundations networking. This module assumes you already know TCP/IP packet structure, DNS resolution, and Linux network namespaces well enough to recognize when a packet is local, forwarded, or leaving through a host interface.
 

--- a/src/content/docs/linux/foundations/system-essentials/module-1.1-kernel-architecture.md
+++ b/src/content/docs/linux/foundations/system-essentials/module-1.1-kernel-architecture.md
@@ -13,8 +13,6 @@ lab:
   environment: "ubuntu"
 ---
 
-# Module 1.1: Kernel & Architecture
-
 > **Linux Foundations** | Complexity: `[MEDIUM]` | Time: 35-45 min
 
 ## Prerequisites

--- a/src/content/docs/linux/foundations/system-essentials/module-1.2-processes-systemd.md
+++ b/src/content/docs/linux/foundations/system-essentials/module-1.2-processes-systemd.md
@@ -11,7 +11,6 @@ lab:
   difficulty: "intermediate"
   environment: "ubuntu"
 ---
-# Module 1.2: Processes & systemd
 
 > **Linux Foundations** | Complexity: `[MEDIUM]` | Time: 30-35 min with a hands-on process, signal, boot, and systemd service lab.
 

--- a/src/content/docs/linux/foundations/system-essentials/module-1.3-filesystem-hierarchy.md
+++ b/src/content/docs/linux/foundations/system-essentials/module-1.3-filesystem-hierarchy.md
@@ -12,8 +12,6 @@ lab:
   environment: "ubuntu"
 ---
 
-# Module 1.3: Filesystem Hierarchy
-
 **Complexity**: Intermediate<br>
 **Time to complete**: 45 minutes<br>
 **Prerequisites**: [Module 1.1: Kernel & Architecture](../module-1.1-kernel-architecture/) and [Module 1.2: Processes & systemd](../module-1.2-processes-systemd/)

--- a/src/content/docs/linux/operations/module-8.1-storage-management.md
+++ b/src/content/docs/linux/operations/module-8.1-storage-management.md
@@ -12,8 +12,6 @@ lab:
   environment: ubuntu
 ---
 
-# Module 8.1: Storage Management
-
 > **Operations - LFCS** | Complexity: `[COMPLEX]` | Time: 45-55 min. This module treats storage as a production responsibility, so every command is connected to verification, reboot safety, and failure diagnosis.
 
 ## Prerequisites

--- a/src/content/docs/linux/operations/module-8.2-network-administration.md
+++ b/src/content/docs/linux/operations/module-8.2-network-administration.md
@@ -12,8 +12,6 @@ lab:
   environment: ubuntu
 ---
 
-# Module 8.2: Network Administration
-
 > **Operations - LFCS** | Complexity: `[COMPLEX]` | Time: 45-55 min for administrators who already know basic TCP/IP and now need durable host-level operations.
 
 ## Prerequisites

--- a/src/content/docs/linux/operations/module-8.3-package-user-management.md
+++ b/src/content/docs/linux/operations/module-8.3-package-user-management.md
@@ -12,8 +12,6 @@ lab:
   environment: ubuntu
 ---
 
-# Module 8.3: Package Management & User Administration
-
 > **Operations - LFCS** | Complexity: `[MEDIUM]` | Time: 40-50 min for administrators who need package state, user identity, and sudo delegation to be explainable under pressure.
 
 ## Prerequisites

--- a/src/content/docs/linux/operations/module-8.4-scheduling-backups.md
+++ b/src/content/docs/linux/operations/module-8.4-scheduling-backups.md
@@ -12,8 +12,6 @@ lab:
   environment: ubuntu
 ---
 
-# Module 8.4: Task Scheduling and Backup Strategies
-
 > **Operations — LFCS** | Complexity: `[COMPLEX]` | Time: 45-55 min. This lesson treats scheduling and backups as one reliability practice, because a backup that is not scheduled will be forgotten and a scheduled job that cannot be restored is only noise.
 
 ## Prerequisites

--- a/src/content/docs/linux/operations/performance/module-5.1-use-method.md
+++ b/src/content/docs/linux/operations/performance/module-5.1-use-method.md
@@ -11,7 +11,6 @@ lab:
   difficulty: advanced
   environment: ubuntu
 ---
-# Module 5.1: USE Method
 
 > **Linux Performance** | Complexity: `[MEDIUM]` | Time: 25-30 min. This module treats performance triage as an operational discipline: you will learn how to inspect resources in a repeatable order, explain the evidence clearly, and know when Linux is not the bottleneck.
 

--- a/src/content/docs/linux/operations/performance/module-5.3-memory-management.md
+++ b/src/content/docs/linux/operations/performance/module-5.3-memory-management.md
@@ -12,8 +12,6 @@ lab:
   environment: ubuntu
 ---
 
-# Module 5.3: Memory Management
-
 > **Linux Performance** | Complexity: `[MEDIUM]` | Time: 30-35 min. This module treats memory as an operational system, not a dashboard number, and connects Linux reclaim behavior to Kubernetes 1.35+ container failures.
 
 ## Prerequisites

--- a/src/content/docs/linux/operations/performance/module-5.4-io-performance.md
+++ b/src/content/docs/linux/operations/performance/module-5.4-io-performance.md
@@ -12,8 +12,6 @@ lab:
   environment: ubuntu
 ---
 
-# Module 5.4: I/O Performance
-
 > **Linux Performance** | Complexity: `[MEDIUM]` | Time: 25-30 min. This module assumes you can move around a Linux shell, read command output carefully, and pause long enough to connect symptoms to the layer that produced them.
 
 ## Prerequisites

--- a/src/content/docs/linux/operations/shell-scripting/module-7.3-practical-scripts.md
+++ b/src/content/docs/linux/operations/shell-scripting/module-7.3-practical-scripts.md
@@ -11,7 +11,6 @@ lab:
   difficulty: intermediate
   environment: ubuntu
 ---
-# Module 7.3: Practical Scripts
 
 > **Shell Scripting** | Complexity: `[MEDIUM]` | Time: 25-30 min. This module treats scripts as operational tools that need clear contracts, repeatable behavior, and evidence when something fails.
 

--- a/src/content/docs/linux/operations/shell-scripting/module-7.4-devops-automation.md
+++ b/src/content/docs/linux/operations/shell-scripting/module-7.4-devops-automation.md
@@ -12,8 +12,6 @@ lab:
   environment: ubuntu
 ---
 
-# Module 7.4: DevOps Automation
-
 > **Shell Scripting** | Complexity: `[MEDIUM]` | Time: 30-35 min | Kubernetes: 1.35+
 
 ## Prerequisites

--- a/src/content/docs/linux/operations/troubleshooting/module-6.1-systematic-troubleshooting.md
+++ b/src/content/docs/linux/operations/troubleshooting/module-6.1-systematic-troubleshooting.md
@@ -12,8 +12,6 @@ lab:
   environment: ubuntu
 ---
 
-# Module 6.1: Systematic Troubleshooting
-
 **Linux Troubleshooting** | Complexity: `[MEDIUM]` | Time: 25-30 min
 
 This module teaches the operating discipline behind reliable debugging: how to slow down just enough to collect evidence, choose the next useful test, protect diagnostic state, and restore service without turning one fault into several new ones.

--- a/src/content/docs/linux/operations/troubleshooting/module-6.2-log-analysis.md
+++ b/src/content/docs/linux/operations/troubleshooting/module-6.2-log-analysis.md
@@ -12,8 +12,6 @@ lab:
   environment: ubuntu
 ---
 
-# Module 6.2: Log Analysis
-
 > **Linux Troubleshooting** | Complexity: `[MEDIUM]` | Time: 25-30 min for a focused learner, with extra practice time encouraged if you are new to production log formats.
 
 ## Prerequisites

--- a/src/content/docs/linux/security/hardening/module-4.1-kernel-hardening.md
+++ b/src/content/docs/linux/security/hardening/module-4.1-kernel-hardening.md
@@ -11,7 +11,6 @@ lab:
   difficulty: "advanced"
   environment: "ubuntu"
 ---
-# Module 4.1: Kernel Hardening & sysctl
 
 > **Linux Security** | Complexity: `[MEDIUM]` | Time: 25-30 min, focused on practical kernel controls for production Linux and Kubernetes nodes.
 

--- a/src/content/docs/linux/security/hardening/module-4.2-apparmor.md
+++ b/src/content/docs/linux/security/hardening/module-4.2-apparmor.md
@@ -12,8 +12,6 @@ lab:
   environment: "ubuntu"
 ---
 
-# Module 4.2: AppArmor Profiles
-
 > **Linux Security** | Complexity: `[MEDIUM]` | Time: 30-35 min | Focus: kernel-enforced process confinement for hosts, containers, and Kubernetes workloads.
 
 ## Prerequisites

--- a/src/content/docs/linux/security/hardening/module-4.3-selinux.md
+++ b/src/content/docs/linux/security/hardening/module-4.3-selinux.md
@@ -11,7 +11,6 @@ lab:
   difficulty: "advanced"
   environment: "centos"
 ---
-# Module 4.3: SELinux Contexts
 
 > **Linux Security** | Complexity: `[COMPLEX]` | Time: 35-40 min. This is an advanced hardening module focused on practical diagnosis, durable repair, and container-aware SELinux operations.
 

--- a/src/content/docs/linux/security/hardening/module-4.4-seccomp.md
+++ b/src/content/docs/linux/security/hardening/module-4.4-seccomp.md
@@ -11,7 +11,6 @@ lab:
   difficulty: "advanced"
   environment: "ubuntu"
 ---
-# Module 4.4: seccomp Profiles
 
 > **Linux Security** | Complexity: `[MEDIUM]` | Time: 25-30 min
 


### PR DESCRIPTION
## What

Removes the redundant `# Module X.Y: <title>` H1 from 27 linux modules. Starlight already renders the page H1 from the frontmatter `title:`, so this leaked heading duplicated it and failed the verifier's `gate_no_source_h1`.

Done deterministically via a new reusable tool, `scripts/quality/fix_leaked_source_h1.py` (detection mirrors `verify_module.source_h1_metrics` exactly; verified an exact match against the verifier on prereqs + linux before running).

## Why this, not de-frag

Root-caused that the inherited remediation engine treated `tier == T3` as "needs de-frag," but of 30 failing linux modules only 1 actually fails the density gates. 27 fail `gate_no_source_h1` — a 1-line mechanical fix, not fragmentation.

## Verification

- 27/27 `gate_no_source_h1` flip False → True
- Tier transitions: **8 → T0**, 3 → T2, 16 stay T3 (other gates remain), **0 demotions**
- Content diff is pure single-line deletions (0 insertions)
- `npm run build` green — 2129 pages, 40.4s, 0 errors
- 7 modules now honestly fail `body_words` (they sat 1–14 words above the 5000 floor, propped up by the leaked H1's words — a false pass the fix exposes; flagged for a small top-up follow-up)

## Learner check

> This module teaches the kernel as an operating contract, not as trivia.

(verbatim from the touched `linux/foundations/system-essentials/module-1.1-kernel-architecture.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)