### PR TITLE
chore(content): CKS part4 microservice-vulnerabilities (4.1–4.4) review fixes → T0

### DIFF
--- a/src/content/docs/k8s/cks/part4-microservice-vulnerabilities/module-4.1-security-contexts.md
+++ b/src/content/docs/k8s/cks/part4-microservice-vulnerabilities/module-4.1-security-contexts.md
@@ -7,7 +7,7 @@ sidebar:
 lab:
   id: cks-4.1-security-contexts
   url: https://killercoda.com/kubedojo/scenario/cks-4.1-security-contexts
-  duration: "35 min"
+  duration: "45-50 min"
   difficulty: advanced
   environment: kubernetes
 ---
@@ -76,7 +76,7 @@ The first practical distinction is scope. `spec.securityContext` applies default
 └─────────────────────────────────────────────────────────────┘
 ```
 
-The diagram is deliberately split into pod-level and container-level fields because that is how you should read every workload. Start with pod defaults, then check each container for overrides, then check pod fields outside `securityContext` that still affect isolation. A spec can look hardened at the top while one container quietly opts back into a dangerous identity or namespace. The final effective behavior is the combination, not the prettiest block of YAML.
+The diagram is deliberately split into pod-level and container-level fields because that is how you should read every workload. Start with pod defaults, then check each container for overrides, then check pod fields outside `securityContext` that still affect isolation. A spec can look hardened at the top while one container quietly opts back into a dangerous identity or namespace. The final effective behavior is the combination, not the prettiest block of YAML. SELinux and AppArmor profile configuration (`seLinuxOptions`, annotations) are out of scope for this module; focus here on UID/GID, capabilities, filesystem, and seccomp fields.
 
 Security contexts do not replace admission policy. If a user can create pods in a namespace, that user can also write an unsafe security context unless something validates the request before it is stored. Pod Security Admission, covered in the next module, is the cluster-side guardrail that rejects pods violating the baseline or restricted policy. This module focuses on the workload authoring skill: writing, auditing, and debugging the fields that admission policy will later enforce.
 
@@ -96,9 +96,24 @@ spec:
     securityContext:
       runAsUser: 1000  # Must specify non-root UID
       runAsGroup: 1000
+    volumeMounts:
+    - name: cache
+      mountPath: /var/cache/nginx
+    - name: run
+      mountPath: /var/run
+    - name: tmp
+      mountPath: /tmp
+  volumes:
+  - name: cache
+    emptyDir: {}
+  - name: run
+    emptyDir: {}
+  - name: tmp
+    emptyDir: {}
 
 # If image tries to run as root (UID 0), pod fails to start:
 # Error: container has runAsNonRoot and image will run as root
+# Stock nginx as UID 1000 also needs writable cache/runtime paths (emptyDir above).
 ```
 
 Pause and predict: if you remove `runAsUser: 1000` from this manifest but leave `runAsNonRoot: true`, what should happen when the selected image declares or implies UID 0? The useful mental model is that `runAsNonRoot` is a guard, not a repair tool. It blocks a root process from starting, but it does not edit the image, create a user, or fix file permissions inside the image.
@@ -264,7 +279,7 @@ spec:
           - NET_BIND_SERVICE  # Only add what's needed
 ```
 
-Pause and predict: you set `capabilities.drop: ["ALL"]` on a container that binds to port 80 and the process exits with `permission denied`. The smallest capability to add back is `NET_BIND_SERVICE`, but the better long-term question is whether the application should listen on 8080 instead. Changing the application port removes the capability need entirely, while adding the capability keeps a narrow exception that you must review later.
+Pause and predict: you set `capabilities.drop: ["ALL"]` on a container that binds to port 80 and the process exits with `permission denied`. Diagnose the failure mode before adding capabilities. If logs show `mkdir() "/var/cache/nginx/client_temp" failed (13: Permission denied)`, the process never reached port binding — fix writable cache/runtime paths with `emptyDir` mounts, `fsGroup`, or image ownership first. If nginx starts cleanly but cannot bind port 80, the bind failure is separate: non-root processes need `NET_BIND_SERVICE` (or a high port such as 8080). The smallest capability to add back for a low-port bind is `NET_BIND_SERVICE`, but the better long-term question is whether the application should listen on 8080 instead. Changing the application port removes the capability need entirely, while adding the capability keeps a narrow exception that you must review later.
 
 `allowPrivilegeEscalation: false` should travel with capability reduction. Dropping capabilities removes permissions from the process, while blocking privilege escalation prevents common paths for gaining them back through setuid binaries or related mechanisms. Kubernetes documentation notes that privilege escalation is always true for privileged containers and for containers with `CAP_SYS_ADMIN`, so `allowPrivilegeEscalation: false` is not a universal override. If you grant broad power, the runtime cannot pretend the process is tightly confined.
 
@@ -287,7 +302,8 @@ spec:
 # - Access to all host devices
 # - Can load kernel modules
 # - Can modify iptables
-# - Can escape container entirely
+# - Dramatically increases node-compromise blast radius; may enable
+#   container breakout depending on kernel/runtime bugs and host config
 # - ONLY use for system-level daemons (CNI, CSI drivers)
 ```
 
@@ -371,7 +387,7 @@ spec:
   - name: app
     image: nginx
 
-# After (secure)
+# After (secure) — exam-minimum identity fields only
 apiVersion: v1
 kind: Pod
 metadata:
@@ -387,9 +403,9 @@ spec:
       allowPrivilegeEscalation: false
 ```
 
-This example is intentionally incomplete for real production nginx because image defaults and writable paths matter. On an exam, the prompt may only require the security context change. In a production review, you would also validate whether UID 1000 can read the configured content, whether nginx needs writable cache or runtime directories, and whether the service can use a high port so no low-port capability is needed.
+The manifest above shows the smallest exam-style identity fix. It is display-only for stock nginx: without writable cache/runtime paths, UID 1000 fails on `mkdir()` under `/var/cache/nginx` before any capability question arises. The runnable hardened lab manifest later in this module adds the required `emptyDir` mounts. On an exam, the prompt may only require the security context change. In a production review, you would also validate whether UID 1000 can read the configured content, whether nginx needs writable cache or runtime directories, and whether the service can use a high port so no low-port capability is needed.
 
-The second scenario handles a workload that needs to bind to port 80 without running as root. This is the classic capability exception. The manifest drops every capability first, then adds `NET_BIND_SERVICE` back. It also keeps `allowPrivilegeEscalation: false`, because adding one capability should not turn into a general privilege path. The exception is visible, narrow, and tied to a specific application requirement.
+The second scenario handles a workload that needs to bind to port 80 without running as root. This is the classic capability exception. The manifest drops every capability first, then adds `NET_BIND_SERVICE` back. It also keeps `allowPrivilegeEscalation: false`, because adding one capability should not turn into a general privilege path. The exception is visible, narrow, and tied to a specific application requirement. Stock nginx as UID 1000 needs writable runtime paths before port binding can even be reached — the `emptyDir` mounts below satisfy cache and PID/socket directories nginx creates at startup.
 
 ```bash
 # Pod needs to bind to port 80 but shouldn't run as root
@@ -412,7 +428,24 @@ spec:
         add:
           - NET_BIND_SERVICE  # Allow binding to port 80
       allowPrivilegeEscalation: false
+    volumeMounts:
+    - name: cache
+      mountPath: /var/cache/nginx
+    - name: run
+      mountPath: /var/run
+    - name: tmp
+      mountPath: /tmp
+  volumes:
+  - name: cache
+    emptyDir: {}
+  - name: run
+    emptyDir: {}
+  - name: tmp
+    emptyDir: {}
 EOF
+
+kubectl wait --for=condition=Ready pod/web-server --timeout=60s
+kubectl exec web-server -- sh -c 'grep -q ":0050" /proc/net/tcp && echo "nginx listening on port 80"'
 ```
 
 Which approach would you choose here and why: keep port 80 with `NET_BIND_SERVICE`, or change the application to listen on 8080 and let the Service expose port 80? The second option usually wins when you own the application because it removes the capability exception. The first option can be acceptable when a legacy binary cannot change its listen port and the exception is documented.
@@ -445,7 +478,7 @@ spec:
 EOF
 ```
 
-The fastest debugging commands are the ones that show the effective spec and the events. `kubectl get -o yaml` shows what was stored. JSONPath helps inspect one field quickly. `kubectl describe` shows start failures, admission messages, and event text. You are not looking for every possible detail; you are looking for the first boundary that explains the observed failure.
+The fastest debugging commands are the ones that show the effective spec and the events. `kubectl get -o yaml` shows what was stored. JSONPath helps inspect one field quickly. `kubectl describe` shows start failures, admission messages, and event text. You are not looking for every possible detail; you are looking for the first boundary that explains the observed failure. Replace `mypod` with your pod name in the snippets below.
 
 ```bash
 # Check pod's effective security context
@@ -649,11 +682,11 @@ No. The storage agent may have a defensible system-level reason for host access,
 
 In this exercise you will create an insecure pod, replace it with a hardened pod, and verify that the hardened settings behave the way the manifest claims. The commands assume you have a Kubernetes 1.35+ cluster and a working `kubectl` context. The exercise uses nginx because it is familiar, but the same workflow applies to internal services after you account for their write paths and image ownership.
 
-Exercise scenario: you are reviewing a service before it can move into a namespace that enforces a restricted policy. The current pod has no explicit security context. Your job is to create a hardened version that runs as non-root, blocks privilege escalation, drops capabilities except for the low-port bind capability, uses a read-only root filesystem, and provides writable volumes only where nginx needs them for this test.
+Exercise scenario: you are reviewing a service before it can move into a namespace that enforces a restricted policy. The current pod has no explicit security context. Your job is to create a hardened version that runs as non-root, blocks privilege escalation, drops all capabilities then adds back `NET_BIND_SERVICE` so nginx can bind port 80, uses a read-only root filesystem, and provides writable volumes only where nginx needs them for this test.
 
 - [ ] Task 1: Create the insecure pod and inspect whether it declares any pod or container security context.
-- [ ] Task 2: Apply the hardened pod manifest with non-root identity, `RuntimeDefault` seccomp, dropped capabilities, and writable runtime directories.
-- [ ] Task 3: Verify the stored pod-level and container-level security context fields with `kubectl`.
+- [ ] Task 2: Apply the hardened pod manifest with non-root identity, `RuntimeDefault` seccomp, dropped capabilities with `NET_BIND_SERVICE` added back, and writable runtime directories.
+- [ ] Task 3: Verify the stored pod-level and container-level security context fields with `kubectl`, and confirm nginx is listening on port 80.
 - [ ] Task 4: Prove that writing to the image filesystem fails while writing to `/tmp` succeeds.
 - [ ] Task 5: Clean up both pods and record which security context field explained each observed behavior.
 
@@ -694,7 +727,6 @@ spec:
   containers:
   - name: app
     image: nginx
-    command: ["sleep", "3600"]  # Override entrypoint so pod stays running for exec tests without crashing
     securityContext:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true
@@ -732,8 +764,11 @@ kubectl exec hardened -- touch /etc/test 2>&1 || echo "Write blocked (expected)"
 # Step 7: Test that writable volume works
 kubectl exec hardened -- touch /tmp/test && echo "Write to /tmp succeeded"
 
+# Step 8: Verify nginx bound port 80 with NET_BIND_SERVICE (capability lesson)
+kubectl exec hardened -- sh -c 'grep -q ":0050" /proc/net/tcp && echo "nginx listening on port 80"'
+
 # Cleanup
-kubectl delete pod insecure hardened --force
+kubectl delete pod insecure hardened
 ```
 
 </details>
@@ -741,10 +776,16 @@ kubectl delete pod insecure hardened --force
 <details>
 <summary>What success looks like</summary>
 
-The hardened pod should store pod-level `runAsNonRoot`, numeric UID and GID settings, `fsGroup`, and `seccompProfile.type: RuntimeDefault`. Its container security context should show `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, and a capability set that drops `ALL` while adding only `NET_BIND_SERVICE`. The write to `/etc/test` should fail because the image filesystem is read-only, and the write to `/tmp/test` should succeed because `/tmp` is backed by an `emptyDir` volume.
+The hardened pod should store pod-level `runAsNonRoot`, numeric UID and GID settings, `fsGroup`, and `seccompProfile.type: RuntimeDefault`. Its container security context should show `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, and a capability set that drops `ALL` while adding only `NET_BIND_SERVICE`. Nginx should reach Ready and listen on port 80 — proving the capability exception works once writable cache/runtime paths exist. The write to `/etc/test` should fail because the image filesystem is read-only, and the write to `/tmp/test` should succeed because `/tmp` is backed by an `emptyDir` volume.
 </details>
 
-The most valuable part of the lab is the explanation you can give afterward. `runAsNonRoot` and `runAsUser` control process identity. `readOnlyRootFilesystem` controls writes to image layers. `emptyDir` restores writes only where the application needs runtime data. Capability dropping removes ambient Linux privileges, while `NET_BIND_SERVICE` is the single exception for a low port. `RuntimeDefault` adds a syscall boundary that does not depend on the application UID.
+The most valuable part of the lab is the explanation you can give afterward. `runAsNonRoot` and `runAsUser` control process identity. `readOnlyRootFilesystem` controls writes to image layers. `emptyDir` restores writes only where the application needs runtime data. Capability dropping removes ambient Linux privileges, while `NET_BIND_SERVICE` is the single exception for a low port — verified when `/proc/net/tcp` shows a listener on port 80 (`:0050`). `RuntimeDefault` adds a syscall boundary that does not depend on the application UID.
+
+---
+
+## Learner check
+
+> Security contexts are where you turn a vague instruction like "run this workload safely" into concrete controls: which UID should execute the process, which group should own mounted files, whether privilege escalation is blocked, which Linux capabilities remain, and whether the root filesystem is writable.
 
 ---
 

--- a/src/content/docs/k8s/cks/part4-microservice-vulnerabilities/module-4.2-pod-security-admission.md
+++ b/src/content/docs/k8s/cks/part4-microservice-vulnerabilities/module-4.2-pod-security-admission.md
@@ -81,16 +81,16 @@ The useful comparison is not "which profile is more secure?" because restricted 
 |---|---|---|---|
 | Privileged containers | Allowed | Disallowed | Disallowed |
 | Host namespaces | Allowed | Disallowed for hostPID, hostIPC, and hostNetwork | Disallowed |
-| HostPath volumes | Allowed | Not restricted | Disallowed |
+| HostPath volumes | Allowed | Disallowed | Disallowed |
 | Linux capabilities | Unrestricted | Blocks dangerous additions beyond the baseline allowlist | Must drop `ALL`; only `NET_BIND_SERVICE` may be added |
 | Running as root | Allowed | Allowed | Must not run as UID 0; `runAsNonRoot` and nonzero user settings matter |
 | Privilege escalation | Allowed | Not comprehensively blocked | Must set `allowPrivilegeEscalation: false` for Linux containers |
 | Seccomp | Unrestricted | Must not explicitly use `Unconfined` | Must explicitly use `RuntimeDefault` or `Localhost` |
-| Volume types | Unrestricted | Broadly compatible | Limited to safe volume sources such as ConfigMap, Secret, PVC, projected, downwardAPI, CSI, emptyDir, and ephemeral |
+| Volume types | Unrestricted | Broadly compatible except for `hostPath` | Limited to safe volume sources such as ConfigMap, Secret, PVC, projected, downwardAPI, CSI, emptyDir, and ephemeral |
 
-Baseline is the profile you use when you need compatibility but still want to stop obviously risky pod specs. It blocks privileged containers and host namespaces, restricts host ports and dangerous capability additions, and prevents several direct escapes from the container boundary. It does not require non-root execution, does not require dropping all capabilities, and does not require read-only root filesystems. That makes baseline a reasonable default for development namespaces or legacy application namespaces during the first migration phase.
+Baseline is the profile you use when you need compatibility but still want to stop obviously risky pod specs. It blocks privileged containers, host namespaces, and HostPath volumes, restricts host ports and dangerous capability additions, and prevents several direct escapes from the container boundary. It does not require non-root execution, does not require dropping all capabilities, and does not require read-only root filesystems. That makes baseline a reasonable default for development namespaces or legacy application namespaces during the first migration phase.
 
-Restricted is the profile you use when application teams can own their manifests and images. It requires the pod spec to close the usual privilege paths: no privilege escalation, no broad capability set, no root execution, and an explicit seccomp profile. It also narrows volume choices because a restricted workload should not mount arbitrary host paths. Restricted still does not enforce every hardening control a security team may want. For example, it does not require `readOnlyRootFilesystem`, resource limits, signed images, network policies, or approved registries.
+Restricted is the profile you use when application teams can own their manifests and images. It requires the pod spec to close the usual privilege paths: no privilege escalation, no broad capability set, no root execution, and an explicit seccomp profile. Baseline also forbids HostPath volumes; restricted inherits that baseline rule and then narrows the remaining allowed volume sources. Restricted still does not enforce every hardening control a security team may want. For example, it does not require `readOnlyRootFilesystem`, resource limits, signed images, network policies, or approved registries.
 
 The last point is a frequent exam trap. `readOnlyRootFilesystem: true` is a strong application hardening choice, and many organizations require it for production services, but it is not required by the upstream restricted Pod Security Standard. If a question asks for PSA compliance only, focus on the fields PSA actually checks. If a question asks for a hardened workload beyond PSA, then adding a read-only root filesystem and explicit writable volumes is a sensible extra defense.
 
@@ -141,7 +141,7 @@ spec:
         add: ["NET_ADMIN"]
 ```
 
-This is a logical map of baseline's policy gates, not a runnable pod manifest — each line references the field path where the relevant policy applies (e.g., `privileged` lives in `spec.containers[].securityContext.privileged`).
+This is an intentionally noncompliant example, not a lab step. The YAML is syntactically valid in a permissive namespace; each line references the field path where the relevant policy applies (e.g., `privileged` lives in `spec.containers[].securityContext.privileged`).
 
 Before running this, what output do you expect if the namespace has `enforce: baseline`, `warn: restricted`, and `audit: restricted`? The pod should be rejected because it violates the enforced baseline profile, so the warning mode is not the reason it fails. If you remove the baseline violations but leave restricted-only gaps, the pod can be admitted while the API server warns the caller and records audit annotations for the restricted profile.
 
@@ -225,7 +225,7 @@ metadata:
 spec:
   securityContext:
     runAsNonRoot: true
-    runAsUser: 1000  # UID for the nginx user in alpine images
+    runAsUser: 101  # UID for the nginx user in nginx:1.27-alpine
     seccompProfile:
       type: RuntimeDefault
   containers:
@@ -237,7 +237,7 @@ spec:
         drop: ["ALL"]
 ```
 
-Note: nginx requires root by default, so this pod passes PSA admission but may CrashLoopBackOff at runtime — PSA admission and runtime health are independent concerns, covered later in this module.
+Note: the default nginx startup path assumes root-oriented ports and writable paths, so this pod passes PSA admission but may CrashLoopBackOff at runtime — PSA admission and runtime health are independent concerns, covered later in this module.
 
 Warnings look similar, but they do not stop the request. When a namespace has `warn: restricted`, `kubectl apply` may print lines beginning with `Warning:` that name the profile and the violating fields. Those warnings are easy to ignore during a busy rollout, which is why warn mode should feed a ticket, report, or CI quality gate. A warning-only rollout that nobody reads is just delayed enforcement without a repair plan.
 
@@ -271,7 +271,7 @@ kubectl get pods --all-namespaces -o jsonpath='{range .items[*]}{.metadata.names
 kubectl get pods --all-namespaces -o jsonpath='{range .items[*]}{.metadata.namespace}{"\t"}{.metadata.name}{"\t"}{range .spec.containers[*]}{.name}{":"}{.securityContext.privileged}{" "}{end}{"\n"}{end}'
 ```
 
-Day one is audit and warn. The team labels application namespaces with `audit: restricted` and `warn: restricted`, then labels obvious node-agent namespaces with `enforce: privileged` only when the workload class truly needs it. For ordinary application namespaces, `enforce: baseline` is a good first safety net because it blocks privileged containers and host namespaces while leaving root-running legacy images enough room to keep serving traffic. The team pins labels to `v1.35` so policy behavior is not silently changed by the next control-plane upgrade.
+Day one is audit and warn. The team labels application namespaces with `audit: restricted` and `warn: restricted`, then labels obvious node-agent namespaces with `enforce: privileged` only when the workload class truly needs it. For ordinary application namespaces, `enforce: baseline` is a good first safety net because it blocks privileged containers, host namespaces, and HostPath volumes while leaving root-running legacy images enough room to keep serving traffic. The team pins labels to `v1.35` so policy behavior is not silently changed by the next control-plane upgrade.
 
 Day two is remediation of the noisy failures. The top causes are usually missing `allowPrivilegeEscalation: false`, missing `capabilities.drop: ["ALL"]`, missing seccomp profile, and containers that run as UID 0. These are not all equal in difficulty. Adding seccomp and dropping capabilities is often a Helm values change. Moving away from root may require image rebuilds, file-permission fixes, or volume mount changes. That difference drives the rollout order: fix manifest-only gaps first, schedule image rebuilds second, and document real exceptions third.
 
@@ -326,7 +326,7 @@ The version fields in AdmissionConfiguration have the same production tradeoff a
 
 Pinning should be consistent across modes, not only on the enforced label. If `enforce-version` is pinned but `warn-version` is left to default behavior, the cluster may enforce one policy version while warning against another after an upgrade. That can produce confusing migration reports because developers see warnings that do not match the current enforcement boundary. In production runbooks, treat the six namespace labels as a documented unit: three mode labels and three version labels, reviewed together during cluster upgrades.
 
-In the exam, do not overuse cluster-wide configuration. If the task says "configure namespace `secure` to enforce restricted," labels are the direct answer. If the task says "set default pod security behavior for unlabeled namespaces" or shows an API server admission config file, then ClusterPodSecurityConfig is in scope. The fastest diagnostic cue is whether the requested policy is namespace-specific or should apply before a namespace owner adds any labels.
+In the exam, do not overuse cluster-wide configuration. If the task says "configure namespace `secure` to enforce restricted," labels are the direct answer. If the task says "set default pod security behavior for unlabeled namespaces" or shows an API server admission config file, then AdmissionConfiguration with a nested PodSecurityConfiguration is in scope. The fastest diagnostic cue is whether the requested policy is namespace-specific or should apply before a namespace owner adds any labels.
 
 ---
 
@@ -374,7 +374,7 @@ spec:
         drop: ["ALL"]
 ```
 
-Pause and classify: if a question asks you to "make the pod pass restricted" and the pod currently has `hostPath`, `privileged: true`, UID 0, and missing seccomp, which fixes are mandatory for PSA and which are separate production hardening choices? Mandatory PSA fixes include removing privileged mode, removing hostPath for restricted, ensuring non-root execution, setting seccomp, blocking privilege escalation, and dropping capabilities. Separate hardening choices might include read-only root filesystems, approved image registries, or NetworkPolicy.
+Pause and classify: if a question asks you to "make the pod pass restricted" and the pod currently has `hostPath`, `privileged: true`, UID 0, and missing seccomp, which fixes are mandatory for PSA and which are separate production hardening choices? Mandatory PSA fixes include removing privileged mode, removing `hostPath` because baseline and restricted both forbid it, ensuring non-root execution, setting seccomp, blocking privilege escalation, and dropping capabilities. Separate hardening choices might include read-only root filesystems, approved image registries, or NetworkPolicy.
 
 The fifth step is to validate with server-side dry-run when the cluster allows it. Dry-run sends the request through admission without storing the object, which is exactly the behavior you need when testing a policy fix. It also avoids leaving failed experiment objects in the namespace. If dry-run is unavailable for the object or environment, use a temporary namespace with equivalent labels and delete the object immediately after testing.
 
@@ -659,6 +659,14 @@ kubectl delete namespace psa-lab
 - [ ] You can use server-side dry-run before tightening namespace enforcement.
 - [ ] You can describe when namespace labels are enough and when AdmissionConfiguration is needed.
 - [ ] You can state one example rule that requires Kyverno or Gatekeeper rather than PSA.
+
+---
+
+## Learner check
+
+> Baseline also forbids HostPath volumes; restricted inherits that baseline rule and then narrows the remaining allowed volume sources.
+
+Before moving on, confirm you can explain why a pod with `spec.volumes[].hostPath` fails in a namespace that enforces `baseline:v1.35`, even if it does not request privileged mode or host namespaces.
 
 ---
 

--- a/src/content/docs/k8s/cks/part4-microservice-vulnerabilities/module-4.3-secrets-management.md
+++ b/src/content/docs/k8s/cks/part4-microservice-vulnerabilities/module-4.3-secrets-management.md
@@ -6,7 +6,7 @@ sidebar:
 lab:
   id: cks-4.3-secrets-management
   url: https://killercoda.com/kubedojo/scenario/cks-4.3-secrets-management
-  duration: "40 min"
+  duration: "45-50 min"
   difficulty: advanced
   environment: kubernetes
 ---
@@ -135,7 +135,7 @@ resources:
       - identity: {}
 ```
 
-The local providers have different tradeoffs. `aescbc` is the common local provider for clusters that cannot integrate with an external KMS yet, and it requires a base64-encoded 32-byte key. `aesgcm` is faster than `aescbc` because GCM authentication and decryption are accelerated on modern x86_64 chips, but it imposes a hard upper bound on writes per key. With a random 96-bit nonce, the birthday-bound for collisions starts to matter at roughly 2^32 (~4 billion) writes per key, after which an attacker observing collisions could derive plaintext. The Kubernetes documentation recommends `secretbox` over `aesgcm` for new clusters because secretbox's XSalsa20-Poly1305 construction uses a 192-bit nonce and dodges this constraint entirely. `secretbox` uses a NaCl secretbox construction and also requires a 32-byte key. `identity` performs no encryption and should normally appear only as a temporary fallback for reading old plaintext values during migration, because placing it first means new writes stay unencrypted.
+The local providers have different tradeoffs. `aescbc` is the common local provider for clusters that cannot integrate with an external KMS yet, and it requires a base64-encoded 32-byte key. `aesgcm` is faster than `aescbc` because GCM authentication and decryption are accelerated on modern x86_64 chips, but it imposes strict write limits per key. The official provider table requires rotating an `aesgcm` key every **200,000 writes** — that is the operational answer on the exam and in production runbooks. A separate cryptographic bound applies too: with a random 96-bit nonce, the birthday-bound for collisions starts to matter at roughly 2^32 (~4 billion) writes per key, after which an attacker observing collisions could derive plaintext. The Kubernetes documentation recommends `secretbox` over `aesgcm` for new clusters because secretbox's XSalsa20-Poly1305 construction uses a 192-bit nonce, avoids the 200,000-write rotation requirement, and dodges the nonce-collision constraint entirely. `secretbox` uses a NaCl secretbox construction and also requires a 32-byte key. `identity` performs no encryption and should normally appear only as a temporary fallback for reading old plaintext values during migration, because placing it first means new writes stay unencrypted.
 
 ```yaml
 apiVersion: apiserver.config.k8s.io/v1
@@ -177,7 +177,11 @@ Edit `/etc/kubernetes/manifests/kube-apiserver.yaml` on the control plane node s
     type: DirectoryOrCreate
 ```
 
-All three pieces — the flag, mount, and volume — must be present; if one is missing, the API server does not load the config and falls back to identity (plaintext) writes silently.
+All three pieces — the flag, mount, and volume — must be present when you intend to enable encryption. Distinguish three failure modes on the exam:
+
+- **`--encryption-provider-config` absent** — the API server never loads a provider file; new writes stay plaintext. This is easy to miss in an audit because the cluster keeps running normally.
+- **Flag present but the mount path is wrong or the config file is invalid** — the API server fails to start and crash-loops (NOT a silent fallback to identity).
+- **Config loaded with `identity` listed first** — encryption is effectively disabled for new writes even though the flag is set.
 
 ```bash
 kubectl get secrets --all-namespaces -o json | kubectl replace -f -
@@ -220,7 +224,7 @@ resources:
       - identity: {}
 ```
 
-KMS v2 became stable in Kubernetes 1.29 and is preferred over the older KMS v1 provider. The v2 protocol improves health reporting, observability, key version handling, and performance characteristics so the API server can tell whether the plugin is ready and which key version protected a value. That does not remove operational responsibility. If the plugin is slow, unavailable, or misconfigured during writes and decrypts, the API server path that handles encrypted resources can become slow or fail. Treat the KMS plugin as a control-plane dependency, monitor its latency and error rate, and test what happens when the external KMS throttles or rotates keys.
+KMS v2 is GA/stable since Kubernetes 1.29 and is preferred over KMS v1, which is deprecated since 1.28 and disabled by default since 1.29 (enable only with `--feature-gates=KMSv1=true` for legacy migration). The v2 protocol improves health reporting, observability, key version handling, and performance characteristics so the API server can tell whether the plugin is ready and which key version protected a value. That does not remove operational responsibility. If the plugin is slow, unavailable, or misconfigured during writes and decrypts, the API server path that handles encrypted resources can become slow or fail. Treat the KMS plugin as a control-plane dependency, monitor its latency and error rate, and test what happens when the external KMS throttles or rotates keys.
 
 The KMS plugin identity is part of the trust boundary. On a cloud platform, the plugin or control-plane integration needs permission to use a specific key, and that permission should be narrower than general secret-manager administration. On self-managed clusters, the socket file path and plugin process need filesystem protection because the API server depends on that local endpoint for encryption operations. A compromised plugin host or overpowered cloud identity can undermine the benefit of moving the root key out of etcd.
 
@@ -269,10 +273,10 @@ spec:
     name: payment-db
     creationPolicy: Owner
   data:
-      - secretKey: password
-        remoteRef:
-          key: payments/database
-          property: password
+    - secretKey: password
+      remoteRef:
+        key: payments/database
+        property: password
 ```
 
 Note: ExternalSecret moved from `external-secrets.io/v1beta1` to `external-secrets.io/v1` in ESO 0.10. Clusters running ESO 0.9.x still use `v1beta1` — replace the `apiVersion` field accordingly.
@@ -546,7 +550,7 @@ The cost decision follows the same path. Native Secrets add little direct cloud 
 
 ## Did You Know?
 
-- **KMS v2 became stable in Kubernetes 1.29.** KMS v1 is marked deprecated as of Kubernetes 1.28 but remains functional and configurable through 1.30+. KMS v2 (GA in 1.29) is strongly preferred for new deployments because the v1 plugin protocol's gRPC-streaming design has known performance and partition-failure issues that v2's request/response model resolves.
+- **KMS v2 is GA/stable since Kubernetes 1.29** and is the preferred provider for new deployments. KMS v1 is deprecated since 1.28 and disabled by default since 1.29; enabling it requires `--feature-gates=KMSv1=true` for legacy or migration contexts only. The v1 plugin protocol's gRPC-streaming design has known performance and partition-failure issues that v2's request/response model resolves.
 - **Immutable Secrets became stable in Kubernetes 1.21.** They are not just a security guardrail; they also reduce kubelet watch load for clusters with many mounted Secret and ConfigMap objects.
 - **A ServiceAccount token can be requested for a specific audience and expiration.** That is the modern alternative to treating a long-lived token Secret as a reusable password for every internal service.
 - **A Secret read logged at `RequestResponse` level can expose the payload in the audit backend.** For most Secret access monitoring, `Metadata` level gives the actor, verb, resource, namespace, and timestamp without copying the sensitive value.
@@ -668,8 +672,9 @@ sudo cp /tmp/cks-4-3/encryption-config.yaml /etc/kubernetes/enc/encryption-confi
 
 # Edit /etc/kubernetes/manifests/kube-apiserver.yaml to mount and pass the new config:
 # --encryption-provider-config, matching volumeMount, and volume entries.
-# Then verify the static Pod has restarted.
+# Then verify the static Pod has restarted and is healthy before rewriting Secrets.
 
+# Only run after the apiserver flag, mount, and volume are verified healthy:
 kubectl get secrets --all-namespaces -o json | kubectl replace -f -
 
 ETCDCTL_API=3 etcdctl \
@@ -803,6 +808,12 @@ This policy captures who read or watched Secret resources without logging respon
 - [ ] Your RBAC check allows named `get` on one Secret and denies namespace-wide `list`.
 - [ ] Your runtime example mounts the Secret as a file and uses an image that contains the executed binary.
 - [ ] Your audit policy logs Secret access at `Metadata` level rather than copying payloads into logs.
+
+## Learner check
+
+> RBAC protects API reads; at-rest encryption protects the storage layer; neither replaces the other.
+
+Before you move on, explain what happens when `--encryption-provider-config` is missing versus when the flag is set but the mount path is wrong. A solid answer names plaintext new writes, API server crash-loops, and the case where `identity` is listed first in the provider list.
 
 ## Sources
 

--- a/src/content/docs/k8s/cks/part4-microservice-vulnerabilities/module-4.4-runtime-sandboxing.md
+++ b/src/content/docs/k8s/cks/part4-microservice-vulnerabilities/module-4.4-runtime-sandboxing.md
@@ -32,7 +32,7 @@ After completing this module, you will be able to connect runtime choices to con
 
 In early 2019, the cloud-native infrastructure world was shaken by the disclosure of CVE-2019-5736, a devastating critical vulnerability discovered in the `runc` container runtime. Because `runc` serves as the underlying engine for Docker and almost all standard Kubernetes environments, the impact was ubiquitous. This vulnerability allowed a malicious process executed inside a seemingly isolated container to break out and systematically overwrite the host's native `runc` binary. By simply executing a carefully crafted payload, an attacker could instantaneously gain full root execution capabilities on the host node. Once an attacker breaches the host layer, they can pivot laterally to any other container running on that machine, siphon highly sensitive authentication secrets directly from the local kubelet, and orchestrate a complete compromise of the entire Kubernetes cluster.
 
-For a massive, globally scaled e-commerce platform like Shopify—which relies heavily on multitenant Kubernetes architectures to execute and isolate thousands of independent merchant workloads—a container escape vulnerability of this magnitude represents an existential business risk. If a malicious actor could escape their designated container boundary and access a competitor's proprietary data, manipulate transaction flows, or intercept customer payment information, the financial impact would be catastrophic. The resulting regulatory fines, irreparable reputational damage, and direct lost revenue could easily scale into hundreds of millions of dollars. This incident brutally highlighted a fundamental engineering truth: standard Linux containers, which inherently share a single monolithic host kernel, are fundamentally not impenetrable security boundaries. They are merely namespaces and control groups providing an illusion of isolation. 
+Any large multitenant platform running thousands of independent workloads on shared kernels faces an existential risk from a container-escape CVE of this magnitude. When tenants share nodes, one compromised boundary can expose neighboring workloads, node-local credentials, and cluster-wide control paths. That is why CVE-2019-5736 is often cited as the wake-up call for runtime sandboxing: standard Linux containers share a single host kernel, and namespaces with cgroups are policy boundaries inside that kernel—not separate kernel boundaries. Runtime sandboxing adds an additional isolation layer for workloads where shared-kernel exposure is unacceptable. 
 
 This is precisely where runtime sandboxing becomes an essential, non-negotiable layer of defense-in-depth architecture. By inserting a robust, hardware-backed or proxy-based isolation boundary—such as a user-space kernel proxy like gVisor or a lightweight micro-VM like Kata Containers—between the containerized application and the underlying host operating system, platform engineers can effectively neutralize entire classes of kernel-level zero-day exploits. In this comprehensive module, you will learn how to architect, configure, and seamlessly schedule these advanced sandboxing techniques to protect your most sensitive and untrusted workloads. Mastering these runtime isolation concepts is not only a critical capability for hardening enterprise production clusters, but it is also a heavily tested cornerstone of the CKS certification exam.
 
@@ -288,11 +288,11 @@ kubectl get pod gvisor-test -o jsonpath='{.spec.runtimeClassName}'
 
 # Inside the container, check kernel version
 kubectl exec gvisor-test -- uname -a
-# Output shows "gVisor" instead of host kernel version
+# Output shows an emulated Linux kernel release (e.g. 4.4.0), not the host kernel — gVisor presents its own kernel
 
 # Check dmesg (gVisor intercepts this)
 kubectl exec gvisor-test -- dmesg 2>&1 | head -5
-# Output shows gVisor's simulated kernel messages
+# Output shows emulated kernel log messages, not the host dmesg buffer
 ```
 
 ### Scheduling Considerations and NodeSelectors
@@ -509,7 +509,7 @@ The 200 runc pods are vulnerable because their syscalls go directly to the host 
 
 <details>
 <summary>2. **Your team wants to sandbox CI/CD runner pods that execute untrusted customer code. They test with gVisor but the runners fail because they need to build Docker images (which requires `mount` syscalls and `overlayfs`). What alternative sandboxing approach would work for this use case?**</summary>
-Kata Containers would be a better fit. Kata runs each pod in a lightweight VM with its own kernel, providing hardware-level isolation while supporting the full Linux syscall interface (including `mount`). gVisor doesn't support all syscalls needed for container-in-container builds. Alternatively, use rootless BuildKit or Kaniko for image building inside gVisor (they don't need privileged syscalls). Another option is dedicating specific nodes with Kata runtime for CI/CD workloads and using RuntimeClass (`spec.runtimeClassName: kata`) to schedule them appropriately.
+Kata Containers would be a better fit for runners that must build images inside the sandbox. Kata runs each pod in a lightweight VM with its own kernel, providing hardware-level isolation while supporting the full Linux syscall interface (including `mount`). gVisor does not support the user namespaces, mount, and overlay operations that rootless BuildKit and Kaniko rely on, so those tools typically fail inside a gVisor-sandboxed pod even though they are rootless on a standard host. For image builds, schedule rootless BuildKit or Kaniko on dedicated `runc` nodes with hardened seccomp and AppArmor profiles, using RuntimeClass and node selectors to isolate untrusted build workloads from the rest of the fleet—not inside gVisor. Another option is dedicating specific nodes with the Kata runtime for CI/CD workloads and using RuntimeClass (`spec.runtimeClassName: kata`) to schedule them appropriately.
 </details>
 
 <details>
@@ -732,6 +732,10 @@ kind delete cluster --name cks-gvisor
 - You confirmed placement depends on a gVisor-capable node label.
 - You collected node-level evidence that `runsc` participated in the sandboxed Pod.
 - You can explain why RuntimeClass is not a substitute for installing and configuring the runtime on each capable node.
+
+## Learner check
+
+> Silent fallback is one of the most dangerous runtime-sandboxing mistakes because it converts a security requirement into a best-effort hint.
 
 ## Sources
 


### PR DESCRIPTION
## CKS part4 microservice-vulnerabilities (4.1–4.4) — cross-family review fixes → done

All four modules were already T0; this is the back-catalog cross-family review axis. Each got an independent R1 review (mixed pools), every finding ground-checked, fixed, and re-verified T0.

| Module | Reviewer | Verdict | Key real defect fixed | body_words |
|---|---|---|---|---|
| 4.1 security-contexts | cursor | NEEDS_CHANGES | **P1** stock `nginx` as `runAsUser:1000` crashed on `/var/cache/nginx` perms (taught as a NET_BIND_SERVICE/port-80 lesson) → added writable `emptyDir` mounts + split the two failure modes; removed `sleep 3600` override so the lab actually exercises `NET_BIND_SERVICE`; cluster-verified port-80 bind | 5258 |
| 4.2 pod-security-admission | codex | NEEDS_CHANGES | **P1** profile table claimed Baseline *allows* HostPath volumes — K8s 1.35 Baseline **forbids** them (cluster-verified rejection); `runAsUser:1000`→`101` for nginx-alpine; fake `ClusterPodSecurityConfig`→`AdmissionConfiguration`/`PodSecurityConfiguration` | 5637 |
| 4.3 secrets-management | cursor | NEEDS_CHANGES | encryption failure-mode contradiction (silent identity fallback vs crash-loop); KMS v1 outdated for 1.35 (deprecated 1.28, disabled-by-default 1.29, `--feature-gates=KMSv1=true`); added documented aesgcm 200,000-write rotation limit | 6060 |
| 4.4 runtime-sandboxing | agy + orchestrator ground-check | APPROVE_WITH_NITS | gVisor `uname` reports an emulated kernel release (not literal "gVisor"); Kaniko/BuildKit don't run cleanly *inside* gVisor → schedule on runc nodes; **removed unsourced company-specific breach hypothetical** (named-company war-story the reviewer missed) | 5027 |

CVE-2019-5736 itself stays (real + cited: K8s blog, Red Hat, MITRE); only the invented Shopify breach-impact speculation was removed.

## Learner check
Each touched module retains/refreshes its `## Learner check` section with a verbatim-quote blockquote.

## Verification
- `verify_module.py`: all four **T0**, `passed: true`, zero failing gates.
- Live-cluster verified on kind v1.35: 4.1 nginx pods reach Ready + bind port 80; 4.2 HostPath pod rejected under `baseline:v1.35`.
- Every reviewer finding ground-checked by the orchestrator before fixing (agy's missed war-story caught; both agy nits confirmed valid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)