### PR TITLE
chore(content): cka 2.5-resource-management review fixes

### DIFF
--- a/src/content/docs/k8s/cka/part2-workloads-scheduling/module-2.5-resource-management.md
+++ b/src/content/docs/k8s/cka/part2-workloads-scheduling/module-2.5-resource-management.md
@@ -322,9 +322,9 @@ spec:
 
 ```text
 Eviction Order (first to last):
-1. BestEffort pods exceeding request
-2. Burstable pods exceeding request
-3. Burstable pods below request
+1. BestEffort pods (no requests set - evicted first)
+2. Burstable pods using more than their requests
+3. Burstable pods using less than their requests
 4. Guaranteed pods (last resort)
 ```
 
@@ -760,7 +760,7 @@ kubectl get pod test-defaults -n limits-test -o yaml | grep -A8 resources
 
 ### Task 5: Test ResourceQuota admission
 
-Add a pod-count quota and create pods until the namespace budget is exhausted. The third pod should fail because the quota already accounts for the pods created in this namespace.
+Add a pod-count quota and create pods until the namespace budget is exhausted. `test-defaults` from Task 4 already consumes one of the two allowed pod slots, so `pod1` brings the namespace to `2/2` and the second new pod is rejected.
 
 ```bash
 cat << 'EOF' | kubectl apply -f -
@@ -776,8 +776,7 @@ EOF
 
 # Create pods until quota exceeded
 kubectl run pod1 --image=nginx -n limits-test
-kubectl run pod2 --image=nginx -n limits-test
-kubectl run pod3 --image=nginx -n limits-test  # Should fail
+kubectl run pod2 --image=nginx -n limits-test  # Should fail: test-defaults + pod1 already reach 2/2
 
 kubectl describe resourcequota pod-quota -n limits-test
 ```
@@ -950,6 +949,9 @@ spec:
       requests:
         cpu: "200m"
         memory: "256Mi"
+      limits:
+        cpu: "400m"
+        memory: "512Mi"
 ---
 apiVersion: v1
 kind: Pod
@@ -964,6 +966,9 @@ spec:
       requests:
         cpu: "200m"
         memory: "256Mi"
+      limits:
+        cpu: "400m"
+        memory: "512Mi"
 ---
 apiVersion: v1
 kind: Pod
@@ -978,6 +983,9 @@ spec:
       requests:
         cpu: "200m"
         memory: "256Mi"
+      limits:
+        cpu: "400m"
+        memory: "512Mi"
 EOF
 
 cat << 'EOF' | kubectl apply -f -
@@ -994,6 +1002,9 @@ spec:
       requests:
         cpu: "200m"
         memory: "256Mi"
+      limits:
+        cpu: "400m"
+        memory: "512Mi"
 EOF
 
 kubectl describe resourcequota compute-quota -n quota-test


### PR DESCRIPTION
Phase-1 cross-family **review → done** for CKA **2.5 Resource Management**. R1 by gemini (agy), every finding ground-checked by the orchestrator against k8s quota-admission behavior; fixes by codex. Now **T0**, build green.

### Fixes (all 3 P2s — verified real)
- **Eviction order (line 324):** "BestEffort pods exceeding request" is nonsensical (BestEffort pods set *no* requests). Rewrote the order to be accurate (BestEffort evicted first because they set no requests/limits).
- **Quota off-by-one (Task 5):** `test-defaults` from Task 4 already consumes one of the two pod slots, so it's the **second** new pod that's rejected, not the third. Corrected the narrative + the `# Should fail` marker; dropped the redundant `pod3`.
- **Drill-4 admission (lines 949+):** the `compute-quota` sets `limits.cpu`/`limits.memory` but the pods declared only `requests` and there's no LimitRange — admission would reject them before the pod-count lesson. Added `limits` to every drill pod (within quota bounds).

## Learner check
> BestEffort pods (no requests set - evicted first)

(module-2.5-resource-management.md — the corrected eviction-order box.)
