### PR TITLE
chore(content): cka 2.9-autoscaling + 3.1-services review fixes

### DIFF
--- a/src/content/docs/k8s/cka/part2-workloads-scheduling/module-2.9-autoscaling.md
+++ b/src/content/docs/k8s/cka/part2-workloads-scheduling/module-2.9-autoscaling.md
@@ -239,14 +239,22 @@ kubectl autoscale deployment web --min=1 --max=5 --cpu-percent=50
 # Generate load.
 kubectl run load-generator --image=busybox --restart=Never -- \
   /bin/sh -c "while true; do wget -q -O- http://web; done"
+```
 
+```bash
 # Watch HPA respond.
+# Press Ctrl-C after observing a few scaling events
 kubectl get hpa web -w
+```
 
+```bash
 # Stop load.
 kubectl delete pod load-generator
+```
 
+```bash
 # Watch HPA scale back down after stabilization.
+# Press Ctrl-C after observing a few scaling events
 kubectl get hpa web -w
 ```
 
@@ -281,7 +289,7 @@ spec:
     kind: Deployment
     name: web
   updatePolicy:
-    updateMode: "Auto"  # Options: Off, Initial, Recreate, Auto
+    updateMode: "Off"  # Options: Off, Initial, Recreate, InPlaceOrRecreate
 ```
 
 The example above is intentionally small because VPA details vary by installation and policy. The key fields are `targetRef`, which tells VPA which workload to analyze, and `updatePolicy`, which controls whether recommendations are merely reported or applied. In cautious environments, `Off` is a strong first choice because it produces evidence before it changes workload behavior.
@@ -529,14 +537,26 @@ kubectl get hpa challenge-web
 # 5. Generate load.
 kubectl run load --image=busybox --restart=Never -- \
   /bin/sh -c "while true; do wget -q -O- http://challenge-web; done"
+```
 
+```bash
 # 6. Watch scaling happen.
+# Press Ctrl-C after observing a few scaling events
 kubectl get hpa challenge-web -w
+```
 
-# 7. Stop load and watch scale-down.
+```bash
+# 7. Stop load.
 kubectl delete pod load
-kubectl get hpa challenge-web -w
+```
 
+```bash
+# Watch scale-down after stabilization.
+# Press Ctrl-C after observing a few scaling events
+kubectl get hpa challenge-web -w
+```
+
+```bash
 # 8. Cleanup.
 kubectl delete deployment challenge-web
 kubectl delete svc challenge-web

--- a/src/content/docs/k8s/cka/part3-services-networking/module-3.1-services.md
+++ b/src/content/docs/k8s/cka/part3-services-networking/module-3.1-services.md
@@ -651,7 +651,7 @@ spec:
 
 | Value | Behavior |
 |-------|----------|
-| `PreferSameNode` | [Strictly prefer endpoints on the same node, fall back to remote (GA in 1.35)](https://kubernetes.io/docs/concepts/services-networking/service/) |
+| `PreferSameNode` | [Prefer endpoints on the same node, fall back to remote (GA in 1.35)](https://kubernetes.io/docs/concepts/services-networking/service/) |
 | `PreferSameZone` | Prefer endpoints topologically close — same zone when using topology-aware routing |
 
 Pause and predict: if you set `externalTrafficPolicy: Local` for a NodePort Service and send traffic to a node with no local backend Pod, what should you check before blaming DNS? The DNS name may be resolving correctly, and the NodePort may be open, but the policy intentionally refuses to forward to remote endpoints. The right evidence is node placement, EndpointSlice hints, Service policy fields, and whether the receiving node has a local ready endpoint.
@@ -1263,7 +1263,13 @@ kubectl delete svc external-api
 ```
 
 ```bash
-# YOUR TASK: Complete in under 5 minutes
+# YOUR TASK (complete in under 5 minutes):
+# 1. Create a deployment 'challenge-app' (nginx, 3 replicas)
+# 2. Expose it as a ClusterIP Service on port 80
+# 3. Verify it has 3 endpoints
+# 4. Scale to 5 replicas and re-check endpoints
+# 5. Switch the Service to NodePort and read the assigned nodePort
+# 6. Clean up the deployment and Service
 ```
 
 <details>
@@ -1314,7 +1320,6 @@ kubectl delete svc challenge-app
 - [Virtual IPs and Service proxies](https://kubernetes.io/docs/reference/networking/virtual-ips)
 - [DNS for Services and Pods](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/)
 - [kube-proxy command reference](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/)
-- [Service reference page](https://kubernetes.io/docs/concepts/services-networking/service/index.html)
 - [Service v1 API reference](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/)
 - [Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
 - [EndpointSlices concept documentation](https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/)


### PR DESCRIPTION
Phase-1 cross-family **review → done** for CKA **2.9 Autoscaling** + **3.1 Services**. R1 by cursor (2.9, live-verified) and agy (3.1, ground-checked — its YAML-indentation finding was a verified false positive and rejected). Fixes by cursor. Both **T0**, build green.

### 2.9 Autoscaling
- **VPA mode:** legacy `updateMode: "Auto"` → `"Off"`; comment updated to current modes (`Off, Initial, Recreate, InPlaceOrRecreate`) — verified against the VPA docs.
- **Watch blocks (×2):** `kubectl get hpa … -w` sat before cleanup in a paste-block (hangs forever). Split each watch into its own block with a "Press Ctrl-C" note so cleanup stays reachable.

### 3.1 Services
- **Challenge:** the task block was empty (`# YOUR TASK…` only) — added the actual objectives so it's attemptable without reading the solution.
- `PreferSameNode`: "Strictly prefer" → "Prefer" (it's a soft preference; matches the prose).
- Removed a duplicate `…/service/index.html` source.
- (Manual Endpoints YAML confirmed valid — agy's indentation flag rejected.)

## Learner check
> produces evidence before it changes workload behavior

(module-2.9-autoscaling.md — why VPA `Off` mode is the cautious default.)
