### PR TITLE
chore(content): linux Phase-1 review fixes wave 3 — 3.4 + hardening 4.1/4.2/4.3

### DIFF
--- a/src/content/docs/linux/foundations/networking/module-3.4-iptables-netfilter.md
+++ b/src/content/docs/linux/foundations/networking/module-3.4-iptables-netfilter.md
@@ -27,7 +27,7 @@ Before starting this module, complete [Module 3.1: TCP/IP Essentials](../module-
 
 ## Why This Module Matters
 
-During a holiday sale, a regional retailer watched checkout latency climb from a few hundred milliseconds to many seconds after a routine Kubernetes Service rollout. The pods were healthy, DNS resolved, and the load balancer reported open connections, but customers still abandoned carts while engineers bounced between application logs, cloud firewalls, and kube-proxy restarts. The root cause was not in the application at all: the node had accumulated thousands of service and endpoint rules, a stale drop rule sat before the expected accept path, and the only clue was an iptables counter that stopped increasing where it should have climbed. The financial impact was measured in lost orders, refund credits, and emergency consulting time, all because the team treated node packet filtering as invisible plumbing.
+**Hypothetical scenario:** During a holiday sale, a regional retailer watched checkout latency climb from a few hundred milliseconds to many seconds after a routine Kubernetes Service rollout. The pods were healthy, DNS resolved, and the load balancer reported open connections, but customers still abandoned carts while engineers bounced between application logs, cloud firewalls, and kube-proxy restarts. The root cause was not in the application at all: the node had accumulated thousands of service and endpoint rules, a stale drop rule sat before the expected accept path, and the only clue was an iptables counter that stopped increasing where it should have climbed. The financial impact was measured in lost orders, refund credits, and emergency consulting time, all because the team treated node packet filtering as invisible plumbing.
 
 That kind of incident is why iptables and netfilter still matter even in clusters that advertise higher-level networking. Kubernetes Services, NodePorts, many network policy engines, container egress NAT, and debugging workflows still rely on the Linux kernel's packet filtering hooks. When traffic disappears, the important question is rarely "what command lists rules?" The useful question is "where was this packet in the kernel when it changed direction, changed address, or stopped moving?"
 
@@ -71,7 +71,7 @@ The tables are another layer over the same hooks. The filter table decides wheth
 | Table | Purpose | Chains |
 |-------|---------|--------|
 | filter | Accept/drop packets | INPUT, FORWARD, OUTPUT |
-| nat | Address translation | PREROUTING, OUTPUT, POSTROUTING |
+| nat | Address translation | PREROUTING, INPUT, OUTPUT, POSTROUTING |
 | mangle | Packet modification | All chains |
 | raw | Connection tracking exceptions | PREROUTING, OUTPUT |
 
@@ -146,7 +146,7 @@ sudo iptables -L INPUT -n --line-numbers
 sudo iptables-save
 ```
 
-One war story illustrates why the saved format matters. A team allowed an emergency SSH source by appending a rule, verified that the rule existed, and still remained locked out from a maintenance subnet. The problem was a previous reject rule with a broader subnet match above the new rule. `iptables -L` showed both rules, but `iptables-save` made the order and table context obvious enough to spot the mistake during a bridge call.
+**Hypothetical scenario:** One war story illustrates why the saved format matters. A team allowed an emergency SSH source by appending a rule, verified that the rule existed, and still remained locked out from a maintenance subnet. The problem was a previous reject rule with a broader subnet match above the new rule. `iptables -L` showed both rules, but `iptables-save` made the order and table context obvious enough to spot the mistake during a bridge call.
 
 When deleting rules, prefer deletion by exact specification when you can reproduce the rule safely, and deletion by line number only after listing the chain immediately beforehand. Line numbers are not stable if another automation loop edits the chain between your list and delete commands. Kubernetes and CNI agents may reconcile their own chains continuously, so manual edits inside their managed chains are usually overwritten. Manual rules belong in your own chain or in a host firewall system that is designed to coexist with cluster automation.
 
@@ -213,7 +213,7 @@ sudo iptables -F INPUT
 sudo iptables -F
 
 # Save rules (Debian/Ubuntu)
-sudo iptables-save > /etc/iptables/rules.v4
+sudo sh -c 'iptables-save > /etc/iptables/rules.v4'
 
 # Restore rules
 sudo iptables-restore < /etc/iptables/rules.v4
@@ -288,10 +288,10 @@ Network policy adds another layer, and the exact chain names depend on the plugi
 
 ```bash
 # Network policy rules (typically in KUBE-NWPLCY chains)
-sudo iptables -L KUBE-NWPLCY-* -n 2>/dev/null
+sudo iptables-save | grep -E 'KUBE-NWPLCY|cali-'
 
 # Calico uses its own chains
-sudo iptables -L cali-* -n 2>/dev/null | head -50
+sudo iptables-save | grep -E 'KUBE-NWPLCY|cali-'
 ```
 
 To inspect kube-proxy behavior with the alias, use the Kubernetes API for intent and iptables for implementation. The API tells you which Service and endpoints should exist; the node rules tell you whether kube-proxy actually programmed a path. If the API object is right but no matching rule exists, look at kube-proxy health, permissions, node selectors, and EndpointSlice readiness. If the rule exists but the counter stays at zero, the packet may be taking a different node, interface, IP family, or policy path.
@@ -319,12 +319,15 @@ sudo iptables -t raw -A PREROUTING -p tcp --dport 80 -j TRACE
 sudo iptables -t raw -A OUTPUT -p tcp --dport 80 -j TRACE
 
 # View traces
+# Legacy iptables stores TRACE entries in kernel logs
 sudo dmesg | grep TRACE
 
-# Or
-sudo tail -f /var/log/kern.log | grep TRACE
+# nft-backed iptables surfaces trace events via xtables-monitor
+sudo xtables-monitor --trace
 
-# Don't forget to remove trace rules when done!
+# Remove temporary trace rules
+sudo iptables -t raw -D PREROUTING -p tcp --dport 80 -j TRACE
+sudo iptables -t raw -D OUTPUT -p tcp --dport 80 -j TRACE
 ```
 
 TRACE is powerful because it shows rule traversal, but it is also noisy enough to damage your ability to see anything else. On a high-traffic node, tracing a common port can flood kernel logs, increase CPU load, and rotate away useful messages from the incident. Use narrow matches, reproduce once or twice, save the evidence, and remove the trace rules immediately. Stop and think: why is a trace rule in the raw table especially risky if you forget it during peak traffic?
@@ -381,7 +384,7 @@ The table is useful, but it should not be treated as a universal ranking. iptabl
 
 ```text
 Small cluster (< 100 services): iptables is fine
-Medium cluster (100-1000 services): Consider IPVS
+Medium cluster (100-1000 services): Prefer nftables for new Linux kube-proxy designs; IPVS is legacy/compatibility only
 Large cluster (1000+ services): nftables or eBPF (Cilium)
 Advanced features needed: eBPF (Cilium)
 ```
@@ -458,8 +461,8 @@ For change review, translate every proposed rule into a sentence that includes a
 
 - **A busy Kubernetes node can have 10,000+ iptables rules** - Each service creates multiple rules, and Kubernetes 1.35+ operators should evaluate nftables or eBPF when service scale makes linear rule traversal expensive.
 - **iptables is just the CLI** - The packet filtering work happens in the kernel's netfilter subsystem, while iptables loads rules into that subsystem from user space.
-- **nftables is replacing iptables in many distributions** - RHEL 9 and Debian 11 ship nftables tooling by default, and the `nft` command uses a cleaner ruleset model.
-- **Every Kubernetes service creates multiple generated decisions** - A Service needs dispatch rules, per-Service chains, and endpoint rules, so 100 Services with three endpoints each can produce 1,500+ service-related rule entries.
+- **nftables is replacing iptables in many distributions** - Most modern Linux distributions ship nftables tooling by default, and the `nft` command uses a cleaner ruleset model.
+- **Every Kubernetes service creates multiple generated decisions** - A Service needs dispatch rules, per-Service chains, and endpoint rules, so 100 Services with three endpoints each can produce on the order of a thousand-plus service-related rule entries.
 
 ## Common Mistakes
 
@@ -592,19 +595,16 @@ The custom chain should log and accept ICMP packets that reach it from INPUT. Th
 ### Part 3: NAT Example
 
 ```bash
-# 1. Enable forwarding
-sudo sysctl -w net.ipv4.ip_forward=1
-
-# 2. View current NAT
+# 1. View current NAT
 sudo iptables -t nat -L -n -v
 
-# 3. Add a port redirect (local)
+# 2. Add a port redirect (local)
 sudo iptables -t nat -A OUTPUT -p tcp --dport 8888 -j REDIRECT --to-port 80
 
-# 4. Test (if web server on 80)
+# 3. Test (if web server on 80)
 # curl localhost:8888  # Would go to localhost:80
 
-# 5. Remove rule
+# 4. Remove rule
 sudo iptables -t nat -D OUTPUT -p tcp --dport 8888 -j REDIRECT --to-port 80
 ```
 
@@ -628,7 +628,8 @@ sudo iptables -t nat -L KUBE-SERVICES -n | head -20
 kubectl get svc my-service -o wide
 
 # Find iptables rules for it
-sudo iptables-save | grep <ClusterIP>
+CLUSTER_IP=$(kubectl get svc my-service -o jsonpath='{.spec.clusterIP}')
+sudo iptables-save | grep -- "$CLUSTER_IP"
 
 # 4. View DNAT rules
 sudo iptables -t nat -L -n | grep DNAT | head -10

--- a/src/content/docs/linux/security/hardening/module-4.1-kernel-hardening.md
+++ b/src/content/docs/linux/security/hardening/module-4.1-kernel-hardening.md
@@ -7,7 +7,7 @@ sidebar:
 lab:
   id: "linux-4.1-kernel-hardening"
   url: "https://killercoda.com/kubedojo/scenario/linux-4.1-kernel-hardening"
-  duration: "35 min"
+  duration: "25-30 min"
   difficulty: "advanced"
   environment: "ubuntu"
 ---
@@ -31,7 +31,7 @@ After this module, you will be able to make and defend kernel-hardening decision
 
 ## Why This Module Matters
 
-On October 21, 2016, Dyn's managed DNS platform was hit by the Mirai botnet, and the outage rippled into major websites because a network control plane dependency was suddenly unreachable. That incident was not solved by a single sysctl flag, but it is the kind of event that makes kernel hardening practical rather than academic. When hosts accept spoofed routes, answer broadcast probes, keep weak TCP defaults, or expose kernel internals to untrusted processes, they become easier to abuse during the first minutes of an incident, when responders have the least time and the worst visibility.
+On October 21, 2016, Dyn's managed DNS platform was hit by the Mirai botnet, and the outage rippled into major websites because a network control plane dependency was suddenly unreachable. Source: [2016 Dyn cyberattack (Wikipedia)](https://en.wikipedia.org/wiki/DDoS_attacks_on_Dyn). That incident was not solved by a single sysctl flag, but it is the kind of event that makes kernel hardening practical rather than academic. When hosts accept spoofed routes, answer broadcast probes, keep weak TCP defaults, or expose kernel internals to untrusted processes, they become easier to abuse during the first minutes of an incident, when responders have the least time and the worst visibility.
 
 A Kubernetes platform team sees the same lesson at a smaller scale. A worker node is not just a Linux server running containers; it is also a packet forwarder, a bridge participant, a conntrack consumer, a process scheduler, and a shared memory boundary for workloads from different teams. If a hardening script blindly disables IP forwarding, pods lose cross-node traffic. If the team leaves pointer exposure and unrestricted tracing enabled, a compromised workload gains better reconnaissance inside the node. The financial impact usually shows up as missed SLOs, wasted incident hours, emergency consulting, SLA credits, and delayed releases, even when no public breach headline appears.
 
@@ -377,6 +377,7 @@ net.bridge.bridge-nf-call-ip6tables = 1
 
 # Load br_netfilter module first
 modprobe br_netfilter
+echo br_netfilter | sudo tee /etc/modules-load.d/br_netfilter.conf
 ```
 
 Bridge netfilter settings are a good example of dependency order. If the `br_netfilter` module is not loaded, the corresponding sysctl keys may not exist yet, and a configuration reload can appear to fail or skip the setting. A node bootstrap process should load required modules before applying the sysctl file, then verify that the expected keys exist and hold the intended values.
@@ -416,6 +417,8 @@ Notice that `kernel.kptr_restrict = 1` appears here rather than the stricter val
 
 CIS benchmark rules are valuable because they make common hardening expectations explicit, measurable, and reviewable. They are not a substitute for architecture knowledge. Some rules include phrases such as "unless routing is required," and a Kubernetes worker is exactly the kind of host where routing may be required. Your job is to document that exception, keep compensating controls in place, and verify the final risk posture.
 
+CIS section numbers vary by benchmark and platform (e.g. RHEL 9 maps several of these to §3.3.x); cross-check against the benchmark PDF for your distribution.
+
 ```bash
 # Key CIS Benchmark sysctl requirements:
 
@@ -445,7 +448,7 @@ Persistent configuration is where hardening becomes reproducible. A running valu
 
 ```bash
 # Create configuration file
-cat <<EOF | sudo tee /etc/sysctl.d/99-hardening.conf
+cat <<'EOF' | sudo tee /etc/sysctl.d/99-hardening.conf
 # Network hardening
 net.ipv4.conf.all.send_redirects = 0
 net.ipv4.conf.default.send_redirects = 0
@@ -780,4 +783,4 @@ Next up: [Module 4.2: AppArmor Profiles](/linux/security/hardening/module-4.2-ap
 - [Kubernetes install tools: Linux sysctl bridge prerequisites](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/)
 - [Kubernetes networking concepts](https://kubernetes.io/docs/concepts/cluster-administration/networking/)
 - [AIDE manual](https://aide.github.io/doc/)
-- [Red Hat rpm verify documentation](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/managing_software_with_the_dnf_tool/verifying-installed-packages_using-appstream)
+- [rpm(8) — package verification](https://man7.org/linux/man-pages/man8/rpm.8.html)

--- a/src/content/docs/linux/security/hardening/module-4.2-apparmor.md
+++ b/src/content/docs/linux/security/hardening/module-4.2-apparmor.md
@@ -147,7 +147,7 @@ Profiles are stored as plain text files on the disk before being compiled by the
 /var/cache/apparmor/
 ```
 
-A useful war story is the deployment that "worked on two nodes" and failed on the third after a routine rollout. The manifest was identical, the image digest was identical, and the team spent an hour inspecting registry credentials before checking `aa-status` on the failing node. The profile file had been copied by hand during testing but never included in the node bootstrap process, so Kubernetes asked for a `Localhost` profile that the scheduled worker had never loaded.
+**Hypothetical scenario:** A useful war story is the deployment that "worked on two nodes" and failed on the third after a routine rollout. The manifest was identical, the image digest was identical, and the team spent an hour inspecting registry credentials before checking `aa-status` on the failing node. The profile file had been copied by hand during testing but never included in the node bootstrap process, so Kubernetes asked for a `Localhost` profile that the scheduled worker had never loaded.
 
 Before running this in your own environment, what output do you expect if AppArmor is compiled into the kernel but the service has not loaded any profiles? You should expect the module to report as loaded while profile counts are low or zero, which points you toward the profile lifecycle rather than toward kernel support or application permissions.
 
@@ -334,7 +334,7 @@ Notice the explicit `deny` rules at the bottom. AppArmor is already default-deny
 
 There is a tradeoff hiding in this example. The profile allows recursive reads of `/var/www/**` because a static site can have nested directories, but it allows writes only where runtime behavior requires writes. If the application later grows an upload feature, the right response is not to make the entire content root writable; create a specific upload path, constrain it, and make the application architecture match the confinement boundary.
 
-A practical production team once discovered this distinction during a certificate rotation incident. The profile allowed `/etc/ssl/** r,` but the automation wrote a temporary file under a different staging directory before atomically moving it into place, so Nginx reloads failed only during rotation. The fix was not to unconfine Nginx; the fix was to decide whether Nginx should read the staging path, then encode that path explicitly or change the rotation workflow so runtime reads stayed inside the approved certificate directory.
+**Hypothetical scenario:** A practical production team once discovered this distinction during a certificate rotation incident. The profile allowed `/etc/ssl/** r,` but the automation wrote a temporary file under a different staging directory before atomically moving it into place, so Nginx reloads failed only during rotation. The fix was not to unconfine Nginx; the fix was to decide whether Nginx should read the staging path, then encode that path explicitly or change the rotation workflow so runtime reads stayed inside the approved certificate directory.
 
 ## AppArmor in Containerized Environments
 
@@ -579,7 +579,7 @@ The AppArmor-versus-SELinux decision should also consider how your organization 
 - **Mainline Kernel Integration:** Linus Torvalds merged AppArmor into the mainline Linux kernel in version 2.6.36 in October 2010, ending a long debate over competing security module approaches.
 - **Docker's Silent Shield:** Docker's default AppArmor profile blocks many privileged mount and process-tracing paths, giving ordinary containers a MAC baseline even when users never mention AppArmor directly.
 - **High-Performance Parsing:** AppArmor policies are compiled into a deterministic finite automaton, so path mediation can be evaluated quickly in the kernel rather than interpreted as slow text rules.
-- **Ubuntu's Adoption Path:** Canonical acquired Immunix in 2005, and Ubuntu later made AppArmor a default MAC system for the distribution family that many Kubernetes labs still use.
+- **Ubuntu's Adoption Path:** Novell acquired Immunix (AppArmor's creator) in 2005. After Novell's acquisition by Attachmate in 2011, Canonical took over as AppArmor's primary maintainer and made it Ubuntu's default MAC system.
 
 ## Common Mistakes
 
@@ -747,17 +747,18 @@ sudo aa-enforce /etc/apparmor.d/tmp.test-app.sh
 If you have Docker installed on your host, observe how the runtime automatically applies the default baseline profile to contain behavior. This step is optional, but it helps connect the host-level policy language to the container defaults you inherit in many development environments.
 
 ```bash
-# 1. Check default profile
-docker run --rm alpine cat /proc/1/attr/current
+# 1. Check default profile (on modern multi-LSM kernels, use /proc/1/attr/apparmor/current)
+docker run --rm alpine cat /proc/1/attr/apparmor/current
 # Should show: docker-default
 
 # 2. Run unconfined (compare)
-docker run --rm --security-opt apparmor=unconfined alpine cat /proc/1/attr/current
+docker run --rm --security-opt apparmor=unconfined alpine cat /proc/1/attr/apparmor/current
 # Shows: unconfined
 
 # 3. Test restriction
 docker run --rm alpine cat /etc/shadow
-# Fails due to docker-default profile
+# docker-default does NOT deny reading files inside the container. Shadow access is governed by
+# DAC (file permissions/user); AppArmor's default profile restricts capabilities, mount, and ptrace.
 
 docker run --rm --security-opt apparmor=unconfined alpine cat /etc/shadow
 # May work (if root)
@@ -805,8 +806,8 @@ Next, move to **[Module 4.3: SELinux Contexts](/linux/security/hardening/module-
 
 - [Linux kernel AppArmor documentation](https://docs.kernel.org/admin-guide/LSM/apparmor.html)
 - [AppArmor project documentation](https://apparmor.net/)
-- [Ubuntu AppArmor documentation](https://documentation.ubuntu.com/server/how-to/security/apparmor/)
-- [Ubuntu AppArmor profiles reference](https://documentation.ubuntu.com/server/explanation/intro-to/apparmor/)
+- [Ubuntu AppArmor documentation](https://ubuntu.com/server/docs/how-to/security/apparmor/)
+- [Ubuntu AppArmor profiles reference](https://ubuntu.com/server/docs/apparmor)
 - [Kubernetes AppArmor tutorial](https://kubernetes.io/docs/tutorials/security/apparmor/)
 - [Kubernetes security context documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
 - [Kubernetes Linux kernel security constraints](https://kubernetes.io/docs/concepts/security/linux-kernel-security-constraints/)

--- a/src/content/docs/linux/security/hardening/module-4.3-selinux.md
+++ b/src/content/docs/linux/security/hardening/module-4.3-selinux.md
@@ -34,7 +34,7 @@ After this module, you will be able to make evidence-based SELinux decisions ins
 
 ## Why This Module Matters
 
-At a payment processor, a routine operating-system migration moved a fleet of web nodes from an Ubuntu image to a RHEL-derived image because the security team wanted vendor-supported FIPS and SELinux controls. The application had passed staging, the file permissions on its static assets were world-readable, and the same Nginx container image had served traffic for months. When the first production slice received traffic, customers saw 403 errors for hosted receipts while synthetic checks reported that the pods were healthy, the service endpoints were ready, and the filesystem mode bits looked harmlessly permissive.
+**Hypothetical scenario:** At a payment processor, a routine operating-system migration moved a fleet of web nodes from an Ubuntu image to a RHEL-derived image because the security team wanted vendor-supported FIPS and SELinux controls. The application had passed staging, the file permissions on its static assets were world-readable, and the same Nginx container image had served traffic for months. When the first production slice received traffic, customers saw 403 errors for hosted receipts while synthetic checks reported that the pods were healthy, the service endpoints were ready, and the filesystem mode bits looked harmlessly permissive.
 
 The outage did not come from a broken web server. It came from a hidden second authorization system that the team had not modeled: SELinux mandatory access control. Discretionary access control said the Nginx worker could read the mounted files, but SELinux saw a process domain that was not permitted to read the target file type and blocked the request anyway. The emergency rollback cost the team an evening of incident work, but the larger cost was confidence, because every subsequent "permission denied" error on RHEL now carried the suspicion that the visible permissions were only half the story.
 
@@ -765,9 +765,9 @@ Next, read [Module 4.4: seccomp Profiles](./module-4.4-seccomp/) to learn how sy
 ## Sources
 
 - [Red Hat SELinux Guide](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/using_selinux/)
-- [SELinux Project Wiki](https://selinuxproject.org/page/Main_Page)
+- [SELinux Project Wiki](https://github.com/SELinuxProject/selinux/wiki)
 - [Fedora SELinux Guide](https://docs.fedoraproject.org/en-US/quick-docs/selinux-getting-started/)
-- [Container SELinux](https://www.redhat.com/en/blog/container-security-and-selinux)
+- [container-selinux project](https://github.com/containers/container-selinux)
 - [Red Hat Enterprise Linux 9: Using SELinux](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/using_selinux/)
 - [Fedora Quick Docs: Changing SELinux States and Modes](https://docs.fedoraproject.org/en-US/quick-docs/selinux-changing-states-and-modes/)
 - [Fedora Quick Docs: Troubleshooting SELinux](https://docs.fedoraproject.org/en-US/quick-docs/selinux-troubleshooting/)


### PR DESCRIPTION
## linux track Phase-1 — R1 review fixes wave 3 (4 modules)

Ground-checked R1 cross-family review fixes for the next curriculum-order batch (4-pool review mix).

- **networking 3.4-iptables-netfilter** (codex review): fixed invalid `iptables-save | grep <ClusterIP>` shell syntax (derive `CLUSTER_IP` var); nat table chain list corrected to include **INPUT**; **IPVS→nftables** guidance for K8s 1.35 (IPVS deprecated); `iptables -L KUBE-NWPLCY-*` shell-glob bug → `iptables-save | grep -E`; non-root redirect `sudo iptables-save > file` → `sudo sh -c`; TRACE-rule cleanup + `xtables-monitor --trace` for nft-backed iptables; removed an unrestored `ip_forward` sysctl; 2 war-stories → `Hypothetical scenario:`.
- **hardening 4.1-kernel-hardening** (cursor review): dead Red Hat dnf URL → `rpm(8)` man page; Dyn/Mirai 2016 incident now cited (real event); CIS section-number benchmark-version note; `br_netfilter` persistence; heredoc quoting; duration aligned.
- **hardening 4.2-apparmor** (claude review): **factual fix — Immunix was acquired by Novell (2005), not Canonical** (Canonical became maintainer after Attachmate's 2011 Novell acquisition); dead Ubuntu AppArmor URL → `ubuntu.com/server/docs/apparmor`; corrected the misleading `docker-default` `/etc/shadow` claim (DAC governs file reads, not the AppArmor profile); 2 war-stories → `Hypothetical scenario:`; `/proc/1/attr/apparmor/current` per-LSM path. (Capital One incident kept — real documented event.)
- **hardening 4.3-selinux** (gemini review): payment-processor war-story → `Hypothetical scenario:`; `selinuxproject.org` (unreachable) → SELinux GitHub wiki; dead Red Hat container-SELinux blog → `container-selinux` project (both verified 200).

**Rejected FPs / ground-checked:** within-section links, "Kubernetes 1.35", gnu.org URLs; reviewer "dead URL" claims re-verified (Red Hat dnf was a 403 bot-block, swapped to man7 anyway; the rest were real 404/unreachable). Build green (2129 pages, 0 errors); health 0 errors; `verify_module.py` passing on the edited modules (4.3 is ~9 words under the soft body-words floor — pre-existing on origin/main, tracked as a minor follow-up). Each fix self-verified against the R1 findings.

## Learner check

> Novell acquired Immunix (AppArmor's creator) in 2005

🤖 Generated with [Claude Code](https://claude.com/claude-code)
