### PR TITLE
chore(content): remove leaked source-H1 from 61 modules (cloud/ai-ml-eng/on-prem/platform)

### DIFF
--- a/src/content/docs/ai-ml-engineering/advanced-genai/module-1.1-fine-tuning-llms.md
+++ b/src/content/docs/ai-ml-engineering/advanced-genai/module-1.1-fine-tuning-llms.md
@@ -5,8 +5,6 @@ sidebar:
   order: 802
 ---
 
-# Fine-tuning LLMs
-
 ## Why This Module Matters
 
 In 2014, Amazon initiated a secretive engineering project to build an artificial intelligence recruiting tool. The primary objective was to review job applicants' resumes and rate them mechanically from one to five stars, aiming to automate the initial screening process. To achieve this, engineers fine-tuned their natural language processing models on a massive dataset of resumes submitted to the company over the previous ten years. By 2015, the company realized their system was fundamentally flawed. Because the historical data reflected a male-dominated technology industry, the fine-tuned model explicitly taught itself that male candidates were mathematically preferable. It actively penalized resumes that included the word "women's" (such as "women's chess club captain") and structurally downgraded graduates of two specific all-women's colleges.

--- a/src/content/docs/ai-ml-engineering/advanced-genai/module-1.2-lora-parameter-efficient-fine-tuning.md
+++ b/src/content/docs/ai-ml-engineering/advanced-genai/module-1.2-lora-parameter-efficient-fine-tuning.md
@@ -5,8 +5,6 @@ sidebar:
   order: 803
 ---
 
-# LoRA & Parameter-Efficient Fine-tuning
-
 ## Why This Module Matters
 
 Generative artificial intelligence fundamentally redefines how software systems synthesize novel data, but the computational reality of modern neural architectures presents severe operational bottlenecks. Full-parameter fine-tuning on large generative models can become extremely expensive and can still fail if the training setup, data quality, and regularization strategy are poor. The operational lesson is that adaptation strategy matters as much as raw compute budget.

--- a/src/content/docs/ai-ml-engineering/ai-infrastructure/module-1.4-local-inference-stack-for-learners.md
+++ b/src/content/docs/ai-ml-engineering/ai-infrastructure/module-1.4-local-inference-stack-for-learners.md
@@ -5,7 +5,6 @@ slug: ai-ml-engineering/ai-infrastructure/module-1.4-local-inference-stack-for-l
 sidebar:
   order: 705
 ---
-# Local Inference Stack for Learners
 
 > **AI/ML Engineering Track** | Complexity: `[MEDIUM]` | Time: 2-3 hours
 

--- a/src/content/docs/ai-ml-engineering/ai-native-development/module-1.10-anthropic-agent-sdk-and-runtime-patterns.md
+++ b/src/content/docs/ai-ml-engineering/ai-native-development/module-1.10-anthropic-agent-sdk-and-runtime-patterns.md
@@ -6,8 +6,6 @@ sidebar:
   order: 111
 ---
 
-# Anthropic Agent SDK and Runtime Patterns
-
 > **AI/ML Engineering Track** | Complexity: `[MEDIUM]` | Time: 2-3 hours
 
 **Reading Time**: 2-3 hours

--- a/src/content/docs/ai-ml-engineering/ai-native-development/module-1.2-local-models-for-ai-coding.md
+++ b/src/content/docs/ai-ml-engineering/ai-native-development/module-1.2-local-models-for-ai-coding.md
@@ -7,8 +7,6 @@ sidebar:
 
 > **AI/ML Engineering Track** | Complexity: `[MEDIUM]` | Time: 3-4 hours
 
-# Local Models for AI Coding
-
 **Reading Time**: 3-4 hours
 
 **Prerequisites**: Module 1.1 complete, comfort using a terminal, basic Git workflow, and at least 8 GB RAM. A 16 GB machine is strongly recommended for the examples in this module.

--- a/src/content/docs/ai-ml-engineering/ai-native-development/module-1.3-claude-code-cli-deep-dive.md
+++ b/src/content/docs/ai-ml-engineering/ai-native-development/module-1.3-claude-code-cli-deep-dive.md
@@ -5,7 +5,6 @@ sidebar:
   order: 204
 ---
 > **AI/ML Engineering Track** | Complexity: `[MEDIUM]` | Time: 4-5
-# Or: The 90% of Claude Code You've Been Missing
 
 **Reading Time**: 4-5 hours
 **Prerequisites**: Module 1.1, Claude Code installed and working

--- a/src/content/docs/ai-ml-engineering/ai-native-development/module-1.4-agent-first-ides.md
+++ b/src/content/docs/ai-ml-engineering/ai-native-development/module-1.4-agent-first-ides.md
@@ -5,7 +5,6 @@ sidebar:
   order: 205
 ---
 > **AI/ML Engineering Track** | Complexity: `[MEDIUM]` | Time: 4-6
-# The New Paradigm: From Autocomplete to Autonomous Agents
 
 ---
 **Prerequisites**: Module 1.1-1.3 complete

--- a/src/content/docs/ai-ml-engineering/ai-native-development/module-1.7-ai-powered-code-generation.md
+++ b/src/content/docs/ai-ml-engineering/ai-native-development/module-1.7-ai-powered-code-generation.md
@@ -7,8 +7,6 @@ sidebar:
 
 > **AI/ML Engineering Track** | Complexity: `[MEDIUM]` | Time: 4-5 Hours
 
-# AI-Powered Code Generation
-
 **Reading Time**: 4-5 hours
 **Prerequisites**: Modules 1-2
 

--- a/src/content/docs/ai-ml-engineering/deep-learning/module-1.3-training-neural-networks.md
+++ b/src/content/docs/ai-ml-engineering/deep-learning/module-1.3-training-neural-networks.md
@@ -6,8 +6,6 @@ sidebar:
   order: 1004
 ---
 
-# Training Neural Networks
-
 > **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 6-8 hours
 >
 > **Prerequisites**: Python fundamentals, NumPy arrays, matrix multiplication, gradient descent, and the previous neural-network-from-scratch module.

--- a/src/content/docs/ai-ml-engineering/deep-learning/module-1.5-rnns-sequence-models.md
+++ b/src/content/docs/ai-ml-engineering/deep-learning/module-1.5-rnns-sequence-models.md
@@ -6,8 +6,6 @@ sidebar:
 ---
 > **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 5-6
 
-# Or: How AI Learned to See (And Why It Still Can't Find Waldo)
-
 ## Why This Module Matters
 
 This module is designed to bridge the gap between theoretical mathematics and production-grade engineering. You will dissect the precise mathematical operations that allow machines to detect spatial hierarchies, recognize complex patterns, and parse messy reality. By understanding the inner workings of convolutions, pooling layers, and residual connections, you will possess the fundamental prerequisites to design, debug, and deploy vision systems that are robust, efficient, and safe for real-world application.

--- a/src/content/docs/ai-ml-engineering/deep-learning/module-1.6-backpropagation-deep-dive.md
+++ b/src/content/docs/ai-ml-engineering/deep-learning/module-1.6-backpropagation-deep-dive.md
@@ -6,8 +6,6 @@ sidebar:
 ---
 > **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 5-6 Hours
 
-# Backpropagation Deep Dive: From Autograd to Transformers
-
 **Reading Time**: 8-10 hours
 **Prerequisites**: Module 29
 

--- a/src/content/docs/ai-ml-engineering/deep-learning/module-1.7-backpropagation-and-autograd-from-scratch.md
+++ b/src/content/docs/ai-ml-engineering/deep-learning/module-1.7-backpropagation-and-autograd-from-scratch.md
@@ -7,8 +7,6 @@ sidebar:
 ---
 > **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 8-10 hours
 
-# Backpropagation and Autograd from Scratch
-
 **Reading Time**: 6-7 hours
 
 **Prerequisites**: Python, NumPy basics, matrix multiplication, basic derivatives, and prior neural network training experience.

--- a/src/content/docs/ai-ml-engineering/frameworks-agents/module-1.1-langchain-fundamentals.md
+++ b/src/content/docs/ai-ml-engineering/frameworks-agents/module-1.1-langchain-fundamentals.md
@@ -8,8 +8,6 @@ sidebar:
 
 > **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 5-6 hours
 
-# LangChain Fundamentals: The Framework That Took Over AI Development
-
 **Reading Time**: 6-7 hours  
 **Prerequisites**: Module 14, Python fundamentals, basic HTTP/API concepts, and beginner familiarity with LLM prompts.
 

--- a/src/content/docs/ai-ml-engineering/frameworks-agents/module-1.2-langchain-advanced.md
+++ b/src/content/docs/ai-ml-engineering/frameworks-agents/module-1.2-langchain-advanced.md
@@ -7,8 +7,6 @@ sidebar:
 
 > **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 5-6
 
-# LangChain Advanced: Teaching AI to Use Tools Like a Human
-
 **Reading Time**: 6-7 hours
 **Prerequisites**: Module 15
 

--- a/src/content/docs/ai-ml-engineering/frameworks-agents/module-1.5-building-ai-agents.md
+++ b/src/content/docs/ai-ml-engineering/frameworks-agents/module-1.5-building-ai-agents.md
@@ -7,8 +7,6 @@ sidebar:
 
 > **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 6-8
 
-# Building AI Agents: The Framework Ecosystem
-
 **Reading Time**: 6-8 hours
 **Prerequisites**: Module 18
 

--- a/src/content/docs/ai-ml-engineering/frameworks-agents/module-1.6-agent-memory-planning.md
+++ b/src/content/docs/ai-ml-engineering/frameworks-agents/module-1.6-agent-memory-planning.md
@@ -6,8 +6,6 @@ sidebar:
   order: 507
 ---
 
-# Agent Memory & Planning
-
 > **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 5-6 hours
 >
 > **Reading Time**: 8-9 hours

--- a/src/content/docs/ai-ml-engineering/frameworks-agents/module-1.7-multi-agent-systems.md
+++ b/src/content/docs/ai-ml-engineering/frameworks-agents/module-1.7-multi-agent-systems.md
@@ -5,8 +5,6 @@ sidebar:
   order: 508
 ---
 
-# Multi-Agent Systems: Production Deployments
-
 ## Why This Module Matters
 
 In 2022, Air Canada deployed an AI agent to handle customer service inquiries. When a grieving passenger asked about bereavement fares, the chatbot hallucinated a completely fictitious policy, instructing the passenger to book a full-price ticket and claim a refund later. When Air Canada refused the refund based on their real policy, the passenger sued. The civil tribunal ruled against Air Canada, forcing them to pay damages and publicly acknowledging the failure of their AI deployment. 

--- a/src/content/docs/ai-ml-engineering/generative-ai/module-1.1-introduction-to-large-language-models.md
+++ b/src/content/docs/ai-ml-engineering/generative-ai/module-1.1-introduction-to-large-language-models.md
@@ -6,8 +6,6 @@ sidebar:
   order: 302
 ---
 
-# Introduction to Large Language Models
-
 > **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 5-6 hours
 >
 > **Prerequisites**: Phase 1 complete, basic Python, basic HTTP/API concepts, and comfort reading small configuration files

--- a/src/content/docs/ai-ml-engineering/generative-ai/module-1.2-tokenization-text-processing.md
+++ b/src/content/docs/ai-ml-engineering/generative-ai/module-1.2-tokenization-text-processing.md
@@ -6,8 +6,6 @@ sidebar:
   order: 303
 ---
 
-# Tokenization & Text Processing
-
 > **Complexity**: `[MEDIUM]`
 >
 > **Time to Complete**: 55-75 minutes

--- a/src/content/docs/ai-ml-engineering/generative-ai/module-1.3-text-generation-sampling-strategies.md
+++ b/src/content/docs/ai-ml-engineering/generative-ai/module-1.3-text-generation-sampling-strategies.md
@@ -8,8 +8,6 @@ sidebar:
 
 > **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 5-6 hours
 
-# Text Generation & Sampling Strategies: The Art of Controlled Randomness
-
 ## Learning Outcomes
 
 By the end of this module, you will be able to:

--- a/src/content/docs/ai-ml-engineering/generative-ai/module-1.4-embeddings-semantic-search.md
+++ b/src/content/docs/ai-ml-engineering/generative-ai/module-1.4-embeddings-semantic-search.md
@@ -5,7 +5,6 @@ slug: ai-ml-engineering/generative-ai/module-1.4-embeddings-semantic-search
 sidebar:
   order: 305
 ---
-# Embeddings & Semantic Search
 
 > **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 5-6 hours
 >

--- a/src/content/docs/ai-ml-engineering/generative-ai/module-1.5-vector-space-visualization.md
+++ b/src/content/docs/ai-ml-engineering/generative-ai/module-1.5-vector-space-visualization.md
@@ -5,8 +5,6 @@ sidebar:
   order: 306
 ---
 
-# Vector Space Visualization
-
 ## Why This Module Matters
 
 In November 2018, a leading global fashion retailer deployed a highly anticipated feature for the holiday shopping season: an updated search engine for their catalog. Historically, the retailer relied strictly on exact keyword matching, utilizing traditional inverted indices and TF-IDF scoring. If a user searched for "crimson winter coat," the system would strictly scan the relational database for the exact strings "crimson," "winter," and "coat." While highly predictable and easily debuggable, this rigid approach entirely ignored the implicit semantic intent of the user's query. When users began searching for "burgundy cold weather jacket," the keyword-based system returned zero results, despite the warehouse being fully stocked with thousands of perfectly matching items that happened to use slightly different product descriptions.

--- a/src/content/docs/ai-ml-engineering/mlops/module-1.12-small-team-private-ai-platform.md
+++ b/src/content/docs/ai-ml-engineering/mlops/module-1.12-small-team-private-ai-platform.md
@@ -6,8 +6,6 @@ sidebar:
   order: 613
 ---
 
-# Small-Team Private AI Platform
-
 > **AI/ML Engineering Track** | Complexity: `[MEDIUM]` | Time: 2-3 hours
 
 **Reading Time**: 2-3 hours  

--- a/src/content/docs/ai-ml-engineering/multimodal-ai/module-1.3-video-ai.md
+++ b/src/content/docs/ai-ml-engineering/multimodal-ai/module-1.3-video-ai.md
@@ -5,8 +5,6 @@ sidebar:
   order: 904
 ---
 
-# Video AI: When Images Just Aren't Enough
-
 ## Why This Module Matters
 
 In May 2016, a fatal crash involving a semi-autonomous vehicle operating on a major highway highlighted a catastrophic limitation in early computer vision systems. The vehicle's cameras detected a white tractor-trailer crossing the road against a brightly lit sky, but the system failed to recognize the obstruction and did not brake, underscoring how brittle perception systems can be in complex real-world conditions. This incident tragically demonstrated that analyzing the world one frame at a time is fundamentally insufficient for understanding dynamic environments.

--- a/src/content/docs/ai-ml-engineering/multimodal-ai/module-1.4-multimodal-first-design.md
+++ b/src/content/docs/ai-ml-engineering/multimodal-ai/module-1.4-multimodal-first-design.md
@@ -5,8 +5,6 @@ sidebar:
   order: 905
 ---
 
-# Multimodal-First AI Design
-
 ## Learning Outcomes
 
 By the end of this module, you will be able to:

--- a/src/content/docs/ai-ml-engineering/vector-rag/module-1.1-vector-databases-deep-dive.md
+++ b/src/content/docs/ai-ml-engineering/vector-rag/module-1.1-vector-databases-deep-dive.md
@@ -6,8 +6,6 @@ sidebar:
   order: 402
 ---
 
-# Vector Databases Deep Dive
-
 > **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 5-6 hours
 >
 > **Prerequisites**: Prior experience with embeddings, semantic search, Python, HTTP APIs, and basic database concepts.

--- a/src/content/docs/cloud/gcp-essentials/module-2.7-cloud-run.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.7-cloud-run.md
@@ -6,8 +6,6 @@ sidebar:
   order: 8
 ---
 
-# Module 2.7: GCP Cloud Run (Serverless Containers)
-
 **Complexity**: [COMPLEX] | **Time to Complete**: 2.5h | **Prerequisites**: Module 2.1 (IAM), Module 2.6 (Artifact Registry)
 
 ## Learning Outcomes

--- a/src/content/docs/cloud/managed-services/module-9.9-api-gateways.md
+++ b/src/content/docs/cloud/managed-services/module-9.9-api-gateways.md
@@ -6,8 +6,6 @@ sidebar:
   order: 10
 ---
 
-# Module 9.9: Cloud-Native API Gateways & WAF
-
 **Complexity**: [COMPLEX] | **Time to Complete**: 2.5h | **Prerequisites**: Module 9.3 (Serverless Interoperability), Kubernetes Ingress and Services, HTTP/TLS basics
 
 ## What You'll Be Able to Do

--- a/src/content/docs/on-premises/operations/module-7.6-self-hosted-cicd.md
+++ b/src/content/docs/on-premises/operations/module-7.6-self-hosted-cicd.md
@@ -6,8 +6,6 @@ sidebar:
   order: 76
 ---
 
-# Self-Hosted CI/CD
-
 ## Why This Module Matters
 
 Recent software supply-chain incidents have shown that compromising CI/CD tooling can expose build secrets and create downstream customer risk when runner isolation and credential scoping are weak. 

--- a/src/content/docs/on-premises/operations/module-7.7-self-hosted-registry.md
+++ b/src/content/docs/on-premises/operations/module-7.7-self-hosted-registry.md
@@ -6,8 +6,6 @@ sidebar:
   order: 77
 ---
 
-# Self-Hosted Container Registry
-
 ## Learning Outcomes
 
 * Configure a production-grade OCI-compliant container registry on bare metal Kubernetes.

--- a/src/content/docs/on-premises/operations/module-7.8-observability-at-scale.md
+++ b/src/content/docs/on-premises/operations/module-7.8-observability-at-scale.md
@@ -8,8 +8,6 @@ sidebar:
   order: 78
 ---
 
-# Observability at Scale
-
 **Complexity:** Advanced. **Time to complete:** 90-120 minutes. **Prerequisites:** Prometheus fundamentals, Kubernetes operations, basic object storage concepts, and comfort reading YAML manifests.
 
 ## Learning Outcomes

--- a/src/content/docs/on-premises/operations/module-7.9-serverless-bare-metal.md
+++ b/src/content/docs/on-premises/operations/module-7.9-serverless-bare-metal.md
@@ -6,8 +6,6 @@ sidebar:
   order: 79
 ---
 
-# Serverless on Bare Metal
-
 ## Learning Outcomes
 
 *   **Design and evaluate** Knative Serving architectures alongside bare-metal compatible networking layers like Kourier and Contour.

--- a/src/content/docs/on-premises/security/module-6.4-compliance.md
+++ b/src/content/docs/on-premises/security/module-6.4-compliance.md
@@ -7,8 +7,6 @@ sidebar:
   order: 5
 ---
 
-# Module 6.4: Compliance for Regulated Industries
-
 **Complexity**: `[ADVANCED]` | **Time**: 75 minutes | **Prerequisites**: [Physical Security & Air-Gapped Environments](../module-6.1-air-gapped/), [Hardware Security (HSM/TPM)](../module-6.2-hardware-security/), and [Enterprise Identity](../module-6.3-enterprise-identity/). These examples assume Kubernetes 1.35 or newer; when running Kubernetes commands, define `alias k=kubectl` once in your shell and then use `k` for CLI examples.
 
 ## What You'll Be Able to Do

--- a/src/content/docs/on-premises/security/module-6.5-workload-identity-spiffe.md
+++ b/src/content/docs/on-premises/security/module-6.5-workload-identity-spiffe.md
@@ -6,8 +6,6 @@ sidebar:
   order: 65
 ---
 
-# Workload Identity with SPIFFE/SPIRE
-
 ## Why This Module Matters
 
 The 2019 Capital One metadata-service incident (see *Node Metadata Security*) <!-- incident-xref: capital-one-2019 --> shows why static, infrastructure-bound credentials are dangerous: one compromised interface can become a pathway to broad compromise when workload identity is not dynamically validated at runtime.

--- a/src/content/docs/on-premises/security/module-6.6-secrets-management-vault.md
+++ b/src/content/docs/on-premises/security/module-6.6-secrets-management-vault.md
@@ -6,8 +6,6 @@ sidebar:
   order: 66
 ---
 
-# Secrets Management on Bare Metal
-
 ## Learning Outcomes
 
 *   Architect a highly available HashiCorp Vault cluster using Integrated Storage (Raft) on bare metal.

--- a/src/content/docs/on-premises/security/module-6.7-policy-as-code.md
+++ b/src/content/docs/on-premises/security/module-6.7-policy-as-code.md
@@ -8,8 +8,6 @@ sidebar:
   order: 67
 ---
 
-# Policy as Code & Governance
-
 ## Why This Module Matters
 
 A cluster-wide admission policy change can cascade into control-plane instability if critical system namespaces or dependencies are not exempted. For example, a policy that blocks essential system pods from restarting can turn a routine rollout into a widespread outage.

--- a/src/content/docs/on-premises/security/module-6.8-zero-trust-architecture.md
+++ b/src/content/docs/on-premises/security/module-6.8-zero-trust-architecture.md
@@ -6,8 +6,6 @@ sidebar:
   order: 68
 ---
 
-# Zero Trust Architecture
-
 ## Why This Module Matters
 
 In early 2024, the healthcare sector witnessed one of the most devastating cyberattacks in history: the UnitedHealth Group (Change Healthcare) breach. The intrusion began simply enough—attackers from the ALPHV/BlackCat ransomware gang compromised credentials on a remote access portal that lacked multi-factor authentication. However, the catastrophic damage was not caused by the initial entry, but by the network architecture that awaited the attackers once inside. Because the internal infrastructure operated on a legacy, perimeter-based implicit trust model, the attackers were able to move laterally with absolute impunity.

--- a/src/content/docs/on-premises/storage/module-4.4-object-storage-bare-metal.md
+++ b/src/content/docs/on-premises/storage/module-4.4-object-storage-bare-metal.md
@@ -7,8 +7,6 @@ sidebar:
   order: 44
 ---
 
-# Object Storage on Bare Metal
-
 ## Learning Outcomes
 * Architect distributed topologies using Server Pools for horizontal scalability on bare metal hardware.
 * Configure erasure coding profiles to balance storage efficiency against strict fault tolerance requirements.

--- a/src/content/docs/on-premises/storage/module-4.5-database-operators.md
+++ b/src/content/docs/on-premises/storage/module-4.5-database-operators.md
@@ -7,8 +7,6 @@ sidebar:
   order: 45
 ---
 
-# Database Operators
-
 Operating stateful databases on bare-metal Kubernetes requires replacing cloud-provider managed services (like RDS or ElastiCache) with in-cluster orchestration. Standard `StatefulSet` primitives handle identity and stable storage, but lack application-specific knowledge required for safe failover, replication scaling, Point-in-Time Recovery (PITR), and zero-downtime upgrades. 
 
 Database operators encode DBA operational routines into custom controllers. Following the standard Kubernetes Operator pattern, they combine a Custom Resource Definition (CRD) with a custom controller that implements a continuous reconciliation loop, constantly driving the observed state of the database cluster toward the desired state.

--- a/src/content/docs/platform/disciplines/core-platform/platform-engineering/module-2.5-self-service-infrastructure.md
+++ b/src/content/docs/platform/disciplines/core-platform/platform-engineering/module-2.5-self-service-infrastructure.md
@@ -6,8 +6,6 @@ sidebar:
   order: 6
 ---
 
-# Module 2.5: Self-Service Infrastructure
-
 > **Discipline Module** | Complexity: `[COMPLEX]` | Time: 50-60 min
 
 ## Prerequisites

--- a/src/content/docs/platform/disciplines/data-ai/aiops/module-6.5-predictive-operations.md
+++ b/src/content/docs/platform/disciplines/data-ai/aiops/module-6.5-predictive-operations.md
@@ -6,8 +6,6 @@ sidebar:
   order: 6
 ---
 
-# Module 6.5: Predictive Operations
-
 > **Discipline Track** | Complexity: `[COMPLEX]` | Time: 40-45 min
 
 ## Prerequisites

--- a/src/content/docs/platform/disciplines/delivery-automation/gitops/module-3.4-drift-detection.md
+++ b/src/content/docs/platform/disciplines/delivery-automation/gitops/module-3.4-drift-detection.md
@@ -6,8 +6,6 @@ sidebar:
   order: 5
 ---
 
-# Module 3.4: Drift Detection and Remediation
-
 > **Discipline Module** | Complexity: `[MEDIUM]` | Time: 35-45 min | Track: Platform Engineering / GitOps
 
 ## Prerequisites

--- a/src/content/docs/platform/disciplines/reliability-security/devsecops/module-4.2-shift-left-security.md
+++ b/src/content/docs/platform/disciplines/reliability-security/devsecops/module-4.2-shift-left-security.md
@@ -6,8 +6,6 @@ sidebar:
   order: 3
 ---
 
-# Module 4.2: Shift-Left Security
-
 > **Discipline Module** | Complexity: `[MEDIUM]` | Time: 45-55 min | Track: DevSecOps
 
 ## Prerequisites

--- a/src/content/docs/platform/disciplines/reliability-security/devsecops/module-4.5-runtime-security.md
+++ b/src/content/docs/platform/disciplines/reliability-security/devsecops/module-4.5-runtime-security.md
@@ -6,8 +6,6 @@ sidebar:
   order: 7
 ---
 
-# Module 4.5: Runtime Security
-
 > **Discipline Module** | Complexity: `[COMPLEX]` | Time: 45-60 min
 
 ## Prerequisites

--- a/src/content/docs/platform/toolkits/cicd-delivery/ci-cd-pipelines/module-3.3-argo-workflows.md
+++ b/src/content/docs/platform/toolkits/cicd-delivery/ci-cd-pipelines/module-3.3-argo-workflows.md
@@ -6,8 +6,6 @@ sidebar:
   order: 4
 ---
 
-# Module 3.3: Argo Workflows
-
 > **Toolkit Track** | Complexity: `[COMPLEX]` | Time: 55-70 min | Prerequisites: CI/CD concepts, Kubernetes Pods and Jobs, container images, basic YAML, and the idea of a Directed Acyclic Graph.
 
 ## Learning Outcomes

--- a/src/content/docs/platform/toolkits/cicd-delivery/gitops-deployments/module-2.2-argo-rollouts.md
+++ b/src/content/docs/platform/toolkits/cicd-delivery/gitops-deployments/module-2.2-argo-rollouts.md
@@ -6,8 +6,6 @@ sidebar:
   order: 3
 ---
 
-# Module 2.2: Argo Rollouts
-
 > **Toolkit Track** | Complexity: `[COMPLEX]` | Time: 50-65 min
 
 ## Prerequisites

--- a/src/content/docs/platform/toolkits/data-ai-platforms/ml-platforms/module-9.10-bentoml.md
+++ b/src/content/docs/platform/toolkits/data-ai-platforms/ml-platforms/module-9.10-bentoml.md
@@ -5,8 +5,6 @@ sidebar:
   order: 11
 ---
 
-# Module 9.10: BentoML — Python-First Model Packaging and Serving
-
 ## Complexity: [COMPLEX]
 
 **Time to Complete**: 50-60 min

--- a/src/content/docs/platform/toolkits/data-ai-platforms/ml-platforms/module-9.11-bare-metal-mlops.md
+++ b/src/content/docs/platform/toolkits/data-ai-platforms/ml-platforms/module-9.11-bare-metal-mlops.md
@@ -4,7 +4,6 @@ sidebar:
   order: 12
 slug: module-9.11-bare-metal-mlops
 ---
-# Module 9.11: Bare-Metal MLOps — Building a Production ML Platform Without Managed Cloud
 
 ## Complexity: [COMPLEX]
 

--- a/src/content/docs/platform/toolkits/data-ai-platforms/ml-platforms/module-9.8-kserve.md
+++ b/src/content/docs/platform/toolkits/data-ai-platforms/ml-platforms/module-9.8-kserve.md
@@ -5,8 +5,6 @@ sidebar:
   order: 9
 ---
 
-# Module 9.8: KServe — Production-Grade Model Inference on Kubernetes
-
 > **Complexity**: `[COMPLEX]`
 >
 > **Time to Complete**: 55-65 minutes

--- a/src/content/docs/platform/toolkits/data-ai-platforms/ml-platforms/module-9.9-seldon-core.md
+++ b/src/content/docs/platform/toolkits/data-ai-platforms/ml-platforms/module-9.9-seldon-core.md
@@ -5,8 +5,6 @@ sidebar:
   order: 10
 ---
 
-# Module 9.9: Seldon Core — Multi-Framework Model Serving with Inference Graphs
-
 > **Complexity**: `[COMPLEX]`
 >
 > **Time to Complete**: 55-65 minutes

--- a/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.2-opentofu.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.2-opentofu.md
@@ -6,8 +6,6 @@ sidebar:
   order: 3
 ---
 
-# Module 7.2: OpenTofu - The Open Source Fork
-
 ## Complexity: [MEDIUM]
 
 ## Time to Complete: 50 minutes

--- a/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.8-sst.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.8-sst.md
@@ -6,8 +6,6 @@ sidebar:
   order: 9
 ---
 
-# Module 7.8: SST - The Modern Serverless Framework
-
 ## Complexity: [MEDIUM]
 
 ## Time to Complete: 45-50 minutes

--- a/src/content/docs/platform/toolkits/infrastructure-networking/k8s-distributions/module-14.6-managed-kubernetes.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/k8s-distributions/module-14.6-managed-kubernetes.md
@@ -6,8 +6,6 @@ sidebar:
   order: 7
 ---
 
-# Module 14.6: Managed Kubernetes - EKS vs GKE vs AKS
-
 ## Complexity: [COMPLEX]
 
 ## Time to Complete: 55-60 minutes

--- a/src/content/docs/platform/toolkits/infrastructure-networking/networking/module-5.4-metallb.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/networking/module-5.4-metallb.md
@@ -6,8 +6,6 @@ sidebar:
   order: 5
 ---
 
-# Module 5.4: MetalLB - Load Balancing for Bare-Metal Kubernetes
-
 > **Toolkit Track** | Complexity: `[MEDIUM]` | Time: ~45 minutes
 
 **Prerequisites**:

--- a/src/content/docs/platform/toolkits/observability-intelligence/aiops-tools/module-10.2-event-correlation-platforms.md
+++ b/src/content/docs/platform/toolkits/observability-intelligence/aiops-tools/module-10.2-event-correlation-platforms.md
@@ -6,8 +6,6 @@ sidebar:
   order: 3
 ---
 
-# Module 10.2: Event Correlation Platforms
-
 > **Toolkit Track** | Complexity: `[MEDIUM]` | Time: 50-60 min
 
 ## Prerequisites

--- a/src/content/docs/platform/toolkits/observability-intelligence/aiops-tools/module-10.3-observability-ai-features.md
+++ b/src/content/docs/platform/toolkits/observability-intelligence/aiops-tools/module-10.3-observability-ai-features.md
@@ -6,8 +6,6 @@ sidebar:
   order: 4
 ---
 
-# Module 10.3: Observability AI Features
-
 > **Toolkit Track** | Complexity: `[MEDIUM]` | Time: 50-65 minutes
 
 ## Prerequisites

--- a/src/content/docs/platform/toolkits/observability-intelligence/aiops-tools/module-10.4-building-custom-aiops.md
+++ b/src/content/docs/platform/toolkits/observability-intelligence/aiops-tools/module-10.4-building-custom-aiops.md
@@ -6,8 +6,6 @@ sidebar:
   order: 5
 ---
 
-# Module 10.4: Building Custom AIOps
-
 > **Toolkit Track** | Complexity: `[COMPLEX]` | Time: 60-75 minutes
 
 ## Prerequisites

--- a/src/content/docs/platform/toolkits/observability-intelligence/observability/module-1.1-prometheus.md
+++ b/src/content/docs/platform/toolkits/observability-intelligence/observability/module-1.1-prometheus.md
@@ -6,8 +6,6 @@ sidebar:
   order: 2
 ---
 
-# Module 1.1: Prometheus
-
 > **Toolkit Track** | Complexity: `[COMPLEX]` | Time: 45-50 min
 
 ## Prerequisites

--- a/src/content/docs/platform/toolkits/observability-intelligence/observability/module-1.3-grafana.md
+++ b/src/content/docs/platform/toolkits/observability-intelligence/observability/module-1.3-grafana.md
@@ -6,8 +6,6 @@ sidebar:
   order: 4
 ---
 
-# Module 1.3: Grafana
-
 > **Comprehensive Toolkit Track Evaluation Path** | Architectural Complexity Level: `[MEDIUM]` | Estimated Completion Timeframe: 40-45 minutes of focused reading and practical exercises
 
 Prerequisites: complete Module 1.1 on Prometheus metrics collection and Module 1.2 on OpenTelemetry tracing before starting this module. You should already be comfortable reading PromQL, recognizing Kubernetes workload labels, and explaining why modern services need metrics, logs, and traces instead of a single monitoring feed. Kubernetes examples assume version 1.35 or later; when commands use `k`, set the standard shortcut with `alias k=kubectl` before you begin.

--- a/src/content/docs/platform/toolkits/observability-intelligence/observability/module-1.5-tracing.md
+++ b/src/content/docs/platform/toolkits/observability-intelligence/observability/module-1.5-tracing.md
@@ -7,8 +7,6 @@ sidebar:
   order: 6
 ---
 
-# Module 1.5: Distributed Tracing
-
 > **Toolkit Track** | Complexity: `[COMPLEX]` | Time: 55-70 min
 
 > **Prerequisites**: [Module 1.2: OpenTelemetry](../module-1.2-opentelemetry/), [Module 1.1: Prometheus](../module-1.1-prometheus/), [Module 1.4: Loki](../module-1.4-loki/), and working familiarity with HTTP services, Kubernetes Deployments, and basic microservice request flows.

--- a/src/content/docs/platform/toolkits/security-quality/code-quality/module-12.1-sonarqube.md
+++ b/src/content/docs/platform/toolkits/security-quality/code-quality/module-12.1-sonarqube.md
@@ -6,8 +6,6 @@ sidebar:
   order: 2
 ---
 
-# Module 12.1: SonarQube - The Code Quality Platform
-
 ## Complexity: [COMPLEX]
 
 ## Time to Complete: 50-60 minutes


### PR DESCRIPTION
## What

Completes the repo-wide leaked source-H1 cleanup started in #1666 (linux, 27) and #1667 (k8s, 87). Removes the redundant `# Module X.Y: <title>` H1 from the remaining 61 modules across cloud (2), ai-ml-engineering (26), on-premises (11), platform (22). Reconciled exactly against the verifier per track before running.

## Verification

- 61/61 `gate_no_source_h1` flip pass; **0 tier demotions**; pure single-line deletions (0 insertions)
- `npm run build` green — 2129 pages
- Most of these modules still fail body_words/density/other gates — this is correct cleanup, not completion

## Learner check

> First, inventory the machine. The exact numbers will differ on your system, but the interpretation pattern is the important part.

(verbatim from touched `ai-ml-engineering/ai-infrastructure/module-1.4-local-inference-stack-for-learners.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)