### PR TITLE
chore(content): KCNA wave-5 part4 (4.1–4.3) — CNCF maturity, curriculum-complete relocation, TSB date fix (completes KCNA 28/28)

### DIFF
--- a/src/content/docs/k8s/kcna/part4-application-delivery/module-4.1-ci-cd.md
+++ b/src/content/docs/k8s/kcna/part4-application-delivery/module-4.1-ci-cd.md
@@ -153,7 +153,7 @@ The package stage is where container registries become central. A registry store
 │  ─────────────────────────────────────────────────────────  │
 │  • Docker Hub (docker.io)                                │
 │  • GitHub Container Registry (ghcr.io)                   │
-│  • Google Container Registry (gcr.io)                    │
+│  • Google Container Registry (gcr.io, legacy; now served via Artifact Registry) │
 │  • Quay.io                                               │
 │                                                             │
 │  Private registries:                                      │
@@ -230,7 +230,7 @@ Kubernetes-native CI/CD adds a second category of tools. Tekton builds and runs 
 │              KUBERNETES-NATIVE CI/CD                        │
 ├─────────────────────────────────────────────────────────────┤
 │                                                             │
-│  TEKTON (CNCF)                                            │
+│  TEKTON (CNCF Incubating)                                 │
 │  ─────────────────────────────────────────────────────────  │
 │  • CI/CD as Kubernetes resources                          │
 │  • Tasks, Pipelines, PipelineRuns                        │
@@ -248,7 +248,7 @@ Kubernetes-native CI/CD adds a second category of tools. Tekton builds and runs 
 │  • Similar to Argo CD                                     │
 │  • Tight Helm integration                                │
 │                                                             │
-│  ARGO WORKFLOWS (CNCF)                                    │
+│  ARGO WORKFLOWS (CNCF Graduated)                          │
 │  ─────────────────────────────────────────────────────────  │
 │  • Workflow engine for Kubernetes                        │
 │  • DAG-based workflows                                    │

--- a/src/content/docs/k8s/kcna/part4-application-delivery/module-4.2-application-packaging.md
+++ b/src/content/docs/k8s/kcna/part4-application-delivery/module-4.2-application-packaging.md
@@ -24,7 +24,7 @@ After completing this module, you will be able to make packaging decisions from 
 
 ## Why This Module Matters
 
-In late 2023, a payments team at a large retailer spent a full launch evening chasing a production outage that did not come from Kubernetes itself. The Deployment was valid, the Service was valid, and the container image had passed every pipeline check, yet the checkout API kept recycling because production had a memory limit copied from a small development namespace. The bad value lived in one of several nearly identical YAML files, and the on-call engineer fixed the staging copy first because the filenames looked alike at a glance. By the time the production manifest was corrected, customers had seen failed payments, support had opened an incident bridge, and the team had learned that raw manifests do not stay simple once environments multiply.
+**Hypothetical scenario:** A payments team at a large retailer spends a full launch evening chasing a production outage that does not come from Kubernetes itself. The Deployment is valid, the Service is valid, and the container image has passed every pipeline check, yet the checkout API keeps recycling because production has a memory limit copied from a small development namespace. The bad value lives in one of several nearly identical YAML files, and the on-call engineer fixes the staging copy first because the filenames look alike at a glance. By the time the production manifest is corrected, customers have seen failed payments, support has opened an incident bridge, and the team learns that raw manifests do not stay simple once environments multiply.
 
 That kind of failure is why application packaging matters. Kubernetes gives you an API for declaring desired state, but it does not automatically tell you how to organize the many objects that make up one application across teams, environments, and release versions. Packaging tools sit in the space between application code and cluster reconciliation: they help you reuse a known structure, change the few values that should differ, preview the YAML that will be applied, and keep enough release history to recover when a change behaves differently in the real cluster than it did in a review.
 
@@ -226,7 +226,7 @@ helm rollback checkout --namespace payments
 | `helm uninstall` | Remove a release |
 | `helm list` | List releases |
 | `helm repo add` | Add chart repository |
-| `helm search` | Search for charts |
+| `helm search repo` | Search chart repositories; use `helm search hub` for Artifact Hub |
 
 Before running this in a lab cluster, what output do you expect from `helm template` if the values file sets `replicas: 5` but the template accidentally hardcodes `replicas: 2`? The rendered YAML will show `2`, because templates control the final manifest and values only matter where the chart author references them. That is the practical debugging habit to build: do not assume a values file is active just because it exists. Render the chart and confirm that the value appears in the object Kubernetes will actually receive.
 
@@ -490,7 +490,7 @@ Helm and Kustomize dominate KCNA-level packaging discussions, but they are not t
 
 Jsonnet and Tanka appeal to teams that want programmable configuration with reusable functions and data structures. CUE appeals to teams that want validation and constraints built into the configuration language itself. Carvel provides a suite of tools around templating, image resolution, and application deployment. Operators go beyond packaging by adding a controller that watches custom resources and performs lifecycle actions, which is useful for stateful systems that need domain-specific automation. The decision is less about fashion and more about whether the team needs simple variation, reusable packaging, typed configuration, or active reconciliation logic.
 
-Artifact discovery adds another operational question: when should you build a package yourself, and when should you use a package from the ecosystem? Artifact Hub is a CNCF project that indexes Helm charts and other cloud native artifacts, making it a common starting point when teams need a known application such as PostgreSQL, Prometheus, cert-manager, or an ingress controller. Discovery is useful, but it does not replace review. A chart found through a hub still needs source inspection, version pinning, values review, and a test installation before it belongs in production.
+Artifact discovery adds another operational question: when should you build a package yourself, and when should you use a package from the ecosystem? Artifact Hub is a CNCF Incubating project that indexes Helm charts and other cloud native artifacts, making it a common starting point when teams need a known application such as PostgreSQL, Prometheus, cert-manager, or an ingress controller. Discovery is useful, but it does not replace review. A chart found through a hub still needs source inspection, version pinning, values review, and a test installation before it belongs in production.
 
 ```text
 ┌─────────────────────────────────────────────────────────────┐
@@ -498,7 +498,7 @@ Artifact discovery adds another operational question: when should you build a pa
 ├─────────────────────────────────────────────────────────────┤
 │                                                             │
 │  artifacthub.io                                           │
-│  CNCF project                                              │
+│  CNCF Incubating project                                   │
 │                                                             │
 │  Central repository for:                                  │
 │  ─────────────────────────────────────────────────────────  │
@@ -810,19 +810,7 @@ For the decision note, Kustomize is a reasonable answer because the application 
 - [Kustomize kustomization reference](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/)
 - [Kustomize built-ins reference](https://kubectl.docs.kubernetes.io/references/kustomize/builtins/)
 - [kubectl apply reference](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_apply/)
+- [Artifact Hub (CNCF Incubating project)](https://www.cncf.io/projects/artifact-hub/)
 - [Artifact Hub documentation](https://artifacthub.io/docs/)
 - [Artifact Hub repositories documentation](https://artifacthub.io/docs/topics/repositories/)
 - [Kubernetes Secrets documentation](https://kubernetes.io/docs/concepts/configuration/secret/)
-
-## KCNA Curriculum Complete!
-
-Congratulations. You have completed the KCNA application delivery sequence covering CI/CD fundamentals, application packaging, and release strategy selection.
-
-| Part | Topic | Weight |
-|------|-------|--------|
-| Part 1 | Kubernetes Fundamentals | 44% |
-| Part 2 | Container Orchestration | 28% |
-| Part 3 | Cloud Native Architecture (incl. Observability) | 12% |
-| Part 4 | Application Delivery | 16% |
-
-Use the packaging decision framework from this module as a final exam review tool. If you can explain why a team would choose Helm, Kustomize, or both, and if you can describe how to inspect the rendered manifests before rollout, you are ready for the KCNA level of application delivery questions.

--- a/src/content/docs/k8s/kcna/part4-application-delivery/module-4.3-release-strategies.md
+++ b/src/content/docs/k8s/kcna/part4-application-delivery/module-4.3-release-strategies.md
@@ -23,7 +23,7 @@ After completing this module, you will be able to evaluate release strategies as
 
 ## Why This Module Matters
 
-In June 2019, a major UK bank pushed a database migration to production using a single big-bang deployment. Every customer-facing service, including mobile banking, online transfers, and card payments, went down simultaneously at 14:23 on a Friday afternoon. The rollback took 9 hours, 1.9 million customers could not access their accounts over an entire weekend, and the bank was fined 48.65 million GBP by regulators. Post-incident analysis showed that the deepest failure was not a missing unit test or a malformed manifest; it was a release strategy that sent a risky change to everyone at once with no incremental validation path and no fast way to redirect traffic.
+**Hypothetical scenario:** A major bank pushes a database migration to production using a single big-bang deployment. Every customer-facing service, including mobile banking, online transfers, and card payments, goes down simultaneously on a Friday afternoon. The rollback takes many hours, customers cannot access their accounts over an entire weekend, and regulators later impose a substantial fine. Post-incident analysis shows that the deepest failure is not a missing unit test or a malformed manifest; it is a release strategy that sends a risky change to everyone at once with no incremental validation path and no fast way to redirect traffic.
 
 The fix was not simply "write better code." The organization changed how it exposed production to new versions. Later migrations used progressive release controls, better readiness checks, and rollback decisions tied to observable symptoms instead of conference-room optimism. That shift matters because Kubernetes can reconcile Deployments all day long, yet it is unable to decide whether your new payment path is safe for every customer. The cluster can replace Pods, but the release strategy determines how much damage one bad change can do before a human or automated controller stops it.
 
@@ -329,7 +329,7 @@ Canary rollback must be designed before promotion begins. If the canary is purel
 
 Small systems can still use canary thinking even without exact weighted routing. A team might deploy one canary Pod behind a separate internal Service, run synthetic checks against it, then manually shift a small customer group through an Ingress rule. Another team might use a feature flag to expose a code path to selected tenants while the underlying Deployment rolls normally. These are not identical to a service-mesh canary, but they preserve the core idea: expose a risky change to a limited, observable audience before it becomes the default behavior.
 
-War story: a media platform once canaried a new transcoder that passed error-rate checks because the service returned HTTP 200 for every job. The actual problem was degraded video quality for a subset of older codecs, and the first alarm came from support tickets rather than automated analysis. The team fixed the release process by adding domain-specific quality metrics to the canary gate. The strategy had limited blast radius, but the metrics had been too generic to catch the real failure mode.
+**Hypothetical scenario:** A media platform canaries a new transcoder that passes error-rate checks because the service returns HTTP 200 for every job. The actual problem is degraded video quality for a subset of older codecs, and the first alarm comes from support tickets rather than automated analysis. The team fixes the release process by adding domain-specific quality metrics to the canary gate. The strategy has limited blast radius, but the metrics were too generic to catch the real failure mode.
 
 Stop and think: a canary deployment sends 5 percent of traffic to the new version, but 5 percent of 10 million daily users is 500,000 people. Is 5 percent always safe? Consider how many users are exposed, whether the failure is reversible, whether the canary touches shared state, how fast metrics arrive, and whether you can isolate the canary to lower-risk cohorts before broad exposure.
 
@@ -587,3 +587,19 @@ k delete namespace release-lab
 ## Next Module
 
 [Back to KCNA Overview](/k8s/kcna/) - Revisit the KCNA map and connect release strategies to the broader application delivery domain.
+
+## KCNA Curriculum Complete!
+
+Congratulations. You have completed the full KCNA curriculum — from Kubernetes fundamentals through container orchestration, cloud native architecture, observability, and application delivery. This module closes Part 4 and the entire KCNA learning path.
+
+| Exam domain | Official KCNA exam weight |
+|-------------|--------------------------|
+| Kubernetes Fundamentals | 46% |
+| Container Orchestration | 22% |
+| Cloud Native Architecture | 16% |
+| Cloud Native Observability | 8% |
+| Cloud Native Application Delivery | 8% |
+
+See [Module 0.1: KCNA Overview](../../part0-introduction/module-0.1-kcna-overview/) for the full domain breakdown and study strategy.
+
+Use the release-strategy decision framework from this module as a final exam review tool. If you can explain when to choose rolling update, blue/green, or canary, and if you can describe the promotion and rollback gates that keep a failed change from reaching every user, you are ready for KCNA-level application delivery questions.


### PR DESCRIPTION
## KCNA wave 5 — part4 (application delivery), 3 modules → **completes the KCNA track (28/28)**

Cross-family R1 of the final 3 KCNA modules: **opus 4.8** (4.1), **cursor `--model auto`** (4.2),
**deepseek-v4-pro** (4.3). Fix by cursor in a worktree; all findings ground-checked + maturity facts
web-verified against cncf.io.

### CNCF maturity corrections (web-verified, mid-2026)
- 4.1: **Tekton → CNCF Incubating** (2026-03-24, from CD Foundation); **Argo Workflows → CNCF Graduated** (sibling of Argo CD).
- 4.2: **Artifact Hub → CNCF Incubating** (2024-05-30). (Helm Graduated, Carvel Sandbox confirmed correct.)

### Structural + accuracy
- 4.2→4.3: the misplaced **"KCNA Curriculum Complete!"** block (it sat *after* 4.2's "Next → 4.3" link) **relocated to 4.3**, the true final module; weight table now uses the **official KCNA exam domain split** (46/22/16/8/8) + Module 0.1 pointer (was conflicting KubeDojo track weights).
- 4.3: opening incident had a **wrong date** (said "June 2019"; the real TSB migration failure was April 2018) — reframed to a fingerprint-free `Hypothetical scenario:` (fixes the date error + anti-fab; incident-dedup gate green).
- 4.2: `helm search` → `helm search repo`; 4.1: gcr.io noted legacy.

### Hygiene / gates
- War-story + dated anecdotes reframed `Hypothetical scenario:` (4.2, 4.3). body_words floor met (4.3). All 3 modules verify **T0, 0 failed gates**. incident-dedup gate: PASS.

## Learner check

> Rolling updates optimize for routine compatibility, blue/green deployments optimize for clean traffic switches and fast rollback, and canary releases optimize for learning from a small slice of real traffic before wider promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
