### PR TITLE
chore(content): CKAD wave 3 (part3-observability) R1 remediation — 3.2, 3.3, 3.4, 3.5

### DIFF
--- a/src/content/docs/k8s/ckad/part3-observability/module-3.2-logging.md
+++ b/src/content/docs/k8s/ckad/part3-observability/module-3.2-logging.md
@@ -15,7 +15,7 @@ lab:
 >
 > **Time to Complete**: 25-30 minutes
 >
-> **Prerequisites**: Module 1.1 (Pods), basic understanding of stdout/stderr
+> **Prerequisites**: [Module 1.1 (Pods)](../part1-design-build/module-1.3-multi-container-pods/), basic understanding of stdout/stderr
 
 ---
 
@@ -113,7 +113,7 @@ kubectl logs --since=30m pod-name
 kubectl logs --since=10s pod-name
 
 # Logs since specific time
-kubectl logs --since-time=2024-01-15T10:00:00Z pod-name
+kubectl logs --since-time=2024-01-15T10:00:00Z pod-name  # replace with a recent RFC3339 time
 
 # Show timestamps
 kubectl logs --timestamps pod-name
@@ -553,15 +553,15 @@ spec:
     command: ['sh', '-c', 'echo "Starting..."; echo "About to crash!"; exit 1']
 EOF
 
-# Wait for restart, then check previous logs
-sleep 15
+# Wait until the container has restarted at least once, then check previous logs
+until [ "$(kubectl get pod crasher -o jsonpath='{.status.containerStatuses[0].restartCount}')" -ge 1 ]; do sleep 2; done
 kubectl get pod crasher
 kubectl logs crasher --previous
 ```
 
 <details><summary>Solution notes for Task 3</summary>
 
-After the restart, the pod should show evidence of failure or repeated starts, depending on timing. The previous logs should include "Starting..." and "About to crash!" from the terminated instance. If you run the command too early, the previous instance may not exist yet; wait a little longer and check the pod state again. This is the same habit you need for CrashLoopBackOff triage.
+After the restart, the pod should show evidence of failure or repeated starts, depending on timing. The previous logs should include "Starting..." and "About to crash!" from the terminated instance. If you run `--previous` before `restartCount` reaches 1, Kubernetes 1.35 returns an empty or error response; poll restart count instead of relying on a fixed sleep. This is the same habit you need for CrashLoopBackOff triage.
 
 </details>
 
@@ -667,7 +667,7 @@ kubectl delete pod -l app=drill4
 
 ### Drill 5: Previous Instance (Target: 3 minutes)
 
-This drill reinforces the previous-instance muscle memory. The container prints a line, sleeps briefly, and exits with failure. Wait for the restart, inspect the pod, and then read the previous logs rather than the current fresh attempt.
+This drill reinforces the previous-instance muscle memory. The container prints a line, sleeps briefly, and exits with failure. Poll until `restartCount` is at least 1, inspect the pod, and then read the previous logs rather than the current fresh attempt. If `--previous` is unavailable on a very fast crash, fall back to `kubectl logs drill5` (current) before the next restart erases the evidence.
 
 ```bash
 # Create crashing pod
@@ -683,8 +683,8 @@ spec:
     command: ['sh', '-c', 'echo "Run at $(date)"; sleep 5; exit 1']
 EOF
 
-# Watch it crash
-sleep 15
+# Wait until the container has restarted at least once
+until [ "$(kubectl get pod drill5 -o jsonpath='{.status.containerStatuses[0].restartCount}')" -ge 1 ]; do sleep 2; done
 kubectl get pod drill5
 
 # After restart, get previous logs
@@ -732,6 +732,7 @@ kubectl logs -l app=drill6 --tail=10
 
 # Get previous instance logs
 POD=$(kubectl get pods -l app=drill6 -o jsonpath='{.items[0].metadata.name}')
+until [ "$(kubectl get pod "$POD" -o jsonpath='{.status.containerStatuses[0].restartCount}')" -ge 1 ]; do sleep 2; done
 kubectl logs "$POD" --previous
 
 # Cleanup
@@ -746,6 +747,12 @@ Your success criteria are practical. You should be able to run each command, exp
 - [ ] I can retrieve previous logs from a restarted container before deleting the pod.
 - [ ] I can use a label selector to inspect logs across related pods.
 - [ ] I can explain when a central logging backend is required instead of relying on local `kubectl logs`.
+
+## Learner check
+
+> If you run `--previous` before `restartCount` reaches 1, Kubernetes 1.35 returns an empty or error response; poll restart count instead of relying on a fixed sleep.
+
+Before you move on, explain why the restart-count poll is more reliable than `sleep 15` when a pod is in `CrashLoopBackOff`, and when you would read current-instance logs instead of waiting for `--previous`.
 
 ## Sources
 

--- a/src/content/docs/k8s/ckad/part3-observability/module-3.3-debugging.md
+++ b/src/content/docs/k8s/ckad/part3-observability/module-3.3-debugging.md
@@ -7,7 +7,7 @@ sidebar:
 lab:
   id: ckad-3.3-debugging
   url: https://killercoda.com/kubedojo/scenario/ckad-3.3-debugging
-  duration: "40 min"
+  duration: "45 min"
   difficulty: advanced
   environment: kubernetes
 ---
@@ -15,7 +15,7 @@ lab:
 >
 > **Time to Complete**: 45-55 minutes
 >
-> **Prerequisites**: Module 3.1 (Probes), Module 3.2 (Logging)
+> **Prerequisites**: [Module 3.1 (Probes)](../module-3.1-probes/), [Module 3.2 (Logging)](../module-3.2-logging/)
 
 ---
 
@@ -107,12 +107,16 @@ Logs are most useful after you know a container actually started. A running cont
 
 Log output should be treated as application testimony rather than as a complete source of truth. The process may report a missing file, but Kubernetes tells you whether the volume was mounted; the process may report a port bind failure, but the pod spec tells you which command and environment variables were supplied. Strong debugging combines the two views, using logs to reveal the application complaint and `describe` to verify whether the platform delivered the inputs the application expected.
 
+On kind and other containerd-backed clusters, `kubectl logs --previous` can return `unable to retrieve container logs` during very fast crash loops because the terminated instance has not been retained yet. When that happens, read Last State and terminationMessage from `kubectl describe pod` instead, and wait for one more restart cycle if the evidence is still empty.
+
 ```bash
 # Current logs
 kubectl logs POD
 
 # Previous instance (after crash)
 kubectl logs POD --previous
+# Fallback when --previous is empty (fast crash loops on kind/containerd):
+kubectl describe pod POD | grep -A5 "Last State"
 
 # Specific container
 kubectl logs POD -c CONTAINER
@@ -217,9 +221,11 @@ Separate process exits from probe-driven restarts before you change application 
 ```bash
 # Check logs from crashed instance
 kubectl logs POD --previous
+# Fallback when --previous is empty (fast crash loops):
+kubectl describe pod POD | grep -A5 "Last State"
 
-# Check exit code
-kubectl describe pod POD | grep "Last State"
+# Check exit code and termination message
+kubectl describe pod POD | grep -A5 "Last State"
 
 # Common causes:
 # 1. Application error (check logs)
@@ -268,12 +274,12 @@ kubectl exec -it POD -- sh
 # Check processes
 kubectl exec POD -- ps aux
 
-# Check network
+# Check network (busybox has netstat, not ss)
 kubectl exec POD -- netstat -tlnp
-kubectl exec POD -- ss -tlnp
+# ss -tlnp requires a full image (netshoot/debian); busybox → use netstat
 
-# Check DNS
-kubectl exec POD -- nslookup kubernetes
+# Check DNS (prefer FQDN — see note below)
+kubectl exec POD -- nslookup kubernetes.default.svc.cluster.local
 kubectl exec POD -- cat /etc/resolv.conf
 
 # Check connectivity
@@ -286,6 +292,8 @@ kubectl exec POD -- cat /etc/config/file
 ```
 
 These commands deliberately test different classes of assumptions. Process commands tell you whether the expected process is alive, socket commands tell you whether anything is listening, DNS commands tell you whether the pod resolver can translate service names, and file commands tell you whether volumes and projected configuration appeared where the application expects them. If a command is missing, that is evidence about the image, not a reason to abandon the investigation.
+
+> **Note:** Busybox `nslookup` does not expand the `search` path in `/etc/resolv.conf` the way glibc or netshoot does, so short-name lookups often return `NXDOMAIN` on Kubernetes 1.35 even when cluster DNS is healthy — and the command may exit non-zero even when it printed a useful `Address:` line. Prefer FQDNs such as `SERVICE.NAMESPACE.svc.cluster.local` (for example `kubernetes.default.svc.cluster.local`), or use netshoot `dig` when you need short-name resolution behavior.
 
 ### When Shell Isn't Available
 
@@ -335,12 +343,16 @@ kubectl debug POD -it --image=nicolaka/netshoot --target=app
 kubectl debug POD -it --image=busybox --target=app
 # Then: ls, cat, find
 
-# Process debugging
-kubectl debug POD -it --image=busybox --target=app --share-processes
+# Process debugging (--target shares the target container's process namespace)
+kubectl debug POD -it --image=busybox --target=app
 # Then: ps aux
+
+# Copy-based alternative (--share-processes requires --copy-to)
+kubectl debug POD --copy-to=debug-copy --share-processes --set-image='*=busybox' -- sleep 3600
+# Then: kubectl exec debug-copy -- ps aux
 ```
 
-Ephemeral debug containers are powerful precisely because they reduce pressure to mutate the broken workload. Instead of adding tools to the production image, you temporarily place tools beside it. Instead of restarting a pod that is still serving partial traffic, you inspect from the same network context. That separation matters in exams and in real clusters because observation should not create more drift than the original failure.
+The `--target` flag attaches the debug container to an existing container and shares that target's process namespace, which is why `ps aux` can see application processes. The `--share-processes` flag applies only with `--copy-to`; it is a no-op on a plain `--target` debug attach. Ephemeral debug containers are powerful precisely because they reduce pressure to mutate the broken workload. Instead of adding tools to the production image, you temporarily place tools beside it. Instead of restarting a pod that is still serving partial traffic, you inspect from the same network context. That separation matters in exams and in real clusters because observation should not create more drift than the original failure.
 
 ## Trace Services from Selector to Endpoint to DNS
 
@@ -358,6 +370,7 @@ kubectl get svc SERVICE
 
 # Check endpoints (should list pod IPs)
 kubectl get endpoints SERVICE
+# On Kubernetes 1.35+, kubectl may warn that EndpointSlice is preferred; the address list is still valid.
 
 # If no endpoints:
 # - Check pod labels match service selector
@@ -375,12 +388,11 @@ DNS tests are useful only after you know what name the client should resolve. A 
 Name scope is a frequent source of false negatives. A debugging pod in a different namespace may fail to resolve the short name even though the real client in the Service namespace would succeed. Conversely, a full cluster DNS name can resolve from a diagnostic pod while the original client still fails because policy or port mapping differs. Match the test location to the failing client whenever the task gives you that context.
 
 ```bash
-# From inside a pod
-kubectl exec POD -- nslookup SERVICE
+# From inside a pod (prefer FQDN — busybox nslookup ignores search domains)
 kubectl exec POD -- nslookup SERVICE.NAMESPACE.svc.cluster.local
 
 # Create test pod for debugging
-kubectl run test --image=busybox --rm -it -- nslookup SERVICE
+kubectl run test --image=busybox --rm -it -- nslookup SERVICE.NAMESPACE.svc.cluster.local
 ```
 
 ### Test Service Connectivity
@@ -430,9 +442,11 @@ kubectl get pod crashing-pod
 
 # Step 2: Check previous logs
 kubectl logs crashing-pod --previous
+# Fallback when --previous is empty (fast crash loops):
+kubectl describe pod crashing-pod | grep -A5 "Last State"
 
-# Step 3: Check exit code
-kubectl describe pod crashing-pod | grep -A3 "Last State"
+# Step 3: Check exit code and termination message
+kubectl describe pod crashing-pod | grep -A5 "Last State"
 
 # Step 4: Check liveness probe
 kubectl describe pod crashing-pod | grep -A5 Liveness
@@ -495,7 +509,7 @@ Use time pressure as a reason to narrow the question, not as a reason to skip th
 
 - **Exit code 137 is commonly interpreted as 128 plus signal 9**, so it often points toward SIGKILL; in Kubernetes descriptions, pair it with the termination reason to confirm whether OOMKilled is involved.
 
-- **`kubectl logs --previous` reads the terminated container instance**, which is why it is often more useful than current logs during CrashLoopBackOff investigations.
+- **`kubectl logs --previous` reads the terminated container instance**, which is why it is often more useful than current logs during CrashLoopBackOff investigations. When `--previous` is empty on fast crash loops, read Last State from `kubectl describe pod` instead.
 
 - **A Service with zero endpoints can still have a valid ClusterIP**, because endpoint membership is controlled by selector matches and readiness, not by whether the Service object itself exists.
 
@@ -505,7 +519,7 @@ Use time pressure as a reason to narrow the question, not as a reason to skip th
 |---------|----------------|---------------|
 | Random guessing | A broken pod exposes many symptoms, so it feels faster to try edits than to classify the layer. | Follow the workflow: status, describe, logs, exec or debug, then events for wider context. |
 | Skipping `describe` | Learners assume application logs contain every cause, even when the container never started. | Read conditions, container states, and Events before looking for process output. |
-| Not checking `--previous` | CrashLoopBackOff creates a fresh container, so current logs can hide the failed instance. | Use `kubectl logs POD --previous` and compare it with Last State in `describe`. |
+| Not checking `--previous` | CrashLoopBackOff creates a fresh container, so current logs can hide the failed instance. | Use `kubectl logs POD --previous`; if empty, read Last State with `kubectl describe pod POD \| grep -A5 "Last State"`. |
 | Ignoring exit codes | The same visible crash loop can come from application exit, OOMKilled, or signal termination. | Read termination reason, exit code, resource limits, and probe events together. |
 | Forgetting readiness | Running containers look healthy even when readiness removes every backend from traffic. | Check the `READY` column, readiness events, and Service endpoints. |
 | Debugging Service traffic before checking selectors | Network tests feel concrete, but a Service with no endpoints has no backend to route toward. | Compare `kubectl describe svc` selector output with `kubectl get pods --show-labels`. |
@@ -523,7 +537,7 @@ Start with scheduling evidence, not logs, because the container has not started.
 <details>
 <summary>Question 2: A pod named `api-server` is in CrashLoopBackOff. Current logs show only a new startup line, but the restart count is increasing. How do you find the real failure?</summary>
 
-Use `kubectl logs api-server --previous` because the previous container instance is the one that exited. Then inspect `kubectl describe pod api-server` for Last State, termination reason, exit code, and liveness probe events. Current logs can be incomplete during a crash loop because they belong to the newest attempt. The fix depends on what the evidence says: application error, missing config, OOMKilled, wrong command, or an aggressive probe.
+Use `kubectl logs api-server --previous` because the previous container instance is the one that exited. If `--previous` returns no logs during a fast crash loop, fall back to `kubectl describe pod api-server | grep -A5 "Last State"` for termination reason, exit code, and terminationMessage. Then inspect liveness probe events in the same describe output. Current logs can be incomplete during a crash loop because they belong to the newest attempt. The fix depends on what the evidence says: application error, missing config, OOMKilled, wrong command, or an aggressive probe.
 
 </details>
 
@@ -551,7 +565,7 @@ Use an ephemeral debug container with a toolbox image, or create a debug copy if
 <details>
 <summary>Question 6: You have ten minutes left in an exam task. The Deployment exists, the pod restarts repeatedly, and the Service has no usable backend. How do you implement a repeatable debugging workflow without chasing every symptom?</summary>
 
-First classify the pod state with `kubectl get pod -o wide`, then use `kubectl describe pod` to read container state, Last State, events, and probes. Because restarts are present, get `kubectl logs --previous` before relying on current logs. Once the pod is stable and Ready, check Service selector and endpoints to confirm it can receive traffic. This sequence separates the crash root cause from the Service symptom and prevents you from patching networking before the backend is eligible.
+First classify the pod state with `kubectl get pod -o wide`, then use `kubectl describe pod` to read container state, Last State, events, and probes. Because restarts are present, get `kubectl logs --previous` before relying on current logs; if previous logs are unavailable, use `kubectl describe pod | grep -A5 "Last State"`. Once the pod is stable and Ready, check Service selector and endpoints to confirm it can receive traffic. This sequence separates the crash root cause from the Service symptom and prevents you from patching networking before the backend is eligible.
 
 </details>
 
@@ -625,6 +639,8 @@ kubectl get pod broken2
 # Wait for crashloop to trigger a restart (minimum 10s backoff)
 sleep 20
 kubectl logs broken2 --previous
+# Fallback when --previous is empty (fast crash loops):
+kubectl describe pod broken2 | grep -A5 "Last State"
 # Fix: Provide correct config by replacing the pod
 kubectl delete pod broken2
 cat << 'EOF' | kubectl apply -f -
@@ -732,6 +748,8 @@ kubectl get pod drill3
 
 # Get logs from previous
 kubectl logs drill3 --previous
+# Fallback when --previous is empty:
+kubectl describe pod drill3 | grep -A5 "Last State"
 
 # Cleanup
 kubectl delete pod drill3
@@ -872,11 +890,21 @@ Drill 5 is a selector problem, so empty endpoints should lead you to compare the
 ### Success Criteria
 
 - [ ] Diagnose pod failures by recording status, events, logs, and describe output before editing.
-- [ ] Debug CrashLoopBackOff with `kubectl logs --previous` and Last State evidence.
+- [ ] Debug CrashLoopBackOff with `kubectl logs --previous`, falling back to Last State in `describe` when previous logs are unavailable.
 - [ ] Debug ImagePullBackOff by reading image pull events and fixing only the image reference.
 - [ ] Diagnose Pending by reading scheduling or resource events before looking for logs.
 - [ ] Troubleshoot service and pod networking by comparing selectors, labels, readiness, endpoints, and DNS.
 - [ ] Implement the repeatable debugging workflow without using shell aliases or manual in-container repairs.
+
+## Learner check
+
+Before moving on, confirm you can explain these remediation points in your own words:
+
+> Busybox `nslookup` does not expand the `search` path in `/etc/resolv.conf` the way glibc or netshoot does, so short-name lookups often return `NXDOMAIN` on Kubernetes 1.35 even when cluster DNS is healthy — and the command may exit non-zero even when it printed a useful `Address:` line.
+
+> The `--target` flag attaches the debug container to an existing container and shares that target's process namespace, which is why `ps aux` can see application processes. The `--share-processes` flag applies only with `--copy-to`; it is a no-op on a plain `--target` debug attach.
+
+> On kind and other containerd-backed clusters, `kubectl logs --previous` can return `unable to retrieve container logs` during very fast crash loops because the terminated instance has not been retained yet.
 
 ## Sources
 

--- a/src/content/docs/k8s/ckad/part3-observability/module-3.4-monitoring.md
+++ b/src/content/docs/k8s/ckad/part3-observability/module-3.4-monitoring.md
@@ -73,7 +73,7 @@ If the Metrics Server deployment exists but `kubectl top` still fails, the failu
 
 ## Reading Node, Pod, and Container Metrics
 
-Start monitoring at the widest level that can answer your immediate question. Node metrics help you decide whether the cluster has broad capacity pressure, while pod metrics help you identify the workload consuming resources in a namespace. Container metrics are the next layer when a pod has more than one container, because resource requests and limits are set on containers even though `kubectl top pods` first presents an aggregate pod view.
+Start monitoring at the widest level that can answer your immediate question. Node metrics help you decide whether the cluster has broad capacity pressure, while pod metrics help you identify the workload consuming resources in a namespace. Container metrics are the next layer when a pod has more than one container, because resource requests and limits are set on containers even though `kubectl top pods` first presents an aggregate pod view. Kubernetes 1.35 also supports optional pod-level resources via `spec.resources` when the PodLevelResources feature gate is enabled, but container-level settings remain what `kubectl top pods --containers` inspects in the common CKAD case.
 
 ```bash
 # All nodes
@@ -85,7 +85,7 @@ kubectl top nodes
 # node-2     500m         25%    2048Mi          50%
 ```
 
-Node output is useful when you suspect a scheduling or shared-capacity problem. A node at high memory usage may not have enough room for new pods, and a node with high CPU usage may be running latency-sensitive workloads that compete for time. The percentages in node output are based on node capacity, so they answer a different question than pod usage: "How busy is this machine?" rather than "How close is this container to its configured limit?"
+Node output is useful when you suspect a scheduling or shared-capacity problem. A node at high memory usage may not have enough room for new pods, and a node with high CPU usage may be running latency-sensitive workloads that compete for time. The percentages in node output are based on node allocatable by default, so they answer a different question than pod usage: "How busy is this machine?" rather than "How close is this container to its configured limit?" Pass `--show-capacity` to compare against node capacity instead.
 
 ```bash
 # All pods in current namespace
@@ -140,10 +140,10 @@ This quick health check is intentionally short because monitoring should reduce 
 
 ```bash
 # Top CPU consumers
-kubectl top pods -A --sort-by=cpu | head -10
+kubectl top pods -A --sort-by=cpu --no-headers | head -10
 
 # Top memory consumers
-kubectl top pods -A --sort-by=memory | head -10
+kubectl top pods -A --sort-by=memory --no-headers | head -10
 ```
 
 The `head` filter is a practical way to turn noisy cluster output into a shortlist. In a real incident you would pair this with ownership and namespace checks before changing anything, because the largest consumer might be expected batch work rather than a faulty service. In a CKAD exercise, it helps you quickly locate the pod the task is trying to make you notice.
@@ -185,11 +185,11 @@ NAME        CPU(cores)   CPU%     MEMORY(bytes)   MEMORY%
 my-pod      100m         10%      256Mi           12%
 ```
 
-In this output, `100m` means the pod is using 100 millicores, or roughly 10 percent of one CPU core. `256Mi` means it is currently using 256 mebibytes of memory. Percentages on node output relate to node capacity, while pod output is most useful when you compare the absolute values against the workload's requests and limits.
+In this output, `100m` means the pod is using 100 millicores, or roughly 10 percent of one CPU core. `256Mi` means it is currently using 256 mebibytes of memory. Percentages on node output relate to node allocatable by default (`--show-capacity` uses capacity), while pod output is most useful when you compare the absolute values against the workload's requests and limits.
 
 The key habit is to avoid treating every high number as the same kind of emergency. High CPU can explain slowness, queue buildup, or throttling, but it may also be expected during a short batch job. High memory near a limit can explain restarts, OOMKilled events, and sudden process death, and it often needs either more headroom or application-level memory controls.
 
-CPU percentages can be especially misleading if you forget what the percentage is relative to. Node percentages are relative to node capacity, while pod CPU values are more useful as millicores that you compare to the container's request and limit. When in doubt, trust the absolute unit first, then use percentages only as a quick capacity signal for the node view.
+CPU percentages can be especially misleading if you forget what the percentage is relative to. Node percentages are relative to node allocatable by default (or capacity with `--show-capacity`), while pod CPU values are more useful as millicores that you compare to the container's request and limit. When in doubt, trust the absolute unit first, then use percentages only as a quick capacity signal for the node view.
 
 ```yaml
 resources:
@@ -409,7 +409,7 @@ The core Kubernetes API is reachable, but the resource metrics API is not servin
 <details>
 <summary>A multi-container pod has an application container and a logging sidecar. Pod-level metrics show 200m CPU total. How do you identify the real consumer and why does it matter?</summary>
 
-Run `kubectl top pods POD_NAME --containers` or use the same command with a selector to see per-container CPU and memory. The distinction matters because resources are configured per container, not as one shared pod knob in the manifest. If the sidecar uses 180m, raising the application container's request would miss the cause. The correct fix might be sidecar configuration, image behavior, or a sidecar-specific limit.
+Run `kubectl top pods POD_NAME --containers` or use the same command with a selector to see per-container CPU and memory. The distinction matters because resources are commonly configured per container, not as one shared pod knob in the manifest—though Kubernetes 1.35 also supports optional pod-level resources via `spec.resources` when the PodLevelResources feature gate is enabled. If the sidecar uses 180m, raising the application container's request would miss the cause. The correct fix might be sidecar configuration, image behavior, or a sidecar-specific limit.
 </details>
 
 <details>
@@ -666,6 +666,14 @@ The expected workflow is selector first, sorted selector second, container break
 - [ ] You used `--containers` to separate container-level metrics in a multi-container pod.
 - [ ] You explained whether a high memory value near a limit is more urgent than a high CPU value near a limit.
 - [ ] You cleaned up all practice pods and deployments created during the exercise.
+
+---
+
+## Learner check
+
+> The percentages in node output are based on node allocatable by default, so they answer a different question than pod usage: "How busy is this machine?" rather than "How close is this container to its configured limit?" Pass `--show-capacity` to compare against node capacity instead.
+
+Before you move on, explain why node CPU% and memory% can differ from what you would calculate against total node capacity, and when you would pass `--show-capacity`.
 
 ---
 

--- a/src/content/docs/k8s/ckad/part3-observability/module-3.5-api-deprecations.md
+++ b/src/content/docs/k8s/ckad/part3-observability/module-3.5-api-deprecations.md
@@ -7,13 +7,13 @@ sidebar:
 lab:
   id: ckad-3.5-api-deprecations
   url: https://killercoda.com/kubedojo/scenario/ckad-3.5-api-deprecations
-  duration: "30 min"
+  duration: "40 min"
   difficulty: intermediate
   environment: kubernetes
 ---
 > **Complexity**: `[QUICK]` - Conceptual understanding with practical commands
 >
-> **Time to Complete**: 35-40 minutes
+> **Time to Complete**: 40 minutes
 >
 > **Prerequisites**: Understanding of Kubernetes API versioning
 
@@ -99,24 +99,34 @@ kubectl api-resources --sort-by=name
 The output of `api-resources` can feel wide at first, but it answers a practical question: "Can this cluster serve the thing I am about to apply?" If the resource kind is not listed, the manifest is not going to work without installing the missing API or changing the object. If the resource is listed under a different group than the manifest uses, the manifest may be old, copied from a different Kubernetes era, or meant for a CRD that is not installed in this cluster.
 
 ```bash
-# Get API version for a resource
+# Get API group and version for a resource
 kubectl explain deployment
-# Output shows: VERSION: apps/v1
+# GROUP:      apps
+# KIND:       Deployment
+# VERSION:    v1
 
 kubectl explain ingress
-# Output shows: VERSION: networking.k8s.io/v1
+# GROUP:      networking.k8s.io
+# KIND:       Ingress
+# VERSION:    v1
 
 kubectl explain cronjob
-# Output shows: VERSION: batch/v1
+# GROUP:      batch
+# KIND:       CronJob
+# VERSION:    v1
 ```
 
-`kubectl explain` is the command to reach for when you need field-level confidence. The top of its output shows the current version for the resource, and deeper paths show the fields Kubernetes expects. For example, `kubectl explain ingress.spec.rules.http.paths` shows the current Ingress path structure, which is exactly where many old examples fail because `serviceName` and `servicePort` moved under `backend.service`.
+`kubectl explain` is the command to reach for when you need field-level confidence. The top of its output shows the current group and version separately, and deeper paths show the fields Kubernetes expects. For a named API group, combine `GROUP` and `VERSION` to form the manifest's `apiVersion`: `apps/v1`, `networking.k8s.io/v1`, or `batch/v1`. Core resources such as Pods and Services have no group prefix, so their manifest value stays just `v1`.
 
 ```bash
-# See what version existing objects use
+# See what version existing objects use.
+# If this Deployment is absent, create it first or skip this optional check.
+# kubectl create deployment nginx --image=nginx
 kubectl get deployment nginx -o yaml | head -5
 # apiVersion: apps/v1
 # kind: Deployment
+# If you created the disposable Deployment, clean it up afterward:
+# kubectl delete deployment nginx
 ```
 
 Looking at an existing object can help when the cluster already has a similar resource. Kubernetes stores and serves objects through preferred versions, so the first lines of `kubectl get ... -o yaml` usually show the version the API server returns now. That output should not be treated as a conversion guide by itself, but it gives you a concrete reference for the group and version in the same cluster.
@@ -142,6 +152,7 @@ The CKAD exam uses recent Kubernetes versions, and this module assumes Kubernete
 
 ```bash
 # Convert old manifest to new API
+# requires the kubectl-convert plugin (not in default kubectl)
 kubectl convert -f old-deployment.yaml --output-version apps/v1
 ```
 
@@ -465,8 +476,14 @@ The next task builds a small lookup table for resources you commonly use. This i
 ```bash
 # Find the current version for every resource you commonly use
 for res in pod service deployment statefulset daemonset job cronjob ingress networkpolicy; do
-  version=$(kubectl explain "$res" 2>/dev/null | grep "VERSION:" | awk '{print $2}')
-  echo "$res: $version"
+  header=$(kubectl explain "$res" 2>/dev/null)
+  group=$(printf '%s\n' "$header" | awk '/^GROUP:/ {print $2}')
+  version=$(printf '%s\n' "$header" | awk '/^VERSION:/ {print $2}')
+  if [ -n "$version" ]; then
+    echo "$res: ${group:+$group/}$version"
+  else
+    echo "$res: unavailable"
+  fi
 done
 ```
 
@@ -539,8 +556,14 @@ Drill 5 combines several common resources into one lookup loop. This is the same
 
 # Quick lookup
 for res in deployment service ingress configmap secret networkpolicy; do
-  echo -n "$res: "
-  kubectl explain "$res" 2>/dev/null | grep "VERSION:" | awk '{print $2}'
+  header=$(kubectl explain "$res" 2>/dev/null)
+  group=$(printf '%s\n' "$header" | awk '/^GROUP:/ {print $2}')
+  version=$(printf '%s\n' "$header" | awk '/^VERSION:/ {print $2}')
+  if [ -n "$version" ]; then
+    echo "$res: ${group:+$group/}$version"
+  else
+    echo "$res: unavailable"
+  fi
 done
 ```
 
@@ -557,6 +580,12 @@ done
 Part 3 covered the maintenance skills that keep applications observable and repairable after they are deployed. Probes tell Kubernetes when a container is alive and ready, logs expose application output, debugging commands let you move from symptoms to evidence, metrics show current resource pressure, and API deprecation checks keep manifests compatible with the cluster. The unifying habit is the same across the section: read what Kubernetes already knows before making a change.
 
 API deprecations fit naturally at the end because they connect day-two maintenance with cluster lifecycle. A manifest is not a timeless artifact; it is a request written against a moving API surface. When you treat API versions as contracts that can age, warnings become useful early signals instead of noisy log lines, and removed APIs become straightforward repair tasks rather than mysterious deployment failures.
+
+## Learner check
+
+> For a named API group, combine `GROUP` and `VERSION` to form the manifest's `apiVersion`: `apps/v1`, `networking.k8s.io/v1`, or `batch/v1`.
+
+Before you move on, explain why this quote matters for `kubectl explain deployment`. A solid answer says that modern `kubectl explain` prints `GROUP: apps` and `VERSION: v1` separately, while the YAML manifest needs the combined value `apiVersion: apps/v1`.
 
 ## Sources
 


### PR DESCRIPTION
## CKAD wave 3 — part3-observability cross-family R1 remediation → finalize-to-done

Back-catalog review-first pass for the 4 part3-observability stragglers (3.1-probes already `done`).
Cross-family R1 (cursor `--model auto` + codex gpt-5.5, both ran the labs on real kind v1.35.0
clusters); every finding ground-checked against the live file by the orchestrator; fixes
self-verified vs the diff.

| Module | Verdict | Real findings fixed | Fixer |
|---|---|---|---|
| 3.2-logging | NEEDS_CHANGES 4.6/5 | 3× `kubectl logs --previous` ran before the pod restarted (fails on 1.35/containerd) → replaced fixed `sleep`/no-wait with `restartCount`-poll gates + current-logs fallback note | cursor |
| 3.3-debugging | NEEDS_CHANGES 4.3/5 | busybox `nslookup <short-name>` NXDOMAIN → FQDN forms; `kubectl debug --share-processes` misused with `--target` (no-op without `--copy-to`) → corrected; `ss` absent from busybox → qualified; `--previous` Last-State/`terminationMessage` fallback | cursor |
| 3.4-monitoring | NEEDS_CHANGES 4.2/5 | `kubectl top node` % is **Allocatable by default** not Capacity (`--show-capacity` for capacity); container-only resources clarified for 1.35 (pod-level `spec.resources` exists); `top ... | head -10` header off-by-one → `--no-headers` | codex |
| 3.5-api-deprecations | NEEDS_CHANGES 4.9/5 | `kubectl explain` output comments showed combined `VERSION: apps/v1` but 1.35 prints GROUP+VERSION on separate lines → fixed comments + both audit loops now combine `${group}/${version}` to match the prose | codex (draft) |

All 4 verify `passed: true`, tier T0. Protected visual assets preserved. `chore(content):` only.

## Learner check

> The percentages in node output are based on node allocatable by default, so they answer a different question than pod usage: "How busy is this machine?" rather than "How close is this container to its configured limit?" Pass `--show-capacity` to compare against node capacity instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
