### PR TITLE
chore(content): cka 1.6-rbac + 2.1-pods review fixes

### DIFF
--- a/src/content/docs/k8s/cka/part1-cluster-architecture/module-1.6-rbac.md
+++ b/src/content/docs/k8s/cka/part1-cluster-architecture/module-1.6-rbac.md
@@ -46,7 +46,7 @@ The physical badge analogy is useful as long as you keep the scope clear. A Role
 
 Every Kubernetes API request enters the API server with a set of attributes: the authenticated user, optional groups, requested verb, API group, resource, namespace, resource name, and sometimes a non-resource URL such as `/metrics`. Authorization begins only after authentication has identified the caller, so RBAC is not a login system. It is the policy layer that answers whether an already identified subject can perform one requested action.
 
-The API server can run several authorizers, and their order matters. The traditional flag is `--authorization-mode`, with values such as `Node`, `RBAC`, `Webhook`, `ABAC`, `AlwaysAllow`, and `AlwaysDeny`; modern clusters can also use an authorization configuration file. Each authorizer returns allow, deny, or no opinion, and the API server stops once an authorizer gives a definitive answer.
+The API server can run several authorizers, and their order matters. The traditional flag is `--authorization-mode`, with values such as `Node`, `RBAC`, `Webhook`, `ABAC` (deprecated and absent from CKA exam clusters), `AlwaysAllow`, and `AlwaysDeny`; modern clusters can also use an authorization configuration file. Each authorizer returns allow, deny, or no opinion, and the API server stops once an authorizer gives a definitive answer.
 
 RBAC permissions are additive, which means there is no deny rule you can place in a Role to cancel a permission granted somewhere else. If Alice has one binding that grants `get` on pods and another binding that grants `delete` on pods, Alice has both powers. This additive model keeps evaluation predictable, but it also means least privilege must be designed by granting less, not by granting broadly and trying to subtract later.
 
@@ -516,16 +516,18 @@ Kubernetes 1.35 and newer deserve special attention for streaming subresources u
 The safest way to update those streaming permissions is to treat them as interactive access, not as ordinary viewing. A user who can exec into a container may read environment variables, inspect mounted files, and run commands with the container's Linux permissions. Granting `pods/exec` should therefore be closer to granting shell access than granting `pods/log`, and it deserves a separate role when only a subset of responders need it.
 
 ```yaml
-# OLD (broken in 1.35+):
+# FRAGILE (worked for kubectl's WebSocket path before v1.35):
 - apiGroups: [""]
   resources: ["pods/exec"]
   verbs: ["get"]
 
-# FIXED:
+# CORRECT (required for SPDY and WebSocket, enforced everywhere in v1.35+):
 - apiGroups: [""]
   resources: ["pods/exec", "pods/attach", "pods/portforward"]
   verbs: ["get", "create"]
 ```
+
+The streaming subresources have always *intended* `create` to be the authorizing verb: the legacy SPDY transport always required it. The WebSocket upgrade path, which `kubectl` defaults to in recent versions, historically only checked `get` — an inconsistency that let a `get`-only role exec into pods. Kubernetes v1.35 closes that gap (feature gate `AuthorizePodWebsocketUpgradeCreatePermission`, beta and on by default), so grant `create` on these subresources rather than relying on `get`.
 
 Exam scenarios usually combine scope and subject mistakes rather than exotic authorizer behavior. Work through the target action first: who is calling, what verb is requested, which API group and resource are involved, and whether the resource is namespaced. Once you can say that sentence clearly, the required Role, ClusterRole, RoleBinding, or ClusterRoleBinding often becomes obvious.
 
@@ -644,10 +646,10 @@ When an existing built-in role looks close, inspect it before binding it. The `v
 
 ## Did You Know?
 
-1. RBAC entered beta in Kubernetes v1.6 and reached general availability in Kubernetes v1.8, released in October 2017.
+1. RBAC entered beta in Kubernetes v1.6 and reached general availability in Kubernetes v1.8, released in September 2017.
 2. The RBAC API uses four object kinds: Role, ClusterRole, RoleBinding, and ClusterRoleBinding.
 3. ServiceAccount token behavior changed significantly after Kubernetes v1.24, with short-lived projected tokens replacing automatic long-lived Secret tokens for ordinary pods.
-4. Node authorization is a special-purpose kubelet authorizer, and the Kubernetes documentation marks it stable as of Kubernetes v1.34.
+4. Node authorization is a special-purpose kubelet authorizer that has been stable since Kubernetes v1.8; a later refinement, `AuthorizeNodeWithSelectors`, reached GA in Kubernetes v1.33 and tightens each kubelet's access to only the nodes and pods relevant to it.
 
 ## Common Mistakes
 
@@ -949,6 +951,9 @@ EOF
 
 # The built-in 'view' ClusterRole automatically includes rules from
 # any ClusterRole with label aggregate-to-view: "true"
+# Note: 'view' already grants get/list/watch on configmaps, so this example
+# proves the mechanism rather than adding new access; to see a brand-new rule
+# appear, aggregate a resource 'view' lacks by default (e.g. a CRD).
 
 # Check what 'view' includes
 kubectl get clusterrole view -o yaml | grep -A20 "rules:"

--- a/src/content/docs/k8s/cka/part2-workloads-scheduling/module-2.1-pods.md
+++ b/src/content/docs/k8s/cka/part2-workloads-scheduling/module-2.1-pods.md
@@ -114,8 +114,9 @@ kubectl run nginx --image=nginx --labels="app=web,env=prod"
 # Create pod with environment variables
 kubectl run nginx --image=nginx --env="ENV=production"
 
-# Set resource requests and limits on an existing pod
-kubectl set resources pod nginx --requests="cpu=100m,memory=128Mi" --limits="cpu=200m,memory=256Mi"
+# Resource requests/limits cannot be patched onto a running bare pod — its
+# resources are immutable. Set them in the pod spec at creation time (see the
+# YAML workflow below).
 
 # Generate YAML without creating (essential for exam!)
 kubectl run nginx --image=nginx --dry-run=client -o yaml > pod.yaml
@@ -381,9 +382,8 @@ kubectl logs nginx --previous
 # Run a command
 kubectl exec nginx -- ls /
 
-# Interactive shell
-kubectl exec -it nginx -- /bin/bash
-kubectl exec -it nginx -- /bin/sh   # If bash not available
+# Interactive shell (/bin/sh works on minimal images; many images lack bash)
+kubectl exec -it nginx -- /bin/sh
 
 # Specific container in multi-container pod
 kubectl exec -it nginx -c sidecar -- /bin/sh
@@ -951,9 +951,9 @@ kubectl run webserver --image=nginx --port=80
 # 4. Pod with environment variables
 kubectl run envpod --image=nginx --env="ENV=production" --env="DEBUG=false"
 
-# 5. Pod with resource requests
-kubectl run limited --image=nginx
-kubectl set resources pod limited --requests="cpu=100m,memory=128Mi" --limits="cpu=200m,memory=256Mi"
+# 5. Pod with resource requests (set at creation via --overrides; a running
+#    bare pod's resources are immutable, so they cannot be patched in afterward)
+kubectl run limited --image=nginx --overrides='{"spec":{"containers":[{"name":"limited","image":"nginx","resources":{"requests":{"cpu":"100m","memory":"128Mi"},"limits":{"cpu":"200m","memory":"256Mi"}}}]}}'
 
 # Verify all pods
 kubectl get pods


### PR DESCRIPTION
Phase-1 cross-family **review → done** for two more CKA modules. R1 by claude-sonnet (1.6) and agy (2.1); every finding ground-checked by the orchestrator (agy's findings validated this time; the version-sensitive 1.6 claims verified against k8s docs + PR #134577).

### 1.6 RBAC (claude — APPROVE_WITH_NITS)
- k8s v1.8 released **September** 2017 (was October).
- Node authorization stable since v1.8; cite `AuthorizeNodeWithSelectors` GA v1.33 (was a dubious "v1.34").
- pods/exec RBAC reframed per **PR #134577**: `get`-only worked only on kubectl's WebSocket path pre-1.35 (SPDY always required `create`); v1.35 requires `create` for both.
- nits: ABAC flagged deprecated; aggregation-drill note (`view` already covers configmaps).

### 2.1 Pods (agy — NEEDS_CHANGES, both findings valid)
- Removed `kubectl set resources pod` (immutable on a running bare pod); resources now set at creation (`--overrides` / YAML).
- `kubectl exec ... /bin/bash` → `/bin/sh` (nginx not in the verifier's bash allowlist) — clears `lab_image_binary_match`.

Both now **T0**; build green (2129 pages).

## Learner check
> resources are immutable. Set them in the pod spec at creation time

(module-2.1-pods.md — the corrected pod-resources teaching point.)
