### PR TITLE
chore(content): CKAD wave 4 (part4-environment) R1 remediation — 4.1, 4.2, 4.4, 4.5, 4.6 (+4.3 as-is)

### DIFF
--- a/src/content/docs/k8s/ckad/part4-environment/module-4.1-configmaps.md
+++ b/src/content/docs/k8s/ckad/part4-environment/module-4.1-configmaps.md
@@ -561,6 +561,60 @@ kubectl get configmap web-config -o yaml
 
 This setup creates a short ConfigMap that is naturally shaped like environment variables. The verification step matters because it confirms the exact key names before a Pod tries to consume them. If you see `APP_COLOUR` in the object but `APP_COLOR` in the Pod, Kubernetes will not guess the spelling you intended.
 
+### Setup: Create from a Directory
+
+Each regular file in the directory becomes one ConfigMap key. This matches the directory workflow shown earlier in the theory section and is useful when you already have a small folder of configuration files on disk.
+
+```bash
+mkdir -p ./config-dir
+echo "database.host=db.example.com" > ./config-dir/app.properties
+echo "log.level=debug" > ./config-dir/logging.properties
+
+kubectl create configmap web-config-dir --from-file=./config-dir/
+kubectl get configmap web-config-dir -o yaml
+
+kubectl delete cm web-config-dir
+rm -rf ./config-dir
+```
+
+<details>
+<summary>Solution notes</summary>
+
+The resulting ConfigMap should contain two keys named after the filenames: `app.properties` and `logging.properties`. If extra files appear, check the directory for editor backups or temporary files before creating the object.
+
+</details>
+
+### Setup: Create from Declarative YAML
+
+Declarative YAML is the form you should prefer for reviewable changes and Git-based delivery. Apply the manifest below, inspect the keys under `data`, then delete the object.
+
+```bash
+cat << 'EOF' > /tmp/app-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config-yaml
+data:
+  APP_ENV: production
+  LOG_LEVEL: info
+  app.properties: |
+    database.host=db.example.com
+    database.port=5432
+    database.name=myapp
+EOF
+
+kubectl apply -f /tmp/app-config.yaml
+kubectl get configmap app-config-yaml -o yaml
+kubectl delete cm app-config-yaml
+```
+
+<details>
+<summary>Solution notes</summary>
+
+Literal-style keys such as `APP_ENV` appear as plain strings under `data`, while `app.properties` preserves line breaks through the YAML block scalar. This is the same shape you will wire into Pods through environment variables or volume mounts in the next parts.
+
+</details>
+
 ### Part 1: Environment Variables
 
 ```bash
@@ -689,7 +743,7 @@ EOF
 
 kubectl wait --for=condition=Ready pod/drill3 --timeout=30s
 kubectl logs drill3
-kubectl delete pod drill3 cm drill3
+kubectl delete pod/drill3 cm/drill3
 ```
 
 <details>
@@ -725,7 +779,7 @@ EOF
 
 kubectl wait --for=condition=Ready pod/drill4 --timeout=30s
 kubectl logs drill4
-kubectl delete pod drill4 cm drill4
+kubectl delete pod/drill4 cm/drill4
 ```
 
 <details>
@@ -766,7 +820,7 @@ EOF
 
 kubectl wait --for=condition=Ready pod/drill5 --timeout=30s
 kubectl logs drill5
-kubectl delete pod drill5 cm drill5
+kubectl delete pod/drill5 cm/drill5
 ```
 
 <details>
@@ -817,7 +871,7 @@ EOF
 kubectl wait --for=condition=Ready pod/drill6 --timeout=30s
 kubectl exec drill6 -- nginx -T 2>&1 | grep -F "Custom Config Works!"
 
-kubectl delete pod drill6 cm drill6-nginx
+kubectl delete pod/drill6 cm/drill6-nginx
 ```
 
 <details>
@@ -826,6 +880,10 @@ kubectl delete pod drill6 cm drill6-nginx
 The `nginx -T` command dumps the effective nginx configuration, and the `grep` match should print the `Custom Config Works!` response rule from the mounted file. The `subPath` mount places one ConfigMap key at the file path nginx expects while preserving the rest of the directory. If you change `/tmp/nginx.conf` and recreate the ConfigMap, replace the Pod as well because the `subPath` file does not live-update.
 
 </details>
+
+## Learner check
+
+> When you delete mixed resource types in one `kubectl delete` command, use slash notation such as `kubectl delete pod/drill3 cm/drill3` so each argument names both the resource type and the object.
 
 ## Sources
 

--- a/src/content/docs/k8s/ckad/part4-environment/module-4.2-secrets.md
+++ b/src/content/docs/k8s/ckad/part4-environment/module-4.2-secrets.md
@@ -7,15 +7,15 @@ sidebar:
 lab:
   id: ckad-4.2-secrets
   url: https://killercoda.com/kubedojo/scenario/ckad-4.2-secrets
-  duration: "30 min"
+  duration: "45 min"
   difficulty: intermediate
   environment: kubernetes
 ---
 > **Complexity**: `[MEDIUM]` - Similar to ConfigMaps but with security considerations
 >
-> **Time to Complete**: 40-50 minutes
+> **Time to Complete**: 45 minutes
 >
-> **Prerequisites**: Module 4.1 (ConfigMaps), understanding of base64 encoding
+> **Prerequisites**: [Module 4.1: ConfigMaps](../module-4.1-configmaps/), understanding of base64 encoding
 
 ---
 
@@ -367,12 +367,13 @@ Rotation adds one more operational layer. Updating a Secret object does not nece
 
 ```bash
 kubectl create secret generic db-secret \
+  -n secret-lab \
   --from-literal=username=admin \
   --from-literal=password='rotated-example-password' \
   --dry-run=client \
-  -o yaml | kubectl apply -f -
+  -o yaml | kubectl apply -n secret-lab -f -
 
-kubectl rollout restart deployment/app
+kubectl rollout restart deployment/app -n secret-lab
 ```
 
 The quick reference below keeps the original module's command coverage but removes shorthand that only works in an interactive shell. Read it as a set of diagnostic verbs: create the object, view the encoded representation, decode a specific key, edit only when appropriate, and delete lab resources when finished. In real teams, prefer declarative or secret-manager-driven rotation over manual edits for long-lived credentials.
@@ -505,17 +506,30 @@ Immutable Secrets are a good fit when the name includes a version and the worklo
 
 They are a poor fit when many teams expect to patch the same Secret name in place. If the Secret is immutable, a normal `kubectl apply` with changed data will fail, and deleting the object can break existing Pod startup while you recreate it. The key is not whether immutable is good or bad; it is whether your rotation workflow expects replacement by name or mutation under a stable name.
 
+The default CKAD rotation path is kubelet-native: change the Secret reference in the Pod template so the Deployment template hash changes and new Pods roll out. Patch `secretKeyRef.name`, a volume `secretName`, or an `imagePullSecrets` entry — not a generic `kubectl set env` unless the application reads that variable and fetches the Secret itself.
+
+```yaml
+# Default mechanism: update the Pod template reference, then apply
+env:
+- name: DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: db-secret-v2   # was db-secret-v1
+      key: password
+```
+
 ```bash
 kubectl create secret generic db-secret-v2 \
   -n secret-lab \
   --from-literal=username=admin \
   --from-literal=password='rotated-example-password'
 
+# application-side only: this works ONLY if the app reads $DB_SECRET_NAME and fetches the secret itself
 kubectl set env deployment/app -n secret-lab DB_SECRET_NAME=db-secret-v2
 kubectl rollout status deployment/app -n secret-lab
 ```
 
-The previous command illustrates a common application-level indirection, but it is not the only option. Some workloads reference the Secret name directly in the Pod template, so rotation means changing `secretKeyRef.name`, a volume `secretName`, or an `imagePullSecrets` entry. Any of those Pod template changes should trigger new Pods in a Deployment because the template hash changes.
+The `kubectl set env` command above illustrates application-level indirection — a pattern some custom controllers use, but not the kubelet's built-in Secret delivery path. Most CKAD workloads reference the Secret name directly in the Pod template, so rotation means changing `secretKeyRef.name`, a volume `secretName`, or an `imagePullSecrets` entry. Any of those Pod template changes trigger new Pods in a Deployment because the template hash changes.
 
 For mounted volumes, rotation has two timelines: Kubernetes updating the projected files and the application noticing the file content. The kubelet can refresh Secret volume data after the API object changes, but an application that reads the file once at startup will still use the old in-memory value. If the application does not reload credentials, the correct operational action is still a Pod restart.
 
@@ -749,7 +763,7 @@ Create a second Pod that mounts the same Secret as files under `/secrets`, with 
 
 - [ ] Pod `secret-vol` becomes Ready.
 - [ ] `/secrets` contains files named after the Secret keys.
-- [ ] The volume mount is read-only and the Secret volume uses `defaultMode: 0400`.
+- [ ] The volume mount is read-only and the Secret volume uses `defaultMode: 0400`. (`ls -la /secrets` shows symlinks with `lrwxrwxrwx`; check file modes under `/secrets/..data/` instead.)
 
 <details>
 <summary>Solution</summary>
@@ -778,6 +792,7 @@ EOF
 
 kubectl wait --for=condition=Ready pod/secret-vol -n secret-lab --timeout=60s
 kubectl logs secret-vol -n secret-lab
+# Symlinks under /secrets show lrwxrwxrwx; verify defaultMode on real files: ls -la /secrets/..data/
 ```
 
 </details>
@@ -869,6 +884,14 @@ Delete the namespace to remove every object created in the lab. In a shared clus
 ```bash
 kubectl delete namespace secret-lab
 ```
+
+---
+
+## Learner check
+
+> The default CKAD rotation path is kubelet-native: change the Secret reference in the Pod template so the Deployment template hash changes and new Pods roll out.
+
+Before you move on, explain why `kubectl set env deployment/app DB_SECRET_NAME=db-secret-v2` is not a generic Secret rotation fix, and which Pod template fields you would patch instead for a workload that uses `secretKeyRef` or a Secret volume.
 
 ---
 

--- a/src/content/docs/k8s/ckad/part4-environment/module-4.4-securitycontext.md
+++ b/src/content/docs/k8s/ckad/part4-environment/module-4.4-securitycontext.md
@@ -15,7 +15,7 @@ lab:
 >
 > **Time to Complete**: 40-50 minutes
 >
-> **Prerequisites**: Basic Linux user/group concepts, Module 1.1 (Pods)
+> **Prerequisites**: Basic Linux user/group concepts, [Module 1.1 (Pods)](../part1-design-build/module-1.3-multi-container-pods/)
 
 ---
 
@@ -198,6 +198,8 @@ spec:
     emptyDir: {}
 ```
 
+The official nginx image listens on port 80 by default. Ports below 1024 traditionally required the `NET_BIND_SERVICE` capability, yet this example drops all capabilities and still starts on many practice clusters because modern container runtimes may set `net.ipv4.ip_unprivileged_port_start=0`, which lets unprivileged processes bind low ports. CKAD tasks that explicitly require binding a port below 1024 still expect you to add `NET_BIND_SERVICE` rather than relying on that runtime sysctl behavior.
+
 Stop and think: if the application now fails with `permission denied` while writing `/var/log/nginx/access.log`, should you disable `readOnlyRootFilesystem`, change the UID, or add a writable mount for the log path? The best answer depends on whether the application truly needs to write there. If the write is expected runtime behavior, add a specific volume mount or reconfigure the app to log to stdout; do not remove the broader read-only root protection just to hide one missing writable path.
 
 The operational habit is to make writable paths boring and explicit. A reviewer should be able to scan the manifest and see that `/tmp` is writable because it is scratch space, `/var/run` is writable because a socket or PID file may be created there, and application data is handled by the right storage type. When those paths are not explicit, an application can pass development tests and fail only after a cluster policy enforces a read-only root.
@@ -228,7 +230,7 @@ Capabilities are powerful because they sit below Kubernetes in the Linux kernel.
 | `SYS_PTRACE` | Debug other processes |
 | `CHOWN` | Change file ownership |
 
-The table lists common capabilities you may see in examples, not a recommendation to use them casually. `NET_BIND_SERVICE` is much narrower than `NET_ADMIN`, and `SYS_TIME` is rarely appropriate for an application container. `SYS_PTRACE` can be useful for debugging tools but is risky in normal workloads. `CHOWN` can hide image-permission problems if you use it as a crutch instead of fixing ownership during the build.
+The table lists common capabilities you may see in examples, not a recommendation to use them casually. `NET_BIND_SERVICE` is much narrower than `NET_ADMIN`, and `SYS_TIME` is rarely appropriate for an application container. When a task asks you to bind a port below 1024, add `NET_BIND_SERVICE` even if your local cluster happens to allow unprivileged low ports through `ip_unprivileged_port_start`. `SYS_PTRACE` can be useful for debugging tools but is risky in normal workloads. `CHOWN` can hide image-permission problems if you use it as a crutch instead of fixing ownership during the build.
 
 ```yaml
 securityContext:
@@ -322,7 +324,7 @@ The first decision is identity. Because the task requires non-root behavior, set
 
 This example is not asking you to memorize nginx internals. It is teaching the diagnostic shape that applies to many images: after you lock down identity and the root filesystem, watch for specific paths that still need runtime writes. Mount only those paths, keep the rest of the image immutable, and leave capability additions out unless the task gives you a concrete reason.
 
-The resulting manifest is the earlier secure pod example, and it is deliberately CKAD-friendly. It uses one pod, one container, clear numeric IDs, and explicit volume mounts. During verification, you can run `kubectl logs` to confirm the process starts, `kubectl exec -- id` to confirm identity, and `kubectl exec -- touch /test` to confirm the root remains read-only. Those checks tie the YAML to observable behavior.
+The resulting manifest is the earlier secure pod example, and it is deliberately CKAD-friendly. It uses one pod, one container, clear numeric IDs, and explicit volume mounts. During verification, you can run `kubectl logs secure-pod` to confirm the process starts, `kubectl exec secure-pod -- id` to confirm identity, and `kubectl exec secure-pod -- touch /test` to confirm the root remains read-only. Those checks tie the YAML to observable behavior.
 
 The same reasoning also applies when you are repairing an existing manifest. Read the current fields, identify which requirement is missing, and make the smallest change that satisfies that requirement without weakening another one. Adding an `emptyDir` to `/tmp` is a small change. Removing `readOnlyRootFilesystem` because one path needs writes is a broad weakening, and broad weakenings are rarely the correct answer in an exam or in review.
 
@@ -414,7 +416,7 @@ For CKAD speed, memorize the decision order rather than every possible field. Id
 ## Did You Know?
 
 - Kubernetes documents SecurityContext separately for pods and containers because `PodSecurityContext` and `SecurityContext` are different API objects with overlapping but non-identical fields.
-- `NET_BIND_SERVICE` exists because Unix-like systems historically restricted binding ports below `1024` to privileged processes.
+- `NET_BIND_SERVICE` exists because Unix-like systems historically restricted binding ports below `1024` to privileged processes; some modern runtimes relax that through `ip_unprivileged_port_start`, but CKAD still expects the capability when a task requires a low port.
 - `allowPrivilegeEscalation: false` maps to the Linux `no_new_privs` idea, which prevents a process from gaining privilege through exec transitions.
 - `fsGroup` affects supported mounted volumes, not ordinary files already baked into the container image layer.
 
@@ -791,6 +793,10 @@ The logs should show UID `1000`, primary GID `1000`, and group access that inclu
 
 </details>
 
+## Learner check
+
+> CKAD tasks that explicitly require binding a port below 1024 still expect you to add `NET_BIND_SERVICE` rather than relying on that runtime sysctl behavior.
+
 ## Sources
 
 - https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -799,7 +805,6 @@ The logs should show UID `1000`, primary GID `1000`, and group access that inclu
 - https://kubernetes.io/docs/concepts/security/pod-security-standards/
 - https://kubernetes.io/docs/concepts/security/linux-kernel-security-constraints/
 - https://kubernetes.io/docs/concepts/storage/volumes/#emptydir
-- https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/
 - https://kubernetes.io/docs/reference/kubectl/generated/kubectl_exec/
 - https://man7.org/linux/man-pages/man7/capabilities.7.html
 - https://man7.org/linux/man-pages/man2/setuid.2.html

--- a/src/content/docs/k8s/ckad/part4-environment/module-4.5-serviceaccounts.md
+++ b/src/content/docs/k8s/ckad/part4-environment/module-4.5-serviceaccounts.md
@@ -7,7 +7,7 @@ sidebar:
 lab:
   id: ckad-4.5-serviceaccounts
   url: https://killercoda.com/kubedojo/scenario/ckad-4.5-serviceaccounts
-  duration: "30 min"
+  duration: "45 min"
   difficulty: intermediate
   environment: kubernetes
 ---
@@ -16,7 +16,7 @@ lab:
 >
 > **Time to Complete**: 40-55 minutes
 >
-> **Prerequisites**: Module 4.4 (SecurityContexts), basic Pod manifests, and RBAC vocabulary
+> **Prerequisites**: [Module 4.4: SecurityContexts](../module-4.4-securitycontext/), basic Pod manifests, and RBAC vocabulary
 
 ---
 
@@ -46,16 +46,22 @@ That distinction matters because a Pod is not a person, even when a human create
 Every namespace receives a ServiceAccount named `default` when the namespace is created. If you create a Pod without specifying `spec.serviceAccountName`, the ServiceAccount admission controller mutates the Pod and assigns that namespace default. The default identity usually has no useful RBAC permissions beyond baseline API discovery, but it is still an authenticated identity, and it may still receive a mounted token unless automounting is disabled. That is why "no explicit ServiceAccount" is not the same as "no identity."
 
 ```bash
-# View default ServiceAccount
+# View default ServiceAccount (Kubernetes 1.35 — NAME and AGE only)
 kubectl get serviceaccount
-# NAME      SECRETS   AGE
-# default   0         10d
+# NAME      AGE
+# default   10d
 
-# Describe it
+# Describe shows no legacy token Secret — Pods still get projected tokens
 kubectl describe sa default
+# Name:                default
+# Namespace:           default
+# Tokens:              <none>
+
+# Or inspect the object directly
+kubectl get sa default -o yaml
 ```
 
-The `SECRETS` column commonly surprises engineers who learned Kubernetes before the modern token model. In current Kubernetes releases, including 1.35, the default ServiceAccount normally shows zero automatically generated token Secrets. That does not mean Pods receive no credentials. It means Kubernetes now uses bound, projected ServiceAccount tokens instead of creating a long-lived Secret object for every ServiceAccount.
+Engineers who learned Kubernetes before 1.24 often expect a `SECRETS` column on `kubectl get serviceaccount`. That column was removed in Kubernetes 1.24+, so current clusters—including 1.35—list only `NAME` and `AGE`. `kubectl describe sa default` may show `Tokens: <none>` even while admitted Pods still receive bound, projected tokens under `/var/run/secrets/kubernetes.io/serviceaccount/`. The absence of a legacy token Secret on the ServiceAccount object does not mean the workload has no API credential; it means Kubernetes no longer auto-creates long-lived `kubernetes.io/service-account-token` Secrets for every ServiceAccount.
 
 When a Pod exists, you can confirm which identity it received by reading the Pod spec or by using `kubectl describe`. This is often the fastest first check during an exam troubleshooting question because it tells you whether you are debugging the intended identity or the namespace default. A manifest can look correct in Git while an older ReplicaSet, a stale Pod, or a hand-created debugging Pod is actually running with something different.
 
@@ -273,14 +279,26 @@ spec:
 
 This projected volume is different from the default mount path, so an application must be configured to read the token from the custom location. That is useful when a sidecar or helper process needs a token for a particular audience while the main application should not use the default client-library path. The more specific the mount, audience, and lifetime are, the smaller the blast radius if that particular file is exposed.
 
-Historically, before Kubernetes 1.24 stopped automatically creating ServiceAccount token Secrets, clusters often contained long-lived token Secrets for each ServiceAccount. Those tokens were convenient but risky because a copied Secret could remain valid until someone deleted it or rotated signing keys. In current clusters, `kubectl create token` creates a short-lived token through TokenRequest rather than reviving the old automatic Secret pattern.
+Historically, before Kubernetes 1.24 stopped automatically creating ServiceAccount token Secrets, clusters often contained long-lived token Secrets for each ServiceAccount. Those tokens were convenient but risky because a copied Secret could remain valid until someone deleted it or rotated signing keys. In Kubernetes 1.35 you should not recreate that legacy Secret pattern for new workloads.
 
-```bash
-# Old way (deprecated) - DO NOT use for persistent credential distribution
-kubectl create token my-app-sa    # Creates short-lived token instead
+```text
+# Legacy credential model (deprecated — do not use in 1.35)
+# Pre-1.24 clusters auto-created Secrets of type:
+#   kubernetes.io/service-account-token
+# Manually creating that Secret type revives long-lived bearer credentials.
 ```
 
-The comment in that block matters: the command is not deprecated, but using it as a replacement for old persistent token Secrets is the bad habit. It is a debugging and integration tool, not a reason to paste bearer tokens into configuration repositories. If a human asks for a ServiceAccount token that never expires, your design review should pause and ask what system is going to store, rotate, scope, and audit that credential.
+For workstation debugging, `kubectl create token` is the current approach. It calls the TokenRequest API and returns a short-lived bearer token. It is not a substitute for designing external identity, but it is the right tool when you need to reproduce an authorization problem with `curl` from outside the Pod.
+
+```bash
+# Current debugging approach (TokenRequest API — short-lived token)
+kubectl create token my-app-sa
+
+# Optional expiration for manual tests
+kubectl create token my-app-sa --duration=1h
+```
+
+Using `kubectl create token` as a replacement for old persistent token Secrets is the bad habit—not the command itself. It is a debugging and integration tool, not a reason to paste bearer tokens into configuration repositories. If a human asks for a ServiceAccount token that never expires, your design review should pause and ask what system is going to store, rotate, scope, and audit that credential.
 
 Which approach would you choose here and why: a batch Job needs to list ConfigMaps in its own namespace for two minutes at startup, while a web frontend in the same namespace never calls the API? A strong answer creates a custom ServiceAccount for the Job, binds only the required read permission, and disables token automounting for the frontend. Sharing `default` between them solves the YAML quickly and creates a broader identity than either workload needs.
 
@@ -416,7 +434,7 @@ For CKAD exam speed, memorize a compact path: ServiceAccount object, Pod templat
 
 ## Did You Know?
 
-- Kubernetes 1.24 stopped automatically creating long-lived ServiceAccount token Secrets, which is why modern ServiceAccounts commonly show `SECRETS` as zero even though Pods still receive projected tokens.
+- Kubernetes 1.24 stopped automatically creating long-lived ServiceAccount token Secrets and removed the `SECRETS` column from `kubectl get serviceaccount`, so `Tokens: <none>` on describe does not mean Pods receive no projected tokens.
 - A ServiceAccount username is formatted as `system:serviceaccount:<namespace>:<name>`, and that exact subject string is what you often see in authorization errors and audit events.
 - Bound ServiceAccount tokens became the default projection model before Kubernetes 1.35, so current clusters expect token rotation and expiration rather than static token files that live forever.
 - The TokenRequest API supports audiences, which lets one ServiceAccount request a token meant for the Kubernetes API and a separate token meant for a different trusted recipient.
@@ -514,6 +532,12 @@ Success criteria:
 - [ ] Debug an in-cluster API failure by separating token projection from RBAC authorization.
 - [ ] Design a least-privilege Role and RoleBinding that grant only namespace-scoped Pod reads.
 - [ ] Diagnose token exposure risk by proving that an API-free Pod has no automatic ServiceAccount token mount.
+
+## Learner check
+
+> Engineers who learned Kubernetes before 1.24 often expect a `SECRETS` column on `kubectl get serviceaccount`. That column was removed in Kubernetes 1.24+, so current clusters—including 1.35—list only `NAME` and `AGE`.
+
+Before you move on, explain why `kubectl describe sa default` can show `Tokens: <none>` while a Pod using that ServiceAccount still has a bearer token under `/var/run/secrets/kubernetes.io/serviceaccount/token`. A solid answer separates the ServiceAccount object (no legacy auto-created token Secret) from Pod admission and kubelet token projection (bound, short-lived JWT mounted at runtime).
 
 ## Sources
 

--- a/src/content/docs/k8s/ckad/part4-environment/module-4.6-crds.md
+++ b/src/content/docs/k8s/ckad/part4-environment/module-4.6-crds.md
@@ -273,9 +273,14 @@ kubectl get crd myresource.example.com
 `kubectl explain` works for CRDs when the CRD publishes a structural schema. That makes it a fast exam tool because it can tell you accepted field paths without opening documentation in another window. If `kubectl explain database.spec` returns useful field information, the CRD author has exposed enough schema for the client to navigate the custom object shape.
 
 ```bash
-# Works for CRDs too (if installed)
+# Works for installed CRDs too, after discovery refreshes
+until kubectl explain database >/dev/null 2>&1; do sleep 1; done
 kubectl explain database
+
+until kubectl explain database.spec >/dev/null 2>&1; do sleep 1; done
 kubectl explain database.spec
+
+until kubectl explain certificate.spec.secretName >/dev/null 2>&1; do sleep 1; done
 kubectl explain certificate.spec.secretName
 ```
 
@@ -488,13 +493,14 @@ kubectl get ws my-blog -o yaml
 kubectl patch website my-blog --type=merge -p '{"spec":{"replicas":2}}'
 ```
 
-Finally, confirm discovery and schema visibility. `kubectl api-resources` shows the new resource group, namespaced status, kind, and short names. `kubectl explain` reads the published schema and helps you navigate the custom object fields without leaving the terminal.
+Finally, confirm discovery and schema visibility. `kubectl api-resources` shows the new resource group, namespaced status, kind, and short names. The safest discovery habit is to wait for the CRD to become established, then retry `kubectl explain` until discovery can resolve the custom resource. `kubectl explain` reads the published schema and helps you navigate the custom object fields without leaving the terminal.
 
 ```bash
 # Check API resources
 kubectl api-resources | grep example.com
 
 # Use explain
+until kubectl explain website >/dev/null 2>&1; do sleep 1; done
 kubectl explain website
 ```
 
@@ -688,6 +694,7 @@ EOF
 
 kubectl wait --for condition=established --timeout=60s crd/websites.example.com
 kubectl api-resources | grep example.com
+until kubectl explain website.spec >/dev/null 2>&1; do sleep 1; done
 kubectl explain website.spec
 ```
 </details>
@@ -732,7 +739,7 @@ kubectl get ws my-blog -o yaml
 
 - [ ] List every CRD installed in the cluster and count them.
 - [ ] Describe `certificates.cert-manager.io` if cert-manager is installed, otherwise describe the first available CRD.
-- [ ] Filter API resources for CRD-backed groups and note which ones are namespaced.
+- [ ] List CRD definitions with their groups, kinds, and scopes, then filter API resources for one known extension group.
 
 <details>
 <summary>Solution</summary>
@@ -757,11 +764,14 @@ kubectl get crd -o name | head -1 | xargs kubectl describe
 # List all API resources
 kubectl api-resources
 
-# Filter for a specific group
-kubectl api-resources | grep networking
+# Filter for a specific built-in API group
+kubectl api-resources --api-group=networking.k8s.io
 
-# Show only CRD-backed resources (custom)
-kubectl api-resources | grep -v "^NAME" | grep "\."
+# Show only CRD definitions with CRD-specific metadata
+kubectl get crd -o custom-columns=NAME:.metadata.name,GROUP:.spec.group,KIND:.spec.names.kind,SCOPE:.spec.scope
+
+# Show resources from the extension group created earlier in the lab
+kubectl api-resources --api-group=example.com
 ```
 </details>
 
@@ -897,7 +907,9 @@ EOF
 kubectl wait --for condition=established --timeout=60s crd/configs.drill.example.com
 
 # Use explain
+until kubectl explain config >/dev/null 2>&1; do sleep 1; done
 kubectl explain config
+until kubectl explain config.spec >/dev/null 2>&1; do sleep 1; done
 kubectl explain config.spec
 
 # Cleanup
@@ -949,7 +961,7 @@ EOF
 # Verify CRD is established
 kubectl wait --for condition=established --timeout=60s crd/caches.drill.example.com
 
-# 2. Try to apply an invalid CR (memoryLimit is a string instead of integer, and too small)
+# 2. Try to apply an invalid CR (memoryLimit is a string instead of an integer)
 cat << 'EOF' | kubectl apply -f -
 apiVersion: drill.example.com/v1
 kind: Cache
@@ -988,6 +1000,12 @@ kubectl delete crd caches.drill.example.com
 - [ ] You can create and remove the drill CRDs without leaving custom resources behind.
 - [ ] You can describe when a CRD is unnecessary because a ConfigMap, Secret, or built-in Kubernetes resource is simpler.
 
+## Learner check
+
+> The safest discovery habit is to wait for the CRD to become established, then retry `kubectl explain` until discovery can resolve the custom resource.
+
+Before moving on, explain why the CRD's Established condition and client-side discovery refresh are related but separate readiness checks. Your answer should mention what the API server has accepted, what `kubectl explain` still needs to discover, and how a retry avoids a misleading failure immediately after CRD creation.
+
 ## Sources
 
 - https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/
@@ -1001,7 +1019,7 @@ kubectl delete crd caches.drill.example.com
 - https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/
 - https://kubernetes.io/docs/concepts/architecture/controller/
 - https://cert-manager.io/docs/concepts/certificate/
-- https://gateway-api.sigs.k8s.io/concepts/api-overview/
+- https://gateway-api.sigs.k8s.io/docs/concepts/api-overview/
 - https://prometheus-operator.dev/docs/getting-started/introduction/
 
 ## Next Module


### PR DESCRIPTION
## CKAD wave 4 — part4-environment cross-family R1 remediation → finalize-to-done

Back-catalog review-first pass for part4-environment (6 modules). Cross-family R1 (cursor `--model
auto` + codex gpt-5.5, both ran labs/CRDs on real kind v1.35.0 clusters); every finding
ground-checked against the live file by the orchestrator; fixes self-verified vs the diff.

**4.3-resources reviewed APPROVE 4.7/5 with ZERO findings** (codex ran all 6 lab tasks; OOMKilled/
exit-137, QoS classes, LimitRange defaults all verified) → finalized as-is, not in this PR.

| Module | Verdict | Real findings fixed | Fixer |
|---|---|---|---|
| 4.1-configmaps | NEEDS_CHANGES | **P1** `kubectl delete pod drillN cm drillN` parses `cm` as a pod name → ConfigMaps never deleted → slash notation `pod/drillN cm/drillN` (4 drills); P2 added the directory + declarative-YAML lab steps the LO promised | cursor |
| 4.2-secrets | APPROVE_WITH_NITS 4.6/5 | `set env` rotation could be over-generalized → kubelet-native path (`secretKeyRef.name`/volume `secretName`) set as the default + inline "application-side only" caveat; `-n secret-lab` added to the earlier rotation snippet | cursor |
| 4.4-securitycontext | NEEDS_CHANGES | `kubectl exec -- id` missing pod name (errors) → `kubectl exec secure-pod -- ...`; low-port teaching inconsistency (drops all caps yet binds :80) reconciled with `ip_unprivileged_port_start`/`NET_BIND_SERVICE` note | cursor |
| 4.5-serviceaccounts | APPROVE_WITH_NITS 4.7/5 | stale `SECRETS` column (removed in 1.24+) → current `NAME`/`AGE` output; `# Old way (deprecated)` mislabel on the current `kubectl create token` → reframed (command is current; misusing it as a secret factory is the anti-pattern) | cursor |
| 4.6-crds | NEEDS_CHANGES 3.8/5 | **P1** `kubectl explain <cr>.spec` races CRD establishment → `kubectl wait --for condition=established` + `until kubectl explain` retry across all CRD explains; `api-resources | grep "."` (matched built-ins) → `kubectl get crd -o custom-columns`; stale Gateway API URL (404) → `/docs/` path (verified 200) | codex (draft) |

All verify `passed: true`, tier T0. Protected visual assets preserved. `chore(content):` only.

## Learner check

> The default CKAD rotation path is kubelet-native: change the Secret reference in the Pod template so the Deployment template hash changes and new Pods roll out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
