### PR TITLE
chore(content): LFCS tool-cert wave-2 — review fixes (4 modules: glob/awk/tar correctness + leak cleanup + blueprint table + cross-links)

### DIFF
--- a/src/content/docs/k8s/lfcs/module-1.1-exam-strategy-and-workflow.md
+++ b/src/content/docs/k8s/lfcs/module-1.1-exam-strategy-and-workflow.md
@@ -27,7 +27,7 @@ This module turns the broad LFCS track into an exam-day operating method. You wi
 
 The LFCS mental model starts with the difference between answer recognition and state production. In a multiple-choice exam, the prompt and options often carry enough context to jog your memory, and partial recognition can still help you eliminate poor choices. In a performance exam, the machine is the answer sheet. If a service is supposed to be enabled, a user is supposed to belong to a group, or a mount is supposed to persist after reboot, the scorer does not care whether you knew the right concept in conversation. It can only inspect the final system state.
 
-That is why the original short version of this module emphasized the sentence "change, verify, move on." The phrase is simple, but it should shape every minute of your preparation. You should practice tasks in a way that forces recall, execution, and proof in the same loop. Reading a command table can introduce vocabulary, but it does not teach your hands to recover from a mistyped option, recognize a misleading success message, or decide whether a reload is enough when the prompt asked for persistence.
+That is why the operating principle is "change, verify, move on." The phrase is simple, but it should shape every minute of your preparation. You should practice tasks in a way that forces recall, execution, and proof in the same loop. Reading a command table can introduce vocabulary, but it does not teach your hands to recover from a mistyped option, recognize a misleading success message, or decide whether a reload is enough when the prompt asked for persistence.
 
 The official LFCS instructions also matter because they make the exam feel more like a constrained administration shift than a classroom exercise. Current Linux Foundation candidate-facing material describes a remotely proctored session, a two-hour time box, and performance-based command-line tasks. Those constraints mean you must prepare for attention management as seriously as command syntax. A candidate who spends too long polishing one fragile task can lose points elsewhere even if the eventual fix is correct.
 
@@ -36,6 +36,22 @@ Think of LFCS as a queue of small operational tickets. Each ticket names an obje
 The distribution-independent flavor of LFCS preparation reinforces this workflow. You may practice on one distribution and encounter slightly different package names, service defaults, or helper tools elsewhere, but the exam still rewards general Linux administration competence. For example, `systemctl status` and `journalctl` habits transfer across many modern distributions, while package-manager muscle memory may vary. Strong preparation therefore balances command fluency with the ability to read local help, inspect current state, and adapt without panic.
 
 This is also why you should avoid building your plan around exam folklore. Candidate reports can be useful for understanding stress, but they are not a stable source of task content, and they can push you toward memorizing someone else's sequence instead of learning an adaptable workflow. The durable skill is the ability to enter any ordinary Linux environment, observe what is true, and move the system toward a requested state with commands you can justify.
+
+### LFCS Exam Blueprint (Domains & Weightings)
+
+The current LFCS exam (2-hour, performance-based, distribution-independent) is scored across five domains:
+
+| Domain | Weight |
+|---|---|
+| Operations Deployment | 25% |
+| Networking | 25% |
+| Storage | 20% |
+| Essential Commands | 20% |
+| Users and Groups | 10% |
+
+Source: [Linux Foundation — LFCS certification page](https://training.linuxfoundation.org/certification/linux-foundation-certified-sysadmin-lfcs/) (verify the live blueprint before exam day; the Linux Foundation updates domains periodically).
+
+The KubeDojo LFCS practice modules regroup these domains for hands-on flow: essential commands (module 1.2), running systems + networking (module 1.3), and storage + services + users (module 1.4).
 
 Here is the compact operating model you should keep in your head while studying. It is intentionally more like a runbook than a syllabus because LFCS preparation is about doing, not collecting definitions.
 
@@ -91,7 +107,7 @@ Prompt reading also helps you decide when a command should be avoided. If the ta
 
 ## The Three-Pass Exam Strategy
 
-A performance exam should not be approached as a sacred linear sequence. The question order may be convenient, but it is not necessarily optimized for your confidence, speed, or current recall. The original module proposed three passes: quick wins, medium tasks, and heavy or fragile tasks. That strategy remains the backbone of this rewrite because it protects throughput without encouraging careless skipping.
+A performance exam should not be approached as a sacred linear sequence. The question order may be convenient, but it is not necessarily optimized for your confidence, speed, or current recall. A three-pass strategy — quick wins, medium tasks, and heavy or fragile tasks — protects throughput without encouraging careless skipping.
 
 Pass one is for obvious, low-risk, fast-to-verify work. These tasks usually involve creating users or groups, adjusting straightforward permissions, creating files or links, inspecting requested state, or making small command-line changes where the failure surface is limited. The purpose is not merely emotional comfort, though confidence does matter. The purpose is to reduce the number of untouched prompts quickly, collect points that should not be left on the table, and warm up your command recall on tasks where a mistake is easy to see.
 
@@ -158,7 +174,7 @@ One useful practice habit is to record failed proofs, not just failed commands. 
 
 ## Building a Tiny Task Journal
 
-The original module recommended a tiny task journal because cognitive load becomes the enemy during hands-on exams. That advice is easy to underestimate until you experience a timed terminal session with multiple half-finished tasks. Your memory starts mixing prompt numbers, file paths, service names, and suspected fixes. A journal gives your attention a control surface so you do not waste time rediscovering what you already decided.
+A tiny task journal helps because cognitive load becomes the enemy during hands-on exams. That advice is easy to underestimate until you experience a timed terminal session with multiple half-finished tasks. Your memory starts mixing prompt numbers, file paths, service names, and suspected fixes. A journal gives your attention a control surface so you do not waste time rediscovering what you already decided.
 
 The journal should be small enough that it does not become a second exam. You only need the task identifier, a status, and one useful detail such as a path, unit, user, device, or verification gap. The statuses can be simple: `done`, `needs verify`, `skip`, and `broken/revisit`. The detail should be whatever lets you resume the task without rereading the full prompt from zero. If the journal takes more than a few seconds to update, it is too elaborate.
 
@@ -187,13 +203,13 @@ Journal discipline also reveals whether your study plan is balanced. If every pr
 
 ## Turning KubeDojo into Terminal-First Practice
 
-KubeDojo can give you topic coverage, but LFCS readiness comes from converting that coverage into repeated terminal work. The original module warned against treating the hub as the only prep asset. That warning matters because reading feels productive even when it does not build recall. A certification training system must turn each module into tasks, each task into commands, and each command sequence into verified system state.
+KubeDojo can give you topic coverage, but LFCS readiness comes from converting that coverage into repeated terminal work. Treating the hub as the only prep asset is a mistake because reading feels productive even when it does not build recall. A certification training system must turn each module into tasks, each task into commands, and each command sequence into verified system state.
 
 The practice loop should be simple. Read or review a mapped module, extract a few concrete administration tasks, perform them in a clean shell, verify each result, and repeat the tasks that felt slow or uncertain. If a topic does not become a task, it remains passive knowledge. If a task does not include verification, it trains you to trust command output instead of system state. If a practice session has no time limit, it may build depth but it will not fully prepare you for exam pacing.
 
 For example, a users and permissions study block should not end with "I reviewed ownership." It should end with a sequence such as creating a user, creating a group, adding the user to the group, preparing a shared directory, applying the intended mode, creating a test file, and proving access. A services block should not end with "I read about systemd." It should end with starting, stopping, enabling, disabling, checking logs, and explaining the difference between runtime state and boot state.
 
-The following practice plan keeps the original module's weekly prep loop but makes it more operational. Each session combines review, execution, timing, and postmortem because those parts reinforce different skills. Review gives you vocabulary, execution builds recall, timing exposes hesitation, and postmortem turns mistakes into the next session's target.
+The following practice plan uses a weekly prep loop made operational. Each session combines review, execution, timing, and postmortem because those parts reinforce different skills. Review gives you vocabulary, execution builds recall, timing exposes hesitation, and postmortem turns mistakes into the next session's target.
 
 | Session | Primary goal | Practice shape | Postmortem question |
 |---|---|---|---|
@@ -302,7 +318,7 @@ For practice, time-box each prompt family differently. Quick file and user tasks
 
 <details><summary>Question 1: You read an LFCS prompt asking you to make a service active now and enabled after reboot. You can remember only one command confidently. What should your workflow protect against?</summary>
 
-The workflow should protect against proving only one of the two requested states. Starting the service does not prove boot enablement, and enabling the service does not prove that it is active right now. A strong answer names both proof checks, such as `systemctl is-active` and `systemctl is-enabled`, before calling the task done. This directly evaluates the LFCS task prompt and uses the three-pass strategy only after the desired state is clear.
+The workflow should protect against proving only one of the two requested states. Starting the service does not prove boot enablement, and enabling the service does not prove that it is active right now. A strong answer names both proof checks, such as `systemctl is-active` and `systemctl is-enabled`, before calling the task done. This directly evaluates the LFCS task prompt: the three-pass strategy only helps once the required states are clear — here, those states are "active now" and "enabled at boot."
 
 </details>
 

--- a/src/content/docs/k8s/lfcs/module-1.2-essential-commands-practice.md
+++ b/src/content/docs/k8s/lfcs/module-1.2-essential-commands-practice.md
@@ -63,7 +63,7 @@ Before `ls`, `rm`, `find`, or almost any other external command receives its arg
 
 The important mental model is that a glob is not a pattern handed to every tool automatically. An unquoted `*.log` belongs to the shell first. If files in the current directory match, the shell replaces the pattern with those local filenames before `find` or `tar` sees anything. If no files match, many shells leave the literal pattern in place, which means the same command can behave differently depending on the current directory. That context sensitivity is why unquoted patterns are a frequent exam-time trap.
 
-- `*`: Matches zero or more characters. For example, `*.log` matches `error.log` and `.log`.
+- `*`: Matches zero or more characters, but **not** a leading dot. For example, `*.log` matches `error.log` but **not** the hidden file `.log` — to match dotfiles you must write the leading dot explicitly (e.g. `.*log`).
 - `?`: Matches exactly one character. For example, `file?.txt` matches `file1.txt` but not `file10.txt`.
 - `[abc]`: Matches any one character listed inside the brackets.
 - `[!abc]` or `[^abc]`: Matches any one character not listed inside the brackets.
@@ -94,7 +94,7 @@ ls -li /tmp/drill1/dir1  # Note identical inode numbers for file1 and hardlink
 readlink /tmp/drill1/dir2/symlink.txt
 ```
 
-This preserved drill does more than create a toy tree. It lets you see how directory entries relate to inodes, which is the foundation for understanding why hard links and symbolic links behave differently. When `ls -li` shows identical inode numbers for `file1.txt` and `hardlink.txt`, you are not looking at two independent file payloads. You are looking at two names for the same underlying inode, and that fact drives both the power and the constraints of hard links.
+This drill does more than create a toy tree. It lets you see how directory entries relate to inodes, which is the foundation for understanding why hard links and symbolic links behave differently. When `ls -li` shows identical inode numbers for `file1.txt` and `hardlink.txt`, you are not looking at two independent file payloads. You are looking at two names for the same underlying inode, and that fact drives both the power and the constraints of hard links.
 
 ## Search, Metadata, and Text Extraction
 
@@ -107,7 +107,7 @@ find /var/log -name "*.log"
 find /etc -type f -mtime -1
 grep -R "error" /var/log
 sed -n '1,20p' /etc/fstab
-awk '{print $1, $3}' /etc/passwd
+awk -F':' '{print $1, $3}' /etc/passwd
 ```
 
 The first two commands ask metadata questions: which names end in `.log`, and which regular files under `/etc` changed recently. The `grep` command asks a content question, so it opens files under `/var/log` and searches for the string `error`. The `sed` command prints a controlled line range without opening an editor, and the `awk` command prints selected fields from each input line. These tools overlap at the edges, but their strengths are distinct enough that choosing well saves both time and mistakes.
@@ -132,7 +132,7 @@ sed -n '1,10p' /etc/passwd
 awk -F':' '{print $1, $3}' /etc/passwd
 ```
 
-That preserved drill is intentionally ordinary because ordinary commands are what you execute under pressure. The better version of `grep -R "root" /var/log` would often add `--binary-files=without-match` or narrow the path further, but the central point remains: use recursive content search only after the directory is small enough to justify opening files. If the task is merely to locate configuration filenames, `find /etc -name "*.conf"` avoids reading every configuration file payload.
+This drill is intentionally ordinary because ordinary commands are what you execute under pressure. The better version of `grep -R "root" /var/log` would often add `--binary-files=without-match` or narrow the path further, but the central point remains: use recursive content search only after the directory is small enough to justify opening files. If the task is merely to locate configuration filenames, `find /etc -name "*.conf"` avoids reading every configuration file payload.
 
 Pause and predict: if `/etc` contains both files and directories modified during the last day, what does `find /etc -mtime -1` return compared with `find /etc -type f -mtime -1`? The first command can return any filesystem object that passes the time test, while the second returns only regular files. That `-type f` predicate is small, but it removes false positives and keeps later commands from accidentally treating directories as files.
 
@@ -187,12 +187,12 @@ tar -cJf backup.tar.xz /etc/myapp
 tar -xJf backup.tar.xz -C /tmp/restore
 ```
 
-The preserved examples show the three common compression families, but a production-quality command usually improves the path handling. Creating an archive from `/etc/myapp` can store absolute path information or emit warnings depending on the implementation. A cleaner pattern is to change into the parent directory and archive the relative child name: `tar -czf backup.tar.gz -C /etc myapp`. That way, extraction creates `myapp` under the chosen restore directory instead of trying to recreate a path rooted at `/`.
+These examples show the three common compression families, but a production-quality command usually improves the path handling. Creating an archive from `/etc/myapp` can store absolute path information or emit warnings depending on the implementation. A cleaner pattern is to change into the parent directory and archive the relative child name: `tar -czf backup.tar.gz -C /etc myapp`. That way, extraction creates `myapp` under the chosen restore directory instead of trying to recreate a path rooted at `/`.
 
 ```bash
 gzip file.txt          # produces file.txt.gz, removes original
 gunzip file.txt.gz     # restores file.txt
-bzip2 file.txt         # produces file.txt.bz2
+bzip2 file.txt         # produces file.txt.bz2 (removes original)
 bunzip2 file.txt.bz2
 xz file.txt            # produces file.txt.xz
 unxz file.txt.xz
@@ -381,7 +381,7 @@ The framework is intentionally compact because you should be able to apply it du
 
 ## Did You Know?
 
-- In 1984, the standard `tar` utility was formally codified by POSIX, though the Unix `tar` program originated in the late 1970s for writing archives to sequential magnetic tape.
+- In 1988, the `ustar` (Unix Standard TAR) format was standardized in POSIX.1 (IEEE Std 1003.1-1988), though the Unix `tar` program originated in the late 1970s for writing archives to sequential magnetic tape.
 - The `xz` file format appeared in 2009 and uses the LZMA2 compression algorithm, which often improves size compared with `gzip` while trading away compression speed.
 - A Linux directory is conceptually a mapping from filenames to inode numbers, which is why a hard link can make two names refer to one underlying file object.
 - The standard `cp` command was present in early Unix history, and its modern administrative value comes from metadata-preserving options such as `-p` and `-a`.
@@ -422,7 +422,7 @@ The shell processes redirections from left to right, so `2>&1` first points stde
 <details>
 <summary>4. You are under time pressure to archive a web directory located at `/var/www/app`. You want the archive to extract cleanly. You use `tar -czf backup.tar.gz -C /backup /var/www/app`. Will this work as intended?</summary>
 
-No, this command is structurally flawed because `-C /backup` tells `tar` to change into `/backup` before looking for the source path. Unless `/backup/var/www/app` exists, the command fails or captures something other than the intended tree. A cleaner command is `tar -czf backup.tar.gz -C /var/www app`, followed by `tar -tzf backup.tar.gz` to verify that the archive contains a relative `app` directory. The important idea is to control archive layout before you need to restore it.
+Because `/var/www/app` is absolute, `-C /backup` is ignored for path resolution; `tar` still archives it but strips the leading `/`, so the archive stores `var/www/app/…` (with a *Removing leading /* warning) instead of a clean relative `app/`. Use `tar -czf backup.tar.gz -C /var/www app` so it stores `app/`. List with `tar -tzf backup.tar.gz` to verify layout before you need to restore it.
 </details>
 
 <details>

--- a/src/content/docs/k8s/lfcs/module-1.3-running-systems-and-networking-practice.md
+++ b/src/content/docs/k8s/lfcs/module-1.3-running-systems-and-networking-practice.md
@@ -17,6 +17,7 @@ Before starting this module, make sure you can navigate a shell, edit text files
 - **Required**: [LFCS Essential Commands Practice](./module-1.2-essential-commands-practice/)
 - **Helpful**: [Module 1.2: Processes & systemd](/linux/foundations/system-essentials/module-1.2-processes-systemd/)
 - **Helpful**: [Module 3.1: TCP/IP Essentials](/linux/foundations/networking/module-3.1-tcp-ip-essentials/)
+- **Helpful**: [Module 3.2: DNS on Linux](/linux/foundations/networking/module-3.2-dns-linux/)
 - **Helpful**: [Module 3.4: iptables & netfilter](/linux/foundations/networking/module-3.4-iptables-netfilter/)
 
 ## Learning Outcomes
@@ -36,6 +37,8 @@ This module trains that evidence chain. LFCS running-system work is not about me
 
 The exam pressure matters because the wrong move is often more expensive than waiting ten seconds to inspect. Rebooting early can erase useful state, restarting repeatedly can rotate away the most relevant log line, and editing persistent network configuration before proving a runtime route can strand your session. The goal here is not to move slowly; it is to move in a sequence that preserves your options. When you can explain what changed, why it changed, and how you verified it, you stop treating recovery as luck.
 
+This section covers SSH client reachability; `sshd_config` server hardening (`PermitRootLogin`, host keys) is practiced in the full mock exam (module 1.5) and the Linux track.
+
 ## Diagnose systemd Service Failures with Evidence
 
 Running-system diagnosis starts with a simple distinction: a process is a running program, while a `systemd` unit is the manager's record of how that program should be started, stopped, restarted, and connected to dependencies. LFCS tasks often blur those two layers. A daemon can be running even when the unit is disabled for boot, a unit can be enabled even when the process is currently dead, and a process can be alive but bound to the wrong port. If you treat the process list as the truth, you miss persistence. If you treat `systemctl status` as the only truth, you may miss an unrelated process that owns the socket.
@@ -43,7 +46,7 @@ Running-system diagnosis starts with a simple distinction: a process is a runnin
 The first pass is deliberately small. Look for the process, identify its command line, decide whether it is healthy enough to keep, and only then take action. `kill -TERM` asks the process to exit cleanly, which gives it a chance to flush files and release locks. `kill -KILL` is the last resort because the kernel terminates the process immediately. `nice` and `renice` do not fix a failed service, but they matter in exam scenarios where a background job consumes CPU and makes the machine feel broken while core services are technically healthy.
 
 ```bash
-ps aux | grep nginx
+ps aux | grep nginx   # also matches the grep process itself; pgrep is cleaner
 top
 pgrep -a ssh
 kill -TERM <pid>
@@ -91,6 +94,8 @@ Use a running-system troubleshooting ladder to keep that discipline visible whil
 6. persistence
 
 The ladder is not a law, but it is a good default. Process state tells you what is happening right now, unit state tells you what the service manager thinks should happen, logs tell you why a transition succeeded or failed, configuration tells you what the program was asked to do, network checks tell you whether the service can be reached, and persistence checks tell you whether the fix survives reboot. When the task is vague, following the ladder prevents the common exam failure of changing three things before verifying any one of them.
+
+Authoring unit files from scratch (`[Unit]`/`[Service]`/`ExecStart`, `daemon-reload`) is practiced in [Linux: Processes & systemd](/linux/foundations/system-essentials/module-1.2-processes-systemd/).
 
 There is another reason to keep the ladder explicit: it gives you a defensible stopping point. If a service is active, enabled, logging cleanly, and listening on the expected address, you do not need to keep editing simply because the original symptom made you nervous. If the service is active but the port is closed, you know the next layer is socket ownership or service configuration. If the port is open but the client still cannot connect, you know the next layer is routing, firewall policy, or name resolution. This is how you convert a vague failure into a small set of testable claims.
 
@@ -237,7 +242,7 @@ nmcli device status
 systemctl is-enabled NetworkManager
 ```
 
-Use the output as a sequence of questions. Does the interface have the address you expected? Does the route table choose the gateway you expected? Can the host reach an IP address without DNS? Does `getent hosts` resolve the name through the system's configured resolver path? Is a service actually listening on the port you expect, and is it enabled for boot if the task asks for persistence? These questions keep route, DNS, firewall, and service failures from collapsing into a vague statement like "networking is broken."
+Use the output as a sequence of questions. Does the interface have the address you expected? Does the route table choose the gateway you expected? Can the host reach an IP address without DNS? Does `getent hosts` resolve the name through the system's configured resolver path? Resolver files (`/etc/resolv.conf`) and `resolvectl` are covered in [Module 3.2: DNS on Linux](/linux/foundations/networking/module-3.2-dns-linux/); this module stays at `getent hosts`-level name checks. Is a service actually listening on the port you expect, and is it enabled for boot if the task asks for persistence? These questions keep route, DNS, firewall, and service failures from collapsing into a vague statement like "networking is broken."
 
 Service reachability has both a local and a remote side. Locally, `ss` can prove that a daemon is listening on an address and port, but it cannot prove that a remote client can traverse the path. Remotely, a connection failure may reflect routing, firewall policy, service binding, or authentication. Keep those layers separate. If a service listens only on `127.0.0.1`, a remote client cannot reach it even though the local socket looks healthy. If a service listens on the expected address but remote traffic fails, the next question is the path between client and server.
 
@@ -546,4 +551,4 @@ Success criteria should prove both repair and cleanup, so do not mark the exerci
 
 ## Next Module
 
-*Next module coming soon.*
+Continue to [LFCS Storage, Services & Users Practice](./module-1.4-storage-services-and-users-practice/).

--- a/src/content/docs/k8s/lfcs/module-1.4-storage-services-and-users-practice.md
+++ b/src/content/docs/k8s/lfcs/module-1.4-storage-services-and-users-practice.md
@@ -50,11 +50,11 @@ groupadd ops
 getent passwd alice
 getent group ops
 id alice
-sudo -l
+sudo -l -U alice
 visudo
 ```
 
-After running those commands, read the output as evidence rather than noise. `getent passwd alice` confirms the account database can resolve the user through the configured name service, which matters on systems that use local files, LDAP, or another NSS source. `getent group ops` confirms the group exists through the same resolution path. `id alice` shows effective group membership as the system sees it, and `sudo -l` tests sudo policy for the current user rather than assuming the group name is sufficient on every distribution.
+After running those commands, read the output as evidence rather than noise. `getent passwd alice` confirms the account database can resolve the user through the configured name service, which matters on systems that use local files, LDAP, or another NSS source. `getent group ops` confirms the group exists through the same resolution path. `id alice` shows effective group membership as the system sees it, and `sudo -l -U alice` tests sudo policy for that user rather than assuming the group name is sufficient on every distribution.
 
 Ownership and permissions are where identity becomes operational. A file mode is only meaningful when paired with owner and group, and a directory mode is only meaningful when you remember that directory execute means traversal, not program execution. If a user cannot open `/srv/app/config.yml`, you need to ask two questions before changing anything: can the user traverse every parent directory, and does the final file grant read permission through owner, group, ACL, or other mode bits? Guessing between `chmod` and `chown` is slower than inspecting the path carefully.
 
@@ -183,6 +183,7 @@ Storage tasks feel dangerous because they touch durable state, so the safe appro
 ```bash
 lsblk
 blkid
+# run only ONE of these (choose ext4 OR xfs)
 mkfs.ext4 /dev/sdb1
 mkfs.xfs /dev/sdb1
 mkdir -p /data
@@ -218,6 +219,7 @@ pvcreate /dev/sdb1
 vgcreate vg_data /dev/sdb1
 lvcreate -n lv_app -L 10G vg_data
 mkfs.ext4 /dev/vg_data/lv_app
+mkdir -p /srv/app
 mount /dev/vg_data/lv_app /srv/app
 ```
 
@@ -266,8 +268,8 @@ apt install -y nginx
 systemctl enable --now nginx
 systemctl status nginx
 systemctl is-enabled nginx
-systemctl restart nginx
 systemctl daemon-reload
+systemctl restart nginx
 ```
 
 The `enable --now` form is efficient because it expresses both boot persistence and immediate startup. Still, you should inspect state afterward because a unit can be enabled and failed at the same time. `systemctl status nginx` shows the active state and recent log context, while `systemctl is-enabled nginx` answers whether boot policy is set. If the service fails, read the status output before reinstalling packages or changing permissions; many failures are caused by missing paths, invalid configuration, unavailable ports, or a user that cannot read required files.
@@ -584,6 +586,7 @@ Use a spare lab disk, a partition created for practice, or a loopback device. Cr
 ```bash
 lsblk
 blkid
+# run only ONE of these (choose ext4 OR xfs)
 mkfs.ext4 /dev/sdb1
 mkfs.xfs /dev/sdb1
 mkdir -p /data
@@ -597,7 +600,7 @@ echo "UUID=$UUID /data ext4 defaults 0 2" | sudo tee -a /etc/fstab
 mount -a
 ```
 
-Choose either ext4 or XFS for the actual lab run; the commands are shown together because the original practice module covered both filesystem choices. If you choose XFS, make the `/etc/fstab` filesystem type match `xfs`, not `ext4`.
+Choose either ext4 or XFS for the actual lab run; the commands are shown together so you can compare both filesystem choices. If you choose XFS, make the `/etc/fstab` filesystem type match `xfs`, not `ext4`.
 
 </details>
 
@@ -617,6 +620,7 @@ pvcreate /dev/sdb1
 vgcreate vg_data /dev/sdb1
 lvcreate -n lv_app -L 10G vg_data
 mkfs.ext4 /dev/vg_data/lv_app
+mkdir -p /srv/app
 mount /dev/vg_data/lv_app /srv/app
 ```
 
@@ -656,8 +660,8 @@ apt install -y nginx
 systemctl enable --now nginx
 systemctl status nginx
 systemctl is-enabled nginx
-systemctl restart nginx
 systemctl daemon-reload
+systemctl restart nginx
 ```
 
 After the service starts, check the exact success condition the task names. If the task only asks for boot persistence, `systemctl is-enabled` is relevant. If the task asks for a running service, `systemctl status` and logs are relevant. If the task asks the service to read from `/srv/app`, path ownership, mode bits, mount state, and service user identity are all relevant.
@@ -677,8 +681,8 @@ After the service starts, check the exact success condition the task names. If t
 - https://man7.org/linux/man-pages/man5/fstab.5.html
 - https://man7.org/linux/man-pages/man8/blkid.8.html
 - https://man7.org/linux/man-pages/man8/lsblk.8.html
-- https://man7.org/linux/man-pages/man8/systemctl.1.html
-- https://docs.kernel.org/admin-guide/device-mapper/lvm.html
+- https://man7.org/linux/man-pages/man1/systemctl.1.html
+- https://man7.org/linux/man-pages/man8/lvm.8.html
 
 ## Next Module
 


### PR DESCRIPTION
## LFCS (Linux Foundation Certified System Administrator) — tool-cert wave-2

Finalizes four back-catalog LFCS practice modules toward `done` via the no-codex review-first loop.
All four were `shipped_unreviewed` / `needs_review`; each got a cross-family R1, every finding was
orchestrator-ground-checked against the actual file + web-verified where it touched exam facts.

### Reviews (mixed pools, ≤2/OAuth, command-correctness-weighted)
| Module | Reviewer | Verdict |
|---|---|---|
| 1.1 exam-strategy-and-workflow | deepseek-v4-pro | NEEDS_CHANGES 3.5/5 |
| 1.2 essential-commands-practice | opus-4.8 | NEEDS_CHANGES 4/5 |
| 1.3 running-systems-and-networking-practice | cursor `--model auto` | APPROVE_WITH_NITS |
| 1.4 storage-services-and-users-practice | opus-4.8 | NEEDS_CHANGES 4.5/5 |

### Fixes
- **1.1**: removed 5 authoring-leak back-references to "the original module / this rewrite" (reworded as
  self-contained learner prose); added the **official current LFCS domain/weighting blueprint table**
  (Operations Deployment 25% / Networking 25% / Storage 20% / Essential Commands 20% / Users 10% —
  web-verified against training.linuxfoundation.org) with a note that the practice modules regroup those
  domains; tightened a quiz-answer sentence.
- **1.2**: **P1 glob correctness** — fixed `*.log` claimed to match `.log` (shell `*` does not match a
  leading dot); added `-F':'` to the first `awk '{print $1,$3}' /etc/passwd` (colon-delimited; matched
  its own correct twin); corrected the Knowledge-Check #4 `tar -C` explanation (an **absolute** source
  path makes `-C` irrelevant — the old reason taught a wrong mental model); fixed a history date
  ("POSIX 1984" → ustar standardized in **POSIX.1, IEEE Std 1003.1-1988**); removed 3 "preserved"
  authoring-leak words.
- **1.3**: added a DNS cross-link to `/linux/foundations/networking/module-3.2-dns-linux/` (+ a
  resolver/`resolvectl` scope sentence) so the DNS claim stays honest at `getent hosts`-level; added an
  SSH "client-reachability only; server hardening → mock 1.5" scope line; cross-linked unit-file
  authoring to the Linux track's `module-1.2-processes-systemd`; replaced the dead-end
  "*Next module coming soon.*" with a real link to 1.4; noted the `ps aux | grep` self-match.
- **1.4**: fixed two genuinely dead source URLs (`man8/systemctl.1.html` → `man1/systemctl.1.html`;
  `docs.kernel.org/.../device-mapper/lvm.html` → `man7.org/.../man8/lvm.8.html` — LVM is userspace);
  removed one authoring leak; added copy-paste safety nits (`# run only ONE of these` before the
  ext4/xfs `mkfs` pair, `mkdir -p /srv/app` before the LVM mount, `sudo -l -U alice` to verify the new
  grant, and reordered `daemon-reload` before `restart`). opus independently verified all LVM grow
  sequences, fstab fields, limits.conf↔ulimit mappings, PAM stack, permissions/setgid, and all 7 quiz
  answers as **correct**.

### Ground-check value-adds (the point of the loop)
- **Rejected** a deepseek false-positive: it claimed the LFCS passing score should be 66% — web-verified
  **67% is correct** for LFCS (66% belongs to the Kubernetes CKA/CKAD/CKS exams). The 67% line is left
  intact; changing it would have injected an error.
- **Caught** deepseek's proposed domain table using the **stale** 6-domain blueprint; replaced with the
  web-verified current 5-domain split.

### Gates (local, from worktree)
- `verify_module.py`: 1.1 / 1.3 / 1.4 **T0**; 1.2 **T3** only on `body_words_floor` (~pre-existing
  43-word gap) + `sources_all_reachable` (local-prober network-block FP on official man-pages) — both
  non-blocking, unchanged by this PR; finalized on the review axis.
- `incident_dedup_gate.py --mode absolute --base origin/main`: **PASS** (this PR adds no incident prose).

## Learner check

From `module-1.1-exam-strategy-and-workflow.md`, the new blueprint-table note explaining how the
practice modules map to the official LFCS domains:

> The KubeDojo LFCS practice modules regroup these domains for hands-on flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
