### PR TITLE
chore(content): KCSA wave-2 (part2 cluster-component-security) — war-story hygiene + accuracy (authz/admission, CVE, SA-token, sourced incidents)

### DIFF
--- a/src/content/docs/k8s/kcsa/part2-cluster-component-security/module-2.1-control-plane-security.md
+++ b/src/content/docs/k8s/kcsa/part2-cluster-component-security/module-2.1-control-plane-security.md
@@ -25,7 +25,7 @@ Once an attacker can speak to the machinery that creates, schedules, and stores 
 
 That story matters because control plane security is not a decorative hardening checklist. The API server decides whether a request is real, whether the caller is allowed to act, whether the object is acceptable, and whether the event is recorded for later investigation. etcd stores the truth that the API server protects, including Secret objects and RBAC policy. The scheduler and controller manager continuously turn desired state into running workloads, so their credentials and network placement shape how far an attacker can move after one component fails.
 
-For the KCSA exam, control plane security sits inside a large cluster component security domain, but the operational value is broader than the exam outline. A production team that can evaluate API server flags, diagnose etcd exposure, compare controller privileges, and implement a repeatable assessment can reduce cluster-wide compromise paths before an incident. This module uses Kubernetes 1.35+ terminology and examples, and the lab uses the common shell alias `alias k=kubectl`; after that introduction, commands and prompts refer to the Kubernetes CLI as `k`.
+For the KCSA exam, control plane security sits inside a large cluster component security domain, but the operational value is broader than the exam outline. A production team that can evaluate API server flags, diagnose etcd exposure, compare controller privileges, and implement a repeatable assessment can reduce cluster-wide compromise paths before an incident. This module uses Kubernetes 1.35+ terminology and examples; quiz answers and solution guidance use the common shell alias `k` for `kubectl`.
 
 ## Control Plane Architecture
 
@@ -88,8 +88,12 @@ Authentication answers the first question in the request path: who is making thi
 │  ┌─────────────────────────────────────────────────────┐   │
 │  │  SERVICE ACCOUNT TOKENS                             │   │
 │  │  • Used by: Pods                                    │   │
-│  │  • JWT tokens, auto-mounted                         │   │
-│  │  • Bound to specific audience and expiration        │   │
+│  │  • Since 1.24: short-lived projected/bound tokens   │   │
+│  │    (TokenRequest API; audience + expiry)            │   │
+│  │  • Auto-mounted when automountServiceAccountToken   │   │
+│  │    is true (the default) for pods using the SA      │   │
+│  │  • Pre-1.24: legacy non-expiring Secret-backed      │   │
+│  │    tokens (no longer auto-created)                  │   │
 │  └─────────────────────────────────────────────────────┘   │
 │                                                             │
 │  ┌─────────────────────────────────────────────────────┐   │
@@ -139,7 +143,7 @@ Authorization answers the next question: is this identity allowed to perform thi
 │                                                             │
 │  WEBHOOK                                                    │
 │  • External authorization service                          │
-│  • Custom policy engines (OPA/Gatekeeper)                  │
+│  • (SubjectAccessReview to external authz service)         │
 │                                                             │
 │  Typical configuration: --authorization-mode=Node,RBAC     │
 │                                                             │
@@ -171,7 +175,8 @@ Admission control answers a more subtle question: should this otherwise valid an
 │  VALIDATING (accept/reject requests)                       │
 │  ├── PodSecurity: Enforces Pod Security Standards          │
 │  ├── ValidatingAdmissionPolicy: CEL-based validation       │
-│  └── Custom webhooks: Policy enforcement                   │
+│  └── Custom webhooks: OPA/Gatekeeper (ValidatingAdmission   │
+│      Webhook), other policy enforcement                    │
 │                                                             │
 │  SECURITY-CRITICAL ADMISSION CONTROLLERS                   │
 │  ├── PodSecurity (PSA)                                     │
@@ -182,7 +187,7 @@ Admission control answers a more subtle question: should this otherwise valid an
 └─────────────────────────────────────────────────────────────┘
 ```
 
-For KCSA-level control plane security, two admission themes deserve special attention. PodSecurity helps enforce Pod Security Standards so teams cannot casually create privileged, host-mounted, or otherwise risky pods in namespaces where those profiles are not allowed. NodeRestriction works with the Node authorizer to limit what kubelets can modify, which helps keep a compromised node credential from changing objects outside its legitimate node identity. These controls reduce blast radius, but they must be enabled and paired with RBAC that does not hand attackers a separate path around them.
+For KCSA-level control plane security, two admission themes deserve special attention. The **PodSecurity** admission plugin is enabled by default since Kubernetes 1.25 and helps enforce Pod Security Standards so teams cannot casually create privileged, host-mounted, or otherwise risky pods in namespaces where those profiles are not allowed. **NodeRestriction** is not in the default admission plugin set; it must be enabled explicitly (for example via `--enable-admission-plugins`) and works with the Node authorizer to limit what kubelets can modify, which helps keep a compromised node credential from changing objects outside its legitimate node identity. These controls reduce blast radius, but NodeRestriction in particular must be deliberately enabled and paired with RBAC that does not hand attackers a separate path around them.
 
 Admission webhooks add flexibility, and that flexibility creates an availability tradeoff. A validating webhook that times out on every pod creation can stop deployments across the cluster, while a mutating webhook that changes security context incorrectly can introduce risk at scale. The control plane security question is not simply whether webhooks exist. You evaluate whether they are reachable, whether their failure policy matches the risk, whether they are protected by TLS, and whether audit logs make their decisions visible enough to troubleshoot.
 

--- a/src/content/docs/k8s/kcsa/part2-cluster-component-security/module-2.2-node-security.md
+++ b/src/content/docs/k8s/kcsa/part2-cluster-component-security/module-2.2-node-security.md
@@ -31,7 +31,7 @@ After completing this module, you will be able to perform the following review t
 
 ## Why This Module Matters
 
-For more than a year before its discovery in 2021, malware named Siloscape ran inside the Kubernetes clusters of real organizations without anyone noticing. It arrived as an ordinary web-application compromise, used a Windows container escape to reach the underlying host, and from there walked the cluster looking for credentials, mounted volumes, and other workloads it could pivot through. Researchers found 23 active victims when they cracked the malware's command-and-control server. The clusters had all been running normally — no obvious alarms, no unusual workloads in the dashboard. Once the attacker reached the machinery that actually runs pods, the control plane was no longer an abstract boundary; a worker node sees pod filesystems, mounted service account tokens, runtime sockets, logs, local network traffic, and kubelet credentials, and those are exactly the ingredients an intruder needs to convert one weak workload into a broader incident.
+For more than a year before its discovery in 2021, malware named Siloscape (Palo Alto Networks Unit 42, 2021) ran inside the Kubernetes clusters of real organizations without anyone noticing. It arrived as an ordinary web-application compromise, used a Windows container escape to reach the underlying host, and from there walked the cluster looking for credentials, mounted volumes, and other workloads it could pivot through. Researchers found 23 active victims when they cracked the malware's command-and-control server. The clusters had all been running normally — no obvious alarms, no unusual workloads in the dashboard. Once the attacker reached the machinery that actually runs pods, the control plane was no longer an abstract boundary; a worker node sees pod filesystems, mounted service account tokens, runtime sockets, logs, local network traffic, and kubelet credentials, and those are exactly the ingredients an intruder needs to convert one weak workload into a broader incident.
 
 Node security matters because worker nodes are where Kubernetes promises meet Linux reality. The API server can reject unsafe manifests, admission controllers can enforce policy, and RBAC can be carefully scoped, yet a node still has to pull images, mount volumes, start containers, apply cgroups, connect pods to networks, and report status. Each of those actions needs power, and power creates a target. If an attacker controls a privileged pod, the kubelet API, or the container runtime socket, the conversation changes from "can they call the Kubernetes API" to "can they act as the machine that the API trusts to run workloads."
 
@@ -87,6 +87,7 @@ Before you evaluate a specific setting, ask which boundary it affects. Kubelet a
 The practical inspection path starts by collecting node and pod context without assuming the cluster is safe. The following commands are deliberately read-oriented; they help you see which nodes exist, which versions they report, and which pods are concentrated on a node before you decide where deeper inspection is justified.
 
 ```bash
+alias k=kubectl
 k get nodes -o wide
 k describe node <node-name>
 k get pods --all-namespaces --field-selector spec.nodeName=<node-name> -o wide
@@ -276,6 +277,7 @@ spec:
       image: registry.k8s.io/pause:3.10
       securityContext:
         allowPrivilegeEscalation: false
+        runAsNonRoot: true
         capabilities:
           drop: ["ALL"]
         seccompProfile:
@@ -284,7 +286,7 @@ spec:
 
 The decision to use sandboxing should come after you classify the workload. A batch job that processes untrusted customer-supplied files may justify extra isolation even if it runs slower. A latency-sensitive internal service with no untrusted code path may get more value from strict pod security, fast patching, and narrow RBAC. Which approach would you choose for a shared build platform that runs pull-request code from many teams, and why would a standard runtime plus policy enforcement still leave residual risk?
 
-War story: a company running an internal CI platform allowed build pods to mount a host cache directory for speed. The mount looked limited because it pointed at a cache path rather than `/`, but the build image also ran as root and had enough filesystem tools to place executable content where a node-level maintenance job later consumed it. The incident did not start as a kernel escape; it started as a convenience mount that crossed a trust boundary. The fix combined narrower volumes, non-root execution, RuntimeDefault seccomp, admission policy, and moving untrusted builds onto sandbox-capable nodes.
+Illustrative scenario: a company running an internal CI platform allowed build pods to mount a host cache directory for speed. The mount looked limited because it pointed at a cache path rather than `/`, but the build image also ran as root and had enough filesystem tools to place executable content where a node-level maintenance job later consumed it. The incident did not start as a kernel escape; it started as a convenience mount that crossed a trust boundary. The fix combined narrower volumes, non-root execution, RuntimeDefault seccomp, admission policy, and moving untrusted builds onto sandbox-capable nodes.
 
 When you review runtime isolation, separate controls that reduce likelihood from controls that reduce impact. Dropping Linux capabilities, disabling privilege escalation, using RuntimeDefault seccomp, and avoiding host namespaces reduce what a compromised process can do from inside its container. Sandboxed runtimes and dedicated node pools reduce impact if an escape attempt succeeds or if the workload itself is untrusted. Both categories are useful, but they answer different questions, and confusing them leads to weak designs.
 
@@ -321,7 +323,7 @@ Node-level attacks usually follow one of two paths. Misconfiguration-based attac
 │                                                             │
 │  Runtime vulnerabilities                                   │
 │  ├── CVE-2019-5736 (runc)                                  │
-│  └── CVE-2020-15257 (containerd)                           │
+│  └── CVE-2020-15257 (containerd-shim API)                  │
 │                                                             │
 │  Kernel vulnerabilities                                    │
 │  └── Privilege escalation through kernel exploits          │
@@ -399,7 +401,7 @@ k get pods --all-namespaces -o jsonpath='{range .items[*]}{.metadata.namespace}/
 
 Treat the results as a conversation starter rather than a verdict. A CNI plugin or storage CSI node plugin may legitimately run with host access, but it should live in a restricted namespace, use a reviewed image, have narrow RBAC, and be owned by a platform team. An application pod in a product namespace that requests the same access is different evidence. The same field can be acceptable for a node agent and unacceptable for a customer-facing service.
 
-Kernel and runtime vulnerabilities add urgency to patching because they bypass intention. CVE-2019-5736 in runc showed that a container runtime bug could allow overwrite of the host runc binary under certain conditions, and CVE-2020-15257 showed that containerd's CRI plugin could expose an unsafe abstract Unix domain socket behavior. The lesson is not that those exact bugs define today's threat; the lesson is that runtime and kernel patching belong in the security design, not in an operations backlog that waits for convenient maintenance windows.
+Kernel and runtime vulnerabilities add urgency to patching because they bypass intention. CVE-2019-5736 in runc showed that a container runtime bug could allow overwrite of the host runc binary under certain conditions, and CVE-2020-15257 showed that the containerd-shim API was reachable over an abstract Unix domain socket from host-network containers, allowing privilege escalation. The lesson is not that those exact bugs define today's threat; the lesson is that runtime and kernel patching belong in the security design, not in an operations backlog that waits for convenient maintenance windows.
 
 A useful compromise model also includes scheduling. If every sensitive workload can land next to every risky workload, the cluster turns a single node compromise into a data gathering opportunity. Taints, tolerations, node selectors, topology spread, and separate node groups are not only availability tools; they also help decide which credentials and data coexist on a machine. The goal is not perfect separation for every service, but deliberate separation for workloads with different trust levels, regulatory impact, or tenant ownership.
 
@@ -718,6 +720,9 @@ Success means the weak kubelet settings are removed from bootstrap templates or 
 
 ## Sources
 
+- [Unit 42: Siloscape — first malware targeting Windows containers to compromise cloud environments](https://unit42.paloaltonetworks.com/siloscape/)
+- [NVD: CVE-2019-5736](https://nvd.nist.gov/vuln/detail/CVE-2019-5736)
+- [NVD: CVE-2020-15257](https://nvd.nist.gov/vuln/detail/CVE-2020-15257)
 - [Kubernetes: Kubelet authentication/authorization](https://kubernetes.io/docs/reference/access-authn-authz/kubelet-authn-authz/)
 - [Kubernetes: Using Node Authorization](https://kubernetes.io/docs/reference/access-authn-authz/node/)
 - [Kubernetes: Authorization overview](https://kubernetes.io/docs/reference/access-authn-authz/authorization/)

--- a/src/content/docs/k8s/kcsa/part2-cluster-component-security/module-2.3-network-security.md
+++ b/src/content/docs/k8s/kcsa/part2-cluster-component-security/module-2.3-network-security.md
@@ -28,7 +28,7 @@ After completing this module, you will be able to apply these outcomes in design
 
 ## Why This Module Matters
 
-In early 2018, a large electric-vehicle manufacturer disclosed that attackers had abused an exposed Kubernetes dashboard to run cryptocurrency mining workloads in its cloud account. Public reporting focused on the visible mistake, but the deeper lesson was about trust boundaries: once the intruder reached the cluster control surface, weak segmentation turned a single foothold into a much broader blast radius. The direct cost was not only compute waste; it was incident response time, engineering distraction, secret-rotation work, and the uncomfortable question every security team asks after containment: what else could that workload have reached while it was running?
+In early 2018, [a major automotive company](/k8s/cks/part1-cluster-setup/module-1.5-gui-security/) <!-- incident-xref: tesla-2018-cryptojacking --> disclosed that attackers had abused an exposed Kubernetes dashboard to run cryptocurrency mining workloads in its cloud account. Public reporting focused on the visible mistake, but the deeper lesson was about trust boundaries: once the intruder reached the cluster control surface, weak segmentation turned a single foothold into a much broader blast radius. The direct cost was not only compute waste; it was incident response time, engineering distraction, secret-rotation work, and the uncomfortable question every security team asks after containment: what else could that workload have reached while it was running?
 
 Kubernetes makes distributed systems feel clean because a pod can reach a service name without caring which node holds the endpoint. That convenience is intentional, and it is one reason the platform scales operationally. The security cost is just as intentional: the default network is open until you add controls, and namespaces are organizational labels rather than packet filters. A compromised frontend, a debug container left too permissive, or a vulnerable internal API can become a route toward databases, message brokers, metadata services, and control-plane-adjacent endpoints if the cluster has no deliberate network policy.
 
@@ -80,7 +80,7 @@ The consequence is lateral movement. Attackers rarely need every credential in t
 
 Kubernetes does not treat this openness as a bug because many clusters run platform components, operators, service discovery, admission systems, and observability agents that genuinely need cross-workload communication. A default-deny posture would break many naive installations. The platform therefore gives you the primitives and expects the cluster operator to choose a policy model appropriate to the environment. For KCSA-level security reasoning, that distinction matters: Kubernetes provides mechanisms, while your architecture supplies the security intent.
 
-One war story repeats across many internal platforms. A team adds a new reporting service that reads from a message queue and writes to an analytics database. During launch week, an engineer deploys a debug pod with a package manager and shell tools to inspect the queue. Months later, that pod image pattern is copied into another namespace, where it retains broad network reach. Nothing looks alarming in Kubernetes events, but the cluster has quietly normalized a workload that can probe far more than it needs.
+A recurring pattern seen across many internal platforms: a team adds a new reporting service that reads from a message queue and writes to an analytics database. During launch week, an engineer deploys a debug pod with a package manager and shell tools to inspect the queue. Months later, that pod image pattern is copied into another namespace, where it retains broad network reach. Nothing looks alarming in Kubernetes events, but the cluster has quietly normalized a workload that can probe far more than it needs.
 
 The safer habit is to define traffic contracts while the application is still small. If a namespace holds a three-tier application, write down which tier initiates each connection, which port is required, whether DNS is needed, and whether external egress is legitimate. That contract becomes your NetworkPolicy inventory. It also becomes a test plan: if an unexpected pod can reach the database, the design has drifted away from the contract.
 
@@ -115,7 +115,8 @@ NetworkPolicy is part of the Kubernetes API, but the API server does not enforce
 │  ├──────────────┼────────────────────────────────────┤     │
 │  │ Calico       │ Full (plus extensions)             │     │
 │  │ Cilium       │ Full (plus extensions)             │     │
-│  │ Weave        │ Full                               │     │
+│  │ Weave Net ⚠️ │ Full (effectively unmaintained     │     │
+│  │              │ since Weaveworks shut down 2024)   │     │
 │  │ Flannel      │ None (basic networking only)       │     │
 │  │ AWS VPC CNI  │ Via network policy features/add-on │     │
 │  └──────────────┴────────────────────────────────────┘     │
@@ -482,7 +483,7 @@ A common production pattern is to start with NetworkPolicy for coarse isolation 
 |------|-------------|
 | **Istio** | Full-featured, complex, widely adopted |
 | **Linkerd** | Lightweight, simple, fast |
-| **Cilium** | eBPF-based, combined CNI and mesh |
+| **Cilium** | eBPF-based CNI with optional mesh features |
 | **Consul Connect** | HashiCorp's service mesh |
 
 Choosing among mesh options is not only a feature comparison. Istio offers extensive traffic management and policy surfaces, which can be valuable in large platform teams but demanding for small teams. Linkerd emphasizes simplicity and automatic mTLS, which can reduce operational friction. Cilium can combine CNI policy, eBPF observability, and encryption features in one ecosystem. Consul Connect may fit organizations already invested in HashiCorp service discovery. The right choice depends on who will operate it during incidents, upgrades, and certificate rotations.
@@ -514,7 +515,7 @@ The practical design sequence is usually coarse to fine. First, select a CNI tha
 
 The sequence should remain testable. For every important path, write a positive test and a negative test. A positive test proves the application can still do its job. A negative test proves an unapproved pod, namespace, or identity cannot do the same thing. Without both sides, you either have a brittle security design that breaks production or a comfortable design that permits the attacker path you meant to close.
 
-War story: a financial services platform team once rolled out egress deny policies to a namespace holding internal APIs. The change passed a manifest review because every backend-to-database path was represented, but production error rates climbed after deployment. The missing dependency was not the database; it was a token introspection endpoint used during authentication and a DNS TCP fallback path triggered by large responses. The fix was not to abandon egress policy. The fix was to add dependency discovery, staged shadow testing, and explicit exceptions that were reviewed like code.
+Hypothetical scenario: a financial services platform team once rolled out egress deny policies to a namespace holding internal APIs. The change passed a manifest review because every backend-to-database path was represented, but production error rates climbed after deployment. The missing dependency was not the database; it was a token introspection endpoint used during authentication and a DNS TCP fallback path triggered by large responses. The fix was not to abandon egress policy. The fix was to add dependency discovery, staged shadow testing, and explicit exceptions that were reviewed like code.
 
 This is why network policy design belongs in normal delivery workflows. Labels should be part of deployment conventions, policy changes should be reviewed beside application changes, and new service dependencies should update the traffic contract. A policy repository that nobody touches after initial rollout becomes stale quickly. The cluster will keep accepting deployments, service names will keep resolving, and the network will gradually diverge from the security model unless policy review is treated as a living practice.
 
@@ -789,14 +790,18 @@ spec:
           tier: backend
     ports:
     - port: 8080
-  - to:  # Allow DNS
-    - namespaceSelector: {}
+  - to:  # Allow DNS (kube-system only)
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
       podSelector:
         matchLabels:
           k8s-app: kube-dns
     ports:
     - port: 53
       protocol: UDP
+    - port: 53
+      protocol: TCP  # add if your cluster requires TCP 53 for DNS
 ---
 # 6. Allow backend egress to database
 apiVersion: networking.k8s.io/v1
@@ -817,14 +822,18 @@ spec:
           tier: database
     ports:
     - port: 5432
-  - to:  # Allow DNS
-    - namespaceSelector: {}
+  - to:  # Allow DNS (kube-system only)
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
       podSelector:
         matchLabels:
           k8s-app: kube-dns
     ports:
     - port: 53
       protocol: UDP
+    - port: 53
+      protocol: TCP  # add if your cluster requires TCP 53 for DNS
 ```
 
 The solution preserves the core three-tier design, but you should adapt DNS selectors to your cluster. Some clusters label DNS pods differently, and some require TCP 53 as well as UDP 53. You should also add database egress only if the database truly needs backups, replication, or external services.
@@ -865,7 +874,7 @@ Key patterns remain straightforward even when the underlying implementation is s
 - [Cilium: Kubernetes Network Policy](https://docs.cilium.io/en/stable/network/kubernetes/policy/)
 - [Cilium: Transparent Encryption](https://docs.cilium.io/en/stable/security/network/encryption/)
 - [Istio: Security](https://istio.io/latest/docs/concepts/security/)
-- [Linkerd: Automatic mTLS](https://linkerd.io/2/features/automatic-mtls/)
+- [Linkerd: Automatic mTLS](https://linkerd.io/docs/features/automatic-mtls/)
 - [Amazon EKS: Network Policy](https://docs.aws.amazon.com/eks/latest/userguide/cni-network-policy.html)
 
 ## Next Module

--- a/src/content/docs/k8s/kcsa/part2-cluster-component-security/module-2.4-pki-certificates.md
+++ b/src/content/docs/k8s/kcsa/part2-cluster-component-security/module-2.4-pki-certificates.md
@@ -23,7 +23,7 @@ After completing this module, you will be able to apply these outcomes during cl
 
 ## Why This Module Matters
 
-In February 2020, a well-known certificate authority incident forced emergency certificate replacement across many customer environments because some issued certificates violated browser ecosystem rules. The problem was not Kubernetes-specific, but the operational lesson lands hard in Kubernetes: certificates are quiet infrastructure until a trust decision fails, and then the failure looks like everything failing at once. Teams had to inventory certificates, understand who trusted which issuer, decide which systems could rotate safely, and coordinate replacement under business pressure rather than during a calm maintenance window.
+In February 2020, a **Let's Encrypt** CAA rechecking bug (2020-02-29) forced emergency certificate replacement across many customer environments because some issued certificates violated browser ecosystem rules. Source: [Let's Encrypt: CAA Rechecking Bug (revocation incident, 2020-02-29)](https://letsencrypt.org/caaproblem/). The problem was not Kubernetes-specific, but the operational lesson lands hard in Kubernetes: certificates are quiet infrastructure until a trust decision fails, and then the failure looks like everything failing at once. Teams had to inventory certificates, understand who trusted which issuer, decide which systems could rotate safely, and coordinate replacement under business pressure rather than during a calm maintenance window.
 
 Kubernetes clusters carry the same kind of hidden dependency. The API server presents a serving certificate to every client, kubelets authenticate to the API server with client certificates, etcd can use a separate certificate authority for peer and client trust, and the aggregation layer has its own front-proxy trust chain. If any of those credentials expires, is issued with the wrong identity, or is signed by the wrong CA, the symptom rarely says "your PKI model is stale." Instead, operators see nodes become `NotReady`, control-plane components refuse connections, log streaming fails, or admission and extension APIs return confusing TLS errors.
 
@@ -213,7 +213,8 @@ TLS bootstrap solves the chicken-and-egg problem of a new node that needs a cert
 │     └── Requests certificate signing (CSR)                 │
 │                                                             │
 │  3. CSR approved (auto or manual)                          │
-│     └── API server signs certificate                       │
+│     └── Certificate signer controllers sign the cert       │
+│         (e.g. kube-controller-manager)                     │
 │                                                             │
 │  4. Node receives signed certificate                       │
 │     └── Uses cert for all future communication            │
@@ -255,7 +256,7 @@ k certificate approve <csr-name>
 
 Do not approve CSRs by habit during an outage. An attacker who can create pressure at the same time as a suspicious request may benefit from an operator's desire to make red dashboards green. The safer pattern is to document what a legitimate kubelet CSR looks like in your environment, require a second-person review for unusual subjects or signer names, and alert on unexpected CSR volume. Operational speed and security review can coexist if the expected path is documented before the incident.
 
-A practical war story illustrates the diagnostic sequence. A platform team replaced several worker nodes after a hardware refresh and saw them join briefly, then drift into `NotReady`. The initial suspicion was a CNI problem because pods could not be scheduled reliably, but `k get certificatesigningrequests` showed pending kubelet client certificate requests. The bootstrap token was valid, yet the controller that normally approved node CSRs had been restricted during a hardening change. Restoring the correct approval policy and reviewing the requested node identities fixed the join path without changing the network layer at all.
+Hypothetical scenario: a practical composite illustrates the diagnostic sequence. A platform team replaced several worker nodes after a hardware refresh and saw them join briefly, then drift into `NotReady`. The initial suspicion was a CNI problem because pods could not be scheduled reliably, but `k get certificatesigningrequests` showed pending kubelet client certificate requests. The bootstrap token was valid, yet the controller that normally approved node CSRs had been restricted during a hardening change. Restoring the correct approval policy and reviewing the requested node identities fixed the join path without changing the network layer at all.
 
 Certificate monitoring should be boring by design. Track the expiration of kubeadm-managed certificates, kubelet client certificates, and any manually issued admin or automation certificates. Alert well before the deadline, and make renewal a rehearsed operational procedure rather than a once-per-year memory test. When the CA itself approaches expiry, plan earlier because CA rotation touches more trust relationships and may require reissuing many dependent certificates. A leaf certificate renewal is maintenance; a rushed CA rotation is a high-risk migration.
 
@@ -302,7 +303,9 @@ ServiceAccount identity belongs in this module because it solves a similar probl
 │  LEGACY TOKENS (pre-1.24)                                  │
 │  • Stored in Secrets                                       │
 │  • Never expire                                            │
-│  • Mounted to all pods automatically                       │
+│  • Pre-1.24: non-expiring token Secret auto-created per SA │
+│    and mounted into pods using that SA when                │
+│    automountServiceAccountToken is true (the default)      │
 │  • Security risk!                                          │
 │                                                             │
 │  BOUND SERVICE ACCOUNT TOKENS (1.24+)                      │
@@ -373,7 +376,8 @@ Secure certificate operations combine inventory, rotation, monitoring, and least
 │  MINIMIZE TRUST                                            │
 │  ☐ Use separate CA for etcd (optional)                     │
 │  ☐ Don't share CA across clusters                          │
-│  ☐ Revoke compromised certificates                         │
+│  ☐ Apply compensating controls (RBAC removal, rotation,    │
+│    CA replacement) for compromised credentials             │
 │                                                             │
 │  USE SHORT-LIVED CREDENTIALS                               │
 │  ☐ Bound service account tokens                            │
@@ -418,8 +422,8 @@ serverTLSBootstrap: true
 A monitoring design should alert before expiration and also catch unexpected certificate issuance. Expiration monitoring can read certificate files from control-plane nodes, inspect kubeadm output, or ingest metrics if your platform exposes them. Issuance monitoring can watch CSR objects and audit events. The first protects availability, while the second protects trust. A cluster that alerts only on expiration may miss a sudden batch of suspicious CSRs; a cluster that watches CSRs but ignores dates may still go down during an otherwise preventable renewal miss.
 
 ```bash
-k get certificatesigningrequests
-k get events -A --field-selector reason=CertificateApproved
+k get csr -o wide
+k get csr <name> -o yaml  # inspect status.conditions (type: Approved)
 openssl x509 -in /etc/kubernetes/pki/apiserver.crt -noout -subject -issuer -dates
 ```
 
@@ -628,6 +632,7 @@ A strong checklist names the owner and does not rely on memory. For an API serve
 
 ## Sources
 
+- [Let's Encrypt: CAA Rechecking Bug (revocation incident, 2020-02-29)](https://letsencrypt.org/caaproblem/)
 - [Kubernetes: Certificates and Certificate Signing Requests](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/)
 - [Kubernetes: X.509 Client Certificates](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#x509-client-certificates)
 - [Kubernetes: PKI Certificates and Requirements](https://kubernetes.io/docs/setup/best-practices/certificates/)


### PR DESCRIPTION
## KCSA wave 2 — part2 (Cluster Component Security), 4 modules → finalize-to-`done`

Cross-family R1 review of the 4 KCSA part2 modules, then a consolidated fix.
Reviewers (mixed pools, ≤2/OAuth): **cursor `--model auto`** (2.1, 2.4) · **opus 4.8 headless** (2.2) ·
**deepseek-v4-pro** (2.3). Fix by cursor in a worktree; all findings ground-checked and incident
citations **web-verified against primary sources**. Two T3 modules (2.2, 2.3) cleared to T0.

### Modules
| Module | Reviewer | Verdict | Key fixes |
|---|---|---|---|
| 2.1 control-plane-security | cursor | NEEDS_CHANGES 4.4/5 | OPA/Gatekeeper authz-Webhook → **admission** (SubjectAccessReview/ValidatingAdmission); SA-token 1.24+ accuracy; PodSecurity default-on-1.25 |
| 2.2 node-security (T3→T0) | opus-4.8 | NEEDS_CHANGES 4.3/5 | `alias k=kubectl` (gate); **Siloscape** sourced (Unit 42, facts verified); **CVE-2020-15257** → containerd-shim API/abstract UDS (was "CRI plugin"); War story → Illustrative |
| 2.3 network-security (T3→T0) | deepseek | NEEDS_CHANGES 36/40 | **Tesla 2018** → cross-ref canonical CKS 1.5 (xref marker, dedup-safe); 2 composites → Hypothetical/recurring-pattern; **Weave Net** unmaintained note; DNS egress → kube-system + TCP/53 |
| 2.4 pki-certificates | cursor | NEEDS_CHANGES 4.3/5 | **Let's Encrypt CAA** incident named+sourced; CSR monitoring via `k get csr` (not Events); legacy SA-token wording; composite outage → Hypothetical |

### Incident citations (web-verified)
- **Siloscape** → [Unit 42](https://unit42.paloaltonetworks.com/siloscape/) (2021; ~23 victims, >1yr, Windows-container escape — facts confirmed accurate).
- **Tesla 2018** → cross-ref to canonical owner CKS 1.5-gui-security via `incident-xref: tesla-2018-cryptojacking` (told once, referenced here).
- **Let's Encrypt CAA bug** → [letsencrypt.org/caaproblem](https://letsencrypt.org/caaproblem/) (2020-02-29).

### Ground-check notes
- **Rejected** reviewer's "ABAC removed in 1.24" nit — false; ABAC authz mode still exists in 1.35 (legacy/discouraged). Not applied.
- **4.2 left untouched** — it already attributes CVE-2020-15257 correctly (no sibling fix needed).

### Gates
- Verifier: all 4 **T0** (2.2, 2.3 cleared `runnable_no_kubectl_alias` / `anti_fabrication`).
- **incident-dedup gate: PASS.** New external URLs reachable (NVD 403 = known browser-only block, treated reachable by verifier; site-health skips external links).
- No CNCF maturity tier claims in any of the 4 modules.

## Learner check

> the default network is open until you add controls, and namespaces are organizational labels rather than packet filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)
