### PR TITLE
chore(content): CKS part3 system-hardening (3.1–3.4) review fixes + clear 1.4 revision flag

### DIFF
--- a/src/content/docs/k8s/cks/part1-cluster-setup/module-1.4-node-metadata.md
+++ b/src/content/docs/k8s/cks/part1-cluster-setup/module-1.4-node-metadata.md
@@ -1,6 +1,6 @@
 ---
 citations_verified: true
-revision_pending: true
+revision_pending: false
 title: "Module 1.4: Node Metadata Protection"
 slug: k8s/cks/part1-cluster-setup/module-1.4-node-metadata
 sidebar:

--- a/src/content/docs/k8s/cks/part3-system-hardening/module-3.1-apparmor.md
+++ b/src/content/docs/k8s/cks/part3-system-hardening/module-3.1-apparmor.md
@@ -13,7 +13,7 @@ lab:
 ---
 > **Complexity**: `[MEDIUM]` - Linux security essential
 >
-> **Time to Complete**: 45-50 minutes
+> **Time to Complete**: 40 minutes
 >
 > **Prerequisites**: Linux basics, container runtime knowledge
 
@@ -108,14 +108,14 @@ Complain mode is where many successful profiles begin. You place the profile aro
 
 Pause and predict: if a new profile denies writes under `/etc/**`, what do you expect from an image that generates configuration files in `/etc/nginx/conf.d/` before launching nginx? The important answer is not just "it might fail." The important answer is that the failure will surface at the application layer first, while the reason you trust is in the kernel log where AppArmor records the blocked write.
 
-You can inspect a node before you touch a pod. The first command checks whether the kernel module is enabled. The second asks the AppArmor tooling for a summary. The third verifies that the container runtime advertises AppArmor support. In a CKS-style environment, these checks also keep you from debugging a Kubernetes manifest when the real problem is that the node cannot enforce the profile.
+You can inspect a node before you touch a pod. The first command checks whether the kernel module is enabled. The second asks the AppArmor tooling for a summary. The third confirms that the kernel has loaded profiles registered for enforcement. In a CKS-style environment, these checks also keep you from debugging a Kubernetes manifest when the real problem is that the node cannot enforce the profile. CKS and kind lab nodes are containerd-first; `docker` is often absent, so do not rely on `docker info` for AppArmor support.
 
 ```bash
-# Check if AppArmor is enabled
+# Check if AppArmor is enabled (kernel module)
 cat /sys/module/apparmor/parameters/enabled
 # Output: Y (enabled) or N (disabled)
 
-# Check AppArmor status
+# Check AppArmor status (loaded profiles and modes)
 sudo aa-status
 
 # Output example:
@@ -131,9 +131,11 @@ sudo aa-status
 # List loaded profiles
 sudo aa-status --profiles
 
-# Check if container runtime supports AppArmor
-docker info | grep -i apparmor
-# Output: Security Options: apparmor
+# containerd / CRI nodes: confirm profiles are visible to the kernel
+# (no docker CLI required)
+sudo grep -E '^profile ' /sys/kernel/security/apparmor/profiles | head
+# Or list profile names from aa-status
+sudo aa-status --profiles
 ```
 
 The container runtime's default profile is a baseline, not a workload policy. Docker historically called its default profile `docker-default`, and containerd installations often expose a runtime default profile through Kubernetes as `RuntimeDefault`. These profiles usually block dangerous operations such as mounting filesystems, writing to sensitive `/proc` paths, and using raw network features, while allowing enough behavior for normal containers to start.
@@ -346,7 +348,7 @@ What would happen if you create an AppArmor profile and load it on `node-1`, but
 
 That behavior creates an operational rule: custom profiles are cluster rollout artifacts, not one-off files. If every worker node may run the pod, every worker node needs the profile loaded before the manifest is applied. If only a subset of nodes has the profile, label those nodes and constrain the workload there. Without that discipline, a reschedule event can turn a successful security change into an availability incident.
 
-AppArmor also interacts with Pod Security Admission. The restricted policy expects workloads to avoid unconfined profiles, and the baseline policy prevents several unsafe profile combinations. That means AppArmor configuration is not just a node concern; it can also be an admission concern. A manifest that asks for `Unconfined` may be rejected before it reaches kubelet, while a manifest that asks for a missing `Localhost` profile may pass admission but fail at the node.
+AppArmor also interacts with Pod Security Admission. Under Pod Security **Baseline** (and therefore Restricted), `Unconfined` AppArmor profiles are rejected at admission; `Localhost` profiles missing on the node still fail at the kubelet. That means AppArmor configuration is not just a node concern; admission can block unsafe profile types before scheduling, while node-local profile loading remains your responsibility for `Localhost` references.
 
 Auditing a running container should include the kernel's view, not only the YAML you submitted. The reliable check is to read `/proc/1/attr/current` inside the container. If the output says `k8s-deny-write (enforce)`, the root process is running under that profile. If it says a runtime default profile, an unexpected profile, or `unconfined`, your manifest, node state, or runtime configuration does not match your intent.
 
@@ -555,8 +557,33 @@ EOF
 # Load profile
 sudo apparmor_parser -r /etc/apparmor.d/k8s-deny-etc-write
 
-# Legacy annotation example for older clusters
+# Kubernetes 1.35+ — apply with securityContext.appArmorProfile
 cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: secured-nginx
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    securityContext:
+      appArmorProfile:
+        type: Localhost
+        localhostProfile: k8s-deny-etc-write
+EOF
+
+# Wait for pod to be ready
+kubectl wait --for=condition=Ready pod/secured-nginx --timeout=60s
+
+# Verify
+kubectl exec secured-nginx -- touch /etc/test
+# Should fail due to AppArmor
+```
+
+Legacy recognition only (deprecated since v1.30; emits a warning on v1.35 — do not use in new manifests):
+
+```yaml
 apiVersion: v1
 kind: Pod
 metadata:
@@ -567,14 +594,6 @@ spec:
   containers:
   - name: nginx
     image: nginx
-EOF
-
-# Wait for pod to be ready
-kubectl wait --for=condition=Ready pod/secured-nginx --timeout=60s
-
-# Verify
-kubectl exec secured-nginx -- touch /etc/test
-# Should fail due to AppArmor
 ```
 
 Debugging AppArmor issues is a layered process. Pod events tell you whether Kubernetes or kubelet rejected the profile reference. Node commands tell you whether the profile exists and whether AppArmor is enabled. Kernel logs tell you which exact operation, profile, process, path, and requested mask caused a denial. You need all three layers because any one layer by itself can point you in the wrong direction.
@@ -759,6 +778,8 @@ The YAML shows the requested configuration, but it does not prove kubelet admitt
 
 ## Hands-On Exercise
 
+**Prerequisite:** This lab requires an AppArmor-enabled Linux worker (typical CKS/killercoda Ubuntu). If `cat /sys/module/apparmor/parameters/enabled` does not return `Y`, run the node-side profile steps on a supported host before applying pods.
+
 In this exercise you will create a custom AppArmor profile that denies network access, load it on a node, apply it to a pod with the Kubernetes 1.35+ security context field, and verify both the intended failure and a control case. The original lab command sequence is preserved in spirit, but the manifest uses `appArmorProfile` instead of the legacy annotation. Run the node commands on the worker that will host the pod, or use a single-node lab cluster where the control plane node also runs workloads.
 
 - [ ] Confirm that AppArmor is enabled on the node and that `aa-status` can report loaded profiles.
@@ -827,7 +848,7 @@ kubectl run network-allowed --image=curlimages/curl --rm -i --restart=Never -- \
 # Should succeed (200)
 
 # Cleanup
-kubectl delete pod no-network-pod --force --grace-period=0
+kubectl delete pod no-network-pod --grace-period=0
 sudo apparmor_parser -R /etc/apparmor.d/k8s-deny-network
 ```
 
@@ -853,6 +874,14 @@ Deleting the pod removes the workload, but it does not remove the host profile. 
 </details>
 
 The success criteria are deliberately evidence-based. You should be able to show that the node has the profile, the container runs with that profile, the denied operation fails, the control operation succeeds outside the profile, and the cleanup step leaves no temporary pod behind. If any one of those claims is unsupported, continue debugging until the observed state and the intended policy match.
+
+---
+
+## Learner check
+
+> AppArmor profiles are node-local kernel assets: Kubernetes 1.35+ references them with `securityContext.appArmorProfile`, but every worker that may run the pod must load the profile before kubelet can enforce `type: Localhost`.
+
+Before you move on, explain why a pod can pass admission yet fail on a drained node, and which three checks prove enforcement (node profile state, pod events, and `/proc/1/attr/current`). A solid answer names Pod Security Admission limits on `Unconfined`, distinguishes missing `Localhost` profiles at the kubelet from admission rejection, and cites at least one kernel denial log path.
 
 ---
 

--- a/src/content/docs/k8s/cks/part3-system-hardening/module-3.2-seccomp.md
+++ b/src/content/docs/k8s/cks/part3-system-hardening/module-3.2-seccomp.md
@@ -237,6 +237,7 @@ spec:
         type: RuntimeDefault
   - name: sidecar
     image: busybox
+    command: ["sleep", "3600"]
     securityContext:
       seccompProfile:
         type: Localhost
@@ -367,10 +368,9 @@ Understanding how to structure custom profiles is essential for strict security 
 
 ### Profile That Blocks ptrace
 
-If your environment defaults to allowing most syscalls, you might want to create a denylist profile that specifically blocks known dangerous system calls like `ptrace`.
+If your environment defaults to allowing most syscalls, you might want to create a denylist profile that specifically blocks known dangerous system calls like `ptrace`. Save this profile as `/var/lib/kubelet/seccomp/profiles/deny-ptrace.json`:
 
 ```json
-// /var/lib/kubelet/seccomp/profiles/deny-ptrace.json
 {
   "defaultAction": "SCMP_ACT_ALLOW",
   "syscalls": [
@@ -387,10 +387,9 @@ This profile is intentionally narrow. It does not try to describe the whole appl
 
 ### Profile That Only Allows Specific Syscalls
 
-This is a strict allowlist approach. The `defaultAction` is `SCMP_ACT_ERRNO`, meaning anything not explicitly listed in the `syscalls` array will be blocked. This is highly secure but brittle.
+This is a strict allowlist approach. The `defaultAction` is `SCMP_ACT_ERRNO`, meaning anything not explicitly listed in the `syscalls` array will be blocked. This is highly secure but brittle. Save this profile as `/var/lib/kubelet/seccomp/profiles/minimal.json`:
 
 ```json
-// /var/lib/kubelet/seccomp/profiles/minimal.json
 {
   "defaultAction": "SCMP_ACT_ERRNO",
   "architectures": ["SCMP_ARCH_X86_64"],
@@ -411,10 +410,9 @@ This minimal profile is educational rather than a ready-made production profile.
 
 ### Profile That Logs Suspicious Calls
 
-This is an excellent pattern for debugging and auditing. Instead of blocking the calls and potentially crashing the application, this profile allows them but triggers an audit log entry. This lets security teams observe behavior before enforcing a block.
+This is an excellent pattern for debugging and auditing. Instead of blocking the calls and potentially crashing the application, this profile allows them but triggers an audit log entry. This lets security teams observe behavior before enforcing a block. Save this profile as `/var/lib/kubelet/seccomp/profiles/audit.json`:
 
 ```json
-// /var/lib/kubelet/seccomp/profiles/audit.json
 {
   "defaultAction": "SCMP_ACT_ALLOW",
   "syscalls": [
@@ -752,29 +750,44 @@ spec:
       localhostProfile: profiles/no-ptrace.json
   containers:
   - name: app
-    image: busybox
-    command: ["sleep", "3600"]
+    image: alpine
+    command: ["sh", "-c", "apk add --no-cache strace && sleep 3600"]
 EOF
 
 # Step 5: Wait for pod
-kubectl wait --for=condition=Ready pod/no-ptrace-pod --timeout=60s
+kubectl wait --for=condition=Ready pod/no-ptrace-pod --timeout=120s
 
 # Step 6: Verify seccomp is applied
 kubectl get pod no-ptrace-pod -o jsonpath='{.spec.securityContext.seccompProfile}' | jq .
 
 # Step 7: Test that ptrace would be blocked
-# (strace uses ptrace internally)
-kubectl exec no-ptrace-pod -- strace -f echo test 2>&1 || echo "strace blocked (expected)"
+# (strace uses ptrace internally — alpine installs strace at startup)
+kubectl exec no-ptrace-pod -- sh -c "strace -f echo test" 2>&1 || echo "strace blocked (expected)"
 
-# Step 8: Create comparison pod without seccomp restriction
-kubectl run allowed-pod --image=busybox --rm -it --restart=Never -- \
-  sh -c "ls /proc/self/status && echo 'No seccomp issues'"
+# Step 8: Create comparison pod with explicit Unconfined seccomp
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allowed-pod
+spec:
+  securityContext:
+    seccompProfile:
+      type: Unconfined
+  containers:
+  - name: app
+    image: alpine
+    command: ["sh", "-c", "apk add --no-cache strace && sleep 3600"]
+EOF
+
+kubectl wait --for=condition=Ready pod/allowed-pod --timeout=120s
+kubectl exec allowed-pod -- sh -c "strace echo test"
 
 # Cleanup
-kubectl delete pod no-ptrace-pod
+kubectl delete pod no-ptrace-pod allowed-pod
 ```
 
-If your chosen image does not include `strace`, keep the profile and Pod pattern but use a lab image that includes tracing tools, or test another blocked syscall with a command available in the image. The security claim you are validating is not tied to BusyBox specifically. You are checking that `Localhost` resolves to the expected node file and that the runtime enforces the configured syscall action.
+The alpine image installs `strace` at container startup so Step 7 exercises a real `ptrace` denial instead of a missing-binary error. Step 8 sets `seccompProfile.type: Unconfined` explicitly so the comparison pod is not constrained by kubelet or runtime defaults on Kubernetes 1.35+. You should see `strace` succeed in `allowed-pod` and fail in `no-ptrace-pod`, proving the profile blocks the syscall rather than the tool.
 
 ### Progressive Tasks
 
@@ -797,23 +810,27 @@ Create the profile under `/var/lib/kubelet/seccomp/profiles/no-ptrace.json`, the
 - [ ] Directory `/var/lib/kubelet/seccomp/profiles/` exists on the node.
 - [ ] JSON profile `no-ptrace.json` is syntactically valid and saved to the correct location.
 - [ ] The Pod `no-ptrace-pod` is created without a `CreateContainerError`.
-- [ ] Running `strace` inside `no-ptrace-pod` results in an "Operation not permitted" error when the image includes `strace`.
-- [ ] The comparison workload executes normally, demonstrating the specific impact of the profile.
+- [ ] Running `strace` inside `no-ptrace-pod` results in an "Operation not permitted" error.
+- [ ] Running `strace echo test` inside `allowed-pod` succeeds, demonstrating allowed-vs-blocked behavior under explicit `Unconfined`.
 - [ ] You can explain why this lab proves profile loading and one enforcement rule, not complete application compatibility.
+
+## Learner check
+
+> A seccomp lab only proves enforcement when the test command actually invokes the blocked syscall: install `strace` in the container, run it under the restrictive profile and confirm denial, then repeat under explicit `Unconfined` and confirm success.
 
 ## Sources
 
-- https://kubernetes.io/docs/tutorials/security/seccomp/
-- https://kubernetes.io/docs/reference/node/seccomp/
-- https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-- https://kubernetes.io/docs/concepts/security/pod-security-standards/
-- https://kubernetes.io/docs/concepts/security/pod-security-admission/
-- https://github.com/moby/moby/blob/master/profiles/seccomp/default.json
-- https://github.com/opencontainers/runtime-spec/blob/main/config-linux.md#seccomp
-- https://docs.kernel.org/userspace-api/seccomp_filter.html
-- https://man7.org/linux/man-pages/man2/seccomp.2.html
-- https://man7.org/linux/man-pages/man2/syscalls.2.html
-- https://github.com/kubernetes-sigs/security-profiles-operator
+- <https://kubernetes.io/docs/tutorials/security/seccomp/>
+- <https://kubernetes.io/docs/reference/node/seccomp/>
+- <https://kubernetes.io/docs/tasks/configure-pod-container/security-context/>
+- <https://kubernetes.io/docs/concepts/security/pod-security-standards/>
+- <https://kubernetes.io/docs/concepts/security/pod-security-admission/>
+- <https://github.com/moby/moby/blob/master/profiles/seccomp/default.json>
+- <https://github.com/opencontainers/runtime-spec/blob/main/config-linux.md#seccomp>
+- <https://docs.kernel.org/userspace-api/seccomp_filter.html>
+- <https://man7.org/linux/man-pages/man2/seccomp.2.html>
+- <https://man7.org/linux/man-pages/man2/syscalls.2.html>
+- <https://github.com/kubernetes-sigs/security-profiles-operator>
 
 ## Next Module
 

--- a/src/content/docs/k8s/cks/part3-system-hardening/module-3.3-kernel-hardening.md
+++ b/src/content/docs/k8s/cks/part3-system-hardening/module-3.3-kernel-hardening.md
@@ -161,12 +161,14 @@ Automatic updates require a policy, not just a package. On pets-style servers, u
 
 SSH hardening belongs in the same baseline because emergency shell access is powerful and often forgotten. If SSH exists, root login should be disabled, password authentication should be disabled, allowed users should be narrow, and access should be logged. If the platform supports a no-SSH model, prefer a controlled break-glass workflow and Kubernetes-native debugging for routine application investigation.
 
-```bash
+```text
 # /etc/ssh/sshd_config
 PermitRootLogin no
 PasswordAuthentication no
 AllowUsers admin
+```
 
+```bash
 # Restart SSH
 sudo systemctl restart sshd
 ```
@@ -205,10 +207,12 @@ The first group reduces network abuse that should not be needed on a worker node
 ```bash
 # View current settings
 sysctl -a | grep -E "net.ipv4|kernel" | head -20
+```
 
-# Recommended security settings
-# Add to /etc/sysctl.d/99-kubernetes-security.conf
+Add the hardened values to a managed sysctl file rather than pasting the configuration lines directly into a shell prompt.
 
+```ini
+# /etc/sysctl.d/99-kubernetes-security.conf
 # Disable IP forwarding if not needed (kubelets need it!)
 # net.ipv4.ip_forward = 0  # Don't disable on K8s nodes!
 
@@ -237,7 +241,9 @@ kernel.dmesg_restrict = 1
 
 # Restrict kernel pointers
 kernel.kptr_restrict = 1
+```
 
+```bash
 # Apply settings
 sudo sysctl -p /etc/sysctl.d/99-kubernetes-security.conf
 ```
@@ -246,7 +252,7 @@ The kernel settings in that file do not all protect the same phase of an attack.
 
 Network sysctls need special attention because Kubernetes networking uses forwarding deliberately. Pod traffic may cross veth pairs, bridges, overlay interfaces, and the node's primary interface, depending on the CNI. If a generic compliance rule says every Linux host must disable forwarding, applying it blindly can break cross-node Pod communication and Service routing even though the node looks more secure to the scanner.
 
-```bash
+```ini
 # /etc/sysctl.d/99-kubernetes.conf
 
 # Required for Kubernetes networking
@@ -315,7 +321,7 @@ When you set `kernel.kptr_restrict = 2`, you are choosing a stricter posture tha
 
 The Linux kernel exposes enormous amounts of system information through pseudo-filesystems such as `/proc` and `/sys`. That visibility is useful for administrators and monitoring agents, but it can also help attackers enumerate processes, kernel modules, command lines, device information, and runtime state. Host hardening therefore includes both what ordinary users can see on the node and what containers are allowed to see through their mounts.
 
-```bash
+```text
 # Restrict access to process information
 # In /etc/fstab or mount options:
 proc    /proc    proc    defaults,hidepid=2    0    0
@@ -359,7 +365,7 @@ ls -la /var/lib/kubelet/config.yaml
 
 Filesystem mount options add another layer of defense after a process gains some write access. `nodev` prevents device files from being interpreted on that filesystem, `nosuid` prevents setuid bits from granting privilege, and `noexec` prevents direct execution from paths that should only store data or logs. These controls are not perfect bypass-proof walls, but they force attackers to work harder and remove common shortcuts.
 
-```bash
+```text
 # /etc/fstab entries with security options
 
 # Separate partitions for:
@@ -382,7 +388,7 @@ Mount choices must respect workload reality. Applying `noexec` to `/tmp` on the 
 
 Read-only root filesystems are the strongest version of this idea. In immutable infrastructure, the node image is replaced instead of modified, writable state is isolated, and configuration comes from a controlled pipeline. This model sharply reduces drift, but it requires good operational tooling because the old habit of "SSH in and edit a file" no longer works.
 
-```bash
+```text
 # For immutable infrastructure:
 # Mount root as read-only, use overlay for writes
 
@@ -419,20 +425,19 @@ Container runtime hardening is where host controls meet Pod controls. The runtim
       runtime_type = "io.containerd.runc.v2"
 
       [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
-        # Enable seccomp
+        # Use systemd cgroups
         SystemdCgroup = true
 ```
 
-This containerd snippet preserves the common `runc` path while showing where runtime choices live. `SystemdCgroup = true` aligns the runtime with systemd-managed cgroups, which is the expected posture for many Kubernetes distributions. Seccomp defaults are normally controlled through the runtime and Pod security context together, so verify both the node default and the workload declarations before assuming syscall filtering is active.
+This containerd snippet preserves the common `runc` path while showing where runtime choices live. `SystemdCgroup = true` aligns the runtime with systemd-managed cgroups, which is the expected posture for many Kubernetes distributions. It is not a seccomp switch. Teach seccomp at the Pod layer with `securityContext.seccompProfile.type: RuntimeDefault`, and on clusters that deliberately default every workload, verify kubelet `--seccomp-default` behavior instead of assuming the cgroup setting filtered syscalls.
 
-Some environments still use Docker Engine as the node runtime layer or for adjacent build hosts, so the same hardening ideas appear in Docker configuration. User namespace remapping can make container root map to a less privileged host identity, `no-new-privileges` blocks privilege escalation across exec, and seccomp profiles constrain syscall access. Inter-container communication and live restore settings then become additional operational decisions.
+Some environments still use Docker Engine for adjacent build hosts, so the same hardening ideas appear in Docker configuration even when Kubernetes nodes run containerd. User namespace remapping can make container root map to a less privileged host identity, `no-new-privileges` blocks privilege escalation across exec, and seccomp profiles constrain syscall access. Inter-container communication and live restore settings then become additional operational decisions.
 
-```bash
-# /etc/docker/daemon.json
+```json
 {
   "userns-remap": "default",
   "no-new-privileges": true,
-  "seccomp-profile": "/etc/docker/seccomp.json",
+  "seccomp-profile": "/path/to/seccomp-profile.json",
   "icc": false,
   "live-restore": true
 }
@@ -442,29 +447,32 @@ Runtime isolation is also visible from Kubernetes manifests. A Pod that runs as 
 
 The old habit of leaving debugging tools permanently installed on the node conflicts with runtime hardening. Kubernetes gives you better tools now, including ephemeral debug containers and node debugging workflows, so you can investigate without keeping compilers, scanners, and shell utilities on every worker forever. That distinction matters because a tool that helps an administrator after login can also help an attacker after escape.
 
-Audit evidence closes the loop. Hardening without audit gives you a desired state but little proof that it stayed true, while audit without hardening gives you detailed records of preventable exposure. The useful middle ground is to monitor high-value runtime binaries, configuration directories, container storage paths, kubelet configuration, and Kubernetes certificate locations for changes that should be rare.
+Audit evidence closes the loop. Hardening without audit gives you a desired state but little proof that it stayed true, while audit without hardening gives you detailed records of preventable exposure. The useful middle ground is to monitor high-value runtime binaries, configuration directories, container storage paths, kubelet configuration, and Kubernetes certificate locations for changes that should be rare. Start with the paths that exist on the node; for example, kind nodes running containerd expose the runtime binary at `/usr/local/bin/containerd`, so do not assume a distribution-specific binary location.
 
 ```bash
 # Install auditd
 sudo apt install -y auditd
 
-# Configure audit rules for container security
-# /etc/audit/rules.d/docker.rules
+# Configure containerd-first audit rules
+sudo install -m 0640 /dev/null /etc/audit/rules.d/container-runtime.rules
+for rule in \
+  "containerd:/usr/local/bin/containerd" \
+  "containerd-storage:/var/lib/containerd" \
+  "containerd-config:/etc/containerd" \
+  "kubernetes:/etc/kubernetes" \
+  "kubelet:/var/lib/kubelet"
+do
+  key="${rule%%:*}"
+  path="${rule#*:}"
+  if sudo test -e "$path"; then
+    printf -- "-w %s -p wa -k %s\n" "$path" "$key" | sudo tee -a /etc/audit/rules.d/container-runtime.rules >/dev/null
+  else
+    echo "Skipping missing audit path: $path"
+  fi
+done
 
-# Monitor Docker daemon
--w /usr/bin/dockerd -k docker
--w /usr/bin/containerd -k containerd
-
-# Monitor Docker config
--w /etc/docker -k docker-config
-
-# Monitor container directories
--w /var/lib/docker -k docker-storage
--w /var/lib/containerd -k containerd-storage
-
-# Monitor Kubernetes files
--w /etc/kubernetes -k kubernetes
--w /var/lib/kubelet -k kubelet
+# Legacy Docker Engine watches belong only on nodes where these paths exist.
+# Add dockerd, Docker config, and Docker storage watches after test -e confirms them.
 
 # Apply rules
 sudo augenrules --load
@@ -613,13 +621,21 @@ Focus audit rules on high-value paths where change should be rare: runtime binar
 
 ---
 
+## Learner check
+
+> A hardening lab is only useful when you can name the exact kernel boundary it proved and the boundary it merely inspected.
+
+Before you trust a command as evidence, ask whether it tests the control named in the lesson. A failed read of `/etc/shadow` from a non-root container proves ordinary file permissions and user identity, not `allowPrivilegeEscalation: false`. For that control, inspect the Linux `NoNewPrivs` flag or run a deliberately scoped setuid demonstration in a disposable lab.
+
+---
+
 ## Hands-On Exercise
 
 This exercise uses Kubernetes security contexts to demonstrate host-hardening concepts safely. You will compare an insecure Pod with a hardened Pod, then map each observed difference back to the kernel or OS control it resembles. If you are working on a real cluster, use a disposable namespace and avoid running privileged experiments on production nodes.
 
 ### Setup
 
-Run the preserved lab script below in a test cluster where you can create and delete a namespace. The script deploys two BusyBox Pods, compares identity, filesystem, process, `/proc`, and security context behavior, then prints host sysctl checks you would run on the actual node. It intentionally uses full `kubectl` commands so the block works in non-interactive shells.
+Run the preserved lab script below in a test cluster where you can create and delete a namespace. The script deploys two BusyBox Pods, compares identity, filesystem, default Pod PID namespace, `/proc`, `NoNewPrivs`, and security context behavior, then prints host sysctl checks you would run on the actual node. It intentionally uses full `kubectl` commands so the block works in non-interactive shells.
 
 ### Tasks
 
@@ -650,7 +666,7 @@ Check that kubelet configuration and kubeconfigs are root-owned and restrictive,
 <details>
 <summary>Solution guide for task 4</summary>
 
-Evaluate runtime isolation by asking what the workload can ask the kernel to do after compromise. `RuntimeDefault` seccomp removes many unnecessary syscall paths, dropping capabilities reduces privileged kernel operations, `allowPrivilegeEscalation: false` blocks common escalation paths, and a read-only root filesystem removes easy persistence locations. These controls are strongest when paired with host patching, sysctl restrictions, minimal packages, and focused audit evidence.
+Evaluate runtime isolation by asking what the workload can ask the kernel to do after compromise. `RuntimeDefault` seccomp removes many unnecessary syscall paths, dropping capabilities reduces privileged kernel operations, `allowPrivilegeEscalation: false` maps to the Linux `NoNewPrivs` flag, and a read-only root filesystem removes easy persistence locations. These controls are strongest when paired with host patching, sysctl restrictions, minimal packages, and focused audit evidence.
 </details>
 
 <details>
@@ -728,12 +744,13 @@ kubectl exec -n kernel-test insecure-pod -- sh -c "echo 'test' > /tmp/test.txt &
 echo "=== Secure Pod: Can write to /tmp? (should fail - readOnlyRootFilesystem) ==="
 kubectl exec -n kernel-test secure-pod -- sh -c "echo 'test' > /tmp/test.txt && echo 'Write succeeded' || echo 'Write blocked!'"
 
-# Step 6: Test process visibility (demonstrates hidepid concept)
-echo "=== Insecure Pod: Process list ==="
+# Step 6: Observe default Pod PID namespace visibility
+echo "=== Insecure Pod: Process list inside its Pod PID namespace ==="
 kubectl exec -n kernel-test insecure-pod -- ps aux | head -5
 
-echo "=== Secure Pod: Process list (limited view) ==="
+echo "=== Secure Pod: Process list inside its Pod PID namespace ==="
 kubectl exec -n kernel-test secure-pod -- ps aux | head -5
+echo "Both Pods use normal isolated Pod PID namespaces; host hidepid must be checked on the node."
 
 # Step 7: Check proc access
 echo "=== Checking /proc access in secure pod ==="
@@ -746,12 +763,18 @@ kubectl get pod insecure-pod -n kernel-test -o jsonpath='{.spec.securityContext}
 echo "Secure pod security context:"
 kubectl get pod secure-pod -n kernel-test -o jsonpath='{.spec.securityContext}' && echo ""
 
-# Step 9: Test privilege escalation (critical kernel hardening)
-echo "=== Testing Privilege Escalation Prevention ==="
-# Secure pod should block this
-kubectl exec -n kernel-test secure-pod -- sh -c "cat /etc/shadow 2>&1" || echo "Access denied (expected)"
+# Step 9: Verify allowPrivilegeEscalation through no_new_privs
+echo "=== no_new_privs flag (allowPrivilegeEscalation=false) ==="
+echo "Insecure pod:"
+kubectl exec -n kernel-test insecure-pod -- sh -c "grep NoNewPrivs /proc/self/status"
+echo "Secure pod:"
+kubectl exec -n kernel-test secure-pod -- sh -c "grep NoNewPrivs /proc/self/status"
 
-# Step 10: Check host sysctl (if running on actual node)
+# Step 10: Check non-root permissions without confusing them for no_new_privs
+echo "=== Non-root file permission check ==="
+kubectl exec -n kernel-test secure-pod -- sh -c "cat /etc/shadow 2>&1" || echo "Root-only file blocked for non-root user (expected)"
+
+# Step 11: Check host sysctl (if running on actual node)
 echo ""
 echo "=== Host Kernel Checks (run on actual node) ==="
 echo "To check on your actual cluster nodes:"
@@ -759,6 +782,7 @@ echo "  sysctl kernel.randomize_va_space    # Should be 2"
 echo "  sysctl kernel.dmesg_restrict        # Should be 1"
 echo "  sysctl kernel.kptr_restrict         # Should be 1 or 2"
 echo "  sysctl net.ipv4.conf.all.accept_redirects  # Should be 0"
+echo "  findmnt -no OPTIONS /proc           # Check host hidepid options on the node"
 
 # Cleanup
 echo ""
@@ -771,8 +795,9 @@ echo "Key learnings demonstrated:"
 echo "1. ✓ runAsNonRoot prevents root execution"
 echo "2. ✓ readOnlyRootFilesystem blocks writes"
 echo "3. ✓ Dropping capabilities limits syscalls"
-echo "4. ✓ allowPrivilegeEscalation=false prevents escalation"
+echo "4. ✓ allowPrivilegeEscalation=false maps to NoNewPrivs"
 echo "5. ✓ seccompProfile applies syscall filtering"
+echo "6. ✓ default Pod PID namespaces are not the same as host hidepid"
 ```
 
 ### Success Criteria

--- a/src/content/docs/k8s/cks/part3-system-hardening/module-3.4-network-security.md
+++ b/src/content/docs/k8s/cks/part3-system-hardening/module-3.4-network-security.md
@@ -123,7 +123,7 @@ The loopback interface adds another subtle boundary. A service bound to `127.0.0
 
 Before you can write a firewall rule, you need to know whether a port is required, optional, local-only, or obsolete. Kubernetes documents standard ports for the control plane and worker nodes, but those tables are starting points rather than final policy. A secure rule set adds source restrictions, because the question is not only "Should port 10250 exist?" but "Which systems should ever be able to reach 10250?"
 
-Control-plane nodes usually expose the API server on 6443, etcd client traffic on 2379, etcd peer traffic on 2380, and kubelet on 10250. Scheduler and controller-manager secure endpoints are commonly bound for local or controlled access, and managed distributions may differ in placement. Worker nodes usually expose kubelet on 10250 and may expose NodePort sockets in the service range, which defaults to 30000-32767 unless the cluster is configured otherwise.
+Control-plane nodes usually expose the API server on 6443, etcd client traffic on 2379, etcd peer traffic on 2380, and kubelet on 10250. Scheduler and controller-manager secure endpoints are commonly bound for local or controlled access, and managed distributions may differ in placement. Worker nodes usually expose kubelet on 10250, kube-proxy health and metrics on 10256/tcp, and may expose NodePort sockets in the service range, which defaults to 30000-32767 unless the cluster is configured otherwise.
 
 ```mermaid
 flowchart LR
@@ -169,6 +169,7 @@ The static port map below is intentionally conservative. It treats 10255 and 808
 |  Worker Nodes:                                              |
 |  ---------------------------------------------------------  |
 |  10250  - Kubelet API (authenticated)                       |
+|  10256  - kube-proxy health/metrics (TCP)                   |
 |  30000-32767 - NodePort services (if used)                  |
 |                                                             |
 |  Should be DISABLED:                                        |
@@ -188,6 +189,7 @@ Trust zones should be defined by routes and identity, not by vague labels like "
 | 22/tcp | SSH | Bastion or privileged admin subnet | Restrict tightly and log access attempts |
 | 6443/tcp | API server | Admin networks, CI/CD, control integrations | Never leave broadly public without strong compensating controls |
 | 10250/tcp | Kubelet API | Control-plane nodes and authenticated operational tools | Block direct user and internet access |
+| 10256/tcp | kube-proxy health/metrics | Control plane and monitoring subnets | Restrict like kubelet; do not expose cluster-wide |
 | 2379/tcp | etcd client | API server only | Treat as critical cluster state access |
 | 2380/tcp | etcd peer | Other etcd members only | Allow exact peer addresses in stacked or external etcd |
 | 30000-32767/tcp | NodePort services | Service-specific client networks | Prefer ingress or load balancer when possible |
@@ -217,7 +219,7 @@ sudo netstat -tlnp
 ss -tlnp | grep -E '6443|10250|2379'
 
 # Check for insecure ports
-ss -tlnp | grep -E '10255|8080'
+ss -tlnp | grep -E ':10255|:8080'
 
 # Using nmap from external host
 nmap -p 6443,10250,10255,2379 <node-ip>
@@ -242,6 +244,8 @@ Remote scans should be run from meaningful locations. A scan from the node itsel
 Host firewalls protect the Linux `INPUT` path: traffic destined for the node itself. They are not a replacement for cloud security groups, physical firewalls, Kubernetes NetworkPolicy, or service mesh policy, but they add a local enforcement point that travels with the node. A useful host firewall rule is explicit about protocol, destination port, source network, and fallback behavior.
 
 The main operational hazard is that Kubernetes also uses Linux packet filtering and forwarding machinery. Kube-proxy, CNIs, and container runtimes can create iptables or nftables state for service routing, masquerade, connection tracking, overlay encapsulation, and health checks. A host firewall that blocks the wrong node-to-node protocol may "harden" the host by cutting the pod network apart, which is why the audit and trust-zone model must come first.
+
+Before you apply a default `INPUT DROP` on worker nodes, verify your CNI's documented node-to-node ports and protocols. Overlay plugins often need UDP encapsulation (for example VXLAN on 4789/udp or Geneve on 6081/udp), BGP-based CNIs may require TCP 179 between nodes, and some implementations use additional control ports for IPAM or tunnel health. Segmenting etcd, kubelet, and SSH on the host does not replace allowing the overlay control plane; it complements it. If you are unsure, read the CNI install guide for your distribution, allow those paths explicitly, then retest DNS, Service routing, and cross-node pod traffic after every host rule change.
 
 ### Using iptables
 
@@ -343,12 +347,12 @@ ss -tlnp | grep 10255  # Should return nothing
 The old insecure API server port belongs in the same category of historical risk. Kubernetes 1.35+ clusters should not rely on an unauthenticated API endpoint, and older references to `--insecure-port=0` should be read as historical hardening guidance. Your operational check is straightforward: nothing should be listening on 8080 as an insecure API server endpoint.
 
 ```bash
-# The insecure port (8080) is removed in Kubernetes v1.35+ (historical reference)
-# For older versions, ensure it's disabled:
+# The insecure API port (8080) was removed in releases before 1.35; it is absent on 1.35+ clusters.
+# On legacy clusters only, ensure it stays disabled:
 # --insecure-port=0 in API server flags
 
 # Verify no insecure port
-ss -tlnp | grep 8080
+ss -tlnp | grep ':8080'
 ```
 
 The second removal category is less obvious because the listener can be created by a workload. A pod with `hostNetwork: true` joins the node network namespace and can bind host ports, access node-local services, and bypass ordinary pod network isolation. This setting is legitimate for some system agents, CNIs, proxies, and security tools, but it is rarely appropriate for application workloads.
@@ -374,7 +378,7 @@ spec:
 
 What would happen if a pod is deployed with `hostNetwork: true` in a namespace that has strict default-deny NetworkPolicy? The policy may still exist, but the pod is no longer using the normal pod network namespace that the CNI policy is designed to govern. That is why admission control belongs in the design, not just runtime network policy.
 
-Pod Security Admission gives you a native namespace-level control for this boundary. The `restricted` profile disallows host networking for ordinary workloads, while privileged system namespaces can be handled as deliberate exceptions. The important operational point is not to label every namespace the same way; it is to keep application namespaces restrictive and make any privileged namespace small, named, reviewed, and auditable.
+Pod Security Admission gives you a native namespace-level control for this boundary. The `restricted` and `baseline` profiles both disallow `hostNetwork` for ordinary workloads, while privileged system namespaces can be handled as deliberate exceptions. The important operational point is not to label every namespace the same way; it is to keep application namespaces restrictive and make any privileged namespace small, named, reviewed, and auditable.
 
 ```yaml
 # Use Pod Security Admission to block
@@ -530,17 +534,17 @@ This scenario is about classification. Port 10256 might be kube-proxy health che
 ### Scenario 3: Configure Firewall
 
 ```bash
-# Block external access to kubelet
-sudo iptables -A INPUT -p tcp --dport 10250 ! -s 10.0.0.0/8 -j DROP
+# Allow only the control-plane kubelet client, then drop every other source on 10250
+sudo iptables -I INPUT -p tcp --dport 10250 -s 10.0.0.10/32 -j ACCEPT
+sudo iptables -A INPUT -p tcp --dport 10250 -j DROP
 
-# Allow only control plane to access kubelet
-sudo iptables -I INPUT -p tcp --dport 10250 -s 10.0.0.10 -j ACCEPT
-
-# Verify
+# Verify: allowed CP IP succeeds; another internal IP (e.g. 10.0.0.20) is denied
 sudo iptables -L INPUT -n | grep 10250
+# From 10.0.0.10: curl -k https://<node-ip>:10250/healthz  # should work
+# From 10.0.0.20: same curl should fail (timeout/refused) — not merely non-CP subnets
 ```
 
-The rule pair demonstrates a useful pattern: insert the allowed control-plane source before a broader drop. Rule order matters because the first matching rule wins in a traditional chain. After applying rules, verify kubelet health from the control plane and verify denial from a non-control-plane source, because either failure tells you a different part of the boundary is wrong.
+The rule pair demonstrates a useful pattern: insert the allowed control-plane `/32` first, then append an unconditional drop for the same port. A rule like `! -s 10.0.0.0/8 -j DROP` still permits any other address inside `10.0.0.0/8`, which is weaker than "only the control plane." Rule order matters because the first matching rule wins in a traditional chain. After applying rules, verify kubelet health from the control-plane IP and verify denial from another internal IP such as `10.0.0.20`, because either failure tells you a different part of the boundary is wrong.
 
 ### Securing etcd Network Access
 
@@ -616,7 +620,7 @@ The decision framework also helps you avoid false confidence from "secure by def
 
 - Kubernetes documents 6443/tcp as the default secure API server port and 10250/tcp as the kubelet API port, which is why both appear repeatedly in CKS network-hardening tasks.
 - The default NodePort service range is 30000-32767, so exposing one NodePort feature can create a broad scan surface unless external network controls narrow the reachable paths.
-- The Pod Security Standards `restricted` profile disallows `hostNetwork`, `hostPID`, and `hostIPC`, making it a native way to block several host-namespace escape hatches for application namespaces.
+- The Pod Security Standards `restricted` and `baseline` profiles both disallow `hostNetwork` (along with other host-namespace fields in `restricted`), making PSA a native way to block host-network pods in application namespaces.
 - Etcd uses 2379/tcp for client traffic and 2380/tcp for peer traffic, so a multi-member etcd topology needs different allow rules for API server clients and etcd-to-etcd replication.
 
 ---
@@ -732,7 +736,7 @@ sudo iptables -L INPUT -n --line-numbers 2>/dev/null | head -20 || echo "Check i
 
 # Step 6: Check for pods with hostNetwork
 echo "=== Pods with hostNetwork ==="
-kubectl get pods -A -o json | jq -r '.items[] | select(.spec.hostNetwork==true) | "\(.metadata.namespace)/\(.metadata.name)"'
+kubectl get pods -A -o jsonpath='{range .items[?(@.spec.hostNetwork==true)]}{.metadata.namespace}/{.metadata.name}{"\n"}{end}'
 
 # Success criteria:
 # - No insecure ports open
@@ -755,6 +759,12 @@ Success criteria for your finished review:
 - [ ] Application namespaces enforce Pod Security settings that block `hostNetwork: true`.
 - [ ] Firewall changes are verified from both allowed and denied source locations.
 - [ ] Sysctl hardening values are persistent and do not break required Kubernetes networking.
+
+---
+
+## Learner check
+
+> Host firewall rules for kubelet must allow a specific control-plane `/32` and then unconditionally drop all other sources on port 10250; a broad `10.0.0.0/8` exception still leaves kubelet reachable from other internal addresses such as `10.0.0.20`.
 
 ---
 


### PR DESCRIPTION
## CKS part3 system-hardening (3.1–3.4) — review fixes → T0

Consolidated cross-family review fixes for the four CKS part3 modules, all verified **T0** (`verify_module.py`, zero failing gates):

| Module | Reviewer | Key real defect fixed | body_words |
|---|---|---|---|
| 3.1 apparmor | cursor | APPROVE; P2 swoop — legacy annotation → display-only + modern `appArmorProfile` runnable; containerd-first node check; PSA wording; AppArmor-enabled-node prereq | 5222 |
| 3.2 seccomp | agy (Gemini 3.5 Flash) | P1 `strace`-in-`busybox` false-pass (`\|\| echo blocked` masks missing-binary) → alpine+strace, explicit Unconfined comparison; JSON `//` comments out of fences | 5074 |
| 3.3 kernel-hardening | codex | `SystemdCgroup` mislabeled "seccomp" → systemd cgroups; `/etc/shadow` relabeled non-root perm check (not priv-esc proof); real `NoNewPrivs` check for `allowPrivilegeEscalation: false`; hidepid vs Pod PID ns | 5215 |
| 3.4 network-security | cursor | P1 Scenario-3 iptables left internal IPs able to reach kubelet → allow-/32-then-unconditional-DROP; port 10256; CNI segmentation; insecure-port wording | 5263 |

### Also: clear CKS 1.4 `revision_pending` flag
1.4 node-metadata was rewritten T3→T0 and merged (PR #1730), but its frontmatter kept `revision_pending: true`, which the status ladder (`local_api.py`) forces to `needs_rewrite`. One-line flip to `false` so the board reflects the completed rewrite (folded here per one-swoop).

## Learner check
Each touched module retains its `## Learner check` section with a verbatim-quote blockquote.

## Verification
- `verify_module.py`: all four part3 modules **T0**, `passed: true`, zero failing gates.
- 3.3 cluster-verified on kind v1.35: insecure pod `NoNewPrivs: 0`, secure pod `NoNewPrivs: 1`, `/etc/shadow` denied.
- Build/link gate = PR CI (site-health + incident-dedup + CodeQL + cross-family review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)