### PR TITLE
chore(content): CKS batch 1 (part0/part1) R1 remediation — 0.1, 1.1, 1.5

### DIFF
--- a/src/content/docs/k8s/cks/part0-environment/module-0.1-cks-overview.md
+++ b/src/content/docs/k8s/cks/part0-environment/module-0.1-cks-overview.md
@@ -7,7 +7,7 @@ sidebar:
 lab:
   id: cks-0.1-cks-overview
   url: https://killercoda.com/kubedojo/scenario/cks-0.1-cks-overview
-  duration: "30 min"
+  duration: "25 min"
   difficulty: advanced
   environment: kubernetes
 ---
@@ -95,13 +95,13 @@ The CKS exam is performance-based, delivered online, and solved on the command l
 |--------|---------|
 | **Duration** | 2 hours (120 minutes) |
 | **Format** | Performance-based (CLI tasks) |
-| **Questions** | 15-20 tasks |
+| **Questions** | ~17 tasks (per current LF/Killer.sh simulator; verify LF Important Instructions before booking) |
 | **Passing Score** | 67% |
 | **Prerequisite** | CKA certification (passed before attempting CKS) |
 | **Environment** | Linux command line, Kubernetes clusters, current LF-published version |
 | **Validity** | 2 years |
 
-The table is more than trivia because every row implies a behavior. A two-hour window for roughly 15-20 tasks means you must budget time, record skipped work, and avoid turning one hard problem into the reason you lose several easier ones. A 67% passing score means partial progress matters; if you can fix the RBAC part of a question but not the audit policy part, you should still do the fix you can prove.
+The table is more than trivia because every row implies a behavior. A two-hour window for roughly seventeen performance tasks means you must budget time, record skipped work, and avoid turning one hard problem into the reason you lose several easier ones. Task counts can shift when the Linux Foundation updates the simulator, so treat the Important Instructions page as the source of truth close to your exam date. A 67% passing score means partial progress matters; if you can fix the RBAC part of a question but not the audit policy part, you should still do the fix you can prove.
 
 The prerequisite row should also shape your readiness test. The Linux Foundation states that CKS candidates must have taken and passed CKA before attempting CKS, and the CKS certification is designed for accomplished Kubernetes practitioners. That wording does not mean you must be a full-time security engineer, but it does mean the exam assumes CKA-level command speed while it evaluates security-specific tasks.
 
@@ -267,14 +267,14 @@ The three-pass strategy below is a time-management model, not a rigid exam scrip
 │  ├── Create NetworkPolicy                                  │
 │  ├── Apply existing AppArmor profile                       │
 │  ├── Fix obvious RBAC issue                                │
-│  ├── Set runAsNonRoot: true                                │
-│  └── Enable audit logging                                  │
+│  └── Set runAsNonRoot: true                                │
 │                                                             │
 │  PASS 2: Tool-Based Tasks (4-6 min each)                   │
 │  ├── Scan image with Trivy, fix vulnerabilities            │
 │  ├── Create seccomp profile                                │
 │  ├── Configure Pod Security Admission                       │
-│  └── Run kube-bench, fix findings                          │
+│  ├── Run kube-bench, fix findings                          │
+│  └── Configure audit policy (when task supplies manifest)  │
 │                                                             │
 │  PASS 3: Complex Scenarios (7+ min each)                   │
 │  ├── Write custom Falco rule                               │
@@ -355,7 +355,7 @@ The decision rule is therefore straightforward: choose the path that matches the
 
 ## Did You Know?
 
-- **CKS was announced as generally available on November 17, 2020.** The Linux Foundation and CNCF created it to validate practical Kubernetes security skills after the ecosystem already had administrator and application-developer exams.
+- **CKS was announced as generally available on November 17, 2020.** The [CNCF GA announcement](https://www.cncf.io/announcements/2020/11/17/kubernetes-security-specialist-certification-now-available/) describes the launch as a performance-based exam for securing container workloads and Kubernetes platforms across build, deployment, and runtime.
 
 - **The CKS passing score is 67%, and the certification is valid for 2 years.** That combination means the exam expects practical competence, but it also expects candidates to refresh because Kubernetes security tooling and exam environments change over time.
 
@@ -459,13 +459,13 @@ if [ "$NETPOL_COUNT" -eq 0 ]; then
   echo "No NetworkPolicies found. Pods may communicate freely unless another control enforces policy."
 fi
 
-# Step 3: Check for pods running as root
+# Step 3: Check Pod-level runAsNonRoot (container-level fields are covered in later modules)
 echo "=== Pods Running as Root ==="
 kubectl get pods -A -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}: runAsNonRoot={.spec.securityContext.runAsNonRoot}{"\n"}{end}' | head -10
 
-# Step 4: Check for privileged containers
+# Step 4: List privileged containers with namespace/Pod/container context (positives only)
 echo "=== Privileged Containers ==="
-kubectl get pods -A -o jsonpath='{range .items[*]}{range .spec.containers[*]}{.name}: privileged={.securityContext.privileged}{"\n"}{end}{end}' 2>/dev/null | grep -v "privileged=$" | head -10
+kubectl get pods -A -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}/{range .spec.containers[*]}{.name}: privileged={.securityContext.privileged}{"\n"}{end}{end}' | grep 'privileged=true'
 
 # Step 5: Check Pod Security Admission labels
 echo "=== Pod Security Standards ==="
@@ -487,7 +487,7 @@ The NetworkPolicy count is a starting point, not a complete policy audit. A clus
 
 The `runAsNonRoot` query checks the Pod-level security context, which is only one place the setting can appear. Container-level security context may override or complement Pod-level settings, and Pod Security Admission may enforce restrictions even when a manifest omits explicit fields. The point of this first pass is to notice unset posture, then learn the deeper rules in workload-hardening modules.
 
-The privileged-container query is deliberately narrow because privileged mode is one of the clearest escalation signals. If output appears, your next step is to inspect the full Pod manifest and determine whether host namespaces, host paths, capabilities, or ServiceAccount permissions make the risk worse. If output is empty, you still need other controls, because "not privileged" is not the same as "least privilege."
+The privileged-container query prints `namespace/pod/container: privileged=true` lines only, so you can record the exact context a CKS task would ask you to inspect next. If output appears, inspect the full Pod manifest and determine whether host namespaces, host paths, capabilities, or ServiceAccount permissions make the risk worse. If output is empty, you still need other controls, because "not privileged" is not the same as "least privilege."
 
 The Pod Security Admission label check tells you whether namespaces advertise an enforcement level such as `baseline` or `restricted`. Missing labels are common in practice clusters, and they give you a concrete improvement path for later modules. The labels are also a reminder that CKS often tests namespace-level policy and workload-level fields together.
 
@@ -515,8 +515,13 @@ Success criteria:
 
 ---
 
+## Learner check
+
+> A two-hour window for roughly seventeen performance tasks means you must budget time, record skipped work, and avoid turning one hard problem into the reason you lose several easier ones. Task counts can shift when the Linux Foundation updates the simulator, so treat the Important Instructions page as the source of truth close to your exam date.
+
 ## Sources
 
+- https://www.cncf.io/announcements/2020/11/17/kubernetes-security-specialist-certification-now-available/
 - https://training.linuxfoundation.org/certification/certified-kubernetes-security-specialist/
 - https://docs.linuxfoundation.org/tc-docs/certification/faq-cka-ckad-cks
 - https://docs.linuxfoundation.org/tc-docs/certification/important-instructions-cks

--- a/src/content/docs/k8s/cks/part1-cluster-setup/module-1.1-network-policies.md
+++ b/src/content/docs/k8s/cks/part1-cluster-setup/module-1.1-network-policies.md
@@ -703,13 +703,16 @@ kubectl create namespace exercise
 kubectl label namespace exercise name=exercise
 
 kubectl run web --image=curlimages/curl -n exercise --labels="tier=web" --command -- sleep 3600
-kubectl run api --image=curlimages/curl -n exercise --labels="tier=api" --command -- sleep 3600
-kubectl run db --image=nginx -n exercise --labels="tier=db" --port=80
+kubectl run api --image=nginx -n exercise --labels="tier=api" --expose --port=80
+kubectl run api-client --image=curlimages/curl -n exercise --labels="tier=api" --command -- sleep 3600
+kubectl run db --image=nginx -n exercise --labels="tier=db" --expose --port=80
 
 kubectl wait --for=condition=Ready pod --all -n exercise
 ```
 
-Before you apply any policy, test a few paths so you have a baseline. In most clusters, `web` can reach `api`, `api` can reach `db`, and `web` can reach `db` because the namespace starts open. If your cluster already has admission automation that injects default-deny policies, note that difference and continue by inspecting the existing policies before creating the lab manifests.
+The `api` and `db` pods run nginx and are created with `--expose` so their pod names resolve through cluster DNS and port 80 accepts HTTP connections. The `web`, `api-client`, and `metrics` pods stay as curl clients that initiate connections only. Use `api-client` when you need to test outbound traffic from the `tier=api` label set, because the `api` nginx pod listens rather than curls.
+
+Before you apply any policy, test a few paths so you have a baseline. In most clusters, `web` can reach `api`, `api-client` can reach `db`, and `web` can reach `db` because the namespace starts open. If your cluster already has admission automation that injects default-deny policies, note that difference and continue by inspecting the existing policies before creating the lab manifests.
 
 ### Task 1: Establish a Baseline
 
@@ -731,10 +734,10 @@ spec:
 ```
 </details>
 
-Verify that the `api` pod can no longer reach the `db` pod:
+Verify that a pod labeled `tier=api` can no longer reach the `db` pod:
 
 ```bash
-kubectl exec -n exercise api -- curl -s --connect-timeout 2 db || echo "Blocked (expected)"
+kubectl exec -n exercise api-client -- curl -s --connect-timeout 2 db || echo "Blocked (expected)"
 ```
 
 This failure is the desired baseline. If the connection still works, do not continue adding allow rules yet. Check whether the CNI enforces NetworkPolicies, whether the policy exists in the `exercise` namespace, and whether the pods are actually in that namespace. Debugging a failed deny is much easier before you add more policies that can obscure the result.
@@ -803,7 +806,7 @@ Verify your policies:
 
 ```bash
 kubectl exec -n exercise web -- curl -s --connect-timeout 2 api  # Should work
-kubectl exec -n exercise api -- curl -s --connect-timeout 2 db   # Should work
+kubectl exec -n exercise api-client -- curl -s --connect-timeout 2 db   # Should work
 kubectl exec -n exercise web -- curl -s --connect-timeout 2 db   # Should fail
 ```
 
@@ -883,10 +886,10 @@ kubectl exec -n exercise metrics -- curl -s --connect-timeout 2 db  # Should wor
 
 ### Success Criteria
 
-- [ ] The `exercise` namespace exists and contains `web`, `api`, `db`, and `metrics` pods with the intended tier labels.
+- [ ] The `exercise` namespace exists and contains `web`, `api`, `api-client`, `db`, and `metrics` pods with the intended tier labels.
 - [ ] A default-deny ingress policy selects all pods in the `exercise` namespace.
 - [ ] `web` can reach `api` on port 80 after the allow policy is applied.
-- [ ] `api` can reach `db` on port 80 after the allow policy is applied.
+- [ ] A pod labeled `tier=api` can reach `db` on port 80 after the allow policy is applied.
 - [ ] `web` cannot reach `db` directly, proving the chained design blocks tier skipping.
 - [ ] The corrected metrics policy selects `tier=db` as the target and allows `tier=metrics` as the source.
 
@@ -900,6 +903,14 @@ kubectl delete namespace exercise
 
 ---
 
+## Learner check
+
+> The `api` and `db` pods run nginx and are created with `--expose` so their pod names resolve through cluster DNS and port 80 accepts HTTP connections.
+
+Before you continue, explain why a curl client pod cannot substitute for an nginx target pod in this lab. A useful answer names both missing pieces: without a listener on port 80 the connection is refused, and without `--expose` the short DNS names `api` and `db` do not resolve for other pods in the namespace.
+
+---
+
 ## Sources
 
 - https://kubernetes.io/docs/concepts/services-networking/network-policies/
@@ -909,7 +920,7 @@ kubectl delete namespace exercise
 - https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 - https://kubernetes.io/docs/tasks/debug/debug-application/debug-service/
 - https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/
-- https://docs.tigera.io/calico/latest/network-policy/get-started/kubernetes-policy/kubernetes-policy
+- https://docs.tigera.io/calico/latest/network-policy/get-started/kubernetes-policy
 - https://docs.cilium.io/en/stable/network/kubernetes/policy/
 - https://docs.cilium.io/en/stable/security/network/encryption/
 - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html

--- a/src/content/docs/k8s/cks/part1-cluster-setup/module-1.5-gui-security.md
+++ b/src/content/docs/k8s/cks/part1-cluster-setup/module-1.5-gui-security.md
@@ -187,6 +187,8 @@ kubectl proxy
 
 Port-forwarding is also narrow, but it targets one service port instead of using the API server proxy path. It is useful when a lab or troubleshooting workflow expects HTTPS directly on a local port. The tradeoff is that operators must manage certificates and browser warnings more often, and a careless bind address can expose the local forward beyond the workstation. Keep the binding local unless you have a deliberate reason and a compensating control.
 
+`kubectl port-forward` tunnels through the kubelet on the node, so it can reach dashboard pods even when a CNI-enforced NetworkPolicy sets `ingress: []` — unlike `kubectl proxy`, which routes traffic from the API server as a client on the pod network and is blocked by that same deny-all policy. That distinction matters in labs and audits where you harden dashboard pods with deny-all ingress and then wonder why the proxy URL times out.
+
 For exam thinking, classify proxy and port-forwarding as temporary access paths rather than deployment architectures. They are initiated by an authenticated user, they end when the process exits, and they do not create a standing external endpoint. That makes them excellent defaults for emergency inspection. Their weakness is operational friction: non-technical users may struggle to start them, and teams sometimes work around that friction by publishing the dashboard permanently.
 
 ```bash
@@ -362,6 +364,8 @@ kubectl patch deployment kubernetes-dashboard -n kubernetes-dashboard \
   --type='json' \
   -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--enable-skip-login=false"}]'
 ```
+
+Dashboard v2.0.0+ disables skip login by default; the patch above is defense-in-depth against legacy manifests that explicitly set `--enable-skip-login=true`.
 
 Ingress is the one exposure method that can be acceptable in tightly controlled environments, but only when it is treated as a privileged administrative endpoint. TLS protects data in transit, but TLS alone does not prove that the client should see the login page. Mutual TLS, VPN restrictions, identity-aware proxies, and controller-level allowlists reduce who can reach the dashboard before token authentication is even evaluated.
 
@@ -686,11 +690,11 @@ TLS protects transport confidentiality, but it does not restrict who can reach t
 
 ## Hands-On Exercise
 
-In this exercise you will harden a Kubernetes Dashboard deployment using the same sequence you would use during a review: install the application, create a constrained identity, disable anonymous entry, restrict network reachability, generate a short-lived token, and access the UI through a local proxy. The commands are intentionally compact so you can focus on the security decisions behind each object rather than on typing a long manifest from memory.
+In this exercise you will harden a Kubernetes Dashboard deployment using the same sequence you would use during a review: install the application, create a constrained identity, disable anonymous entry, restrict network reachability, generate a short-lived token, and access the UI through a local port-forward. The commands are intentionally compact so you can focus on the security decisions behind each object rather than on typing a long manifest from memory.
 
 - [ ] Diagnose the current Dashboard attack path by identifying the Service, ServiceAccount, and any binding that could grant privilege escalation.
 - [ ] Implement read-only RBAC, short-lived ServiceAccount token access, and NetworkPolicy controls for the Dashboard namespace.
-- [ ] Compare the resulting local proxy access with NodePort exposure and explain why the proxy has a smaller network attack surface.
+- [ ] Compare the resulting local port-forward access with NodePort exposure and explain why the port-forward has a smaller network attack surface.
 - [ ] Design a rollback and incident response note that lists which binding, token, Service, and deployment setting you would change during compromise.
 - [ ] Evaluate whether the native Dashboard should remain installed after the lab or be replaced by client-side alternatives for routine inspection.
 
@@ -732,7 +736,8 @@ subjects:
   namespace: kubernetes-dashboard
 EOF
 
-# Step 4: Disable skip button
+# Step 4: Disable skip button (defense-in-depth — Dashboard v2.0.0+ disables it by default,
+# but legacy manifests may set --enable-skip-login=true explicitly)
 kubectl patch deployment kubernetes-dashboard -n kubernetes-dashboard \
   --type='json' \
   -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--enable-skip-login=false"}]'
@@ -750,15 +755,15 @@ spec:
       k8s-app: kubernetes-dashboard
   policyTypes:
   - Ingress
-  ingress: []  # Deny all ingress - only kubectl proxy works
+  ingress: []  # Deny all pod ingress — blocks apiserver proxy; port-forward via kubelet still works
 EOF
 
 # Step 6: Get token for readonly user
 kubectl create token dashboard-readonly -n kubernetes-dashboard
 
-# Step 7: Access via proxy
-kubectl proxy &
-echo "Access dashboard at: http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/"
+# Step 7: Access via port-forward (kubelet tunnel bypasses pod ingress NetworkPolicy)
+kubectl port-forward -n kubernetes-dashboard svc/kubernetes-dashboard 8443:443 &
+echo "Access dashboard at https://localhost:8443 (paste the token from Step 6)"
 
 # Cleanup
 kubectl delete namespace kubernetes-dashboard
@@ -771,18 +776,24 @@ Start with the Service because it tells you whether the dashboard is reachable t
 
 <details>
 <summary>Solution guidance for the hardening task</summary>
-The restricted ClusterRole should allow only the resource types needed for viewing and should avoid mutation verbs. The token should come from `kubectl create token` rather than a long-lived Secret unless the lab specifically asks you to audit the old behavior. The NetworkPolicy should select the dashboard pods and deny or narrowly allow ingress, depending on whether you are using proxy-only access or a controlled administrative source.
+The restricted ClusterRole should allow only the resource types needed for viewing and should avoid mutation verbs. The token should come from `kubectl create token` rather than a long-lived Secret unless the lab specifically asks you to audit the old behavior. The NetworkPolicy should select the dashboard pods and deny or narrowly allow ingress; when ingress is fully denied, verify access with `kubectl port-forward` rather than `kubectl proxy`.
 </details>
 
 <details>
 <summary>Solution guidance for the exposure comparison task</summary>
-A local proxy requires a user with kubeconfig access to initiate the path, while NodePort opens a service port on every node. That difference changes who can even try to reach the login page. Your explanation should mention that RBAC still matters after login, but the proxy greatly reduces unauthenticated network probing compared with a routable NodePort.
+A local port-forward requires a user with kubeconfig access to initiate the path, while NodePort opens a service port on every node. That difference changes who can even try to reach the login page. Your explanation should mention that RBAC still matters after login, but the port-forward greatly reduces unauthenticated network probing compared with a routable NodePort, and that deny-all ingress NetworkPolicy blocks `kubectl proxy` but not kubelet-based port-forwarding.
 </details>
 
 <details>
 <summary>Success criteria</summary>
 The dashboard deployment becomes available, anonymous login is not accepted, a short-lived read-only token is used for access, direct ingress to the dashboard pods is denied or tightly scoped, and your notes identify the exact objects to change during an incident. You should also be able to explain why deleting the dashboard entirely may be the best final state for a production cluster.
 </details>
+
+## Learner check
+
+> `kubectl port-forward` tunnels through the kubelet on the node, so it can reach dashboard pods even when a CNI-enforced NetworkPolicy sets `ingress: []` — unlike `kubectl proxy`, which routes traffic from the API server as a client on the pod network and is blocked by that same deny-all policy.
+
+Before you move on, explain why Step 7 uses port-forward after Step 5 applies deny-all ingress. A solid answer names the kubelet tunnel path, contrasts it with the API server proxy path, and states that both still require kubeconfig access and token login before the dashboard can act on your behalf.
 
 ## Sources
 


### PR DESCRIPTION
## CKS batch 1 — part0/part1 cross-family R1 remediation (3 of the wider CKS sweep)

First merged batch of the CKS (security) track review-first sweep, run with **wide parallel fan-out**
(8+ dispatches concurrent across cursor/codex/gemini pools). Each finding ground-checked against the
live file by the orchestrator; fixes verified T0.

| Module | Verdict | Real findings fixed | Fixer |
|---|---|---|---|
| 0.1-cks-overview | NEEDS_CHANGES 4.4/5 | Task-4 jsonpath emitted container-name only → path-aware positives-only query; audit-logging mis-listed as a 1-3min quick win; "15-20 tasks"→~17; uncited GA date; duration | cursor |
| 1.1-network-policies | NEEDS_CHANGES | **P1** lab targets had no listener + no Services (curl/DNS failed) → nginx + `--expose`; dead Calico citation (404) → verified-200 URL | cursor |
| 1.5-gui-security | NEEDS_CHANGES 3/5 | **P1** NetworkPolicy `ingress: []` also drops the apiserver-routed `kubectl proxy` (comment was wrong) → switched verify to `kubectl port-forward`; skip-login defense-in-depth note | cursor |

All 3 verify `passed: true`, tier T0. `chore(content):` only. (Wider CKS sweep continues — part0/part1
remaining: 0.2, 0.3, 0.4, 1.2, 1.3 briefed; 1.4 needs genuine expansion; parts 2-6 ahead.)

## Learner check

> The rule becomes OR logic and permits too many sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)
