### PR TITLE
chore(content): KCSA wave-3 (part3 security-fundamentals) — war-story hygiene + security accuracy (KMS v2, RBAC verbs, TokenRequest)

### DIFF
--- a/src/content/docs/k8s/kcsa/part3-security-fundamentals/module-3.2-rbac.md
+++ b/src/content/docs/k8s/kcsa/part3-security-fundamentals/module-3.2-rbac.md
@@ -20,9 +20,9 @@ After completing this module, you will be able to make and defend practical auth
 
 ## Why This Module Matters
 
-In 2023, a financial services platform suffered a severe Kubernetes incident after a deployment automation account was granted broad write permissions during a weekend release freeze. The change was supposed to be temporary, but it remained in the cluster after the release succeeded. When attackers later obtained the automation token from a compromised build job, they did not need a kernel exploit or a novel container escape. They used the permissions already granted to the ServiceAccount, created privileged workloads, mounted sensitive volumes, and turned a CI compromise into a cluster-wide recovery effort that consumed days of engineering time and delayed customer-facing work.
+**Hypothetical scenario:** Consider a financial services platform that grants a deployment automation account broad write permissions during a weekend release freeze. The change is supposed to be temporary, but it remains in the cluster after the release succeeds. When attackers later obtain the automation token from a compromised build job, they do not need a kernel exploit or a novel container escape. They use the permissions already granted to the ServiceAccount, create privileged workloads, mount sensitive volumes, and turn a CI compromise into a cluster-wide recovery effort that demands urgent credential rotation, workload review, and binding cleanup.
 
-RBAC is the guardrail that decides whether an authenticated Kubernetes request is allowed after the API server knows who made the request. Authentication answers "who are you?", admission answers "is this object acceptable?", and authorization answers "may this subject do this verb on this resource in this scope?". If that middle authorization decision is too generous, every other control has to work harder. If it is too narrow or confusing, operators start bypassing the model with emergency bindings that become permanent risk.
+RBAC is the guardrail that decides whether an authenticated Kubernetes request is allowed after the API server knows who made the request. Authentication answers "who are you?", authorization answers "may this subject do this verb on this resource in this scope?", and admission — which runs after authorization — answers "is this object acceptable?". If that authorization decision is too generous, every other control has to work harder. If it is too narrow or confusing, operators start bypassing the model with emergency bindings that become permanent risk.
 
 This module treats RBAC as an engineering design problem rather than a list of object names to memorize. You will learn how Roles, ClusterRoles, RoleBindings, ClusterRoleBindings, users, groups, and ServiceAccounts combine into effective permissions; why apparently harmless verbs like `create` can become escalation paths; and how to reason about access before applying a manifest. When this module mentions command-line checks, it uses the short alias `alias k=kubectl`, so a command like `k auth can-i get pods -n production` means the standard Kubernetes client command with a shorter name.
 
@@ -169,7 +169,7 @@ Each rule is a tuple of API group, resource, optional resource name, and verb. Y
 │  SPECIAL VERBS                                             │
 │  ├── deletecollection - Delete multiple resources          │
 │  ├── bind     - Bind roles (for RoleBindings)              │
-│  ├── escalate - Modify roles (requires special permission) │
+│  ├── escalate - Grant role permissions beyond your own     │
 │  ├── impersonate - Act as another user                     │
 │  └── * (wildcard) - All verbs (DANGEROUS)                  │
 │                                                             │
@@ -723,7 +723,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ```
 
-The solution follows the scenario but it is still worth reviewing critically. The developer and team-lead roles use read wildcards for namespace resources, which may be acceptable in a training exercise but should be narrowed in sensitive production namespaces. The CI/CD role avoids direct Pod creation and does not use a ClusterRoleBinding, which keeps the automation boundary closer to the stated deployment need. In a stricter environment, you would also separate secret management into a smaller role and require additional approval before binding it.
+The solution follows the scenario but it is still worth reviewing critically. The developer and team-lead roles use read wildcards for namespace resources, which may be acceptable in a training exercise but should be narrowed in sensitive production namespaces. Note: `resources: ["*"]` read **includes Secrets** — in a real `dev` namespace this is the first grant to narrow, since it gives every developer credential-read access. Compare the built-in `view` ClusterRole, which deliberately excludes Secrets. The CI/CD role avoids direct Pod creation and does not use a ClusterRoleBinding, which keeps the automation boundary closer to the stated deployment need. In a stricter environment, you would also separate secret management into a smaller role and require additional approval before binding it.
 
 </details>
 

--- a/src/content/docs/k8s/kcsa/part3-security-fundamentals/module-3.3-secrets.md
+++ b/src/content/docs/k8s/kcsa/part3-security-fundamentals/module-3.3-secrets.md
@@ -19,7 +19,7 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-An operations team at a mid-sized payments company spent a long weekend investigating why a routine database password rotation kept failing. The first clue was not a Kubernetes event or an application alert; it was a security engineer finding the old password in a crash report that had been uploaded to an internal ticket. The team traced the value through a Deployment manifest, an environment variable, a process argument, a debug log, and finally a stale Secret stored in a cluster backup. The secret had not been exploited, but the audit response still consumed several engineering days, delayed a product launch, and forced emergency rotation of credentials across multiple environments.
+**Hypothetical scenario:** An operations team at a mid-sized payments company spends a long weekend investigating why a routine database password rotation keeps failing. The first clue is not a Kubernetes event or an application alert; it is a security engineer finding the old password in a crash report uploaded to an internal ticket. The team traces the value through a Deployment manifest, an environment variable, a process argument, a debug log, and finally a stale Secret stored in a cluster backup. The secret is not exploited, but the audit response still consumes several engineering days, delays a product launch, and forces emergency rotation of credentials across multiple environments.
 
 That story is uncomfortable because every individual decision looked ordinary at the time. Kubernetes Secrets were used instead of ConfigMaps, RBAC existed, and only a small group could administer the namespace. The problem was that the team treated a Secret object as a vault instead of as an API object with special handling rules. Once a sensitive value enters the Kubernetes API, it can be copied into etcd, delivered to kubelets, mounted into pods, exposed to authorized clients, included in backups, and accidentally printed by applications that were never designed to protect credentials.
 
@@ -82,6 +82,8 @@ The `data` field contains base64-encoded values, while `stringData` lets you sub
 | `kubernetes.io/basic-auth` | Username + password | Basic authentication |
 | `kubernetes.io/ssh-auth` | SSH private key | SSH authentication |
 | `kubernetes.io/service-account-token` | SA token | Service account auth |
+
+Legacy type; auto-creation removed in 1.24 — prefer projected ServiceAccount tokens (see [Module 3.4](../module-3.4-serviceaccounts/)).
 
 Secret `type` is partly documentation and partly validation. A `kubernetes.io/tls` Secret must contain the expected certificate and key fields, while an `Opaque` Secret can hold arbitrary names. The type does not choose a stronger encryption mode, and it does not automatically rotate the value. The value of typing is that humans and controllers can reason about intent: a registry pull secret should be referenced by image pull configuration, a TLS secret should feed ingress or service TLS, and an arbitrary app credential should be named and scoped so its purpose is obvious during review.
 
@@ -183,7 +185,7 @@ The recommendation to prefer volume mounts is a risk-reduction default, not a la
 
 Before running this in a lab cluster, what output do you expect from `k describe pod app` if a Secret is used through `secretKeyRef`? You should expect to see that an environment variable is sourced from a Secret reference, not the decoded value itself. That is useful, but it is not a complete protection story, because the value still exists in the running process environment once the container starts.
 
-A practical war story: one platform team allowed developers to use `envFrom` for entire Secret objects because it made onboarding quick. Months later, a single shared Secret contained both a database password and an unrelated third-party API token. A service that needed only the database password inherited the API token too, and a debug endpoint printed the whole process environment during a production incident. The fix was not only "use mounts"; it was also to split Secrets by consumer, mount only specific keys, and make secret names reflect the credential owner and rotation plan.
+**Hypothetical scenario:** One platform team allows developers to use `envFrom` for entire Secret objects because it makes onboarding quick. Months later, a single shared Secret contains both a database password and an unrelated third-party API token. A service that needs only the database password inherits the API token too, and a debug endpoint prints the whole process environment during a production incident. The fix is not only "use mounts"; it is also to split Secrets by consumer, mount only specific keys, and make secret names reflect the credential owner and rotation plan.
 
 That kind of cleanup is easier when applications have a narrow configuration contract. If a service expects every possible credential in its environment, platform teams cannot reason about which value is actually required. If the service reads one file path for one purpose, reviewers can connect the Secret, the mount, the application code, and the rotation plan. This is why secrets work often becomes application architecture work. A platform can provide the safer delivery pattern, but each workload still needs a clear agreement about what it consumes and what it must never print.
 
@@ -282,12 +284,13 @@ Provider order matters because the first provider writes new data and later prov
 | Provider | Description | Use Case |
 |----------|-------------|----------|
 | `identity` | No encryption | Never for secrets |
-| `aescbc` | AES-CBC encryption | Self-managed clusters |
-| `aesgcm` | AES-GCM encryption | Faster than aescbc |
-| `kms` | External KMS | Production, compliance |
+| `aescbc` | Legacy local AES-CBC; keys live on the control plane (upstream not recommended) | Migration/fallback only |
+| `aesgcm` | Legacy local AES-GCM; keys live on the control plane (upstream not recommended) | Migration/fallback only |
+| `kms v2` | Stable since 1.29; envelope encryption with keys in an external KMS (recommended production/compliance path) | Production, compliance |
+| `kms v1` | Deprecated since 1.28 | Migrate to `kms v2` |
 | `secretbox` | XSalsa20 + Poly1305 | Alternative to AES |
 
-The local providers encrypt data using keys that the API server can access. That may satisfy a storage-at-rest requirement, but it still leaves key custody close to the control plane. KMS providers move key operations to an external service or plugin, often using envelope encryption. The API server encrypts each object with a data encryption key, while the key encryption key stays in the KMS. This gives security teams central key policy, audit logs, and rotation controls that fit better with enterprise compliance programs.
+The local AES providers encrypt data using keys that the API server can access. That may satisfy a storage-at-rest requirement, but it still leaves key custody close to the control plane. KMS providers move key operations to an external service or plugin, often using envelope encryption. The API server encrypts each object with a data encryption key, while the key encryption key stays in the KMS. This gives security teams central key policy, audit logs, and rotation controls that fit better with enterprise compliance programs.
 
 ### KMS Integration
 
@@ -312,8 +315,11 @@ The local providers encrypt data using keys that the API server can access. That
 │  • Audit logging in KMS                                    │
 │  • Compliance requirements met                             │
 │                                                             │
-│  PROVIDERS: AWS KMS, GCP KMS, Azure Key Vault, HashiCorp  │
-│             Vault                                          │
+│  KMS ENCRYPTION PLUGINS (EncryptionConfiguration):         │
+│  AWS KMS, GCP KMS, Azure Key Vault                         │
+│                                                             │
+│  EXTERNAL SECRET STORES (separate integration path):       │
+│  HashiCorp Vault, cloud secret managers                    │
 │                                                             │
 └─────────────────────────────────────────────────────────────┘
 ```
@@ -351,10 +357,9 @@ For production, consider external secrets managers:
 │  ├── Azure Key Vault                                       │
 │  └── CSI driver integration                                │
 │                                                             │
-│  KUBERNETES OPERATORS                                      │
-│  ├── External Secrets Operator                             │
-│  ├── Secrets Store CSI Driver                              │
-│  └── Sync external secrets to K8s Secrets                  │
+│  KUBERNETES INTEGRATIONS                                   │
+│  ├── External Secrets Operator — sync external → K8s Secret│
+│  └── Secrets Store CSI Driver — direct mount; sync optional│
 │                                                             │
 │  BENEFITS OVER NATIVE SECRETS:                             │
 │  • Centralized management                                  │
@@ -599,8 +604,8 @@ Work through the review as if you were the platform engineer approving a product
 
 2. **Secret in command args**
    - `--db-password=$(DB_PASSWORD)` exposes secret in process list
-   - Visible via `ps aux`, logged in audit logs
-   - Fix: Pass via file or env var, read in app
+   - Visible via `ps aux`, `/proc`, and process listings on the node
+   - Fix: Read from a read-only Secret volume mount (or CSI/provider file path); do not pass via command args or env
 
 3. **Secret as environment variable**
    - `API_KEY` via env is visible in /proc

--- a/src/content/docs/k8s/kcsa/part3-security-fundamentals/module-3.4-serviceaccounts.md
+++ b/src/content/docs/k8s/kcsa/part3-security-fundamentals/module-3.4-serviceaccounts.md
@@ -24,9 +24,7 @@ After completing this module, you will be able to review real workload manifests
 
 ## Why This Module Matters
 
-A retail engineering team once treated Kubernetes ServiceAccounts as background plumbing. Their payment dashboard ran in a production namespace, but the pod never called the Kubernetes API during normal operation, so nobody reviewed the identity mounted into the container. Months earlier, a troubleshooting shortcut had bound a broad role to the namespace's `default` ServiceAccount, and that shortcut stayed behind after the incident ticket closed. When an attacker exploited a server-side request forgery bug in the dashboard, the first useful file they reached was the mounted ServiceAccount token, and that single token gave them enough API access to enumerate pods, read selected Secrets, and find cloud credentials that were never meant to leave the cluster.
-
-The company did not lose data because ServiceAccounts are inherently dangerous. It lost control because every pod identity had been treated like a generic keycard instead of a scoped credential with a clear purpose, expiration, and audience. The team spent several days rotating Secrets, rebuilding trust in audit logs, and proving to customers that the compromised dashboard could not reach their data path. The cloud bill for the incident response environment and unauthorized compute was roughly $50,000, but the larger cost was the discovery that a convenience setting had become a lateral movement path.
+Many teams treat Kubernetes ServiceAccounts as background plumbing until a pod compromise turns an auto-mounted token into a lateral movement path. The hypothetical scenario later in this module walks through how that pattern plays out when the `default` ServiceAccount carries broad RBAC and an application vulnerability exposes the token file. Shared implicit identity makes future drift hard to reason about: if someone binds a broad role to `default` for a troubleshooting shortcut, every unnamed pod in the namespace inherits that permission until someone notices. The secure habit is to treat every pod identity as a scoped credential with a clear purpose, expiration, and audience — not a generic keycard every workload shares by default.
 
 This module teaches ServiceAccount security as an operational discipline rather than a checkbox. You will learn how pods authenticate to the Kubernetes API in Kubernetes 1.35+, why default identities create hidden blast radius, how bound tokens reduce but do not erase risk, and how RBAC decisions shape the attack paths available after a container compromise. You will also practice reviewing a flawed manifest, replacing it with a safer identity design, and deciding when a pod should have no API token at all.
 
@@ -116,11 +114,10 @@ Bound tokens are still bearer tokens. Anyone who can read the token file can use
 The TokenRequest API is the control plane mechanism behind explicit token requests. You can request a token with a defined audience and expiration, and you can bind it to a particular object such as a pod. In practice, most application teams use projected ServiceAccount token volumes in pod specs rather than creating TokenRequest objects by hand, but reading the API shape helps you see the security properties Kubernetes is trying to express.
 
 ```yaml
+# Illustrative TokenRequest body — POST .../serviceaccounts/{name}/token
+# Not a persisted object; in practice use `kubectl create token <sa>` or a projected-token volume.
 apiVersion: authentication.k8s.io/v1
 kind: TokenRequest
-metadata:
-  name: my-token
-  namespace: default
 spec:
   audiences:
   - api                      # Who can use this token
@@ -251,11 +248,11 @@ Securing the default ServiceAccount is a namespace hygiene step, not a complete 
 
 Policy enforcement can turn that hygiene into a stable standard. Admission policies can reject pods in production namespaces when they omit `serviceAccountName`, use `default`, or request automatic token mounting without an approved label. The exact mechanism varies by cluster, but the principle is consistent: prevent implicit identity from reaching production unnoticed. Start with audit mode if you expect many violations, then move high-confidence rules to enforcement after teams have migration examples and a clear exception path.
 
-### War Story: The $50,000 Dashboard Breach
+### Hypothetical scenario: The $50,000 Dashboard Breach
 
-In a real-world incident at a mid-sized tech company, developers deployed an internal monitoring dashboard using the `default` ServiceAccount in a production namespace. To make setup "easier," someone had previously bound a `ClusterRole` with `get secrets` permissions to this default account.
+Developers deploy an internal monitoring dashboard using the `default` ServiceAccount in a production namespace. To make setup "easier," someone had previously bound a `ClusterRole` with `get` and `list` on `secrets` (cluster-scoped) to this default account.
 
-When an attacker discovered a simple Server-Side Request Forgery vulnerability in the dashboard application, they did not need to break out of the container to inflict massive damage. They simply directed the vulnerable application to read the auto-mounted token at `/var/run/secrets/kubernetes.io/serviceaccount/token`. Using this token, the attacker queried the Kubernetes API, downloaded every Secret in the cluster, extracted cloud provider credentials, and spun up cryptocurrency miners. The result was a $50,000 cloud bill and a frantic, full-scale credentials rotation, all stemming from a leaked token that should never have been mounted in the first place.
+When an attacker discovered a simple Server-Side Request Forgery vulnerability in the dashboard application, they did not need to break out of the container to inflict massive damage. They simply directed the vulnerable application to read the auto-mounted token at `/var/run/secrets/kubernetes.io/serviceaccount/token`. Using this token, the attacker queried the Kubernetes API, listed and read sensitive Secrets across the cluster, extracted cloud provider credentials, and spun up cryptocurrency miners. The result was a $50,000 cloud bill and a frantic, full-scale credentials rotation, all stemming from a leaked token that should never have been mounted in the first place.
 
 The lesson is not that every `default` ServiceAccount already has dangerous permissions. Many clusters will show limited access when you test it. The lesson is that a shared implicit identity makes future drift hard to reason about. A safe namespace should make the secure path boring: every app has a named ServiceAccount, pods without API needs receive no token, and any RBAC binding to `default` is treated as a security exception that requires a short-lived migration plan.
 
@@ -411,7 +408,7 @@ The strongest ServiceAccount programs are boring in the best sense. A reviewer c
 | Pattern | When to Use It | Why It Works | Scaling Consideration |
 |---------|----------------|--------------|-----------------------|
 | Dedicated ServiceAccount per application | Any workload with distinct ownership or API needs | It keeps identity, audit, and RBAC blast radius aligned to one app | Name accounts consistently so reviews and dashboards can group them by namespace and owner |
-| Token-free workload by default | Pods that do not call the Kubernetes API | A compromised container cannot steal a token that was never mounted | Use admission policy to flag missing `automountServiceAccountToken: false` for simple app templates |
+| Token-free workload by default | Pods that do not call the Kubernetes API | A compromised container cannot steal a token that was never mounted | Use admission policy to flag pods that still auto-mount tokens (implicit `true`) for simple app templates |
 | Narrow RoleBinding with `k auth can-i` proof | Controllers, leader election, config watchers, and operators | Live authorization checks catch permissions that static review misses | Add expected `can-i` checks to release review for high-risk workloads |
 | Workload identity for cloud access | Pods that need AWS, Google Cloud, or Azure APIs | It removes static cloud keys from Kubernetes Secrets and improves audit trails | Keep cloud IAM policies as narrow as Kubernetes RBAC, because either side can widen blast radius |
 
@@ -528,7 +525,7 @@ The important skill is to explain both the obvious and hidden issues. The `clust
 
 As you work through the exercise, separate evidence from preference. "I dislike the default namespace" is weaker than "the default namespace often lacks ownership boundaries, and this manifest gives no reason the workload belongs there." "ClusterRoleBinding feels too broad" is weaker than "this subject receives `cluster-admin`, so a stolen token can perform any API action accepted by admission." KCSA-style reasoning rewards that precision because the goal is to identify how an attacker would use each misconfiguration.
 
-**Scenario**: Review the following setup and identify the ServiceAccount, namespace, RBAC, and token-mounting issues before writing a safer replacement:
+**Exercise scenario**: Review the following setup and identify the ServiceAccount, namespace, RBAC, and token-mounting issues before writing a safer replacement:
 
 ```yaml
 # ServiceAccount with too much access

--- a/src/content/docs/k8s/kcsa/part3-security-fundamentals/module-3.5-network-policies.md
+++ b/src/content/docs/k8s/kcsa/part3-security-fundamentals/module-3.5-network-policies.md
@@ -246,7 +246,9 @@ spec:
   - Egress
   egress:
   - to:
-    - namespaceSelector: {}
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
       podSelector:
         matchLabels:
           k8s-app: kube-dns
@@ -257,7 +259,7 @@ spec:
       port: 53
 ```
 
-The DNS example deliberately shows both UDP and TCP port 53. UDP handles most queries, but TCP may be used for larger responses, retries, or specific resolver behavior, so allowing only UDP can create intermittent failures that are hard to reproduce. The namespace selector shown here is broad because cluster DNS lives outside the application namespace, but in a real cluster you should verify the actual namespace and labels used by your DNS deployment before applying the rule.
+The DNS example deliberately shows both UDP and TCP port 53. UDP handles most queries, but TCP may be used for larger responses, retries, or specific resolver behavior, so allowing only UDP can create intermittent failures that are hard to reproduce. The namespace selector targets `kube-system` where cluster DNS typically runs, but in a real cluster you should verify the actual namespace and labels used by your DNS deployment before applying the rule.
 
 Some namespaces need an internal collaboration zone where workloads can talk to each other but not to the rest of the cluster. That model is weaker than per-service least privilege, yet it is still a major improvement over a flat cluster when used for tightly owned workloads with similar sensitivity. It is also a useful migration step when a team is not ready to map every individual flow on day one.
 
@@ -292,8 +294,7 @@ spec:
   policyTypes:
   - Ingress
   ingress:
-  - from: []  # Empty = allow from anywhere
-    ports:
+  - ports:
     - port: 443
 ---
 # Allow web to reach API
@@ -339,7 +340,7 @@ spec:
 
 This example allows web ingress from anywhere because it represents a public-facing tier, but many clusters should replace that broad peer with an ingress controller namespace selector. The phrase "from anywhere" can mean the internet, the node network, or the pod network depending on CNI and traffic path, so do not treat it as a harmless shortcut. The safer habit is to describe the real caller and encode that caller with labels whenever the dataplane makes it possible.
 
-A practical rollout often starts with a war-room exercise rather than a production change. One team I worked with placed a default-deny policy in a staging namespace and immediately discovered that the API tier made outbound calls to a legacy metrics collector during startup. The dependency was not on the architecture diagram, but the failing connection created a concrete decision: either document and allow it, remove it, or keep the namespace open forever. NetworkPolicy is useful partly because it forces those hidden dependencies into daylight.
+A common rollout pattern is to apply a default-deny policy in a staging namespace first. Often this immediately reveals that the API tier makes outbound calls to a legacy metrics collector during startup. The dependency is not on the architecture diagram, but the failing connection creates a concrete decision: either document and allow it, remove it, or keep the namespace open forever. NetworkPolicy is useful partly because it forces those hidden dependencies into daylight.
 
 Default deny also changes how you design deployment pipelines. A new service should not ship with a policy added days later after someone remembers segmentation; the policy is part of the service interface. Review the Deployment labels, Service selectors, NetworkPolicy selectors, and smoke tests together in the same pull request. If the application cannot start under the policy, that is not a network team problem alone, because the application has an undocumented dependency.
 
@@ -791,6 +792,8 @@ spec:
     ports:
     - port: 53
       protocol: UDP
+    - port: 53
+      protocol: TCP
 ---
 # Allow API ingress from web
 apiVersion: networking.k8s.io/v1
@@ -842,6 +845,8 @@ spec:
     ports:
     - port: 53
       protocol: UDP
+    - port: 53
+      protocol: TCP
 ---
 # Allow DB ingress from API
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
## KCSA wave 3 — part3 (Security Fundamentals), 4 modules → finalize-to-`done`

Cross-family R1 review of the 4 KCSA part3 modules, then a consolidated fix.
Reviewers (mixed pools, ≤2/OAuth): **opus 4.8 headless** (3.2 RBAC) · **cursor `--model auto`** (3.3, 3.4) ·
**deepseek-v4-pro** (3.5). Fix by cursor in a worktree; all findings ground-checked and KMS version
facts **web-verified against kubernetes.io**. Three T3 modules (3.3, 3.4, 3.5) cleared to T0.

### Modules
| Module | Reviewer | Verdict | Key fixes |
|---|---|---|---|
| 3.2 rbac | opus-4.8 | NEEDS_CHANGES 4.5/5 | opener → Hypothetical; **dev-Role `resources:["*"]` includes Secrets** caveat (the module's own central lesson); authn→authz→admission order |
| 3.3 secrets (T3→T0) | cursor | NEEDS_CHANGES 4.7/5 | 2 war stories → Hypothetical; **KMS v2** added (GA 1.29), aescbc/aesgcm marked legacy, KMS v1 deprecated 1.28; **Vault** moved out of native-KMS providers; hands-on → volume mount |
| 3.4 serviceaccounts (T3→T0) | cursor | NEEDS_CHANGES 4.0/5 | War Story → Hypothetical + **de-duplicated** the twice-told $50k incident; RBAC verb `get`→`get`+`list`; TokenRequest shown as subresource body, not appliable manifest |
| 3.5 network-policies (T3→T0) | deepseek | NEEDS_CHANGES 4/5 | personal anecdote → generalized; DNS egress solution gains **TCP/53** (matches body); `from:[]` omitted; nsSelector → kube-system |

### Web-verified facts (kubernetes.io)
- **KMS v2** stable/GA in **1.29**; **KMS v1** deprecated **1.28**, disabled-by-default 1.29; KMS v2 is the recommended path.

### Ground-check notes
- opus caught a real pedagogical self-contradiction in 3.2: the worked-solution developer Role granted Secret read (`resources:["*"]` on core API group) while the module teaches 4× that `view` excludes Secrets — turned into an explicit teaching caveat.
- No real named incidents added — every war story became `Hypothetical scenario:` or a generalized pattern, so **no new citations** and **no dedup risk**.

### Gates
- Verifier: all 4 **T0** (3.3, 3.4, 3.5 cleared `anti_fabrication_no_unsourced_anecdote`).
- **incident-dedup gate: PASS.** No CNCF maturity-tier claims in any of the 4 modules.

## Learner check

> The secure habit is to treat every pod identity as a scoped credential with a clear purpose, expiration, and audience

🤖 Generated with [Claude Code](https://claude.com/claude-code)
