### PR TITLE
chore(content): KCSA wave-5 (part5 platform-security) — war-story hygiene + tool-currency + signing/RHACS accuracy

### DIFF
--- a/src/content/docs/k8s/kcsa/part5-platform-security/module-5.1-image-security.md
+++ b/src/content/docs/k8s/kcsa/part5-platform-security/module-5.1-image-security.md
@@ -23,7 +23,7 @@ After completing this module, you will be able to apply the following skills dur
 
 ## Why This Module Matters
 
-In 2019, a large financial technology company traced a production compromise back to a container image that looked ordinary in Kubernetes but carried an outdated web framework, a leaked package token in an image layer, and a debugging shell that should never have shipped. The cluster controls were not obviously broken: Pods were scheduled normally, the registry required authentication, and the Deployment had passed a basic CI job. The loss came from treating the image as a delivery box instead of a security boundary, and the cleanup cost grew because every node that pulled the image had cached evidence, dependencies, and secrets in different places.
+Hypothetical scenario: a large financial technology company traced a production compromise back to a container image that looked ordinary in Kubernetes but carried an outdated web framework, a leaked package token in an image layer, and a debugging shell that should never have shipped. The cluster controls were not obviously broken: Pods were scheduled normally, the registry required authentication, and the Deployment had passed a basic CI job. The loss came from treating the image as a delivery box instead of a security boundary, and the cleanup cost grew because every node that pulled the image had cached evidence, dependencies, and secrets in different places.
 
 That pattern is common because Kubernetes makes images feel routine. A Pod specification names an image, kubelet pulls it, and the workload starts; the dangerous parts happened earlier, when the base image was chosen, dependencies were installed, files were copied, tags were assigned, and scan results were interpreted. An attacker does not need to break the Kubernetes API if the image already contains a vulnerable package, a root process, writable filesystem paths, or a mutable tag that can be replaced after approval. Image security is therefore not one tool or one scan report; it is a chain of decisions from build to store to deploy to run.
 
@@ -97,13 +97,14 @@ Compatibility is the main reason teams cannot always jump straight to scratch or
 │              BASE IMAGE COMPARISON                          │
 ├─────────────────────────────────────────────────────────────┤
 │                                                             │
-│  IMAGE TYPE           SIZE      CVEs    USE CASE            │
+│  IMAGE TYPE           SIZE      CVEs*   USE CASE            │
 │  ───────────────────────────────────────────────────────    │
 │  ubuntu:22.04        ~77MB     100+    Development          │
 │  debian:bookworm     ~50MB     50+     General purpose      │
 │  alpine:3.19         ~7MB      10-20   Lightweight apps     │
 │  distroless/static   ~2MB      0-5     Static binaries      │
 │  scratch             0MB       0       Go/Rust binaries     │
+│  *CVE counts are illustrative and go stale as bases change │
 │                                                             │
 │  RECOMMENDATIONS:                                          │
 │  ├── Production: Distroless or Alpine                      │
@@ -179,7 +180,7 @@ The security value is not only smaller size. Source code left in an image can re
 └─────────────────────────────────────────────────────────────┘
 ```
 
-A realistic war story: a platform team once blocked a service because its image scanner found Critical CVEs in `gcc` and `make`, even though the application never invoked either binary at runtime. The application team argued that the findings were false positives because the vulnerable packages were "only build tools." The platform response was correct: if the packages are in the runtime image, they are runtime packages, regardless of intent. Moving the compiler into a builder stage removed the findings, reduced pull time, and made the production container easier to reason about.
+Hypothetical scenario: a platform team once blocked a service because its image scanner found Critical CVEs in `gcc` and `make`, even though the application never invoked either binary at runtime. The application team argued that the findings were false positives because the vulnerable packages were "only build tools." The platform response was correct: if the packages are in the runtime image, they are runtime packages, regardless of intent. Moving the compiler into a builder stage removed the findings, reduced pull time, and made the production container easier to reason about.
 
 Multi-stage builds are not a license to ignore the builder stage. A compromised compiler, package manager plugin, or build script can still affect the artifact copied into the runtime stage. That is why secure teams combine multi-stage builds with pinned dependency inputs, locked package manifests, controlled build networks, and provenance records. The builder stage may not ship to production, but it still has influence over the bytes that do ship.
 
@@ -254,7 +255,7 @@ The most practical scanning programs use multiple scan points. Build-time scanni
 │  ├── Multiple DB sources                                   │
 │  └── CI/CD integration                                     │
 │                                                             │
-│  CLAIR (CoreOS/Red Hat)                                    │
+│  CLAIR (Quay/Red Hat)                                      │
 │  ├── API-based scanning                                    │
 │  ├── Registry integration                                  │
 │  └── Continuous monitoring                                 │
@@ -428,7 +429,7 @@ The most effective admission policies are written with developer ergonomics in m
 
 ### Policy Enforcement
 
-Good image admission policies are specific enough to reduce risk and clear enough that developers can fix violations. "Only use trusted registries" is a useful rule when the registry has scanning and promotion controls. "No latest tag" is useful because it removes a class of non-repeatable deployments. "Require digest" is stronger because it pins content identity, although it usually needs tooling support so humans are not hand-editing long hashes. "Require signature" adds provenance and tamper evidence, but it depends on key management and trustworthy build identities.
+Good image admission policies are specific enough to reduce risk and clear enough that developers can fix violations. "Only use trusted registries" is a useful rule when the registry has scanning and promotion controls. "No latest tag" is useful because it removes a class of non-repeatable deployments. "Require digest" is stronger because it pins content identity, although it usually needs tooling support so humans are not hand-editing long hashes. "Require signature" adds provenance and tamper evidence, but it depends on key management and trustworthy build identities. CI pipelines typically sign release images with [Cosign](https://docs.sigstore.dev/cosign/overview/) through the [Sigstore](https://www.sigstore.dev/) project; at deploy time, Kyverno `verifyImages` rules or dedicated controllers such as Connaisseur check that signatures match trusted keys or certificate authorities before the Pod is admitted.
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -491,9 +492,11 @@ spec:
         spec:
           containers:
           - image: "gcr.io/my-project/* | myregistry.io/*"
+          initContainers:
+          - image: "gcr.io/my-project/* | myregistry.io/*"
 ```
 
-This policy is intentionally simple because the concept matters more than the exact syntax. It validates Pod image references and rejects images outside the trusted registry list. In a real cluster, you would also cover init containers and ephemeral containers, define namespace exceptions for system workloads, and pair the registry rule with digest and signature checks. The security outcome is strongest when the policy points developers toward a promotion path, such as mirroring an approved external image into the private registry after scanning and signing.
+This policy is intentionally simple because the concept matters more than the exact syntax. It validates Pod and init container image references and rejects images outside the trusted registry list. Production policies should also cover `ephemeralContainers`, define namespace exceptions for system workloads, and pair the registry rule with digest and signature checks. The security outcome is strongest when the policy points developers toward a promotion path, such as mirroring an approved external image into the private registry after scanning and signing.
 
 A common operational failure is allowing admission rules to drift away from pipeline rules. If CI signs images but admission does not verify signatures, signing becomes a compliance artifact rather than a cluster control. If admission requires private registries but the registry allows arbitrary pushes by humans, the policy proves only location, not trust. The engineering target is consistency: the build pipeline creates evidence, the registry stores evidence and artifacts, and admission checks that evidence before Kubernetes accepts the workload.
 
@@ -627,7 +630,7 @@ The framework deliberately asks practical questions instead of naming tools firs
 
 ## Did You Know?
 
-- **The average container image has 300+ packages** and 100+ known vulnerabilities. Minimal base images can reduce this by 90%.
+- **Container images often carry hundreds of OS packages**, each with its own vulnerability record. Minimal base images substantially reduce scan surface and patch burden.
 
 - **Distroless images have no shell**; if an attacker gets code execution, they cannot easily run ordinary shell commands. This is defense in depth.
 
@@ -802,7 +805,7 @@ Use the solution below to compare your findings with a complete review that sepa
 FROM node:20-alpine@sha256:abc123 AS builder
 WORKDIR /app
 COPY package*.json ./
-RUN npm ci --only=production
+RUN npm ci --omit=dev
 COPY src/ ./src/
 
 FROM gcr.io/distroless/nodejs20:nonroot

--- a/src/content/docs/k8s/kcsa/part5-platform-security/module-5.2-observability.md
+++ b/src/content/docs/k8s/kcsa/part5-platform-security/module-5.2-observability.md
@@ -19,7 +19,7 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-In 2024, a regional payments company discovered that an attacker had used a compromised service account to list production Secrets, exec into a long-running container, and open a quiet outbound connection to a database replica. The cluster had prevention controls: images were scanned, Pod Security Admission was enabled, and developers did not have direct cluster-admin access. The incident still lasted long enough to become expensive because the team could not quickly answer a basic sequence of questions: who touched the Secret, which pod ran the shell, what namespace sent the unusual traffic, and whether the same identity had modified RBAC earlier in the week.
+Hypothetical scenario: a regional payments company discovered that an attacker had used a compromised service account to list production Secrets, exec into a long-running container, and open a quiet outbound connection to a database replica. The cluster had prevention controls: images were scanned, Pod Security Admission was enabled, and developers did not have direct cluster-admin access. The incident still lasted long enough to become expensive because the team could not quickly answer a basic sequence of questions: who touched the Secret, which pod ran the shell, what namespace sent the unusual traffic, and whether the same identity had modified RBAC earlier in the week.
 
 The financial impact came less from a single failed control than from slow reconstruction. Engineers pulled fragments from API server audit logs, node logs, application logs, cloud firewall exports, and a chat channel where runtime alerts had been posted without paging anyone. Each source told part of the truth, but no one had designed the signals as an investigation system. By the time the company understood the path from credential use to container activity to database access, the response had already expanded into customer notification, compliance review, and several weeks of platform hardening.
 
@@ -95,7 +95,7 @@ An audit policy decides which requests are logged and at what level. The level i
 │  Panic            - On panic                               │
 │                                                             │
 │  WHAT TO LOG:                                              │
-│  • All authentication failures                             │
+│  • Anonymous / unauthenticated API access                  │
 │  • Secrets access                                          │
 │  • RBAC changes                                            │
 │  • Pod creation/deletion                                   │
@@ -105,13 +105,13 @@ An audit policy decides which requests are logged and at what level. The level i
 └─────────────────────────────────────────────────────────────┘
 ```
 
-The policy below is intentionally security-biased. It logs anonymous access, Secret access, exec and attach activity, RBAC changes, and pod mutations with more detail than ordinary reads. That ordering matters because audit policy rules are evaluated in order. A broad `Metadata` rule placed too early can accidentally prevent later high-value rules from taking effect. When you evaluate an audit policy, read it like a firewall policy: from top to bottom, asking which rule catches a request first.
+The policy below is intentionally security-biased. It logs anonymous access, Secret access, exec and attach activity, RBAC changes, and pod mutations with more detail than ordinary reads. Broader visibility into failed authentication for known users usually requires API server logs, authentication metrics, or identity-provider audit trails—not a single audit rule. That ordering matters because audit policy rules are evaluated in order. A broad `Metadata` rule placed too early can accidentally prevent later high-value rules from taking effect. When you evaluate an audit policy, read it like a firewall policy: from top to bottom, asking which rule catches a request first.
 
 ```yaml
 apiVersion: audit.k8s.io/v1
 kind: Policy
 rules:
-  # Log authentication failures at metadata level
+  # Log anonymous / unauthenticated API access at metadata level
   - level: Metadata
     users: ["system:anonymous"]
     verbs: ["*"]
@@ -162,7 +162,7 @@ An audit event becomes useful when responders know which fields to inspect first
 │    "level": "Request",                                     │
 │    "auditID": "abc-123-def",                              │
 │    "stage": "ResponseComplete",                            │
-│    "requestURI": "/api/v1/namespaces/prod/secrets/db-cred",│
+│    "requestURI": "/api/v1/namespaces/prod/secrets/db-credentials",│
 │    "verb": "get",                                          │
 │    "user": {                                               │
 │      "username": "alice@example.com",                      │
@@ -186,7 +186,7 @@ The example above can answer several incident questions quickly. It says a human
 
 For command-line checks during a lab or incident drill, define `alias k=kubectl` and then use `k auth can-i get secrets --as system:serviceaccount:prod:checkout`. That command does not prove a Secret was accessed, but it helps evaluate whether the identity had the permission needed to perform the access shown in the audit log. In real investigations, permission checks are strongest when combined with the actual audit event, because RBAC may have changed after the suspicious request occurred.
 
-War story: one platform team discovered that its audit policy logged RBAC changes at `Metadata` but not `Request`. During a compromise review, responders could see that a ClusterRoleBinding had been patched, but not which subject had been added because the request body was absent and the object had already been changed again. The team could eventually reconstruct the change from GitOps history, but the delay exposed a design flaw. For high-impact mutation resources, metadata alone may tell you that something happened without preserving enough detail to explain why it mattered.
+Hypothetical scenario: one platform team discovered that its audit policy logged RBAC changes at `Metadata` but not `Request`. During a compromise review, responders could see that a ClusterRoleBinding had been patched, but not which subject had been added because the request body was absent and the object had already been changed again. The team could eventually reconstruct the change from GitOps history, but the delay exposed a design flaw. For high-impact mutation resources, metadata alone may tell you that something happened without preserving enough detail to explain why it mattered.
 
 ## Runtime Security Monitoring
 
@@ -206,7 +206,8 @@ Falco is a common open source runtime security tool because it observes system c
 │  • Kubernetes-aware (pod context)                          │
 │                                                             │
 │  HOW IT WORKS:                                             │
-│  Kernel → eBPF/kernel module → Falco → Rules → Alerts     │
+│  Kernel → eBPF (modern driver) or legacy kernel module →  │
+│           Falco → Rules → Alerts                           │
 │                                                             │
 │  DETECTS:                                                  │
 │  • Shell spawned in container                              │
@@ -291,13 +292,14 @@ Falco is not the only runtime option, and the tool choice should follow the oper
 │  ├── Managed rules and compliance                          │
 │  └── Enterprise features                                   │
 │                                                             │
-│  KUBEARMOR                                                 │
+│  KUBEARMOR (CNCF Sandbox)                                  │
 │  ├── LSM-based enforcement                                 │
 │  ├── Process, file, network policies                       │
 │  ├── Less established than Falco                           │
 │  └── Focus on enforcement                                  │
 │                                                             │
-│  AQUA/PRISMA/STACKROX                                      │
+│  AQUA/PRISMA/STACKROX (RHACS)                              │
+│  ├── StackRox → Red Hat Advanced Cluster Security         │
 │  ├── Commercial platforms                                  │
 │  ├── Full-stack security                                   │
 │  ├── Runtime + vulnerability management                    │
@@ -389,7 +391,7 @@ Correlation is where these queries become powerful. Imagine an audit alert for a
 
 The inverse is also true: correlation can reduce false positives. If a production exec occurs during an approved incident, from the expected engineer, after a change ticket, and without any runtime follow-on indicators, the alert may remain informational. That does not mean it should be ignored; it means the response can be evidence preservation and review rather than emergency containment. A strong monitoring program supports both escalation and de-escalation by providing enough surrounding facts.
 
-War story: a team once alerted on every denied RBAC request and created so much noise that engineers stopped reading the channel. During a real incident, the attacker generated denied requests while probing permissions, but the signal blended into the background. The fix was not to delete the alert. The team changed it to detect unusual denied-request rates by identity, namespace, and source, then paired it with successful sensitive operations by the same principal. The result was fewer alerts with a clearer story.
+Hypothetical scenario: a team once alerted on every denied RBAC request and created so much noise that engineers stopped reading the channel. During a real incident, the attacker generated denied requests while probing permissions, but the signal blended into the background. The fix was not to delete the alert. The team changed it to detect unusual denied-request rates by identity, namespace, and source, then paired it with successful sensitive operations by the same principal. The result was fewer alerts with a clearer story.
 
 ### Worked Example: Following One Suspicious Identity
 

--- a/src/content/docs/k8s/kcsa/part5-platform-security/module-5.3-runtime-security.md
+++ b/src/content/docs/k8s/kcsa/part5-platform-security/module-5.3-runtime-security.md
@@ -126,7 +126,7 @@ spec:
       type: RuntimeDefault
   containers:
   - name: nginx
-    image: nginx:1.25.3
+    image: nginx:1.27
     securityContext:
       # You can also define it at the container level
       # which overrides the pod-level setting
@@ -273,7 +273,7 @@ spec:
     image: nginx:alpine
 ```
 
-War story: during a red-team exercise, a Java service had a path traversal bug that allowed attackers to request files outside the intended content directory. The application ran as root in its container, so normal file ownership would not have been enough protection. The AppArmor profile denied reads from sensitive host and system paths, so the exploit still manipulated strings successfully, but the kernel rejected the file operation and produced audit evidence that defenders could investigate.
+Hypothetical scenario: during a red-team exercise, a Java service had a path traversal bug that allowed attackers to request files outside the intended content directory. The application ran as root in its container, so normal file ownership would not have been enough protection. The AppArmor profile denied reads from sensitive host and system paths, so the exploit still manipulated strings successfully, but the kernel rejected the file operation and produced audit evidence that defenders could investigate.
 
 That story is also a reminder that MAC is not only about prevention. A well-named AppArmor or SELinux denial gives defenders a high-signal event because ordinary applications should not attempt to read Kubernetes node credentials, host configuration, or shadow password files. Runtime security observability from the previous module becomes more useful when the enforced profile is specific enough that a violation says something meaningful about the workload's behavior.
 
@@ -517,14 +517,15 @@ Seccomp, capabilities, and MAC all reduce what a process can do to a shared kern
 │  gVisor (runsc)                                           │
 │  ├── User-space kernel (Sentry)                           │
 │  ├── Intercepts and emulates syscalls                     │
-│  ├── ~70% syscall coverage                                │
+│  ├── Implements a large portion of the Linux syscall      │
+│  │   interface (see gVisor compatibility notes)           │
 │  ├── Performance overhead (varies by workload)            │
 │  └── Use for: Untrusted workloads, multi-tenant           │
 │                                                             │
 │  Kata Containers                                          │
 │  ├── Lightweight VM per container                         │
 │  ├── Separate kernel (not shared)                         │
-│  ├── Hardware virtualization (KVM)                        │
+│  ├── Typically KVM (also Firecracker, Cloud Hypervisor)   │
 │  ├── Higher overhead than gVisor                          │
 │  └── Use for: Maximum isolation, compliance               │
 │                                                             │

--- a/src/content/docs/k8s/kcsa/part5-platform-security/module-5.4-security-tooling.md
+++ b/src/content/docs/k8s/kcsa/part5-platform-security/module-5.4-security-tooling.md
@@ -24,9 +24,7 @@ After completing this module, you will be able to perform the following security
 
 ## Why This Module Matters
 
-In late 2021, a widely used Java logging library vulnerability forced operations teams into an uncomfortable race. A platform team at a large online retailer discovered that it could inventory container images quickly, but it could not prove which workloads were already running vulnerable packages, which namespaces would block emergency patches, or which suspicious runtime activity deserved immediate response. The team had expensive tools, several dashboards, and plenty of alerts, yet the incident bridge still spent hours arguing over ownership because each tool described only one slice of the risk.
-
-That kind of failure is not caused by one missing scanner. It is caused by an unplanned security tooling stack where build-time checks, admission policy, runtime detection, cluster hardening, secret handling, and service identity do not form a chain. Kubernetes makes this problem sharper because the attack surface spans images, manifests, admission controllers, kubelet behavior, cloud identity, network paths, and the kernel boundary beneath containers. A finding from one layer is useful only when the team knows which other layer should prevent, confirm, or compensate for it.
+During the December 2021 [Log4Shell disclosure](/platform/disciplines/reliability-security/devsecops/module-4.4-supply-chain-security/) <!-- incident-xref: log4shell --> (CVE-2021-44228), many platform teams found they could inventory container images quickly but could not prove which running workloads were affected, which namespaces would block emergency patches, or which suspicious runtime activity deserved immediate response. A platform team discovered that it had expensive tools, several dashboards, and plenty of alerts, yet the incident bridge still spent hours arguing over ownership because each tool described only one slice of the risk. That kind of failure is not caused by one missing scanner. It is caused by an unplanned security tooling stack where build-time checks, admission policy, runtime detection, cluster hardening, secret handling, and service identity do not form a chain. Kubernetes makes this problem sharper because the attack surface spans images, manifests, admission controllers, kubelet behavior, cloud identity, network paths, and the kernel boundary beneath containers. A finding from one layer is useful only when the team knows which other layer should prevent, confirm, or compensate for it.
 
 This module teaches the security tools named most often in Kubernetes security practice and KCSA preparation, but the goal is not memorizing logos. You will learn how to evaluate tool categories, compare overlapping tools honestly, design a small stack that fits a team, and diagnose gaps before an incident exposes them. The examples assume Kubernetes 1.35+ behavior and use `alias k=kubectl`; when you see an inline command such as `k get pods -A`, read it as the standard kubectl client through that short alias.
 
@@ -227,7 +225,7 @@ kube-bench maps cluster and node configuration to the CIS Kubernetes Benchmark. 
 
 The important nuance is that kube-bench findings are not all equally actionable in every cluster. A self-managed cluster gives the platform team direct access to control plane flags and host files. A managed service may hide those components or implement equivalent controls differently. The finding still matters, but the remediation path may be a provider setting, an upgrade, a support ticket, or a compensating control. Treat benchmark results as a structured conversation with the platform owner, not as a blind pass-fail score.
 
-kubeaudit focuses more on workload manifests and running resources. It looks for practical workload risks such as privileged containers, root users, added capabilities, missing resource limits, host namespace usage, and service account token exposure. This makes it complementary to kube-bench. If kube-bench is inspecting the building's locks and fire doors, kubeaudit is walking through each office to see whether people propped doors open, stored keys on desks, or ran machinery without guards.
+kubeaudit focuses more on workload manifests and running resources. It looks for practical workload risks such as privileged containers, root users, added capabilities, missing resource limits, host namespace usage, and service account token exposure. Status: archived / read-only since Oct 2024 — included for tool-category awareness. This makes it complementary to kube-bench. If kube-bench is inspecting the building's locks and fire doors, kubeaudit is walking through each office to see whether people propped doors open, stored keys on desks, or ran machinery without guards.
 
 ```text
 ┌─────────────────────────────────────────────────────────────┐
@@ -236,6 +234,7 @@ kubeaudit focuses more on workload manifests and running resources. It looks for
 │                                                             │
 │  WHAT: Kubernetes security auditing tool                    │
 │  BY: Shopify (open source)                                 │
+│  STATUS: Archived / read-only since Oct 2024               │
 │                                                             │
 │  AUDITS FOR:                                               │
 │  ├── Privileged containers                                │
@@ -290,7 +289,7 @@ Polaris overlaps with workload auditing, but it presents findings as best-practi
 └─────────────────────────────────────────────────────────────┘
 ```
 
-kube-hunter moves from audit into controlled penetration testing. It looks for exposed Kubernetes components, kubelet weaknesses, etcd exposure, and other discoverable risks. Because it can run in remote, internal, and active modes, it must be used with change-control discipline. An internal scan can reveal what an attacker might see after gaining a foothold, while an active scan can alter systems or trigger alarms. That makes authorization and scoping part of the tool, not paperwork around the tool.
+kube-hunter moves from audit into controlled penetration testing. It looks for exposed Kubernetes components, kubelet weaknesses, etcd exposure, and other discoverable risks. Status: no longer actively maintained (last release 2022); upstream recommends Trivy. Because it can run in remote, internal, and active modes, it must be used with change-control discipline. An internal scan can reveal what an attacker might see after gaining a foothold, while an active scan can alter systems or trigger alarms. That makes authorization and scoping part of the tool, not paperwork around the tool.
 
 ```text
 ┌─────────────────────────────────────────────────────────────┐
@@ -299,6 +298,8 @@ kube-hunter moves from audit into controlled penetration testing. It looks for e
 │                                                             │
 │  WHAT: Kubernetes penetration testing tool                  │
 │  BY: Aqua Security (open source)                           │
+│  STATUS: No longer actively maintained (last release 2022); │
+│          upstream recommends Trivy                          │
 │                                                             │
 │  FINDS:                                                    │
 │  ├── Exposed API servers                                  │
@@ -327,7 +328,7 @@ kube-hunter moves from audit into controlled penetration testing. It looks for e
 
 A useful assessment program starts with baselines and trends. The first run will often produce a discouraging list, especially on older clusters where teams have accumulated exceptions and legacy manifests. Do not respond by hiding the results. Categorize findings by platform ownership, workload ownership, severity, exploitability, and remediation cost. Then decide which findings become admission policies, which become tickets, and which remain documented risks because the platform cannot change them immediately.
 
-War story: a financial services team once ran a benchmark tool shortly before an external audit and found several control-plane checks marked as failures. The first reaction was panic, but the deeper review showed that some checks applied to self-managed clusters while the team's managed control plane used provider-managed equivalents. The real gap was not the failed label; it was the absence of documented evidence. They fixed the evidence path, then focused engineering effort on worker-node and workload issues they actually controlled.
+Hypothetical scenario: a financial services team once ran a benchmark tool shortly before an external audit and found several control-plane checks marked as failures. The first reaction was panic, but the deeper review showed that some checks applied to self-managed clusters while the team's managed control plane used provider-managed equivalents. The real gap was not the failed label; it was the absence of documented evidence. They fixed the evidence path, then focused engineering effort on worker-node and workload issues they actually controlled.
 
 ## Policy Enforcement: Admission as a Control Point
 
@@ -446,7 +447,7 @@ Tetragon approaches runtime security through eBPF observability and enforcement,
 
 Runtime security succeeds or fails on signal quality. A "shell in container" rule is valuable when production web containers never need shells, but noisy when maintenance jobs legitimately run shell scripts all day. Suppressing the rule globally destroys coverage. The better approach is contextual tuning: allow known maintenance pods by label, downgrade expected events, keep high-priority alerts for unusual namespaces, and route severe events to people who can act. Detection rules should encode operational knowledge, not fight it.
 
-War story: a platform team deployed Falco with default alerts and routed every warning to the same incident channel. Within two weeks, engineers had trained themselves to ignore the stream because batch jobs produced noisy shell alerts and backup containers wrote to paths that looked suspicious. The fix was not uninstalling Falco. The team built namespace-specific exceptions, mapped severities to response channels, attached runbooks, and reviewed the top noisy rules every Friday until alerts became rare enough to deserve attention.
+Hypothetical scenario: a platform team deployed Falco with default alerts and routed every warning to the same incident channel. Within two weeks, engineers had trained themselves to ignore the stream because batch jobs produced noisy shell alerts and backup containers wrote to paths that looked suspicious. The fix was not uninstalling Falco. The team built namespace-specific exceptions, mapped severities to response channels, attached runbooks, and reviewed the top noisy rules every Friday until alerts became rare enough to deserve attention.
 
 Runtime tooling also depends on response maturity. If Falco or Tetragon detects a suspicious process, the responder needs to know whether to isolate a namespace, scale a deployment to zero, capture forensic data, rotate credentials, block egress, or open an application incident. A tool can say "this behavior is unusual"; it cannot decide the business impact alone. The stack is complete only when detection leads to a practiced action.
 
@@ -477,7 +478,7 @@ HashiCorp Vault is a broad secrets platform rather than a Kubernetes-only tool. 
 │                                                             │
 │  3. EXTERNAL SECRETS OPERATOR                              │
 │     ├── Syncs Vault secrets to K8s Secrets                │
-│     └── Automatic rotation                                 │
+│     └── Periodic refresh from the source secret store      │
 │                                                             │
 │  BENEFITS:                                                 │
 │  • Dynamic secrets (auto-generated)                       │
@@ -511,7 +512,7 @@ Sealed Secrets solves a narrower GitOps problem. Teams want declarative manifest
 │  5. Controller decrypts to regular Secret in cluster       │
 │                                                             │
 │  WORKFLOW:                                                 │
-│  kubectl create secret ... --dry-run -o yaml |            │
+│  kubectl create secret ... --dry-run=client -o yaml |     │
 │    kubeseal > sealed-secret.yaml                          │
 │  git add sealed-secret.yaml                               │
 │  git commit -m "Add encrypted secret"                     │
@@ -543,7 +544,7 @@ Service mesh security adds another layer by giving workloads stronger service id
 │  └── More granular than NetworkPolicy                     │
 │                                                             │
 │  EXAMPLE:                                                  │
-│  apiVersion: security.istio.io/v1beta1                    │
+│  apiVersion: security.istio.io/v1                         │
 │  kind: AuthorizationPolicy                                │
 │  spec:                                                    │
 │    selector:                                              │


### PR DESCRIPTION
## KCSA wave 5 — part5 (Platform Security), 4 modules → finalize-to-`done`

Cross-family R1 review of the 4 KCSA part5 modules, then a consolidated fix.
Reviewers (mixed pools, ≤2/OAuth): **cursor `--model auto`** (5.1, 5.2) · **deepseek-v4-pro** (5.3) ·
**opus 4.8 headless** (5.4). Fix by cursor in a worktree; all findings ground-checked and **every CNCF
maturity claim web-verified against cncf.io**. All four T3 modules cleared to T0.

### Modules
| Module | Reviewer | Verdict | Key fixes |
|---|---|---|---|
| 5.1 image-security (T3→T0) | cursor | NEEDS_CHANGES 4.1/5 | 2 anecdotes→Hypothetical; Dockerfile layer order; unsourced stats softened; cosign/sigstore in core prose; Kyverno init/ephemeral note |
| 5.2 observability (T3→T0) | cursor | NEEDS_CHANGES 4.5/5 | 3 anecdotes→Hypothetical; "all auth failures"→anonymous-only (audit policy matches `system:anonymous`); **StackRox→RHACS** |
| 5.3 runtime-security (T3→T0) | deepseek | APPROVE_WITH_NITS 38/40 | anecdote→Hypothetical; stale gVisor "~70% syscall" → qualitative; nginx/Kata nits |
| 5.4 security-tooling (T3→T0) | opus-4.8 | NEEDS_CHANGES 4.0/5 | **both `War story:`→Hypothetical** (verifier-required); Log4Shell→CVE-2021-44228 anchor; **kubeaudit (archived) / kube-hunter (EOL→Trivy)** status notes; Istio v1beta1→v1 |

### CNCF maturity (web-verified against cncf.io — kept the correct ones, no false "corrections")
- **Falco** Graduated 2024-02-29 ✓ (5.2/5.4 claims kept) · **Cilium** Graduated 2023-10-11 ✓ (Tetragon = sub-project) · **KubeArmor** Sandbox (2021-11) · **Cosign** = Sigstore/Linux Foundation, *not* CNCF ✓ (module correct).

### Ground-check notes
- opus didn't run the verifier and said 5.4's two `War story:` blocks were fine; the gate flags the **literal lead-in regardless of fingerprint**, so both were relabeled to clear T3.
- **Tool currency**: kubeaudit (Shopify-archived Oct 2024) and kube-hunter (last release 2022; Aqua → Trivy) were presented as current — both web-verified EOL and annotated, not deleted (KCSA recall value).

### Gates
- Verifier: all 4 **T0** (every module cleared `anti_fabrication`; zero `war story:` lead-ins remain).
- **incident-dedup gate: PASS** (Tesla xref in 5.3 preserved).

## Learner check

> A finding from one layer is useful only when the team knows which other layer should prevent, confirm, or compensate for it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
