### PR TITLE
chore(content): cka 2.2-deployments + 2.3-daemonsets review fixes

### DIFF
--- a/src/content/docs/k8s/cka/part2-workloads-scheduling/module-2.2-deployments.md
+++ b/src/content/docs/k8s/cka/part2-workloads-scheduling/module-2.2-deployments.md
@@ -305,8 +305,8 @@ Any change to the Pod template can trigger a rollout. Updating an image is the o
 # Update image (triggers rolling update)
 kubectl set image deployment/nginx nginx=nginx:1.26
 
-# Update with record (saves command in history)
-kubectl set image deployment/nginx nginx=nginx:1.26 --record
+# Record change cause for rollout history (replaces deprecated --record)
+kubectl annotate deployment/nginx kubernetes.io/change-cause="Update nginx image to 1.26" --overwrite
 
 # Update environment variable
 kubectl set env deployment/nginx ENV=production
@@ -729,7 +729,8 @@ You should see five Pods after scheduling and startup complete. The current Repl
 Perform a normal image update, inspect history, then deliberately use a bad image tag so you can practice diagnosing and rolling back a stuck rollout.
 
 ```bash
-kubectl set image deployment/webapp nginx=nginx:1.25 --record
+kubectl set image deployment/webapp nginx=nginx:1.25
+kubectl annotate deployment/webapp kubernetes.io/change-cause="Update nginx image to 1.25" --overwrite
 kubectl rollout status deployment/webapp
 ```
 
@@ -739,7 +740,8 @@ kubectl get replicaset  # Notice two ReplicaSets now
 ```
 
 ```bash
-kubectl set image deployment/webapp nginx=nginx:broken --record
+kubectl set image deployment/webapp nginx=nginx:broken
+kubectl annotate deployment/webapp kubernetes.io/change-cause="Deliberately broken image for rollback drill" --overwrite
 kubectl rollout status deployment/webapp --timeout=10s || true  # Timeout prevents hanging
 kubectl get pods  # Some in ImagePullBackOff
 ```
@@ -822,11 +824,13 @@ kubectl create deployment app --image=nginx:1.24 --replicas=3
 kubectl rollout status deployment/app
 
 # Update 1
-kubectl set image deployment/app nginx=nginx:1.25 --record
+kubectl set image deployment/app nginx=nginx:1.25
+kubectl annotate deployment/app kubernetes.io/change-cause="Update 1: nginx 1.25" --overwrite
 kubectl rollout status deployment/app
 
 # Update 2 (bad version)
-kubectl set image deployment/app nginx=nginx:bad --record
+kubectl set image deployment/app nginx=nginx:bad
+kubectl annotate deployment/app kubernetes.io/change-cause="Update 2: bad image tag" --overwrite
 # Don't wait - it will fail
 
 # Check history
@@ -880,8 +884,10 @@ kubectl set image deployment/paused nginx=nginx:1.25
 kubectl set env deployment/paused ENV=production
 kubectl set resources deployment/paused -c nginx --requests=cpu=100m
 
-# Check - still old image
+# Spec already shows the NEW image (pause defers the rollout, not the spec write):
 kubectl get deployment paused -o jsonpath='{.spec.template.spec.containers[0].image}'
+# Running pods still serve the OLD image (no new ReplicaSet created yet):
+kubectl get pods -l app=paused -o jsonpath='{.items[0].spec.containers[0].image}'
 
 # Resume - single rollout
 kubectl rollout resume deployment/paused
@@ -972,14 +978,16 @@ kubectl rollout status deployment/lifecycle-test
 kubectl scale deployment lifecycle-test --replicas=5
 
 # 3. Update to 1.25
-kubectl set image deployment/lifecycle-test nginx=nginx:1.25 --record
+kubectl set image deployment/lifecycle-test nginx=nginx:1.25
+kubectl annotate deployment/lifecycle-test kubernetes.io/change-cause="Update nginx image to 1.25" --overwrite
 kubectl rollout status deployment/lifecycle-test
 
 # 4. Check history
 kubectl rollout history deployment/lifecycle-test
 
 # 5. Update to 1.26
-kubectl set image deployment/lifecycle-test nginx=nginx:1.26 --record
+kubectl set image deployment/lifecycle-test nginx=nginx:1.26
+kubectl annotate deployment/lifecycle-test kubernetes.io/change-cause="Update nginx image to 1.26" --overwrite
 kubectl rollout status deployment/lifecycle-test
 
 # 6. Rollback to revision 1

--- a/src/content/docs/k8s/cka/part2-workloads-scheduling/module-2.3-daemonsets-statefulsets.md
+++ b/src/content/docs/k8s/cka/part2-workloads-scheduling/module-2.3-daemonsets-statefulsets.md
@@ -96,7 +96,7 @@ spec:
     spec:
       containers:
       - name: fluentd
-        image: fluentd:v1.35
+        image: fluent/fluentd:v1.18-debian-1
         resources:
           limits:
             memory: 200Mi
@@ -256,7 +256,7 @@ A useful DaemonSet troubleshooting loop has three layers. First, inspect the Dae
 
 Be careful with resource requests on DaemonSets because the cost scales with node count rather than replica count. A request that looks tiny on a three-node lab cluster may become meaningful across many worker nodes, and a memory-heavy agent can reduce allocatable capacity everywhere. This does not mean node agents should omit requests; it means requests must represent the real minimum needed for stable operation. Under-requested agents can be evicted or throttled precisely when the cluster is already under pressure.
 
-The CKA often frames DaemonSet questions as "why is the pod missing from this node?" In those scenarios, resist the urge to recreate the controller first. Check whether the node has a taint the pod does not tolerate, whether a node selector excludes it, whether the node is cordoned, and whether the DaemonSet status already reports a lower desired count. Recreating the controller with the same template rarely changes the scheduling answer because the same rules are applied again.
+The CKA often frames DaemonSet questions as "why is the pod missing from this node?" In those scenarios, resist the urge to recreate the controller first. Check whether the node has a taint the DaemonSet pod does not tolerate, whether a nodeSelector or affinity rule excludes it, whether allocatable CPU or memory is insufficient, whether an image pull or admission rejection blocked the pod, and whether node-specific events explain a lower desired count. Cordoning alone does not stop DaemonSet pods—they tolerate `node.kubernetes.io/unschedulable:NoSchedule` by default. Recreating the controller with the same template rarely changes the scheduling answer because the same rules are applied again.
 
 ## StatefulSets: Identity, Storage, and Ordered Change
 
@@ -1007,7 +1007,7 @@ EOF
 ```
 
 ```bash
-kubectl wait --for=condition=ready pod/web-0 pod/web-1 --timeout=60s
+kubectl rollout status sts/web --timeout=60s
 kubectl run dns-test --image=busybox --rm -it --restart=Never -- nslookup nginx
 kubectl run dns-test --image=busybox --rm -it --restart=Never -- nslookup web-0.nginx
 kubectl run dns-test --image=busybox --rm -it --restart=Never -- nslookup web-1.nginx


### PR DESCRIPTION
Phase-1 cross-family **review → done** for two CKA workload modules. R1 by claude (2.2) and cursor (2.3); fixes by cursor, ground-checked by the orchestrator. Both now **T0**, build green.

### 2.2 Deployments (claude — NEEDS_CHANGES)
- **Correctness (P1):** the paused-rollout block claimed the spec still shows the old image — wrong. `kubectl set image` writes the spec **immediately**; pause only defers the new ReplicaSet. Fixed to show spec=new vs running-pods=old.
- **Deprecation (P2):** replaced every `--record` (deprecated) with the modern `kubectl annotate … kubernetes.io/change-cause=… --overwrite`, preserving the rollout-history lesson.

### 2.3 DaemonSets/StatefulSets (cursor — NEEDS_CHANGES, live-verified)
- **Invalid image (P1):** `fluentd:v1.35` (k8s version mistaken for a fluentd tag) → `fluent/fluentd:v1.18-debian-1` (verified pullable).
- **Wrong cause (P2):** a cordoned node is **not** why a DaemonSet pod goes missing — DS pods tolerate `node.kubernetes.io/unschedulable:NoSchedule`. Replaced with real causes (taints, selectors/affinity, resources, image pull, admission, events).
- **Race (P2):** `kubectl wait pod/web-0 pod/web-1` → `kubectl rollout status sts/web --timeout=60s` (StatefulSet pods are created sequentially).

## Learner check
> pause defers the rollout, not the spec write

(module-2.2-deployments.md — the corrected pause semantics.)
