### PR TITLE
chore(content): fix Phase-1 review findings in cloud-native-101 1.1-1.4

### DIFF
--- a/src/content/docs/prerequisites/cloud-native-101/module-1.1-what-are-containers.md
+++ b/src/content/docs/prerequisites/cloud-native-101/module-1.1-what-are-containers.md
@@ -125,8 +125,8 @@ The diagram shows why startup time and density differ. A VM boots a guest OS bef
 | Startup | Minutes | Seconds |
 | OS | Full guest OS per VM | Shared host kernel |
 | Isolation | Hardware virtualization | Process isolation |
-| Portability | VM image formats vary | Universal container images |
-| Density | ~10-20 VMs per server | ~100s of containers per server |
+| Portability | VM image formats vary | Often portable across hosts with the same OS kernel family and CPU architecture |
+| Density | Typically fewer VMs per host | Often many more containers per host because they share one kernel |
 
 The table should not be read as a scoreboard where every smaller number wins. Hardware virtualization is the right tool when a workload requires a different operating system kernel, custom kernel modules, or a stronger isolation boundary between tenants. A legacy Windows Server application does not become Linux-compatible because it is packaged in a Linux container. If it needs Windows kernel behavior, it needs a Windows environment, usually a VM or a Windows container on a Windows host.
 
@@ -235,7 +235,7 @@ flowchart LR
     subgraph Cloud [Cloud Registries]
         direction TB
         AWS[AWS ECR: *.dkr.ecr.*.amazonaws.com]
-        GCP[Google GCR: gcr.io]
+        GCP[Google Artifact Registry: LOCATION-docker.pkg.dev]
         AZ[Azure ACR: *.azurecr.io]
     end
 ```
@@ -244,7 +244,12 @@ Pulling an image downloads the referenced layers and metadata to a machine that 
 
 ```bash
 docker pull nginx              # From Docker Hub
-docker pull gcr.io/project/app # From Google
+```
+
+Google Artifact Registry uses a different hostname than Docker Hub. Private repositories require authentication, so the pull syntax is shown here as a reference rather than a copy-paste lab command:
+
+```text
+docker pull us-docker.pkg.dev/my-project/my-repo/my-app:latest
 ```
 
 Image references carry a specific structure. The registry portion is optional because Docker Hub is the default in many tools. A namespace or organization may be present. The repository identifies the image name, and the tag identifies a named version or channel. The danger is that tags are not guaranteed to be immutable unless your registry policy enforces it. A tag is a pointer, and pointers can move.
@@ -254,9 +259,10 @@ Image references carry a specific structure. The registry portion is optional be
 
 Examples:
 nginx                           # Docker Hub, library/nginx:latest
-nginx:1.25                      # Docker Hub, specific version
+nginx:1.31.1                    # Docker Hub, specific version
 mycompany/myapp:v1.0.0         # Docker Hub, custom namespace
-gcr.io/myproject/myapp:latest  # Google Container Registry
+us-docker.pkg.dev/my-project/my-repo/my-app:latest  # Google Artifact Registry
+gcr.io/myproject/myapp:latest  # Legacy Google Container Registry (read-only; migrated to Artifact Registry)
 ghcr.io/username/app:sha-abc123 # GitHub Container Registry
 ```
 
@@ -264,15 +270,15 @@ Production deployments should avoid mutable tags like `latest` because they hide
 
 ```text
 nginx:latest     # Whatever is newest (unpredictable!)
-nginx:1.25       # Specific version (better)
-nginx:1.25.3     # Exact version (best for production)
+nginx:1.31       # Specific version line (better)
+nginx:1.31.1     # Exact patch version (best for production)
 
 Rule: Never use :latest in production
 ```
 
 Hypothetical scenario: a team runs `postgres:latest` for months because the first demo worked and nobody revisits the image reference. The container starts cleanly after each routine restart until a host reboot pulls a newer major image with incompatible expectations for the data directory. The database refuses to start, recovery requires downgrading and careful data handling, and the team loses most of a night to a deployment choice that had looked harmless. Pinning tags is not bureaucracy; it is how you make time behave when automation repeats a deployment after humans have stopped watching the registry.
 
-Before running this in your own environment, what output would you expect if you pulled `nginx:1.25` twice in a row? The second pull should reuse layers already present locally unless the registry metadata has changed. That small observation previews a major operational benefit: layered images make repeated deployments cheaper because unchanged content does not need to move again.
+Before running this in your own environment, what output would you expect if you pulled `nginx:1.31.1` twice in a row? The second pull should reuse layers already present locally unless the registry metadata has changed. That small observation previews a major operational benefit: layered images make repeated deployments cheaper because unchanged content does not need to move again.
 
 Image naming also becomes a supply-chain control. A registry path can tell you who owns the artifact, a tag can tell you the intended release channel, and a digest can tell you the exact content. Mature teams use all three pieces deliberately. They avoid ambiguous image names, restrict who can push production repositories, scan images before promotion, and record the image reference used in each deployment so an incident can be traced to a precise artifact.
 
@@ -353,7 +359,7 @@ The same vocabulary check helps during reviews of learning labs. A command that 
 
 ## Did You Know?
 
-- **Containers are older than Docker.** Unix had chroot in 1979, FreeBSD Jails arrived in 2000, Linux Containers appeared in 2008, and Docker made the workflow approachable in 2013.
+- **Containers are older than Docker.** The ideas trace back through Unix chroot, BSD jails, and Linux container features, which Docker made approachable for everyday use in 2013.
 - **Alpine Linux is tiny by design.** A minimal Alpine base image is commonly only a few megabytes, while a general Ubuntu base is much larger and a full VM image can be measured in gigabytes.
 - **Container images are intended to be immutable release artifacts.** Once an image is built and identified by digest, changing behavior should mean building a new image rather than editing a running container by hand.
 - **The Docker whale is named Moby Dock.** The mascot works because the metaphor connects software containers to standardized shipping containers carried across different transport systems.

--- a/src/content/docs/prerequisites/cloud-native-101/module-1.2-docker-fundamentals.md
+++ b/src/content/docs/prerequisites/cloud-native-101/module-1.2-docker-fundamentals.md
@@ -318,7 +318,7 @@ Record the Python dependency in `requirements.txt` so dependency installation ca
 flask==3.0.0
 ```
 
-> **Stop and think**: A developer once typed `docker build .` in their home directory instead of the project directory. Because they lacked a `.dockerignore` file, Docker dutifully attempted to copy their entire `Documents`, `Downloads`, and `Pictures` folders into the Docker build context. The build hung for 20 minutes before crashing the machine's memory, which is why build context should be treated as part of the artifact design rather than a harmless default.
+> **Stop and think**: If you run `docker build .` in your home directory without a `.dockerignore`, Docker will try to copy everything — Documents, Downloads, Pictures — into the build context, which can hang the build and exhaust memory. That's why build context belongs in your artifact design, not left to default.
 
 Now create the Dockerfile for the application image, keeping the dependency copy before the source copy so normal code edits do not reinstall Flask.
 ```dockerfile

--- a/src/content/docs/prerequisites/cloud-native-101/module-1.3-what-is-kubernetes.md
+++ b/src/content/docs/prerequisites/cloud-native-101/module-1.3-what-is-kubernetes.md
@@ -9,7 +9,7 @@ sidebar:
 >
 > **Time to Complete**: 30-35 minutes
 >
-> **Prerequisites**: Module 1 (Containers), Module 2 (Docker). This lesson assumes you can explain why teams package applications as containers and can recognize a basic Docker image or container command, but it does not assume previous Kubernetes experience.
+> **Prerequisites**: Module 1.1 (Containers), Module 1.2 (Docker). This lesson assumes you can explain why teams package applications as containers and can recognize a basic Docker image or container command, but it does not assume previous Kubernetes experience.
 
 ---
 
@@ -150,7 +150,7 @@ flowchart TD
     API <==>|"Manages"| K3
 ```
 
-> **Connect to Module 0.1**: Remember the restaurant kitchen from Module 0.1? The control plane is the restaurant management team. The API Server is the front desk where all orders go, the Scheduler is the floor manager deciding which kitchen handles which order, etcd is the order log recording the truth, and the Controller Manager is the shift supervisor checking that the right number of staff are working.
+> **Restaurant analogy**: Picture a busy restaurant kitchen. The control plane is the management team that coordinates work without cooking every dish itself. The API Server is the front desk where all orders go, the Scheduler is the floor manager deciding which kitchen station handles which order, etcd is the order log recording the truth, and the Controller Manager is the shift supervisor checking that the right number of staff are working.
 
 The API server is the front door to the cluster. Every create, update, delete, and read operation goes through it, whether the request came from `k`, a CI pipeline, a controller, or a custom operator. This central entry point gives Kubernetes a consistent place to authenticate users, authorize requests, validate resource shape, and store accepted changes. When the API server is unreachable, the cluster becomes hard to manage even if many workloads are still serving traffic.
 

--- a/src/content/docs/prerequisites/cloud-native-101/module-1.4-cloud-native-ecosystem.md
+++ b/src/content/docs/prerequisites/cloud-native-101/module-1.4-cloud-native-ecosystem.md
@@ -26,9 +26,9 @@ After this module, you will be able to:
 
 ## Why This Module Matters
 
-At 02:18 on a holiday sale weekend, a mid-sized e-commerce company discovered that its Kubernetes migration had not created a platform; it had created a museum of every cloud native project that had impressed someone in a conference talk. The lead architect had mandated a complex service mesh before the team had reliable metrics, selected a sandbox distributed database before the operations team had backup drills, and enabled advanced eBPF networking before anyone could explain the packet path during an outage. When checkout latency spiked, the incident room filled with dashboards, proxy logs, custom resource definitions, and half-remembered architecture diagrams, but no one could tell which layer owned the failure.
+Imagine a holiday-sale weekend where a team discovers their Kubernetes migration did not create a platform; it created a museum of every cloud native project that had impressed someone in a conference talk. The lead architect mandated a complex service mesh before the team had reliable metrics, selected a sandbox distributed database before the operations team had backup drills, and enabled advanced eBPF networking before anyone could explain the packet path during an outage. When checkout latency spikes, the incident room fills with dashboards, proxy logs, custom resource definitions, and half-remembered architecture diagrams, but no one can tell which layer owns the failure.
 
-The bill was not theoretical. The company lost a full afternoon of peak orders, paid emergency consulting fees, and spent the following quarter unwinding tools that had been adopted before their problem statements were clear. The painful lesson was that the CNCF landscape is a menu, not a checklist. A production platform needs a small set of well-operated tools that solve known problems; it does not need every project that appears near Kubernetes on a landscape map.
+In that scenario, the cost is real: a full afternoon of peak orders lost, emergency consulting fees, and a quarter spent unwinding tools adopted before their problem statements were clear. The painful lesson is that the CNCF landscape is a menu, not a checklist. A production platform needs a small set of well-operated tools that solve known problems; it does not need every project that appears near Kubernetes on a landscape map.
 
 This module teaches you how to read that ecosystem without drowning in it. You will learn how CNCF maturity levels signal risk, how tool categories map to real operational problems, and why a beginner should recognize more tools than they can operate deeply. The goal is not to memorize hundreds of logos. The goal is to hear a teammate say "we need policy enforcement," "we need GitOps," or "we need distributed tracing," and know which part of the ecosystem they are reaching for, what trade-off they are accepting, and what question to ask before the tool enters production.
 
@@ -50,19 +50,16 @@ flowchart TD
             K8s[Kubernetes]
             Helm[Helm]
             Prom[Prometheus]
-            Cont[containerd]
-            Flu[Fluentd]
-            Env[Envoy]
-            Jae[Jaeger]
-            Vit[Vitess]
+            Arg[Argo]
+            Cil[Cilium]
+            Fal[Falco]
         end
         
         subgraph Incubating ["INCUBATING PROJECTS (Growing adoption, maturing)"]
             direction LR
-            Arg[Argo]
-            Cil[Cilium]
-            Fal[Falco]
-            Kus[Kustomize]
+            BS[Backstage]
+            Th[Thanos]
+            Lit[Litmus]
         end
         
         subgraph Sandbox ["SANDBOX PROJECTS (Early stage, experimental)"]


### PR DESCRIPTION
## What

Phase-1 back-catalog cross-family review fixes for **Cloud Native 101** modules 1.1–1.4 (continuing the curriculum-order review sweep after the zero-to-terminal chapter). Each was cross-family reviewed (1.1 codex 4.3, 1.2 agy 4.5, 1.3 cursor-auto 4.6, 1.4 gemini 4.5), found NEEDS_CHANGES, fixed (cursor `--model auto`), and verified against the reviewers' specified corrections.

**1.1 — What are Containers:** deprecated Google Container Registry → Artifact Registry (`LOCATION-docker.pkg.dev/...`, gcr.io noted as legacy); stale `nginx:1.25` → current `nginx:1.31` line; unsourced exact density counts → qualified tendencies with portability caveats; unsourced container-history dates → simplified; non-runnable `gcr.io/project/app` pull moved to a `text` reference block.

**1.2 — Docker Fundamentals:** reframed a fabricated war-story (a build-context mishap stated as something that "once" happened) into an explicit hypothetical.

**1.3 — What is Kubernetes:** fixed prerequisite cross-references ("Module 1/2" → "Module 1.1/1.2"); made the restaurant-kitchen analogy self-contained instead of depending on an unlinked Zero-to-Terminal module.

**1.4 — Cloud Native Ecosystem:** reframed a fabricated "02:18 holiday-sale" war-story as a hypothetical; corrected the CNCF maturity diagram (Argo/Cilium/Falco are Graduated not Incubating; removed Kustomize which isn't a standalone CNCF project; Incubating now shows Backstage/Thanos/Litmus).

Build: green.

## Learner check

> The API Server is the front desk where all orders go, the Scheduler is the floor manager deciding which kitchen station handles which order, etcd is the order log recording the truth, and the Controller Manager is the shift supervisor checking that the right number of staff are working.

Refs #1504
