### PR TITLE
chore(content): CKAD wave 2 (part2-deployment) R1 remediation — 2.1, 2.2, 2.3, 2.4

### DIFF
--- a/src/content/docs/k8s/ckad/part2-deployment/module-2.1-deployments.md
+++ b/src/content/docs/k8s/ckad/part2-deployment/module-2.1-deployments.md
@@ -7,7 +7,7 @@ sidebar:
 lab:
   id: ckad-2.1-deployments
   url: https://killercoda.com/kubedojo/scenario/ckad-2.1-deployments
-  duration: "30 min"
+  duration: "45 min"
   difficulty: intermediate
   environment: kubernetes
 ---
@@ -552,9 +552,9 @@ For production, add a time dimension to the same framework. A safe rollout is no
 ## Did You Know?
 
 - `kubectl rollout restart` works by changing the Pod template annotations, so it creates a normal rolling update even when the image tag stays the same.
-- Deployments keep old ReplicaSets scaled to zero for rollback, and `revisionHistoryLimit` controls how many old templates remain available.
-- The default Deployment strategy is `RollingUpdate`, and `Recreate` is a deliberate downtime tradeoff rather than a safer default.
-- Kubernetes 1.35 still uses the Deployment, ReplicaSet, and Pod controller chain for stateless rollouts; Pods are never patched in place during an image update.
+- Deployments keep old ReplicaSets scaled to zero for rollback. The default `revisionHistoryLimit` is **10** old ReplicaSets retained — set it explicitly in production so rollback depth matches your release policy.
+- The default Deployment strategy is `RollingUpdate` with `maxSurge: 25%` and `maxUnavailable: 25%`; `Recreate` is a deliberate downtime tradeoff rather than a safer default.
+- Kubernetes 1.35 still uses the Deployment, ReplicaSet, and Pod controller chain for stateless rollouts; if a rollout makes no progress for **600** seconds (`progressDeadlineSeconds` default), the controller marks it failed but does not auto-rollback.
 
 ## Common Mistakes
 
@@ -713,7 +713,26 @@ kubectl rollout status deployment/webapp
 Pausing lets you collect template changes before the Deployment starts a new ReplicaSet. After resume, Kubernetes reconciles the final template state. If you forget to resume, later changes can appear confusing because the Deployment remains paused. Check `.spec.paused` when rollout behavior does not match your expectations.
 </details>
 
-### Task 5: Cleanup
+### Task 5: Rolling Restart
+
+```bash
+# Restart pods without changing the image
+kubectl rollout restart deployment/webapp
+
+# Verify the rolling restart completes
+kubectl rollout status deployment/webapp
+
+# Confirm new pods were created (AGE should reset)
+kubectl get pods -l app=webapp
+```
+
+<details>
+<summary>Solution notes for Task 5</summary>
+
+`kubectl rollout restart` triggers a rolling update by changing the Pod template annotation, not the container image. The Deployment keeps the same image tag but replaces every Pod so processes pick up mounted ConfigMap changes or other runtime state. Watch rollout status because restart still needs scheduling capacity and readiness, just like an image update.
+</details>
+
+### Task 6: Cleanup
 
 ```bash
 kubectl delete deployment webapp
@@ -721,7 +740,7 @@ kubectl delete namespace ckad-deployments
 ```
 
 <details>
-<summary>Solution notes for Task 5</summary>
+<summary>Solution notes for Task 6</summary>
 
 Deleting the Deployment removes the controller and its managed ReplicaSets and Pods. Deleting the namespace is a convenient cleanup step for a disposable lab, but do not delete a shared namespace unless you created it for the exercise. If namespace deletion is blocked, inspect remaining resources in that namespace before retrying.
 </details>
@@ -896,6 +915,12 @@ kubectl delete service production
 - [ ] Diagnose a stalled rollout by reading Deployment conditions, ReplicaSets, Pod status, and events.
 - [ ] Evaluate whether pause, resume, rollback, restart, or recreate is the right release action for a given situation.
 - [ ] Clean up the Deployment, Service, and namespace resources created during the exercise.
+
+## Learner check
+
+> Rollout restart is different from rollback. Restart keeps the same image and template fields but changes the Pod template annotation so the Deployment creates fresh Pods.
+
+After Task 5, explain why `kubectl rollout restart deployment/webapp` creates a new ReplicaSet even though the nginx image tag did not change, and what you would check if the restart stalled halfway.
 
 ## Sources
 

--- a/src/content/docs/k8s/ckad/part2-deployment/module-2.2-helm.md
+++ b/src/content/docs/k8s/ckad/part2-deployment/module-2.2-helm.md
@@ -156,7 +156,7 @@ helm install my-release bitnami/nginx \
   --set service.type=NodePort
 
 # Dry-run (see what would be created)
-helm install my-release bitnami/nginx --dry-run
+helm install my-release bitnami/nginx --dry-run=client
 
 # Generate name automatically
 helm install bitnami/nginx --generate-name
@@ -213,7 +213,7 @@ helm get manifest my-release
 helm history my-release
 ```
 
-Before running this, what output do you expect from `helm show values bitnami/nginx` compared with `helm get values my-release` after you install with `--set replicaCount=3`? The first command should show the chart's default configuration, while the second should show values stored for the release. If you need every computed value, including defaults, use the appropriate Helm flag for all values rather than assuming user-supplied values are the whole picture.
+Before running this, what output do you expect from `helm show values bitnami/nginx` compared with `helm get values my-release` after you install with `--set replicaCount=3`? The first command should show the chart's default configuration, while the second should show values stored for the release. If you need every computed value, including defaults, use `helm get values <release> -a` (or `--all`) rather than assuming user-supplied values are the whole picture.
 
 Namespace targeting is also why Helm and `kubectl` verification commands should be paired. If you install `my-release` into `web`, verify the release with `helm list -n web` and verify the workload with `kubectl get pods -n web`. Keeping the namespace flag consistent makes your transcript easy to audit and prevents you from chasing objects in the wrong place.
 
@@ -249,7 +249,8 @@ image:
 
 service:
   type: NodePort
-  port: 80
+  ports:
+    http: 80
 
 resources:
   limits:
@@ -402,7 +403,7 @@ helm list -n web
 helm get values my-nginx -n web
 
 # Upgrade
-helm upgrade my-nginx bitnami/nginx --set replicaCount=3 -n web
+helm upgrade my-nginx bitnami/nginx --reuse-values --set replicaCount=3 -n web
 
 # Verify upgrade
 helm history my-nginx -n web
@@ -415,7 +416,7 @@ helm rollback my-nginx 1 -n web
 helm list -n web
 ```
 
-This second scenario is intentionally narrow: only replica count changes. In a real environment, you would usually prefer a values file or `--reuse-values` so the upgrade does not depend on remembering every previous override. In an exam, the important habit is to check values and history before taking recovery action, because rolling back to the wrong revision wastes time and may hide the actual mistake.
+This second scenario is intentionally narrow: only replica count changes because `--reuse-values` carries forward the prior `service.type=ClusterIP` override. Omitting `--reuse-values` on an upgrade that passes only `--set replicaCount=3` re-applies chart defaults for every value not listed on that command line (for example, `service.type` can revert to `LoadBalancer`). In a real environment, you would usually prefer a values file or `--reuse-values` so the upgrade does not depend on remembering every previous override. In an exam, the important habit is to check values and history before taking recovery action, because rolling back to the wrong revision wastes time and may hide the actual mistake.
 
 ### Scenario 3: Inspect Before Install
 
@@ -424,7 +425,7 @@ This second scenario is intentionally narrow: only replica count changes. In a r
 helm show values bitnami/nginx | head -50
 
 # Dry run to see generated manifests
-helm install test bitnami/nginx --dry-run | head -n 50
+helm install test bitnami/nginx --dry-run=client | head -n 50
 
 # Then install
 helm install test-nginx bitnami/nginx
@@ -483,13 +484,13 @@ Rendered-manifest debugging should stay connected to ownership. If you hand-edit
 helm template my-release bitnami/nginx > rendered.yaml
 
 # Validate without installing
-helm install my-release bitnami/nginx --dry-run --debug
+helm install my-release bitnami/nginx --dry-run=client --debug
 
 # Get notes (post-install instructions)
 helm get notes my-release
 ```
 
-`helm template` renders locally and is excellent for understanding how values turn into YAML. `helm install --dry-run --debug` simulates the install path and prints diagnostic context. `helm get notes` is easy to ignore, but many charts include post-install instructions there, including service discovery hints or default credentials placeholders that explain how to test the application safely.
+`helm template` renders locally and is excellent for understanding how values turn into YAML. `helm install --dry-run=client --debug` simulates the install path and prints diagnostic context. `helm get notes` is easy to ignore, but many charts include post-install instructions there, including service discovery hints or default credentials placeholders that explain how to test the application safely.
 
 A practical debugging sequence for CKAD work is: list the release, get status, get values, get manifest, inspect Kubernetes objects by label, then read events from a failing Pod. Do not start by changing values blindly. The fastest fix is usually the one that proves whether the failure is chart selection, namespace scope, values precedence, rendered YAML, or runtime behavior.
 
@@ -625,6 +626,7 @@ helm install web bitnami/nginx \
 
 # Verify installation
 helm list
+kubectl version --short
 kubectl get pods -l app.kubernetes.io/instance=web
 ```
 
@@ -810,7 +812,7 @@ resources:
 EOF
 
 # 2. Dry-run first
-helm install prod-web bitnami/nginx -f /tmp/prod-values.yaml --dry-run
+helm install prod-web bitnami/nginx -f /tmp/prod-values.yaml --dry-run=client
 
 # 3. Install
 helm install prod-web bitnami/nginx -f /tmp/prod-values.yaml
@@ -836,12 +838,17 @@ helm uninstall prod-web
 
 ### Success Criteria
 
+- [ ] Your cluster reports Kubernetes 1.35+ (`kubectl version` shows a compatible server version).
 - [ ] You can add and update the Bitnami repository without relying on a preconfigured environment.
 - [ ] You can deploy a named Helm release with custom values and verify it with both Helm and `kubectl`.
 - [ ] You can explain which value wins when defaults, values files, and `--set` all define the same key.
 - [ ] You can upgrade a release while preserving previous values intentionally.
 - [ ] You can inspect release history and roll back to a specific revision.
 - [ ] You can clean up releases and namespaces without leaving stale lab resources.
+
+## Learner check
+
+> Omitting `--reuse-values` on an upgrade that passes only `--set replicaCount=3` re-applies chart defaults for every value not listed on that command line (for example, `service.type` can revert to `LoadBalancer`).
 
 ## Sources
 

--- a/src/content/docs/k8s/ckad/part2-deployment/module-2.3-kustomize.md
+++ b/src/content/docs/k8s/ckad/part2-deployment/module-2.3-kustomize.md
@@ -7,7 +7,7 @@ sidebar:
 lab:
   id: ckad-2.3-kustomize
   url: https://killercoda.com/kubedojo/scenario/ckad-2.3-kustomize
-  duration: "30 min"
+  duration: "40-50 minutes"
   difficulty: intermediate
   environment: kubernetes
 ---
@@ -226,15 +226,14 @@ configMapGenerator:
 
 Generating from files is useful when configuration already lives in application-like formats. Each file becomes a key in the ConfigMap unless you use a custom key mapping. This keeps large configuration blobs out of the Deployment manifest while still making the full rendered result inspectable. For CKAD practice, literals are faster to type, but file-based generation is common in real repositories because it mirrors how applications read local configuration.
 
+The same kustomization can declare multiple Secret generators in one list — literals for credentials and files for TLS material:
+
 ```yaml
 secretGenerator:
 - name: db-credentials
   literals:
   - username=admin
   - password=secret123
-
-# Or from files
-secretGenerator:
 - name: tls-certs
   files:
   - tls.crt
@@ -1165,6 +1164,12 @@ echo "=== PROD ===" && kubectl kustomize overlays/prod/
 # Cleanup
 cd /tmp && rm -rf drill6
 ```
+
+## Learner check
+
+> The same kustomization can declare multiple Secret generators in one list — literals for credentials and files for TLS material:
+
+When you render that kustomization with `kubectl kustomize`, how many Secret objects should appear, and what would happen if you used two separate top-level `secretGenerator:` keys instead?
 
 ## Sources
 

--- a/src/content/docs/k8s/ckad/part2-deployment/module-2.4-deployment-strategies.md
+++ b/src/content/docs/k8s/ckad/part2-deployment/module-2.4-deployment-strategies.md
@@ -15,7 +15,7 @@ lab:
 >
 > **Time to Complete**: 40-50 minutes
 >
-> **Prerequisites**: Module 2.1 (Deployments), understanding of Services
+> **Prerequisites**: [Module 2.1 (Deployments)](../module-2.1-deployments/), understanding of Services
 
 ---
 
@@ -282,7 +282,7 @@ spec:
     spec:
       containers:
       - name: app
-        image: myapp:1.0
+        image: nginx:1.25
 ```
 
 ### Step 2: Create Service (Points to Blue)
@@ -323,7 +323,7 @@ spec:
     spec:
       containers:
       - name: app
-        image: myapp:2.0
+        image: nginx:1.26
 ```
 
 ### Step 4: Switch Traffic
@@ -358,7 +358,8 @@ kubectl apply -f green-deployment.yaml
 # Test green directly (port-forward or separate service)
 kubectl port-forward deploy/app-green 8080:80 &
 sleep 2
-curl localhost:8080
+curl 127.0.0.1:8080
+kill %1
 
 # Switch traffic to green
 kubectl patch svc myapp -p '{"spec":{"selector":{"version":"green"}}}'
@@ -375,9 +376,9 @@ Exercise scenario: you have blue serving `nginx:1.25` and green serving `nginx:1
 ```bash
 # Create blue deployment
 kubectl create deploy app-blue --image=nginx:1.25 --replicas=3
-kubectl label deploy app-blue version=blue
 
-# Add version label to pod template
+# NOTE: labeling the Deployment object does NOT change pod labels or Service endpoints.
+# Add the version label to the pod template instead.
 kubectl patch deploy app-blue -p '{"spec":{"template":{"metadata":{"labels":{"version":"blue"}}}}}'
 
 # Create service
@@ -428,7 +429,7 @@ spec:
     spec:
       containers:
       - name: app
-        image: myapp:1.0
+        image: nginx:1.25
 ```
 
 ### Canary Deployment (10% traffic)
@@ -452,7 +453,7 @@ spec:
     spec:
       containers:
       - name: app
-        image: myapp:2.0
+        image: nginx:1.26
 ```
 
 Stop and think: in the canary setup below, the Service selector uses `app: myapp`, which matches both the stable and canary pods. How does Kubernetes distribute traffic between them, and what would happen if the canary pod is not Ready? The useful answer is that only ready endpoints receive traffic, so a one-pod canary that fails readiness effectively receives no Service traffic even though its Deployment exists.
@@ -487,7 +488,7 @@ kubectl scale deploy app-canary --replicas=5
 kubectl scale deploy app-stable --replicas=5
 
 # Full rollout (update stable to new version)
-kubectl set image deploy/app-stable app=myapp:2.0
+kubectl set image deploy/app-stable app=nginx:1.26
 kubectl rollout status deploy/app-stable
 
 # Cleanup: remove canary
@@ -509,6 +510,8 @@ Readiness is what prevents a deployment strategy from becoming a polite way to s
 Without readiness probes, Kubernetes may treat a container as ready as soon as it is running. That default can be acceptable for very simple containers, but it is unsafe for applications with meaningful startup work. A rolling update with `maxUnavailable: 0` can still cause user-visible errors if the new pod enters the Service endpoint set before the application can serve real requests.
 
 Good readiness probes are specific enough to protect users but cheap enough to run frequently. A probe that only checks whether the process exists may pass while the application cannot answer real requests. A probe that performs a slow, fragile dependency check can flap and remove healthy pods from traffic. For CKAD examples, an HTTP check against a lightweight readiness endpoint is usually the clearest pattern.
+
+The next fragment is display-only because it focuses on readiness fields rather than a complete runnable Deployment. Replace `myapp` and the `/ready` path with your real container image and readiness endpoint before applying the pattern in a cluster.
 
 ```yaml
 spec:
@@ -721,7 +724,7 @@ Before starting, decide how you will observe each task. For rolling update, obse
 
 ### Task 1: Rolling Update with Conservative Parameters
 
-Create a Deployment that allows one surge pod and zero unavailable pods, then update the image and observe the rollout. The important observation is the maximum pod count during the transition: with four desired replicas and `maxSurge: 1`, you should not see more than five pods for this Deployment. If the fifth pod cannot schedule, the old four pods should remain because the controller is not allowed to make any desired pod unavailable.
+Create a Deployment that allows one surge pod and zero unavailable pods, then update the image and observe the rollout. The important observation is controller-budget language: with four desired replicas and `maxSurge: 1`, the Deployment budget allows at most five scheduled pods for the active rollout, but terminating pods from the old ReplicaSet may briefly inflate the `kubectl get pods` count. If the fifth active pod cannot schedule, the old four pods should remain because the controller is not allowed to make any desired pod unavailable.
 
 ```bash
 # Create deployment with custom rolling update
@@ -932,8 +935,9 @@ spec:
 EOF
 
 # Gradually increase canary
-kubectl scale deploy canary --replicas=3  # approximately 30% if stable is 7
+kubectl scale deploy canary --replicas=3
 kubectl scale deploy stable --replicas=7
+# approximately 30% after stable is scaled down
 kubectl get endpoints canary-svc
 
 # Full rollout
@@ -1097,6 +1101,14 @@ After `kubectl set selector svc production release=production`, the Service shou
 - [ ] You observed or reasoned through how `Recreate` avoids mixed versions by accepting downtime.
 - [ ] You added readiness-aware rollout reasoning and connected probe behavior to Service endpoint selection.
 - [ ] You cleaned up all Deployments and Services created during the exercise.
+
+---
+
+## Learner check
+
+> With four desired replicas and `maxSurge: 1`, the Deployment budget allows at most five scheduled pods for the active rollout, but terminating pods from the old ReplicaSet may briefly inflate the `kubectl get pods` count.
+
+Before you move on, explain why the quote uses controller-budget language rather than a raw pod-count ceiling. A solid answer mentions `maxSurge`, terminating pods, and the difference between the controller's active rollout budget and what a momentary `kubectl get pods` listing may show.
 
 ---
 


### PR DESCRIPTION
## CKAD wave 2 — part2-deployment cross-family R1 remediation → finalize-to-done

Back-catalog review-first pass for the 4 part2-deployment modules (all were `needs_review`).
Cross-family R1 (cursor `--model auto` + codex gpt-5.5, both ran the labs on real kind v1.35.0
clusters); every finding ground-checked against the live file by the orchestrator; fixes
self-verified vs the diff.

| Module | Verdict | Real findings fixed | Fixer |
|---|---|---|---|
| 2.1-deployments | APPROVE 4.6/5 | duration 30→45; `kubectl rollout restart` was taught but never run → added a lab step; `revisionHistoryLimit` default **10** added to Did-You-Know | cursor |
| 2.2-helm | NEEDS_CHANGES 4.4/5 | **P1** "only replica count changes" was false — `helm upgrade --set` without `--reuse-values` resets prior overrides to chart defaults → added `--reuse-values` (+ footgun callout) across all upgrade examples; `service.port`→`service.ports.http` (bitnami key); all bare `--dry-run`→`--dry-run=client` (Helm 4); named `helm get values -a` | cursor |
| 2.3-kustomize | NEEDS_CHANGES 4.5/5 | duplicate `secretGenerator:` key in one fence silently dropped the first example on render → merged into one valid list (both generators render); duration aligned | cursor |
| 2.4-deployment-strategies | APPROVE_WITH_NITS 4.6/5 | unpullable `myapp:1.0/2.0` in runnable blocks → `nginx:1.25/1.26`; `kubectl label deploy` (object, not pod template) caveated; "no more than five pods" reframed to controller-budget (terminating pods inflate counts); canary % comment math corrected; 2.1 prereq linked | codex (draft) |

All 4 verify `passed: true`, tier T0. Protected visual assets preserved. `chore(content):` only.

## Learner check

> With four desired replicas and `maxSurge: 1`, the Deployment budget allows at most five scheduled pods for the active rollout, but terminating pods from the old ReplicaSet may briefly inflate the `kubectl get pods` count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
