### PR TITLE
chore(content): KCSA wave-1 (part0+part1) — war-story hygiene, 4 Cs/exam-format accuracy, sourced incidents

### DIFF
--- a/src/content/docs/k8s/kcsa/part0-introduction/module-0.1-kcsa-overview.md
+++ b/src/content/docs/k8s/kcsa/part0-introduction/module-0.1-kcsa-overview.md
@@ -23,7 +23,7 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-A regional payments company once treated Kubernetes security as a specialist concern rather than a shared operating discipline. The platform team owned the cluster, the developers owned the application, and the compliance team owned the audit spreadsheet, but no group could explain how a default service account token, an overly broad RoleBinding, and missing NetworkPolicies combined into a real attack path. When a vulnerable internal service was exploited, the attacker did not need an exotic kernel flaw or a custom exploit chain. They used ordinary Kubernetes behavior to query the API, discover other workloads, and pivot toward data services that the original application never needed to reach.
+Consider a regional payments company that treats Kubernetes security as a specialist concern rather than a shared operating discipline. The platform team owns the cluster, the developers own the application, and the compliance team owns the audit spreadsheet, but no group can explain how a default service account token, an overly broad RoleBinding, and missing NetworkPolicies combine into a real attack path. If a vulnerable internal service is exploited, an attacker need not rely on an exotic kernel flaw or a custom exploit chain. They can use ordinary Kubernetes behavior to query the API, discover other workloads, and pivot toward data services that the original application never needed to reach.
 
 The direct financial loss in that kind of incident is rarely limited to the first compromised workload. Engineers spend nights rotating credentials, auditors ask why baseline controls were not mapped to a framework, customers ask whether their data crossed trust boundaries, and product work stalls while leaders decide which environments can be trusted again. The expensive part is not merely that one pod was misconfigured. The expensive part is that several teams had partial knowledge, no shared vocabulary, and no confident way to recognize a basic Kubernetes security failure before production exposed it.
 
@@ -33,7 +33,7 @@ This module gives you the map before the journey begins. You will see where KCSA
 
 ## What KCSA Is Really Testing
 
-The Kubernetes and Cloud Native Security Associate is a pre-professional, multiple-choice certification focused on security knowledge in the Kubernetes and cloud native ecosystem. The official Linux Foundation page describes it as a starting point for candidates who want to advance toward professional-level security work, and the current public exam page lists it as online, proctored, multiple choice, 90 minutes, beginner level, and available without prerequisites. That combination matters because KCSA measures judgment before muscle memory: you must recognize risks, choose safer designs, and connect controls to threats even when you are not asked to type commands into a live cluster.
+The Kubernetes and Cloud Native Security Associate is a pre-professional, multiple-choice and multi-select certification focused on security knowledge in the Kubernetes and cloud native ecosystem. The official Linux Foundation page describes it as a starting point for candidates who want to advance toward professional-level security work, and the current public exam page lists it as online, proctored, multiple-choice and multi-select, 90 minutes, beginner level, and available without prerequisites. That combination matters because KCSA measures judgment before muscle memory: you must recognize risks, choose safer designs, and connect controls to threats even when you are not asked to type commands into a live cluster.
 
 The most useful way to understand KCSA is as a bridge. KCNA gives broad cloud native literacy, KCSA narrows that literacy into security reasoning, and CKS later asks you to implement and troubleshoot security controls under time pressure. A candidate who has only studied general Kubernetes objects may recognize a Deployment, Service, and namespace, but still miss why a workload that can list Secrets or talk to every service has become a lateral movement platform. A candidate who jumps straight into CKS commands without the KCSA foundation may memorize hardening steps without understanding which threat each step is meant to reduce.
 
@@ -42,7 +42,7 @@ The most useful way to understand KCSA is as a bridge. KCNA gives broad cloud na
 │           KUBERNETES SECURITY CERTIFICATION PATH            │
 ├─────────────────────────────────────────────────────────────┤
 │                                                             │
-│  ENTRY LEVEL (Multiple Choice)                             │
+│  ENTRY LEVEL (Multiple Choice & Multi-select)              │
 │  ┌─────────────────────────────────────────────────────┐   │
 │  │  KCNA - Kubernetes and Cloud Native Associate       │   │
 │  │  • General Kubernetes concepts                      │   │
@@ -67,12 +67,12 @@ The most useful way to understand KCSA is as a bridge. KCNA gives broad cloud na
 └─────────────────────────────────────────────────────────────┘
 ```
 
-There is one important correction to carry forward from the original overview. Older study notes often described the KCSA certification validity as three years, but the current Linux Foundation training page visible in May 2026 lists certification validity as two years. The practical exam-planning facts remain familiar: the exam is multiple choice, the duration is 90 minutes, there are no prerequisites, and the curriculum is organized around six security domains. Treat any exam detail you see in a cached blog post as something to verify against the official page before scheduling, because certification programs can change policy details faster than curriculum sites change prose.
+There is one important correction to carry forward from the original overview. Older study notes often described the KCSA certification validity as three years, but the current Linux Foundation training page visible in May 2026 lists certification validity as two years. The practical exam-planning facts remain familiar: the exam is multiple-choice and multi-select, the duration is 90 minutes, there are no prerequisites, and the curriculum is organized around six security domains. Treat any exam detail you see in a cached blog post as something to verify against the official page before scheduling, because certification programs can change policy details faster than curriculum sites change prose.
 
 | Aspect | Details |
 |--------|---------|
 | **Duration** | 90 minutes |
-| **Questions** | About 60 multiple choice |
+| **Questions** | About 60 multiple-choice and multi-select |
 | **Passing Score** | 75% target in common study guidance; verify current policy before exam day |
 | **Format** | Online proctored |
 | **Prerequisites** | None |
@@ -82,7 +82,7 @@ The KCSA-versus-CKS distinction is the first decision point most learners ask ab
 
 | Aspect | KCSA | CKS |
 |--------|------|-----|
-| Format | Multiple choice | Hands-on CLI |
+| Format | Multiple-choice and multi-select | Hands-on CLI |
 | Focus | Security concepts | Security implementation |
 | Skills tested | Understanding threats and defenses | Configuring security |
 | Prerequisites | None | Active CKA |
@@ -271,7 +271,7 @@ Which approach would you choose here and why: equal time for every domain, or we
 
 ## Patterns & Anti-Patterns
 
-Because this is an introductory module, the most important pattern is to study KCSA as applied security reasoning rather than as a glossary. The exam is multiple choice, but the best preparation is still active: read a concept, place it in the 4 Cs or one of the six domains, imagine a failure, name the control that reduces that failure, and explain the tradeoff. That rhythm turns a large curriculum into a repeatable diagnostic process.
+Because this is an introductory module, the most important pattern is to study KCSA as applied security reasoning rather than as a glossary. The exam is multiple-choice and multi-select, but the best preparation is still active: read a concept, place it in the 4 Cs or one of the six domains, imagine a failure, name the control that reduces that failure, and explain the tradeoff. That rhythm turns a large curriculum into a repeatable diagnostic process.
 
 | Pattern | When to Use It | Why It Works | Scaling Consideration |
 |---------|----------------|--------------|-----------------------|
@@ -318,7 +318,7 @@ The decision is not about prestige. It is about the evidence you need and the wo
 | Ignoring the threat model domain | Attack-path language feels less concrete than RBAC or Secrets | For every control, write the attacker behavior it is meant to interrupt |
 | Skipping compliance because it is 10% | The domain looks small compared with the two 22% domains | Learn the basic purpose of CIS, NIST, benchmarks, assessments, and evidence |
 | Not connecting concepts across domains | The curriculum is divided into sections, but incidents cross those boundaries | Practice scenarios that combine identity, network, workload, platform, and evidence |
-| Rushing through subtle wording | Multiple-choice questions can include several security-sounding options | Read for the exact asset, threat, layer, and constraint before choosing |
+| Rushing through subtle wording | Multiple-choice and multi-select questions can include several security-sounding options | Read for the exact asset, threat, layer, and constraint before choosing |
 | Treating KCSA as a miniature CKS | Hands-on labs feel more concrete than conceptual review | Use light `k` inspection for anchoring, then return to scenario reasoning |
 | Trusting stale exam logistics | Blog posts and old notes can outlive policy changes | Verify duration, validity, prerequisites, and curriculum links on official pages |
 
@@ -330,7 +330,7 @@ It depends on the gap they are trying to close. CKS is the right target if they 
 
 </details>
 
-<details><summary>You have 90 minutes and about 60 multiple-choice questions on exam day. After 45 minutes you have answered 25 questions. Should you be worried, and what strategy would you apply?</summary>
+<details><summary>You have 90 minutes and about 60 multiple-choice and multi-select questions on exam day. After 45 minutes you have answered 25 questions. Should you be worried, and what strategy would you apply?</summary>
 
 You are slightly behind a simple even-time pace, so you should adjust without panicking. The safer strategy is to move through a first pass answering questions you can reason through confidently, mark questions where two options remain plausible, and return later instead of letting one scenario consume too much time. KCSA rewards careful reading, but careful does not mean slow on every item. The goal is to collect the points your preparation has made available while preserving time for the questions that need deeper elimination.
 

--- a/src/content/docs/k8s/kcsa/part0-introduction/module-0.2-security-mindset.md
+++ b/src/content/docs/k8s/kcsa/part0-introduction/module-0.2-security-mindset.md
@@ -19,7 +19,7 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-In 2023, a midsize software company discovered that an exposed Kubernetes dashboard had become the front door for a cluster compromise. The attacker did not need a cinematic zero-day or a custom exploit chain; they found a reachable interface, used excessive permissions to inspect workloads, and followed service credentials until customer data and deployment secrets were at risk. The incident response bill, emergency consulting, downtime, and customer notification work quickly turned a small configuration mistake into a seven-figure business problem.
+**Hypothetical scenario:** In 2023, a midsize software company discovers that an exposed Kubernetes dashboard has become the front door for a cluster compromise. The attacker does not need a cinematic zero-day or a custom exploit chain; they find a reachable interface, use excessive permissions to inspect workloads, and follow service credentials until customer data and deployment secrets are at risk. The incident response bill, emergency consulting, downtime, and customer notification work can quickly turn a small configuration mistake into a costly business problem.
 
 The painful part was that nearly every individual setting could be explained away in isolation. The dashboard was useful for debugging, the service account was convenient during a release crunch, the network was open because teams did not want blocked traffic during development, and the image tag was mutable because it simplified deployments. Each choice saved a little time, but together they formed a path an attacker could walk from discovery to impact without meeting a serious barrier.
 
@@ -371,7 +371,7 @@ In exam terms, this means you should not memorize slogans as absolute rules. "De
 
 - **Most serious Kubernetes incidents are chains, not single mistakes**, because an exposed workload, broad service account, permissive network, and weak runtime settings become far more dangerous together than they look separately.
 
-- **The 4 Cs model is Kubernetes-specific terminology**, but the concept is universal: infrastructure, platform, workload packaging, and application code all contribute to whether one weakness becomes a system compromise.
+- **The 4 Cs model is CNCF cloud-native security vocabulary adopted in Kubernetes security guidance**; the layered concept is universal across cloud, cluster, container, and code.
 
 ## Common Mistakes
 
@@ -407,7 +407,7 @@ Think from the attacker's next move. `hostNetwork: true` is especially dangerous
 
 <details><summary>During incident response, you discover that an attacker compromised a pod, read the service account token, and used it to list secrets. Map this to the attack chain and name defenses that could have broken it.</summary>
 
-The chain begins with initial access through the compromised pod, then moves to credential theft through the service account token, then reaches impact when secrets are listed. Defenses could break the chain at several points: prevent token mounting where it is unnecessary, narrow RBAC so the token cannot list secrets, segment network paths to the API where appropriate, and alert on unusual secret access. The lesson is that a single exploited pod should not automatically become a cluster credential. Multiple controls make each step harder and more visible.
+The chain begins with initial access through the compromised pod, then moves to credential theft through the service account token, then reaches impact when secrets are listed. Defenses could break the chain at several points: narrow RBAC so the token cannot list secrets; disable or restrict ServiceAccount token mounting where unnecessary (`automountServiceAccountToken: false`); alert on unusual Secret access; optionally restrict egress to the Kubernetes API Service where the CNI supports it. The lesson is that a single exploited pod should not automatically become a cluster credential. Multiple controls make each step harder and more visible.
 
 </details>
 
@@ -500,7 +500,7 @@ Success criteria:
 - [Kubernetes documentation: Admission Controllers](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/)
 - [Kubernetes documentation: Auditing](https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/)
 - [NIST Special Publication 800-207: Zero Trust Architecture](https://csrc.nist.gov/pubs/sp/800/207/final)
-- [Kubernetes documentation: Cloud Native Security and Kubernetes](https://kubernetes.io/docs/concepts/security/cloud-native-security/)
+- [CNCF Cloud Native Security Whitepaper](https://www.cncf.io/reports/cloud-native-security-whitepaper/)
 
 ## Next Module
 

--- a/src/content/docs/k8s/kcsa/part1-cloud-native-security/module-1.2-cloud-provider-security.md
+++ b/src/content/docs/k8s/kcsa/part1-cloud-native-security/module-1.2-cloud-provider-security.md
@@ -26,7 +26,7 @@ After completing this module, you will be able to make provider-aware Kubernetes
 
 ## Why This Module Matters
 
-The textbook 2019 cloud-IAM case study is documented in [the CKS node-metadata module](../../../cks/part1-cluster-setup/module-1.4-node-metadata/) <!-- incident-xref: capital-one-2019 -->: a workload bug became a cloud identity problem, and a cloud identity problem became a data exposure problem affecting tens of millions of records. The lesson worth carrying into KCSA is not the specific exploit; it is the architecture boundary that the exploit crossed. A workload running inside a cluster is also running inside a cloud account, and that cloud account holds identities, network paths, storage buckets, and privileges that the cluster itself cannot revoke. The breach also led to regulatory action and a widely reported settlement, which is the kind of consequence that turns an abstract architecture boundary into an executive concern.
+The metadata/SSRF pivot pattern covered in [the CKS node-metadata module](/k8s/cks/part1-cluster-setup/module-1.4-node-metadata/) <!-- incident-xref: capital-one-2019 --> mirrors the architecture boundary crossed in the 2019 Capital One breach (~100M individuals affected; an $80M OCC civil money penalty in 2020). A workload bug became a cloud identity problem, and a cloud identity problem became a data exposure problem. The lesson worth carrying into KCSA is not the specific exploit; it is the architecture boundary that the exploit crossed. A workload running inside a cluster is also running inside a cloud account, and that cloud account holds identities, network paths, storage buckets, and privileges that the cluster itself cannot revoke. Regulatory action and a widely reported settlement turned that abstract boundary into an executive concern.
 
 Kubernetes does not erase that boundary. A managed control plane can remove the operational burden of patching API server binaries, maintaining etcd availability, and hardening physical infrastructure, yet it still leaves your team responsible for who can reach the API endpoint, which pods can talk across namespaces, which cloud roles a service account may assume, and where application data is encrypted. The danger is not that the provider is careless; the danger is that teams mistake a secure service for a secure deployment.
 
@@ -182,9 +182,9 @@ The most common provider-default surprise is API server reachability. A public e
 | Security Feature | Amazon EKS | Google GKE | Azure AKS |
 |------------------|------------|------------|-----------|
 | **API Server Endpoint** | Public by default (can be restricted) | Public by default (Private clusters recommended) | Public by default (Private clusters available) |
-| **Node OS** | Amazon Linux 2 / Bottlerocket | Container-Optimized OS (COS) | Ubuntu / Azure Linux |
-| **Workload Identity** | IAM Roles for Service Accounts (IRSA/Pod Identity) | Workload Identity (enabled by default on Autopilot) | Microsoft Entra Workload ID |
-| **Network Policies** | Requires add-on (e.g., Calico or VPC CNI) | Dataplane V2 (Cilium) built-in | Azure Network Policies or Calico |
+| **Node OS** | Amazon Linux 2023 / Bottlerocket (AL2 legacy) | Container-Optimized OS (COS) | Ubuntu / Azure Linux |
+| **Workload Identity** | IAM Roles for Service Accounts (IRSA/Pod Identity) | Workload Identity (enabled by default on Autopilot) | Microsoft Entra Workload ID (formerly Azure AD Workload Identity) |
+| **Network Policies** | Requires add-on (e.g., Calico or VPC CNI) | Built-in when Dataplane V2 is enabled (default on Autopilot; opt-in at create time on Standard clusters) | Azure Network Policies or Calico |
 
 That table is a starting point, not a verdict. EKS gives strong integration with AWS IAM, but the team must choose endpoint settings, node role scope, add-ons, and workload identity design. GKE offers strong managed defaults, especially in Autopilot, yet teams still need to review authorized networks, service accounts, and policy posture. AKS integrates naturally with Microsoft Entra ID and Azure networking, but production readiness still depends on private cluster decisions, node pool controls, workload identity, and policy enforcement.
 
@@ -262,6 +262,8 @@ Kubernetes adds a second authorization layer, and the order matters. A human mig
 │                                                             │
 └─────────────────────────────────────────────────────────────┘
 ```
+
+On modern EKS clusters, EKS Access Entries (`accessConfig.authenticationMode`) can map IAM principals to Kubernetes permissions; the `aws-auth` ConfigMap remains the legacy path on older clusters.
 
 The most dangerous IAM mistake in Kubernetes is giving a node role broad permissions and then letting every pod inherit the node's cloud identity. That pattern was common before workload identity matured, because it was easy to attach one storage policy to a node group and call the application done. It also meant a small application compromise could become a cloud account compromise if the attacker reached the instance metadata service or abused a library that could request credentials.
 
@@ -488,7 +490,7 @@ The final decision should leave an audit trail that future teams can understand.
 
 ## Did You Know?
 
-- **85% of cloud breaches** involve human error according to several industry summaries, and the recurring pattern is usually misconfigured access or exposed storage rather than a cinematic exploit chain.
+- **Many cloud breaches involve human error**, and the recurring pattern is usually misconfigured access or exposed storage rather than a cinematic exploit chain.
 
 - **Workload Identity** eliminates the need for static cloud credentials in many pod designs. GKE Workload Identity, EKS IAM Roles for Service Accounts or Pod Identity, and AKS Workload Identity all implement this pattern with provider-specific details.
 
@@ -659,6 +661,7 @@ Remember that the cloud provider gives you secure building blocks, while your te
 - [Kubernetes security overview](https://kubernetes.io/docs/concepts/security/)
 - [Kubernetes Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
 - [Kubernetes Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
+- [OCC News Release 2020-101: Capital One civil money penalty (Aug 6, 2020)](https://occ.gov/news-issuances/news-releases/2020/nr-occ-2020-101.html)
 
 ## Next Module
 

--- a/src/content/docs/k8s/kcsa/part1-cloud-native-security/module-1.3-security-principles.md
+++ b/src/content/docs/k8s/kcsa/part1-cloud-native-security/module-1.3-security-principles.md
@@ -21,6 +21,8 @@ After completing this module, you will be able to perform security review work r
 
 In 2023, the MOVEit Transfer compromise showed how quickly a single exposed system can become a business crisis. Attackers exploited one managed file transfer product, then used the access to steal data from hundreds of organizations across government, finance, health care, and education. Public estimates placed the total downstream cost in the billions of dollars once response work, legal exposure, customer notification, and operational disruption were counted. The lesson was not merely that one product had a serious flaw; the deeper lesson was that many organizations had trusted one perimeter control too much and had not sufficiently limited what a successful compromise could reach.
 
+Source: CISA Advisory AA23-158A (June 2023), "#StopRansomware: CL0P Ransomware Gang Exploits MOVEit Vulnerability."
+
 Kubernetes clusters create the same kind of risk in a more dynamic form. A pod is rarely just a pod; it may carry a service account token, talk to other services, mount configuration, call the Kubernetes API, and run on a node shared with unrelated workloads. If that pod is configured with broad RBAC, privileged container settings, unrestricted network egress, and no admission guardrails, a single application bug can turn into a cluster-wide incident. If the same pod is surrounded by layered controls, narrow permissions, verified service-to-service communication, and secure defaults, the same bug may remain a contained workload event instead of becoming a platform compromise.
 
 This module teaches the principles behind those choices. Kubernetes changes quickly, and this course targets Kubernetes 1.35+, but the principles are older and more durable than any one API version. Defense in depth, least privilege, zero trust, separation of duties, fail secure design, the CIA triad, attack surface reduction, and blast radius management give you a way to reason when the exact command, product, or incident is unfamiliar. KCSA questions often describe a situation rather than ask for a command, so your job is to recognize which principle is being tested and choose the control that makes the system more resilient.
@@ -471,8 +473,8 @@ Finally, use the CIA triad to explain why a finding matters to the service owner
 ## Did You Know?
 
 - **Defense in depth** comes from military strategy, where layered positions made attackers spend time and resources before reaching the protected asset.
-- **Least privilege** was formalized by Jerome Saltzer in the 1970s, long before containers, cloud IAM, or Kubernetes RBAC existed.
-- **Zero Trust** was described by Forrester Research in 2010, and Google's BeyondCorp publications later showed how large organizations could apply it at enterprise scale.
+- **Least privilege** was formalized by Jerome Saltzer (Saltzer & Schroeder, 1975), long before containers, cloud IAM, or Kubernetes RBAC existed.
+- **Zero Trust** was described by Forrester Research analyst John Kindervag in 2010, and Google's BeyondCorp publications (Google BeyondCorp, 2014+) later showed how large organizations could apply it at enterprise scale.
 - **The CIA triad** dates back to early information-security teaching and remains useful because almost every control protects confidentiality, integrity, availability, or some combination of the three.
 
 ## Common Mistakes


### PR DESCRIPTION
## KCSA wave 1 — part0 + part1, 4 modules → finalize-to-`done`

Cross-family R1 review of the 4 remaining KCSA part0+part1 modules, then a consolidated fix.
Reviewers (mixed pools, ≤2/OAuth): **opus 4.8 headless** (0.1) · **cursor `--model auto`** (0.2, 1.2) ·
**deepseek-v4-pro** (1.3). Fix authored by cursor in a worktree; all findings ground-checked and the
two incident citations **web-verified against primary sources**.

### Modules
| Module | Reviewer | Verdict | Key fixes |
|---|---|---|---|
| 0.1 kcsa-overview | opus-4.8 | NEEDS_CHANGES 4.5/5 | opener → conditional; exam format → "multiple-choice **and multi-select**" (LF web-verified) |
| 0.2 security-mindset | cursor | NEEDS_CHANGES 4.1/5 | dashboard incident → `Hypothetical scenario:`; 4 Cs → CNCF cloud-native vocabulary; API-access answer corrected; dup URL removed |
| 1.2 cloud-provider-security | cursor | NEEDS_CHANGES 4.4/5 | Capital One → attack-pattern cross-ref (xref marker kept, absolute link, sourced figures); "85%" stat dropped; GKE DPv2 qualified; EKS Access Entries added |
| 1.3 security-principles | deepseek | APPROVE_WITH_NITS 34/40 | MOVEit sourced (CISA AA23-158A); Did-You-Know historical refs |

### Incident citations (web-verified)
- **Capital One** → [OCC News Release 2020-101](https://www.occ.gov/news-issuances/news-releases/2020/nr-occ-2020-101.html) — $80M civil money penalty, Aug 6 2020 (~100M individuals). Cross-ref keeps the `incident-xref: capital-one-2019` marker.
- **MOVEit** → [CISA AA23-158A](https://www.cisa.gov/news-events/cybersecurity-advisories/aa23-158a) — CL0P/TA505, CVE-2023-34362, June 2023.

### Gates
- Verifier: all 4 stay **T0** (0 failed gates).
- **incident-dedup gate: PASS.**
- New external URLs return 200; absolute `/k8s/cks/...` link target exists.
- No CNCF maturity claims in any of the 4 modules (nothing to web-verify on the maturity axis this wave).

## Learner check

> The danger is not that the provider is careless; the danger is that teams mistake a secure service for a secure deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
