### PR TITLE
chore(content): CNPA tool-cert wave-2 — review fixes (2 modules: API disambiguation + delivery contrast + leak cleanup + diagram)

### DIFF
--- a/src/content/docs/k8s/cnpa/module-1.3-delivery-apis-and-observability-review.md
+++ b/src/content/docs/k8s/cnpa/module-1.3-delivery-apis-and-observability-review.md
@@ -36,6 +36,8 @@ happened, how bad is it for users, and who should act?" If any one contract is m
 system does not help if the alert that should page on user-visible error budget burn never fires. A service mesh retry policy can make a transient fault survivable, but it can also amplify load if the platform does not define where retries
 are allowed and how they are measured. ([Gateway API: API Overview](https://gateway-api.sigs.k8s.io/docs/concepts/api-overview/), [Google SRE Workbook: Alerting on SLOs](https://sre.google/workbook/alerting-on-slos/))
 
+In this module, *platform API* means a north–south exposure contract (Gateway API / Ingress / HTTPRoute). The CNPA *provisioning* platform APIs — Crossplane XRDs/Compositions/Claims and CRD+operator patterns — are covered in module 1.2 and the Platform Engineering track; don't conflate the two on the exam.
+
 Platform engineers need literacy across the whole path because they are the translators between product teams and infrastructure implementations. The application team should not need to know which controller watches a `HelmRelease`, which
 Gateway implementation programmed an external proxy, or which collector tier exports traces to a backend. They do need a stable interface, clear ownership boundaries, and a way to diagnose whether today's incident belongs to delivery,
 routing, or telemetry. Flux describes reconciliation as ensuring actual state matches a declarative desired state, Argo CD describes automated sync and self-heal in terms of out-of-sync applications, and the OpenTelemetry Protocol describes
@@ -74,6 +76,8 @@ converges or reports why it cannot. Argo CD describes automated sync as acting o
 `Kustomization` objects reconciling manifests from those artifacts, including periodic dry-run detection and drift correction. The shared idea is durable desired state plus repeated comparison, which is why manual cluster edits are usually
 drift, not a supported deployment path. ([Argo CD: Automated Sync Policy](https://argo-cd.readthedocs.io/en/stable/user-guide/auto_sync/), [Argo CD: Diff Strategies](https://argo-cd.readthedocs.io/en/stable/user-guide/diff-strategies/),
 [Flux: Kustomization](https://fluxcd.io/flux/components/kustomize/kustomizations/))
+
+GitOps tools like Argo CD and Flux reconcile *manifests* to desired state; progressive-delivery controllers like Argo Rollouts and Flagger handle *workload* rollout strategies (canary, blue-green) on top of that synced state.
 
 ```mermaid
 flowchart LR

--- a/src/content/docs/k8s/cnpa/module-1.5-practice-questions-set-2.md
+++ b/src/content/docs/k8s/cnpa/module-1.5-practice-questions-set-2.md
@@ -52,16 +52,16 @@ The important exam distinction is that reconciliation is continuous, not ceremon
 You can reason about reconciliation with a simple mental model. The platform receives desired state from a source such as Git, an API request, or a service catalog form. A controller or reconciler reads the current state from Kubernetes, cloud APIs, or platform inventory. The system then decides whether to create, update, delete, or alert, and it repeats that comparison on a regular schedule or after events.
 
 ```text
-+--------------------+       ++--------------------+
++--------------------+       +---------------------+
 | Desired state      |       | Actual state        |
 | Git, API, catalog  |       | Cluster, cloud, IAM |
-+---------+----------+       ++----------+---------+
++---------+----------+       +----------+----------+
           |                             ^
           v                             |
-+--------------------+       ++---------+----------+
++--------------------+       +----------+----------+
 | Reconciler         | ----> | Change or report    |
 | compare and decide |       | until states align  |
-+--------------------+       ++--------------------+
++--------------------+       +---------------------+
 ```
 
 That diagram is intentionally small because the exam usually tests the concept rather than the machinery. The best answer often says the loop compares desired and actual state, then brings them together. Weaker answers describe reconciliation as a deployment phase, a manual meeting, or a way to hide drift. Hiding drift is especially wrong because mature platforms make drift visible and actionable; they do not pretend reality matches the document.
@@ -114,9 +114,9 @@ Consider a scorecard that combines user and system signals. Adoption shows wheth
 
 Do not reduce platform measurement to cost reduction. Cost matters because platform work consumes people, infrastructure, and tooling, but a cheaper platform that slows every team is not a win. Likewise, a costly platform may be justified when it removes broad delivery risk and accelerates many teams. The exam answer should reflect balanced measurement rather than a single financial or activity metric.
 
-## Connecting the Original Comparison Traps
+## Connecting the Comparison Traps
 
-The original five questions in this set were short, but they represented important CNPA comparison traps. The first trap asks whether platform engineering means every team builds alone, a dedicated group builds reusable internal products, operations handles everything manually, or standards disappear. The reusable-product answer is strongest because it combines specialization with leverage; one platform team improves the shared path so many application teams can move with less duplicated effort.
+These comparison-trap questions are short, but each represents an important CNPA distinction. The first trap asks whether platform engineering means every team builds alone, a dedicated group builds reusable internal products, operations handles everything manually, or standards disappear. The reusable-product answer is strongest because it combines specialization with leverage; one platform team improves the shared path so many application teams can move with less duplicated effort.
 
 The second trap asks whether reconciliation is one-time setup, a continuous desired-versus-actual loop, a manual approval process, or a way to hide drift. The continuous-loop answer is strongest because it reflects Kubernetes controller thinking and GitOps-style operations. Drift is not embarrassing noise to hide; it is evidence the system needs to correct, report, or ask for a new desired state.
 
@@ -144,7 +144,7 @@ The third question is whether guardrails are encoded in a way developers can und
 
 The fourth question is whether measurement reflects user value. A dashboard that counts catalog clicks may be useful, but it does not prove the path works. A stronger dashboard shows how many services completed onboarding, how long onboarding took, how often reconciliation failed, which policies rejected requests, and how many support tickets came from the same workflow step. Those measures help the platform team improve the product instead of merely reporting activity.
 
-Now test the proposal against the original distractors. “Every team builds its own deployment tooling” would be a poor outcome because the proposed workflow should replace duplicated service onboarding scripts. “The ops team handles all provisioning requests manually” would also be weak because the routine path should be automated and reconciled. “Developers may use any workflow, with no standards” would conflict with the idea of a supported path, even if some exceptions remain possible for unusual workloads.
+Now test the proposal against these trap distractors. “Every team builds its own deployment tooling” would be a poor outcome because the proposed workflow should replace duplicated service onboarding scripts. “The ops team handles all provisioning requests manually” would also be weak because the routine path should be automated and reconciled. “Developers may use any workflow, with no standards” would conflict with the idea of a supported path, even if some exceptions remain possible for unusual workloads.
 
 The most subtle weakness would be a platform that looks self-service but secretly depends on manual approvals for ordinary work. A portal can collect a request while an operator still copies YAML later, and the user may not notice until work queues up. During review, ask whether the platform returns status automatically, whether it records why a request is waiting, and whether the normal request can complete without a private handoff. Those checks reveal whether the workflow truly reduces dependency on the platform team.
 
@@ -388,7 +388,7 @@ Start by writing a one-page review in your notes. Describe the repeated develope
 - [ ] Diagnose reconciliation and drift scenarios by identifying desired state, actual state, and the component that compares them.
 - [ ] Design guardrails by listing at least four controls, including policy, limits, auditability, and scoped developer autonomy.
 - [ ] Measure platform health with adoption, reliability, and time-to-value signals instead of team busyness alone.
-- [ ] Explain why each original comparison-trap distractor is wrong in one or two sentences.
+- [ ] Explain why each comparison-trap distractor is wrong in one or two sentences.
 
 <details><summary>Solution guide</summary>
 


### PR DESCRIPTION
## CNPA (Certified Cloud Native Platform Engineering Associate) — tool-cert wave-2

Finalizes the two remaining CNPA modules toward `done` via the no-codex review-first loop. Both were
back-catalog `needs_review`; each got a cross-family R1, every finding was orchestrator-ground-checked,
and **all quiz/practice answer keys were independently verified correct** (CNPA is a multiple-choice
concept exam — a wrong answer key is the highest-severity defect, and there were none).

### Reviews (mixed pools, ≤2/OAuth)
| Module | Reviewer | Verdict |
|---|---|---|
| 1.3 delivery-apis-and-observability-review | cursor `--model auto` | APPROVE |
| 1.5 practice-questions-set-2 | opus-4.8 | NEEDS_CHANGES 4/5 (all 7 keys correct) |

### Fixes
- **1.3** (APPROVE — two reviewer-endorsed clarity adds): disambiguated the two meanings of
  "platform API" — *exposure* contracts (Gateway API / Ingress / HTTPRoute) here vs the CNPA blueprint's
  **Domain 4 "Platform APIs & Provisioning Infrastructure" (12%)** *provisioning* APIs (Crossplane
  XRD/Composition/Claim, CRD+operators) which live in module 1.2 / the Platform track; added one
  sentence contrasting GitOps **manifest sync** (Argo CD / Flux) with **workload progressive delivery**
  (Argo Rollouts / Flagger).
- **1.5**: removed the "original five questions" authoring leak (the set now has **seven** questions, so
  "the original five" presumed an editorial history the learner doesn't have — 4 instances + the section
  header reworded); fixed a malformed ASCII reconciliation diagram (doubled `++` borders → aligned
  single `+`). **No quiz question, answer, or distractor was changed** — opus traced all seven and
  confirmed every key correct.

### Ground-check
- CNPA blueprint domain/weighting (Core Fundamentals 36 / Observability-Security-Conformance 20 /
  Continuous Delivery 16 / Platform APIs 12 / IDP-DevEx 8 / Measuring 8) web-verified against cncf.io;
  cursor's Domain-4 reference checked out.
- Sibling-grep confirmed the 1.5 leak was exactly 4 instances (no hidden extras).

### Gates (local, from worktree)
- `verify_module.py`: both **T0 / passed=True**.
- `incident_dedup_gate.py --mode absolute --base origin/main`: **PASS** (no incident prose added).

## Learner check

From `module-1.3-delivery-apis-and-observability-review.md`, the new manifest-sync vs progressive-delivery
contrast:

> GitOps tools like Argo CD and Flux reconcile *manifests* to desired state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
