### PR TITLE
chore(content): CNPE wave-2 — review fixes (5 modules)

### DIFF
--- a/src/content/docs/k8s/cnpe/module-1.1-exam-strategy-and-environment.md
+++ b/src/content/docs/k8s/cnpe/module-1.1-exam-strategy-and-environment.md
@@ -64,6 +64,7 @@ Another practical prompt-reading habit is to separate nouns from verbs. The noun
 |-------------|----------------|---------------|--------------|
 | GitOps delivery | Which repository path owns the desired state? | application diff, sync status, rollout status | editing live cluster objects that Git will overwrite |
 | Platform API | Which custom object is the user-facing contract? | claim, XR, resource refs, conditions | debugging only the managed resource and ignoring the claim |
+| Platform architecture / infrastructure | Which topology, tenancy, or sizing choice matches the prompt? | namespace layout, node pools, storage class, cost signals | patching one workload when the platform design is wrong |
 | Observability | Which signal proves user-visible behavior changed? | metric query, trace span, log correlation, alert state | treating one log line as the whole incident |
 | Security and policy | Is the rule supposed to audit or enforce? | admission event, policy report, denied request | changing policy before confirming match scope |
 | Operations | Which component owns reconciliation? | controller logs, events, status conditions | restarting components without reading status |
@@ -86,7 +87,7 @@ kubectl config current-context
 kubectl get events -A --sort-by=.lastTimestamp | tail -n 10
 ```
 
-That command block is intentionally plain. It preserves the original module's verification habit because it catches three high-value mistakes: uncommitted local edits, the wrong Kubernetes context, and recent cluster-level warnings. It does not solve the task, but it prevents you from solving a task in the wrong place. In an exam, that is often the difference between a recoverable typo and a long detour.
+That command block is intentionally plain. This short environment check catches three high-value mistakes: uncommitted local edits, the wrong Kubernetes context, and recent cluster-level warnings. It does not solve the task, but it prevents you from solving a task in the wrong place. In an exam, that is often the difference between a recoverable typo and a long detour.
 
 Timeboxing is the discipline that makes the three-pass strategy real. If a task does not reveal a credible next action after a bounded inspection, mark it and move on. A useful scratchpad entry can be short: `Q3: app out of sync, repo path unclear, return after GitOps tasks`. You are not abandoning the task; you are preserving the rest of the exam while keeping enough state to resume.
 
@@ -144,7 +145,7 @@ Once you understand the prompt and trust your environment, the next question is 
 
 For GitOps tasks, treat Git as the desired-state contract unless the prompt clearly says otherwise. Inspect the application, repository path, target revision, sync status, and health before changing manifests. Argo CD distinguishes desired state from live state, and that distinction is exactly why GitOps helps platform teams operate at scale. If the desired state is wrong, fix Git; if the desired state is right but sync is blocked, inspect the controller, diff, hooks, waves, and permissions.
 
-For platform API tasks, identify the user-facing object first. In Crossplane terms, a claim can be namespaced while a composite resource is cluster-scoped, and the composition owns managed resources behind the abstraction. That separation is the point of a platform API: application teams request an outcome without managing every infrastructure detail. In an exam task, debugging only the cloud resource or only the Kubernetes object can waste time if you skip the relationship between claim, composite resource, composition, and managed resource conditions.
+For platform API tasks, identify the user-facing object first. In Crossplane terms, a claim can be namespaced while a composite resource is cluster-scoped, and the composition owns managed resources behind the abstraction. That separation is the point of a platform API: application teams request an outcome without managing every infrastructure detail. In Crossplane v1 (and v2 LegacyCluster mode), a namespaced **Claim** maps to a cluster-scoped composite resource (XR); in Crossplane v2 the XR is namespaced by default and there is no separate Claim API. Exam tasks may use either model — diagnosis still flows claim → XR → composition → managed-resource refs in v1, or namespaced-XR conditions in v2. In an exam task, debugging only the cloud resource or only the Kubernetes object can waste time if you skip the relationship between claim, composite resource, composition, and managed resource conditions.
 
 For observability tasks, resist the urge to treat the first signal as the truth. Metrics, logs, traces, events, and policy reports answer different questions. A metric can show rate or saturation, a trace can show request path, a log can show a local event, and a Kubernetes event can show controller behavior. CNPE-style operations work often asks you to combine signals just enough to choose a safe lever, not to conduct an open-ended investigation.
 
@@ -152,7 +153,7 @@ For security and policy tasks, confirm the intended mode before changing the rul
 
 ```bash
 kubectl get applications.argoproj.io -A
-kubectl get claims -A 2>/dev/null || true
+kubectl get claims -A 2>/dev/null || true  # claim plural is per-XRD — substitute your claim CRD plural
 kubectl get events -A --sort-by=.lastTimestamp | tail -n 20
 kubectl auth can-i create deployments --namespace default
 ```
@@ -308,10 +309,20 @@ The framework is intentionally small enough to memorize, but your implementation
 
 ## Did You Know?
 
-- CNPE is described by CNCF as a 120-minute online, proctored, performance-based exam, so time management is part of the tested skill rather than an afterthought.
-- The CNPE domain weights published by CNCF put GitOps and continuous delivery at 25% and platform APIs and self-service capabilities at 25%, which means half the blueprint rewards source-of-truth and abstraction work.
+- CNPE is a 120-minute, online, proctored, performance-based exam; cost is $445 with one free retake, so time management is part of the tested skill rather than an afterthought.
+- The official CNPE exam blueprint weights five domains as follows:
+
+| Domain | Weight |
+|---|---|
+| Platform Architecture and Infrastructure | 15% |
+| GitOps and Continuous Delivery | 25% |
+| Platform APIs and Self-Service Capabilities | 25% |
+| Observability and Operations | 20% |
+| Security and Policy Enforcement | 15% |
+
+  GitOps and platform APIs together account for half the blueprint, which means source-of-truth and abstraction work are central to the exam.
 - Kubernetes custom resources extend the Kubernetes API, so a platform API built on CRDs can be inspected with ordinary API habits even when the underlying resources are complex.
-- OpenTelemetry groups telemetry into signals such as traces, metrics, logs, and baggage, which is a useful mental model when choosing evidence for operations tasks.
+- OpenTelemetry groups telemetry into signals such as traces, metrics, and logs (with baggage for cross-service context), which is a useful mental model when choosing evidence for operations tasks.
 
 ## Common Mistakes
 

--- a/src/content/docs/k8s/cnpe/module-1.2-gitops-and-delivery-lab.md
+++ b/src/content/docs/k8s/cnpe/module-1.2-gitops-and-delivery-lab.md
@@ -47,7 +47,7 @@ The first professional habit is to ask which state you are observing. Desired st
 |------|-------|---------------------|------------------|-------------|
 | Desired state | Git repository and rendering tool | What should exist after reconciliation? | Kustomize overlay sets `replicas: 3` | Assuming a local edit exists in Git before it is committed |
 | Rendered state | Helm, Kustomize, or another generator | What manifests will the controller apply? | `kustomize build overlays/staging` output | Debugging raw templates without checking rendered YAML |
-| Live state | Kubernetes API server | What exists in the cluster right now? | `kubectl get deploy payment-api -n payments -o yaml` | Treating a manual live patch as the new source of truth |
+| Live state | Kubernetes API server | What exists in the cluster right now? | `kubectl get deploy payment-api -n payments-staging -o yaml` | Treating a manual live patch as the new source of truth |
 | Sync state | GitOps controller | Do desired and live match from the controller's view? | Argo CD `Synced`, Flux `Ready=True` | Assuming sync means the application is healthy |
 | Health state | GitOps controller and workload status | Are resources usable after they exist? | Deployment available condition, Pod readiness | Missing a bad readiness probe after sync succeeds |
 | Rollout state | Kubernetes workload controller or rollout controller | Is traffic safely moving to the new revision? | `kubectl rollout status`, Rollout phase, analysis result | Stopping after a ReplicaSet exists without checking availability |
@@ -89,7 +89,7 @@ Use a consistent inspection order during exam work. Start with the GitOps object
 ```bash
 APP_NAMESPACE="${APP_NAMESPACE:-argocd}"
 APP_NAME="${APP_NAME:-payment-api-staging}"
-WORKLOAD_NAMESPACE="${WORKLOAD_NAMESPACE:-payments}"
+WORKLOAD_NAMESPACE="${WORKLOAD_NAMESPACE:-payments-staging}"
 
 kubectl get application "$APP_NAME" -n "$APP_NAMESPACE" -o wide
 kubectl describe application "$APP_NAME" -n "$APP_NAMESPACE"
@@ -418,7 +418,7 @@ A successful render should show the Deployment and Service named `payment-api`, 
 
 The controller will likely report successful sync because the manifests are valid and applied. Users may still experience failure because the Service no longer selects the Pods. This is a classic example of sync state being clean while application health or traffic behavior is wrong, and it is why senior verification includes selectors, endpoints, and readiness rather than only controller status.
 
-Now create an Argo CD `Application` that points at the staging overlay. Replace `https://example.com/org/platform-repo.git` with the actual repository URL in a real lab. The YAML itself is valid and shows the required fields: [source repository, path, target revision, destination cluster, destination namespace, and sync policy](https://argo-cd.readthedocs.io/en/stable/user-guide/application-specification/).
+Now create an Argo CD `Application` that points at the staging overlay. Replace `https://example.com/org/platform-repo.git` with the actual repository URL in a real lab. This shows the required fields: [source repository, path, target revision, destination cluster, destination namespace, and sync policy](https://argo-cd.readthedocs.io/en/stable/user-guide/application-specification/).
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1
@@ -462,7 +462,7 @@ kubectl describe application payment-api-staging -n argocd
 
 Read the status fields as a sequence of claims. [A sync status of `Synced` means desired and live resources match according to Argo CD. A health status of `Healthy` means Argo CD considers the managed resources usable](https://argo-cd.readthedocs.io/en/release-3.4/getting_started/). A revision field tells you which Git revision was reconciled. If the revision is old, the controller may be healthy but not yet operating on your commit.
 
-For Flux, the equivalent object might be a [`Kustomization` that points at a `GitRepository`](https://fluxcd.io/flux/components/kustomize/kustomizations/). The object names differ, but the same evidence sequence applies: source fetched, artifact created, kustomization reconciled, resources applied, workload healthy. The following YAML is a valid shape for Flux-style reconciliation.
+For Flux, the equivalent object might be a [`Kustomization` that points at a `GitRepository`](https://fluxcd.io/flux/components/kustomize/kustomizations/). The object names differ, but the same evidence sequence applies: source fetched, artifact created, kustomization reconciled, resources applied, workload healthy. The following YAML shows a Flux-style reconciliation shape.
 
 ```yaml
 apiVersion: source.toolkit.fluxcd.io/v1
@@ -689,7 +689,7 @@ A CNPE prompt might not name the strategy. Instead, it might say that only a sma
 
 The payment authorization change deserves stronger progressive delivery because the blast radius and business risk are higher. The CSS change may be safe with a direct rollout and normal verification. The decision is not based on whether canary sounds modern; it is based on failure impact, detectability, rollback speed, and the quality of signals available during the release.
 
-Argo Rollouts is one common Kubernetes-native way to express progressive delivery. The following canary example is intentionally small. [It sets an initial traffic weight, pauses for observation, increases exposure, pauses again, and then completes if the rollout remains healthy](https://argoproj.github.io/argo-rollouts/features/canary/). Real production setups often integrate service mesh or ingress traffic routing and metric analysis.
+Argo Rollouts is one common Kubernetes-native way to express progressive delivery. The following canary example is intentionally small. [It sets an initial traffic weight, pauses for observation, increases exposure, pauses again, and then completes if the rollout remains healthy](https://argoproj.github.io/argo-rollouts/features/canary/). Real production setups often integrate service mesh or ingress traffic routing and metric analysis. An Argo Rollout replaces the Deployment for this workload — do not run both against the same selector; alternatively reference an existing Deployment via `spec.workloadRef`.
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1

--- a/src/content/docs/k8s/cnpe/module-1.3-platform-apis-and-self-service-lab.md
+++ b/src/content/docs/k8s/cnpe/module-1.3-platform-apis-and-self-service-lab.md
@@ -41,7 +41,7 @@ Example:
   Claim   -> Namespace + Policy + App Template -> Deployment, Service, Secret, RBAC
 ```
 
-That original mental model is intentionally short because it is the core of the module. User intent should flow into a platform contract, and the implementation should be reconciled behind the contract rather than edited as a one-off artifact. When the contract is healthy, the user can explain the desired state in plain language, the platform can create the right resources consistently, and both sides can look at status to decide what happened next.
+That mental model is intentionally short — it is the through-line of this lesson. User intent should flow into a platform contract, and the implementation should be reconciled behind the contract rather than edited as a one-off artifact. When the contract is healthy, the user can explain the desired state in plain language, the platform can create the right resources consistently, and both sides can look at status to decide what happened next.
 
 The first CNPE move is therefore not `kubectl apply` against every generated resource you can find. The first move is to locate the object that owns the user-facing intent and then read it carefully. In a Crossplane-based platform, that might be a claim whose fields describe class, region, size, and team ownership. In a Kubebuilder operator, it might be a custom resource whose spec declares the desired workspace. In Backstage, it might begin as a form-backed template that eventually commits or applies the custom resource.
 
@@ -110,7 +110,11 @@ Self-service does not mean every user receives cluster-admin access and a pile o
 
 Backstage is useful when discoverability and developer workflow matter. A Software Template can collect inputs, scaffold a repository, register a component, and trigger automation that creates or updates platform resources. The template is not necessarily the source of truth for the running infrastructure; it is often the front door that helps a user produce a valid request. Treat Backstage as the menu board and ordering workflow, not automatically as the reconciler that keeps every generated resource healthy.
 
-Crossplane is useful when the platform needs composite resources and claims that reconcile infrastructure or Kubernetes resources over time. A platform team can define a composite type, bind it to a composition, and expose a claim that developers consume without learning the provider details underneath. This is powerful because it separates the user-facing contract from the implementation recipe, but it also means troubleshooting includes both the claim and the composed resources.
+Crossplane is useful when the platform needs composite resources and claims that reconcile infrastructure or Kubernetes resources over time. A platform team can define a `CompositeResourceDefinition (XRD)`, bind it to a composition, and expose a claim that developers consume without learning the provider details underneath. This is powerful because it separates the user-facing contract from the implementation recipe, but it also means troubleshooting includes both the claim and the composed resources.
+
+> **Crossplane API kinds on the CNPE exam**
+>
+> The fictional `TeamWorkspace` CRD in this lab teaches the contract pattern; on the exam you will also see real Crossplane kinds: `CompositeResourceDefinition (XRD)` = the schema/contract, `Composition` = how it is implemented, and `Claim`/namespaced-XR = what the user submits (v1 claim + cluster XR; v2 namespaced XR with no separate claim). See the [Crossplane toolkit module](/platform/toolkits/infrastructure-networking/platforms/module-7.2-crossplane/) for the full mapping.
 
 Kubebuilder and custom operators are useful when the domain has behavior that cannot be expressed cleanly as templated resources. If creating a workspace requires sequencing, external checks, finalizers, status aggregation, or ongoing repair, a controller can encode those rules. The tradeoff is operational responsibility: once you author a controller, you own reconcile logic, upgrades, failure handling, RBAC, metrics, and the user experience of status messages.
 
@@ -150,7 +154,7 @@ spec:
   networkProfile: internal-only
 ```
 
-This request is intentionally small because a platform API should keep the common path narrow. The controller can translate `quotaClass: small` into concrete ResourceQuota and LimitRange objects, translate `networkProfile: internal-only` into policy, and translate `team: payments` into access bindings. If a learner is tempted to add every generated label, selector, and RoleBinding subject to the claim, that is a sign the abstraction is leaking.
+This request is intentionally small because a platform API should keep the common path narrow. The controller can translate `quotaClass: small` into concrete ResourceQuota and LimitRange objects, translate `networkProfile: internal-only` into policy, and translate `team: payments` into access bindings. If a learner is tempted to add every generated label, selector, and RoleBinding subject to the workspace request, that is a sign the abstraction is leaking.
 
 Apply and inspect the request through the supported object first. The commands below assume the CRD exists in the lab cluster; if it does not, use the same reading pattern with any platform-track CRD or template available in your environment. The point is to learn the sequence, not to depend on this exact fictional API group.
 
@@ -161,9 +165,9 @@ kubectl describe teamworkspace payments-dev -n platform-requests
 kubectl get events -n platform-requests --sort-by=.lastTimestamp
 ```
 
-The healthy path should show accepted input, progressing status, and eventually a ready condition or equivalent signal. If the controller creates a namespace, quota, policy, and access binding, inspect them as evidence but resist treating them as the primary interface. Generated resources tell you what the controller did. The claim tells you what the platform is supposed to keep doing.
+The healthy path should show accepted input, progressing status, and eventually a ready condition or equivalent signal. If the controller creates a namespace, quota, policy, and access binding, inspect them as evidence but resist treating them as the primary interface. Generated resources tell you what the controller did. The workspace request tells you what the platform is supposed to keep doing.
 
-Governed self-service also depends on RBAC. A user may be allowed to create a claim in `platform-requests` without being allowed to create namespaces or cluster-wide roles directly. That is a feature, not a restriction to bypass. The platform controller can hold the broader permissions because it applies policy consistently, while users receive the narrow permission needed to request approved outcomes. This keeps accidental privilege expansion out of the normal developer workflow.
+Governed self-service also depends on RBAC. A user may be allowed to create a platform contract object in `platform-requests` without being allowed to create namespaces or cluster-wide roles directly. That is a feature, not a restriction to bypass. The platform controller can hold the broader permissions because it applies policy consistently, while users receive the narrow permission needed to request approved outcomes. This keeps accidental privilege expansion out of the normal developer workflow.
 
 ```bash
 kubectl auth can-i create teamworkspaces.platform.example.com -n platform-requests
@@ -175,7 +179,7 @@ The expected answer for many users is yes to the first command and no to the dir
 
 Admission policy can add another guardrail before the controller even runs. A validating rule might reject unknown quota classes, require an owner label, or prevent production workspaces from using a permissive network profile. A mutating rule might add standard labels or defaults. Admission does not replace reconciliation because it does not keep resources healthy over time, but it prevents invalid intent from entering the system and gives users faster feedback.
 
-This is where the restaurant analogy from the original module still helps. A good platform API is like a menu, not a kitchen tour. The caller should order outcomes, and the platform should handle the cooking, plating, and cleanup. If the menu lets every customer rewrite the kitchen inventory during lunch, the result is not empowerment; it is a failure to define the operating boundary.
+This is where the restaurant analogy from earlier still helps. A good platform API is like a menu, not a kitchen tour. The caller should order outcomes, and the platform should handle the cooking, plating, and cleanup. If the menu lets every customer rewrite the kitchen inventory during lunch, the result is not empowerment; it is a failure to define the operating boundary.
 
 ## Diagnosing Reconciliation Failures
 
@@ -189,7 +193,7 @@ kubectl describe <custom-resource>
 kubectl get events -A --sort-by=.lastTimestamp | tail -n 15
 ```
 
-Those original verification commands are still the right compact starting point. `kubectl get` lets you compare spec and status, `kubectl describe` often aggregates conditions and recent events, and sorted events reveal recent failures across namespaces when the object is not namespace-scoped or when generated resources live elsewhere. In a larger cluster, you would narrow the event query to the relevant namespace or involved object once you know where the controller is acting.
+Those verification commands are the right compact starting point. `kubectl get` lets you compare spec and status, `kubectl describe` often aggregates conditions and recent events, and sorted events reveal recent failures across namespaces when the object is not namespace-scoped or when generated resources live elsewhere. In a larger cluster, you would narrow the event query to the relevant namespace or involved object once you know where the controller is acting.
 
 The first failure family is invalid input. A field may be missing, an enum value may be unsupported, a referenced secret may not exist, or an environment value may violate policy. Invalid input should be fixed in the claim, template input, or custom resource spec because that is where the user expresses intent. If the controller reports `InvalidQuotaClass`, editing the generated ResourceQuota avoids the lesson and leaves the next reconciliation with the same bad request.
 
@@ -412,7 +416,7 @@ A strong recommendation includes the smallest durable change. For example: "Cons
 
 ### Verification Commands
 
-Use the commands below with the real kind, name, and namespace from your lab. The first block preserves the compact verification sequence from the original module; the second block adds access-boundary checks that make governance visible.
+Use the commands below with the real kind, name, and namespace from your lab. The first block preserves the compact verification sequence above; the second block adds access-boundary checks that make governance visible.
 
 ```bash
 kubectl get <custom-resource> -o yaml

--- a/src/content/docs/k8s/cnpe/module-1.4-observability-security-and-operations-lab.md
+++ b/src/content/docs/k8s/cnpe/module-1.4-observability-security-and-operations-lab.md
@@ -213,7 +213,7 @@ kubectl logs deploy/<name> -n <namespace> --tail=50
 kubectl describe deploy/<name> -n <namespace>
 ```
 
-Preserving that exact command block matters because it is the original module's minimal verification asset. It is not enough for every incident, and it deliberately omits metrics, traces, and policy engine logs that would be available in a fuller platform, but it remains a useful last-mile check. Events show whether the control plane is still rejecting or warning, logs show whether the workload is still failing locally, and the Deployment description shows whether the controller reached the desired state.
+This minimal command block matters as a last-mile check. It is not enough for every incident, and it deliberately omits metrics, traces, and policy engine logs that would be available in a fuller platform, but it remains useful for quick orientation. Events show whether the control plane is still rejecting or warning, logs show whether the workload is still failing locally, and the Deployment description shows whether the controller reached the desired state.
 
 For a CNPE lab, you should also practice writing a remediation note in the same structure every time. State the symptom, the evidence, the cause, the change, the verification, and the guardrail status. This is not bureaucratic ceremony. It forces you to identify whether your fix preserved RBAC, admission, runtime controls, network policy, and secret handling, which is the difference between fixing a service and quietly creating a platform exception nobody can audit later.
 
@@ -334,7 +334,7 @@ First determine whether privileged mode is actually required. If it is accidenta
 <details>
 <summary>Question 3: A workload receives `forbidden` when trying to read one ConfigMap in its own namespace. Which remediation best preserves the platform security posture?</summary>
 
-Create or update a namespace-scoped Role that grants the specific verb on the specific resource, then bind it to the workload's service account. A cluster-wide binding or broad secret access would make the immediate error disappear while expanding blast radius beyond the evidence. You should verify with `kubectl auth can-i` using the service account identity and then confirm the application recovers. This answer maps the symptom to RBAC authorization rather than admission or runtime policy.
+Create or update a namespace-scoped Role that grants the specific verb on the specific resource, then bind it to the workload's service account. A cluster-wide binding or broad resource access would make the immediate error disappear while expanding blast radius beyond the evidence. You should verify with `kubectl auth can-i` using the service account identity and then confirm the application recovers. This answer maps the symptom to RBAC authorization rather than admission or runtime policy.
 </details>
 
 <details>

--- a/src/content/docs/k8s/cnpe/module-1.5-full-mock-exam.md
+++ b/src/content/docs/k8s/cnpe/module-1.5-full-mock-exam.md
@@ -38,13 +38,13 @@ Pause and predict: if an application is unhealthy after a Git commit, what evide
 
 Think of the exam as a set of inspection lanes in a workshop. You do not disassemble the engine because the dashboard light is on; you check the signal, confirm the system, and isolate the layer with the cheapest trustworthy evidence. In Kubernetes 1.35+ environments, that evidence often comes from resource status, events, controller conditions, and narrow command output. The platform operator habit is to move from broad signal to specific cause without turning the investigation into a scavenger hunt.
 
-The original practice module summarized the sample exam flow in four tasks: GitOps delivery, platform API self-service, observability or security incident response, and operations follow-up. That sequence still works as the backbone of the mock exam, but the deeper lesson is that each task has a different success definition. A delivery fix is not complete because a manifest was edited; it is complete when the intended environment converges. A platform API fix is not complete because a claim was accepted; it is complete when the contract is valid, status is meaningful, and reconciliation reaches the expected state.
+The mock exam is built around four task types: GitOps delivery, platform API self-service, observability or security incident response, and operations follow-up. That sequence still works as the backbone of the mock exam, but the deeper lesson is that each task has a different success definition. A delivery fix is not complete because a manifest was edited; it is complete when the intended environment converges. A platform API fix is not complete because a claim was accepted; it is complete when the contract is valid, status is meaningful, and reconciliation reaches the expected state.
 
 In a realistic rehearsal, the task text may deliberately include tempting details. A namespace name, a failed pod, or an angry event is useful evidence, but it is not automatically the root cause. Good exam work turns each clue into a question: which system produced this clue, what does that system own, and what would change if my hypothesis were true? That habit keeps you from confusing implementation noise with platform intent, especially when a task spans GitOps, APIs, and runtime behavior.
 
 ## Running the Mock Exam Under Real Pressure
 
-The rules of the rehearsal are simple because the complexity should come from the work, not from ceremony. Set a timer and do not pause it. Keep a small scratchpad of task state. Verify every change before moving on. Do not optimize for perfect elegance when a smaller correct fix exists. If a task stalls, park it and return later with a fresh hypothesis. These rules preserve the original module's purpose: build pressure tolerance and sequencing skill rather than produce a polished design document.
+The rules of the rehearsal are simple because the complexity should come from the work, not from ceremony. Set a timer and do not pause it. Keep a small scratchpad of task state. Verify every change before moving on. Do not optimize for perfect elegance when a smaller correct fix exists. If a task stalls, park it and return later with a fresh hypothesis. These rules keep the rehearsal focused on building pressure tolerance and sequencing skill rather than producing a polished design document.
 
 Timer discipline matters because platform engineers often lose time in respectable ways. You can spend ten minutes making a solution prettier, five minutes collecting evidence you already have, and another stretch rereading documentation while easier points wait untouched. The mock exam exposes those habits because the clock keeps moving. A stable pacing workflow protects you from the false comfort of effort, which is when you are busy but not improving the score.
 
@@ -54,9 +54,21 @@ Exercise scenario: You have a 90-minute practice window and four tasks. The deli
 
 Before running this, what output do you expect from your final verification pass, and what would make you stop trusting that pass? Strong candidates answer in terms of signals, not vibes. They expect a clean Git state or intentional file diff, current events that no longer show the failing symptom, and workload state that matches the repaired namespace. They stop trusting the pass if the command checks the wrong namespace, if the resource name is stale, or if the verification proves only that a command ran.
 
-The original module used a dress rehearsal analogy, and it is still a useful mental model. A real performance does not test whether you can memorize the score; it tests whether you can keep tempo, recover from mistakes, and finish strongly. CNPE works the same way. The best rehearsal outcome is not a perfect first run, but a repeatable read-act-verify loop that survives distraction and leaves behind enough evidence for an examiner to follow.
+A dress-rehearsal analogy is a useful mental model here. A real performance does not test whether you can memorize the score; it tests whether you can keep tempo, recover from mistakes, and finish strongly. CNPE works the same way. The best rehearsal outcome is not a perfect first run, but a repeatable read-act-verify loop that survives distraction and leaves behind enough evidence for an examiner to follow.
 
 ## Working Each Domain Without Losing the Thread
+
+The CNCF CNPE blueprint weights five domains on the exam. Use this table when pacing your mock run so you do not undertrain any slice of the blueprint:
+
+| Domain | Weight |
+|---|---|
+| Platform Architecture and Infrastructure | 15% |
+| GitOps and Continuous Delivery | 25% |
+| Platform APIs and Self-Service Capabilities | 25% |
+| Observability and Operations | 20% |
+| Security and Policy Enforcement | 15% |
+
+Platform Architecture and Infrastructure tasks ask you to reason about IDP architecture decisions, cluster topology, infrastructure-as-code patterns, multi-tenancy boundaries, and cost or right-sizing choices — not just patch a single workload. Typical prompts involve namespace layout, node pool or storage class selection, network segmentation, and whether a platform design matches tenancy or compliance requirements. Treat these tasks like the other domains: identify the contract, change the owning layer, and verify with evidence.
 
 GitOps delivery tasks begin with intent. You inspect the repository change, identify the environment boundary, and compare that desired state with the controller's view and the live Kubernetes result. The highest-value question is not, "Which command fixes this?" but, "Which source of truth is wrong or blocked?" If the repository is wrong, repair the manifest or overlay. If the controller is blocked, inspect sync status, health, or diff behavior. If live state was manually changed, restore convergence rather than normalize drift.
 
@@ -66,11 +78,11 @@ Observability and security tasks begin with evidence. A failing request may show
 
 Operations follow-up tasks begin with the next person. After an incident or repair, the platform should be easier to operate than it was before. That may mean adding a missing alert, improving a runbook clue, clarifying a status message, or documenting the verification signal that proved the fix. The follow-up should not be theatrical. It should reduce ambiguity for the operator who sees the same class of symptom later and needs to know where to look first.
 
-The sample exam flow from the original module remains a practical map. Task one is GitOps delivery: inspect repository intent, repair the environment-specific change, restore sync or correct rollout, and verify that live state matches desired state. Task two is platform API self-service: read the CRD or claim, identify contract fields, repair validation, status, or reconciliation issues, and confirm that the object reaches the expected healthy state. Task three is observability or security: narrow the cause with metrics, logs, traces, or events, apply the smallest safe fix, preserve guardrails, and verify that the symptom is gone. Task four is operations follow-up: confirm the right alert or runbook signal exists, document the operational clue, and keep the platform explainable.
+The sample exam flow remains a practical map: Task one is GitOps delivery: inspect repository intent, repair the environment-specific change, restore sync or correct rollout, and verify that live state matches desired state. Task two is platform API self-service: read the CRD or claim, identify contract fields, repair validation, status, or reconciliation issues, and confirm that the object reaches the expected healthy state. Task three is observability or security: narrow the cause with metrics, logs, traces, or events, apply the smallest safe fix, preserve guardrails, and verify that the symptom is gone. Task four is operations follow-up: confirm the right alert or runbook signal exists, document the operational clue, and keep the platform explainable.
 
 The difference between a strong and weak run is often visible in the verbs. Strong runs inspect, compare, narrow, repair, verify, and record. Weak runs poke, hope, broaden, rewrite, and move on. That contrast is not about personality; it is about observability and control. Under pressure, precise verbs help you notice whether you are moving toward proof or merely creating more changes to reason about.
 
-The original scoring rubric is worth keeping because it mirrors the platform layers you must integrate during the rehearsal.
+The scoring rubric below is worth keeping because it mirrors the platform layers you must integrate during the rehearsal.
 
 | Area | Full Credit | Partial Credit |
 |------|-------------|----------------|
@@ -92,7 +104,7 @@ Which approach would you choose here and why: a broad command that lists everyth
 
 There is also a social dimension to verification, even in a solo exam. The command output is the explanation you leave for your future self during the final review pass. If your verification is only "it looks better," the final pass has nothing to audit. If your verification names the resource, namespace, condition, and expected transition, the final pass can quickly confirm that the work still holds. That distinction matters because late corrections are expensive and often happen under fatigue.
 
-Keep the original module's simple verification block as the end-of-run baseline. It is deliberately small: check Git state, inspect recent events, and list the workload state in the relevant namespace. In a real mock exam you should add task-specific proof around it, but this baseline catches a surprising number of avoidable mistakes. It also reinforces the habit that verification belongs in the workflow, not as an optional ceremony after the timer has already expired.
+Keep this simple verification block as the end-of-run baseline. It is deliberately small: check Git state, inspect recent events, and list the workload state in the relevant namespace. In a real mock exam you should add task-specific proof around it, but this baseline catches a surprising number of avoidable mistakes. It also reinforces the habit that verification belongs in the workflow, not as an optional ceremony after the timer has already expired.
 
 ## Debriefing Like an Examiner
 
@@ -100,7 +112,7 @@ The debrief is where a mock exam becomes training instead of merely a stressful 
 
 Start by reconstructing the timeline from your scratchpad. Which task did you open first, when did you switch, where did you park work, and how much time remained for review? Then examine the layer choices. Did you patch an implementation detail when the intent was wrong? Did you treat a policy denial as a workload failure? Did you keep digging after the evidence was already enough? These questions are uncomfortable in exactly the way good practice should be.
 
-The original module's debrief questions still work because they force cause and consequence into the same conversation. Which task consumed the most time, and why? Did you move too early on any hard task? Where did verification save you from a bad assumption? Which platform layer was easiest to reason about under pressure? Answer each question with evidence from the run, not with a general feeling about your readiness.
+These debrief questions work because they force cause and consequence into the same conversation. Which task consumed the most time, and why? Did you move too early on any hard task? Where did verification save you from a bad assumption? Which platform layer was easiest to reason about under pressure? Answer each question with evidence from the run, not with a general feeling about your readiness.
 
 An examiner-style debrief should produce a small set of concrete practice changes. For example, you might decide to rehearse CRD contract reading for twenty minutes before the next mock, write a tighter verification checklist for GitOps tasks, or practice parking an incident after a fixed timebox. Those are useful changes because they are observable. During the next run, you can tell whether you actually did them.
 
@@ -152,7 +164,7 @@ Another useful pattern is parking stuck work with a named return condition. Park
 
 A third pattern is layer ownership. Before changing anything, ask which layer owns the failing behavior: Git intent, controller reconciliation, platform API contract, policy guardrail, workload runtime, or operational signal. This pattern works because platform systems are built from contracts. If you repair the wrong layer, the symptom may briefly disappear while the underlying contract remains broken, which is exactly the sort of weak answer a full mock exam is designed to expose.
 
-The original module identified several common failure patterns, and they remain useful because they describe habits rather than tool-specific mistakes.
+Several common failure patterns are worth naming because they describe habits rather than tool-specific mistakes.
 
 | Failure Pattern | What It Looks Like | Better Habit |
 |-----------------|--------------------|--------------|


### PR DESCRIPTION
## CNPE (Cloud Native Platform Engineering Associate) — tool-cert wave-2, sub-track 7/9

Finalizes the five CNPE modules to `done` via the no-codex review-first loop. All five were back-catalog
`shipped_unreviewed`; each got a cross-family R1, every finding was orchestrator-ground-checked against
upstream, and all quiz/mock answer keys were independently verified correct.

### Reviews (mixed pools, ≤2/OAuth)
| Module | Reviewer | Verdict |
|---|---|---|
| 1.1 exam-strategy | cursor composer-2.5 | NEEDS_CHANGES 4/5 |
| 1.2 gitops-lab | opus-4.8 | APPROVE 4.5/5 |
| 1.3 platform-apis-lab | cursor composer-2.5 | APPROVE_WITH_NITS 4.6/5 |
| 1.4 obs-security-lab | opus-4.8 | NEEDS_CHANGES 4.5/5 |
| 1.5 mock-exam | deepseek-v4-pro | APPROVE_WITH_NITS 4/5 |

### Fixes
- **Systematic authoring-leak cleanup** — a rewrite left 14 "the original module" back-references across 1.1/1.3/1.4/1.5. All removed and reworded as self-contained learner prose, while **preserving** the legitimate teaching vocabulary "verify the *original symptom* / *original issue* / *original plan* / *original intent*" (a sibling-grep distinguished the two; reviewers had only sampled 1.1/1.3).
- **1.1**: official CNPE 5-domain blueprint table (Platform Architecture 15% / GitOps 25% / Platform APIs 25% / Observability 20% / Security 15%; 120-min, $445) + a Platform Architecture row in the domain-clue table; **Crossplane v1-vs-v2 note** (v2 makes XRs namespaced and removes Claims — verified against docs.crossplane.io); OTel-baggage wording fix.
- **1.2**: Argo `Rollout`-replaces-`Deployment` collision clarifier (same name/selector would make two controllers fight); namespace default aligned to `payments-staging`; trimmed a self-referential phrase. (All manifests were opus-verified schema-valid + correctly attributed.)
- **1.3**: Crossplane **XRD/Composition/Claim** exposure gap closed via an absolute cross-link to `/platform/toolkits/infrastructure-networking/platforms/module-7.2-crossplane/` with a v1/v2 mapping; `composite type`→`CompositeResourceDefinition (XRD)`; `TeamWorkspace` reworded off "claim".
- **1.4**: Quiz-3 answer "broad secret access" → "broad resource access" (the question is about a ConfigMap).
- **1.5**: added the 5-domain blueprint table + a Platform Architecture & Infrastructure paragraph (the section had covered only 4 of 5 domains). A deepseek hallucination (it claimed the CNPE directory was empty) was rejected — the line-29 cross-reference is accurate and left intact. All 7 mock-exam answer keys independently verified correct.

### Gates (local, from worktree)
- `verify_module.py`: all five **T0 / passed=True** (body_words 5071–5416).
- `incident_dedup_gate.py --mode absolute --base origin/main`: **PASS**.

## Learner check

From `module-1.1-exam-strategy-and-environment.md`, the new Crossplane v1-vs-v2 note:

> in Crossplane v2 the XR is namespaced by default and there is no separate Claim API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
