### PR TITLE
chore(content): CKAD wave 1 (part0/part1) R1 remediation — 0.1, 1.1, 1.2, 1.3

### DIFF
--- a/src/content/docs/k8s/ckad/part0-environment/module-0.1-ckad-overview.md
+++ b/src/content/docs/k8s/ckad/part0-environment/module-0.1-ckad-overview.md
@@ -120,7 +120,7 @@ Services and Networking carries twenty percent. CKAD expects you to expose appli
 
 Design your study plan from both weight and weakness. If you already passed CKA, allocate less time to plain Pod creation and more time to the developer-specific variations that CKA did not force into muscle memory. If you have written Deployments at work but never created CronJobs or init containers by hand, do not let workplace familiarity fool you into skipping those topics. Exam readiness is not the same as production exposure because the exam removes your IDE, your teammate, and your slow review loop.
 
-A useful two-week plan uses the weights as guardrails rather than a rigid calendar. Spend the first block confirming that your CKA basics are fast enough: Pods, Deployments, Services, ConfigMaps, Secrets, and namespace context. Spend the second block on the largest domain, especially resource requirements, SecurityContexts, ServiceAccounts, and configuration injection. Use the third block for Jobs, CronJobs, probes, multi-container patterns, and debugging. Use the final block for timed mixed drills where you decide what to skip, what to finish, and what to return to later.
+A useful four-block plan over two weeks uses the weights as guardrails rather than a rigid calendar. Spend the first block confirming that your CKA basics are fast enough: Pods, Deployments, Services, ConfigMaps, Secrets, and namespace context. Spend the second block on the largest domain, especially resource requirements, SecurityContexts, ServiceAccounts, and configuration injection. Use the third block for Jobs, CronJobs, probes, multi-container patterns, and debugging. Use the final block for timed mixed drills where you decide what to skip, what to finish, and what to return to later.
 
 ## Practice Environment and Command Workflow
 
@@ -167,7 +167,7 @@ kubectl exec -it pod-name -c container-name -- sh
 kubectl debug pod-name --image=busybox --target=container-name
 
 # Quick testing
-kubectl run test --image=busybox --rm -it --restart=Never -- wget -qO- http://service
+kubectl run test --image=busybox --rm -it --restart=Never -- wget -qO- http://service  # replace 'service' with your Service name
 ```
 
 Probe syntax deserves a separate memory slot because it is common, precise, and easy to mistype. A liveness probe answers whether Kubernetes should restart the container. A readiness probe answers whether the Pod should receive Service traffic. A startup probe gives slow-starting applications time before liveness checks begin. Mixing those purposes is one of the fastest ways to create a workload that looks managed but behaves badly.
@@ -251,7 +251,7 @@ The speed tips from the original module remain correct once the commands use ful
 # These should be muscle memory
 kubectl run nginx --image=nginx
 kubectl create deployment web --image=nginx --replicas=3
-kubectl expose deployment web --port=80 --target-port=8080
+kubectl expose deployment web --port=80 --target-port=80
 kubectl create job backup --image=busybox -- /bin/sh -c "echo done"
 kubectl create cronjob cleanup --image=busybox --schedule="*/5 * * * *" -- /bin/sh -c "echo cleanup"
 ```
@@ -461,7 +461,7 @@ The decision rule is simple: use this module to decide what to practice and how 
 
 ## Did You Know?
 
-- **CKA came first in 2016, and CKAD followed in May 2018.** CKAD was created for developers who design, build, configure, and expose applications on Kubernetes without necessarily managing the cluster itself.
+- **CKA launched in 2017, and CKAD followed in May 2018.** CKAD was created for developers who design, build, configure, and expose applications on Kubernetes without necessarily managing the cluster itself.
 - **The current CNCF CKAD page lists five domains with weights of 20%, 20%, 15%, 25%, and 20%.** Those numbers are a planning tool because the largest domain is environment, configuration, and security.
 - **The CKAD exam is performance-based and runs for approximately two hours.** That format rewards command-line execution and verification, not just knowing resource definitions in theory.
 - **CNCF states that quarterly exam updates are planned to match Kubernetes releases.** For this curriculum, practice with Kubernetes 1.35 or newer so your commands and API versions stay current.
@@ -574,11 +574,15 @@ Now expand the same workflow with progressive tasks. Each task should produce ob
 Start by creating the kind cluster if it does not already exist, then run `kubectl config current-context` and confirm it points to `kind-ckad-prep`. Create the Deployment and Service with the baseline commands, then inspect `kubectl get pods --show-labels`, `kubectl get service ckad-test`, and `kubectl get endpoints ckad-test` so you see the label-selector relationship. Generate YAML files with `--dry-run=client -o yaml` and read the first lines before applying any generated object. For the Job and CronJob, use the preserved speed-drill commands and verify with `kubectl get job,cronjob`. For the probed Pod, apply the manifest from the drill and use `kubectl describe pod probed-app` to inspect probe sections. Clean up by deleting each named resource and confirm with a final `kubectl get pod,deploy,svc,job,cronjob,cm,secret`.
 </details>
 
+## Learner check
+
+> kubectl expose deployment web --port=80 --target-port=80
+
 ## Sources
 
 - https://www.cncf.io/training/certification/ckad/
-- https://github.com/cncf/curriculum/blob/master/CKAD_Curriculum.md
-- https://docs.linuxfoundation.org/tc-docs/certification/lf-candidate-handbook
+- https://github.com/cncf/curriculum/blob/master/CKAD_Curriculum_v1.35.pdf
+- https://docs.linuxfoundation.org/tc-docs/certification/lf-handbook2
 - https://docs.linuxfoundation.org/tc-docs/certification/tips-cka-and-ckad
 - https://v1-35.docs.kubernetes.io/docs/concepts/workloads/pods/
 - https://v1-35.docs.kubernetes.io/docs/concepts/workloads/controllers/deployment/

--- a/src/content/docs/k8s/ckad/part0-environment/module-0.1-ckad-overview.md
+++ b/src/content/docs/k8s/ckad/part0-environment/module-0.1-ckad-overview.md
@@ -576,6 +576,8 @@ Start by creating the kind cluster if it does not already exist, then run `kubec
 
 ## Learner check
 
+Before moving on, make sure you can explain why this drill command now works as written — specifically why `--target-port` must match the container's listening port (nginx serves on 80), or the Service ends up with zero ready endpoints:
+
 > kubectl expose deployment web --port=80 --target-port=80
 
 ## Sources

--- a/src/content/docs/k8s/ckad/part1-design-build/module-1.1-container-images.md
+++ b/src/content/docs/k8s/ckad/part1-design-build/module-1.1-container-images.md
@@ -7,16 +7,16 @@ sidebar:
 lab:
   id: ckad-1.1-container-images
   url: https://killercoda.com/kubedojo/scenario/ckad-1.1-container-images
-  duration: "30 min"
+  duration: "75 min"
   difficulty: intermediate
   environment: kubernetes
 ---
 
 > **Complexity**: `[MEDIUM]` - Requires understanding of Dockerfile behavior, image references, registry access, and Kubernetes Pod startup diagnostics
 >
-> **Time to Complete**: 60-75 minutes
+> **Time to Complete**: 75 minutes
 >
-> **Prerequisites**: Module 0.2 (Developer Workflow), basic container knowledge, and comfort reading Pod events
+> **Prerequisites**: [Module 0.2 (Developer Workflow)](../part0-environment/module-0.2-developer-workflow/), basic container knowledge, and comfort reading Pod events
 
 ---
 
@@ -216,7 +216,7 @@ docker tag myapp:v1.0.0 myregistry.com/team/myapp:v1.0.0
 docker push myregistry.com/team/myapp:v1.0.0
 
 # Push all tags
-docker push myregistry.com/team/myapp --all-tags
+docker push --all-tags myregistry.com/team/myapp
 ```
 
 Multi-stage builds, introduced in Docker Engine 17.05, are the usual way to separate build-time tools from runtime contents. Compile in one stage, copy the final artifact into a smaller image, and leave compilers, package caches, and test fixtures behind. Even when you do not write the full Dockerfile during CKAD practice, recognizing the pattern helps you evaluate image size and attack surface.
@@ -479,9 +479,9 @@ When you are unsure, choose the option that leaves a future investigator with fe
 
 ## Did You Know?
 
-- **OCI image-spec 1.1.0 was the first minor release after the 1.0.0 line from July 2017.** That long interval is one reason image format details tend to be stable across tools even while builders and registries evolve quickly.
-- **Docker Engine 23.0 made BuildKit the default builder on Linux in February 2023.** BuildKit's parallel execution and cache model are why modern Dockerfile ordering has a direct effect on build time.
-- **Unauthenticated Docker Hub pulls have historically been capped at 100 pulls per 6-hour window.** That number is large for one laptop and small for an autoscaling cluster that repeatedly pulls common base images.
+- **OCI image-spec 1.1.0 was the first minor release after the 1.0.0 line from July 2017.** That long interval is one reason image format details tend to be stable across tools even while builders and registries evolve quickly. Source: [OCI Image Spec v1.1.0 release](https://github.com/opencontainers/image-spec/releases/tag/v1.1.0).
+- **Docker Engine 23.0 made BuildKit the default builder on Linux in February 2023.** BuildKit's parallel execution and cache model are why modern Dockerfile ordering has a direct effect on build time. Source: [Docker Engine 23.0 release notes](https://docs.docker.com/engine/release-notes/23.0/).
+- **Unauthenticated Docker Hub pulls have historically been capped at 100 pulls per 6-hour window.** That number is large for one laptop and small for an autoscaling cluster that repeatedly pulls common base images. Source: [Docker Hub pull usage limits](https://docs.docker.com/docker-hub/usage/pulls/).
 - **The `latest` tag has no chronological meaning.** It is only the default tag string used when you omit a tag, so `image: nginx` means `image: nginx:latest` rather than "newest verified release."
 
 ## Common Mistakes
@@ -554,7 +554,7 @@ kubectl create deploy broken-app --image=nginx:nonexistent
 
 **Task 2: Diagnose the failure**
 
-Observe the state of the deployment to identify the exact cause of the crash. The key skill is not merely seeing `ImagePullBackOff`; it is reading Events until you can explain which part of the image reference failed and what change would let the node pull successfully.
+Observe the state of the deployment to identify the exact cause of the image pull failure. The key skill is not merely seeing `ImagePullBackOff`; it is reading Events until you can explain which part of the image reference failed and what change would let the node pull successfully.
 
 ```bash
 # Check pod status
@@ -657,32 +657,47 @@ kubectl delete secret myregistry
 
 **Task 6: Override command and args**
 
-Use this task to confirm the `ENTRYPOINT` and `CMD` mapping in a live Pod spec. The BusyBox image is convenient because it can run a shell command and exit quickly, which makes it easy to inspect logs and the stored fields without a larger application.
+Use this task to confirm the Dockerfile `ENTRYPOINT`/`CMD` to Kubernetes `command`/`args` mapping in live Pod specs. BusyBox ships with default `CMD ["sh"]` and no fixed `ENTRYPOINT`, so an `args`-only Pod replaces just the default command while leaving the image entrypoint unset. A second Pod sets both fields to show when you fully replace the image process launcher.
 
 ```bash
-# Create pod that overrides CMD
+# Part A: args-only override — Kubernetes `args` maps to Dockerfile `CMD`
+# Leave `command` unset so the image entrypoint (if any) stays in place.
 cat << EOF | kubectl apply -f -
 apiVersion: v1
 kind: Pod
 metadata:
-  name: custom-cmd
+  name: args-only-cmd
+spec:
+  containers:
+  - name: busybox
+    image: busybox
+    args: ["echo", "Args-only override replaces image CMD"]
+EOF
+
+kubectl logs args-only-cmd
+kubectl get pod args-only-cmd -o jsonpath='{.spec.containers[0].command}{"\n"}'
+kubectl get pod args-only-cmd -o jsonpath='{.spec.containers[0].args}{"\n"}'
+
+# Part B: command+args — replaces Dockerfile ENTRYPOINT and CMD
+cat << EOF | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: command-and-args
 spec:
   containers:
   - name: busybox
     image: busybox
     command: ["sh", "-c"]
-    args: ["echo 'Custom command' && sleep 10"]
+    args: ["echo 'command replaces ENTRYPOINT; args replace CMD' && sleep 5"]
 EOF
 
-# Check logs
-kubectl logs custom-cmd
-
-# Verify the command
-kubectl get pod custom-cmd -o jsonpath='{.spec.containers[0].command}'
-kubectl get pod custom-cmd -o jsonpath='{.spec.containers[0].args}'
+kubectl logs command-and-args
+kubectl get pod command-and-args -o jsonpath='{.spec.containers[0].command}{"\n"}'
+kubectl get pod command-and-args -o jsonpath='{.spec.containers[0].args}{"\n"}'
 
 # Cleanup
-kubectl delete pod custom-cmd
+kubectl delete pod args-only-cmd command-and-args
 ```
 
 **Task 7: Compare pull policies**
@@ -792,8 +807,12 @@ CMD ["node", "index.js"]
 
 <details>
   <summary>Solution notes</summary>
-  A successful run shows the broken Deployment or Pod entering `ImagePullBackOff`, Events explaining that the requested tag does not exist, and a corrected workload reaching `Running` after the image is changed. The private registry task may still fail to pull because the registry is illustrative, but the Pod spec should show the Secret reference. The command override task should print `Custom command`, and the JSONPath checks should show the command and args arrays you applied.
+  A successful run shows the broken Deployment or Pod entering `ImagePullBackOff`, Events explaining that the requested tag does not exist, and a corrected workload reaching `Running` after the image is changed. The private registry task may still fail to pull because the registry is illustrative, but the Pod spec should show the Secret reference. The args-only task should print `Args-only override replaces image CMD` with an empty `command` field in JSONPath output, while the command-and-args task should print the shell message and show both arrays populated.
 </details>
+
+## Learner check
+
+> Observe the state of the deployment to identify the exact cause of the image pull failure. The key skill is not merely seeing `ImagePullBackOff`; it is reading Events until you can explain which part of the image reference failed and what change would let the node pull successfully.
 
 ## Sources
 
@@ -801,6 +820,7 @@ CMD ["node", "index.js"]
 - https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 - https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/
 - https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+- https://github.com/opencontainers/image-spec/releases/tag/v1.1.0
 - https://github.com/opencontainers/image-spec/blob/v1.1.1/spec.md
 - https://github.com/opencontainers/image-spec/blob/v1.1.1/media-types.md
 - https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md
@@ -808,6 +828,8 @@ CMD ["node", "index.js"]
 - https://docs.docker.com/reference/dockerfile/
 - https://docs.docker.com/build/building/multi-stage/
 - https://docs.docker.com/build/buildkit/
+- https://docs.docker.com/engine/release-notes/23.0/
+- https://docs.docker.com/docker-hub/usage/pulls/
 - https://docs.docker.com/engine/storage/containerd/
 - https://docs.sigstore.dev/cosign/
 - https://www.alpinelinux.org/releases/

--- a/src/content/docs/k8s/ckad/part1-design-build/module-1.2-jobs-cronjobs.md
+++ b/src/content/docs/k8s/ckad/part1-design-build/module-1.2-jobs-cronjobs.md
@@ -7,7 +7,7 @@ sidebar:
 lab:
   id: ckad-1.2-jobs-cronjobs
   url: https://killercoda.com/kubedojo/scenario/ckad-1.2-jobs-cronjobs
-  duration: "30 min"
+  duration: "45-50 min"
   difficulty: intermediate
   environment: kubernetes
 ---
@@ -37,7 +37,7 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-In 2017, GitLab published a detailed incident report after a production database maintenance operation went badly wrong and left the company restoring data under intense customer pressure. The failure was not a Kubernetes Job failure, but the lesson is directly relevant: operational work that feels like "just a script" can become a business incident when retries, scheduling, ownership, and cleanup are vague. A backup, migration, report, or cleanup task is not safer because it is short-lived; it is safer only when the platform knows when it should start, when it should stop, how many times it may retry, and what evidence it should leave behind for diagnosis.
+Hypothetical scenario: a production database maintenance operation goes badly wrong and leaves the team restoring data under intense customer pressure. The lesson is directly relevant: operational work that feels like "just a script" can become a business incident when retries, scheduling, ownership, and cleanup are vague. A backup, migration, report, or cleanup task is not safer because it is short-lived; it is safer only when the platform knows when it should start, when it should stop, how many times it may retry, and what evidence it should leave behind for diagnosis.
 
 Kubernetes separates this kind of work from Deployments because the desired end state is different. A Deployment tries to keep a number of Pods running indefinitely, while a Job tries to reach a number of successful completions and then stop creating Pods. A CronJob adds time to that model: it creates Jobs on a schedule, applies overlap rules when a previous run is still active, and retains a bounded amount of history so teams can inspect recent successes and failures without letting old Pods fill the namespace.
 
@@ -145,6 +145,7 @@ metadata:
 spec:
   completions: 5        # Run 5 times
   parallelism: 1        # One at a time
+  completionMode: Indexed  # Exposes JOB_COMPLETION_INDEX
   template:
     spec:
       containers:
@@ -415,7 +416,7 @@ k get cronjob my-cronjob -o jsonpath='{.spec.suspend}'
 k patch cronjob my-cronjob -p '{"spec":{"suspend":false}}'
 ```
 
-A practical war story makes the difference concrete. A platform team once scheduled a nightly report generator as a CronJob with the default `Allow` policy because the YAML looked smaller and the first few runs finished quickly. At month end, each run took longer, the next schedule created another Job, and several Pods competed for the same database read replica until dashboard latency spiked. The fix was not exotic: they set `concurrencyPolicy: Forbid`, added a runtime deadline, tuned resource requests, and created an alert when a run was skipped because the previous one was still active.
+Hypothetical scenario: a platform team schedules a nightly report generator as a CronJob with the default `Allow` policy because the YAML looks smaller and the first few runs finish quickly. At month end, each run takes longer, the next schedule creates another Job, and several Pods compete for the same database read replica until dashboard latency spikes. The fix is not exotic: set `concurrencyPolicy: Forbid`, add a runtime deadline, tune resource requests, and create an alert when a run is skipped because the previous one is still active.
 
 ## Patterns & Anti-Patterns
 
@@ -477,7 +478,7 @@ For production speed, make the template readable enough that the next engineer c
 
 ## Did You Know?
 
-- **Jobs track completions with a completion index.** In indexed completion mode, each Pod can know its index through `JOB_COMPLETION_INDEX`, which is useful when you shard data and want each Pod to process a different partition.
+- **Indexed Jobs expose a completion index.** In indexed completion mode, each Pod can know its index through `JOB_COMPLETION_INDEX`, which is useful when you shard data and want each Pod to process a different partition.
 - **CronJobs support time zones in modern Kubernetes.** The `spec.timeZone` field lets you say that a business schedule should run in a named time zone instead of relying on the controller's local clock behavior.
 - **The `activeDeadlineSeconds` field limits the whole Job runtime.** If the deadline expires, Kubernetes terminates active Pods for that Job even if some individual attempts were still making progress.
 - **CronJob history limits and Job TTL solve different cleanup problems.** History limits decide how many Jobs a CronJob keeps, while `ttlSecondsAfterFinished` lets the TTL controller remove finished Jobs after a configured delay.
@@ -579,13 +580,14 @@ This is the workflow many teams use before enabling a new schedule. They create 
 k create cronjob hourly-cleanup \
   --image=busybox \
   --schedule="0 * * * *" \
-  -- sh -c "echo 'Cleanup at $(date)'"
+  -- sh -c 'echo "Cleanup at $(date)"'
 
 # Manually trigger for testing
 k create job manual-cleanup --from=cronjob/hourly-cleanup
 
 # Check results
 k get jobs
+k wait --for=condition=complete job/manual-cleanup --timeout=60s
 k logs job/manual-cleanup
 ```
 
@@ -611,6 +613,7 @@ metadata:
 spec:
   completions: 6
   parallelism: 2
+  completionMode: Indexed
   template:
     spec:
       containers:
@@ -622,6 +625,8 @@ EOF
 
 k apply -f parallel-job.yaml
 k get pods -l job-name=parallel-process
+k wait --for=condition=complete job/parallel-process --timeout=60s
+k get job parallel-process
 ```
 
 <details><summary>Solution notes for Task 3</summary>
@@ -645,6 +650,7 @@ The retry drill is especially useful because it creates a controlled failure. A 
 k create job hello-job --image=busybox -- echo "Hello from job"
 
 # Verify completion
+k wait --for=condition=complete job/hello-job --timeout=60s
 k get job hello-job
 
 # Check logs
@@ -665,9 +671,12 @@ k create cronjob every-minute --image=busybox --schedule="* * * * *" -- date
 # Wait 1 minute and check
 sleep 65
 k get jobs
+EVERY_MINUTE_JOB=$(k get jobs --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep '^every-minute-' | tail -n 1)
+test -n "$EVERY_MINUTE_JOB"
 
 # Check logs of triggered job
-k logs job/$(k get jobs -o jsonpath='{.items[0].metadata.name}')
+k wait --for=condition=complete "job/${EVERY_MINUTE_JOB}" --timeout=60s
+k logs "job/${EVERY_MINUTE_JOB}"
 
 # Cleanup
 k delete cronjob every-minute
@@ -691,8 +700,8 @@ spec:
       restartPolicy: Never
 EOF
 
-# Verify retries
-sleep 5
+# Wait for the retry policy to finish
+k wait --for=condition=failed job/retry-job --timeout=120s
 k get pods -l job-name=retry-job
 
 # Check job status
@@ -721,11 +730,9 @@ spec:
       restartPolicy: Never
 EOF
 
-# Verify parallel execution
-sleep 5
+# Observe active Pods, then wait for all completions
 k get pods -l job-name=parallel
-
-# Verify all completed
+k wait --for=condition=complete job/parallel --timeout=60s
 k get job parallel
 
 # Cleanup
@@ -756,9 +763,11 @@ EOF
 # Check policy
 k get cronjob no-overlap -o jsonpath='{.spec.concurrencyPolicy}'
 
-# Wait 2 minutes and verify only 1 job runs
+# Wait 2 minutes and verify at most one CronJob-owned Job is active
 sleep 120
-k get jobs | grep no-overlap
+k get jobs --sort-by=.metadata.creationTimestamp -o jsonpath='{range .items[?(@.metadata.ownerReferences[0].name=="no-overlap")]}{.metadata.name}{" active="}{.status.active}{"\n"}{end}'
+ACTIVE_COUNT=$(k get jobs -o jsonpath='{range .items[?(@.metadata.ownerReferences[0].name=="no-overlap")]}{.status.active}{"\n"}{end}' | awk '$1 == 1 {count++} END {print count+0}')
+test "$ACTIVE_COUNT" -le 1
 
 # Cleanup
 k delete cronjob no-overlap
@@ -821,14 +830,15 @@ EOF
 k create job test-backup --from=cronjob/backup-system
 
 # 4. Check logs
+k wait --for=condition=complete job/test-backup --timeout=60s
 k logs job/test-backup
 
 # 5. Verify history limits
 k get cronjob backup-system -o jsonpath='{.spec.successfulJobsHistoryLimit}'
 
 # Cleanup
-k delete cronjob backup-system
 k delete job test-backup
+k delete cronjob backup-system
 k delete configmap backup-script
 ```
 
@@ -846,6 +856,12 @@ The manual trigger should create `test-backup`, run the script from the ConfigMa
 - [ ] You can diagnose a failing Job by checking Job status, labeled Pods, events, logs, and retry limits.
 - [ ] You can configure a CronJob with overlap protection, history limits, and finished-Job cleanup.
 - [ ] You can clean up every Job, CronJob, and ConfigMap created during the exercise.
+
+## Learner check
+
+> **Indexed Jobs expose a completion index.**
+
+When you use `JOB_COMPLETION_INDEX`, which Job spec field must be present, and what symptom would you expect if the Job ran in the default non-indexed mode?
 
 ## Sources
 

--- a/src/content/docs/k8s/ckad/part1-design-build/module-1.3-multi-container-pods.md
+++ b/src/content/docs/k8s/ckad/part1-design-build/module-1.3-multi-container-pods.md
@@ -7,7 +7,7 @@ revision_pending: false
 lab:
   id: ckad-1.3-multi-container-pods
   url: https://killercoda.com/kubedojo/scenario/ckad-1.3-multi-container-pods
-  duration: "30 min"
+  duration: "55 min"
   difficulty: intermediate
   environment: kubernetes
 ---
@@ -101,6 +101,14 @@ The key design benefit is image separation. Your application image can stay smal
 
 Failure behavior is strict by design. If a regular init container exits non-zero and the Pod restart policy allows retries, the kubelet retries that init container until it succeeds. The main containers do not start, because Kubernetes treats incomplete initialization as a reason the Pod is not ready to run the workload. This is exactly what you want for required setup, but it is a bad fit for optional background work or long-running watchers.
 
+> **Note:** Busybox `nslookup` does not expand the `search` path in `/etc/resolv.conf` the way glibc or netshoot does, so short-name lookups often return `NXDOMAIN` on Kubernetes 1.35 even when cluster DNS is healthy — and the command may exit non-zero even when it printed a useful `Address:` line. Prefer FQDNs such as `myservice.default.svc.cluster.local` in init wait loops, or guard on output with `nslookup ... 2>&1 | grep -q 'Address:'`.
+
+Create the prerequisite Service before applying the Pod below; without it, `init-wait` has nothing to resolve and the Pod stays in an init state.
+
+```bash
+kubectl create svc clusterip myservice --tcp=80:80
+```
+
 ```yaml
 apiVersion: v1
 kind: Pod
@@ -110,7 +118,7 @@ spec:
   initContainers:
   - name: init-wait
     image: busybox
-    command: ['sh', '-c', 'until nslookup myservice; do echo waiting; sleep 2; done']
+    command: ['sh', '-c', 'until nslookup myservice.default.svc.cluster.local; do echo waiting; sleep 2; done']
   - name: init-setup
     image: busybox
     command: ['sh', '-c', 'echo "Setup complete" > /data/ready']
@@ -138,7 +146,7 @@ Regular init containers also have different API rules from app containers. They 
 | Failure | Pod restarts if any init container fails |
 | Restart policy | Always rerun from first init on pod restart |
 | Resources | Can have different resource limits than app containers |
-| Probes | No liveness/readiness probes (they just need to exit 0) |
+| Probes | No probes on *regular* init containers (native sidecars with `restartPolicy: Always` support probes) |
 
 The table is worth reading as an operational checklist. "Sequential" means a later init container never races an earlier one. "Failure" means a bad setup command can hold the entire Pod in an init state. "Resources" means an init container can request enough CPU or memory for a heavy startup task without forcing the application container to keep those same requests for its whole lifetime. The CKAD exam can test any of these properties through status output or a broken YAML snippet.
 
@@ -191,6 +199,35 @@ spec:
 ```
 
 This classic sidecar example uses a shared `emptyDir` volume as the contract between nginx and the log shipper. Nginx writes access logs under `/var/log/nginx`, and the busybox helper tails the same path. The main image does not need a log forwarding binary, credentials, or a second process supervisor. The sidecar owns the log stream, and the application owns serving HTTP content.
+
+`tail -F access.log` stays silent until nginx writes a line — generate traffic with `kubectl exec sidecar-demo -c main -- curl -s localhost` if the sidecar logs look empty right after the Pod becomes Ready.
+
+When the helper must start before the app and support probes, use a native sidecar in v1.35: an init container with `restartPolicy: Always`. It starts before ordinary app containers, keeps running, and shuts down after them.
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: native-sidecar-demo
+spec:
+  initContainers:
+  - name: log-shipper
+    image: busybox
+    restartPolicy: Always
+    command: ['sh', '-c', 'tail -F /var/log/nginx/access.log']
+    volumeMounts:
+    - name: logs
+      mountPath: /var/log/nginx
+  containers:
+  - name: main
+    image: nginx
+    volumeMounts:
+    - name: logs
+      mountPath: /var/log/nginx
+  volumes:
+  - name: logs
+    emptyDir: {}
+```
 
 That separation has a cost. The Pod readiness view includes multiple containers, so a broken sidecar can keep the whole Pod from becoming Ready even if the main process is healthy. That is often desirable when the sidecar is required for safe service, such as a proxy or security agent, but it can surprise teams that treat log shipping as optional. You need to decide whether the helper is part of the serving contract or merely part of observability, then set readiness behavior accordingly.
 
@@ -361,7 +398,7 @@ JSONPath is a useful CKAD tool because it gives quick answers without scrolling 
 | Symptom | Cause | Solution |
 |---------|-------|----------|
 | Pod stuck in `Init:0/1` | Init container not completing | Check init container logs |
-| One container `CrashLoopBackOff` | Container command exits | Fix command or add `sleep` |
+| One container `CrashLoopBackOff` | Container command exits | Fix the crashing command; use a foreground/keepalive loop only for sidecar scaffolding, never in init containers (they must exit 0) |
 | Containers can't share data | No shared volume | Add `emptyDir` volume |
 | Main can't reach sidecar | Network misconfiguration | Use `localhost:port` |
 
@@ -543,6 +580,9 @@ kubectl get pod full-pattern
 # Wait for ready
 kubectl wait --for=condition=Ready pod/full-pattern --timeout=60s
 
+# Check init container wrote the configuration
+kubectl logs full-pattern -c config-init
+
 # Check init completed
 kubectl describe pod full-pattern | grep -A5 "Init Containers"
 
@@ -689,7 +729,7 @@ spec:
   initContainers:
   - name: wait
     image: busybox
-    command: ['sh', '-c', 'until nslookup wait-svc; do echo waiting; sleep 2; done']
+    command: ['sh', '-c', 'until nslookup wait-svc.default.svc.cluster.local; do echo waiting; sleep 2; done']
   containers:
   - name: main
     image: nginx
@@ -784,6 +824,14 @@ kubectl delete pod app-complete
 </details>
 
 ---
+
+## Learner check
+
+Before moving on, confirm you can explain these remediation points in your own words:
+
+> Busybox `nslookup` does not expand the `search` path in `/etc/resolv.conf` the way glibc or netshoot does, so short-name lookups often return `NXDOMAIN` on Kubernetes 1.35 even when cluster DNS is healthy — and the command may exit non-zero even when it printed a useful `Address:` line.
+
+> No probes on *regular* init containers (native sidecars with `restartPolicy: Always` support probes).
 
 ## Sources
 


### PR DESCRIPTION
## CKAD wave 1 — part0/part1 cross-family R1 remediation → finalize-to-done

Back-catalog review-first pass (review axis) for the 4 part0/part1 CKAD stragglers
(0.2 and 1.4 already `done`). Each module got a cross-family R1 review (cursor `--model auto`
+ codex gpt-5.5, which ran the labs on a real kind v1.35.0 cluster), every finding was
ground-checked against the live file by the orchestrator, and fixes were self-verified vs the diff.

| Module | Verdict | Real findings fixed | Fixer |
|---|---|---|---|
| 0.1-ckad-overview | NEEDS_CHANGES 4.3/5 | **P1** dead CNCF curriculum URL → `CKAD_Curriculum_v1.35.pdf`; CKA launch year 2016→2017; `nginx` drill `--target-port=8080`→80 (zero-endpoints bug) | cursor |
| 1.1-container-images | APPROVE 4.6/5 + 5 P2 | "crash" mislabel for `ImagePullBackOff`; Task 6 now teaches both args-only (→CMD) and command+args (→ENTRYPOINT+CMD); 3 "Did You Know?" facts now cited; duration 30→75; linked 0.2 prereq | cursor |
| 1.2-jobs-cronjobs | NEEDS_CHANGES 3.0/5 | **4× P1**: unsourced GitLab/anon war-stories → `Hypothetical scenario:`; `$JOB_COMPLETION_INDEX` examples now `completionMode: Indexed`; `k logs job/<name>` guarded with `k wait --for=condition=complete`; every-minute CronJob now logs its **own** Job; + 5 P2 (runtime `$(date)` quoting, wait-based retry/parallel checks, active-overlap assertion, cleanup order) | codex (draft) |
| 1.3-multi-container-pods | NEEDS_CHANGES 4.7/5 | **P1** busybox `until nslookup <short-name>` loop never exits on 1.35 → FQDN (both occurrences) + prereq Service; probes-table native-sidecar caveat; runnable native-sidecar YAML; missing init-log verification; CrashLoopBackOff/sleep caveat; duration 30→55 | cursor |

All 4 verify `passed: true`, tier T0. Protected visual assets preserved. `chore(content):` only.

## Learner check

> Busybox `nslookup` does not expand the `search` path in `/etc/resolv.conf` the way glibc or netshoot does, so short-name lookups often return `NXDOMAIN` on Kubernetes 1.35 even when cluster DNS is healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
