### PR TITLE
chore(content): cka wave-1 review fixes (0.2/0.4/1.2)

### DIFF
--- a/src/content/docs/k8s/cka/part0-environment/module-0.2-shell-mastery.md
+++ b/src/content/docs/k8s/cka/part0-environment/module-0.2-shell-mastery.md
@@ -665,6 +665,8 @@ kubectl create secret generic app-secret --from-literal=password=demo-password $
 kubectl apply -f pod.yaml --dry-run=client
 kubectl apply -f deploy.yaml --dry-run=client
 kubectl apply -f svc.yaml --dry-run=client
+kubectl apply -f cm.yaml --dry-run=client
+kubectl apply -f secret.yaml --dry-run=client
 ```
 
 <details><summary>Solution</summary>
@@ -748,6 +750,7 @@ After cleanup, `ls *.yaml` should either show no files or only files unrelated t
 - https://www.gnu.org/software/bash/manual/bash.html
 - https://github.com/tmux/tmux/wiki
 - https://starship.rs/config/#kubernetes
+- https://support.apple.com/en-us/102360
 
 ## Next Module
 

--- a/src/content/docs/k8s/cka/part0-environment/module-0.4-k8s-docs.md
+++ b/src/content/docs/k8s/cka/part0-environment/module-0.4-k8s-docs.md
@@ -340,9 +340,9 @@ The primary pattern is "Task for skeleton, Reference for precision, dry run for 
 
 Another strong pattern is version-first reading. Before copying any manifest from an unfamiliar page, look at the Kubernetes version, the page section, and the `apiVersion` in the snippet. This is especially important for Ingress, Gateway API, beta resources, and examples discovered through search rather than direct navigation. Version-first reading is not slow once it becomes automatic. It is a small up-front cost that prevents a much larger debugging cost.
 
-A fourth pattern is "copy less than you understand, then validate more than you trust." Copying a complete example is acceptable when the example is official and close to the task, but you should still know which lines are essential and which lines are sample-specific. Names, labels, hosts, ports, storage classes, and namespaces often need prompt-specific edits. Validation then becomes more meaningful because you are not merely asking whether the YAML parses; you are checking whether the adapted object still expresses the requested behavior.
+A third pattern is "copy less than you understand, then validate more than you trust." Copying a complete example is acceptable when the example is official and close to the task, but you should still know which lines are essential and which lines are sample-specific. Names, labels, hosts, ports, storage classes, and namespaces often need prompt-specific edits. Validation then becomes more meaningful because you are not merely asking whether the YAML parses; you are checking whether the adapted object still expresses the requested behavior.
 
-A third pattern is controlled tab usage. Keep the main task page, the API reference or cheat sheet, and any vendor-specific docs in predictable places. Avoid opening a new tab for every search result because that changes the problem from "find the field" to "find the tab that had the field." In a real terminal workflow, the equivalent pattern is keeping a manifest file, a validation command, and a schema lookup command close together instead of scattering partial attempts across many files.
+A fourth pattern is controlled tab usage. Keep the main task page, the API reference or cheat sheet, and any vendor-specific docs in predictable places. Avoid opening a new tab for every search result because that changes the problem from "find the field" to "find the tab that had the field." In a real terminal workflow, the equivalent pattern is keeping a manifest file, a validation command, and a schema lookup command close together instead of scattering partial attempts across many files.
 
 The last pattern is deliberate recovery from wrong turns. During practice, intentionally click one plausible but wrong result, then time how quickly you can recognize the mismatch and move to the right section. This trains an important exam behavior: a wrong click should cost seconds, not minutes. The clue is usually in the page type, heading, or absence of a runnable example. If the page is explaining background and you need an object, recover toward Tasks. If the page gives a command but you need nested schema, recover toward Reference or `kubectl explain`.
 
@@ -506,7 +506,7 @@ kubectl get cm,secret,netpol
 
 # Cleanup
 kubectl delete cm --all
-kubectl delete secret --all  # careful: leaves default secrets
+kubectl delete secret --all  # careful: deletes service account tokens too; run in a disposable namespace only
 kubectl delete netpol --all
 ```
 

--- a/src/content/docs/k8s/cka/part1-cluster-architecture/module-1.2-extension-interfaces.md
+++ b/src/content/docs/k8s/cka/part1-cluster-architecture/module-1.2-extension-interfaces.md
@@ -863,8 +863,8 @@ Verify CNI behavior across nodes when your cluster has more than one worker. On 
 ```bash
 # Create pods on different nodes
 NODE1=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
-NODE2=$(kubectl get nodes -o jsonpath='{.items[1].metadata.name}')
-NODE2=${NODE2:-$NODE1}
+NODE2=$(kubectl get nodes -o jsonpath='{.items[1].metadata.name}' 2>/dev/null)
+NODE2=${NODE2:-$NODE1}  # single-node clusters fall back to NODE1
 kubectl run net-test-1 --image=nginx:alpine --overrides='{"spec":{"nodeName":"'"$NODE1"'"}}'
 kubectl run net-test-2 --image=nginx:alpine --overrides='{"spec":{"nodeName":"'"$NODE2"'"}}'
 


### PR DESCRIPTION
Phase-1 cross-family **review → done** for three back-catalog CKA modules. Cross-family R1 by cursor (0.2), claude-sonnet (0.4), and agy (1.2); every finding ground-checked by the orchestrator against the live file before applying.

### Modules
- **0.2 shell-mastery** — Task 3 now validates all five generated manifests (`cm.yaml`/`secret.yaml` were missing); added the Apple Catalina/Zsh support source. (Its T3 is the gnu.org CI-network-block false positive only.)
- **0.4 k8s-docs** — fixed inverted "third"/"fourth" pattern ordinals; corrected the misleading `kubectl delete secret --all` comment (it removes service-account tokens, not "leaves default secrets").
- **1.2 extension-interfaces** — silenced the single-node jsonpath array-index error (`2>/dev/null` + fallback comment). Rejected agy's hallucinated "leaked H1" (verifier confirms no `gate_no_source_h1` failure).

Pre-existing T2 `body_words` on 0.4 (4987) and 1.2 (4991) is left for the density workstream — these are finalized on the **review axis** per session-78 precedent. Build green (2129 pages).

## Learner check
> Client-side dry-run catches many structural errors before a live create or update

(module-0.2-shell-mastery.md — the validate-before-apply habit Task 3 drills.)
