### PR TITLE
chore(content): CKA wave 5 (3.2–3.5 services-networking) — R1 review fixes

### DIFF
--- a/src/content/docs/k8s/cka/part3-services-networking/module-3.2-endpoints.md
+++ b/src/content/docs/k8s/cka/part3-services-networking/module-3.2-endpoints.md
@@ -144,7 +144,7 @@ One useful habit is to treat endpoint generation as a reconciliation chain rathe
 
 ### 1.3 Viewing Endpoints
 
-You can inspect the legacy Endpoints API using standard `kubectl` commands. Even though EndpointSlices are the modern source for service proxies in current Kubernetes, legacy Endpoints output remains useful because many humans, scripts, and older controllers still expose it during troubleshooting. Use it as a quick compatibility view, then confirm anything scale-sensitive or condition-sensitive with EndpointSlices.
+You can inspect the legacy Endpoints API using standard `kubectl` commands. The legacy Endpoints API is deprecated since Kubernetes v1.33 (still served); EndpointSlices are the replacement. Even though EndpointSlices are the modern source for service proxies in current Kubernetes, legacy Endpoints output remains useful because many humans, scripts, and older controllers still expose it during troubleshooting. Use it as a quick compatibility view, then confirm anything scale-sensitive or condition-sensitive with EndpointSlices.
 
 ```bash
 # List all endpoints
@@ -320,7 +320,7 @@ EndpointSlices have their own resource names and generated object names, so the 
 ```bash
 # List all EndpointSlices
 kubectl get endpointslices
-kubectl get eps                   # Short form (might conflict with endpoints)
+# EndpointSlices have no short alias — type the resource name in full.
 
 # Get EndpointSlices for a service
 kubectl get endpointslices -l kubernetes.io/service-name=web-svc
@@ -345,7 +345,7 @@ Before running a describe command, first list the slices and copy the generated 
 | Dual-stack support | Limited | Full IPv4/IPv6 |
 | Topology hints | No | Yes |
 
-This comparison is useful, but it needs one correction in your mental model: "unlimited" in the legacy Endpoints row does not mean safe at any size. Kubernetes documents that the legacy Endpoints API truncates over-capacity backend sets at 1,000 endpoints and marks the object with the `endpoints.kubernetes.io/over-capacity: truncated` annotation. If a tool reads only the legacy object, it can miss backends that EndpointSlices still represent.
+This comparison is useful, but it needs one correction in your mental model: "unlimited" in the legacy Endpoints row does not mean safe at any size. As of current Kubernetes versions, the legacy Endpoints API truncates over-capacity backend sets at 1,000 endpoints and marks the object with the `endpoints.kubernetes.io/over-capacity: truncated` annotation. If a tool reads only the legacy object, it can miss backends that EndpointSlices still represent.
 
 For exam and production work, treat EndpointSlices as the authoritative modern view while still knowing how to interpret Endpoints. You will often inspect both because old commands are fast and familiar, but your conclusion should account for which API has the fidelity needed for the situation. Large Services, dual-stack clusters, terminating endpoint behavior, and topology-aware routing all push you toward EndpointSlices.
 
@@ -436,7 +436,7 @@ kubectl describe endpoints web-svc
 
 Pods listed in `NotReadyAddresses` are actively shielded from receiving normal traffic. In the modern `EndpointSlice` API, routing is driven by endpoint conditions: `ready`, `serving`, and `terminating`. The `serving` condition maps directly to pod readiness for pod-backed endpoints, while `terminating` indicates the endpoint is currently shutting down.
 
-For pod-backed endpoints, nil values in `ready` or `serving` are safely interpreted as `true`, while nil in `terminating` is interpreted as `false`. Service proxies normally ignore terminating endpoints, but they may route to endpoints marked as both `serving` and `terminating` if all available endpoints are terminating. That fallback helps avoid an immediate total outage during aggressive rollouts, but you should still fix the rollout shape so healthy replacements exist before old Pods disappear.
+For pod-backed endpoints only, nil values in `ready` or `serving` are interpreted as `true`, and nil in `terminating` as `false`; that defaulting applies to endpoints the controller derives from Pods, not to manually authored EndpointSlice entries without a `targetRef`. Service proxies normally ignore terminating endpoints, but they may route to endpoints marked as both `serving` and `terminating` if all available endpoints are terminating. That fallback helps avoid an immediate total outage during aggressive rollouts, but you should still fix the rollout shape so healthy replacements exist before old Pods disappear.
 
 When diagnosing a readiness-related outage, keep the human explanation tied to the condition. Say "the Pods are Running but excluded because readiness is false" instead of "Kubernetes lost the Pods." That phrasing prevents the team from deleting random resources and points them toward probe paths, dependency checks, application startup time, or resource pressure. It also maps cleanly to the CKA troubleshooting style, where you need to identify the broken link and correct it directly.
 
@@ -626,6 +626,8 @@ kubectl run test --rm -i --image=busybox:1.36 --restart=Never -- \
 # Address: 10.244.1.12
 ```
 
+BusyBox `nslookup` exit code is unreliable — judge success by the printed `Address:` lines for the intended record, not the pod exit code; use a netshoot pod for `host`/`dig` if you need a clean exit.
+
 DNS tests are most meaningful when run from inside the cluster because cluster DNS names and search paths are meant for Pods. If you test from your laptop, you may be querying a completely different resolver that knows nothing about `svc.cluster.local`. A CKA troubleshooting answer should be precise about vantage point: inspect Kubernetes objects with `kubectl`, then test in-cluster name resolution with a temporary Pod.
 
 ---
@@ -715,7 +717,7 @@ Use that framework during troubleshooting as well as design. If a Service has a 
 ## Did You Know?
 
 - **EndpointSlices became stable in Kubernetes 1.21:** The discovery API is not experimental in modern clusters; it is the scalable replacement for watching one giant legacy Endpoints object.
-- **Legacy Endpoints truncate over-capacity backends at 1,000 addresses:** Kubernetes marks the object with `endpoints.kubernetes.io/over-capacity: truncated`, which is a warning that legacy readers may see only part of the backend set.
+- **Legacy Endpoints truncate over-capacity backends at 1,000 addresses (as of current Kubernetes versions):** Kubernetes marks the object with `endpoints.kubernetes.io/over-capacity: truncated`, which is a warning that legacy readers may see only part of the backend set.
 - **EndpointSlices are normally split around 100 endpoints each:** The controller creates additional slices as Services grow, reducing the update payload when one Pod changes.
 - **EndpointSlice conditions distinguish readiness from termination:** `ready`, `serving`, and `terminating` let service proxies reason about rollout edge cases that the legacy object cannot describe as clearly.
 
@@ -771,13 +773,13 @@ Use that framework during troubleshooting as well as design. If a Service has a 
 6. **You are reviewing the YAML of an EndpointSlice for a legacy application. Under one of the endpoints, the `ready` and `serving` conditions are missing entirely (`nil`). A junior engineer worries that kube-proxy will drop traffic to this endpoint because it is not explicitly marked ready. Are they correct, and why?**
    <details>
    <summary>Answer</summary>
-   They are not correct for pod-backed endpoints. Kubernetes interprets nil `ready` or `serving` values as true for compatibility, while nil `terminating` is interpreted as false. That does not mean missing conditions are ideal for clarity, but it does mean the endpoint is not automatically dropped only because those fields are absent. You should still evaluate the broader EndpointSlice, Pod readiness, and rollout state before concluding the proxy behavior is wrong.
+   They are not correct for pod-backed endpoints. For pod-backed endpoints only, Kubernetes interprets nil `ready` or `serving` as true and nil `terminating` as false; manual endpoints without a Pod `targetRef` do not get those defaults. That does not mean missing conditions are ideal for clarity, but it does mean the endpoint is not automatically dropped only because those fields are absent on a controller-managed slice. You should still evaluate the broader EndpointSlice, Pod readiness, and rollout state before concluding the proxy behavior is wrong.
    </details>
 
 7. **During a traffic spike, your application auto-scales to 1,200 pods. Metrics show that 200 of the newest pods receive zero traffic while the older 1,000 pods are overloaded. You inspect the `Endpoints` object and notice an `endpoints.kubernetes.io/over-capacity: truncated` annotation. What is the architectural root cause, and how do you route traffic to the stranded pods?**
    <details>
    <summary>Answer</summary>
-   The root cause is reliance on the legacy Endpoints API after the backend set exceeded its documented truncation behavior. The annotation tells you the old object is not representing every backend, so any component reading only that object can make incomplete routing decisions. EndpointSlices are designed to represent the full backend set in smaller objects, so use EndpointSlice-aware service routing and diagnostics. The stranded pods are not necessarily unhealthy; they are invisible to legacy readers that cannot represent the whole set.
+   The root cause is reliance on the legacy Endpoints API after the backend set exceeded its documented truncation limit (1,000 addresses as of current Kubernetes versions). The annotation tells you the old object is not representing every backend, so any component reading only that object can make incomplete routing decisions. EndpointSlices are designed to represent the full backend set in smaller objects, so use EndpointSlice-aware service routing and diagnostics. The stranded pods are not necessarily unhealthy; they are invisible to legacy readers that cannot represent the whole set.
    </details>
 
 8. **During an aggressive rolling update of a critical microservice, you observe a brief window where all available pods are terminating. To your surprise, `kube-proxy` is still routing active traffic to these pods instead of dropping it immediately. The endpoints show both `serving: true` and `terminating: true`. Is this a bug in the proxy or intended behavior?**
@@ -963,8 +965,8 @@ spec:
   - port: 80
 EOF
 
-# Check - no endpoints yet
-kubectl get endpoints external-svc
+# Check - no endpoints yet (none exist until the manual Endpoints object is created)
+kubectl get endpoints external-svc --ignore-not-found
 
 # Create manual endpoints
 cat << 'EOF' | kubectl apply -f -
@@ -985,8 +987,8 @@ kubectl get endpoints external-svc
 kubectl describe endpoints external-svc
 
 # Cleanup
+kubectl delete endpoints external-svc --ignore-not-found=true
 kubectl delete svc external-svc
-kubectl delete endpoints external-svc
 ```
 
 ### Drill 4: Headless Service (Target: 3 minutes)
@@ -1216,7 +1218,7 @@ kubectl get endpoints manual-svc
 # 8. Cleanup
 kubectl delete deployment ep-challenge
 kubectl delete svc fixed-svc headless-challenge manual-svc
-kubectl delete endpoints manual-svc
+kubectl delete endpoints manual-svc --ignore-not-found=true
 ```
 
 </details>
@@ -1235,10 +1237,14 @@ If one of the drills behaves differently in your cluster, treat that as useful s
 - [Topology Aware Routing](https://kubernetes.io/docs/concepts/services-networking/topology-aware-routing/) — Explains zone-aware routing behavior and EndpointSlice hints.
 - [Service Internal Traffic Policy](https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/) — Covers how Service routing policy can narrow eligible endpoints.
 - [EndpointSlice API reference](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/endpoint-slice-v1/) — Defines EndpointSlice fields, conditions, address types, ports, and topology fields.
-- [Endpoints API reference](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/endpoints-v1/) — Defines the legacy Endpoints object shape used in compatibility examples.
+- [Endpoints API reference](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/endpoints-v1/) (deprecated since v1.33) — Defines the legacy Endpoints object shape used in compatibility examples.
 - [Debug Services](https://kubernetes.io/docs/tasks/debug/debug-application/debug-service/) — Kubernetes task guide for tracing Service selector and endpoint failures.
 - [StatefulSet Basics](https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/) — Demonstrates stable network identity and headless Service usage for StatefulSets.
 - [Virtual IPs and Service Proxies](https://kubernetes.io/docs/reference/networking/virtual-ips/) — Explains how Kubernetes service proxying uses Service and endpoint data.
+
+## Learner check
+
+> Kubernetes 1.35 uses EndpointSlices as the scalable discovery API behind Services, while the older Endpoints API remains visible mostly for compatibility and troubleshooting.
 
 ## Next Module
 

--- a/src/content/docs/k8s/cka/part3-services-networking/module-3.3-dns.md
+++ b/src/content/docs/k8s/cka/part3-services-networking/module-3.3-dns.md
@@ -7,7 +7,7 @@ sidebar:
 lab:
   id: cka-3.3-dns
   url: https://killercoda.com/kubedojo/scenario/cka-3.3-dns
-  duration: "35 min"
+  duration: "45 min"
   difficulty: intermediate
   environment: kubernetes
 ---
@@ -231,6 +231,7 @@ SRV records add port information to the DNS answer, which is useful when clients
 
 ```bash
 # Query an SRV record for a named Service port.
+# From a netshoot (or other dig-equipped) pod:
 dig SRV _http._tcp.web-svc.default.svc.cluster.local
 
 # Typical answer shape:
@@ -397,7 +398,7 @@ DNS debugging should start from a real client Pod or from a temporary Pod in the
 DNS Issue?
     │
     ├── Step 1: Test from inside a Pod
-    │   kubectl run test --rm -it --image=busybox:1.36 -- nslookup <service>
+    │   kubectl run test --rm -it --image=busybox:1.36 --restart=Never -- nslookup <service>
     │       │
     │       ├── Works? -> DNS is fine, issue is elsewhere
     │       │
@@ -419,7 +420,7 @@ DNS Issue?
     │       └── Wrong nameserver? -> Check kubelet and Pod DNS policy
     │
     └── Step 5: Test external DNS
-        kubectl run test --rm -it --image=busybox:1.36 -- nslookup example.com
+        kubectl run test --rm -it --image=busybox:1.36 --restart=Never -- nslookup example.com
             │
             └── Fails? -> Check forward config and upstream reachability
 ```
@@ -437,10 +438,10 @@ kubectl run dns-test --rm -it --image=busybox:1.36 --restart=Never -- \
 
 # Test with the DNS Service IP explicitly.
 kubectl run dns-test --rm -it --image=busybox:1.36 --restart=Never -- \
-  nslookup web-svc 10.96.0.10
+  nslookup web-svc "$(kubectl get svc kube-dns -n kube-system -o jsonpath='{.spec.clusterIP}')"
 ```
 
-Those three tests answer different questions. The first asks whether the default resolver path in the temporary Pod can resolve a known cluster Service. The second removes namespace ambiguity by using the full Service name. The third bypasses the Pod's `nameserver` setting and sends the query to the DNS Service IP you provide, which helps identify whether `/etc/resolv.conf` is wrong or CoreDNS itself is not answering correctly.
+Those three tests answer different questions. The first asks whether the default resolver path in the temporary Pod can resolve a known cluster Service. The second removes namespace ambiguity by using the full Service name. The third bypasses the Pod's `nameserver` setting and sends the query to the current DNS Service IP, which helps identify whether `/etc/resolv.conf` is wrong or CoreDNS itself is not answering correctly.
 
 ```bash
 # Check resolver configuration in an existing Pod.
@@ -588,6 +589,7 @@ spec:
 ```bash
 # SRV record format:
 # _<port-name>._<protocol>.<service>.<namespace>.svc.cluster.local
+# From a netshoot (or other dig-equipped) pod:
 dig SRV _http._tcp.web-svc.default.svc.cluster.local
 ```
 
@@ -764,6 +766,8 @@ Use a headless Service with the StatefulSet so each Pod receives a predictable D
 
 Exercise scenario: you are the on-call engineer for a training cluster, and a developer says Service names are unreliable. Your task is to prove the normal DNS path, create Services that show same-namespace and cross-namespace behavior, inspect CoreDNS, and then clean up without leaving test resources behind. Run the commands from a shell where `kubectl` already points at a disposable Kubernetes 1.35 or newer cluster.
 
+> **Note:** Kubernetes DNS search domains can expand `service.namespace` to `service.namespace.svc.cluster.local`, but BusyBox `nslookup` in `busybox:1.36` does not apply that two-label expansion and may print `NXDOMAIN` for names like `web.default`. BusyBox `nslookup` also exits non-zero even when it printed a useful `Name:` and `Address:` answer for the intended record, so judge its success by the displayed record rather than only the Pod exit code. For namespace-qualified verification, use `wget -qO- --timeout=2 http://<name>.<ns>/`, query the full FQDN with `nslookup`, or run a netshoot pod with `host` or `dig`.
+
 ### Task 1: Verify the Cluster DNS Baseline
 
 Start by checking the shared DNS components before creating workload resources. This gives you a baseline for later failures and teaches you which objects are involved in the DNS path. If your environment uses different labels for CoreDNS, adapt the selector after inspecting Pods in `kube-system`.
@@ -797,7 +801,7 @@ kubectl run test1 --rm -it --image=busybox:1.36 --restart=Never -- \
   nslookup web
 
 kubectl run test2 --rm -it --image=busybox:1.36 --restart=Never -- \
-  nslookup web.default
+  wget -qO- --timeout=2 http://web.default/
 
 kubectl run test3 --rm -it --image=busybox:1.36 --restart=Never -- \
   nslookup web.default.svc.cluster.local
@@ -806,7 +810,7 @@ kubectl run test3 --rm -it --image=busybox:1.36 --restart=Never -- \
 <details>
 <summary>Solution notes</summary>
 
-All three forms should resolve from the `default` namespace because the short name expands through the Pod search domains. Compare the returned address with `kubectl get svc web` and confirm it matches the Service ClusterIP for a normal ClusterIP Service. If only the full FQDN works, inspect the temporary Pod's resolver search list.
+The short-name and full-FQDN `nslookup` commands should print the Service ClusterIP for a normal ClusterIP Service, and the `wget` command verifies that the namespace-qualified `web.default` form works through a resolver-backed client. The Kubernetes DNS spec expands `service.namespace`, but BusyBox `nslookup` reports `NXDOMAIN` for that two-label form, so verify it with a libc-style resolver such as `wget`, a full-FQDN `nslookup`, or a netshoot `host` or `dig` command before blaming CoreDNS. If only the full FQDN works, inspect the temporary Pod's resolver search list.
 
 </details>
 
@@ -839,13 +843,13 @@ kubectl get svc db -n other
 
 ```bash
 kubectl run test4 --rm -it --image=busybox:1.36 --restart=Never -- \
-  nslookup db.other
+  wget -qO- --timeout=2 http://db.other/
 ```
 
 <details>
 <summary>Solution notes</summary>
 
-The query should resolve because `db.other` can expand to `db.other.svc.cluster.local`. If `nslookup db` from `default` fails or reaches a different Service, that is expected search-domain behavior. The fix for real applications is explicit naming, not a CoreDNS patch.
+The namespace-qualified query should resolve because the Kubernetes DNS spec allows `db.other` to expand to `db.other.svc.cluster.local`, and the `wget` command verifies that behavior with an application-style lookup. BusyBox `nslookup db.other` will report `NXDOMAIN` for this two-label form, so use a libc-style resolver such as `wget`, the full FQDN, or a netshoot Pod when you need to prove namespace-qualified resolution. If `nslookup db` from `default` fails or reaches a different Service, that is expected search-domain behavior. The fix for real applications is explicit naming, not a CoreDNS patch.
 
 </details>
 
@@ -974,7 +978,7 @@ These drills are optional, but they preserve the fast command practice from the 
 kubectl create deployment dns-test --image=nginx
 kubectl expose deployment dns-test --port=80
 kubectl run test --rm -it --image=busybox:1.36 --restart=Never -- \
-  sh -c 'nslookup dns-test && nslookup dns-test.default && nslookup dns-test.default.svc.cluster.local'
+  sh -c 'nslookup dns-test; wget -qO- --timeout=2 http://dns-test.default/; nslookup dns-test.default.svc.cluster.local'
 kubectl delete deployment dns-test
 kubectl delete svc dns-test
 ```
@@ -996,9 +1000,9 @@ kubectl create deployment app2 -n ns2 --image=nginx
 kubectl expose deployment app1 -n ns1 --port=80
 kubectl expose deployment app2 -n ns2 --port=80
 kubectl run test -n ns1 --rm -it --image=busybox:1.36 --restart=Never -- \
-  nslookup app2.ns2
+  wget -qO- --timeout=2 http://app2.ns2/
 kubectl run test -n ns2 --rm -it --image=busybox:1.36 --restart=Never -- \
-  nslookup app1.ns1
+  wget -qO- --timeout=2 http://app1.ns1/
 kubectl delete namespace ns1 ns2
 ```
 
@@ -1038,16 +1042,16 @@ kubectl get pods -n kube-system -l k8s-app=kube-dns
 kubectl create deployment challenge --image=nginx
 kubectl expose deployment challenge --port=80
 kubectl run test --rm -it --image=busybox:1.36 --restart=Never -- \
-  sh -c 'nslookup challenge; nslookup challenge.default; nslookup challenge.default.svc.cluster.local'
-kubectl create namespace test
-kubectl create deployment challenge -n test --image=nginx
-kubectl expose deployment challenge -n test --port=80
+  sh -c 'nslookup challenge; wget -qO- --timeout=2 http://challenge.default/; nslookup challenge.default.svc.cluster.local'
+kubectl create namespace dns-demo
+kubectl create deployment challenge -n dns-demo --image=nginx
+kubectl expose deployment challenge -n dns-demo --port=80
 kubectl run test --rm -it --image=busybox:1.36 --restart=Never -- \
-  nslookup challenge.test
+  wget -qO- --timeout=2 http://challenge.dns-demo/
 kubectl logs -n kube-system -l k8s-app=kube-dns --tail=10
 kubectl delete deployment challenge
 kubectl delete svc challenge
-kubectl delete namespace test
+kubectl delete namespace dns-demo
 ```
 
 ---
@@ -1067,9 +1071,16 @@ kubectl delete namespace test
 - [CoreDNS forward plugin](https://coredns.io/plugins/forward/)
 - [CoreDNS cache plugin](https://coredns.io/plugins/cache/)
 - [CoreDNS hosts plugin](https://coredns.io/plugins/hosts/)
+- [BusyBox Bug 14671: nslookup not working in Kubernetes](https://lists.busybox.net/pipermail/busybox-cvs/2022-March/041133.html)
 
 ---
 
 ## Next Module
 
 [Module 3.4: Ingress](../module-3.4-ingress/) - HTTP routing and external access to services.
+
+---
+
+## Learner check
+
+> DNS debugging should start from a real client Pod or from a temporary Pod in the same namespace.

--- a/src/content/docs/k8s/cka/part3-services-networking/module-3.4-ingress.md
+++ b/src/content/docs/k8s/cka/part3-services-networking/module-3.4-ingress.md
@@ -114,6 +114,7 @@ For exam practice and local labs, you will still see NGINX-shaped examples becau
 
 ```bash
 # For kind
+# retired controller — lab/learning use only; see Sources for maintained alternatives
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
 
 # For minikube
@@ -226,7 +227,7 @@ spec:
 
 `Prefix` is usually the CKA-friendly choice because it covers both the base path and child paths. `Exact` is valuable when one endpoint must be isolated from nearby paths, such as `/healthz` or a callback route that should not match `/healthz/debug`. `ImplementationSpecific` can unlock controller-specific behavior, including regex-like matches in some controllers, but it trades portability for power and should be used only when you know which controller will process the resource.
 
-Pause and predict: you have two Ingress path rules, `/api` with `pathType: Prefix` and `/api/v1` with `pathType: Exact`. A request arrives for `/api/v1/users`, and a second request arrives for `/api/v1`; which rule handles each request? The longer exact path handles only `/api/v1`, while `/api/v1/users` falls back to the `/api` prefix unless another matching prefix exists.
+Pause and predict: you have two Ingress path rules, `/api` with `pathType: Prefix` and `/api/v1` with `pathType: Exact`. A request arrives for `/api/v1/users`, and a second request arrives for `/api/v1`; which rule handles each request? The longer exact path handles only `/api/v1`, while `/api/v1/users` falls back to the `/api` prefix, which is the only prefix that matches `/api/v1/users` in this example.
 
 Host-based routing, also called virtual hosting, uses the HTTP `Host` header to choose a backend. This is the same idea that lets one web server host several websites on one IP address. In Kubernetes, it lets one controller Service accept traffic for `api.example.com` and `web.example.com` while sending each hostname to a different internal Service.
 
@@ -318,17 +319,13 @@ TLS termination is the point where encrypted HTTPS traffic becomes decrypted HTT
 
 ```bash
 # Generate self-signed certificate (for testing)
+# self-signed, no SAN — modern curl needs --insecure (lab/testing only)
 openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
   -keyout tls.key -out tls.crt \
   -subj "/CN=example.com"
 
 # Create secret
 kubectl create secret tls example-tls --cert=tls.crt --key=tls.key
-
-# Or using kubectl
-kubectl create secret tls example-tls \
-  --cert=path/to/tls.crt \
-  --key=path/to/tls.key
 ```
 
 That Secret must live in the same namespace as the Ingress. This namespace rule is not a controller quirk; it is part of how the Ingress API references Secrets. If you create `example-tls` in `default` and the Ingress in `production`, the controller cannot use that Secret through the Ingress reference, and you may see a default certificate or a TLS error depending on the controller.
@@ -800,7 +797,8 @@ INGRESS_IP=$(kubectl get ingress multi-path-ingress -o jsonpath='{.status.loadBa
 [ -z "$INGRESS_IP" ] && INGRESS_IP="localhost"
 
 # Test paths directly from the host node (since INGRESS_IP might be localhost)
-curl -s -H "Host: example.com" http://$INGRESS_IP/api
+curl -s http://$INGRESS_IP/api
+curl -s http://$INGRESS_IP/
 ```
 
 <details>
@@ -862,6 +860,7 @@ The describe output should show two host rules, each with a `/` prefix and a dif
 Create a self-signed certificate for practice and store it as a Kubernetes TLS Secret. Self-signed certificates are not production material, but they are good for learning because they let you practice the object shape without relying on an external certificate issuer.
 
 ```bash
+# self-signed, no SAN — modern curl needs --insecure (lab/testing only)
 openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
   -keyout tls.key -out tls.crt \
   -subj "/CN=example.com"
@@ -1074,6 +1073,7 @@ kubectl create deployment secure-app --image=nginx
 kubectl expose deployment secure-app --port=80
 
 # Generate certificate
+# self-signed, no SAN — modern curl needs --insecure (lab/testing only)
 openssl req -x509 -nodes -days 1 -newkey rsa:2048 \
   -keyout tls.key -out tls.crt -subj "/CN=secure.local"
 
@@ -1126,7 +1126,7 @@ kubectl get ingressclass
 kubectl describe ingressclass nginx
 
 # Check which is default
-kubectl get ingressclass -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.annotations.ingressclass\.kubernetes\.io/is-default-class}{"\n"}{end}'
+kubectl get ingressclass -o jsonpath="{range .items[*]}{.metadata.name}{\"\\t\"}{.metadata.annotations['ingressclass\\.kubernetes\\.io/is-default-class']}{\"\\n\"}{end}"
 ```
 
 #### Drill 6: Ingress with Annotations
@@ -1260,6 +1260,7 @@ spec:
 EOF
 
 # 4. Add TLS
+# self-signed, no SAN — modern curl needs --insecure (lab/testing only)
 openssl req -x509 -nodes -days 1 -newkey rsa:2048 \
   -keyout tls.key -out tls.crt -subj "/CN=myapp.local"
 kubectl create secret tls myapp-tls --cert=tls.crt --key=tls.key
@@ -1318,12 +1319,16 @@ rm tls.key tls.crt
 - [Services, Load Balancing, and Networking | Kubernetes](https://kubernetes.io/docs/concepts/services-networking/)
 - [Service | Kubernetes](https://kubernetes.io/docs/concepts/services-networking/service/)
 - [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/)
-- [Migrating from Ingress | Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/guides/getting-started/migrating-from-ingress/)
+- [Migrating from Ingress | Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/guides/migrating-from-ingress/)
 - [Ingress NGINX Retirement: What You Need to Know | Kubernetes Blog](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/)
 - [Ingress NGINX Statement | Kubernetes Blog](https://kubernetes.io/blog/2026/01/29/ingress-nginx-statement/)
 - [ingress2gateway | Kubernetes SIGs](https://github.com/kubernetes-sigs/ingress2gateway)
-- [ingress-nginx kind deployment manifest](https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml)
+- [ingress-nginx kind deployment manifest](https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml) — retired controller; lab/learning use only; see maintained alternatives above
 
 ## Next Module
 
 [Module 3.5: Gateway API](../module-3.5-gateway-api/) - The next generation of Kubernetes ingress, with richer route resources and cleaner platform ownership boundaries.
+
+## Learner check
+
+> If you remember only one debugging sentence, make it this: no address points toward controller or class reconciliation, 404 points toward host and path matching, and 503 points toward matched routes with unavailable backends.

--- a/src/content/docs/k8s/cka/part3-services-networking/module-3.5-gateway-api.md
+++ b/src/content/docs/k8s/cka/part3-services-networking/module-3.5-gateway-api.md
@@ -131,6 +131,7 @@ Controller choice also affects how quickly status becomes useful. A controller t
 istioctl install --set profile=minimal
 
 # Or for quick testing with kind/minikube, use Contour.
+# unversioned — pin to a Contour release tag for reproducible labs; GatewayClass name may differ
 kubectl apply -f https://projectcontour.io/quickstart/contour-gateway.yaml
 ```
 
@@ -428,7 +429,7 @@ spec:
   parentRefs:
   - name: example-gateway
   rules:
-    - matches:
+  - matches:
     - path:
         type: PathPrefix
         value: /old-path
@@ -502,7 +503,7 @@ Pause and predict: an HTTPRoute in namespace `team-a` references a Service in na
 
 ```yaml
 # In the target namespace (where the service lives)
-apiVersion: gateway.networking.k8s.io/v1
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
   name: allow-routes-from-default
@@ -544,7 +545,7 @@ ReferenceGrant is intentionally narrow. It does not grant broad namespace-to-nam
 
 Gateway listeners can terminate TLS or pass encrypted traffic through depending on the protocol and route type. In termination mode, the Gateway presents a certificate, decrypts the connection, and forwards HTTP traffic to a backend. In passthrough-style designs, the Gateway uses TLS details such as SNI to select a backend while the backend terminates the encrypted connection. Those choices affect certificate ownership, observability, and where policy can inspect traffic.
 
-In Gateway API v1.5.0, several capabilities achieved Standard status, including Gateway client certificate validation, certificate selection for TLS origination, `ListenerSet` support, and `TLSRoute` `v1`, while older `TLSRoute` alpha forms remained strictly experimental. Notably, TLSRoute CEL validation requires a cluster running Kubernetes 1.31 or higher, so a Kubernetes 1.35 cluster is an appropriate baseline for studying the current behavior.
+In Gateway API v1.5.0, several capabilities achieved Standard status, including Gateway client certificate validation, certificate selection for TLS origination, `ListenerSet` support, and `TLSRoute` `v1`, while older `TLSRoute` alpha forms remained strictly experimental. Notably, TLSRoute CEL validation depends on CRD CEL validation support in the cluster (Kubernetes 1.25+), so a Kubernetes 1.35 cluster is an appropriate baseline for studying the current behavior.
 
 ```yaml
 apiVersion: gateway.networking.k8s.io/v1
@@ -884,6 +885,7 @@ Because `example.io/gateway-controller` and `drill.io/controller` are non-functi
 
 ```bash
 # 1. Install Contour Gateway Controller.
+# unversioned — pin to a Contour release tag for reproducible labs; GatewayClass name may differ
 kubectl apply -f https://projectcontour.io/quickstart/contour-gateway.yaml
 
 # 2. Wait for the Contour GatewayClass to be accepted.
@@ -1387,7 +1389,11 @@ kubectl delete svc frontend backend admin
 - [Gateway API v1.5.0 release notes](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.5.0)
 - [Gateway API v1.5.1 release](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v1.5.1)
 - [Gateway API v1.5 announcement on Kubernetes Blog](https://kubernetes.io/blog/2026/04/21/gateway-api-v1-5/)
-- https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.0.0/standard-install.yaml
+- [Gateway API v1.0.0 standard install manifest](https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.0.0/standard-install.yaml)
+
+## Learner check
+
+> Gateway API exists because Kubernetes networking needed a stronger contract than "put every advanced behavior into an annotation and hope the controller interprets it the same way."
 
 ## Next Module
 


### PR DESCRIPTION
## CKA Wave 5 (part3 services-networking) — R1 cross-family review fixes

Back-catalog finalize-to-`done` for four CKA networking modules. Each was reviewed by a
different-family reviewer; this PR applies the R1 findings. All four pass
`scripts/quality/verify_module.py` (tier T0, density gates green) and the site builds clean.

| Module | Reviewer | Verdict | Key fixes |
|---|---|---|---|
| 3.2-endpoints | codex (gpt-5.5) | NEEDS_CHANGES → fixed | removed invalid `kubectl get eps` alias; busybox `nslookup` exit-code note; `--ignore-not-found` on Drill-3 check + manual-svc cleanup; Endpoints-API v1.33 deprecation + over-capacity hedge |
| 3.3-dns | composer-2.5 (cursor) | NEEDS_CHANGES → fixed | busybox `nslookup` returns NXDOMAIN for `service.namespace` → `wget` verification (+ solution notes); `dig` via netshoot; substitute DNS Service IP; duration 45m; drill ns rename; busybox-bug citation |
| 3.4-ingress | Claude Sonnet | APPROVE_WITH_NITS → fixed | dropped duplicate TLS-secret block; retired ingress-nginx URL caveat; curl host-header no-op fix + `/` test; openssl SAN notes; jsonpath bracket form; migration URL |
| 3.5-gateway-api | Claude Sonnet | NEEDS_CHANGES → fixed | **fixed malformed `redirect-route` YAML that silently never matched**; `ReferenceGrant` `v1`→`v1beta1`; CEL claim `1.31`→`1.25+`; Contour URL caveats; source label |

All reviewer findings were ground-checked by the orchestrator before applying; each module
gained a `## Learner check` section. No fabrication introduced; targeted edits only.

## Learner check

> Gateway API exists because Kubernetes networking needed a stronger contract than "put every advanced behavior into an annotation and hope the controller interprets it the same way."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
