### PR TITLE
chore(content): linux Phase-1 review fixes wave 5 — 5.4 + troubleshooting 6.1/6.2/6.4

### DIFF
--- a/src/content/docs/linux/operations/performance/module-5.4-io-performance.md
+++ b/src/content/docs/linux/operations/performance/module-5.4-io-performance.md
@@ -28,13 +28,13 @@ After this module, you will be able to perform the following tasks in a lab or p
 
 - **Measure** disk I/O performance using `iostat`, `iotop`, and `fio` benchmarks.
 - **Diagnose** I/O bottlenecks by interpreting `await`, `%util`, and queue depth metrics together.
-- **Configure** I/O schedulers and cgroup `blkio` limits for container workloads.
+- **Inspect and evaluate** I/O schedulers and cgroup I/O limits for container workloads.
 - **Evaluate** storage performance requirements for database, logging, cache, and Kubernetes PersistentVolume workloads.
 - **Implement** a repeatable I/O test plan that separates page cache effects from real device behavior.
 
 ## Why This Module Matters
 
-At 02:10 on a payroll processing night, a regional payments company watched its checkout latency climb from normal subsecond responses to timeouts that lasted long enough for customers to abandon carts. The on-call engineer saw idle CPUs, plenty of free memory, and application logs that only said database queries were slow. The incident review later traced the outage to a small burst of synchronous audit logging on the same cloud block volume that stored the database write-ahead log, and the team estimated that the hour of degraded service cost more than a senior engineer's annual training budget.
+**Hypothetical scenario:** At 02:10 on a payroll processing night, a regional payments company watched its checkout latency climb from normal subsecond responses to timeouts that lasted long enough for customers to abandon carts. The on-call engineer saw idle CPUs, plenty of free memory, and application logs that only said database queries were slow. The incident review later traced the outage to a small burst of synchronous audit logging on the same cloud block volume that stored the database write-ahead log, and the team estimated that the hour of degraded service cost more than a senior engineer's annual training budget.
 
 That kind of failure feels unfair when you first meet Linux performance work, because the obvious dashboards can make the machine look healthy. CPU utilization may be low because threads are asleep, memory may look comfortable because the page cache is doing exactly what it should, and the application may only report that file operations are taking too long. I/O diagnosis is therefore a discipline of following latency through layers rather than staring at a single red number.
 
@@ -94,7 +94,7 @@ iostat -x 1
 # svctm = service time (deprecated/removed in newer iostat)
 ```
 
-A practical war story illustrates the difference. A team moved a small PostgreSQL database from local SSD to a managed network volume because the cloud console promised enough provisioned IOPS. Bulk report exports still looked fine, but checkout writes became spiky because each commit waited for network round trips and durability acknowledgements. Their old dashboard tracked MB/s, so it missed the latency regression that users actually felt.
+**Hypothetical scenario:** A team moved a small PostgreSQL database from local SSD to a managed network volume because the cloud console promised enough provisioned IOPS. Bulk report exports still looked fine, but checkout writes became spiky because each commit waited for network round trips and durability acknowledgements. Their old dashboard tracked MB/s, so it missed the latency regression that users actually felt.
 
 Before running any command in a production incident, write down what you expect the metric to prove. If you expect high IOPS with low latency, you are testing whether the device is busy but healthy. If you expect low IOPS with high latency, you are looking for remote storage delays, a failing disk, filesystem stalls, or a workload that is serializing on synchronous writes. That prediction keeps you from changing schedulers or buying storage before you know which layer is responsible.
 
@@ -107,7 +107,7 @@ The core measurement tool for block devices is `iostat -x`, because it shows rat
 ```bash
 # Basic I/O stats
 iostat -x 1
-# Device         r/s     w/s   rkB/s   wkB/s  %util  await  avgqu-sz
+# Device         r/s     w/s   rkB/s   wkB/s  %util  await  aqu-sz
 # sda          100.0   200.0  4000.0  8000.0   75.2   12.5      2.3
 # nvme0n1      500.0   300.0 20000.0 12000.0   45.0    1.5      0.8
 
@@ -116,16 +116,16 @@ iostat -x 1
 # rkB/s, wkB/s = Throughput
 # %util        = Percentage of time device was busy
 # await        = Average I/O time (ms)
-# avgqu-sz     = Average queue size (saturation indicator)
+# aqu-sz       = Average queue size (formerly avgqu-sz; saturation indicator)
 ```
 
-Read `iostat` as a cluster of clues. The `r/s` and `w/s` columns describe operation rate, while `rkB/s` and `wkB/s` describe byte throughput. The `await` column tells you the average time an operation spends from submission to completion, including queue wait. The `avgqu-sz` column shows whether requests are backing up, and `%util` tells you whether the device was busy during the interval rather than whether the workload has reached the device's true ceiling.
+Read `iostat` as a cluster of clues. The `r/s` and `w/s` columns describe operation rate, while `rkB/s` and `wkB/s` describe byte throughput. The `await` column tells you the average time an operation spends from submission to completion, including queue wait. The `aqu-sz` column shows whether requests are backing up, and `%util` tells you whether the device was busy during the interval rather than whether the workload has reached the device's true ceiling.
 
 | Metric | Meaning | Concerning Value |
 |--------|---------|-----------------|
 | `%util` | Time busy | >80% for HDDs |
 | `await` | Total latency | >10ms for SSD, >50ms for HDD |
-| `avgqu-sz` | Queue depth | >1 means I/O backing up |
+| `aqu-sz` | Queue depth | >1 means I/O backing up |
 | `r_await/w_await` | Read/write latency separately | Large difference indicates problem |
 
 Those concerning values are starting points, not laws. A busy HDD at 80 percent can become user-visible trouble because it has little parallelism and expensive seeks. A busy NVMe device can show high `%util` while keeping `await` under a millisecond, which means it is working hard but not necessarily hurting callers. The right question is whether latency and queueing are rising relative to the service objective for the application.
@@ -202,7 +202,7 @@ Treat scheduler changes as experiments, not rituals. `mq-deadline` can protect l
 | NVMe | none or kyber |
 | VM disk | none (host handles it) |
 
-A common scheduler war story starts with a team changing every server to the same setting after one benchmark improves. The database hosts improve because their virtual disks stop paying unnecessary scheduler overhead, but the log aggregation host with older SATA SSDs becomes less predictable during burst writes. The lesson is that the scheduler is part of a workload and device pairing, so a setting that is correct in one place can be a regression in another.
+**Hypothetical scenario:** A team changed every server to the same scheduler setting after one benchmark improved. The database hosts improved because their virtual disks stopped paying unnecessary scheduler overhead, but the log aggregation host with older SATA SSDs became less predictable during burst writes. The lesson is that the scheduler is part of a workload and device pairing, so a setting that is correct in one place can be a regression in another.
 
 Filesystems add another layer of tradeoffs. ext4 is mature, widely understood, and excellent for general-purpose Linux systems. XFS is strong for large files and high concurrency, which is why it is common in enterprise Linux environments. Btrfs brings snapshots and checksums, but its copy-on-write behavior can be costly for some database patterns unless configured carefully. tmpfs is fastest because it lives in memory, but data disappears when the system restarts.
 
@@ -262,14 +262,18 @@ Containers do not remove the Linux I/O stack; they add ownership and isolation q
 
 ```bash
 # View container I/O limits
-cat /sys/fs/cgroup/blkio/docker/<container>/blkio.throttle.read_bps_device
-cat /sys/fs/cgroup/blkio/docker/<container>/blkio.throttle.write_bps_device
+CONTAINER_ID="..."
+CG="/sys/fs/cgroup/blkio/docker/$CONTAINER_ID"
+cat "$CG/blkio.throttle.read_bps_device"
+cat "$CG/blkio.throttle.write_bps_device"
 
 # Format: major:minor bytes_per_second
 # 8:0 10485760  = sda limited to 10MB/s
 
-# I/O stats
-cat /sys/fs/cgroup/blkio/docker/<container>/blkio.io_service_bytes
+# cgroup v2
+CG="/sys/fs/cgroup/kubepods.slice"
+cat "$CG/io.max" 2>/dev/null
+cat "$CG/io.stat" 2>/dev/null
 ```
 
 The exact cgroup paths differ between cgroup v1, cgroup v2, Docker, containerd, and the host distribution, but the principle is stable. Limits attach I/O policy to a control group, and the kernel accounts work against that group. If a container is throttled, the application may report slow writes even while the device itself looks underused, because the queue is not at the device; it is at the policy boundary.
@@ -302,6 +306,20 @@ parameters:
   type: gp3
   iops: "3000"
   throughput: "125"
+volumeBindingMode: WaitForFirstConsumer
+---
+# PVC for the StorageClass above
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: my-pvc
+spec:
+  accessModes:
+  - ReadWriteOnce
+  storageClassName: fast-storage
+  resources:
+    requests:
+      storage: 10Gi
 ---
 # Pod using PVC
 apiVersion: v1
@@ -321,7 +339,7 @@ spec:
       claimName: my-pvc
 ```
 
-A Kubernetes war story: an operations team moved a write-heavy queue worker to a PersistentVolume backed by a general-purpose cloud disk and kept the same pod resource requests. CPU and memory graphs stayed calm, but queue lag grew after the daily reporting job started. The fix was not a CPU request change; it was separating the queue data from report exports and choosing a volume class with explicit IOPS and throughput guarantees.
+**Hypothetical scenario:** An operations team moved a write-heavy queue worker to a PersistentVolume backed by a general-purpose cloud disk and kept the same pod resource requests. CPU and memory graphs stayed calm, but queue lag grew after the daily reporting job started. The fix was not a CPU request change; it was separating the queue data from report exports and choosing a volume class with explicit IOPS and throughput guarantees.
 
 When you evaluate a Kubernetes storage problem, follow the path from pod to node to volume. Check whether many pods share a node-local device, whether the CSI driver provisions the expected class, whether the workload is mounted through a network filesystem, and whether the application uses many small synchronous writes. If `k get pvc` says the claim is bound, that only proves scheduling and provisioning worked; it does not prove the workload has the latency budget it needs.
 
@@ -351,8 +369,8 @@ High utilization with acceptable latency can be normal during backups, compactio
 ```bash
 # Long I/O times - check queue
 iostat -x 1
-# If avgqu-sz > 1, requests are queuing
-# If avgqu-sz ~ 0 but await high, device is slow
+# If aqu-sz > 1, requests are queuing
+# If aqu-sz ~ 0 but await high, device is slow
 
 # For HDDs: Could be fragmentation, failing disk
 # For network storage: Network latency
@@ -363,7 +381,7 @@ dmesg | grep -i "error\|fault\|reset" | grep -i sd
 smartctl -a /dev/sda | grep -i error
 ```
 
-High `await` with a growing queue suggests saturation or contention. High `await` with a small queue suggests each operation is intrinsically slow, which is common with network-backed disks, degraded hardware, forced flushes, or storage throttling. That distinction is why `avgqu-sz` belongs beside `await` in your mental model. Latency without queueing is a service-time problem; latency with queueing is often a demand problem.
+High `await` with a growing queue suggests saturation or contention. High `await` with a small queue suggests each operation is intrinsically slow, which is common with network-backed disks, degraded hardware, forced flushes, or storage throttling. That distinction is why `aqu-sz` belongs beside `await` in your mental model. Latency without queueing is a service-time problem; latency with queueing is often a demand problem.
 
 ```bash
 # Check what's waiting
@@ -401,7 +419,7 @@ rm /tmp/testfile /tmp/fiotest
 
 `fio --direct=1` is especially useful because it reduces page cache distortion for device-focused tests. That does not make direct I/O the only valid measurement; many real applications benefit from the page cache and should be measured with it. The point is to know which path you are measuring. If you benchmark cached reads and later size a cold recovery path from that result, the number will mislead you.
 
-The best incident notes turn raw metrics into a causal sentence. "At 13:05, `w_await` rose above 70ms while `avgqu-sz` exceeded 8 on the database volume; `iotop` showed backup compression writing to the same device; moving backups to a separate volume removed queueing." That sentence names time, symptom, queue behavior, owner, and fix. It is far more useful than "disk was slow," which cannot be tested or prevented.
+The best incident notes turn raw metrics into a causal sentence. "At 13:05, `w_await` rose above 70ms while `aqu-sz` exceeded 8 on the database volume; `iotop` showed backup compression writing to the same device; moving backups to a separate volume removed queueing." That sentence names time, symptom, queue behavior, owner, and fix. It is far more useful than "disk was slow," which cannot be tested or prevented.
 
 When the evidence is still ambiguous, choose the next command by elimination. If process-level writers are quiet, inspect filesystem and mount behavior. If local block metrics are quiet but the application waits on file operations, inspect network storage, remote database calls, or cgroup throttles. If the benchmark is healthy but production is slow, compare block size, concurrency, cache state, and durability requirements. This narrowing process is slower than guessing, but it leaves a trail that another engineer can audit.
 
@@ -453,10 +471,10 @@ This framework also helps you decide when not to tune Linux. If the application 
 | Mistake | Why It Happens | How to Fix It |
 |---------|----------------|---------------|
 | Ignoring iowait context | CPU tools show `%wa`, so the team assumes the CPU is the bottleneck. | Check `iostat`, `iotop`, and `D` state processes before adding CPU capacity. |
-| Treating `%util` as capacity | The metric looks like CPU utilization, but storage devices can process parallel queues. | Read `%util` with `await`, `avgqu-sz`, device type, and application latency. |
+| Treating `%util` as capacity | The metric looks like CPU utilization, but storage devices can process parallel queues. | Read `%util` with `await`, `aqu-sz`, device type, and application latency. |
 | Choosing the wrong scheduler | A setting that helped one device is copied to every host. | Match scheduler experiments to HDD, SSD, NVMe, or VM disk behavior and record rollback steps. |
 | Adding sync writes everywhere | Developers use flushes for safety without measuring the latency cost. | Keep durability where it matters, batch where safe, and measure `w_await` around commits. |
-| Not monitoring queue depth | Dashboards show throughput but hide the line of waiting requests. | Add `avgqu-sz` or equivalent queue-depth panels beside latency and IOPS graphs. |
+| Not monitoring queue depth | Dashboards show throughput but hide the line of waiting requests. | Add `aqu-sz` or equivalent queue-depth panels beside latency and IOPS graphs. |
 | Placing log files on slow shared disks | Operational logs are treated as harmless background traffic. | Separate log volumes, reduce noisy logs, or apply cgroup limits to protect critical paths. |
 | Forgetting SSD maintenance | TRIM and discard policy are left to defaults that may not match the device. | Use the distribution's recommended scheduled trim or discard configuration for the storage type. |
 
@@ -477,7 +495,7 @@ The page cache explains the change. During the first pass, the service reads dat
 </details>
 
 <details>
-<summary>An older HDD server shows `avgqu-sz` spikes above 15 and `await` above 200ms during user complaints, while `%util` averages 60 percent. What is the likely bottleneck?</summary>
+<summary>An older HDD server shows `aqu-sz` spikes above 15 and `await` above 200ms during user complaints, while `%util` averages 60 percent. What is the likely bottleneck?</summary>
 
 The workload is overwhelming the mechanical disk during bursts, even if the average busy percentage does not reach 100 percent. HDDs have limited parallelism because seek time and rotational delay dominate random access. A queue depth above 15 means requests are waiting in line, and `await` includes that waiting time. You should identify the writer or reader causing bursts, then reduce contention, move the workload, or use storage with better random I/O performance.
 
@@ -552,16 +570,25 @@ Record the device that backs the filesystem you will test, such as `sda`, `vda`,
 Check the active scheduler and queue depth for the test device. Do not change the scheduler yet. The point is to learn what the host is using, connect the setting to the device type, and decide what you would test if a scheduler change became part of a controlled experiment.
 
 ```bash
-# 1. Check current scheduler
-cat /sys/block/sda/queue/scheduler 2>/dev/null || \
-cat /sys/block/vda/queue/scheduler 2>/dev/null || \
-echo "Check your disk name with lsblk"
+# 1. Derive the test disk from lsblk
+DEV=$(lsblk -ndo NAME,TYPE | awk '$2=="disk"{print $1; exit}')
 
-# 2. List available schedulers
+# 2. Check current scheduler
+if [ -n "$DEV" ]; then
+  cat "/sys/block/$DEV/queue/scheduler" 2>/dev/null
+else
+  echo "No block disk detected; check your disk name with lsblk"
+fi
+
+# 3. List available schedulers
 # Bracketed one is active
 
-# 3. Check queue depth
-cat /sys/block/sda/queue/nr_requests 2>/dev/null
+# 4. Check queue depth
+if [ -n "$DEV" ]; then
+  cat "/sys/block/$DEV/queue/nr_requests" 2>/dev/null
+else
+  echo "No block disk detected; check your disk name with lsblk"
+fi
 ```
 
 <details>
@@ -584,6 +611,7 @@ dd if=/dev/zero of=/tmp/iotest bs=1M count=500 2>&1
 iostat -x 1 10
 
 # 3. Test read
+sync
 echo 3 | sudo tee /proc/sys/vm/drop_caches  # Clear cache
 dd if=/tmp/iotest of=/dev/null bs=1M 2>&1
 
@@ -674,7 +702,7 @@ docker rm -f io-test
 ### Success Criteria
 
 - [ ] Identified disk devices and current utilization.
-- [ ] Measured `iostat` output for utilization, latency, and queue depth.
+- [ ] Measured `iostat` output for utilization, latency, and queue depth (`aqu-sz`).
 - [ ] Observed I/O during file operations and explained cache effects.
 - [ ] Found per-process I/O consumers with `iotop` or `pidstat`.
 - [ ] Checked filesystem mount options, byte usage, and inode usage.

--- a/src/content/docs/linux/operations/troubleshooting/module-6.1-systematic-troubleshooting.md
+++ b/src/content/docs/linux/operations/troubleshooting/module-6.1-systematic-troubleshooting.md
@@ -36,7 +36,7 @@ After this module, you will be able to:
 
 ## Why This Module Matters
 
-At 03:12 one Saturday, a regional retailer lost checkout across its web and mobile properties during a promotion that finance had expected to generate several million dollars in same-day revenue. The first responder saw 500 errors, restarted the checkout service, flushed a cache, and rolled back the most recent deployment within the first few minutes. Each action looked reasonable in isolation, but the combined effect erased the logs that showed database connection refusals, caused a cache stampede against an already memory-starved database, and made the later post-incident review depend on guesses instead of evidence.
+**Hypothetical scenario:** At 03:12 one Saturday, a regional retailer lost checkout across its web and mobile properties during a promotion that finance had expected to drive heavy same-day revenue. The first responder saw 500 errors, restarted the checkout service, flushed a cache, and rolled back the most recent deployment within the first few minutes. Each action looked reasonable in isolation, but the combined effect erased the logs that showed database connection refusals, caused a cache stampede against an already memory-starved database, and made the later post-incident review depend on guesses instead of evidence.
 
 The incident did not last because the team lacked Linux commands. It lasted because the team lacked a shared method for deciding which command came next and what decision the output should drive. The final root cause was ordinary: a database process had been killed under memory pressure after a batch job consumed more memory than expected. The expensive part was not the bug itself; the expensive part was the unstructured response that destroyed the trail, hid the trigger, and made every engineer argue from a different partial story.
 
@@ -80,7 +80,7 @@ Hypotheses (by likelihood):
 6. Bad deployment
 
 Test each:
-1. curl localhost:5432    # Can reach DB?
+1. nc -zv localhost 5432  # Can reach DB? (or pg_isready)
 2. systemctl status api   # Service running?
 3. df -h                  # Disk space?
 4. dmesg | grep oom       # OOM events?
@@ -92,7 +92,7 @@ Notice that the test list is not a script to run blindly. It is a set of questio
 
 The scientific method also protects teams from status games during an incident. Instead of saying "I think the database is fine," you can say "The database accepts TCP connections from the API host, the service account can authenticate, and the slow query log did not spike during the incident window." That is more useful because another engineer can inspect the same evidence and build the next test from it.
 
-War story: a platform team once spent most of an incident chasing a deployment because errors began within minutes of a release. The release was innocent. The real cause was an external certificate bundle update on a subset of hosts, which broke TLS validation only for calls leaving those hosts. The team found it after returning to the method: compare affected and unaffected hosts, predict what should differ, and test the smallest environmental difference first.
+**Hypothetical scenario:** A platform team once spent most of an incident chasing a deployment because errors began within minutes of a release. The release was innocent. The real cause was an external certificate bundle update on a subset of hosts, which broke TLS validation only for calls leaving those hosts. The team found it after returning to the method: compare affected and unaffected hosts, predict what should differ, and test the smallest environmental difference first.
 
 ## Triage Severity and Resource Scope in the First Minute
 
@@ -236,6 +236,8 @@ Before running this, what output do you expect if DNS is broken for clients but 
 In Kubernetes, divide and conquer usually means moving across layers deliberately. Start outside the cluster if the user sees a public failure, then test the ingress or load balancer, then the service, then the endpoints, then the pod, then the application dependency. With the `k` alias in place, commands such as `k get events`, `k describe pod`, and `k logs` are useful, but they should answer a question rather than become a reflexive sequence.
 
 ```bash
+alias k=kubectl
+
 # Recent system changes
 rpm -qa --last | head -20                    # Package installs
 ls -lt /etc/*.conf | head -10                # Config changes
@@ -274,7 +276,7 @@ cat /var/log/dnf.log | tail -50           # RHEL
 
 The danger in "what changed?" is confirmation bias. If you personally deployed something, you may overfocus on that deployment because it is vivid and embarrassing. If another team changed a dependency, you may underweight it because it feels outside your area. A timeline is useful because it lists candidate changes in time order and lets evidence, not ownership, drive priority.
 
-War story: an API team once rolled back three versions because a latency spike started after a release. The real trigger was a cron job that compressed a large log tree and saturated disk I/O on the database host. The release had merely increased traffic enough to reveal the shared bottleneck. Timeline analysis found the overlap; the USE Method explained the resource saturation.
+**Hypothetical scenario:** An API team once rolled back three versions because a latency spike started after a release. The real trigger was a cron job that compressed a large log tree and saturated disk I/O on the database host. The release had merely increased traffic enough to reveal the shared bottleneck. Timeline analysis found the overlap; the USE Method explained the resource saturation.
 
 ## Diagnose Slow Systems Without Guessing
 
@@ -291,7 +293,7 @@ vmstat 1 5
 free -h
 vmstat 1 5 | awk '{print $7, $8}'  # si/so
 
-# Disk bottleneck?
+# Disk bottleneck? (iostat and sar require the sysstat package)
 iostat -x 1 5
 
 # Network?
@@ -322,7 +324,7 @@ curl -I endpoint          # Test connectivity
 # Non-destructive tests
 ping host                 # Network reachability
 dig domain                # DNS resolution
-telnet host port          # Port connectivity
+nc -zv host port          # Port connectivity (telnet may be absent)
 
 # Careful with write operations
 # - Don't restart unless sure
@@ -694,7 +696,7 @@ Next, continue to [Module 6.2: Log Analysis](/linux/operations/troubleshooting/m
 
 - [Google SRE Book - Effective Troubleshooting](https://sre.google/sre-book/effective-troubleshooting/)
 - [Brendan Gregg's USE Method](https://www.brendangregg.com/usemethod.html)
-- [How to Debug Anything](https://www.youtube.com/watch?v=0Vl8i5QwKp8)
+- [How to Debug Anything — GoRuCo 2014](https://www.youtube.com/watch?v=VV7b7fs4VI8)
 - [Rubber Duck Debugging](https://rubberduckdebugging.com/)
 - [systemd journalctl manual](https://www.freedesktop.org/software/systemd/man/latest/journalctl.html)
 - [systemd systemctl manual](https://www.freedesktop.org/software/systemd/man/latest/systemctl.html)
@@ -702,5 +704,5 @@ Next, continue to [Module 6.2: Log Analysis](/linux/operations/troubleshooting/m
 - [Linux man-pages: dmesg](https://man7.org/linux/man-pages/man1/dmesg.1.html)
 - [Kubernetes docs: Debug Running Pods](https://kubernetes.io/docs/tasks/debug/debug-application/debug-running-pod/)
 - [Kubernetes docs: Events](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/event-v1/)
-- [Red Hat: Getting started with systemd](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/configuring_basic_system_settings/assembly_getting-started-with-systemd_configuring-basic-system-settings)
-- [Ubuntu Server documentation: Logs](https://documentation.ubuntu.com/server/explanation/logs/)
+- [systemctl(1) — Linux manual page](https://man7.org/linux/man-pages/man1/systemctl.1.html)
+- [systemd-journald.service(8) — Linux manual page](https://man7.org/linux/man-pages/man8/systemd-journald.service.8.html)

--- a/src/content/docs/linux/operations/troubleshooting/module-6.2-log-analysis.md
+++ b/src/content/docs/linux/operations/troubleshooting/module-6.2-log-analysis.md
@@ -33,7 +33,7 @@ After this module, you will be able to make evidence-based troubleshooting decis
 
 ## Why This Module Matters
 
-In 2017, British Airways suffered a major IT outage that disrupted flights across London airports and forced thousands of passengers into cancellations, delays, and manual recovery work. Public reporting described costs in the tens of millions of pounds, but the operational pain was not only financial: teams had to reconstruct which services failed first, which alarms were symptoms, and which restart actions made recovery better or worse. During incidents like that, logs become the closest thing an engineering team has to a flight recorder, and the team that can read them calmly has a decisive advantage over the team that only reacts to the loudest error message.
+In 2017, British Airways suffered a major IT outage that disrupted flights across London airports and forced thousands of passengers into cancellations, delays, and manual recovery work [source]. The operational pain was not only financial: teams had to reconstruct which services failed first, which alarms were symptoms, and which restart actions made recovery better or worse. During incidents like that, logs become the closest thing an engineering team has to a flight recorder, and the team that can read them calmly has a decisive advantage over the team that only reacts to the loudest error message.
 
 Modern Linux systems generate logs from many layers at once. The kernel records device, memory, and networking events; `systemd-journald` indexes service messages; traditional files under `/var/log` hold syslog, authentication, package, web server, and database history; container runtimes collect stdout and stderr; Kubernetes exposes a simplified view through `kubectl logs`, and later examples define `alias k=kubectl` before using the shorter `k logs` form. A single outage might leave useful clues in all of those places, and the important evidence is often not the first scary line you find but the sequence of smaller events that led to it.
 
@@ -175,7 +175,7 @@ journalctl -p warning
 # 0: emerg, 1: alert, 2: crit, 3: err
 # 4: warning, 5: notice, 6: info, 7: debug
 
-# Range
+# Range (warning=4 down to err=3; lower number = higher severity)
 journalctl -p warning..err
 ```
 
@@ -831,7 +831,7 @@ k logs -l app=nginx --all-containers --tail=100
 
 <details><summary>Solution notes for Task 6</summary>
 
-The retention commands help you design rather than merely consume logs. If a journal is large, identify whether the cause is retention policy, debug verbosity, or a noisy service. The Kubernetes commands reinforce the habit of checking previous logs, choosing the correct container, and controlling volume with labels, time filters, and tails.
+The retention commands help you design rather than merely consume logs. If a journal is large, identify whether the cause is retention policy, debug verbosity, or a noisy service. The Kubernetes commands reinforce the habit of checking previous logs, choosing the correct container, and controlling volume with labels, time filters, and tails. If no cluster is available, a not-found error is expected — the goal is recognizing the flag pattern.
 
 </details>
 
@@ -851,9 +851,10 @@ The retention commands help you design rather than merely consume logs. If a jou
 
 ## Sources
 
-- [journalctl man page](https://www.freedesktop.org/software/systemd/man/journalctl.html)
-- [systemd-journald.service man page](https://www.freedesktop.org/software/systemd/man/systemd-journald.service.html)
-- [journald.conf man page](https://www.freedesktop.org/software/systemd/man/journald.conf.html)
+- [journalctl(1) — Linux manual page](https://man7.org/linux/man-pages/man1/journalctl.1.html)
+- [systemd-journald.service(8) — Linux manual page](https://man7.org/linux/man-pages/man8/systemd-journald.8.html)
+- [journald.conf(5) — Linux manual page](https://man7.org/linux/man-pages/man5/journald.conf.5.html)
+- [British Airways 2017 IT outage — FlightGlobal](https://www.flightglobal.com/interruption-of-power-supply-took-out-it-systems-ba/124220.article)
 - [GNU Grep Manual](https://www.gnu.org/software/grep/manual/)
 - [GNU Awk User's Guide](https://www.gnu.org/software/gawk/manual/)
 - [AWK One-Liners](https://catonmat.net/awk-one-liners-explained-part-one)

--- a/src/content/docs/linux/operations/troubleshooting/module-6.4-network-debugging.md
+++ b/src/content/docs/linux/operations/troubleshooting/module-6.4-network-debugging.md
@@ -34,7 +34,7 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-At 03:40 during a regional incident, checkout latency spikes while CPU graphs stay flat. Application logs blame “upstream timeouts,” the ingress team insists TLS is healthy, and someone proposes restarting kube-proxy on every node because “that fixed it last time.” Twenty minutes later the cluster is noisier, SSH sessions on two nodes flicker, and nobody can answer a simple question: did the client’s SYN packet reach the pod listener, or did it die in overlay MTU, a full conntrack table, or a resolver search storm?
+**Hypothetical scenario:** At 03:40 during a regional incident, checkout latency spikes while CPU graphs stay flat. Application logs blame “upstream timeouts,” the ingress team insists TLS is healthy, and someone proposes restarting kube-proxy on every node because “that fixed it last time.” Twenty minutes later the cluster is noisier, SSH sessions on two nodes flicker, and nobody can answer a simple question: did the client’s SYN packet reach the pod listener, or did it die in overlay MTU, a full conntrack table, or a resolver search storm?
 
 Network outages punish confident narratives. `ping` succeeding does not prove TCP handshakes work. CoreDNS pods being Ready does not prove a pod’s `ndots:5` search list is sane. A Service object with endpoints does not prove kube-proxy programmed the mode you think you run. The expensive mistake is attributing a transport failure to application code, or a DNS failure to kube-proxy, because the first command an operator ran happened to return plausible text.
 
@@ -145,8 +145,8 @@ Process columns (`-p`) require privileges matching `/proc` access—typically ro
 For Kubernetes, run parallel checks on the node and inside the pod network namespace:
 
 ```bash
-POD=$(kubectl get pod -n default -l app=target -o jsonpath='{.items[0].metadata.name}')
-PID=$(pgrep -f "$POD" | head -n 1)
+CONTAINER_ID=$(kubectl get pod -n default -l app=target -o jsonpath='{.items[0].status.containerStatuses[0].containerID}' | sed 's|.*://||')
+PID=$(sudo crictl inspect "$CONTAINER_ID" | jq .info.pid)
 sudo nsenter -t "$PID" -n ss -tanp
 ```
 
@@ -228,7 +228,8 @@ When CoreDNS returns `SERVFAIL` or times out, split the path:
 
 ```bash
 kubectl -n kube-system get endpoints kube-dns -o wide
-kubectl -n kube-system exec -it deploy/coredns -- wget -qO- --timeout=2 http://127.0.0.1:8080/health 2>/dev/null || true
+POD_IP=$(kubectl -n kube-system get pod -l k8s-app=kube-dns -o jsonpath='{.items[0].status.podIP}')
+kubectl run -n default dns-check --rm -it --restart=Never --image=nicolaka/netshoot -- curl -s "http://${POD_IP}:8080/health"
 kubectl run -n default dns-upstream --rm -it --restart=Never --image=nicolaka/netshoot -- \
   dig +time=2 +tries=1 @kube-dns.kube-system.svc.cluster.local kubernetes.default.svc.cluster.local
 ```
@@ -575,7 +576,7 @@ Optional (lab only, when you have node `docker exec` access): lower the **server
 ```bash
 NODE=$(docker ps --filter "name=${KIND_CLUSTER:-netdebug}-control-plane" -q)
 CONTAINER_ID=$(kubectl get pod -l app=mtu-demo -o jsonpath='{.items[0].status.containerStatuses[0].containerID}' | sed 's|containerd://||')
-PID=$(docker exec "$NODE" crictl inspect "$CONTAINER_ID" | python3 -c "import sys,json; print(json.load(sys.stdin)['info']['pid'])")
+PID=$(docker exec "$NODE" sh -c "crictl inspect \"$CONTAINER_ID\" | jq .info.pid")
 docker exec "$NODE" nsenter -t "$PID" -n ip link set dev eth0 mtu 1450
 # re-run the kubectl exec netshoot block above; restore: nsenter ... ip link set dev eth0 mtu 1500
 ```


### PR DESCRIPTION
## linux track Phase-1 — R1 review fixes wave 5 (4 modules)

Ground-checked R1 cross-family review fixes (4-pool mix) for the next curriculum-order batch.

- **performance 5.4-io-performance** (codex review): `avgqu-sz` → modern `aqu-sz` (multi-line); cgroup I/O example gains the cgroup-v2 path (`io.max`/`io.stat`) and a safe variable (was v1-blkio-only with a `<container>` shell-redirect trap); `sync;` added before `echo 3 > drop_caches` (kernel docs); StorageClass gains `volumeBindingMode: WaitForFirstConsumer` + PVC; outcome "Configure" → "Inspect and evaluate" (matches the lab); 4 war-stories → `Hypothetical scenario:`.
- **troubleshooting 6.1-systematic-troubleshooting** (cursor review): opening + 2 war-stories → `Hypothetical scenario:`; `alias k=kubectl` block added (clears the alias gate); dead sources swapped (invalid YouTube id → the real James Golick talk; Red Hat systemd 404 → `systemctl(1)` man7; dead Ubuntu logs URL → `journald` man7); `telnet`→`nc -zv`, misleading `curl :5432`→`nc`/`pg_isready`, `sysstat` note.
- **troubleshooting 6.2-log-analysis** (claude review, APPROVE_WITH_NITS): British Airways 2017 reference now cited (FlightGlobal) with the unverifiable "tens of millions" dropped; three `freedesktop.org` systemd URLs → `man7.org` equivalents; no-cluster + severity-range nits. (Residual source-gate flag is only the gnu.org network-block false-positive.)
- **troubleshooting 6.4-network-debugging** (gemini review): `pgrep -f "$POD"` host PID discovery (returns empty — pod name isn't in process argv) → `crictl inspect … | jq .info.pid`; `kubectl exec coredns -- wget` (fails on the distroless image) → a `netshoot` debug pod hitting the CoreDNS Pod IP; `python3 -c` JSON parse in `kindest/node` → `jq`; opening incident → `Hypothetical scenario:`.

**Ground-checked FPs rejected** (within-section links, k8s 1.35, gnu.org `000`=network-block). Build green (2129 pages, 0 errors); health 0 errors; `verify_module.py` T0 on 5.4/6.1 (6.2 residual = gnu.org artifact; 6.4 is pre-existing T3 density — both finalized on the review axis, tracked as follow-ups). Each fix self-verified against the R1 findings.

## Learner check

> Average queue size (formerly avgqu-sz; saturation indicator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
