### PR TITLE
chore(content): Phase-1 review fixes for modern-devops 1.2-1.6

### DIFF
--- a/src/content/docs/prerequisites/modern-devops/module-1.2-gitops.md
+++ b/src/content/docs/prerequisites/modern-devops/module-1.2-gitops.md
@@ -26,7 +26,7 @@ By the end of this module, you will be able to:
 
 ## Why This Module Matters
 
-On June 21, 2022, a routine BGP community update at Cloudflare reordered policy terms inside its automated tooling, placing a global rejection rule ahead of every site-local advertisement term. Within minutes, nineteen data centers handling roughly half of Cloudflare's global traffic withdrew their routes and became unreachable. The outage lasted about seventy-five minutes. The change was reviewable in principle — it was source-controlled, written by a human, deployable by a tool — but it was not reviewed before it shipped, and there was no live controller comparing intended state with actual state. A configuration change that looks reviewable in a pull request is also reviewable before it ships when Git serves as the operational contract; one-off commands leave neither audit trail nor a controller to detect divergence between intended and actual cluster state. GitOps makes that audit trail and that controller the default, not the exception.
+On June 21, 2022, a routine BGP community update at Cloudflare reordered policy terms inside its automated tooling, placing a global rejection rule ahead of every site-local advertisement term. Within minutes, nineteen data centers handling roughly half of Cloudflare's global traffic withdrew their routes and became unreachable. The outage lasted about seventy-five minutes. The change was reviewable in principle — it was source-controlled, written by a human, deployable by a tool — but it was rolled out everywhere at once, with no staged rollout and no live controller comparing intended state with actual state. A configuration change that looks reviewable in a pull request is also reviewable before it ships when Git serves as the operational contract; one-off commands leave neither audit trail nor a controller to detect divergence between intended and actual cluster state. GitOps makes that audit trail and that controller the default, not the exception.
 
 Kubernetes solves part of that problem by giving teams declarative APIs, controllers, health checks, and rollout mechanics, but Kubernetes does not automatically make a team disciplined. An engineer can still run an urgent command against the wrong namespace, a CI job can still hold broad cluster credentials, and a production fix can still live only in terminal history. GitOps addresses the gap by making Git the operational contract for the cluster. The repository describes the intended state, peer review controls how that state changes, and a controller inside the cluster continuously reconciles reality toward that contract.
 
@@ -86,12 +86,12 @@ Declarative configuration is powerful because Kubernetes controllers already wor
 ```bash
 git log --oneline manifests/
 a1b2c3d Scale web to 5 replicas
-d4e5f6g Add redis cache
-g7h8i9j Initial deployment
+d4e5f6a Add redis cache
+b7c8d9e Initial deployment
 
 # Every change is:
 # - Versioned (commit hash)
-# - Immutable (can't change history)
+# - Immutable (commit objects don't change; protected branches prevent history rewrites)
 # - Attributed (who made it)
 # - Reviewable (PR history)
 ```
@@ -165,6 +165,21 @@ flowchart TD
 The Application below preserves the essential production pattern. The controller runs in the `argocd` namespace, reads a configuration repository, targets the in-cluster Kubernetes API, and deploys only into the application namespace. The `prune` option lets Argo CD delete resources that were removed from Git, while `selfHeal` lets it repair drift without waiting for a new commit. Those two flags are powerful enough that teams normally pair them with branch protection, project boundaries, and careful namespace RBAC.
 
 ```yaml
+# Production apps should run under a restricted AppProject, never the permissive
+# built-in `default` project (which allows any repo, cluster, and resource kind).
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: frontend-prod
+  namespace: argocd
+spec:
+  sourceRepos:
+    - 'https://github.com/myorg/gitops-config.git'
+  destinations:
+    - namespace: 'frontend'
+      server: 'https://kubernetes.default.svc'
+  clusterResourceWhitelist: []
+---
 # A worked ArgoCD Application example
 apiVersion: argoproj.io/v1alpha1
 kind: Application
@@ -172,7 +187,7 @@ metadata:
   name: frontend-prod
   namespace: argocd
 spec:
-  project: default
+  project: frontend-prod
   source:
     repoURL: 'https://github.com/myorg/gitops-config.git'
     path: clusters/production/frontend
@@ -379,20 +394,19 @@ A useful incident question is "which layer disagrees with which other layer?" If
 ```bash
 # Production has a bug!
 
-# Option 1: Revert the commit
+# Normal GitOps rollback: revert the bad commit in Git
 git revert abc123
 git push
 
 # GitOps agent syncs: old version restored
 # Time to rollback: < 5 minutes
 
-# Option 2: Use Argo CD UI
-# Click "Rollback" on the application
-# Argo reverts to previous sync state
+# Emergency only: Argo CD UI "Rollback" reverts to a previous sync state
+# (blocked when automated sync is enabled; does not create a Git commit).
+# Follow any UI rollback with a matching git revert so Git stays authoritative.
 
-# All rollbacks are tracked in Git history
 git log --oneline
-def456 Revert "Deploy v1.2.3"  # Rollback recorded
+def456 Revert "Deploy v1.2.3"  # Rollback recorded in Git
 abc123 Deploy v1.2.3           # Bad deployment
 ```
 
@@ -408,7 +422,7 @@ metadata:
     argocd-image-updater.argoproj.io/myapp.update-strategy: semver
 
 # Flux Image Automation
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImageUpdateAutomation
 metadata:
   name: flux-system
@@ -425,7 +439,7 @@ spec:
       author:
         email: fluxcdbot@users.noreply.github.com
         name: fluxcdbot
-      messageTemplate: 'Update image to {{.NewTag}}'
+      messageTemplate: 'Update image to {{range .Changed.Changes}}{{println .NewValue}}{{end}}'
     push:
       branch: main
 ```
@@ -502,7 +516,7 @@ The framework should lead to an explicit operating decision. A platform team mig
 ## Did You Know?
 
 - **The term "GitOps" was coined by Weaveworks** in August 2017 when the company described how it operated Kubernetes by using Git as the control surface for cluster state.
-- **The OpenGitOps working group published version 1.0.0 of the GitOps principles** on October 21, 2021, formalizing the declarative, versioned, pulled, and reconciled model.
+- **The OpenGitOps working group published version 1.0.0 of the GitOps principles** in 2021, formalizing the declarative, versioned, pulled, and reconciled model.
 - **Argo CD began at Intuit in 2018** and later became a CNCF graduated project, which is one reason many enterprise teams recognize its application-centered workflow.
 - **Flux reached CNCF graduated status in 2022** and is organized as a set of Kubernetes controllers, which explains why many platform teams describe it as strongly Kubernetes-native.
 
@@ -566,13 +580,17 @@ It is safer when tags are immutable, artifacts are scanned and signed, tests cov
 
 In this exercise, you will manually simulate the exact behavior of a GitOps agent. Instead of installing Argo CD or Flux, you will act as the continuous reconciliation controller to understand the underlying mechanics of drift detection and correction. The lab uses a local directory as the Git source of truth and a Kubernetes cluster as the live environment, so it works best on a disposable local cluster where you can safely create and delete a Deployment.
 
-Before starting, make sure `kubectl` is configured for a disposable Kubernetes cluster where you are comfortable creating and deleting a small Deployment. The command examples below use the full `kubectl` binary name so they remain copy-paste-safe in scripts and terminals. If you are on macOS, the included `sed -i ''` command works as written; on GNU/Linux, use `sed -i 's/nginx:1.27/nginx:1.28/' manifests/deployment.yaml` instead.
+Before starting, make sure `kubectl` is configured for a disposable Kubernetes cluster where you are comfortable creating and deleting a small Deployment. The command examples below use the full `kubectl` binary name so they remain copy-paste-safe in scripts and terminals.
 
 Below is the complete simulation script for reference.
 
 ```bash
 # This simulates GitOps behavior manually
 # In real GitOps, an agent does this automatically
+
+# Confirm cluster context and use a dedicated lab namespace
+kubectl config current-context
+kubectl create namespace gitops-demo
 
 # 1. Create a "Git repo" (directory)
 mkdir -p ~/gitops-demo/manifests
@@ -600,35 +618,37 @@ spec:
 EOF
 
 # 3. Apply (simulate GitOps sync)
-kubectl apply -f manifests/
+kubectl apply -n gitops-demo -f manifests/
 
 # 4. Verify
-kubectl get deployment gitops-demo
+kubectl get deployment gitops-demo -n gitops-demo
 
 # 5. Simulate drift (manual change)
-kubectl scale deployment gitops-demo --replicas=5
+kubectl scale deployment gitops-demo -n gitops-demo --replicas=5
 
 # 6. Check drift
-kubectl get deployment gitops-demo
+kubectl get deployment gitops-demo -n gitops-demo
 # Shows 5 replicas
 
 # 7. Reconcile (simulate GitOps correction)
-kubectl apply -f manifests/
+kubectl apply -n gitops-demo -f manifests/
 # Back to 2 replicas!
 
 # 8. Make a "Git change"
-sed -i '' 's/nginx:1.27/nginx:1.28/' manifests/deployment.yaml
+sed 's/nginx:1.27/nginx:1.28/' manifests/deployment.yaml > manifests/deployment.yaml.tmp
+mv manifests/deployment.yaml.tmp manifests/deployment.yaml
 
 # 9. Apply new state (simulate GitOps sync)
-kubectl apply -f manifests/
+kubectl apply -n gitops-demo -f manifests/
 
 # 10. Verify update
-kubectl get deployment gitops-demo -o jsonpath='{.spec.template.spec.containers[0].image}'
+kubectl get deployment gitops-demo -n gitops-demo -o jsonpath='{.spec.template.spec.containers[0].image}'
 # Shows nginx:1.28
 
 # 11. Cleanup
-kubectl delete -f manifests/
-rm -rf ~/gitops-demo
+kubectl delete -n gitops-demo -f manifests/
+DEMO_DIR="$HOME/gitops-demo"
+rm -r "$DEMO_DIR"
 ```
 
 ### Progressive Tasks
@@ -694,6 +714,7 @@ Execute steps 8, 9, 10, and 11. By using `sed` or a text editor, you update the 
 
 ## Sources
 
+- [Cloudflare outage on June 21, 2022](https://blog.cloudflare.com/cloudflare-outage-on-june-21-2022/)
 - [OpenGitOps Principles](https://opengitops.dev/)
 - [CNCF GitOps microsurvey and project landscape](https://www.cncf.io/blog/2022/02/17/cncf-gitops-microsurvey/)
 - [Argo CD documentation](https://argo-cd.readthedocs.io/en/stable/)

--- a/src/content/docs/prerequisites/modern-devops/module-1.2-gitops.md
+++ b/src/content/docs/prerequisites/modern-devops/module-1.2-gitops.md
@@ -26,7 +26,7 @@ By the end of this module, you will be able to:
 
 ## Why This Module Matters
 
-On June 21, 2022, a routine BGP community update at Cloudflare reordered policy terms inside its automated tooling, placing a global rejection rule ahead of every site-local advertisement term. Within minutes, nineteen data centers handling roughly half of Cloudflare's global traffic withdrew their routes and became unreachable. The outage lasted about seventy-five minutes. The change was reviewable in principle — it was source-controlled, written by a human, deployable by a tool — but it was rolled out everywhere at once, with no staged rollout and no live controller comparing intended state with actual state. A configuration change that looks reviewable in a pull request is also reviewable before it ships when Git serves as the operational contract; one-off commands leave neither audit trail nor a controller to detect divergence between intended and actual cluster state. GitOps makes that audit trail and that controller the default, not the exception.
+On June 21, 2022, a routine BGP community update at Cloudflare reordered policy terms inside its automated tooling, placing a global rejection rule ahead of every site-local advertisement term. Within minutes, nineteen data centers handling roughly half of Cloudflare's global traffic withdrew their routes and became unreachable. The outage lasted about seventy-five minutes. The change was reviewable in principle — it was source-controlled, written by a human, deployable by a tool — but its staggered rollout was not granular enough to catch the MCP-specific failure before the final step reached every busy data center, and there was no live controller comparing intended state with actual state. A configuration change that looks reviewable in a pull request is also reviewable before it ships when Git serves as the operational contract; one-off commands leave neither audit trail nor a controller to detect divergence between intended and actual cluster state. GitOps makes that audit trail and that controller the default, not the exception.
 
 Kubernetes solves part of that problem by giving teams declarative APIs, controllers, health checks, and rollout mechanics, but Kubernetes does not automatically make a team disciplined. An engineer can still run an urgent command against the wrong namespace, a CI job can still hold broad cluster credentials, and a production fix can still live only in terminal history. GitOps addresses the gap by making Git the operational contract for the cluster. The repository describes the intended state, peer review controls how that state changes, and a controller inside the cluster continuously reconciles reality toward that contract.
 
@@ -176,7 +176,7 @@ spec:
   sourceRepos:
     - 'https://github.com/myorg/gitops-config.git'
   destinations:
-    - namespace: 'frontend'
+    - namespace: 'frontend-prod'
       server: 'https://kubernetes.default.svc'
   clusterResourceWhitelist: []
 ---

--- a/src/content/docs/prerequisites/modern-devops/module-1.3-cicd-pipelines.md
+++ b/src/content/docs/prerequisites/modern-devops/module-1.3-cicd-pipelines.md
@@ -10,7 +10,7 @@ sidebar:
 >
 > **Time to Complete:** 60-75 minutes
 >
-> **Prerequisites:** [Module 1.1: Infrastructure as Code](/prerequisites/modern-devops/module-1.1-infrastructure-as-code/), basic Git knowledge
+> **Prerequisites:** [Module 1.1: Infrastructure as Code](/prerequisites/modern-devops/module-1.1-infrastructure-as-code/), [Module 1.2: GitOps](/prerequisites/modern-devops/module-1.2-gitops/), basic Git knowledge
 
 ---
 
@@ -26,9 +26,9 @@ By the end of this module, you will be able to:
 
 ## Why This Module Matters
 
-On July 2, 2019, Cloudflare pushed a new Web Application Firewall rule to every edge node simultaneously. The rule contained a regular expression whose backtracking behaviour was quadratic, and within seconds CPU on every machine serving HTTP traffic saturated to 100%. Global traffic dropped 82%; the fix took twenty-seven minutes. The rule had passed static review, but a safety mechanism that would have caught the catastrophic regex had been deleted in a refactor weeks earlier. A CI/CD pipeline is the single chokepoint where the safety of an artifact is decided. If the pipeline's verification weakens, every downstream node receives the same flawed artifact at the same time; if the verification holds, the blast radius of a human error stays bounded by the gates the pipeline still enforces.
+On [July 2, 2019](https://blog.cloudflare.com/details-of-the-cloudflare-outage-on-july-2-2019/), Cloudflare pushed a new Web Application Firewall rule to every edge node simultaneously. The rule contained a regular expression whose backtracking behaviour was quadratic, and within seconds CPU on every machine serving HTTP traffic saturated to 100%. Global traffic dropped 82%; the fix took twenty-seven minutes. The rule had passed static review, but a safety mechanism that would have caught the catastrophic regex had been deleted in a refactor weeks earlier. A CI/CD pipeline is the single chokepoint where the safety of an artifact is decided. If the pipeline's verification weakens, every downstream node receives the same flawed artifact at the same time; if the verification holds, the blast radius of a human error stays bounded by the gates the pipeline still enforces.
 
-In 2020, attackers compromised the SolarWinds Orion build environment and inserted malicious code into a signed software update that customers trusted. That incident widened the definition of deployment risk from "will our app crash?" to "can we prove where this artifact came from, who changed it, which dependencies are inside it, and whether anything touched it after the build?" A modern pipeline is therefore not a convenience script wrapped around Git. It is the software factory, the audit trail, the security checkpoint, the release controller, and the first place where weak engineering discipline becomes visible.
+In [2020](https://www.cisa.gov/news-events/alerts/2020/12/13/active-exploitation-solarwinds-software), attackers compromised the SolarWinds Orion build environment and inserted malicious code into a signed software update that customers trusted. That incident widened the definition of deployment risk from "will our app crash?" to "can we prove where this artifact came from, who changed it, which dependencies are inside it, and whether anything touched it after the build?" A modern pipeline is therefore not a convenience script wrapped around Git. It is the software factory, the audit trail, the security checkpoint, the release controller, and the first place where weak engineering discipline becomes visible.
 
 Think of CI/CD as the automated assembly line for software. Source code enters as raw material, moves through quality stations, becomes a container image, receives a label and signature, and is promoted only if each station records a clean result. A team can still choose when a release reaches users, but the release should never depend on someone remembering which commands to run on which host. Kubernetes 1.35+ assumes this world: applications arrive as versioned container images, rollout controllers converge toward desired state, and platform teams rely on repeatable automation rather than personal deployment folklore.
 
@@ -151,7 +151,7 @@ SLSA, the Supply-chain Levels for Software Artifacts framework, gives teams a ma
 | **Trivy** (Aqua) | Comprehensive Container & Repo scanning | Yes | Incredibly fast. Scans OS packages, language dependencies, and Infrastructure as Code (Terraform). The gold standard for easy CI integration. |
 | **Grype** (Anchore) | Vulnerability scanning for containers | Yes | Often paired directly with Syft (for SBOM generation). Excellent accuracy and deep inspection. |
 | **Snyk** | Developer-focused security platform | Freemium | Deep IDE integration, provides automated fix pull requests to developers before they even commit code. |
-| **Kube-linter** | IaC / Kubernetes Manifest scanning | Yes | Checks Kubernetes YAML manifests for security misconfigurations (e.g., running containers as root, missing resource limits) *before* deployment. |
+| **KubeLinter** | IaC / Kubernetes Manifest scanning | Yes | Checks Kubernetes YAML manifests for security misconfigurations (e.g., running containers as root, missing resource limits) *before* deployment. |
 
 Security gates need thresholds, not vibes. Blocking on every low-severity finding can train developers to ignore the pipeline, especially when the fix is unavailable or unrelated to runtime risk. Blocking on critical exploitable vulnerabilities in the base image, leaked credentials, unsigned release images, or privileged Kubernetes manifests is much easier to defend. A strong platform team publishes the policy in plain language, runs the checks consistently, and gives developers a fast remediation path instead of a mysterious red mark.
 
@@ -241,8 +241,8 @@ When a pipeline fails, diagnose it by layer. If the build fails, inspect depende
 
 ## Did You Know?
 
-- **300x Faster:** The DORA research program has repeatedly found that high-performing software delivery organizations deploy far more frequently than low performers while also recovering faster from incidents.
-- **50% Less Time:** Teams that integrate automated vulnerability scanning early in the pipeline often spend far less time remediating critical security issues than teams that scan only before release.
+- **Deploy far more frequently:** The [DORA research program](https://dora.dev/research/) has repeatedly found that high-performing software delivery organizations deploy far more frequently than low performers while also recovering faster from incidents.
+- **Less time remediating vulnerabilities:** Teams that integrate automated vulnerability scanning early in the pipeline often spend far less time remediating critical security issues than teams that scan only before release.
 - **The First CI Server:** CruiseControl, one of the first widely used Continuous Integration tools, was created by ThoughtWorks developers in 2001 and helped popularize automated build feedback.
 - **10 Deploys a Day:** In 2009, Flickr engineers presented "10+ Deploys per Day," a talk that made frequent production deployment feel practical to many teams that still treated monthly releases as fast.
 
@@ -322,19 +322,18 @@ server.listen(8080, () => {
 });
 ```
 
-3. Create a `package.json` to simulate real-world dependencies:
+3. Create a `package.json` (no runtime dependencies — the app uses only Node's built-in `http` module):
 
 ```json
 {
   "name": "kubedojo-pipeline-app",
-  "version": "1.0.0",
-  "dependencies": {
-    "express": "^4.18.2"
-  }
+  "version": "1.0.0"
 }
 ```
 
-4. Create a `Dockerfile`. Notice that this base image is intentionally outdated for the lab:
+4. Generate a lockfile for the npm cache key: run `npm install` locally and commit the resulting `package-lock.json` before pushing (the workflow's `cache: 'npm'` keys off that file).
+
+5. Create a `Dockerfile`. Notice that this base image is intentionally outdated for the lab:
 
 ```dockerfile
 # INSECURE BASE IMAGE FOR TESTING PIPELINE GATES
@@ -370,12 +369,13 @@ EOF
 cat <<EOF > package.json
 {
   "name": "kubedojo-pipeline-app",
-  "version": "1.0.0",
-  "dependencies": {
-    "express": "^4.18.2"
-  }
+  "version": "1.0.0"
 }
 EOF
+
+# Generate package-lock.json for the workflow cache key
+npm install
+git add package-lock.json
 
 # Create Dockerfile
 cat <<EOF > Dockerfile
@@ -465,7 +465,7 @@ Append this step to your `build-and-test` job:
 If you pushed this to GitHub, the workflow would run and fail when Trivy reports critical vulnerabilities in the old base image. For a local simulation, build the image and run Trivy with Docker against the local image. The important learning moment is the non-zero exit code: CI/CD tools do not need to understand every vulnerability detail as long as the scanning step produces a clear pass or fail result.
 
 1. Build the image locally to test: `docker build -t kubedojo-app:test .`
-2. Run Trivy locally using Docker: `docker run --rm -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy image --severity CRITICAL --exit-code 1 kubedojo-app:test`
+2. Run Trivy locally using Docker (match CI flags): `docker run --rm -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy image --severity CRITICAL --ignore-unfixed --vuln-type os,library --exit-code 1 kubedojo-app:test`
 3. Observe that the scanner returns exit code `1`, which would halt the pipeline before deployment.
 
 <details>
@@ -618,6 +618,11 @@ If a slow install, hung test, or stalled scan takes longer than 15 minutes, GitH
 
 ## Sources
 
+- [Cloudflare outage on July 2, 2019 (post-mortem)](https://blog.cloudflare.com/details-of-the-cloudflare-outage-on-july-2-2019/)
+- [CISA: SolarWinds Orion supply-chain compromise (2020)](https://www.cisa.gov/news-events/alerts/2020/12/13/active-exploitation-solarwinds-software)
+- [DORA Research Program](https://dora.dev/research/)
+- [CruiseControl (ThoughtWorks, 2001)](https://www.thoughtworks.com/en-us/insights/blog/history-cruise-control)
+- [Flickr: 10+ Deploys Per Day (Velocity 2009)](https://www.slideshare.net/slideshow/velocity-2009/1302790)
 - [GitHub Actions workflow syntax](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions)
 - [GitHub Actions dependency caching](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)
 - [GitLab CI/CD YAML syntax reference](https://docs.gitlab.com/ci/yaml/)

--- a/src/content/docs/prerequisites/modern-devops/module-1.4-observability.md
+++ b/src/content/docs/prerequisites/modern-devops/module-1.4-observability.md
@@ -479,7 +479,7 @@ This framework is intentionally operational. It does not ask which vendor you bo
 - **GitHub published a public availability report** for its August 2021 MySQL incident, naming the secondary-incident root cause (a service-discovery misconfiguration during GitHub Actions setup) — the kind of separately-failing dependency that observability is supposed to surface before users do.
 - **The term "observability"** comes from control theory and is associated with Rudolf E. Kalman's 1960 work on dynamic systems.
 - **Prometheus graduated from the CNCF** on August 9, 2018, becoming one of the foundation's earliest graduated cloud-native projects after Kubernetes.
-- **W3C Trace Context reached Recommendation status** in 2021, giving distributed tracing tools a standard way to propagate trace identifiers across services.
+- **W3C Trace Context reached Recommendation status** in 2020, giving distributed tracing tools a standard way to propagate trace identifiers across services.
 
 ## Common Mistakes
 
@@ -562,7 +562,8 @@ kubectl patch deployment metrics-server -n kube-system --type=json \
 # Wait for metrics-server to become ready:
 kubectl rollout status deployment/metrics-server -n kube-system
 
-# Note: It may take an additional 30-60 seconds for metrics to propagate to the API.
+# Note: metrics-server needs a scrape cycle before top reports values.
+sleep 60
 kubectl top pods
 kubectl top nodes
 ```
@@ -587,7 +588,7 @@ kubectl get events --sort-by='.lastTimestamp'
 ```bash
 # 5. Restore application and view pod status
 kubectl scale deployment web --replicas=1
-kubectl wait --for=condition=ready pod -l app=web --timeout=60s
+kubectl wait --for=condition=available deployment/web --timeout=60s
 kubectl get pods -o wide
 kubectl describe pod -l app=web
 ```

--- a/src/content/docs/prerequisites/modern-devops/module-1.5-platform-engineering.md
+++ b/src/content/docs/prerequisites/modern-devops/module-1.5-platform-engineering.md
@@ -127,7 +127,7 @@ metadata:
   annotations:
     github.com/project-slug: acme-corp/payment-routing-service
     pagerduty.com/integration-key: "xyz123abc_critical_alerts"
-    prometheus.io/rule: "payment-service-high-latency-alerts"
+    custom-org/prometheus-alert-rule: "payment-service-high-latency-alerts"
     snyk.io/org-id: "security-org-123-finance"
     backstage.io/techdocs-ref: dir:.
 spec:
@@ -168,6 +168,7 @@ The same declaration can be cheap in development and resilient in production. Lo
 Kratix takes a Kubernetes-native path by letting platform teams define "Promises" that developers request as custom resources. A Promise can represent a database, message broker, cache, environment, or higher-level capability. This approach fits organizations that already trust GitOps and Kubernetes control loops because the platform interface itself becomes declarative. Developers request a capability, and the platform pipeline produces the resources needed to honor it.
 
 ```yaml
+# Illustrative example — the exact API group, version, and fields vary by Promise.
 # Example: Developer requesting a Kratix Promise
 apiVersion: postgres.marketplace.kratix.io/v1alpha1
 kind: PostgreSQL
@@ -347,7 +348,7 @@ metadata:
     
     # Observability Integration
     datadoghq.com/dashboard-url: "https://app.datadoghq.com/dashboard/auth-service-prod"
-    prometheus.io/rule: "auth-team-critical-alerts"
+    custom-org/prometheus-alert-rule: "auth-team-critical-alerts"
     
     # Incident Management
     pagerduty.com/integration-key: "auth-team-critical-alerts"
@@ -425,6 +426,7 @@ The platform team should shadow product developers during real service creation 
 
 ## Sources
 
+- [Gartner: 80% of large software engineering organizations will establish platform engineering teams by 2026 (2023)](https://www.gartner.com/en/newsroom/press-releases/2023-09-06-gartner-says-80-percent-of-large-software-engineering-organizations-will-establish-platform-engineering-teams-by-2026)
 - [CNCF Platforms White Paper](https://tag-app-delivery.cncf.io/whitepapers/platforms/)
 - [CNCF Platform Engineering Maturity Model](https://tag-app-delivery.cncf.io/whitepapers/platform-eng-maturity-model/)
 - [Backstage Documentation](https://backstage.io/docs/overview/what-is-backstage/)

--- a/src/content/docs/prerequisites/modern-devops/module-1.6-devsecops.md
+++ b/src/content/docs/prerequisites/modern-devops/module-1.6-devsecops.md
@@ -28,7 +28,7 @@ After completing this module, you will be able to:
 
 Cloud-native incidents tend to start small. A management interface gets deployed without authentication so a developer can iterate quickly; an IAM role gets a permissive policy because the precise list of required actions was hard to enumerate; a workload gets a host-path mount because a pre-flight check was easier to write that way. Each of those choices, by itself, looks like a reasonable trade-off in a sprint. Together, they create the conditions where one misconfiguration cascades into a cluster-wide compromise — because the network, identity, and runtime layers were never tightened independently. The CKS-track modules walk through two canonical examples in detail: an [exposed Kubernetes dashboard](/k8s/cks/part1-cluster-setup/module-1.5-gui-security/) <!-- incident-xref: tesla-2018-cryptojacking --> and a [cloud metadata service compromise](/k8s/cks/part1-cluster-setup/module-1.4-node-metadata/) <!-- incident-xref: capital-one-2019 -->. This module operates one layer up: how do engineering teams stop those small choices from accumulating in the first place?
 
-In April 2021, the answer to that question was rewritten by a single supply-chain attack. The Codecov bash uploader — a script that thousands of CI pipelines piped directly into `bash` — was modified to exfiltrate environment variables from every CI run that used it. The attackers harvested credentials, deploy keys, and signed-artifact secrets from the pipelines of dozens of high-profile customers. The lesson was uncomfortable: a CI tool that handles secrets is itself a production system, and "trusted" external scripts deserve the same scrutiny as internal code. DevSecOps is the engineering discipline that makes that scrutiny routine rather than reactive.
+In April 2021, the answer to that question was rewritten by a single supply-chain attack. The Codecov bash uploader — a script that thousands of CI pipelines piped directly into `bash` — was modified to exfiltrate environment variables from every CI run that used it. The attackers harvested credentials, deploy keys, and signed-artifact secrets from the pipelines of customers whose CI environment variables could be exfiltrated. The lesson was uncomfortable: a CI tool that handles secrets is itself a production system, and "trusted" external scripts deserve the same scrutiny as internal code. DevSecOps is the engineering discipline that makes that scrutiny routine rather than reactive.
 
 DevSecOps is the engineering response to that pattern. It does not mean adding one scanner to the end of a pipeline or asking a security team to approve every release by hand. It means turning security requirements into repeatable checks that run where engineers already work, then enforcing the highest-risk rules at the cluster boundary so a tired person cannot accidentally deploy a dangerous workload on a Friday afternoon.
 
@@ -115,7 +115,7 @@ COPY app /app
 CMD ["nginx"]
 
 # GOOD: Minimal image, non-root user
-FROM nginx:1.25-alpine
+FROM nginx:1.27-alpine
 RUN adduser -D -u 1000 appuser
 COPY --chown=appuser:appuser app /app
 USER appuser
@@ -124,14 +124,14 @@ EXPOSE 8080
 
 The bad example uses a floating tag and leaves the process running as root. The good example still needs validation, but it makes two important choices explicit: a more constrained base image and a non-root user. Pinning to a specific image tag improves traceability, while running as a dedicated user limits what the process can do if the application is exploited.
 
-Image tags deserve special attention because they are human-friendly labels, not immutable guarantees. The tag `nginx:1.25-alpine` is more specific than a floating tag, but a digest is stronger when you need reproducibility. In production pipelines, teams often build from approved base images, scan the output, sign the digest, and deploy by digest so the workload that passed review is the workload the cluster receives.
+Image tags deserve special attention because they are human-friendly labels, not immutable guarantees. The tag `nginx:1.27-alpine` is more specific than a floating tag, but a digest is stronger when you need reproducibility. In production pipelines, teams often build from approved base images, scan the output, sign the digest, and deploy by digest so the workload that passed review is the workload the cluster receives.
 
 ```bash
 # Trivy - most popular open-source scanner
-trivy image nginx:1.25
+trivy image nginx:1.27
 
 # Example output:
-# nginx:1.25 (debian 12.0)
+# nginx:1.27 (debian 12.0)
 # Total: 142 (UNKNOWN: 0, LOW: 89, MEDIUM: 45, HIGH: 7, CRITICAL: 1)
 ```
 
@@ -193,6 +193,8 @@ spec:
     runAsNonRoot: true
     runAsUser: 1000
     fsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: app
     image: myapp
@@ -238,10 +240,13 @@ The important operational choice is enforcement mode. `warn` helps developers se
 
 Use full `kubectl` commands in shared examples and automation, even if you personally use a shorter interactive alias in your terminal. The habit matters because a command copied from curriculum into CI, a runbook, or a shell script should work in a non-interactive environment without depending on local shell setup.
 
+> **Warning:** Labeling a namespace changes Pod Security Admission for every workload in it. Use a disposable demo cluster and a throwaway namespace — not a shared `production` namespace.
+
 ```bash
-kubectl label namespace production pod-security.kubernetes.io/enforce=restricted --overwrite
-kubectl label namespace production pod-security.kubernetes.io/warn=restricted --overwrite
-kubectl label namespace production pod-security.kubernetes.io/audit=restricted --overwrite
+kubectl create namespace devsecops-demo
+kubectl label namespace devsecops-demo pod-security.kubernetes.io/enforce=restricted --overwrite
+kubectl label namespace devsecops-demo pod-security.kubernetes.io/warn=restricted --overwrite
+kubectl label namespace devsecops-demo pod-security.kubernetes.io/audit=restricted --overwrite
 ```
 
 Before running this in a shared cluster, what output do you expect when a developer submits the earlier insecure pod to a namespace with `enforce=restricted`? The correct expectation is an admission rejection before scheduling, because the API server evaluates the request and refuses to persist a pod that violates the selected profile.
@@ -314,7 +319,9 @@ metadata:
 subjects:
 - kind: User
   name: developer@company.com
+  apiGroup: rbac.authorization.k8s.io
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cluster-admin    # Too much power!
 ```
@@ -347,7 +354,9 @@ metadata:
 subjects:
 - kind: User
   name: developer@company.com
+  apiGroup: rbac.authorization.k8s.io
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: developer
 ```
@@ -435,7 +444,7 @@ trivy image myapp:v1
 trivy config .
 
 # Scan running cluster
-trivy k8s --report summary cluster
+trivy k8s --report summary
 ```
 
 Trivy is often chosen because one tool can cover several surfaces: images, repositories, infrastructure configuration, and clusters. That breadth is convenient for smaller teams, but it still requires policy decisions. A scanner can produce data; your program must define which findings block a merge, which create tickets, and which are accepted with documented reasoning.
@@ -706,9 +715,11 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
         fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: app
-        image: nginx:1.25-alpine
+        image: nginxinc/nginx-unprivileged:1.27-alpine
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
@@ -717,6 +728,13 @@ spec:
             - ALL
         ports:
         - containerPort: 8080
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: cache
+          mountPath: /var/cache/nginx
+        - name: run
+          mountPath: /var/run
         resources:
           limits:
             memory: "128Mi"
@@ -724,6 +742,13 @@ spec:
           requests:
             memory: "64Mi"
             cpu: "250m"
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      - name: cache
+        emptyDir: {}
+      - name: run
+        emptyDir: {}
 EOF
 
 # 6. Compare the two
@@ -756,6 +781,7 @@ Success criteria:
 
 ## Sources
 
+- [Codecov security update (April 2021)](https://about.codecov.io/security-update/)
 - [Kubernetes: Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
 - [Kubernetes: Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/)
 - [Kubernetes: Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/)


### PR DESCRIPTION
Phase-1 cross-family review fixes for the **prerequisites / modern-devops** section (modules 1.2–1.6). Part of the review-first back-catalog progression (curriculum order). Each module was reviewed by a different model family than the author; this PR applies the must-fix findings.

## Per-module fixes

**1.2 gitops** (codex review, was 3.0) — Cloudflare June-2022 outage reframed (dropped unsupported "not reviewed before it shipped"; cited the post-mortem); restricted `AppProject` added, Application moved off the permissive `default` project; rollback section corrected (`git revert` is the normal GitOps path; Argo UI rollback is emergency-only and not a Git commit); Flux `ImageUpdateAutomation` bumped to `image.toolkit.fluxcd.io/v1` with a valid `messageTemplate`; lab uses a dedicated `gitops-demo` namespace + context check, portable `sed`, guarded cleanup; valid hex commit hashes; OpenGitOps date corrected.

**1.3 cicd-pipelines** (cursor/composer-2.5 review, 4.3) — Cloudflare 2019 + SolarWinds/CISA citations added for the opening incidents (facts were already correct, just uncited); npm cache lab now generates/commits `package-lock.json`; local Trivy flags match CI; unused `express` dep removed so the scan lesson is about the base image; DORA stats softened; KubeLinter branding; prerequisites now include Module 1.2.

**1.4 observability** (agy/gemini-3.1-pro review, 4.8) — lab runnability: wait on `deployment/web` (avoids the pod-not-yet-created race), `sleep 60` before `kubectl top`; W3C Trace Context Recommendation corrected to 2020.

**1.5 platform-engineering** (deepseek review, APPROVE 4.0) — Kratix example marked illustrative; Gartner platform-teams prediction cited; non-standard `prometheus.io/rule` Backstage annotation renamed to an org-namespaced key.

**1.6 devsecops** (codex review, 3.4) — `seccompProfile: RuntimeDefault` added to both "restricted"-compliant manifests; PSS-label demo moved to a throwaway `devsecops-demo` namespace with a warning; RBAC `roleRef`/User subjects given the required `apiGroup`; the hardened Deployment is now actually deployable (`nginxinc/nginx-unprivileged` + writable `emptyDir` mounts under a read-only root fs); Codecov incident cited + over-claim softened; `trivy k8s` command fixed; stale `nginx:1.25` → `1.27`.

The two heavy modules (1.2, 1.6) get a codex re-review before merge; 1.3/1.4/1.5 were orchestrator-verified against the review findings.

## Learner check

> GitOps addresses the gap by making Git the operational contract for the cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
