### PR TITLE
chore(content): linux Phase-1 review fixes wave 2 — 1.3 + networking 3.1/3.2/3.3

### DIFF
--- a/src/content/docs/linux/foundations/networking/module-3.1-tcp-ip-essentials.md
+++ b/src/content/docs/linux/foundations/networking/module-3.1-tcp-ip-essentials.md
@@ -36,7 +36,7 @@ After completing this module, you will be able to reason about TCP/IP as an oper
 
 ## Why This Module Matters
 
-At 02:11, a platform team sees checkout requests timing out through an ingress controller. Pods are Ready, the Service exists, CoreDNS is healthy, and the application logs show no errors. The first useful clue comes from a node: `ip route get <pod-ip>` chooses the wrong interface, `ss -tan` shows many client sockets in `SYN-SENT`, and `conntrack -L` shows stale translated Service flows. Nothing in that evidence is Kubernetes-specific. Kubernetes supplied the objects, but Linux made the packet decisions.
+**Hypothetical scenario:** Picture a page when a platform team sees checkout requests timing out through an ingress controller. Pods are Ready, the Service exists, CoreDNS is healthy, and the application logs show no errors. The first useful clue comes from a node: `ip route get <pod-ip>` chooses the wrong interface, `ss -tan` shows many client sockets in `SYN-SENT`, and `conntrack -L` shows stale translated Service flows. Nothing in that evidence is Kubernetes-specific. Kubernetes supplied the objects, but Linux made the packet decisions.
 
 A platform engineer who cannot reason about TCP state machines, MTU, ARP/NDP, routes, and conntrack is blind during real outages. Service IPs are virtual addresses, CNI plugins may use overlays or direct routing, ingress may terminate TCP or QUIC, egress often rewrites source addresses, and active-active VIPs rely on neighbor behavior. The abstraction is useful only when you can descend through it to a packet-on-the-wire decision. Kubernetes documents that Services get cluster IPs through a virtual IP mechanism, and kube-proxy programs Linux packet forwarding rules in iptables, nftables, or IPVS modes depending on configuration. ([Kubernetes Services](https://v1-35.docs.kubernetes.io/docs/concepts/services-networking/service/), [Kubernetes Virtual IPs and Service Proxies](https://v1-35.docs.kubernetes.io/docs/reference/networking/virtual-ips/))
 
@@ -96,6 +96,8 @@ network:       10.244.2.0
 usable range:  10.244.2.1 - 10.244.2.254
 broadcast:     10.244.2.255
 ```
+
+> **Predict:** Before reading the network and broadcast lines, compute them yourself for `10.244.9.200/24`.
 
 A Kubernetes cluster normally has at least three address domains. Node IPs belong to the underlay: cloud VPC, bare-metal VLAN, or host network. Pod IPs come from CNI-managed ranges and must be reachable according to the cluster networking design. Service ClusterIPs come from a Service CIDR and are virtual destinations that kube-proxy or another dataplane captures and redirects. Kubernetes states that normal Services resolve to cluster IPs, while headless Services return endpoint IPs instead of relying on virtual IP forwarding. ([Kubernetes DNS for Services and Pods](https://v1-35.docs.kubernetes.io/docs/concepts/services-networking/dns-pod-service/), [Kubernetes Services](https://v1-35.docs.kubernetes.io/docs/concepts/services-networking/service/))
 
@@ -185,6 +187,8 @@ stateDiagram-v2
     LAST_ACK --> CLOSED: receive ACK
     TIME_WAIT --> CLOSED: 2MSL timeout
 ```
+
+> **Predict:** A client shows `SYN-SENT` for 30 seconds — is this a refused connection or a timeout, and which command proves it?
 
 Read `ss -tan` as evidence. `SYN-SENT` on a client means SYN packets left or are queued but no SYN-ACK has completed the handshake. `SYN-RECV` on a server means SYNs arrived and replies were attempted, but the final ACK did not complete or accept queue pressure exists; it is the `SYN_RECEIVED` state in the diagram above. `ESTAB` proves the handshake completed. `CLOSE-WAIT` means the peer closed and the local application has not closed its side. `TIME-WAIT` is normal on the side that actively closed; it prevents old duplicate segments from corrupting a later connection using the same tuple.
 
@@ -373,9 +377,9 @@ The pattern behind these mistakes is premature conclusion. Each command proves o
 
 ## Knowledge Check
 
-<details><summary>Question 1: A client gets `connection refused` to a ClusterIP Service, but `kubectl get endpoints` shows ready pods. What is your first split?</summary>
+<details><summary>Question 1: A client gets `connection refused` to a ClusterIP Service, but `kubectl get endpointslices` shows ready pods. What is your first split?</summary>
 
-Separate Service translation from backend socket state. `connection refused` usually means a RST returned, so inspect whether the selected backend pod actually has a listener on the targetPort with `ss -tlnp` in the correct namespace or debug container. Then inspect Service port to targetPort mapping and kube-proxy rules. Do not start with MTU or DNS; the refusal is transport evidence.
+Separate Service translation from backend socket state. `connection refused` usually means a RST returned, so inspect whether the selected backend pod actually has a listener on the targetPort with `ss -tlnp` in the correct namespace or debug container. Then inspect Service port to targetPort mapping and kube-proxy rules. Do not start with MTU or DNS; the refusal is transport evidence. For endpoint selection on Kubernetes 1.35+, use `kubectl get endpointslices` rather than the legacy Endpoints API.
 
 </details>
 
@@ -411,7 +415,11 @@ Inspect conntrack and kube-proxy rules. Long-lived Service flows may keep transl
 
 ## Hands-On Exercise
 
-Use a disposable Linux VM, lab node, or Kubernetes worker where you have permission to inspect networking state. Capture outputs in a scratch note and label each one with the layer it proves.
+Use a disposable Linux VM, lab node, or Kubernetes worker where you have permission to inspect networking state. Capture outputs in a scratch note and label each one with the layer it proves. On minimal images, `tracepath` and `mtr` may require `sudo apt install iputils-tracepath mtr`.
+
+### Task 0: Prefix boundaries (IPv4 and IPv6)
+
+For `10.244.9.200/24`, write the network address, broadcast address, and usable host range. For `fd00:abcd:1234::/48`, identify the `/48` prefix boundary (the first 48 bits of the address). Use `ipcalc` or manual bit math; compare with `ip route get` only after you have your answers.
 
 ### Task 1: Map Your Current Packet Path
 
@@ -473,7 +481,7 @@ Find the egress interface MTU and any PMTU clue from `tracepath`. If you are on 
 - [ ] Trace TCP connection state from `SYN-SENT` through `TIME-WAIT` and use `ss -tan` output to distinguish refusal, timeout, backlog, close, and keepalive symptoms.
 - [ ] Diagnose Service and ingress failures by connecting Linux conntrack, DNAT, netfilter hooks, sockets, and kube-proxy proxy modes.
 - [ ] Design a triage sequence for MTU, DNS, ARP/NDP, routing, and transport incidents without falling back to legacy net-tools.
-- [ ] Chose modern `ip`, `ss`, `tcpdump`, `dig`, `mtr`, `nc`, and `conntrack` tools instead of legacy net-tools.
+- [ ] Choose modern `ip`, `ss`, `tcpdump`, `dig`, `mtr`, `nc`, and `conntrack` tools instead of legacy net-tools.
 
 ## Next Module
 
@@ -496,6 +504,11 @@ Next, continue to [Module 3.2: DNS in Linux](../module-3.2-dns-linux/) to go dee
 - [Linux ip-route manual](https://man7.org/linux/man-pages/man8/ip-route.8.html)
 - [Linux ip-rule manual](https://man7.org/linux/man-pages/man8/ip-rule.8.html)
 - [Linux ip-neighbour manual](https://man7.org/linux/man-pages/man8/ip-neighbour.8.html)
+- [Linux ip-link manual](https://man7.org/linux/man-pages/man8/ip-link.8.html)
+- [Linux tcp manual](https://man7.org/linux/man-pages/man7/tcp.7.html)
+- [Linux udp manual](https://man7.org/linux/man-pages/man7/udp.7.html)
+- [Linux nsswitch.conf manual](https://man7.org/linux/man-pages/man5/nsswitch.conf.5.html)
+- [Linux resolv.conf manual](https://man7.org/linux/man-pages/man5/resolv.conf.5.html)
 - [Linux ss manual](https://man7.org/linux/man-pages/man8/ss.8.html)
 - [Linux kernel netfilter documentation](https://docs.kernel.org/networking/netfilter.html)
 - [Linux kernel conntrack sysctl documentation](https://docs.kernel.org/networking/nf_conntrack-sysctl.html)

--- a/src/content/docs/linux/foundations/networking/module-3.2-dns-linux.md
+++ b/src/content/docs/linux/foundations/networking/module-3.2-dns-linux.md
@@ -31,7 +31,7 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-The Facebook 2021 BGP outage (see *Route 53*) <!-- incident-xref: facebook-2021-bgp --> showed how DNS and routing failures can appear as separate symptoms while actually forming part of one incident, and why troubleshooting should trace failures from resolver behavior through routing topology.
+The Facebook 2021 BGP outage <!-- incident-xref: facebook-2021-bgp --> showed how DNS and routing failures can appear as separate symptoms while actually forming part of one incident, and why troubleshooting should trace failures from resolver behavior through routing topology.
 
 The same pattern appears at smaller scale inside Linux fleets and Kubernetes clusters. A database migration succeeds, the new service IP is healthy, and the application still connects to the old address because a local cache ignored the intended TTL. A pod can reach `8.8.8.8` by IP, yet it fails every request to `api.partner.example` because the resolver burns time trying cluster search suffixes first. A developer proves that `dig` returns the right answer, but the application keeps using a stale `/etc/hosts` override because applications do not necessarily resolve names the same way diagnostic DNS tools do.
 
@@ -150,13 +150,13 @@ Query: "api.example.com" (2 dots < 5)
   Try: api.example.com.cluster.local
   Try: api.example.com  <- What we wanted
 
-Query: "a.b.c.d.example.com" (4 dots < 5)
-  Still tries search domains first! (need 5+ dots)
+Query: "a.b.c.example.com" (4 dots < 5)
+  Still tries search domains first! (need ≥5 dots to skip search expansion)
 ```
 
 The trailing dot is the clean escape hatch when you mean "this name is already complete." In DNS notation, `api.example.com.` is absolute, while `api.example.com` may still be treated as a candidate for search expansion depending on resolver settings. That final dot looks odd in application configuration, but it can remove several failed queries per outbound request in clusters that use `ndots:5`. The tradeoff is readability and compatibility; some application libraries accept absolute names cleanly, while a few configuration validators reject the trailing dot.
 
-Kubernetes uses this behavior deliberately. A pod in the `default` namespace can connect to a Service named `payments` by using the short name `payments`, because the pod search list expands it into `payments.default.svc.cluster.local`, then broader service and cluster domains. This is ergonomic for internal calls, but the same ergonomics can punish external calls such as `api.external-partner.com`, which contains fewer dots than the Kubernetes default threshold and may trigger cluster-suffix attempts before the external query.
+Kubernetes uses this behavior deliberately. A pod in the `default` namespace can connect to a Service named `payments` by using the short name `payments`, because the pod search list expands it into `payments.default.svc.cluster.local`, then broader service and cluster domains. This is ergonomic for internal calls, but the same ergonomics can punish external calls such as `api.external-partner.com`, which contains fewer dots than the Kubernetes default threshold and may trigger cluster-suffix attempts before the external query. With `ndots:5`, a name needs five or more dots before the resolver tries it as absolute first; a four-dot name like `a.b.c.example.com` still goes through search expansion.
 
 ```bash
 # In a Kubernetes pod
@@ -318,6 +318,9 @@ graph TD
 The fully qualified Service name encodes four useful facts: service name, namespace, record type marker, and cluster domain. The short name `my-service` only works when the resolver search list expands it to the namespace you intended. That is convenient inside a single namespace and risky across namespace boundaries. A production incident often begins with a service moved from `default` to `payments`, while clients still use a short name that now expands inside the wrong namespace first.
 
 ```bash
+# examples below use the kubectl shortcut
+alias k=kubectl
+
 # Run a temporary busybox pod to test DNS resolution
 k run dnstest --image=busybox --rm -it --restart=Never -- sh
 
@@ -390,17 +393,17 @@ TTL planning is a deployment skill. If a service is going to move next week, low
 Pause and predict: a database record changes from an old IP to a new IP, the authoritative record now has a TTL of 60 seconds, and five minutes later one Ubuntu web server still connects to the old IP while `dig db.internal` returns the new one. Which layer is most suspicious, and what evidence would you collect before restarting application processes?
 
 ```bash
-# Check the current status of systemd-resolved
-systemd-resolve --status
+# Check resolver status (Ubuntu 22.04/24.04 canonical tool)
+resolvectl status
 
 # Flush the DNS cache maintained by systemd-resolved
-systemd-resolve --flush-caches
+sudo resolvectl flush-caches
 
 # Display statistics about systemd-resolved operations
-systemd-resolve --statistics
+resolvectl statistics
 ```
 
-Many modern Linux distributions use `systemd-resolved` as a local resolver and cache. Depending on distribution version and configuration, applications may send queries to a local stub address, and `/etc/resolv.conf` may be a generated file that points at that stub rather than directly at upstream DNS servers. In that model, editing `/etc/resolv.conf` by hand is often the wrong fix because the file is regenerated by the network stack. Use the owning tool to change configuration, and use resolver-specific commands to inspect and flush cache state.
+Many modern Linux distributions use `systemd-resolved` as a local resolver and cache. On Ubuntu 22.04 and 24.04, `resolvectl` is the supported interface; legacy `systemd-resolve` commands may still exist but are deprecated. Depending on distribution version and configuration, applications may send queries to a local stub address, and `/etc/resolv.conf` may be a generated file that points at that stub rather than directly at upstream DNS servers. In that model, editing `/etc/resolv.conf` by hand is often the wrong fix because the file is regenerated by the network stack. Use the owning tool to change configuration, and use resolver-specific commands to inspect and flush cache state.
 
 ```bash
 # Check if systemd-resolved is active
@@ -416,20 +419,19 @@ sudo resolvectl flush-caches
 resolvectl status
 ```
 
-`resolvectl status` is a better modern habit than only reading the symlink target of `/etc/resolv.conf`. It shows per-link DNS servers and routing domains, which matters on laptops, VPN-connected hosts, and servers with multiple interfaces. A host can send corporate domains to one resolver and public domains to another. If the wrong link owns the domain route, DNS symptoms may appear only for a subset of names.
+`resolvectl status` is a better modern habit than only reading the symlink target of `/etc/resolv.conf`. It shows per-link DNS servers and routing domains, which matters on laptops, VPN-connected hosts, and servers with multiple interfaces. A host can send corporate domains to one resolver and public domains to another. If the wrong link owns the domain route, DNS symptoms may appear only for a subset of names. The `DNS Domain` and `DNS Servers` lines are scoped per link (for example `eth0` versus `wlan0`), so a name can resolve on one interface and fail on another even when `/etc/resolv.conf` lists a single stub address.
 
 ```bash
 # Symptom: An application connects to an old IP address for a domain, even after DNS records have been updated.
 
 # Solutions:
 # 1. Flush the local DNS cache (if systemd-resolved is in use)
-sudo systemd-resolve --flush-caches
-# Or using resolvectl
 sudo resolvectl flush-caches
+# Legacy: systemd-resolve --flush-caches (deprecated on Ubuntu 22.04/24.04)
 
 # 2. Check the Time To Live (TTL) of the DNS record to understand how long it's designed to be cached
 dig example.com | grep -E "^example.*IN.*A"
-# The number after 'IN' in the ANSWER SECTION is the TTL in seconds. A low TTL means changes propagate faster.
+# The TTL is the number BEFORE 'IN' in the answer section (e.g. 3600 = cached for 1 hour).
 
 # 3. In Kubernetes, if CoreDNS is caching stale external records, you might need to restart its pods to force a refresh
 k rollout restart deployment coredns -n kube-system
@@ -441,17 +443,25 @@ Restarting CoreDNS is a blunt instrument and should not be the first move for ev
 
 A repeatable DNS workflow starts with the failing name, the failing environment, and the expected destination. Those three facts sound basic, but many incidents skip one of them and drift into vague claims. A short Service name inside a pod, a public FQDN from a node, and a corporate split-DNS name from a VPN-connected host are different cases. Write the exact name and the exact place where it failed before collecting commands, because the rest of the evidence only has meaning in that context.
 
+### Symptom Triage
+
 The second step is to decide whether the symptom is name resolution or post-resolution connectivity. If a log says `connection refused`, the name may have resolved correctly and the remote service may be rejecting connections. If a log says `temporary failure in name resolution`, the resolver path is still suspicious. If a TLS client rejects a certificate, DNS may have sent the client to an unexpected endpoint, but the immediate evidence lives in certificate identity and connection destination. Good DNS debugging does not absorb every network symptom; it proves or clears the name-to-address step.
 
 Raw IP tests are useful when you already know the expected address, but they must be interpreted carefully. Reaching an IP address does not prove DNS is healthy, and failing to reach an IP address does not prove DNS is broken. The value is separation. If `curl http://10.96.45.123` reaches a Service while `curl http://payments` does not, the name path deserves attention. If both fail, DNS may still be wrong, but service routing, endpoints, network policy, or application health are at least as likely.
 
+### Layer Separation
+
 After that separation, compare direct DNS with application-style resolution. A direct query to the configured resolver answers "what does this DNS server say?" while `getent hosts` answers "what does this Linux resolver path return?" If those two results differ, you have a local policy problem, not a generic DNS outage. If they agree, the next question is whether the application runtime uses that same resolver path or maintains its own cache and connection behavior.
+
+### Evidence Collection
 
 On hosts, collect `/etc/nsswitch.conf`, `/etc/hosts`, `/etc/resolv.conf`, and resolver service status together. Reading only one file can mislead you because generated resolver files often point at local stubs, and local stubs may route different domains to different upstream servers. A useful incident note says, "NSS is `files dns`; no hosts override exists; resolved routes this suffix to resolver X; `getent` returns address Y." That sentence gives the next engineer a coherent model instead of a pile of commands.
 
 On Kubernetes, collect the pod namespace, pod DNS policy, pod `/etc/resolv.conf`, CoreDNS Service ClusterIP, CoreDNS pod status, and a lookup from the affected context. These facts let you distinguish a missing Service record from a broken DNS service path. A short name failing while the fully qualified name works points toward search domains or namespace assumptions. Both names failing while external names work points toward Kubernetes record generation or service existence. Everything failing points toward CoreDNS health, service routing, or network reachability to the DNS service.
 
 When external names are slow inside Kubernetes, inspect query shape before scaling DNS. A workload that calls `api.partner.example` without a trailing dot may force the resolver to try several cluster-suffixed names first. CoreDNS metrics may show high QPS, but the root cause can be client-side expansion. Scaling CoreDNS may reduce immediate pain, yet it leaves wasted queries in place. The better fix might be an absolute FQDN, a pod-specific DNS option, or application connection reuse that reduces lookup frequency.
+
+### Cache Ownership
 
 When DNS answers are correct but applications still use old addresses, shift from record correctness to cache ownership. The stale answer may live in `systemd-resolved`, CoreDNS, a recursive resolver, a browser, a JVM, a Go process, or a connection pool. Each owner has different visibility and different clearing behavior. Restarting every component is tempting, but it destroys evidence and broadens impact. Start with the narrowest cache you can prove, then widen only if before-and-after checks show the stale answer remains.
 
@@ -571,7 +581,7 @@ First inspect the pod's `/etc/resolv.conf` to confirm the nameserver points at t
 
 <details><summary>A database DNS record moved to a new IP with a 60-second TTL, but one Ubuntu web server still uses the old IP five minutes later while `dig` returns the new IP. What is the probable layer and response?</summary>
 
-The probable layer is a local resolver cache, application DNS cache, or stale local override rather than authoritative DNS. Compare `getent hosts db.internal` with `dig db.internal`, inspect `resolvectl statistics`, and check `/etc/hosts` before restarting services. If `systemd-resolved` is serving stale data, `sudo resolvectl flush-caches` is the targeted fix. If the application maintains its own DNS cache or long-lived connections, you may need an application reload after collecting evidence.
+The probable layer is a local resolver cache, application DNS cache, or stale local override rather than authoritative DNS. Compare `getent hosts db.internal` with `dig db.internal`, inspect `resolvectl statistics` (cache hits and misses), and check `/etc/hosts` before restarting services. If `systemd-resolved` is serving stale data, `sudo resolvectl flush-caches` is the targeted fix. If the application maintains its own DNS cache or long-lived connections, you may need an application reload after collecting evidence.
 
 </details>
 

--- a/src/content/docs/linux/foundations/networking/module-3.3-network-namespaces.md
+++ b/src/content/docs/linux/foundations/networking/module-3.3-network-namespaces.md
@@ -282,7 +282,7 @@ On Ubuntu 24.04, `ip netns identify` can be run from a process context to learn 
 # From inside an ip netns exec shell, learn the namespace name
 ip netns identify
 
-# From the host, see which namespace a PID uses (if linked to a named handle)
+# From the host, read the network-namespace inode a PID is in (e.g. net:[...]); use 'ip netns identify <pid>' to map it to a named handle.
 readlink /proc/self/ns/net
 ```
 

--- a/src/content/docs/linux/foundations/system-essentials/module-1.3-filesystem-hierarchy.md
+++ b/src/content/docs/linux/foundations/system-essentials/module-1.3-filesystem-hierarchy.md
@@ -28,7 +28,7 @@ Upon completing this module, you will be able to:
 
 ## Why This Module Matters
 
-During a major retail sale, a payments team watched healthy application pods restart until checkout traffic collapsed. The application code had not changed, the cluster control plane was available, and CPU graphs looked ordinary, so the first responders spent valuable time chasing deployment history and network policies. The failure lived lower in the stack: container logs had grown until `/var/log` on several nodes had no usable space, kubelet could not rotate or write the files it needed, and a storage choice that had looked harmless during testing turned into a revenue incident measured in millions of dollars.
+**Hypothetical scenario:** During a major retail sale, a payments team watched healthy application pods restart until checkout traffic collapsed. The application code had not changed, the cluster control plane was available, and CPU graphs looked ordinary, so the first responders spent valuable time chasing deployment history and network policies. The failure lived lower in the stack: container logs had grown until `/var/log` on several nodes had no usable space, kubelet could not rotate or write the files it needed, and a storage choice that had looked harmless during testing turned into a major business-impacting incident.
 
 That kind of outage feels unfair until you know how Linux organizes the machine. The filesystem hierarchy is not a decorative directory tree; it is an operating contract between the kernel, boot process, service manager, package manager, container runtime, Kubernetes components, and administrators. When `/etc` is treated like a scratchpad, configuration drift becomes invisible. When `/var` is treated like an unlimited bucket, logs and runtime data can starve the node. When `/proc` and `/sys` are mistaken for ordinary directories, an operator can misread live kernel state or write a dangerous runtime setting.
 
@@ -242,7 +242,7 @@ cat /sys/fs/cgroup/cgroup.controllers 2>/dev/null && echo "cgroup v2" || echo "c
 graph LR
     dev["/dev/"] --> null_dev["null (Discard all data)"]
     dev --> zero["zero (Endless stream of zero bytes)"]
-    dev --> random["random (Blocking secure RNG)"]
+    dev --> random["random (secure RNG; may block only during early boot before the pool is initialized)"]
     dev --> urandom["urandom (Non-blocking RNG)"]
     dev --> tty["tty (Current terminal)"]
     dev --> stdin["stdin (Standard input symlink)"]
@@ -263,7 +263,7 @@ echo "hello, world!" > /dev/null
 # Generate 16 cryptographically secure random bytes and display them in hexadecimal
 head -c 16 /dev/urandom | xxd
 
-# Create a 1MB file filled with zeros (useful for testing disk I/O or creating swap files)
+# Stream 1 MiB of zeros and count the bytes (nothing is written to disk)
 dd if=/dev/zero bs=1M count=1 | wc -c  # Counts the bytes written
 ```
 
@@ -448,8 +448,8 @@ Kubernetes is portable at the API level, but a node is still a Linux machine wit
 | `/var/lib/kubelet/` | Kubelet's persistent data directory, including its internal state, plugin data, and volume information. |
 | `/var/lib/kubelet/pods/` | Subdirectory where Kubelet stores data related to running pods, including mounted volumes and temporary files. |
 | `/var/lib/containerd/` | Containerd's data directory, holding image layers, container metadata, and writable container layers. |
-| `/var/log/pods/` | Directory where Kubernetes stores symlinks to container logs. Each pod has its own subdirectory. |
-| `/var/log/containers/` | Contains actual container log files, often symlinked from `/var/log/pods`. |
+| `/var/log/pods/` | Directory where the container runtime writes the actual container log files; each pod has its own subdirectory. |
+| `/var/log/containers/` | Per-container symlinks that point to the log files under `/var/log/pods/`, commonly consumed by node log agents. |
 | `/run/containerd/` | Location for the containerd socket and runtime-specific data, typically transient. |
 
 The table is not a promise that every distribution uses only these paths, but it is the right starting map for kubeadm-style nodes and many common installations. Managed services, hardened images, and custom runtime configurations can move or hide pieces, so your first command should confirm existence and ownership rather than assuming the textbook path is authoritative. If the directory exists, inspect it carefully; if it does not, use service configuration and runtime documentation to find the configured alternative.
@@ -512,10 +512,10 @@ You can use this framework during design review as well as incident response. As
 
 ## Did You Know?
 
-- **The Filesystem Hierarchy Standard dates back to 1994**: FHS 1.0 appeared in 1994, and FHS 3.0 was published in 2015 to keep core locations predictable across distributions and software packages.
+- **The Filesystem Hierarchy Standard evolved over time**: The predecessor FSSTND was released in 1994, and the FHS name followed as the scope widened to other Unix-like systems.
 - **Everything really is a file in Linux**: hardware devices can appear under `/dev`, process state appears under `/proc`, and kernel device relationships appear under `/sys`, which gives scripts a common read and write model.
 - **`/proc` is not stored on disk**: reading `/proc/meminfo` asks the kernel to synthesize current memory information at that moment, so the file's contents can change immediately between reads.
-- **Container images often carry more shared operating-system content than application content**: an image over 200 MB may contain only 20-50 MB of unique application files because layers reuse common Linux directories and libraries.
+- **Container images often carry more shared operating-system content than application content**: a large image is often mostly shared base-OS layers, with application files making up a smaller portion because layers commonly reuse common Linux directories and libraries.
 
 ## Common Mistakes
 


### PR DESCRIPTION
## linux track Phase-1 — R1 review fixes wave 2 (4 modules)

Applies ground-checked R1 cross-family review findings to the next curriculum-order batch so they can be finalized to `done`. Reviewed via the 4-pool mix (codex/cursor/claude/gemini, one per pool).

- **system-essentials 1.3-filesystem-hierarchy** (codex review): **reversed Kubernetes log paths fixed** — `/var/log/pods/` holds the actual runtime-written log files and `/var/log/containers/` holds the per-container symlinks (the module had them backwards); opening incident → `Hypothetical scenario:` + dropped the "millions of dollars" claim; `dd … | wc -c` comment corrected (streams bytes, writes no file); `/dev/random` blocking note modernized (Linux 5.6+); FHS/FSSTND-1994 precision; image-size claim made qualitative.
- **networking 3.1-tcp-ip** (cursor review): opening war-story → `Hypothetical scenario:`; two inline "Predict" active-learning prompts; new Hands-On Task 0 (IPv4 `/24` + IPv6 ULA prefix calculation, matching outcome #2); `kubectl get endpoints`→`endpointslices`; "Chose"→"Choose"; `tracepath`/`mtr` install note; Sources parity (added inline-cited man pages).
- **networking 3.2-dns** (claude review): **ndots factual fix** — `a.b.c.d.example.com` has 5 dots not 4, so the example name → `a.b.c.example.com` and the threshold wording → "≥5 dots" (and the dots-not-labels clarifier corrected on self-verify); `alias k=kubectl` preamble block added (clears `runnable_no_kubectl_alias` gate); body raised over the 5000-word floor; misleading Facebook-2021/Route 53 cross-reference removed (Route 53 was not involved); **TTL field-order fixed** (TTL is *before* `IN`, not after); `systemd-resolve`→`resolvectl` as the lead command; "DNS Incident Workflow" wall-of-prose split with subheadings.
- **networking 3.3-network-namespaces** (gemini review, APPROVE+nit): `readlink /proc/self/ns/net` comment clarified (returns the namespace inode, not a named handle; `ip netns identify <pid>` maps to the name).

**Rejected FPs (ground-checked):** within-section `../module-X/` links, "Kubernetes 1.35", gnu.org URLs. Build green (2129 pages, 0 errors); health 0 errors; `verify_module.py` T0/passing on all four (3.2 now clears body-words + alias gates). Each fix self-verified against the R1 findings.

## Learner check

> The TTL is the number BEFORE 'IN' in the answer section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
