### PR TITLE
chore(content): fix Phase-1 review findings in zero-to-terminal 0.6 + 0.7

### DIFF
--- a/src/content/docs/prerequisites/zero-to-terminal/module-0.6-git-basics.md
+++ b/src/content/docs/prerequisites/zero-to-terminal/module-0.6-git-basics.md
@@ -92,12 +92,14 @@ git version 2.39.2
 
 Before creating commits, configure the identity Git will place into commit metadata. This is not the same thing as authenticating to GitHub during a push. The name and email configured here answer the question, "Who authored this snapshot?" Remote authentication answers a different question: "Is this person allowed to upload to that server?" Keeping those concepts separate prevents confusion when a commit succeeds locally but a push later asks for credentials.
 
+Replace the placeholder name and email below with your own real values before you run the commands.
+
 ```bash
 # Set your name (use your real name, this appears in the history)
-git config --global user.name "Alex Chen"
+git config --global user.name "Your Name"
 
 # Set your email address
-git config --global user.email "alex.chen@example.com"
+git config --global user.email "you@example.com"
 ```
 
 The `--global` flag writes to configuration associated with your user account on this computer, usually in `~/.gitconfig`. You can also set repository-specific configuration without `--global`, which is useful when one laptop contributes to both personal and work repositories. For now, a global beginner setup is enough, and you can inspect it with a command that prints the settings Git sees.
@@ -114,7 +116,7 @@ mkdir k8s-webapp
 cd k8s-webapp
 
 # Tell Git to start tracking this directory
-git init
+git init --initial-branch=main
 ```
 
 Expected output should confirm that Git created an empty repository database in a hidden `.git` directory.
@@ -306,13 +308,13 @@ The output should show the most recent commit first, followed by the earlier roo
 
 ```text
 commit 9f8e7d6c5b4a39281716151413121110abcdef12 (HEAD -> main)
-Author: Alex Chen <alex.chen@example.com>
+Author: Your Name <you@example.com>
 Date:   Wed Oct 12 10:45:12 2023 -0400
 
     chore: add environment label to namespace
 
 commit a1b2c3d4e5f60718293a4b5c6d7e8f9012345678
-Author: Alex Chen <alex.chen@example.com>
+Author: Your Name <you@example.com>
 Date:   Wed Oct 12 10:15:30 2023 -0400
 
     feat: add production namespace definition
@@ -540,7 +542,7 @@ Create a new directory named `dojo-k8s-project`, navigate into it, and initializ
 ```bash
 mkdir dojo-k8s-project
 cd dojo-k8s-project
-git init
+git init --initial-branch=main
 git status
 ```
 
@@ -646,7 +648,7 @@ git commit -m "fix: set deployment replicas to 3"
 
 ### Task 5: Reviewing the Timeline
 
-Run a command to view your complete commit history in a compact, single-line format. Verify that all three of your commits are present in chronological order. If a commit is missing, use `git status` to determine whether the change is still unstaged, staged, or never created.
+Run a command to view your complete commit history in a compact, single-line format. Verify that all three of your commits are present with the most recent first (the default for `git log --oneline`). If a commit is missing, use `git status` to determine whether the change is still unstaged, staged, or never created.
 
 - [ ] History command executed.
 - [ ] Three distinct commits visible in the output.

--- a/src/content/docs/prerequisites/zero-to-terminal/module-0.7-what-is-networking.md
+++ b/src/content/docs/prerequisites/zero-to-terminal/module-0.7-what-is-networking.md
@@ -373,7 +373,7 @@ Keep this decision framework in your notes as a small checklist, not as a script
 
 ## Did You Know?
 
-1. **DNS replaced a hand-maintained host list.** Before DNS became the standard in 1983, early internet hosts relied on centrally maintained host tables, and RFC 1034 explains why that approach stopped scaling as the network grew.
+1. **DNS replaced a hand-maintained host list.** Before DNS became standard in 1983, early internet hosts relied on a centrally distributed `HOSTS.TXT` file; as the network grew, that single-file approach stopped scaling. DNS was introduced in 1983, and the familiar hierarchical design most systems use today was documented in 1987 (RFC 1034).
 2. **IPv4 has about 4.3 billion possible addresses.** That once sounded enormous, but the public internet, mobile devices, cloud platforms, and always-connected systems made address sharing and IPv6 adoption necessary.
 3. **Ports have a standardized registry.** RFC 6335 describes how service names and port numbers are managed, which is why familiar services such as HTTP, HTTPS, DNS, and SSH have widely recognized default ports.
 4. **Kubernetes has its own default API port.** The Kubernetes API server commonly uses secure port 6443, so beginner port reasoning applies directly when `kubectl` cannot reach a cluster.


### PR DESCRIPTION
## What

Phase-1 back-catalog cross-family review fixes for two more **Zero to Terminal** modules (0.6 codex 4.4, 0.7 composer-2.5 4.4). Reviewed → NEEDS_CHANGES → fixed (cursor) → mechanical/factual fixes orchestrator-verified against the reviewer must-fix list.

**0.6 — Git Basics:**
- `git init` assumed a `main` branch, but modern Git defaults to `master` → now `git init --initial-branch=main` (both occurrences), so the `On branch main` output and later `git push -u origin main` are correct.
- Beginner foot-gun: a copy-paste block set **global** git identity to a fake person ("Alex Chen") → now obvious placeholders (`Your Name` / `you@example.com`) with a substitute-your-own note; sample author lines reconciled.
- "Verify ... in chronological order" contradicted `git log --oneline`'s newest-first default → now "most recent first (the default for `git log --oneline`)".

**0.7 — What is Networking:**
- Factual/citation error: implied RFC 1034 (1987) explained pre-1983 DNS history → corrected timeline (centrally distributed `HOSTS.TXT` → DNS introduced 1983 → hierarchical design documented 1987, RFC 1034).

Build: green.

## Learner check

> Construct focused commits by moving selected file changes from the working directory into the staging area and then into repository history.

Refs #1504
