### PR TITLE
chore(content): fix Phase-1 review findings in kubernetes-basics 1.1/1.3/1.6/1.7/1.8

### DIFF
--- a/src/content/docs/prerequisites/kubernetes-basics/module-1.1-first-cluster.md
+++ b/src/content/docs/prerequisites/kubernetes-basics/module-1.1-first-cluster.md
@@ -127,10 +127,10 @@ Local Kubernetes tools all answer the same high-level need, but they do not buil
 
 | Tool | Underlying Architecture | Primary Use Case | Pros | Cons |
 |---|---|---|---|---|
-| **minikube** | Virtual Machines (historically) or Containers | Traditional local development | Massive feature set, mature ecosystem. VM mode uses fixed-size virtual disks, protecting host disk space. | Can be heavily resource intensive. Slower startup times. Emulates a cluster rather than running pure upstream. |
+| **minikube** | Virtual Machines (historically) or Containers | Traditional local development | Massive feature set, mature ecosystem. VM mode uses fixed-size virtual disks, protecting host disk space. | Can be heavily resource intensive. Slower startup times. Driver and runtime choices, add-ons, and local-dev defaults differ from a bare upstream cluster even though minikube runs real Kubernetes locally. |
 | **kind** (Kubernetes IN Docker) | Docker Containers acting as Nodes | CI/CD pipelines, automated testing, rigorous local dev | Extremely fast, identical to pure upstream Kubernetes, highly customizable multi-node topologies. | Requires Docker daemon. Complex networking edge cases when exposing services to host. |
 | **k3d** | Docker Containers running k3s | Edge computing simulation, IoT | Minimal memory footprint, extraordinarily fast startup. | Uses k3s (a stripped-down, modified Kubernetes distribution), which may lack 100% parity with cloud providers. |
-| **Docker Desktop / Colima** | Integrated Hypervisor / Lightweight VM | Quick validation for Mac/Windows users | Zero configuration, GUI integration, easy volume mounting. | Inflexible, limited strictly to a single monolithic node, tightly coupled to the virtualization engine. |
+| **Docker Desktop / Colima** | Integrated Hypervisor / Lightweight VM | Quick validation for Mac/Windows users | Zero configuration, GUI integration, easy volume mounting. | Inflexible compared with scriptable tools; Docker Desktop Kubernetes was historically single-node, though newer versions can provision multi-node clusters via the kind provisioner. Tightly coupled to the virtualization engine. |
 
 `kind` stands for Kubernetes IN Docker, and the name is literal. A `kind` node is a Docker container that is privileged enough to run Kubernetes node processes inside it. When you create a three-node `kind` cluster, Docker starts three node containers, and each node container runs its own kubelet and `containerd`. The cluster feels distributed to Kubernetes because each node has a separate identity and network address, even though all of those nodes are ultimately containers on your workstation. This is not the same as production hardware, but it is close enough to teach scheduling, kubeconfig, controller behavior, and many networking patterns.
 
@@ -604,8 +604,10 @@ You should see exactly three nodes listed, all explicitly marked with the contro
 Finally, practice cleaning up the environment and observing a raw control plane failure.
 
 ```bash
-# Aggressively clean up the environment
-kind delete cluster --all
+# Delete only the lab clusters created earlier in this exercise
+kind delete cluster --name primary-dojo
+kind delete cluster --name legacy-dojo
+kind delete cluster --name ha-dojo
 
 # Create the target cluster
 kind create cluster --name broken-dojo
@@ -621,6 +623,11 @@ kubectl get nodes
 ```
 
 The connection will either hang until timeout or immediately fail with a TCP connection refused error. This demonstrates that without the API server container operating, the cluster interface is unavailable. You cannot read state through Kubernetes, nor can you alter it, even if some previous workload process might have existed before the control plane disappeared.
+
+```bash
+# Remove the failure-lab cluster when you are done observing
+kind delete cluster --name broken-dojo
+```
 </details>
 
 ### Success Criteria

--- a/src/content/docs/prerequisites/kubernetes-basics/module-1.3-pods.md
+++ b/src/content/docs/prerequisites/kubernetes-basics/module-1.3-pods.md
@@ -155,7 +155,7 @@ spec:
   initContainers:
     - name: vault-bootstrap
       image: hashicorp/vault-agent:1.16
-      command: ["/bin/sh", "-c", "vault pull-secrets > /shared/secrets.env"]
+      command: ["/app/fetch-secrets.sh"]
       volumeMounts:
         - name: tmp-scratch-data
           mountPath: /shared
@@ -373,7 +373,21 @@ In this hands-on exercise, you will create a multi-container Pod, inspect its sh
 
 Write a declarative YAML manifest named `multi-pod.yaml` that creates a single Pod containing two communicating containers. The Pod name should be `web-logger`. The first container should be named `nginx-server`, use the `nginx:1.27-alpine` public image, and mount a shared volume named `html-dir` at `/usr/share/nginx/html`. The second container should be named `content-writer`, use the `busybox:1.36.1` public image, mount the same volume at `/data`, and continuously write the current date to `/data/index.html` every 5 seconds. The shared volume must be an `emptyDir`.
 
-**Solution:**
+<details>
+<summary>Concept hint</summary>
+
+Both containers need the same `emptyDir` volume declared once under `spec.volumes`, then mounted at different paths so the writer updates a file the web server can serve.
+</details>
+
+<details>
+<summary>Command hint</summary>
+
+Define `spec.volumes` with `emptyDir: {}`, then give each container a `volumeMounts` entry pointing at that volume name with the paths from the task description.
+</details>
+
+<details>
+<summary>Full solution</summary>
+
 ```yaml
 apiVersion: v1
 kind: Pod
@@ -397,13 +411,28 @@ spec:
           mountPath: /data
 ```
 </details>
+</details>
 
 <details>
 <summary>Task 2: Apply and Verify the Architecture</summary>
 
 Apply the declarative manifest to your local cluster. Verify that the Pod transitions through `Pending` into `Running`, confirm both containers become ready, and then use port-forwarding to view the generated page through the API server tunnel.
 
-**Solution:**
+<details>
+<summary>Concept hint</summary>
+
+Use `kubectl apply` to submit the manifest, wait until the Pod reports Ready, then tunnel port 80 from the Pod to a local port and curl it from your workstation.
+</details>
+
+<details>
+<summary>Command hint</summary>
+
+Run `kubectl apply -f multi-pod.yaml`, then `kubectl wait --for=condition=Ready pod/web-logger --timeout=60s`, then `kubectl port-forward pod/web-logger 8080:80` in the background and curl `http://localhost:8080`.
+</details>
+
+<details>
+<summary>Full solution</summary>
+
 ```bash
 # Apply the declarative manifest to the API Server
 kubectl apply -f multi-pod.yaml
@@ -429,13 +458,28 @@ curl http://localhost:8080
 kill %1
 ```
 </details>
+</details>
 
 <details>
 <summary>Task 3: Interactive Namespace Exploration</summary>
 
 The `content-writer` container continuously overwrites the physical file on the shared volume. Use `kubectl exec` to open an interactive shell inside the `nginx-server` container. Once inside, install `curl` and make a local HTTP request to `localhost:80`. Explain why this works across container boundaries.
 
-**Solution:**
+<details>
+<summary>Concept hint</summary>
+
+Containers in the same Pod share a network namespace, so `localhost` inside one container reaches listeners in another. The shared volume is what lets one container write the file another serves.
+</details>
+
+<details>
+<summary>Command hint</summary>
+
+Use `kubectl exec -it web-logger -c nginx-server -- /bin/sh`, install curl with `apk add --no-cache curl`, then curl `http://localhost:80`.
+</details>
+
+<details>
+<summary>Full solution</summary>
+
 ```bash
 # Execute an interactive shell inside the specific container
 kubectl exec -it web-logger -c nginx-server -- /bin/sh
@@ -455,13 +499,28 @@ exit
 ```
 Even though you entered the `nginx-server` container's filesystem namespace, Nginx listens on port 80 of the Pod's shared network namespace. The loopback interface is shared by all containers in the Pod, while the mounted volume lets one container write the file another container serves.
 </details>
+</details>
 
 <details>
 <summary>Task 4: Intentionally Triggering an OOMKilled Event</summary>
 
 Create a new file named `oom-pod.yaml`. Define a Pod that runs the `polinux/stress` image, give it a strict memory limit of `50Mi`, and set the command to allocate more memory than the cgroup permits. Apply the file and watch its lifecycle status.
 
-**Solution:**
+<details>
+<summary>Concept hint</summary>
+
+Set a low `resources.limits.memory` value, then run a stress command that asks for substantially more memory than the limit allows. Wait for the container to terminate before checking status.
+</details>
+
+<details>
+<summary>Command hint</summary>
+
+Use the `polinux/stress` image with `--vm-bytes` above the limit, apply the manifest, then wait for `OOMKilled` with `kubectl wait --for=jsonpath='{.status.containerStatuses[0].state.terminated.reason}'=OOMKilled pod/memory-hog --timeout=60s` or watch with `kubectl get pod memory-hog --watch`.
+</details>
+
+<details>
+<summary>Full solution</summary>
+
 ```yaml
 # oom-pod.yaml
 apiVersion: v1
@@ -481,11 +540,12 @@ spec:
 # Apply the doomed pod to the cluster
 kubectl apply -f oom-pod.yaml
 
-# Watch the failure unfold after the process asks for too much memory
-sleep 5
+# Wait until the kernel terminates the over-limit process
+kubectl wait --for=jsonpath='{.status.containerStatuses[0].state.terminated.reason}'=OOMKilled pod/memory-hog --timeout=60s
 kubectl get pod memory-hog
 ```
 You should briefly see the Pod run and then observe a restart cycle. The process asks the kernel for substantially more memory than the configured cgroup permits, so the kernel terminates it to protect the node.
+</details>
 </details>
 
 <details>
@@ -493,12 +553,27 @@ You should briefly see the Pod run and then observe a restart cycle. The process
 
 Use `kubectl describe` to prove why the `memory-hog` Pod died. Find the exact reason and exit code in the container's last state, and connect that result back to the memory limit in the manifest.
 
-**Solution:**
+<details>
+<summary>Concept hint</summary>
+
+`kubectl describe pod` shows container state history. Look for `Last State` with reason `OOMKilled` and exit code `137`.
+</details>
+
+<details>
+<summary>Command hint</summary>
+
+Run `kubectl describe pod memory-hog` and scroll to the `Containers:` section for the `stress-test` container.
+</details>
+
+<details>
+<summary>Full solution</summary>
+
 ```bash
 # Extract the forensic log of the dead pod
 kubectl describe pod memory-hog
 ```
 Scroll to the `Containers:` section, locate the `stress-test` container, and inspect the `Last State:` block. The important evidence is `Reason: OOMKilled` alongside `Exit Code: 137`, which shows that the kernel killed the process after it exceeded the configured memory limit.
+</details>
 </details>
 
 <details>
@@ -506,11 +581,26 @@ Scroll to the `Containers:` section, locate the `stress-test` container, and ins
 
 Cleanly delete both Pods created during this exercise to free cluster resources and leave the training environment ready for the next module.
 
-**Solution:**
+<details>
+<summary>Concept hint</summary>
+
+Delete the Pod objects you created; graceful deletion is the default and appropriate here.
+</details>
+
+<details>
+<summary>Command hint</summary>
+
+Run `kubectl delete pod web-logger memory-hog`.
+</details>
+
+<details>
+<summary>Full solution</summary>
+
 ```bash
 # Delete the pods, returning the cluster to a clean state
-kubectl delete pod web-logger memory-hog --force --grace-period=0
+kubectl delete pod web-logger memory-hog
 ```
+</details>
 </details>
 
 Success criteria:

--- a/src/content/docs/prerequisites/kubernetes-basics/module-1.6-configmaps-secrets.md
+++ b/src/content/docs/prerequisites/kubernetes-basics/module-1.6-configmaps-secrets.md
@@ -27,7 +27,7 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-A credential that should have lived as runtime configuration becomes part of an application artifact the moment it is baked into a container image, committed into source control, or hardcoded in a deployment manifest. Once that happens, rotation is no longer a single operation — the team must find every copy, invalidate every leaked credential, rebuild every artifact that contains it, retest every deployment that uses it, and hope no old image is still running in a forgotten environment. The CKS-track module on [secrets management](/k8s/cks/part4-microservice-vulnerabilities/module-4.3-secrets-management/) walks through one of the canonical examples of this failure mode in detail. <!-- incident-xref: uber-2022-hardcoded-creds --> The lesson for prerequisites is simpler: the choice between treating a value as configuration or as code is the choice between rotating in seconds and rotating in weeks.
+A credential that should have lived as runtime configuration becomes part of an application artifact the moment it is baked into a container image, committed into source control, or hardcoded in a deployment manifest. Once that happens, rotation is no longer a single operation — the team must find every copy, invalidate every leaked credential, rebuild every artifact that contains it, retest every deployment that uses it, and hope no old image is still running in a forgotten environment. The CKS-track module on [secrets management](/k8s/cks/part4-microservice-vulnerabilities/module-4.3-secrets-management/) explores this failure mode further for exam-focused security work. <!-- incident-xref: uber-2022-hardcoded-creds --> The lesson for prerequisites is simpler: the choice between treating a value as configuration or as code is the choice between rotating in seconds and rotating in weeks.
 
 Kubernetes gives you two built-in resources for avoiding that trap: ConfigMaps for non-sensitive configuration and Secrets for sensitive data. They let the same container image run in development, staging, and production while the cluster supplies the values that vary between those environments. That design is powerful, but it also creates a new responsibility: you must know exactly how those resources are stored, delivered, refreshed, and protected, because moving a password into a Secret does not automatically make the surrounding workflow secure.
 
@@ -198,6 +198,8 @@ spec:
     - configMapRef:
         name: app-config
 ```
+
+You can combine `env` and `envFrom` in the same container when you need one key addressed explicitly and the rest imported in bulk — they are not mutually exclusive.
 
 This environment variable pattern is easy to read and works well for values that are naturally scalar, such as `LOG_LEVEL`, `ENVIRONMENT`, or a feature flag. Its limitation is just as important: changing the ConfigMap later does not mutate the environment of a running process. Linux processes receive their environment at start time, and Kubernetes does not rewrite it under the process. To pick up a new value, you delete the Pod, trigger a Deployment rollout, or use a controller pattern that changes a Pod template annotation when config changes.
 
@@ -451,7 +453,7 @@ Finally, ask how often the value changes and how dangerous a bad change would be
 
 ## Did You Know?
 
-- **1 MiB Payload Limit**: ConfigMap and Secret individual object sizes are strictly limited to exactly 1 MiB to protect the etcd datastore from bloated memory consumption and unresponsive queries.
+- **1 MiB Payload Limit**: ConfigMap and Secret individual object sizes cannot exceed 1 MiB to protect the etcd datastore from bloated memory consumption and unresponsive queries.
 - **KMS v2 GA Date**: The modern KMS v2 encryption provider achieved General Availability in Kubernetes v1.29, finally replacing the slow, network-heavy KMS v1 architecture that is disabled by default.
 - **Immutability GA Timeline**: Immutable ConfigMaps and Secrets reached stable status in Kubernetes v1.21, though early enhancement planning materials targeted an earlier release.
 - **Two-Minute Propagation Window**: When mounting ConfigMaps as volumes, changes can take roughly two minutes to appear because kubelet sync timing and cache propagation both matter.
@@ -531,28 +533,32 @@ No. ConfigMaps and Secrets have a 1 MiB object size limit, and pushing multi-meb
 
 This exercise uses a disposable namespace so you can inspect ConfigMaps and Secrets without touching other work. You will create non-sensitive application settings, create a Secret, run a Pod that consumes both, and then modify the design to practice file-based delivery. The goal is not just to make the YAML apply; it is to predict which values are visible where and which changes require a new Pod.
 
-Before you begin, confirm that your current context points at a disposable cluster or namespace where creating and deleting lab resources is safe:
+Before you begin, confirm that your current context points at a disposable cluster where creating and deleting lab resources is safe, then create an isolated lab namespace:
 
 ```bash
 kubectl config current-context
-kubectl get namespace default
+kubectl create namespace config-lab
 ```
+
+All commands in this exercise use `-n config-lab` so lab objects stay separate from other work.
 
 ### Task 1: Create the configuration objects
 
-Use the original quick path to create a ConfigMap and Secret, then inspect them with the alias. The literal Secret value is intentionally a lab placeholder, not a production credential pattern.
+Use the original quick path to create a ConfigMap and Secret, then inspect them with full `kubectl get ... -o yaml` commands. The literal Secret value is intentionally a lab placeholder, not a production credential pattern.
 
 ```bash
 # 1. Create ConfigMap
 kubectl create configmap app-config \
   --from-literal=LOG_LEVEL=debug \
-  --from-literal=APP_NAME=myapp
+  --from-literal=APP_NAME=myapp \
+  -n config-lab
 
 # 2. DECISION POINT: Create the secret.
 # Will you use --from-literal or create a YAML file with stringData? 
 # We'll use the CLI for speed here:
 kubectl create secret generic app-secret \
-  --from-literal=DB_PASS=secretpassword
+  --from-literal=DB_PASS=secretpassword \
+  -n config-lab
 
 # 3. Create pod using both
 cat << 'EOF' | kubectl apply -f -
@@ -560,6 +566,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: config-test
+  namespace: config-lab
 spec:
   containers:
   - name: test
@@ -577,13 +584,13 @@ spec:
 EOF
 
 # 4. Verify env vars are present
-kubectl wait --for=condition=Ready pod/config-test --timeout=60s
-kubectl logs config-test | grep -E "LOG_LEVEL|APP_NAME|DB_PASSWORD"
+kubectl wait --for=condition=Ready pod/config-test -n config-lab --timeout=60s
+kubectl logs config-test -n config-lab | grep -E "LOG_LEVEL|APP_NAME|DB_PASSWORD"
 ```
 
 <details><summary>Solution notes for Task 1</summary>
 
-The original commands create one ConfigMap, one Secret, and one Pod. Useful inspection commands at this point are `kubectl get configmap app-config -o yaml`, `kubectl get secret app-secret -o yaml`, and `kubectl logs config-test`. Notice that the Pod logs show plaintext environment values because the process received them at startup. That visibility is useful for a lab and risky for real credentials in production logs.
+The original commands create one ConfigMap, one Secret, and one Pod in `config-lab`. Useful inspection commands at this point are `kubectl get configmap app-config -n config-lab -o yaml`, `kubectl get secret app-secret -n config-lab -o yaml`, and `kubectl logs config-test -n config-lab`. Notice that the Pod logs show plaintext environment values because the process received them at startup. That visibility is useful for a lab and risky for real credentials in production logs.
 
 </details>
 
@@ -592,8 +599,8 @@ The original commands create one ConfigMap, one Secret, and one Pod. Useful insp
 Read the stored Secret and decode the single value so you can see exactly where base64 applies. This step builds the habit of distinguishing Kubernetes serialization from actual confidentiality.
 
 ```bash
-kubectl get secret app-secret -o yaml
-kubectl get secret app-secret -o jsonpath='{.data.DB_PASS}' | base64 -d
+kubectl get secret app-secret -n config-lab -o yaml
+kubectl get secret app-secret -n config-lab -o jsonpath='{.data.DB_PASS}' | base64 -d
 ```
 
 <details><summary>Solution notes for Task 2</summary>
@@ -610,9 +617,10 @@ Update the ConfigMap after the Pod is running, then compare the API object with 
 kubectl create configmap app-config \
   --from-literal=LOG_LEVEL=info \
   --from-literal=APP_NAME=myapp \
+  -n config-lab \
   --dry-run=client -o yaml | kubectl apply -f -
-kubectl get configmap app-config -o jsonpath='{.data.LOG_LEVEL}'
-kubectl logs config-test | grep LOG_LEVEL
+kubectl get configmap app-config -n config-lab -o jsonpath='{.data.LOG_LEVEL}'
+kubectl logs config-test -n config-lab | grep LOG_LEVEL
 ```
 
 <details><summary>Solution notes for Task 3</summary>
@@ -626,12 +634,13 @@ The ConfigMap object changes, but the environment in the existing container does
 Delete the original Pod and recreate it with the ConfigMap mounted at `/etc/app-config`. Then inspect the directory to see how keys become files.
 
 ```bash
-kubectl delete pod config-test
+kubectl delete pod config-test -n config-lab
 cat << 'EOF' | kubectl apply -f -
 apiVersion: v1
 kind: Pod
 metadata:
   name: config-test
+  namespace: config-lab
 spec:
   containers:
   - name: test
@@ -645,9 +654,9 @@ spec:
     configMap:
       name: app-config
 EOF
-kubectl wait --for=condition=Ready pod/config-test --timeout=60s
-kubectl exec config-test -- ls -l /etc/app-config
-kubectl exec config-test -- cat /etc/app-config/LOG_LEVEL
+kubectl wait --for=condition=Ready pod/config-test -n config-lab --timeout=60s
+kubectl exec config-test -n config-lab -- ls -l /etc/app-config
+kubectl exec config-test -n config-lab -- cat /etc/app-config/LOG_LEVEL
 ```
 
 <details><summary>Solution notes for Task 4</summary>
@@ -661,14 +670,15 @@ Each ConfigMap key appears as a file under `/etc/app-config`. This layout is bet
 Remove the disposable resources after you have confirmed both environment and file delivery behavior. Cleanup matters because stale Secrets and ConfigMaps make later debugging harder.
 
 ```bash
-kubectl delete pod config-test
-kubectl delete configmap app-config
-kubectl delete secret app-secret
+kubectl delete pod config-test -n config-lab
+kubectl delete configmap app-config -n config-lab
+kubectl delete secret app-secret -n config-lab
+kubectl delete namespace config-lab
 ```
 
 <details><summary>Solution notes for Task 5</summary>
 
-The cleanup commands remove only the resources created in this exercise. If a delete command reports that a resource is not found, confirm you are in the expected namespace before assuming the resource never existed. In a shared cluster, explicit namespaces are safer than relying on the current context.
+The cleanup commands remove only the resources created in `config-lab`. If a delete command reports that a resource is not found, confirm you passed `-n config-lab` before assuming the resource never existed.
 
 </details>
 
@@ -679,7 +689,7 @@ Success criteria:
 - [ ] Pod `config-test` reached the Running state and displayed the expected environment values.
 - [ ] Updating the ConfigMap did not change the already-running environment variable.
 - [ ] The ConfigMap was mounted as files under `/etc/app-config`.
-- [ ] All lab resources were deleted after verification.
+- [ ] All lab resources in `config-lab` were deleted after verification.
 
 ## Sources
 

--- a/src/content/docs/prerequisites/kubernetes-basics/module-1.7-namespaces-labels.md
+++ b/src/content/docs/prerequisites/kubernetes-basics/module-1.7-namespaces-labels.md
@@ -25,7 +25,7 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-At 2:00 AM on a Friday, a platform engineer at a busy online retailer is paged because checkout latency has crossed the customer-facing error budget and internal APIs are timing out. The first suspect is the payment service, but the real cause is quieter: a load-testing job was launched in the same shared Kubernetes cluster as production, without a dedicated namespace budget, without default resource limits, and without a label scheme that made ownership obvious. The job was meant to run against a staging endpoint, but it landed in `default`, consumed most allocatable CPU on several nodes, and forced the team to burn precious minutes asking a basic question: whose workload is this?
+Imagine a 2 a.m. page: checkout latency crosses the customer-facing error budget and internal APIs start timing out. The first suspect is the payment service, but the real cause is quieter: a load-testing job was launched in the same shared Kubernetes cluster as production, without a dedicated namespace budget, without default resource limits, and without a label scheme that made ownership obvious. The job was meant to run against a staging endpoint, but it landed in `default`, consumed most allocatable CPU on several nodes, and forced the team to burn precious minutes asking a basic question: whose workload is this?
 
 The outage is not really about one careless command. It is about a cluster that has grown past the point where memory, discipline, and naming conventions can protect it. A single physical Kubernetes cluster is attractive because it centralizes capacity, networking, observability, and operational skill, but that same centralization creates a shared fate unless the cluster is divided into understandable operating zones. Without namespaces, teams collide over names and permissions; without labels, controllers and humans cannot reliably find the objects they mean to affect; without quotas and defaults, one tenant can unintentionally starve another.
 
@@ -108,7 +108,7 @@ Constantly typing `-n team-frontend` is useful for clarity in scripts, but it is
 
 ```bash
 # View your current context configuration to see your active namespace
-kubectl config view --minify | grep namespace:
+kubectl config view --minify -o jsonpath='{..namespace}'
 
 # Set the default namespace for your current context to 'team-frontend'
 kubectl config set-context --current --namespace=team-frontend
@@ -538,7 +538,7 @@ kubectl create namespace alpha-team
 kubectl config set-context --current --namespace=alpha-team
 
 # Verify you are in the new namespace
-kubectl config view --minify | grep namespace:
+kubectl config view --minify -o jsonpath='{..namespace}'
 ```
 </details>
 

--- a/src/content/docs/prerequisites/kubernetes-basics/module-1.8-yaml-kubernetes.md
+++ b/src/content/docs/prerequisites/kubernetes-basics/module-1.8-yaml-kubernetes.md
@@ -542,7 +542,7 @@ The framework also tells you when YAML is not the real problem. If server-side d
 
 In this exercise, you will build a small multi-resource application manifest, intentionally encounter structural failures, and use the module's debugging workflow to repair them. The exercise assumes access to a Kubernetes 1.35-compatible cluster such as kind, minikube, or a shared development namespace. If you do not have a cluster, you can still read the dry-run commands and compare the expected diagnostics, but the server-side validation step requires an API server.
 
-Use a scratch directory outside your source repository for the lab file so you do not accidentally commit exercise artifacts. Define the alias before you start, then create a file named `dojo-app.yaml`. The first version is intentionally broken in several ways: the API version is wrong for a Deployment, a numeric field is quoted as a string, and the container list is missing its sequence structure.
+Use a scratch directory outside your source repository for the lab file so you do not accidentally commit exercise artifacts. Create a file named `dojo-app.yaml`. The first version is intentionally broken in several ways: the API version is wrong for a Deployment, a numeric field is quoted as a string, and the container list is missing its sequence structure.
 
 ### Task 1: The Broken Foundation
 


### PR DESCRIPTION
## What

Phase-1 back-catalog cross-family review fixes for **Kubernetes Basics** modules 1.1, 1.3, 1.6, 1.7, 1.8 (continuing the curriculum-order sweep). Each cross-family reviewed (1.1 codex 3.7, 1.3 agy 4.1, 1.6 cursor-auto 4.3, 1.7 gemini 4.8, 1.8 cursor-auto), found NEEDS_CHANGES, fixed (cursor `--model auto`), verified against the reviewers' specified corrections.

**1.1 — First Cluster:** `kind delete cluster --all` (invalid flag in kind v0.31.0, and unsafe global delete) → explicit named lab-cluster deletes + missing `broken-dojo` cleanup; corrected outdated Docker Desktop ("single-node only") and minikube ("emulates") characterizations.

**1.3 — Pods:** replaced a **fabricated** `vault pull-secrets` CLI command with a generic placeholder script; removed an unsafe `--force --grace-period=0` cleanup taught to beginners; fixed a lab race (`sleep 5` → `kubectl wait` for `OOMKilled`); staged exercise solutions into tiered hints.

**1.6 — ConfigMaps & Secrets:** replaced an undefined `k` alias with full `kubectl`; added real lab-namespace isolation (`config-lab` + `-n` on every command); softened an inaccurate CKS cross-reference; "exactly 1 MiB" → "cannot exceed 1 MiB"; clarified an `env`+`envFrom` example.

**1.7 — Namespaces & Labels:** reframed a fabricated "2 a.m. Friday" war-story as an explicit hypothetical; made a namespace-lookup command robust (`-o jsonpath`).

**1.8 — YAML for Kubernetes:** dropped an "alias before you start" instruction that contradicted the module's full-`kubectl` convention.

Build: green. (1.4/1.5 are `needs_rewrite` → Phase 2.)

## Learner check

> The first suspect is the payment service, but the real cause is quieter: a load-testing job was launched in the same shared Kubernetes cluster as production, without a dedicated namespace budget, without default resource limits, and without a label scheme that made ownership obvious.

Refs #1504
