### PR TITLE
chore(content): Extending-K8s wave-2 (1.4-1.7) — reconcile/clusterIP fix + v1.35 scheduler signatures + operator maturity (sub-track complete)

### DIFF
--- a/src/content/docs/k8s/extending/module-1.4-kubebuilder.md
+++ b/src/content/docs/k8s/extending/module-1.4-kubebuilder.md
@@ -42,7 +42,7 @@ If you are learning the operator pattern or building a Go operator for internal 
 |---------|-------------|--------------|
 | Maintained by | Kubernetes SIG API Machinery | Operator Framework (Red Hat) |
 | Language support | Go only | Go, Ansible, Helm |
-| Project layout | Kubebuilder layout | Kubebuilder layout (since v1.25+) |
+| Project layout | Kubebuilder layout | Kubebuilder layout (aligned since Operator SDK v1.0) |
 | OLM integration | Manual | Built-in |
 | Scorecard testing | No | Yes |
 | Dependency | controller-runtime | controller-runtime |
@@ -353,6 +353,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/record"
 
 	appsv1beta1 "github.com/kubedojo/webapp-operator/api/v1beta1"
 )
@@ -360,7 +361,8 @@ import (
 // WebAppReconciler reconciles a WebApp object.
 type WebAppReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
 }
 
 // +kubebuilder:rbac:groups=apps.kubedojo.io,resources=webapps,verbs=get;list;watch;create;update;patch;delete
@@ -413,25 +415,25 @@ func (r *WebAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			"app.kubernetes.io/part-of":    webapp.Name,
 		}
 
-		deployment.Spec = appsv1.DeploymentSpec{
-			Replicas: &replicas,
-			Selector: &metav1.LabelSelector{
+		deployment.Spec.Replicas = &replicas
+		if deployment.CreationTimestamp.IsZero() {
+			deployment.Spec.Selector = &metav1.LabelSelector{
 				MatchLabels: labels,
+			}
+		}
+		deployment.Spec.Template = corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: labels,
 			},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name:  "app",
-							Image: webapp.Spec.Image,
-							Ports: []corev1.ContainerPort{
-								{
-									ContainerPort: port,
-									Protocol:      corev1.ProtocolTCP,
-								},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "app",
+						Image: webapp.Spec.Image,
+						Ports: []corev1.ContainerPort{
+							{
+								ContainerPort: port,
+								Protocol:      corev1.ProtocolTCP,
 							},
 						},
 					},
@@ -470,16 +472,14 @@ func (r *WebAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	svcResult, err := controllerutil.CreateOrUpdate(ctx, r.Client, service, func() error {
-		service.Spec = corev1.ServiceSpec{
-			Selector: map[string]string{"app": webapp.Name},
-			Ports: []corev1.ServicePort{
-				{
-					Port:       port,
-					TargetPort: intstr.FromInt32(port),
-					Protocol:   corev1.ProtocolTCP,
-				},
+		service.Spec.Selector = map[string]string{"app": webapp.Name}
+		service.Spec.Type = corev1.ServiceTypeClusterIP
+		service.Spec.Ports = []corev1.ServicePort{
+			{
+				Port:       port,
+				TargetPort: intstr.FromInt32(port),
+				Protocol:   corev1.ProtocolTCP,
 			},
-			Type: corev1.ServiceTypeClusterIP,
 		}
 		return controllerutil.SetControllerReference(webapp, service, r.Scheme)
 	})
@@ -523,6 +523,7 @@ func (r *WebAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			deployment.Status.ReadyReplicas, replicas)
 	}
 
+	previousPhase := webapp.Status.Phase
 	webapp.Status.ReadyReplicas = deployment.Status.ReadyReplicas
 	webapp.Status.AvailableReplicas = deployment.Status.AvailableReplicas
 	webapp.Status.Phase = phase
@@ -531,6 +532,10 @@ func (r *WebAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	if err := r.Status().Update(ctx, webapp); err != nil {
 		return ctrl.Result{}, fmt.Errorf("updating status: %w", err)
+	}
+
+	if phase == "Running" && previousPhase != "Running" {
+		r.Recorder.Event(webapp, corev1.EventTypeNormal, "Running", readyCondition.Message)
 	}
 
 	// If not fully ready, requeue to check again
@@ -579,7 +584,7 @@ flowchart TD
 
 Idempotency is what keeps this from becoming noisy. If the live Deployment already matches the desired Deployment, controller-runtime does not need to issue an update, which reduces API traffic and avoids triggering unnecessary rollouts. If a user edits a managed field, the next reconciliation sees the difference, applies the mutation again, and updates the child object back to the operator-owned shape.
 
-There is a subtle design choice inside every mutation function: which fields are truly owned by the operator. In the WebApp example, the operator owns the main container image, port, labels, selector, replica count, and Service shape because those are part of the WebApp abstraction. In a larger platform, you might intentionally preserve annotations injected by policy tools or sidecar configuration added by another controller. Idempotent does not mean overwriting everything; it means repeatedly applying the ownership model you chose.
+There is a subtle design choice inside every mutation function: which fields are truly owned by the operator. In the WebApp example, the operator owns the main container image, port, labels, selector, replica count, and Service shape because those are part of the WebApp abstraction. The mutate functions set only those owned fields and leave server-assigned values such as `spec.clusterIP` untouched; resetting `clusterIP` to empty on every reconcile would make the second `Update` fail because that field is immutable. In a larger platform, you might intentionally preserve annotations injected by policy tools or sidecar configuration added by another controller. Idempotent does not mean overwriting everything; it means repeatedly applying the ownership model you chose.
 
 | Return Value | Meaning |
 |-------------|---------|
@@ -702,7 +707,7 @@ func main() {
 	var metricsAddr string
 	var probeAddr string
 	var enableLeaderElection bool
-	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "Metrics endpoint address")
+	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "Metrics endpoint address") // "0" disables metrics in this simplified main.go; generated v4 scaffolds serve secure metrics on :8443
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "Health probe address")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false, "Enable leader election")
 	flag.Parse()
@@ -720,14 +725,17 @@ func main() {
 		LeaderElectionID:       "webapp-operator.kubedojo.io",
 	})
 	if err != nil {
+		// real scaffold logs setupLog.Error(err, ...) before exit
 		os.Exit(1)
 	}
 
 	// Register the WebApp controller
 	if err = (&controller.WebAppReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("webapp-controller"),
 	}).SetupWithManager(mgr); err != nil {
+		// real scaffold logs setupLog.Error(err, ...) before exit
 		os.Exit(1)
 	}
 
@@ -737,6 +745,7 @@ func main() {
 
 	// Start the manager (blocks until context cancelled)
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+		// real scaffold logs setupLog.Error(err, ...) before exit
 		os.Exit(1)
 	}
 }
@@ -751,7 +760,7 @@ The scheme registration in `init()` is another small block with large consequenc
 | Shared cache | One informer per GVK, shared across controllers |
 | Leader election | Kubernetes Lease-based, built in |
 | Health probes | `/healthz` and `/readyz` endpoints |
-| Metrics | Prometheus-compatible `/metrics` |
+| Metrics | Prometheus-compatible `/metrics` when `metrics-bind-address` is not `"0"` (this simplified `main.go` disables metrics by default; generated v4 scaffolds serve secure metrics on `:8443`) |
 | Webhook server | HTTPS server for admission webhooks |
 | Graceful shutdown | SIGTERM handling, drains controllers |
 

--- a/src/content/docs/k8s/extending/module-1.5-advanced-operators.md
+++ b/src/content/docs/k8s/extending/module-1.5-advanced-operators.md
@@ -169,7 +169,7 @@ The most reliable cleanup functions are written like reconciliation functions. T
 
 You should avoid long blocking cleanup inside one reconcile call when the external API has slow operations. If deleting a managed database requires a multi-minute asynchronous operation, the finalizer can initiate deletion, write a condition such as `CleanupPending`, emit a Normal event, and requeue after a short delay to poll progress. The object remains in `Terminating`, but the controller does not hold a goroutine indefinitely or hide progress from users. The important rule is that the finalizer stays present until the external system has reached the safe terminal state.
 
-Finalizers are not a replacement for owner references. For Kubernetes children such as Deployments and Services, owner references allow built-in garbage collection to do the right thing after the parent is deleted. For resources outside the cluster, or resources you intentionally do not own through Kubernetes metadata, finalizers are the hook that lets your controller participate in deletion. Production operators often use both: owner references for in-cluster dependents and finalizers for external systems or cleanup ordering that garbage collection cannot express.
+Finalizers are not a replacement for owner references. Owner references only garbage-collect Kubernetes objects in the same cluster — they cannot cascade-delete external or cloud resources or cross-cluster objects, which is exactly why finalizers exist for that cleanup. For Kubernetes children such as Deployments and Services, owner references allow built-in garbage collection to do the right thing after the parent is deleted. For resources outside the cluster, or resources you intentionally do not own through Kubernetes metadata, finalizers are the hook that lets your controller participate in deletion. Production operators often use both: owner references for in-cluster dependents and finalizers for external systems or cleanup ordering that garbage collection cannot express.
 
 When a deletion becomes stuck, resist the reflex to remove the finalizer manually. Manual removal is sometimes the right emergency action, but it should be treated as an operator override with a known cleanup debt, not as the normal fix. First read the object's events, controller logs, and status conditions to identify whether the cleanup function is failing, timing out, or waiting on a dependency. If you do patch the finalizer away during an incident, record the external resource identifiers so a human can complete cleanup afterward.
 
@@ -193,7 +193,7 @@ type Condition struct {
     ObservedGeneration int64
 
     // LastTransitionTime: when the status last changed
-    LastTransitionTime Time
+    LastTransitionTime metav1.Time
 
     // Reason: machine-readable CamelCase reason
     Reason string
@@ -292,7 +292,7 @@ func (r *WebAppReconciler) updateConditions(ctx context.Context,
 		readyCondition.Status = metav1.ConditionTrue
 		readyCondition.Reason = ReasonAvailable
 		readyCondition.Message = "All components are ready"
-		webapp.Status.Phase = "Running"
+		webapp.Status.Phase = "Running" // production code would use a typed phase constant
 	} else {
 		readyCondition.Status = metav1.ConditionFalse
 		readyCondition.Reason = ReasonReconciling
@@ -498,11 +498,23 @@ spec:
 
 Watch design is the other half of production reconciliation. `For(&WebApp{})` tells the controller to reconcile when the primary resource changes, while `Owns(&Deployment{})` and `Owns(&Service{})` enqueue the owning WebApp when owned children change. Custom watches are useful when a WebApp depends on a resource it does not own, such as a ConfigMap selected by name. The risk is fan-out: a single ConfigMap update can enqueue many WebApps, so the mapping function should be simple, bounded, and scoped to a namespace unless the operator is intentionally cluster-wide.
 
+The WebApp `EnvVar` type from module 1.4 is extended here with an optional `valueFrom` field naming a ConfigMap to source the value from, so the mapping function can detect ConfigMap references without using core `EnvVarSource`:
+
+```go
+type EnvVar struct {
+	Name      string `json:"name"`
+	Value     string `json:"value,omitempty"`
+	ValueFrom string `json:"valueFrom,omitempty"` // ConfigMap name when value is sourced externally
+}
+```
+
 ```go
 import (
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 func (r *WebAppReconciler) SetupWithManager(mgr ctrl.Manager) error {
@@ -562,8 +574,6 @@ func (r *WebAppReconciler) findWebAppsForConfigMap(
 Predicates are filters, not correctness features, and they can easily hide events your controller needs. `GenerationChangedPredicate` is useful on the primary custom resource because status updates do not change generation and should not necessarily trigger another full pass. Applying the same predicate to owned Deployments can be wrong if you expect to react to readiness changes, Pod failures, or other status-driven signals. A good watch strategy filters the noisy event source, not the event source that carries evidence of drift.
 
 ```go
-import "sigs.k8s.io/controller-runtime/pkg/predicate"
-
 func (r *WebAppReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&appsv1beta1.WebApp{},
@@ -944,6 +954,18 @@ make test
 KUBEBUILDER_ASSETS=$($ENVTEST use --print-path latest) \
   go test ./internal/controller/ -v -ginkgo.v
 ```
+
+### Operator Capability Levels
+
+The [Operator Capability Model](https://github.com/operator-framework/operator-sdk/blob/master/doc/images/operator-capability-model.svg) describes how mature an operator is across five levels. Use it to set expectations with users and to plan incremental investment:
+
+- **Level 1 — Basic Install:** automated install and configuration of the operand.
+- **Level 2 — Seamless Upgrades:** operator manages patch and minor version upgrades of the operand.
+- **Level 3 — Full Lifecycle:** app lifecycle plus storage lifecycle — backups, failure recovery, restore.
+- **Level 4 — Deep Insights:** metrics, alerts, log processing, and workload analysis (operand observability).
+- **Level 5 — Auto Pilot:** auto-scaling (horizontal/vertical), auto-tuning, abnormality detection, scheduling tuning.
+
+Finalizers and structured conditions in this module are stepping stones toward **Level 3 (Full Lifecycle)**: they make deletion and readiness observable instead of best-effort. Distribution and upgrade paths sit in the **Operator Framework**, a CNCF Incubating project: **Operator Lifecycle Manager (OLM)** installs, upgrades, and manages operators and their dependencies on a cluster, and **[OperatorHub.io](https://operatorhub.io/)** is the public catalog where many OLM-packaged operators are published.
 
 ## Patterns & Anti-Patterns
 

--- a/src/content/docs/k8s/extending/module-1.6-admission-webhooks.md
+++ b/src/content/docs/k8s/extending/module-1.6-admission-webhooks.md
@@ -77,7 +77,7 @@ The distinction between mutation and validation is partly about capability and p
 
 | Feature | Mutating | Validating |
 |---------|----------|------------|
-| Can modify the object | Yes, by returning JSON Patch | No, it returns allow, deny, and optional warnings |
+| Can modify the object | Yes, by returning JSON Patch | No, it returns allow, deny, and optional warnings (mutating webhooks can also return `warnings` since Kubernetes 1.19) |
 | Can reject the request | Yes | Yes |
 | Execution order | First, before final validation | Second, after all mutation passes finish |
 | Typical use | Inject sidecars, set defaults, add labels | Enforce policies, naming rules, security rules |
@@ -411,13 +411,13 @@ func handleMutate(w http.ResponseWriter, r *http.Request) {
 	var admissionReview admissionv1.AdmissionReview
 	if err := json.NewDecoder(r.Body).Decode(&admissionReview); err != nil {
 		klog.Errorf("Failed to decode request: %v", err)
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		sendResponse(w, "", false, fmt.Sprintf("failed to decode request: %v", err))
 		return
 	}
 
 	request := admissionReview.Request
 	if request == nil {
-		http.Error(w, "admission review request is required", http.StatusBadRequest)
+		sendResponse(w, "", false, "admission review request is required")
 		return
 	}
 	klog.Infof("Processing %s %s/%s by %s",
@@ -515,6 +515,7 @@ func sendResponse(w http.ResponseWriter, uid types.UID, allowed bool, message st
 	json.NewEncoder(w).Encode(response)
 }
 
+// Always return an AdmissionReview envelope. Raw http.Error bodies are treated as webhook call failures under failurePolicy: Fail, not structured denials.
 func sendPatchResponse(w http.ResponseWriter, uid types.UID, patch []byte) {
 	patchType := admissionv1.PatchTypeJSONPatch
 	response := admissionv1.AdmissionReview{
@@ -737,7 +738,7 @@ Matching is the second half of reliability. A broad webhook rule increases API s
 
 ```yaml
 webhooks:
-- name: mwebapp.kubedojo.io
+- name: sidecar-injector.kubedojo.io
   rules:
   - apiGroups: [""]
     apiVersions: ["v1"]
@@ -768,14 +769,16 @@ webhooks:
   - name: "not-system-namespace"
     expression: "!request.namespace.startsWith('kube-')"
   - name: "has-annotation"
-    expression: "object.metadata.annotations['validate'] == 'true'"
+    expression: "has(object.metadata.annotations) && object.metadata.annotations['validate'] == 'true'"
 ```
+
+A matchConditions evaluation error is fail-closed when `failurePolicy: Fail` — the webhook is not invoked and the request is rejected, so guard optional maps and keys in CEL expressions.
 
 Matching choices should also be reviewed as part of change management, not only as code. If a team changes a namespace label that controls webhook participation, that label change can alter admission behavior for every workload in the namespace even though no webhook manifest changed. For that reason, mature platforms treat opt-in labels as part of the namespace contract, restrict who can change them, and include them in onboarding documentation. The goal is to make admission behavior predictable from the namespace metadata rather than hidden in a cluster-scoped object that application teams rarely inspect.
 
 Timeouts deserve the same explicit ownership. A long timeout may feel safer because it gives the webhook more time to answer, but it also extends the time every matching API request can be stalled. A very short timeout reduces stall time but may create noisy intermittent failures if the webhook performs heavy decoding, logging, or remote calls. Start with a small value, measure admission latency under load, and then tune based on observed request behavior instead of copying the default into every configuration.
 
-Kubernetes also offers ValidatingAdmissionPolicy, which uses CEL expressions for many validation cases without requiring a webhook server. That feature is not a drop-in replacement for every webhook, because it cannot call external systems or perform arbitrary mutation, but it is often the better answer for simple field checks. If your policy is "deny Pods without a label" or "deny images outside a pattern," evaluate CEL-based validation before deciding to own an HTTPS service in the control-plane request path.
+Kubernetes also offers ValidatingAdmissionPolicy, which uses CEL expressions for many validation cases without requiring a webhook server. **MutatingAdmissionPolicy** also exists but is **beta as of Kubernetes 1.35** (GA in 1.36) and is out of scope here — this module focuses on webhook-based admission. ValidatingAdmissionPolicy is not a drop-in replacement for every webhook, because it cannot call external systems or perform arbitrary mutation, but it is often the better answer for simple field checks. If your policy is "deny Pods without a label" or "deny images outside a pattern," evaluate CEL-based validation before deciding to own an HTTPS service in the control-plane request path.
 
 There is also a social reason to prefer the simplest enforcement mechanism that works. A webhook is usually owned by a platform or security team, while the workloads it affects are owned by many application teams. When a denial happens, the user sees an API error during their deployment, not a ticket explaining your design history. The closer a rule is to native Kubernetes schema, CEL policy, or well-documented namespace configuration, the easier it is for users to predict and correct their own mistakes without waiting for a platform engineer.
 
@@ -1125,6 +1128,8 @@ webhooks:
     matchLabels:
       webhook: enabled
 ```
+
+An `objectSelector` (for example `sidecar.kubedojo.io/inject: "true"`) would narrow matches before the handler runs and cut unnecessary webhook calls; this lab filters by annotation inside the handler instead.
 
 <details>
 <summary>Solution notes for Task 3</summary>

--- a/src/content/docs/k8s/extending/module-1.7-scheduler-plugins.md
+++ b/src/content/docs/k8s/extending/module-1.7-scheduler-plugins.md
@@ -38,17 +38,17 @@ The Scheduling Framework is the extension mechanism inside `kube-scheduler`. It 
 
 That split is the first design constraint for plugin authors. Anything that runs once per scheduling cycle can afford more work than logic that runs once per node, and anything in the binding cycle must treat the node decision as already made. If you put a network call inside `Score`, it may run across thousands of nodes for one pod. If you put irreversible side effects inside `Reserve`, you must also implement cleanup behavior for failures later in the cycle. Scheduler code is not ordinary controller code; it is hot-path control-plane code, and small latency mistakes multiply quickly.
 
-The queueing phase deserves special attention because it determines when a pod is even considered. A `PreEnqueue` plugin can keep pods out of the active queue until required state exists, and a `Sort` plugin influences which pending pod gets scheduled first. Most custom scheduler work starts later, in filtering and scoring, because queue behavior changes fairness across workloads. If you do touch queueing, define the fairness contract explicitly: which pods wait, which pods jump ahead, and how operators can explain that behavior during an outage.
+The queueing phase deserves special attention because it determines when a pod is even considered. A `PreEnqueue` plugin can keep pods out of the active queue until required state exists, and a `QueueSort` plugin influences which pending pod gets scheduled first. Most custom scheduler work starts later, in filtering and scoring, because queue behavior changes fairness across workloads. If you do touch queueing, define the fairness contract explicitly: which pods wait, which pods jump ahead, and how operators can explain that behavior during an outage.
 
 ```mermaid
 flowchart TD
     Start([Pod enters scheduling queue]) --> PreEnqueue
 
     subgraph Queueing Phase
-        PreEnqueue[1. PreEnqueue<br/>Reject pods before queuing] --> Sort[2. Sort<br/>Order pods in the queue]
+        PreEnqueue[1. PreEnqueue<br/>Reject pods before queuing] --> QueueSort[2. QueueSort<br/>Order pods in the queue]
     end
 
-    Sort --> PreFilter
+    QueueSort --> PreFilter
 
     subgraph Scheduling Cycle
         PreFilter[3. PreFilter<br/>Compute shared state] --> Filter[4. Filter<br/>Eliminate infeasible nodes]
@@ -76,7 +76,7 @@ The scheduler framework also gives you a useful mental model for performance rev
 | Extension Point | When It Runs | What It Does | Return Type |
 |----------------|-------------|-------------|-------------|
 | **PreEnqueue** | Before queuing | Gate pods from entering queue | Allow/Reject |
-| **Sort** | Queue ordering | Prioritize pods in queue | Less function |
+| **QueueSort** | Queue ordering | Prioritize pods in queue | Less function |
 | **PreFilter** | Once per cycle | Compute shared filter state | Status |
 | **Filter** | Per node | Eliminate infeasible nodes | Status (pass/fail) |
 | **PostFilter** | After no node fits | Try preemption | Status + nominated node |
@@ -139,6 +139,8 @@ scheduler-plugins/
 
 The Score plugin below ranks nodes based on a tier label. Nodes labeled `scheduling.kubedojo.io/tier: premium` receive a higher score than `standard` or unlabeled nodes, so mission-critical workloads drift toward more reliable hardware without making every workload author write a large node affinity stanza. The plugin reads from the scheduler's shared snapshot, not from the API server, and it accepts scores as structured arguments so operators can tune policy through configuration rather than recompiling the binary for every change.
 
+Scheduler framework plugin interfaces evolve across Kubernetes minor versions; confirm exact method signatures against the godoc for your cluster's version when you build out-of-tree plugins. Examples here target Kubernetes 1.35.
+
 This example intentionally uses node labels because labels are visible, cacheable, and already part of Kubernetes scheduling vocabulary. In a production system, those labels should be maintained by automation rather than by humans typing commands during an incident. A node inventory controller might set the tier label based on hardware class, maintenance state, or procurement metadata. The scheduler plugin should consume that normalized signal, not become responsible for discovering hardware facts itself. Keeping discovery outside the scheduler makes the plugin simpler and keeps placement latency predictable.
 
 ```go
@@ -191,18 +193,15 @@ func (pl *NodePreference) Name() string {
 // Score scores a node based on its tier label.
 func (pl *NodePreference) Score(
 	ctx context.Context,
-	state *framework.CycleState,
+	state framework.CycleState,
 	pod *v1.Pod,
-	nodeName string,
+	nodeInfo framework.NodeInfo,
 ) (int64, *framework.Status) {
 
-	// Get the node info from the snapshot.
-	nodeInfo, err := pl.handle.SnapshotSharedLister().NodeInfos().Get(nodeName)
-	if err != nil {
-		return 0, framework.AsStatus(fmt.Errorf("getting node %q: %w", nodeName, err))
-	}
-
 	node := nodeInfo.Node()
+	if node == nil {
+		return 0, framework.AsStatus(fmt.Errorf("node info has no node"))
+	}
 
 	// Check for the tier label.
 	tierValue, exists := node.Labels[LabelKey]
@@ -227,7 +226,7 @@ func (pl *NodePreference) ScoreExtensions() framework.ScoreExtensions {
 // NormalizeScore normalizes the scores to [0, MaxNodeScore].
 func (pl *NodePreference) NormalizeScore(
 	ctx context.Context,
-	state *framework.CycleState,
+	state framework.CycleState,
 	pod *v1.Pod,
 	scores framework.NodeScoreList,
 ) *framework.Status {
@@ -253,10 +252,10 @@ func (pl *NodePreference) NormalizeScore(
 }
 
 // EventsToRegister returns the events that trigger rescheduling.
-func (pl *NodePreference) EventsToRegister() []framework.ClusterEventWithHint {
+func (pl *NodePreference) EventsToRegister(_ context.Context) ([]framework.ClusterEventWithHint, error) {
 	return []framework.ClusterEventWithHint{
 		{ClusterEvent: framework.ClusterEvent{Resource: framework.Node, ActionType: framework.Add | framework.Update}},
-	}
+	}, nil
 }
 
 // New creates a new NodePreference plugin.
@@ -265,6 +264,7 @@ func New(ctx context.Context, obj runtime.Object, handle framework.Handle) (fram
 	if !ok {
 		return nil, fmt.Errorf("want args to be of type NodePreferenceArgs, got %T", obj)
 	}
+	// Typed plugin args must be registered with the scheduler component-config scheme (as kubernetes-sigs/scheduler-plugins does via apis/config AddToScheme), or the framework passes *runtime.Unknown and this assertion fails at startup.
 
 	return &NodePreference{
 		handle: handle,
@@ -332,8 +332,9 @@ const preFilterStateKey = "PreFilter" + Name
 
 func (pl *GPUFilter) PreFilter(
 	ctx context.Context,
-	state *framework.CycleState,
+	state framework.CycleState,
 	pod *v1.Pod,
+	nodes []framework.NodeInfo,
 ) (*framework.PreFilterResult, *framework.Status) {
 
 	gpuType := pod.Annotations[PodGPUAnnotation]
@@ -359,9 +360,9 @@ func (pl *GPUFilter) PreFilterExtensions() framework.PreFilterExtensions {
 // Filter checks if a node has the required GPU type and available GPUs.
 func (pl *GPUFilter) Filter(
 	ctx context.Context,
-	state *framework.CycleState,
+	state framework.CycleState,
 	pod *v1.Pod,
-	nodeInfo *framework.NodeInfo,
+	nodeInfo framework.NodeInfo,
 ) *framework.Status {
 
 	// Read pre-filter state.
@@ -625,6 +626,9 @@ data:
     profiles:
     - schedulerName: custom-scheduler
       plugins:
+        filter:
+          enabled:
+          - name: GPUFilter
         score:
           enabled:
           - name: NodePreference
@@ -995,9 +999,10 @@ The image must be visible to the kind nodes, not only to your local Docker daemo
 
 ```bash
 kubectl apply -f manifests/rbac.yaml
-kubectl apply -f manifests/scheduler-config.yaml
 kubectl apply -f manifests/deployment.yaml
 ```
+
+`KubeSchedulerConfiguration` has no cluster REST endpoint — configuration is delivered through the `custom-scheduler-config` ConfigMap mounted in the Deployment, not via a standalone `kubectl apply` of `scheduler-config.yaml`.
 
 <details>
 <summary>Solution notes for task 4</summary>


### PR DESCRIPTION
## Extending K8s — wave 2 (modules 1.4–1.7) → finalize-to-`done` · **completes the Extending K8s sub-track**

Cross-family R1 review of the final 4 Extending-Kubernetes modules, then a consolidated fix.
Reviewers (mixed pools): **opus 4.8 headless** (1.4, 1.7) · **deepseek-v4-pro** (1.5) · **cursor `--model auto`** (1.6).
Fix by cursor in a worktree; every finding ground-checked; scheduler-framework signatures web-verified.
With 1.8 (API Aggregation, already `done`), this finishes the sub-track.

### Modules
| Module | Reviewer | Verdict | Key fixes |
|---|---|---|---|
| 1.4 kubebuilder (T0) | opus 4.8 | NEEDS_CHANGES 4/5 | **P1: Service `CreateOrUpdate` mutate wiped the immutable `clusterIP`** (whole-`Spec` assignment) → 2nd reconcile rejected `field is immutable` → perpetual error loop → now sets only owned fields (Selector/Type/Ports), preserves `clusterIP`; Deployment mutate likewise sets owned fields only (Selector guarded on create); `EventRecorder` wired + emits on phase transition (was granted unused `events` RBAC); SDK-layout "v1.25"→v1.0; metrics-disabled note |
| 1.5 advanced-operators (T2→T0) | deepseek | NEEDS_CHANGES 36/40 | **P1: broken Go** — `env.ValueFrom` referenced a field the custom `EnvVar{Name,Value}` type never had (reviewer wrongly assumed `corev1.EnvVarSource`; real fix = document a `ValueFrom string` field so the ConfigMap→WebApp mapper compiles); **added Operator Capability Levels (L1–L5) + OLM/OperatorHub** (Operator Framework = CNCF **Incubating**, web-verified); removed unused `source` import; explicit owner-ref-vs-finalizer limitation; body_words 4991→5144 |
| 1.6 admission-webhooks (T0) | cursor | APPROVE_WITH_NITS 4.7/5 | `matchConditions` CEL guarded with `has(...)` (errored fail-closed under `failurePolicy: Fail`); standalone server now returns an `AdmissionReview` envelope on decode errors (not raw `http.Error`); Pod webhook renamed `sidecar-injector.kubedojo.io`; `MutatingAdmissionPolicy` noted **beta in 1.35** |
| 1.7 scheduler-plugins (T0) | opus 4.8 | NEEDS_CHANGES 3.5/5 | **P1: plugin Go used pre-1.31/1.32 signatures** — `Score(...nodeName string)` → `nodeInfo framework.NodeInfo` (web-verified v1.35); `*CycleState`/`*NodeInfo` → interfaces (no `*`); `PreFilter` gains `nodes []NodeInfo`; `EventsToRegister(ctx) (..., error)`; **broken `kubectl apply` of a `KubeSchedulerConfiguration`** removed (no REST endpoint; config comes from the ConfigMap, which now enables both GPUFilter + NodePreference); `Sort`→`QueueSort`; version-evolution hedge |

### Accuracy highlights (ground-checked / web-verified)
- **1.4 reconcile loop** confirmed by tracing `CreateOrUpdate`: `service.Spec = ServiceSpec{}` blanks the server-assigned `clusterIP`, and `clusterIP` is immutable → the second `Update` is rejected. Fix sets only owned fields.
- **1.5 Go diagnosis corrected:** deepseek said `ValueFrom` is `*corev1.EnvVarSource`; the actual `EnvVar` (defined in 1.4) has only `Name`/`Value`, so `env.ValueFrom` didn't compile at all. Fixed by documenting a `ValueFrom string` field.
- **1.7 signatures web-verified** against the v1.35 `kube-scheduler/framework` interface: `Score(ctx, state CycleState, p *v1.Pod, nodeInfo NodeInfo)`; `CycleState`/`NodeInfo` are interfaces. Kept the module's existing `k8s.io/kubernetes/pkg/scheduler/framework` import path (the unverified package-move was NOT applied).
- **Maturity claims:** Operator Framework = CNCF **Incubating** (cncf.io); MutatingAdmissionPolicy **beta in 1.35 / GA in 1.36**; ValidatingAdmissionPolicy GA 1.30.

### Gates
- Verifier: all 4 **T0** (body_words 5034 / 5144 / 5202 / 5262; anti-fab clear; sources reachable).
- **incident-dedup gate: PASS** (CI-mode `--mode absolute --base origin/main`). All war-stories are `**Hypothetical scenario:**`; no real named incidents.

## Learner check

> Owner references only garbage-collect Kubernetes objects in the same cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)
