### PR TITLE
chore(content): ai foundations 1.5/1.6 — R1 review fixes (Ollama pull, Presidio .text, cross-section link)

### DIFF
--- a/src/content/docs/ai/foundations/module-1.5-privacy-safety-and-trust.md
+++ b/src/content/docs/ai/foundations/module-1.5-privacy-safety-and-trust.md
@@ -53,9 +53,12 @@ The following preserved example shows a local model path for sensitive manifest 
 # Deploy a local instance to ensure data sovereignty
 docker run -d -v ollama:/root/.ollama -p 11434:11434 --name ollama ollama/ollama
 
+# Pull a model before the first API call (required on a fresh setup)
+docker exec ollama ollama pull llama3.2
+
 # Execute an inference call where the prompt never leaves your local network
 curl http://localhost:11434/api/generate -d '{
-  "model": "llama3",
+  "model": "llama3.2",
   "prompt": "Review this internal k8s manifest for security misconfigurations: [MANIFEST_CONTENT]",
   "stream": false
 }'
@@ -75,7 +78,9 @@ Metadata is a third boundary. Even if the content is sanitized, the pattern of r
 
 Before running this, what output do you expect if the incident file includes customer names after a manual redaction pass? A local model will still summarize what it sees, so the risk depends on whether the file stays inside the approved boundary. If the same command were pointed at a public chat tool, the lack of passwords would not be enough. The safer workflow is to scrub first, route to the right environment, and treat the result as advisory.
 
-```bash
+The following is an illustrative example only — it assumes a running Ollama server and an on-disk incident file that are not created elsewhere in this module.
+
+```text
 # Example: Using a local inference engine to analyze sensitive logs
 # This keeps all data within your VPC or local machine, bypassing cloud privacy risks.
 ollama run llama3:8b "Summarize this internal post-mortem and identify the root cause: $(cat production_incident_log.txt)"
@@ -115,7 +120,9 @@ raw_prompt = "Contact Jane Smith (ID: 9912) regarding the Berlin deployment."
 results = analyzer.analyze(text=raw_prompt, entities=["PERSON", "LOCATION"], language='en')
 
 # Anonymize ensures the LLM sees the context but not the identity
-sanitized_prompt = anonymizer.anonymize(text=raw_prompt, analyzer_results=results)
+anonymized = anonymizer.anonymize(text=raw_prompt, analyzer_results=results)
+sanitized_prompt = anonymized.text
+print(sanitized_prompt)
 # Output: "Contact <PERSON> (ID: 9912) regarding the <LOCATION> deployment."
 ```
 

--- a/src/content/docs/ai/foundations/module-1.6-using-ai-for-learning-writing-research-and-coding.md
+++ b/src/content/docs/ai/foundations/module-1.6-using-ai-for-learning-writing-research-and-coding.md
@@ -289,21 +289,28 @@ The diagnostic decision tree fits the module best because it keeps the human in 
 </details>
 
 <details>
-<summary>Question 5: AI generates a Kubernetes RBAC policy that makes a deployment work immediately, but it uses wildcards for nearly every resource and verb. The rollout is blocked, and the team is tempted to merge it because the model probably knows the standard pattern. What is the correct response?</summary>
+<summary>Question 5: A teammate prompts "Explain Kubernetes networking." The answer is generic. Which revised prompt best matches this module's decompose, compare, constrain, verify pattern?</summary>
+
+The strongest revision decomposes the topic, adds constraints, and asks for reviewable output instead of a single broad summary. For example: "I am preparing for CKAD and already understand Services and Endpoints. Decompose Kubernetes networking into layers I should study in order. For each layer, compare two common misconceptions, constrain the explanation to Kubernetes 1.35 behavior, and give me three self-quiz questions with answers I can verify against official docs." That prompt matches the Diagnose and Improve Prompts section because it names context, asks for structure before depth, and defines how to verify the result. A weaker revision would only say "explain it better" or "make it simpler," which leaves the model guessing level, goal, and evidence.
+
+</details>
+
+<details>
+<summary>Question 6: AI generates a Kubernetes RBAC policy that makes a deployment work immediately, but it uses wildcards for nearly every resource and verb. The rollout is blocked, and the team is tempted to merge it because the model probably knows the standard pattern. What is the correct response?</summary>
 
 Do not merge the broad policy simply because it works. The generated YAML may pass a functional check while violating least privilege and increasing cluster-wide blast radius. The correct response is to identify the exact resources and verbs the workload needs, narrow the role, and test that narrower policy. This answer compares the pattern of AI as code assistant with the anti-pattern of permission by convenience.
 
 </details>
 
 <details>
-<summary>Question 6: A developer says, "The tests passed, so I do not need to understand the AI-generated change." How should they apply the module's self-check?</summary>
+<summary>Question 7: A developer says, "The tests passed, so I do not need to understand the AI-generated change." How should they apply the module's self-check?</summary>
 
 They should ask whether they can explain the output in their own words, defend the decision without the model, and name what still needs verification. Passing tests are important, but tests may not cover maintainability, security scope, edge cases, or operational intent. If the developer cannot explain the change, they have not completed the human checkpoint. The right next step is to read the code, inspect risk areas, and add or adjust tests where the generated change is under-specified.
 
 </details>
 
 <details>
-<summary>Question 7: You want a reusable practice routine for AI-supported learning, writing, research, and coding. What loop should you implement, and why does it work across all four workflows?</summary>
+<summary>Question 8: You want a reusable practice routine for AI-supported learning, writing, research, and coding. What loop should you implement, and why does it work across all four workflows?</summary>
 
 Implement a loop that starts with your own attempt, asks AI for targeted help, compares the output against your intent, verifies risky parts, and records what you accepted or rejected. It works across learning, writing, research, and coding because each workflow can fail when fluent output arrives before understanding or evidence. The baseline preserves your thinking, the targeted prompt focuses assistance, and the verification checkpoint keeps responsibility with you. Recording the decision makes the work reviewable later.
 
@@ -448,4 +455,4 @@ Success criteria:
 
 ## Next Module
 
-Continue to [AI-Native Work](../ai-native-work/) to examine how workflows, tools, and team practices change when AI becomes a regular part of engineering delivery.
+Continue to [AI-Native Work](../../ai-native-work/) to examine how workflows, tools, and team practices change when AI becomes a regular part of engineering delivery.


### PR DESCRIPTION
## ai/foundations — R1 review fixes (1.5 + 1.6) — clears the ai-track review backlog

The last 2 ai modules needing review on `/quality` (the rest of the track was already `done`). Ground-checked R1 fixes (codex on 1.5, cursor on 1.6).

- **1.5-privacy-safety-and-trust** (codex review): the Ollama `/api/generate` example pulled no model (`model 'llama3' not found`) → added `docker exec ollama ollama pull llama3.2` + consistent `llama3.2` tag; a post-mortem `ollama run … $(cat …)` block that depends on an undeclared file → relabelled illustrative (`text` fence); the Presidio snippet stored the `EngineResult` object instead of the anonymized string → `sanitized_prompt = anonymized.text`.
- **1.6-using-ai-for-learning-writing-research-and-coding** (cursor review): cross-section "Next Module" link `../ai-native-work/` (resolved to a nonexistent `/ai/foundations/ai-native-work/`) → `../../ai-native-work/` (`ai-native-work` is a section under `ai/`); added a quiz item assessing the prompt-diagnose/rewrite learning outcome.

Build green (2129 pages, 0 errors); health 0 errors; `verify_module.py` T0 on both. Each fix self-verified against the R1 findings (the cross-section link target confirmed against the directory layout).

## Learner check

> you are preparing for a Kubernetes 1.35 platform review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
