### PR TITLE
fix(quality): kubectl-alias gate accepts documented `alias k=kubectl` convention

### DIFF
--- a/scripts/quality/test_verify_module.py
+++ b/scripts/quality/test_verify_module.py
@@ -220,7 +220,7 @@ kubectl get pods
     assert _gate_results(runnable_shell=metrics)["runnable_no_kubectl_alias"] is True
 
 
-def test_runnable_no_kubectl_alias_fails_on_alias_definition() -> None:
+def test_runnable_no_kubectl_alias_passes_on_alias_definition() -> None:
     text = """---
 title: Demo
 ---
@@ -229,11 +229,11 @@ alias k=kubectl
 ```
 """
     metrics = verify_module.runnable_shell_metrics(text)
-    assert metrics["kubectl_alias_violations"] == ["alias k=kubectl"]
-    assert _gate_results(runnable_shell=metrics)["runnable_no_kubectl_alias"] is False
+    assert metrics["kubectl_alias_violations"] == []
+    assert _gate_results(runnable_shell=metrics)["runnable_no_kubectl_alias"] is True
 
 
-def test_runnable_no_kubectl_alias_fails_on_kubectl_shorthand() -> None:
+def test_runnable_no_kubectl_alias_fails_on_kubectl_shorthand_without_alias() -> None:
     text = """---
 title: Demo
 ---
@@ -244,6 +244,20 @@ k get pods
     metrics = verify_module.runnable_shell_metrics(text)
     assert metrics["kubectl_alias_violations"] == ["k get"]
     assert _gate_results(runnable_shell=metrics)["runnable_no_kubectl_alias"] is False
+
+
+def test_runnable_no_kubectl_alias_passes_on_documented_alias_then_shorthand() -> None:
+    text = """---
+title: Demo
+---
+```bash
+alias k=kubectl
+k get pods
+```
+"""
+    metrics = verify_module.runnable_shell_metrics(text)
+    assert metrics["kubectl_alias_violations"] == []
+    assert _gate_results(runnable_shell=metrics)["runnable_no_kubectl_alias"] is True
 
 
 def test_runnable_no_kubectl_alias_allows_text_blocks() -> None:

--- a/scripts/quality/verify_module.py
+++ b/scripts/quality/verify_module.py
@@ -1215,12 +1215,15 @@ def anti_leak_metrics(text: str) -> dict[str, object]:
 
 def runnable_shell_metrics(text: str) -> dict[str, object]:
     _, body = _strip_frontmatter(text)
+    runnable_blocks = [
+        code for info, code in _fenced_code_blocks(body) if _fence_language(info) in RUNNABLE_SHELL_LANGS
+    ]
+    alias_defined = any(KUBECTL_ALIAS_RE.search(code) for code in runnable_blocks)
+    if alias_defined:
+        return {"kubectl_alias_violations": []}
+
     violations: list[str] = []
-    for info, code in _fenced_code_blocks(body):
-        if _fence_language(info) not in RUNNABLE_SHELL_LANGS:
-            continue
-        if KUBECTL_ALIAS_RE.search(code):
-            violations.append("alias k=kubectl")
+    for code in runnable_blocks:
         for match in KUBECTL_SHORTHAND_RE.finditer(code):
             violations.append(match.group(0).strip())
     return {"kubectl_alias_violations": violations}


### PR DESCRIPTION
## What

Retunes the `runnable_no_kubectl_alias` gate so the curriculum's **deliberate** `alias k=kubectl` shorthand convention passes (user decision, 2026-05-30: keep `k`, retune the gate).

**New semantics:** if a module defines `alias k=kubectl` in a runnable block, it's using the documented convention → no violations. Only `k <verb>` shorthand used *without* defining the alias is flagged (genuinely broken copy-paste).

## Impact (measured across the curriculum)

- 129 modules were failing the gate
- **86 now pass** (they define the documented alias)
- **43 still fail** — they use `k` shorthand without ever defining the alias = a real copy-paste bug, correctly caught (content follow-up)
- **67 modules reach T0** from this change alone

## Tests

- 44/44 verifier tests pass (3 kubectl tests updated + 1 added per the three-way rule)

Regression test: scripts/quality/test_verify_module.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)