### PR TITLE
chore(content): cka 2.4-jobs-cronjobs review fixes

### DIFF
--- a/src/content/docs/k8s/cka/part2-workloads-scheduling/module-2.4-jobs-cronjobs.md
+++ b/src/content/docs/k8s/cka/part2-workloads-scheduling/module-2.4-jobs-cronjobs.md
@@ -701,8 +701,8 @@ kubectl get jobs
 kubectl wait --for=condition=complete job/backup-now --timeout=60s
 kubectl logs job/backup-now
 
-kubectl delete cronjob backup
 kubectl delete job backup-now
+kubectl delete cronjob backup
 ```
 
 <details>
@@ -818,7 +818,7 @@ sleep 15
 kill %1 2>/dev/null
 
 # Check status
-kubectl describe job timeout-test | grep -A3 "Conditions"
+kubectl get job timeout-test -o jsonpath='{range .status.conditions[*]}{.type}{"="}{.status}{" reason="}{.reason}{"\n"}{end}'
 
 # Cleanup
 kubectl delete job timeout-test
@@ -854,8 +854,8 @@ kubectl wait --for=condition=complete job/daily-manual-run --timeout=60s
 kubectl logs job/daily-manual-run
 
 # Cleanup
-kubectl delete cronjob daily
 kubectl delete job daily-manual-run
+kubectl delete cronjob daily
 ```
 
 ```bash


### PR DESCRIPTION
Phase-1 cross-family **review → done** for CKA **2.4 Jobs & CronJobs**. R1 by **codex** (live-run on a kind cluster); fixes by cursor, ground-checked by the orchestrator. **T0**, build green.

### Fixes (codex live-verified)
- **Cleanup order (P1, ×2):** deleting the CronJob before the manual Job it spawned left the follow-up `kubectl delete job …` failing `NotFound`. Reversed both cleanups to delete the Job first (Task 5 + the daily-CronJob drill).
- **Status query (P2):** `kubectl describe job timeout-test | grep -A3 "Conditions"` returned nothing on a real cluster; replaced with a reliable `kubectl get job … -o jsonpath='{…conditions…}'`.

## Learner check
> is one of the most useful operational commands

(module-2.4-jobs-cronjobs.md — on `kubectl create job --from=cronjob/…` manual triggering.)
