### PR TITLE
chore(content): fix Phase-1 review findings in zero-to-terminal 0.9 + 0.10 + 0.11

### DIFF
--- a/src/content/docs/prerequisites/zero-to-terminal/module-0.10-what-is-the-cloud.md
+++ b/src/content/docs/prerequisites/zero-to-terminal/module-0.10-what-is-the-cloud.md
@@ -9,7 +9,7 @@ revision_pending: false
 >
 > **Time to Complete**: 35 minutes
 >
-> **Prerequisites**: [Module 0.7 - Servers and SSH](/prerequisites/zero-to-terminal/module-0.8-servers-and-ssh/)
+> **Prerequisites**: [Module 0.8 - Servers and SSH](/prerequisites/zero-to-terminal/module-0.8-servers-and-ssh/)
 
 ---
 
@@ -124,7 +124,7 @@ AWS launched its early public cloud services in 2006 and became the reference po
 
 ```
 - The first major cloud provider (launched 2006)
-- As of Q4 2025, Synergy Research Group and Canalys both still placed AWS first by public-cloud revenue
+- AWS is generally the largest public cloud by revenue, with Microsoft Azure and Google Cloud the other two leaders
 - The "original" -- many companies' first cloud platform
 - Kitchen analogy: The biggest chain, the one everyone knows
 ```
@@ -259,8 +259,9 @@ Kubernetes belongs at the end of this beginner path because it manages the compl
 Module 0.1: You learned about one computer (one kitchen)
 Module 0.3: You learned to give commands to that kitchen
 Module 0.5: You learned to write instructions (recipes/scripts)
-Module 0.7: You learned to connect to remote kitchens
-Module 0.9: You learned that the cloud has THOUSANDS of kitchens for rent
+Module 0.8: You learned to connect to remote kitchens (servers and SSH)
+Module 0.9: You learned to install software and manage packages on those kitchens
+Module 0.10: You learned that the cloud has THOUSANDS of kitchens for rent
 
 NOW: Kubernetes is the system that manages all of those kitchens.
 ```
@@ -295,16 +296,17 @@ Kubernetes also shows why abstraction is useful but never free. A Deployment can
 You have also reached the point where the Zero to Terminal track turns into cloud-native work. The next modules will introduce containers, Docker fundamentals, Kubernetes basics, and eventually certification-oriented skills. Those topics will add commands and objects, but the foundation remains the same: software runs on computers, computers need storage and networks, and reliable systems require deliberate operating models.
 
 ```
-Zero to Terminal (YOU ARE HERE -- COMPLETE!)
+Zero to Terminal (YOU ARE HERE -- almost done!)
   ✓ Understand computers
   ✓ Use the terminal
   ✓ Edit files
   ✓ Understand servers and SSH
   ✓ Understand cloud computing
+  → Capstone next: Module 0.11 (Your First Server)
 
         ↓
 
-Cloud Native 101 (NEXT)
+Cloud Native 101 (after Zero to Terminal)
   → What are containers?
   → Docker fundamentals
   → What is Kubernetes?

--- a/src/content/docs/prerequisites/zero-to-terminal/module-0.11-your-first-server.md
+++ b/src/content/docs/prerequisites/zero-to-terminal/module-0.11-your-first-server.md
@@ -102,7 +102,11 @@ On macOS or Windows, install one of those desktop tools and start it before usin
 sudo apt update && sudo apt install docker.io -y
 sudo systemctl start docker
 sudo usermod -aG docker $USER
+```
 
+**Important:** The new `docker` group is not active in your current shell. Start a **new terminal session** (log out and back in), or run `newgrp docker`, **before** the `docker run` commands below — otherwise you will get "permission denied".
+
+```bash
 # Option B: Podman (no daemon, no root needed)
 sudo apt update && sudo apt install podman -y
 ```
@@ -472,7 +476,13 @@ The expected result is the raw HTML of your page or an HTTP response that clearl
 
 ### Task 3: Break the Deployment Deliberately
 
-Introduce one controlled failure and write down the symptom before fixing it. For Option A, stop and remove your working container, then start a replacement with a different host port such as `docker run -d -p 9090:80 --name broken-site nginx`; visiting the old 8080 URL should fail. For Option B, rename `/var/www/html/index.html` to `/var/www/html/broken.html`; the root URL should no longer show the custom page.
+Introduce one controlled failure and write down the symptom before fixing it. For Option A, stop and remove your working container, then start a replacement with a different host port such as `docker run -d -p 9090:80 --name broken-site nginx`; visiting the old 8080 URL should fail. For Option B, rename the web root file:
+
+```bash
+sudo mv /var/www/html/index.html /var/www/html/broken.html
+```
+
+The root URL should no longer show the custom page.
 
 <details>
 <summary>Solution guidance</summary>
@@ -531,7 +541,7 @@ You have finished **Zero to Terminal**. From here, choose [Linux Fundamentals](/
 
 ```mermaid
 graph TD
-    Current(["YOU ARE HERE<br/>Module 0.10 (Capstone)"]) --> PathA["Path A<br/>Linux Deep Dive"]
+    Current(["YOU ARE HERE<br/>Module 0.11 (Capstone)"]) --> PathA["Path A<br/>Linux Deep Dive"]
     Current --> PathB["Path B<br/>Cloud Native 101"]
 
     PathA --> L1["Kernel, processes<br/>Networking internals<br/>Security, hardening"]

--- a/src/content/docs/prerequisites/zero-to-terminal/module-0.9-software-and-packages.md
+++ b/src/content/docs/prerequisites/zero-to-terminal/module-0.9-software-and-packages.md
@@ -257,7 +257,19 @@ A possible output might look like this. The exact home directory prefix and file
         └── pasta-carbonara.txt
 ```
 
-Updating installed software is a separate operational decision. On Ubuntu and Debian, you normally refresh metadata first and then apply available upgrades. The first command asks what is available now; the second changes installed packages based on that refreshed view.
+Updating installed software is a separate operational decision, and the inspect-before-mutate habit matters here too. On Ubuntu and Debian, list packages that would be upgraded before you change anything:
+
+```bash
+apt list --upgradable
+```
+
+On macOS, Homebrew's non-mutating equivalent is:
+
+```bash
+brew outdated
+```
+
+Read that plan first. Only after you understand what would change should you refresh metadata and apply upgrades. On Ubuntu and Debian, `apt update` refreshes the catalog and `apt upgrade` applies available package upgrades:
 
 ```bash
 sudo apt update
@@ -270,11 +282,15 @@ You will often see the two commands joined with `&&`. The operator means "run th
 sudo apt update && sudo apt upgrade
 ```
 
+Run those upgrade commands only after reviewing the plan, ideally in a disposable lab or VM.
+
 Homebrew uses a similar two-step shape with different verbs. `brew update` refreshes Homebrew's metadata, while `brew upgrade` upgrades installed formulae that have newer versions available.
 
 ```bash
 brew update && brew upgrade
 ```
+
+Again, run `brew update && brew upgrade` only after reviewing `brew outdated`, ideally in a disposable lab or VM.
 
 Removing software should also go through the package manager when possible. If you installed a package with `apt`, let `apt` remove it so the package database stays accurate. Manually deleting binaries can leave configuration files, dependencies, service units, or package records behind, which makes later troubleshooting harder.
 
@@ -482,10 +498,10 @@ The successful result is not a particular package count. The important sign is t
 
 ### Task 2: Install and Run `htop`
 
-On Ubuntu or Debian, install `htop` with `apt`. The `-y` flag automatically answers yes to confirmation prompts, which is convenient in labs but should be used carefully on important machines because it skips a manual confirmation moment.
+On Ubuntu or Debian, install `htop` with `apt`. When prompted, read the proposed package and dependency plan, then type `y` only if it matches your expectations. The `-y` flag automatically answers yes to confirmation prompts, which is convenient in scripted labs but skips that manual confirmation moment on important machines.
 
 ```bash
-sudo apt install htop -y
+sudo apt install htop
 ```
 
 On macOS, install the same tool with Homebrew. Notice again that the package name is the same while the package manager and privilege model differ.
@@ -508,10 +524,10 @@ A successful run opens the interactive `htop` interface rather than printing "co
 
 ### Task 3: Install and Use `tree`
 
-On Ubuntu or Debian, install `tree` through `apt`. This utility is small, but it teaches the same install pattern you will later use for more important tools.
+On Ubuntu or Debian, install `tree` through `apt`. Read the dependency plan when prompted, then confirm with `y` only if it looks right. This utility is small, but it teaches the same install pattern you will later use for more important tools.
 
 ```bash
-sudo apt install tree -y
+sudo apt install tree
 ```
 
 On macOS, install `tree` through Homebrew. If the package is already installed, Homebrew should tell you instead of installing a duplicate copy.


### PR DESCRIPTION
## What

Phase-1 back-catalog cross-family review fixes for the last three reviewed **Zero to Terminal** modules. Each was cross-family reviewed (0.9 codex 4.1, 0.10 cursor 4.6, 0.11 gemini-cli 4.8), found NEEDS_CHANGES, fixed (cursor `--model auto`), and orchestrator-verified against the reviewer must-fix list. (0.8 reviewed APPROVE separately — no change needed.)

**0.9 — Software and Packages:** lead with inspect-first (`apt list --upgradable` / `brew outdated`) before bulk-upgrade commands; removed `-y` from beginner install exercises so the confirmation-reading habit the module teaches isn't skipped.

**0.10 — What is the Cloud:** fixed module cross-reference numbers (prereq link text 0.7→0.8; recap remapped to 0.8 ssh / 0.9 packages / 0.10 cloud); "Zero to Terminal COMPLETE!" → "almost done, capstone 0.11 next"; softened an uncited "Q4 2025 Synergy/Canalys" analyst claim to a non-dated general statement.

**0.11 — Your First Server:** added a bold new-terminal/`newgrp docker` caution after `usermod -aG docker` (otherwise `docker run` fails with permission denied); fixed Mermaid diagram label 0.10→0.11; added the explicit `sudo mv` command for Task 3 Option B parity.

Build: green.

## Learner check

> This utility is small, but it teaches the same install pattern you will later use for more important tools.

Refs #1504
