### PR TITLE
chore(content): remove leaked source-H1 from 87 k8s modules

### DIFF
--- a/src/content/docs/k8s/cca/module-1.1-advanced-cilium.md
+++ b/src/content/docs/k8s/cca/module-1.1-advanced-cilium.md
@@ -5,7 +5,6 @@ sidebar:
   order: 2
 revision_pending: false
 ---
-# Module 1.1: Advanced Cilium for CCA
 
 > **CCA Track** | Complexity: `[COMPLEX]` | Time: 75-90 minutes
 

--- a/src/content/docs/k8s/cgoa/module-1.1-exam-strategy-and-blueprint-review.md
+++ b/src/content/docs/k8s/cgoa/module-1.1-exam-strategy-and-blueprint-review.md
@@ -7,8 +7,6 @@ sidebar:
   order: 101
 ---
 
-# CGOA Exam Strategy and Blueprint Review
-
 > **CGOA Track** | **Complexity**: Medium | **Time to Complete**: 90 minutes | **Prerequisites**: No Kubernetes operations experience required, but basic Git and CI/CD vocabulary will help
 
 ## Learning Outcomes

--- a/src/content/docs/k8s/cgoa/module-1.2-gitops-principles-review.md
+++ b/src/content/docs/k8s/cgoa/module-1.2-gitops-principles-review.md
@@ -7,8 +7,6 @@ sidebar:
 revision_pending: false
 ---
 
-# CGOA GitOps Principles Review
-
 > **Complexity**: `[MEDIUM]`
 >
 > **Time to Complete**: 45-60 minutes

--- a/src/content/docs/k8s/cgoa/module-1.3-patterns-and-tooling-review.md
+++ b/src/content/docs/k8s/cgoa/module-1.3-patterns-and-tooling-review.md
@@ -6,8 +6,6 @@ sidebar:
   order: 103
 ---
 
-# CGOA Patterns and Tooling Review
-
 > **CGOA Track** | Complexity: **MEDIUM** | Time: **75 minutes** | Prerequisites: GitOps principles, Kubernetes objects, basic CI/CD vocabulary | Kubernetes target: **1.35+**
 
 ## Learning Outcomes

--- a/src/content/docs/k8s/cgoa/module-1.4-practice-questions-set-1.md
+++ b/src/content/docs/k8s/cgoa/module-1.4-practice-questions-set-1.md
@@ -7,8 +7,6 @@ sidebar:
 revision_pending: false
 ---
 
-# CGOA Practice Questions Set 1
-
 > **CGOA Track** | Practice questions | Set 1  
 > **Complexity:** Beginner to intermediate  
 > **Estimated time:** 45-60 minutes  

--- a/src/content/docs/k8s/cgoa/module-1.5-practice-questions-set-2.md
+++ b/src/content/docs/k8s/cgoa/module-1.5-practice-questions-set-2.md
@@ -6,8 +6,6 @@ sidebar:
   order: 105
 ---
 
-# CGOA Practice Questions Set 2
-
 > **CGOA Track** | Practice questions | Set 2
 > **Complexity:** Beginner to intermediate
 > **Estimated time:** 60-75 minutes

--- a/src/content/docs/k8s/cka/part0-environment/part0-cumulative-quiz.md
+++ b/src/content/docs/k8s/cka/part0-environment/part0-cumulative-quiz.md
@@ -5,8 +5,6 @@ sidebar:
   order: 6
 ---
 
-# Part 0 Cumulative Quiz: Environment & Exam Technique
-
 > **Complexity**: `[MEDIUM]`
 >
 > **Time to Complete**: 45-60 minutes

--- a/src/content/docs/k8s/cka/part1-cluster-architecture/module-1.1-control-plane.md
+++ b/src/content/docs/k8s/cka/part1-cluster-architecture/module-1.1-control-plane.md
@@ -12,8 +12,6 @@ lab:
   environment: kubernetes
 ---
 
-# Module 1.1: Control Plane Deep-Dive
-
 > **Complexity**: `[MEDIUM]` - Conceptual understanding required
 >
 > **Time to Complete**: 35-45 minutes

--- a/src/content/docs/k8s/cka/part1-cluster-architecture/module-1.2-extension-interfaces.md
+++ b/src/content/docs/k8s/cka/part1-cluster-architecture/module-1.2-extension-interfaces.md
@@ -12,8 +12,6 @@ lab:
   environment: kubernetes
 ---
 
-# Module 1.2: Extension Interfaces - CNI, CSI, CRI
-
 > **Complexity**: `[MEDIUM]` - Conceptual with practical diagnostics
 >
 > **Time to Complete**: 35-45 minutes

--- a/src/content/docs/k8s/cka/part1-cluster-architecture/module-1.4-kustomize.md
+++ b/src/content/docs/k8s/cka/part1-cluster-architecture/module-1.4-kustomize.md
@@ -13,8 +13,6 @@ lab:
   environment: kubernetes
 ---
 
-# Module 1.4: Kustomize - Template-Free Configuration
-
 > **Complexity**: `[MEDIUM]` - Essential CKA skill for Kubernetes 1.35+
 >
 > **Time to Complete**: 40-55 minutes

--- a/src/content/docs/k8s/cka/part1-cluster-architecture/module-1.5-crds-operators.md
+++ b/src/content/docs/k8s/cka/part1-cluster-architecture/module-1.5-crds-operators.md
@@ -12,8 +12,6 @@ lab:
   environment: kubernetes
 ---
 
-# Module 1.5: CRDs & Operators - Extending Kubernetes
-
 > **Complexity**: `[MEDIUM]` - New to CKA 2025
 >
 > **Time to Complete**: 35-45 minutes

--- a/src/content/docs/k8s/cka/part4-storage/part4-cumulative-quiz.md
+++ b/src/content/docs/k8s/cka/part4-storage/part4-cumulative-quiz.md
@@ -5,8 +5,6 @@ sidebar:
   order: 7
 ---
 
-# Part 4 Cumulative Quiz: Storage
-
 > **Complexity**: `[COMPLEX]`
 >
 > **Time to Complete**: 65-80 minutes

--- a/src/content/docs/k8s/ckad/part0-environment/module-0.2-developer-workflow.md
+++ b/src/content/docs/k8s/ckad/part0-environment/module-0.2-developer-workflow.md
@@ -12,8 +12,6 @@ lab:
   environment: kubernetes
 ---
 
-# Module 0.2: Developer Workflow
-
 > **Complexity**: `[QUICK]` - Essential kubectl patterns for CKAD speed and accuracy
 >
 > **Time to Complete**: 35-45 minutes

--- a/src/content/docs/k8s/ckad/part1-design-build/module-1.2-jobs-cronjobs.md
+++ b/src/content/docs/k8s/ckad/part1-design-build/module-1.2-jobs-cronjobs.md
@@ -12,8 +12,6 @@ lab:
   environment: kubernetes
 ---
 
-# Module 1.2: Jobs and CronJobs
-
 > **Complexity**: `[MEDIUM]` - Essential CKAD skill with specific production tradeoffs
 >
 > **Time to Complete**: 45-50 minutes

--- a/src/content/docs/k8s/ckad/part2-deployment/part2-cumulative-quiz.md
+++ b/src/content/docs/k8s/ckad/part2-deployment/part2-cumulative-quiz.md
@@ -5,8 +5,6 @@ sidebar:
   order: 5
 ---
 
-# Part 2 Cumulative Quiz: Application Deployment
-
 > **Complexity**: `[COMPLEX]`
 >
 > **Time to Complete**: 70-90 minutes

--- a/src/content/docs/k8s/cnpa/module-1.1-exam-strategy-and-blueprint-review.md
+++ b/src/content/docs/k8s/cnpa/module-1.1-exam-strategy-and-blueprint-review.md
@@ -7,8 +7,6 @@ sidebar:
   order: 101
 ---
 
-# CNPA Exam Strategy and Blueprint Review
-
 > **CNPA Track** | Multiple-choice exam prep | **120 minutes** | **No prerequisites** | **Beginner to Senior**
 
 ## Learning Outcomes

--- a/src/content/docs/k8s/cnpa/module-1.2-core-platform-fundamentals-review.md
+++ b/src/content/docs/k8s/cnpa/module-1.2-core-platform-fundamentals-review.md
@@ -7,8 +7,6 @@ sidebar:
   order: 102
 ---
 
-# CNPA Core Platform Fundamentals Review
-
 > **Complexity**: `[MEDIUM]`
 >
 > **Time to Complete**: 75-95 minutes

--- a/src/content/docs/k8s/cnpa/module-1.4-practice-questions-set-1.md
+++ b/src/content/docs/k8s/cnpa/module-1.4-practice-questions-set-1.md
@@ -7,8 +7,6 @@ sidebar:
   order: 104
 ---
 
-# CNPA Practice Questions Set 1
-
 > **Complexity**: `[MEDIUM]`
 > **Time to Complete**: 55-70 minutes
 > **Prerequisites**: Platform engineering foundations, cloud native architecture basics, Kubernetes API objects, observability basics, and self-service delivery concepts

--- a/src/content/docs/k8s/cnpa/module-1.5-practice-questions-set-2.md
+++ b/src/content/docs/k8s/cnpa/module-1.5-practice-questions-set-2.md
@@ -6,8 +6,6 @@ sidebar:
   order: 105
 ---
 
-# CNPA Practice Questions Set 2
-
 > **CNPA Track** | Practice questions | Set 2 | Complexity: Medium | Time: 75 minutes | Prerequisites: CNPA modules 1.1 through 1.4, basic Kubernetes objects, and platform engineering vocabulary
 
 This second practice set focuses on comparison traps: platform engineering versus traditional operations, reconciliation versus one-time deployment, guardrails versus unrestricted access, and measurement that proves the platform is useful rather than merely busy. Read the explanations as carefully as the answers, because the exam often rewards the learner who can explain why three plausible answers are still weaker than the best answer.

--- a/src/content/docs/k8s/cnpe/module-1.3-platform-apis-and-self-service-lab.md
+++ b/src/content/docs/k8s/cnpe/module-1.3-platform-apis-and-self-service-lab.md
@@ -6,8 +6,6 @@ sidebar:
   order: 103
 ---
 
-# CNPE Platform APIs and Self-Service Lab
-
 > **CNPE Track** | Complexity: `[COMPLEX]` | Time to Complete: 75-90 min
 >
 > **Prerequisites**: CNPE Exam Strategy and Environment, Platform Engineering fundamentals, CRDs and Operators, Backstage, Crossplane, Kubebuilder, vCluster

--- a/src/content/docs/k8s/cnpe/module-1.4-observability-security-and-operations-lab.md
+++ b/src/content/docs/k8s/cnpe/module-1.4-observability-security-and-operations-lab.md
@@ -6,8 +6,6 @@ sidebar:
   order: 104
 ---
 
-# CNPE Observability, Security, and Operations Lab
-
 > **CNPE Track** | Complexity: `[COMPLEX]` | Time to Complete: 75-90 min
 >
 > **Prerequisites**: CNPE Exam Strategy and Environment, Observability Theory, SRE, Security Principles, DevSecOps, Prometheus, OpenTelemetry, Grafana, Loki, OPA/Gatekeeper, Kyverno, Falco

--- a/src/content/docs/k8s/cnpe/module-1.5-full-mock-exam.md
+++ b/src/content/docs/k8s/cnpe/module-1.5-full-mock-exam.md
@@ -6,8 +6,6 @@ sidebar:
   order: 105
 ---
 
-# CNPE Full Mock Exam
-
 - **CNPE Track**: Complexity `[COMPLEX]`
 - **Time to Complete**: 90-120 min
 - **Prerequisites**: CNPE Exam Strategy and Environment, GitOps and Delivery Lab, Platform APIs and Self-Service Lab, Observability Security and Operations Lab

--- a/src/content/docs/k8s/extending/module-1.1-api-deep-dive.md
+++ b/src/content/docs/k8s/extending/module-1.1-api-deep-dive.md
@@ -11,8 +11,6 @@ sidebar:
 >
 > **Prerequisites**: CKA or equivalent Kubernetes experience, basic Go programming, and access to a Kubernetes 1.35+ cluster
 
-# Module 1.1: Kubernetes API & Extensibility Architecture
-
 ## Learning Outcomes
 
 After completing this module, you will be able to:

--- a/src/content/docs/k8s/extending/module-1.2-crds-advanced.md
+++ b/src/content/docs/k8s/extending/module-1.2-crds-advanced.md
@@ -6,8 +6,6 @@ sidebar:
   order: 3
 ---
 
-# Module 1.2: Custom Resource Definitions Deep Dive
-
 > **Complexity**: `[MEDIUM]` - Defining your own Kubernetes APIs
 >
 > **Time to Complete**: 3 hours

--- a/src/content/docs/k8s/extending/module-1.3-controllers-client-go.md
+++ b/src/content/docs/k8s/extending/module-1.3-controllers-client-go.md
@@ -5,7 +5,6 @@ revision_pending: false
 sidebar:
   order: 4
 ---
-# Module 1.3: Building Controllers with client-go
 
 > **Complexity**: `[COMPLEX]` - Full controller implementation from scratch
 >

--- a/src/content/docs/k8s/extending/module-1.4-kubebuilder.md
+++ b/src/content/docs/k8s/extending/module-1.4-kubebuilder.md
@@ -13,8 +13,6 @@ sidebar:
 
 ---
 
-# Module 1.4: The Operator Pattern & Kubebuilder
-
 ## Learning Outcomes
 
 After completing this module, you will be able to:

--- a/src/content/docs/k8s/extending/module-1.5-advanced-operators.md
+++ b/src/content/docs/k8s/extending/module-1.5-advanced-operators.md
@@ -6,8 +6,6 @@ sidebar:
   order: 6
 ---
 
-# Module 1.5: Advanced Operator Development
-
 > **Complexity**: `[COMPLEX]` - Production-grade operator patterns
 >
 > **Time to Complete**: 5 hours

--- a/src/content/docs/k8s/extending/module-1.7-scheduler-plugins.md
+++ b/src/content/docs/k8s/extending/module-1.7-scheduler-plugins.md
@@ -6,8 +6,6 @@ sidebar:
   order: 8
 ---
 
-# Module 1.7: Customizing the Scheduler
-
 > **Complexity**: `[COMPLEX]` - Extending Kubernetes scheduling decisions
 >
 > **Time to Complete**: 4 hours

--- a/src/content/docs/k8s/extending/module-1.8-api-aggregation.md
+++ b/src/content/docs/k8s/extending/module-1.8-api-aggregation.md
@@ -7,8 +7,6 @@ sidebar:
   order: 9
 ---
 
-# Module 1.8: API Aggregation & Extension API Servers
-
 > **Complexity**: `[COMPLEX]` - Building custom API servers
 >
 > **Time to Complete**: 5 hours

--- a/src/content/docs/k8s/ica/module-1.2-istio-traffic-management.md
+++ b/src/content/docs/k8s/ica/module-1.2-istio-traffic-management.md
@@ -6,8 +6,6 @@ sidebar:
   order: 3
 ---
 
-# Module 1.2: Istio Traffic Management
-
 ## Complexity: `[COMPLEX]`
 ## Time to Complete: 60-75 minutes
 

--- a/src/content/docs/k8s/kca/module-1.1-advanced-kyverno-policies.md
+++ b/src/content/docs/k8s/kca/module-1.1-advanced-kyverno-policies.md
@@ -5,7 +5,6 @@ revision_pending: false
 sidebar:
   order: 2
 ---
-# Module 1.1: Advanced Kyverno Policies
 
 > **Complexity**: `[COMPLEX]` - Domain 5: Kyverno Advanced Policy Writing (32% of exam)
 >

--- a/src/content/docs/k8s/kca/module-1.2-kyverno-operations-cli.md
+++ b/src/content/docs/k8s/kca/module-1.2-kyverno-operations-cli.md
@@ -6,8 +6,6 @@ sidebar:
   order: 3
 ---
 
-# Module 1.2: Kyverno Operations & CLI
-
 > **Complexity**: `[MEDIUM]` - Multiple tools and operational concepts
 >
 > **Time to Complete**: 70-80 minutes

--- a/src/content/docs/k8s/kcna/part0-introduction/module-0.1-kcna-overview.md
+++ b/src/content/docs/k8s/kcna/part0-introduction/module-0.1-kcna-overview.md
@@ -5,7 +5,6 @@ slug: k8s/kcna/part0-introduction/module-0.1-kcna-overview
 sidebar:
   order: 2
 ---
-# Module 0.1: KCNA Exam Overview
 
 > **Complexity**: `[QUICK]` - Essential orientation
 >

--- a/src/content/docs/k8s/kcna/part0-introduction/module-0.2-study-strategy.md
+++ b/src/content/docs/k8s/kcna/part0-introduction/module-0.2-study-strategy.md
@@ -6,8 +6,6 @@ sidebar:
   order: 3
 ---
 
-# Module 0.2: KCNA Study Strategy
-
 | Metadata | Value |
 |---|---|
 | Complexity | `[QUICK]` - Essential exam preparation |

--- a/src/content/docs/k8s/kcna/part1-kubernetes-fundamentals/module-1.1-what-is-kubernetes.md
+++ b/src/content/docs/k8s/kcna/part1-kubernetes-fundamentals/module-1.1-what-is-kubernetes.md
@@ -5,7 +5,6 @@ slug: k8s/kcna/part1-kubernetes-fundamentals/module-1.1-what-is-kubernetes
 sidebar:
   order: 2
 ---
-# Module 1.1: What is Kubernetes?
 
 **Complexity**: `[QUICK]` - Foundational concepts. **Time to Complete**: 35-45 minutes. **Prerequisites**: None, although basic familiarity with servers, applications, and containers will make the examples easier to connect to real work.
 

--- a/src/content/docs/k8s/kcna/part1-kubernetes-fundamentals/module-1.2-container-fundamentals.md
+++ b/src/content/docs/k8s/kcna/part1-kubernetes-fundamentals/module-1.2-container-fundamentals.md
@@ -6,8 +6,6 @@ sidebar:
   order: 3
 ---
 
-# Module 1.2: Container Fundamentals
-
 Complexity: `[QUICK]` foundational concepts. Time to complete: 35-45 minutes. Prerequisites: Module 1.1 and basic Linux command-line comfort. The examples assume Kubernetes 1.35 or newer, and when Kubernetes commands appear later, set `alias k=kubectl` so the short `k` form is clear.
 
 ## Learning Outcomes

--- a/src/content/docs/k8s/kcna/part1-kubernetes-fundamentals/module-1.3-control-plane.md
+++ b/src/content/docs/k8s/kcna/part1-kubernetes-fundamentals/module-1.3-control-plane.md
@@ -6,8 +6,6 @@ sidebar:
   order: 4
 ---
 
-# Module 1.3: Kubernetes Architecture - Control Plane
-
 > **Complexity**: `[MEDIUM]` - Core architecture concepts
 >
 > **Time to Complete**: 60-75 minutes

--- a/src/content/docs/k8s/kcna/part1-kubernetes-fundamentals/module-1.4-node-components.md
+++ b/src/content/docs/k8s/kcna/part1-kubernetes-fundamentals/module-1.4-node-components.md
@@ -5,7 +5,6 @@ slug: k8s/kcna/part1-kubernetes-fundamentals/module-1.4-node-components
 sidebar:
   order: 5
 ---
-# Module 1.4: Kubernetes Architecture - Node Components
 
 > **Complexity**: `[MEDIUM]` - Core architecture concepts
 >

--- a/src/content/docs/k8s/kcna/part1-kubernetes-fundamentals/module-1.5-pods.md
+++ b/src/content/docs/k8s/kcna/part1-kubernetes-fundamentals/module-1.5-pods.md
@@ -6,8 +6,6 @@ sidebar:
   order: 6
 ---
 
-# Module 1.5: Pods
-
 > **Complexity**: `[MEDIUM]` - Core resource concept
 >
 > **Time to Complete**: 45-55 minutes

--- a/src/content/docs/k8s/kcna/part1-kubernetes-fundamentals/module-1.6-workload-resources.md
+++ b/src/content/docs/k8s/kcna/part1-kubernetes-fundamentals/module-1.6-workload-resources.md
@@ -6,8 +6,6 @@ sidebar:
   order: 7
 ---
 
-# Module 1.6: Workload Resources
-
 > **Complexity**: `[MEDIUM]` - Core resource concepts
 >
 > **Time to Complete**: 30-35 minutes

--- a/src/content/docs/k8s/kcna/part1-kubernetes-fundamentals/module-1.7-services.md
+++ b/src/content/docs/k8s/kcna/part1-kubernetes-fundamentals/module-1.7-services.md
@@ -6,8 +6,6 @@ sidebar:
   order: 8
 ---
 
-# Module 1.7: Services
-
 > **Complexity**: `[MEDIUM]` - Core networking concept
 >
 > **Time to Complete**: 65-75 minutes

--- a/src/content/docs/k8s/kcna/part1-kubernetes-fundamentals/module-1.8-namespaces-labels.md
+++ b/src/content/docs/k8s/kcna/part1-kubernetes-fundamentals/module-1.8-namespaces-labels.md
@@ -6,8 +6,6 @@ sidebar:
   order: 9
 ---
 
-# Module 1.8: Namespaces and Labels
-
 **Complexity**: `[QUICK]` - Organization concepts. **Time to Complete**: 35-40 minutes. **Prerequisites**: Modules 1.5-1.7. This is a fundamentals module, but it deliberately treats namespaces and labels as production reliability tools rather than vocabulary flashcards.
 
 This module assumes Kubernetes 1.35 or newer and uses `k` as the short alias for `kubectl`. If your shell does not already define it, run `alias k=kubectl` before the hands-on section so the commands match the examples and your muscle memory starts forming around the same compact workflow operators use during troubleshooting.

--- a/src/content/docs/k8s/kcna/part1-kubernetes-fundamentals/module-1.9-debugging-basics.md
+++ b/src/content/docs/k8s/kcna/part1-kubernetes-fundamentals/module-1.9-debugging-basics.md
@@ -7,8 +7,6 @@ sidebar:
   order: 10
 ---
 
-# Module 1.9: Debugging Basics
-
 > **Complexity**: `[QUICK]` - Fast triage mindset for Kubernetes 1.35+
 >
 > **Time to Complete**: 35-45 minutes

--- a/src/content/docs/k8s/kcna/part2-container-orchestration/module-2.1-scheduling.md
+++ b/src/content/docs/k8s/kcna/part2-container-orchestration/module-2.1-scheduling.md
@@ -6,8 +6,6 @@ sidebar:
 revision_pending: false
 ---
 
-# Module 2.1: Scheduling
-
 > **Complexity**: `[MEDIUM]` - Orchestration concepts
 >
 > **Time to Complete**: 60-75 minutes

--- a/src/content/docs/k8s/kcna/part2-container-orchestration/module-2.2-scaling.md
+++ b/src/content/docs/k8s/kcna/part2-container-orchestration/module-2.2-scaling.md
@@ -6,8 +6,6 @@ sidebar:
 revision_pending: false
 ---
 
-# Module 2.2: Scaling
-
 **Complexity**: `[HIGH]` - advanced orchestration concepts with direct impact on reliability, cost, and application design. **Time to complete**: 45-60 minutes. **Prerequisites**: Module 2.1, Scheduling. This module assumes Kubernetes 1.35 or newer behavior for autoscaling APIs and examples. The full Kubernetes command is `kubectl`; in runnable commands after the setup line, this module uses the shorter exam-friendly alias `k`, defined as `alias k=kubectl`.
 
 ```bash

--- a/src/content/docs/k8s/kcna/part2-container-orchestration/module-2.3-storage.md
+++ b/src/content/docs/k8s/kcna/part2-container-orchestration/module-2.3-storage.md
@@ -6,8 +6,6 @@ sidebar:
   order: 4
 ---
 
-# Module 2.3: Storage Orchestration
-
 **Complexity**: `[MEDIUM]` - Storage concepts. **Time to Complete**: 45-60 minutes. **Prerequisites**: Module 2.2 (Scaling). All commands in this module assume Kubernetes 1.35 or newer and use the standard shell shortcut `alias k=kubectl`, so `k get pods` means the same API request as the longer command while keeping examples readable.
 
 ---

--- a/src/content/docs/k8s/kcna/part2-container-orchestration/module-2.4-configuration.md
+++ b/src/content/docs/k8s/kcna/part2-container-orchestration/module-2.4-configuration.md
@@ -6,8 +6,6 @@ sidebar:
   order: 5
 ---
 
-# Module 2.4: Configuration
-
 > **Complexity**: `[MEDIUM]` - Configuration concepts
 >
 > **Time to Complete**: 40-50 minutes

--- a/src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.1-cloud-native-principles.md
+++ b/src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.1-cloud-native-principles.md
@@ -6,8 +6,6 @@ sidebar:
   order: 2
 ---
 
-# Module 3.1: Cloud Native Principles
-
 **Complexity**: `[MEDIUM]` architecture concepts. **Time to Complete**: 45-55 minutes. **Prerequisites**: Part 2, Container Orchestration, including basic familiarity with Pods, Deployments, Services, and the difference between desired state and actual state.
 
 ## What You'll Be Able to Do

--- a/src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.10-green-computing.md
+++ b/src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.10-green-computing.md
@@ -7,8 +7,6 @@ sidebar:
   order: 11
 ---
 
-# Module 3.10: Green Computing and Sustainability
-
 > **Complexity**: `[QUICK]` - Awareness and applied analysis level
 > **Time to Complete**: 45-60 minutes
 > **Prerequisites**: Module 3.1 (Cloud Native Principles), Module 3.2 (CNCF Ecosystem), basic Kubernetes resource requests and limits, and the ability to inspect Kubernetes objects with `kubectl` or its common alias `k`.

--- a/src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.2-cncf-ecosystem.md
+++ b/src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.2-cncf-ecosystem.md
@@ -5,7 +5,6 @@ slug: k8s/kcna/part3-cloud-native-architecture/module-3.2-cncf-ecosystem
 sidebar:
   order: 3
 ---
-# Module 3.2: CNCF Ecosystem
 
 > **Complexity**: `[QUICK]` - Knowledge-based
 >

--- a/src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.3-patterns.md
+++ b/src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.3-patterns.md
@@ -6,8 +6,6 @@ sidebar:
 revision_pending: false
 ---
 
-# Module 3.3: Cloud Native Patterns
-
 **Complexity**: `[MEDIUM]` architecture concepts. **Time to Complete**: 60-75 minutes. **Prerequisites**: Module 3.2, working Kubernetes vocabulary, and a Kubernetes 1.35+ cluster for the optional practice. We use the `k` alias for kubectl in examples; configure it with `alias k=kubectl` before running commands.
 
 ## Learning Outcomes

--- a/src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.4-observability-fundamentals.md
+++ b/src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.4-observability-fundamentals.md
@@ -6,8 +6,6 @@ sidebar:
   order: 5
 ---
 
-# Module 3.4: Observability Fundamentals
-
 Complexity: `[MEDIUM]` - Observability concepts for Kubernetes 1.35 and newer. Time to complete: 45-55 minutes. Prerequisites: Module 3.3, Cloud Native Patterns, plus basic comfort reading Pods, Services, and application logs in a Kubernetes cluster.
 
 ## What You'll Be Able to Do

--- a/src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.5-observability-tools.md
+++ b/src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.5-observability-tools.md
@@ -6,8 +6,6 @@ sidebar:
   order: 6
 ---
 
-# Module 3.5: Observability Tools
-
 - **Complexity**: `[QUICK]` - tool selection and first-run practice
 - **Time to Complete**: 40-55 minutes
 - **Prerequisites**: Module 3.4 (Observability Fundamentals), basic Kubernetes workloads, and a local Kubernetes 1.35+ cluster for the optional lab

--- a/src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.6-security-basics.md
+++ b/src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.6-security-basics.md
@@ -6,8 +6,6 @@ sidebar:
 revision_pending: false
 ---
 
-# Module 3.6: Security Basics (Theory)
-
 - **Complexity**: `[QUICK]` - Foundations only
 - **Time to Complete**: 35-40 minutes
 - **Prerequisites**: Modules 3.1-3.5 (Cloud Native Architecture)

--- a/src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.7-community-collaboration.md
+++ b/src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.7-community-collaboration.md
@@ -6,8 +6,6 @@ sidebar:
 revision_pending: false
 ---
 
-# Module 3.7: Cloud Native Community & Collaboration
-
 > **Complexity**: `[MEDIUM]` | **Time**: 45-60 minutes | **Prerequisites**: Modules 3.1-3.6, basic Kubernetes operations, and enough command-line comfort to inspect public repositories and run Kubernetes 1.35+ commands after introducing `alias k=kubectl` for the `k` alias.
 
 ## Learning Outcomes

--- a/src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.8-ai-ml-cloud-native.md
+++ b/src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.8-ai-ml-cloud-native.md
@@ -7,8 +7,6 @@ sidebar:
 revision_pending: false
 ---
 
-# Module 3.8: AI/ML on Cloud Native Infrastructure
-
 > **Complexity**: `[MEDIUM]` - Cloud native architecture and workload design
 >
 > **Time to Complete**: 35-45 minutes

--- a/src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.9-webassembly.md
+++ b/src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.9-webassembly.md
@@ -6,8 +6,6 @@ sidebar:
   order: 10
 ---
 
-# Module 3.9: WebAssembly and Cloud Native
-
 > **Complexity**: `[MEDIUM]` - Runtime architecture and workload placement
 >
 > **Time to Complete**: 45-60 minutes

--- a/src/content/docs/k8s/kcna/part4-application-delivery/module-4.1-ci-cd.md
+++ b/src/content/docs/k8s/kcna/part4-application-delivery/module-4.1-ci-cd.md
@@ -5,7 +5,6 @@ slug: k8s/kcna/part4-application-delivery/module-4.1-ci-cd
 sidebar:
   order: 2
 ---
-# Module 4.1: CI/CD Fundamentals
 
 > **Complexity**: `[MEDIUM]` - Delivery concepts
 >

--- a/src/content/docs/k8s/kcna/part4-application-delivery/module-4.2-application-packaging.md
+++ b/src/content/docs/k8s/kcna/part4-application-delivery/module-4.2-application-packaging.md
@@ -6,8 +6,6 @@ sidebar:
   order: 3
 ---
 
-# Module 4.2: Application Packaging
-
 > **Complexity**: `[MEDIUM]` - Tool concepts
 >
 > **Time to Complete**: 35-40 minutes

--- a/src/content/docs/k8s/kcna/part4-application-delivery/module-4.3-release-strategies.md
+++ b/src/content/docs/k8s/kcna/part4-application-delivery/module-4.3-release-strategies.md
@@ -6,8 +6,6 @@ sidebar:
   order: 4
 ---
 
-# Module 4.3: Release Strategies
-
 > **Complexity**: `[MEDIUM]` - Delivery strategy and operational trade-offs
 >
 > **Time to Complete**: 40-50 minutes

--- a/src/content/docs/k8s/kcsa/part0-introduction/module-0.1-kcsa-overview.md
+++ b/src/content/docs/k8s/kcsa/part0-introduction/module-0.1-kcsa-overview.md
@@ -6,8 +6,6 @@ sidebar:
   order: 2
 ---
 
-# Module 0.1: KCSA Exam Overview
-
 | Metadata | Value |
 |----------|-------|
 | **Complexity** | `[QUICK]` - Essential orientation |

--- a/src/content/docs/k8s/kcsa/part0-introduction/module-0.2-security-mindset.md
+++ b/src/content/docs/k8s/kcsa/part0-introduction/module-0.2-security-mindset.md
@@ -6,8 +6,6 @@ sidebar:
   order: 3
 ---
 
-# Module 0.2: Security Mindset
-
 This is a `[QUICK]` foundational module for the Kubernetes and Cloud Native Security Associate path. Plan for 20-25 minutes, and complete [Module 0.1: KCSA Overview](../module-0.1-kcsa-overview/) first so the exam domains and certification goal are already familiar before you start judging security trade-offs.
 
 ## What You'll Be Able to Do

--- a/src/content/docs/k8s/kcsa/part1-cloud-native-security/module-1.2-cloud-provider-security.md
+++ b/src/content/docs/k8s/kcsa/part1-cloud-native-security/module-1.2-cloud-provider-security.md
@@ -6,8 +6,6 @@ sidebar:
   order: 3
 ---
 
-# Module 1.2: Cloud Provider Security
-
 > **Complexity**: `[MEDIUM]` - Foundational knowledge
 >
 > **Time to Complete**: 45-60 minutes

--- a/src/content/docs/k8s/kcsa/part1-cloud-native-security/module-1.3-security-principles.md
+++ b/src/content/docs/k8s/kcsa/part1-cloud-native-security/module-1.3-security-principles.md
@@ -6,8 +6,6 @@ sidebar:
   order: 4
 ---
 
-# Module 1.3: Security Principles
-
 **Complexity**: `[MEDIUM]` - Foundational concepts. **Time to Complete**: 45-60 minutes. **Prerequisites**: [Module 1.2: Cloud Provider Security](../module-1.2-cloud-provider-security/). This module assumes you can recognize core Kubernetes objects and now need a reliable way to evaluate whether those objects are configured with secure operating principles.
 
 ## Learning Outcomes

--- a/src/content/docs/k8s/kcsa/part2-cluster-component-security/module-2.1-control-plane-security.md
+++ b/src/content/docs/k8s/kcsa/part2-cluster-component-security/module-2.1-control-plane-security.md
@@ -6,8 +6,6 @@ sidebar:
   order: 2
 ---
 
-# Module 2.1: Control Plane Security
-
 - **Complexity**: `[MEDIUM]` - Core knowledge
 - **Time to Complete**: 30-35 minutes
 - **Prerequisites**: [Module 1.3: Security Principles](/k8s/kcsa/part1-cloud-native-security/module-1.3-security-principles/)

--- a/src/content/docs/k8s/kcsa/part2-cluster-component-security/module-2.2-node-security.md
+++ b/src/content/docs/k8s/kcsa/part2-cluster-component-security/module-2.2-node-security.md
@@ -5,7 +5,6 @@ slug: k8s/kcsa/part2-cluster-component-security/module-2.2-node-security
 sidebar:
   order: 3
 ---
-# Module 2.2: Node Security
 
 > **Complexity**: `[MEDIUM]` - Core knowledge
 >

--- a/src/content/docs/k8s/kcsa/part2-cluster-component-security/module-2.3-network-security.md
+++ b/src/content/docs/k8s/kcsa/part2-cluster-component-security/module-2.3-network-security.md
@@ -6,8 +6,6 @@ sidebar:
   order: 4
 ---
 
-# Module 2.3: Network Security
-
 > **Complexity**: `[MEDIUM]` - Core knowledge
 >
 > **Time to Complete**: 35-40 minutes

--- a/src/content/docs/k8s/kcsa/part2-cluster-component-security/module-2.4-pki-certificates.md
+++ b/src/content/docs/k8s/kcsa/part2-cluster-component-security/module-2.4-pki-certificates.md
@@ -6,8 +6,6 @@ sidebar:
   order: 5
 ---
 
-# Module 2.4: PKI and Certificates
-
 > **Complexity**: `[MEDIUM]` - Core knowledge | **Time to Complete**: 45-60 minutes | **Prerequisites**: [Module 2.3: Network Security](../module-2.3-network-security/)
 
 This module uses Kubernetes 1.35+ behavior and the short command alias `k` for `kubectl`. If you run the examples in a lab cluster, define the alias once with `alias k=kubectl`, then keep using `k` so the commands match the lesson and the troubleshooting flow stays concise.

--- a/src/content/docs/k8s/kcsa/part3-security-fundamentals/module-3.2-rbac.md
+++ b/src/content/docs/k8s/kcsa/part3-security-fundamentals/module-3.2-rbac.md
@@ -5,7 +5,6 @@ slug: k8s/kcsa/part3-security-fundamentals/module-3.2-rbac
 sidebar:
   order: 3
 ---
-# Module 3.2: RBAC Fundamentals
 
 **Complexity**: `[MEDIUM]` - Core knowledge. **Time to Complete**: 40-50 minutes. **Prerequisites**: [Module 3.1: Pod Security](../module-3.1-pod-security/). This lesson assumes you already know the Pod Security Standards from the previous module and are ready to connect workload hardening with API authorization decisions.
 

--- a/src/content/docs/k8s/kcsa/part3-security-fundamentals/module-3.3-secrets.md
+++ b/src/content/docs/k8s/kcsa/part3-security-fundamentals/module-3.3-secrets.md
@@ -6,8 +6,6 @@ sidebar:
   order: 4
 ---
 
-# Module 3.3: Secrets Management
-
 **Complexity**: `[MEDIUM]` - Core knowledge. **Time to Complete**: 25-30 minutes. **Prerequisites**: [Module 3.2: RBAC Fundamentals](../module-3.2-rbac/). This module assumes Kubernetes 1.35 or newer and uses `k` as the `kubectl` alias after you define it with `alias k=kubectl` in your shell.
 
 ## Learning Outcomes

--- a/src/content/docs/k8s/kcsa/part3-security-fundamentals/module-3.4-serviceaccounts.md
+++ b/src/content/docs/k8s/kcsa/part3-security-fundamentals/module-3.4-serviceaccounts.md
@@ -5,7 +5,6 @@ slug: k8s/kcsa/part3-security-fundamentals/module-3.4-serviceaccounts
 sidebar:
   order: 5
 ---
-# Module 3.4: ServiceAccount Security
 
 > **Complexity**: `[MEDIUM]` - Core knowledge
 >

--- a/src/content/docs/k8s/kcsa/part3-security-fundamentals/module-3.5-network-policies.md
+++ b/src/content/docs/k8s/kcsa/part3-security-fundamentals/module-3.5-network-policies.md
@@ -5,7 +5,6 @@ slug: k8s/kcsa/part3-security-fundamentals/module-3.5-network-policies
 sidebar:
   order: 6
 ---
-# Module 3.5: Network Policies
 
 > **Complexity**: `[MEDIUM]` - Core knowledge
 >

--- a/src/content/docs/k8s/kcsa/part4-threat-model/module-4.1-attack-surfaces.md
+++ b/src/content/docs/k8s/kcsa/part4-threat-model/module-4.1-attack-surfaces.md
@@ -6,8 +6,6 @@ sidebar:
   order: 2
 ---
 
-# Module 4.1: Attack Surfaces
-
 | Complexity | Time to Complete | Prerequisites |
 |------------|------------------|---------------|
 | `[MEDIUM]` - Threat awareness | 35-45 minutes | [Module 3.5: Network Policies](/k8s/kcsa/part3-security-fundamentals/module-3.5-network-policies/) |

--- a/src/content/docs/k8s/kcsa/part4-threat-model/module-4.2-vulnerabilities.md
+++ b/src/content/docs/k8s/kcsa/part4-threat-model/module-4.2-vulnerabilities.md
@@ -6,8 +6,6 @@ sidebar:
   order: 3
 ---
 
-# Module 4.2: Common Vulnerabilities
-
 **Complexity**: `[MEDIUM]` threat awareness and prioritization. **Time to Complete**: 25-30 minutes. **Prerequisites**: [Module 4.1: Attack Surfaces](../module-4.1-attack-surfaces/). This module assumes Kubernetes 1.35 or newer, and command examples use the `alias k=kubectl` shorthand after naming `kubectl` once.
 
 ## What You'll Be Able to Do

--- a/src/content/docs/k8s/kcsa/part4-threat-model/module-4.3-container-escape.md
+++ b/src/content/docs/k8s/kcsa/part4-threat-model/module-4.3-container-escape.md
@@ -6,8 +6,6 @@ sidebar:
   order: 4
 ---
 
-# Module 4.3: Container Escape
-
 > **Complexity**: `[MEDIUM]` - Threat awareness
 >
 > **Time to Complete**: 55-65 minutes

--- a/src/content/docs/k8s/kcsa/part5-platform-security/module-5.1-image-security.md
+++ b/src/content/docs/k8s/kcsa/part5-platform-security/module-5.1-image-security.md
@@ -6,8 +6,6 @@ sidebar:
   order: 2
 ---
 
-# Module 5.1: Image Security
-
 > **Complexity**: `[MEDIUM]` - Core knowledge for engineers who can read Pod YAML and now need to evaluate image risk across build, registry, admission, and runtime boundaries.
 >
 > **Time to Complete**: 35-40 minutes, including the audit exercise and the policy reasoning needed to connect Dockerfile choices to Kubernetes 1.35+ controls.

--- a/src/content/docs/k8s/kcsa/part5-platform-security/module-5.2-observability.md
+++ b/src/content/docs/k8s/kcsa/part5-platform-security/module-5.2-observability.md
@@ -5,7 +5,6 @@ slug: k8s/kcsa/part5-platform-security/module-5.2-observability
 sidebar:
   order: 3
 ---
-# Module 5.2: Security Observability
 
 > **Complexity**: `[MEDIUM]` - Core knowledge. **Time to Complete**: 25-30 minutes. **Prerequisites**: [Module 5.1: Image Security](../module-5.1-image-security/). This module assumes Kubernetes 1.35 or newer and uses `k` as the short command form after you define `alias k=kubectl` in your shell.
 

--- a/src/content/docs/k8s/kcsa/part5-platform-security/module-5.3-runtime-security.md
+++ b/src/content/docs/k8s/kcsa/part5-platform-security/module-5.3-runtime-security.md
@@ -6,8 +6,6 @@ sidebar:
 revision_pending: false
 ---
 
-# Module 5.3: Runtime Security
-
 > **Complexity**: `[MEDIUM]` - Core knowledge
 >
 > **Time to Complete**: 60-75 minutes

--- a/src/content/docs/k8s/kcsa/part5-platform-security/module-5.4-security-tooling.md
+++ b/src/content/docs/k8s/kcsa/part5-platform-security/module-5.4-security-tooling.md
@@ -6,8 +6,6 @@ sidebar:
   order: 5
 ---
 
-# Module 5.4: Security Tooling
-
 > **Complexity**: `[MEDIUM]` - Tool awareness, operational comparison, and practical stack design
 >
 > **Time to Complete**: 55-65 minutes

--- a/src/content/docs/k8s/kcsa/part6-compliance/module-6.1-compliance-frameworks.md
+++ b/src/content/docs/k8s/kcsa/part6-compliance/module-6.1-compliance-frameworks.md
@@ -6,8 +6,6 @@ sidebar:
   order: 2
 ---
 
-# Module 6.1: Compliance Frameworks
-
 > **Complexity**: `[MEDIUM]` - Conceptual knowledge with practical Kubernetes control mapping
 >
 > **Time to Complete**: 35-45 minutes

--- a/src/content/docs/k8s/kcsa/part6-compliance/module-6.2-cis-benchmarks.md
+++ b/src/content/docs/k8s/kcsa/part6-compliance/module-6.2-cis-benchmarks.md
@@ -6,8 +6,6 @@ sidebar:
   order: 3
 ---
 
-# Module 6.2: CIS Benchmarks
-
 > **Complexity**: `[MEDIUM]` - Technical knowledge
 >
 > **Time to Complete**: 35-45 minutes

--- a/src/content/docs/k8s/kcsa/part6-compliance/module-6.3-security-assessments.md
+++ b/src/content/docs/k8s/kcsa/part6-compliance/module-6.3-security-assessments.md
@@ -6,8 +6,6 @@ sidebar:
   order: 4
 ---
 
-# Module 6.3: Security Assessments
-
 > **Complexity**: `[MEDIUM]` - Conceptual knowledge with practical triage
 >
 > **Time to Complete**: 45-60 minutes

--- a/src/content/docs/k8s/lfcs/module-1.1-exam-strategy-and-workflow.md
+++ b/src/content/docs/k8s/lfcs/module-1.1-exam-strategy-and-workflow.md
@@ -5,7 +5,6 @@ slug: k8s/lfcs/module-1.1-exam-strategy-and-workflow
 sidebar:
   order: 101
 ---
-# LFCS Exam Strategy and Workflow
 
 Complexity: `[MEDIUM]` | Time: 1-2 hours | Prerequisites: familiarity with the LFCS hub, Linux command-line fundamentals, and enough shell confidence to create files, inspect services, and read manual pages without a graphical helper. KubeDojo's Kubernetes certification material targets Kubernetes 1.35+, but this LFCS module is focused on Linux administration habits that transfer into every later terminal-heavy track.
 

--- a/src/content/docs/k8s/lfcs/module-1.3-running-systems-and-networking-practice.md
+++ b/src/content/docs/k8s/lfcs/module-1.3-running-systems-and-networking-practice.md
@@ -6,8 +6,6 @@ sidebar:
   order: 103
 ---
 
-# LFCS Running Systems and Networking Practice
-
 > **LFCS Track** | Complexity: `[COMPLEX]` | Time: 45-60 min | Kubernetes target: 1.35+. This practice module focuses on Linux host operations that also support reliable Kubernetes node administration.
 
 **Reading Time**: 45-60 minutes, depending on whether you only read the chapter or also run the drills in a disposable lab environment.

--- a/src/content/docs/k8s/lfcs/module-1.4-storage-services-and-users-practice.md
+++ b/src/content/docs/k8s/lfcs/module-1.4-storage-services-and-users-practice.md
@@ -6,8 +6,6 @@ sidebar:
   order: 104
 ---
 
-# LFCS Storage, Services, and Users Practice
-
 > **LFCS Track** | Complexity: `[COMPLEX]` | Time: 50-70 min for an integrated Linux administration practice module covering identity, storage, services, limits, and verification.
 
 **Reading Time**: 50-70 minutes, with enough hands-on depth to pause between sections, run the commands in a disposable lab, and compare evidence after each change.

--- a/src/content/docs/k8s/lfcs/module-1.5-full-mock-exam.md
+++ b/src/content/docs/k8s/lfcs/module-1.5-full-mock-exam.md
@@ -6,8 +6,6 @@ sidebar:
   order: 105
 ---
 
-# LFCS Full Mock Exam
-
 > **LFCS Track** | Complexity: `[COMPLEX]` | Time: 90-120 min
 
 **Reading Time**: 25-35 minutes to brief, then one full timed run and one structured debrief.

--- a/src/content/docs/k8s/pca/module-1.1-promql-deep-dive.md
+++ b/src/content/docs/k8s/pca/module-1.1-promql-deep-dive.md
@@ -5,7 +5,6 @@ slug: k8s/pca/module-1.1-promql-deep-dive
 sidebar:
   order: 2
 ---
-# Module 1.1: PromQL Deep Dive
 
 > **PCA Track** | Complexity: `[COMPLEX]` | Time: 50-60 min | Kubernetes target: 1.35 and newer for the lab examples and operational assumptions.
 


### PR DESCRIPTION
## What

Removes the redundant `# Module X.Y: <title>` H1 from 87 k8s (Certifications) modules — same deterministic fix as #1666 (which did linux), now applied in curriculum order to the k8s track. Starlight renders the page H1 from frontmatter `title:`, so the leaked heading duplicated it and failed `gate_no_source_h1`.

Tool: `scripts/quality/fix_leaked_source_h1.py` (detection reconciled exactly against the verifier on k8s: 87 flagged = 87 violations, zero over-flag).

## Verification

- 87/87 `gate_no_source_h1` flip False → True
- Tier transitions: **33 → T0**, 6 → T2, 48 stay T3 (other gates remain), **0 demotions** (the fixer only touches already-non-T0 modules, so no T0 can regress)
- Content diff is pure single-line deletions (0 insertions)
- `npm run build` green — 2129 pages, 43s, 0 errors

## Learner check

> Desired state and actual state differ in replica count and container image.

(verbatim from a touched k8s module: `k8s/cgoa/module-1.2-gitops-principles-review.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)