### PR TITLE
chore(content): Phase-1 review fixes for git-deep-dive 2-10

### DIFF
--- a/src/content/docs/prerequisites/git-deep-dive/module-10-gitops-bridge.md
+++ b/src/content/docs/prerequisites/git-deep-dive/module-10-gitops-bridge.md
@@ -26,7 +26,7 @@ sidebar:
 
 ## Why This Module Matters
 
-The payment gateway went down at 2:00 PM on the busiest shopping day of the year. Dashboards turned red across the operations room while the checkout API returned HTTP 503 responses to thousands of customers per minute. The first symptom looked ordinary: the `payment-processing` Deployment lacked an environment variable needed to authenticate with a newly provisioned database cluster. The confusing part was that every deployment job had succeeded, the infrastructure repository already contained the variable, and the live pods still did not.
+Hypothetical scenario: the payment gateway went down at 2:00 PM on the busiest shopping day of the year. Dashboards turned red across the operations room while the checkout API returned HTTP 503 responses to thousands of customers per minute. The first symptom looked ordinary: the `payment-processing` Deployment lacked an environment variable needed to authenticate with a newly provisioned database cluster. The confusing part was that every deployment job had succeeded, the infrastructure repository already contained the variable, and the live pods still did not.
 
 The team reconstructed the incident and found the uncomfortable cause. Three days earlier, an engineer had been chasing a production resource exhaustion problem under intense time pressure. They opened a terminal, edited the live Deployment directly, and accidentally replaced part of the pending database configuration while testing a quick change. They intended to follow up in Git, then moved to the next incident thread and forgot. Because the old push pipeline only touched the cluster after a new commit triggered it, the cluster quietly drifted away from the repository until the legacy database was decommissioned and the missing variable became a customer-facing outage.
 
@@ -250,9 +250,9 @@ Commit signing is the first part of identity. A normal Git author line is easy t
 
 ```bash
 # Configuring Git to sign commits using an SSH key
-git config --global gpg.format ssh
-git config --global user.signingkey ~/.ssh/id_ed25519.pub
-git config --global commit.gpgsign true
+git config --local gpg.format ssh
+git config --local user.signingkey ~/.ssh/id_ed25519.pub
+git config --local commit.gpgsign true
 
 # Creating a signed commit (Git automatically uses the configured key)
 git commit -S -m "feat: enforce network policies in production"
@@ -291,9 +291,9 @@ The operational differences are stark when you compare the two models across com
 
 | Security Vector | Traditional CI/CD (Push) | Zero-Trust GitOps (Pull) |
 | :--- | :--- | :--- |
-| **Cluster Credentials** | Stored externally in CI servers; high risk of exfiltration. | Stored exclusively inside the cluster; never leave the boundary. |
-| **Auditability** | Difficult; requires cross-referencing CI logs, Git history, and cluster audit logs. | Absolute; `git log` provides a mathematically proven, exact history of all cluster states. |
-| **Drift Prevention** | Weak; manual cluster changes can persist indefinitely until overwritten. | Strong; operator continuously overwrites manual changes with Git truth within minutes. |
+| **Cluster Credentials** | Stored externally in CI servers; high risk of exfiltration. | Routine production mutation credentials stay in-cluster; CI no longer needs a cluster-admin kubeconfig for deploys (GitOps controllers still use outbound credentials to pull Git). |
+| **Auditability** | Difficult; requires cross-referencing CI logs, Git history, and cluster audit logs. | Strong; Git provides an immutable, cryptographically linked audit trail of declared desired-state changes (commit-object integrity, not live cluster state). |
+| **Drift Prevention** | Weak; manual cluster changes can persist indefinitely until overwritten. | Strong when automated sync and self-heal are enabled; the operator can overwrite manual changes with Git truth within minutes. |
 | **Authorization** | Relies on complex CI system permissions mapping to Kubernetes RBAC. | Relies entirely on Git repository permissions and branch protection rules. |
 
 Secrets require special treatment because "everything in Git" is not the same as "everything in plaintext Git." Kubernetes Secret manifests are only base64-encoded, not encrypted, and Git history preserves mistakes long after a file is removed. GitOps teams usually choose one of two patterns: encrypted secrets in Git using a tool such as SOPS, or secret references in Git using an operator that fetches values from a managed secret store at runtime. Both patterns keep the deployment declarative without turning the repository into a password archive.
@@ -308,7 +308,7 @@ State drift means the live cluster differs from the desired state in Git. Drift 
 
 A disciplined investigation follows the path of intent. First, confirm which repository revision the operator is watching and whether that revision contains the expected change. Second, render or inspect the overlay that should produce the final object. Third, inspect the GitOps application status and events. Fourth, compare the live object only after you know what the operator believes it should apply. This order prevents a common mistake where engineers stare at the live Deployment for ten minutes while the real error is a broken Kustomize path.
 
-For an Argo CD managed application, the first useful command is a description of the Application resource. The output can show whether the app is synced, out of sync, healthy, degraded, or blocked by a rendering error. In a real investigation, you might run `kubectl describe application frontend-production -n gitops-system`, then inspect events with `kubectl get events -n gitops-system --field-selector involvedObject.name=frontend-production`, and finally read controller logs with `kubectl logs -n gitops-system deployment/argocd-application-controller`.
+For an Argo CD managed application, the first useful command is a description of the Application resource. The output can show whether the app is synced, out of sync, healthy, degraded, or blocked by a rendering error. In a real investigation, you might run `kubectl describe application frontend-production -n gitops-system`, then inspect events with `kubectl get events -n gitops-system --field-selector involvedObject.name=frontend-production`, and finally read controller logs with `kubectl logs -n gitops-system statefulset/argocd-application-controller`.
 
 Flux exposes similar information through its custom resources and controller logs. A Flux `Kustomization` reports the last attempted revision, conditions, and reconciliation failures. The exact object names differ from Argo CD, but the thinking is the same: inspect the controller resource, inspect its events, and inspect its logs before assuming the cluster object itself is the root cause.
 
@@ -437,7 +437,7 @@ git init
 
 ### Task 1: Establish the Base Architecture
 
-Create the directory structure for a `catalog-api` application with a base configuration and two environment overlays: `staging` and `production`. This first step is intentionally small because the directory layout is the design contract that all later patches depend on.
+Create the directory structure for a `catalog-api` application with a base configuration and two environment overlays: `staging` and `prod`. This first step is intentionally small because the directory layout is the design contract that all later patches depend on.
 
 <details>
 <summary>Solution</summary>

--- a/src/content/docs/prerequisites/git-deep-dive/module-2-advanced-merging.md
+++ b/src/content/docs/prerequisites/git-deep-dive/module-2-advanced-merging.md
@@ -27,7 +27,7 @@ revision_pending: false
 
 ## Why This Module Matters
 
-On October 21, 2018, routine optical hardware maintenance disconnected GitHub's US-East hub from its primary database for 43 seconds. An automated failover promoted the US-West hub to primary, but the US-East hub continued to accept writes. Both sites held authoritative-looking records for the same rows. Recovery required 24 hours of manual reconciliation between two diverged timelines, and approximately 200,000 webhook payloads were permanently dropped. The incident demonstrated that divergent timelines can each appear correct in isolation while creating massive conflict at infrastructure scale. The same problem exists in source control every time long-lived branches are reconciled. Advanced Git merging is the practiced skill that keeps that reconciliation from becoming an outage.
+On October 21, 2018, routine optical hardware maintenance severed the US East Coast network hub from the primary US East Coast data center for 43 seconds. An automated failover promoted the US-West hub to primary, but the US-East hub continued to accept writes. Both sites held authoritative-looking records for the same rows. Recovery required 24 hours of manual reconciliation between two diverged timelines, and approximately 200,000 webhook payloads were permanently dropped. The incident demonstrated that divergent timelines can each appear correct in isolation while creating massive conflict at infrastructure scale. The same problem exists in source control every time long-lived branches are reconciled. Advanced Git merging is the practiced skill that keeps that reconciliation from becoming an outage.
 
 For Kubernetes platform work, merging is more than a repository housekeeping task because the merged text often becomes a desired-state contract consumed by controllers, admission policies, scanners, and deployment automation. A clean-looking merge can still leave a selector pointing at the wrong labels, a generated Secret missing from a Kustomize overlay, or a release branch carrying assumptions that are no longer true for Kubernetes 1.35 clusters. This module treats merging as an operational design skill: you will inspect graph shape, choose the right integration method, resolve conflicts by synthesizing intent, and validate that the resulting manifests still describe a coherent system.
 
@@ -119,7 +119,7 @@ The true hidden genius of Git's architecture lies in exactly how it calculates a
 git merge-base main feature/ingress-update
 ```
 
-The output of `git merge-base` is the single commit hash that represents the best common ancestor of the two branches, which Git uses as the starting point for its three-way merge calculation. Understanding exactly which commit acts as the base is critical when diagnosing why Git seems to be generating strange or counterintuitive conflicts.
+The output of `git merge-base` is one selected best common ancestor commit hash for the two branches, which Git uses as the starting point for its three-way merge calculation. In criss-cross histories with multiple equally good bases, run `git merge-base --all` to list every candidate. Understanding exactly which commit acts as the base is critical when diagnosing why Git seems to be generating strange or counterintuitive conflicts.
 
 > **Pause and predict**: Look at the following branch topology:
 > ```mermaid
@@ -142,7 +142,7 @@ The output of `git merge-base` is the single commit hash that represents the bes
 > 
 > *Answer*: The merge base is commit `B`. To find it, trace backwards from `main` (commit D) and `feature/cache` (commit H) until their paths intersect. They first meet at `B`, making it the common ancestor used for the three-way merge.
 
-Git provides six distinct, mathematically specialized merge strategies that govern how files are combined: `ort`, `recursive`, `resolve`, `octopus`, `ours`, and `subtree`. 
+Git provides several merge strategies that govern how files are combined: `ort`, `recursive` (now an alias/synonym for `ort`), `resolve`, `octopus`, `ours`, and `subtree`. 
 
 For standard two-branch merges, modern Git uses the `ort` strategy as the universal default. Standing for "Ostensibly Recursive's Twin", the `ort` strategy became the default in Git 2.34.0 (released in November 2021) and it defaults to using `diff-algorithm=histogram` internally. This algorithmic choice makes it significantly faster and vastly more accurate at handling massive file renames and complex directory restructurings across diverged branches. The `ort` backend entirely replaced the legacy `recursive` strategy, which was subsequently fully deprecated in Git 2.50.0 and now exists merely as a silent synonym and alias for `ort` to preserve backwards compatibility for old scripts.
 
@@ -218,7 +218,7 @@ git merge feature/redis-auth
 # Automatic merge failed; fix conflicts and then commit the result.
 ```
 
-If you panic upon seeing massive multi-file infrastructure conflicts, remember that running `git merge --abort` is functionally equivalent to running `git reset --merge` when a `MERGE_HEAD` is present. It will safely and immediately return your entire repository to the pristine pre-merge state. If you choose to proceed, you must synthesize the conflicting configurations accurately, ensuring no YAML structures are broken.
+If you panic upon seeing massive multi-file infrastructure conflicts, remember that running `git merge --abort` is functionally equivalent to running `git reset --merge` when a `MERGE_HEAD` is present, but only when your working tree and index are clean enough for Git to unwind the merge safely. If you have unstaged edits outside the conflict, stash or commit them first, or use `git merge --abort` only after understanding what will be discarded. When `merge.autostash` is enabled, Git may temporarily stash local changes during the merge and restore them on abort via `MERGE_AUTOSTASH`. If you choose to proceed instead of aborting, you must synthesize the conflicting configurations accurately, ensuring no YAML structures are broken.
 
 To successfully resolve this specific scenario, we must determine the desired outcome across all files: we want High Availability (replicas: 3) AND authentication (env vars). For the infrastructure to actually work, the Kustomization file must include BOTH the `commonLabels` AND the `secretGenerator` so that the `redis-secret` referenced in the deployment actually exists.
 
@@ -256,7 +256,7 @@ Always comprehensively validate the structural integrity of your infrastructure-
 After finalizing a complex merge, you or a reviewer may need to isolate and review only the specific manual conflict resolutions you made, without the noise of unrelated feature changes. You can achieve this by inspecting the merge commit with `git show <merge-commit-hash>`, which displays a specialized "combined diff" that intelligently filters the output to highlight only the lines modified differently from both parent branches.
 
 ```bash
-kustomize build . | kubectl apply -f - --dry-run=client
+kubectl kustomize . | kubeconform -summary -
 
 # If successful:
 git add redis-deployment.yaml kustomization.yaml
@@ -523,7 +523,7 @@ git merge feature/ingress feature/autoscaling feature/network-policies
 
 > **Pause and predict**: What do you think happens if Git successfully merges `feature/ingress` and `feature/autoscaling`, but then detects a complex conflict when attempting to merge `feature/network-policies`? Will it pause and ask you to resolve it like a standard three-way merge?
 
-**The All-or-Nothing Rule:** Unlike a standard two-branch three-way merge which politely pauses mid-flight and leaves interactive conflict markers directly in your working directory, an octopus merge is an inherently brittle operation. It will categorically refuse to complete and will immediately abort the entire transaction if it encounters *any* conflict requiring manual resolution across any of the branches involved.
+**The All-or-Nothing Rule:** Unlike a standard two-branch three-way merge, which pauses mid-flight and leaves interactive conflict markers in your working directory while keeping the branch pointer unchanged, an octopus merge stops as soon as it hits a conflict it cannot resolve automatically. Git prints `Automatic merge failed; fix conflicts and then commit the result.`, does **not** move the branch ref, and leaves the working tree and index in a conflicted or partially merged state. Run `git merge --abort` to discard that in-progress merge and return to the pre-merge snapshot.
 
 > **Stop and think**: If an octopus merge fails due to a conflict between `feature/autoscaling` and `feature/network-policies`, which approach would you choose:
 > A) Abandon the octopus merge entirely and merge all three sequentially.
@@ -602,7 +602,7 @@ Advanced merging becomes safer when a team treats every integration as a design 
 
 The most reliable pattern is small, frequent integration against a protected trunk. A developer can still use a short-lived branch for review, but the branch should be measured in hours or a small number of days rather than weeks. This cadence keeps the merge base close to current reality, which means Git compares each branch against a recent ancestor and produces smaller, more intelligible conflict regions. For Kubernetes manifests, that difference is practical rather than aesthetic: a small conflict might ask whether `replicas` should be three or five, while a stale branch may force the resolver to reconcile probes, selectors, container names, generated Secrets, and network policy labels all at once.
 
-Another durable pattern is schema-aware validation immediately after conflict resolution. Git knows that two lines of YAML text differ, but it does not know whether a `secretKeyRef` points at a Secret that Kustomize still generates, whether a selector matches the labels inside a Pod template, or whether an API field is valid in Kubernetes 1.35. The resolver therefore has to move from text reconciliation to platform reconciliation. Running `kubectl apply --dry-run=client`, `kustomize build`, or an admission-style validation tool is the engineering step that converts "Git accepted the file" into "this configuration still represents a coherent cluster object."
+Another durable pattern is schema-aware validation immediately after conflict resolution. Git knows that two lines of YAML text differ, but it does not know whether a `secretKeyRef` points at a Secret that Kustomize still generates, whether a selector matches the labels inside a Pod template, or whether an API field is valid in Kubernetes 1.35. The resolver therefore has to move from text reconciliation to platform reconciliation. Running `kubeconform -summary <manifest.yaml>` (offline schema validation), `kubectl kustomize`, or an admission-style validation tool is the engineering step that converts "Git accepted the file" into "this configuration still represents a coherent cluster object."
 
 A third pattern is reviewable merge commits. When a merge commit exists only because two timelines were joined, it should contain only the conflict synthesis required to join them. That discipline makes `git show <merge-commit>` useful during review because the combined diff can focus on the lines changed differently from both parents. If the resolver also folds in refactors, formatting changes, or unrelated policy edits, the merge commit becomes an opaque bundle, and reviewers lose the ability to distinguish conflict resolution from opportunistic feature work. This is how teams accidentally bless an "evil merge" that introduces behavior neither parent branch intended.
 
@@ -631,7 +631,7 @@ Use the following decision matrix as a practical guide when you are under pressu
 | :--- | :--- | :--- | :--- |
 | Current branch is behind and has no unique commits | `git merge --ff-only incoming` | The branch pointer can move without creating a synthetic merge commit. | Run the relevant tests or render manifests if the incoming branch was not already validated. |
 | Two fresh branches touched different files | Normal three-way merge with `ort` | Git can synthesize independent file changes cleanly while preserving both parents. | Review the merge commit and run targeted CI for changed areas. |
-| Two branches touched the same Kubernetes manifest | Manual conflict resolution with schema validation | Human intent matters more than text adjacency when selectors, probes, and generated resources interact. | Run `kubectl apply --dry-run=client`, `kustomize build`, and any policy checks your repo requires. |
+| Two branches touched the same Kubernetes manifest | Manual conflict resolution with schema validation | Human intent matters more than text adjacency when selectors, probes, and generated resources interact. | Run `kubeconform -summary` on rendered manifests, `kubectl kustomize`, and any policy checks your repo requires. |
 | Several independent branches need one release branch | Octopus merge only if conflicts are unlikely | The history stays compact, but the operation refuses manual conflicts. | Pre-merge each branch against trunk and retry only when every pair is clean. |
 | Old branch has a stale merge base | Recreate from current `main` and cherry-pick intent | The old graph encodes obsolete assumptions about the platform. | Test each selected commit after replay, especially migrations and API changes. |
 | Pull request contains noisy local commits | Interactive rebase before review | Reviewers see a coherent story instead of temporary savepoints. | Re-run tests after rewriting and force-push only to branches you own. |
@@ -644,7 +644,7 @@ For day-to-day work, a compact flow helps prevent panic decisions. Start with `g
 
 1. The `ort` merge strategy, short for Ostensibly Recursive's Twin, became the default two-head merge engine in Git 2.34.0 in November 2021 and uses the histogram diff algorithm internally for many merge comparisons.
 2. Running the maintenance command `git rerere gc` prunes unresolved conflict records older than 15 days and resolved conflict records older than 60 days, which keeps repeated-resolution caches from growing without bound.
-3. Linus Torvalds designed Git's octopus merge for the Linux kernel workflow, where subsystem maintainer branches often needed to be joined into a single integration history without a long sequence of two-parent merge commits.
+3. Octopus merges fit the Linux-style maintainer workflow of bundling many topic branches into a single integration history without a long sequence of two-parent merge commits.
 4. The conflict marker symbols (`<<<<<<<`, `=======`, `>>>>>>>`) predate Git by decades and were established by earlier merge tooling in the RCS era, which is why they appear familiar across many version control systems.
 
 ## Common Mistakes
@@ -652,7 +652,7 @@ For day-to-day work, a compact flow helps prevent panic decisions. Start with `g
 | Mistake | Why It Happens | How to Fix It |
 | :--- | :--- | :--- |
 | **Panic committing unresolved markers** | Engineer feels overwhelmed, attempts to save work mid-conflict by running `git commit -a`, thereby committing `<<<<<<<` directly into the codebase. | Run `git merge --abort` immediately to reset the working directory to the pre-merge state, take a breath, and start over. |
-| **Breaking YAML indentation** | Manually deleting conflict markers and inadvertently shifting blocks of YAML, creating invalid structural relationships. | Always use `kubectl diff` or `kubectl apply --dry-run=client` on the modified file before finalizing the merge commit. |
+| **Breaking YAML indentation** | Manually deleting conflict markers and inadvertently shifting blocks of YAML, creating invalid structural relationships. | Always use `kubectl diff` or `kubeconform -summary` on the modified file before finalizing the merge commit. |
 | **"Ostrich merging" (ignoring upstream)** | Keeping a feature branch alive for 6 weeks without pulling from main, resulting in a monolithic, unresolvable conflict later. | Merge `main` into your feature branch (or rebase against it) daily. Conflict resolution should be a continuous, small-scale tax, not a massive end-of-project penalty. |
 | **Resolving logic, breaking syntax** | Focusing so hard on getting both sets of configuration into the file that you create duplicate keys (e.g., two `spec` blocks in a pod definition). | Understand the schema of the file you are editing. Use IDE plugins with Kubernetes schema validation enabled during conflict resolution. |
 | **Accidental "Evil Merges"** | While resolving a conflict, the engineer sneaks in an unrelated fix or typo correction that was not part of either branch. | A merge commit should *only* contain the resolution of the conflict. Make unrelated fixes in a separate, discrete commit afterward. |
@@ -669,7 +669,7 @@ To safely integrate your work without creating a messy history, you should fetch
 
 <details>
 <summary>Question 2: You trigger an automated pipeline that attempts an octopus merge, integrating four different microservice deployment updates into a staging branch. Git halts and reports a conflict between two of the branches. What happens to the staging branch in this exact moment, and how is the pipeline affected?</summary>
-In this exact moment, nothing happens to the staging branch because an octopus merge is an all-or-nothing operation designed for independent branches. Unlike a standard two-branch merge that pauses mid-flight and leaves conflict markers in your working directory, Git will completely abort the octopus merge automatically upon detecting any conflict. It immediately resets your working directory and staging branch back to their exact pre-merge state. This built-in safety mechanism is highly beneficial for automated pipelines, as it prevents CI/CD systems from becoming trapped in complex, multi-dimensional conflict states that require manual human intervention.
+In this exact moment, the staging branch ref does not move because an octopus merge stops when it cannot finish automatically. Git reports `Automatic merge failed; fix conflicts and then commit the result.` Unlike a standard two-branch merge that pauses with conflict markers while leaving the merge in progress, an octopus merge does not advance the branch pointer, but it **does** leave the working tree and index dirty with conflict markers or partial merge results until you run `git merge --abort` (or resolve and commit). Pipelines must treat this as a failed merge attempt that needs cleanup, not as a no-op that left the workspace pristine.
 </details>
 
 <details>
@@ -696,13 +696,13 @@ Attempting a direct three-way merge with a year-old base is extremely dangerous,
 
 In this lab you will create a small Kubernetes manifest repository, force a real conflict that modern Git cannot safely auto-merge, inspect the merge base, resolve the conflict by synthesizing intent, and validate the final object before committing. The exercise uses a Deployment and a ConfigMap because they reveal the two failure modes you will see in platform work: one conflict is about competing runtime behavior, while the other is about a dependency between files. The goal is not to memorize conflict markers; the goal is to practice slowing down enough to identify what each branch was trying to accomplish.
 
-Work in a scratch directory outside any production repository. The commands below assume a Unix-like shell and Git with the default `ort` merge engine. They also assume `kubectl` is installed and available on your `PATH`. If you do not have a live cluster context, `--dry-run=client` still validates local object structure, which is enough for this exercise because the point is to catch broken YAML and object references before committing the merge.
+Work in a scratch directory outside any production repository. The commands below assume a Unix-like shell and Git with the default `ort` merge engine. They also assume `kubeconform` is installed and available on your `PATH` (for example `brew install kubeconform` on macOS). `kubeconform -summary` validates manifest shape against Kubernetes OpenAPI schemas without contacting a cluster, which is enough for this exercise because the point is to catch broken YAML and object references before committing the merge.
 
 - [ ] Create the repository, add the baseline Deployment and ConfigMap, and commit the initial state.
 - [ ] Create `feature/harden-api` to add a health probe and stricter ConfigMap setting.
 - [ ] Create `feature/scale-api` to change replicas and a competing ConfigMap setting.
-- [ ] Merge `feature/scale-api` into `feature/harden-api`, inspect the merge base, and resolve both conflicted files.
-- [ ] Validate the resolved manifests with `kubectl apply --dry-run=client` before committing the merge.
+- [ ] Merge `feature/scale-api` into `feature/harden-api`, inspect the merge base, review the auto-merged `deployment.yaml`, and resolve the conflict in `configmap.yaml`.
+- [ ] Validate the resolved manifests with `kubeconform -summary` before committing the merge.
 - [ ] Inspect the final merge commit with `git show` and explain which lines were human conflict resolutions.
 
 <details>
@@ -788,7 +788,7 @@ git merge feature/scale-api
 git status
 ```
 
-Resolve `deployment.yaml` by keeping both the readiness probe and the scaled replica count:
+Review `deployment.yaml`. Git should auto-merge it cleanly, combining the readiness probe from `feature/harden-api` with the scaled replica count from `feature/scale-api`. Confirm the file matches this expected result:
 
 ```yaml
 apiVersion: apps/v1
@@ -834,8 +834,8 @@ data:
 Validate and commit:
 
 ```bash
-kubectl apply -f configmap.yaml --dry-run=client
-kubectl apply -f deployment.yaml --dry-run=client
+kubeconform -summary configmap.yaml
+kubeconform -summary deployment.yaml
 git add configmap.yaml deployment.yaml
 git commit -m "Merge scale-api into harden-api resolving replicas and feature mode"
 git show --stat --summary HEAD
@@ -844,7 +844,7 @@ git show HEAD
 
 </details>
 
-The success criteria are intentionally broader than "Git says the merge is complete." You should be able to point to the merge base, describe each branch's intent, explain why one ConfigMap value survived, show that the Deployment still references an existing ConfigMap, and demonstrate that Kubernetes 1.35-compatible client validation accepts both objects. If you cannot explain those facts from the final commit, the merge may be mechanically complete but operationally unreviewable.
+The success criteria are intentionally broader than "Git says the merge is complete." You should be able to point to the merge base, describe each branch's intent, explain why one ConfigMap value survived, show that the Deployment still references an existing ConfigMap, and demonstrate that `kubeconform -summary` accepts both objects. If you cannot explain those facts from the final commit, the merge may be mechanically complete but operationally unreviewable.
 
 ## Sources
 
@@ -857,6 +857,7 @@ The success criteria are intentionally broader than "Git says the merge is compl
 - [Git attributes documentation for merge drivers](https://git-scm.com/docs/gitattributes)
 - [Kubernetes kubectl apply reference](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_apply/)
 - [Kubernetes Kustomize documentation](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/)
+- [GitHub October 21 2018 post-incident analysis](https://github.blog/news-insights/company-news/oct21-post-incident-analysis/)
 - [GitHub pull request merge methods](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/about-merge-methods-on-github)
 - [GitLab merge request methods](https://docs.gitlab.com/user/project/merge_requests/methods/)
 

--- a/src/content/docs/prerequisites/git-deep-dive/module-2-advanced-merging.md
+++ b/src/content/docs/prerequisites/git-deep-dive/module-2-advanced-merging.md
@@ -27,7 +27,7 @@ revision_pending: false
 
 ## Why This Module Matters
 
-On October 21, 2018, routine optical hardware maintenance severed the US East Coast network hub from the primary US East Coast data center for 43 seconds. An automated failover promoted the US-West hub to primary, but the US-East hub continued to accept writes. Both sites held authoritative-looking records for the same rows. Recovery required 24 hours of manual reconciliation between two diverged timelines, and approximately 200,000 webhook payloads were permanently dropped. The incident demonstrated that divergent timelines can each appear correct in isolation while creating massive conflict at infrastructure scale. The same problem exists in source control every time long-lived branches are reconciled. Advanced Git merging is the practiced skill that keeps that reconciliation from becoming an outage.
+On October 21, 2018, routine optical hardware maintenance severed the US East Coast network hub from the primary US East Coast data center for 43 seconds. An automated failover promoted the US-West hub to primary, but the US-East hub continued to accept writes. Both sites held authoritative-looking records for the same rows. The incident caused more than 24 hours of degraded service; engineers had to manually reconcile the records that both sites had accepted during the brief split before consistency could be restored, and approximately 200,000 webhook payloads were permanently dropped. The incident demonstrated that divergent timelines can each appear correct in isolation while creating massive conflict at infrastructure scale. The same problem exists in source control every time long-lived branches are reconciled. Advanced Git merging is the practiced skill that keeps that reconciliation from becoming an outage.
 
 For Kubernetes platform work, merging is more than a repository housekeeping task because the merged text often becomes a desired-state contract consumed by controllers, admission policies, scanners, and deployment automation. A clean-looking merge can still leave a selector pointing at the wrong labels, a generated Secret missing from a Kustomize overlay, or a release branch carrying assumptions that are no longer true for Kubernetes 1.35 clusters. This module treats merging as an operational design skill: you will inspect graph shape, choose the right integration method, resolve conflicts by synthesizing intent, and validate that the resulting manifests still describe a coherent system.
 
@@ -385,8 +385,8 @@ spec:
 
 The exercise then required validation before committing, because a syntactically broken Deployment is still a failed merge even when the Git conflict markers have been removed:
 ```bash
-kubectl apply -f deployment.yaml --dry-run=client
-# Expect output: deployment.apps/api-server created (dry run)
+kubeconform -summary deployment.yaml
+# Expect output confirming the Deployment schema is valid
 ```
 ```bash
 git add deployment.yaml
@@ -481,8 +481,8 @@ spec:
 
 **Task 5: Validate the YAML**
 ```bash
-kubectl apply -f deployment.yaml --dry-run=client
-# Expect output: deployment.apps/api-server created (dry run)
+kubeconform -summary deployment.yaml
+# Expect output confirming the Deployment schema is valid
 ```
 
 **Task 6: Finalize the Merge**

--- a/src/content/docs/prerequisites/git-deep-dive/module-3-interactive-rebasing.md
+++ b/src/content/docs/prerequisites/git-deep-dive/module-3-interactive-rebasing.md
@@ -350,7 +350,7 @@ When the decision involves sensitive data, add one more question: has the value 
 
 ## Did You Know?
 
-- Git 1.7.0, released in 2010, added autosquash support with `--fixup` and `--squash` workflows that later became central to fast interactive cleanup.
+- The Git 1.7 series (early 1.7-era releases around 2010) introduced `--fixup` and `--squash` commit options; autosquash in interactive rebase matured across that same 1.7 line and later became central to fast interactive cleanup.
 - Git stores rewritten commits as new objects, and the default reflog expiration policy often keeps reachable reflog entries for 90 days, giving you a recovery window after many local mistakes.
 - The Linux kernel workflow strongly favors linear, reviewable patch series from contributors, which is one reason rebasing and patch cleanup are treated as everyday engineering skills in that ecosystem.
 - `git rebase --exec` can run a command after each replayed commit, so a fast manifest check can catch the exact commit that first breaks a Kubernetes 1.35+ deployment example.

--- a/src/content/docs/prerequisites/git-deep-dive/module-5-worktrees-stashing.md
+++ b/src/content/docs/prerequisites/git-deep-dive/module-5-worktrees-stashing.md
@@ -131,7 +131,7 @@ Here is a small practice workflow that focuses on the untracked-file trap. It us
 
 ```bash
 mkdir stash-practice && cd stash-practice
-git init
+git init -b main
 ```
 
 Create an initial commit so the repository has a clean baseline. Git stash depends on a repository with commits because it needs a `HEAD` commit as the reference point for the saved changes. In a brand-new repository with no commit, many normal history operations do not yet have a stable anchor.
@@ -166,6 +166,12 @@ Finally, restore with `apply` rather than `pop`. The working tree gets the chang
 
 ```bash
 git stash apply stash@{0}
+```
+
+When you are finished experimenting, remove the throwaway directory:
+
+```bash
+cd ../.. && rm -r stash-practice
 ```
 
 ## The Power of Git Worktrees
@@ -385,7 +391,7 @@ Start in a temporary directory so the practice repository can be deleted when yo
 
 ```bash
 mkdir k8s-fleet-manager && cd k8s-fleet-manager
-git init
+git init -b main
 ```
 
 Create the stable base state. This manifest is intentionally minimal so the difference between production and unfinished feature work is easy to see. Commit it before starting the feature branch because the hotfix worktree needs a real `main` commit as its starting point.

--- a/src/content/docs/prerequisites/git-deep-dive/module-6-troubleshooting.md
+++ b/src/content/docs/prerequisites/git-deep-dive/module-6-troubleshooting.md
@@ -316,8 +316,10 @@ That result gives you a concise timeline, but an incident investigator usually n
 
 The `-G` option answers a broader question. Instead of counting occurrences of one exact string, it searches diff lines with a regular expression. This is useful when the value changes over time or the exact text is unknown. CPU limits, memory quantities, port numbers, hostnames, and API versions are often better searched by pattern than by one literal value.
 
+`git log -G` and `git log -S` use POSIX extended regular expressions (ERE), not PCRE, so use `[[:space:]]` instead of `\s` for whitespace.
+
 ```bash
-git log -G "cpu:\s*[0-9]+m" --oneline -p
+git log -G "cpu:[[:space:]]*[0-9]+m" --oneline -p
 ```
 
 Output snippet:
@@ -336,9 +338,8 @@ diff --git a/k8s/frontend-deployment.yaml b/k8s/frontend-deployment.yaml
          resources:
            requests:
              cpu: 100m
--          limits:
+           limits:
 -            cpu: 200m
-+          limits:
 +            cpu: 500m
 ```
 
@@ -531,7 +532,7 @@ In practice, investigations loop through this framework more than once. A Pickax
 1. **The Pickaxe name is old Git culture**: `git log -S` is commonly called Pickaxe because it digs through patch history for string additions and removals rather than searching only the current checkout.
 2. **`git bisect visualize` can show your current search state**: during a complicated bisection, `git bisect visualize` or `git bisect view` opens a viewer such as `gitk` so you can inspect commits marked good, bad, and untested.
 3. **Reverse blame can search deletion history**: `git blame --reverse START..END file` can help identify where a line disappeared across a bounded range, which is useful when normal blame cannot see removed text.
-4. **Kubernetes dry-run modes changed operational habits**: server-side dry runs let teams validate manifests against the API server without persisting objects, which makes Git bisection safer for Kubernetes 1.35-era troubleshooting.
+4. **Kubernetes dry-run modes changed operational habits**: server-side dry runs (available since roughly Kubernetes 1.18, including modern 1.35+ clusters) let teams validate manifests against the API server without persisting objects, which makes Git bisection safer when a reachable cluster is available.
 
 ## Common Mistakes
 
@@ -747,4 +748,4 @@ The `git blame` command targets the regular expression `/containerPort/` and ren
 
 ## Next Module
 
-Now that you can dissect history to locate regressions and build forensic audit trails, look outward to collaboration workflows. Learn how to synchronize local work with external servers, handle complex merge conflicts, and manage upstream changes safely in [Module 7: Professional Collaboration](../module-7-remotes-prs/).
+Now that you can dissect history to locate regressions and build forensic audit trails, look outward to collaboration workflows. Learn how to synchronize local work with external servers, handle complex merge conflicts, and manage upstream changes safely in [Module 7: Professional Collaboration - Remotes and PRs](../module-7-remotes-prs/).

--- a/src/content/docs/prerequisites/git-deep-dive/module-7-remotes-prs.md
+++ b/src/content/docs/prerequisites/git-deep-dive/module-7-remotes-prs.md
@@ -542,12 +542,13 @@ Create the Kubernetes manifests using two distinct, atomic commits with conventi
 
 Create the namespace manifest first. Keeping the namespace in its own file lets reviewers verify the target scope before they inspect workload settings that depend on it:
 
-```yaml
-# namespace.yaml
+```bash
+cat <<'EOF' > namespace.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: web-tier
+EOF
 ```
 
 Commit only the namespace prerequisite. This makes the first commit a small, reversible change with one clear purpose:
@@ -559,8 +560,8 @@ git commit -m "feat(k8s): add web-tier namespace"
 
 Create the deployment manifest as a separate review unit. Its diff should show the workload, replica count, labels, and image without mixing in namespace setup:
 
-```yaml
-# deployment.yaml
+```bash
+cat <<'EOF' > deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -579,6 +580,7 @@ spec:
       containers:
       - name: nginx
         image: nginx:1.27-alpine
+EOF
 ```
 
 Commit only the workload. The second commit now tells reviewers exactly when application runtime configuration entered the branch:
@@ -652,10 +654,10 @@ Push the newly squashed commit to upstream, simulating the maintainer hitting "M
 git push upstream main
 ```
 
-Now delete your local feature branch to keep your workspace clean after the integration branch contains the accepted change:
+Now delete your local feature branch to keep your workspace clean after the integration branch contains the accepted change. A squash merge does not record merge ancestry, so Git still treats `feat/nginx-deployment` as unmerged; use force delete (`-D`) after the squash commit is on `main`:
 
 ```bash
-git branch -d feat/nginx-deployment
+git branch -D feat/nginx-deployment
 ```
 
 Fetch from upstream and sync your fork's `main`. The final rebase makes your fork reflect the accepted upstream history instead of leaving a stale local integration state:

--- a/src/content/docs/prerequisites/git-deep-dive/module-8-scale.md
+++ b/src/content/docs/prerequisites/git-deep-dive/module-8-scale.md
@@ -250,6 +250,7 @@ A subtree makes the opposite trade-off. It brings external files into a director
 git remote add shared-crds https://git.example.com/shared-crds.git
 
 # Pull the shared repo into a specific directory using the subtree strategy
+# (`git subtree` is a contrib script shipped with Git; `man git-subtree` may be absent on minimal installs)
 git subtree add --prefix=manifests/crds shared-crds main --squash
 ```
 
@@ -328,7 +329,7 @@ A good rollout plan starts with one repository and one workflow rather than a si
 
 ## Did You Know?
 
-* **The Linux Kernel Repo:** The Linux kernel repository contains more than 1.2 million commits and roughly 80,000 tracked files, yet a properly optimized local clone can still make common status checks feel interactive on modern hardware.
+* **The Linux Kernel Repo:** The Linux kernel repository contains more than 1.2 million commits and roughly 90,000 tracked files, yet a properly optimized local clone can still make common status checks feel interactive on modern hardware.
 * **Git LFS Origins:** Git LFS was announced by GitHub in 2015 because teams working with games, media, and machine learning datasets needed Git workflows without storing every large binary revision in the normal object database.
 * **The 2GB Limit:** Very large single files have historically exposed memory and tooling limits in Git clients and surrounding libraries, which is one reason large payloads should move to LFS or an artifact system before they become routine.
 * **Zero-Byte Commits:** `git commit --allow-empty` creates a commit with no working tree changes, and platform engineers often use it to trigger CI/CD flows without inventing a meaningless file edit.
@@ -498,7 +499,7 @@ Committing `.gitattributes` makes the LFS policy part of the repository contract
 - [Git LFS documentation](https://git-lfs.com/)
 - [Git LFS specification](https://github.com/git-lfs/git-lfs/blob/main/docs/spec.md)
 - [Git submodule documentation](https://git-scm.com/docs/git-submodule)
-- [Git subtree documentation](https://git-scm.com/docs/git-subtree)
+- [Git subtree contrib documentation](https://github.com/git/git/blob/master/contrib/subtree/git-subtree.txt)
 - [Git garbage collection documentation](https://git-scm.com/docs/git-gc)
 - [Git commit-graph documentation](https://git-scm.com/docs/git-commit-graph)
 - [Git maintenance documentation](https://git-scm.com/docs/git-maintenance)

--- a/src/content/docs/prerequisites/git-deep-dive/module-9-hooks-rerere.md
+++ b/src/content/docs/prerequisites/git-deep-dive/module-9-hooks-rerere.md
@@ -196,7 +196,7 @@ spec:
         image: nginx:1.26
         env:
         - name: DATABASE_PASSWORD
-          value: "super_secret_production_123!" # FATAL ERROR: Hardcoded secret exposed
+          value: "password=super_secret_production_123!" # FATAL ERROR: Hardcoded secret exposed
 ```
 
 ```bash
@@ -212,9 +212,7 @@ stdin
 
 CRITICAL: YAML validation failed for manifest -> broken-deploy.yaml
 --> Scanning staged blobs for hardcoded credentials...
-        - name: DATABASE_PASSWORD
-          value: "super_secret_production_123!" # FATAL ERROR: Hardcoded secret exposed
-FATAL: Potential hardcoded secret identified within -> broken-deploy.yaml
+blocked: potential secret in broken-deploy.yaml
 
 COMMIT ABORTED: Security or syntax violations detected.
 Please remediate the errors highlighted above, stage your fixes, and try again.
@@ -679,7 +677,7 @@ git add aws-credentials.sh
 git commit -m "chore: add local aws credentials script"
 # Expected Output: FATAL: Hardcoded AWS secret string identified...
 # Followed by: COMMIT ABORTED: Quality gates failed.
-git restore --staged aws-credentials.sh
+git rm --cached -f aws-credentials.sh
 rm -f aws-credentials.sh
 ```
 
@@ -690,7 +688,7 @@ dd if=/dev/urandom of=massive_binary.bin bs=1M count=2
 git add massive_binary.bin
 git commit -m "chore: add massive database dump binary"
 # Expected Output: FATAL: File massive_binary.bin violates size constraints...
-git restore --staged massive_binary.bin
+git rm --cached -f massive_binary.bin
 rm -f massive_binary.bin
 ```
 
@@ -738,9 +736,8 @@ exit 0
 Install the hook in the repository you already created (template changes do not retrofit existing repos):
 
 ```bash
-cp ~/.git-templates/hooks/commit-msg k8s-manifests-repo/.git/hooks/commit-msg
-chmod +x k8s-manifests-repo/.git/hooks/commit-msg
-cd k8s-manifests-repo
+cp ~/.git-templates/hooks/commit-msg .git/hooks/commit-msg
+chmod +x .git/hooks/commit-msg
 ```
 
 Test the implementation:
@@ -762,7 +759,49 @@ Enable rerere globally, reproduce the `app-config.yaml` conflict from the lesson
 <details>
 <summary><strong>Solution: Task 5</strong></summary>
 
-Use the rerere sequence from Part 5 in a disposable repository. After Git reports `Resolved 'app-config.yaml' using previous resolution.`, run `git diff` and confirm the file contains `version: "2.0-beta"` without conflict markers. Then stage the file if needed and continue the operation. If you want to prove the memory can be cleared, run `git rerere forget app-config.yaml` and repeat the conflict.
+Create an isolated throwaway repository so the global `commit-msg` template from Task 4 does not reject rerere walkthrough commits:
+
+```bash
+cd ~/git-hooks-lab
+git init -b main rerere-lab
+cd rerere-lab
+rm -f .git/hooks/commit-msg   # isolate from Jira ticket enforcement installed in Task 4
+
+git config rerere.enabled true
+
+# On the main branch
+echo 'version: "1.0"' > app-config.yaml
+git add app-config.yaml && git commit -m "chore: add initial config"
+
+git checkout -b feature
+echo 'version: "2.0-beta"' > app-config.yaml
+git commit -am "feat: update config to beta release"
+
+git checkout main
+echo 'version: "1.1"' > app-config.yaml
+git commit -am "chore: bump version to 1.1"
+
+git merge feature
+# Expect: CONFLICT in app-config.yaml and "Recorded preimage for 'app-config.yaml'"
+
+printf 'version: "2.0-beta"\n' > app-config.yaml
+git diff app-config.yaml   # confirm no <<<<<<< conflict markers remain
+git add app-config.yaml
+git commit -m "Merge feature branch"
+# Expect: "Recorded resolution for 'app-config.yaml'."
+
+git reset --hard HEAD~1
+
+git checkout feature
+git rebase main
+# Expect: "Resolved 'app-config.yaml' using previous resolution."
+
+git diff   # confirm version: "2.0-beta" without conflict markers
+git add app-config.yaml
+git rebase --continue
+```
+
+After Git reports `Resolved 'app-config.yaml' using previous resolution.`, run `git diff` and confirm the file contains `version: "2.0-beta"` without conflict markers. Then stage the file if needed and continue the operation. If you want to prove the memory can be cleared, run `git rerere forget app-config.yaml` and repeat the conflict.
 
 </details>
 

--- a/src/content/docs/prerequisites/git-deep-dive/module-9-hooks-rerere.md
+++ b/src/content/docs/prerequisites/git-deep-dive/module-9-hooks-rerere.md
@@ -89,19 +89,16 @@ The critical implementation detail is that a commit records the staging area, no
 Begin by inspecting the local hooks directory. Git creates sample hook files in `.git/hooks`, but their `.sample` suffix means Git will not run them. The active hook must be named exactly after the hook phase, with no extension, and the file must be executable according to the operating system.
 
 ```bash
-# Navigate to the hidden hooks directory
-cd .git/hooks
-
-# Inspect the default samples provided by Git
-ls -l
+# Inspect the default sample hooks Git ships (inactive until copied to exact names)
+ls -l .git/hooks
 ```
 
 Before running this, predict what you expect to see in a new repository. You should see sample files such as `pre-commit.sample`, `commit-msg.sample`, and `pre-push.sample`, but Git ignores them until you create files with the exact active names. That naming rule matters because a hook called `pre-commit.py` can be perfectly executable and still never run.
 
 ```bash
 # Create the file and grant it execute permissions
-touch pre-commit
-chmod +x pre-commit
+touch .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
 ```
 
 The hook below implements two phases. First it identifies staged files that were added, copied, or modified, then it lints staged YAML content by streaming the index version through `git show ":$FILE"`. Second it scans staged blobs for simple credential-shaped markers. The credential pattern is intentionally basic for teaching; production teams should use a maintained scanner such as Gitleaks, TruffleHog, or a hosted secret-scanning service in addition to any local hook.
@@ -149,8 +146,8 @@ while IFS= read -r -d '' FILE; do
     # Search the staged blob content for a regex of forbidden, high-risk keywords.
     # Note: This is a simplistic regex for educational illustration. Real-world
     # production setups should utilize dedicated engines like TruffleHog or Gitleaks.
-    if git show ":$FILE" | grep -iE 'password\s*[:=]|secret\s*[:=]|api_key|aws_access_key_id'; then
-        echo "FATAL: Potential hardcoded secret identified within -> $FILE"
+    if git show ":$FILE" | grep -qiE 'password\s*[:=]|secret\s*[:=]|api_key|aws_access_key_id'; then
+        echo "blocked: potential secret in $FILE"
         ERROR_FOUND=1
     fi
 done < <(git diff --cached --name-only --diff-filter=ACM -z)
@@ -241,8 +238,8 @@ The following hook reads the commit message from the file path supplied as the f
 #!/bin/bash
 # .git/hooks/commit-msg
 
-# The first argument ($1) passed to this specific script by Git is the absolute path
-# to a temporary hidden file containing the exact commit message the user just typed.
+# The first argument ($1) passed to this specific script by Git is the name/path of the
+# commit message file Git passes for this hook invocation.
 MESSAGE_FILE=$1
 MESSAGE=$(cat "$MESSAGE_FILE")
 
@@ -379,6 +376,8 @@ Automatic merge failed; fix conflicts and then commit the result.
 The phrase `Recorded preimage` means rerere has captured the conflict side of the mapping. It has not yet learned the answer. You teach it the answer by editing the file to the correct resolved state, staging that result, and completing the merge or rebase step. Only then can Git record the postimage and reuse that resolution later.
 
 ```bash
+printf 'version: "2.0-beta"\n' > app-config.yaml
+git diff app-config.yaml   # confirm no <<<<<<< conflict markers remain
 git add app-config.yaml
 git commit -m "Merge feature branch"
 ```
@@ -434,10 +433,6 @@ The aliases below are intentionally practical for DevOps and SRE work. The log a
     # Perfect for when you forgot to add a critical file or made a typo in the message.
     undo = reset --soft HEAD~1
     
-    # Hard "Nuke" of your current working directory back to a completely clean slate.
-    # WARNING: Irreversibly destroys all uncommitted tracked and untracked changes.
-    nuke = !git clean -fd && git reset --hard && git checkout .
-    
     # Rapidly check which branches currently contain a specific commit hash
     contains = branch --contains
     
@@ -445,7 +440,7 @@ The aliases below are intentionally practical for DevOps and SRE work. The log a
     pub = push -u origin HEAD
 ```
 
-The `nuke` alias is included because it appears in many real-world dotfiles, but it deserves caution. It deletes untracked files and resets tracked changes, so it is appropriate only when the repository is disposable or when you have verified that no useful work remains. Powerful aliases should be named in a way that makes their danger obvious, and teams should avoid normalizing destructive shortcuts for beginners.
+**Anti-pattern — do not add a `nuke` alias to beginner dotfiles.** A common destructive shortcut is `nuke = !git clean -fd && git reset --hard && git checkout .`, which permanently deletes untracked files and discards local changes. If you must inspect what would be removed, run `git clean -nd` first (dry-run), verify the listed paths, and only then decide whether a destructive reset is justified.
 
 Global configuration changes can also shift default Git behavior. Setting `pull.rebase` to `true` makes `git pull` fetch and rebase instead of fetch and merge, which helps teams that prefer linear local history. Setting `push.default` to `current` lets `git push` publish the current branch to a remote branch with the same name. These defaults save time, but they also encode workflow choices, so document them when onboarding a team.
 
@@ -589,7 +584,7 @@ Hooks may run with a different PATH or shell environment than an interactive ter
 
 ## Hands-On Exercise
 
-In this exercise, you will set up a local Git template directory, build a reusable `pre-commit` hook, test it against staged content, and extend the workflow with a `commit-msg` hook. Use a throwaway workspace so every command is safe to experiment with. The exercise deliberately changes global Git configuration, so record the original `init.templatedir` value before starting if you already use one.
+In this exercise, you will set up a local Git template directory, build a reusable `pre-commit` hook, test it against staged content, and extend the workflow with a `commit-msg` hook. Use a throwaway workspace so every command is safe to experiment with. The exercise deliberately changes global Git configuration, so save your previous value first with `OLD_TEMPLATEDIR=$(git config --global --get init.templatedir || true)` and restore it when finished: run `git config --global init.templatedir "$OLD_TEMPLATEDIR"` if `OLD_TEMPLATEDIR` is non-empty, or `git config --global --unset init.templatedir` if it was unset.
 
 ```bash
 mkdir -p ~/git-hooks-lab
@@ -606,6 +601,7 @@ Create a template directory at `~/.git-templates/hooks`, configure Git to use it
 <summary><strong>Solution: Task 1</strong></summary>
 
 ```bash
+OLD_TEMPLATEDIR=$(git config --global --get init.templatedir || true)
 mkdir -p ~/.git-templates/hooks
 git config --global init.templatedir '~/.git-templates'
 ```
@@ -670,7 +666,7 @@ Create a completely new repository so Git copies the template hook into `.git/ho
 
 ```bash
 cd ~/git-hooks-lab
-git init k8s-manifests-repo
+git init -b main k8s-manifests-repo
 cd k8s-manifests-repo
 cat .git/hooks/pre-commit # You should clearly see your injected script logic!
 ```
@@ -683,6 +679,8 @@ git add aws-credentials.sh
 git commit -m "chore: add local aws credentials script"
 # Expected Output: FATAL: Hardcoded AWS secret string identified...
 # Followed by: COMMIT ABORTED: Quality gates failed.
+git restore --staged aws-credentials.sh
+rm -f aws-credentials.sh
 ```
 
 **Step 4: Test Strict File Size Limitation**
@@ -692,6 +690,8 @@ dd if=/dev/urandom of=massive_binary.bin bs=1M count=2
 git add massive_binary.bin
 git commit -m "chore: add massive database dump binary"
 # Expected Output: FATAL: File massive_binary.bin violates size constraints...
+git restore --staged massive_binary.bin
+rm -f massive_binary.bin
 ```
 
 **Step 5: Test Clean, Valid Commit Execution**
@@ -735,7 +735,15 @@ fi
 exit 0
 ```
 
-Test the implementation in your repository:
+Install the hook in the repository you already created (template changes do not retrofit existing repos):
+
+```bash
+cp ~/.git-templates/hooks/commit-msg k8s-manifests-repo/.git/hooks/commit-msg
+chmod +x k8s-manifests-repo/.git/hooks/commit-msg
+cd k8s-manifests-repo
+```
+
+Test the implementation:
 
 ```bash
 git commit -m "update readme" --allow-empty
@@ -766,6 +774,16 @@ Break the hook in one controlled way, such as removing execute permissions or re
 <summary><strong>Solution: Task 6</strong></summary>
 
 Run `mv .git/hooks/pre-commit .git/hooks/pre-commit.sh` and try a commit that should fail. Git will ignore the renamed file because it does not match the hook phase name. Move it back with `mv .git/hooks/pre-commit.sh .git/hooks/pre-commit`, then run `chmod +x .git/hooks/pre-commit`. If a hook still behaves unexpectedly, temporarily add `pwd`, `echo "$PATH"`, and `command -v yamllint` diagnostics near the top.
+
+Restore your previous template directory setting:
+
+```bash
+if [ -n "$OLD_TEMPLATEDIR" ]; then
+  git config --global init.templatedir "$OLD_TEMPLATEDIR"
+else
+  git config --global --unset init.templatedir
+fi
+```
 
 </details>
 


### PR DESCRIPTION
Phase-1 cross-family review fixes for the **prerequisites / git-deep-dive** section (modules 2–10). Final unreviewed prerequisites section. Each module reviewed by a different model family; module 4 needed no fix (its only flags were illustrative-snippet false-positives, rejected).

## Per-module fixes

**2 advanced-merging** (codex, was 3.2) — corrected the false octopus-merge teaching (on conflict the branch ref is unchanged but the working tree/index are left dirty → `git merge --abort`; Quiz 2 updated); replaced the bogus offline `kubectl apply --dry-run=client` validation with `kubeconform -summary` throughout; fixed the lab so it states `deployment.yaml` auto-merges and only `configmap.yaml` conflicts; cited + tightened the GitHub Oct-2018 incident; 5 P2 (merge-base `--all`, recursive=ort, `merge --abort` caveats, `kubectl kustomize`, Torvalds attribution).

**3 interactive-rebasing** (cursor, APPROVE 4.9) — softened a Git-version claim (1.7 series, not exactly 1.7.0).

**5 worktrees-stashing** (deepseek, APPROVE 4.5) — `git init` → `git init -b main` in both labs (stock Git defaults to `master`, breaking later `main` refs); added stash-practice cleanup.

**6 troubleshooting** (cursor, 4.5) — pickaxe regex `\s` → `[[:space:]]` (`git log -G` uses POSIX ERE, not PCRE; `\s` silently under-matched) + a note; fixed invalid YAML in a sample diff; aligned a Next-module link; `--dry-run=server` wording (since ~1.18).

**7 remotes-prs** (agy, 4.5) — `git branch -d` → `-D` after `git merge --squash` (squash doesn't record ancestry); manifests now written via `cat <<'EOF'` heredocs so the lab's `git add` works.

**8 scale** (deepseek, APPROVE 4.5) — fixed a 404 `git-subtree` source URL (contrib); corrected the Linux-kernel tracked-files count (~90k).

**9 hooks-rerere** (codex, was 3.0) — **removed two unsafe patterns**: the pre-commit secret-scanner no longer prints the detected secret (`grep -qiE`, filename-only), and the destructive `nuke` global alias is removed/reframed as an anti-pattern. Plus runnability: hook setup stays in the work tree, `git init -b main`, test files unstaged between steps, the `commit-msg` hook is actually installed into the repo, and the rerere example shows a real resolution before `git add`.

**10 gitops-bridge** (cursor, APPROVE 4.7) — opening scenario prefixed `Hypothetical scenario:`; `argocd-application-controller` corrected to a StatefulSet; `commit.gpgsign` scoped `--local`; overlay name aligned (`prod`); GitOps security-table overclaims reworded.

The two heavy modules (2, 9) get a codex R2 before merge; 3/5/6/7/8/10 were orchestrator-verified against the review findings.

## Learner check

> Advanced Git merging is the practiced skill that keeps that reconciliation from becoming an outage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
