### PR TITLE
chore(content): CGOA wave 2 — review fixes (DevSecOps, Argo/ApplicationSet, pull-semantics, density)

### DIFF
--- a/src/content/docs/k8s/cgoa/module-1.1-exam-strategy-and-blueprint-review.md
+++ b/src/content/docs/k8s/cgoa/module-1.1-exam-strategy-and-blueprint-review.md
@@ -35,7 +35,7 @@ The CGOA blueprint is a signal about where the exam expects judgment. [Higher-we
 |---|---:|---|---|
 | GitOps Terminology | 20% | Whether you can interpret desired state, drift, reconciliation, state store, and feedback loop in scenario wording | Build a working vocabulary by explaining each term through a small incident |
 | GitOps Principles | 30% | Whether you can evaluate a workflow against OpenGitOps ideas instead of tool preference | Practice eliminating answers that break declarative, versioned, pulled, or reconciled behavior |
-| Related Practices | 16% | Whether you can compare GitOps with IaC, CaC, DevOps, CI, CD, and progressive delivery | Use contrast tables and ask which system owns which decision |
+| Related Practices | 16% | Whether you can compare GitOps with IaC, CaC, DevOps, DevSecOps, CI, CD, and progressive delivery | Use contrast tables and ask which system owns which decision |
 | GitOps Patterns | 20% | Whether you can reason about promotion, rollback, environments, multi-cluster layout, and drift handling | Work through sequence-based scenarios and identify the source of truth |
 | Tooling | 14% | Whether you can place ArgoCD, Flux, Helm, Kustomize, and policy tools into the model | Learn tool roles and trade-offs, but keep principles ahead of product names |
 
@@ -135,8 +135,11 @@ CGOA expects you to understand GitOps in context, not in isolation. Infrastructu
 | CI | How do we build, test, scan, and package changes? | CI can validate artifacts and update desired state through reviewed changes | Letting CI become the production deploy authority |
 | CD | How do changes reach environments reliably? | GitOps can be a CD operating model for deployment reconciliation | Equating every deployment pipeline with GitOps |
 | DevOps | How do teams improve flow, feedback, and shared ownership? | GitOps supports DevOps goals with auditable automated operations | Treating DevOps as a specific tool or command sequence |
+| DevSecOps | How do security controls run on the delivery path? | DevSecOps embeds shift-left scanning and policy in the pipeline; GitOps governs how versioned desired state is pulled and reconciled by agents | Treating security scanning alone as GitOps reconciliation |
 | Progressive delivery | How do we reduce risk during rollout? | GitOps can manage desired rollout configuration for canary or blue-green patterns | Assuming rollout strategy replaces source-of-truth discipline |
 | Policy as Code | How do we define and enforce rules automatically? | Policy can validate desired state before or during reconciliation | Assuming policy checks alone provide deployment reconciliation |
+
+DevSecOps is orthogonal to GitOps in the same way CI is: it governs what security gates run on the way to production (shift-left scanning, policy checks, supply-chain controls), while GitOps governs how reviewed desired state reaches the cluster through pull-based reconciliation. A pipeline can be strong on DevSecOps and still weak on GitOps if CI pushes manifests directly after scans pass.
 
 The boundary between CI and GitOps is especially important. CI is excellent at producing evidence that a change is safe enough to propose: tests passed, images were built, vulnerabilities were scanned, and manifests were rendered. GitOps is concerned with the reviewed desired state and the reconciliation of that desired state into runtime environments. The practices cooperate, but the exam will punish answers that collapse them into one push pipeline.
 
@@ -382,7 +385,7 @@ Before running a timed practice set, write the following decision sequence on sc
 
 3. **Drift detection is useful because it protects both reliability and auditability.** It tells teams when runtime state no longer matches the reviewed target, which helps them separate intentional change from accidental or unauthorized change.
 
-4. **Tooling questions are often principle questions in disguise.** The exam may name ArgoCD, Flux, Helm, or Kustomize, but the stronger answer usually depends on source of truth, reconciliation, immutability, or feedback.
+4. **The CGOA blueprint is weighted toward principles.** GitOps Principles is the single heaviest domain at **30%**, followed by GitOps Terminology and GitOps Patterns at **20%** each, Related Practices at **16%**, and Tooling at **14%** — so principle-level reasoning earns more than tool trivia.
 
 ## Common Mistakes
 
@@ -520,6 +523,10 @@ EOF
 - [ ] You have identified one weakest domain for follow-up review and linked it to a module in the recommended KubeDojo path.
 
 **Reflection prompt:** After completing the worksheet, choose the scenario that felt most ambiguous and write a short explanation of what made it hard. Ambiguity is useful feedback. If the difficulty came from vocabulary, review terminology. If it came from two answers sounding correct, practice tracing the full control loop. If it came from tool names, rewrite the scenario in tool-neutral language and solve it again.
+
+## Learner check
+
+> DevSecOps is orthogonal to GitOps in the same way CI is: it governs what security gates run on the way to production (shift-left scanning, policy checks, supply-chain controls), while GitOps governs how reviewed desired state reaches the cluster through pull-based reconciliation.
 
 ## Sources
 

--- a/src/content/docs/k8s/cgoa/module-1.3-patterns-and-tooling-review.md
+++ b/src/content/docs/k8s/cgoa/module-1.3-patterns-and-tooling-review.md
@@ -208,7 +208,7 @@ When comparing these tools under exam pressure, watch for answers that describe 
 
 You should also separate install topology from operating model. ArgoCD can manage multiple clusters from one control plane, and Flux can be installed per cluster or in patterns that support fleet management. Those choices affect credentials, network paths, and blast radius. A centralized control plane can simplify visibility but concentrates trust, while per-cluster controllers reduce shared blast radius but require consistent bootstrapping and alerting across many targets.
 
-Another comparison point is how each tool expresses dependencies. ArgoCD teams often model ordering with sync waves, hooks, and app-of-apps structures, while Flux teams may model dependencies between Kustomizations or HelmReleases. Both approaches can work, and both can be abused. If a database operator, namespace policy, and application deployment all reconcile in the wrong order, the issue is dependency design, not the mere presence of GitOps.
+Another comparison point is how each tool expresses dependencies. ArgoCD teams often model ordering with sync waves, hooks, and app-of-apps structures, while Flux teams may model dependencies between Kustomizations or HelmReleases. `ApplicationSet` generates Argo CD `Application`s from generators (e.g. a list of clusters, Git directories, or pull requests), which is the standard multi-cluster / fleet pattern — distinct from hand-maintaining one `Application` per target. Both approaches can work, and both can be abused. If a database operator, namespace policy, and application deployment all reconcile in the wrong order, the issue is dependency design, not the mere presence of GitOps.
 
 Finally, consider how each tool handles drift in human workflows. ArgoCD's visual diff can make drift obvious to a responder, while Flux's Kubernetes resources can make drift visible through familiar object conditions and events. In either model, the team still needs a rule for manual changes: observe with cluster commands, repair desired state in Git, and reserve direct mutation for documented emergencies. Without that rule, the tool only automates a conflict between humans and controllers.
 
@@ -376,7 +376,7 @@ The final decision is rarely permanent. Teams often begin with one repository, K
 
 ## Did You Know?
 
-- ArgoCD began as an open source project at Intuit in 2018, and it later became part of the Cloud Native Computing Foundation ecosystem through the Argo project.
+- ArgoCD began as an open source project at Intuit in 2018. The Argo project reached CNCF Graduated status in December 2022 (the same year Flux graduated); Argo CD is its best-known sub-project.
 - Flux reached CNCF Graduated status in 2022, which reflects broad adoption and project maturity rather than a change in the basic GitOps control-loop idea.
 - Kustomize has been available through `kubectl kustomize` for years, so teams can render overlays with Kubernetes-native tooling even when they do not run a GitOps controller locally.
 - Kubernetes Secrets are only base64-encoded by default, not encrypted for every reader of the repository, which is why GitOps designs need deliberate secret-management patterns.
@@ -516,7 +516,7 @@ patches:
 
 <details><summary>Solution outline for Tasks 3 through 5</summary>
 
-Render the overlay first with `kustomize build apps/checkout/overlays/prod > /tmp/checkout-prod.yaml`, then inspect it as a reviewer. If you have a cluster, run `k diff -f /tmp/checkout-prod.yaml`; if you do not, explain which objects would be created or changed and why. Choose ArgoCD when the team needs an application-centric view, visible sync health, and shared dashboard operations; choose Flux when the team needs modular Kubernetes-native resources and delegated controller composition. The promotion note should name the reviewed production overlay change and the immutable image tag or digest being moved forward.
+Render the overlay first with `kustomize build apps/checkout/overlays/prod > /tmp/checkout-prod.yaml`, then inspect it as a reviewer. If you have a cluster, run `kubectl diff -f /tmp/checkout-prod.yaml`; if you do not, explain which objects would be created or changed and why. Choose ArgoCD when the team needs an application-centric view, visible sync health, and shared dashboard operations; choose Flux when the team needs modular Kubernetes-native resources and delegated controller composition. The promotion note should name the reviewed production overlay change and the immutable image tag or digest being moved forward.
 
 </details>
 
@@ -527,6 +527,10 @@ Success criteria:
 - [ ] You can explain whether a problem belongs to rendering, reconciliation, rollout safety, or cluster policy.
 - [ ] You can justify ArgoCD or Flux based on operating model rather than popularity.
 - [ ] You can state how production promotion is reviewed and traced.
+
+## Learner check
+
+> `ApplicationSet` generates Argo CD `Application`s from generators (e.g. a list of clusters, Git directories, or pull requests), which is the standard multi-cluster / fleet pattern — distinct from hand-maintaining one `Application` per target.
 
 ## Sources
 

--- a/src/content/docs/k8s/cgoa/module-1.4-practice-questions-set-1.md
+++ b/src/content/docs/k8s/cgoa/module-1.4-practice-questions-set-1.md
@@ -100,10 +100,6 @@ Now imagine that the Deployment creates Pods and Kubernetes later writes status 
 
 A practical drift investigation starts by asking three questions. First, which object and field differ between Git and the cluster? Second, who is supposed to own that field: Git, a Kubernetes controller, an autoscaler, or a human operator during a break-glass event? Third, what should the reconciliation system do now: report, sync, pause, or escalate? These questions turn a vague "GitOps is broken" complaint into a concrete diagnosis.
 
-```bash
-kubectl -n shop get deployment checkout -o yaml
-```
-
 In KubeDojo modules, commands are shown with the full `kubectl` invocation to match the course style and the anti-alias checks:
 
 ```bash
@@ -340,7 +336,7 @@ The framework also helps compare push-based and pull-based approaches without sl
 
 ## Did You Know?
 
-1. OpenGitOps principles emphasize a declarative desired state, versioned and immutable storage, automatic application, and continuous reconciliation.
+1. OpenGitOps principles emphasize a declarative desired state, versioned and immutable storage, pulled automatically (agents pull the desired state), and continuous reconciliation.
 2. A GitOps controller can report drift without automatically fixing it if the platform is configured for manual synchronization or approval gates.
 3. Helm and Kustomize can both produce Kubernetes manifests, and GitOps controllers can use either one as part of the rendering step.
 4. Pull-based GitOps reduces the need for external systems to hold direct cluster credentials, but it still requires careful RBAC and secret-management design.
@@ -584,6 +580,10 @@ Write a final answer as if you were explaining the scenario to a teammate prepar
 
 A strong final explanation says GitOps uses Git as the reviewed desired-state source and a controller to continuously reconcile the cluster toward that state. It defines drift as the mismatch between Git-declared state and live cluster state, then explains that CI/CD may build and scan the hotfix image while GitOps owns runtime reconciliation. It also notes that pull-based reconciliation can reduce direct production credentials in external systems, but it still requires RBAC, repository access, and secret controls.
 </details>
+
+## Learner check
+
+> OpenGitOps principles emphasize a declarative desired state, versioned and immutable storage, pulled automatically (agents pull the desired state), and continuous reconciliation.
 
 ## Sources
 

--- a/src/content/docs/k8s/cgoa/module-1.5-practice-questions-set-2.md
+++ b/src/content/docs/k8s/cgoa/module-1.5-practice-questions-set-2.md
@@ -269,7 +269,7 @@ When you review missed questions, write the stage name beside the miss. Use labe
 
 1. The OpenGitOps project describes four principles: declarative desired state, versioned and immutable storage, automatically applied agents, and continuous reconciliation.
 2. Flux graduated from the Cloud Native Computing Foundation in 2022, and its architecture is intentionally split across specialized controllers rather than presented only as one central dashboard.
-3. Argo CD graduated from the Cloud Native Computing Foundation in 2022, and its Application custom resource is a central concept for grouping sync, health, and source configuration.
+3. The Argo project graduated from the Cloud Native Computing Foundation in 2022; in Argo CD, the Application custom resource is a central concept for grouping sync, health, and source configuration.
 4. Kustomize has been available through `kubectl kustomize` since Kubernetes 1.14, which is why many Kubernetes users encounter overlays before they install any separate templating tool.
 
 ## Common Mistakes
@@ -361,7 +361,7 @@ Option 1 is correct because rendering and reconciliation are separate responsibi
 <details>
 <summary>Analysis</summary>
 
-Option 1 is correct because the failure is at admission, so updating signing/policy inputs is the shortest path to resolving the block. Option 2 is wrong because rebuild alone does not address an existing admission denial on unsigned images. Option 3 is not correct because credentials are not the failure point when admission blocks apply due image policy. Option 4 is wrong because a direct edit may hide the immediate symptom but leaves the cluster diverged from reviewed Git state and risks repeat rejection after controller-driven reconciliation.
+Option 1 is correct because the failure is at admission, so updating signing/policy inputs is the shortest path to resolving the block. Until the image meets policy, every sync attempt will fail the same way and the Deployment will keep serving the last admitted revision — fixing CI output alone does not clear an admission webhook that rejects unsigned images. Option 2 is wrong because rebuild alone does not address an existing admission denial on unsigned images. Option 3 is not correct because credentials are not the failure point when admission blocks apply due image policy. Option 4 is wrong because a direct edit may hide the immediate symptom but leaves the cluster diverged from reviewed Git state and risks repeat rejection after controller-driven reconciliation.
 </details>
 
 ### 7. A team uses CI to build images, update the desired-state repository, and directly apply the manifests while Argo CD watches the same path. What design risk should you identify?
@@ -374,7 +374,7 @@ Option 1 is correct because the failure is at admission, so updating signing/pol
 <details>
 <summary>Analysis</summary>
 
-Option 1 is correct because CI and Argo CD both mutating runtime state creates non-authoritative outcomes and confusing evidence trails. Option 2 is wrong because speed is not equivalent to correctness when two systems can write different states. Option 3 is incorrect because overlap can create mismatched versions and drift reports, not guaranteed safety. Option 4 is wrong because this architecture increases governance and traceability complexity unless direct apply is strictly constrained.
+Option 1 is correct because CI and Argo CD both mutating runtime state creates non-authoritative outcomes and confusing evidence trails — during an incident you may not know whether the live image came from the last pipeline push or the controller's last sync. Option 2 is wrong because speed is not equivalent to correctness when two systems can write different states. Option 3 is incorrect because overlap can create mismatched versions and drift reports, not guaranteed safety. Option 4 is wrong because this architecture increases governance and traceability complexity unless direct apply is strictly constrained.
 </details>
 
 ## Hands-On Exercise
@@ -461,6 +461,10 @@ Set a timer for twelve minutes and answer seven scenario questions from this mod
 
 The goal is to produce a compact error log. If you missed the Flux question, the missing phrase might be "specialized controllers." If you missed the Helm and Kustomize question, it might be "renderer, not reconciler." If you missed the incident question, it might be "Git remains desired state." Reviewing by mechanism trains transfer to new questions better than memorizing the exact wording.
 </details>
+
+## Learner check
+
+> Option 1 is correct because CI and Argo CD both mutating runtime state creates non-authoritative outcomes and confusing evidence trails — during an incident you may not know whether the live image came from the last pipeline push or the controller's last sync.
 
 ## Sources
 


### PR DESCRIPTION
## CGOA (GitOps) wave 2 — cross-family review fixes (4 modules)

Tool/specialty-cert wave 2 (session 93). All 5 CGOA modules cross-family R1 reviewed (claude opus-4.8 + cursor) → **all APPROVE** (4.6–4.7/5), no P1s. Module 1.2 (APPROVE 4.7) was clean and is finalized untouched. This PR applies the verified should-fix P2s + deterministic nits + one density top-up to the other 4. Every factual addition orchestrator-verified against cncf.io / opengitops.dev.

### 1.1 — Exam Strategy & Blueprint
- Added **DevOps & DevSecOps** to the Related-Practices coverage (official CGOA scope lists "Configuration as Code, Infrastructure as Code, **DevOps & DevSecOps**, and CI & CD") + a §4 contrast row on DevSecOps-vs-GitOps ownership.
- Added a **quantified** Did-You-Know fact using the verified blueprint weights (Principles 30% / Terminology 20% / Patterns 20% / Related Practices 16% / Tooling 14%).

### 1.3 — Patterns & Tooling
- CNCF maturity parity: the **Argo project (incl. Argo CD) reached CNCF Graduated in December 2022** (was only "became part of the CNCF ecosystem"), paired with the existing Flux-Graduated fact.
- Added **`ApplicationSet`** (generators → multi-cluster/fleet pattern) to the Argo CD coverage.
- Deterministic: `k diff` → `kubectl diff` in the hands-on solution (no `alias k` defined in this module).

### 1.4 — Practice Questions Set 1
- OpenGitOps **principle 3** wording: "automatic application" → **"pulled automatically (agents pull the desired state)"** (opengitops.dev-verified; restores the testable *pull* semantic).
- Removed a duplicate `kubectl … -o yaml` code fence.

### 1.5 — Practice Questions Set 2
- Density top-up (4989 → **5031** body_words, T2→T0): expanded the Q6 (admission/policy) and Q7 (dual-writer ambiguity) answer rationales with substantive consequence reasoning — no filler.

### Verified
- All 4 edited modules **T0/PASS**, body_words ≥ 5000 (1.1 5131, 1.3 5444, 1.4 5278, 1.5 5031).
- All quiz answer keys were verified correct by the reviewers (no wrong keys in any CGOA module).
- Per-module `## Learner check` added (4/4). No stray unicode.

## Learner check
> DevSecOps is orthogonal to GitOps in the same way CI is: it governs what security gates run on the way to production (shift-left scanning, policy checks, supply-chain controls), while GitOps governs how reviewed desired state reaches the cluster through pull-based reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
