### PR TITLE
chore(content): CKS batch 2 (part0/part1) R1 remediation — 0.2, 0.3, 0.4, 1.2, 1.3

### DIFF
--- a/src/content/docs/k8s/cks/part0-environment/module-0.2-security-lab.md
+++ b/src/content/docs/k8s/cks/part0-environment/module-0.2-security-lab.md
@@ -7,7 +7,7 @@ sidebar:
 lab:
   id: cks-0.2-security-lab
   url: https://killercoda.com/kubedojo/scenario/cks-0.2-security-lab
-  duration: "35 min"
+  duration: "45-60 min"
   difficulty: advanced
   environment: kubernetes
 ---
@@ -165,6 +165,30 @@ EOF
 
 # Create the cluster
 kind create cluster --name cks-lab --config kind-cks.yaml
+
+# Prove audit logging before installing security tools
+kubectl wait --for=condition=Ready node --all --timeout=120s
+
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: audit-test
+  namespace: default
+spec:
+  containers:
+  - name: pause
+    image: registry.k8s.io/pause:3.10
+EOF
+
+kubectl wait --for=condition=Ready pod/audit-test --timeout=60s
+sleep 2
+
+# Host-mounted audit log (kind maps /var/log/kubernetes inside the node to ./audit-logs)
+grep '"resource":"pods"' audit-logs/audit.log | tail -5
+grep '"verb":"create"' audit-logs/audit.log | grep audit-test | tail -3
+
+kubectl delete pod audit-test --wait=false
 ```
 
 The audit policy is intentionally small because this is a lab, not an enterprise logging architecture. It records metadata for Secrets and ConfigMaps, request bodies for Pods, suppresses noisy kube-proxy watch traffic, and drops the earliest stage to reduce duplicate records. That gives you enough signal to practice reading audit output without filling the host directory with every watch event produced by normal cluster operation.
@@ -249,8 +273,8 @@ Scanner setup has two separate success conditions. The binary must run, and the 
 # Install Trivy CLI
 # On Ubuntu/Debian
 sudo apt-get install wget apt-transport-https gnupg lsb-release -y
-wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | sudo apt-key add -
-echo deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main | sudo tee /etc/apt/sources.list.d/trivy.list
+wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | sudo gpg --dearmor -o /usr/share/keyrings/trivy.gpg
+echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/trivy.list
 sudo apt-get update
 sudo apt-get install trivy -y
 
@@ -318,9 +342,8 @@ kubectl wait --for=condition=complete job/kube-bench --timeout=120s
 # View results
 kubectl logs job/kube-bench
 
-# For detailed output, run interactively on control plane node
-# Download and run kube-bench directly
-curl -L https://github.com/aquasecurity/kube-bench/releases/download/v0.7.0/kube-bench_0.7.0_linux_amd64.tar.gz -o kube-bench.tar.gz
+# For detailed output on a kubeadm control-plane node (Linux amd64 shell — not a macOS laptop)
+curl -L https://github.com/aquasecurity/kube-bench/releases/download/v0.15.5/kube-bench_0.15.5_linux_amd64.tar.gz -o kube-bench.tar.gz
 tar -xvf kube-bench.tar.gz
 ./kube-bench run --targets=master
 ```
@@ -332,17 +355,8 @@ kubesec gives you a lightweight static analysis pass over manifests. It does not
 kubesec is also useful as a teaching mirror. When it flags a risky field, open the manifest and ask which Kubernetes control would prevent or mitigate that risk. A privileged container might be blocked by Pod Security Admission, a root process might be changed with `runAsNonRoot`, and missing resource settings might be addressed with LimitRange defaults or review policy. This turns one static finding into a map of possible controls.
 
 ```bash
-# Install kubesec
-# Binary installation
-wget https://github.com/controlplaneio/kubesec/releases/download/v2.14.0/kubesec_linux_amd64.tar.gz
-tar -xvf kubesec_linux_amd64.tar.gz
-sudo mv kubesec /usr/local/bin/
-
-# Or use Docker
-# docker run -i kubesec/kubesec scan /dev/stdin < deployment.yaml
-
-# Test kubesec
-cat <<EOF | kubesec scan /dev/stdin
+# Scan a manifest with Docker (primary on macOS/arm64 and when no local binary is installed)
+docker run --rm -i kubesec/kubesec:v2.14.0 scan /dev/stdin <<EOF
 apiVersion: v1
 kind: Pod
 metadata:
@@ -354,6 +368,25 @@ spec:
     securityContext:
       runAsUser: 0
 EOF
+
+# Optional binary install — match host OS and architecture (uname -m)
+ARCH=$(uname -m)
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+case "${OS}-${ARCH}" in
+  linux-x86_64|linux-amd64)
+    KUBESEC_URL=https://github.com/controlplaneio/kubesec/releases/download/v2.14.0/kubesec_linux_amd64.tar.gz ;;
+  linux-aarch64|linux-arm64)
+    KUBESEC_URL=https://github.com/controlplaneio/kubesec/releases/download/v2.14.0/kubesec_linux_arm64.tar.gz ;;
+  darwin-x86_64|darwin-amd64)
+    KUBESEC_URL=https://github.com/controlplaneio/kubesec/releases/download/v2.14.0/kubesec_darwin_amd64.tar.gz ;;
+  darwin-arm64|darwin-aarch64)
+    KUBESEC_URL=https://github.com/controlplaneio/kubesec/releases/download/v2.14.0/kubesec_darwin_arm64.tar.gz ;;
+  *)
+    echo "No binary for ${OS}-${ARCH}; use the Docker one-liner above" >&2; exit 1 ;;
+esac
+curl -L "$KUBESEC_URL" -o kubesec.tar.gz
+tar -xvf kubesec.tar.gz kubesec
+sudo mv kubesec /usr/local/bin/
 ```
 
 Static analysis is not a substitute for admission policy or runtime monitoring. It sees the document you give it, not every mutation that might occur before a pod is admitted, and not the behavior that happens after the container starts. Use kubesec to train your eyes, use admission and policy controls to block bad manifests, and use runtime tools to catch behavior that was not obvious from YAML alone.
@@ -366,16 +399,20 @@ The four tools now form a layered feedback loop. Trivy checks software supply ri
 
 AppArmor and seccomp are node-level mechanisms, so a Kubernetes API check alone is not enough. The API can accept a pod spec that references a profile, but the kubelet and container runtime still need the relevant support on the node where the pod lands. That scheduling detail matters: a custom profile on one node does not magically exist on every other node unless you place it there or automate distribution.
 
+On a kind cluster hosted from macOS or Windows, node paths such as `/sys/module/apparmor` and `/boot/config-$(uname -r)` live inside the kind node container, not on your laptop kernel. Run the checks below with `docker exec` against a kind node, or SSH to a kubeadm/Linux node and run the kubeadm branch there.
+
 ```bash
-# Check if AppArmor is enabled (on nodes)
-cat /sys/module/apparmor/parameters/enabled
-# Should output: Y
-
-# List loaded profiles
-sudo aa-status
-
-# Check if container runtime supports AppArmor
-# For containerd, it's enabled by default
+# kind: check AppArmor inside the control-plane node (not on the macOS host)
+CP_NODE=$(kind get nodes --name cks-lab 2>/dev/null | head -1)
+if [ -n "$CP_NODE" ]; then
+  docker exec "$CP_NODE" cat /sys/module/apparmor/parameters/enabled   # Should output: Y
+  docker exec "$CP_NODE" aa-status 2>/dev/null | head -20 || true
+else
+  # kubeadm/Linux node shell only
+  cat /sys/module/apparmor/parameters/enabled
+  sudo aa-status
+fi
+# containerd enables AppArmor support by default when the node kernel provides it
 ```
 
 AppArmor is easiest to understand as a named rule set loaded into the Linux kernel and then attached to a process. Kubernetes lets you request AppArmor behavior for a container, but the node must have the profile loaded before the workload can use it. In a lab, that means you should verify support on the node itself, then run a small pod experiment after you know the operating system layer is ready.
@@ -387,15 +424,17 @@ Seccomp is similar in spirit but different in what it restricts. Instead of nami
 The `RuntimeDefault` profile is a useful baseline because it gives you a safer default without managing a custom JSON file for every exercise. Custom profiles are still worth practicing because they teach the locality rule and the failure mode when a profile cannot be found. Start with `RuntimeDefault` when the learning goal is general hardening, then use a localhost profile when the learning goal is path placement and node-specific troubleshooting.
 
 ```bash
-# Check kernel seccomp support
-grep CONFIG_SECCOMP /boot/config-$(uname -r)
-# Should see: CONFIG_SECCOMP=y
-
-# Kubernetes default seccomp profile location
-ls /var/lib/kubelet/seccomp/
-
-# Create a test seccomp profile directory
-sudo mkdir -p /var/lib/kubelet/seccomp/profiles
+# kind: check seccomp support inside the node (host /boot/config on macOS is the wrong kernel)
+CP_NODE=$(kind get nodes --name cks-lab 2>/dev/null | head -1)
+if [ -n "$CP_NODE" ]; then
+  docker exec "$CP_NODE" sh -c 'grep CONFIG_SECCOMP /boot/config-$(uname -r) 2>/dev/null || zgrep CONFIG_SECCOMP /proc/config.gz 2>/dev/null'
+  docker exec "$CP_NODE" ls /var/lib/kubelet/seccomp/ 2>/dev/null || true
+else
+  # kubeadm/Linux node shell only
+  grep CONFIG_SECCOMP /boot/config-$(uname -r)   # Should see: CONFIG_SECCOMP=y
+  ls /var/lib/kubelet/seccomp/
+  sudo mkdir -p /var/lib/kubelet/seccomp/profiles
+fi
 ```
 
 Pause and predict: you create `profiles/audit-only.json` on the control-plane node, then schedule a pod onto a worker that references `localhost/profiles/audit-only.json`. What error path do you expect, and where would you look first? The useful answer is not just "the pod fails"; it is that the kubelet on the selected worker asks the runtime for a local profile path that does not exist on that worker.
@@ -519,16 +558,27 @@ echo ""
 
 # Check AppArmor
 echo "5. AppArmor:"
-if [ -f /sys/module/apparmor/parameters/enabled ]; then
+CP_NODE=$(kind get nodes --name cks-lab 2>/dev/null | head -1)
+if [ -n "$CP_NODE" ] && docker exec "$CP_NODE" test -f /sys/module/apparmor/parameters/enabled 2>/dev/null; then
+    docker exec "$CP_NODE" cat /sys/module/apparmor/parameters/enabled
+elif [ -f /sys/module/apparmor/parameters/enabled ]; then
     cat /sys/module/apparmor/parameters/enabled
 else
-    echo "   Check on cluster nodes"
+    echo "   Check inside cluster nodes (kind: docker exec; kubeadm: SSH to node)"
 fi
 echo ""
 
 # Check Audit Logging
 echo "6. Audit Logging:"
-kubectl get pods -n kube-system -l component=kube-apiserver -o yaml 2>/dev/null | grep -q "audit-log-path" && echo "   Enabled" || echo "   Check API server config"
+if kubectl get pods -n kube-system -l component=kube-apiserver -o yaml 2>/dev/null | grep -q "audit-log-path"; then
+    echo "   API server flags: Enabled"
+    if [ -f audit-logs/audit.log ]; then
+        echo "   Host log lines: $(wc -l < audit-logs/audit.log)"
+        grep '"resource":"pods"' audit-logs/audit.log | tail -1 || echo "   No pod events yet — create a test pod"
+    fi
+else
+    echo "   Check API server config"
+fi
 echo ""
 
 echo "=== Validation Complete ==="
@@ -591,11 +641,11 @@ The decision framework should also account for time. Before a timed practice ses
 
 These facts are worth remembering because they explain why the lab has several tools instead of one universal scanner.
 
-- **Falco was originally created in 2016** and later became a Cloud Native Computing Foundation project focused on runtime threat detection for cloud-native workloads.
+- **Falco was originally created in 2016** ([Sysdig release announcement, May 2016](https://sysdig.com/blog/sysdig-falco)) and later became a [CNCF](https://www.cncf.io/projects/falco/) project focused on runtime threat detection for cloud-native workloads.
 
 - **Trivy scans more than container images**; it can inspect filesystems, repositories, Kubernetes resources, and infrastructure-as-code inputs, which makes it useful before and after deployment.
 
-- **The CIS Kubernetes Benchmark includes more than 200 checks** across control-plane, etcd, node, policy, and managed-service areas, so kube-bench output needs triage rather than blind score chasing.
+- **The [CIS Kubernetes Benchmark](https://www.cisecurity.org/benchmark/kubernetes) includes more than 200 checks** across control-plane, etcd, node, policy, and managed-service areas ([kube-bench implements these checks](https://github.com/aquasecurity/kube-bench)), so kube-bench output needs triage rather than blind score chasing.
 
 - **AppArmor and SELinux solve a similar containment problem differently**; Ubuntu-family systems commonly use AppArmor, while RHEL-family systems commonly use SELinux, and CKS practice often emphasizes AppArmor mechanics.
 
@@ -675,22 +725,52 @@ Do the exercise with a timer only after you have completed it slowly once. The f
 # 1. Verify cluster is running
 kubectl get nodes
 
-# 2. Install Trivy and scan an image
+# 2. Prove audit logging records pod events (kind: host-mounted ./audit-logs)
+kubectl wait --for=condition=Ready node --all --timeout=120s
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: audit-test
+  namespace: default
+spec:
+  containers:
+  - name: pause
+    image: registry.k8s.io/pause:3.10
+EOF
+kubectl wait --for=condition=Ready pod/audit-test --timeout=60s
+sleep 2
+grep '"verb":"create"' audit-logs/audit.log | grep audit-test | tail -3
+kubectl delete pod audit-test --wait=false
+
+# 3. Install Trivy and scan an image
 trivy image nginx:latest | head -50
 
-# 3. Check Falco is running (if installed)
+# 4. Check Falco is running (if installed)
 kubectl get pods -n falco
 
-# 4. Run kube-bench
+# 5. Run kube-bench
 kubectl apply -f https://raw.githubusercontent.com/aquasecurity/kube-bench/main/job.yaml
 kubectl wait --for=condition=complete job/kube-bench --timeout=120s
 kubectl logs job/kube-bench | head -100
 
-# 5. Create a test pod and scan it
-kubectl run test-pod --image=nginx:1.25
+# 6. Create a test pod and scan the image (apply avoids default SA race on fresh kind 1.35)
+until kubectl get sa default -n default >/dev/null 2>&1; do sleep 1; done
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: default
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.25
+EOF
+kubectl wait --for=condition=Ready pod/test-pod --timeout=60s
 trivy image nginx:1.25
 
-# 6. Cleanup
+# 7. Cleanup
 kubectl delete pod test-pod
 kubectl delete job kube-bench
 ```
@@ -747,6 +827,14 @@ Success criteria:
 
 ---
 
+## Learner check
+
+> Host-mounted audit log (kind maps /var/log/kubernetes inside the node to ./audit-logs)
+
+Before you move on, explain why `grep audit-logs/audit.log` on your workstation can show pod create events even though the API server process runs inside the kind control-plane container. A solid answer connects the API server `--audit-log-path` flag, the in-node `/var/log/kubernetes` directory, and the kind `extraMounts` mapping that exposes that directory as `./audit-logs` on the host.
+
+---
+
 ## Sources
 
 - [Kubernetes audit logging](https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/)
@@ -764,7 +852,9 @@ Success criteria:
 - [Falco Helm charts](https://falcosecurity.github.io/charts)
 - [kube-bench repository](https://github.com/aquasecurity/kube-bench)
 - [kube-bench Kubernetes Job manifest](https://raw.githubusercontent.com/aquasecurity/kube-bench/main/job.yaml)
-- [kube-bench v0.7.0 release archive](https://github.com/aquasecurity/kube-bench/releases/download/v0.7.0/kube-bench_0.7.0_linux_amd64.tar.gz)
+- [kube-bench v0.15.5 release archive](https://github.com/aquasecurity/kube-bench/releases/download/v0.15.5/kube-bench_0.15.5_linux_amd64.tar.gz)
+- [Sysdig Falco release announcement (May 2016)](https://sysdig.com/blog/sysdig-falco)
+- [CIS Kubernetes Benchmark](https://www.cisecurity.org/benchmark/kubernetes)
 - [kubesec repository](https://github.com/controlplaneio/kubesec)
 - [kubesec v2.14.0 release archive](https://github.com/controlplaneio/kubesec/releases/download/v2.14.0/kubesec_linux_amd64.tar.gz)
 - [KubeDojo CKS lab scenario](https://killercoda.com/kubedojo/scenario/cks-0.2-security-lab)

--- a/src/content/docs/k8s/cks/part0-environment/module-0.3-security-tools.md
+++ b/src/content/docs/k8s/cks/part0-environment/module-0.3-security-tools.md
@@ -311,7 +311,7 @@ helm upgrade falco falcosecurity/falco \
   -f falco-custom-rules.yaml \
   --wait
 
-# Method 2: ConfigMap (alternative — also persists)
+# Method 2: ConfigMap mounted via Helm (alternative — also persists)
 kubectl create configmap falco-custom-rules \
   --namespace falco \
   --from-literal=custom-rules.yaml='
@@ -326,9 +326,30 @@ kubectl create configmap falco-custom-rules \
   priority: WARNING
 '
 
-# Then reference the ConfigMap in Helm values or mount it manually
-# Restart Falco pods to pick up changes
-kubectl rollout restart daemonset/falco -n falco
+# Mount the ConfigMap and list it in rules_files — a restart alone does not load the rule
+cat <<EOF > falco-configmap-mount.yaml
+extraVolumes:
+  - name: falco-custom-rules
+    configMap:
+      name: falco-custom-rules
+extraVolumeMounts:
+  - name: falco-custom-rules
+    mountPath: /etc/falco/rules.d/custom-rules.yaml
+    subPath: custom-rules.yaml
+    readOnly: true
+falco:
+  rules_files:
+    - /etc/falco/falco_rules.yaml
+    - /etc/falco/falco_rules.local.yaml
+    - /etc/falco/rules.d/custom-rules.yaml
+EOF
+
+helm upgrade falco falcosecurity/falco \
+  --namespace falco \
+  --reuse-values \
+  -f falco-configmap-mount.yaml \
+  --wait
+
 kubectl rollout status daemonset/falco -n falco --timeout=120s
 ```
 
@@ -415,13 +436,15 @@ The remediation text is helpful, but it is not a substitute for understanding th
 
 ### Common CIS Failures and Fixes
 
+The check IDs below match kube-bench's **cis-1.12** profile (the profile used for Kubernetes 1.35 practice clusters in this module). IDs are not interchangeable across benchmark versions — always read the check title in kube-bench output before editing a static pod or kubelet file.
+
 | Check | Issue | Remediation |
 |-------|-------|-------------|
-| 1.2.1 | Anonymous auth enabled | `--anonymous-auth=false` on API server |
-| 1.2.6 | No audit logging | Configure audit policy and log path |
-| 1.2.16 | No admission plugins | Enable PodSecurity admission |
-| 4.2.1 | kubelet anonymous auth | `--anonymous-auth=false` on kubelet |
-| 4.2.6 | TLS not enforced | Configure kubelet TLS certs |
+| 1.2.1 | API server anonymous auth enabled | `--anonymous-auth=false` on API server static pod |
+| 1.2.6 | API server `--authorization-mode` includes AlwaysAllow | Set `--authorization-mode` to modes that include Node and RBAC (not AlwaysAllow alone) |
+| 1.2.16 | API server audit logging not configured | Set `--audit-log-path` and mount an audit policy file on the API server |
+| 4.2.1 | kubelet anonymous auth enabled | `--anonymous-auth=false` on kubelet |
+| 4.2.9 | kubelet TLS cert/key not configured | Set `tlsCertFile` and `tlsPrivateKeyFile` in kubelet config (or matching CLI flags) |
 
 ```bash
 # Fix API server anonymous auth
@@ -724,6 +747,10 @@ The kubesec scan should flag the privileged container as a critical manifest iss
 - [ ] Explain which finding would block deployment and which findings would become follow-up work.
 
 ---
+
+## Learner check
+
+> In kube-bench **cis-1.12**, check **1.2.6** validates API server authorization mode (not audit logging), and **1.2.16** validates `--audit-log-path`. Under exam pressure, swapping those IDs sends you to the wrong static pod flags.
 
 ## Sources
 

--- a/src/content/docs/k8s/cks/part0-environment/module-0.4-exam-strategy.md
+++ b/src/content/docs/k8s/cks/part0-environment/module-0.4-exam-strategy.md
@@ -54,7 +54,7 @@ The budget below preserves the original three windows from the short version of 
 │  0:00  ─────── Pass 1 Start ───────                        │
 │  │                                                          │
 │  │     Quick wins: RBAC, basic NetworkPolicy,              │
-│  │     securityContext, AppArmor annotations               │
+│  │     securityContext, AppArmor profiles                  │
 │  │                                                          │
 │  0:50  ─────── Pass 2 Start ───────                        │
 │  │                                                          │
@@ -145,7 +145,7 @@ Quick tasks often use familiar verbs and narrow scopes. "Set runAsNonRoot" tells
 | "Set runAsNonRoot" | Add field to securityContext | 1-2 min |
 | "Create NetworkPolicy to allow..." | Single ingress/egress rule | 2-3 min |
 | "Grant permission to..." | Create Role/RoleBinding | 2-3 min |
-| "Apply AppArmor profile" | Add annotation | 1-2 min |
+| "Apply AppArmor profile" | Set `appArmorProfile` in securityContext | 1-2 min |
 | "Scan image with Trivy" | Run command, report findings | 2-3 min |
 
 The quick table is not telling you to rush blindly. It is telling you that the task shape has low uncertainty if you have practiced the pattern. You still read the prompt twice, identify the namespace, and verify the final behavior. The difference is that you do not open three documentation pages before starting, because the correct response is likely a small adaptation of a pattern you already know.
@@ -471,7 +471,7 @@ Before starting, set a visible 15-minute timer and decide how you will record sk
 
 <details><summary>Suggested solution approach for the timing drill</summary>
 
-Treat tasks 1, 2, and 3 as Pass 1 work because they are narrow object edits with direct verification. Treat task 4 as Pass 1 only if Trivy is installed and familiar; otherwise mark it as a tool availability finding and continue. Treat task 5 as Pass 1 if the AppArmor profile is already available and the prompt only asks for annotation, but move it to Pass 2 in an environment where profile loading or node inspection is required.
+Treat tasks 1, 2, and 3 as Pass 1 work because they are narrow object edits with direct verification. Treat task 4 as Pass 1 only if Trivy is installed and familiar; otherwise mark it as a tool availability finding and continue. Treat task 5 as Pass 1 if the AppArmor profile is already available and the prompt only asks for an `appArmorProfile` field, but move it to Pass 2 in an environment where profile loading or node inspection is required.
 </details>
 
 ```bash
@@ -554,25 +554,32 @@ kubectl auth can-i list pods -n secure --as=system:serviceaccount:secure:app-sa
 # (Requires Trivy installed - skip if not available)
 trivy image --severity CRITICAL nginx:1.20 2>/dev/null || echo "Trivy not installed - would scan for CVEs"
 
-# Task 5 (4 min): AppArmor
+# Task 5 (4 min): AppArmor (Kubernetes 1.35+ GA field)
 cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: Pod
 metadata:
   name: web
   namespace: secure
-  annotations:
-    container.apparmor.security.beta.kubernetes.io/web: runtime/default
 spec:
   containers:
   - name: web
     image: nginx:alpine
     securityContext:
       runAsNonRoot: false  # nginx needs root initially
+      appArmorProfile:
+        type: RuntimeDefault
 EOF
 
-# Verify:
-kubectl get pod web -n secure -o jsonpath='{.metadata.annotations}'
+# Verify the GA field is set (not the legacy annotation API):
+kubectl get pod web -n secure -o jsonpath='{.spec.containers[0].securityContext.appArmorProfile}'
+echo ""
+
+# Verify confinement is active (should not show "unconfined"):
+kubectl exec web -n secure -- cat /proc/1/attr/current
+
+# Verify enforcement: RuntimeDefault blocks mounting new filesystems
+kubectl exec web -n secure -- sh -c 'mount -t tmpfs tmpfs /mnt 2>&1' | grep -Ei 'permission denied|operation not permitted|not permitted'
 echo ""
 
 # STOP TIMER - How did you do?
@@ -590,12 +597,18 @@ If you finished at least four tasks with verification, your Pass 1 mechanics are
 
 Success criteria for this exercise are intentionally behavior-focused. You are not only checking whether the objects exist; you are checking whether your strategy survived time pressure. A clean run should leave you with completed objects, verification output, a short list of timing surprises, and one concrete adjustment to your exam-day checklist. That adjustment is the learning artifact you should carry into the next full practice exam.
 
+## Learner check
+
+> The useful mental model is a scoreboard rather than a checklist. A checklist asks, "Have I done the next item?" A scoreboard asks, "How many points have I protected, how much time remains, and which task has the best return now?"
+
+Before you continue, explain how the three-pass strategy uses that scoreboard view during the first scan. A solid answer names quick wins as protected points, treats skipping as a deliberate deferral rather than failure, and includes verification before leaving each completed task.
+
 ## Sources
 
 - https://killercoda.com/kubedojo/scenario/cks-0.4-exam-strategy
 - https://www.cncf.io/training/certification/cks/
 - https://training.linuxfoundation.org/certification/certified-kubernetes-security-specialist/
-- https://docs.linuxfoundation.org/tc-docs/certification/lf-candidate-handbook
+- https://docs.linuxfoundation.org/tc-docs/certification/lf-handbook1
 - https://kubernetes.io/docs/concepts/services-networking/network-policies/
 - https://kubernetes.io/docs/concepts/security/pod-security-standards/
 - https://kubernetes.io/docs/reference/access-authn-authz/rbac/

--- a/src/content/docs/k8s/cks/part1-cluster-setup/module-1.2-cis-benchmarks.md
+++ b/src/content/docs/k8s/cks/part1-cluster-setup/module-1.2-cis-benchmarks.md
@@ -89,6 +89,8 @@ k get pods -n kube-system
 
 Running `kube-bench` as a Kubernetes Job is convenient in lab clusters because the result is captured in pod logs and can be repeated without installing a host binary. The tradeoff is that the pod must mount host paths that contain sensitive configuration, so the job itself must be treated as privileged audit tooling. Do not leave it running forever, do not grant broader access than the audit needs, and do not copy the pattern into tenant namespaces where untrusted users can modify it.
 
+The manifest below deliberately targets a control-plane node. Without the selector and taint toleration, the scheduler can place the job on a worker where `/etc/kubernetes` or `/var/lib/etcd` are absent, producing noisy control-plane findings that describe the wrong host rather than the cluster posture.
+
 ```yaml
 apiVersion: batch/v1
 kind: Job
@@ -100,6 +102,11 @@ spec:
     spec:
       hostPID: true
       restartPolicy: Never
+      nodeSelector:
+        node-role.kubernetes.io/control-plane: ""
+      tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        effect: NoSchedule
       containers:
       - name: kube-bench
         image: aquasec/kube-bench:latest
@@ -302,6 +309,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Configure cluster access
       run: ./scripts/ci/configure-kubeconfig.sh
     - name: Run kube-bench job
@@ -317,6 +326,8 @@ jobs:
         name: kube-bench-result
         path: kube-bench.txt
 ```
+
+The checkout step disables persisted credentials because later audit steps do not need a reusable `GITHUB_TOKEN` in `.git/config`. Production workflows should also pin every `uses:` action to a full commit SHA with a version comment; the tag form here keeps the teaching snippet readable while the security rule remains stricter for real workflow files.
 
 The pipeline should preserve raw output because raw evidence is easier to review than a summarized badge. At the same time, humans need a concise diff. A practical implementation parses check identifiers, compares them with the previous successful run, and prints new failures separately from known exceptions. The goal is to make a new insecure API server flag feel as urgent as a failing unit test while keeping historical provider-owned warnings from blocking unrelated work.
 
@@ -416,6 +427,12 @@ The framework is deliberately simple because complicated decision trees fail dur
 | Accepting vague exceptions | Teams need to ship quickly, so they mark a failed check as not applicable without evidence | Require owner, rationale, compensating control, expiry date, and review trigger for every exception |
 | Fixing worker nodes one at a time | Manual node edits clear the immediate result but disappear when nodes are replaced | Update node bootstrap configuration and roll through a controlled node replacement plan |
 | Failing the pipeline on historical warnings without context | Early automation produces too much noise, so engineers stop paying attention | Classify known exceptions and fail only on new required failures or expired exceptions |
+
+## Learner check
+
+> A kube-bench job that reads control-plane host paths must be scheduled onto a control-plane node, tolerate the control-plane taint, and be treated as privileged audit tooling.
+
+Before you continue, explain what false signal you might get if the same manifest lands on a worker node. A strong answer names the missing host paths, separates audit-runner placement from real cluster drift, and explains why noisy findings should not enter the remediation backlog until the runner has inspected the intended evidence source.
 
 ## Quiz
 

--- a/src/content/docs/k8s/cks/part1-cluster-setup/module-1.3-ingress-security.md
+++ b/src/content/docs/k8s/cks/part1-cluster-setup/module-1.3-ingress-security.md
@@ -91,8 +91,10 @@ openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
   -keyout tls.key -out tls.crt \
   -subj "/CN=myapp.example.com"
 
-# Create a Kubernetes TLS Secret named 'myapp-tls' in the 'production' namespace
+# Create the namespace used by the lab objects, then create the TLS Secret there.
 # This secret will hold the certificate and key, allowing Ingress to use them.
+kubectl create namespace production
+
 kubectl create secret tls myapp-tls \
   --cert=tls.crt \
   --key=tls.key \
@@ -243,6 +245,8 @@ sequenceDiagram
 The trust anchor for mTLS is a CA certificate, not every individual client certificate. The controller receives a client certificate during the handshake, verifies that certificate against the trusted CA bundle, checks the chain depth, and only then forwards the request. This means a single Secret containing the CA public certificate can authorize many clients, but it also means compromise of the issuing CA is a much larger event than compromise of one client key.
 
 ```bash
+# The TLS setup above creates the production namespace. If you run only this
+# mTLS block in a fresh lab, create that namespace before creating the Secret.
 # Assume 'ca.crt' is the public CA certificate that signed your client certificates.
 # This secret tells the Ingress controller which CA to trust for client authentication.
 kubectl create secret generic ca-secret \
@@ -307,24 +311,23 @@ metadata:
   name: hardened-ingress
   annotations:
     # The configuration-snippet allows injecting arbitrary NGINX configuration.
-    # Here, we add several crucial security headers.
+    # Here, we add security headers that still matter in modern browsers.
     nginx.ingress.kubernetes.io/configuration-snippet: |
       add_header X-Frame-Options "SAMEORIGIN" always; # Prevents clickjacking by controlling iframe usage
       add_header X-Content-Type-Options "nosniff" always; # Prevents MIME-type sniffing, enforcing declared content types
-      add_header X-XSS-Protection "1; mode=block" always; # Enables browser's built-in XSS filter
       add_header Referrer-Policy "strict-origin-when-cross-origin" always; # Controls how much referrer information is sent
       add_header Content-Security-Policy "default-src 'self'" always; # Restricts resource loading to trusted sources (e.g., same origin)
 spec:
   # ... rest of Ingress specification ...
 ```
 
-Each header answers a different browser question. `X-Frame-Options` tells the browser whether another site may frame the page, which affects clickjacking. `X-Content-Type-Options` tells the browser not to reinterpret content as a different type, which matters when uploads or static assets are involved. Content Security Policy is broader and more delicate because it can block legitimate scripts if the policy does not match the application.
+Each header answers a different browser question. `X-Frame-Options` tells the browser whether another site may frame the page, which affects clickjacking. `X-Content-Type-Options` tells the browser not to reinterpret content as a different type, which matters when uploads or static assets are involved. Content Security Policy is broader and more delicate because it can block legitimate scripts if the policy does not match the application. Do not treat `X-XSS-Protection` as a modern baseline: it is deprecated and non-standard, so CSP and application-side output handling are the controls to design around.
 
 ```mermaid
 graph TD
     H1["X-Frame-Options: SAMEORIGIN"] --> H1D["Prevents clickjacking attacks by controlling iframes"]
     H2["X-Content-Type-Options: nosniff"] --> H2D["Prevents MIME type sniffing, enforcing declared content types"]
-    H3["X-XSS-Protection: 1; mode=block"] --> H3D["Enables browser's built-in XSS filtering"]
+    H3["X-XSS-Protection"] --> H3D["Deprecated legacy filter; prefer CSP"]
     H4["Referrer-Policy: strict-origin-when-cross-origin"] --> H4D["Controls referrer information leakage to third parties"]
     H5["Content-Security-Policy: default-src 'self'"] --> H5D["Restricts resource loading to trusted sources, mitigating XSS"]
     H6["Strict-Transport-Security (HSTS)"] --> H6D["Forces HTTPS for specified duration, preventing protocol downgrade attacks"]
@@ -379,8 +382,7 @@ metadata:
     # This regex matches '/admin', '/metrics', '/health', or '/debug'.
     nginx.ingress.kubernetes.io/server-snippet: |
       location ~ ^/(admin|metrics|health|debug) {
-        deny all; # Block access from all IP addresses
-        return 403; # Return Forbidden status
+        return 403; # Block matching paths with Forbidden status
       }
 
     # Alternatively, require external authentication for a path or service.
@@ -432,7 +434,7 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-          name: ingress-nginx # Selects the namespace where the ingress controller runs
+          kubernetes.io/metadata.name: ingress-nginx # Selects the ingress controller namespace by its standard label
       podSelector:
         matchLabels:
           app.kubernetes.io/name: ingress-nginx # Selects the ingress controller pods
@@ -449,11 +451,19 @@ metadata:
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ingress-nginx
+      app.kubernetes.io/component: controller
   template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/component: controller
     spec:
       containers:
       - name: controller
-        image: registry.k8s.sio/ingress-nginx/controller:v1.9.0 # Use a specific, well-vetted image version
+        image: registry.k8s.io/ingress-nginx/controller:v1.9.0 # Use a specific, well-vetted image version
         securityContext:
           runAsNonRoot: true # Ensure the container does not run as root
           runAsUser: 101 # Run as an arbitrary non-root user (e.g., 101, common for nginx)
@@ -644,6 +654,12 @@ Match the NetworkPolicy selectors to real labels on the backend pods, ingress na
 Separate failures by layer. Certificate warnings point to host, chain, Secret, or SNI issues; 403 responses point to path or authentication rules; 429 responses point to limits; missing application logs during mTLS failure point to controller-side rejection. Compare controller access logs with application logs to detect bypasses. A request visible in the app but absent from controller logs likely did not follow the intended edge path.
 </details>
 
+## Learner check
+
+> A secure Ingress is only secure on the path that actually reaches the controller: the namespace must exist before namespaced Secrets are created, selectors must match real namespace and pod labels, and the controller Deployment must include the selector/template label contract Kubernetes validates.
+
+Before moving on, explain why a TLS Secret, an mTLS annotation, and strict browser headers do not protect a backend Service that accepts traffic from arbitrary in-cluster pods. A solid answer names the bypass path, the NetworkPolicy that forces traffic through the controller, and the Deployment labels that make the controller manifest valid on Kubernetes 1.35.
+
 ## Sources
 
 - https://kubernetes.io/docs/concepts/services-networking/ingress/
@@ -656,6 +672,7 @@ Separate failures by layer. Certificate warnings point to host, chain, Secret, o
 - https://cert-manager.io/docs/usage/ingress/
 - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
 - https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+- https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-XSS-Protection
 - https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html
 - https://hstspreload.org/
 - https://www.pcisecuritystandards.org/document_library?category=pcidss&document=pci_dss


### PR DESCRIPTION
## CKS batch 2 — part0/part1 cross-family R1 remediation (5 modules)

Second merged batch of the CKS review-first sweep (wide parallel fan-out, cursor+codex+gemini). Each
finding ground-checked against the live file; fixes verified T0.

| Module | Verdict | Real findings fixed | Fixer |
|---|---|---|---|
| 0.2-security-lab | NC 4.1/5 | 8×P2: kube-bench version split, missing runnable audit-proof step, `kubectl run` vs default-SA race, node-checks run on the wrong host (kind-on-macOS), kubesec amd64-only, duration, uncited DYK | cursor |
| 0.3-security-tools | NC 3.5/5 | **P1** kube-bench CIS check IDs wrong for the cis-1.12 profile (would remediate the wrong control); Falco ConfigMap rule wasn't actually loaded | cursor |
| 0.4-exam-strategy | NC 3.8/5 | **P1** AppArmor lab used the deprecated annotation API + only checked the annotation, not enforcement → GA `securityContext.appArmorProfile` + an enforcement check; stale source URL | cursor |
| 1.2-cis-benchmarks | NC 3/5 | **P1** kube-bench Job had no control-plane nodeSelector/tolerations → ran on a worker → spurious control-plane FAILs; GHA snippet given `persist-credentials: false` (repo SHA-pin rule) | codex |
| 1.3-ingress-security | NC | **P1** ingress-nginx Deployment omitted `spec.selector`/template labels (invalid) + `registry.k8s.sio` image typo → ImagePullBackOff → fixed both; `production` namespace pre-created | codex |

All 5 verify `passed: true`, tier T0. `chore(content):` only. (Wider CKS sweep continues — 1.3 fixing,
1.4 needs a genuine expansion, parts 2-6 ahead; see session-85 handoff.)

## Learner check

> CIS auditing deliberately crosses that boundary, which is why a serious cluster audit requires both API-level access and node-level inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
