### PR TITLE
chore(content): Extending-K8s wave-1 (1.1-1.3) — deadlock fix + CRD conversion accuracy + density floor

### DIFF
--- a/src/content/docs/k8s/extending/module-1.1-api-deep-dive.md
+++ b/src/content/docs/k8s/extending/module-1.1-api-deep-dive.md
@@ -32,7 +32,7 @@ The airport security analogy is useful, with one important adjustment. The Kuber
 
 ## Core Concept 1: The API Server Request Pipeline
 
-When you run `kubectl create deployment nginx --image=nginx`, `kubectl` constructs an HTTP request, signs it using credentials from your kubeconfig, and sends it to the API Server. The API Server does not immediately write the Deployment to etcd. It first turns the network request into a Kubernetes identity and a requested verb, checks whether that identity is allowed to perform that verb on that resource, applies admission logic, validates the resulting object, and only then persists the accepted object.
+When you run `kubectl create deployment nginx --image=nginx:1.27`, `kubectl` constructs an HTTP request, signs it using credentials from your kubeconfig, and sends it to the API Server. The API Server does not immediately write the Deployment to etcd. It first turns the network request into a Kubernetes identity and a requested verb, checks whether that identity is allowed to perform that verb on that resource, applies admission logic, validates the resulting object, and only then persists the accepted object.
 
 The order matters because each stage receives a different form of the request. Authentication sees credentials and produces user information. Authorization sees the user, verb, API group, resource, namespace, and name. Mutating admission sees the object before final validation and may add defaults or sidecars. Validating admission sees the final candidate object and may accept or reject it, but it cannot rewrite it. Persistence stores the approved state and advances the resource version that watch clients use to stay synchronized.
 
@@ -97,7 +97,8 @@ The API Server is intentionally stateless with respect to durable cluster data. 
 │   ┌─────────────────────────────────────────────────────────┐      │
 │   │  6. PERSISTENCE                                          │      │
 │   │     Write to etcd                                        │      │
-│   │     • Serialize to storage format (protobuf)             │      │
+│   │     • Serialize to storage format (protobuf for built-in   │      │
+│   │       resources; JSON for CustomResources)                 │      │
 │   │     • Apply resource version                             │      │
 │   │     • Notify watchers via etcd watch                     │      │
 │   └─────────────────────────────────────────────────────────┘      │
@@ -127,7 +128,7 @@ kubectl auth can-i create pods --as=system:serviceaccount:default:my-sa
 kubectl auth can-i --list
 ```
 
-Admission is the extension-heavy part of the pipeline. Mutating admission can change an incoming object by adding labels, injecting containers, setting defaults, or normalizing fields. Validating admission evaluates the final object and returns accept or reject. Kubernetes 1.35 clusters can use admission webhooks for external logic and ValidatingAdmissionPolicy for in-tree CEL expressions, so the design choice is no longer "webhook or nothing." Use the simplest mechanism that can express the policy and reserve webhooks for logic that needs external data, complex calls, or mutation.
+Admission is the extension-heavy part of the pipeline. Mutating admission can change an incoming object by adding labels, injecting containers, setting defaults, or normalizing fields. Validating admission evaluates the final object and returns accept or reject. Kubernetes 1.35 clusters can use admission webhooks for external logic and ValidatingAdmissionPolicy (stable since Kubernetes 1.30) for in-tree CEL expressions, so the design choice is no longer "webhook or nothing." Use the simplest mechanism that can express the policy and reserve webhooks for logic that needs external data, complex calls, or mutation.
 
 Mutation should be used carefully because it changes the object that every later stage sees. A sidecar injector that adds containers can accidentally trigger a validating policy that counts containers, and a defaulting webhook that adds labels can affect selectors, quotas, or controller behavior. Validation is easier to reason about because it does not rewrite the request, but it can still create operational risk if a webhook is slow or unreachable. In production, the admission design includes timeout, failure policy, namespace selection, object selection, and a rollout plan, not just the webhook code.
 
@@ -414,7 +415,7 @@ func main() {
 	podInformer := factory.Core().V1().Pods().Informer()
 
 	// Register event handlers.
-	podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	if _, err := podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			pod := obj.(*corev1.Pod)
 			fmt.Printf("[ADDED]    %s/%s (Phase: %s)\n",
@@ -433,7 +434,10 @@ func main() {
 			pod := obj.(*corev1.Pod)
 			fmt.Printf("[DELETED]  %s/%s\n", pod.Namespace, pod.Name)
 		},
-	})
+	}); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to register event handler: %v\n", err)
+		os.Exit(1)
+	}
 
 	// Start the informer in background goroutines.
 	stopCh := make(chan struct{})
@@ -445,7 +449,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, "Failed to sync informer cache")
 		os.Exit(1)
 	}
-	fmt.Println("Cache synced! Watching for Pod changes...\n")
+	fmt.Println("Cache synced! Watching for Pod changes...")
 
 	// Use the Lister to read from cache, not from the API Server.
 	lister := factory.Core().V1().Pods().Lister()
@@ -490,6 +494,7 @@ AddFunc: func(obj interface{}) {
 }
 
 // Process items from the queue.
+// Simplified for teaching — see the complete program below for bounded retries and Forget.
 func processNextItem(queue workqueue.TypedRateLimitingInterface[string]) bool {
 	key, shutdown := queue.Get()
 	if shutdown {
@@ -579,7 +584,7 @@ Dry run is also a safe way to test admission behavior before a rollout. If a new
 
 ```bash
 # Create a deployment manifest locally.
-kubectl create deployment my-app --image=nginx --dry-run=client -o yaml > deployment.yaml
+kubectl create deployment my-app --image=nginx:1.27 --dry-run=client -o yaml > deployment.yaml
 
 # Server-side dry run validates through the API Server without persisting.
 kubectl apply -f deployment.yaml --dry-run=server
@@ -656,6 +661,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 // AnnotationWatcher watches Pods for annotation changes.
@@ -690,7 +697,7 @@ func NewAnnotationWatcher(clientset kubernetes.Interface) *AnnotationWatcher {
 		factory:   factory,
 	}
 
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	if _, err := podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			pod := obj.(*corev1.Pod)
 			if len(pod.Annotations) > 0 {
@@ -707,7 +714,9 @@ func NewAnnotationWatcher(clientset kubernetes.Interface) *AnnotationWatcher {
 		DeleteFunc: func(obj interface{}) {
 			w.enqueue(obj)
 		},
-	})
+	}); err != nil {
+		klog.Fatalf("Failed to register event handler: %v", err)
+	}
 
 	return w
 }
@@ -723,12 +732,11 @@ func (w *AnnotationWatcher) enqueue(obj interface{}) {
 
 // Run starts the informer and processes the workqueue.
 func (w *AnnotationWatcher) Run(ctx context.Context) error {
+	defer utilruntime.HandleCrash()
 	defer w.queue.ShutDown()
 
-	// Start informers.
 	w.factory.Start(ctx.Done())
 
-	// Wait for cache sync.
 	klog.Info("Waiting for informer cache to sync...")
 	if !cache.WaitForCacheSync(ctx.Done(), w.informer.HasSynced) {
 		return fmt.Errorf("failed to sync informer cache")
@@ -751,18 +759,16 @@ func (w *AnnotationWatcher) Run(ctx context.Context) error {
 	klog.Infof("Initial state: %d total Pods, %d with annotations",
 		len(pods), annotatedCount)
 
-	// Process workqueue items.
 	klog.Info("Starting workers...")
-	for {
-		select {
-		case <-ctx.Done():
-			klog.Info("Context cancelled, shutting down")
-			return nil
-		default:
-			if !w.processNextItem() {
-				return nil
-			}
-		}
+	go wait.Until(w.runWorker, time.Second, ctx.Done())
+
+	<-ctx.Done()
+	klog.Info("Context cancelled, shutting down")
+	return nil
+}
+
+func (w *AnnotationWatcher) runWorker() {
+	for w.processNextItem() {
 	}
 }
 
@@ -1021,7 +1027,7 @@ go build -o pod-watcher .
 
 ```bash
 # Create a Pod.
-kubectl run test-pod --image=nginx
+kubectl run test-pod --image=nginx:1.27
 
 # Checkpoint: wait for the Pod to be Ready.
 kubectl wait --for=condition=Ready pod/test-pod --timeout=120s

--- a/src/content/docs/k8s/extending/module-1.2-crds-advanced.md
+++ b/src/content/docs/k8s/extending/module-1.2-crds-advanced.md
@@ -327,7 +327,7 @@ properties:
 
 The `ports` example is a practical server-side apply decision. Without map semantics, a manager that owns one list item can conflict with or overwrite another manager that owns a different item because the whole list may be treated as one field. With `x-kubernetes-list-type: map` and a stable key, Kubernetes can reason about individual entries, which is closer to how operators expect lists of ports, conditions, and named rules to behave.
 
-CEL rules are best used for relationships that OpenAPI does not express cleanly, such as `minReplicas` being less than or equal to `maxReplicas` or requiring an ingress host when TLS is enabled. Keep CEL rules small, deterministic, and directly tied to the field being validated. If the rule requires network calls, large lookups, or business policy that changes frequently, use an admission webhook or controller logic instead.
+CEL rules are best used for relationships that OpenAPI does not express cleanly, such as `minReplicas` being less than or equal to `maxReplicas` or requiring an ingress host when TLS is enabled. CEL validation rules via `x-kubernetes-validations` graduated to GA in Kubernetes 1.29, so they are a dependable, server-enforced layer on every supported cluster rather than an alpha convenience. Keep CEL rules small, deterministic, and directly tied to the field being validated. If the rule requires network calls, large lookups, or business policy that changes frequently, use an admission webhook or controller logic instead.
 
 ```yaml
 spec:
@@ -338,7 +338,7 @@ spec:
     fieldPath: ".minReplicas"
   - rule: "self.replicas >= self.minReplicas && self.replicas <= self.maxReplicas"
     message: "replicas must be between minReplicas and maxReplicas"
-  - rule: "!self.ingress.tlsEnabled || self.ingress.host != ''"
+  - rule: "!has(self.ingress) || !self.ingress.tlsEnabled || self.ingress.host != ''"
     message: "host is required when TLS is enabled"
   properties:
     minReplicas:
@@ -468,7 +468,7 @@ spec:
                       type: string
 ```
 
-In this example, both versions remain served, but only `v1beta1` is stored. A client may create a `v1alpha1` object, but the API server converts it to the storage version before writing it. A client may later request the same object as `v1alpha1`, and the API server converts the stored `v1beta1` form back into the requested version before returning it.
+In this example, both versions remain served, but only `v1beta1` is stored. Because these two versions are structurally different, automatic conversion between them requires a conversion webhook (`strategy: Webhook`, shown next). With the default `None` strategy the API server only rewrites the `apiVersion` label and copies fields as-is, which is safe ONLY when the schemas are compatible. A client may create a `v1alpha1` object and the API server persists it in the storage version; on read, it returns the stored fields under the requested version label without translating `port` into `ports` unless a webhook performs that mapping.
 
 There are two conversion strategies. The `None` strategy is effectively a no-op and is only safe when the schemas are compatible enough that the same object can be represented across versions without semantic translation. The `Webhook` strategy sends conversion reviews to a service you operate, and that service must handle every supported version pair correctly enough that old and new clients see stable meaning.
 
@@ -497,6 +497,7 @@ kubectl get webapps --all-namespaces -o yaml > /dev/null
 
 # Or use the storage version migrator (kube-storage-version-migrator)
 # This systematically reads and rewrites all objects in the new storage version
+# (optional component — not installed on default kind/minikube clusters)
 ```
 
 Pause and predict: if you have 10,000 `WebApp` resources stored as `v1alpha1` and you mark `v1beta1` as storage, do those objects instantly rewrite in etcd? They do not. The API server can serve converted views on demand, but you still need a rewrite or a storage-version migration process if you want the backing data to move to the new storage representation.
@@ -551,9 +552,12 @@ Now standard scaling commands can target the custom resource:
 # Scale the custom resource
 kubectl scale webapp my-app --replicas=5
 
-# Use HPA
+# Use HPA (also requires Metrics Server and a controller that keeps
+# status.replicas, status.selector, and readyReplicas current)
 kubectl autoscale webapp my-app --min=2 --max=10 --cpu-percent=80
 ```
+
+CPU-based autoscaling on arbitrary CRDs is not automatic just because the scale subresource exists. HPA reads metrics through Metrics Server and writes desired replicas through the scale endpoint, but your controller must maintain the status fields HPA consults and reconcile child workloads accordingly.
 
 Pause and predict: if you configure HPA for your custom resource but omit the `scale` subresource, what breaks first? The HPA has no standard scale endpoint to read or write for that resource, so it can not reliably determine current replicas or update desired replicas. The fix is not an HPA flag; it is a CRD contract that exposes scale paths with fields your controller actually maintains.
 
@@ -739,8 +743,8 @@ spec:
                     value:
                       type: string
                     valueFrom:
-                      type: string
-                      description: "Secret or ConfigMap reference (name:key format)."
+                      type: object
+                      description: "Simplified placeholder — in Kubernetes, valueFrom is an object with secretKeyRef or configMapKeyRef, not a string."
               resources:
                 type: object
                 properties:
@@ -1038,7 +1042,7 @@ Add schema validation to the `schedule` field so the API server rejects malforme
 
 ```yaml
 x-kubernetes-validations:
-- rule: "self.matches('^(\\\\S+\\\\s+){4}\\\\S+$')"
+- rule: "self.matches('^(\\S+\\s+){4}\\S+$')"
   message: "schedule must be a valid cron expression with 5 fields"
 ```
 
@@ -1066,9 +1070,9 @@ Keep only the essential fields at priority zero, because those columns are shown
 </details>
 
 <details>
-<summary>8. A developer writes `imgae` instead of `image` in a strict custom resource manifest. The apply succeeds, but the misspelled field disappears when they read the object back. What happened?</summary>
+<summary>8. A developer writes `imgae` instead of `image` in a strict custom resource manifest that omits the required `image` field. What happens?</summary>
 
-The API server pruned the unknown field because the CRD has a structural schema that does not include `imgae`. Pruning removes fields outside the declared schema before persistence, which keeps stored objects aligned with the API contract. The apply can still succeed if the required real `image` field is absent only when the schema failed to mark it required. The fix is to require important fields and use server-side dry run tests that include common typos and omissions.
+The apply fails validation because `spec.image` is required. If the schema did not mark `image` as required and the manifest contained only the misspelled `imgae` field, the API server would prune that unknown field during admission because the CRD has a structural schema that does not include `imgae`. Pruning removes fields outside the declared schema before persistence, which keeps stored objects aligned with the API contract. The fix is to require important fields and use server-side dry run tests that include common typos and omissions.
 
 </details>
 
@@ -1080,7 +1084,7 @@ Exercise scenario: you are publishing a `BackupPolicy` API for application teams
 
 ### Task 1: Create the CRD
 
-Apply a CRD that serves both versions, marks `v1beta1` as storage, deprecates `v1alpha1`, enables status, and publishes useful printer columns. Read the manifest before running it and identify which validation rule prevents `retention.maxCount` from being lower than `retention.minCount`.
+Apply a CRD that serves both versions, marks `v1beta1` as storage, deprecates `v1alpha1`, enables status, and publishes useful printer columns. Because `v1alpha1` and `v1beta1` use different schemas and this CRD has no `spec.conversion` block, the default `None` strategy only relabels `apiVersion` — cross-version reads return stored fields untranslated. In production you would add `spec.conversion.strategy: Webhook` or keep version schemas compatible. Read the manifest before running it and identify which validation rule prevents `retention.maxCount` from being lower than `retention.minCount`.
 
 ```bash
 cat << 'CRDEOF' | kubectl apply -f -
@@ -1406,7 +1410,7 @@ EOF
 <details>
 <summary>Solution notes</summary>
 
-The request should still succeed because `v1alpha1` is served, but the warning tells users which version to adopt. Because `v1beta1` is storage, a complete production system would need conversion behavior if the versions have different shapes. This exercise focuses on the CRD surface, so treat the warning as a prompt to plan conversion before a real migration.
+The request should still succeed because `v1alpha1` is served, but the warning tells users which version to adopt. Because `v1beta1` is storage and the two versions have different shapes with default `None` conversion, reading the object as `v1beta1` returns the stored `v1alpha1` fields without translating `target: "deployment/web"` into the structured `v1beta1` target object. This exercise focuses on the CRD surface, so treat the warning as a prompt to plan a conversion webhook before a real migration.
 
 </details>
 

--- a/src/content/docs/k8s/extending/module-1.3-controllers-client-go.md
+++ b/src/content/docs/k8s/extending/module-1.3-controllers-client-go.md
@@ -207,7 +207,7 @@ func (c *Controller) handleOwnedResource(obj interface{}) {
         }
         object, ok = tombstone.Obj.(metav1.Object)
         if !ok {
-            return
+            return // production code logs decode failures via utilruntime.HandleError
         }
     }
 
@@ -887,7 +887,10 @@ func buildConfig() (*rest.Config, error) {
 	}
 
 	// Fall back to kubeconfig
-	home, _ := os.UserHomeDir()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		klog.Warningf("Could not determine home directory, using empty path: %v", err)
+	}
 	kubeconfig := filepath.Join(home, ".kube", "config")
 	return clientcmd.BuildConfigFromFlags("", kubeconfig)
 }
@@ -903,7 +906,7 @@ The next part says that deletion of the parent is not an error. When the control
 
 Defaulting is another contract boundary. In this module, the controller applies defaults for replicas and port before building child objects, while the CRD schema also defines defaults for those fields. In production you should be clear about where defaulting happens and how it is tested. If defaults live in the CRD schema, clients and controllers see a more consistent object. If defaults live only in controller code, other API readers may see missing fields until reconciliation interprets them.
 
-The Deployment reconciliation block demonstrates create-or-update behavior. On not-found, the controller creates a child from the desired shape. On other read errors, it returns the error because the controller does not know enough to proceed. On an existing Deployment, it compares only the fields it owns, such as replica count and image, then deep-copies the object before updating so it does not mutate cache state directly.
+The Deployment reconciliation block demonstrates create-or-update behavior. On not-found, the controller creates a child from the desired shape. On other read errors, it returns the error because the controller does not know enough to proceed. On an existing Deployment, it compares only the fields it owns, such as replica count and image, then deep-copies the object before updating so it does not mutate cache state directly. Objects returned from a lister live in the informer's shared cache and are read-only; mutating them in place corrupts the cache for every other reader and can cause subtle, hard-to-reproduce reconciliation bugs, so you copy first and write the copy.
 
 The Service block is simpler because the preserved code creates the Service when missing and otherwise leaves it alone. That is a design choice worth noticing. If the `WebApp` port changes, a stricter controller might patch the Service, while a conservative controller might treat Service port changes as immutable and report a condition. The right answer depends on the API contract you document for `WebApp`.
 
@@ -1077,7 +1080,10 @@ import (
 func runWithLeaderElection(ctx context.Context, kubeClient kubernetes.Interface,
     startFunc func(ctx context.Context)) {
 
-    id, _ := os.Hostname()
+    id, err := os.Hostname()
+    if err != nil {
+        klog.Warningf("Could not determine hostname for leader identity, using empty string: %v", err)
+    }
 
     lock := &resourcelock.LeaseLock{
         LeaseMeta: metav1.ObjectMeta{
@@ -1399,7 +1405,7 @@ kubectl get deployment demo-app     # Should be gone (GC'd via OwnerRef)
 kubectl get svc demo-app             # Should be gone
 ```
 
-8. **Cleanup**:
+7. **Cleanup**:
 ```bash
 kind delete cluster --name controller-lab
 ```


### PR DESCRIPTION
## Extending K8s — wave 1 (modules 1.1–1.3) → finalize-to-`done`

Cross-family R1 review of the first 3 Extending-Kubernetes modules, then a consolidated fix.
Reviewers (mixed pools): **opus 4.8 headless** (1.1) · **cursor `--model auto`** (1.2) · **deepseek-v4-pro** (1.3).
Fix by cursor in a worktree; every finding ground-checked against the file; version facts web-verified.

### Modules
| Module | Reviewer | Verdict | Key fixes |
|---|---|---|---|
| 1.1 api-deep-dive (T0) | opus 4.8 | NEEDS_CHANGES 4/5 | **P1: pod-watcher `main.go` deadlocked on Ctrl+C** (signal goroutine called `cancel()` only; worker parked in `queue.Get()`; `defer ShutDown()` could never fire) → `Run` now mirrors module 1.3 (`go wait.Until(runWorker, …)` + block on `<-ctx.Done()` + deferred `ShutDown()`); `AddEventHandler` errors checked; protobuf-vs-JSON(CRD) note; VAP "stable since 1.30"; `nginx` pinned `:1.27` |
| 1.2 crds-advanced (T2→T0) | cursor | NEEDS_CHANGES 4.1/5 | **P1: `None`-vs-`Webhook` conversion accuracy** — prose claimed automatic `port`↔`ports` translation for a differing-schema CRD with no `spec.conversion` (defaults to `None`, which only relabels `apiVersion`); same caveat added to the BackupPolicy hands-on; CEL `x-kubernetes-validations` **GA 1.29** stated; `has(self.ingress)` guard; HPA-needs-Metrics-Server; quiz-8 required-`image` logic; `valueFrom` object; over-escaped cron regex fixed; body_words 4984→5131 |
| 1.3 controllers-client-go (T2→T0) | deepseek | NEEDS_CHANGES 4.5/5 | DeepCopy-before-mutate rationale (shared read-only informer cache); lab step renumber 6→**7** (was skipping to 8); `os.UserHomeDir`/`os.Hostname` error logging; tombstone-decode comment. **Controller code logic was already idiomatically correct — left unchanged.** body_words 4977→5017 |

### Accuracy highlights (ground-checked / web-verified)
- **Deadlock (1.1)** confirmed by tracing `Run`→`processNextItem`→`queue.Get()` parking + the signal path; decisive evidence is the sibling module **1.3**, which already teaches the correct shutdown idiom the same audience.
- **CRD conversion (1.2):** with the default `None` strategy the API server only rewrites the `apiVersion` label and copies fields as-is — it does **not** translate structurally-different versions; that needs a conversion webhook. Reframed the prose to match (multi-version CRDs with `None` still *establish* and accept applies; the gap is only cross-version content translation).
- **Versions (web-verified):** ValidatingAdmissionPolicy **GA 1.30**; CEL `x-kubernetes-validations` **GA 1.29**; SSA 1.22 / APF 1.29 (left as-is, already correct).

### Gates
- Verifier: all 3 **T0** (body_words 5070 / 5131 / 5017; anti-fab clear; sources reachable).
- **incident-dedup gate: PASS** (CI-mode `--mode absolute --base origin/main`). No real named incidents (all `**Hypothetical scenario:**`); no CNCF maturity-tier claims.

## Learner check

> A temporary processing error, however, is returned to the queue so the item can be retried with rate limiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
