### PR TITLE
chore(content): CKS part2 cluster-hardening 2.1–2.5 review fixes

### DIFF
--- a/src/content/docs/k8s/cks/part2-cluster-hardening/module-2.1-rbac-deep-dive.md
+++ b/src/content/docs/k8s/cks/part2-cluster-hardening/module-2.1-rbac-deep-dive.md
@@ -13,7 +13,7 @@ lab:
 ---
 > **Complexity**: `[MEDIUM]` - Core security skill
 >
-> **Time to Complete**: 45-50 minutes
+> **Time to Complete**: 40-45 minutes
 >
 > **Prerequisites**: CKA RBAC knowledge, ServiceAccounts basics
 
@@ -142,9 +142,9 @@ rules:
   verbs: ["create", "update", "patch"]
 
 # WHY IT'S BAD:
-# - Can grant themselves cluster-admin
-# - Privilege escalation attack
-# - Only admins should modify RBAC
+# - Can mutate RBAC objects cluster-wide
+# - Dangerous combined with bind/escalate or existing broad grants
+# - Only tightly controlled admins should modify RBAC
 ```
 
 The subtle version of this mistake is giving namespace administrators too much RBAC write access because the cluster uses shared namespaces poorly. A namespace Role that can update Roles and RoleBindings is still powerful inside that namespace, especially when privileged ServiceAccounts already exist there. Before granting RBAC write rights, check whether the subject can bind to existing roles, whether admission policy restricts the ServiceAccounts they can use, and whether the namespace contains credentials for workloads outside the requester's responsibility.
@@ -163,10 +163,10 @@ rules:
   verbs: ["create"]
 
 # WHY IT'S BAD:
-# - Can create privileged pods
-# - Can mount service account tokens
-# - Can escape container to node
-# - Needs Pod Security to be safe
+# - Can create pods that request privileged settings or stronger ServiceAccounts
+# - Can mount service account tokens into the workload
+# - Node-level escape depends on admission controls (Pod Security Admission, etc.)
+# - RBAC alone does not evaluate whether the pod spec is safe
 ```
 
 Stop and think: a developer has a Role that allows `create` on `pods` but nothing else, and they claim they cannot do anything dangerous. If the namespace contains a more powerful ServiceAccount and admission allows the pod to use it, the developer may create a pod that runs with that ServiceAccount token. The RBAC grant looked narrow on paper, but the workload object became a bridge to another identity.
@@ -434,10 +434,10 @@ Escalation prevention is about blocking paths, not only blocking obvious admin r
 │  Direct Escalation:                                        │
 │  ─────────────────────────────────────────────────────────  │
 │  1. Create/update ClusterRoleBindings                      │
-│     → Bind self to cluster-admin                           │
+│     → Attach powerful roles (bind guardrail applies)       │
 │                                                             │
-│  2. Create/update ClusterRoles                             │
-│     → Add * permissions                                    │
+│  2. bind / escalate on RBAC resources                      │
+│     → Expand permissions beyond current grants             │
 │                                                             │
 │  Indirect Escalation:                                      │
 │  ─────────────────────────────────────────────────────────  │
@@ -571,7 +571,7 @@ The final decision rule is ownership. A platform team can own ClusterRoles, name
 
 - **Kubernetes RBAC became stable in the `rbac.authorization.k8s.io/v1` API during the 1.8 release line.** That stability is why the same core Role and RoleBinding structure still appears in Kubernetes 1.35 training and production audits.
 
-- **The `system:masters` group bypasses ordinary RBAC policy through the built-in cluster-admin relationship.** Treat membership in that group as emergency-level authority because removing RoleBindings will not narrow a certificate or identity that still belongs to it.
+- **The `system:masters` group is treated as a static superuser identity, not a permission you grant through a RoleBinding.** The API server authorizer grants cluster-admin-equivalent access to this group directly, so removing RBAC bindings will not narrow a client certificate or identity that still belongs to it.
 
 - **Aggregated ClusterRoles extend built-in roles through labels such as `rbac.authorization.k8s.io/aggregate-to-view`.** This lets custom resources add read rules to `view`, but it also means built-in role behavior can change when new labeled ClusterRoles are installed.
 
@@ -676,7 +676,7 @@ EOF
 # Task 1: Audit the permissions
 kubectl auth can-i --list --as=system:serviceaccount:rbac-test:admin-app
 
-# Task 2: Check if it can read secrets (it shouldn't!)
+# Task 2: Confirm it can read secrets (expected with the wildcard grant)
 kubectl auth can-i get secrets --as=system:serviceaccount:rbac-test:admin-app
 
 # Task 3: Create a restricted role (only pods in namespace)
@@ -750,6 +750,14 @@ For a read-only workload, remove `create` and `delete` from the `pods` rule and 
 </details>
 
 Success is not just a passing command. A secure answer has evidence that the ServiceAccount kept the intended namespace pod capability, lost cluster-wide reach, lost Secret access, and no longer depends on wildcard permissions. That evidence is what you would put in a pull request, incident note, or exam answer to show that the repair is controlled rather than lucky.
+
+---
+
+## Learner check
+
+> A wildcard ClusterRole bound through a ClusterRoleBinding lets a namespace ServiceAccount read Secrets cluster-wide; the hands-on exercise proves that over-broad baseline with `kubectl auth can-i` before you replace the binding with a namespace-scoped RoleBinding.
+
+Before you move on, explain why mutating ClusterRoleBindings is not automatically equivalent to granting yourself `cluster-admin`, and which RBAC verbs make that difference explicit. A solid answer names the `bind` and `escalate` guardrails, contrasts direct RBAC mutation with indirect pod-based escalation, and includes at least one negative `kubectl auth can-i` check after your repair.
 
 ---
 

--- a/src/content/docs/k8s/cks/part2-cluster-hardening/module-2.2-serviceaccount-security.md
+++ b/src/content/docs/k8s/cks/part2-cluster-hardening/module-2.2-serviceaccount-security.md
@@ -101,9 +101,8 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: ui
-          image: nginx:1.27
-          ports:
-            - containerPort: 80
+          image: registry.k8s.io/e2e-test-images/agnhost:2.54
+          args: ["pause"]
 ```
 
 Pause and predict: if you apply that deployment and then open a shell in a running pod, what should happen when you list `/var/run/secrets/kubernetes.io/serviceaccount`? The directory should not contain the usual token material because the pod explicitly opted out. If the directory still appears, inspect the rendered pod spec with `kubectl get pod -o yaml`; many debugging mistakes come from looking at the Deployment template while a different ReplicaSet is still running older pods.
@@ -115,7 +114,7 @@ kubectl -n reports get pods -l app=reports-ui
 kubectl -n reports exec deploy/reports-ui -- ls -la /var/run/secrets/kubernetes.io/serviceaccount
 ```
 
-The command may fail if the image has no `ls` binary, which is normal for minimal containers. In that case, inspect the pod's rendered volumes and mounts rather than changing the workload image just for verification. The security point is the same: a missing token volume is a deliberate hardening control, and a present token volume needs an explicit justification that appears in reviewable YAML.
+The agnhost image includes standard shell utilities, so the `ls` check should succeed when token automounting is disabled. If the directory still appears, inspect the pod's rendered volumes and mounts rather than assuming the Deployment template matches the running pod. The security point is the same: a missing token volume is a deliberate hardening control, and a present token volume needs an explicit justification that appears in reviewable YAML.
 
 ```bash
 kubectl -n reports get pod -l app=reports-ui -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{.spec.volumes}{"\n"}{end}'
@@ -242,7 +241,7 @@ For mature platforms, the ServiceAccount name becomes part of the workload contr
 
 ## Bound Tokens, Audiences, and Legacy Token Secrets
 
-Modern Kubernetes ServiceAccount credentials are delivered through the TokenRequest API and projected volumes. The kubelet requests a time-bound token for the pod, writes it into a projected volume, and refreshes it before it expires. The default projected credential is bound to the pod and intended for the Kubernetes API server audience. When the pod is deleted, the API credentials are revoked after the deletion lifecycle rather than remaining useful forever.
+Modern Kubernetes ServiceAccount credentials are delivered through the TokenRequest API and projected volumes. The kubelet requests a time-bound token for the pod, writes it into a projected volume, and refreshes it before it expires. The default projected credential is bound to the pod and intended for the Kubernetes API server audience. When the pod is deleted, bound tokens expire as part of the pod lifecycle or when they reach their configured `expirationSeconds`, rather than remaining useful forever.
 
 This behavior replaced the older automatic creation of Secret-based ServiceAccount tokens. In clusters before the modern defaults, the control plane created long-lived `kubernetes.io/service-account-token` Secrets for ServiceAccounts. Those Secrets did not expire, and they were easy to copy into CI systems, scripts, and forgotten notebooks. Kubernetes still supports manually created token Secrets for compatibility, but the safer default is short-lived TokenRequest credentials.
 
@@ -269,7 +268,16 @@ sequenceDiagram
 
 A projected `serviceAccountToken` source lets you request a token for a specific audience and lifetime. Use this when a workload needs to present a Kubernetes-issued identity to a relying party other than the Kubernetes API server, such as an internal identity broker that validates TokenReview responses. The audience field is critical because a recipient should reject tokens not intended for it, reducing the value of a token replayed to the wrong service.
 
+Create the ServiceAccount before applying the Pod or running `kubectl create token`. Kubernetes does not create a named ServiceAccount automatically from a Pod spec alone.
+
 ```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: reports-broker-client
+  namespace: reports
+automountServiceAccountToken: false
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -305,6 +313,10 @@ Kubernetes requires projected ServiceAccount token lifetimes to meet API server 
 Audience design is where many otherwise careful implementations become vague. A token with a broad or default audience may be accepted by more recipients than the workload owner intended. A token with a specific audience forces the relying service to declare itself, and it gives incident responders a clear question: which services should accept this stolen credential? If the answer is unclear, the audience boundary is not doing enough work.
 
 ```bash
+kubectl create namespace reports --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n reports create sa reports-broker-client
+kubectl apply -f reports-broker-client.yaml
+
 kubectl -n reports create token reports-broker-client \
   --audience reports-broker \
   --duration 1h
@@ -333,7 +345,7 @@ kubectl get pods --all-namespaces \
   -o custom-columns='NAMESPACE:.metadata.namespace,POD:.metadata.name,SERVICEACCOUNT:.spec.serviceAccountName,AUTOMOUNT:.spec.automountServiceAccountToken'
 
 kubectl get rolebindings,clusterrolebindings --all-namespaces \
-  -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,SUBJECTS:.subjects[*].name,ROLE:.roleRef.name'
+  -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,SUBJECT_KIND:.subjects[*].kind,SUBJECTS:.subjects[*].name,ROLE:.roleRef.name'
 ```
 
 The first command can show blank ServiceAccount fields because the API default may not be visible the way you expect in custom columns for every object shape. When precision matters, inspect full YAML or JSON and remember that an omitted `serviceAccountName` means the pod uses `default`. A practical audit report should normalize blank values to `default`, then flag any pod where both the effective identity and automount decision are not documented.
@@ -385,9 +397,12 @@ kubectl -n reports auth can-i update configmaps \
 
 For a pod-level view, inspect events and the rendered pod spec. Failed mounts, missing ServiceAccounts, and invalid references often show up before the application even starts. Kubernetes does not let you change `serviceAccountName` on an existing pod; you update the controller template and recreate pods through rollout. That immutability is useful because identity changes should be visible as a deployment change, not as a silent mutation of a running process.
 
+Apply the `reports-config-watcher` manifests from the least-privilege section above, then inspect the pod the Deployment creates. Because `serviceAccountName` is immutable on a running Pod, restart the Deployment when you change identity fields in the template.
+
 ```bash
-kubectl -n reports describe pod reports-config-watcher-example
-kubectl -n reports get pod reports-config-watcher-example -o yaml
+kubectl apply -f reports-config-watcher.yaml
+kubectl -n reports describe pod -l app=reports-config-watcher
+kubectl -n reports get pod -l app=reports-config-watcher -o yaml
 kubectl -n reports rollout restart deployment/reports-config-watcher
 ```
 
@@ -774,6 +789,16 @@ If the UI pod still has a `kube-api-access` projected volume, inspect the pod te
 - [ ] Any remaining exception has an owner, a reason, and a planned review date in your own notes.
 
 When you finish, keep the verification commands as your personal runbook. The exact namespace and account names will change, but the questions stay stable: who is the pod, does it have a token, what can that identity do, and which old grants still exist? That runbook is the practical bridge between CKS exam tasks and production hardening work.
+
+---
+
+## Learner check
+
+> A Pod with `serviceAccountName: reports-broker-client` and `kubectl create token reports-broker-client` both require the ServiceAccount object to exist in the `reports` namespace first — create or apply the ServiceAccount before the Pod or token command, or admission fails with `serviceaccount ... not found`.
+
+Before you continue, explain why diagnosing a 403 with `kubectl auth can-i` is the wrong first step when the application reports 401 Unauthorized from a projected token with audience `reports-broker`. A solid answer names the authentication boundary, states that audience mismatch fails before RBAC, and describes what you would inspect on the mounted token path instead of editing RoleBindings.
+
+---
 
 ## Sources
 

--- a/src/content/docs/k8s/cks/part2-cluster-hardening/module-2.3-api-server-security.md
+++ b/src/content/docs/k8s/cks/part2-cluster-hardening/module-2.3-api-server-security.md
@@ -436,7 +436,7 @@ Verification must read from etcd rather than merely checking that the API server
 kubectl create secret generic test-secret --from-literal=key=value
 
 # Check etcd directly (should be encrypted)
-ETCDCTL_API=3 etcdctl \
+sudo ETCDCTL_API=3 etcdctl \
   --endpoints=https://127.0.0.1:2379 \
   --cacert=/etc/kubernetes/pki/etcd/ca.crt \
   --cert=/etc/kubernetes/pki/etcd/server.crt \
@@ -513,7 +513,7 @@ The third scenario checks authorization mode directly from the running static po
 
 ```bash
 # Verify authorization mode
-kubectl get pods -n kube-system kube-apiserver-* -o yaml | grep authorization-mode
+kubectl get pods -n kube-system -l component=kube-apiserver -o yaml | grep authorization-mode
 
 # Should see: --authorization-mode=Node,RBAC
 # Should NOT see: AlwaysAllow
@@ -764,6 +764,12 @@ Success criteria:
 - [ ] `NodeRestriction` remains enabled alongside required admission plugins.
 - [ ] Audit logging has a valid policy, writable log path, rotation flags, and required mounts.
 - [ ] The manifest contains no removed insecure serving flags before a Kubernetes v1.35 upgrade.
+
+## Learner check
+
+> Before editing this file, ask yourself what will keep working if the API server does not come back. `kubectl get pods -n kube-system` depends on the API server, so it is not your first recovery tool when the process is down. The safer workflow is to keep one root shell on the control plane node, use `crictl` to inspect static pod containers, and be prepared to revert a single line in the manifest.
+
+Before moving on, explain why verifying encryption at rest requires reading raw etcd output rather than checking only that `--encryption-provider-config` appears in the kube-apiserver manifest. A solid answer names the difference between configured intent and stored bytes, mentions rewriting existing Secrets, and describes what encrypted provider output looks like in an etcd read.
 
 ## Sources
 

--- a/src/content/docs/k8s/cks/part2-cluster-hardening/module-2.4-kubernetes-upgrades.md
+++ b/src/content/docs/k8s/cks/part2-cluster-hardening/module-2.4-kubernetes-upgrades.md
@@ -141,7 +141,7 @@ Before running this, what output do you expect from a healthy pre-upgrade assess
 
 ```bash
 # 1. Check current version vulnerabilities
-kubectl version --short 2>/dev/null || kubectl version
+kubectl version
 # Research CVEs for your version
 
 # 2. Review release notes for security fixes
@@ -151,11 +151,13 @@ kubectl version --short 2>/dev/null || kubectl version
 kubectl get all -A -o yaml > cluster-backup.yaml
 ETCDCTL_API=3 etcdctl snapshot save backup.db
 
-# 4. Check deprecation warnings
-kubectl api-resources --verbs=list -o name | xargs -n 1 kubectl get --show-labels -A 2>&1 | grep -i deprecated
+# 4. Check deprecated APIs in use (cluster-wide request traffic)
+kubectl get --raw /metrics | grep apiserver_requested_deprecated
+# Optional manifest spot-check for critical workloads:
+kubectl get pod -n <namespace> <name> -o yaml | grep apiVersion
 ```
 
-That checklist is intentionally conservative. The all-namespaces YAML export is not a complete disaster-recovery backup, but it captures enough workload intent to compare before and after state. The etcd snapshot is the high-value control-plane artifact in a self-managed cluster, because kubeadm cannot simply unwind every control-plane state change if the API server or datastore becomes unhealthy. The deprecated API scan is noisy, yet useful, because a security upgrade can fail for reasons that are not themselves security vulnerabilities.
+That checklist is intentionally conservative. The all-namespaces YAML export is not a complete disaster-recovery backup, but it captures enough workload intent to compare before and after state. The etcd snapshot is the high-value control-plane artifact in a self-managed cluster, because kubeadm cannot simply unwind every control-plane state change if the API server or datastore becomes unhealthy. The `apiserver_requested_deprecated` metric shows actual deprecated API traffic, not kubectl client warnings, because a security upgrade can fail for reasons that are not themselves security vulnerabilities.
 
 When choosing between fixed releases, evaluate both exposure and blast radius. A same-minor patch usually has the smallest behavioral surface, while a minor upgrade may include API removals, feature-gate changes, default changes, and new benchmark expectations. The security answer is not always "latest immediately"; the security answer is "fixed, supported, compatible, and verifiable within the shortest responsible window."
 
@@ -259,7 +261,7 @@ Version skew is the formal boundary around this compatibility work. The API serv
 |  +-- Same minor as API server or one minor older             |
 |                                                             |
 |  kubelet:                                                   |
-|  +-- Same minor, one minor older, or two minors older        |
+|  +-- Up to three minors older (kubelet 1.25+)                |
 |  +-- Never newer than the API server                         |
 |                                                             |
 |  kubectl:                                                   |
@@ -272,6 +274,8 @@ Version skew is the formal boundary around this compatibility work. The API serv
 |                                                             |
 +-------------------------------------------------------------+
 ```
+
+For kubelet 1.25 and later, the API server at 1.35 may pair with kubelets as old as 1.32 (three minor versions behind). Before kubelet 1.25, the limit was two minor versions older. See the [Kubernetes version skew policy](https://kubernetes.io/releases/version-skew-policy/).
 
 Pause and predict: what happens if you correctly upgrade the API server to 1.35, but a worker node's kubelet is upgraded before the controller-manager, which still runs 1.33? The kubelet may still be legal if it is not newer than the API server, but the controller-manager relationship may violate skew once the API server is two minors ahead, so the cluster can enter a state that is partially functional yet unsupported.
 
@@ -296,7 +300,7 @@ Finally, decide who signs off on the upgraded security posture. Platform enginee
 # https://kubernetes.io/docs/reference/issues-security/security/
 
 # Check specific component for CVEs
-trivy image registry.k8s.io/kube-apiserver:v1.30.0
+trivy image registry.k8s.io/kube-apiserver:v1.35.0
 
 # Check node OS for security updates
 apt list --upgradable 2>/dev/null | grep -i security
@@ -362,30 +366,79 @@ The `apiserver_requested_deprecated` metric is a useful clue because it shows re
 
 ```bash
 # After upgrade, verify security settings
-# 1. Check API server is running
+# 1. Check API server is running — expect at least one Running apiserver pod
 kubectl get pods -n kube-system | grep apiserver
 
-# 2. Verify RBAC is working
-kubectl auth can-i create pods --as=developer
+# 2. Verify RBAC allow + deny with a lab ServiceAccount and RoleBinding
+kubectl create namespace upgrade-test --dry-run=client -o yaml | kubectl apply -f -
+kubectl create serviceaccount probe-sa -n upgrade-test --dry-run=client -o yaml | kubectl apply -f -
+cat <<EOF | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pod-lister
+  namespace: upgrade-test
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["list", "get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pod-lister-binding
+  namespace: upgrade-test
+subjects:
+- kind: ServiceAccount
+  name: probe-sa
+  namespace: upgrade-test
+roleRef:
+  kind: Role
+  name: pod-lister
+  apiGroup: rbac.authorization.k8s.io
+EOF
+kubectl auth can-i list pods -n upgrade-test --as=system:serviceaccount:upgrade-test:probe-sa
+# Expect: yes
+kubectl auth can-i create pods -n upgrade-test --as=system:serviceaccount:upgrade-test:probe-sa
+# Expect: no
 
-# 3. Check admission controllers
-kubectl get pods -n kube-system -o yaml | grep admission
+# 3. Confirm admission webhook configurations are registered — expect resource names (may be empty on minimal clusters)
+kubectl get validatingwebhookconfiguration,mutatingwebhookconfiguration
 
-# 4. Run kube-bench
+# 4. Negative Pod Security Admission test — expect Admission denied for privileged pod
+kubectl label namespace upgrade-test pod-security.kubernetes.io/enforce=restricted --overwrite
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: psa-probe
+  namespace: upgrade-test
+spec:
+  containers:
+  - name: probe
+    image: busybox
+    command: ["sleep", "60"]
+    securityContext:
+      privileged: true
+EOF
+# Expect: error contains "violates PodSecurity"
+kubectl delete pod psa-probe -n upgrade-test --ignore-not-found
+
+# 5. Run kube-bench
 kubectl apply -f https://raw.githubusercontent.com/aquasecurity/kube-bench/main/job.yaml
 kubectl logs job/kube-bench
 ```
 
-The RBAC check should include both allowed and denied expectations. A single `can-i` result can be misleading if you ask only for a permission the user is supposed to have. For security validation, test a representative normal action and a representative forbidden action, because an upgrade that accidentally broadens permissions can be more dangerous than one that blocks too much.
+The RBAC check should include both allowed and denied expectations. A single `can-i` result can be misleading if you ask only for a permission the user is supposed to have. For security validation, test a representative normal action and a representative forbidden action with a ServiceAccount you created in the lab, because an upgrade that accidentally broadens permissions can be more dangerous than one that blocks too much.
 
-Admission validation should also include a negative test. If the cluster is expected to deny privileged pods in restricted namespaces, attempt a clearly unsafe test object in a disposable namespace and confirm that admission rejects it. Do not run destructive probes against production workloads, but do prove that the policy path still exists. A successful upgrade should preserve both the ability to run valid workloads and the ability to block invalid ones.
+Admission validation should also include a negative test. Listing webhook configurations confirms the admission path is registered, and a Pod Security Admission probe in a restricted namespace confirms enforcement still rejects unsafe workloads. Do not run destructive probes against production workloads, but do prove that the policy path still exists. A successful upgrade should preserve both the ability to run valid workloads and the ability to block invalid ones.
 
 ```bash
 # Question: "Upgrade cluster to version that fixes CVE-2024-XXXX"
 
 # 1. Research CVE (exam may provide info)
 # 2. Find fixed version
-kubectl version --short 2>/dev/null || kubectl version
+kubectl version
 
 # 3. Plan upgrade
 sudo kubeadm upgrade plan | grep -E "v1\.[0-9]+\.[0-9]+"
@@ -504,6 +557,12 @@ Security upgrade failures usually come from missing evidence rather than missing
 | Trusting benchmark failures without triage | New benchmark versions can add or reinterpret checks. | Compare old and new benchmark profiles, then classify each finding. |
 | Assuming managed service upgrades finish the job | Provider-owned and customer-owned responsibilities blur during incidents. | Verify node pools, add-ons, workloads, policies, and identity bindings separately. |
 
+## Learner check
+
+> Version skew is the formal boundary around this compatibility work. The API server should be the newest Kubernetes component in the cluster; controller-manager and scheduler follow tightly; kubelets may lag within the documented policy, but they must not lead the API server.
+
+Before you continue, explain why a kubelet at 1.32 can remain legal on an API server at 1.35 while a controller-manager at 1.33 cannot. A strong answer names the separate skew rules for kubelets versus control-plane components and cites the three-minor kubelet allowance for kubelet 1.25+.
+
 ## Quiz
 
 <details><summary>Question 1: Your security team receives a CVE advisory for a container escape vulnerability affecting Kubernetes 1.33 through 1.34.3. Production runs 1.34.1, and the advisory says the fix is in 1.34.4 and 1.35.0. What do you recommend during a short change freeze?</summary>
@@ -561,6 +620,8 @@ kind: Pod
 metadata:
   name: security-test
   namespace: upgrade-test
+  labels:
+    app: security-test
 spec:
   securityContext:
     runAsNonRoot: true
@@ -587,7 +648,7 @@ Audit the current versions of your cluster components. You need to know exactly 
 
 ```bash
 echo "=== Current Versions ==="
-kubectl version --short 2>/dev/null || kubectl version
+kubectl version
 
 echo "=== Node Versions ==="
 kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}: {.status.nodeInfo.kubeletVersion}{"\n"}{end}'
@@ -607,7 +668,36 @@ After the upgrade or simulated validation point, verify that Role-Based Access C
 
 ```bash
 echo "=== RBAC Verification ==="
-kubectl auth can-i list pods -n upgrade-test --as=system:serviceaccount:upgrade-test:default
+kubectl create serviceaccount probe-sa -n upgrade-test --dry-run=client -o yaml | kubectl apply -f -
+cat <<EOF | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pod-lister
+  namespace: upgrade-test
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["list", "get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pod-lister-binding
+  namespace: upgrade-test
+subjects:
+- kind: ServiceAccount
+  name: probe-sa
+  namespace: upgrade-test
+roleRef:
+  kind: Role
+  name: pod-lister
+  apiGroup: rbac.authorization.k8s.io
+EOF
+kubectl auth can-i list pods -n upgrade-test --as=system:serviceaccount:upgrade-test:probe-sa
+# Expect: yes
+kubectl auth can-i create pods -n upgrade-test --as=system:serviceaccount:upgrade-test:probe-sa
+# Expect: no
 ```
 
 Confirm that the security contexts applied to your workload are still present. This does not prove every runtime control is enforced, but it catches accidental manifest drift and gives you a starting point for admission and runtime policy checks.
@@ -633,7 +723,7 @@ echo "On control plane, would run: ./kube-bench run --targets=master"
 echo "On worker nodes, would run: ./kube-bench run --targets=node"
 ```
 
-Verify that NetworkPolicy resources are still accepted by the API server. Remember that API acceptance is not the same as enforcement, so a real production validation should also test traffic behavior through the CNI.
+Verify that NetworkPolicy resources are still accepted by the API server and select the rehearsal pod. Remember that API acceptance is not the same as enforcement, so a real production validation should also test traffic behavior through the CNI.
 
 ```bash
 echo "=== Testing NetworkPolicy Support ==="
@@ -652,7 +742,8 @@ spec:
   - Egress
 EOF
 
-kubectl get networkpolicy -n upgrade-test
+kubectl get networkpolicy test-policy -n upgrade-test -o jsonpath='{.spec.podSelector.matchLabels.app}{"\n"}'
+# Expect: security-test (policy selects the rehearsal pod)
 ```
 
 Finally, clean up the testing environment. The cleanup should remove both cluster objects and local evidence files that are no longer needed.

--- a/src/content/docs/k8s/cks/part2-cluster-hardening/module-2.5-restricting-api-access.md
+++ b/src/content/docs/k8s/cks/part2-cluster-hardening/module-2.5-restricting-api-access.md
@@ -15,7 +15,7 @@ lab:
 >
 > **Time to Complete**: 35-40 minutes
 >
-> **Prerequisites**: Module 2.3 (API Server Security), networking basics
+> **Prerequisites**: [Module 2.3: API Server Security](../module-2.3-api-server-security/), networking basics
 
 ---
 
@@ -171,10 +171,11 @@ spec:
   containers:
   - command:
     - kube-apiserver
-    # Bind only to specific interface
-    - --bind-address=10.0.0.10  # Internal IP only
-    # Or bind to all (less secure)
-    - --bind-address=0.0.0.0
+    # Secure alternative: bind only to the internal control-plane interface.
+    - --bind-address=10.0.0.10
+
+    # Insecure alternative to avoid: this listens on every host interface.
+    # - --bind-address=0.0.0.0
 ```
 
 The CKS-relevant detail is that kubeadm places the API server manifest under `/etc/kubernetes/manifests/kube-apiserver.yaml`, and the static pod restarts when the manifest changes. That restart can interrupt access, so you should have console access or a known recovery path before changing bind addresses on a live control plane. A careful operator checks the node interface addresses first, edits the manifest once, then watches the static pod return to readiness.
@@ -197,10 +198,11 @@ Anonymous authentication is the first setting to verify because it creates an id
 
 # Verification
 curl -k "https://api-server.local:6443/api/v1/namespaces"
-# Should return 401 Unauthorized
+# 401 means anonymous auth is disabled; 403 mentioning system:anonymous means
+# anonymous auth is enabled but RBAC denies the request.
 ```
 
-The expected result depends on where you run the test. From an untrusted network, the ideal result may be no route or a firewall block before HTTP appears. From a trusted diagnostic host, a request without credentials should return `401 Unauthorized`, not a namespace list and not a partial discovery response that implies anonymous access was granted. Those two tests answer different questions, so do not collapse them into one checkbox.
+The expected result depends on where you run the test. From an untrusted network, the ideal result may be a timeout, no route, or a firewall block before HTTP appears. From a trusted diagnostic host, a request without credentials should return `401 Unauthorized` when anonymous authentication is disabled, or `403 Forbidden` mentioning `system:anonymous` when anonymous authentication is enabled but RBAC denies the request. Resource data in the response is the real misconfiguration because it means an anonymous identity has been granted useful permissions.
 
 Client certificate authentication is common for control-plane components and administrative users in kubeadm-style clusters. The API server trusts certificates signed by the configured client CA, then derives the username and groups from certificate subject fields. This is strong cryptographic authentication, but it has a lifecycle problem: revoking a single long-lived client certificate is awkward unless you have added a separate authorizer or rotated the issuing CA.
 
@@ -342,7 +344,7 @@ metadata:
   name: batch-jobs-low-priority
 spec:
   priorityLevelConfiguration:
-    name: low-priority
+    name: workload-low
   matchingPrecedence: 1000
   rules:
   - subjects:
@@ -352,11 +354,12 @@ spec:
         namespace: batch
     resourceRules:
     - apiGroups: ["batch"]
+      namespaces: ["batch"]
       resources: ["jobs"]
       verbs: ["*"]
 ```
 
-The example lowers priority for a known batch service account, but the decision rule is broader. Identify request sources that are useful but not urgent, then keep them from consuming the same concurrency budget as kubelets, controllers, and emergency operator actions. APF does not excuse poorly designed clients; it gives the API server a way to remain usable while you fix those clients.
+The example lowers priority for a known batch service account by referencing the built-in `workload-low` PriorityLevelConfiguration and scoping the namespaced resource rule to `batch`. A FlowSchema and its referenced PriorityLevelConfiguration must both exist for the apply to succeed. The decision rule is broader: identify request sources that are useful but not urgent, then keep them from consuming the same concurrency budget as kubelets, controllers, and emergency operator actions. APF does not excuse poorly designed clients; it gives the API server a way to remain usable while you fix those clients.
 
 APF also changes how you diagnose API slowness. Without fairness, one noisy actor can make every client look slow, and logs may show only broad request latency. With APF, you can inspect flow schemas, priority levels, rejected requests, queued requests, and seat usage to determine which class is under pressure. That evidence helps you distinguish a malicious flood, a broken controller, and a legitimate workload spike.
 
@@ -370,21 +373,21 @@ Client-side throttling still matters even when APF is configured well. Many Kube
 
 Visibility is the layer that tells you whether the previous layers are doing what you intended. A private endpoint that no one tests can drift back to public exposure. Anonymous authentication that appears disabled can be reintroduced during a control-plane rebuild. A webhook cache that looks harmless can hide a revocation delay. Audit logs and metrics turn those assumptions into evidence.
 
-Kubernetes audit policy controls which requests are recorded and at what level. Logging every request body at `RequestResponse` sounds thorough, but it can create high storage costs and may capture sensitive data. Logging only metadata is cheaper, but it may not preserve enough detail for some investigations. The policy below keeps the original example by capturing authentication activity and failed requests while omitting the noisy `RequestReceived` stage.
+Kubernetes audit policy controls which requests are recorded and at what level. The [Kubernetes auditing documentation](https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/) defines `Metadata` as metadata only, while `RequestResponse` includes both request and response bodies. That body capture can be justified for narrow investigations, but it can also create high storage costs and capture sensitive data, so the safer default policy below records authentication API metadata plus catch-all metadata while omitting the noisy `RequestReceived` stage.
 
 ```yaml
 # Audit policy to log all API access attempts
 apiVersion: audit.k8s.io/v1
 kind: Policy
 rules:
-# Log all authentication attempts
-- level: RequestResponse
+# Log authentication API metadata without request or response bodies
+- level: Metadata
   omitStages:
   - RequestReceived
   resources:
   - group: "authentication.k8s.io"
 
-# Log failed requests
+# Catch-all metadata for remaining requests; filter 401/403 downstream in SIEM
 - level: Metadata
   omitStages:
   - RequestReceived
@@ -434,17 +437,19 @@ sudo vi /etc/kubernetes/manifests/kube-apiserver.yaml
 # API server will restart automatically
 ```
 
-Anonymous access verification is the next common scenario. The important detail is to interpret the response based on the network path. If you are testing from a trusted host that can route to the API, an unauthenticated request should receive an unauthorized status. If you are testing from an untrusted host, you ideally should not reach the Kubernetes API response path at all.
+Anonymous access verification is the next common scenario. The important detail is to interpret the response based on the network path. If you are testing from an untrusted host, you ideally should not reach the Kubernetes API response path at all — a timeout or no route means the network boundary is doing its job. From a trusted host that can route to the API, read the HTTP status carefully: `401 Unauthorized` means anonymous authentication is disabled; `403 Forbidden` mentioning `system:anonymous` means anonymous authentication is enabled but RBAC denies the request; resource data in the body means anonymous RBAC is misconfigured.
 
 ```bash
 # Test anonymous access
 curl -k "https://api-server.local:6443/api/v1/namespaces"
 
-# If anonymous is disabled, should get:
+# If anonymous is disabled, expect 401:
 # {"kind":"Status","apiVersion":"v1","status":"Failure","message":"Unauthorized",...}
 
-# If anonymous is enabled, may get namespace list or partial data
-# Fix by adding --anonymous-auth=false to API server
+# If anonymous is enabled but RBAC denies, expect 403 mentioning system:anonymous
+
+# If anonymous is enabled and RBAC grants access, may get namespace list or partial data
+# Fix by adding --anonymous-auth=false to API server and reviewing anonymous bindings
 ```
 
 Kubeconfig construction is another place where access restrictions become concrete. A kubeconfig does not just name a user; it names a cluster endpoint and credentials. If the endpoint is public, a stolen file can be replayed from anywhere that can reach the public route. If the endpoint is internal and the credential is least-privileged or short-lived, the same theft has a smaller blast radius.
@@ -545,7 +550,7 @@ These mistakes are common because each one looks like a small shortcut during de
 |---------|----------------|---------------|
 | Public API endpoint | Teams rely on strong credentials and forget that reachability enables scanning and resource pressure | Implement private endpoints where possible, or restrict ingress to known administrative CIDRs |
 | No firewall rules | Self-managed clusters inherit broad host or perimeter access during bootstrap | Add explicit allow rules for trusted ranges and a final drop rule for port 6443 |
-| Anonymous auth enabled | Default assumptions or legacy manifests leave `system:anonymous` reachable | Set `--anonymous-auth=false` and verify unauthenticated requests return `401` from a trusted test path |
+| Anonymous auth enabled | Default assumptions or legacy manifests leave `system:anonymous` reachable | Prefer `--anonymous-auth=false`; if a lab keeps anonymous auth enabled, verify RBAC returns only `403` for `system:anonymous` and never resource data |
 | No rate limiting | Operators assume authentication protects availability as well as identity | Use APF for request fairness and EventRateLimit for noisy Event producers |
 | Not monitoring access | Teams configure controls once and never check whether they drift | Enable audit logging, collect API metrics, and alert on unusual authentication or flow-control changes |
 | Long-lived client certs | Certificates are easy to create and hard to revoke individually | Prefer OIDC for humans, short-lived tokens where possible, and narrow RBAC for all identities |
@@ -611,10 +616,14 @@ In this exercise, you will audit the API access posture of a running cluster or 
 echo "=== API Server Config ==="
 kubectl get pods -n kube-system -l component=kube-apiserver -o yaml | grep -E "bind-address|anonymous-auth|authorization-mode"
 
-# Step 2: Test anonymous access (from within cluster) to verify internal isolation
+# Step 2: Test anonymous access from a trusted in-cluster route
 echo "=== Anonymous Access Test ==="
-kubectl run curlpod --image=curlimages/curl --rm -it --restart=Never -- \
-  curl -sk "https://kubernetes.default.svc.cluster.local/api/v1/namespaces" 2>&1 | head -5
+kubectl run curlpod --image=curlimages/curl --restart=Never --command -- \
+  curl -sk -w "\nHTTP %{http_code}\n" \
+  "https://kubernetes.default.svc.cluster.local/api/v1/namespaces"
+kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/curlpod --timeout=60s || true
+kubectl logs curlpod | head -20
+kubectl delete pod curlpod --ignore-not-found
 
 # Step 3: Check if API is accessible externally (Network Boundary Check)
 echo "=== External Access Check ==="
@@ -622,7 +631,7 @@ API_IP=$(kubectl get svc kubernetes -o jsonpath='{.spec.clusterIP}')
 echo "API Server internal IP: $API_IP"
 # In production, also resolve the external DNS/IP and attempt an external nmap or curl
 
-# Step 4: Review authentication methods for multiple identity providers
+# Step 4: Document the authentication methods configured in this cluster
 echo "=== Authentication Config ==="
 kubectl get pods -n kube-system -l component=kube-apiserver -o yaml | grep -E "client-ca|oidc|token|webhook"
 
@@ -636,15 +645,16 @@ kubectl get flowschemas --no-headers | head -5
 
 # Success criteria:
 # - Identified bind-address and verified it is properly scoped
-# - Anonymous access is actively denied (HTTP 401)
-# - Multiple robust auth methods (OIDC/x509) configured
+# - Anonymous access denied: timeout/no route (network block), 401 (anonymous disabled),
+#   or 403 mentioning system:anonymous (anonymous enabled but RBAC denies) — not resource data
+# - Document configured auth methods (client CA / bootstrap token minimum; OIDC/webhook if present)
 # - Rate limiting or APF FlowSchemas are actively routing traffic
 ```
 
 Complete the tasks in order, and write down both the observed output and the control you think it proves. If a command returns no matching flag, do not assume the setting is safe; check the API server documentation for defaults and inspect the full static pod manifest when you have node access.
 
 - [ ] Record the API server bind address, public endpoint status, and the network path that administrators are expected to use.
-- [ ] Test unauthenticated API access from a trusted diagnostic path and confirm whether the response is `401 Unauthorized`.
+- [ ] Test unauthenticated API access from a trusted diagnostic path and confirm the response is `401 Unauthorized`, `403 Forbidden` mentioning `system:anonymous`, or blocked before HTTP — not resource data.
 - [ ] Identify which authentication methods are configured, including client CA, service account issuer, OIDC, or webhook settings.
 - [ ] Inspect APF FlowSchemas and PriorityLevelConfigurations, then identify at least one low-priority or catch-all request class.
 - [ ] Review whether ordinary application namespaces can reach `kubernetes.default.svc` and whether their service accounts need that access.
@@ -658,7 +668,7 @@ Start with the provider or firewall view, then confirm the API server listener. 
 
 <details><summary>Solution guidance for anonymous and identity checks</summary>
 
-Run the unauthenticated `curl` only from a place that is supposed to reach the API. If you receive `401 Unauthorized`, anonymous access is being rejected for that route. If you receive resource data, inspect `--anonymous-auth` and any bindings for `system:anonymous` or `system:unauthenticated`. For identity, look for `--client-ca-file`, service account issuer flags, OIDC flags, and webhook authentication configuration. Then connect each identity method to its revocation story.
+Run the unauthenticated `curl` only from a place that is supposed to reach the API. A timeout or no route means the network boundary blocked the probe. `401 Unauthorized` means anonymous authentication is disabled. `403 Forbidden` mentioning `system:anonymous` means anonymous authentication is enabled but RBAC denies the request — common on kind and kubeadm labs with default RBAC. Resource data in the response is the real misconfiguration: inspect `--anonymous-auth` and any bindings for `system:anonymous` or `system:unauthenticated`. For identity, look for `--client-ca-file`, service account issuer flags, OIDC flags, and webhook authentication configuration — kind labs often show client CA only. Then connect each configured identity method to its revocation story.
 
 </details>
 
@@ -669,6 +679,14 @@ For workload egress, choose an ordinary application namespace and determine whet
 </details>
 
 The final deliverable for the exercise is a short access review note. It should name the current exposure path, the authentication methods, the weakest remaining route, the highest-risk credential type, and one metric or audit query that would show suspicious activity. That note is more useful than a screenshot because it connects the observed configuration to an operational decision.
+
+---
+
+## Learner check
+
+> The lesson is not that network controls replace identity controls. The correct model is layered: restrict the route, verify the client, authorize the request, limit the request rate, and record enough evidence to investigate suspicious access.
+
+Before you move on, explain what an unauthenticated `curl` to `/api/v1/namespaces` tells you when the response is `401`, when it is `403` mentioning `system:anonymous`, and when namespace data is returned. A solid answer names the network, authentication, and RBAC layers separately and states which misconfiguration each outcome reveals.
 
 ---
 


### PR DESCRIPTION
## CKS part2 (cluster-hardening) — review-first finalize batch

Cross-family R1 review → fix → verify loop for all five part2 modules, in curriculum order. Each was reviewed by a different-family reviewer, ground-checked, fixed, and re-verified T0/PASS. Build green (2129 pages, 38.45s).

| Module | Reviewer | Verdict | Key fixes |
|---|---|---|---|
| 2.1 rbac-deep-dive | cursor (R1, session 85) | NEEDS_CHANGES | Task-2 comment contradicted the lab (SA *can* read secrets); softened RBAC escalation overstatement + bind/escalate guardrail |
| 2.2 serviceaccount-security | cursor (R1, session 85) | NEEDS_CHANGES | Create `reports-broker-client` SA before use (apply was failing); removed nonexistent `reports-config-watcher-example` pod; agnhost exec alignment |
| 2.3 api-server-security | **agy / Gemini 3.5 Flash** | NEEDS_CHANGES | **P1**: `kubectl get pods kube-apiserver-*` glob is a literal pod name → NotFound → label selector; `sudo` on etcdctl PKI read |
| 2.4 kubernetes-upgrades | cursor | NEEDS_CHANGES | **P1**: kubelet version-skew was "two minors" — policy is **three** (kubelet ≥1.25); NetworkPolicy selected 0 pods (missing labels); removed `kubectl version --short` (×3); deprecated-API metric method; trivy v1.35 |
| 2.5 restricting-api-access | cursor + codex (2 convergent R1s, both verified live kind v1.35) | NEEDS_CHANGES | **P1**: APF FlowSchema referenced nonexistent PLC `low-priority` → `workload-low` + scoped `namespaces`; anonymous probe taught `401`-only, real cluster returns `403 system:anonymous` → full ladder; audit policy `Metadata` (was mislabeled) |

Each module carries a `## Learner check` blockquote (merge hook). `chore(` prefix (content-only). Finalizes part2 to `done` on the review axis → CKS 13/30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
